### PR TITLE
H-741: Provide the authorization API to every Graph function

### DIFF
--- a/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
@@ -56,7 +56,7 @@ async fn seed_db(
     eprintln!("Seeding database: {}", store_wrapper.bench_db_name);
 
     transaction
-        .insert_account_id(account_id)
+        .insert_account_id(account_id, &NoAuthorization, account_id)
         .await
         .expect("could not insert account id");
 
@@ -93,6 +93,7 @@ async fn seed_db(
     let entity_metadata_list = transaction
         .insert_entities_batched_by_type(
             account_id,
+            &NoAuthorization,
             repeat((owned_by_id, None, properties.clone(), None, None)).take(total),
             &entity_type_id,
         )
@@ -102,6 +103,7 @@ async fn seed_db(
     let link_entity_metadata_list = transaction
         .insert_entities_batched_by_type(
             account_id,
+            &NoAuthorization,
             entity_metadata_list.iter().flat_map(|entity_a_metadata| {
                 entity_metadata_list.iter().map(|entity_b_metadata| {
                     (
@@ -166,6 +168,7 @@ pub fn bench_get_entity_by_id(
             store
                 .get_entity(
                     actor_id,
+                    &NoAuthorization,
                     &StructuralQuery {
                         filter: Filter::for_entity_by_entity_id(entity_record_id.entity_id),
                         graph_resolve_depths,
@@ -177,7 +180,6 @@ pub fn bench_get_entity_by_id(
                             ),
                         },
                     },
-                    &NoAuthorization,
                 )
                 .await
                 .expect("failed to read entity from store");

--- a/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
@@ -56,7 +56,7 @@ async fn seed_db(
     eprintln!("Seeding database: {}", store_wrapper.bench_db_name);
 
     transaction
-        .insert_account_id(account_id, &NoAuthorization, account_id)
+        .insert_account_id(account_id, &mut NoAuthorization, account_id)
         .await
         .expect("could not insert account id");
 
@@ -93,7 +93,7 @@ async fn seed_db(
     let entity_metadata_list = transaction
         .insert_entities_batched_by_type(
             account_id,
-            &NoAuthorization,
+            &mut NoAuthorization,
             repeat((owned_by_id, None, properties.clone(), None, None)).take(total),
             &entity_type_id,
         )
@@ -103,7 +103,7 @@ async fn seed_db(
     let link_entity_metadata_list = transaction
         .insert_entities_batched_by_type(
             account_id,
-            &NoAuthorization,
+            &mut NoAuthorization,
             entity_metadata_list.iter().flat_map(|entity_a_metadata| {
                 entity_metadata_list.iter().map(|entity_b_metadata| {
                     (

--- a/apps/hash-graph/bench/read_scaling/knowledge/linkless/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/linkless/entity.rs
@@ -45,7 +45,7 @@ async fn seed_db(
     eprintln!("Seeding database: {}", store_wrapper.bench_db_name);
 
     transaction
-        .insert_account_id(account_id, &NoAuthorization, account_id)
+        .insert_account_id(account_id, &mut NoAuthorization, account_id)
         .await
         .expect("could not insert account id");
 
@@ -80,7 +80,7 @@ async fn seed_db(
     let entity_metadata_list = transaction
         .insert_entities_batched_by_type(
             account_id,
-            &NoAuthorization,
+            &mut NoAuthorization,
             repeat((OwnedById::new(account_id), None, properties, None, None)).take(total),
             &entity_type_id,
         )

--- a/apps/hash-graph/bench/read_scaling/knowledge/linkless/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/linkless/entity.rs
@@ -45,7 +45,7 @@ async fn seed_db(
     eprintln!("Seeding database: {}", store_wrapper.bench_db_name);
 
     transaction
-        .insert_account_id(account_id)
+        .insert_account_id(account_id, &NoAuthorization, account_id)
         .await
         .expect("could not insert account id");
 
@@ -80,6 +80,7 @@ async fn seed_db(
     let entity_metadata_list = transaction
         .insert_entities_batched_by_type(
             account_id,
+            &NoAuthorization,
             repeat((OwnedById::new(account_id), None, properties, None, None)).take(total),
             &entity_type_id,
         )
@@ -122,6 +123,7 @@ pub fn bench_get_entity_by_id(
             store
                 .get_entity(
                     actor_id,
+                    &NoAuthorization,
                     &StructuralQuery {
                         filter: Filter::for_entity_by_entity_id(entity_record_id.entity_id),
                         graph_resolve_depths: GraphResolveDepths::default(),
@@ -133,7 +135,6 @@ pub fn bench_get_entity_by_id(
                             ),
                         },
                     },
-                    &NoAuthorization,
                 )
                 .await
                 .expect("failed to read entity from store");

--- a/apps/hash-graph/bench/representative_read/knowledge/entity.rs
+++ b/apps/hash-graph/bench/representative_read/knowledge/entity.rs
@@ -43,6 +43,7 @@ pub fn bench_get_entity_by_id(
             let subgraph = store
                 .get_entity(
                     actor_id,
+                    &NoAuthorization,
                     &StructuralQuery {
                         filter: Filter::Equal(
                             Some(FilterExpression::Path(EntityQueryPath::Uuid)),
@@ -56,7 +57,6 @@ pub fn bench_get_entity_by_id(
                             variable: VariableTemporalAxisUnresolved::new(None, None),
                         },
                     },
-                    &NoAuthorization,
                 )
                 .await
                 .expect("failed to read entity from store");
@@ -90,6 +90,7 @@ pub fn bench_get_entities_by_property(
         let subgraph = store
             .get_entity(
                 actor_id,
+                &NoAuthorization,
                 &StructuralQuery {
                     filter,
                     graph_resolve_depths,
@@ -101,7 +102,6 @@ pub fn bench_get_entities_by_property(
                         ),
                     },
                 },
-                &NoAuthorization,
             )
             .await
             .expect("failed to read entity from store");
@@ -137,6 +137,7 @@ pub fn bench_get_link_by_target_by_property(
         let subgraph = store
             .get_entity(
                 actor_id,
+                &NoAuthorization,
                 &StructuralQuery {
                     filter,
                     graph_resolve_depths,
@@ -148,7 +149,6 @@ pub fn bench_get_link_by_target_by_property(
                         ),
                     },
                 },
-                &NoAuthorization,
             )
             .await
             .expect("failed to read entity from store");

--- a/apps/hash-graph/bench/representative_read/ontology/entity_type.rs
+++ b/apps/hash-graph/bench/representative_read/ontology/entity_type.rs
@@ -1,3 +1,4 @@
+use authorization::NoAuthorization;
 use criterion::{BatchSize::SmallInput, Bencher};
 use graph::{
     store::{query::Filter, EntityTypeStore},
@@ -37,6 +38,7 @@ pub fn bench_get_entity_type_by_id(
             store
                 .get_entity_type(
                     actor_id,
+                    &NoAuthorization,
                     &StructuralQuery {
                         filter: Filter::for_versioned_url(entity_type_id),
                         graph_resolve_depths: GraphResolveDepths::default(),

--- a/apps/hash-graph/bench/representative_read/seed.rs
+++ b/apps/hash-graph/bench/representative_read/seed.rs
@@ -4,6 +4,7 @@ use std::{
     str::FromStr,
 };
 
+use authorization::NoAuthorization;
 use graph::store::{AccountStore, AsClient, EntityStore};
 use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::{
@@ -126,7 +127,7 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
     eprintln!("Seeding database: {}", store_wrapper.bench_db_name);
 
     transaction
-        .insert_account_id(account_id)
+        .insert_account_id(account_id, &NoAuthorization, account_id)
         .await
         .expect("could not insert account id");
 
@@ -155,6 +156,7 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
         let uuids = transaction
             .insert_entities_batched_by_type(
                 account_id,
+                &NoAuthorization,
                 repeat((OwnedById::new(account_id), None, properties, None, None)).take(quantity),
                 &entity_type_id,
             )
@@ -176,6 +178,7 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
         let uuids = transaction
             .insert_entities_batched_by_type(
                 account_id,
+                &NoAuthorization,
                 entity_uuids[*left_entity_index]
                     .iter()
                     .zip(&entity_uuids[*right_entity_index])

--- a/apps/hash-graph/bench/representative_read/seed.rs
+++ b/apps/hash-graph/bench/representative_read/seed.rs
@@ -127,7 +127,7 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
     eprintln!("Seeding database: {}", store_wrapper.bench_db_name);
 
     transaction
-        .insert_account_id(account_id, &NoAuthorization, account_id)
+        .insert_account_id(account_id, &mut NoAuthorization, account_id)
         .await
         .expect("could not insert account id");
 
@@ -156,7 +156,7 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
         let uuids = transaction
             .insert_entities_batched_by_type(
                 account_id,
-                &NoAuthorization,
+                &mut NoAuthorization,
                 repeat((OwnedById::new(account_id), None, properties, None, None)).take(quantity),
                 &entity_type_id,
             )
@@ -178,7 +178,7 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
         let uuids = transaction
             .insert_entities_batched_by_type(
                 account_id,
-                &NoAuthorization,
+                &mut NoAuthorization,
                 entity_uuids[*left_entity_index]
                     .iter()
                     .zip(&entity_uuids[*right_entity_index])

--- a/apps/hash-graph/bench/util.rs
+++ b/apps/hash-graph/bench/util.rs
@@ -217,7 +217,7 @@ pub async fn seed<D, P, E, C>(
         match store
             .create_data_type(
                 account_id,
-                &NoAuthorization,
+                &mut NoAuthorization,
                 data_type.clone(),
                 PartialOntologyElementMetadata {
                     record_id: data_type.id().clone().into(),
@@ -232,7 +232,7 @@ pub async fn seed<D, P, E, C>(
             Err(report) => {
                 if report.contains::<BaseUrlAlreadyExists>() {
                     store
-                        .update_data_type(account_id, &NoAuthorization, data_type)
+                        .update_data_type(account_id, &mut NoAuthorization, data_type)
                         .await
                         .expect("failed to update data type");
                 } else {
@@ -251,7 +251,7 @@ pub async fn seed<D, P, E, C>(
         match store
             .create_property_type(
                 account_id,
-                &NoAuthorization,
+                &mut NoAuthorization,
                 property_type.clone(),
                 PartialOntologyElementMetadata {
                     record_id: property_type.id().clone().into(),
@@ -266,7 +266,7 @@ pub async fn seed<D, P, E, C>(
             Err(report) => {
                 if report.contains::<BaseUrlAlreadyExists>() {
                     store
-                        .update_property_type(account_id, &NoAuthorization, property_type)
+                        .update_property_type(account_id, &mut NoAuthorization, property_type)
                         .await
                         .expect("failed to update property type");
                 } else {
@@ -285,7 +285,7 @@ pub async fn seed<D, P, E, C>(
         match store
             .create_entity_type(
                 account_id,
-                &NoAuthorization,
+                &mut NoAuthorization,
                 entity_type.clone(),
                 PartialEntityTypeMetadata {
                     record_id: entity_type.id().clone().into(),
@@ -303,7 +303,7 @@ pub async fn seed<D, P, E, C>(
             Err(report) => {
                 if report.contains::<BaseUrlAlreadyExists>() {
                     store
-                        .update_entity_type(account_id, &NoAuthorization, entity_type, None)
+                        .update_entity_type(account_id, &mut NoAuthorization, entity_type, None)
                         .await
                         .expect("failed to update entity type");
                 } else {

--- a/apps/hash-graph/bench/util.rs
+++ b/apps/hash-graph/bench/util.rs
@@ -1,5 +1,6 @@
 use std::mem::ManuallyDrop;
 
+use authorization::NoAuthorization;
 use graph::{
     load_env,
     store::{
@@ -216,6 +217,7 @@ pub async fn seed<D, P, E, C>(
         match store
             .create_data_type(
                 account_id,
+                &NoAuthorization,
                 data_type.clone(),
                 PartialOntologyElementMetadata {
                     record_id: data_type.id().clone().into(),
@@ -230,7 +232,7 @@ pub async fn seed<D, P, E, C>(
             Err(report) => {
                 if report.contains::<BaseUrlAlreadyExists>() {
                     store
-                        .update_data_type(account_id, data_type)
+                        .update_data_type(account_id, &NoAuthorization, data_type)
                         .await
                         .expect("failed to update data type");
                 } else {
@@ -249,6 +251,7 @@ pub async fn seed<D, P, E, C>(
         match store
             .create_property_type(
                 account_id,
+                &NoAuthorization,
                 property_type.clone(),
                 PartialOntologyElementMetadata {
                     record_id: property_type.id().clone().into(),
@@ -263,7 +266,7 @@ pub async fn seed<D, P, E, C>(
             Err(report) => {
                 if report.contains::<BaseUrlAlreadyExists>() {
                     store
-                        .update_property_type(account_id, property_type)
+                        .update_property_type(account_id, &NoAuthorization, property_type)
                         .await
                         .expect("failed to update property type");
                 } else {
@@ -282,6 +285,7 @@ pub async fn seed<D, P, E, C>(
         match store
             .create_entity_type(
                 account_id,
+                &NoAuthorization,
                 entity_type.clone(),
                 PartialEntityTypeMetadata {
                     record_id: entity_type.id().clone().into(),
@@ -299,7 +303,7 @@ pub async fn seed<D, P, E, C>(
             Err(report) => {
                 if report.contains::<BaseUrlAlreadyExists>() {
                     store
-                        .update_entity_type(account_id, entity_type, None)
+                        .update_entity_type(account_id, &NoAuthorization, entity_type, None)
                         .await
                         .expect("failed to update entity type");
                 } else {

--- a/apps/hash-graph/bin/cli/src/subcommand/server.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/server.rs
@@ -226,7 +226,7 @@ async fn stop_gap_setup(pool: &PostgresStorePool<NoTls>) -> Result<(), GraphErro
     // TODO: When we improve error management we need to match on it here, this will continue
     //  normally even if the DB is down
     if connection
-        .insert_account_id(root_account_id)
+        .insert_account_id(root_account_id, &NoAuthorization, root_account_id)
         .await
         .change_context(GraphError)
         .is_err()
@@ -248,7 +248,12 @@ async fn stop_gap_setup(pool: &PostgresStorePool<NoTls>) -> Result<(), GraphErro
         };
 
         if let Err(error) = connection
-            .create_data_type(root_account_id, data_type, data_type_metadata)
+            .create_data_type(
+                root_account_id,
+                &NoAuthorization,
+                data_type,
+                data_type_metadata,
+            )
             .await
             .change_context(GraphError)
         {
@@ -290,7 +295,12 @@ async fn stop_gap_setup(pool: &PostgresStorePool<NoTls>) -> Result<(), GraphErro
     let title = link_entity_type.title().to_owned();
 
     if let Err(error) = connection
-        .create_entity_type(root_account_id, link_entity_type, link_entity_type_metadata)
+        .create_entity_type(
+            root_account_id,
+            &NoAuthorization,
+            link_entity_type,
+            link_entity_type_metadata,
+        )
         .await
     {
         if error.contains::<VersionedUrlAlreadyExists>() {

--- a/apps/hash-graph/bin/cli/src/subcommand/server.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/server.rs
@@ -226,7 +226,7 @@ async fn stop_gap_setup(pool: &PostgresStorePool<NoTls>) -> Result<(), GraphErro
     // TODO: When we improve error management we need to match on it here, this will continue
     //  normally even if the DB is down
     if connection
-        .insert_account_id(root_account_id, &NoAuthorization, root_account_id)
+        .insert_account_id(root_account_id, &mut NoAuthorization, root_account_id)
         .await
         .change_context(GraphError)
         .is_err()
@@ -250,7 +250,7 @@ async fn stop_gap_setup(pool: &PostgresStorePool<NoTls>) -> Result<(), GraphErro
         if let Err(error) = connection
             .create_data_type(
                 root_account_id,
-                &NoAuthorization,
+                &mut NoAuthorization,
                 data_type,
                 data_type_metadata,
             )
@@ -297,7 +297,7 @@ async fn stop_gap_setup(pool: &PostgresStorePool<NoTls>) -> Result<(), GraphErro
     if let Err(error) = connection
         .create_entity_type(
             root_account_id,
-            &NoAuthorization,
+            &mut NoAuthorization,
             link_entity_type,
             link_entity_type_metadata,
         )

--- a/apps/hash-graph/lib/graph/src/api/rest.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest.rs
@@ -109,10 +109,10 @@ impl<S> FromRequestParts<S> for AuthenticatedUserHeader {
 
 #[async_trait]
 pub trait RestApiStore: Store + TypeFetcher {
-    async fn load_external_type<A: AuthorizationApi + Sync>(
+    async fn load_external_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &A,
+        authorization_api: &mut A,
         domain_validator: &DomainValidator,
         reference: OntologyTypeReference<'_>,
     ) -> Result<OntologyElementMetadata, StatusCode>;
@@ -123,10 +123,10 @@ impl<S> RestApiStore for S
 where
     S: Store + TypeFetcher + Send,
 {
-    async fn load_external_type<A: AuthorizationApi + Sync>(
+    async fn load_external_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &A,
+        authorization_api: &mut A,
         domain_validator: &DomainValidator,
         reference: OntologyTypeReference<'_>,
     ) -> Result<OntologyElementMetadata, StatusCode> {

--- a/apps/hash-graph/lib/graph/src/api/rest/account.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/account.rs
@@ -71,14 +71,14 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+    let mut authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
         tracing::error!(?error, "Could not acquire access to the authorization API");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
     let account_id = AccountId::new(Uuid::new_v4());
     store
-        .insert_account_id(actor_id, &authorization_api, account_id)
+        .insert_account_id(actor_id, &mut authorization_api, account_id)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not create account id");

--- a/apps/hash-graph/lib/graph/src/api/rest/account.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/account.rs
@@ -38,7 +38,7 @@ impl RoutedResource for AccountResource {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new().nest(
             "/accounts",
-            Router::new().route("/", post(create_account_id::<S>)),
+            Router::new().route("/", post(create_account_id::<S, A>)),
         )
     }
 }
@@ -56,22 +56,29 @@ impl RoutedResource for AccountResource {
         (status = 500, description = "Store error occurred"),
     )
 )]
-#[tracing::instrument(level = "info", skip(store_pool))]
-async fn create_account_id<S>(
+#[tracing::instrument(level = "info", skip(store_pool, authorization_api_pool))]
+async fn create_account_id<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    authorization_api_pool: Extension<Arc<A>>,
     store_pool: Extension<Arc<S>>,
 ) -> Result<Json<AccountId>, StatusCode>
 where
     S: StorePool + Send + Sync,
+    A: AuthorizationApiPool + Send + Sync,
 {
     let mut store = store_pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
     let account_id = AccountId::new(Uuid::new_v4());
     store
-        .insert_account_id(account_id)
+        .insert_account_id(actor_id, &authorization_api, account_id)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not create account id");

--- a/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
@@ -136,7 +136,7 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+    let mut authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
         tracing::error!(?error, "Could not acquire access to the authorization API");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
@@ -176,7 +176,7 @@ where
     let mut metadata = store
         .create_data_types(
             actor_id,
-            &authorization_api,
+            &mut authorization_api,
             data_types.into_iter().zip(partial_metadata),
             ConflictBehavior::Fail,
         )
@@ -246,7 +246,7 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+    let mut authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
         tracing::error!(?error, "Could not acquire access to the authorization API");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
@@ -257,7 +257,7 @@ where
         store
             .load_external_type(
                 actor_id,
-                &authorization_api,
+                &mut authorization_api,
                 &domain_validator,
                 OntologyTypeReference::DataTypeReference((&data_type_id).into()),
             )
@@ -375,13 +375,13 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+    let mut authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
         tracing::error!(?error, "Could not acquire access to the authorization API");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
     store
-        .update_data_type(actor_id, &authorization_api, data_type)
+        .update_data_type(actor_id, &mut authorization_api, data_type)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not update data type");
@@ -438,13 +438,13 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+    let mut authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
         tracing::error!(?error, "Could not acquire access to the authorization API");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
     store
-        .archive_data_type(actor_id, &authorization_api, &type_to_archive)
+        .archive_data_type(actor_id, &mut authorization_api, &type_to_archive)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not archive data type");
@@ -504,13 +504,13 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+    let mut authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
         tracing::error!(?error, "Could not acquire access to the authorization API");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
     store
-        .unarchive_data_type(actor_id, &authorization_api, &type_to_unarchive)
+        .unarchive_data_type(actor_id, &mut authorization_api, &type_to_unarchive)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not unarchive data type");

--- a/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
@@ -8,7 +8,6 @@ use axum::{
     routing::{post, put},
     Extension, Router,
 };
-use futures::TryFutureExt;
 use graph_types::{
     ontology::{
         DataTypeWithMetadata, OntologyElementMetadata, OntologyTemporalMetadata,
@@ -80,11 +79,14 @@ impl RoutedResource for DataTypeResource {
         Router::new().nest(
             "/data-types",
             Router::new()
-                .route("/", post(create_data_type::<S>).put(update_data_type::<S>))
-                .route("/query", post(get_data_types_by_query::<S>))
-                .route("/load", post(load_external_data_type::<S>))
-                .route("/archive", put(archive_data_type::<S>))
-                .route("/unarchive", put(unarchive_data_type::<S>)),
+                .route(
+                    "/",
+                    post(create_data_type::<S, A>).put(update_data_type::<S, A>),
+                )
+                .route("/query", post(get_data_types_by_query::<S, A>))
+                .route("/load", post(load_external_data_type::<S, A>))
+                .route("/archive", put(archive_data_type::<S, A>))
+                .route("/unarchive", put(unarchive_data_type::<S, A>)),
         )
     }
 }
@@ -113,19 +115,29 @@ struct CreateDataTypeRequest {
         (status = 500, description = "Store error occurred"),
     ),
 )]
-#[tracing::instrument(level = "info", skip(store_pool, domain_validator))]
-async fn create_data_type<S>(
+#[tracing::instrument(
+    level = "info",
+    skip(store_pool, authorization_api_pool, domain_validator)
+)]
+async fn create_data_type<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
     domain_validator: Extension<DomainValidator>,
     body: Json<CreateDataTypeRequest>,
 ) -> Result<Json<ListOrValue<OntologyElementMetadata>>, StatusCode>
 where
     S: StorePool + Send + Sync,
     for<'pool> S::Store<'pool>: RestApiStore,
+    A: AuthorizationApiPool + Send + Sync,
 {
     let mut store = store_pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
@@ -164,6 +176,7 @@ where
     let mut metadata = store
         .create_data_types(
             actor_id,
+            &authorization_api,
             data_types.into_iter().zip(partial_metadata),
             ConflictBehavior::Fail,
         )
@@ -212,19 +225,29 @@ struct LoadExternalDataTypeRequest {
         (status = 500, description = "Store error occurred"),
     ),
 )]
-#[tracing::instrument(level = "info", skip(store_pool, domain_validator))]
-async fn load_external_data_type<S>(
+#[tracing::instrument(
+    level = "info",
+    skip(store_pool, authorization_api_pool, domain_validator)
+)]
+async fn load_external_data_type<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
     domain_validator: Extension<DomainValidator>,
     body: Json<LoadExternalDataTypeRequest>,
 ) -> Result<Json<OntologyElementMetadata>, StatusCode>
 where
     S: StorePool + Send + Sync,
     for<'pool> S::Store<'pool>: RestApiStore,
+    A: AuthorizationApiPool + Send + Sync,
 {
     let mut store = store_pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
@@ -234,6 +257,7 @@ where
         store
             .load_external_type(
                 actor_id,
+                &authorization_api,
                 &domain_validator,
                 OntologyTypeReference::DataTypeReference((&data_type_id).into()),
             )
@@ -256,37 +280,44 @@ where
         (status = 500, description = "Store error occurred"),
     )
 )]
-#[tracing::instrument(level = "info", skip(store_pool))]
-async fn get_data_types_by_query<S>(
+#[tracing::instrument(level = "info", skip(store_pool, authorization_api_pool))]
+async fn get_data_types_by_query<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
     Json(query): Json<serde_json::Value>,
 ) -> Result<Json<Subgraph>, StatusCode>
 where
     S: StorePool + Send + Sync,
+    A: AuthorizationApiPool + Send + Sync,
 {
-    store_pool
-        .acquire()
-        .map_err(|error| {
-            tracing::error!(?error, "Could not acquire access to the store");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })
-        .and_then(|store| async move {
-            let mut query = StructuralQuery::deserialize(&query).map_err(|error| {
-                tracing::error!(?error, "Could not deserialize query");
-                StatusCode::INTERNAL_SERVER_ERROR
-            })?;
-            query.filter.convert_parameters().map_err(|error| {
-                tracing::error!(?error, "Could not validate query");
-                StatusCode::INTERNAL_SERVER_ERROR
-            })?;
-            store.get_data_type(actor_id, &query).await.map_err(|report| {
-                tracing::error!(error=?report, ?query, "Could not read data types from the store");
-                report_to_status_code(&report)
-            })
-        })
+    let store = store_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the store");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let mut query = StructuralQuery::deserialize(&query).map_err(|error| {
+        tracing::error!(?error, "Could not deserialize query");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    query.filter.convert_parameters().map_err(|error| {
+        tracing::error!(?error, "Could not validate query");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    let subgraph = store
+        .get_data_type(actor_id, &authorization_api, &query)
         .await
-        .map(|subgraph| Json(subgraph.into()))
+        .map_err(|report| {
+            tracing::error!(error=?report, ?query, "Could not read data types from the store");
+            report_to_status_code(&report)
+        })?;
+
+    Ok(Json(subgraph.into()))
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -314,14 +345,16 @@ struct UpdateDataTypeRequest {
     ),
     request_body = UpdateDataTypeRequest,
 )]
-#[tracing::instrument(level = "info", skip(store_pool))]
-async fn update_data_type<S>(
+#[tracing::instrument(level = "info", skip(store_pool, authorization_api_pool))]
+async fn update_data_type<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
     body: Json<UpdateDataTypeRequest>,
 ) -> Result<Json<OntologyElementMetadata>, StatusCode>
 where
     S: StorePool + Send + Sync,
+    A: AuthorizationApiPool + Send + Sync,
 {
     let Json(UpdateDataTypeRequest {
         schema,
@@ -342,8 +375,13 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
     store
-        .update_data_type(actor_id, data_type)
+        .update_data_type(actor_id, &authorization_api, data_type)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not update data type");
@@ -382,14 +420,16 @@ struct ArchiveDataTypeRequest {
     ),
     request_body = ArchiveDataTypeRequest,
 )]
-#[tracing::instrument(level = "info", skip(store_pool))]
-async fn archive_data_type<S>(
+#[tracing::instrument(level = "info", skip(store_pool, authorization_api_pool))]
+async fn archive_data_type<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
     body: Json<ArchiveDataTypeRequest>,
 ) -> Result<Json<OntologyTemporalMetadata>, StatusCode>
 where
     S: StorePool + Send + Sync,
+    A: AuthorizationApiPool + Send + Sync,
 {
     let Json(ArchiveDataTypeRequest { type_to_archive }) = body;
 
@@ -398,8 +438,13 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
     store
-        .archive_data_type(actor_id, &type_to_archive)
+        .archive_data_type(actor_id, &authorization_api, &type_to_archive)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not archive data type");
@@ -441,14 +486,16 @@ struct UnarchiveDataTypeRequest {
     ),
     request_body = UnarchiveDataTypeRequest,
 )]
-#[tracing::instrument(level = "info", skip(store_pool))]
-async fn unarchive_data_type<S>(
+#[tracing::instrument(level = "info", skip(store_pool, authorization_api_pool))]
+async fn unarchive_data_type<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
     body: Json<UnarchiveDataTypeRequest>,
 ) -> Result<Json<OntologyTemporalMetadata>, StatusCode>
 where
     S: StorePool + Send + Sync,
+    A: AuthorizationApiPool + Send + Sync,
 {
     let Json(UnarchiveDataTypeRequest { type_to_unarchive }) = body;
 
@@ -457,8 +504,13 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
     store
-        .unarchive_data_type(actor_id, &type_to_unarchive)
+        .unarchive_data_type(actor_id, &authorization_api, &type_to_unarchive)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not unarchive data type");

--- a/apps/hash-graph/lib/graph/src/api/rest/entity.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity.rs
@@ -138,7 +138,7 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+    let mut authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
         tracing::error!(?error, "Could not acquire access to the authorization API");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
@@ -146,7 +146,7 @@ where
     store
         .create_entity(
             actor_id,
-            &authorization_api,
+            &mut authorization_api,
             owned_by_id,
             entity_uuid,
             None,
@@ -272,7 +272,7 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+    let mut authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
         tracing::error!(?error, "Could not acquire access to the authorization API");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
@@ -280,7 +280,7 @@ where
     store
         .update_entity(
             actor_id,
-            &authorization_api,
+            &mut authorization_api,
             entity_id,
             None,
             archived,

--- a/apps/hash-graph/lib/graph/src/api/rest/entity.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use authorization::AuthorizationApiPool;
 use axum::{http::StatusCode, routing::post, Extension, Router};
-use futures::TryFutureExt;
 use graph_types::{
     knowledge::{
         entity::{
@@ -77,7 +76,7 @@ impl RoutedResource for EntityResource {
         Router::new().nest(
             "/entities",
             Router::new()
-                .route("/", post(create_entity::<S>).put(update_entity::<S>))
+                .route("/", post(create_entity::<S, A>).put(update_entity::<S, A>))
                 .route("/query", post(get_entities_by_query::<S, A>)),
         )
     }
@@ -115,14 +114,16 @@ struct CreateEntityRequest {
         (status = 500, description = "Store error occurred"),
     ),
 )]
-#[tracing::instrument(level = "info", skip(store_pool))]
-async fn create_entity<S>(
+#[tracing::instrument(level = "info", skip(store_pool, authorization_api_pool))]
+async fn create_entity<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
     body: Json<CreateEntityRequest>,
 ) -> Result<Json<EntityMetadata>, StatusCode>
 where
     S: StorePool + Send + Sync,
+    A: AuthorizationApiPool + Send + Sync,
 {
     let Json(CreateEntityRequest {
         properties,
@@ -137,9 +138,15 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
     store
         .create_entity(
             actor_id,
+            &authorization_api,
             owned_by_id,
             entity_uuid,
             None,
@@ -183,20 +190,15 @@ where
     S: StorePool + Send + Sync,
     A: AuthorizationApiPool + Send + Sync,
 {
-    let store = store_pool
-        .acquire()
-        .map_err(|error| {
-            tracing::error!(?error, "Could not acquire access to the store");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })
-        .await?;
-    let authorization_api = authorization_api_pool
-        .acquire()
-        .map_err(|error| {
-            tracing::error!(?error, "Could not acquire access to the authorization API");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })
-        .await?;
+    let store = store_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the store");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
     let mut query = StructuralQuery::deserialize(&query).map_err(|error| {
         tracing::error!(?error, "Could not deserialize query");
@@ -207,7 +209,7 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
     let subgraph = store
-        .get_entity(actor_id, &query, &authorization_api)
+        .get_entity(actor_id, &authorization_api, &query)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, ?query, "Could not read entities from the store");
@@ -246,14 +248,16 @@ struct UpdateEntityRequest {
     ),
     request_body = UpdateEntityRequest,
 )]
-#[tracing::instrument(level = "info", skip(store_pool))]
-async fn update_entity<S>(
+#[tracing::instrument(level = "info", skip(store_pool, authorization_api_pool))]
+async fn update_entity<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
     body: Json<UpdateEntityRequest>,
 ) -> Result<Json<EntityMetadata>, StatusCode>
 where
     S: StorePool + Send + Sync,
+    A: AuthorizationApiPool + Send + Sync,
 {
     let Json(UpdateEntityRequest {
         properties,
@@ -268,9 +272,15 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
     store
         .update_entity(
             actor_id,
+            &authorization_api,
             entity_id,
             None,
             archived,

--- a/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
@@ -9,7 +9,6 @@ use axum::{
     routing::{post, put},
     Extension, Router,
 };
-use futures::TryFutureExt;
 use graph_types::{
     ontology::{
         EntityTypeMetadata, EntityTypeWithMetadata, OntologyElementMetadata,
@@ -92,12 +91,12 @@ impl RoutedResource for EntityTypeResource {
             Router::new()
                 .route(
                     "/",
-                    post(create_entity_type::<S>).put(update_entity_type::<S>),
+                    post(create_entity_type::<S, A>).put(update_entity_type::<S, A>),
                 )
-                .route("/query", post(get_entity_types_by_query::<S>))
-                .route("/load", post(load_external_entity_type::<S>))
-                .route("/archive", put(archive_entity_type::<S>))
-                .route("/unarchive", put(unarchive_entity_type::<S>)),
+                .route("/query", post(get_entity_types_by_query::<S, A>))
+                .route("/load", post(load_external_entity_type::<S, A>))
+                .route("/archive", put(archive_entity_type::<S, A>))
+                .route("/unarchive", put(unarchive_entity_type::<S, A>)),
         )
     }
 }
@@ -129,10 +128,14 @@ struct CreateEntityTypeRequest {
         (status = 500, content_type = "application/json", description = "Store error occurred", body = VAR_STATUS),
     ),
 )]
-#[tracing::instrument(level = "info", skip(store_pool, domain_validator))]
-async fn create_entity_type<S>(
+#[tracing::instrument(
+    level = "info",
+    skip(store_pool, authorization_api_pool, domain_validator)
+)]
+async fn create_entity_type<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
     domain_validator: Extension<DomainValidator>,
     body: Json<CreateEntityTypeRequest>,
     // TODO: We want to be able to return `Status` here we should try and create a general way to
@@ -141,6 +144,7 @@ async fn create_entity_type<S>(
 where
     S: StorePool + Send + Sync,
     for<'pool> S::Store<'pool>: RestApiStore,
+    A: AuthorizationApiPool + Send + Sync,
 {
     let mut store = store_pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
@@ -228,9 +232,24 @@ where
         entity_types.push(entity_type);
     }
 
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
+        status_to_response(Status::new(
+            hash_status::StatusCode::Internal,
+            Some(
+                "Could not acquire authorization API. This is an internal error, please report to \
+                 the developers of the HASH Graph with whatever information you can provide \
+                 including request details and logs."
+                    .to_owned(),
+            ),
+            vec![],
+        ))
+    })?;
+
     let mut metadata = store
         .create_entity_types(
             actor_id,
+            &authorization_api,
             entity_types.into_iter().zip(partial_metadata),
             ConflictBehavior::Fail,
         )
@@ -319,10 +338,14 @@ struct LoadExternalEntityTypeRequest {
         (status = 500, content_type = "application/json", description = "Store error occurred", body = VAR_STATUS),
     ),
 )]
-#[tracing::instrument(level = "info", skip(store_pool, domain_validator))]
-async fn load_external_entity_type<S>(
+#[tracing::instrument(
+    level = "info",
+    skip(store_pool, authorization_api_pool, domain_validator)
+)]
+async fn load_external_entity_type<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
     domain_validator: Extension<DomainValidator>,
     body: Json<LoadExternalEntityTypeRequest>,
     // TODO: We want to be able to return `Status` here we should try and create a general way to
@@ -331,6 +354,7 @@ async fn load_external_entity_type<S>(
 where
     S: StorePool + Send + Sync,
     for<'pool> S::Store<'pool>: RestApiStore,
+    A: AuthorizationApiPool + Send + Sync,
 {
     let Json(LoadExternalEntityTypeRequest { entity_type_id }) = body;
 
@@ -356,10 +380,25 @@ where
         ))
     })?;
 
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
+        status_to_response(Status::new(
+            hash_status::StatusCode::Internal,
+            Some(
+                "Could not acquire authorization API. This is an internal error, please report to \
+                 the developers of the HASH Graph with whatever information you can provide \
+                 including request details and logs."
+                    .to_owned(),
+            ),
+            vec![],
+        ))
+    })?;
+
     Ok(Json(
         store
             .load_external_type(
                 actor_id,
+                &authorization_api,
                 &domain_validator,
                 OntologyTypeReference::EntityTypeReference((&entity_type_id).into()),
             )
@@ -398,39 +437,45 @@ where
         (status = 500, description = "Store error occurred"),
     )
 )]
-#[tracing::instrument(level = "info", skip(store_pool))]
-async fn get_entity_types_by_query<S>(
+#[tracing::instrument(level = "info", skip(store_pool, authorization_api_pool))]
+async fn get_entity_types_by_query<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
     Json(query): Json<serde_json::Value>,
 ) -> Result<Json<Subgraph>, StatusCode>
 where
     S: StorePool + Send + Sync,
+    A: AuthorizationApiPool + Send + Sync,
 {
-    store_pool.acquire()
-        .map_err(|error| {
-            tracing::error!(?error, "Could not acquire access to the store");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })
-        .and_then(|store| async move {
-            let mut query = StructuralQuery::deserialize(&query).map_err(|error| {
-                tracing::error!(?error, "Could not deserialize query");
-                StatusCode::INTERNAL_SERVER_ERROR
-            })?;
-            query.filter.convert_parameters().map_err(|error| {
-                tracing::error!(?error, "Could not validate query");
-                StatusCode::INTERNAL_SERVER_ERROR
-            })?;
-            store
-                .get_entity_type(actor_id, &query)
-                .await
-                .map_err(|report| {
-                    tracing::error!(error=?report, ?query, "Could not read entity types from the store");
-                    report_to_status_code(&report)
-                })
-        })
+    let store = store_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the store");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let mut query = StructuralQuery::deserialize(&query).map_err(|error| {
+        tracing::error!(?error, "Could not deserialize query");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    query.filter.convert_parameters().map_err(|error| {
+        tracing::error!(?error, "Could not validate query");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let subgraph = store
+        .get_entity_type(actor_id, &authorization_api, &query)
         .await
-        .map(|subgraph| Json(subgraph.into()))
+        .map_err(|report| {
+            tracing::error!(error=?report, ?query, "Could not read entity types from the store");
+            report_to_status_code(&report)
+        })?;
+
+    Ok(Json(subgraph.into()))
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -461,14 +506,16 @@ struct UpdateEntityTypeRequest {
     ),
     request_body = UpdateEntityTypeRequest,
 )]
-#[tracing::instrument(level = "info", skip(store_pool))]
-async fn update_entity_type<S>(
+#[tracing::instrument(level = "info", skip(store_pool, authorization_api_pool))]
+async fn update_entity_type<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
     body: Json<UpdateEntityTypeRequest>,
 ) -> Result<Json<EntityTypeMetadata>, StatusCode>
 where
     S: StorePool + Send + Sync,
+    A: AuthorizationApiPool + Send + Sync,
 {
     let Json(UpdateEntityTypeRequest {
         schema,
@@ -491,8 +538,13 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
     store
-        .update_entity_type(actor_id, entity_type, label_property)
+        .update_entity_type(actor_id, &authorization_api, entity_type, label_property)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not update entity type");
@@ -531,14 +583,16 @@ struct ArchiveEntityTypeRequest {
     ),
     request_body = ArchiveEntityTypeRequest,
 )]
-#[tracing::instrument(level = "info", skip(store_pool))]
-async fn archive_entity_type<S>(
+#[tracing::instrument(level = "info", skip(store_pool, authorization_api_pool))]
+async fn archive_entity_type<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
     body: Json<ArchiveEntityTypeRequest>,
 ) -> Result<Json<OntologyTemporalMetadata>, StatusCode>
 where
     S: StorePool + Send + Sync,
+    A: AuthorizationApiPool + Send + Sync,
 {
     let Json(ArchiveEntityTypeRequest { type_to_archive }) = body;
 
@@ -547,8 +601,13 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
     store
-        .archive_entity_type(actor_id, &type_to_archive)
+        .archive_entity_type(actor_id, &authorization_api, &type_to_archive)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not archive entity type");
@@ -590,14 +649,16 @@ struct UnarchiveEntityTypeRequest {
     ),
     request_body = UnarchiveEntityTypeRequest,
 )]
-#[tracing::instrument(level = "info", skip(store_pool))]
-async fn unarchive_entity_type<S>(
+#[tracing::instrument(level = "info", skip(store_pool, authorization_api_pool))]
+async fn unarchive_entity_type<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
     body: Json<UnarchiveEntityTypeRequest>,
 ) -> Result<Json<OntologyTemporalMetadata>, StatusCode>
 where
     S: StorePool + Send + Sync,
+    A: AuthorizationApiPool + Send + Sync,
 {
     let Json(UnarchiveEntityTypeRequest { type_to_unarchive }) = body;
 
@@ -606,8 +667,13 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
     store
-        .unarchive_entity_type(actor_id, &type_to_unarchive)
+        .unarchive_entity_type(actor_id, &authorization_api, &type_to_unarchive)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not unarchive entity type");

--- a/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
@@ -232,7 +232,7 @@ where
         entity_types.push(entity_type);
     }
 
-    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+    let mut authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
         tracing::error!(?error, "Could not acquire access to the authorization API");
         status_to_response(Status::new(
             hash_status::StatusCode::Internal,
@@ -249,7 +249,7 @@ where
     let mut metadata = store
         .create_entity_types(
             actor_id,
-            &authorization_api,
+            &mut authorization_api,
             entity_types.into_iter().zip(partial_metadata),
             ConflictBehavior::Fail,
         )
@@ -380,7 +380,7 @@ where
         ))
     })?;
 
-    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+    let mut authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
         tracing::error!(?error, "Could not acquire access to the authorization API");
         status_to_response(Status::new(
             hash_status::StatusCode::Internal,
@@ -398,7 +398,7 @@ where
         store
             .load_external_type(
                 actor_id,
-                &authorization_api,
+                &mut authorization_api,
                 &domain_validator,
                 OntologyTypeReference::EntityTypeReference((&entity_type_id).into()),
             )
@@ -538,13 +538,18 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+    let mut authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
         tracing::error!(?error, "Could not acquire access to the authorization API");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
     store
-        .update_entity_type(actor_id, &authorization_api, entity_type, label_property)
+        .update_entity_type(
+            actor_id,
+            &mut authorization_api,
+            entity_type,
+            label_property,
+        )
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not update entity type");
@@ -601,13 +606,13 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+    let mut authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
         tracing::error!(?error, "Could not acquire access to the authorization API");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
     store
-        .archive_entity_type(actor_id, &authorization_api, &type_to_archive)
+        .archive_entity_type(actor_id, &mut authorization_api, &type_to_archive)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not archive entity type");
@@ -667,13 +672,13 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+    let mut authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
         tracing::error!(?error, "Could not acquire access to the authorization API");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
     store
-        .unarchive_entity_type(actor_id, &authorization_api, &type_to_unarchive)
+        .unarchive_entity_type(actor_id, &mut authorization_api, &type_to_unarchive)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not unarchive entity type");

--- a/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
@@ -8,7 +8,6 @@ use axum::{
     routing::{post, put},
     Extension, Router,
 };
-use futures::TryFutureExt;
 use graph_types::{
     ontology::{
         OntologyElementMetadata, OntologyTemporalMetadata, OntologyTypeReference,
@@ -82,12 +81,12 @@ impl RoutedResource for PropertyTypeResource {
             Router::new()
                 .route(
                     "/",
-                    post(create_property_type::<S>).put(update_property_type::<S>),
+                    post(create_property_type::<S, A>).put(update_property_type::<S, A>),
                 )
-                .route("/query", post(get_property_types_by_query::<S>))
-                .route("/load", post(load_external_property_type::<S>))
-                .route("/archive", put(archive_property_type::<S>))
-                .route("/unarchive", put(unarchive_property_type::<S>)),
+                .route("/query", post(get_property_types_by_query::<S, A>))
+                .route("/load", post(load_external_property_type::<S, A>))
+                .route("/archive", put(archive_property_type::<S, A>))
+                .route("/unarchive", put(unarchive_property_type::<S, A>)),
         )
     }
 }
@@ -116,16 +115,21 @@ struct CreatePropertyTypeRequest {
         (status = 500, description = "Store error occurred"),
     ),
 )]
-#[tracing::instrument(level = "info", skip(store_pool, domain_validator))]
-async fn create_property_type<S>(
+#[tracing::instrument(
+    level = "info",
+    skip(store_pool, authorization_api_pool, domain_validator)
+)]
+async fn create_property_type<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
     domain_validator: Extension<DomainValidator>,
     body: Json<CreatePropertyTypeRequest>,
 ) -> Result<Json<ListOrValue<OntologyElementMetadata>>, StatusCode>
 where
     S: StorePool + Send + Sync,
     for<'pool> S::Store<'pool>: RestApiStore,
+    A: AuthorizationApiPool + Send + Sync,
 {
     let mut store = store_pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
@@ -166,9 +170,15 @@ where
         property_types.push(property_type);
     }
 
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
     let mut metadata = store
         .create_property_types(
             actor_id,
+            &authorization_api,
             property_types.into_iter().zip(partial_metadata),
             ConflictBehavior::Fail,
         )
@@ -216,19 +226,29 @@ struct LoadExternalPropertyTypeRequest {
         (status = 500, description = "Store error occurred"),
     ),
 )]
-#[tracing::instrument(level = "info", skip(store_pool, domain_validator))]
-async fn load_external_property_type<S>(
+#[tracing::instrument(
+    level = "info",
+    skip(store_pool, authorization_api_pool, domain_validator)
+)]
+async fn load_external_property_type<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
     domain_validator: Extension<DomainValidator>,
     body: Json<LoadExternalPropertyTypeRequest>,
 ) -> Result<Json<OntologyElementMetadata>, StatusCode>
 where
     S: StorePool + Send + Sync,
     for<'pool> S::Store<'pool>: RestApiStore,
+    A: AuthorizationApiPool + Send + Sync,
 {
     let mut store = store_pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
@@ -238,6 +258,7 @@ where
         store
             .load_external_type(
                 actor_id,
+                &authorization_api,
                 &domain_validator,
                 OntologyTypeReference::PropertyTypeReference((&property_type_id).into()),
             )
@@ -260,39 +281,44 @@ where
         (status = 500, description = "Store error occurred"),
     )
 )]
-#[tracing::instrument(level = "info", skip(store_pool))]
-async fn get_property_types_by_query<S>(
+#[tracing::instrument(level = "info", skip(store_pool, authorization_api_pool))]
+async fn get_property_types_by_query<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
     Json(query): Json<serde_json::Value>,
 ) -> Result<Json<Subgraph>, StatusCode>
 where
     S: StorePool + Send + Sync,
+    A: AuthorizationApiPool + Send + Sync,
 {
-    store_pool.acquire()
-        .map_err(|error| {
-            tracing::error!(?error, "Could not acquire access to the store");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })
-        .and_then(|store| async move {
-            let mut query = StructuralQuery::deserialize(&query).map_err(|error| {
-                tracing::error!(?error, "Could not deserialize query");
-                StatusCode::INTERNAL_SERVER_ERROR
-            })?;
-            query.filter.convert_parameters().map_err(|error| {
-                tracing::error!(?error, "Could not validate query");
-                StatusCode::INTERNAL_SERVER_ERROR
-            })?;
-            store
-                .get_property_type(actor_id, &query)
-                .await
-                .map_err(|report| {
-                    tracing::error!(error=?report, ?query, "Could not read property types from the store");
-                    report_to_status_code(&report)
-                })
-        })
+    let store = store_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the store");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let mut query = StructuralQuery::deserialize(&query).map_err(|error| {
+        tracing::error!(?error, "Could not deserialize query");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    query.filter.convert_parameters().map_err(|error| {
+        tracing::error!(?error, "Could not validate query");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    let subgraph = store
+        .get_property_type(actor_id, &authorization_api, &query)
         .await
-        .map(|subgraph| Json(subgraph.into()))
+        .map_err(|report| {
+            tracing::error!(error=?report, ?query, "Could not read property types from the store");
+            report_to_status_code(&report)
+        })?;
+
+    Ok(Json(subgraph.into()))
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -320,14 +346,16 @@ struct UpdatePropertyTypeRequest {
     ),
     request_body = UpdatePropertyTypeRequest,
 )]
-#[tracing::instrument(level = "info", skip(store_pool))]
-async fn update_property_type<S>(
+#[tracing::instrument(level = "info", skip(store_pool, authorization_api_pool))]
+async fn update_property_type<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
     body: Json<UpdatePropertyTypeRequest>,
 ) -> Result<Json<OntologyElementMetadata>, StatusCode>
 where
     S: StorePool + Send + Sync,
+    A: AuthorizationApiPool + Send + Sync,
 {
     let Json(UpdatePropertyTypeRequest {
         schema,
@@ -348,8 +376,13 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
     store
-        .update_property_type(actor_id, property_type)
+        .update_property_type(actor_id, &authorization_api, property_type)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not update property type");
@@ -388,14 +421,16 @@ struct ArchivePropertyTypeRequest {
     ),
     request_body = ArchivePropertyTypeRequest,
 )]
-#[tracing::instrument(level = "info", skip(store_pool))]
-async fn archive_property_type<S>(
+#[tracing::instrument(level = "info", skip(store_pool, authorization_api_pool))]
+async fn archive_property_type<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
     body: Json<ArchivePropertyTypeRequest>,
 ) -> Result<Json<OntologyTemporalMetadata>, StatusCode>
 where
     S: StorePool + Send + Sync,
+    A: AuthorizationApiPool + Send + Sync,
 {
     let Json(ArchivePropertyTypeRequest { type_to_archive }) = body;
 
@@ -404,8 +439,13 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
     store
-        .archive_property_type(actor_id, &type_to_archive)
+        .archive_property_type(actor_id, &authorization_api, &type_to_archive)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not archive property type");
@@ -447,14 +487,16 @@ struct UnarchivePropertyTypeRequest {
     ),
     request_body = UnarchivePropertyTypeRequest,
 )]
-#[tracing::instrument(level = "info", skip(store_pool))]
-async fn unarchive_property_type<S>(
+#[tracing::instrument(level = "info", skip(store_pool, authorization_api_pool))]
+async fn unarchive_property_type<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
     body: Json<UnarchivePropertyTypeRequest>,
 ) -> Result<Json<OntologyTemporalMetadata>, StatusCode>
 where
     S: StorePool + Send + Sync,
+    A: AuthorizationApiPool + Send + Sync,
 {
     let Json(UnarchivePropertyTypeRequest { type_to_unarchive }) = body;
 
@@ -463,8 +505,13 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
+    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+        tracing::error!(?error, "Could not acquire access to the authorization API");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
     store
-        .unarchive_property_type(actor_id, &type_to_unarchive)
+        .unarchive_property_type(actor_id, &authorization_api, &type_to_unarchive)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not unarchive property type");

--- a/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
@@ -170,7 +170,7 @@ where
         property_types.push(property_type);
     }
 
-    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+    let mut authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
         tracing::error!(?error, "Could not acquire access to the authorization API");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
@@ -178,7 +178,7 @@ where
     let mut metadata = store
         .create_property_types(
             actor_id,
-            &authorization_api,
+            &mut authorization_api,
             property_types.into_iter().zip(partial_metadata),
             ConflictBehavior::Fail,
         )
@@ -247,7 +247,7 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+    let mut authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
         tracing::error!(?error, "Could not acquire access to the authorization API");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
@@ -258,7 +258,7 @@ where
         store
             .load_external_type(
                 actor_id,
-                &authorization_api,
+                &mut authorization_api,
                 &domain_validator,
                 OntologyTypeReference::PropertyTypeReference((&property_type_id).into()),
             )
@@ -376,13 +376,13 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+    let mut authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
         tracing::error!(?error, "Could not acquire access to the authorization API");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
     store
-        .update_property_type(actor_id, &authorization_api, property_type)
+        .update_property_type(actor_id, &mut authorization_api, property_type)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not update property type");
@@ -439,13 +439,13 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+    let mut authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
         tracing::error!(?error, "Could not acquire access to the authorization API");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
     store
-        .archive_property_type(actor_id, &authorization_api, &type_to_archive)
+        .archive_property_type(actor_id, &mut authorization_api, &type_to_archive)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not archive property type");
@@ -505,13 +505,13 @@ where
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
+    let mut authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
         tracing::error!(?error, "Could not acquire access to the authorization API");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
     store
-        .unarchive_property_type(actor_id, &authorization_api, &type_to_unarchive)
+        .unarchive_property_type(actor_id, &mut authorization_api, &type_to_unarchive)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not unarchive property type");

--- a/apps/hash-graph/lib/graph/src/store/account.rs
+++ b/apps/hash-graph/lib/graph/src/store/account.rs
@@ -13,10 +13,10 @@ pub trait AccountStore {
     /// # Errors
     ///
     /// - if insertion failed, e.g. because the [`AccountId`] already exists.
-    async fn insert_account_id<A: AuthorizationApi + Sync>(
+    async fn insert_account_id<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &A,
+        authorization_api: &mut A,
         account_id: AccountId,
     ) -> Result<(), InsertionError>;
 }

--- a/apps/hash-graph/lib/graph/src/store/account.rs
+++ b/apps/hash-graph/lib/graph/src/store/account.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use authorization::AuthorizationApi;
 use error_stack::Result;
 use graph_types::account::AccountId;
 
@@ -12,5 +13,10 @@ pub trait AccountStore {
     /// # Errors
     ///
     /// - if insertion failed, e.g. because the [`AccountId`] already exists.
-    async fn insert_account_id(&mut self, account_id: AccountId) -> Result<(), InsertionError>;
+    async fn insert_account_id<A: AuthorizationApi + Sync>(
+        &mut self,
+        actor_id: AccountId,
+        authorization_api: &A,
+        account_id: AccountId,
+    ) -> Result<(), InsertionError>;
 }

--- a/apps/hash-graph/lib/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/lib/graph/src/store/knowledge.rs
@@ -33,10 +33,10 @@ pub trait EntityStore: crud::Read<Entity> {
     ///
     /// [`EntityType`]: type_system::EntityType
     #[expect(clippy::too_many_arguments)]
-    async fn create_entity<A: AuthorizationApi + Sync>(
+    async fn create_entity<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &A,
+        authorization_api: &mut A,
         owned_by_id: OwnedById,
         entity_uuid: Option<EntityUuid>,
         decision_time: Option<Timestamp<DecisionTime>>,
@@ -65,10 +65,10 @@ pub trait EntityStore: crud::Read<Entity> {
     /// [`EntityType`]: type_system::EntityType
     #[doc(hidden)]
     #[cfg(hash_graph_test_environment)]
-    async fn insert_entities_batched_by_type<A: AuthorizationApi + Sync>(
+    async fn insert_entities_batched_by_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &A,
+        authorization_api: &mut A,
         entities: impl IntoIterator<
             Item = (
                 OwnedById,
@@ -105,10 +105,10 @@ pub trait EntityStore: crud::Read<Entity> {
     ///
     /// [`EntityType`]: type_system::EntityType
     #[expect(clippy::too_many_arguments)]
-    async fn update_entity<A: AuthorizationApi + Sync>(
+    async fn update_entity<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &A,
+        authorization_api: &mut A,
         entity_id: EntityId,
         decision_time: Option<Timestamp<DecisionTime>>,
         archived: bool,

--- a/apps/hash-graph/lib/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/lib/graph/src/store/knowledge.rs
@@ -33,9 +33,10 @@ pub trait EntityStore: crud::Read<Entity> {
     ///
     /// [`EntityType`]: type_system::EntityType
     #[expect(clippy::too_many_arguments)]
-    async fn create_entity(
+    async fn create_entity<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        authorization_api: &A,
         owned_by_id: OwnedById,
         entity_uuid: Option<EntityUuid>,
         decision_time: Option<Timestamp<DecisionTime>>,
@@ -64,9 +65,10 @@ pub trait EntityStore: crud::Read<Entity> {
     /// [`EntityType`]: type_system::EntityType
     #[doc(hidden)]
     #[cfg(hash_graph_test_environment)]
-    async fn insert_entities_batched_by_type(
+    async fn insert_entities_batched_by_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        authorization_api: &A,
         entities: impl IntoIterator<
             Item = (
                 OwnedById,
@@ -88,8 +90,8 @@ pub trait EntityStore: crud::Read<Entity> {
     async fn get_entity<A: AuthorizationApi + Sync>(
         &self,
         actor_id: AccountId,
-        query: &StructuralQuery<Entity>,
         authorization_api: &A,
+        query: &StructuralQuery<Entity>,
     ) -> Result<Subgraph, QueryError>;
 
     /// Update an existing [`Entity`].
@@ -103,9 +105,10 @@ pub trait EntityStore: crud::Read<Entity> {
     ///
     /// [`EntityType`]: type_system::EntityType
     #[expect(clippy::too_many_arguments)]
-    async fn update_entity(
+    async fn update_entity<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        authorization_api: &A,
         entity_id: EntityId,
         decision_time: Option<Timestamp<DecisionTime>>,
         archived: bool,

--- a/apps/hash-graph/lib/graph/src/store/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/store/ontology.rs
@@ -1,6 +1,7 @@
 use std::iter;
 
 use async_trait::async_trait;
+use authorization::AuthorizationApi;
 use error_stack::Result;
 use graph_types::{
     account::AccountId,
@@ -31,15 +32,17 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     /// - if the [`BaseUrl`] of the `data_type` already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    async fn create_data_type(
+    async fn create_data_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        authorization_api: &A,
         schema: DataType,
         metadata: PartialOntologyElementMetadata,
     ) -> Result<OntologyElementMetadata, InsertionError> {
         Ok(self
             .create_data_types(
                 actor_id,
+                authorization_api,
                 iter::once((schema, metadata)),
                 ConflictBehavior::Fail,
             )
@@ -56,9 +59,10 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     /// - if any [`BaseUrl`] of the data type already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    async fn create_data_types(
+    async fn create_data_types<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        authorization_api: &A,
         data_types: impl IntoIterator<Item = (DataType, PartialOntologyElementMetadata), IntoIter: Send>
         + Send,
         on_conflict: ConflictBehavior,
@@ -69,9 +73,10 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     /// # Errors
     ///
     /// - if the requested [`DataType`] doesn't exist.
-    async fn get_data_type(
+    async fn get_data_type<A: AuthorizationApi + Sync>(
         &self,
         actor_id: AccountId,
+        authorization_api: &A,
         query: &StructuralQuery<DataTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError>;
 
@@ -80,9 +85,10 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     /// # Errors
     ///
     /// - if the [`DataType`] doesn't exist.
-    async fn update_data_type(
+    async fn update_data_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        authorization_api: &A,
         data_type: DataType,
     ) -> Result<OntologyElementMetadata, UpdateError>;
 
@@ -91,9 +97,10 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     /// # Errors
     ///
     /// - if the [`DataType`] doesn't exist.
-    async fn archive_data_type(
+    async fn archive_data_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        authorization_api: &A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError>;
 
@@ -102,9 +109,10 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     /// # Errors
     ///
     /// - if the [`DataType`] doesn't exist.
-    async fn unarchive_data_type(
+    async fn unarchive_data_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        authorization_api: &A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError>;
 }
@@ -120,15 +128,17 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     /// - if the [`BaseUrl`] of the `property_type` already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    async fn create_property_type(
+    async fn create_property_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        authorization_api: &A,
         schema: PropertyType,
         metadata: PartialOntologyElementMetadata,
     ) -> Result<OntologyElementMetadata, InsertionError> {
         Ok(self
             .create_property_types(
                 actor_id,
+                authorization_api,
                 iter::once((schema, metadata)),
                 ConflictBehavior::Fail,
             )
@@ -145,9 +155,10 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     /// - if any [`BaseUrl`] of the property type already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    async fn create_property_types(
+    async fn create_property_types<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        authorization_api: &A,
         property_types: impl IntoIterator<
             Item = (PropertyType, PartialOntologyElementMetadata),
             IntoIter: Send,
@@ -160,9 +171,10 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     /// # Errors
     ///
     /// - if the requested [`PropertyType`] doesn't exist.
-    async fn get_property_type(
+    async fn get_property_type<A: AuthorizationApi + Sync>(
         &self,
         actor_id: AccountId,
+        authorization_api: &A,
         query: &StructuralQuery<PropertyTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError>;
 
@@ -171,9 +183,10 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     /// # Errors
     ///
     /// - if the [`PropertyType`] doesn't exist.
-    async fn update_property_type(
+    async fn update_property_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        authorization_api: &A,
         property_type: PropertyType,
     ) -> Result<OntologyElementMetadata, UpdateError>;
 
@@ -182,9 +195,10 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     /// # Errors
     ///
     /// - if the [`PropertyType`] doesn't exist.
-    async fn archive_property_type(
+    async fn archive_property_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        authorization_api: &A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError>;
 
@@ -193,9 +207,10 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     /// # Errors
     ///
     /// - if the [`PropertyType`] doesn't exist.
-    async fn unarchive_property_type(
+    async fn unarchive_property_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        authorization_api: &A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError>;
 }
@@ -211,15 +226,17 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     /// - if the [`BaseUrl`] of the `entity_type` already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    async fn create_entity_type(
+    async fn create_entity_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        authorization_api: &A,
         schema: EntityType,
         metadata: PartialEntityTypeMetadata,
     ) -> Result<EntityTypeMetadata, InsertionError> {
         Ok(self
             .create_entity_types(
                 actor_id,
+                authorization_api,
                 iter::once((schema, metadata)),
                 ConflictBehavior::Fail,
             )
@@ -236,9 +253,10 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     /// - if any [`BaseUrl`] of the entity type already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    async fn create_entity_types(
+    async fn create_entity_types<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        authorization_api: &A,
         entity_types: impl IntoIterator<Item = (EntityType, PartialEntityTypeMetadata), IntoIter: Send>
         + Send,
         on_conflict: ConflictBehavior,
@@ -249,9 +267,10 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     /// # Errors
     ///
     /// - if the requested [`EntityType`] doesn't exist.
-    async fn get_entity_type(
+    async fn get_entity_type<A: AuthorizationApi + Sync>(
         &self,
         actor_id: AccountId,
+        authorization_api: &A,
         query: &StructuralQuery<EntityTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError>;
 
@@ -260,9 +279,10 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     /// # Errors
     ///
     /// - if the [`EntityType`] doesn't exist.
-    async fn update_entity_type(
+    async fn update_entity_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        authorization_api: &A,
         entity_type: EntityType,
         label_property: Option<BaseUrl>,
     ) -> Result<EntityTypeMetadata, UpdateError>;
@@ -272,9 +292,10 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     /// # Errors
     ///
     /// - if the [`EntityType`] doesn't exist.
-    async fn archive_entity_type(
+    async fn archive_entity_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        authorization_api: &A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError>;
 
@@ -283,9 +304,10 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     /// # Errors
     ///
     /// - if the [`EntityType`] doesn't exist.
-    async fn unarchive_entity_type(
+    async fn unarchive_entity_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        authorization_api: &A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError>;
 }

--- a/apps/hash-graph/lib/graph/src/store/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/store/ontology.rs
@@ -32,10 +32,10 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     /// - if the [`BaseUrl`] of the `data_type` already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    async fn create_data_type<A: AuthorizationApi + Sync>(
+    async fn create_data_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &A,
+        authorization_api: &mut A,
         schema: DataType,
         metadata: PartialOntologyElementMetadata,
     ) -> Result<OntologyElementMetadata, InsertionError> {
@@ -59,10 +59,10 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     /// - if any [`BaseUrl`] of the data type already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    async fn create_data_types<A: AuthorizationApi + Sync>(
+    async fn create_data_types<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &A,
+        authorization_api: &mut A,
         data_types: impl IntoIterator<Item = (DataType, PartialOntologyElementMetadata), IntoIter: Send>
         + Send,
         on_conflict: ConflictBehavior,
@@ -85,10 +85,10 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     /// # Errors
     ///
     /// - if the [`DataType`] doesn't exist.
-    async fn update_data_type<A: AuthorizationApi + Sync>(
+    async fn update_data_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &A,
+        authorization_api: &mut A,
         data_type: DataType,
     ) -> Result<OntologyElementMetadata, UpdateError>;
 
@@ -97,10 +97,10 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     /// # Errors
     ///
     /// - if the [`DataType`] doesn't exist.
-    async fn archive_data_type<A: AuthorizationApi + Sync>(
+    async fn archive_data_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &A,
+        authorization_api: &mut A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError>;
 
@@ -109,10 +109,10 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     /// # Errors
     ///
     /// - if the [`DataType`] doesn't exist.
-    async fn unarchive_data_type<A: AuthorizationApi + Sync>(
+    async fn unarchive_data_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &A,
+        authorization_api: &mut A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError>;
 }
@@ -128,10 +128,10 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     /// - if the [`BaseUrl`] of the `property_type` already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    async fn create_property_type<A: AuthorizationApi + Sync>(
+    async fn create_property_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &A,
+        authorization_api: &mut A,
         schema: PropertyType,
         metadata: PartialOntologyElementMetadata,
     ) -> Result<OntologyElementMetadata, InsertionError> {
@@ -155,10 +155,10 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     /// - if any [`BaseUrl`] of the property type already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    async fn create_property_types<A: AuthorizationApi + Sync>(
+    async fn create_property_types<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &A,
+        authorization_api: &mut A,
         property_types: impl IntoIterator<
             Item = (PropertyType, PartialOntologyElementMetadata),
             IntoIter: Send,
@@ -183,10 +183,10 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     /// # Errors
     ///
     /// - if the [`PropertyType`] doesn't exist.
-    async fn update_property_type<A: AuthorizationApi + Sync>(
+    async fn update_property_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &A,
+        authorization_api: &mut A,
         property_type: PropertyType,
     ) -> Result<OntologyElementMetadata, UpdateError>;
 
@@ -195,10 +195,10 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     /// # Errors
     ///
     /// - if the [`PropertyType`] doesn't exist.
-    async fn archive_property_type<A: AuthorizationApi + Sync>(
+    async fn archive_property_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &A,
+        authorization_api: &mut A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError>;
 
@@ -207,10 +207,10 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     /// # Errors
     ///
     /// - if the [`PropertyType`] doesn't exist.
-    async fn unarchive_property_type<A: AuthorizationApi + Sync>(
+    async fn unarchive_property_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &A,
+        authorization_api: &mut A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError>;
 }
@@ -226,10 +226,10 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     /// - if the [`BaseUrl`] of the `entity_type` already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    async fn create_entity_type<A: AuthorizationApi + Sync>(
+    async fn create_entity_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &A,
+        authorization_api: &mut A,
         schema: EntityType,
         metadata: PartialEntityTypeMetadata,
     ) -> Result<EntityTypeMetadata, InsertionError> {
@@ -253,10 +253,10 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     /// - if any [`BaseUrl`] of the entity type already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    async fn create_entity_types<A: AuthorizationApi + Sync>(
+    async fn create_entity_types<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &A,
+        authorization_api: &mut A,
         entity_types: impl IntoIterator<Item = (EntityType, PartialEntityTypeMetadata), IntoIter: Send>
         + Send,
         on_conflict: ConflictBehavior,
@@ -279,10 +279,10 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     /// # Errors
     ///
     /// - if the [`EntityType`] doesn't exist.
-    async fn update_entity_type<A: AuthorizationApi + Sync>(
+    async fn update_entity_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &A,
+        authorization_api: &mut A,
         entity_type: EntityType,
         label_property: Option<BaseUrl>,
     ) -> Result<EntityTypeMetadata, UpdateError>;
@@ -292,10 +292,10 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     /// # Errors
     ///
     /// - if the [`EntityType`] doesn't exist.
-    async fn archive_entity_type<A: AuthorizationApi + Sync>(
+    async fn archive_entity_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &A,
+        authorization_api: &mut A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError>;
 
@@ -304,10 +304,10 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     /// # Errors
     ///
     /// - if the [`EntityType`] doesn't exist.
-    async fn unarchive_entity_type<A: AuthorizationApi + Sync>(
+    async fn unarchive_entity_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &A,
+        authorization_api: &mut A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError>;
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres.rs
@@ -7,6 +7,7 @@ mod query;
 mod traversal_context;
 
 use async_trait::async_trait;
+use authorization::AuthorizationApi;
 use error_stack::{Report, Result, ResultExt};
 #[cfg(hash_graph_test_environment)]
 use graph_types::knowledge::{
@@ -1188,8 +1189,13 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
 
 #[async_trait]
 impl<C: AsClient> AccountStore for PostgresStore<C> {
-    #[tracing::instrument(level = "info", skip(self))]
-    async fn insert_account_id(&mut self, account_id: AccountId) -> Result<(), InsertionError> {
+    #[tracing::instrument(level = "info", skip(self, _authorization_api))]
+    async fn insert_account_id<A: AuthorizationApi + Sync>(
+        &mut self,
+        _actor_id: AccountId,
+        _authorization_api: &A,
+        account_id: AccountId,
+    ) -> Result<(), InsertionError> {
         self.as_client()
             .query_one(
                 r#"
@@ -1208,9 +1214,13 @@ impl<C: AsClient> AccountStore for PostgresStore<C> {
 }
 
 impl<C: AsClient> PostgresStore<C> {
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "trace", skip(self, _authorization_api))]
     #[cfg(hash_graph_test_environment)]
-    pub async fn delete_accounts(&mut self) -> Result<(), DeletionError> {
+    pub async fn delete_accounts<A: AuthorizationApi + Sync>(
+        &mut self,
+        actor_id: AccountId,
+        _authorization_api: &A,
+    ) -> Result<(), DeletionError> {
         self.as_client()
             .client()
             .simple_query("DELETE FROM accounts;")

--- a/apps/hash-graph/lib/graph/src/store/postgres.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres.rs
@@ -1193,7 +1193,7 @@ impl<C: AsClient> AccountStore for PostgresStore<C> {
     async fn insert_account_id<A: AuthorizationApi + Sync>(
         &mut self,
         _actor_id: AccountId,
-        _authorization_api: &A,
+        _authorization_api: &mut A,
         account_id: AccountId,
     ) -> Result<(), InsertionError> {
         self.as_client()

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -270,7 +270,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
     async fn create_entity<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
-        _authorization_api: &A,
+        _authorization_api: &mut A,
         owned_by_id: OwnedById,
         entity_uuid: Option<EntityUuid>,
         decision_time: Option<Timestamp<DecisionTime>>,
@@ -437,7 +437,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
     async fn insert_entities_batched_by_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
-        _authorization_api: &A,
+        _authorization_api: &mut A,
         entities: impl IntoIterator<
             Item = (
                 OwnedById,
@@ -649,7 +649,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
     async fn update_entity<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
-        _authorization_api: &A,
+        _authorization_api: &mut A,
         entity_id: EntityId,
         decision_time: Option<Timestamp<DecisionTime>>,
         archived: bool,

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -85,7 +85,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
     async fn create_data_types<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
-        _authorization_api: &A,
+        _authorization_api: &mut A,
         data_types: impl IntoIterator<Item = (DataType, PartialOntologyElementMetadata), IntoIter: Send>
         + Send,
         on_conflict: ConflictBehavior,
@@ -202,7 +202,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
     async fn update_data_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
-        _authorization_api: &A,
+        _authorization_api: &mut A,
         data_type: DataType,
     ) -> Result<OntologyElementMetadata, UpdateError> {
         let transaction = self.transaction().await.change_context(UpdateError)?;
@@ -220,7 +220,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
     async fn archive_data_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
-        _authorization_api: &A,
+        _authorization_api: &mut A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
         self.archive_ontology_type(id, RecordArchivedById::new(actor_id))
@@ -231,7 +231,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
     async fn unarchive_data_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
-        _authorization_api: &A,
+        _authorization_api: &mut A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
         self.unarchive_ontology_type(id, RecordCreatedById::new(actor_id))

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
+use authorization::AuthorizationApi;
 use error_stack::{Report, Result, ResultExt};
 use futures::{stream, TryStreamExt};
 use graph_types::{
@@ -205,10 +206,11 @@ impl<C: AsClient> PostgresStore<C> {
 
 #[async_trait]
 impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
-    #[tracing::instrument(level = "info", skip(self, entity_types))]
-    async fn create_entity_types(
+    #[tracing::instrument(level = "info", skip(self, entity_types, _authorization_api))]
+    async fn create_entity_types<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        _authorization_api: &A,
         entity_types: impl IntoIterator<Item = (EntityType, PartialEntityTypeMetadata), IntoIter: Send>
         + Send,
         on_conflict: ConflictBehavior,
@@ -270,10 +272,11 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         Ok(inserted_entity_type_metadata)
     }
 
-    #[tracing::instrument(level = "info", skip(self))]
-    async fn get_entity_type(
+    #[tracing::instrument(level = "info", skip(self, _authorization_api))]
+    async fn get_entity_type<A: AuthorizationApi + Sync>(
         &self,
         _actor_id: AccountId,
+        _authorization_api: &A,
         query: &StructuralQuery<EntityTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError> {
         let StructuralQuery {
@@ -343,10 +346,11 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         Ok(subgraph)
     }
 
-    #[tracing::instrument(level = "info", skip(self, entity_type))]
-    async fn update_entity_type(
+    #[tracing::instrument(level = "info", skip(self, entity_type, _authorization_api))]
+    async fn update_entity_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        _authorization_api: &A,
         entity_type: EntityType,
         label_property: Option<BaseUrl>,
     ) -> Result<EntityTypeMetadata, UpdateError> {
@@ -397,18 +401,22 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         ))
     }
 
-    async fn archive_entity_type(
+    #[tracing::instrument(level = "info", skip(self, _authorization_api))]
+    async fn archive_entity_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        _authorization_api: &A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
         self.archive_ontology_type(id, RecordArchivedById::new(actor_id))
             .await
     }
 
-    async fn unarchive_entity_type(
+    #[tracing::instrument(level = "info", skip(self, _authorization_api))]
+    async fn unarchive_entity_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        _authorization_api: &A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
         self.unarchive_ontology_type(id, RecordCreatedById::new(actor_id))

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -210,7 +210,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
     async fn create_entity_types<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
-        _authorization_api: &A,
+        _authorization_api: &mut A,
         entity_types: impl IntoIterator<Item = (EntityType, PartialEntityTypeMetadata), IntoIter: Send>
         + Send,
         on_conflict: ConflictBehavior,
@@ -350,7 +350,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
     async fn update_entity_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
-        _authorization_api: &A,
+        _authorization_api: &mut A,
         entity_type: EntityType,
         label_property: Option<BaseUrl>,
     ) -> Result<EntityTypeMetadata, UpdateError> {
@@ -405,7 +405,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
     async fn archive_entity_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
-        _authorization_api: &A,
+        _authorization_api: &mut A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
         self.archive_ontology_type(id, RecordArchivedById::new(actor_id))
@@ -416,7 +416,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
     async fn unarchive_entity_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
-        _authorization_api: &A,
+        _authorization_api: &mut A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
         self.unarchive_ontology_type(id, RecordCreatedById::new(actor_id))

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -182,7 +182,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
     async fn create_property_types<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
-        _authorization_api: &A,
+        _authorization_api: &mut A,
         property_types: impl IntoIterator<
             Item = (PropertyType, PartialOntologyElementMetadata),
             IntoIter: Send,
@@ -320,7 +320,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
     async fn update_property_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
-        _authorization_api: &A,
+        _authorization_api: &mut A,
         property_type: PropertyType,
     ) -> Result<OntologyElementMetadata, UpdateError> {
         let transaction = self.transaction().await.change_context(UpdateError)?;
@@ -353,7 +353,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
     async fn archive_property_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
-        _authorization_api: &A,
+        _authorization_api: &mut A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
         self.archive_ontology_type(id, RecordArchivedById::new(actor_id))
@@ -364,7 +364,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
     async fn unarchive_property_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
-        _authorization_api: &A,
+        _authorization_api: &mut A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
         self.unarchive_ontology_type(id, RecordCreatedById::new(actor_id))

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
+use authorization::AuthorizationApi;
 use error_stack::{Report, Result, ResultExt};
 use futures::{stream, TryStreamExt};
 use graph_types::{
@@ -177,10 +178,11 @@ impl<C: AsClient> PostgresStore<C> {
 
 #[async_trait]
 impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
-    #[tracing::instrument(level = "info", skip(self, property_types))]
-    async fn create_property_types(
+    #[tracing::instrument(level = "info", skip(self, property_types, _authorization_api))]
+    async fn create_property_types<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        _authorization_api: &A,
         property_types: impl IntoIterator<
             Item = (PropertyType, PartialOntologyElementMetadata),
             IntoIter: Send,
@@ -240,10 +242,11 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         Ok(inserted_property_type_metadata)
     }
 
-    #[tracing::instrument(level = "info", skip(self))]
-    async fn get_property_type(
+    #[tracing::instrument(level = "info", skip(self, _authorization_api))]
+    async fn get_property_type<A: AuthorizationApi + Sync>(
         &self,
         _actor_id: AccountId,
+        _authorization_api: &A,
         query: &StructuralQuery<PropertyTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError> {
         let StructuralQuery {
@@ -313,10 +316,11 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         Ok(subgraph)
     }
 
-    #[tracing::instrument(level = "info", skip(self, property_type))]
-    async fn update_property_type(
+    #[tracing::instrument(level = "info", skip(self, property_type, _authorization_api))]
+    async fn update_property_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        _authorization_api: &A,
         property_type: PropertyType,
     ) -> Result<OntologyElementMetadata, UpdateError> {
         let transaction = self.transaction().await.change_context(UpdateError)?;
@@ -345,18 +349,22 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         Ok(metadata)
     }
 
-    async fn archive_property_type(
+    #[tracing::instrument(level = "info", skip(self, _authorization_api))]
+    async fn archive_property_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        _authorization_api: &A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
         self.archive_ontology_type(id, RecordArchivedById::new(actor_id))
             .await
     }
 
-    async fn unarchive_property_type(
+    #[tracing::instrument(level = "info", skip(self, _authorization_api))]
+    async fn unarchive_property_type<A: AuthorizationApi + Sync>(
         &mut self,
         actor_id: AccountId,
+        _authorization_api: &A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
         self.unarchive_ontology_type(id, RecordCreatedById::new(actor_id))

--- a/apps/hash-graph/tests/integration/postgres/lib.rs
+++ b/apps/hash-graph/tests/integration/postgres/lib.rs
@@ -125,7 +125,7 @@ impl DatabaseTestWrapper {
 
         let account_id = AccountId::new(Uuid::new_v4());
         store
-            .insert_account_id(account_id, &NoAuthorization, account_id)
+            .insert_account_id(account_id, &mut NoAuthorization, account_id)
             .await
             .expect("could not insert account id");
 
@@ -146,7 +146,7 @@ impl DatabaseTestWrapper {
         store
             .create_data_types(
                 account_id,
-                &NoAuthorization,
+                &mut NoAuthorization,
                 data_types_iter,
                 ConflictBehavior::Skip,
             )
@@ -170,7 +170,7 @@ impl DatabaseTestWrapper {
         store
             .create_property_types(
                 account_id,
-                &NoAuthorization,
+                &mut NoAuthorization,
                 property_types_iter,
                 ConflictBehavior::Skip,
             )
@@ -197,7 +197,7 @@ impl DatabaseTestWrapper {
         store
             .create_entity_types(
                 account_id,
-                &NoAuthorization,
+                &mut NoAuthorization,
                 entity_types_iter,
                 ConflictBehavior::Skip,
             )
@@ -234,7 +234,7 @@ impl DatabaseApi<'_> {
         };
 
         self.store
-            .create_data_type(self.account_id, &NoAuthorization, data_type, metadata)
+            .create_data_type(self.account_id, &mut NoAuthorization, data_type, metadata)
             .await
     }
 
@@ -250,7 +250,7 @@ impl DatabaseApi<'_> {
         };
 
         self.store
-            .create_data_type(self.account_id, &NoAuthorization, data_type, metadata)
+            .create_data_type(self.account_id, &mut NoAuthorization, data_type, metadata)
             .await
     }
 
@@ -287,7 +287,7 @@ impl DatabaseApi<'_> {
         data_type: DataType,
     ) -> Result<OntologyElementMetadata, UpdateError> {
         self.store
-            .update_data_type(self.account_id, &NoAuthorization, data_type)
+            .update_data_type(self.account_id, &mut NoAuthorization, data_type)
             .await
     }
 
@@ -303,7 +303,7 @@ impl DatabaseApi<'_> {
         };
 
         self.store
-            .create_property_type(self.account_id, &NoAuthorization, property_type, metadata)
+            .create_property_type(self.account_id, &mut NoAuthorization, property_type, metadata)
             .await
     }
 
@@ -340,7 +340,7 @@ impl DatabaseApi<'_> {
         property_type: PropertyType,
     ) -> Result<OntologyElementMetadata, UpdateError> {
         self.store
-            .update_property_type(self.account_id, &NoAuthorization, property_type)
+            .update_property_type(self.account_id, &mut NoAuthorization, property_type)
             .await
     }
 
@@ -359,7 +359,7 @@ impl DatabaseApi<'_> {
         };
 
         self.store
-            .create_entity_type(self.account_id, &NoAuthorization, entity_type, metadata)
+            .create_entity_type(self.account_id, &mut NoAuthorization, entity_type, metadata)
             .await
     }
 
@@ -396,7 +396,7 @@ impl DatabaseApi<'_> {
         entity_type: EntityType,
     ) -> Result<EntityTypeMetadata, UpdateError> {
         self.store
-            .update_entity_type(self.account_id, &NoAuthorization, entity_type, None)
+            .update_entity_type(self.account_id, &mut NoAuthorization, entity_type, None)
             .await
     }
 
@@ -409,7 +409,7 @@ impl DatabaseApi<'_> {
         self.store
             .create_entity(
                 self.account_id,
-                &NoAuthorization,
+                &mut NoAuthorization,
                 OwnedById::new(self.account_id),
                 entity_uuid,
                 Some(generate_decision_time()),
@@ -511,7 +511,7 @@ impl DatabaseApi<'_> {
         self.store
             .update_entity(
                 self.account_id,
-                &NoAuthorization,
+                &mut NoAuthorization,
                 entity_id,
                 Some(generate_decision_time()),
                 false,
@@ -533,7 +533,7 @@ impl DatabaseApi<'_> {
         self.store
             .create_entity(
                 self.account_id,
-                &NoAuthorization,
+                &mut NoAuthorization,
                 OwnedById::new(self.account_id),
                 entity_uuid,
                 None,
@@ -705,7 +705,7 @@ impl DatabaseApi<'_> {
         self.store
             .update_entity(
                 self.account_id,
-                &NoAuthorization,
+                &mut NoAuthorization,
                 entity_id,
                 None,
                 true,

--- a/apps/hash-graph/tests/integration/postgres/lib.rs
+++ b/apps/hash-graph/tests/integration/postgres/lib.rs
@@ -303,7 +303,12 @@ impl DatabaseApi<'_> {
         };
 
         self.store
-            .create_property_type(self.account_id, &mut NoAuthorization, property_type, metadata)
+            .create_property_type(
+                self.account_id,
+                &mut NoAuthorization,
+                property_type,
+                metadata,
+            )
             .await
     }
 

--- a/apps/hash-graph/tests/integration/postgres/lib.rs
+++ b/apps/hash-graph/tests/integration/postgres/lib.rs
@@ -125,7 +125,7 @@ impl DatabaseTestWrapper {
 
         let account_id = AccountId::new(Uuid::new_v4());
         store
-            .insert_account_id(account_id)
+            .insert_account_id(account_id, &NoAuthorization, account_id)
             .await
             .expect("could not insert account id");
 
@@ -144,7 +144,12 @@ impl DatabaseTestWrapper {
             (data_type, metadata)
         });
         store
-            .create_data_types(account_id, data_types_iter, ConflictBehavior::Skip)
+            .create_data_types(
+                account_id,
+                &NoAuthorization,
+                data_types_iter,
+                ConflictBehavior::Skip,
+            )
             .await?;
 
         let property_types_iter = property_types.into_iter().map(|property_type_str| {
@@ -163,7 +168,12 @@ impl DatabaseTestWrapper {
             (property_type, metadata)
         });
         store
-            .create_property_types(account_id, property_types_iter, ConflictBehavior::Skip)
+            .create_property_types(
+                account_id,
+                &NoAuthorization,
+                property_types_iter,
+                ConflictBehavior::Skip,
+            )
             .await?;
 
         let entity_types_iter = entity_types.into_iter().map(|entity_type_str| {
@@ -185,7 +195,12 @@ impl DatabaseTestWrapper {
             (entity_type, metadata)
         });
         store
-            .create_entity_types(account_id, entity_types_iter, ConflictBehavior::Skip)
+            .create_entity_types(
+                account_id,
+                &NoAuthorization,
+                entity_types_iter,
+                ConflictBehavior::Skip,
+            )
             .await?;
 
         Ok(DatabaseApi { store, account_id })
@@ -219,7 +234,7 @@ impl DatabaseApi<'_> {
         };
 
         self.store
-            .create_data_type(self.account_id, data_type, metadata)
+            .create_data_type(self.account_id, &NoAuthorization, data_type, metadata)
             .await
     }
 
@@ -235,7 +250,7 @@ impl DatabaseApi<'_> {
         };
 
         self.store
-            .create_data_type(self.account_id, data_type, metadata)
+            .create_data_type(self.account_id, &NoAuthorization, data_type, metadata)
             .await
     }
 
@@ -247,6 +262,7 @@ impl DatabaseApi<'_> {
             .store
             .get_data_type(
                 self.account_id,
+                &NoAuthorization,
                 &StructuralQuery {
                     filter: Filter::for_versioned_url(url),
                     graph_resolve_depths: GraphResolveDepths::default(),
@@ -271,7 +287,7 @@ impl DatabaseApi<'_> {
         data_type: DataType,
     ) -> Result<OntologyElementMetadata, UpdateError> {
         self.store
-            .update_data_type(self.account_id, data_type)
+            .update_data_type(self.account_id, &NoAuthorization, data_type)
             .await
     }
 
@@ -287,7 +303,7 @@ impl DatabaseApi<'_> {
         };
 
         self.store
-            .create_property_type(self.account_id, property_type, metadata)
+            .create_property_type(self.account_id, &NoAuthorization, property_type, metadata)
             .await
     }
 
@@ -299,6 +315,7 @@ impl DatabaseApi<'_> {
             .store
             .get_property_type(
                 self.account_id,
+                &NoAuthorization,
                 &StructuralQuery {
                     filter: Filter::for_versioned_url(url),
                     graph_resolve_depths: GraphResolveDepths::default(),
@@ -323,7 +340,7 @@ impl DatabaseApi<'_> {
         property_type: PropertyType,
     ) -> Result<OntologyElementMetadata, UpdateError> {
         self.store
-            .update_property_type(self.account_id, property_type)
+            .update_property_type(self.account_id, &NoAuthorization, property_type)
             .await
     }
 
@@ -342,7 +359,7 @@ impl DatabaseApi<'_> {
         };
 
         self.store
-            .create_entity_type(self.account_id, entity_type, metadata)
+            .create_entity_type(self.account_id, &NoAuthorization, entity_type, metadata)
             .await
     }
 
@@ -354,6 +371,7 @@ impl DatabaseApi<'_> {
             .store
             .get_entity_type(
                 self.account_id,
+                &NoAuthorization,
                 &StructuralQuery {
                     filter: Filter::for_versioned_url(url),
                     graph_resolve_depths: GraphResolveDepths::default(),
@@ -378,7 +396,7 @@ impl DatabaseApi<'_> {
         entity_type: EntityType,
     ) -> Result<EntityTypeMetadata, UpdateError> {
         self.store
-            .update_entity_type(self.account_id, entity_type, None)
+            .update_entity_type(self.account_id, &NoAuthorization, entity_type, None)
             .await
     }
 
@@ -391,6 +409,7 @@ impl DatabaseApi<'_> {
         self.store
             .create_entity(
                 self.account_id,
+                &NoAuthorization,
                 OwnedById::new(self.account_id),
                 entity_uuid,
                 Some(generate_decision_time()),
@@ -407,6 +426,7 @@ impl DatabaseApi<'_> {
             .store
             .get_entity(
                 self.account_id,
+                &NoAuthorization,
                 &StructuralQuery {
                     filter: Filter::for_entity_by_entity_id(entity_id),
                     graph_resolve_depths: GraphResolveDepths::default(),
@@ -418,7 +438,6 @@ impl DatabaseApi<'_> {
                         ),
                     },
                 },
-                &NoAuthorization,
             )
             .await?
             .vertices
@@ -436,6 +455,7 @@ impl DatabaseApi<'_> {
             .store
             .get_entity(
                 self.account_id,
+                &NoAuthorization,
                 &StructuralQuery {
                     filter: Filter::for_entity_by_entity_id(entity_id),
                     graph_resolve_depths: GraphResolveDepths::default(),
@@ -447,7 +467,6 @@ impl DatabaseApi<'_> {
                         ),
                     },
                 },
-                &NoAuthorization,
             )
             .await?
             .vertices
@@ -463,6 +482,7 @@ impl DatabaseApi<'_> {
             .store
             .get_entity(
                 self.account_id,
+                &NoAuthorization,
                 &StructuralQuery {
                     filter: Filter::for_entity_by_entity_id(entity_id),
                     graph_resolve_depths: GraphResolveDepths::default(),
@@ -471,7 +491,6 @@ impl DatabaseApi<'_> {
                         variable: VariableTemporalAxisUnresolved::new(None, None),
                     },
                 },
-                &NoAuthorization,
             )
             .await?
             .vertices
@@ -492,6 +511,7 @@ impl DatabaseApi<'_> {
         self.store
             .update_entity(
                 self.account_id,
+                &NoAuthorization,
                 entity_id,
                 Some(generate_decision_time()),
                 false,
@@ -513,6 +533,7 @@ impl DatabaseApi<'_> {
         self.store
             .create_entity(
                 self.account_id,
+                &NoAuthorization,
                 OwnedById::new(self.account_id),
                 entity_uuid,
                 None,
@@ -583,6 +604,7 @@ impl DatabaseApi<'_> {
             .store
             .get_entity(
                 self.account_id,
+                &NoAuthorization,
                 &StructuralQuery {
                     filter,
                     graph_resolve_depths: GraphResolveDepths::default(),
@@ -594,7 +616,6 @@ impl DatabaseApi<'_> {
                         ),
                     },
                 },
-                &NoAuthorization,
             )
             .await?;
 
@@ -650,6 +671,7 @@ impl DatabaseApi<'_> {
             .store
             .get_entity(
                 self.account_id,
+                &NoAuthorization,
                 &StructuralQuery {
                     filter,
                     graph_resolve_depths: GraphResolveDepths::default(),
@@ -658,7 +680,6 @@ impl DatabaseApi<'_> {
                         variable: VariableTemporalAxisUnresolved::new(None, None),
                     },
                 },
-                &NoAuthorization,
             )
             .await?;
 
@@ -684,6 +705,7 @@ impl DatabaseApi<'_> {
         self.store
             .update_entity(
                 self.account_id,
+                &NoAuthorization,
                 entity_id,
                 None,
                 true,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To use the authorization API in the store it needs to be made available to it. The mutability was carefully picked so the API does not need to be mutable if only information needs to be fetched but no new permissions has to be inserted. This allows a read-only access to the permission service where the API itself does not need to be `Send`, only `Sync`. The mutable version requires both, `Send` and `Sync`.

## 🚫 Blocked by

- #3114 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph