### PR TITLE
H-767: Fix bugs in type editor form when moving between types

### DIFF
--- a/apps/hash-frontend/package.json
+++ b/apps/hash-frontend/package.json
@@ -85,7 +85,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-dropzone": "14.2.3",
-    "react-hook-form": "7.45.4",
+    "react-hook-form": "7.46.1",
     "react-responsive-carousel": "3.2.23",
     "react-transition-group": "4.4.5",
     "rooks": "7.14.1",

--- a/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
@@ -326,7 +326,7 @@ const Page: NextPageWithLayout = () => {
                           },
                         }
                   }
-                  key={entityType.$id} // reset edit bar state when the entity tpye changes
+                  key={entityType.$id} // reset edit bar state when the entity type changes
                 />
               )}
 

--- a/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
@@ -88,7 +88,7 @@ const Page: NextPageWithLayout = () => {
          * This hacky timeout is here because without it we encounter a bug in the following circumstances:
          * 1. Be on a published type with at least one property or link of its own (inherited are irrelevant)
          * 2. Click 'extend type' to create a new draft type, which calls 'reset' on the form (this line)
-         * 3. The react-hook-form state will incorrectly have malformed entries for as many properties as the source type
+         * 3. The react-hook-form state will incorrectly have malformed entries for as many properties as the source type has
          *
          * This does not happen if the field inputs are not rendered, so it is probably something to do with array field
          * values being retained across a reset somehow.
@@ -97,7 +97,7 @@ const Page: NextPageWithLayout = () => {
          *
          * Moving the reset into a useEffect does not work.
          */
-        setTimeout(() => reset(getFormDataFromSchema(entityType)), 100);
+        setTimeout(() => reset(getFormDataFromSchema(entityType)), 10);
 
         return entityType as EntityType;
       } else {

--- a/apps/hash-frontend/src/shared/entity-types-context/hooks.ts
+++ b/apps/hash-frontend/src/shared/entity-types-context/hooks.ts
@@ -74,7 +74,7 @@ export const useIsSpecialEntityType = (
 
   return useMemo(() => {
     if (loading) {
-      return false;
+      return { isFile: false, isImage: false, isLink: false };
     }
 
     const typesByVersion: Record<VersionedUrl, EntityTypeWithMetadata> =

--- a/apps/hash-frontend/src/shared/entity-types-context/hooks.ts
+++ b/apps/hash-frontend/src/shared/entity-types-context/hooks.ts
@@ -65,19 +65,23 @@ export const useLatestEntityTypesOptional = (params?: {
  *
  * For types already in the db, do this instead:
  *   const { isSpecialEntityTypeLookup } = useEntityTypesContextRequired();
- *   const { file, image, link } = isSpecialEntityTypeLookup?.[entityType.$id] ?? {};
+ *   const { isFile, isImage, isLink } = isSpecialEntityTypeLookup?.[entityType.$id] ?? {};
  */
 export const useIsSpecialEntityType = (
   entityType: Pick<EntityType, "allOf"> & { $id?: EntityType["$id"] },
 ) => {
-  const entityTypes = useEntityTypesOptional({ includeArchived: true });
+  const { loading, entityTypes } = useEntityTypesContextRequired();
 
   return useMemo(() => {
+    if (loading) {
+      return false;
+    }
+
     const typesByVersion: Record<VersionedUrl, EntityTypeWithMetadata> =
       Object.fromEntries(
         (entityTypes ?? []).map((type) => [type.schema.$id, type]),
       );
 
     return isSpecialEntityType(entityType, typesByVersion);
-  }, [entityType, entityTypes]);
+  }, [entityType, entityTypes, loading]);
 };

--- a/libs/@hashintel/query-editor/package.json
+++ b/libs/@hashintel/query-editor/package.json
@@ -33,6 +33,6 @@
     "@mui/system": "^5.11.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "7.45.4"
+    "react-hook-form": "7.46.1"
   }
 }

--- a/libs/@hashintel/type-editor/package.json
+++ b/libs/@hashintel/type-editor/package.json
@@ -41,6 +41,6 @@
     "@mui/system": "^5.11.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-hook-form": "7.45.4"
+    "react-hook-form": "7.46.1"
   }
 }

--- a/libs/@hashintel/type-editor/src/entity-type-editor/shared/use-inherited-values.ts
+++ b/libs/@hashintel/type-editor/src/entity-type-editor/shared/use-inherited-values.ts
@@ -59,17 +59,17 @@ const addInheritedValuesForEntityType = (
   inheritedValuesMap: ValueMap,
   inheritanceChainToHere: EntityType[] = [],
 ) => {
-  const entity = entityTypeOptions[entityTypeId];
+  const entityType = entityTypeOptions[entityTypeId];
 
-  if (!entity) {
+  if (!entityType) {
     throw new Error(
       `Entity type ${entityTypeId} not found in entity type options`,
     );
   }
 
-  const newInheritanceChain = [...inheritanceChainToHere, entity];
+  const newInheritanceChain = [...inheritanceChainToHere, entityType];
 
-  const { properties, links } = getFormDataFromSchema(entity);
+  const { properties, links } = getFormDataFromSchema(entityType);
 
   for (const link of links) {
     // eslint-disable-next-line no-param-reassign
@@ -97,11 +97,11 @@ const addInheritedValuesForEntityType = (
     };
   }
 
-  if (!entity.allOf?.length) {
+  if (!entityType.allOf?.length) {
     // we have reached a root entity type, add the inheritance chain to the map
     inheritedValuesMap.inheritanceChains.push(newInheritanceChain);
   } else {
-    entity.allOf.map(({ $ref }) =>
+    entityType.allOf.map(({ $ref }) =>
       addInheritedValuesForEntityType(
         $ref,
         entityTypeOptions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -20324,10 +20324,10 @@ react-full-screen@1.1.1:
   dependencies:
     fscreen "^1.0.2"
 
-react-hook-form@7.45.4:
-  version "7.45.4"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.45.4.tgz#73d228b704026ae95d7e5f7b207a681b173ec62a"
-  integrity sha512-HGDV1JOOBPZj10LB3+OZgfDBTn+IeEsNOKiq/cxbQAIbKaiJUe/KV8DBUzsx0Gx/7IG/orWqRRm736JwOfUSWQ==
+react-hook-form@7.46.1:
+  version "7.46.1"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.46.1.tgz#39347dbff19d980cb41087ac32a57abdc6045bb3"
+  integrity sha512-0GfI31LRTBd5tqbXMGXT1Rdsv3rnvy0FjEk8Gn9/4tp6+s77T7DPZuGEpBRXOauL+NhyGT5iaXzdIM2R6F/E+w==
 
 react-inspector@^6.0.0:
   version "6.0.1"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR fixes a couple of bugs related to moving from an existing entity type to a draft entity type without leaving the type editor page, which has only been possible since the introduction of the 'Extend type' button
1. Resets the edit bar state when moving between types (fixes click extend type, edit bar shows incorrect version)
2. Update `completedRef.current` when tracking which type we last loaded to take account of moving from a type to a draft and then back to the same type (fixes click extend type, click parent in sidebar, form state does not reset)
3. Wait for entity types to load before checking ancestors (fixes click extend type, then refresh page)
4. Add hacky timeout when resetting form state with a draft (fixes click extend type where the parent has at least one of its own properties, then click 'publish' – will crash, see longer comment). Not happy with this but lost a lot of time looking for a better solution, might be being dumb.

It also

5. Fixes a bug which was introduced by overly strict validation in #3093, which prevented publishing a type if the user hadn't touched the form. Users may wish to publish _new_ types (at v1) without adding any properties or links.
6. Updates `react-hook-form` (did this trying to debug the above, might as well keep it)
7. Correct an incorrect variable name

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- None.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. See bug recreation steps in description.

<!-- Add a screenshot or video showcasing your work -->
