### PR TITLE
H-778: Expose account group membership in the Graph REST API

### DIFF
--- a/apps/hash-graph/lib/authorization/src/api.rs
+++ b/apps/hash-graph/lib/authorization/src/api.rs
@@ -22,16 +22,30 @@ pub enum VisibilityScope {
 }
 
 pub trait AuthorizationApi {
+    fn can_add_group_members(
+        &self,
+        actor: AccountId,
+        account_group: AccountGroupId,
+        consistency: Consistency<'_>,
+    ) -> impl Future<Output = Result<CheckResponse, CheckError>> + Send;
+
+    fn can_remove_group_members(
+        &self,
+        actor: AccountId,
+        account_group: AccountGroupId,
+        consistency: Consistency<'_>,
+    ) -> impl Future<Output = Result<CheckResponse, CheckError>> + Send;
+
     fn add_account_group_member(
         &mut self,
-        actor: AccountId,
         group: AccountGroupId,
+        member: AccountId,
     ) -> impl Future<Output = Result<Zookie<'static>, CheckError>> + Send;
 
     fn remove_account_group_member(
         &mut self,
-        actor: AccountId,
         group: AccountGroupId,
+        member: AccountId,
     ) -> impl Future<Output = Result<Zookie<'static>, CheckError>> + Send;
 
     fn add_entity_owner(

--- a/apps/hash-graph/lib/authorization/src/lib.rs
+++ b/apps/hash-graph/lib/authorization/src/lib.rs
@@ -29,18 +29,42 @@ use crate::{
 pub struct NoAuthorization;
 
 impl AuthorizationApi for NoAuthorization {
+    async fn can_add_group_members(
+        &self,
+        _actor: AccountId,
+        _account_group: AccountGroupId,
+        _consistency: Consistency<'_>,
+    ) -> Result<CheckResponse, CheckError> {
+        Ok(CheckResponse {
+            has_permission: true,
+            checked_at: Zookie::empty(),
+        })
+    }
+
+    async fn can_remove_group_members(
+        &self,
+        _actor: AccountId,
+        _account_group: AccountGroupId,
+        _consistency: Consistency<'_>,
+    ) -> Result<CheckResponse, CheckError> {
+        Ok(CheckResponse {
+            has_permission: true,
+            checked_at: Zookie::empty(),
+        })
+    }
+
     async fn add_account_group_member(
         &mut self,
-        _actor: AccountId,
         _group: AccountGroupId,
+        _member: AccountId,
     ) -> Result<Zookie<'static>, CheckError> {
         Ok(Zookie::empty())
     }
 
     async fn remove_account_group_member(
         &mut self,
-        _actor: AccountId,
         _group: AccountGroupId,
+        _member: AccountId,
     ) -> Result<Zookie<'static>, CheckError> {
         Ok(Zookie::empty())
     }

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -44,6 +44,102 @@
         }
       }
     },
+    "/account_groups/{account_group_id}/members/{account_id}": {
+      "post": {
+        "tags": [
+          "Graph",
+          "Account Group"
+        ],
+        "operationId": "add_account_group_member",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          },
+          {
+            "name": "account_group_id",
+            "in": "path",
+            "description": "The ID of the account group to add the member to",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountGroupId"
+            }
+          },
+          {
+            "name": "account_id",
+            "in": "path",
+            "description": "The ID of the account to add to the group",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "The account group member was added"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "500": {
+            "description": "Store error occurred"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Graph",
+          "Account Group"
+        ],
+        "operationId": "remove_account_group_member",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          },
+          {
+            "name": "account_group_id",
+            "in": "path",
+            "description": "The ID of the account group to remove the member from",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountGroupId"
+            }
+          },
+          {
+            "name": "account_id",
+            "in": "path",
+            "description": "The ID of the account to remove from the group",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The account group member was removed"
+          },
+          "403": {
+            "description": "Permission denied"
+          },
+          "500": {
+            "description": "Store error occurred"
+          }
+        }
+      }
+    },
     "/accounts": {
       "post": {
         "tags": [


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The Graph is not aware how users are added to organizations. For this, the Graph needs to expose the functionality to add and remove members from an account group.

## 🚫 Blocked by

- #3164 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph