### PR TITLE
H-139: Redirect user to login page when logging out

### DIFF
--- a/apps/hash-frontend/src/components/hooks/use-logout-flow.ts
+++ b/apps/hash-frontend/src/components/hooks/use-logout-flow.ts
@@ -1,11 +1,14 @@
 import { useApolloClient } from "@apollo/client";
 import { AxiosError } from "axios";
+import { useRouter } from "next/router";
 
 import { resetLocalStorage } from "../../lib/config";
 import { useAuthInfo } from "../../pages/shared/auth-info-context";
 import { oryKratosClient } from "../../pages/shared/ory-kratos";
 
 export const useLogoutFlow = () => {
+  const router = useRouter();
+
   const client = useApolloClient();
 
   const { refetch: refetchUser } = useAuthInfo();
@@ -18,6 +21,21 @@ export const useLogoutFlow = () => {
           .then(({ data }) => data.logout_token);
 
         await oryKratosClient.updateLogoutFlow({ token: logoutToken });
+
+        /**
+         * @todo: verify that the page is publicly viewable when pages aren't
+         * publicly viewable by default
+         */
+        const isPubliclyViewablePage =
+          router.pathname === "/[shortname]/[page-slug]";
+
+        if (!isPubliclyViewablePage) {
+          /**
+           * Await redirect to prevent runtime errors in the `useAuthenticatedUser`
+           * hook on the current page.
+           */
+          await router.push("/login");
+        }
 
         await refetchUser();
 

--- a/apps/hash-frontend/src/components/hooks/use-logout-flow.ts
+++ b/apps/hash-frontend/src/components/hooks/use-logout-flow.ts
@@ -34,7 +34,10 @@ export const useLogoutFlow = () => {
            * Await redirect to prevent runtime errors in the `useAuthenticatedUser`
            * hook on the current page.
            */
-          await router.push("/login");
+          await router.push({
+            pathname: "/login",
+            query: { return_to: router.asPath },
+          });
         }
 
         await refetchUser();


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR updates the logout behaviour to redirect the user to the login page, when not viewing a publicly viewable page.

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- fixes the `return_to` query parameter on the `/login` page

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Login, and navigate away from the homepage to another page
2. Logout
4. If the page is a publicly accessible page (i.e. any page), ensure the user remains on the page in readonly mode. If the page is any other page, then ensure that you are redirected to the `/login` page. When logging back in you should be redirected to the previously viewed page.

## 📹 Demo

https://github.com/hashintel/hash/assets/42802102/86b92915-9e07-4f5a-a4b3-c6eec23dabfa



