### PR TITLE
H-668: Use UUIDv5 for newly created ontology id

### DIFF
--- a/apps/hash-graph/Cargo.lock
+++ b/apps/hash-graph/Cargo.lock
@@ -2304,6 +2304,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+
+[[package]]
 name = "sha2"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3130,6 +3136,7 @@ checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
  "getrandom",
  "serde",
+ "sha1_smol",
 ]
 
 [[package]]

--- a/apps/hash-graph/lib/graph/Cargo.toml
+++ b/apps/hash-graph/lib/graph/Cargo.toml
@@ -51,7 +51,7 @@ tracing-appender = "0.2.2"
 tracing-error = "0.2.0"
 tracing-opentelemetry = "0.21.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"] }
-uuid = { workspace = true, features = ["v4", "serde"] }
+uuid = { workspace = true, features = ["v4", "v5", "serde"] }
 
 [dev-dependencies]
 graph-test-data = { workspace = true }

--- a/apps/hash-graph/lib/graph/src/snapshot/ontology/entity_type/channel.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/ontology/entity_type/channel.rs
@@ -76,7 +76,8 @@ impl Sink<OntologyTypeSnapshotRecord<EntityType>> for EntityTypeSender {
             .change_context(SnapshotRestoreError::Read)
             .attach_printable("could not convert schema to entity type")?;
 
-        let ontology_id = Uuid::new_v4();
+        let record_id = entity_type.metadata.record_id.to_string();
+        let ontology_id = Uuid::new_v5(&Uuid::NAMESPACE_URL, record_id.as_bytes());
 
         self.metadata
             .start_send_unpin((

--- a/apps/hash-graph/lib/graph/src/store/postgres.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres.rs
@@ -160,7 +160,7 @@ where
                     ontology_id,
                     base_url,
                     version
-                  ) VALUES (gen_random_uuid(), $1, $2)
+                  ) VALUES ($1, $2, $3)
                   ON CONFLICT DO NOTHING
                   RETURNING ontology_ids.ontology_id;
                 "#
@@ -171,13 +171,20 @@ where
                     ontology_id,
                     base_url,
                     version
-                  ) VALUES (gen_random_uuid(), $1, $2)
+                  ) VALUES ($1, $2, $3)
                   RETURNING ontology_ids.ontology_id;
                 "#
             }
         };
         self.as_client()
-            .query_opt(query, &[&record_id.base_url.as_str(), &record_id.version])
+            .query_opt(
+                query,
+                &[
+                    &OntologyId::from_record_id(record_id),
+                    &record_id.base_url.as_str(),
+                    &record_id.version,
+                ],
+            )
             .await
             .map_err(Report::new)
             .map_err(|report| match report.current_context().code() {

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/ontology_id.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/ontology_id.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use graph_types::ontology::OntologyTypeRecordId;
 use postgres_types::{FromSql, ToSql};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -13,6 +14,13 @@ use uuid::Uuid;
 pub struct OntologyId(Uuid);
 
 impl OntologyId {
+    pub fn from_record_id(record_id: &OntologyTypeRecordId) -> Self {
+        Self(Uuid::new_v5(
+            &Uuid::NAMESPACE_URL,
+            record_id.to_string().as_bytes(),
+        ))
+    }
+
     pub const fn as_uuid(self) -> Uuid {
         self.0
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To deterministically create ontology IDs newly inserted IDs will be UUIDv5. This implies that after dumping and restoring a snapshot all IDs will be v5.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph