### PR TITLE
H-745: Apply changes to python packages

### DIFF
--- a/apps/hash-ai-worker-py/turbo.json
+++ b/apps/hash-ai-worker-py/turbo.json
@@ -34,6 +34,7 @@
       "inputs": ["./**/*.py", "pyproject.toml"]
     },
     "lint:mypy": {
+      "dependsOn": ["build"],
       "inputs": ["./**/*.py", "pyproject.toml"]
     }
   }

--- a/apps/hash-ai-worker-py/turbo.json
+++ b/apps/hash-ai-worker-py/turbo.json
@@ -6,11 +6,9 @@
       "persistent": true
     },
     "poetry:install": {
-      "dependsOn": ["^build"],
       "cache": false
     },
     "poetry:install-production": {
-      "dependsOn": ["^build"],
       "cache": false
     },
     "build:docker": {

--- a/libs/@local/hash-graph-client/python/graph_client/__init__.py
+++ b/libs/@local/hash-graph-client/python/graph_client/__init__.py
@@ -72,7 +72,10 @@ async def _send_request(
     return response_t.model_validate(json, strict=False)
 
 
-def _assert_not_none(value: T | None) -> T:
+U = TypeVar("U")
+
+
+def _assert_not_none(value: U | None) -> U:
     """Assert that the value is not None."""
     if value is None:
         msg = "value cannot be None"

--- a/libs/@local/hash-graph-client/python/graph_client/__init__.py
+++ b/libs/@local/hash-graph-client/python/graph_client/__init__.py
@@ -98,7 +98,10 @@ class GraphClient:
         return _assert_not_none(actor)
 
     async def query_entity_types(
-        self, query: EntityTypeStructuralQuery, *, actor: UUID | None = None
+        self,
+        query: EntityTypeStructuralQuery,
+        *,
+        actor: UUID | None = None,
     ) -> Subgraph:
         """Query the HASH API for entity types."""
         endpoint = self.base / "entity-types" / "query"
@@ -231,7 +234,10 @@ class GraphClient:
         )
 
     async def query_data_types(
-        self, query: DataTypeStructuralQuery, *, actor: UUID | None = None
+        self,
+        query: DataTypeStructuralQuery,
+        *,
+        actor: UUID | None = None,
     ) -> Subgraph:
         """Query the HASH API for data types."""
         endpoint = self.base / "data-types" / "query"
@@ -296,7 +302,10 @@ class GraphClient:
         )
 
     async def query_entities(
-        self, query: EntityStructuralQuery, *, actor: UUID | None = None
+        self,
+        query: EntityStructuralQuery,
+        *,
+        actor: UUID | None = None,
     ) -> Subgraph:
         """Query the HASH API for entities."""
         endpoint = self.base / "entities" / "query"
@@ -310,7 +319,10 @@ class GraphClient:
         )
 
     async def create_entity(
-        self, request: CreateEntityRequest, *, actor: UUID | None = None
+        self,
+        request: CreateEntityRequest,
+        *,
+        actor: UUID | None = None,
     ) -> EntityMetadata:
         """Create an entity."""
         endpoint = self.base / "entities"
@@ -324,7 +336,10 @@ class GraphClient:
         )
 
     async def update_entity(
-        self, request: UpdateEntityRequest, *, actor: UUID | None = None
+        self,
+        request: UpdateEntityRequest,
+        *,
+        actor: UUID | None = None,
     ) -> EntityMetadata:
         """Update an entity."""
         endpoint = self.base / "entities"

--- a/libs/@local/hash-graph-client/python/graph_client/__init__.py
+++ b/libs/@local/hash-graph-client/python/graph_client/__init__.py
@@ -72,18 +72,34 @@ async def _send_request(
     return response_t.model_validate(json, strict=False)
 
 
+def _assert_not_none(value: T | None) -> T:
+    """Assert that the value is not None."""
+    if value is None:
+        msg = "value cannot be None"
+        raise ValueError(msg)
+
+    return value
+
+
 class GraphClient:
     """Low-level implementation of the client for the HASH API."""
 
     base: URL
-    actor: UUID
+    actor: UUID | None
 
-    def __init__(self, base: URL, actor: UUID) -> None:
+    def __init__(self, base: URL, *, actor: UUID | None = None) -> None:
         """Initialize the client with the base URL."""
         self.base = base
         self.actor = actor
 
-    async def query_entity_types(self, query: EntityTypeStructuralQuery) -> Subgraph:
+    def _actor(self, override: UUID | None = None) -> UUID:
+        """Get the actor for the client."""
+        actor = override or self.actor
+        return _assert_not_none(actor)
+
+    async def query_entity_types(
+        self, query: EntityTypeStructuralQuery, *, actor: UUID | None = None
+    ) -> Subgraph:
         """Query the HASH API for entity types."""
         endpoint = self.base / "entity-types" / "query"
 
@@ -91,13 +107,15 @@ class GraphClient:
             endpoint,
             "POST",
             query,
-            self.actor,
+            self._actor(actor),
             Subgraph,
         )
 
     async def load_external_entity_type(
         self,
         request: LoadExternalEntityTypeRequest,
+        *,
+        actor: UUID | None = None,
     ) -> OntologyElementMetadata:
         """Load an external entity type."""
         endpoint = self.base / "entity-types" / "load"
@@ -106,13 +124,15 @@ class GraphClient:
             endpoint,
             "POST",
             request,
-            self.actor,
+            self._actor(actor),
             OntologyElementMetadata,
         )
 
     async def create_entity_types(
         self,
         request: CreateEntityTypeRequest,
+        *,
+        actor: UUID | None = None,
     ) -> MaybeListOfOntologyElementMetadata:
         """Create an entity type."""
         endpoint = self.base / "entity-types"
@@ -121,13 +141,15 @@ class GraphClient:
             endpoint,
             "POST",
             request,
-            self.actor,
+            self._actor(actor),
             MaybeListOfOntologyElementMetadata,
         )
 
     async def update_entity_type(
         self,
         request: UpdateEntityTypeRequest,
+        *,
+        actor: UUID | None = None,
     ) -> OntologyElementMetadata:
         """Update an entity type."""
         endpoint = self.base / "entity-types"
@@ -136,13 +158,15 @@ class GraphClient:
             endpoint,
             "PUT",
             request,
-            self.actor,
+            self._actor(actor),
             OntologyElementMetadata,
         )
 
     async def query_property_types(
         self,
         query: PropertyTypeStructuralQuery,
+        *,
+        actor: UUID | None = None,
     ) -> Subgraph:
         """Query the HASH API for property types."""
         endpoint = self.base / "property-types" / "query"
@@ -151,13 +175,15 @@ class GraphClient:
             endpoint,
             "POST",
             query,
-            self.actor,
+            self._actor(actor),
             Subgraph,
         )
 
     async def load_external_property_type(
         self,
         request: LoadExternalPropertyTypeRequest,
+        *,
+        actor: UUID | None = None,
     ) -> OntologyElementMetadata:
         """Load an external property type."""
         endpoint = self.base / "property-types" / "load"
@@ -166,13 +192,15 @@ class GraphClient:
             endpoint,
             "POST",
             request,
-            self.actor,
+            self._actor(actor),
             OntologyElementMetadata,
         )
 
     async def create_property_types(
         self,
         request: CreatePropertyTypeRequest,
+        *,
+        actor: UUID | None = None,
     ) -> MaybeListOfOntologyElementMetadata:
         """Create a property type."""
         endpoint = self.base / "property-types"
@@ -181,13 +209,15 @@ class GraphClient:
             endpoint,
             "POST",
             request,
-            self.actor,
+            self._actor(actor),
             MaybeListOfOntologyElementMetadata,
         )
 
     async def update_property_type(
         self,
         request: UpdatePropertyTypeRequest,
+        *,
+        actor: UUID | None = None,
     ) -> OntologyElementMetadata:
         """Update a property type."""
         endpoint = self.base / "property-types"
@@ -196,11 +226,13 @@ class GraphClient:
             endpoint,
             "PUT",
             request,
-            self.actor,
+            self._actor(actor),
             OntologyElementMetadata,
         )
 
-    async def query_data_types(self, query: DataTypeStructuralQuery) -> Subgraph:
+    async def query_data_types(
+        self, query: DataTypeStructuralQuery, *, actor: UUID | None = None
+    ) -> Subgraph:
         """Query the HASH API for data types."""
         endpoint = self.base / "data-types" / "query"
 
@@ -208,13 +240,15 @@ class GraphClient:
             endpoint,
             "POST",
             query,
-            self.actor,
+            self._actor(actor),
             Subgraph,
         )
 
     async def load_external_data_type(
         self,
         request: LoadExternalDataTypeRequest,
+        *,
+        actor: UUID | None = None,
     ) -> OntologyElementMetadata:
         """Load an external data type."""
         endpoint = self.base / "data-types" / "load"
@@ -223,13 +257,15 @@ class GraphClient:
             endpoint,
             "POST",
             request,
-            self.actor,
+            self._actor(actor),
             OntologyElementMetadata,
         )
 
     async def create_data_types(
         self,
         request: CreateDataTypeRequest,
+        *,
+        actor: UUID | None = None,
     ) -> MaybeListOfOntologyElementMetadata:
         """Create a data type."""
         endpoint = self.base / "data-types"
@@ -238,13 +274,15 @@ class GraphClient:
             endpoint,
             "POST",
             request,
-            self.actor,
+            self._actor(actor),
             MaybeListOfOntologyElementMetadata,
         )
 
     async def update_data_type(
         self,
         request: UpdateDataTypeRequest,
+        *,
+        actor: UUID | None = None,
     ) -> OntologyElementMetadata:
         """Update a data type."""
         endpoint = self.base / "data-types"
@@ -253,11 +291,13 @@ class GraphClient:
             endpoint,
             "PUT",
             request,
-            self.actor,
+            self._actor(actor),
             OntologyElementMetadata,
         )
 
-    async def query_entities(self, query: EntityStructuralQuery) -> Subgraph:
+    async def query_entities(
+        self, query: EntityStructuralQuery, *, actor: UUID | None = None
+    ) -> Subgraph:
         """Query the HASH API for entities."""
         endpoint = self.base / "entities" / "query"
 
@@ -265,11 +305,13 @@ class GraphClient:
             endpoint,
             "POST",
             query,
-            self.actor,
+            self._actor(actor),
             Subgraph,
         )
 
-    async def create_entity(self, request: CreateEntityRequest) -> EntityMetadata:
+    async def create_entity(
+        self, request: CreateEntityRequest, *, actor: UUID | None = None
+    ) -> EntityMetadata:
         """Create an entity."""
         endpoint = self.base / "entities"
 
@@ -277,11 +319,13 @@ class GraphClient:
             endpoint,
             "POST",
             request,
-            self.actor,
+            self._actor(actor),
             EntityMetadata,
         )
 
-    async def update_entity(self, request: UpdateEntityRequest) -> EntityMetadata:
+    async def update_entity(
+        self, request: UpdateEntityRequest, *, actor: UUID | None = None
+    ) -> EntityMetadata:
         """Update an entity."""
         endpoint = self.base / "entities"
 
@@ -289,6 +333,6 @@ class GraphClient:
             endpoint,
             "PUT",
             request,
-            self.actor,
+            self._actor(actor),
             EntityMetadata,
         )

--- a/libs/@local/hash-graph-client/python/graph_client/__init__.py
+++ b/libs/@local/hash-graph-client/python/graph_client/__init__.py
@@ -91,6 +91,7 @@ class GraphClient:
             endpoint,
             "POST",
             query,
+            self.actor,
             Subgraph,
         )
 
@@ -105,6 +106,7 @@ class GraphClient:
             endpoint,
             "POST",
             request,
+            self.actor,
             OntologyElementMetadata,
         )
 
@@ -119,6 +121,7 @@ class GraphClient:
             endpoint,
             "POST",
             request,
+            self.actor,
             MaybeListOfOntologyElementMetadata,
         )
 
@@ -133,6 +136,7 @@ class GraphClient:
             endpoint,
             "PUT",
             request,
+            self.actor,
             OntologyElementMetadata,
         )
 
@@ -147,6 +151,7 @@ class GraphClient:
             endpoint,
             "POST",
             query,
+            self.actor,
             Subgraph,
         )
 
@@ -161,6 +166,7 @@ class GraphClient:
             endpoint,
             "POST",
             request,
+            self.actor,
             OntologyElementMetadata,
         )
 
@@ -175,6 +181,7 @@ class GraphClient:
             endpoint,
             "POST",
             request,
+            self.actor,
             MaybeListOfOntologyElementMetadata,
         )
 
@@ -189,6 +196,7 @@ class GraphClient:
             endpoint,
             "PUT",
             request,
+            self.actor,
             OntologyElementMetadata,
         )
 
@@ -200,6 +208,7 @@ class GraphClient:
             endpoint,
             "POST",
             query,
+            self.actor,
             Subgraph,
         )
 
@@ -214,6 +223,7 @@ class GraphClient:
             endpoint,
             "POST",
             request,
+            self.actor,
             OntologyElementMetadata,
         )
 
@@ -228,6 +238,7 @@ class GraphClient:
             endpoint,
             "POST",
             request,
+            self.actor,
             MaybeListOfOntologyElementMetadata,
         )
 
@@ -242,6 +253,7 @@ class GraphClient:
             endpoint,
             "PUT",
             request,
+            self.actor,
             OntologyElementMetadata,
         )
 
@@ -253,6 +265,7 @@ class GraphClient:
             endpoint,
             "POST",
             query,
+            self.actor,
             Subgraph,
         )
 
@@ -264,6 +277,7 @@ class GraphClient:
             endpoint,
             "POST",
             request,
+            self.actor,
             EntityMetadata,
         )
 
@@ -275,5 +289,6 @@ class GraphClient:
             endpoint,
             "PUT",
             request,
+            self.actor,
             EntityMetadata,
         )

--- a/libs/@local/hash-graph-client/python/graph_client/__init__.py
+++ b/libs/@local/hash-graph-client/python/graph_client/__init__.py
@@ -1,5 +1,6 @@
 """Client for the HASH API."""
 from typing import Literal, TypeAlias, TypeVar
+from uuid import UUID
 
 import httpx
 from pydantic import BaseModel
@@ -51,6 +52,7 @@ async def _send_request(
     endpoint: URL,
     method: Literal["POST", "PUT"],
     body: BaseModel,
+    actor: UUID,
     response_t: type[T],
 ) -> T:
     """Send a request to the HASH API."""
@@ -59,6 +61,9 @@ async def _send_request(
             method,
             str(endpoint),
             json=body.model_dump(by_alias=True, mode="json"),
+            headers={
+                "X-Authenticated-User-Actor-Id": str(actor),
+            },
         )
 
     response.raise_for_status()
@@ -71,10 +76,12 @@ class GraphClient:
     """Low-level implementation of the client for the HASH API."""
 
     base: URL
+    actor: UUID
 
-    def __init__(self, base: URL) -> None:
+    def __init__(self, base: URL, actor: UUID) -> None:
         """Initialize the client with the base URL."""
         self.base = base
+        self.actor = actor
 
     async def query_entity_types(self, query: EntityTypeStructuralQuery) -> Subgraph:
         """Query the HASH API for entity types."""

--- a/libs/@local/hash-graph-client/python/turbo.json
+++ b/libs/@local/hash-graph-client/python/turbo.json
@@ -6,7 +6,7 @@
       "outputs": ["./graph_client/models.py"]
     },
     "build": {
-      "dependsOn": ["^build", "codegen", "lint:mypy"],
+      "dependsOn": ["^build", "codegen"],
       "inputs": ["./**/*.py", "pyproject.toml", "poetry.lock", "LICENSE*"],
       "outputs": ["dist/**"]
     },
@@ -39,6 +39,7 @@
       "inputs": ["./**/*.py", "pyproject.toml"]
     },
     "lint:mypy": {
+      "dependsOn": ["build"],
       "inputs": ["./**/*.py", "pyproject.toml"]
     }
   }

--- a/libs/@local/hash-graph-client/python/turbo.json
+++ b/libs/@local/hash-graph-client/python/turbo.json
@@ -6,7 +6,7 @@
       "outputs": ["./graph_client/models.py"]
     },
     "build": {
-      "dependsOn": ["^build", "codegen"],
+      "dependsOn": ["^build", "codegen", "lint"],
       "inputs": ["./**/*.py", "pyproject.toml", "poetry.lock", "LICENSE*"],
       "outputs": ["dist/**"]
     },

--- a/libs/@local/hash-graph-client/python/turbo.json
+++ b/libs/@local/hash-graph-client/python/turbo.json
@@ -6,7 +6,7 @@
       "outputs": ["./graph_client/models.py"]
     },
     "build": {
-      "dependsOn": ["^build", "codegen", "lint"],
+      "dependsOn": ["^build", "codegen", "lint:mypy"],
       "inputs": ["./**/*.py", "pyproject.toml", "poetry.lock", "LICENSE*"],
       "outputs": ["dist/**"]
     },

--- a/libs/@local/hash-graph-sdk/python/examples/query_company_entities.py
+++ b/libs/@local/hash-graph-sdk/python/examples/query_company_entities.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 import devtools
 from yarl import URL
 
@@ -8,8 +10,9 @@ from graph_sdk.query import Parameter
 from graph_sdk.utils import filter_latest_from_subgraph
 
 COMPANY_URL = "https://blockprotocol.org/@examples/types/entity-type/company/"
+ACTOR_ID = UUID(int=0)  # replace with your actor ID
 
-client = HASHClient(URL("http://localhost:4000/"))
+client = HASHClient(URL("http://localhost:4000/"), actor=ACTOR_ID)
 
 subgraph = client.query_entities(
     EntityQueryPath().type_().base_url() == Parameter(COMPANY_URL),

--- a/libs/@local/hash-graph-sdk/python/examples/query_company_entities_limited_axes.py
+++ b/libs/@local/hash-graph-sdk/python/examples/query_company_entities_limited_axes.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from uuid import UUID
 
 import devtools
 from yarl import URL
@@ -14,8 +15,9 @@ from graph_sdk.query import Parameter
 from graph_sdk.utils import filter_latest_from_subgraph
 
 COMPANY_URL = "https://blockprotocol.org/@examples/types/entity-type/company/"
+ACTOR_ID = UUID(int=0)  # replace with your actor ID
 
-client = HASHClient(URL("http://localhost:4000/"))
+client = HASHClient(URL("http://localhost:4000/"), actor=ACTOR_ID)
 
 options = Options()
 options.temporal_axes = TemporalAxesBuilder.pinned_transaction_time(None).between(

--- a/libs/@local/hash-graph-sdk/python/examples/query_company_entity_type.py
+++ b/libs/@local/hash-graph-sdk/python/examples/query_company_entity_type.py
@@ -14,7 +14,7 @@ reference = EntityTypeReference(
 
 entity_type = async_to_sync(
     reference.create_model(
-        actor_id=UUID("00000000-0000-0000-0000-000000000000"),
+        actor_id=UUID(int=0),  # replace with your actor ID
         graph=graph,
     ),
 )

--- a/libs/@local/hash-graph-sdk/python/graph_sdk/client/blocking.py
+++ b/libs/@local/hash-graph-sdk/python/graph_sdk/client/blocking.py
@@ -62,71 +62,114 @@ class HASHClient:
 
     inner: ConcurrentHASHClient
 
-    def __init__(self, base: URL) -> None:
+    def __init__(self, base: URL, *, actor: UUID | None = None) -> None:
         """Initialize the client with the base URL."""
         self.inner = ConcurrentHASHClient(base)
 
-    def with_actor(self, actor: UUID) -> Self:
+    @property
+    def actor(self) -> UUID | None:
+        """Get the actor for the client."""
+        return self.inner.actor
+
+    @actor.setter
+    def actor(self, actor: UUID | None) -> None:
         """Set the actor for the client."""
-        self.inner.with_actor(actor)
-        return self
+        self.inner.actor = actor
 
-    def query_data_types(self, query: BaseFilter, options: Options) -> Subgraph:
+    def query_data_types(
+        self, query: BaseFilter, options: Options, *, actor: UUID | None = None
+    ) -> Subgraph:
         """Query data types."""
-        return async_to_sync(self.inner.query_data_types(query, options))
+        return async_to_sync(self.inner.query_data_types(query, options, actor=actor))
 
-    def load_external_data_type(self, url: URL) -> OntologyElementMetadata:
+    def load_external_data_type(
+        self, url: URL, *, actor: UUID | None = None
+    ) -> OntologyElementMetadata:
         """Load an external data type."""
-        return async_to_sync(self.inner.load_external_data_type(url))
+        return async_to_sync(self.inner.load_external_data_type(url, actor=actor))
 
     def create_data_types(
-        self, models: list[DataTypeSchema], owned_by_id: UUID
+        self,
+        models: list[DataTypeSchema],
+        owned_by_id: UUID,
+        *,
+        actor: UUID | None = None,
     ) -> MaybeListOfOntologyElementMetadata:
         """Create data types."""
-        return async_to_sync(self.inner.create_data_types(models, owned_by_id))
+        return async_to_sync(
+            self.inner.create_data_types(models, owned_by_id, actor=actor)
+        )
 
-    def update_data_type(self, model: DataTypeSchema) -> OntologyElementMetadata:
+    def update_data_type(
+        self, model: DataTypeSchema, *, actor: UUID | None = None
+    ) -> OntologyElementMetadata:
         """Update a data type."""
-        return async_to_sync(self.inner.update_data_type(model))
+        return async_to_sync(self.inner.update_data_type(model, actor=actor))
 
-    def query_property_types(self, query: BaseFilter, options: Options) -> Subgraph:
+    def query_property_types(
+        self, query: BaseFilter, options: Options, *, actor: UUID | None = None
+    ) -> Subgraph:
         """Query property types."""
-        return async_to_sync(self.inner.query_property_types(query, options))
+        return async_to_sync(
+            self.inner.query_property_types(query, options, actor=actor)
+        )
 
-    def load_external_property_type(self, url: URL) -> OntologyElementMetadata:
+    def load_external_property_type(
+        self, url: URL, *, actor: UUID | None = None
+    ) -> OntologyElementMetadata:
         """Load an external property type."""
-        return async_to_sync(self.inner.load_external_property_type(url))
+        return async_to_sync(self.inner.load_external_property_type(url, actor=actor))
 
     def create_property_types(
-        self, models: list[PropertyTypeSchema], owned_by_id: UUID
+        self,
+        models: list[PropertyTypeSchema],
+        owned_by_id: UUID,
+        *,
+        actor: UUID | None = None,
     ) -> MaybeListOfOntologyElementMetadata:
         """Create property types."""
-        return async_to_sync(self.inner.create_property_types(models, owned_by_id))
+        return async_to_sync(
+            self.inner.create_property_types(models, owned_by_id, actor=actor)
+        )
 
     def update_property_type(
-        self, model: PropertyTypeSchema
+        self, model: PropertyTypeSchema, *, actor: UUID | None = None
     ) -> OntologyElementMetadata:
         """Update a property type."""
-        return async_to_sync(self.inner.update_property_type(model))
+        return async_to_sync(self.inner.update_property_type(model, actor=actor))
 
-    def query_entity_types(self, query: BaseFilter, options: Options) -> Subgraph:
+    def query_entity_types(
+        self, query: BaseFilter, options: Options, *, actor: UUID | None = None
+    ) -> Subgraph:
         """Query entity types."""
-        return async_to_sync(self.inner.query_entity_types(query, options))
+        return async_to_sync(self.inner.query_entity_types(query, options, actor=actor))
 
-    def load_external_entity_type(self, url: URL) -> OntologyElementMetadata:
+    def load_external_entity_type(
+        self, url: URL, *, actor: UUID | None = None
+    ) -> OntologyElementMetadata:
         """Load an external entity type."""
-        return async_to_sync(self.inner.load_external_entity_type(url))
+        return async_to_sync(self.inner.load_external_entity_type(url, actor=actor))
 
     def create_entity_types(
-        self, models: list[EntityTypeSchema], owned_by_id: UUID
+        self,
+        models: list[EntityTypeSchema],
+        owned_by_id: UUID,
+        *,
+        actor: UUID | None = None,
     ) -> MaybeListOfOntologyElementMetadata:
         """Create entity types."""
-        return async_to_sync(self.inner.create_entity_types(models, owned_by_id))
+        return async_to_sync(
+            self.inner.create_entity_types(models, owned_by_id, actor=actor)
+        )
 
-    def update_entity_type(self, model: EntityTypeSchema) -> OntologyElementMetadata:
+    def update_entity_type(
+        self, model: EntityTypeSchema, *, actor: UUID | None = None
+    ) -> OntologyElementMetadata:
         """Update an entity type."""
-        return async_to_sync(self.inner.update_entity_type(model))
+        return async_to_sync(self.inner.update_entity_type(model, actor=actor))
 
-    def query_entities(self, query: BaseFilter, options: Options) -> Subgraph:
+    def query_entities(
+        self, query: BaseFilter, options: Options, *, actor: UUID | None = None
+    ) -> Subgraph:
         """Query entities."""
-        return async_to_sync(self.inner.query_entities(query, options))
+        return async_to_sync(self.inner.query_entities(query, options, actor=actor))

--- a/libs/@local/hash-graph-sdk/python/graph_sdk/client/concurrent.py
+++ b/libs/@local/hash-graph-sdk/python/graph_sdk/client/concurrent.py
@@ -91,7 +91,10 @@ class HASHClient:
         return await self.inner.query_data_types(request, actor=actor)
 
     async def load_external_data_type(
-        self, url: URL, *, actor: UUID | None = None,
+        self,
+        url: URL,
+        *,
+        actor: UUID | None = None,
     ) -> OntologyElementMetadata:
         """Load an external data type."""
         request = LoadExternalDataTypeRequest(
@@ -146,7 +149,10 @@ class HASHClient:
         return await self.inner.query_property_types(request, actor=actor)
 
     async def load_external_property_type(
-        self, url: URL, *, actor: UUID | None = None,
+        self,
+        url: URL,
+        *,
+        actor: UUID | None = None,
     ) -> OntologyElementMetadata:
         """Load an external property type."""
         request = LoadExternalPropertyTypeRequest(
@@ -185,7 +191,11 @@ class HASHClient:
         return await self.inner.update_property_type(request, actor=actor)
 
     async def query_entity_types(
-        self, query: BaseFilter, options: Options, *, actor: UUID | None = None,
+        self,
+        query: BaseFilter,
+        options: Options,
+        *,
+        actor: UUID | None = None,
     ) -> Subgraph:
         """Query entity types."""
         request = EntityTypeStructuralQuery(
@@ -197,7 +207,10 @@ class HASHClient:
         return await self.inner.query_entity_types(request, actor=actor)
 
     async def load_external_entity_type(
-        self, url: URL, *, actor: UUID | None = None,
+        self,
+        url: URL,
+        *,
+        actor: UUID | None = None,
     ) -> OntologyElementMetadata:
         """Load an external entity type."""
         request = LoadExternalEntityTypeRequest(
@@ -236,7 +249,11 @@ class HASHClient:
         return await self.inner.update_entity_type(request, actor=actor)
 
     async def query_entities(
-        self, query: BaseFilter, options: Options, *, actor: UUID | None = None,
+        self,
+        query: BaseFilter,
+        options: Options,
+        *,
+        actor: UUID | None = None,
     ) -> Subgraph:
         """Query entities."""
         request = EntityStructuralQuery(

--- a/libs/@local/hash-graph-sdk/python/graph_sdk/client/concurrent.py
+++ b/libs/@local/hash-graph-sdk/python/graph_sdk/client/concurrent.py
@@ -1,7 +1,5 @@
 """Concurrent (async) client for the HASH API."""
-from collections.abc import Generator
-from contextlib import contextmanager
-from typing import Self, TypeVar
+from typing import TypeVar
 from uuid import UUID
 
 from graph_client import GraphClient as LowLevelClient
@@ -22,7 +20,6 @@ from graph_client.models import (
     OwnedById,
     PropertyType,
     PropertyTypeStructuralQuery,
-    RecordCreatedById,
     Subgraph,
     UpdateDataType,
     UpdateDataTypeRequest,
@@ -52,15 +49,6 @@ def assert_not_none(value: T | None) -> T:
     return value
 
 
-@contextmanager
-def with_actor(client: "HASHClient", actor: UUID) -> Generator[None, None, None]:
-    """Context manager for setting the actor on the client."""
-    old_actor = client.actor
-    client.actor = actor
-    yield
-    client.actor = old_actor
-
-
 # TODO: H-351: Use hash_graph_client for create_entity
 #   https://linear.app/hash/issue/H-351
 class HASHClient:
@@ -70,22 +58,28 @@ class HASHClient:
     """
 
     inner: LowLevelClient
-    actor: UUID | None = None
 
-    def __init__(self, base: URL) -> None:
+    def __init__(self, base: URL, *, actor: UUID | None = None) -> None:
         """Initialize the client with the base URL."""
-        self.inner = LowLevelClient(base)
+        self.inner = LowLevelClient(base, actor=actor)
         self.actor = None
 
-    def with_actor(self, actor: UUID) -> Self:
+    @property
+    def actor(self) -> UUID | None:
+        """Get the actor for the client."""
+        return self.inner.actor
+
+    @actor.setter
+    def actor(self, actor: UUID | None) -> None:
         """Set the actor for the client."""
-        self.actor = actor
-        return self
+        self.inner.actor = actor
 
     async def query_data_types(
         self,
         query: BaseFilter,
         options: Options,
+        *,
+        actor: UUID | None = None,
     ) -> Subgraph:
         """Query data types."""
         request = DataTypeStructuralQuery(
@@ -94,54 +88,53 @@ class HASHClient:
             temporal_axes=options.temporal_axes,
         )
 
-        return await self.inner.query_data_types(request)
+        return await self.inner.query_data_types(request, actor=actor)
 
-    async def load_external_data_type(self, url: URL) -> OntologyElementMetadata:
+    async def load_external_data_type(
+        self, url: URL, *, actor: UUID | None = None,
+    ) -> OntologyElementMetadata:
         """Load an external data type."""
-        actor = assert_not_none(self.actor)
-
         request = LoadExternalDataTypeRequest(
             data_type_id=VersionedURL(root=Url(str(url))),
-            actor_id=RecordCreatedById(root=actor),
         )
 
-        return await self.inner.load_external_data_type(request)
+        return await self.inner.load_external_data_type(request, actor=actor)
 
     async def create_data_types(
         self,
         models: list[DataTypeSchema],
         owned_by_id: UUID,
+        *,
+        actor: UUID | None = None,
     ) -> MaybeListOfOntologyElementMetadata:
         """Create data types."""
-        actor = assert_not_none(self.actor)
-
         request = CreateDataTypeRequest(
-            actor_id=RecordCreatedById(root=actor),
             owned_by_id=OwnedById(root=owned_by_id),
             schema_=[recast(DataType, model) for model in models],
         )
 
-        return await self.inner.create_data_types(request)
+        return await self.inner.create_data_types(request, actor=actor)
 
     async def update_data_type(
         self,
         model: DataTypeSchema,
+        *,
+        actor: UUID | None = None,
     ) -> OntologyElementMetadata:
         """Update a data type."""
-        actor = assert_not_none(self.actor)
-
         request = UpdateDataTypeRequest(
-            actor_id=RecordCreatedById(root=actor),
             schema_=recast(UpdateDataType, model),
             type_to_update=VersionedURL(root=Url(model.identifier)),
         )
 
-        return await self.inner.update_data_type(request)
+        return await self.inner.update_data_type(request, actor=actor)
 
     async def query_property_types(
         self,
         query: BaseFilter,
         options: Options,
+        *,
+        actor: UUID | None = None,
     ) -> Subgraph:
         """Query property types."""
         request = PropertyTypeStructuralQuery(
@@ -150,51 +143,50 @@ class HASHClient:
             temporal_axes=options.temporal_axes,
         )
 
-        return await self.inner.query_property_types(request)
+        return await self.inner.query_property_types(request, actor=actor)
 
-    async def load_external_property_type(self, url: URL) -> OntologyElementMetadata:
+    async def load_external_property_type(
+        self, url: URL, *, actor: UUID | None = None,
+    ) -> OntologyElementMetadata:
         """Load an external property type."""
-        actor = assert_not_none(self.actor)
-
         request = LoadExternalPropertyTypeRequest(
             property_type_id=VersionedURL(root=Url(str(url))),
-            actor_id=RecordCreatedById(root=actor),
         )
 
-        return await self.inner.load_external_property_type(request)
+        return await self.inner.load_external_property_type(request, actor=actor)
 
     async def create_property_types(
         self,
         models: list[PropertyTypeSchema],
         owned_by_id: UUID,
+        *,
+        actor: UUID | None = None,
     ) -> MaybeListOfOntologyElementMetadata:
         """Create property types."""
-        actor = assert_not_none(self.actor)
-
         request = CreatePropertyTypeRequest(
-            actor_id=RecordCreatedById(root=actor),
             owned_by_id=OwnedById(root=owned_by_id),
             schema_=[recast(PropertyType, model) for model in models],
         )
 
-        return await self.inner.create_property_types(request)
+        return await self.inner.create_property_types(request, actor=actor)
 
     async def update_property_type(
         self,
         model: PropertyTypeSchema,
+        *,
+        actor: UUID | None = None,
     ) -> OntologyElementMetadata:
         """Update a property type."""
-        actor = assert_not_none(self.actor)
-
         request = UpdatePropertyTypeRequest(
-            actor_id=RecordCreatedById(root=actor),
             schema_=recast(UpdatePropertyType, model),
             type_to_update=VersionedURL(root=Url(model.identifier)),
         )
 
-        return await self.inner.update_property_type(request)
+        return await self.inner.update_property_type(request, actor=actor)
 
-    async def query_entity_types(self, query: BaseFilter, options: Options) -> Subgraph:
+    async def query_entity_types(
+        self, query: BaseFilter, options: Options, *, actor: UUID | None = None,
+    ) -> Subgraph:
         """Query entity types."""
         request = EntityTypeStructuralQuery(
             filter=query.to_ffi(),
@@ -202,51 +194,50 @@ class HASHClient:
             temporal_axes=options.temporal_axes,
         )
 
-        return await self.inner.query_entity_types(request)
+        return await self.inner.query_entity_types(request, actor=actor)
 
-    async def load_external_entity_type(self, url: URL) -> OntologyElementMetadata:
+    async def load_external_entity_type(
+        self, url: URL, *, actor: UUID | None = None,
+    ) -> OntologyElementMetadata:
         """Load an external entity type."""
-        actor = assert_not_none(self.actor)
-
         request = LoadExternalEntityTypeRequest(
             entity_type_id=VersionedURL(root=Url(str(url))),
-            actor_id=RecordCreatedById(root=actor),
         )
 
-        return await self.inner.load_external_entity_type(request)
+        return await self.inner.load_external_entity_type(request, actor=actor)
 
     async def create_entity_types(
         self,
         models: list[EntityTypeSchema],
         owned_by_id: UUID,
+        *,
+        actor: UUID | None = None,
     ) -> MaybeListOfOntologyElementMetadata:
         """Create entity types."""
-        actor = assert_not_none(self.actor)
-
         request = CreateEntityTypeRequest(
-            actor_id=RecordCreatedById(root=actor),
             owned_by_id=OwnedById(root=owned_by_id),
             schema_=[recast(EntityType, model) for model in models],
         )
 
-        return await self.inner.create_entity_types(request)
+        return await self.inner.create_entity_types(request, actor=actor)
 
     async def update_entity_type(
         self,
         model: EntityTypeSchema,
+        *,
+        actor: UUID | None = None,
     ) -> OntologyElementMetadata:
         """Update an entity type."""
-        actor = assert_not_none(self.actor)
-
         request = UpdateEntityTypeRequest(
-            actor_id=RecordCreatedById(root=actor),
             schema_=recast(UpdateEntityType, model),
             type_to_update=VersionedURL(root=Url(model.identifier)),
         )
 
-        return await self.inner.update_entity_type(request)
+        return await self.inner.update_entity_type(request, actor=actor)
 
-    async def query_entities(self, query: BaseFilter, options: Options) -> Subgraph:
+    async def query_entities(
+        self, query: BaseFilter, options: Options, *, actor: UUID | None = None,
+    ) -> Subgraph:
         """Query entities."""
         request = EntityStructuralQuery(
             filter=query.to_ffi(),
@@ -254,4 +245,4 @@ class HASHClient:
             temporal_axes=options.temporal_axes,
         )
 
-        return await self.inner.query_entities(request)
+        return await self.inner.query_entities(request, actor=actor)

--- a/libs/@local/hash-graph-sdk/python/graph_sdk/types.py
+++ b/libs/@local/hash-graph-sdk/python/graph_sdk/types.py
@@ -8,7 +8,7 @@ from graph_types import (
 )
 from yarl import URL
 
-from graph_sdk.client.concurrent import HASHClient, with_actor
+from graph_sdk.client.concurrent import HASHClient
 from graph_sdk.filter import (
     DataTypeQueryPath,
     EntityTypeQueryPath,
@@ -38,10 +38,7 @@ class TypeAPI:
         actor_id: UUID,
     ) -> DataTypeSchema:
         """Load an external data type."""
-        with with_actor(self.inner, actor_id):
-            await self.inner.load_external_data_type(
-                URL(data_type_id),
-            )
+        await self.inner.load_external_data_type(URL(data_type_id), actor=actor_id)
 
         return await self.get_data_type(
             data_type_id,
@@ -62,11 +59,11 @@ class TypeAPI:
         the actor ID to authenticate the request.
         TODO: remove this once H-136 is resolved.
         """
-        with with_actor(self.inner, actor_id):
-            subgraph = await self.inner.query_data_types(
-                DataTypeQueryPath().versioned_url() == Parameter(data_type_id),
-                Options(),
-            )
+        subgraph = await self.inner.query_data_types(
+            DataTypeQueryPath().versioned_url() == Parameter(data_type_id),
+            Options(),
+            actor=actor_id,
+        )
 
         latest = filter_latest_ontology_types_from_subgraph(subgraph)
         if not latest:
@@ -97,10 +94,10 @@ class TypeAPI:
         actor_id: UUID,
     ) -> PropertyTypeSchema:
         """Load an external property type."""
-        with with_actor(self.inner, actor_id):
-            await self.inner.load_external_property_type(
-                URL(property_type_id),
-            )
+        await self.inner.load_external_property_type(
+            URL(property_type_id),
+            actor=actor_id,
+        )
 
         return await self.get_property_type(
             property_type_id,
@@ -121,11 +118,11 @@ class TypeAPI:
         the actor ID to authenticate the request.
         TODO: remove this once H-136 is resolved.
         """
-        with with_actor(self.inner, actor_id):
-            subgraph = await self.inner.query_property_types(
-                PropertyTypeQueryPath().versioned_url() == Parameter(property_type_id),
-                Options(),
-            )
+        subgraph = await self.inner.query_property_types(
+            PropertyTypeQueryPath().versioned_url() == Parameter(property_type_id),
+            Options(),
+            actor=actor_id,
+        )
 
         latest = filter_latest_ontology_types_from_subgraph(subgraph)
         if not latest:
@@ -160,10 +157,10 @@ class TypeAPI:
         actor_id: UUID,
     ) -> EntityTypeSchema:
         """Load an external entity type."""
-        with with_actor(self.inner, actor_id):
-            await self.inner.load_external_entity_type(
-                URL(entity_type_id),
-            )
+        await self.inner.load_external_entity_type(
+            URL(entity_type_id),
+            actor=actor_id,
+        )
 
         return await self.get_entity_type(
             entity_type_id,
@@ -184,11 +181,11 @@ class TypeAPI:
         the actor ID to authenticate the request.
         TODO: remove this once H-136 is resolved.
         """
-        with with_actor(self.inner, actor_id):
-            subgraph = await self.inner.query_entity_types(
-                EntityTypeQueryPath().versioned_url() == Parameter(entity_type_id),
-                Options(),
-            )
+        subgraph = await self.inner.query_entity_types(
+            EntityTypeQueryPath().versioned_url() == Parameter(entity_type_id),
+            Options(),
+            actor=actor_id,
+        )
 
         latest = filter_latest_ontology_types_from_subgraph(subgraph)
 

--- a/libs/@local/hash-graph-sdk/python/turbo.json
+++ b/libs/@local/hash-graph-sdk/python/turbo.json
@@ -19,7 +19,7 @@
       "dependsOn": ["codegen:blocking", "codegen:filter"]
     },
     "build": {
-      "dependsOn": ["^build", "codegen"],
+      "dependsOn": ["^build", "codegen", "lint"],
       "inputs": ["./**/*.py", "pyproject.toml", "poetry.lock", "LICENSE*"],
       "outputs": ["dist/**"]
     },

--- a/libs/@local/hash-graph-sdk/python/turbo.json
+++ b/libs/@local/hash-graph-sdk/python/turbo.json
@@ -19,7 +19,7 @@
       "dependsOn": ["codegen:blocking", "codegen:filter"]
     },
     "build": {
-      "dependsOn": ["^build", "codegen", "lint"],
+      "dependsOn": ["^build", "codegen", "lint:mypy"],
       "inputs": ["./**/*.py", "pyproject.toml", "poetry.lock", "LICENSE*"],
       "outputs": ["dist/**"]
     },

--- a/libs/@local/hash-graph-sdk/python/turbo.json
+++ b/libs/@local/hash-graph-sdk/python/turbo.json
@@ -19,7 +19,7 @@
       "dependsOn": ["codegen:blocking", "codegen:filter"]
     },
     "build": {
-      "dependsOn": ["^build", "codegen", "lint:mypy"],
+      "dependsOn": ["^build", "codegen"],
       "inputs": ["./**/*.py", "pyproject.toml", "poetry.lock", "LICENSE*"],
       "outputs": ["dist/**"]
     },
@@ -52,6 +52,7 @@
       "inputs": ["./**/*.py", "pyproject.toml"]
     },
     "lint:mypy": {
+      "dependsOn": ["build"],
       "inputs": ["./**/*.py", "pyproject.toml"]
     }
   }

--- a/libs/@local/hash-graph-types/turbo.json
+++ b/libs/@local/hash-graph-types/turbo.json
@@ -2,7 +2,7 @@
   "extends": ["//"],
   "pipeline": {
     "build": {
-      "dependsOn": ["^build", "codegen", "lint"],
+      "dependsOn": ["^build", "codegen", "lint:mypy"],
       "inputs": ["./**/*.py", "pyproject.toml", "poetry.lock", "LICENSE*"],
       "outputs": ["dist/**"]
     },

--- a/libs/@local/hash-graph-types/turbo.json
+++ b/libs/@local/hash-graph-types/turbo.json
@@ -2,7 +2,7 @@
   "extends": ["//"],
   "pipeline": {
     "build": {
-      "dependsOn": ["^build", "codegen"],
+      "dependsOn": ["^build", "codegen", "lint"],
       "inputs": ["./**/*.py", "pyproject.toml", "poetry.lock", "LICENSE*"],
       "outputs": ["dist/**"]
     },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This applies the recent change of #3103 to the `hash-graph-client` (and subsequently `hash-graph-sdk`) packages and _significantly_ improves the ergonomics of setting and using an actor.

As a drive-by, an issue with the `turbo.json` that was discovered in #3119 has been fixed by requiring that `lint` is a dependency of `build`.


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this
