### PR TITLE
Fix `hash-external-apps` README backup command invocation

### DIFF
--- a/apps/hash-external-services/README.md
+++ b/apps/hash-external-services/README.md
@@ -65,10 +65,10 @@ To apply the backups you can use:
 # we use `-c -f` here to force output, `pg-backup` always ends archives with `.dmp`, which gunzip will otherwise refuse to uncompress
 # You can skip this step if you haven't compressed (`-Z`) the backup.
 gunzip -c -f /local/registry/backups/[date].dev_kratos.dmp > .tmp
-./compose.sh -T --env PGPASSWORD=[password] postgres psql --user postgres dev_kratos -v ON_ERROR_STOP=1 < .tmp
+./compose.sh exec -T --env PGPASSWORD=[password] postgres psql --user postgres dev_kratos -v ON_ERROR_STOP=1 < .tmp
 
 gunzip -c -f /local/registry/backups/[date].dev_graph.dmp > .tmp
-./compose.sh -T --env PGPASSWORD=[password] postgres psql --user postgres dev_graph -v ON_ERROR_STOP=1 < .tmp
+./compose.sh exec -T --env PGPASSWORD=[password] postgres psql --user postgres dev_graph -v ON_ERROR_STOP=1 < .tmp
 ```
 
 You do **not** need to restore the `globals.sql` file, the init script of the postgres container already does this for you.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes the command used to apply the snapshots to include the `exec` subcommand, previously I must've removed it accidentally.

> Huge PR, I know.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
