### PR TITLE
H-795: Remove filter from permission queries

### DIFF
--- a/apps/hash-graph/lib/authorization/src/backend.rs
+++ b/apps/hash-graph/lib/authorization/src/backend.rs
@@ -6,7 +6,7 @@ use std::error::Error;
 use error_stack::Report;
 
 pub use self::spicedb::SpiceDbOpenApi;
-use crate::zanzibar::{Affiliation, Consistency, Relation, Resource, Tuple, UntypedTuple, Zookie};
+use crate::zanzibar::{Consistency, Tuple, UntypedTuple, Zookie};
 
 /// A backend for interacting with an authorization system based on the Zanzibar model.
 pub trait ZanzibarBackend {
@@ -36,48 +36,24 @@ pub trait ZanzibarBackend {
     /// # Errors
     ///
     /// Returns an error if the relation already exists or could not be created.
-    async fn create_relations<'p, 't, T>(
+    async fn create_relations<'t, T>(
         &mut self,
         tuples: impl IntoIterator<Item = &'t T, IntoIter: Send> + Send,
-        preconditions: impl IntoIterator<Item = Precondition<'p, T::Object, T::User>, IntoIter: Send>
-        + Send
-        + 'p,
     ) -> Result<CreateRelationResponse, Report<CreateRelationError>>
     where
-        T: Tuple + 't,
-        <T::Object as Resource>::Id: Sync + 'p,
-        <T::User as Resource>::Id: Sync + 'p;
+        T: Tuple + Sync + 't;
 
     /// Deletes the relation specified by the [`Tuple`].
     ///
     /// # Errors
     ///
     /// Returns an error if the relation does not exist or could not be deleted.
-    async fn delete_relations<'p, 't, T>(
+    async fn delete_relations<'t, T>(
         &mut self,
         tuples: impl IntoIterator<Item = &'t T, IntoIter: Send> + Send,
-        preconditions: impl IntoIterator<Item = Precondition<'p, T::Object, T::User>, IntoIter: Send>
-        + Send
-        + 'p,
     ) -> Result<DeleteRelationResponse, Report<DeleteRelationError>>
     where
-        T: Tuple + 't,
-        <T::Object as Resource>::Id: Sync + 'p,
-        <T::User as Resource>::Id: Sync + 'p;
-
-    /// Deletes all relations matching the specified [`RelationFilter`].
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the relations could not be deleted.
-    async fn delete_relations_by_filter<'f, O, U>(
-        &mut self,
-        filter: RelationFilter<'_, O, U>,
-        preconditions: impl IntoIterator<Item = Precondition<'f, O, U>> + Send,
-    ) -> Result<DeleteRelationsResponse, Report<DeleteRelationsError>>
-    where
-        O: Resource<Id: Sync + 'f> + ?Sized,
-        U: Resource<Id: Sync + 'f> + ?Sized;
+        T: Tuple + Sync + 't;
 
     /// Returns if the subject of the [`Tuple`] has the specified permission or relation to an
     /// [`Resource`].
@@ -95,9 +71,7 @@ pub trait ZanzibarBackend {
         consistency: Consistency<'_>,
     ) -> Result<CheckResponse, Report<CheckError>>
     where
-        T: Tuple + Sync,
-        <T::Object as Resource>::Id: Sync,
-        <T::User as Resource>::Id: Sync;
+        T: Tuple + Sync;
 }
 
 /// Return value for [`ZanzibarBackend::import_schema`].
@@ -178,25 +152,6 @@ impl fmt::Display for DeleteRelationError {
 
 impl Error for DeleteRelationError {}
 
-/// Return value for [`ZanzibarBackend::delete_relations`].
-#[derive(Debug)]
-pub struct DeleteRelationsResponse {
-    /// A token to determine the time at which the relation was deleted.
-    pub deleted_at: Zookie<'static>,
-}
-
-/// Error returned from [`ZanzibarBackend::delete_relations`].
-#[derive(Debug)]
-pub struct DeleteRelationsError;
-
-impl fmt::Display for DeleteRelationsError {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.write_str("failed to delete relations")
-    }
-}
-
-impl Error for DeleteRelationsError {}
-
 /// Return value for [`ZanzibarBackend::check`].
 #[derive(Debug)]
 #[must_use]
@@ -258,114 +213,3 @@ impl fmt::Display for PermissionAssertion {
 }
 
 impl Error for PermissionAssertion {}
-
-pub struct UserFilter<'s, R>
-where
-    R: Resource + ?Sized,
-{
-    pub id: Option<&'s R::Id>,
-    pub affiliation: Option<&'s str>,
-}
-
-pub struct RelationFilter<'f, O, U>
-where
-    O: Resource + ?Sized,
-    U: Resource + ?Sized,
-{
-    pub id: Option<&'f O::Id>,
-    pub affiliation: Option<&'f str>,
-    pub subject: Option<UserFilter<'f, U>>,
-}
-
-pub struct Precondition<'f, O, U>
-where
-    O: Resource + ?Sized,
-    U: Resource + ?Sized,
-{
-    pub must_match: bool,
-    pub filter: RelationFilter<'f, O, U>,
-}
-
-impl<'f, O, U> Precondition<'f, O, U>
-where
-    O: Resource + ?Sized,
-    U: Resource + ?Sized,
-{
-    #[must_use]
-    pub const fn must_match(filter: RelationFilter<'f, O, U>) -> Self {
-        Self {
-            must_match: true,
-            filter,
-        }
-    }
-
-    #[must_use]
-    pub const fn must_not_match(filter: RelationFilter<'f, O, U>) -> Self {
-        Self {
-            must_match: false,
-            filter,
-        }
-    }
-}
-
-impl<'f, O, U> RelationFilter<'f, O, U>
-where
-    O: Resource + ?Sized,
-    U: Resource + ?Sized,
-{
-    #[must_use]
-    pub const fn for_object_namespace() -> Self {
-        Self {
-            id: None,
-            affiliation: None,
-            subject: None,
-        }
-    }
-
-    pub fn for_object(object: &'f O) -> Self {
-        Self {
-            id: Some(object.id()),
-            affiliation: None,
-            subject: None,
-        }
-    }
-
-    #[must_use]
-    pub fn by_relation<A>(mut self, relation: &'f A) -> Self
-    where
-        A: Relation<O> + ?Sized,
-    {
-        self.affiliation = Some(relation.as_ref());
-        self
-    }
-
-    #[must_use]
-    pub const fn with_user_namespace(mut self) -> Self {
-        self.subject = Some(UserFilter {
-            id: None,
-            affiliation: None,
-        });
-        self
-    }
-
-    #[must_use]
-    pub fn with_user(mut self, user: &'f U) -> Self {
-        self.subject = Some(UserFilter {
-            id: Some(user.id()),
-            affiliation: None,
-        });
-        self
-    }
-
-    #[must_use]
-    pub fn with_user_set<A>(mut self, user: &'f U, affiliation: &'f A) -> Self
-    where
-        A: Affiliation<U> + ?Sized,
-    {
-        self.subject = Some(UserFilter {
-            id: Some(user.id()),
-            affiliation: Some(affiliation.as_ref()),
-        });
-        self
-    }
-}

--- a/apps/hash-graph/lib/authorization/src/backend.rs
+++ b/apps/hash-graph/lib/authorization/src/backend.rs
@@ -65,6 +65,8 @@ pub trait ZanzibarBackend {
     /// Note, that this will not fail if the subject does not have the specified permission or
     /// relation to the [`Resource`]. Instead, the [`CheckResponse::has_permission`] field will be
     /// set to `false`.
+    ///
+    /// [`Resource`]: crate::zanzibar::Resource
     async fn check<T>(
         &self,
         tuple: &T,
@@ -157,6 +159,8 @@ impl Error for DeleteRelationError {}
 #[must_use]
 pub struct CheckResponse {
     /// If the subject has the specified permission or relation to an [`Resource`].
+    ///
+    /// [`Resource`]: crate::zanzibar::Resource
     pub has_permission: bool,
     /// A token to determine the time at which the check was performed.
     pub checked_at: Zookie<'static>,
@@ -169,6 +173,8 @@ impl CheckResponse {
     ///
     /// Returns an error if the subject does not have the specified permission or relation to the
     /// [`Resource`].
+    ///
+    /// [`Resource`]: crate::zanzibar::Resource
     pub fn assert_permission(self) -> Result<Zookie<'static>, PermissionAssertion> {
         if self.has_permission {
             Ok(self.checked_at)

--- a/apps/hash-graph/lib/authorization/src/backend/spicedb/model.rs
+++ b/apps/hash-graph/lib/authorization/src/backend/spicedb/model.rs
@@ -2,10 +2,7 @@ use std::collections::HashMap;
 
 use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
 
-use crate::{
-    zanzibar,
-    zanzibar::{Relation, Resource, Tuple},
-};
+use crate::zanzibar::{self, Tuple};
 
 /// Error response returned from the API
 #[derive(Debug, Deserialize)]
@@ -140,16 +137,6 @@ impl From<ZedToken> for zanzibar::Zookie<'static> {
     }
 }
 
-/// A filter on the subject of a relationship.
-#[derive(Debug)]
-pub struct SubjectFilter<'a, U, S>
-where
-    U: Resource + ?Sized,
-    S: Relation<U> + ?Sized,
-{
-    pub subject_id: Option<&'a U::Id>,
-    pub relation: Option<&'a S>,
-}
 /// Used for mutating a single relationship within the service.
 #[derive(Debug, Copy, Clone, Serialize)]
 pub enum RelationshipUpdateOperation {

--- a/apps/hash-graph/lib/authorization/tests/api.rs
+++ b/apps/hash-graph/lib/authorization/tests/api.rs
@@ -4,11 +4,10 @@
 use authorization::{
     backend::{
         CheckError, CheckResponse, CreateRelationError, CreateRelationResponse,
-        DeleteRelationError, DeleteRelationResponse, DeleteRelationsError, DeleteRelationsResponse,
-        ExportSchemaError, ExportSchemaResponse, ImportSchemaError, ImportSchemaResponse,
-        Precondition, RelationFilter, SpiceDbOpenApi, ZanzibarBackend,
+        DeleteRelationError, DeleteRelationResponse, ExportSchemaError, ExportSchemaResponse,
+        ImportSchemaError, ImportSchemaResponse, SpiceDbOpenApi, ZanzibarBackend,
     },
-    zanzibar::{Consistency, Resource, Tuple},
+    zanzibar::{Consistency, Tuple},
 };
 use error_stack::Report;
 
@@ -55,48 +54,24 @@ impl ZanzibarBackend for TestApi {
         self.client.export_schema().await
     }
 
-    async fn create_relations<'p, 't, T>(
+    async fn create_relations<'t, T>(
         &mut self,
         tuples: impl IntoIterator<Item = &'t T, IntoIter: Send> + Send,
-        preconditions: impl IntoIterator<Item = Precondition<'p, T::Object, T::User>, IntoIter: Send>
-        + Send
-        + 'p,
     ) -> Result<CreateRelationResponse, Report<CreateRelationError>>
     where
-        T: Tuple + 't,
-        <T::Object as Resource>::Id: Sync + 'p,
-        <T::User as Resource>::Id: Sync + 'p,
+        T: Tuple + Sync + 't,
     {
-        self.client.create_relations(tuples, preconditions).await
+        self.client.create_relations(tuples).await
     }
 
-    async fn delete_relations<'p, 't, T>(
+    async fn delete_relations<'t, T>(
         &mut self,
         tuples: impl IntoIterator<Item = &'t T, IntoIter: Send> + Send,
-        preconditions: impl IntoIterator<Item = Precondition<'p, T::Object, T::User>, IntoIter: Send>
-        + Send
-        + 'p,
     ) -> Result<DeleteRelationResponse, Report<DeleteRelationError>>
     where
-        T: Tuple + 't,
-        <T::Object as Resource>::Id: Sync + 'p,
-        <T::User as Resource>::Id: Sync + 'p,
+        T: Tuple + Sync + 't,
     {
-        self.client.delete_relations(tuples, preconditions).await
-    }
-
-    async fn delete_relations_by_filter<'f, O, U>(
-        &mut self,
-        filter: RelationFilter<'_, O, U>,
-        preconditions: impl IntoIterator<Item = Precondition<'f, O, U>> + Send,
-    ) -> Result<DeleteRelationsResponse, Report<DeleteRelationsError>>
-    where
-        O: Resource<Id: Sync + 'f> + ?Sized,
-        U: Resource<Id: Sync + 'f> + ?Sized,
-    {
-        self.client
-            .delete_relations_by_filter(filter, preconditions)
-            .await
+        self.client.delete_relations(tuples).await
     }
 
     async fn check<T>(
@@ -106,8 +81,6 @@ impl ZanzibarBackend for TestApi {
     ) -> Result<CheckResponse, Report<CheckError>>
     where
         T: Tuple + Sync,
-        <T::Object as Resource>::Id: Sync,
-        <T::User as Resource>::Id: Sync,
     {
         self.client.check(tuple, consistency).await
     }

--- a/apps/hash-graph/lib/authorization/tests/schema.rs
+++ b/apps/hash-graph/lib/authorization/tests/schema.rs
@@ -1,11 +1,13 @@
+use std::fmt::Display;
+
 use authorization::zanzibar::{Affiliation, Permission, Relation, Resource};
+use serde::Serialize;
 
 #[derive(Debug, Copy, Clone)]
 pub struct Account(&'static str);
 
 pub const ALICE: Account = Account("alice");
 pub const BOB: Account = Account("bob");
-pub const CHARLIE: Account = Account("charlie");
 
 impl Resource for Account {
     type Id = str;
@@ -24,7 +26,6 @@ pub struct Entity(&'static str);
 
 pub const ENTITY_A: Entity = Entity("a");
 pub const ENTITY_B: Entity = Entity("b");
-pub const ENTITY_C: Entity = Entity("c");
 
 impl Resource for Entity {
     type Id = str;
@@ -38,34 +39,32 @@ impl Resource for Entity {
     }
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum EntityRelation {
     Writer,
     Reader,
 }
 
-impl AsRef<str> for EntityRelation {
-    fn as_ref(&self) -> &str {
-        match self {
-            Self::Writer => "writer",
-            Self::Reader => "reader",
-        }
+impl Display for EntityRelation {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.serialize(fmt)
     }
 }
 
 impl Affiliation<Entity> for EntityRelation {}
 impl Relation<Entity> for EntityRelation {}
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum EntityPermission {
     Edit,
     View,
 }
 
-impl AsRef<str> for EntityPermission {
-    fn as_ref(&self) -> &str {
-        match self {
-            Self::Edit => "edit",
-            Self::View => "view",
-        }
+impl Display for EntityPermission {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.serialize(fmt)
     }
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

SpiceDB allows to set preconditions or deletions by filter. We don't use them currently (and don't plan to use them in the near future) and this overcomplicates the current API by a fair bit. It's easier to just defer it  until we need it.

This allows making the Tuple trait more generic, which greatly simplifies the API to speed up development in #3179.

## 🔍 What does this change?

- Removes preconditions and filter-by deletions (both are unused)
- Stop using `Resource` trait as associated type in `Tuple`. This has the major advantage that it's now finally possible to specify typed tuples without a userset-field, which was not possible before.

## 🚫 Blocked by

- #3171 
- #3174 
- #3176 
- #3177

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph