### PR TITLE
H-804: Use SpiceDB schema in the Graph to check/alter permissions

### DIFF
--- a/apps/hash-graph/lib/authorization/schemas/v1__initial_schema.zed
+++ b/apps/hash-graph/lib/authorization/schemas/v1__initial_schema.zed
@@ -20,7 +20,7 @@ definition graph/entity {
 	permission view = direct_viewer + update
 }
 
-definition graph/owner {
+definition graph/web {
 	relation direct_owner: graph/account | graph/account_group#member
 
 	permission create_entity = direct_owner

--- a/apps/hash-graph/lib/authorization/src/api.rs
+++ b/apps/hash-graph/lib/authorization/src/api.rs
@@ -9,6 +9,7 @@ use graph_types::{
 
 use crate::{
     backend::{CheckError, CheckResponse, ModifyRelationError},
+    schema::OwnerId,
     zanzibar::{Consistency, Zookie},
 };
 
@@ -25,13 +26,25 @@ pub trait AuthorizationApi {
     fn add_account_group_admin(
         &mut self,
         member: AccountId,
-        group: AccountGroupId,
+        account_group: AccountGroupId,
     ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
 
     fn remove_account_group_admin(
         &mut self,
         member: AccountId,
-        group: AccountGroupId,
+        account_group: AccountGroupId,
+    ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
+
+    fn add_namespace(
+        &mut self,
+        namespace: impl Into<OwnedById> + Send,
+        owner: OwnerId,
+    ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
+
+    fn remove_namespace(
+        &mut self,
+        namespace: impl Into<OwnedById> + Send,
+        owner: OwnerId,
     ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
 
     fn can_add_group_members(
@@ -51,31 +64,31 @@ pub trait AuthorizationApi {
     fn add_account_group_member(
         &mut self,
         member: AccountId,
-        group: AccountGroupId,
+        account_group: AccountGroupId,
     ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
 
     fn remove_account_group_member(
         &mut self,
         member: AccountId,
-        group: AccountGroupId,
+        account_group: AccountGroupId,
     ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
 
     fn add_entity_owner(
         &mut self,
-        actor: AccountId,
         scope: VisibilityScope,
+        entity: EntityId,
     ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
 
     fn remove_entity_owner(
         &mut self,
-        actor: AccountId,
         scope: VisibilityScope,
+        entity: EntityId,
     ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
 
     fn can_create_entity(
         &self,
         actor: AccountId,
-        web: OwnedById,
+        namespace: impl Into<OwnedById> + Send,
         consistency: Consistency<'_>,
     ) -> impl Future<Output = Result<CheckResponse, CheckError>> + Send;
 

--- a/apps/hash-graph/lib/authorization/src/api.rs
+++ b/apps/hash-graph/lib/authorization/src/api.rs
@@ -4,7 +4,7 @@ use error_stack::Result;
 use graph_types::{
     account::{AccountGroupId, AccountId},
     knowledge::entity::EntityId,
-    provenance::OwnedById,
+    web::WebId,
 };
 
 use crate::{
@@ -35,16 +35,16 @@ pub trait AuthorizationApi {
         account_group: AccountGroupId,
     ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
 
-    fn add_namespace(
+    fn add_web_owner(
         &mut self,
-        namespace: impl Into<OwnedById> + Send,
         owner: OwnerId,
+        web: impl Into<WebId> + Send,
     ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
 
-    fn remove_namespace(
+    fn remove_web_owner(
         &mut self,
-        namespace: impl Into<OwnedById> + Send,
         owner: OwnerId,
+        web: impl Into<WebId> + Send,
     ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
 
     fn can_add_group_members(
@@ -88,7 +88,7 @@ pub trait AuthorizationApi {
     fn can_create_entity(
         &self,
         actor: AccountId,
-        namespace: impl Into<OwnedById> + Send,
+        web: impl Into<WebId> + Send,
         consistency: Consistency<'_>,
     ) -> impl Future<Output = Result<CheckResponse, CheckError>> + Send;
 

--- a/apps/hash-graph/lib/authorization/src/api.rs
+++ b/apps/hash-graph/lib/authorization/src/api.rs
@@ -38,13 +38,13 @@ pub trait AuthorizationApi {
     fn add_web_owner(
         &mut self,
         owner: OwnerId,
-        web: impl Into<WebId> + Send,
+        web: WebId,
     ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
 
     fn remove_web_owner(
         &mut self,
         owner: OwnerId,
-        web: impl Into<WebId> + Send,
+        web: WebId,
     ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
 
     fn can_add_group_members(

--- a/apps/hash-graph/lib/authorization/src/backend/spicedb/model.rs
+++ b/apps/hash-graph/lib/authorization/src/backend/spicedb/model.rs
@@ -74,17 +74,17 @@ impl<T: Tuple> Serialize for SubjectReference<'_, T> {
 /// Specifies how a resource relates to a subject.
 ///
 /// Relationships form the data for the graph over which all permissions questions are answered.
-pub struct Relationship<'t, T>(pub &'t T);
+pub struct Relationship<T>(pub T);
 
-impl<T: Tuple> Serialize for Relationship<'_, T> {
+impl<T: Tuple> Serialize for Relationship<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         let mut serialize = serializer.serialize_struct("Relationship", 3)?;
-        serialize.serialize_field("resource", &ObjectReference(self.0))?;
+        serialize.serialize_field("resource", &ObjectReference(&self.0))?;
         serialize.serialize_field("relation", self.0.affiliation())?;
-        serialize.serialize_field("subject", &SubjectReference(self.0))?;
+        serialize.serialize_field("subject", &SubjectReference(&self.0))?;
         serialize.end()
     }
 }

--- a/apps/hash-graph/lib/authorization/src/lib.rs
+++ b/apps/hash-graph/lib/authorization/src/lib.rs
@@ -23,6 +23,7 @@ use graph_types::{
 
 use crate::{
     backend::{CheckError, CheckResponse, ModifyRelationError},
+    schema::OwnerId,
     zanzibar::{Consistency, Zookie},
 };
 
@@ -42,6 +43,22 @@ impl AuthorizationApi for NoAuthorization {
         &mut self,
         _member: AccountId,
         _group: AccountGroupId,
+    ) -> Result<Zookie<'static>, ModifyRelationError> {
+        Ok(Zookie::empty())
+    }
+
+    async fn add_namespace(
+        &mut self,
+        _namespace: impl Into<OwnedById> + Send,
+        _owner: OwnerId,
+    ) -> Result<Zookie<'static>, ModifyRelationError> {
+        Ok(Zookie::empty())
+    }
+
+    async fn remove_namespace(
+        &mut self,
+        _namespace: impl Into<OwnedById> + Send,
+        _owner: OwnerId,
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(Zookie::empty())
     }
@@ -88,16 +105,16 @@ impl AuthorizationApi for NoAuthorization {
 
     async fn add_entity_owner(
         &mut self,
-        _actor: AccountId,
         _scope: VisibilityScope,
+        _entity: EntityId,
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(Zookie::empty())
     }
 
     async fn remove_entity_owner(
         &mut self,
-        _actor: AccountId,
         _scope: VisibilityScope,
+        _entity: EntityId,
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(Zookie::empty())
     }
@@ -105,7 +122,7 @@ impl AuthorizationApi for NoAuthorization {
     async fn can_create_entity(
         &self,
         _actor: AccountId,
-        _web: OwnedById,
+        _namespace: impl Into<OwnedById> + Send,
         _consistency: Consistency<'_>,
     ) -> Result<CheckResponse, CheckError> {
         Ok(CheckResponse {

--- a/apps/hash-graph/lib/authorization/src/lib.rs
+++ b/apps/hash-graph/lib/authorization/src/lib.rs
@@ -50,7 +50,7 @@ impl AuthorizationApi for NoAuthorization {
     async fn add_web_owner(
         &mut self,
         _owner: OwnerId,
-        _web: impl Into<WebId> + Send,
+        _web: WebId,
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(Zookie::empty())
     }
@@ -58,7 +58,7 @@ impl AuthorizationApi for NoAuthorization {
     async fn remove_web_owner(
         &mut self,
         _owner: OwnerId,
-        _web: impl Into<WebId> + Send,
+        _web: WebId,
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(Zookie::empty())
     }

--- a/apps/hash-graph/lib/authorization/src/lib.rs
+++ b/apps/hash-graph/lib/authorization/src/lib.rs
@@ -18,7 +18,7 @@ use error_stack::Result;
 use graph_types::{
     account::{AccountGroupId, AccountId},
     knowledge::entity::EntityId,
-    provenance::OwnedById,
+    web::WebId,
 };
 
 use crate::{
@@ -47,18 +47,18 @@ impl AuthorizationApi for NoAuthorization {
         Ok(Zookie::empty())
     }
 
-    async fn add_namespace(
+    async fn add_web_owner(
         &mut self,
-        _namespace: impl Into<OwnedById> + Send,
         _owner: OwnerId,
+        _web: impl Into<WebId> + Send,
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(Zookie::empty())
     }
 
-    async fn remove_namespace(
+    async fn remove_web_owner(
         &mut self,
-        _namespace: impl Into<OwnedById> + Send,
         _owner: OwnerId,
+        _web: impl Into<WebId> + Send,
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(Zookie::empty())
     }
@@ -122,7 +122,7 @@ impl AuthorizationApi for NoAuthorization {
     async fn can_create_entity(
         &self,
         _actor: AccountId,
-        _namespace: impl Into<OwnedById> + Send,
+        _web: impl Into<WebId> + Send,
         _consistency: Consistency<'_>,
     ) -> Result<CheckResponse, CheckError> {
         Ok(CheckResponse {

--- a/apps/hash-graph/lib/authorization/src/schema.rs
+++ b/apps/hash-graph/lib/authorization/src/schema.rs
@@ -1,10 +1,10 @@
 mod account;
 mod account_group;
 mod entity;
-mod owner;
+mod web;
 
 pub use self::{
     account_group::{AccountGroupPermission, AccountGroupRelation},
     entity::{EntityPermission, EntityRelation},
-    owner::{OwnerId, OwnerPermission, OwnerRelation},
+    web::{OwnerId, WebPermission, WebRelation},
 };

--- a/apps/hash-graph/lib/authorization/src/schema/web.rs
+++ b/apps/hash-graph/lib/authorization/src/schema/web.rs
@@ -14,6 +14,18 @@ pub enum OwnerId {
     AccountGroup(AccountGroupId),
 }
 
+impl From<AccountId> for OwnerId {
+    fn from(account_id: AccountId) -> Self {
+        Self::Account(account_id)
+    }
+}
+
+impl From<AccountGroupId> for OwnerId {
+    fn from(account_group_id: AccountGroupId) -> Self {
+        Self::AccountGroup(account_group_id)
+    }
+}
+
 impl Resource for WebId {
     type Id = Self;
 

--- a/apps/hash-graph/lib/authorization/src/schema/web.rs
+++ b/apps/hash-graph/lib/authorization/src/schema/web.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use graph_types::{
     account::{AccountGroupId, AccountId},
-    provenance::OwnedById,
+    web::WebId,
 };
 use serde::{Deserialize, Serialize};
 
@@ -14,11 +14,11 @@ pub enum OwnerId {
     AccountGroup(AccountGroupId),
 }
 
-impl Resource for OwnedById {
+impl Resource for WebId {
     type Id = Self;
 
     fn namespace() -> &'static str {
-        "graph/namespace"
+        "graph/web"
     }
 
     fn id(&self) -> &Self::Id {
@@ -28,30 +28,32 @@ impl Resource for OwnedById {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum OwnerRelation {
+pub enum WebRelation {
     DirectOwner,
 }
 
-impl fmt::Display for OwnerRelation {
+impl fmt::Display for WebRelation {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.serialize(fmt)
     }
 }
 
-impl Affiliation<OwnedById> for OwnerRelation {}
-impl Relation<OwnedById> for OwnerRelation {}
+impl Affiliation<WebId> for WebRelation {}
+
+impl Relation<WebId> for WebRelation {}
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum OwnerPermission {
+pub enum WebPermission {
     CreateEntity,
 }
 
-impl fmt::Display for OwnerPermission {
+impl fmt::Display for WebPermission {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.serialize(fmt)
     }
 }
 
-impl Affiliation<OwnedById> for OwnerPermission {}
-impl Permission<OwnedById> for OwnerPermission {}
+impl Affiliation<WebId> for WebPermission {}
+
+impl Permission<WebId> for WebPermission {}

--- a/apps/hash-graph/lib/authorization/src/zanzibar/api.rs
+++ b/apps/hash-graph/lib/authorization/src/zanzibar/api.rs
@@ -59,18 +59,18 @@ where
     async fn add_web_owner(
         &mut self,
         owner: OwnerId,
-        web: impl Into<WebId> + Send,
+        web: WebId,
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(match owner {
             OwnerId::Account(account) => {
                 self.backend
-                    .create_relations([(web.into(), WebRelation::DirectOwner, account)])
+                    .create_relations([(web, WebRelation::DirectOwner, account)])
                     .await
             }
             OwnerId::AccountGroup(account_group) => {
                 self.backend
                     .create_relations([(
-                        web.into(),
+                        web,
                         WebRelation::DirectOwner,
                         account_group,
                         AccountGroupPermission::Member,
@@ -85,18 +85,18 @@ where
     async fn remove_web_owner(
         &mut self,
         owner: OwnerId,
-        web: impl Into<WebId> + Send,
+        web: WebId,
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(match owner {
             OwnerId::Account(account) => {
                 self.backend
-                    .delete_relations([(web.into(), WebRelation::DirectOwner, account)])
+                    .delete_relations([(web, WebRelation::DirectOwner, account)])
                     .await
             }
             OwnerId::AccountGroup(account_group) => {
                 self.backend
                     .delete_relations([(
-                        web.into(),
+                        web,
                         WebRelation::DirectOwner,
                         account_group,
                         AccountGroupPermission::Member,

--- a/apps/hash-graph/lib/authorization/tests/api.rs
+++ b/apps/hash-graph/lib/authorization/tests/api.rs
@@ -54,22 +54,22 @@ impl ZanzibarBackend for TestApi {
         self.client.export_schema().await
     }
 
-    async fn create_relations<'t, T>(
+    async fn create_relations<T>(
         &mut self,
-        tuples: impl IntoIterator<Item = &'t T, IntoIter: Send> + Send,
+        tuples: impl IntoIterator<Item = T, IntoIter: Send> + Send,
     ) -> Result<CreateRelationResponse, Report<CreateRelationError>>
     where
-        T: Tuple + Sync + 't,
+        T: Tuple + Send + Sync,
     {
         self.client.create_relations(tuples).await
     }
 
-    async fn delete_relations<'t, T>(
+    async fn delete_relations<T>(
         &mut self,
-        tuples: impl IntoIterator<Item = &'t T, IntoIter: Send> + Send,
+        tuples: impl IntoIterator<Item = T, IntoIter: Send> + Send,
     ) -> Result<DeleteRelationResponse, Report<DeleteRelationError>>
     where
-        T: Tuple + Sync + 't,
+        T: Tuple + Send + Sync,
     {
         self.client.delete_relations(tuples).await
     }

--- a/apps/hash-graph/lib/authorization/tests/simple.rs
+++ b/apps/hash-graph/lib/authorization/tests/simple.rs
@@ -42,9 +42,9 @@ async fn plain_permissions() -> Result<(), Box<dyn Error>> {
 
     let token = api
         .create_relations([
-            &(ENTITY_A, EntityRelation::DirectOwner, ALICE),
-            &(ENTITY_A, EntityRelation::DirectViewer, BOB),
-            &(ENTITY_B, EntityRelation::DirectOwner, BOB),
+            (ENTITY_A, EntityRelation::DirectOwner, ALICE),
+            (ENTITY_A, EntityRelation::DirectViewer, BOB),
+            (ENTITY_B, EntityRelation::DirectOwner, BOB),
         ])
         .await?
         .written_at;
@@ -142,7 +142,7 @@ async fn plain_permissions() -> Result<(), Box<dyn Error>> {
     );
 
     let token = api
-        .delete_relations([&(ENTITY_A, EntityRelation::DirectViewer, BOB)])
+        .delete_relations([(ENTITY_A, EntityRelation::DirectViewer, BOB)])
         .await?
         .deleted_at;
 

--- a/apps/hash-graph/lib/graph-types/src/lib.rs
+++ b/apps/hash-graph/lib/graph-types/src/lib.rs
@@ -4,3 +4,5 @@ pub mod ontology;
 pub mod provenance;
 
 pub mod account;
+
+pub mod web;

--- a/apps/hash-graph/lib/graph-types/src/provenance.rs
+++ b/apps/hash-graph/lib/graph-types/src/provenance.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::{openapi, ToSchema};
 use uuid::Uuid;
 
-use crate::account::AccountId;
+use crate::account::{AccountGroupId, AccountId};
 
 macro_rules! define_provenance_id {
     ($name:tt) => {
@@ -75,6 +75,18 @@ pub struct ProvenanceMetadata {
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[repr(transparent)]
 pub struct OwnedById(Uuid);
+
+impl From<AccountId> for OwnedById {
+    fn from(account_id: AccountId) -> Self {
+        Self(account_id.into_uuid())
+    }
+}
+
+impl From<AccountGroupId> for OwnedById {
+    fn from(account_group_id: AccountGroupId) -> Self {
+        Self(account_group_id.into_uuid())
+    }
+}
 
 impl OwnedById {
     #[must_use]

--- a/apps/hash-graph/lib/graph-types/src/web.rs
+++ b/apps/hash-graph/lib/graph-types/src/web.rs
@@ -1,0 +1,53 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    account::{AccountGroupId, AccountId},
+    provenance::OwnedById,
+};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct WebId(Uuid);
+
+impl From<AccountId> for WebId {
+    fn from(account_id: AccountId) -> Self {
+        Self(account_id.into_uuid())
+    }
+}
+
+impl From<AccountGroupId> for WebId {
+    fn from(account_group_id: AccountGroupId) -> Self {
+        Self(account_group_id.into_uuid())
+    }
+}
+
+impl From<OwnedById> for WebId {
+    fn from(owned_by_id: OwnedById) -> Self {
+        Self(owned_by_id.into_uuid())
+    }
+}
+
+impl WebId {
+    #[must_use]
+    pub const fn new(uuid: Uuid) -> Self {
+        Self(uuid)
+    }
+
+    #[must_use]
+    pub const fn as_uuid(&self) -> &Uuid {
+        &self.0
+    }
+
+    #[must_use]
+    pub const fn into_uuid(self) -> Uuid {
+        self.0
+    }
+}
+
+impl fmt::Display for WebId {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, fmt)
+    }
+}

--- a/apps/hash-graph/lib/graph/src/store/postgres.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres.rs
@@ -21,6 +21,7 @@ use graph_types::{
         OntologyTypeRecordId, OntologyTypeVersion, PartialCustomOntologyMetadata,
     },
     provenance::{OwnedById, ProvenanceMetadata, RecordArchivedById, RecordCreatedById},
+    web::WebId,
 };
 #[cfg(hash_graph_test_environment)]
 use temporal_versioning::{DecisionTime, Timestamp};
@@ -1262,13 +1263,13 @@ impl<C: AsClient> AccountStore for PostgresStore<C> {
             .attach_printable(account_id)?;
 
         authorization_api
-            .add_web_owner(OwnerId::Account(account_id), account_id)
+            .add_web_owner(OwnerId::from(account_id), WebId::from(account_id))
             .await
             .change_context(InsertionError)?;
 
         if let Err(mut error) = transaction.commit().await.change_context(InsertionError) {
             if let Err(auth_error) = authorization_api
-                .remove_web_owner(OwnerId::Account(account_id), account_id)
+                .remove_web_owner(OwnerId::from(account_id), WebId::from(account_id))
                 .await
                 .change_context(InsertionError)
             {
@@ -1326,7 +1327,10 @@ impl<C: AsClient> AccountStore for PostgresStore<C> {
             .change_context(InsertionError)?;
 
         authorization_api
-            .add_web_owner(OwnerId::AccountGroup(account_group_id), account_group_id)
+            .add_web_owner(
+                OwnerId::from(account_group_id),
+                WebId::from(account_group_id),
+            )
             .await
             .change_context(InsertionError)?;
 
@@ -1341,7 +1345,10 @@ impl<C: AsClient> AccountStore for PostgresStore<C> {
                 error.extend_one(auth_error);
             }
             if let Err(auth_error) = authorization_api
-                .remove_web_owner(OwnerId::AccountGroup(account_group_id), account_group_id)
+                .remove_web_owner(
+                    OwnerId::from(account_group_id),
+                    WebId::from(account_group_id),
+                )
                 .await
                 .change_context(InsertionError)
             {

--- a/apps/hash-graph/lib/graph/src/store/postgres.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres.rs
@@ -1262,13 +1262,13 @@ impl<C: AsClient> AccountStore for PostgresStore<C> {
             .attach_printable(account_id)?;
 
         authorization_api
-            .add_namespace(account_id, OwnerId::Account(account_id))
+            .add_web_owner(OwnerId::Account(account_id), account_id)
             .await
             .change_context(InsertionError)?;
 
         if let Err(mut error) = transaction.commit().await.change_context(InsertionError) {
             if let Err(auth_error) = authorization_api
-                .remove_namespace(account_id, OwnerId::Account(account_id))
+                .remove_web_owner(OwnerId::Account(account_id), account_id)
                 .await
                 .change_context(InsertionError)
             {
@@ -1326,7 +1326,7 @@ impl<C: AsClient> AccountStore for PostgresStore<C> {
             .change_context(InsertionError)?;
 
         authorization_api
-            .add_namespace(account_group_id, OwnerId::AccountGroup(account_group_id))
+            .add_web_owner(OwnerId::AccountGroup(account_group_id), account_group_id)
             .await
             .change_context(InsertionError)?;
 
@@ -1341,7 +1341,7 @@ impl<C: AsClient> AccountStore for PostgresStore<C> {
                 error.extend_one(auth_error);
             }
             if let Err(auth_error) = authorization_api
-                .remove_namespace(account_group_id, OwnerId::AccountGroup(account_group_id))
+                .remove_web_owner(OwnerId::AccountGroup(account_group_id), account_group_id)
                 .await
                 .change_context(InsertionError)
             {

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -429,13 +429,13 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         };
 
         authorization_api
-            .add_entity_owner(actor_id, visibility_scope)
+            .add_entity_owner(visibility_scope, entity_id)
             .await
             .change_context(InsertionError)?;
 
         if let Err(mut error) = transaction.commit().await.change_context(InsertionError) {
             if let Err(auth_error) = authorization_api
-                .remove_entity_owner(actor_id, visibility_scope)
+                .remove_entity_owner(visibility_scope, entity_id)
                 .await
                 .change_context(InsertionError)
             {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With #3179 an initial SpiceDB schema is created. The `AuthorizationApi` has to be adjusted to use the new permissions and the correct functions has to be called everywhere.

This does not enable the permissions in `dev` yet. BE tests don't cover the tests, yet, as snapshots has not been adjusted and I hesitate to enable permissions in `dev` until they are somewhat tested at least.

## 🚫 Blocked by

- #3171 
- #3174 
- #3176 
- #3177
- #3189 
- #3179 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph