### PR TITLE
H-722: Create an `AuthorizationApiPool` to create connections to the auth backend

### DIFF
--- a/apps/hash-graph/lib/authorization/src/api.rs
+++ b/apps/hash-graph/lib/authorization/src/api.rs
@@ -1,5 +1,6 @@
 use std::future::Future;
 
+use error_stack::Result;
 use futures::Stream;
 use graph_types::{account::AccountId, knowledge::entity::EntityId};
 
@@ -33,15 +34,15 @@ pub trait AuthorizationApi {
 }
 
 /// Managed pool to keep track about [`AuthorizationApi`]s.
-pub trait AuthorizationApiPool: Sync {
+pub trait AuthorizationApiPool {
     /// The error returned when acquiring an [`AuthorizationApi`].
     type Error;
 
     /// The [`AuthorizationApi`] returned when acquiring.
-    type Api<'pool>: AuthorizationApi + Send;
+    type Api<'pool>: AuthorizationApi + Send + Sync;
 
     /// Retrieves an [`AuthorizationApi`] from the pool.
-    async fn acquire(&self) -> Result<Self::Api<'_>, Self::Error>;
+    fn acquire(&self) -> impl Future<Output = Result<Self::Api<'_>, Self::Error>> + Send;
 
     /// Retrieves an owned [`AuthorizationApi`] from the pool.
     ///

--- a/apps/hash-graph/lib/authorization/src/api.rs
+++ b/apps/hash-graph/lib/authorization/src/api.rs
@@ -1,0 +1,54 @@
+use std::future::Future;
+
+use futures::Stream;
+use graph_types::{account::AccountId, knowledge::entity::EntityId};
+
+use crate::{
+    backend::CheckError,
+    zanzibar::{Consistency, Zookie},
+};
+
+pub trait AuthorizationApi {
+    async fn view_entity(
+        &self,
+        actor: AccountId,
+        entity: EntityId,
+        consistency: Consistency<'_>,
+    ) -> Result<(bool, Zookie<'static>), CheckError>;
+
+    fn view_entities(
+        &self,
+        actor: AccountId,
+        entities: impl IntoIterator<Item = EntityId, IntoIter: Send> + Send,
+        consistency: Consistency<'_>,
+    ) -> impl Future<
+        Output = Result<
+            (
+                impl Stream<Item = Result<(EntityId, bool), CheckError>> + Send,
+                Zookie<'static>,
+            ),
+            CheckError,
+        >,
+    > + Send;
+}
+
+/// Managed pool to keep track about [`AuthorizationApi`]s.
+pub trait AuthorizationApiPool: Sync {
+    /// The error returned when acquiring an [`AuthorizationApi`].
+    type Error;
+
+    /// The [`AuthorizationApi`] returned when acquiring.
+    type Api<'pool>: AuthorizationApi + Send;
+
+    /// Retrieves an [`AuthorizationApi`] from the pool.
+    async fn acquire(&self) -> Result<Self::Api<'_>, Self::Error>;
+
+    /// Retrieves an owned [`AuthorizationApi`] from the pool.
+    ///
+    /// Using an owned [`AuthorizationApi`] makes it easier to leak the connection pool and it's not
+    /// possible to reuse that connection. Therefore, [`acquire`] (which stores a
+    /// lifetime-bound reference to the `StorePool`) should be preferred whenever possible.
+    ///
+    /// [`acquire`]: Self::acquire
+    async fn acquire_owned(&self) -> Result<Self::Api<'static>, Self::Error>;
+}

--- a/apps/hash-graph/lib/authorization/src/lib.rs
+++ b/apps/hash-graph/lib/authorization/src/lib.rs
@@ -6,6 +6,7 @@
     return_position_impl_trait_in_trait
 )]
 
+use error_stack::Result;
 use futures::Stream;
 use graph_types::{account::AccountId, knowledge::entity::EntityId};
 

--- a/apps/hash-graph/lib/graph/src/api/rest.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest.rs
@@ -21,7 +21,7 @@ mod property_type;
 use std::{borrow::Cow, fs, io, str::FromStr, sync::Arc};
 
 use async_trait::async_trait;
-use authorization::AuthorizationApi;
+use authorization::AuthorizationApiPool;
 use axum::{
     extract::{FromRequestParts, Path},
     http::{request::Parts, StatusCode},
@@ -152,17 +152,18 @@ where
 
 static STATIC_SCHEMAS: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/src/api/rest/json_schemas");
 
-fn api_resources<P: StorePool + Send + 'static, A: AuthorizationApi + Send + Sync + 'static>()
--> Vec<Router>
+fn api_resources<S, A>() -> Vec<Router>
 where
-    for<'pool> P::Store<'pool>: RestApiStore,
+    S: StorePool + Send + Sync + 'static,
+    A: AuthorizationApiPool + Send + Sync + 'static,
+    for<'pool> S::Store<'pool>: RestApiStore,
 {
     vec![
-        account::AccountResource::routes::<P, A>(),
-        data_type::DataTypeResource::routes::<P, A>(),
-        property_type::PropertyTypeResource::routes::<P, A>(),
-        entity_type::EntityTypeResource::routes::<P, A>(),
-        entity::EntityResource::routes::<P, A>(),
+        account::AccountResource::routes::<S, A>(),
+        data_type::DataTypeResource::routes::<S, A>(),
+        property_type::PropertyTypeResource::routes::<S, A>(),
+        entity_type::EntityTypeResource::routes::<S, A>(),
+        entity::EntityResource::routes::<S, A>(),
     ]
 }
 
@@ -186,11 +187,12 @@ fn report_to_status_code<C>(report: &Report<C>) -> StatusCode {
     status_code
 }
 
-pub struct RestRouterDependencies<
-    P: StorePool + Send + 'static,
-    A: AuthorizationApi + Send + Sync + 'static,
-> {
-    pub store: Arc<P>,
+pub struct RestRouterDependencies<S, A>
+where
+    S: StorePool + Send + Sync + 'static,
+    A: AuthorizationApiPool + Send + Sync + 'static,
+{
+    pub store: Arc<S>,
     pub authorization_api: Arc<A>,
     pub domain_regex: DomainValidator,
 }
@@ -209,14 +211,14 @@ pub fn openapi_only_router() -> Router {
 }
 
 /// A [`Router`] that serves all of the REST API routes, and the `OpenAPI` specification.
-pub fn rest_api_router<P: StorePool + Send + 'static, A: AuthorizationApi + Send + Sync + 'static>(
-    dependencies: RestRouterDependencies<P, A>,
-) -> Router
+pub fn rest_api_router<S, A>(dependencies: RestRouterDependencies<S, A>) -> Router
 where
-    for<'pool> P::Store<'pool>: RestApiStore,
+    S: StorePool + Send + Sync + 'static,
+    A: AuthorizationApiPool + Send + Sync + 'static,
+    for<'pool> S::Store<'pool>: RestApiStore,
 {
     // All api resources are merged together into a super-router.
-    let merged_routes = api_resources::<P, A>()
+    let merged_routes = api_resources::<S, A>()
         .into_iter()
         .fold(Router::new(), Router::merge);
 

--- a/apps/hash-graph/lib/graph/src/api/rest/api_resource.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/api_resource.rs
@@ -1,4 +1,4 @@
-use authorization::AuthorizationApi;
+use authorization::AuthorizationApiPool;
 use axum::Router;
 
 use crate::{api::rest::RestApiStore, store::StorePool};
@@ -10,9 +10,11 @@ use crate::{api::rest::RestApiStore, store::StorePool};
 /// through a `Router`, making it explicitly clear we want to provide `OpenApi` specification as
 /// documentation for the routes.
 pub(super) trait RoutedResource: utoipa::OpenApi {
-    fn routes<P: StorePool + Send + 'static, A: AuthorizationApi + Send + Sync + 'static>() -> Router
+    fn routes<S, A>() -> Router
     where
-        for<'pool> P::Store<'pool>: RestApiStore;
+        S: StorePool + Send + Sync + 'static,
+        A: AuthorizationApiPool + Send + Sync + 'static,
+        for<'pool> S::Store<'pool>: RestApiStore;
 
     fn documentation() -> utoipa::openapi::OpenApi {
         Self::openapi()

--- a/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use authorization::AuthorizationApi;
+use authorization::AuthorizationApiPool;
 use axum::{
     http::StatusCode,
     routing::{post, put},
@@ -70,19 +70,21 @@ pub struct DataTypeResource;
 
 impl RoutedResource for DataTypeResource {
     /// Create routes for interacting with data types.
-    fn routes<P: StorePool + Send + 'static, A: AuthorizationApi + Send + Sync + 'static>() -> Router
+    fn routes<S, A>() -> Router
     where
-        for<'pool> P::Store<'pool>: RestApiStore,
+        S: StorePool + Send + Sync + 'static,
+        A: AuthorizationApiPool + Send + Sync + 'static,
+        for<'pool> S::Store<'pool>: RestApiStore,
     {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new().nest(
             "/data-types",
             Router::new()
-                .route("/", post(create_data_type::<P>).put(update_data_type::<P>))
-                .route("/query", post(get_data_types_by_query::<P>))
-                .route("/load", post(load_external_data_type::<P>))
-                .route("/archive", put(archive_data_type::<P>))
-                .route("/unarchive", put(unarchive_data_type::<P>)),
+                .route("/", post(create_data_type::<S>).put(update_data_type::<S>))
+                .route("/query", post(get_data_types_by_query::<S>))
+                .route("/load", post(load_external_data_type::<S>))
+                .route("/archive", put(archive_data_type::<S>))
+                .route("/unarchive", put(unarchive_data_type::<S>)),
         )
     }
 }
@@ -111,17 +113,18 @@ struct CreateDataTypeRequest {
         (status = 500, description = "Store error occurred"),
     ),
 )]
-#[tracing::instrument(level = "info", skip(pool, domain_validator))]
-async fn create_data_type<P: StorePool + Send>(
+#[tracing::instrument(level = "info", skip(store_pool, domain_validator))]
+async fn create_data_type<S>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
-    pool: Extension<Arc<P>>,
+    store_pool: Extension<Arc<S>>,
     domain_validator: Extension<DomainValidator>,
     body: Json<CreateDataTypeRequest>,
 ) -> Result<Json<ListOrValue<OntologyElementMetadata>>, StatusCode>
 where
-    for<'pool> P::Store<'pool>: RestApiStore,
+    S: StorePool + Send + Sync,
+    for<'pool> S::Store<'pool>: RestApiStore,
 {
-    let mut store = pool.acquire().await.map_err(|report| {
+    let mut store = store_pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
@@ -209,17 +212,18 @@ struct LoadExternalDataTypeRequest {
         (status = 500, description = "Store error occurred"),
     ),
 )]
-#[tracing::instrument(level = "info", skip(pool, domain_validator))]
-async fn load_external_data_type<P: StorePool + Send>(
+#[tracing::instrument(level = "info", skip(store_pool, domain_validator))]
+async fn load_external_data_type<S>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
-    pool: Extension<Arc<P>>,
+    store_pool: Extension<Arc<S>>,
     domain_validator: Extension<DomainValidator>,
     body: Json<LoadExternalDataTypeRequest>,
 ) -> Result<Json<OntologyElementMetadata>, StatusCode>
 where
-    for<'pool> P::Store<'pool>: RestApiStore,
+    S: StorePool + Send + Sync,
+    for<'pool> S::Store<'pool>: RestApiStore,
 {
-    let mut store = pool.acquire().await.map_err(|report| {
+    let mut store = store_pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
@@ -252,13 +256,17 @@ where
         (status = 500, description = "Store error occurred"),
     )
 )]
-#[tracing::instrument(level = "info", skip(pool))]
-async fn get_data_types_by_query<P: StorePool + Send>(
+#[tracing::instrument(level = "info", skip(store_pool))]
+async fn get_data_types_by_query<S>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
-    pool: Extension<Arc<P>>,
+    store_pool: Extension<Arc<S>>,
     Json(query): Json<serde_json::Value>,
-) -> Result<Json<Subgraph>, StatusCode> {
-    pool.acquire()
+) -> Result<Json<Subgraph>, StatusCode>
+where
+    S: StorePool + Send + Sync,
+{
+    store_pool
+        .acquire()
         .map_err(|error| {
             tracing::error!(?error, "Could not acquire access to the store");
             StatusCode::INTERNAL_SERVER_ERROR
@@ -306,12 +314,15 @@ struct UpdateDataTypeRequest {
     ),
     request_body = UpdateDataTypeRequest,
 )]
-#[tracing::instrument(level = "info", skip(pool))]
-async fn update_data_type<P: StorePool + Send>(
+#[tracing::instrument(level = "info", skip(store_pool))]
+async fn update_data_type<S>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
-    pool: Extension<Arc<P>>,
+    store_pool: Extension<Arc<S>>,
     body: Json<UpdateDataTypeRequest>,
-) -> Result<Json<OntologyElementMetadata>, StatusCode> {
+) -> Result<Json<OntologyElementMetadata>, StatusCode>
+where
+    S: StorePool + Send + Sync,
+{
     let Json(UpdateDataTypeRequest {
         schema,
         mut type_to_update,
@@ -326,7 +337,7 @@ async fn update_data_type<P: StorePool + Send>(
         //  https://app.asana.com/0/1201095311341924/1202574350052904/f
     })?;
 
-    let mut store = pool.acquire().await.map_err(|report| {
+    let mut store = store_pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
@@ -371,15 +382,18 @@ struct ArchiveDataTypeRequest {
     ),
     request_body = ArchiveDataTypeRequest,
 )]
-#[tracing::instrument(level = "info", skip(pool))]
-async fn archive_data_type<P: StorePool + Send>(
+#[tracing::instrument(level = "info", skip(store_pool))]
+async fn archive_data_type<S>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
-    pool: Extension<Arc<P>>,
+    store_pool: Extension<Arc<S>>,
     body: Json<ArchiveDataTypeRequest>,
-) -> Result<Json<OntologyTemporalMetadata>, StatusCode> {
+) -> Result<Json<OntologyTemporalMetadata>, StatusCode>
+where
+    S: StorePool + Send + Sync,
+{
     let Json(ArchiveDataTypeRequest { type_to_archive }) = body;
 
-    let mut store = pool.acquire().await.map_err(|report| {
+    let mut store = store_pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
@@ -427,15 +441,18 @@ struct UnarchiveDataTypeRequest {
     ),
     request_body = UnarchiveDataTypeRequest,
 )]
-#[tracing::instrument(level = "info", skip(pool))]
-async fn unarchive_data_type<P: StorePool + Send>(
+#[tracing::instrument(level = "info", skip(store_pool))]
+async fn unarchive_data_type<S>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
-    pool: Extension<Arc<P>>,
+    store_pool: Extension<Arc<S>>,
     body: Json<UnarchiveDataTypeRequest>,
-) -> Result<Json<OntologyTemporalMetadata>, StatusCode> {
+) -> Result<Json<OntologyTemporalMetadata>, StatusCode>
+where
+    S: StorePool + Send + Sync,
+{
     let Json(UnarchiveDataTypeRequest { type_to_unarchive }) = body;
 
-    let mut store = pool.acquire().await.map_err(|report| {
+    let mut store = store_pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;

--- a/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::hash_map, sync::Arc};
 
-use authorization::AuthorizationApi;
+use authorization::AuthorizationApiPool;
 use axum::{
     http::StatusCode,
     response::Response,
@@ -80,9 +80,11 @@ pub struct EntityTypeResource;
 
 impl RoutedResource for EntityTypeResource {
     /// Create routes for interacting with entity types.
-    fn routes<P: StorePool + Send + 'static, A: AuthorizationApi + Send + Sync + 'static>() -> Router
+    fn routes<S, A>() -> Router
     where
-        for<'pool> P::Store<'pool>: RestApiStore,
+        S: StorePool + Send + Sync + 'static,
+        A: AuthorizationApiPool + Send + Sync + 'static,
+        for<'pool> S::Store<'pool>: RestApiStore,
     {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new().nest(
@@ -90,12 +92,12 @@ impl RoutedResource for EntityTypeResource {
             Router::new()
                 .route(
                     "/",
-                    post(create_entity_type::<P>).put(update_entity_type::<P>),
+                    post(create_entity_type::<S>).put(update_entity_type::<S>),
                 )
-                .route("/query", post(get_entity_types_by_query::<P>))
-                .route("/load", post(load_external_entity_type::<P>))
-                .route("/archive", put(archive_entity_type::<P>))
-                .route("/unarchive", put(unarchive_entity_type::<P>)),
+                .route("/query", post(get_entity_types_by_query::<S>))
+                .route("/load", post(load_external_entity_type::<S>))
+                .route("/archive", put(archive_entity_type::<S>))
+                .route("/unarchive", put(unarchive_entity_type::<S>)),
         )
     }
 }
@@ -127,19 +129,20 @@ struct CreateEntityTypeRequest {
         (status = 500, content_type = "application/json", description = "Store error occurred", body = VAR_STATUS),
     ),
 )]
-#[tracing::instrument(level = "info", skip(pool, domain_validator))]
-async fn create_entity_type<P: StorePool + Send>(
+#[tracing::instrument(level = "info", skip(store_pool, domain_validator))]
+async fn create_entity_type<S>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
-    pool: Extension<Arc<P>>,
+    store_pool: Extension<Arc<S>>,
     domain_validator: Extension<DomainValidator>,
     body: Json<CreateEntityTypeRequest>,
     // TODO: We want to be able to return `Status` here we should try and create a general way to
     //  call `status_to_response` for our routes that return Status
 ) -> Result<Json<ListOrValue<EntityTypeMetadata>>, Response>
 where
-    for<'pool> P::Store<'pool>: RestApiStore,
+    S: StorePool + Send + Sync,
+    for<'pool> S::Store<'pool>: RestApiStore,
 {
-    let mut store = pool.acquire().await.map_err(|report| {
+    let mut store = store_pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
         status_to_response(Status::new(
             hash_status::StatusCode::Internal,
@@ -316,21 +319,22 @@ struct LoadExternalEntityTypeRequest {
         (status = 500, content_type = "application/json", description = "Store error occurred", body = VAR_STATUS),
     ),
 )]
-#[tracing::instrument(level = "info", skip(pool, domain_validator))]
-async fn load_external_entity_type<P: StorePool + Send>(
+#[tracing::instrument(level = "info", skip(store_pool, domain_validator))]
+async fn load_external_entity_type<S>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
-    pool: Extension<Arc<P>>,
+    store_pool: Extension<Arc<S>>,
     domain_validator: Extension<DomainValidator>,
     body: Json<LoadExternalEntityTypeRequest>,
     // TODO: We want to be able to return `Status` here we should try and create a general way to
     //  call `status_to_response` for our routes that return Status
 ) -> Result<Json<OntologyElementMetadata>, Response>
 where
-    for<'pool> P::Store<'pool>: RestApiStore,
+    S: StorePool + Send + Sync,
+    for<'pool> S::Store<'pool>: RestApiStore,
 {
     let Json(LoadExternalEntityTypeRequest { entity_type_id }) = body;
 
-    let mut store = pool.acquire().await.map_err(|report| {
+    let mut store = store_pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
         status_to_response(Status::new(
             hash_status::StatusCode::Internal,
@@ -394,13 +398,16 @@ where
         (status = 500, description = "Store error occurred"),
     )
 )]
-#[tracing::instrument(level = "info", skip(pool))]
-async fn get_entity_types_by_query<P: StorePool + Send>(
+#[tracing::instrument(level = "info", skip(store_pool))]
+async fn get_entity_types_by_query<S>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
-    pool: Extension<Arc<P>>,
+    store_pool: Extension<Arc<S>>,
     Json(query): Json<serde_json::Value>,
-) -> Result<Json<Subgraph>, StatusCode> {
-    pool.acquire()
+) -> Result<Json<Subgraph>, StatusCode>
+where
+    S: StorePool + Send + Sync,
+{
+    store_pool.acquire()
         .map_err(|error| {
             tracing::error!(?error, "Could not acquire access to the store");
             StatusCode::INTERNAL_SERVER_ERROR
@@ -454,12 +461,15 @@ struct UpdateEntityTypeRequest {
     ),
     request_body = UpdateEntityTypeRequest,
 )]
-#[tracing::instrument(level = "info", skip(pool))]
-async fn update_entity_type<P: StorePool + Send>(
+#[tracing::instrument(level = "info", skip(store_pool))]
+async fn update_entity_type<S>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
-    pool: Extension<Arc<P>>,
+    store_pool: Extension<Arc<S>>,
     body: Json<UpdateEntityTypeRequest>,
-) -> Result<Json<EntityTypeMetadata>, StatusCode> {
+) -> Result<Json<EntityTypeMetadata>, StatusCode>
+where
+    S: StorePool + Send + Sync,
+{
     let Json(UpdateEntityTypeRequest {
         schema,
         mut type_to_update,
@@ -476,7 +486,7 @@ async fn update_entity_type<P: StorePool + Send>(
         //  https://app.asana.com/0/1201095311341924/1202574350052904/f
     })?;
 
-    let mut store = pool.acquire().await.map_err(|report| {
+    let mut store = store_pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
@@ -521,15 +531,18 @@ struct ArchiveEntityTypeRequest {
     ),
     request_body = ArchiveEntityTypeRequest,
 )]
-#[tracing::instrument(level = "info", skip(pool))]
-async fn archive_entity_type<P: StorePool + Send>(
+#[tracing::instrument(level = "info", skip(store_pool))]
+async fn archive_entity_type<S>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
-    pool: Extension<Arc<P>>,
+    store_pool: Extension<Arc<S>>,
     body: Json<ArchiveEntityTypeRequest>,
-) -> Result<Json<OntologyTemporalMetadata>, StatusCode> {
+) -> Result<Json<OntologyTemporalMetadata>, StatusCode>
+where
+    S: StorePool + Send + Sync,
+{
     let Json(ArchiveEntityTypeRequest { type_to_archive }) = body;
 
-    let mut store = pool.acquire().await.map_err(|report| {
+    let mut store = store_pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
@@ -577,15 +590,18 @@ struct UnarchiveEntityTypeRequest {
     ),
     request_body = UnarchiveEntityTypeRequest,
 )]
-#[tracing::instrument(level = "info", skip(pool))]
-async fn unarchive_entity_type<P: StorePool + Send>(
+#[tracing::instrument(level = "info", skip(store_pool))]
+async fn unarchive_entity_type<S>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
-    pool: Extension<Arc<P>>,
+    store_pool: Extension<Arc<S>>,
     body: Json<UnarchiveEntityTypeRequest>,
-) -> Result<Json<OntologyTemporalMetadata>, StatusCode> {
+) -> Result<Json<OntologyTemporalMetadata>, StatusCode>
+where
+    S: StorePool + Send + Sync,
+{
     let Json(UnarchiveEntityTypeRequest { type_to_unarchive }) = body;
 
-    let mut store = pool.acquire().await.map_err(|report| {
+    let mut store = store_pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;

--- a/apps/hash-graph/lib/graph/src/store/pool.rs
+++ b/apps/hash-graph/lib/graph/src/store/pool.rs
@@ -5,7 +5,7 @@ use crate::store::Store;
 
 /// Managed pool to keep track about [`Store`]s.
 #[async_trait]
-pub trait StorePool: Sync {
+pub trait StorePool {
     /// The error returned when acquiring a [`Store`].
     type Error;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We need to create new connections to the underlying Authorization client per request. The current design enforces this as otherwise it's not possible to (properly) get a mutable instance of the backend in the code. I took the opportunity to make the REST interface a bit more readable and unified the parameter names/types so the follow-up PR will be easier.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph