### PR TITLE
H-734: Increase size of "email" icon shown on successful subscription to hash.dev blog

### DIFF
--- a/apps/hashdotdev/src/components/pre-footer.tsx
+++ b/apps/hashdotdev/src/components/pre-footer.tsx
@@ -130,12 +130,11 @@ export const Subscribe: FunctionComponent<
               sx={{
                 color: ({ palette }) => palette.teal[50],
                 fontWeight: 900,
-                fontSize: 48,
                 lineHeight: 1,
                 mb: 2,
               }}
             >
-              <EnvelopeDotSolidIcon />
+              <EnvelopeDotSolidIcon sx={{ fontSize: 48 }} />
             </Box>
             <Typography
               variant="hashHeading2"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR fixes the icon size for the "email" icon shown on successful subscription to the hash.dev blog.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-734

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Go to the `/blog` page and subscribe to the email list to see the success state.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

<img width="1346" alt="image" src="https://github.com/hashintel/hash/assets/42802102/5d629569-9f6d-46d3-b151-45f606cd5c66">

