### PR TITLE
H-749, H-750: Distinguish between `AccountId` and `AccountGroupId`

### DIFF
--- a/apps/hash-api/src/graph/knowledge/system-types/account.fields.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/account.fields.ts
@@ -28,6 +28,9 @@ export const shortnameIsRestricted: PureGraphFunction<
   return RESTRICTED_SHORTNAMES.includes(shortname);
 };
 
+// TODO: Depending on the approached chosen outlined in `get*ByShortname` functions, this function may be changed
+//       to use another function to determine existence of a shortname.
+//   see https://linear.app/hash/issue/H-757
 export const shortnameIsTaken: ImpureGraphFunction<
   { shortname: string },
   Promise<boolean>

--- a/apps/hash-api/src/graph/knowledge/system-types/file.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/file.ts
@@ -42,7 +42,7 @@ export const createFileFromUploadRequest: ImpureGraphFunction<
   const editionIdentifier = genId();
 
   const key = uploadProvider.getFileEntityStorageKey({
-    accountId: ownedById,
+    ownedById,
     editionIdentifier,
     filename: name,
   });

--- a/apps/hash-api/src/graph/knowledge/system-types/linear-user-secret.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/linear-user-secret.ts
@@ -8,6 +8,7 @@ import {
   EntityId,
   EntityRootType,
   extractOwnedByIdFromEntityId,
+  OwnedById,
   splitEntityId,
   Subgraph,
 } from "@local/hash-subgraph";
@@ -58,15 +59,15 @@ export const getLinearUserSecretFromEntity: PureGraphFunction<
  * Get a Linear user secret by the linear org ID
  */
 export const getLinearUserSecretByLinearOrgId: ImpureGraphFunction<
-  { userAccountId: AccountId; linearOrgId: string },
+  { ownedById: OwnedById; linearOrgId: string },
   Promise<LinearUserSecret>
-> = async ({ graphApi }, { actorId }, { userAccountId, linearOrgId }) => {
+> = async ({ graphApi }, { actorId }, { ownedById, linearOrgId }) => {
   const entities = await graphApi
     .getEntitiesByQuery(actorId, {
       filter: {
         all: [
           {
-            equal: [{ path: ["ownedById"] }, { parameter: userAccountId }],
+            equal: [{ path: ["ownedById"] }, { parameter: ownedById }],
           },
           {
             equal: [
@@ -203,7 +204,7 @@ export const getLinearSecretValueByHashWorkspaceId: ImpureGraphFunction<
       linearOrgId: integrationEntity.properties[
         SYSTEM_TYPES.propertyType.linearOrgId.metadata.recordId.baseUrl
       ] as string,
-      userAccountId: extractOwnedByIdFromEntityId(
+      ownedById: extractOwnedByIdFromEntityId(
         integrationEntity.metadata.recordId.entityId,
       ),
     },

--- a/apps/hash-api/src/graph/knowledge/system-types/linear-user-secret.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/linear-user-secret.ts
@@ -3,12 +3,11 @@ import {
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import {
-  AccountEntityId,
   AccountId,
   Entity,
   EntityId,
   EntityRootType,
-  extractAccountId,
+  extractOwnedByIdFromEntityId,
   OwnedById,
   splitEntityId,
   Subgraph,
@@ -208,9 +207,9 @@ export const getLinearSecretValueByHashWorkspaceId: ImpureGraphFunction<
       linearOrgId: integrationEntity.properties[
         SYSTEM_TYPES.propertyType.linearOrgId.metadata.recordId.baseUrl
       ] as string,
-      userAccountId: extractAccountId(
-        integrationEntity.metadata.recordId.entityId as AccountEntityId,
-      ),
+      userAccountId: extractOwnedByIdFromEntityId(
+        integrationEntity.metadata.recordId.entityId,
+      ) as AccountId,
     },
   );
 

--- a/apps/hash-api/src/graph/knowledge/system-types/linear-user-secret.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/linear-user-secret.ts
@@ -3,7 +3,6 @@ import {
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import {
-  AccountId,
   Entity,
   EntityId,
   EntityRootType,

--- a/apps/hash-api/src/graph/knowledge/system-types/linear-user-secret.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/linear-user-secret.ts
@@ -3,10 +3,12 @@ import {
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import {
+  AccountEntityId,
+  AccountId,
   Entity,
   EntityId,
   EntityRootType,
-  extractOwnedByIdFromEntityId,
+  extractAccountId,
   OwnedById,
   splitEntityId,
   Subgraph,
@@ -58,15 +60,18 @@ export const getLinearUserSecretFromEntity: PureGraphFunction<
  * Get a Linear user secret by the linear org ID
  */
 export const getLinearUserSecretByLinearOrgId: ImpureGraphFunction<
-  { ownedById: OwnedById; linearOrgId: string },
+  { userAccountId: AccountId; linearOrgId: string },
   Promise<LinearUserSecret>
-> = async ({ graphApi }, { actorId }, { ownedById, linearOrgId }) => {
+> = async ({ graphApi }, { actorId }, { userAccountId, linearOrgId }) => {
   const entities = await graphApi
     .getEntitiesByQuery(actorId, {
       filter: {
         all: [
           {
-            equal: [{ path: ["ownedById"] }, { parameter: ownedById }],
+            equal: [
+              { path: ["ownedById"] },
+              { parameter: userAccountId as OwnedById },
+            ],
           },
           {
             equal: [
@@ -203,8 +208,8 @@ export const getLinearSecretValueByHashWorkspaceId: ImpureGraphFunction<
       linearOrgId: integrationEntity.properties[
         SYSTEM_TYPES.propertyType.linearOrgId.metadata.recordId.baseUrl
       ] as string,
-      ownedById: extractOwnedByIdFromEntityId(
-        integrationEntity.metadata.recordId.entityId,
+      userAccountId: extractAccountId(
+        integrationEntity.metadata.recordId.entityId as AccountEntityId,
       ),
     },
   );

--- a/apps/hash-api/src/graph/knowledge/system-types/org-membership.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/org-membership.ts
@@ -1,9 +1,4 @@
-import {
-  EntityId,
-  extractEntityUuidFromEntityId,
-  OwnedById,
-  Uuid,
-} from "@local/hash-subgraph";
+import { EntityId, extractOwnedByIdFromEntityId } from "@local/hash-subgraph";
 
 import { EntityTypeMismatchError } from "../../../lib/error";
 import { ImpureGraphFunction, PureGraphFunction } from "../..";
@@ -65,7 +60,7 @@ export const createOrgMembership: ImpureGraphFunction<
   Promise<OrgMembership>
 > = async (ctx, authentication, { userEntityId, orgEntityId }) => {
   const linkEntity = await createLinkEntity(ctx, authentication, {
-    ownedById: extractEntityUuidFromEntityId(orgEntityId) as Uuid as OwnedById,
+    ownedById: extractOwnedByIdFromEntityId(orgEntityId),
     linkEntityType: SYSTEM_TYPES.linkEntityType.orgMembership,
     leftEntityId: userEntityId,
     rightEntityId: orgEntityId,

--- a/apps/hash-api/src/graph/knowledge/system-types/org-membership.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/org-membership.ts
@@ -1,4 +1,9 @@
-import { EntityId, extractOwnedByIdFromEntityId } from "@local/hash-subgraph";
+import {
+  AccountGroupEntityId,
+  EntityId,
+  extractAccountGroupId,
+  OwnedById,
+} from "@local/hash-subgraph";
 
 import { EntityTypeMismatchError } from "../../../lib/error";
 import { ImpureGraphFunction, PureGraphFunction } from "../..";
@@ -60,7 +65,9 @@ export const createOrgMembership: ImpureGraphFunction<
   Promise<OrgMembership>
 > = async (ctx, authentication, { userEntityId, orgEntityId }) => {
   const linkEntity = await createLinkEntity(ctx, authentication, {
-    ownedById: extractOwnedByIdFromEntityId(orgEntityId),
+    ownedById: extractAccountGroupId(
+      orgEntityId as AccountGroupEntityId,
+    ) as OwnedById,
     linkEntityType: SYSTEM_TYPES.linkEntityType.orgMembership,
     leftEntityId: userEntityId,
     rightEntityId: orgEntityId,

--- a/apps/hash-api/src/graph/knowledge/system-types/org.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/org.ts
@@ -3,6 +3,7 @@ import {
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import {
+  AccountGroupEntityId,
   AccountGroupId,
   AccountId,
   Entity,
@@ -10,10 +11,9 @@ import {
   EntityPropertiesObject,
   EntityRootType,
   EntityUuid,
-  extractEntityUuidFromEntityId,
+  extractAccountGroupId,
   OwnedById,
   Subgraph,
-  Uuid,
 } from "@local/hash-subgraph";
 import { getRoots } from "@local/hash-subgraph/stdlib";
 
@@ -50,7 +50,7 @@ export type OrgProvidedInfo = {
 };
 
 export type Org = {
-  accountId: AccountId;
+  accountGroupId: AccountGroupId;
   orgName: string;
   shortname: string;
   entity: Entity;
@@ -76,9 +76,9 @@ export const getOrgFromEntity: PureGraphFunction<{ entity: Entity }, Org> = ({
   ] as string;
 
   return {
-    accountId: extractEntityUuidFromEntityId(
-      entity.metadata.recordId.entityId,
-    ) as Uuid as AccountId,
+    accountGroupId: extractAccountGroupId(
+      entity.metadata.recordId.entityId as AccountGroupEntityId,
+    ),
     shortname,
     orgName,
     entity,

--- a/apps/hash-api/src/graph/knowledge/system-types/org.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/org.ts
@@ -3,6 +3,7 @@ import {
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import {
+  AccountGroupId,
   AccountId,
   Entity,
   EntityId,
@@ -90,7 +91,6 @@ export const getOrgFromEntity: PureGraphFunction<{ entity: Entity }, Org> = ({
  * @param params.shortname - the shortname of the organization
  * @param params.name - the name of the organization
  * @param params.providedInfo - optional metadata about the organization
- * @param params.orgAccountId - the account Id of the org
  * @param params.website - the website of the organization
  *
  * @see {@link createEntity} for the documentation of the remaining parameters
@@ -115,14 +115,18 @@ export const createOrg: ImpureGraphFunction<
     shortnameIsRestricted({ shortname }) ||
     (await shortnameIsTaken(ctx, authentication, { shortname }))
   ) {
-    throw new Error(`An account with shortname "${shortname}" already exists.`);
+    throw new Error(
+      `An account or an account group with shortname "${shortname}" already exists.`,
+    );
   }
 
   const { graphApi } = ctx;
 
-  const orgAccountId =
+  const orgAccountGroupId =
     params.orgAccountId ??
-    (await graphApi.createAccountId(authentication.actorId)).data;
+    (await graphApi
+      .createAccountGroup(authentication.actorId)
+      .then(({ data: accountGroupId }) => accountGroupId as AccountGroupId));
 
   const properties: EntityPropertiesObject = {
     [SYSTEM_TYPES.propertyType.shortname.metadata.recordId.baseUrl]: shortname,
@@ -148,7 +152,7 @@ export const createOrg: ImpureGraphFunction<
     ownedById: systemUserAccountId as OwnedById,
     properties,
     entityTypeId: SYSTEM_TYPES.entityType.org.schema.$id,
-    entityUuid: orgAccountId as EntityUuid,
+    entityUuid: orgAccountGroupId as string as EntityUuid,
   });
 
   return getOrgFromEntity({ entity });
@@ -203,6 +207,10 @@ export const getOrgByShortname: ImpureGraphFunction<
         ],
       },
       graphResolveDepths: zeroedGraphResolveDepths,
+      // TODO: Should this be an all-time query? What happens if the org is
+      //       archived/deleted, do we want to allow orgs to replace their
+      //       shortname?
+      //   see https://linear.app/hash/issue/H-757
       temporalAxes: currentTimeInstantTemporalAxes,
     })
     .then(({ data: userEntitiesSubgraph }) =>

--- a/apps/hash-api/src/graph/knowledge/system-types/page.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/page.ts
@@ -241,13 +241,13 @@ export const isPageArchived: ImpureGraphFunction<
  */
 export const getAllPagesInWorkspace: ImpureGraphFunction<
   {
-    accountId: AccountId;
+    ownedById: OwnedById;
     includeArchived?: boolean;
   },
   Promise<Page[]>
 > = async (ctx, authentication, params) => {
   const { graphApi } = ctx;
-  const { accountId, includeArchived = false } = params;
+  const { ownedById, includeArchived = false } = params;
   const pageEntities = await graphApi
     .getEntitiesByQuery(authentication.actorId, {
       filter: {
@@ -259,7 +259,7 @@ export const getAllPagesInWorkspace: ImpureGraphFunction<
             ],
           },
           {
-            equal: [{ path: ["ownedById"] }, { parameter: accountId }],
+            equal: [{ path: ["ownedById"] }, { parameter: ownedById }],
           },
         ],
       },

--- a/apps/hash-api/src/graph/knowledge/system-types/page.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/page.ts
@@ -5,7 +5,6 @@ import {
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import {
-  AccountId,
   Entity,
   EntityId,
   EntityPropertiesObject,

--- a/apps/hash-api/src/graph/knowledge/system-types/user.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user.ts
@@ -3,16 +3,17 @@ import {
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import {
+  AccountEntityId,
   AccountId,
   Entity,
   EntityId,
   EntityPropertiesObject,
   EntityRootType,
   EntityUuid,
+  extractAccountId,
   extractEntityUuidFromEntityId,
   OwnedById,
   Subgraph,
-  Uuid,
 } from "@local/hash-subgraph";
 import { getRoots } from "@local/hash-subgraph/stdlib";
 
@@ -87,9 +88,9 @@ export const getUserFromEntity: PureGraphFunction<{ entity: Entity }, User> = ({
   const isAccountSignupComplete = !!shortname && !!preferredName;
 
   return {
-    accountId: extractEntityUuidFromEntityId(
-      entity.metadata.recordId.entityId,
-    ) as Uuid as AccountId,
+    accountId: extractAccountId(
+      entity.metadata.recordId.entityId as AccountEntityId,
+    ),
     shortname,
     preferredName,
     isAccountSignupComplete,

--- a/apps/hash-api/src/graph/system-user.ts
+++ b/apps/hash-api/src/graph/system-user.ts
@@ -73,8 +73,9 @@ export const ensureSystemUserAccountIdExists = async (params: {
     );
   } else {
     // The account id generated here is the very origin on all `AccountId` instances.
-    systemUserAccountId = (await graphApi.createAccountId(publicUserAccountId))
-      .data as AccountId;
+    systemUserAccountId = await graphApi
+      .createAccount(publicUserAccountId)
+      .then(({ data: accountId }) => accountId as AccountId);
     logger.info(`Created system user account id: ${systemUserAccountId}`);
   }
 };

--- a/apps/hash-api/src/graphql/resolvers/integrations/linear/linear-organization.ts
+++ b/apps/hash-api/src/graphql/resolvers/integrations/linear/linear-organization.ts
@@ -1,3 +1,5 @@
+import { OwnedById } from "@local/hash-subgraph";
+
 import { getLinearUserSecretByLinearOrgId } from "../../../../graph/knowledge/system-types/linear-user-secret";
 import { getOrganization, listTeams } from "../../../../integrations/linear";
 import {
@@ -17,7 +19,7 @@ export const getLinearOrganizationResolver: ResolverFn<
     dataSources,
     authentication,
     {
-      userAccountId: user.accountId,
+      ownedById: user.accountId as OwnedById,
       linearOrgId: params.linearOrgId,
     },
   );

--- a/apps/hash-api/src/graphql/resolvers/integrations/linear/linear-organization.ts
+++ b/apps/hash-api/src/graphql/resolvers/integrations/linear/linear-organization.ts
@@ -1,5 +1,3 @@
-import { OwnedById } from "@local/hash-subgraph";
-
 import { getLinearUserSecretByLinearOrgId } from "../../../../graph/knowledge/system-types/linear-user-secret";
 import { getOrganization, listTeams } from "../../../../integrations/linear";
 import {
@@ -19,7 +17,7 @@ export const getLinearOrganizationResolver: ResolverFn<
     dataSources,
     authentication,
     {
-      ownedById: user.accountId as OwnedById,
+      userAccountId: user.accountId,
       linearOrgId: params.linearOrgId,
     },
   );

--- a/apps/hash-api/src/graphql/resolvers/integrations/linear/sync-workspaces-with-teams.ts
+++ b/apps/hash-api/src/graphql/resolvers/integrations/linear/sync-workspaces-with-teams.ts
@@ -1,4 +1,9 @@
-import { Entity, extractOwnedByIdFromEntityId } from "@local/hash-subgraph";
+import {
+  AccountEntityId,
+  Entity,
+  extractAccountId,
+  extractOwnedByIdFromEntityId,
+} from "@local/hash-subgraph";
 
 import { archiveEntity } from "../../../../graph/knowledge/primitive/entity";
 import {
@@ -40,15 +45,15 @@ export const syncLinearIntegrationWithWorkspacesMutation: ResolverFn<
     },
   );
 
-  const ownedById = extractOwnedByIdFromEntityId(
-    linearIntegration.entity.metadata.recordId.entityId,
+  const userAccountId = extractAccountId(
+    linearIntegration.entity.metadata.recordId.entityId as AccountEntityId,
   );
 
   const linearUserSecret = await getLinearUserSecretByLinearOrgId(
     dataSources,
     authentication,
     {
-      ownedById,
+      userAccountId,
       linearOrgId: linearIntegration.linearOrgId,
     },
   );

--- a/apps/hash-api/src/graphql/resolvers/integrations/linear/sync-workspaces-with-teams.ts
+++ b/apps/hash-api/src/graphql/resolvers/integrations/linear/sync-workspaces-with-teams.ts
@@ -1,10 +1,4 @@
-import {
-  AccountId,
-  Entity,
-  extractEntityUuidFromEntityId,
-  extractOwnedByIdFromEntityId,
-  Uuid,
-} from "@local/hash-subgraph";
+import { Entity, extractOwnedByIdFromEntityId } from "@local/hash-subgraph";
 
 import { archiveEntity } from "../../../../graph/knowledge/primitive/entity";
 import {

--- a/apps/hash-api/src/graphql/resolvers/integrations/linear/sync-workspaces-with-teams.ts
+++ b/apps/hash-api/src/graphql/resolvers/integrations/linear/sync-workspaces-with-teams.ts
@@ -2,7 +2,9 @@ import {
   AccountEntityId,
   Entity,
   extractAccountId,
-  extractOwnedByIdFromEntityId,
+  extractEntityUuidFromEntityId,
+  OwnedById,
+  Uuid,
 } from "@local/hash-subgraph";
 
 import { archiveEntity } from "../../../../graph/knowledge/primitive/entity";
@@ -90,8 +92,9 @@ export const syncLinearIntegrationWithWorkspacesMutation: ResolverFn<
       }),
     ),
     ...syncWithWorkspaces.map(async ({ workspaceEntityId, linearTeamIds }) => {
-      const workspaceOwnedById =
-        extractOwnedByIdFromEntityId(workspaceEntityId);
+      const workspaceOwnedById = extractEntityUuidFromEntityId(
+        workspaceEntityId,
+      ) as Uuid as OwnedById;
       return Promise.all([
         linearClient.triggerWorkspaceSync({
           authentication,

--- a/apps/hash-api/src/graphql/resolvers/integrations/linear/sync-workspaces-with-teams.ts
+++ b/apps/hash-api/src/graphql/resolvers/integrations/linear/sync-workspaces-with-teams.ts
@@ -46,7 +46,7 @@ export const syncLinearIntegrationWithWorkspacesMutation: ResolverFn<
     },
   );
 
-  const userAccountId = extractOwnedByIdFromEntityId(
+  const ownedById = extractOwnedByIdFromEntityId(
     linearIntegration.entity.metadata.recordId.entityId,
   );
 
@@ -54,7 +54,7 @@ export const syncLinearIntegrationWithWorkspacesMutation: ResolverFn<
     dataSources,
     authentication,
     {
-      userAccountId,
+      ownedById,
       linearOrgId: linearIntegration.linearOrgId,
     },
   );
@@ -91,13 +91,12 @@ export const syncLinearIntegrationWithWorkspacesMutation: ResolverFn<
       }),
     ),
     ...syncWithWorkspaces.map(async ({ workspaceEntityId, linearTeamIds }) => {
-      const workspaceAccountId = extractEntityUuidFromEntityId(
-        workspaceEntityId,
-      ) as Uuid as AccountId;
+      const workspaceOwnedById =
+        extractOwnedByIdFromEntityId(workspaceEntityId);
       return Promise.all([
         linearClient.triggerWorkspaceSync({
           authentication,
-          workspaceAccountId,
+          workspaceOwnedById,
           teamIds: linearTeamIds,
         }),
         linkIntegrationToWorkspace(dataSources, authentication, {

--- a/apps/hash-api/src/graphql/resolvers/integrations/linear/sync-workspaces-with-teams.ts
+++ b/apps/hash-api/src/graphql/resolvers/integrations/linear/sync-workspaces-with-teams.ts
@@ -1,8 +1,8 @@
 import {
-  AccountEntityId,
+  AccountId,
   Entity,
-  extractAccountId,
   extractEntityUuidFromEntityId,
+  extractOwnedByIdFromEntityId,
   OwnedById,
   Uuid,
 } from "@local/hash-subgraph";
@@ -47,9 +47,9 @@ export const syncLinearIntegrationWithWorkspacesMutation: ResolverFn<
     },
   );
 
-  const userAccountId = extractAccountId(
-    linearIntegration.entity.metadata.recordId.entityId as AccountEntityId,
-  );
+  const userAccountId = extractOwnedByIdFromEntityId(
+    linearIntegration.entity.metadata.recordId.entityId,
+  ) as AccountId;
 
   const linearUserSecret = await getLinearUserSecretByLinearOrgId(
     dataSources,

--- a/apps/hash-api/src/graphql/resolvers/knowledge/page/page.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/page/page.ts
@@ -1,3 +1,5 @@
+import { OwnedById } from "@local/hash-subgraph";
+
 import {
   createPage,
   getAllPagesInWorkspace,
@@ -88,7 +90,7 @@ export const pagesResolver: ResolverFn<
   const accountId = ownedById ?? user.accountId;
 
   const pages = await getAllPagesInWorkspace(context, authentication, {
-    accountId,
+    ownedById: accountId as OwnedById,
     includeArchived: includeArchived ?? false,
   });
 

--- a/apps/hash-api/src/graphql/resolvers/knowledge/page/update-page-contents.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/page/update-page-contents.ts
@@ -68,6 +68,7 @@ export const updatePageContents: ResolverFn<
   const placeholderResults = new PlaceholderResultsMap();
 
   const createEntityWithPlaceholders = createEntityWithPlaceholdersFn(
+    authentication,
     context,
     placeholderResults,
   );

--- a/apps/hash-api/src/integrations/linear.ts
+++ b/apps/hash-api/src/integrations/linear.ts
@@ -1,6 +1,6 @@
 import { LinearClient, Organization, Team } from "@linear/sdk";
 import { SyncWorkspaceWorkflow } from "@local/hash-backend-utils/temporal-workflow-types";
-import { AccountId, OwnedById } from "@local/hash-subgraph";
+import { OwnedById } from "@local/hash-subgraph";
 
 import { AuthenticationContext } from "../graphql/context";
 import { TemporalClient } from "../temporal";

--- a/apps/hash-api/src/integrations/linear.ts
+++ b/apps/hash-api/src/integrations/linear.ts
@@ -1,6 +1,6 @@
 import { LinearClient, Organization, Team } from "@linear/sdk";
 import { SyncWorkspaceWorkflow } from "@local/hash-backend-utils/temporal-workflow-types";
-import { AccountId } from "@local/hash-subgraph";
+import { AccountId, OwnedById } from "@local/hash-subgraph";
 
 import { AuthenticationContext } from "../graphql/context";
 import { TemporalClient } from "../temporal";
@@ -45,7 +45,7 @@ export class Linear {
 
   public async triggerWorkspaceSync(params: {
     authentication: AuthenticationContext;
-    workspaceAccountId: AccountId;
+    workspaceOwnedById: OwnedById;
     teamIds: string[];
   }): Promise<void> {
     // TODO: Implement error handling

--- a/apps/hash-api/src/integrations/linear/sync-back.ts
+++ b/apps/hash-api/src/integrations/linear/sync-back.ts
@@ -52,7 +52,10 @@ export const processEntityChange = async (
   const owningAccountUuId = extractOwnedByIdFromEntityId(
     entity.metadata.recordId.entityId,
   );
-  const authentication = { actorId: owningAccountUuId };
+
+  // @todo: Figure out who the actor should be
+  //    see https://linear.app/hash/issue/H-756
+  const authentication = { actorId: systemUserAccountId };
 
   const linearApiKey = await getLinearSecretValueByHashWorkspaceId(
     { graphApi, uploadProvider: null as any }, // @todo uploadProvider shouldn't be required

--- a/apps/hash-api/src/integrations/linear/sync-back.ts
+++ b/apps/hash-api/src/integrations/linear/sync-back.ts
@@ -55,7 +55,9 @@ export const processEntityChange = async (
 
   // @todo: Figure out who the actor should be
   //    see https://linear.app/hash/issue/H-756
-  const authentication = { actorId: systemUserAccountId };
+  const authentication = {
+    actorId: entity.metadata.provenance.recordCreatedById,
+  };
 
   const linearApiKey = await getLinearSecretValueByHashWorkspaceId(
     { graphApi, uploadProvider: null as any }, // @todo uploadProvider shouldn't be required

--- a/apps/hash-api/src/seed-data/index.ts
+++ b/apps/hash-api/src/seed-data/index.ts
@@ -1,4 +1,5 @@
 import { Logger } from "@local/hash-backend-utils/logger";
+import { OwnedById } from "@local/hash-subgraph";
 
 import { ImpureGraphContext } from "../graph";
 import {
@@ -55,7 +56,7 @@ const seedOrg = async (params: {
     },
   ];
 
-  await seedPages(pageTitles, sharedOrg.accountId, params);
+  await seedPages(pageTitles, sharedOrg.accountGroupId as OwnedById, params);
 
   logger.info(
     `Development Org with shortname = "${sharedOrg.shortname}" now has seeded pages.`,
@@ -108,7 +109,7 @@ export const seedOrgsAndUsers = async (params: {
         },
       ];
 
-      await seedPages(pageTitles, user.accountId, params);
+      await seedPages(pageTitles, user.accountId as OwnedById, params);
       logger.info(
         `Seeded User with shortname = "${user.shortname}" now has seeded pages.`,
       );

--- a/apps/hash-api/src/seed-data/seed-pages.ts
+++ b/apps/hash-api/src/seed-data/seed-pages.ts
@@ -1,5 +1,5 @@
 import { Logger } from "@local/hash-backend-utils/logger";
-import { AccountId, OwnedById } from "@local/hash-subgraph";
+import { OwnedById } from "@local/hash-subgraph";
 
 import { ImpureGraphContext } from "../graph";
 import {
@@ -7,6 +7,7 @@ import {
   Page,
   setPageParentPage,
 } from "../graph/knowledge/system-types/page";
+import { systemUserAccountId } from "../graph/system-user";
 
 export type PageDefinition = {
   title: string;
@@ -15,7 +16,7 @@ export type PageDefinition = {
 
 export const seedPages = async (
   pageDefinitions: PageDefinition[],
-  owningActorId: AccountId,
+  ownedById: OwnedById,
   sharedParams: {
     logger: Logger;
     context: ImpureGraphContext;
@@ -23,13 +24,13 @@ export const seedPages = async (
   parentPage?: Page,
 ) => {
   const { context } = sharedParams;
-  const authentication = { actorId: owningActorId };
+  const authentication = { actorId: systemUserAccountId };
 
   let prevIndex: string | undefined;
 
   for (const pageDefinition of pageDefinitions) {
     const newPage: Page = await createPage(context, authentication, {
-      ownedById: owningActorId as OwnedById,
+      ownedById,
       title: pageDefinition.title,
       prevIndex,
     });
@@ -48,7 +49,7 @@ export const seedPages = async (
     if (pageDefinition.nestedPages) {
       await seedPages(
         pageDefinition.nestedPages,
-        owningActorId,
+        ownedById,
         sharedParams,
         newPage,
       );

--- a/apps/hash-api/src/storage/aws-s3-storage-provider.ts
+++ b/apps/hash-api/src/storage/aws-s3-storage-provider.ts
@@ -53,10 +53,10 @@ export class AwsS3StorageProvider implements UploadableStorageProvider {
   }
 
   getFileEntityStorageKey({
-    accountId,
+    ownedById,
     editionIdentifier,
     filename,
   }: GetFileEntityStorageKeyParams) {
-    return `files/${accountId}/${editionIdentifier}/${filename}`;
+    return `files/${ownedById}/${editionIdentifier}/${filename}`;
   }
 }

--- a/apps/hash-api/src/storage/local-file-storage.ts
+++ b/apps/hash-api/src/storage/local-file-storage.ts
@@ -76,17 +76,17 @@ export class LocalFileSystemStorageProvider implements StorageProvider {
   }
 
   getFileEntityStorageKey({
-    accountId,
+    ownedById,
     editionIdentifier,
     filename,
   }: GetFileEntityStorageKeyParams) {
-    const folder = `${accountId}/${editionIdentifier}`;
+    const folder = `${ownedById}/${editionIdentifier}`;
 
     if (!fs.existsSync(path.join(this.fileUploadPath, folder))) {
       fs.mkdirSync(path.join(this.fileUploadPath, folder), { recursive: true });
     }
 
-    return `${accountId}/${editionIdentifier}/${filename}`;
+    return `${ownedById}/${editionIdentifier}/${filename}`;
   }
 
   /** Sets up express routes required for uploading and downloading files */

--- a/apps/hash-api/src/storage/storage-provider.ts
+++ b/apps/hash-api/src/storage/storage-provider.ts
@@ -1,4 +1,4 @@
-import { AccountId } from "@local/hash-subgraph";
+import { OwnedById } from "@local/hash-subgraph";
 import { DataSource } from "apollo-datasource";
 
 export enum StorageType {
@@ -21,7 +21,7 @@ export interface StorageProvider {
 }
 
 export interface GetFileEntityStorageKeyParams {
-  accountId: AccountId;
+  ownedById: OwnedById;
   editionIdentifier: string;
   filename: string;
 }

--- a/apps/hash-frontend/src/blocks/page/comments/comment-text-field.tsx
+++ b/apps/hash-frontend/src/blocks/page/comments/comment-text-field.tsx
@@ -74,7 +74,7 @@ export const CommentTextField: FunctionComponent<CommentTextFieldProps> = ({
 }) => {
   const viewRef = useRef<EditorView>();
   const [portals, renderPortal] = usePortals();
-  const { activeWorkspaceAccountId } = useContext(WorkspaceContext);
+  const { activeWorkspaceOwnedById } = useContext(WorkspaceContext);
   const editorContainerRef = useRef<HTMLDivElement>();
   const editableRef = useRef(false);
   const eventsRef = useRef({ onClose, onSubmit, onLineCountChange });
@@ -100,7 +100,7 @@ export const CommentTextField: FunctionComponent<CommentTextFieldProps> = ({
   useEffect(() => {
     const editorContainer = editorContainerRef.current;
 
-    if (editorContainer && activeWorkspaceAccountId) {
+    if (editorContainer && activeWorkspaceOwnedById) {
       const schema = createSchema({
         doc: {
           content: "inline*",
@@ -133,7 +133,7 @@ export const CommentTextField: FunctionComponent<CommentTextFieldProps> = ({
           formatKeymap(schema),
           createSuggester(
             renderPortal,
-            activeWorkspaceAccountId,
+            activeWorkspaceOwnedById,
             editorContainer,
           ),
           commentPlaceholderPlugin(renderPortal),
@@ -144,7 +144,7 @@ export const CommentTextField: FunctionComponent<CommentTextFieldProps> = ({
         state,
         editorContainer,
         renderPortal,
-        activeWorkspaceAccountId,
+        activeWorkspaceOwnedById,
         {
           dispatchTransaction: (tr) => {
             const newState = view.state.apply(tr);
@@ -187,7 +187,7 @@ export const CommentTextField: FunctionComponent<CommentTextFieldProps> = ({
         viewRef.current = undefined;
       };
     }
-  }, [onChange, activeWorkspaceAccountId, renderPortal]);
+  }, [onChange, activeWorkspaceOwnedById, renderPortal]);
 
   useEffect(() => {
     viewRef.current?.setProps({ editable: () => editable });

--- a/apps/hash-frontend/src/blocks/page/comments/comment-thread.tsx
+++ b/apps/hash-frontend/src/blocks/page/comments/comment-thread.tsx
@@ -1,10 +1,9 @@
 import { TextToken } from "@local/hash-graphql-shared/graphql/types";
 import { types } from "@local/hash-isomorphic-utils/ontology-types";
 import {
-  AccountId,
+  AccountEntityId,
   EntityId,
-  extractEntityUuidFromEntityId,
-  Uuid,
+  extractAccountId,
 } from "@local/hash-subgraph";
 import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
@@ -81,9 +80,9 @@ export const CommentThread: FunctionComponent<CommentThreadProps> = ({
 
   const authorId = useMemo(
     () =>
-      extractEntityUuidFromEntityId(
-        comment.author.metadata.recordId.entityId,
-      ) as Uuid as AccountId,
+      extractAccountId(
+        comment.author.metadata.recordId.entityId as AccountEntityId,
+      ),
     [comment.author],
   );
 

--- a/apps/hash-frontend/src/blocks/page/create-editor-view.ts
+++ b/apps/hash-frontend/src/blocks/page/create-editor-view.ts
@@ -12,7 +12,7 @@ import {
 // import { apiOrigin } from "@local/hash-graphql-shared/environment";
 import { ProsemirrorManager } from "@local/hash-isomorphic-utils/prosemirror-manager";
 import { save } from "@local/hash-isomorphic-utils/save";
-import { AccountId, EntityId, OwnedById } from "@local/hash-subgraph";
+import { EntityId, OwnedById } from "@local/hash-subgraph";
 import { debounce } from "lodash";
 // import applyDevTools from "prosemirror-dev-tools";
 import { Plugin, PluginKey } from "prosemirror-state";
@@ -132,7 +132,7 @@ const createSavePlugin = (
 export const createEditorView = (
   renderNode: HTMLElement,
   renderPortal: RenderPortal,
-  accountId: AccountId,
+  ownedById: OwnedById,
   pageEntityId: EntityId,
   blocks: () => ComponentIdHashBlockMap,
   readonly: boolean,
@@ -148,14 +148,14 @@ export const createEditorView = (
     ? []
     : [
         ...createFormatPlugins(renderPortal),
-        createSuggester(renderPortal, accountId, renderNode, () => manager),
+        createSuggester(renderPortal, ownedById, renderNode, () => manager),
         createPlaceholderPlugin(renderPortal),
         errorPlugin,
         createFocusPageTitlePlugin(pageTitleRef),
-        createSavePlugin(accountId as OwnedById, pageEntityId, blocks, client),
+        createSavePlugin(ownedById, pageEntityId, blocks, client),
       ];
 
-  const state = createProseMirrorState({ accountId, plugins });
+  const state = createProseMirrorState({ ownedById, plugins });
 
   let connection: EditorConnection | undefined;
 
@@ -163,7 +163,7 @@ export const createEditorView = (
     state,
     renderNode,
     renderPortal,
-    accountId,
+    ownedById,
     {
       nodeViews: {
         block(currentNode, currentView, getPos) {
@@ -190,7 +190,7 @@ export const createEditorView = (
 
   manager = new ProsemirrorManager(
     state.schema,
-    accountId,
+    ownedById,
     view,
     (block) => (node, editorView, getPos) => {
       if (typeof getPos === "boolean") {

--- a/apps/hash-frontend/src/blocks/page/create-suggester/create-suggester.tsx
+++ b/apps/hash-frontend/src/blocks/page/create-suggester/create-suggester.tsx
@@ -1,7 +1,7 @@
 import type { BlockVariant } from "@blockprotocol/core";
 import { HashBlockMeta } from "@local/hash-isomorphic-utils/blocks";
 import { ProsemirrorManager } from "@local/hash-isomorphic-utils/prosemirror-manager";
-import { AccountId, EntityId } from "@local/hash-subgraph";
+import { EntityId, OwnedById } from "@local/hash-subgraph";
 import { Popper } from "@mui/material";
 import {
   EditorState,
@@ -128,7 +128,7 @@ const docChangedInTransaction = (tr: Transaction) => {
  */
 export const createSuggester = (
   renderPortal: RenderPortal,
-  accountId: AccountId,
+  ownedById: OwnedById,
   documentRoot: HTMLElement,
   getManager?: () => ProsemirrorManager,
 ) =>
@@ -321,7 +321,7 @@ export const createSuggester = (
                 <MentionSuggester
                   search={search}
                   onChange={onMentionChange}
-                  accountId={accountId}
+                  ownedById={ownedById}
                 />
               );
           }

--- a/apps/hash-frontend/src/blocks/page/create-suggester/mention-suggester.tsx
+++ b/apps/hash-frontend/src/blocks/page/create-suggester/mention-suggester.tsx
@@ -42,7 +42,7 @@ export const MentionSuggester: FunctionComponent<MentionSuggesterProps> = ({
     accountId as OwnedById,
   );
 
-  const { activeWorkspaceAccountId } = useContext(WorkspaceContext);
+  const { activeWorkspaceOwnedById } = useContext(WorkspaceContext);
 
   const loading = usersLoading && pagesLoading && entitiesLoading;
 
@@ -54,8 +54,8 @@ export const MentionSuggester: FunctionComponent<MentionSuggesterProps> = ({
         entityId: user.entityRecordId.entityId,
         mentionType: "user",
         isActiveOrgMember: user.memberOf.some(
-          ({ accountId: userAccountId }) =>
-            userAccountId === activeWorkspaceAccountId,
+          ({ accountGroupId: orgGroupId }) =>
+            orgGroupId === activeWorkspaceOwnedById,
         ),
       })) ?? [];
 
@@ -101,7 +101,7 @@ export const MentionSuggester: FunctionComponent<MentionSuggesterProps> = ({
     );
 
     return [...peopleSearch, ...pagesSearch, ...entitiesSearch];
-  }, [search, users, activeWorkspaceAccountId, pages, entities]);
+  }, [search, users, activeWorkspaceOwnedById, pages, entities]);
 
   return (
     <Suggester

--- a/apps/hash-frontend/src/blocks/page/create-suggester/mention-suggester.tsx
+++ b/apps/hash-frontend/src/blocks/page/create-suggester/mention-suggester.tsx
@@ -1,5 +1,5 @@
 import { types } from "@local/hash-isomorphic-utils/ontology-types";
-import { AccountId, EntityId, OwnedById } from "@local/hash-subgraph";
+import { EntityId, OwnedById } from "@local/hash-subgraph";
 import { Box } from "@mui/material";
 import { FunctionComponent, useContext, useMemo } from "react";
 
@@ -15,7 +15,7 @@ export type MentionType = "user" | "page" | "entity";
 export interface MentionSuggesterProps {
   search?: string;
   onChange(entityId: EntityId, mentionType: MentionType): void;
-  accountId: AccountId;
+  ownedById: OwnedById;
 }
 
 type SearchableItem = {
@@ -31,16 +31,14 @@ type SearchableItem = {
 export const MentionSuggester: FunctionComponent<MentionSuggesterProps> = ({
   search = "",
   onChange,
-  accountId,
+  ownedById,
 }) => {
   const { users, loading: usersLoading } = useUsers();
   const { entities, loading: entitiesLoading } = useAllEntitiesExcept([
     types.entityType.user.entityTypeId,
     types.entityType.page.entityTypeId,
   ]);
-  const { data: pages, loading: pagesLoading } = useAccountPages(
-    accountId as OwnedById,
-  );
+  const { data: pages, loading: pagesLoading } = useAccountPages(ownedById);
 
   const { activeWorkspaceOwnedById } = useContext(WorkspaceContext);
 

--- a/apps/hash-frontend/src/blocks/page/create-text-editor-view.ts
+++ b/apps/hash-frontend/src/blocks/page/create-text-editor-view.ts
@@ -1,4 +1,4 @@
-import { AccountId } from "@local/hash-subgraph";
+import { OwnedById } from "@local/hash-subgraph";
 import { EditorState } from "prosemirror-state";
 import { DirectEditorProps, EditorView } from "prosemirror-view";
 
@@ -10,7 +10,7 @@ export const createTextEditorView = (
   state: EditorState,
   renderNode: HTMLElement,
   renderPortal: RenderPortal,
-  accountId: AccountId,
+  ownedById: OwnedById,
   editorProps?: Partial<DirectEditorProps>,
 ) =>
   new EditorView(renderNode, {
@@ -21,6 +21,6 @@ export const createTextEditorView = (
     ),
     nodeViews: {
       ...(editorProps?.nodeViews ?? {}),
-      mention: mentionNodeView(renderPortal, accountId),
+      mention: mentionNodeView(renderPortal, ownedById),
     },
   });

--- a/apps/hash-frontend/src/blocks/page/mention-view/mention-display.tsx
+++ b/apps/hash-frontend/src/blocks/page/mention-view/mention-display.tsx
@@ -1,6 +1,5 @@
 import { systemUserShortname } from "@local/hash-isomorphic-utils/environment";
 import {
-  AccountId,
   EntityId,
   extractEntityUuidFromEntityId,
   OwnedById,
@@ -10,7 +9,7 @@ import { FunctionComponent, useMemo } from "react";
 import { useAccountPages } from "../../../components/hooks/use-account-pages";
 import { useEntityById } from "../../../components/hooks/use-entity-by-id";
 import { useUsers } from "../../../components/hooks/use-users";
-import { useWorkspaceShortnameByAccountId } from "../../../components/hooks/use-workspace-shortname-by-account-id";
+import { useWorkspaceShortnameByOwnedById } from "../../../components/hooks/use-workspace-shortname-by-owned-by-id";
 import { PageIcon } from "../../../components/page-icon";
 import { generateEntityLabel } from "../../../lib/entities";
 import { constructPageRelativeUrl } from "../../../lib/routes";
@@ -20,22 +19,20 @@ import { MentionType } from "../create-suggester/mention-suggester";
 interface MentionDisplayProps {
   entityId: EntityId;
   mentionType: MentionType;
-  accountId: AccountId;
+  ownedById: OwnedById;
 }
 
 export const MentionDisplay: FunctionComponent<MentionDisplayProps> = ({
   entityId,
   mentionType,
-  accountId,
+  ownedById,
 }) => {
   const { users, loading: usersLoading } = useUsers(true);
-  const { data: pages, loading: pagesLoading } = useAccountPages(
-    accountId as OwnedById,
-  );
+  const { data: pages, loading: pagesLoading } = useAccountPages(ownedById);
   const { loading: entityLoading, entitySubgraph } = useEntityById(entityId);
 
   const { shortname: workspaceShortname, loading: workspaceShortnameLoading } =
-    useWorkspaceShortnameByAccountId({ accountId });
+    useWorkspaceShortnameByOwnedById({ ownedById });
 
   const { title, href, icon } = useMemo(() => {
     switch (mentionType) {

--- a/apps/hash-frontend/src/blocks/page/mention-view/mention-node-view.ts
+++ b/apps/hash-frontend/src/blocks/page/mention-view/mention-node-view.ts
@@ -1,4 +1,4 @@
-import { AccountId } from "@local/hash-subgraph";
+import { OwnedById } from "@local/hash-subgraph";
 import { Node } from "prosemirror-model";
 import { EditorView } from "prosemirror-view";
 
@@ -6,7 +6,7 @@ import { RenderPortal } from "../block-portals";
 import { MentionView } from "./mention-view";
 
 export const mentionNodeView =
-  (renderPortal: RenderPortal, accountId: AccountId) =>
+  (renderPortal: RenderPortal, ownedById: OwnedById) =>
   (currentNode: Node, currentView: EditorView, getPos: () => number) => {
     if (typeof getPos === "boolean") {
       throw new Error("Invalid config for nodeview");
@@ -17,6 +17,6 @@ export const mentionNodeView =
       currentView,
       getPos,
       renderPortal,
-      accountId,
+      ownedById,
     );
   };

--- a/apps/hash-frontend/src/blocks/page/mention-view/mention-view.tsx
+++ b/apps/hash-frontend/src/blocks/page/mention-view/mention-view.tsx
@@ -1,4 +1,4 @@
-import { AccountId } from "@local/hash-subgraph";
+import { OwnedById } from "@local/hash-subgraph";
 import { Node } from "prosemirror-model";
 import { EditorView, NodeView } from "prosemirror-view";
 
@@ -13,7 +13,7 @@ export class MentionView implements NodeView {
     public view: EditorView,
     public getPos: () => number,
     public renderPortal: RenderPortal,
-    public accountId: AccountId,
+    public ownedById: OwnedById,
   ) {
     this.dom = document.createElement("span");
     this.dom.classList.add("mention-stuff");
@@ -32,7 +32,7 @@ export class MentionView implements NodeView {
       <MentionDisplay
         entityId={node.attrs.entityId}
         mentionType={node.attrs.mentionType}
-        accountId={this.accountId}
+        ownedById={this.ownedById}
       />,
       this.dom,
     );

--- a/apps/hash-frontend/src/blocks/page/page-block.tsx
+++ b/apps/hash-frontend/src/blocks/page/page-block.tsx
@@ -2,7 +2,7 @@ import "prosemirror-view/style/prosemirror.css";
 
 import { useApolloClient } from "@apollo/client";
 import { ProsemirrorManager } from "@local/hash-isomorphic-utils/prosemirror-manager";
-import { AccountId, EntityId } from "@local/hash-subgraph";
+import { EntityId } from "@local/hash-subgraph";
 import { Box } from "@mui/material";
 import { SxProps } from "@mui/system";
 import { EditorView } from "prosemirror-view";
@@ -27,7 +27,7 @@ import {
 type PageBlockProps = {
   contents: PageContentItem[];
   pageComments: PageThread[];
-  accountId: AccountId;
+  ownedById: OwnedById;
   entityId: EntityId;
 };
 
@@ -40,7 +40,7 @@ type PageBlockProps = {
 export const PageBlock: FunctionComponent<PageBlockProps> = ({
   contents,
   pageComments,
-  accountId,
+  ownedById,
   entityId,
 }) => {
   const root = useRef<HTMLDivElement>(null);
@@ -68,7 +68,7 @@ export const PageBlock: FunctionComponent<PageBlockProps> = ({
     currentBlocks.current = newestBlocks;
   }, [newestBlocks]);
 
-  const isReadonlyMode = useIsReadonlyModeForResource(accountId);
+  const isReadonlyMode = useIsReadonlyModeForResource(ownedById);
 
   const { setEditorContext, pageTitleRef } = usePageContext();
 
@@ -88,7 +88,7 @@ export const PageBlock: FunctionComponent<PageBlockProps> = ({
     const { view, connection, manager } = createEditorView(
       node,
       renderPortal,
-      accountId,
+      ownedById,
       entityId,
       () => currentBlocks.current,
       isReadonlyMode,
@@ -113,7 +113,7 @@ export const PageBlock: FunctionComponent<PageBlockProps> = ({
       prosemirrorSetup.current = null;
     };
   }, [
-    accountId,
+    ownedById,
     currentBlocks,
     entityId,
     renderPortal,

--- a/apps/hash-frontend/src/blocks/page/page-block.tsx
+++ b/apps/hash-frontend/src/blocks/page/page-block.tsx
@@ -2,7 +2,7 @@ import "prosemirror-view/style/prosemirror.css";
 
 import { useApolloClient } from "@apollo/client";
 import { ProsemirrorManager } from "@local/hash-isomorphic-utils/prosemirror-manager";
-import { EntityId } from "@local/hash-subgraph";
+import { EntityId, OwnedById } from "@local/hash-subgraph";
 import { Box } from "@mui/material";
 import { SxProps } from "@mui/system";
 import { EditorView } from "prosemirror-view";

--- a/apps/hash-frontend/src/components/block-loader/block-loader.tsx
+++ b/apps/hash-frontend/src/components/block-loader/block-loader.tsx
@@ -9,7 +9,7 @@ import { VersionedUrl } from "@blockprotocol/type-system/slim";
 import { TextToken } from "@local/hash-graphql-shared/graphql/types";
 import { HashBlockMeta } from "@local/hash-isomorphic-utils/blocks";
 import { TEXT_TOKEN_PROPERTY_TYPE_BASE_URL } from "@local/hash-isomorphic-utils/entity-store";
-import { BaseUrl, Entity, EntityId, OwnedById } from "@local/hash-subgraph";
+import { BaseUrl, Entity, EntityId } from "@local/hash-subgraph";
 import {
   FunctionComponent,
   useCallback,
@@ -60,18 +60,18 @@ export const BlockLoader: FunctionComponent<BlockLoaderProps> = ({
   wrappingEntityId,
   readonly,
 }) => {
-  const { activeWorkspaceAccountId } = useContext(WorkspaceContext);
+  const { activeWorkspaceOwnedById } = useContext(WorkspaceContext);
 
   const { queryEntities } = useBlockProtocolQueryEntities();
   const { createEntity } = useBlockProtocolCreateEntity(
-    (activeWorkspaceAccountId as OwnedById | undefined) ?? null,
+    activeWorkspaceOwnedById ?? null,
     readonly,
   );
   const { archiveEntity: deleteEntity } = useBlockProtocolArchiveEntity();
   const { getEntity } = useBlockProtocolGetEntity();
   const { updateEntity } = useBlockProtocolUpdateEntity();
   const { uploadFile } = useBlockProtocolFileUpload(
-    activeWorkspaceAccountId as OwnedById | undefined,
+    activeWorkspaceOwnedById,
     readonly,
   );
 

--- a/apps/hash-frontend/src/components/hooks/use-account-pages.ts
+++ b/apps/hash-frontend/src/components/hooks/use-account-pages.ts
@@ -16,7 +16,7 @@ export type AccountPagesInfo = {
 };
 
 export const useAccountPages = (
-  ownedById: OwnedById,
+  ownedById?: OwnedById,
   includeArchived?: boolean,
 ): AccountPagesInfo => {
   const { hashInstance } = useHashInstance();

--- a/apps/hash-frontend/src/components/hooks/use-account-pages.ts
+++ b/apps/hash-frontend/src/components/hooks/use-account-pages.ts
@@ -26,7 +26,7 @@ export const useAccountPages = (
     GetAccountPagesTreeQueryVariables
   >(getAccountPagesTree, {
     variables: { ownedById, includeArchived },
-    skip: !hashInstance?.properties.pagesAreEnabled,
+    skip: !ownedById || !hashInstance?.properties.pagesAreEnabled,
   });
 
   const pages = useMemo(() => {

--- a/apps/hash-frontend/src/components/hooks/use-get-owner-for-entity.ts
+++ b/apps/hash-frontend/src/components/hooks/use-get-owner-for-entity.ts
@@ -15,24 +15,22 @@ export const useGetOwnerForEntity = () => {
 
   return useCallback(
     (entity: Entity) => {
-      const ownerUuid = extractOwnedByIdFromEntityId(
+      const ownedById = extractOwnedByIdFromEntityId(
         entity.metadata.recordId.entityId,
       );
 
       const owner =
-        users.find((user) => ownerUuid === user.accountId) ??
-        orgs.find((org) => ownerUuid === org.accountId);
+        users.find((user) => ownedById === user.accountId) ??
+        orgs.find((org) => ownedById === org.accountGroupId);
 
       if (!owner) {
         throw new Error(
-          `Owner with accountId ${ownerUuid} not found – possibly a caching issue if it has been created mid-session`,
+          `Owner with accountId ${ownedById} not found – possibly a caching issue if it has been created mid-session`,
         );
       }
 
-      const isUser = "userAccountId" in owner;
-
       return {
-        accountId: isUser ? owner.userAccountId : owner.accountId,
+        ownedById,
         shortname: owner.shortname ?? "incomplete-user-account",
       };
     },

--- a/apps/hash-frontend/src/components/hooks/use-workspace-shortname-by-entity-uuid.ts
+++ b/apps/hash-frontend/src/components/hooks/use-workspace-shortname-by-entity-uuid.ts
@@ -9,6 +9,7 @@ import { getRoots } from "@local/hash-subgraph/stdlib";
 import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 import { useEffect, useMemo, useState } from "react";
 
+import { User } from "../../lib/user-and-org";
 import { useBlockProtocolGetEntity } from "./block-protocol-functions/knowledge/use-block-protocol-get-entity";
 import { useWorkspaceByShortname } from "./use-workspace-by-shortname";
 
@@ -26,7 +27,10 @@ export const useWorkspaceShortnameByEntityUuid = (params: {
   const {
     workspace: systemUserWorkspace,
     loading: loadingSystemUserWorkspace,
-  } = useWorkspaceByShortname(systemUserShortname);
+  } = useWorkspaceByShortname(systemUserShortname) as {
+    workspace?: User;
+    loading: boolean;
+  };
 
   const systemUserOwnedById = useMemo(
     () => systemUserWorkspace?.accountId as OwnedById | undefined,

--- a/apps/hash-frontend/src/components/hooks/use-workspace-shortname-by-owned-by-id.ts
+++ b/apps/hash-frontend/src/components/hooks/use-workspace-shortname-by-owned-by-id.ts
@@ -1,12 +1,13 @@
+import { OwnedById } from "@local/hash-subgraph";
 import { useMemo } from "react";
 
 import { useOrgs } from "./use-orgs";
 import { useUsers } from "./use-users";
 
-export const useWorkspaceShortnameByAccountId = (params: {
-  accountId: string;
+export const useWorkspaceShortnameByOwnedById = (params: {
+  ownedById: OwnedById;
 }) => {
-  const { accountId } = params;
+  const { ownedById } = params;
   /**
    * @todo: getting an org or user by their account ID should not be happening
    * client side. This could be addressed by exposing structural querying
@@ -20,10 +21,10 @@ export const useWorkspaceShortnameByAccountId = (params: {
   const shortname = useMemo(
     () =>
       (
-        orgs?.find((org) => org.accountId === accountId) ??
-        users?.find((user) => user.accountId === accountId)
+        orgs?.find((org) => org.accountGroupId === ownedById) ??
+        users?.find((user) => user.accountId === ownedById)
       )?.shortname,
-    [users, orgs, accountId],
+    [users, orgs, ownedById],
   );
 
   return { shortname, loading: loadingUsers || loadingOrgs };

--- a/apps/hash-frontend/src/lib/config.ts
+++ b/apps/hash-frontend/src/lib/config.ts
@@ -5,7 +5,7 @@ export const isProduction = process.env.NEXT_PUBLIC_VERCEL_ENV === "production";
  * keys used by HASH in the browser.
  */
 export const localStorageKeys = {
-  workspaceAccountId: "workspaceAccountId",
+  workspaceOwnedById: "workspaceOwnedById",
 } as const;
 
 export const resetLocalStorage = () => {

--- a/apps/hash-frontend/src/lib/user-and-org.ts
+++ b/apps/hash-frontend/src/lib/user-and-org.ts
@@ -17,6 +17,7 @@ import {
   entityRecordIdToString,
   extractAccountGroupId,
   extractAccountId,
+  OwnedById,
   Subgraph,
   Timestamp,
 } from "@local/hash-subgraph";
@@ -339,3 +340,18 @@ export const constructOrg = (params: {
 
   return org;
 };
+
+export const isUser = (
+  userOrOrg: MinimalUser | MinimalOrg,
+): userOrOrg is MinimalUser => "accountId" in userOrOrg;
+
+export const isOrg = (
+  userOrOrg: MinimalUser | MinimalOrg,
+): userOrOrg is MinimalOrg => "accountGroupId" in userOrOrg;
+
+export const extractOwnedById = (
+  userOrOrg: MinimalUser | MinimalOrg,
+): OwnedById =>
+  isUser(userOrOrg)
+    ? (userOrOrg.accountId as OwnedById)
+    : (userOrOrg.accountGroupId as OwnedById);

--- a/apps/hash-frontend/src/lib/user-and-org.ts
+++ b/apps/hash-frontend/src/lib/user-and-org.ts
@@ -8,11 +8,14 @@ import {
 } from "@local/hash-isomorphic-utils/system-types/shared";
 import {
   AccountEntityId,
+  AccountGroupEntityId,
+  AccountGroupId,
   AccountId,
   Entity,
   EntityRecordId,
   EntityRecordIdString,
   entityRecordIdToString,
+  extractAccountGroupId,
   extractAccountId,
   Subgraph,
   Timestamp,
@@ -188,7 +191,7 @@ export const constructAuthenticatedUser = (params: {
 export type MinimalOrg = {
   kind: "org";
   entityRecordId: EntityRecordId;
-  accountId: AccountId;
+  accountGroupId: AccountGroupId;
   description?: string;
   location?: string;
   name: string;
@@ -212,8 +215,8 @@ export const constructMinimalOrg = (params: {
   return {
     kind: "org",
     entityRecordId: orgEntity.metadata.recordId,
-    accountId: extractAccountId(
-      orgEntity.metadata.recordId.entityId as AccountEntityId,
+    accountGroupId: extractAccountGroupId(
+      orgEntity.metadata.recordId.entityId as AccountGroupEntityId,
     ),
     description,
     location,

--- a/apps/hash-frontend/src/pages/[shortname]/[page-slug].page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/[page-slug].page.tsx
@@ -18,7 +18,6 @@ import {
   EntityRootType,
   extractEntityUuidFromEntityId,
   extractOwnedByIdFromEntityId,
-  OwnedById,
   Subgraph,
 } from "@local/hash-subgraph";
 import { getRoots } from "@local/hash-subgraph/stdlib";
@@ -54,6 +53,7 @@ import { constructPageRelativeUrl } from "../../lib/routes";
 import {
   constructMinimalOrg,
   constructMinimalUser,
+  extractOwnedById,
   MinimalOrg,
   MinimalUser,
 } from "../../lib/user-and-org";
@@ -162,7 +162,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
     );
   }
 
-  const pageOwnedById = pageWorkspace.accountId as OwnedById;
+  const pageOwnedById = extractOwnedById(pageWorkspace);
 
   const pageEntityId = entityIdFromOwnedByIdAndEntityUuid(
     pageOwnedById,
@@ -442,7 +442,7 @@ const Page: NextPageWithLayout<PageProps> = ({
                 <CanvasPageBlock contents={contents} />
               ) : (
                 <PageBlock
-                  accountId={pageWorkspace.accountId}
+                  ownedById={extractOwnedById(pageWorkspace)}
                   contents={contents}
                   pageComments={pageComments}
                   entityId={pageEntityId}

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/create-entity-page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/create-entity-page.tsx
@@ -2,7 +2,6 @@ import { BaseUrl, VersionedUrl } from "@blockprotocol/type-system";
 import {
   EntityPropertiesObject,
   extractEntityUuidFromEntityId,
-  OwnedById,
 } from "@local/hash-subgraph";
 import { getRoots } from "@local/hash-subgraph/stdlib";
 import { useRouter } from "next/router";
@@ -44,10 +43,10 @@ export const CreateEntityPage = ({ entityTypeId }: CreateEntityPageProps) => {
   const [draftEntitySubgraph, setDraftEntitySubgraph, loading] =
     useDraftEntitySubgraph(entityTypeId);
 
-  const { activeWorkspace, activeWorkspaceAccountId } =
+  const { activeWorkspace, activeWorkspaceOwnedById } =
     useContext(WorkspaceContext);
   const { createEntity } = useBlockProtocolCreateEntity(
-    (activeWorkspaceAccountId as OwnedById | undefined) ?? null,
+    activeWorkspaceOwnedById ?? null,
   );
 
   const [creating, setCreating] = useState(false);

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/linked-with-cell/entity-selector.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/linked-with-cell/entity-selector.tsx
@@ -5,12 +5,7 @@ import {
   GRID_CLICK_IGNORE_CLASS,
   SelectorAutocomplete,
 } from "@hashintel/design-system";
-import {
-  Entity,
-  EntityId,
-  EntityTypeWithMetadata,
-  OwnedById,
-} from "@local/hash-subgraph";
+import { Entity, EntityId, EntityTypeWithMetadata } from "@local/hash-subgraph";
 import { getRoots } from "@local/hash-subgraph/stdlib";
 import { PaperProps, Stack, Typography } from "@mui/material";
 import {
@@ -162,11 +157,11 @@ export const EntitySelector = ({
   };
 
   const { uploadFile } = useFileUploads();
-  const { activeWorkspaceAccountId } = useContext(WorkspaceContext);
+  const { activeWorkspaceOwnedById } = useContext(WorkspaceContext);
 
   const onFileProvided = useCallback(
     async (file: File) => {
-      if (!activeWorkspaceAccountId) {
+      if (!activeWorkspaceOwnedById) {
         throw new Error("Cannot upload file without active workspace");
       }
 
@@ -175,7 +170,7 @@ export const EntitySelector = ({
 
       const upload = await uploadFile({
         fileData: { entityTypeId: expectedEntityTypes[0]?.schema.$id, file },
-        ownedById: activeWorkspaceAccountId as OwnedById,
+        ownedById: activeWorkspaceOwnedById,
         /**
          * Link creation is handled in the onSelect, since we might need to manage drafts,
          * but we supply linkEntityTypeId so we can track which files are being loaded against which link on an entity
@@ -193,7 +188,7 @@ export const EntitySelector = ({
       // @todo handle errored uploads – H-724
     },
     [
-      activeWorkspaceAccountId,
+      activeWorkspaceOwnedById,
       entityId,
       expectedEntityTypes,
       linkEntityTypeId,

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/shared/use-apply-draft-link-entity-changes.ts
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/shared/use-apply-draft-link-entity-changes.ts
@@ -1,4 +1,4 @@
-import { EntityId, OwnedById } from "@local/hash-subgraph";
+import { EntityId } from "@local/hash-subgraph";
 import { useContext } from "react";
 
 import { useBlockProtocolArchiveEntity } from "../../../../../components/hooks/block-protocol-functions/knowledge/use-block-protocol-archive-entity";
@@ -10,12 +10,12 @@ import {
 } from "./use-draft-link-state";
 
 export const useApplyDraftLinkEntityChanges = () => {
-  const { activeWorkspaceAccountId } = useContext(WorkspaceContext);
+  const { activeWorkspaceOwnedById } = useContext(WorkspaceContext);
 
   const { archiveEntity } = useBlockProtocolArchiveEntity();
 
   const { createEntity } = useBlockProtocolCreateEntity(
-    (activeWorkspaceAccountId as OwnedById | undefined) ?? null,
+    activeWorkspaceOwnedById ?? null,
   );
 
   const applyDraftLinkEntityChanges = async (

--- a/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
@@ -145,7 +145,7 @@ const Page: NextPageWithLayout = () => {
   });
 
   const userUnauthorized = useIsReadonlyModeForResource(
-    routeNamespace?.accountId,
+    routeNamespace?.accountId as OwnedById,
   );
 
   const isLatest = !requestedVersion || requestedVersion === latestVersion;

--- a/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/entities-tab.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/entities-tab.tsx
@@ -17,7 +17,7 @@ import { useEntityType } from "./shared/entity-type-context";
 export const EntitiesTab: FunctionComponent = () => {
   const { entities } = useEntityTypeEntities();
 
-  const { activeWorkspaceAccountId } = useContext(WorkspaceContext);
+  const { activeWorkspaceOwnedById } = useContext(WorkspaceContext);
 
   const entityType = useEntityType();
 
@@ -26,14 +26,14 @@ export const EntitiesTab: FunctionComponent = () => {
       entities?.filter(
         (entity) =>
           extractOwnedByIdFromEntityId(entity.metadata.recordId.entityId) ===
-          activeWorkspaceAccountId,
+          activeWorkspaceOwnedById,
       ) ?? [];
 
     return {
       namespace: namespaceEntities.length,
       public: (entities?.length ?? 0) - namespaceEntities.length,
     };
-  }, [entities, activeWorkspaceAccountId]);
+  }, [entities, activeWorkspaceOwnedById]);
 
   const isEmpty = entitiesCount.namespace + entitiesCount.public === 0;
 

--- a/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/file-uploads-tab.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/file-uploads-tab.tsx
@@ -1,7 +1,6 @@
 import { faCircleQuestion } from "@fortawesome/free-regular-svg-icons";
 import { CheckIcon } from "@hashintel/block-design-system";
 import { CloseIcon, FontAwesomeIcon } from "@hashintel/design-system";
-import { OwnedById } from "@local/hash-subgraph";
 import {
   Box,
   CircularProgress,
@@ -45,7 +44,7 @@ export const FileUploadsTab = ({ isImage }: { isImage: boolean }) => {
 
   const uploadsProgress = useFileUploadsProgress();
 
-  const { activeWorkspaceAccountId } = useContext(WorkspaceContext);
+  const { activeWorkspaceOwnedById } = useContext(WorkspaceContext);
 
   const relevantUploads = uploads.filter(
     (upload) => upload.fileData.entityTypeId === entityType.$id,
@@ -59,7 +58,7 @@ export const FileUploadsTab = ({ isImage }: { isImage: boolean }) => {
         entityTypeId: entityType.$id,
         file,
       },
-      ownedById: activeWorkspaceAccountId as OwnedById,
+      ownedById: activeWorkspaceOwnedById!,
     });
     setShowUploadForm(false);
   };

--- a/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/file-uploads-tab/action.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/file-uploads-tab/action.tsx
@@ -2,7 +2,7 @@ import { ArrowRotateLeftIcon } from "@hashintel/design-system";
 import { EntityId, extractEntityUuidFromEntityId } from "@local/hash-subgraph";
 import { Box, Stack, SxProps, Theme, Tooltip } from "@mui/material";
 
-import { useWorkspaceShortnameByAccountId } from "../../../../../../components/hooks/use-workspace-shortname-by-account-id";
+import { useWorkspaceShortnameByOwnedById } from "../../../../../../components/hooks/use-workspace-shortname-by-owned-by-id";
 import { FileUpload } from "../../../../../../shared/file-upload-context";
 import { ArrowUpRightIcon } from "../../../../../../shared/icons/arrow-up-right-icon";
 import { DashIcon } from "../../../../../../shared/icons/dash-icon";
@@ -26,8 +26,8 @@ export const Action = ({
   onRetry: () => void;
   upload: FileUpload;
 }) => {
-  const { shortname } = useWorkspaceShortnameByAccountId({
-    accountId: upload.ownedById,
+  const { shortname } = useWorkspaceShortnameByOwnedById({
+    ownedById: upload.ownedById,
   });
 
   switch (upload.status) {

--- a/apps/hash-frontend/src/pages/entities.page.tsx
+++ b/apps/hash-frontend/src/pages/entities.page.tsx
@@ -1,7 +1,7 @@
 import { extractVersion, VersionedUrl } from "@blockprotocol/type-system";
 import { AsteriskRegularIcon } from "@hashintel/design-system";
 import { types } from "@local/hash-isomorphic-utils/ontology-types";
-import { extractOwnedById, isBaseUrl, OwnedById } from "@local/hash-subgraph";
+import { isBaseUrl } from "@local/hash-subgraph";
 import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 import {
   Box,
@@ -45,7 +45,7 @@ type ParsedQueryParams = {
 
 const EntitiesPage: NextPageWithLayout = () => {
   const router = useRouter();
-  const { activeWorkspace } = useContext(WorkspaceContext);
+  const { activeWorkspaceOwnedById } = useContext(WorkspaceContext);
 
   const { hashInstance } = useHashInstance();
 
@@ -67,12 +67,8 @@ const EntitiesPage: NextPageWithLayout = () => {
     return {};
   }, [router]);
 
-  const lastRootPageIndex = activeWorkspace
-    ? useAccountPages(extractOwnedById(activeWorkspace)).lastRootPageIndex
-    : undefined;
-  const [createUntitledPage] = useCreatePage(
-    activeWorkspace?.accountId as OwnedById,
-  );
+  const { lastRootPageIndex } = useAccountPages(activeWorkspaceOwnedById);
+  const [createUntitledPage] = useCreatePage(activeWorkspaceOwnedById!);
 
   const createPage = useCallback(async () => {
     await createUntitledPage(lastRootPageIndex);

--- a/apps/hash-frontend/src/pages/entities.page.tsx
+++ b/apps/hash-frontend/src/pages/entities.page.tsx
@@ -1,7 +1,7 @@
 import { extractVersion, VersionedUrl } from "@blockprotocol/type-system";
 import { AsteriskRegularIcon } from "@hashintel/design-system";
 import { types } from "@local/hash-isomorphic-utils/ontology-types";
-import { isBaseUrl, OwnedById } from "@local/hash-subgraph";
+import { extractOwnedById, isBaseUrl, OwnedById } from "@local/hash-subgraph";
 import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 import {
   Box,
@@ -67,9 +67,9 @@ const EntitiesPage: NextPageWithLayout = () => {
     return {};
   }, [router]);
 
-  const { lastRootPageIndex } = useAccountPages(
-    activeWorkspace?.accountId as OwnedById,
-  );
+  const lastRootPageIndex = activeWorkspace
+    ? useAccountPages(extractOwnedById(activeWorkspace)).lastRootPageIndex
+    : undefined;
   const [createUntitledPage] = useCreatePage(
     activeWorkspace?.accountId as OwnedById,
   );

--- a/apps/hash-frontend/src/pages/login.page.tsx
+++ b/apps/hash-frontend/src/pages/login.page.tsx
@@ -1,5 +1,6 @@
 import { TextField } from "@hashintel/design-system";
 import { frontendUrl } from "@local/hash-isomorphic-utils/environment";
+import { OwnedById } from "@local/hash-subgraph";
 import { Box, Container, Typography } from "@mui/material";
 import { LoginFlow } from "@ory/client";
 import { isUiNodeInputAttributes } from "@ory/integrations/ui";
@@ -26,7 +27,7 @@ const LoginPage: NextPageWithLayout = () => {
   // Get ?flow=... from the URL
   const router = useRouter();
   const { refetch } = useAuthInfo();
-  const { updateActiveWorkspaceAccountId } = useContext(WorkspaceContext);
+  const { updateActiveWorkspaceOwnedById } = useContext(WorkspaceContext);
   const { hashInstance } = useHashInstance();
 
   const {
@@ -157,7 +158,9 @@ const LoginPage: NextPageWithLayout = () => {
               );
             }
 
-            updateActiveWorkspaceAccountId(authenticatedUser.accountId);
+            updateActiveWorkspaceOwnedById(
+              authenticatedUser.accountId as OwnedById,
+            );
 
             void router.push(returnTo ?? flow.return_to ?? "/");
           })

--- a/apps/hash-frontend/src/pages/settings/integrations.page.tsx
+++ b/apps/hash-frontend/src/pages/settings/integrations.page.tsx
@@ -2,6 +2,7 @@ import { apiOrigin } from "@local/hash-graphql-shared/environment";
 import { Box, Container, Paper, Typography } from "@mui/material";
 import { FunctionComponent, useContext } from "react";
 
+import { extractOwnedById } from "../../lib/user-and-org";
 import { NextPageWithLayout } from "../../shared/layout";
 import { Button } from "../../shared/ui/button";
 import { WorkspaceContext } from "../shared/workspace-context";
@@ -30,7 +31,9 @@ const AddNewIntegrations: FunctionComponent = () => {
               openInNewTab={false}
               variant="tertiary"
               size="small"
-              href={`${apiOrigin}/oauth/linear?ownedById=${activeWorkspace.accountId}`}
+              href={`${apiOrigin}/oauth/linear?ownedById=${extractOwnedById(
+                activeWorkspace,
+              )}`}
               sx={{
                 padding: ({ spacing }) => spacing(1, 1.5),
                 minHeight: 1,

--- a/apps/hash-frontend/src/pages/settings/organizations/[shortname]/members.page/add-member-form.tsx
+++ b/apps/hash-frontend/src/pages/settings/organizations/[shortname]/members.page/add-member-form.tsx
@@ -31,7 +31,7 @@ export const AddMemberForm = ({ org }: { org: Org }) => {
   const { refetch } = useAuthenticatedUser();
 
   const { createEntity } = useBlockProtocolCreateEntity(
-    org.accountId as OwnedById,
+    org.accountGroupId as OwnedById,
   );
   const [queryEntities] = useLazyQuery<
     QueryEntitiesQuery,

--- a/apps/hash-frontend/src/pages/settings/organizations/index.page.tsx
+++ b/apps/hash-frontend/src/pages/settings/organizations/index.page.tsx
@@ -59,7 +59,7 @@ const OrganizationListPage: NextPageWithLayout = () => {
             {authenticatedUser.memberOf
               .sort((a, b) => a.name.localeCompare(b.name))
               .map((org) => (
-                <OrgRow key={org.accountId} org={org} />
+                <OrgRow key={org.accountGroupId} org={org} />
               ))}
           </TableBody>
         </OrgTable>

--- a/apps/hash-frontend/src/pages/settings/organizations/shared/org-form.tsx
+++ b/apps/hash-frontend/src/pages/settings/organizations/shared/org-form.tsx
@@ -69,8 +69,11 @@ const InputGroup = ({ children }: PropsWithChildren) => {
 
 export type OrgFormData = Omit<
   Org,
-  "accountId" | "kind" | "entityRecordId" | "memberships"
-> & { accountId?: Org["accountId"]; entityRecordId?: Org["entityRecordId"] };
+  "accountGroupId" | "kind" | "entityRecordId" | "memberships"
+> & {
+  accountId?: Org["accountGroupId"];
+  entityRecordId?: Org["entityRecordId"];
+};
 
 type OrgFormProps = {
   onSubmit: (org: OrgFormData) => Promise<void>;

--- a/apps/hash-frontend/src/pages/shared/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table.tsx
@@ -40,7 +40,7 @@ export const EntitiesTable: FunctionComponent<{
 }> = ({ hideEntityTypeVersionColumn, hidePropertiesColumns, height }) => {
   const router = useRouter();
 
-  const { activeWorkspaceAccountId } = useContext(WorkspaceContext);
+  const { activeWorkspaceOwnedById } = useContext(WorkspaceContext);
 
   const [filterState, setFilterState] = useState<FilterState>({
     includeGlobal: false,
@@ -73,7 +73,7 @@ export const EntitiesTable: FunctionComponent<{
             ? true
             : extractOwnedByIdFromEntityId(
                 entity.metadata.recordId.entityId,
-              ) === activeWorkspaceAccountId) &&
+              ) === activeWorkspaceOwnedById) &&
           (filterState.includeArchived === undefined ||
           filterState.includeArchived ||
           entity.metadata.entityTypeId !== types.entityType.page.entityTypeId
@@ -82,7 +82,7 @@ export const EntitiesTable: FunctionComponent<{
                 extractBaseUrl(types.propertyType.archived.propertyTypeId)
               ] !== true),
       ),
-    [entities, filterState, activeWorkspaceAccountId],
+    [entities, filterState, activeWorkspaceOwnedById],
   );
 
   const { columns, rows } =

--- a/apps/hash-frontend/src/pages/shared/workspace-context.tsx
+++ b/apps/hash-frontend/src/pages/shared/workspace-context.tsx
@@ -1,4 +1,4 @@
-import { AccountId } from "@local/hash-subgraph";
+import { OwnedById } from "@local/hash-subgraph";
 import {
   createContext,
   FunctionComponent,
@@ -10,19 +10,19 @@ import {
 } from "react";
 
 import { localStorageKeys } from "../../lib/config";
-import { MinimalOrg, User } from "../../lib/user-and-org";
+import { MinimalOrg, MinimalUser } from "../../lib/user-and-org";
 import { useAuthInfo } from "./auth-info-context";
 
 export type WorkspaceContextValue = {
-  activeWorkspace?: User | MinimalOrg;
-  activeWorkspaceAccountId?: AccountId;
-  updateActiveWorkspaceAccountId: (
-    updatedActiveWorkspaceAccountId: AccountId,
+  activeWorkspace?: MinimalUser | MinimalOrg;
+  activeWorkspaceOwnedById?: OwnedById;
+  updateActiveWorkspaceOwnedById: (
+    updatedActiveWorkspaceAccountId: OwnedById,
   ) => void;
 };
 
 const defaultWorkspaceContextValue: WorkspaceContextValue = {
-  updateActiveWorkspaceAccountId: (_updatedActiveWorkspaceAccountId: string) =>
+  updateActiveWorkspaceOwnedById: (_updateActiveWorkspaceOwnedById: string) =>
     undefined,
 };
 
@@ -35,73 +35,75 @@ export const WorkspaceContextProvider: FunctionComponent<{
 }> = ({ children }) => {
   const { authenticatedUser } = useAuthInfo();
 
-  const [activeWorkspaceAccountId, setActiveWorkspaceAccountId] =
-    useState<AccountId>();
+  const [activeWorkspaceOwnedById, setActiveWorkspaceOwnedById] =
+    useState<OwnedById>();
 
-  const updateActiveWorkspaceAccountId = useCallback(
-    (updatedActiveWorkspaceAccountId: AccountId) => {
+  const updateActiveWorkspaceOwnedById = useCallback(
+    (updatedActiveWorkspaceOwnedById: OwnedById) => {
       localStorage.setItem(
-        localStorageKeys.workspaceAccountId,
-        updatedActiveWorkspaceAccountId,
+        localStorageKeys.workspaceOwnedById,
+        updatedActiveWorkspaceOwnedById,
       );
-      setActiveWorkspaceAccountId(updatedActiveWorkspaceAccountId);
+      setActiveWorkspaceOwnedById(updatedActiveWorkspaceOwnedById);
     },
     [],
   );
 
   useEffect(() => {
-    if (!activeWorkspaceAccountId) {
+    if (!activeWorkspaceOwnedById) {
       /**
-       * Initialize the `activeWorkspaceAccountId` with what has been persisted
+       * Initialize the `activeWorkspaceOwnedById` with what has been persisted
        * in `localStorage` (if anything)
        */
       const localStorageInitialValue = localStorage.getItem(
-        localStorageKeys.workspaceAccountId,
+        localStorageKeys.workspaceOwnedById,
       );
 
       if (localStorageInitialValue) {
-        setActiveWorkspaceAccountId(localStorageInitialValue as AccountId);
+        setActiveWorkspaceOwnedById(localStorageInitialValue as OwnedById);
       } else if (authenticatedUser) {
         /**
-         * Initialize the `activeWorkspaceAccountId` to the account ID of the
+         * Initialize the `activeWorkspaceOwnedById` to the account ID of the
          * currently authenticated user
          */
-        updateActiveWorkspaceAccountId(authenticatedUser.accountId);
+        updateActiveWorkspaceOwnedById(
+          authenticatedUser.accountId as OwnedById,
+        );
       }
     }
   }, [
-    activeWorkspaceAccountId,
-    updateActiveWorkspaceAccountId,
+    activeWorkspaceOwnedById,
+    updateActiveWorkspaceOwnedById,
     authenticatedUser,
   ]);
 
   const workspaceContextValue = useMemo<WorkspaceContextValue>(() => {
     const activeWorkspace =
       authenticatedUser &&
-      authenticatedUser.accountId === activeWorkspaceAccountId
+      authenticatedUser.accountId === activeWorkspaceOwnedById
         ? authenticatedUser
         : authenticatedUser?.memberOf.find(
-            ({ accountId }) => accountId === activeWorkspaceAccountId,
+            ({ accountGroupId }) => accountGroupId === activeWorkspaceOwnedById,
           );
 
     /**
-     * If there is an `activeWorkspaceAccountId` and an `authenticatedUser`, but
-     * `activeWorkspace` is not defined, reset `activeWorkspaceAccountId` to the
+     * If there is an `activeWorkspaceOwnedById` and an `authenticatedUser`, but
+     * `activeWorkspace` is not defined, reset `activeWorkspaceOwnedById` to the
      * authenticated user's account ID
      */
-    if (activeWorkspaceAccountId && authenticatedUser && !activeWorkspace) {
-      updateActiveWorkspaceAccountId(authenticatedUser.accountId);
+    if (activeWorkspaceOwnedById && authenticatedUser && !activeWorkspace) {
+      updateActiveWorkspaceOwnedById(authenticatedUser.accountId as OwnedById);
     }
 
     return {
       activeWorkspace,
-      activeWorkspaceAccountId,
-      updateActiveWorkspaceAccountId,
+      activeWorkspaceOwnedById,
+      updateActiveWorkspaceOwnedById,
     };
   }, [
     authenticatedUser,
-    activeWorkspaceAccountId,
-    updateActiveWorkspaceAccountId,
+    activeWorkspaceOwnedById,
+    updateActiveWorkspaceOwnedById,
   ]);
 
   return (

--- a/apps/hash-frontend/src/pages/types/[[...type-kind]].page/types-table.tsx
+++ b/apps/hash-frontend/src/pages/types/[[...type-kind]].page/types-table.tsx
@@ -24,6 +24,7 @@ import {
 import { Grid } from "../../../components/grid/grid";
 import { useOrgs } from "../../../components/hooks/use-orgs";
 import { useUsers } from "../../../components/hooks/use-users";
+import { extractOwnedById } from "../../../lib/user-and-org";
 import { useEntityTypesContextRequired } from "../../../shared/entity-types-context/hooks/use-entity-types-context-required";
 import { isTypeArchived } from "../../../shared/entity-types-context/util";
 import { HEADER_HEIGHT } from "../../../shared/layout/layout-with-header/page-header";
@@ -72,7 +73,7 @@ export const TypesTable: FunctionComponent<{
 }> = ({ types, kind }) => {
   const router = useRouter();
 
-  const { activeWorkspaceAccountId } = useContext(WorkspaceContext);
+  const { activeWorkspaceOwnedById } = useContext(WorkspaceContext);
 
   const [filterState, setFilterState] = useState<FilterState>({
     includeArchived: true,
@@ -126,16 +127,16 @@ export const TypesTable: FunctionComponent<{
         .map((type) => {
           const isExternal = isExternalOntologyElementMetadata(type.metadata)
             ? true
-            : type.metadata.custom.ownedById !== activeWorkspaceAccountId;
+            : type.metadata.custom.ownedById !== activeWorkspaceOwnedById;
 
-          const namespaceAccountId = isExternalOntologyElementMetadata(
+          const namespaceOwnedById = isExternalOntologyElementMetadata(
             type.metadata,
           )
             ? undefined
             : type.metadata.custom.ownedById;
 
           const namespace = namespaces?.find(
-            ({ accountId }) => accountId === namespaceAccountId,
+            (workspace) => extractOwnedById(workspace) === namespaceOwnedById,
           );
 
           return {
@@ -165,7 +166,7 @@ export const TypesTable: FunctionComponent<{
       types,
       namespaces,
       filterState,
-      activeWorkspaceAccountId,
+      activeWorkspaceOwnedById,
     ],
   );
 

--- a/apps/hash-frontend/src/shared/command-bar.tsx
+++ b/apps/hash-frontend/src/shared/command-bar.tsx
@@ -1,5 +1,4 @@
 import { Chip, TextField } from "@hashintel/design-system";
-import { OwnedById } from "@local/hash-subgraph/.";
 import {
   Autocomplete,
   AutocompleteChangeDetails,
@@ -211,16 +210,12 @@ export const CommandBar: FunctionComponent = () => {
 
   const router = useRouter();
 
-  const { activeWorkspaceAccountId } = useContext(WorkspaceContext);
+  const { activeWorkspaceOwnedById } = useContext(WorkspaceContext);
 
   const { hashInstance } = useHashInstance();
 
-  const [createUntitledPage] = useCreatePage(
-    activeWorkspaceAccountId as OwnedById,
-  );
-  const { lastRootPageIndex } = useAccountPages(
-    activeWorkspaceAccountId as OwnedById,
-  );
+  const { lastRootPageIndex } = useAccountPages(activeWorkspaceOwnedById);
+  const [createUntitledPage] = useCreatePage(activeWorkspaceOwnedById!);
 
   const [inputValue, setInputValue] = useState("");
   const [selectedOptionPath, setSelectedOptionPath] = useState<

--- a/apps/hash-frontend/src/shared/layout/layout-with-header/actions-dropdown.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-header/actions-dropdown.tsx
@@ -1,6 +1,6 @@
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@hashintel/design-system";
-import { AccountId } from "@local/hash-subgraph";
+import { OwnedById } from "@local/hash-subgraph";
 import {
   Box,
   listItemSecondaryActionClasses,
@@ -22,8 +22,8 @@ import { CreatePageMenuItem } from "./actions-dropdown/create-page-menu-item";
 import { HeaderIconButton } from "./shared/header-icon-button";
 
 const ActionsDropdownInner: FunctionComponent<{
-  activeWorkspaceAccountId: AccountId;
-}> = ({ activeWorkspaceAccountId }) => {
+  activeWorkspaceOwnedById: OwnedById;
+}> = ({ activeWorkspaceOwnedById }) => {
   const theme = useTheme();
 
   const { hashInstance } = useHashInstance();
@@ -75,7 +75,7 @@ const ActionsDropdownInner: FunctionComponent<{
       >
         {hashInstance?.properties.pagesAreEnabled ? (
           <CreatePageMenuItem
-            activeWorkspaceAccountId={activeWorkspaceAccountId}
+            activeWorkspaceOwnedById={activeWorkspaceOwnedById}
             onClick={popupState.close}
           />
         ) : null}
@@ -93,9 +93,9 @@ const ActionsDropdownInner: FunctionComponent<{
 };
 
 export const ActionsDropdown: FunctionComponent = () => {
-  const { activeWorkspaceAccountId } = useContext(WorkspaceContext);
+  const { activeWorkspaceOwnedById } = useContext(WorkspaceContext);
 
-  return activeWorkspaceAccountId ? (
-    <ActionsDropdownInner activeWorkspaceAccountId={activeWorkspaceAccountId} />
+  return activeWorkspaceOwnedById ? (
+    <ActionsDropdownInner activeWorkspaceOwnedById={activeWorkspaceOwnedById} />
   ) : null;
 };

--- a/apps/hash-frontend/src/shared/layout/layout-with-header/actions-dropdown/create-page-menu-item.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-header/actions-dropdown/create-page-menu-item.tsx
@@ -1,4 +1,4 @@
-import { AccountId, OwnedById } from "@local/hash-subgraph";
+import { OwnedById } from "@local/hash-subgraph";
 import { ListItemText } from "@mui/material";
 import { usePopupState } from "material-ui-popup-state/hooks";
 import { useCallback, useState } from "react";
@@ -8,20 +8,16 @@ import { useCreatePage } from "../../../../components/hooks/use-create-page";
 import { MenuItem } from "../../../ui/menu-item";
 
 export const CreatePageMenuItem = ({
-  activeWorkspaceAccountId,
+  activeWorkspaceOwnedById,
   onClick,
 }: {
-  activeWorkspaceAccountId: AccountId;
+  activeWorkspaceOwnedById: OwnedById;
   onClick: () => void;
 }) => {
   const [loading, setLoading] = useState(false);
 
-  const { lastRootPageIndex } = useAccountPages(
-    activeWorkspaceAccountId as OwnedById,
-  );
-  const [createUntitledPage] = useCreatePage(
-    activeWorkspaceAccountId as OwnedById,
-  );
+  const { lastRootPageIndex } = useAccountPages(activeWorkspaceOwnedById);
+  const [createUntitledPage] = useCreatePage(activeWorkspaceOwnedById);
 
   const popupState = usePopupState({
     variant: "popover",

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-page-list/account-page-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-page-list/account-page-list.tsx
@@ -19,7 +19,6 @@ import {
 } from "@dnd-kit/sortable";
 import { IconButton } from "@hashintel/design-system";
 import {
-  AccountId,
   EntityUuid,
   extractEntityUuidFromEntityId,
   isEntityId,
@@ -40,7 +39,7 @@ import { useArchivePage } from "../../../../components/hooks/use-archive-page";
 import { useCreatePage } from "../../../../components/hooks/use-create-page";
 import { useCreateSubPage } from "../../../../components/hooks/use-create-sub-page";
 import { useReorderPage } from "../../../../components/hooks/use-reorder-page";
-import { useWorkspaceShortnameByAccountId } from "../../../../components/hooks/use-workspace-shortname-by-account-id";
+import { useWorkspaceShortnameByOwnedById } from "../../../../components/hooks/use-workspace-shortname-by-owned-by-id";
 import { constructPageRelativeUrl } from "../../../../lib/routes";
 import { PlusRegularIcon } from "../../../icons/plus-regular";
 import { NavLink } from "../nav-link";
@@ -57,7 +56,7 @@ import {
 } from "./utils";
 
 type AccountPageListProps = {
-  accountId: AccountId;
+  ownedById: OwnedById;
   currentPageEntityUuid?: EntityUuid;
 };
 
@@ -69,21 +68,18 @@ const measuringConfig = {
 
 export const AccountPageList: FunctionComponent<AccountPageListProps> = ({
   currentPageEntityUuid,
-  accountId,
+  ownedById,
 }) => {
-  const { data, loading: pagesLoading } = useAccountPages(
-    accountId as OwnedById,
-  );
+  const { data, loading: pagesLoading } = useAccountPages(ownedById);
 
-  const { shortname: ownerShortname } = useWorkspaceShortnameByAccountId({
-    accountId,
+  const { shortname: ownerShortname } = useWorkspaceShortnameByOwnedById({
+    ownedById,
   });
 
   const [createUntitledPage, { loading: createUntitledPageLoading }] =
-    useCreatePage(accountId as OwnedById);
-  const [createSubPage, { loading: createSubpageLoading }] = useCreateSubPage(
-    accountId as OwnedById,
-  );
+    useCreatePage(ownedById);
+  const [createSubPage, { loading: createSubpageLoading }] =
+    useCreateSubPage(ownedById);
   const [reorderPage, { loading: reorderLoading }] = useReorderPage();
   const { archivePage, loading: archivePageLoading } = useArchivePage();
 

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar.tsx
@@ -20,7 +20,7 @@ export const SIDEBAR_WIDTH = 260;
 export const PageSidebar: FunctionComponent = () => {
   const router = useRouter();
   const { sidebarOpen, closeSidebar } = useSidebarContext();
-  const { activeWorkspaceAccountId } = useContext(WorkspaceContext);
+  const { activeWorkspaceOwnedById } = useContext(WorkspaceContext);
   const { routePageEntityUuid } =
     useRoutePageInfo({ allowUndefined: true }) ?? {};
 
@@ -98,17 +98,17 @@ export const PageSidebar: FunctionComponent = () => {
           overflowY: "auto",
         }}
       >
-        {activeWorkspaceAccountId ? (
+        {activeWorkspaceOwnedById ? (
           <>
             {/* PAGES */}
             {hashInstance?.properties.pagesAreEnabled ? (
               <AccountPageList
                 currentPageEntityUuid={routePageEntityUuid}
-                accountId={activeWorkspaceAccountId}
+                ownedById={activeWorkspaceOwnedById}
               />
             ) : null}
             {/* TYPES */}
-            <AccountEntityTypeList ownedById={activeWorkspaceAccountId} />
+            <AccountEntityTypeList ownedById={activeWorkspaceOwnedById} />
           </>
         ) : null}
       </Box>

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/workspace-switcher.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/workspace-switcher.tsx
@@ -1,5 +1,6 @@
 import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
 import { Avatar, FontAwesomeIcon } from "@hashintel/design-system";
+import { OwnedById } from "@local/hash-subgraph";
 import {
   Box,
   Divider,
@@ -32,16 +33,16 @@ export const WorkspaceSwitcher: FunctionComponent<
   });
   const { authenticatedUser } = useAuthenticatedUser();
   const { logout } = useLogoutFlow();
-  const { activeWorkspaceAccountId, updateActiveWorkspaceAccountId } =
+  const { activeWorkspaceOwnedById, updateActiveWorkspaceOwnedById } =
     useContext(WorkspaceContext);
 
   const activeWorkspaceName = useMemo(() => {
-    if (activeWorkspaceAccountId === authenticatedUser.accountId) {
+    if (activeWorkspaceOwnedById === authenticatedUser.accountId) {
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- @todo how to handle empty preferredName
       return authenticatedUser.preferredName || authenticatedUser.shortname!;
     } else {
       const activeOrg = authenticatedUser.memberOf.find(
-        ({ accountId }) => accountId === activeWorkspaceAccountId,
+        ({ accountGroupId }) => accountGroupId === activeWorkspaceOwnedById,
       );
 
       if (activeOrg) {
@@ -50,22 +51,24 @@ export const WorkspaceSwitcher: FunctionComponent<
     }
 
     return "User";
-  }, [activeWorkspaceAccountId, authenticatedUser]);
+  }, [activeWorkspaceOwnedById, authenticatedUser]);
 
   const workspaceList = useMemo(() => {
     return [
       {
-        accountId: authenticatedUser.accountId,
+        ownedById: authenticatedUser.accountId as OwnedById,
         title: "My personal workspace",
         subText: `@${authenticatedUser.shortname ?? "user"}`,
         avatarTitle: authenticatedUser.preferredName ?? "U",
       },
-      ...authenticatedUser.memberOf.map(({ accountId, name, memberships }) => ({
-        accountId,
-        title: name,
-        subText: `${memberships.length} members`,
-        avatarTitle: name,
-      })),
+      ...authenticatedUser.memberOf.map(
+        ({ accountGroupId, name, memberships }) => ({
+          ownedById: accountGroupId as OwnedById,
+          title: name,
+          subText: `${memberships.length} members`,
+          avatarTitle: name,
+        }),
+      ),
     ];
   }, [authenticatedUser]);
 
@@ -116,12 +119,12 @@ export const WorkspaceSwitcher: FunctionComponent<
         }}
         autoFocus={false}
       >
-        {workspaceList.map(({ title, subText, accountId }) => (
+        {workspaceList.map(({ title, subText, ownedById }) => (
           <MenuItem
-            key={accountId}
-            selected={accountId === activeWorkspaceAccountId}
+            key={ownedById}
+            selected={ownedById === activeWorkspaceOwnedById}
             onClick={() => {
-              updateActiveWorkspaceAccountId(accountId);
+              updateActiveWorkspaceOwnedById(ownedById);
               popupState.close();
             }}
           >
@@ -129,7 +132,7 @@ export const WorkspaceSwitcher: FunctionComponent<
               <Avatar
                 size={34}
                 title={
-                  accountId === authenticatedUser.accountId
+                  ownedById === authenticatedUser.accountId
                     ? authenticatedUser.preferredName
                     : title
                 }

--- a/apps/hash-frontend/src/shared/readonly-mode.tsx
+++ b/apps/hash-frontend/src/shared/readonly-mode.tsx
@@ -21,7 +21,9 @@ export const useIsReadonlyModeForApp = () => {
   return isReadonlyMode;
 };
 
-export const useIsReadonlyModeForResource = (resourceAccountId?: AccountId) => {
+export const useIsReadonlyModeForResource = (
+  resourceAccountId?: AccountId | AccountGroupId,
+) => {
   const { authenticatedUser } = useAuthInfo();
 
   const appIsReadOnly = useIsReadonlyModeForApp();
@@ -31,6 +33,8 @@ export const useIsReadonlyModeForResource = (resourceAccountId?: AccountId) => {
   }
 
   return (
-    appIsReadOnly || !canUserEditResource(resourceAccountId, authenticatedUser)
+    !resourceAccountId ||
+    appIsReadOnly ||
+    !canUserEditResource(resourceAccountId, authenticatedUser)
   );
 };

--- a/apps/hash-frontend/src/shared/readonly-mode.tsx
+++ b/apps/hash-frontend/src/shared/readonly-mode.tsx
@@ -1,22 +1,15 @@
-import { AccountId } from "@local/hash-subgraph";
+import { AccountGroupId, AccountId } from "@local/hash-subgraph";
 import { useRouter } from "next/router";
 
 import { AuthenticatedUser } from "../lib/user-and-org";
 import { useAuthInfo } from "../pages/shared/auth-info-context";
 
 export const canUserEditResource = (
-  resourceAccountId?: AccountId,
-  user?: AuthenticatedUser,
-) => {
-  if (!resourceAccountId || !user) {
-    return false;
-  }
-
-  return (
-    resourceAccountId === user.accountId ||
-    user.memberOf.find((org) => org.accountId === resourceAccountId)
-  );
-};
+  resourceAccountId: AccountId | AccountGroupId,
+  user: AuthenticatedUser,
+) =>
+  resourceAccountId === user.accountId ||
+  user.memberOf.find((org) => resourceAccountId === org.accountGroupId);
 
 export const useIsReadonlyModeForApp = () => {
   const router = useRouter();

--- a/apps/hash-frontend/src/shared/readonly-mode.tsx
+++ b/apps/hash-frontend/src/shared/readonly-mode.tsx
@@ -1,15 +1,15 @@
-import { AccountGroupId, AccountId } from "@local/hash-subgraph";
+import { OwnedById } from "@local/hash-subgraph";
 import { useRouter } from "next/router";
 
 import { AuthenticatedUser } from "../lib/user-and-org";
 import { useAuthInfo } from "../pages/shared/auth-info-context";
 
 export const canUserEditResource = (
-  resourceAccountId: AccountId | AccountGroupId,
+  resourceOwnerId: OwnedById,
   user: AuthenticatedUser,
 ) =>
-  resourceAccountId === user.accountId ||
-  user.memberOf.find((org) => resourceAccountId === org.accountGroupId);
+  resourceOwnerId === user.accountId ||
+  user.memberOf.find((org) => resourceOwnerId === org.accountGroupId);
 
 export const useIsReadonlyModeForApp = () => {
   const router = useRouter();
@@ -21,9 +21,7 @@ export const useIsReadonlyModeForApp = () => {
   return isReadonlyMode;
 };
 
-export const useIsReadonlyModeForResource = (
-  resourceAccountId?: AccountId | AccountGroupId,
-) => {
+export const useIsReadonlyModeForResource = (resourceOwnerId?: OwnedById) => {
   const { authenticatedUser } = useAuthInfo();
 
   const appIsReadOnly = useIsReadonlyModeForApp();
@@ -33,8 +31,8 @@ export const useIsReadonlyModeForResource = (
   }
 
   return (
-    !resourceAccountId ||
+    !resourceOwnerId ||
     appIsReadOnly ||
-    !canUserEditResource(resourceAccountId, authenticatedUser)
+    !canUserEditResource(resourceOwnerId, authenticatedUser)
   );
 };

--- a/apps/hash-frontend/src/shared/table-header.tsx
+++ b/apps/hash-frontend/src/shared/table-header.tsx
@@ -87,7 +87,8 @@ export const TableHeader: FunctionComponent<TableHeaderProps> = ({
   setFilterState,
   toggleSearch,
 }) => {
-  const { activeWorkspace } = useContext(WorkspaceContext);
+  const { activeWorkspace, activeWorkspaceOwnedById } =
+    useContext(WorkspaceContext);
 
   const [displayFilters, setDisplayFilters] = useState<boolean>(false);
 
@@ -96,15 +97,15 @@ export const TableHeader: FunctionComponent<TableHeaderProps> = ({
       ? items.filter(({ metadata }) =>
           "entityTypeId" in metadata
             ? extractOwnedByIdFromEntityId(metadata.recordId.entityId) ===
-              activeWorkspace.accountId
+              activeWorkspaceOwnedById
             : isExternalOntologyElementMetadata(metadata)
             ? false
-            : metadata.custom.ownedById === activeWorkspace.accountId,
+            : metadata.custom.ownedById === activeWorkspaceOwnedById,
         )
       : undefined;
 
     return activeWorkspaceItems ? activeWorkspaceItems.length : undefined;
-  }, [items, activeWorkspace]);
+  }, [items, activeWorkspace, activeWorkspaceOwnedById]);
 
   const numberOfGlobalItems =
     typeof numberOfActiveWorkspaceItems !== "undefined"

--- a/apps/hash-graph/lib/graph/src/api/rest/account.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/account.rs
@@ -17,7 +17,7 @@ use crate::{
 #[derive(OpenApi)]
 #[openapi(
     paths(
-        create_account_id,
+        create_account,
         create_account_group,
     ),
     components(
@@ -38,7 +38,7 @@ impl RoutedResource for AccountResource {
     {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new()
-            .route("/accounts", post(create_account_id::<S, A>))
+            .route("/accounts", post(create_account::<S, A>))
             .route("/account_groups", post(create_account_group::<S, A>))
     }
 }
@@ -57,7 +57,7 @@ impl RoutedResource for AccountResource {
     )
 )]
 #[tracing::instrument(level = "info", skip(store_pool, authorization_api_pool))]
-async fn create_account_id<S, A>(
+async fn create_account<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     authorization_api_pool: Extension<Arc<A>>,
     store_pool: Extension<Arc<S>>,

--- a/apps/hash-graph/lib/graph/src/store/postgres.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres.rs
@@ -1256,9 +1256,9 @@ impl<C: AsClient> AccountStore for PostgresStore<C> {
             .as_client()
             .query_one(
                 r#"
-                INSERT INTO account_groups (accoun_group_id)
+                INSERT INTO account_groups (account_group_id)
                 VALUES ($1)
-                RETURNING accoun_group_id;
+                RETURNING account_group_id;
                 "#,
                 &[&account_group_id],
             )

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -50,7 +50,7 @@
           "Graph",
           "Account"
         ],
-        "operationId": "create_account_id",
+        "operationId": "create_account",
         "parameters": [
           {
             "name": "X-Authenticated-User-Actor-Id",

--- a/apps/hash-integration-worker/src/activities.ts
+++ b/apps/hash-integration-worker/src/activities.ts
@@ -13,6 +13,7 @@ import {
   AccountId,
   EntityPropertiesObject,
   EntityRootType,
+  OwnedById,
   Subgraph,
 } from "@local/hash-subgraph";
 import { getRoots } from "@local/hash-subgraph/stdlib";
@@ -37,7 +38,7 @@ const createOrUpdateHashEntity = async (params: {
   authentication: { actorId: AccountId };
   graphApiClient: GraphApi;
   entity: PartialEntity;
-  workspaceAccountId?: AccountId;
+  workspaceOwnedById?: OwnedById;
 }): Promise<void> => {
   const idBaseUrl = extractBaseUrl(linearTypes.propertyType.id.propertyTypeId);
   const updatedAtBaseUrl = extractBaseUrl(
@@ -65,13 +66,13 @@ const createOrUpdateHashEntity = async (params: {
       ],
     },
   ];
-  if (params.workspaceAccountId) {
+  if (params.workspaceOwnedById) {
     filters.push({
       equal: [
         {
           path: ["ownedById"],
         },
-        { parameter: params.workspaceAccountId },
+        { parameter: params.workspaceOwnedById },
       ],
     });
   }
@@ -125,9 +126,9 @@ const createOrUpdateHashEntity = async (params: {
     });
   }
 
-  if (entities.length === 0 && params.workspaceAccountId) {
+  if (entities.length === 0 && params.workspaceOwnedById) {
     await params.graphApiClient.createEntity(params.authentication.actorId, {
-      ownedById: params.workspaceAccountId,
+      ownedById: params.workspaceOwnedById,
       ...params.entity,
     });
   }
@@ -155,14 +156,14 @@ export const createLinearIntegrationActivities = ({
   async createPartialEntities(params: {
     authentication: { actorId: AccountId };
     entities: PartialEntity[];
-    workspaceAccountId: AccountId;
+    workspaceOwnedById: OwnedById;
   }): Promise<void> {
     await Promise.all(
       params.entities.map((entity) =>
         createOrUpdateHashEntity({
           graphApiClient,
           authentication: params.authentication,
-          workspaceAccountId: params.workspaceAccountId,
+          workspaceOwnedById: params.workspaceOwnedById,
           entity,
         }),
       ),
@@ -178,13 +179,13 @@ export const createLinearIntegrationActivities = ({
   async createHashUser(params: {
     authentication: { actorId: AccountId };
     user: User;
-    workspaceAccountId: AccountId;
+    workspaceOwnedById: OwnedById;
   }): Promise<void> {
     const entity = userToEntity(params.user);
     await createOrUpdateHashEntity({
       graphApiClient,
       authentication: params.authentication,
-      workspaceAccountId: params.workspaceAccountId,
+      workspaceOwnedById: params.workspaceOwnedById,
       entity,
     });
   },
@@ -212,13 +213,13 @@ export const createLinearIntegrationActivities = ({
   async createHashIssue(params: {
     authentication: { actorId: AccountId };
     issue: Issue;
-    workspaceAccountId: AccountId;
+    workspaceOwnedById: OwnedById;
   }): Promise<void> {
     const entity = issueToEntity(params.issue);
     await createOrUpdateHashEntity({
       graphApiClient,
       authentication: params.authentication,
-      workspaceAccountId: params.workspaceAccountId,
+      workspaceOwnedById: params.workspaceOwnedById,
       entity,
     });
   },

--- a/apps/hash-integration-worker/src/workflows.ts
+++ b/apps/hash-integration-worker/src/workflows.ts
@@ -21,14 +21,14 @@ const linear = proxyActivities<
 });
 
 export const syncWorkspace: SyncWorkspaceWorkflow = async (params) => {
-  const { apiKey, workspaceAccountId, authentication, teamIds } = params;
+  const { apiKey, workspaceOwnedById, authentication, teamIds } = params;
 
   const organization = linear
     .readLinearOrganization({ apiKey })
     .then((organizationEntity) =>
       linear.createPartialEntities({
         authentication,
-        workspaceAccountId,
+        workspaceOwnedById,
         entities: [organizationEntity],
       }),
     );
@@ -36,7 +36,7 @@ export const syncWorkspace: SyncWorkspaceWorkflow = async (params) => {
   const users = linear.readLinearUsers({ apiKey }).then((userEntities) =>
     linear.createPartialEntities({
       authentication,
-      workspaceAccountId,
+      workspaceOwnedById,
       entities: userEntities,
     }),
   );
@@ -47,7 +47,7 @@ export const syncWorkspace: SyncWorkspaceWorkflow = async (params) => {
       .then((issueEntities) =>
         linear.createPartialEntities({
           authentication,
-          workspaceAccountId,
+          workspaceOwnedById,
           entities: issueEntities,
         }),
       ),
@@ -60,7 +60,7 @@ export const createHashUser: CreateHashUserWorkflow = async (params) => {
   await linear.createHashUser({
     authentication: params.authentication,
     user: params.payload,
-    workspaceAccountId: params.ownedById,
+    workspaceOwnedById: params.ownedById,
   });
 };
 
@@ -74,7 +74,7 @@ export const createHashIssue: CreateHashIssueWorkflow = async (params) => {
   await linear.createHashIssue({
     authentication: params.authentication,
     issue: params.payload,
-    workspaceAccountId: params.ownedById,
+    workspaceOwnedById: params.ownedById,
   });
 };
 

--- a/libs/@local/hash-backend-utils/src/temporal-workflow-types.ts
+++ b/libs/@local/hash-backend-utils/src/temporal-workflow-types.ts
@@ -31,7 +31,7 @@ export type ReadLinearTeamsWorkflow = (params: {
 export type SyncWorkspaceWorkflow = (params: {
   authentication: { actorId: AccountId };
   apiKey: string;
-  workspaceAccountId: AccountId;
+  workspaceOwnedById: OwnedById;
   teamIds: string[];
 }) => Promise<void>;
 

--- a/libs/@local/hash-isomorphic-utils/src/create-prose-mirror-state.ts
+++ b/libs/@local/hash-isomorphic-utils/src/create-prose-mirror-state.ts
@@ -1,3 +1,4 @@
+import { OwnedById } from "@local/hash-subgraph";
 import { cloneDeep } from "lodash";
 import { baseKeymap } from "prosemirror-commands";
 import { dropCursor } from "prosemirror-dropcursor";
@@ -31,11 +32,11 @@ const defaultPlugins: Plugin<unknown>[] = [
 ];
 
 export const createProseMirrorState = ({
-  accountId,
+  ownedById,
   doc = createInitialDoc(),
   plugins = [],
 }: {
-  accountId: string;
+  ownedById: OwnedById;
   doc?: Node;
   plugins?: Plugin<unknown>[];
 }) => {
@@ -43,7 +44,7 @@ export const createProseMirrorState = ({
     doc,
     plugins: [
       ...defaultPlugins,
-      createEntityStorePlugin({ accountId }),
+      createEntityStorePlugin({ ownedById }),
       formatKeymap(doc.type.schema),
       ...plugins,
     ],

--- a/libs/@local/hash-isomorphic-utils/src/entity-store-plugin.ts
+++ b/libs/@local/hash-isomorphic-utils/src/entity-store-plugin.ts
@@ -1,4 +1,8 @@
-import { EntityId, EntityPropertiesObject } from "@local/hash-subgraph";
+import {
+  EntityId,
+  EntityPropertiesObject,
+  OwnedById,
+} from "@local/hash-subgraph";
 import { castDraft, Draft, produce } from "immer";
 import { isEqual } from "lodash";
 import { Node } from "prosemirror-model";
@@ -75,7 +79,7 @@ export type EntityStorePluginAction = { received?: boolean } & (
   | {
       type: "newDraftEntity";
       payload: {
-        accountId: string;
+        ownedById: OwnedById;
         draftId: string;
         entityId: EntityId | null;
       };
@@ -452,7 +456,7 @@ class ProsemirrorStateChangeHandler {
 
   constructor(
     private state: EditorState,
-    private accountId: string,
+    private ownedById: OwnedById,
   ) {
     this.tr = state.tr;
   }
@@ -624,7 +628,7 @@ class ProsemirrorStateChangeHandler {
       addEntityStoreAction(this.state, this.tr, {
         type: "newDraftEntity",
         payload: {
-          accountId: this.accountId,
+          ownedById: this.ownedById,
           draftId,
           entityId: entityId ?? null,
         },
@@ -705,9 +709,9 @@ const scheduleNotifyEntityStoreSubscribers = collect<
 });
 
 export const createEntityStorePlugin = ({
-  accountId,
+  ownedById,
 }: {
-  accountId: string;
+  ownedById: OwnedById;
 }) => {
   const entityStorePlugin = new Plugin<EntityStorePluginState>({
     key: entityStorePluginKey,
@@ -753,7 +757,7 @@ export const createEntityStorePlugin = ({
         return;
       }
 
-      return new ProsemirrorStateChangeHandler(state, accountId).handleDoc();
+      return new ProsemirrorStateChangeHandler(state, ownedById).handleDoc();
     },
   });
   return entityStorePlugin;

--- a/libs/@local/hash-isomorphic-utils/src/prosemirror-manager.ts
+++ b/libs/@local/hash-isomorphic-utils/src/prosemirror-manager.ts
@@ -1,5 +1,5 @@
 import { BlockVariant, JsonObject } from "@blockprotocol/core";
-import { EntityId } from "@local/hash-subgraph";
+import { EntityId, OwnedById } from "@local/hash-subgraph";
 import { Node, Schema } from "prosemirror-model";
 import { EditorState, Transaction } from "prosemirror-state";
 import { EditorProps, EditorView } from "prosemirror-view";
@@ -44,7 +44,7 @@ type ComponentNodeViewFactory = (block: HashBlock) => NodeViewFactory;
 export class ProsemirrorManager {
   constructor(
     private schema: Schema,
-    private accountId: string,
+    private ownedById: OwnedById,
     private view: EditorView | null = null,
     private componentNodeViewFactory: ComponentNodeViewFactory | null = null,
   ) {}
@@ -510,7 +510,7 @@ export class ProsemirrorManager {
     addEntityStoreAction(this.view.state, tr, {
       type: "newDraftEntity",
       payload: {
-        accountId: this.accountId,
+        ownedById: this.ownedById,
         draftId: newBlockId,
         entityId: null,
       },
@@ -520,7 +520,7 @@ export class ProsemirrorManager {
     addEntityStoreAction(this.view.state, tr, {
       type: "newDraftEntity",
       payload: {
-        accountId: this.accountId,
+        ownedById: this.ownedById,
         draftId: blockDataDraftId,
         entityId: null,
       },

--- a/libs/@local/hash-subgraph/src/types/shared/branded.ts
+++ b/libs/@local/hash-subgraph/src/types/shared/branded.ts
@@ -72,10 +72,10 @@ export type RecordCreatedById = Brand<AccountId, "RecordCreatedById">;
 /** An account ID of an actor that has created a record */
 export type RecordArchivedById = Brand<AccountId, "RecordArchivedById">;
 
-/** An `EntityId` which is the base of an Account Entity */
+/** An `EntityId` identifying a `User` Entity */
 export type AccountEntityId = Brand<EntityId, "AccountEntityId">;
 
-/** An `EntityId` which is the base of an Account Group Entity */
+/** An `EntityId`identifying an Account Group Entity, e.g. an `Org` */
 export type AccountGroupEntityId = Brand<EntityId, "AccountGroupEntityId">;
 
 /** If the underlying `EntityUuid` is an `AccountId`, use this cast to convert the type */

--- a/libs/@local/hash-subgraph/src/types/shared/branded.ts
+++ b/libs/@local/hash-subgraph/src/types/shared/branded.ts
@@ -1,4 +1,8 @@
 import {
+  MinimalOrg,
+  MinimalUser,
+} from "@apps/hash-frontend/src/lib/user-and-org";
+import {
   BaseUrl as BaseUrlBp,
   validateBaseUrl,
 } from "@blockprotocol/type-system/slim";
@@ -14,11 +18,14 @@ export const isBaseUrl = (baseUrl: string): baseUrl is BaseUrl => {
 /** Valid Uuids of the system */
 export type Uuid = Brand<string, "Uuid">;
 
-/** An ID to uniquely identify an account (e.g. a User or an Org) */
+/** An ID to uniquely identify an account (e.g. a User) */
 export type AccountId = Brand<Uuid, "AccountId">;
 
+/** An ID to uniquely identify an account group (e.g. an Org) */
+export type AccountGroupId = Brand<Uuid, "AccountGroupId">;
+
 /** An account ID of an actor that is the owner of something */
-export type OwnedById = Brand<AccountId, "OwnedById">;
+export type OwnedById = Brand<AccountId | AccountGroupId, "OwnedById">;
 
 /** A `Uuid` that points to an Entity without any edition */
 export type EntityUuid = Brand<Uuid, "EntityUuid">;
@@ -72,8 +79,17 @@ export type RecordArchivedById = Brand<AccountId, "RecordArchivedById">;
 /** An `EntityId` which is the base of an Account Entity */
 export type AccountEntityId = Brand<EntityId, "AccountEntityId">;
 
-/** If the underlying entityUuid is an accountId, use this cast to convert the type */
+/** An `EntityId` which is the base of an Account Group Entity */
+export type AccountGroupEntityId = Brand<EntityId, "AccountGroupEntityId">;
+
+/** If the underlying `EntityUuid` is an `AccountId`, use this cast to convert the type */
 export const extractAccountId = extractEntityUuidFromEntityId as (
   entityId: AccountEntityId,
-  // The type cannot be cast directly to AccountId, so we do it over two casts, but without `unknown`
+  // The type cannot be cast directly to `AccountId`, so we do it over two casts, but without `unknown`
 ) => string as (entityId: AccountEntityId) => AccountId;
+
+/** If the underlying `EntityUuid` is an `AccountGroupId`, use this cast to convert the type */
+export const extractAccountGroupId = extractEntityUuidFromEntityId as (
+  entityId: AccountGroupEntityId,
+  // The type cannot be cast directly to `AccountGroupId`, so we do it over two casts, but without `unknown`
+) => string as (entityId: AccountGroupEntityId) => AccountGroupId;

--- a/libs/@local/hash-subgraph/src/types/shared/branded.ts
+++ b/libs/@local/hash-subgraph/src/types/shared/branded.ts
@@ -1,8 +1,4 @@
 import {
-  MinimalOrg,
-  MinimalUser,
-} from "@apps/hash-frontend/src/lib/user-and-org";
-import {
   BaseUrl as BaseUrlBp,
   validateBaseUrl,
 } from "@blockprotocol/type-system/slim";

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/page.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/page.test.ts
@@ -141,7 +141,7 @@ describe("Page", () => {
       graphContext,
       authentication,
       {
-        accountId: testUser.accountId,
+        ownedById: testUser.accountId as OwnedById,
       },
     );
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, no distinction is being made between an account ID of an organization and an account if of a user. It turned out that in many locations they were actually mixed up (e.g. the workspace account ID (which could be an org) is used as the actor account for authentication).

This changes the `OwnedById` type to be either `AccountId` or `AccountGroupId` (which are returned by `create_account` and `create_account_group` respectively). This comes with a long tail of changes all over the workspace. Most noticeable is probably that many functions take an `AccountId`, which is then passed to an `ownedById` query.

A few drive-by improvements/fixes have been made and TODOs have been added where appropriate.

## 🚫 Blocked by

- #3127 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph