### PR TITLE
H-786: fix `TextField` ref not being passed to component correctly

### DIFF
--- a/libs/@hashintel/design-system/src/text-field.tsx
+++ b/libs/@hashintel/design-system/src/text-field.tsx
@@ -163,7 +163,9 @@ export const TextField: FunctionComponent<TextFieldProps> = forwardRef(
           error,
           autoResize,
           multiline: textFieldProps.multiline,
-          inputProps: theme.components?.MuiInputBase?.defaultProps?.inputProps,
+          slotProps: {
+            input: theme.components?.MuiInputBase?.defaultProps?.inputProps,
+          },
         })}
         helperText={
           <Collapse in={!!helperText}>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR fixes a bug that was introduced in https://github.com/hashintel/hash/pull/3155, where the usage of `inputProps` on the `TextField` component to disable 1Password on inputs by default prevented the `ref` from being passed to the component correctly for some reason.

This broke several inputs in the application which relied upon the `ref` being set, for example the link type selector in the entity type editor, the link selector in the entity editor, etc.

After some trial and error, I discovered that using the `slotProps` prop to achieve the override does not introduce this issue.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-786

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Try adding a link to an entity type, and confirm this is working again.

Go to `/settings/organizations/example-org/members` and inspect the "Add member" input to see the 1Password overlay is not being displayed to confirm the override still works.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

Adding link types to an entity type works again:

https://github.com/hashintel/hash/assets/42802102/bf5b6b8e-9004-4015-9c97-7532f5e3e252

The unwanted 1Password overlay is not displayed on the "Add member" input thanks to the override:

<img width="330" alt="image" src="https://github.com/hashintel/hash/assets/42802102/e9111baf-58e6-4d76-8769-0784cd68a25a">
