### PR TITLE
H-760: Check `labelProperty`s when generating an entity's label

### DIFF
--- a/apps/hash-frontend/src/lib/entities.ts
+++ b/apps/hash-frontend/src/lib/entities.ts
@@ -94,6 +94,7 @@ export const generateEntityLabel = (
     "preferredName",
     "displayName",
     "title",
+    "organizationName",
     "shortname",
     "fileName",
     "originalFileName",

--- a/apps/hash-frontend/src/lib/entities.ts
+++ b/apps/hash-frontend/src/lib/entities.ts
@@ -1,16 +1,47 @@
-import { typedKeys } from "@local/advanced-types/typed-entries";
+import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
 import {
-  BaseUrl,
   Entity,
   EntityRootType,
+  EntityTypeWithMetadata,
   extractEntityUuidFromEntityId,
   Subgraph,
 } from "@local/hash-subgraph";
 import {
-  getEntityTypeById,
-  getPropertyTypesByBaseUrl,
+  getEntityTypeAndParentsById,
   getRoots,
 } from "@local/hash-subgraph/stdlib";
+
+const getLabelPropertyValue = (
+  entityToLabel: Entity,
+  entityType: EntityTypeWithMetadata,
+) => {
+  if (entityType.metadata.custom.labelProperty) {
+    const label =
+      entityToLabel.properties[entityType.metadata.custom.labelProperty];
+
+    if (label) {
+      return label.toString();
+    }
+  }
+};
+
+const getFallbackLabel = ({
+  entityType,
+  entity,
+}: {
+  entityType?: EntityTypeWithMetadata;
+  entity: Entity;
+}) => {
+  // fallback to the entity type and a few characters of the entityUuid
+  const entityId = entity.metadata.recordId.entityId;
+
+  const entityTypeName = entityType?.schema.title ?? "Entity";
+
+  return `${entityTypeName}-${extractEntityUuidFromEntityId(entityId).slice(
+    0,
+    5,
+  )}`;
+};
 
 /**
  * Generate a display label for an entity
@@ -23,71 +54,56 @@ export const generateEntityLabel = (
 ): string => {
   const entityToLabel: Entity = entity ?? getRoots(entitySubgraph)[0]!;
 
-  const getFallbackLabel = () => {
-    // fallback to the entity type and a few characters of the entityUuid
-    const entityId = entityToLabel.metadata.recordId.entityId;
+  const entityTypeAndAncestors = getEntityTypeAndParentsById(
+    entitySubgraph,
+    entityToLabel.metadata.entityTypeId,
+  );
 
-    const entityType = getEntityTypeById(
-      entitySubgraph,
-      entityToLabel.metadata.entityTypeId,
-    );
-    const entityTypeName = entityType?.schema.title ?? "Entity";
+  const entityType = entityTypeAndAncestors[0];
 
-    return `${entityTypeName}-${extractEntityUuidFromEntityId(entityId).slice(
-      0,
-      5,
-    )}`;
-  };
+  const entityTypesToCheck = entityType ? [entityType] : [];
 
-  const getFallbackIfNotString = (val: any) => {
-    if (!val || typeof val !== "string") {
-      return getFallbackLabel();
+  /**
+   * Return any truthy value for a property which is set as the labelProperty for the entity's type,
+   * or any of its ancestors, using a breadth-first search in the inheritance tree starting from the entity's own type.
+   */
+  for (let i = 0; i < entityTypesToCheck.length; i++) {
+    const typeToCheck = entityTypesToCheck[i]!;
+
+    const label = getLabelPropertyValue(entityToLabel, typeToCheck);
+
+    if (label) {
+      return label;
     }
 
-    return val;
-  };
+    entityTypesToCheck.push(
+      ...entityTypeAndAncestors.filter(
+        (type) =>
+          typeToCheck.schema.allOf?.find(
+            ({ $ref }) => $ref === type.schema.$id,
+          ),
+      ),
+    );
+  }
+
+  const simplifiedProperties = simplifyProperties(entityToLabel.properties);
 
   // fallback to some likely display name properties
   const options = [
     "name",
-    "preferred name",
-    "display name",
+    "preferredName",
+    "displayName",
     "title",
     "shortname",
-    "file name",
-    "original file name",
-  ];
-
-  const propertyTypes: { title?: string; propertyTypeBaseUrl: BaseUrl }[] =
-    typedKeys(entityToLabel.properties).map((propertyTypeBaseUrl) => {
-      /** @todo - pick the latest version rather than first element? */
-      const [propertyType] = getPropertyTypesByBaseUrl(
-        entitySubgraph,
-        propertyTypeBaseUrl,
-      );
-
-      return propertyType
-        ? {
-            title: propertyType.schema.title.toLowerCase(),
-            propertyTypeBaseUrl,
-          }
-        : {
-            title: undefined,
-            propertyTypeBaseUrl,
-          };
-    });
+    "fileName",
+    "originalFileName",
+  ] as (keyof typeof simplifiedProperties)[];
 
   for (const option of options) {
-    const found = propertyTypes.find(
-      ({ title }) => title && title.toLowerCase() === option.toLowerCase(),
-    );
-
-    if (found) {
-      return getFallbackIfNotString(
-        entityToLabel.properties[found.propertyTypeBaseUrl],
-      );
+    if (typeof simplifiedProperties[option] === "string") {
+      return simplifiedProperties[option];
     }
   }
 
-  return getFallbackLabel();
+  return getFallbackLabel({ entityType, entity: entityToLabel });
 };

--- a/apps/hash-frontend/src/lib/entities.ts
+++ b/apps/hash-frontend/src/lib/entities.ts
@@ -1,3 +1,4 @@
+import { EntityPropertyValue } from "@blockprotocol/graph";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
 import {
   Entity,
@@ -86,7 +87,9 @@ export const generateEntityLabel = (
     );
   }
 
-  const simplifiedProperties = simplifyProperties(entityToLabel.properties);
+  const simplifiedProperties = simplifyProperties(
+    entityToLabel.properties,
+  ) as Record<string, EntityPropertyValue>;
 
   // fallback to some likely display name properties
   const options = [
@@ -98,11 +101,14 @@ export const generateEntityLabel = (
     "shortname",
     "fileName",
     "originalFileName",
-  ] as (keyof typeof simplifiedProperties)[];
+  ];
 
   for (const option of options) {
-    if (typeof simplifiedProperties[option] === "string") {
-      return simplifiedProperties[option];
+    if (
+      simplifiedProperties[option] &&
+      typeof simplifiedProperties[option] === "string"
+    ) {
+      return simplifiedProperties[option] as string;
     }
   }
 

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/shared/use-draft-entity-subgraph.ts
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/shared/use-draft-entity-subgraph.ts
@@ -18,7 +18,7 @@ export const useDraftEntitySubgraph = (
   Dispatch<SetStateAction<Subgraph<EntityRootType> | undefined>>,
   boolean,
 ] => {
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [draftEntitySubgraph, setDraftEntitySubgraph] =
     useState<Subgraph<EntityRootType>>();
 
@@ -27,8 +27,6 @@ export const useDraftEntitySubgraph = (
   useEffect(() => {
     const init = async () => {
       try {
-        setLoading(true);
-
         const { data: subgraph } = await getEntityType({
           data: {
             entityTypeId,

--- a/libs/@local/hash-isomorphic-utils/src/simplify-properties.ts
+++ b/libs/@local/hash-isomorphic-utils/src/simplify-properties.ts
@@ -38,13 +38,11 @@ export type Simplified<T extends Entity | BpEntity> = Omit<T, "properties"> & {
 export const simplifyProperties = <T extends EntityPropertiesObject>(
   properties: T,
 ): SimpleProperties<T> => {
-  const simpleProperties = typedEntries(properties).reduce(
+  return typedEntries(properties).reduce(
     (acc, [key, value]) => ({
       ...acc,
       [camelCase(key.split("/").slice(-2, -1).pop())]: value,
     }),
     {} as SimpleProperties<T>,
   );
-
-  return simpleProperties;
 };

--- a/libs/@local/hash-subgraph/src/stdlib/subgraph/element/entity-type.ts
+++ b/libs/@local/hash-subgraph/src/stdlib/subgraph/element/entity-type.ts
@@ -46,8 +46,8 @@ export const getEntityTypeById = (
  *
  * @param subgraph a subgraph containing the entity type and its ancestors
  * @param entityTypeId the `VersionedUrl` of the entity type
- * @throws if the entity type or any of its ancestors aren't present in the subgraph
- * @returns an array of `EntityTypeWithMetadata`
+ * @throws Error if the entity type or any of its ancestors aren't present in the subgraph
+ * @returns EntityTypeWithMetadata[] an array of `EntityTypeWithMetadata`, where the first element is the entity type
  */
 export const getEntityTypeAndParentsById = (
   subgraph: Subgraph,
@@ -63,6 +63,7 @@ export const getEntityTypeAndParentsById = (
     (parent) => parent.$ref,
   );
 
+  // Return the entity type, followed by its ancestors
   return [
     entityType,
     ...parentIds.flatMap((parentId) =>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We have a custom `labelProperty` which can be set on entity types, which indicates which property should be used when labelling an entity in the UI. 

This PR starts using it to label entities, where it is defined on the entity's type or on its type's parents (preferring closer ones).

I've also simplified how we check for fallbacks based on some property names that should make for reasonable labels.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

- H-142: Allow setting a type's label property in the UI (currently only configurable via the API/db)

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Try setting a `labelProperty` on a type or its parents (directly in the db locally is easiest), then creating an entity with that property value

## 📹 Demo


https://github.com/hashintel/hash/assets/37743469/919ea905-dd9a-48e5-ae74-5293fb77f6e4

