### PR TITLE
H-787: Allow usage of non-string values as permission object/subject

### DIFF
--- a/apps/hash-graph/lib/authorization/src/zanzibar.rs
+++ b/apps/hash-graph/lib/authorization/src/zanzibar.rs
@@ -3,8 +3,7 @@
 pub use self::{
     api::ZanzibarClient,
     types::{
-        Affiliation, Consistency, Permission, Relation, Resource, Tuple, UntypedResource,
-        UntypedTuple, Zookie,
+        Affiliation, Consistency, Permission, Relation, Resource, Tuple, UntypedTuple, Zookie,
     },
 };
 

--- a/apps/hash-graph/lib/authorization/src/zanzibar/types.rs
+++ b/apps/hash-graph/lib/authorization/src/zanzibar/types.rs
@@ -1,5 +1,7 @@
+//! General types and traits used throughout the Zanzibar authorization system.
+
 use core::fmt;
-use std::borrow::Cow;
+use std::{borrow::Cow, fmt::Display};
 
 use serde::{Deserialize, Serialize};
 
@@ -13,99 +15,64 @@ pub trait Permission<R: Resource + ?Sized>: Affiliation<R> {}
 pub trait Relation<R: Resource + ?Sized>: Affiliation<R> {}
 
 pub trait Tuple {
-    fn resource_namespace(&self) -> &str;
-    fn resource_id(&self) -> &str;
+    type Object: Resource;
+    type User: Resource;
+
+    fn object_id(&self) -> &<Self::Object as Resource>::Id;
     fn affiliation(&self) -> &str;
-    fn subject_namespace(&self) -> &str;
-    fn subject_id(&self) -> &str;
-    fn subject_set(&self) -> Option<&str>;
+    fn user_id(&self) -> &<Self::User as Resource>::Id;
+    fn user_set(&self) -> Option<&str>;
 }
 
-impl Tuple for UntypedTuple<'_> {
-    fn resource_namespace(&self) -> &str {
-        self.resource.namespace.as_ref()
-    }
-
-    fn resource_id(&self) -> &str {
-        self.resource.id.as_ref()
-    }
-
-    fn affiliation(&self) -> &str {
-        self.affiliation.as_ref()
-    }
-
-    fn subject_namespace(&self) -> &str {
-        self.subject.namespace.as_ref()
-    }
-
-    fn subject_id(&self) -> &str {
-        self.subject.id.as_ref()
-    }
-
-    fn subject_set(&self) -> Option<&str> {
-        self.subject_set.as_ref().map(AsRef::as_ref)
-    }
-}
-
-impl<R, A, S> Tuple for (R, A, S)
+impl<O, A, U> Tuple for (O, A, U)
 where
-    R: Resource,
-    A: Affiliation<R>,
-    S: Resource,
+    O: Resource,
+    A: Affiliation<O>,
+    U: Resource,
 {
-    fn resource_namespace(&self) -> &str {
-        self.0.namespace()
-    }
+    type Object = O;
+    type User = U;
 
-    fn resource_id(&self) -> &str {
-        self.0.id().as_ref()
+    fn object_id(&self) -> &O::Id {
+        self.0.id()
     }
 
     fn affiliation(&self) -> &str {
         self.1.as_ref()
     }
 
-    fn subject_namespace(&self) -> &str {
-        self.2.namespace()
+    fn user_id(&self) -> &U::Id {
+        self.2.id()
     }
 
-    fn subject_id(&self) -> &str {
-        self.2.id().as_ref()
-    }
-
-    fn subject_set(&self) -> Option<&str> {
+    fn user_set(&self) -> Option<&str> {
         None
     }
 }
 
-impl<R, A, S, SA> Tuple for (R, A, S, SA)
+impl<O, A, U, UA> Tuple for (O, A, U, UA)
 where
-    R: Resource,
-    A: Affiliation<R>,
-    S: Resource,
-    SA: Affiliation<S>,
+    O: Resource,
+    A: Affiliation<O>,
+    U: Resource,
+    UA: Affiliation<U>,
 {
-    fn resource_namespace(&self) -> &str {
-        self.0.namespace()
-    }
+    type Object = O;
+    type User = U;
 
-    fn resource_id(&self) -> &str {
-        self.0.id().as_ref()
+    fn object_id(&self) -> &O::Id {
+        self.0.id()
     }
 
     fn affiliation(&self) -> &str {
         self.1.as_ref()
     }
 
-    fn subject_namespace(&self) -> &str {
-        self.2.namespace()
+    fn user_id(&self) -> &U::Id {
+        self.2.id()
     }
 
-    fn subject_id(&self) -> &str {
-        self.2.id().as_ref()
-    }
-
-    fn subject_set(&self) -> Option<&str> {
+    fn user_set(&self) -> Option<&str> {
         Some(self.3.as_ref())
     }
 }
@@ -116,53 +83,13 @@ where
 /// two values separated by a colon.
 pub trait Resource {
     /// The unique identifier for this `Resource`.
-    type Id: AsRef<str> + ?Sized;
+    type Id: Serialize + Display + ?Sized;
 
     /// Returns the namespace for this `Resource`.
-    fn namespace(&self) -> &str;
+    fn namespace() -> &'static str;
 
     /// Returns the unique identifier for this `Resource`.
     fn id(&self) -> &Self::Id;
-}
-
-/// A [`Resource`] that only holds the string representation of it's namespace and id.
-///
-/// This is useful for when the [`Id`] type is not known at compile-time, e.g. when parsing a
-/// [`Tuple`] from a string.
-///
-/// [`Id`]: Resource::Id
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct UntypedResource<'r> {
-    pub namespace: Cow<'r, str>,
-    pub id: Cow<'r, str>,
-}
-
-impl UntypedResource<'_> {
-    #[must_use]
-    pub fn into_owned(self) -> UntypedResource<'static> {
-        UntypedResource {
-            namespace: Cow::Owned(self.namespace.into_owned()),
-            id: Cow::Owned(self.id.into_owned()),
-        }
-    }
-}
-
-impl Resource for UntypedResource<'_> {
-    type Id = str;
-
-    fn namespace(&self) -> &str {
-        &self.namespace
-    }
-
-    fn id(&self) -> &Self::Id {
-        &self.id
-    }
-}
-
-impl fmt::Display for UntypedResource<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "{}:{}", self.namespace, self.id,)
-    }
 }
 
 /// An untyped [`Tuple`] that only holds it's string representation.
@@ -171,20 +98,24 @@ impl fmt::Display for UntypedResource<'_> {
 /// [`Tuple`] from a string.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UntypedTuple<'t> {
-    pub resource: UntypedResource<'t>,
+    pub object_namespace: Cow<'t, str>,
+    pub object_id: Cow<'t, str>,
     pub affiliation: Cow<'t, str>,
-    pub subject: UntypedResource<'t>,
-    pub subject_set: Option<Cow<'t, str>>,
+    pub user_namespace: Cow<'t, str>,
+    pub user_id: Cow<'t, str>,
+    pub user_set: Option<Cow<'t, str>>,
 }
 
 impl UntypedTuple<'_> {
     #[must_use]
     pub fn into_owned(self) -> UntypedTuple<'static> {
         UntypedTuple {
-            resource: self.resource.into_owned(),
+            object_namespace: Cow::Owned(self.object_namespace.into_owned()),
+            object_id: Cow::Owned(self.object_id.into_owned()),
             affiliation: Cow::Owned(self.affiliation.into_owned()),
-            subject: self.subject.into_owned(),
-            subject_set: self.subject_set.map(|cow| Cow::Owned(cow.into_owned())),
+            user_namespace: Cow::Owned(self.user_namespace.into_owned()),
+            user_id: Cow::Owned(self.user_id.into_owned()),
+            user_set: self.user_set.map(|cow| Cow::Owned(cow.into_owned())),
         }
     }
 }
@@ -193,10 +124,14 @@ impl fmt::Display for UntypedTuple<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             fmt,
-            "{}#{}@{}",
-            self.resource, self.affiliation, self.subject
+            "{}:{}#{}@{}:{}",
+            self.object_namespace,
+            self.object_id,
+            self.affiliation,
+            self.user_namespace,
+            self.user_id
         )?;
-        if let Some(affiliation) = &self.subject_set {
+        if let Some(affiliation) = &self.user_set {
             write!(fmt, "#{affiliation}")?;
         }
         Ok(())
@@ -205,18 +140,14 @@ impl fmt::Display for UntypedTuple<'_> {
 
 impl<'t> UntypedTuple<'t> {
     #[must_use]
-    pub fn from_tuple(tuple: &'t impl Tuple) -> Self {
+    pub fn from_tuple<T: Tuple>(tuple: &'t T) -> Self {
         Self {
-            resource: UntypedResource {
-                namespace: Cow::Borrowed(tuple.resource_namespace()),
-                id: Cow::Borrowed(tuple.resource_id()),
-            },
+            object_namespace: Cow::Borrowed(<T::Object as Resource>::namespace()),
+            object_id: Cow::Owned(tuple.object_id().to_string()),
             affiliation: Cow::Borrowed(tuple.affiliation()),
-            subject: UntypedResource {
-                namespace: Cow::Borrowed(tuple.subject_namespace()),
-                id: Cow::Borrowed(tuple.subject_id()),
-            },
-            subject_set: tuple.subject_set().map(Cow::Borrowed),
+            user_namespace: Cow::Borrowed(<T::User as Resource>::namespace()),
+            user_id: Cow::Owned(tuple.user_id().to_string()),
+            user_set: tuple.user_set().map(Cow::Borrowed),
         }
     }
 }

--- a/apps/hash-graph/lib/authorization/tests/api.rs
+++ b/apps/hash-graph/lib/authorization/tests/api.rs
@@ -1,8 +1,6 @@
 #![allow(unused_attributes)] // This file is used as module in other tests
 #![feature(async_fn_in_trait, associated_type_bounds)]
 
-use std::{mem, thread::JoinHandle};
-
 use authorization::{
     backend::{
         CheckError, CheckResponse, CreateRelationError, CreateRelationResponse,
@@ -10,16 +8,12 @@ use authorization::{
         ExportSchemaError, ExportSchemaResponse, ImportSchemaError, ImportSchemaResponse,
         Precondition, RelationFilter, SpiceDbOpenApi, ZanzibarBackend,
     },
-    zanzibar::{Consistency, Tuple, UntypedTuple},
+    zanzibar::{Consistency, Resource, Tuple},
 };
 use error_stack::Report;
-use tokio::sync::oneshot::Sender;
 
 pub struct TestApi {
     client: SpiceDbOpenApi,
-
-    tuples: Vec<UntypedTuple<'static>>,
-    cleanup: Option<(Sender<Vec<UntypedTuple<'static>>>, JoinHandle<()>)>,
 }
 
 impl TestApi {
@@ -42,52 +36,9 @@ impl TestApi {
         let key = std::env::var("HASH_SPICEDB_GRPC_PRESHARED_KEY")
             .unwrap_or_else(|_| "secret".to_owned());
 
-        let client = SpiceDbOpenApi::new(format!("{host}:{http_port}"), &key)
-            .expect("failed to connect to SpiceDB");
-
-        let (tuple_sender, tuple_receiver) = tokio::sync::oneshot::channel();
-
-        let cleanup_task = std::thread::spawn(move || {
-            tokio::runtime::Runtime::new()
-                .expect("failed to create runtime")
-                .block_on(async {
-                    // Sending the client to another thread seems to break the client
-                    // so we create a new one here
-                    let mut client = SpiceDbOpenApi::new(format!("{host}:{http_port}"), &key)
-                        .expect("failed to connect to SpiceDB");
-
-                    let tuples: Vec<UntypedTuple> =
-                        tuple_receiver.await.expect("failed to receive tuples");
-
-                    if let Err(error) = client.delete_relations(&tuples, []).await {
-                        eprintln!(
-                            "failed to delete relations: {error:?} while cleaning up {} tuples",
-                            tuples.len()
-                        );
-                        for tuple in &tuples {
-                            eprintln!("\n  - {tuple}");
-                        }
-                    }
-                });
-        });
-
         Self {
-            client,
-            tuples: Vec::new(),
-            cleanup: Some((tuple_sender, cleanup_task)),
-        }
-    }
-}
-
-impl Drop for TestApi {
-    #[allow(clippy::print_stderr, clippy::use_debug)]
-    fn drop(&mut self) {
-        let (sender, thread) = self.cleanup.take().expect("cleanup task already dropped");
-        sender
-            .send(mem::take(&mut self.tuples))
-            .expect("failed to send namespaces");
-        if let Err(error) = thread.join() {
-            eprintln!("failed to join cleanup thread: {error:?}\n");
+            client: SpiceDbOpenApi::new(format!("{host}:{http_port}"), &key)
+                .expect("failed to connect to SpiceDB"),
         }
     }
 }
@@ -107,52 +58,57 @@ impl ZanzibarBackend for TestApi {
     async fn create_relations<'p, 't, T>(
         &mut self,
         tuples: impl IntoIterator<Item = &'t T, IntoIter: Send> + Send,
-        preconditions: impl IntoIterator<Item = Precondition<'p>, IntoIter: Send> + Send + 'p,
+        preconditions: impl IntoIterator<Item = Precondition<'p, T::Object, T::User>, IntoIter: Send>
+        + Send
+        + 'p,
     ) -> Result<CreateRelationResponse, Report<CreateRelationError>>
     where
-        T: Tuple + Send + Sync + 't,
+        T: Tuple + 't,
+        <T::Object as Resource>::Id: Sync + 'p,
+        <T::User as Resource>::Id: Sync + 'p,
     {
-        let (tuples, untyped_tuples): (Vec<_>, Vec<_>) = tuples
-            .into_iter()
-            .map(|tuple| {
-                let untyped_tuples = UntypedTuple::from_tuple(tuple).into_owned();
-                (tuple, untyped_tuples)
-            })
-            .unzip();
-
-        let result = self.client.create_relations(tuples, preconditions).await?;
-
-        self.tuples.extend(untyped_tuples);
-
-        Ok(result)
+        self.client.create_relations(tuples, preconditions).await
     }
 
     async fn delete_relations<'p, 't, T>(
         &mut self,
         tuples: impl IntoIterator<Item = &'t T, IntoIter: Send> + Send,
-        preconditions: impl IntoIterator<Item = Precondition<'p>, IntoIter: Send> + Send + 'p,
+        preconditions: impl IntoIterator<Item = Precondition<'p, T::Object, T::User>, IntoIter: Send>
+        + Send
+        + 'p,
     ) -> Result<DeleteRelationResponse, Report<DeleteRelationError>>
     where
-        T: Tuple + Send + Sync + 't,
+        T: Tuple + 't,
+        <T::Object as Resource>::Id: Sync + 'p,
+        <T::User as Resource>::Id: Sync + 'p,
     {
         self.client.delete_relations(tuples, preconditions).await
     }
 
-    async fn delete_relations_by_filter<'f>(
+    async fn delete_relations_by_filter<'f, O, U>(
         &mut self,
-        filter: RelationFilter<'_>,
-        preconditions: impl IntoIterator<Item = Precondition<'f>> + Send,
-    ) -> Result<DeleteRelationsResponse, Report<DeleteRelationsError>> {
+        filter: RelationFilter<'_, O, U>,
+        preconditions: impl IntoIterator<Item = Precondition<'f, O, U>> + Send,
+    ) -> Result<DeleteRelationsResponse, Report<DeleteRelationsError>>
+    where
+        O: Resource<Id: Sync + 'f> + ?Sized,
+        U: Resource<Id: Sync + 'f> + ?Sized,
+    {
         self.client
             .delete_relations_by_filter(filter, preconditions)
             .await
     }
 
-    async fn check(
+    async fn check<T>(
         &self,
-        tuple: &(impl Tuple + Sync),
+        tuple: &T,
         consistency: Consistency<'_>,
-    ) -> Result<CheckResponse, Report<CheckError>> {
+    ) -> Result<CheckResponse, Report<CheckError>>
+    where
+        T: Tuple + Sync,
+        <T::Object as Resource>::Id: Sync,
+        <T::User as Resource>::Id: Sync,
+    {
         self.client.check(tuple, consistency).await
     }
 }

--- a/apps/hash-graph/lib/authorization/tests/schema.rs
+++ b/apps/hash-graph/lib/authorization/tests/schema.rs
@@ -10,7 +10,7 @@ pub const CHARLIE: Account = Account("charlie");
 impl Resource for Account {
     type Id = str;
 
-    fn namespace(&self) -> &'static str {
+    fn namespace() -> &'static str {
         "graph/account"
     }
 
@@ -29,7 +29,7 @@ pub const ENTITY_C: Entity = Entity("c");
 impl Resource for Entity {
     type Id = str;
 
-    fn namespace(&self) -> &'static str {
+    fn namespace() -> &'static str {
         "graph/entity"
     }
 

--- a/apps/hash-graph/lib/authorization/tests/simple.rs
+++ b/apps/hash-graph/lib/authorization/tests/simple.rs
@@ -176,9 +176,9 @@ async fn test_preconditions() -> Result<(), Box<dyn Error>> {
                 &(ENTITY_C, EntityRelation::Reader, BOB),
             ],
             [Precondition::must_match(
-                RelationFilter::for_resource(&ENTITY_C)
+                RelationFilter::for_object(&ENTITY_C)
                     .by_relation(&EntityRelation::Writer)
-                    .with_subject(&CHARLIE),
+                    .with_user(&CHARLIE),
             )],
         )
         .await
@@ -213,9 +213,9 @@ async fn test_preconditions() -> Result<(), Box<dyn Error>> {
                 &(ENTITY_C, EntityRelation::Reader, BOB),
             ],
             [Precondition::must_match(
-                RelationFilter::for_resource(&ENTITY_C)
+                RelationFilter::for_object(&ENTITY_C)
                     .by_relation(&EntityRelation::Writer)
-                    .with_subject(&CHARLIE),
+                    .with_user(&CHARLIE),
             )],
         )
         .await?
@@ -240,11 +240,11 @@ async fn test_preconditions() -> Result<(), Box<dyn Error>> {
 
     let _ = api
         .delete_relations_by_filter(
-            RelationFilter::for_resource(&ENTITY_C).by_relation(&EntityRelation::Reader),
+            RelationFilter::for_object(&ENTITY_C).by_relation(&EntityRelation::Reader),
             [Precondition::must_not_match(
-                RelationFilter::for_resource(&ENTITY_C)
+                RelationFilter::for_object(&ENTITY_C)
                     .by_relation(&EntityRelation::Writer)
-                    .with_subject(&CHARLIE),
+                    .with_user(&CHARLIE),
             )],
         )
         .await
@@ -252,11 +252,11 @@ async fn test_preconditions() -> Result<(), Box<dyn Error>> {
 
     let token = api
         .delete_relations_by_filter(
-            RelationFilter::for_resource(&ENTITY_C).by_relation(&EntityRelation::Reader),
+            RelationFilter::for_object(&ENTITY_C).by_relation(&EntityRelation::Reader),
             [Precondition::must_match(
-                RelationFilter::for_resource(&ENTITY_C)
+                RelationFilter::for_object(&ENTITY_C)
                     .by_relation(&EntityRelation::Writer)
-                    .with_subject(&CHARLIE),
+                    .with_user(&CHARLIE),
             )],
         )
         .await?


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The current implementation of the permission system requires `AsRef<str>`. We only use `UUID`s or `UUID`-like identifiers in the Graph, but `Uuid` does not implement the trait (It only implements `AsRef<[u8]>`).

We currently have the compatibility for untyped tuple but we don't expect this to be used as the plan for migrations is do be more fine-grained within snapshots.

To solve this, the `Tuple` trait requires associated types (which would be required to properly implement a gRPC interface as well), so we can directly serialize it into JSON (or a `Message` for gRPC).

## 🚫 Blocked by

- #3171 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

A known issue is that the interface with optional parameters might be more unintuitive to use but as we currently don't use that interface we can worry about that later.
