### PR TITLE
H-585: Individual org's "General" page improvements

### DIFF
--- a/apps/hash-frontend/src/pages/login.page.tsx
+++ b/apps/hash-frontend/src/pages/login.page.tsx
@@ -215,6 +215,7 @@ const LoginPage: NextPageWithLayout = () => {
             <Typography key={id}>{text}</Typography>
           ))}
           required
+          inputProps={{ "data-1p-ignore": false }}
         />
         <TextField
           label="Password"
@@ -229,6 +230,7 @@ const LoginPage: NextPageWithLayout = () => {
             <Typography key={id}>{text}</Typography>
           ))}
           required
+          inputProps={{ "data-1p-ignore": false }}
         />
         <Button type="submit">Log in to your account</Button>
         {flow?.ui.messages?.map(({ text, id }) => (

--- a/apps/hash-frontend/src/pages/settings/organizations/new/index.page/create-org-form.tsx
+++ b/apps/hash-frontend/src/pages/settings/organizations/new/index.page/create-org-form.tsx
@@ -32,5 +32,11 @@ export const CreateOrgForm = () => {
     void router.push(`/@${orgData.shortname}`);
   };
 
-  return <OrgForm onSubmit={onSubmit} submitLabel="Create organization" />;
+  return (
+    <OrgForm
+      onSubmit={onSubmit}
+      submitLabel="Create organization"
+      autoFocusDisplayName
+    />
+  );
 };

--- a/apps/hash-frontend/src/pages/settings/organizations/shared/org-form.tsx
+++ b/apps/hash-frontend/src/pages/settings/organizations/shared/org-form.tsx
@@ -73,6 +73,7 @@ export type OrgFormData = Omit<
 > & { accountId?: Org["accountId"]; entityRecordId?: Org["entityRecordId"] };
 
 type OrgFormProps = {
+  autoFocusDisplayName?: boolean;
   onSubmit: (org: OrgFormData) => Promise<void>;
   /**
    * An existing org to edit. Editing the shortname will not be allowed.
@@ -83,6 +84,7 @@ type OrgFormProps = {
 };
 
 export const OrgForm = ({
+  autoFocusDisplayName = false,
   onSubmit,
   org: initialOrg,
   submitLabel,
@@ -203,7 +205,7 @@ export const OrgForm = ({
           required
         />
         <TextField
-          autoFocus
+          autoFocus={autoFocusDisplayName}
           error={!!nameError}
           id="name"
           helperText={nameError}

--- a/apps/hash-frontend/src/pages/signup.page.tsx
+++ b/apps/hash-frontend/src/pages/signup.page.tsx
@@ -172,6 +172,7 @@ const KratosRegistrationFlowForm: FunctionComponent = () => {
             <Typography key={id}>{text}</Typography>
           ))}
           required
+          inputProps={{ "data-1p-ignore": false }}
         />
         <TextField
           label="Password"
@@ -186,6 +187,7 @@ const KratosRegistrationFlowForm: FunctionComponent = () => {
             <Typography key={id}>{text}</Typography>
           ))}
           required
+          inputProps={{ "data-1p-ignore": false }}
         />
         <Button type="submit">Sign up with email</Button>
         {flow?.ui.messages?.map(({ text, id }) => (

--- a/libs/@hashintel/design-system/src/theme/components.ts
+++ b/libs/@hashintel/design-system/src/theme/components.ts
@@ -18,6 +18,7 @@ import {
   MuiRadioThemeOptions,
   MuiSwitchThemeOptions,
 } from "./components/inputs";
+import { MuiInputBaseThemeOptions } from "./components/inputs/mui-input-base-theme-options";
 import { MuiSelectThemeOptions } from "./components/inputs/mui-select-theme-options";
 import {
   MuiDrawerThemeOptions,
@@ -38,6 +39,7 @@ export const components: Components<Theme> = {
   MuiCheckbox: MuiCheckboxThemeOptions,
   MuiSelect: MuiSelectThemeOptions,
   MuiFormHelperText: MuiFormHelperTextThemeOptions,
+  MuiInputBase: MuiInputBaseThemeOptions,
   /** ===== DATA DISPLAY ===== */
   MuiChip: MuiChipThemeOptions,
   MuiIconButton: MuiIconButtonThemeOptions,

--- a/libs/@hashintel/design-system/src/theme/components/inputs/mui-input-base-theme-options.ts
+++ b/libs/@hashintel/design-system/src/theme/components/inputs/mui-input-base-theme-options.ts
@@ -1,0 +1,9 @@
+import { Components, Theme } from "@mui/material";
+
+export const MuiInputBaseThemeOptions: Components<Theme>["MuiInputBase"] = {
+  defaultProps: {
+    inputProps: {
+      "data-1p-ignore": true,
+    },
+  },
+};

--- a/libs/@hashintel/design-system/src/theme/components/inputs/mui-input-base-theme-options.ts
+++ b/libs/@hashintel/design-system/src/theme/components/inputs/mui-input-base-theme-options.ts
@@ -6,4 +6,18 @@ export const MuiInputBaseThemeOptions: Components<Theme>["MuiInputBase"] = {
       "data-1p-ignore": true,
     },
   },
+  styleOverrides: {
+    input: {
+      /**
+       * This hides the Safari contact autofill button for all inputs. Note that
+       * this doesn't affect the autofill button for other inputs, such as the
+       * login credentials button. These can be similarly overridden using the
+       * `::-webkit-credentials-auto-fill-button` CSS selector.
+       */
+      "&::-webkit-contacts-auto-fill-button": {
+        visibility: "hidden",
+        display: "none !important",
+      },
+    },
+  },
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR stops the display name from autofocusing on the general page for existing orgs, and prevents 1Password from autofilling inputs by default (which is overridden in the `/login` and `/signup` pages where this behaviour is desired).

In addition it disables the Safari contact button for all inputs, which was also appearing on the display name input for organisations.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Go to an individual org's "General" page, and observe the display name no longer being autofocused, and that 1Password/Safari is no longer attempting to autofill the input.
2. Go to the login page, and verify 1Password is still trying to complete the relevant inputs.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

https://github.com/hashintel/hash/assets/42802102/58982e75-ffed-43a0-a387-8c7bbdc46775

