### PR TITLE
H-788: Make the organization creator an admin of the account group

### DIFF
--- a/apps/hash-graph/lib/authorization/src/api.rs
+++ b/apps/hash-graph/lib/authorization/src/api.rs
@@ -22,6 +22,18 @@ pub enum VisibilityScope {
 }
 
 pub trait AuthorizationApi {
+    fn add_account_group_admin(
+        &mut self,
+        member: AccountId,
+        group: AccountGroupId,
+    ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
+
+    fn remove_account_group_admin(
+        &mut self,
+        member: AccountId,
+        group: AccountGroupId,
+    ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
+
     fn can_add_group_members(
         &self,
         actor: AccountId,
@@ -38,14 +50,14 @@ pub trait AuthorizationApi {
 
     fn add_account_group_member(
         &mut self,
-        group: AccountGroupId,
         member: AccountId,
+        group: AccountGroupId,
     ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
 
     fn remove_account_group_member(
         &mut self,
-        group: AccountGroupId,
         member: AccountId,
+        group: AccountGroupId,
     ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
 
     fn add_entity_owner(

--- a/apps/hash-graph/lib/authorization/src/lib.rs
+++ b/apps/hash-graph/lib/authorization/src/lib.rs
@@ -29,6 +29,22 @@ use crate::{
 pub struct NoAuthorization;
 
 impl AuthorizationApi for NoAuthorization {
+    async fn add_account_group_admin(
+        &mut self,
+        _member: AccountId,
+        _group: AccountGroupId,
+    ) -> Result<Zookie<'static>, ModifyRelationError> {
+        Ok(Zookie::empty())
+    }
+
+    async fn remove_account_group_admin(
+        &mut self,
+        _member: AccountId,
+        _group: AccountGroupId,
+    ) -> Result<Zookie<'static>, ModifyRelationError> {
+        Ok(Zookie::empty())
+    }
+
     async fn can_add_group_members(
         &self,
         _actor: AccountId,
@@ -55,16 +71,16 @@ impl AuthorizationApi for NoAuthorization {
 
     async fn add_account_group_member(
         &mut self,
-        _group: AccountGroupId,
         _member: AccountId,
+        _group: AccountGroupId,
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(Zookie::empty())
     }
 
     async fn remove_account_group_member(
         &mut self,
-        _group: AccountGroupId,
         _member: AccountId,
+        _group: AccountGroupId,
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(Zookie::empty())
     }

--- a/apps/hash-graph/lib/authorization/src/zanzibar/api.rs
+++ b/apps/hash-graph/lib/authorization/src/zanzibar/api.rs
@@ -26,6 +26,22 @@ impl<B> AuthorizationApi for ZanzibarClient<B>
 where
     B: ZanzibarBackend + Send + Sync,
 {
+    async fn add_account_group_admin(
+        &mut self,
+        _member: AccountId,
+        _group: AccountGroupId,
+    ) -> Result<Zookie<'static>, ModifyRelationError> {
+        Err(Report::new(ModifyRelationError).attach_printable("not implemented"))
+    }
+
+    async fn remove_account_group_admin(
+        &mut self,
+        _member: AccountId,
+        _group: AccountGroupId,
+    ) -> Result<Zookie<'static>, ModifyRelationError> {
+        Err(Report::new(ModifyRelationError).attach_printable("not implemented"))
+    }
+
     async fn can_add_group_members(
         &self,
         _actor: AccountId,
@@ -52,16 +68,16 @@ where
 
     async fn add_account_group_member(
         &mut self,
-        _group: AccountGroupId,
         _member: AccountId,
+        _group: AccountGroupId,
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Err(Report::new(ModifyRelationError).attach_printable("not implemented"))
     }
 
     async fn remove_account_group_member(
         &mut self,
-        _group: AccountGroupId,
         _member: AccountId,
+        _group: AccountGroupId,
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Err(Report::new(ModifyRelationError).attach_printable("not implemented"))
     }

--- a/apps/hash-graph/lib/graph/src/api/rest/account.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/account.rs
@@ -196,7 +196,7 @@ where
     }
 
     authorization_api
-        .add_account_group_member(account_group_id, account_id)
+        .add_account_group_member(account_id, account_group_id)
         .await
         .map_err(|error| {
             tracing::error!(?error, "Could not add account group member");
@@ -254,7 +254,7 @@ where
     }
 
     authorization_api
-        .remove_account_group_member(account_group_id, account_id)
+        .remove_account_group_member(account_id, account_group_id)
         .await
         .map_err(|error| {
             tracing::error!(?error, "Could not remove account group member");

--- a/apps/hash-graph/lib/graph/src/store/postgres.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres.rs
@@ -1264,11 +1264,11 @@ impl<C: AsClient> AccountStore for PostgresStore<C> {
         transaction.commit().await.change_context(InsertionError)
     }
 
-    #[tracing::instrument(level = "info", skip(self, _authorization_api))]
+    #[tracing::instrument(level = "info", skip(self, authorization_api))]
     async fn insert_account_group_id<A: AuthorizationApi + Send + Sync>(
         &mut self,
-        _actor_id: AccountId,
-        _authorization_api: &mut A,
+        actor_id: AccountId,
+        authorization_api: &mut A,
         account_group_id: AccountGroupId,
     ) -> Result<(), InsertionError> {
         let transaction = self.transaction().await.change_context(InsertionError)?;
@@ -1301,7 +1301,26 @@ impl<C: AsClient> AccountStore for PostgresStore<C> {
             .change_context(InsertionError)
             .attach_printable(account_group_id)?;
 
-        transaction.commit().await.change_context(InsertionError)
+        authorization_api
+            .add_account_group_admin(actor_id, account_group_id)
+            .await
+            .change_context(InsertionError)?;
+
+        if let Err(mut error) = transaction.commit().await.change_context(InsertionError) {
+            if let Err(auth_error) = authorization_api
+                .remove_account_group_admin(actor_id, account_group_id)
+                .await
+                .change_context(InsertionError)
+            {
+                // TODO: Use `add_child`
+                //   see https://linear.app/hash/issue/GEN-105/add-ability-to-add-child-errors
+                error.extend_one(auth_error);
+            }
+
+            Err(error)
+        } else {
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Account groups require some kind of administration, otherwise it would not be possible to add new members. The most straightforward way is to use the creator of the organization.

## 🚫 Blocked by

- #3171 
- #3174 


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph