### PR TITLE
H-743: Determine `OwnedById` type when inserting a record

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/postgres.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres.rs
@@ -59,6 +59,15 @@ enum OntologyLocation {
     External,
 }
 
+// TODO: Replace with something permission specific which can directly be reused once permissions
+//       are implemented.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum VisibilityScope {
+    Public,
+    Account(AccountId),
+    AccountGroup(AccountGroupId),
+}
+
 impl<C> PostgresStore<C>
 where
     C: AsClient,
@@ -336,20 +345,37 @@ where
         &self,
         ontology_id: OntologyId,
         owned_by_id: OwnedById,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<VisibilityScope, InsertionError> {
         let query: &str = r#"
-              INSERT INTO ontology_owned_metadata (
-                ontology_id,
-                owned_by_id
-              ) VALUES ($1, $2);
+                WITH inserted_owners AS (
+                    INSERT INTO ontology_owned_metadata (
+                        ontology_id,
+                        owned_by_id
+                    ) VALUES ($1, $2)
+                    RETURNING owned_by_id
+                )
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM account_groups
+                    JOIN inserted_owners ON account_group_id = inserted_owners.owned_by_id
+                );
             "#;
 
-        self.as_client()
-            .query(query, &[&ontology_id, &owned_by_id])
+        let is_account_group: bool = self
+            .as_client()
+            .query_one(query, &[&ontology_id, &owned_by_id])
             .await
-            .change_context(InsertionError)?;
+            .change_context(InsertionError)?
+            .get(0);
 
-        Ok(())
+        let owned_by_uuid = owned_by_id.as_uuid();
+        if is_account_group {
+            Ok(VisibilityScope::AccountGroup(AccountGroupId::new(
+                owned_by_uuid,
+            )))
+        } else {
+            Ok(VisibilityScope::Account(AccountId::new(owned_by_uuid)))
+        }
     }
 
     async fn create_ontology_external_metadata(
@@ -718,8 +744,14 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
         record_id: &OntologyTypeRecordId,
         custom_metadata: &PartialCustomOntologyMetadata,
         on_conflict: ConflictBehavior,
-    ) -> Result<Option<(OntologyId, LeftClosedTemporalInterval<TransactionTime>)>, InsertionError>
-    {
+    ) -> Result<
+        Option<(
+            OntologyId,
+            LeftClosedTemporalInterval<TransactionTime>,
+            VisibilityScope,
+        )>,
+        InsertionError,
+    > {
         match custom_metadata {
             PartialCustomOntologyMetadata::Owned { owned_by_id } => {
                 self.create_base_url(&record_id.base_url, on_conflict, OntologyLocation::Owned)
@@ -729,9 +761,10 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
                     let transaction_time = self
                         .create_ontology_temporal_metadata(ontology_id, record_created_by_id)
                         .await?;
-                    self.create_ontology_owned_metadata(ontology_id, *owned_by_id)
+                    let visibility = self
+                        .create_ontology_owned_metadata(ontology_id, *owned_by_id)
                         .await?;
-                    Ok(Some((ontology_id, transaction_time)))
+                    Ok(Some((ontology_id, transaction_time, visibility)))
                 } else {
                     Ok(None)
                 }
@@ -750,7 +783,11 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
                         .await?;
                     self.create_ontology_external_metadata(ontology_id, *fetched_at)
                         .await?;
-                    Ok(Some((ontology_id, transaction_time)))
+                    Ok(Some((
+                        ontology_id,
+                        transaction_time,
+                        VisibilityScope::Public,
+                    )))
                 } else {
                     Ok(None)
                 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -13,7 +13,7 @@ use authorization::{
 use error_stack::{Report, Result, ResultExt};
 use futures::TryStreamExt;
 use graph_types::{
-    account::AccountId,
+    account::{AccountGroupId, AccountId},
     knowledge::{
         entity::{
             Entity, EntityEditionId, EntityId, EntityMetadata, EntityProperties, EntityRecordId,
@@ -37,7 +37,7 @@ use crate::{
         error::{EntityDoesNotExist, RaceConditionOnUpdate},
         postgres::{
             knowledge::entity::read::EntityEdgeTraversalData, query::ReferenceTable,
-            TraversalContext,
+            TraversalContext, VisibilityScope,
         },
         AsClient, EntityStore, InsertionError, PostgresStore, QueryError, Record, UpdateError,
     },
@@ -286,17 +286,43 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
 
         let transaction = self.transaction().await.change_context(InsertionError)?;
 
-        transaction
+        let is_account_group: bool = transaction
             .as_client()
-            .query(
+            .query_one(
                 r#"
-                    INSERT INTO entity_ids (owned_by_id, entity_uuid)
-                    VALUES ($1, $2);
+                    WITH inserted_owners AS (
+                        INSERT INTO entity_ids (owned_by_id, entity_uuid)
+                        VALUES ($1, $2)
+                        RETURNING owned_by_id
+                    )
+                    SELECT EXISTS (
+                        SELECT 1
+                        FROM account_groups
+                        JOIN inserted_owners ON account_group_id = inserted_owners.owned_by_id
+                    );
                 "#,
                 &[&entity_id.owned_by_id, &entity_id.entity_uuid],
             )
             .await
-            .change_context(InsertionError)?;
+            .change_context(InsertionError)?
+            .get(0);
+
+        let owned_by_uuid = owned_by_id.as_uuid();
+        let _visibility_scope = if is_account_group {
+            VisibilityScope::AccountGroup(AccountGroupId::new(owned_by_uuid))
+        } else {
+            VisibilityScope::Account(AccountId::new(owned_by_uuid))
+        };
+
+        // TODO: Insert permission for entity, something like
+        //       ```
+        //       authorization_api.grant_permission(
+        //           visibility_scope,
+        //           Relation::Admin,
+        //           entity_id
+        //       )
+        //       ```
+        //       Make sure this will revoke the permission if the transaction fails.
 
         let link_order = if let Some(link_data) = link_data {
             transaction

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -99,7 +99,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
 
         let mut inserted_data_type_metadata = Vec::new();
         for (schema, metadata) in data_types {
-            if let Some((ontology_id, transaction_time)) = transaction
+            if let Some((ontology_id, transaction_time, _visibility_scope)) = transaction
                 .create_ontology_metadata(
                     provenance.record_created_by_id,
                     &metadata.record_id,
@@ -116,6 +116,16 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
                     provenance,
                     transaction_time,
                 ));
+
+                // TODO: Insert permission for data type, something like
+                //       ```
+                //       authorization_api.grant_permission(
+                //           visibility_scope,
+                //           Relation::Admin,
+                //           ontology_id
+                //       )
+                //       ```
+                //       Make sure this will revoke the permission if the transaction fails.
             }
         }
 

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -227,7 +227,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         let mut inserted_entity_type_metadata =
             Vec::with_capacity(inserted_entity_types.capacity());
         for (schema, metadata) in entity_types {
-            if let Some((ontology_id, transaction_time)) = transaction
+            if let Some((ontology_id, transaction_time, _visibility_scope)) = transaction
                 .create_ontology_metadata(
                     provenance.record_created_by_id,
                     &metadata.record_id,
@@ -250,6 +250,16 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
                     provenance,
                     transaction_time,
                 ));
+
+                // TODO: Insert permission for entity type, something like
+                //       ```
+                //       authorization_api.grant_permission(
+                //           visibility_scope,
+                //           Relation::Admin,
+                //           ontology_id
+                //       )
+                //       ```
+                //       Make sure this will revoke the permission if the transaction fails.
             }
         }
 

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -201,7 +201,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         let mut inserted_property_type_metadata =
             Vec::with_capacity(inserted_property_types.capacity());
         for (schema, metadata) in property_types {
-            if let Some((ontology_id, transaction_time)) = transaction
+            if let Some((ontology_id, transaction_time, _visibility_scope)) = transaction
                 .create_ontology_metadata(
                     provenance.record_created_by_id,
                     &metadata.record_id,
@@ -220,6 +220,16 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                     provenance,
                     transaction_time,
                 ));
+
+                // TODO: Insert permission for property type, something like
+                //       ```
+                //       authorization_api.grant_permission(
+                //           visibility_scope,
+                //           Relation::Admin,
+                //           ontology_id
+                //       )
+                //       ```
+                //       Make sure this will revoke the permission if the transaction fails.
             }
         }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When inserting a type or an entity the graph needs to know if the `owned_by_id` is an `AccountId` or an `AccoutGroupId`. Even though it's not used, yet, it will be in the near future.

## 🔍 What does this change?

- Upon insertion check if the id is in the `accounts` table or `account_groups` table
- Store the retrieved information in a variable

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph