### PR TITLE
H-827: Adjust Node API to use authentication for several cases

### DIFF
--- a/apps/hash-api/src/graph/knowledge/system-types/hash-instance.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/hash-instance.ts
@@ -25,6 +25,7 @@ import {
   createEntity,
   CreateEntityParams,
   getEntityOutgoingLinks,
+  makeEntityPublic,
 } from "../primitive/entity";
 import { createLinkEntity } from "../primitive/link-entity";
 import { isUserHashInstanceAdmin, User } from "./user";
@@ -135,6 +136,9 @@ export const createHashInstance: ImpureGraphFunction<
         .baseUrl]: params.orgSelfRegistrationIsEnabled ?? true,
     },
     entityTypeId: SYSTEM_TYPES.entityType.hashInstance.schema.$id,
+  });
+  await makeEntityPublic(ctx, authentication, {
+    entityId: entity.metadata.recordId.entityId,
   });
 
   return getHashInstanceFromEntity({ entity });

--- a/apps/hash-api/src/graph/knowledge/system-types/org.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/org.ts
@@ -25,6 +25,7 @@ import {
   createEntity,
   CreateEntityParams,
   getLatestEntityById,
+  makeEntityPublic,
   updateEntityProperty,
 } from "../primitive/entity";
 import {
@@ -153,6 +154,9 @@ export const createOrg: ImpureGraphFunction<
     properties,
     entityTypeId: SYSTEM_TYPES.entityType.org.schema.$id,
     entityUuid: orgAccountGroupId as string as EntityUuid,
+  });
+  await makeEntityPublic(ctx, authentication, {
+    entityId: entity.metadata.recordId.entityId,
   });
 
   return getOrgFromEntity({ entity });

--- a/apps/hash-api/src/seed-data/seed-users.ts
+++ b/apps/hash-api/src/seed-data/seed-users.ts
@@ -3,12 +3,7 @@ import { AxiosError } from "axios";
 
 import { createKratosIdentity } from "../auth/ory-kratos";
 import { ImpureGraphContext } from "../graph";
-import {
-  createUser,
-  updateUserPreferredName,
-  updateUserShortname,
-  User,
-} from "../graph/knowledge/system-types/user";
+import { createUser, User } from "../graph/knowledge/system-types/user";
 import { systemUserAccountId } from "../graph/system-user";
 import { isDevEnv } from "../lib/env-config";
 
@@ -105,29 +100,13 @@ export const ensureUsersAreSeeded = async ({
       const { traits, id: kratosIdentityId } = maybeNewIdentity;
       const { emails } = traits;
 
-      let user = await createUser(context, authentication, {
+      const user = await createUser(context, authentication, {
         emails,
         kratosIdentityId,
         isInstanceAdmin,
+        shortname,
+        preferredName,
       });
-
-      user = await updateUserShortname(
-        context,
-        { actorId: user.accountId },
-        {
-          user,
-          updatedShortname: shortname,
-        },
-      );
-
-      user = await updateUserPreferredName(
-        context,
-        { actorId: user.accountId },
-        {
-          user,
-          updatedPreferredName: preferredName,
-        },
-      );
 
       createdUsers.push(user);
     }

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/hash-instance.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/hash-instance.test.ts
@@ -71,12 +71,16 @@ describe("Hash Instance", () => {
       "hashInstTest",
       logger,
     );
+
+    await addHashInstanceAdmin(
+      graphContext,
+      { actorId: systemUserAccountId },
+      {
+        user: testHashInstanceAdmin,
+      },
+    );
+
     const authentication = { actorId: testHashInstanceAdmin.accountId };
-
-    await addHashInstanceAdmin(graphContext, authentication, {
-      user: testHashInstanceAdmin,
-    });
-
     const hashOutgoingAdminLinks = await getEntityOutgoingLinks(
       graphContext,
       authentication,

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/org-membership.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/org-membership.test.ts
@@ -11,10 +11,8 @@ import {
   OrgMembership,
 } from "@apps/hash-api/src/graph/knowledge/system-types/org-membership";
 import { User } from "@apps/hash-api/src/graph/knowledge/system-types/user";
-import {
-  systemUser,
-  systemUserAccountId,
-} from "@apps/hash-api/src/graph/system-user";
+import { systemUser } from "@apps/hash-api/src/graph/system-user";
+import { AuthenticationContext } from "@apps/hash-api/src/graphql/context";
 import { TypeSystemInitializer } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
 
@@ -39,14 +37,21 @@ describe("OrgMembership", () => {
   let testUser: User;
 
   let testOrg: Org;
+  let authentication: AuthenticationContext;
 
   beforeAll(async () => {
     await TypeSystemInitializer.initialize();
     await ensureSystemGraphIsInitialized({ logger, context: graphContext });
 
     testUser = await createTestUser(graphContext, "orgMembershipTest", logger);
+    authentication = { actorId: testUser.accountId };
 
-    testOrg = await createTestOrg(graphContext, "orgMembershipTest", logger);
+    testOrg = await createTestOrg(
+      graphContext,
+      { actorId: testUser.accountId },
+      "orgMembershipTest",
+      logger,
+    );
   });
 
   afterAll(async () => {
@@ -63,8 +68,6 @@ describe("OrgMembership", () => {
   let testOrgMembership: OrgMembership;
 
   it("can create an OrgMembership", async () => {
-    const authentication = { actorId: testUser.accountId };
-
     testOrgMembership = await createOrgMembership(
       graphContext,
       authentication,
@@ -76,8 +79,6 @@ describe("OrgMembership", () => {
   });
 
   it("can get the org of an org membership", async () => {
-    const authentication = { actorId: systemUserAccountId };
-
     const fetchedOrg = await getOrgMembershipOrg(graphContext, authentication, {
       orgMembership: testOrgMembership,
     });
@@ -86,8 +87,6 @@ describe("OrgMembership", () => {
   });
 
   it("can get the user of an org membership", async () => {
-    const authentication = { actorId: systemUserAccountId };
-
     const fetchedUser = await getOrgMembershipUser(
       graphContext,
       authentication,

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/org.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/org.test.ts
@@ -50,7 +50,12 @@ describe("Org", () => {
   let createdOrg: Org;
   let shortname: string;
   it("can create an org", async () => {
-    createdOrg = await createTestOrg(graphContext, "orgTest", logger);
+    createdOrg = await createTestOrg(
+      graphContext,
+      { actorId: systemUserAccountId },
+      "orgTest",
+      logger,
+    );
 
     shortname = createdOrg.shortname;
   });

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/user.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/user.test.ts
@@ -13,8 +13,6 @@ import {
   getUserByShortname,
   isUserMemberOfOrg,
   joinOrg,
-  updateUserPreferredName,
-  updateUserShortname,
   User,
 } from "@apps/hash-api/src/graph/knowledge/system-types/user";
 import {
@@ -76,6 +74,8 @@ describe("User model class", () => {
     createdUser = await createUser(graphContext, authentication, {
       emails: ["alice@example.com"],
       kratosIdentityId,
+      shortname,
+      preferredName: "Alice",
     });
   });
 
@@ -88,24 +88,6 @@ describe("User model class", () => {
         kratosIdentityId,
       }),
     ).rejects.toThrowError(`"${kratosIdentityId}" already exists.`);
-  });
-
-  it("can update the shortname of a user", async () => {
-    const authentication = { actorId: createdUser.accountId };
-
-    createdUser = await updateUserShortname(graphContext, authentication, {
-      user: createdUser,
-      updatedShortname: shortname,
-    });
-  });
-
-  it("can update the preferred name of a user", async () => {
-    const authentication = { actorId: createdUser.accountId };
-
-    createdUser = await updateUserPreferredName(graphContext, authentication, {
-      user: createdUser,
-      updatedPreferredName: "Alice",
-    });
   });
 
   it("can get a user by its shortname", async () => {
@@ -138,7 +120,12 @@ describe("User model class", () => {
 
   it("can join an org", async () => {
     const authentication = { actorId: systemUserAccountId };
-    const testOrg = await createTestOrg(graphContext, "userModelTest", logger);
+    const testOrg = await createTestOrg(
+      graphContext,
+      authentication,
+      "userModelTest",
+      logger,
+    );
 
     const orgEntityUuid = extractEntityUuidFromEntityId(
       testOrg.entity.metadata.recordId.entityId,

--- a/tests/hash-backend-integration/src/tests/graph/ontology/primitive/data-type.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/ontology/primitive/data-type.test.ts
@@ -11,6 +11,7 @@ import {
   updateDataType,
 } from "@apps/hash-api/src/graph/ontology/primitive/data-type";
 import { systemUser } from "@apps/hash-api/src/graph/system-user";
+import { publicUserAccountId } from "@apps/hash-api/src/graphql/context";
 import { TypeSystemInitializer } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
 import { ConstructDataTypeParams } from "@local/hash-graphql-shared/graphql/types";
@@ -120,7 +121,11 @@ describe("Data type CRU", () => {
       "https://blockprotocol.org/@blockprotocol/types/data-type/empty-list/v/1";
 
     await expect(
-      getDataTypeById(graphContext, authentication, { dataTypeId }),
+      getDataTypeById(
+        graphContext,
+        { actorId: publicUserAccountId },
+        { dataTypeId },
+      ),
     ).rejects.toThrow("Could not find data type with ID");
 
     await expect(

--- a/tests/hash-backend-integration/src/tests/graph/ontology/primitive/entity-type.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/ontology/primitive/entity-type.test.ts
@@ -13,6 +13,7 @@ import {
 } from "@apps/hash-api/src/graph/ontology/primitive/entity-type";
 import { createPropertyType } from "@apps/hash-api/src/graph/ontology/primitive/property-type";
 import { systemUser } from "@apps/hash-api/src/graph/system-user";
+import { publicUserAccountId } from "@apps/hash-api/src/graphql/context";
 import { TypeSystemInitializer } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
 import {
@@ -241,7 +242,11 @@ describe("Entity type CRU", () => {
       "https://blockprotocol.org/@blockprotocol/types/entity-type/thing/v/1";
 
     await expect(
-      getEntityTypeById(graphContext, authentication, { entityTypeId }),
+      getEntityTypeById(
+        graphContext,
+        { actorId: publicUserAccountId },
+        { entityTypeId },
+      ),
     ).rejects.toThrow("Could not find entity type with ID");
 
     await expect(

--- a/tests/hash-backend-integration/src/tests/graph/ontology/primitive/property-type.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/ontology/primitive/property-type.test.ts
@@ -12,6 +12,7 @@ import {
   updatePropertyType,
 } from "@apps/hash-api/src/graph/ontology/primitive/property-type";
 import { systemUser } from "@apps/hash-api/src/graph/system-user";
+import { publicUserAccountId } from "@apps/hash-api/src/graphql/context";
 import { TypeSystemInitializer } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
 import { ConstructPropertyTypeParams } from "@local/hash-graphql-shared/graphql/types";
@@ -151,7 +152,11 @@ describe("Property type CRU", () => {
       "https://blockprotocol.org/@blockprotocol/types/property-type/name/v/1";
 
     await expect(
-      getPropertyTypeById(graphContext, authentication, { propertyTypeId }),
+      getPropertyTypeById(
+        graphContext,
+        { actorId: publicUserAccountId },
+        { propertyTypeId },
+      ),
     ).rejects.toThrow("Could not find property type with ID");
 
     await expect(

--- a/tests/hash-backend-integration/src/tests/util.ts
+++ b/tests/hash-backend-integration/src/tests/util.ts
@@ -5,12 +5,12 @@ import {
   ImpureGraphContext,
 } from "@apps/hash-api/src/graph";
 import { createOrg } from "@apps/hash-api/src/graph/knowledge/system-types/org";
-import {
-  createUser,
-  updateUserShortname,
-} from "@apps/hash-api/src/graph/knowledge/system-types/user";
+import { createUser } from "@apps/hash-api/src/graph/knowledge/system-types/user";
 import { ensureSystemTypesExist } from "@apps/hash-api/src/graph/system-types";
-import { systemUserAccountId } from "@apps/hash-api/src/graph/system-user";
+import {
+  AuthenticationContext,
+  publicUserAccountId,
+} from "@apps/hash-api/src/graphql/context";
 import { StorageType } from "@apps/hash-api/src/storage";
 import { getRequiredEnv } from "@apps/hash-api/src/util";
 import { Logger } from "@local/hash-backend-utils/logger";
@@ -87,42 +87,31 @@ export const createTestUser = async (
 
   const kratosIdentityId = identity.id;
 
-  const createdUser = await createUser(
+  return createUser(
     context,
-    { actorId: systemUserAccountId },
+    { actorId: publicUserAccountId },
     {
       emails: [`${shortname}@example.com`],
       kratosIdentityId,
+      shortname,
     },
   ).catch((err) => {
     logger.error(`Error making UserModel for ${shortname}`);
-    throw err;
-  });
-
-  return await updateUserShortname(
-    context,
-    { actorId: createdUser.accountId },
-    {
-      user: createdUser,
-      updatedShortname: shortname,
-    },
-  ).catch((err) => {
-    logger.error(`Error updating shortname for UserModel to ${shortname}`);
     throw err;
   });
 };
 
 export const createTestOrg = async (
   context: ImpureGraphContext,
+  authentication: AuthenticationContext,
   shortNamePrefix: string,
   logger: Logger,
 ) => {
   await ensureSystemTypesExist({ logger, context });
-  const authentication = { actorId: systemUserAccountId };
 
   const shortname = generateRandomShortname(shortNamePrefix);
 
-  return await createOrg(context, authentication, {
+  return createOrg(context, authentication, {
     name: "Test org",
     shortname,
     providedInfo: {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With basic entity authorization implemented it's time to adjust a few Node API functions to properly fill the permissions. This includes making users, orgs, and the HASH-instance public and tweak various locations to use more correct actor ids.

This does not enable permissions in `dev` or `prod` by default but with permissions enabled most BE integration tests are passing. The missing parts are the subgraph tests (the snapshots do not know yet about permissions, will be done in H-669) and the instance admin tests (will be done as part of H-817).

## 🚫 Blocked by

- #3179 
- #3190
- #3200
- #3204 
- #3210 


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph