### PR TITLE
H-587: Sidebar styling improvements and fixes

### DIFF
--- a/apps/hash-frontend/src/components/emoji-picker/emoji-picker.tsx
+++ b/apps/hash-frontend/src/components/emoji-picker/emoji-picker.tsx
@@ -28,11 +28,11 @@ export const EmojiPicker = ({
       {...bindPopover(popupState)}
       anchorOrigin={{
         vertical: "bottom",
-        horizontal: "center",
+        horizontal: "left",
       }}
       transformOrigin={{
         vertical: "top",
-        horizontal: "center",
+        horizontal: "left",
       }}
       elevation={4}
       sx={{ mt: 1 }}

--- a/apps/hash-frontend/src/components/page-icon.tsx
+++ b/apps/hash-frontend/src/components/page-icon.tsx
@@ -28,6 +28,7 @@ export const PageIcon = ({ icon, size = "medium", sx = [] }: PageIconProps) => {
           width: sizes.container,
           height: sizes.container,
           fontSize: sizes.font,
+          fontFamily: "auto",
           display: "flex",
           justifyContent: "center",
           alignItems: "center",

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list.tsx
@@ -141,7 +141,6 @@ export const AccountEntityTypeList: FunctionComponent<
               alignItems: "center",
               mx: 0.5,
               minHeight: 36,
-              my: 0.25,
               borderRadius: "4px",
               // "&:hover": {
               //   backgroundColor: palette.gray[20],

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-page-list/account-page-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-page-list/account-page-list.tsx
@@ -431,9 +431,9 @@ export const AccountPageList: FunctionComponent<AccountPageListProps> = ({
             </Box>
           )}
         </NavLink>
-        <ViewAllLink href="/pages" sx={{ marginLeft: 1 }}>
-          View all pages
-        </ViewAllLink>
+        <Box marginLeft={1} marginTop={0.5}>
+          <ViewAllLink href="/pages">View all pages</ViewAllLink>
+        </Box>
       </SortableContext>
     </DndContext>
   );

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-page-list/account-page-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-page-list/account-page-list.tsx
@@ -227,9 +227,10 @@ export const AccountPageList: FunctionComponent<AccountPageListProps> = ({
 
         const sortedItems = arrayMove(clonedItems, activeIndex, overIndex);
 
-        const parentSortedItems = sortedItems.filter(
-          ({ page }) =>
-            page.parentPage?.metadata.recordId.entityId === parentPageEntityId,
+        const parentSortedItems = sortedItems.filter(({ page }) =>
+          parentPageEntityId
+            ? page.parentPage?.metadata.recordId.entityId === parentPageEntityId
+            : !page.parentPage,
         );
 
         const newIndex = parentSortedItems.findIndex(

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-page-list/account-page-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-page-list/account-page-list.tsx
@@ -25,7 +25,7 @@ import {
   isEntityId,
   OwnedById,
 } from "@local/hash-subgraph";
-import { Box, Collapse, Tooltip } from "@mui/material";
+import { Box, Collapse, Tooltip, Typography } from "@mui/material";
 import {
   FunctionComponent,
   useCallback,
@@ -277,7 +277,6 @@ export const AccountPageList: FunctionComponent<AccountPageListProps> = ({
           expandedPageIds.includes(entityId) && activeId !== entityId;
         const children = renderPageTree(treeItemList, entityId);
 
-        const expandable = !!children.length;
         const collapsed = collapsedPageIds.includes(entityId);
 
         const pageEntityUuid = extractEntityUuidFromEntityId(entityId);
@@ -297,11 +296,10 @@ export const AccountPageList: FunctionComponent<AccountPageListProps> = ({
                   })
             }
             depth={entityId === activeId && projected ? projected.depth : depth}
-            onCollapse={expandable ? () => handleToggle(entityId) : undefined}
+            onCollapse={() => handleToggle(entityId)}
             selected={
               currentPageEntityUuid === extractEntityUuidFromEntityId(entityId)
             }
-            expandable={expandable}
             expanded={expanded}
             collapsed={collapsed}
             createSubPage={async () => {
@@ -329,11 +327,21 @@ export const AccountPageList: FunctionComponent<AccountPageListProps> = ({
         return (
           <Box key={entityId}>
             {item}
-            {expandable ? (
-              <Collapse key={`${entityId}-children`} in={expanded}>
-                {children}
-              </Collapse>
-            ) : null}
+            <Collapse key={`${entityId}-children`} in={expanded}>
+              {children.length > 0 ? (
+                children
+              ) : (
+                <Typography
+                  variant="smallTextLabels"
+                  sx={{
+                    color: ({ palette }) => palette.gray[60],
+                    paddingLeft: `${IDENTATION_WIDTH * depth + 28}px`,
+                  }}
+                >
+                  No sub-pages inside
+                </Typography>
+              )}
+            </Collapse>
           </Box>
         );
       });

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-tree-item.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-tree-item.tsx
@@ -25,7 +25,6 @@ export interface PageTreeItemProps {
   depth: number;
   selected: boolean;
   expanded: boolean;
-  expandable: boolean;
   collapsed: boolean;
   createSubPage: () => Promise<void>;
   icon?: string | null;
@@ -46,7 +45,6 @@ export const PageTreeItem = forwardRef<HTMLAnchorElement, PageTreeItemProps>(
     {
       pageEntityId,
       title,
-      expandable,
       pagePath,
       depth,
       selected,
@@ -131,16 +129,9 @@ export const PageTreeItem = forwardRef<HTMLAnchorElement, PageTreeItemProps>(
             unpadded
             rounded
             sx={({ transitions }) => ({
-              visibility: "hidden",
-              pointerEvents: "none",
               mr: 0.5,
-
-              ...(expandable && {
-                visibility: "visible",
-                pointerEvents: "auto",
-                transform: expanded ? `rotate(90deg)` : "none",
-                transition: transitions.create("transform", { duration: 300 }),
-              }),
+              transform: expanded ? `rotate(90deg)` : "none",
+              transition: transitions.create("transform", { duration: 300 }),
             })}
           >
             <FontAwesomeIcon icon={faChevronRight} />

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-tree-item.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-tree-item.tsx
@@ -162,7 +162,7 @@ export const PageTreeItem = forwardRef<HTMLAnchorElement, PageTreeItemProps>(
               variant="smallTextLabels"
               sx={({ palette }) => ({
                 display: "block",
-                fontWeight: 400,
+                fontWeight: 500,
                 marginLeft: 0.75,
                 py: 1,
                 overflow: "hidden",

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-tree-item.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-tree-item.tsx
@@ -185,16 +185,7 @@ export const PageTreeItem = forwardRef<HTMLAnchorElement, PageTreeItemProps>(
             </Typography>
           </Tooltip>
 
-          <Tooltip
-            title="Add subpages, delete, duplicate and more"
-            componentsProps={{
-              tooltip: {
-                sx: {
-                  width: 175,
-                },
-              },
-            }}
-          >
+          <Tooltip title="Options">
             <Box>
               <IconButton
                 {...trigger}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR makes improves the styling and makes some fixes to the sidebar of the HASH app.

Additional ticket addressed in this PR: [Make font weight of types match those of pages, and make whitespace between them and "View all" equal between both.](https://linear.app/hash/issue/H-738/make-font-weight-of-types-match-those-of-pages-and-make-whitespace)

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- changes the “Add subpages, delete, duplicate and more” tooltip to simply read “Options”
- always display the right chevron of pages in the tree, displaying "No sub-pages inside" when un-collapsing a page which has no children
- prevents the emoji picker from repositioning when it is used on non-top-level pages
- fixes a bug which set incorrect fractional indexes for top-level pages when they were repositioned. Previously if you rearranged a top-level page it would become `a0` no matter where it was being placed, meaning that you could end up in a state where multiple top-level pages had the same fractional index leading to their order to change on re-renders.
- adjusts the font-weight of pages in the page tree to be consistent with types in the sidebar
- adjusts the spacing between the page tree and the "View all pages" button to be consistent with the spacing before the "View all types" button


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

- [Improve drag-and-drop behaviour in HASH App sidebar](https://linear.app/hash/issue/H-740/improve-drag-and-drop-behaviour-in-hash-app-sidebar)

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Go to the deployment, and try out the affected functionality in the sidebar. Note that the fractional indexes of top-level pages may be incorrect if you've tried to previously rearrange them when the bug was unaddressed. It may be possible to fix this by rearranging all top-level pages at least once.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

Updated tooltip:
<img width="348" alt="image" src="https://github.com/hashintel/hash/assets/42802102/39f153dc-a6ce-4785-b945-91b4728c34dd">

Un-collapsible pages with no children:
<img width="257" alt="image" src="https://github.com/hashintel/hash/assets/42802102/681d11a4-4397-4f5e-9579-8037b4807edf">


