### PR TITLE
H-802: Skip checking type parents when looking up system entities by type

### DIFF
--- a/apps/hash-api/src/graph/knowledge/system-types/hash-instance.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/hash-instance.ts
@@ -1,5 +1,6 @@
 import {
   currentTimeInstantTemporalAxes,
+  generateVersionedUrlMatchingFilter,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import {
@@ -62,14 +63,10 @@ export const getHashInstance: ImpureGraphFunction<
 > = async ({ graphApi }, { actorId }) => {
   const entities = await graphApi
     .getEntitiesByQuery(actorId, {
-      filter: {
-        equal: [
-          { path: ["type", "versionedUrl"] },
-          {
-            parameter: SYSTEM_TYPES.entityType.hashInstance.schema.$id,
-          },
-        ],
-      },
+      filter: generateVersionedUrlMatchingFilter(
+        SYSTEM_TYPES.entityType.hashInstance.schema.$id,
+        { ignoreParents: true },
+      ),
       graphResolveDepths: zeroedGraphResolveDepths,
       temporalAxes: currentTimeInstantTemporalAxes,
     })

--- a/apps/hash-api/src/graph/knowledge/system-types/linear-integration-entity.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/linear-integration-entity.ts
@@ -1,5 +1,6 @@
 import {
   currentTimeInstantTemporalAxes,
+  generateVersionedUrlMatchingFilter,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import {
@@ -66,14 +67,10 @@ export const getLinearIntegrationByLinearOrgId: ImpureGraphFunction<
           {
             equal: [{ path: ["ownedById"] }, { parameter: userAccountId }],
           },
-          {
-            equal: [
-              { path: ["type", "versionedUrl"] },
-              {
-                parameter: SYSTEM_TYPES.entityType.linearIntegration.schema.$id,
-              },
-            ],
-          },
+          generateVersionedUrlMatchingFilter(
+            SYSTEM_TYPES.entityType.linearIntegration.schema.$id,
+            { ignoreParents: true },
+          ),
           {
             equal: [
               {
@@ -129,15 +126,10 @@ export const getSyncedWorkspacesForLinearIntegration: ImpureGraphFunction<
           {
             equal: [{ path: ["archived"] }, { parameter: false }],
           },
-          {
-            equal: [
-              { path: ["type", "versionedUrl"] },
-              {
-                parameter:
-                  SYSTEM_TYPES.linkEntityType.syncLinearDataWith.schema.$id,
-              },
-            ],
-          },
+          generateVersionedUrlMatchingFilter(
+            SYSTEM_TYPES.linkEntityType.syncLinearDataWith.schema.$id,
+            { ignoreParents: true },
+          ),
           {
             equal: [
               { path: ["leftEntity", "uuid"] },
@@ -192,15 +184,10 @@ export const linkIntegrationToWorkspace: ImpureGraphFunction<
           {
             equal: [{ path: ["archived"] }, { parameter: false }],
           },
-          {
-            equal: [
-              { path: ["type", "versionedUrl"] },
-              {
-                parameter:
-                  SYSTEM_TYPES.linkEntityType.syncLinearDataWith.schema.$id,
-              },
-            ],
-          },
+          generateVersionedUrlMatchingFilter(
+            SYSTEM_TYPES.linkEntityType.syncLinearDataWith.schema.$id,
+            { ignoreParents: true },
+          ),
           {
             equal: [
               { path: ["leftEntity", "uuid"] },

--- a/apps/hash-api/src/graph/knowledge/system-types/linear-user-secret.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/linear-user-secret.ts
@@ -79,7 +79,7 @@ export const getLinearUserSecretByLinearOrgId: ImpureGraphFunction<
           ),
           generateVersionedUrlMatchingFilter(
             SYSTEM_TYPES.linkEntityType.usesUserSecret.schema.$id,
-            { ignoreParents: true },
+            { ignoreParents: true, pathPrefix: ["incomingLinks"] },
           ),
           generateVersionedUrlMatchingFilter(
             SYSTEM_TYPES.entityType.linearIntegration.schema.$id,
@@ -149,7 +149,7 @@ export const getLinearSecretValueByHashWorkspaceId: ImpureGraphFunction<
             SYSTEM_TYPES.linkEntityType.syncLinearDataWith.schema.$id,
             {
               ignoreParents: true,
-              pathPrefix: ["outgoingLInks"],
+              pathPrefix: ["outgoingLinks"],
             },
           ),
           {

--- a/apps/hash-api/src/graph/knowledge/system-types/linear-user-secret.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/linear-user-secret.ts
@@ -1,5 +1,6 @@
 import {
   currentTimeInstantTemporalAxes,
+  generateVersionedUrlMatchingFilter,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import {
@@ -72,31 +73,21 @@ export const getLinearUserSecretByLinearOrgId: ImpureGraphFunction<
               { parameter: userAccountId as OwnedById },
             ],
           },
-          {
-            equal: [
-              { path: ["type", "versionedUrl"] },
-              {
-                parameter: SYSTEM_TYPES.entityType.userSecret.schema.$id,
-              },
-            ],
-          },
-          {
-            equal: [
-              { path: ["incomingLinks", "type", "versionedUrl"] },
-              {
-                parameter:
-                  SYSTEM_TYPES.linkEntityType.usesUserSecret.schema.$id,
-              },
-            ],
-          },
-          {
-            equal: [
-              { path: ["incomingLinks", "leftEntity", "type", "versionedUrl"] },
-              {
-                parameter: SYSTEM_TYPES.entityType.linearIntegration.schema.$id,
-              },
-            ],
-          },
+          generateVersionedUrlMatchingFilter(
+            SYSTEM_TYPES.entityType.userSecret.schema.$id,
+            { ignoreParents: true },
+          ),
+          generateVersionedUrlMatchingFilter(
+            SYSTEM_TYPES.linkEntityType.usesUserSecret.schema.$id,
+            { ignoreParents: true },
+          ),
+          generateVersionedUrlMatchingFilter(
+            SYSTEM_TYPES.entityType.linearIntegration.schema.$id,
+            {
+              ignoreParents: true,
+              pathPrefix: ["incomingLinks", "leftEntity"],
+            },
+          ),
           {
             equal: [
               {
@@ -154,15 +145,13 @@ export const getLinearSecretValueByHashWorkspaceId: ImpureGraphFunction<
     .getEntitiesByQuery(authentication.actorId, {
       filter: {
         all: [
-          {
-            equal: [
-              { path: ["outgoingLinks", "type", "versionedUrl"] },
-              {
-                parameter:
-                  SYSTEM_TYPES.linkEntityType.syncLinearDataWith.schema.$id,
-              },
-            ],
-          },
+          generateVersionedUrlMatchingFilter(
+            SYSTEM_TYPES.linkEntityType.syncLinearDataWith.schema.$id,
+            {
+              ignoreParents: true,
+              pathPrefix: ["outgoingLInks"],
+            },
+          ),
           {
             equal: [
               { path: ["outgoingLinks", "rightEntity", "uuid"] },

--- a/apps/hash-api/src/graph/knowledge/system-types/org.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/org.ts
@@ -1,5 +1,6 @@
 import {
   currentTimeInstantTemporalAxes,
+  generateVersionedUrlMatchingFilter,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import {
@@ -187,12 +188,9 @@ export const getOrgByShortname: ImpureGraphFunction<
     .getEntitiesByQuery(actorId, {
       filter: {
         all: [
-          {
-            equal: [
-              { path: ["type", "versionedUrl"] },
-              { parameter: SYSTEM_TYPES.entityType.org.schema.$id },
-            ],
-          },
+          generateVersionedUrlMatchingFilter(
+            SYSTEM_TYPES.entityType.org.schema.$id,
+          ),
           {
             equal: [
               {

--- a/apps/hash-api/src/graph/knowledge/system-types/page.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/page.ts
@@ -2,6 +2,7 @@ import { CanvasPosition } from "@local/hash-graphql-shared/graphql/types";
 import { paragraphBlockComponentId } from "@local/hash-isomorphic-utils/blocks";
 import {
   currentTimeInstantTemporalAxes,
+  generateVersionedUrlMatchingFilter,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { BlockDataProperties } from "@local/hash-isomorphic-utils/system-types/shared";
@@ -252,12 +253,11 @@ export const getAllPagesInWorkspace: ImpureGraphFunction<
     .getEntitiesByQuery(authentication.actorId, {
       filter: {
         all: [
-          {
-            equal: [
-              { path: ["type", "versionedUrl"] },
-              { parameter: SYSTEM_TYPES.entityType.page.schema.$id },
-            ],
-          },
+          generateVersionedUrlMatchingFilter(
+            SYSTEM_TYPES.entityType.page.schema.$id,
+            // ignoreParents assumes we don't have types which are children of Page which should be returned here
+            { ignoreParents: true },
+          ),
           {
             equal: [{ path: ["ownedById"] }, { parameter: ownedById }],
           },

--- a/apps/hash-api/src/graph/knowledge/system-types/user.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user.ts
@@ -1,5 +1,6 @@
 import {
   currentTimeInstantTemporalAxes,
+  generateVersionedUrlMatchingFilter,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import {
@@ -127,12 +128,10 @@ export const getUserByShortname: ImpureGraphFunction<
     .getEntitiesByQuery(actorId, {
       filter: {
         all: [
-          {
-            equal: [
-              { path: ["type", "versionedUrl"] },
-              { parameter: SYSTEM_TYPES.entityType.user.schema.$id },
-            ],
-          },
+          generateVersionedUrlMatchingFilter(
+            SYSTEM_TYPES.entityType.user.schema.$id,
+            { ignoreParents: true },
+          ),
           {
             equal: [
               {
@@ -179,12 +178,10 @@ export const getUserByKratosIdentityId: ImpureGraphFunction<
     .getEntitiesByQuery(actorId, {
       filter: {
         all: [
-          {
-            equal: [
-              { path: ["type", "versionedUrl"] },
-              { parameter: SYSTEM_TYPES.entityType.user.schema.$id },
-            ],
-          },
+          generateVersionedUrlMatchingFilter(
+            SYSTEM_TYPES.entityType.user.schema.$id,
+            { ignoreParents: true },
+          ),
           {
             equal: [
               {

--- a/apps/hash-api/src/graph/system-user.ts
+++ b/apps/hash-api/src/graph/system-user.ts
@@ -2,6 +2,7 @@ import { Logger } from "@local/hash-backend-utils/logger";
 import { systemUserShortname } from "@local/hash-isomorphic-utils/environment";
 import {
   currentTimeInstantTemporalAxes,
+  generateVersionedUrlMatchingFilter,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { types } from "@local/hash-isomorphic-utils/ontology-types";
@@ -43,12 +44,10 @@ export const ensureSystemUserAccountIdExists = async (params: {
 
   const { data: existingUserEntitiesSubgraph } =
     await graphApi.getEntitiesByQuery(publicUserAccountId, {
-      filter: {
-        equal: [
-          { path: ["type", "versionedUrl"] },
-          { parameter: types.entityType.user.entityTypeId },
-        ],
-      },
+      filter: generateVersionedUrlMatchingFilter(
+        types.entityType.user.entityTypeId,
+        { ignoreParents: true },
+      ),
       graphResolveDepths: zeroedGraphResolveDepths,
       temporalAxes: currentTimeInstantTemporalAxes,
     });

--- a/apps/hash-frontend/src/pages/[shortname]/[page-slug].page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/[page-slug].page.tsx
@@ -8,6 +8,7 @@ import { getPageQuery } from "@local/hash-graphql-shared/queries/page.queries";
 import { HashBlock } from "@local/hash-isomorphic-utils/blocks";
 import {
   currentTimeInstantTemporalAxes,
+  generateVersionedUrlMatchingFilter,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { types } from "@local/hash-isomorphic-utils/ontology-types";
@@ -136,18 +137,14 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
                 },
                 {
                   any: [
-                    {
-                      equal: [
-                        { path: ["type", "versionedUrl"] },
-                        { parameter: types.entityType.user.entityTypeId },
-                      ],
-                    },
-                    {
-                      equal: [
-                        { path: ["type", "versionedUrl"] },
-                        { parameter: types.entityType.org.entityTypeId },
-                      ],
-                    },
+                    generateVersionedUrlMatchingFilter(
+                      types.entityType.user.entityTypeId,
+                      { ignoreParents: true },
+                    ),
+                    generateVersionedUrlMatchingFilter(
+                      types.entityType.org.entityTypeId,
+                      { ignoreParents: true },
+                    ),
                   ],
                 },
               ],

--- a/apps/hash-frontend/src/shared/use-user-or-org.ts
+++ b/apps/hash-frontend/src/shared/use-user-or-org.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@apollo/client";
 import { extractBaseUrl } from "@blockprotocol/type-system";
 import {
   currentTimeInstantTemporalAxes,
+  generateVersionedUrlMatchingFilter,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { types } from "@local/hash-isomorphic-utils/ontology-types";
@@ -66,18 +67,14 @@ export const useUserOrOrg = (
                 },
             {
               any: [
-                {
-                  equal: [
-                    { path: ["type", "versionedUrl"] },
-                    { parameter: types.entityType.user.entityTypeId },
-                  ],
-                },
-                {
-                  equal: [
-                    { path: ["type", "versionedUrl"] },
-                    { parameter: types.entityType.org.entityTypeId },
-                  ],
-                },
+                generateVersionedUrlMatchingFilter(
+                  types.entityType.user.entityTypeId,
+                  { ignoreParents: true },
+                ),
+                generateVersionedUrlMatchingFilter(
+                  types.entityType.org.entityTypeId,
+                  { ignoreParents: true },
+                ),
               ],
             },
           ],

--- a/apps/hash-integration-worker/src/activities.ts
+++ b/apps/hash-integration-worker/src/activities.ts
@@ -8,6 +8,7 @@ import {
 } from "@linear/sdk";
 import { PartialEntity } from "@local/hash-backend-utils/temporal-workflow-types";
 import { GraphApi } from "@local/hash-graph-client";
+import { generateVersionedUrlMatchingFilter } from "@local/hash-isomorphic-utils/graph-queries";
 import { linearTypes } from "@local/hash-isomorphic-utils/ontology-types";
 import {
   AccountId,
@@ -51,12 +52,9 @@ const createOrUpdateHashEntity = async (params: {
   }
 
   const filters = [
-    {
-      equal: [
-        { path: ["type", "versionedUrl"] },
-        { parameter: params.entity.entityTypeId },
-      ],
-    },
+    generateVersionedUrlMatchingFilter(params.entity.entityTypeId, {
+      ignoreParents: true,
+    }),
     {
       equal: [
         {

--- a/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
@@ -1,6 +1,15 @@
 import { GraphResolveDepths } from "@blockprotocol/graph";
 import { VersionedUrl } from "@blockprotocol/type-system";
-import { Filter } from "@local/hash-graph-client";
+import {
+  DataTypeQueryToken,
+  EntityQueryToken,
+  EntityTypeQueryToken,
+  Filter,
+  PathExpression,
+  PathExpressionPathInner,
+  PropertyTypeQueryToken,
+  Selector,
+} from "@local/hash-graph-client";
 import { QueryTemporalAxesUnresolved } from "@local/hash-subgraph";
 import { componentsFromVersionedUrl } from "@local/hash-subgraph/type-system-patch";
 
@@ -70,7 +79,13 @@ export const generateVersionedUrlMatchingFilter = (
   versionedUrl: VersionedUrl,
   options?: {
     ignoreParents?: boolean;
-    pathPrefix?: string[];
+    pathPrefix?: (
+      | DataTypeQueryToken
+      | EntityQueryToken
+      | EntityTypeQueryToken
+      | PropertyTypeQueryToken
+      | Selector
+    )[];
   },
 ): Filter => {
   const { ignoreParents = false, pathPrefix = [] } = options ?? {};

--- a/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
@@ -5,8 +5,6 @@ import {
   EntityQueryToken,
   EntityTypeQueryToken,
   Filter,
-  PathExpression,
-  PathExpressionPathInner,
   PropertyTypeQueryToken,
   Selector,
 } from "@local/hash-graph-client";

--- a/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
@@ -1,5 +1,8 @@
 import { GraphResolveDepths } from "@blockprotocol/graph";
+import { VersionedUrl } from "@blockprotocol/type-system";
+import { Filter } from "@local/hash-graph-client";
 import { QueryTemporalAxesUnresolved } from "@local/hash-subgraph";
+import { componentsFromVersionedUrl } from "@local/hash-subgraph/type-system-patch";
 
 export const zeroedGraphResolveDepths: GraphResolveDepths = {
   inheritsFrom: { outgoing: 0 },
@@ -52,4 +55,41 @@ export const fullDecisionTimeAxis: QueryTemporalAxesUnresolved = {
       end: null,
     },
   },
+};
+
+/**
+ * Generates a query filter to match a type, given its versionedUrl.
+ *
+ * @param versionedUrl
+ * @param [options] configuration of the returned filter
+ * @param [options.ignoreParents] don't check the type's parents for a match against the versionedUrl
+ * @param [options.pathPrefix] the path to the thing to match the type of, if it's not the root of the query
+ *     @example ["outgoingLinks", "rightEntity"] to filter query results to things with a linked entity of the given type
+ */
+export const generateVersionedUrlMatchingFilter = (
+  versionedUrl: VersionedUrl,
+  options?: {
+    ignoreParents?: boolean;
+    pathPrefix?: string[];
+  },
+): Filter => {
+  const { ignoreParents = false, pathPrefix = [] } = options ?? {};
+
+  const { baseUrl, version } = componentsFromVersionedUrl(versionedUrl);
+
+  const basePath = [
+    ...pathPrefix,
+    ignoreParents ? "type(inheritanceDepth = 0)" : "type",
+  ];
+
+  return {
+    all: [
+      {
+        equal: [{ path: [...basePath, "baseUrl"] }, { parameter: baseUrl }],
+      },
+      {
+        equal: [{ path: [...basePath, "version"] }, { parameter: version }],
+      },
+    ],
+  };
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Where we query for entities and match against the type of the entity or of some other entity linked to them, the queries can currently be slow, mainly because of type inheritance.

This PR introduces a `generateVersionedUrlMatchingFilter` function that can create a filter with two ways of improving query performance:
1. Skip checking type parents (major improvement)
2. Split the type id we're matching on to instead match by its components `baseUrl` and `version`, which are top-level database fields, rather than the id which is a property nested in the type's jsonb schema. This has no discernible impact currently but may be better with more data (it may not if a query using indices on `baseUrl` and `version` perform the same as one using a GIN index on `schema -> $id`, and the number of joins involved has no meaningful impact)

It uses this function where we know we can skip checking parents, i.e. because we are dealing with system types that don't have parents.

The relevant queries are reduced (locally) from `400+ms` to around `10-20ms`

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🚫 Blocked by

- [ ] Merging #3191 which this is stacked on

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


## 🐾 Next steps

- Query performance even when parent types are checked to be improved 

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

-

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Run the app locally (backend change, the Vercel deployment will not reflect it)
2. Check response time for relevant queries in the frontend (or in the GraphQL playground), e.g. `hashInstance`, `structuralQueryEntities`

