### PR TITLE
H-789: Rename `as_uuid` and provide a reference getter

### DIFF
--- a/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
@@ -88,7 +88,7 @@ async fn seed_db(
         .id()
         .clone();
 
-    let owned_by_id = OwnedById::new(account_id.as_uuid());
+    let owned_by_id = OwnedById::new(account_id.into_uuid());
 
     let entity_metadata_list = transaction
         .insert_entities_batched_by_type(

--- a/apps/hash-graph/bench/read_scaling/knowledge/linkless/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/linkless/entity.rs
@@ -82,7 +82,7 @@ async fn seed_db(
             account_id,
             &mut NoAuthorization,
             repeat((
-                OwnedById::new(account_id.as_uuid()),
+                OwnedById::new(account_id.into_uuid()),
                 None,
                 properties,
                 None,

--- a/apps/hash-graph/bench/representative_read/knowledge/entity.rs
+++ b/apps/hash-graph/bench/representative_read/knowledge/entity.rs
@@ -48,7 +48,7 @@ pub fn bench_get_entity_by_id(
                         filter: Filter::Equal(
                             Some(FilterExpression::Path(EntityQueryPath::Uuid)),
                             Some(FilterExpression::Parameter(Parameter::Uuid(
-                                entity_uuid.as_uuid(),
+                                entity_uuid.into_uuid(),
                             ))),
                         ),
                         graph_resolve_depths: GraphResolveDepths::default(),

--- a/apps/hash-graph/bench/representative_read/seed.rs
+++ b/apps/hash-graph/bench/representative_read/seed.rs
@@ -158,7 +158,7 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
                 account_id,
                 &mut NoAuthorization,
                 repeat((
-                    OwnedById::new(account_id.as_uuid()),
+                    OwnedById::new(account_id.into_uuid()),
                     None,
                     properties,
                     None,
@@ -191,7 +191,7 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
                     .zip(&entity_uuids[*right_entity_index])
                     .map(|(left_entity_metadata, right_entity_metadata)| {
                         (
-                            OwnedById::new(account_id.as_uuid()),
+                            OwnedById::new(account_id.into_uuid()),
                             None,
                             EntityProperties::empty(),
                             Some(LinkData {

--- a/apps/hash-graph/bench/util.rs
+++ b/apps/hash-graph/bench/util.rs
@@ -222,7 +222,7 @@ pub async fn seed<D, P, E, C>(
                 PartialOntologyElementMetadata {
                     record_id: data_type.id().clone().into(),
                     custom: PartialCustomOntologyMetadata::Owned {
-                        owned_by_id: OwnedById::new(account_id.as_uuid()),
+                        owned_by_id: OwnedById::new(account_id.into_uuid()),
                     },
                 },
             )
@@ -256,7 +256,7 @@ pub async fn seed<D, P, E, C>(
                 PartialOntologyElementMetadata {
                     record_id: property_type.id().clone().into(),
                     custom: PartialCustomOntologyMetadata::Owned {
-                        owned_by_id: OwnedById::new(account_id.as_uuid()),
+                        owned_by_id: OwnedById::new(account_id.into_uuid()),
                     },
                 },
             )
@@ -291,7 +291,7 @@ pub async fn seed<D, P, E, C>(
                     record_id: entity_type.id().clone().into(),
                     custom: PartialCustomEntityTypeMetadata {
                         common: PartialCustomOntologyMetadata::Owned {
-                            owned_by_id: OwnedById::new(account_id.as_uuid()),
+                            owned_by_id: OwnedById::new(account_id.into_uuid()),
                         },
                         label_property: None,
                     },

--- a/apps/hash-graph/lib/graph-types/src/account.rs
+++ b/apps/hash-graph/lib/graph-types/src/account.rs
@@ -18,8 +18,13 @@ impl AccountId {
     }
 
     #[must_use]
-    pub const fn as_uuid(self) -> Uuid {
+    pub const fn into_uuid(self) -> Uuid {
         self.0
+    }
+
+    #[must_use]
+    pub const fn as_uuid(&self) -> &Uuid {
+        &self.0
     }
 }
 
@@ -42,8 +47,13 @@ impl AccountGroupId {
     }
 
     #[must_use]
-    pub const fn as_uuid(self) -> Uuid {
+    pub const fn into_uuid(self) -> Uuid {
         self.0
+    }
+
+    #[must_use]
+    pub const fn as_uuid(&self) -> &Uuid {
+        &self.0
     }
 }
 

--- a/apps/hash-graph/lib/graph-types/src/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph-types/src/knowledge/entity.rs
@@ -31,7 +31,12 @@ impl EntityUuid {
     }
 
     #[must_use]
-    pub const fn as_uuid(self) -> Uuid {
+    pub const fn as_uuid(&self) -> &Uuid {
+        &self.0
+    }
+
+    #[must_use]
+    pub const fn into_uuid(self) -> Uuid {
         self.0
     }
 }
@@ -247,7 +252,12 @@ impl EntityEditionId {
     }
 
     #[must_use]
-    pub const fn as_uuid(self) -> Uuid {
+    pub const fn as_uuid(&self) -> &Uuid {
+        &self.0
+    }
+
+    #[must_use]
+    pub const fn into_uuid(self) -> Uuid {
         self.0
     }
 }

--- a/apps/hash-graph/lib/graph-types/src/provenance.rs
+++ b/apps/hash-graph/lib/graph-types/src/provenance.rs
@@ -30,8 +30,13 @@ macro_rules! define_provenance_id {
             }
 
             #[must_use]
-            pub const fn as_uuid(self) -> Uuid {
+            pub const fn as_uuid(&self) -> &Uuid {
                 self.0.as_uuid()
+            }
+
+            #[must_use]
+            pub const fn into_uuid(self) -> Uuid {
+                self.0.into_uuid()
             }
         }
 
@@ -78,7 +83,12 @@ impl OwnedById {
     }
 
     #[must_use]
-    pub const fn as_uuid(self) -> Uuid {
+    pub const fn as_uuid(&self) -> &Uuid {
+        &self.0
+    }
+
+    #[must_use]
+    pub const fn into_uuid(self) -> Uuid {
         self.0
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres.rs
@@ -359,7 +359,7 @@ where
             .change_context(InsertionError)?
             .get(0);
 
-        let owned_by_uuid = owned_by_id.as_uuid();
+        let owned_by_uuid = owned_by_id.into_uuid();
         if is_account_group {
             Ok(VisibilityScope::AccountGroup(AccountGroupId::new(
                 owned_by_uuid,

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -307,7 +307,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             .change_context(InsertionError)?
             .get(0);
 
-        let owned_by_uuid = owned_by_id.as_uuid();
+        let owned_by_uuid = owned_by_id.into_uuid();
         let visibility_scope = if is_account_group {
             VisibilityScope::AccountGroup(AccountGroupId::new(owned_by_uuid))
         } else {

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/ontology_id.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/ontology_id.rs
@@ -21,7 +21,13 @@ impl OntologyId {
         ))
     }
 
-    pub const fn as_uuid(self) -> Uuid {
+    #[must_use]
+    pub const fn as_uuid(&self) -> &Uuid {
+        &self.0
+    }
+
+    #[must_use]
+    pub const fn into_uuid(self) -> Uuid {
         self.0
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/traversal_context.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/traversal_context.rs
@@ -27,7 +27,7 @@ impl<C: AsClient> PostgresStore<C> {
     ) -> Result<(), QueryError> {
         let ids = vertex_ids
             .into_iter()
-            .map(OntologyId::as_uuid)
+            .map(OntologyId::into_uuid)
             .collect::<Vec<_>>();
 
         for data_type in <Self as Read<DataTypeWithMetadata>>::read_vec(
@@ -56,7 +56,7 @@ impl<C: AsClient> PostgresStore<C> {
     ) -> Result<(), QueryError> {
         let ids = vertex_ids
             .into_iter()
-            .map(OntologyId::as_uuid)
+            .map(OntologyId::into_uuid)
             .collect::<Vec<_>>();
 
         for property_type in <Self as Read<PropertyTypeWithMetadata>>::read_vec(
@@ -85,7 +85,7 @@ impl<C: AsClient> PostgresStore<C> {
     ) -> Result<(), QueryError> {
         let ids = vertex_ids
             .into_iter()
-            .map(OntologyId::as_uuid)
+            .map(OntologyId::into_uuid)
             .collect::<Vec<_>>();
 
         for entity_type in <Self as Read<EntityTypeWithMetadata>>::read_vec(
@@ -114,7 +114,7 @@ impl<C: AsClient> PostgresStore<C> {
     ) -> Result<(), QueryError> {
         let ids = edition_ids
             .into_iter()
-            .map(EntityEditionId::as_uuid)
+            .map(EntityEditionId::into_uuid)
             .collect::<Vec<_>>();
 
         for entity in <Self as Read<Entity>>::read_vec(

--- a/apps/hash-graph/lib/graph/src/store/query/filter.rs
+++ b/apps/hash-graph/lib/graph/src/store/query/filter.rs
@@ -83,13 +83,13 @@ impl<'p> Filter<'p, Entity> {
             Self::Equal(
                 Some(FilterExpression::Path(EntityQueryPath::OwnedById)),
                 Some(FilterExpression::Parameter(Parameter::Uuid(
-                    entity_id.owned_by_id.as_uuid(),
+                    entity_id.owned_by_id.into_uuid(),
                 ))),
             ),
             Self::Equal(
                 Some(FilterExpression::Path(EntityQueryPath::Uuid)),
                 Some(FilterExpression::Parameter(Parameter::Uuid(
-                    entity_id.entity_uuid.as_uuid(),
+                    entity_id.entity_uuid.into_uuid(),
                 ))),
             ),
         ])

--- a/apps/hash-graph/tests/integration/postgres/lib.rs
+++ b/apps/hash-graph/tests/integration/postgres/lib.rs
@@ -137,7 +137,7 @@ impl DatabaseTestWrapper {
             let metadata = PartialOntologyElementMetadata {
                 record_id: data_type.id().clone().into(),
                 custom: PartialCustomOntologyMetadata::Owned {
-                    owned_by_id: OwnedById::new(account_id.as_uuid()),
+                    owned_by_id: OwnedById::new(account_id.into_uuid()),
                 },
             };
 
@@ -161,7 +161,7 @@ impl DatabaseTestWrapper {
             let metadata = PartialOntologyElementMetadata {
                 record_id: property_type.id().clone().into(),
                 custom: PartialCustomOntologyMetadata::Owned {
-                    owned_by_id: OwnedById::new(account_id.as_uuid()),
+                    owned_by_id: OwnedById::new(account_id.into_uuid()),
                 },
             };
 
@@ -186,7 +186,7 @@ impl DatabaseTestWrapper {
                 record_id: entity_type.id().clone().into(),
                 custom: PartialCustomEntityTypeMetadata {
                     common: PartialCustomOntologyMetadata::Owned {
-                        owned_by_id: OwnedById::new(account_id.as_uuid()),
+                        owned_by_id: OwnedById::new(account_id.into_uuid()),
                     },
                     label_property: None,
                 },
@@ -229,7 +229,7 @@ impl DatabaseApi<'_> {
         let metadata = PartialOntologyElementMetadata {
             record_id: data_type.id().clone().into(),
             custom: PartialCustomOntologyMetadata::Owned {
-                owned_by_id: OwnedById::new(self.account_id.as_uuid()),
+                owned_by_id: OwnedById::new(self.account_id.into_uuid()),
             },
         };
 
@@ -298,7 +298,7 @@ impl DatabaseApi<'_> {
         let metadata = PartialOntologyElementMetadata {
             record_id: property_type.id().clone().into(),
             custom: PartialCustomOntologyMetadata::Owned {
-                owned_by_id: OwnedById::new(self.account_id.as_uuid()),
+                owned_by_id: OwnedById::new(self.account_id.into_uuid()),
             },
         };
 
@@ -357,7 +357,7 @@ impl DatabaseApi<'_> {
             record_id: entity_type.id().clone().into(),
             custom: PartialCustomEntityTypeMetadata {
                 common: PartialCustomOntologyMetadata::Owned {
-                    owned_by_id: OwnedById::new(self.account_id.as_uuid()),
+                    owned_by_id: OwnedById::new(self.account_id.into_uuid()),
                 },
                 label_property: None,
             },
@@ -415,7 +415,7 @@ impl DatabaseApi<'_> {
             .create_entity(
                 self.account_id,
                 &mut NoAuthorization,
-                OwnedById::new(self.account_id.as_uuid()),
+                OwnedById::new(self.account_id.into_uuid()),
                 entity_uuid,
                 Some(generate_decision_time()),
                 false,
@@ -539,7 +539,7 @@ impl DatabaseApi<'_> {
             .create_entity(
                 self.account_id,
                 &mut NoAuthorization,
-                OwnedById::new(self.account_id.as_uuid()),
+                OwnedById::new(self.account_id.into_uuid()),
                 entity_uuid,
                 None,
                 false,
@@ -570,7 +570,7 @@ impl DatabaseApi<'_> {
                     direction: EdgeDirection::Outgoing,
                 })),
                 Some(FilterExpression::Parameter(Parameter::Uuid(
-                    source_entity_id.entity_uuid.as_uuid(),
+                    source_entity_id.entity_uuid.into_uuid(),
                 ))),
             ),
             Filter::Equal(
@@ -580,7 +580,7 @@ impl DatabaseApi<'_> {
                     direction: EdgeDirection::Outgoing,
                 })),
                 Some(FilterExpression::Parameter(Parameter::Uuid(
-                    source_entity_id.owned_by_id.as_uuid(),
+                    source_entity_id.owned_by_id.into_uuid(),
                 ))),
             ),
             Filter::Equal(
@@ -653,7 +653,7 @@ impl DatabaseApi<'_> {
                     direction: EdgeDirection::Outgoing,
                 })),
                 Some(FilterExpression::Parameter(Parameter::Uuid(
-                    source_entity_id.entity_uuid.as_uuid(),
+                    source_entity_id.entity_uuid.into_uuid(),
                 ))),
             ),
             Filter::Equal(
@@ -663,7 +663,7 @@ impl DatabaseApi<'_> {
                     direction: EdgeDirection::Outgoing,
                 })),
                 Some(FilterExpression::Parameter(Parameter::Uuid(
-                    source_entity_id.owned_by_id.as_uuid(),
+                    source_entity_id.owned_by_id.into_uuid(),
                 ))),
             ),
             Filter::Equal(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The UUID wrapper only returns a copy of the inner value. This way it's not possible to use it in a generic context. Generally, `as_*` should be used to return a reference, not a copy. For that, either `to_*` (ref -> copy) or `into_*` (value -> value) are supposed to be used.

This PR renames `as_uuid` to `into_uuid` and adds a proper `as_uuid` method.

## 🚫 Blocked by

- #3171 
- #3174 
- #3176 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph