### PR TITLE
H-629: Ensure blurhash appears for author photos on HDEV post pages

### DIFF
--- a/apps/hashdotdev/src/components/blog-post.tsx
+++ b/apps/hashdotdev/src/components/blog-post.tsx
@@ -208,7 +208,11 @@ export const BlogPostHead: FunctionComponent<{
                         overflow="hidden"
                         position="relative"
                       >
-                        <Image src={author.photo.src} layout="fill" />
+                        <Image
+                          {...author.photo}
+                          layout="fill"
+                          placeholder="blur"
+                        />
                       </Box>
                     ) : null}
                     <Stack ml={2} direction="column" spacing={0.5}>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR makes use of the blurred placeholder image for the image of authors of blog posts in the hash.dev site.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-629

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Go to a blog post on the hash.dev site, and click refresh. Observe the image of an author being blurred briefly before loaded.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

https://github.com/hashintel/hash/assets/42802102/89ab25d0-4e50-4a48-822f-5385dad7dfd2

