### PR TITLE
H-809: Change users and orgs to own themselves

### DIFF
--- a/apps/hash-api/src/graph/knowledge/system-types/org.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/org.ts
@@ -21,7 +21,6 @@ import { getRoots } from "@local/hash-subgraph/stdlib";
 import { EntityTypeMismatchError } from "../../../lib/error";
 import { ImpureGraphFunction, PureGraphFunction } from "../..";
 import { SYSTEM_TYPES } from "../../system-types";
-import { systemUserAccountId } from "../../system-user";
 import {
   createEntity,
   CreateEntityParams,
@@ -150,7 +149,7 @@ export const createOrg: ImpureGraphFunction<
   };
 
   const entity = await createEntity(ctx, authentication, {
-    ownedById: systemUserAccountId as OwnedById,
+    ownedById: orgAccountGroupId as OwnedById,
     properties,
     entityTypeId: SYSTEM_TYPES.entityType.org.schema.$id,
     entityUuid: orgAccountGroupId as string as EntityUuid,
@@ -252,14 +251,12 @@ export const updateOrgShortname: ImpureGraphFunction<
     );
   }
 
-  const updatedOrg = await updateEntityProperty(ctx, authentication, {
+  return updateEntityProperty(ctx, authentication, {
     entity: org.entity,
     propertyTypeBaseUrl:
       SYSTEM_TYPES.propertyType.shortname.metadata.recordId.baseUrl,
     value: updatedShortname,
   }).then((updatedEntity) => getOrgFromEntity({ entity: updatedEntity }));
-
-  return updatedOrg;
 };
 
 /**

--- a/apps/hash-api/src/graph/knowledge/system-types/user.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user.ts
@@ -26,7 +26,6 @@ import {
 import { EntityTypeMismatchError } from "../../../lib/error";
 import { ImpureGraphFunction, PureGraphFunction } from "../..";
 import { SYSTEM_TYPES } from "../../system-types";
-import { systemUserAccountId } from "../../system-user";
 import {
   createEntity,
   CreateEntityParams,
@@ -297,7 +296,7 @@ export const createUser: ImpureGraphFunction<
   };
 
   const entity = await createEntity(ctx, authentication, {
-    ownedById: systemUserAccountId as OwnedById,
+    ownedById: userAccountId as OwnedById,
     properties,
     entityTypeId: SYSTEM_TYPES.entityType.user.schema.$id,
     entityUuid: userAccountId as string as EntityUuid,

--- a/apps/hash-api/src/graph/ontology/primitive/util.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/util.ts
@@ -28,13 +28,13 @@ export const getNamespaceOfAccountOwner: ImpureGraphFunction<
       : (
           (await getUserById(ctx, authentication, {
             entityId: entityIdFromOwnedByIdAndEntityUuid(
-              systemUserAccountId as OwnedById,
+              params.ownerId as Uuid as OwnedById,
               params.ownerId as Uuid as EntityUuid,
             ),
           }).catch(() => undefined)) ??
           (await getOrgById(ctx, authentication, {
             entityId: entityIdFromOwnedByIdAndEntityUuid(
-              systemUserAccountId as OwnedById,
+              params.ownerId as Uuid as OwnedById,
               params.ownerId as Uuid as EntityUuid,
             ),
           }).catch(() => undefined))

--- a/apps/hash-api/src/graph/system-types.ts
+++ b/apps/hash-api/src/graph/system-types.ts
@@ -912,8 +912,7 @@ export const ensureSystemTypesExist = async (params: {
       >,
     ][]) {
       logger.debug(`Checking system type: [${key}] exists`);
-      const type = await typeInitializer(context);
-      initializedSystemTypes[typeKind][key] = type;
+      initializedSystemTypes[typeKind][key] = await typeInitializer(context);
     }
   }
 

--- a/apps/hash-api/src/seed-data/index.ts
+++ b/apps/hash-api/src/seed-data/index.ts
@@ -56,7 +56,12 @@ const seedOrg = async (params: {
     },
   ];
 
-  await seedPages(pageTitles, sharedOrg.accountGroupId as OwnedById, params);
+  await seedPages(
+    authentication,
+    pageTitles,
+    sharedOrg.accountGroupId as OwnedById,
+    params,
+  );
 
   logger.info(
     `Development Org with shortname = "${sharedOrg.shortname}" now has seeded pages.`,
@@ -109,7 +114,12 @@ export const seedOrgsAndUsers = async (params: {
         },
       ];
 
-      await seedPages(pageTitles, user.accountId as OwnedById, params);
+      await seedPages(
+        { actorId: user.accountId },
+        pageTitles,
+        user.accountId as OwnedById,
+        params,
+      );
       logger.info(
         `Seeded User with shortname = "${user.shortname}" now has seeded pages.`,
       );

--- a/apps/hash-api/src/seed-data/seed-pages.ts
+++ b/apps/hash-api/src/seed-data/seed-pages.ts
@@ -7,7 +7,7 @@ import {
   Page,
   setPageParentPage,
 } from "../graph/knowledge/system-types/page";
-import { systemUserAccountId } from "../graph/system-user";
+import { AuthenticationContext } from "../graphql/context";
 
 export type PageDefinition = {
   title: string;
@@ -15,6 +15,7 @@ export type PageDefinition = {
 };
 
 export const seedPages = async (
+  authentication: AuthenticationContext,
   pageDefinitions: PageDefinition[],
   ownedById: OwnedById,
   sharedParams: {
@@ -24,7 +25,6 @@ export const seedPages = async (
   parentPage?: Page,
 ) => {
   const { context } = sharedParams;
-  const authentication = { actorId: systemUserAccountId };
 
   let prevIndex: string | undefined;
 
@@ -48,6 +48,7 @@ export const seedPages = async (
 
     if (pageDefinition.nestedPages) {
       await seedPages(
+        authentication,
         pageDefinition.nestedPages,
         ownedById,
         sharedParams,

--- a/apps/hash-api/src/seed-data/seed-users.ts
+++ b/apps/hash-api/src/seed-data/seed-users.ts
@@ -111,15 +111,23 @@ export const ensureUsersAreSeeded = async ({
         isInstanceAdmin,
       });
 
-      user = await updateUserShortname(context, authentication, {
-        user,
-        updatedShortname: shortname,
-      });
+      user = await updateUserShortname(
+        context,
+        { actorId: user.accountId },
+        {
+          user,
+          updatedShortname: shortname,
+        },
+      );
 
-      user = await updateUserPreferredName(context, authentication, {
-        user,
-        updatedPreferredName: preferredName,
-      });
+      user = await updateUserPreferredName(
+        context,
+        { actorId: user.accountId },
+        {
+          user,
+          updatedPreferredName: preferredName,
+        },
+      );
 
       createdUsers.push(user);
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -272,12 +272,14 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         properties: EntityProperties,
         link_data: Option<LinkData>,
     ) -> Result<EntityMetadata, InsertionError> {
-        authorization_api
-            .can_create_entity(actor_id, owned_by_id, Consistency::FullyConsistent)
-            .await
-            .change_context(InsertionError)?
-            .assert_permission()
-            .change_context(InsertionError)?;
+        if Some(owned_by_id.into_uuid()) != entity_uuid.map(EntityUuid::into_uuid) {
+            authorization_api
+                .can_create_entity(actor_id, owned_by_id, Consistency::FullyConsistent)
+                .await
+                .change_context(InsertionError)?
+                .assert_permission()
+                .change_context(InsertionError)?;
+        }
 
         let entity_id = EntityId {
             owned_by_id,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With permissions enabled, it would be required that the system user (the current owner of users and orgs) has the same access to the users and orgs as the users and orgs themself. Instead, users and orgs should own themself, which reduces the dependency on the system user as well.

Either this approach needs to be done or the authorization logic has to be expanded to allow permission granting on the users/orgs.

## 🚫 Blocked by

- #3176 
- #3177
- #3189 
- #3179 
- #3190


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph