### PR TITLE
H-584: Improve context menu on `/settings/organizations` page

### DIFF
--- a/apps/hash-frontend/src/pages/settings/organizations/[shortname]/members.page.tsx
+++ b/apps/hash-frontend/src/pages/settings/organizations/[shortname]/members.page.tsx
@@ -9,7 +9,7 @@ import {
 } from "@mui/material";
 import { useRouter } from "next/router";
 import { NextSeo } from "next-seo";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { NextPageWithLayout } from "../../../../shared/layout";
 import { useAuthenticatedUser } from "../../../shared/auth-info-context";
@@ -42,6 +42,14 @@ const OrgMembersPage: NextPageWithLayout = () => {
   const org = authenticatedUser.memberOf.find(
     (orgOption) => orgOption.shortname === shortname,
   );
+
+  useEffect(() => {
+    const [_, anchorTag] = router.asPath.split("#");
+
+    if (anchorTag && anchorTag === "invite") {
+      setShowAddMemberForm(true);
+    }
+  }, [router]);
 
   if (!org) {
     // @todo show a 404 page

--- a/apps/hash-frontend/src/pages/settings/organizations/[shortname]/members.page/member-row/member-context-menu.tsx
+++ b/apps/hash-frontend/src/pages/settings/organizations/[shortname]/members.page/member-row/member-context-menu.tsx
@@ -29,6 +29,7 @@ export const MemberContextMenu = ({
 
       <Menu {...bindMenu(popupState)} {...contextMenuProps}>
         <MenuItem
+          dangerous
           onClick={() => {
             removeFromOrg();
             popupState.close();

--- a/apps/hash-frontend/src/pages/settings/organizations/[shortname]/members.page/member-row/member-context-menu.tsx
+++ b/apps/hash-frontend/src/pages/settings/organizations/[shortname]/members.page/member-row/member-context-menu.tsx
@@ -27,18 +27,7 @@ export const MemberContextMenu = ({
     <Box>
       <ContextButton {...bindTrigger(popupState)}>...</ContextButton>
 
-      <Menu
-        {...bindMenu(popupState)}
-        {...contextMenuProps}
-        anchorOrigin={{
-          vertical: "bottom",
-          horizontal: "left",
-        }}
-        transformOrigin={{
-          vertical: "top",
-          horizontal: "left",
-        }}
-      >
+      <Menu {...bindMenu(popupState)} {...contextMenuProps}>
         <MenuItem
           onClick={() => {
             removeFromOrg();

--- a/apps/hash-frontend/src/pages/settings/organizations/[shortname]/members.page/member-row/member-context-menu.tsx
+++ b/apps/hash-frontend/src/pages/settings/organizations/[shortname]/members.page/member-row/member-context-menu.tsx
@@ -27,7 +27,18 @@ export const MemberContextMenu = ({
     <Box>
       <ContextButton {...bindTrigger(popupState)}>...</ContextButton>
 
-      <Menu {...bindMenu(popupState)} {...contextMenuProps}>
+      <Menu
+        {...bindMenu(popupState)}
+        {...contextMenuProps}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "left",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "left",
+        }}
+      >
         <MenuItem
           onClick={() => {
             removeFromOrg();

--- a/apps/hash-frontend/src/pages/settings/organizations/index.page/org-row.tsx
+++ b/apps/hash-frontend/src/pages/settings/organizations/index.page/org-row.tsx
@@ -56,7 +56,7 @@ export const OrgRow = ({ org }: { org: Org }) => {
         </Typography>
       </TableCell>
       <TableCell>
-        <OrgContextMenu leaveOrg={leaveOrg} />
+        <OrgContextMenu org={org} leaveOrg={leaveOrg} />
       </TableCell>
     </TableRow>
   );

--- a/apps/hash-frontend/src/pages/settings/organizations/index.page/org-row/org-context-menu.tsx
+++ b/apps/hash-frontend/src/pages/settings/organizations/index.page/org-row/org-context-menu.tsx
@@ -5,10 +5,17 @@ import {
   usePopupState,
 } from "material-ui-popup-state/hooks";
 
+import { MinimalOrg } from "../../../../../lib/user-and-org";
 import { MenuItem } from "../../../../../shared/ui/menu-item";
 import { ContextButton, contextMenuProps } from "../../../shared/context-menu";
 
-export const OrgContextMenu = ({ leaveOrg }: { leaveOrg: () => void }) => {
+export const OrgContextMenu = ({
+  leaveOrg,
+  org,
+}: {
+  leaveOrg: () => void;
+  org: MinimalOrg;
+}) => {
   const popupState = usePopupState({
     variant: "popover",
     popupId: "actions-dropdown-menu",
@@ -19,7 +26,22 @@ export const OrgContextMenu = ({ leaveOrg }: { leaveOrg: () => void }) => {
       <ContextButton {...bindTrigger(popupState)}>...</ContextButton>
 
       <Menu {...bindMenu(popupState)} {...contextMenuProps}>
+        <MenuItem href={`/@${org.shortname}`}>
+          <ListItemText primary="View profile" />
+        </MenuItem>
+        <MenuItem href={`/settings/organizations/${org.shortname}/general`}>
+          <ListItemText primary="Edit profile" />
+        </MenuItem>
+        <MenuItem href={`/settings/organizations/${org.shortname}/members`}>
+          <ListItemText primary="View members" />
+        </MenuItem>
         <MenuItem
+          href={`/settings/organizations/${org.shortname}/members#invite`}
+        >
+          <ListItemText primary="Invite new members" />
+        </MenuItem>
+        <MenuItem
+          dangerous
           onClick={() => {
             leaveOrg();
             popupState.close();

--- a/apps/hash-frontend/src/pages/settings/organizations/index.page/org-row/org-context-menu.tsx
+++ b/apps/hash-frontend/src/pages/settings/organizations/index.page/org-row/org-context-menu.tsx
@@ -18,18 +18,7 @@ export const OrgContextMenu = ({ leaveOrg }: { leaveOrg: () => void }) => {
     <Box>
       <ContextButton {...bindTrigger(popupState)}>...</ContextButton>
 
-      <Menu
-        {...bindMenu(popupState)}
-        {...contextMenuProps}
-        anchorOrigin={{
-          vertical: "bottom",
-          horizontal: "left",
-        }}
-        transformOrigin={{
-          vertical: "top",
-          horizontal: "left",
-        }}
-      >
+      <Menu {...bindMenu(popupState)} {...contextMenuProps}>
         <MenuItem
           onClick={() => {
             leaveOrg();

--- a/apps/hash-frontend/src/pages/settings/organizations/index.page/org-row/org-context-menu.tsx
+++ b/apps/hash-frontend/src/pages/settings/organizations/index.page/org-row/org-context-menu.tsx
@@ -18,7 +18,18 @@ export const OrgContextMenu = ({ leaveOrg }: { leaveOrg: () => void }) => {
     <Box>
       <ContextButton {...bindTrigger(popupState)}>...</ContextButton>
 
-      <Menu {...bindMenu(popupState)} {...contextMenuProps}>
+      <Menu
+        {...bindMenu(popupState)}
+        {...contextMenuProps}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "left",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "left",
+        }}
+      >
         <MenuItem
           onClick={() => {
             leaveOrg();

--- a/apps/hash-frontend/src/pages/settings/shared/context-menu.tsx
+++ b/apps/hash-frontend/src/pages/settings/shared/context-menu.tsx
@@ -23,11 +23,11 @@ export const ContextButton = styled("button")`
 export const contextMenuProps: Partial<MenuProps> = {
   anchorOrigin: {
     vertical: "bottom",
-    horizontal: "right",
+    horizontal: "left",
   },
   transformOrigin: {
     vertical: "top",
-    horizontal: "right",
+    horizontal: "left",
   },
   PaperProps: {
     elevation: 4,

--- a/libs/@hashintel/design-system/src/menu-item.tsx
+++ b/libs/@hashintel/design-system/src/menu-item.tsx
@@ -10,12 +10,21 @@ import { forwardRef, FunctionComponent, ReactNode } from "react";
 export type MenuItemProps = {
   children?: ReactNode;
   faded?: boolean;
+  dangerous?: boolean;
   noSelectBackground?: boolean;
 } & MuiMenuItemProps;
 
 export const MenuItem: FunctionComponent<MenuItemProps> = forwardRef(
   (
-    { children, sx = [], faded, selected, noSelectBackground, ...props },
+    {
+      children,
+      sx = [],
+      faded,
+      dangerous,
+      selected,
+      noSelectBackground,
+      ...props
+    },
     ref,
   ) => {
     return (
@@ -29,6 +38,21 @@ export const MenuItem: FunctionComponent<MenuItemProps> = forwardRef(
                 },
               [`& .${listItemIconClasses.root}, & svg`]: {
                 color: palette.gray[40],
+              },
+            }),
+            ...(dangerous && {
+              [`& .${listItemTextClasses.primary}, .${typographyClasses.root}`]:
+                {
+                  color: palette.red[70],
+                },
+              "&:hover": {
+                [`& .${listItemTextClasses.primary}, .${typographyClasses.root}`]:
+                  {
+                    color: palette.red[90],
+                  },
+              },
+              [`& .${listItemIconClasses.root}, & svg`]: {
+                color: palette.red[50],
               },
             }),
           }),

--- a/libs/@hashintel/design-system/src/text-field.tsx
+++ b/libs/@hashintel/design-system/src/text-field.tsx
@@ -11,6 +11,7 @@ import {
   TextField as MuiTextField,
   TextFieldProps as MuiTextFieldProps,
   Typography,
+  useTheme,
 } from "@mui/material";
 import { forwardRef, FunctionComponent, useState } from "react";
 
@@ -115,6 +116,8 @@ export const TextField: FunctionComponent<TextFieldProps> = forwardRef(
   ) => {
     const frozenHelperText = useFrozenValue(helperText);
 
+    const theme = useTheme();
+
     return (
       <MuiTextField
         ref={ref}
@@ -160,6 +163,7 @@ export const TextField: FunctionComponent<TextFieldProps> = forwardRef(
           error,
           autoResize,
           multiline: textFieldProps.multiline,
+          inputProps: theme.components?.MuiInputBase?.defaultProps?.inputProps,
         })}
         helperText={
           <Collapse in={!!helperText}>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR adds functionality and styling to the context menu on the `/settings/orgs` page, including:
- a "View profile" button
- a "Edit profile" button
- a "View members" button
- an "Invite new members" button

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- updates the styling of the "Leave Organization" button in the org and member context menu to be red
- focuses the invite member input on the members page when a `#invite` anchor tag is provided

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Go to the `/settings/organizations` page and test out the new context menu buttons.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

https://github.com/hashintel/hash/assets/42802102/e7f3a559-c3e3-455a-8343-8dd2d3324c68


