### PR TITLE
H-801: Increase Playwright test timeout

### DIFF
--- a/tests/hash-playwright/tests/shared/login-using-temp-form.ts
+++ b/tests/hash-playwright/tests/shared/login-using-temp-form.ts
@@ -26,7 +26,7 @@ export const loginUsingTempForm = async ({
 
   // Wait for the redirect to the account page
   await expect(page.locator("text=Welcome to HASH")).toBeVisible({
-    timeout: 30_000,
+    timeout: 60_000,
   });
 
   // Wait for user avatar to appear


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We've been noticing increasing flakiness of Playwright tests, specifically timing out while waiting for login.

This doesn't appear to happen consistently – possibly increasing the timeout will help.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

- Playwright test performance and coverage generally is tracked in H-463

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- Playwright ones.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. No retries necessary on this PR's Playwright tests would be a good signal, but otherwise hard to test.
