### PR TITLE
H-718: Change Subgraph traversal logic to check for permissions to see entities 

### DIFF
--- a/apps/hash-graph/Cargo.lock
+++ b/apps/hash-graph/Cargo.lock
@@ -102,6 +102,8 @@ name = "authorization"
 version = "0.0.0"
 dependencies = [
  "error-stack",
+ "futures",
+ "graph-types",
  "reqwest",
  "serde",
  "serde_json",
@@ -756,6 +758,7 @@ name = "graph"
 version = "0.0.0"
 dependencies = [
  "async-trait",
+ "authorization",
  "axum",
  "bb8-postgres",
  "bytes",
@@ -804,6 +807,7 @@ dependencies = [
 name = "graph-benches"
 version = "0.0.0"
 dependencies = [
+ "authorization",
  "criterion",
  "criterion-macro",
  "futures",
@@ -824,6 +828,7 @@ dependencies = [
 name = "graph-integration"
 version = "0.0.0"
 dependencies = [
+ "authorization",
  "error-stack",
  "futures",
  "graph",
@@ -890,6 +895,7 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 name = "hash-graph"
 version = "0.0.0"
 dependencies = [
+ "authorization",
  "axum",
  "clap",
  "clap_complete",

--- a/apps/hash-graph/Cargo.toml
+++ b/apps/hash-graph/Cargo.toml
@@ -21,6 +21,7 @@ graph-test-data = { path = "tests/test_data" }
 # tested in CI if the dependency was changed.
 temporal-versioning = { path = "lib/temporal-versioning" }
 graph-types = { path = "lib/graph-types" }
+authorization = { path = "lib/authorization" }
 
 type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "cdde49" }
 hash-status = { path = "../../libs/@local/status/crate" }
@@ -35,6 +36,7 @@ serde_json = "1.0.105"
 tokio = { version = "1.32.0", default-features = false }
 time = { version = "0.3.28", default-features = false }
 tracing = "0.1.37"
+futures = { version = "0.3.28", default-features = false }
 
 [profile.production]
 inherits = "release"

--- a/apps/hash-graph/bench/Cargo.toml
+++ b/apps/hash-graph/bench/Cargo.toml
@@ -15,12 +15,13 @@ graph = { path = "../lib/graph" }
 graph-test-data = { workspace = true }
 graph-types = { workspace = true }
 temporal-versioning = { workspace = true }
+authorization = { workspace = true }
 
 type-system = { workspace = true }
 
 criterion = { version = "0.5.1", features = ["async_tokio", "html_reports"] }
 criterion-macro = "0.4.0"
-futures = "0.3.28"
+futures = { workspace = true }
 rand = "0.8.5"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"

--- a/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
@@ -1,5 +1,6 @@
 use std::{iter::repeat, str::FromStr};
 
+use authorization::NoAuthorization;
 use criterion::{BatchSize::SmallInput, Bencher, BenchmarkId, Criterion, SamplingMode};
 use criterion_macro::criterion;
 use graph::{
@@ -163,17 +164,20 @@ pub fn bench_get_entity_by_id(
         },
         |entity_record_id| async move {
             store
-                .get_entity(&StructuralQuery {
-                    filter: Filter::for_entity_by_entity_id(entity_record_id.entity_id),
-                    graph_resolve_depths,
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(
-                            Some(TemporalBound::Unbounded),
-                            None,
-                        ),
+                .get_entity(
+                    &StructuralQuery {
+                        filter: Filter::for_entity_by_entity_id(entity_record_id.entity_id),
+                        graph_resolve_depths,
+                        temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                            pinned: PinnedTemporalAxisUnresolved::new(None),
+                            variable: VariableTemporalAxisUnresolved::new(
+                                Some(TemporalBound::Unbounded),
+                                None,
+                            ),
+                        },
                     },
-                })
+                    &NoAuthorization,
+                )
                 .await
                 .expect("failed to read entity from store");
         },

--- a/apps/hash-graph/bench/read_scaling/knowledge/linkless/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/linkless/entity.rs
@@ -1,5 +1,6 @@
 use std::{iter::repeat, str::FromStr};
 
+use authorization::NoAuthorization;
 use criterion::{BatchSize::SmallInput, Bencher, BenchmarkId, Criterion};
 use criterion_macro::criterion;
 use graph::{
@@ -118,17 +119,20 @@ pub fn bench_get_entity_by_id(
         },
         |entity_record_id| async move {
             store
-                .get_entity(&StructuralQuery {
-                    filter: Filter::for_entity_by_entity_id(entity_record_id.entity_id),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(
-                            Some(TemporalBound::Unbounded),
-                            None,
-                        ),
+                .get_entity(
+                    &StructuralQuery {
+                        filter: Filter::for_entity_by_entity_id(entity_record_id.entity_id),
+                        graph_resolve_depths: GraphResolveDepths::default(),
+                        temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                            pinned: PinnedTemporalAxisUnresolved::new(None),
+                            variable: VariableTemporalAxisUnresolved::new(
+                                Some(TemporalBound::Unbounded),
+                                None,
+                            ),
+                        },
                     },
-                })
+                    &NoAuthorization,
+                )
                 .await
                 .expect("failed to read entity from store");
         },

--- a/apps/hash-graph/bench/representative_read/knowledge/entity.rs
+++ b/apps/hash-graph/bench/representative_read/knowledge/entity.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use authorization::NoAuthorization;
 use criterion::{BatchSize::SmallInput, Bencher};
 use graph::{
     knowledge::EntityQueryPath,
@@ -39,19 +40,22 @@ pub fn bench_get_entity_by_id(
         },
         |entity_uuid| async move {
             let subgraph = store
-                .get_entity(&StructuralQuery {
-                    filter: Filter::Equal(
-                        Some(FilterExpression::Path(EntityQueryPath::Uuid)),
-                        Some(FilterExpression::Parameter(Parameter::Uuid(
-                            entity_uuid.as_uuid(),
-                        ))),
-                    ),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                .get_entity(
+                    &StructuralQuery {
+                        filter: Filter::Equal(
+                            Some(FilterExpression::Path(EntityQueryPath::Uuid)),
+                            Some(FilterExpression::Parameter(Parameter::Uuid(
+                                entity_uuid.as_uuid(),
+                            ))),
+                        ),
+                        graph_resolve_depths: GraphResolveDepths::default(),
+                        temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                            pinned: PinnedTemporalAxisUnresolved::new(None),
+                            variable: VariableTemporalAxisUnresolved::new(None, None),
+                        },
                     },
-                })
+                    &NoAuthorization,
+                )
                 .await
                 .expect("failed to read entity from store");
             assert_eq!(subgraph.roots.len(), 1);
@@ -81,17 +85,20 @@ pub fn bench_get_entities_by_property(
             .convert_parameters()
             .expect("failed to convert parameters");
         let subgraph = store
-            .get_entity(&StructuralQuery {
-                filter,
-                graph_resolve_depths,
-                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                    pinned: PinnedTemporalAxisUnresolved::new(None),
-                    variable: VariableTemporalAxisUnresolved::new(
-                        Some(TemporalBound::Unbounded),
-                        None,
-                    ),
+            .get_entity(
+                &StructuralQuery {
+                    filter,
+                    graph_resolve_depths,
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(
+                            Some(TemporalBound::Unbounded),
+                            None,
+                        ),
+                    },
                 },
-            })
+                &NoAuthorization,
+            )
             .await
             .expect("failed to read entity from store");
         assert_eq!(subgraph.roots.len(), 100);
@@ -123,17 +130,20 @@ pub fn bench_get_link_by_target_by_property(
             .convert_parameters()
             .expect("failed to convert parameters");
         let subgraph = store
-            .get_entity(&StructuralQuery {
-                filter,
-                graph_resolve_depths,
-                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                    pinned: PinnedTemporalAxisUnresolved::new(None),
-                    variable: VariableTemporalAxisUnresolved::new(
-                        Some(TemporalBound::Unbounded),
-                        None,
-                    ),
+            .get_entity(
+                &StructuralQuery {
+                    filter,
+                    graph_resolve_depths,
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(
+                            Some(TemporalBound::Unbounded),
+                            None,
+                        ),
+                    },
                 },
-            })
+                &NoAuthorization,
+            )
             .await
             .expect("failed to read entity from store");
         assert_eq!(subgraph.roots.len(), 100);

--- a/apps/hash-graph/bench/util.rs
+++ b/apps/hash-graph/bench/util.rs
@@ -189,6 +189,7 @@ impl Drop for StoreWrapper {
     }
 }
 
+#[expect(clippy::too_many_lines)]
 pub async fn seed<D, P, E, C>(
     store: &mut PostgresStore<C>,
     account_id: AccountId,

--- a/apps/hash-graph/bin/cli/Cargo.toml
+++ b/apps/hash-graph/bin/cli/Cargo.toml
@@ -11,6 +11,7 @@ description = "The entity-graph query-layer for the HASH datastore"
 graph = { path = "../../lib/graph", features = ["clap"] }
 graph-types = { workspace = true }
 type-fetcher = { path = "../../lib/type-fetcher" }
+authorization = { workspace = true }
 
 error-stack = { workspace = true }
 type-system = { workspace = true }

--- a/apps/hash-graph/bin/cli/src/subcommand/server.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/server.rs
@@ -6,6 +6,7 @@ use std::{
     time::Duration,
 };
 
+use authorization::NoAuthorization;
 use clap::Parser;
 use error_stack::{Report, Result, ResultExt};
 use graph::{
@@ -378,6 +379,7 @@ pub async fn server(args: ServerArgs) -> Result<(), GraphError> {
 
     let router = rest_api_router(RestRouterDependencies {
         store: Arc::new(pool),
+        authorization_api: Arc::new(NoAuthorization),
         domain_regex: DomainValidator::new(args.allowed_url_domain),
     });
 

--- a/apps/hash-graph/lib/authorization/Cargo.toml
+++ b/apps/hash-graph/lib/authorization/Cargo.toml
@@ -6,9 +6,11 @@ publish = false
 
 [dependencies]
 error-stack = { workspace = true }
+graph-types = { workspace = true }
 
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+futures = { workspace = true }
 
 reqwest = { version = "0.11.20", default-features = false, features = ["json"] }
 

--- a/apps/hash-graph/lib/authorization/src/backend.rs
+++ b/apps/hash-graph/lib/authorization/src/backend.rs
@@ -9,7 +9,7 @@ pub use self::spicedb::{SpiceDb, SpiceDbConfig};
 use crate::zanzibar::{Affiliation, Consistency, Relation, Resource, Tuple, UntypedTuple, Zookie};
 
 /// A backend for interacting with an authorization system based on the Zanzibar model.
-pub trait AuthorizationApi {
+pub trait ZanzibarBackend {
     /// Loads a schema into the backend.
     ///
     /// Please see the documentation on the corresponding backend for more information.
@@ -85,14 +85,14 @@ pub trait AuthorizationApi {
     ) -> Result<CheckResponse, Report<CheckError>>;
 }
 
-/// Return value for [`AuthorizationApi::import_schema`].
+/// Return value for [`ZanzibarBackend::import_schema`].
 #[derive(Debug)]
 pub struct ImportSchemaResponse {
     /// A token to determine the time at which the schema was writte.
     pub written_at: Zookie<'static>,
 }
 
-/// Error returned from [`AuthorizationApi::import_schema`].
+/// Error returned from [`ZanzibarBackend::import_schema`].
 #[derive(Debug)]
 pub struct ImportSchemaError;
 
@@ -104,7 +104,7 @@ impl fmt::Display for ImportSchemaError {
 
 impl Error for ImportSchemaError {}
 
-/// Return value for [`AuthorizationApi::export_schema`].
+/// Return value for [`ZanzibarBackend::export_schema`].
 #[derive(Debug)]
 pub struct ExportSchemaResponse {
     /// The schema text.
@@ -113,7 +113,7 @@ pub struct ExportSchemaResponse {
     pub read_at: Zookie<'static>,
 }
 
-/// Error returned from [`AuthorizationApi::export_schema`].
+/// Error returned from [`ZanzibarBackend::export_schema`].
 #[derive(Debug)]
 pub struct ExportSchemaError;
 
@@ -125,14 +125,14 @@ impl fmt::Display for ExportSchemaError {
 
 impl Error for ExportSchemaError {}
 
-/// Return value for [`AuthorizationApi::create_relations`].
+/// Return value for [`ZanzibarBackend::create_relations`].
 #[derive(Debug)]
 pub struct CreateRelationResponse {
     /// A token to determine the time at which the relation was created.
     pub written_at: Zookie<'static>,
 }
 
-/// Error returned from [`AuthorizationApi::create_relations`].
+/// Error returned from [`ZanzibarBackend::create_relations`].
 #[derive(Debug)]
 pub struct CreateRelationError;
 
@@ -144,14 +144,14 @@ impl fmt::Display for CreateRelationError {
 
 impl Error for CreateRelationError {}
 
-/// Return value for [`AuthorizationApi::delete_relations`].
+/// Return value for [`ZanzibarBackend::delete_relations`].
 #[derive(Debug)]
 pub struct DeleteRelationResponse {
     /// A token to determine the time at which the relation was deleted.
     pub deleted_at: Zookie<'static>,
 }
 
-/// Error returned from [`AuthorizationApi::delete_relations`].
+/// Error returned from [`ZanzibarBackend::delete_relations`].
 #[derive(Debug)]
 pub struct DeleteRelationError;
 
@@ -163,14 +163,14 @@ impl fmt::Display for DeleteRelationError {
 
 impl Error for DeleteRelationError {}
 
-/// Return value for [`AuthorizationApi::delete_relations`].
+/// Return value for [`ZanzibarBackend::delete_relations`].
 #[derive(Debug)]
 pub struct DeleteRelationsResponse {
     /// A token to determine the time at which the relation was deleted.
     pub deleted_at: Zookie<'static>,
 }
 
-/// Error returned from [`AuthorizationApi::delete_relations`].
+/// Error returned from [`ZanzibarBackend::delete_relations`].
 #[derive(Debug)]
 pub struct DeleteRelationsError;
 
@@ -182,7 +182,7 @@ impl fmt::Display for DeleteRelationsError {
 
 impl Error for DeleteRelationsError {}
 
-/// Return value for [`AuthorizationApi::check`].
+/// Return value for [`ZanzibarBackend::check`].
 #[derive(Debug)]
 pub struct CheckResponse {
     /// If the subject has the specified permission or relation to an [`Resource`].
@@ -191,7 +191,7 @@ pub struct CheckResponse {
     pub checked_at: Zookie<'static>,
 }
 
-/// Error returned from [`AuthorizationApi::check`].
+/// Error returned from [`ZanzibarBackend::check`].
 #[derive(Debug)]
 pub struct CheckError {
     pub tuple: UntypedTuple<'static>,
@@ -271,16 +271,6 @@ impl<'f> RelationFilter<'f> {
         R: Resource + ?Sized,
     {
         self.affiliation = Some(relation.as_ref());
-        self
-    }
-
-    #[must_use]
-    pub fn by_permission<A, R>(mut self, permission: &'f A) -> Self
-    where
-        A: Relation<R> + ?Sized,
-        R: Resource + ?Sized,
-    {
-        self.affiliation = Some(permission.as_ref());
         self
     }
 

--- a/apps/hash-graph/lib/authorization/src/backend/spicedb/api.rs
+++ b/apps/hash-graph/lib/authorization/src/backend/spicedb/api.rs
@@ -5,10 +5,10 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
     backend::{
-        spicedb::model, AuthorizationApi, CheckError, CheckResponse, CreateRelationError,
-        CreateRelationResponse, DeleteRelationError, DeleteRelationResponse, DeleteRelationsError,
-        DeleteRelationsResponse, ExportSchemaError, ExportSchemaResponse, ImportSchemaError,
-        ImportSchemaResponse, Precondition, RelationFilter, SpiceDb,
+        spicedb::model, CheckError, CheckResponse, CreateRelationError, CreateRelationResponse,
+        DeleteRelationError, DeleteRelationResponse, DeleteRelationsError, DeleteRelationsResponse,
+        ExportSchemaError, ExportSchemaResponse, ImportSchemaError, ImportSchemaResponse,
+        Precondition, RelationFilter, SpiceDb, ZanzibarBackend,
     },
     zanzibar::{Consistency, Tuple, UntypedTuple, Zookie},
 };
@@ -143,7 +143,7 @@ impl SpiceDb {
     }
 }
 
-impl AuthorizationApi for SpiceDb {
+impl ZanzibarBackend for SpiceDb {
     async fn import_schema(
         &mut self,
         schema: &str,

--- a/apps/hash-graph/lib/authorization/src/lib.rs
+++ b/apps/hash-graph/lib/authorization/src/lib.rs
@@ -47,7 +47,6 @@ pub trait AuthorizationApi {
 #[derive(Debug, Default)]
 pub struct NoAuthorization;
 
-// #[async_trait]
 impl AuthorizationApi for NoAuthorization {
     async fn view_entity(
         &self,

--- a/apps/hash-graph/lib/authorization/src/lib.rs
+++ b/apps/hash-graph/lib/authorization/src/lib.rs
@@ -1,8 +1,78 @@
-#![feature(associated_type_bounds)]
-#![feature(async_fn_in_trait)]
-#![feature(impl_trait_in_assoc_type)]
-#![feature(lint_reasons)]
+#![feature(
+    associated_type_bounds,
+    async_fn_in_trait,
+    impl_trait_in_assoc_type,
+    lint_reasons,
+    return_position_impl_trait_in_trait
+)]
+
+use std::future::Future;
+
+use futures::Stream;
+use graph_types::{account::AccountId, knowledge::entity::EntityId};
+
+use crate::{
+    backend::CheckError,
+    zanzibar::{Consistency, Zookie},
+};
 
 pub mod backend;
 
 pub mod zanzibar;
+
+pub trait AuthorizationApi {
+    async fn view_entity(
+        &self,
+        actor: AccountId,
+        entity: EntityId,
+        consistency: Consistency<'_>,
+    ) -> Result<(bool, zanzibar::Zookie<'static>), CheckError>;
+
+    fn view_entities(
+        &self,
+        actor: AccountId,
+        entities: impl IntoIterator<Item = EntityId, IntoIter: Send> + Send,
+        consistency: Consistency<'_>,
+    ) -> impl Future<
+        Output = Result<
+            (
+                impl Stream<Item = Result<(EntityId, bool), CheckError>> + Send,
+                Zookie<'static>,
+            ),
+            CheckError,
+        >,
+    > + Send;
+}
+
+#[derive(Debug, Default)]
+pub struct NoAuthorization;
+
+// #[async_trait]
+impl AuthorizationApi for NoAuthorization {
+    async fn view_entity(
+        &self,
+        _actor: AccountId,
+        _entity: EntityId,
+        _consistency: Consistency<'_>,
+    ) -> Result<(bool, Zookie<'static>), CheckError> {
+        Ok((true, Zookie::empty()))
+    }
+
+    async fn view_entities(
+        &self,
+        _actor: AccountId,
+        entities: impl IntoIterator<Item = EntityId, IntoIter: Send> + Send,
+        _consistency: Consistency<'_>,
+    ) -> Result<
+        (
+            impl Stream<Item = Result<(EntityId, bool), CheckError>> + Send,
+            Zookie<'static>,
+        ),
+        CheckError,
+    > {
+        Ok((
+            futures::stream::iter(entities.into_iter().map(|entity| Ok((entity, true)))),
+            Zookie::empty(),
+        ))
+    }
+}

--- a/apps/hash-graph/lib/authorization/src/zanzibar.rs
+++ b/apps/hash-graph/lib/authorization/src/zanzibar.rs
@@ -226,7 +226,13 @@ impl<'t> UntypedTuple<'t> {
 /// Provide causality metadata between Write and Check requests.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct Zookie<'a>(Cow<'a, str>);
+pub struct Zookie<'t>(Cow<'t, str>);
+
+impl Zookie<'_> {
+    pub(crate) const fn empty() -> Self {
+        Self(Cow::Borrowed(""))
+    }
+}
 
 /// Specifies the desired consistency level on a per-request basis.
 ///

--- a/apps/hash-graph/lib/authorization/tests/api.rs
+++ b/apps/hash-graph/lib/authorization/tests/api.rs
@@ -5,10 +5,10 @@ use std::{mem, thread::JoinHandle};
 
 use authorization::{
     backend::{
-        AuthorizationApi, CheckError, CheckResponse, CreateRelationError, CreateRelationResponse,
+        CheckError, CheckResponse, CreateRelationError, CreateRelationResponse,
         DeleteRelationError, DeleteRelationResponse, DeleteRelationsError, DeleteRelationsResponse,
         ExportSchemaError, ExportSchemaResponse, ImportSchemaError, ImportSchemaResponse,
-        Precondition, RelationFilter, SpiceDb,
+        Precondition, RelationFilter, SpiceDb, ZanzibarBackend,
     },
     zanzibar::{Consistency, Tuple, UntypedTuple},
 };
@@ -102,7 +102,7 @@ impl Drop for TestApi {
     }
 }
 
-impl AuthorizationApi for TestApi {
+impl ZanzibarBackend for TestApi {
     async fn import_schema(
         &mut self,
         schema: &str,

--- a/apps/hash-graph/lib/authorization/tests/simple.rs
+++ b/apps/hash-graph/lib/authorization/tests/simple.rs
@@ -7,7 +7,7 @@ mod schema;
 use std::error::Error;
 
 use authorization::{
-    backend::{AuthorizationApi, Precondition, RelationFilter},
+    backend::{Precondition, RelationFilter, ZanzibarBackend},
     zanzibar::Consistency,
 };
 

--- a/apps/hash-graph/lib/graph/Cargo.toml
+++ b/apps/hash-graph/lib/graph/Cargo.toml
@@ -9,6 +9,7 @@ description = "HASH Graph API"
 graph-types = { workspace = true, features = ["postgres", "utoipa"] }
 temporal-versioning = { workspace = true, features = ["postgres", "utoipa"] }
 type-fetcher = { path = "../type-fetcher" }
+authorization = { workspace = true }
 
 error-stack = { workspace = true }
 hash-status = { workspace = true }
@@ -26,7 +27,7 @@ bytes = { workspace = true }
 clap = { version = "4.4.2", features = ["derive", "env"], optional = true }
 derivative = "2.2.0"
 dotenv-flow = "0.15.0"
-futures = "0.3.28"
+futures = { workspace = true }
 hyper = "0.14.27"
 include_dir = "0.7.3"
 mime = "0.3.17"

--- a/apps/hash-graph/lib/graph/src/api/rest/account.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/account.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use authorization::AuthorizationApi;
 use axum::{http::StatusCode, routing::post, Extension, Router};
 use graph_types::account::AccountId;
 use utoipa::OpenApi;
@@ -29,7 +30,8 @@ pub struct AccountResource;
 
 impl RoutedResource for AccountResource {
     /// Create routes for interacting with accounts.
-    fn routes<P: StorePool + Send + 'static>() -> Router {
+    fn routes<P: StorePool + Send + 'static, A: AuthorizationApi + Send + Sync + 'static>() -> Router
+    {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new().nest(
             "/accounts",

--- a/apps/hash-graph/lib/graph/src/api/rest/api_resource.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/api_resource.rs
@@ -1,3 +1,4 @@
+use authorization::AuthorizationApi;
 use axum::Router;
 
 use crate::{api::rest::RestApiStore, store::StorePool};
@@ -9,7 +10,7 @@ use crate::{api::rest::RestApiStore, store::StorePool};
 /// through a `Router`, making it explicitly clear we want to provide `OpenApi` specification as
 /// documentation for the routes.
 pub(super) trait RoutedResource: utoipa::OpenApi {
-    fn routes<P: StorePool + Send + 'static>() -> Router
+    fn routes<P: StorePool + Send + 'static, A: AuthorizationApi + Send + Sync + 'static>() -> Router
     where
         for<'pool> P::Store<'pool>: RestApiStore;
 

--- a/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use authorization::AuthorizationApi;
 use axum::{
     http::StatusCode,
     routing::{post, put},
@@ -68,7 +69,7 @@ pub struct DataTypeResource;
 
 impl RoutedResource for DataTypeResource {
     /// Create routes for interacting with data types.
-    fn routes<P: StorePool + Send + 'static>() -> Router
+    fn routes<P: StorePool + Send + 'static, A: AuthorizationApi + Send + Sync + 'static>() -> Router
     where
         for<'pool> P::Store<'pool>: RestApiStore,
     {

--- a/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
@@ -2,6 +2,7 @@
 
 use std::{collections::hash_map, sync::Arc};
 
+use authorization::AuthorizationApi;
 use axum::{
     http::StatusCode,
     response::Response,
@@ -79,7 +80,7 @@ pub struct EntityTypeResource;
 
 impl RoutedResource for EntityTypeResource {
     /// Create routes for interacting with entity types.
-    fn routes<P: StorePool + Send + 'static>() -> Router
+    fn routes<P: StorePool + Send + 'static, A: AuthorizationApi + Send + Sync + 'static>() -> Router
     where
         for<'pool> P::Store<'pool>: RestApiStore,
     {

--- a/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use authorization::AuthorizationApi;
 use axum::{
     http::StatusCode,
     routing::{post, put},
@@ -69,7 +70,7 @@ pub struct PropertyTypeResource;
 
 impl RoutedResource for PropertyTypeResource {
     /// Create routes for interacting with property types.
-    fn routes<P: StorePool + Send + 'static>() -> Router
+    fn routes<P: StorePool + Send + 'static, A: AuthorizationApi + Sync + Send + 'static>() -> Router
     where
         for<'pool> P::Store<'pool>: RestApiStore,
     {

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use authorization::AuthorizationApi;
 use error_stack::{Report, Result, ResultExt};
 use graph_types::{
     account::AccountId,
@@ -809,8 +810,12 @@ where
             .await
     }
 
-    async fn get_entity(&self, query: &StructuralQuery<Entity>) -> Result<Subgraph, QueryError> {
-        self.store.get_entity(query).await
+    async fn get_entity<Au: AuthorizationApi + Sync>(
+        &self,
+        query: &StructuralQuery<Entity>,
+        authorization_api: &Au,
+    ) -> Result<Subgraph, QueryError> {
+        self.store.get_entity(query, authorization_api).await
     }
 
     async fn update_entity(

--- a/apps/hash-graph/lib/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/lib/graph/src/store/knowledge.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use authorization::AuthorizationApi;
 use error_stack::Result;
 use graph_types::{
     knowledge::{
@@ -83,7 +84,11 @@ pub trait EntityStore: crud::Read<Entity> {
     /// # Errors
     ///
     /// - if the requested [`Entity`] doesn't exist
-    async fn get_entity(&self, query: &StructuralQuery<Entity>) -> Result<Subgraph, QueryError>;
+    async fn get_entity<A: AuthorizationApi + Sync>(
+        &self,
+        query: &StructuralQuery<Entity>,
+        authorization_api: &A,
+    ) -> Result<Subgraph, QueryError>;
 
     /// Update an existing [`Entity`].
     ///

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -554,7 +554,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             .collect())
     }
 
-    // #[tracing::instrument(level = "info", skip(self, authorization_api))]
+    #[tracing::instrument(level = "info", skip(self, authorization_api))]
     async fn get_entity<A: AuthorizationApi + Sync>(
         &self,
         query: &StructuralQuery<Entity>,

--- a/apps/hash-graph/tests/integration/Cargo.toml
+++ b/apps/hash-graph/tests/integration/Cargo.toml
@@ -9,11 +9,12 @@ graph = { path = "../../lib/graph" }
 graph-test-data = { workspace = true }
 graph-types = { workspace = true }
 temporal-versioning = { workspace = true }
+authorization = { workspace = true }
 
 error-stack = { workspace = true }
 type-system = { workspace = true }
 
-futures = "0.3.28"
+futures = { workspace = true }
 rand = "0.8.5"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"

--- a/apps/hash-graph/tests/integration/postgres/lib.rs
+++ b/apps/hash-graph/tests/integration/postgres/lib.rs
@@ -1,5 +1,5 @@
 #![cfg(test)]
-#![feature(associated_type_bounds)]
+#![feature(associated_type_bounds, lint_reasons)]
 #![allow(
     clippy::missing_panics_doc,
     clippy::missing_errors_doc,
@@ -14,6 +14,7 @@ mod property_type;
 
 use std::{borrow::Cow, str::FromStr};
 
+use authorization::NoAuthorization;
 use error_stack::Result;
 use graph::{
     knowledge::EntityQueryPath,
@@ -417,17 +418,20 @@ impl DatabaseApi<'_> {
     pub async fn get_entities(&self, entity_id: EntityId) -> Result<Vec<Entity>, QueryError> {
         Ok(self
             .store
-            .get_entity(&StructuralQuery {
-                filter: Filter::for_entity_by_entity_id(entity_id),
-                graph_resolve_depths: GraphResolveDepths::default(),
-                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                    pinned: PinnedTemporalAxisUnresolved::new(None),
-                    variable: VariableTemporalAxisUnresolved::new(
-                        Some(TemporalBound::Unbounded),
-                        None,
-                    ),
+            .get_entity(
+                &StructuralQuery {
+                    filter: Filter::for_entity_by_entity_id(entity_id),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(
+                            Some(TemporalBound::Unbounded),
+                            None,
+                        ),
+                    },
                 },
-            })
+                &NoAuthorization,
+            )
             .await?
             .vertices
             .entities
@@ -442,17 +446,20 @@ impl DatabaseApi<'_> {
     ) -> Result<Entity, QueryError> {
         let entities = self
             .store
-            .get_entity(&StructuralQuery {
-                filter: Filter::for_entity_by_entity_id(entity_id),
-                graph_resolve_depths: GraphResolveDepths::default(),
-                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                    pinned: PinnedTemporalAxisUnresolved::new(None),
-                    variable: VariableTemporalAxisUnresolved::new(
-                        Some(TemporalBound::Inclusive(timestamp)),
-                        Some(LimitedTemporalBound::Inclusive(timestamp)),
-                    ),
+            .get_entity(
+                &StructuralQuery {
+                    filter: Filter::for_entity_by_entity_id(entity_id),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(
+                            Some(TemporalBound::Inclusive(timestamp)),
+                            Some(LimitedTemporalBound::Inclusive(timestamp)),
+                        ),
+                    },
                 },
-            })
+                &NoAuthorization,
+            )
             .await?
             .vertices
             .entities
@@ -465,14 +472,17 @@ impl DatabaseApi<'_> {
     pub async fn get_latest_entity(&self, entity_id: EntityId) -> Result<Entity, QueryError> {
         let entities = self
             .store
-            .get_entity(&StructuralQuery {
-                filter: Filter::for_entity_by_entity_id(entity_id),
-                graph_resolve_depths: GraphResolveDepths::default(),
-                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                    pinned: PinnedTemporalAxisUnresolved::new(None),
-                    variable: VariableTemporalAxisUnresolved::new(None, None),
+            .get_entity(
+                &StructuralQuery {
+                    filter: Filter::for_entity_by_entity_id(entity_id),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
                 },
-            })
+                &NoAuthorization,
+            )
             .await?
             .vertices
             .entities
@@ -581,17 +591,20 @@ impl DatabaseApi<'_> {
 
         let mut subgraph = self
             .store
-            .get_entity(&StructuralQuery {
-                filter,
-                graph_resolve_depths: GraphResolveDepths::default(),
-                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                    pinned: PinnedTemporalAxisUnresolved::new(None),
-                    variable: VariableTemporalAxisUnresolved::new(
-                        Some(TemporalBound::Unbounded),
-                        None,
-                    ),
+            .get_entity(
+                &StructuralQuery {
+                    filter,
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(
+                            Some(TemporalBound::Unbounded),
+                            None,
+                        ),
+                    },
                 },
-            })
+                &NoAuthorization,
+            )
             .await?;
 
         let roots = subgraph
@@ -644,14 +657,17 @@ impl DatabaseApi<'_> {
 
         let mut subgraph = self
             .store
-            .get_entity(&StructuralQuery {
-                filter,
-                graph_resolve_depths: GraphResolveDepths::default(),
-                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                    pinned: PinnedTemporalAxisUnresolved::new(None),
-                    variable: VariableTemporalAxisUnresolved::new(None, None),
+            .get_entity(
+                &StructuralQuery {
+                    filter,
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
                 },
-            })
+                &NoAuthorization,
+            )
             .await?;
 
         Ok(subgraph

--- a/apps/hash-graph/tests/integration/postgres/links.rs
+++ b/apps/hash-graph/tests/integration/postgres/links.rs
@@ -77,6 +77,7 @@ async fn insert() {
 }
 
 #[tokio::test]
+#[expect(clippy::too_many_lines)]
 async fn get_entity_links() {
     let alice = serde_json::from_str(entity::PERSON_ALICE_V1).expect("could not parse entity");
     let bob = serde_json::from_str(entity::PERSON_BOB_V1).expect("could not parse entity");


### PR DESCRIPTION
Reopen of #3098

## 🌟 What is the purpose of this PR?

Regardless of the specific implementation of authorization the interface for entities should not change. It's expected, that the API can return information if an actor has the permission to view an entity.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph