### PR TITLE
H-671: Add a timeout for the type fetcher

### DIFF
--- a/apps/hash-graph/lib/type-fetcher/src/fetcher_server.rs
+++ b/apps/hash-graph/lib/type-fetcher/src/fetcher_server.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use futures::{stream, StreamExt, TryStreamExt};
 use reqwest::{
     header::{ACCEPT, USER_AGENT},
@@ -30,6 +32,7 @@ impl Fetcher for FetchServer {
                         .get(url.to_url())
                         .header(ACCEPT, "application/json")
                         .header(USER_AGENT, "HASH Graph")
+                        .timeout(Duration::from_secs(10))
                         .send()
                         .await
                         .map_err(|err| {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To avoid doing [H-670](https://linear.app/hash/issue/H-670/make-the-type-fetcher-a-temporalio-worker) right now, we should try to make the type fetcher more robust to external services being unresponsive (e.g. because bp.org is currently redeploying)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph