### PR TITLE
H-834: Fix `ignorePaths` setting in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/target/**",
+    "**/dist/**"
+  ],
   "extends": ["config:base"],
 
   "automerge": true,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

By default, `ignorePaths` is set to
```json
[
  "/node_modules/",
  "/bower_components/"
]
```

however, for some reason, it's set to 

```json
[
  "**/node_modules/**",
  "**/bower_components/**",
  "**/vendor/**",
  "**/examples/**",
  "**/__tests__/**",
  "**/test/**",
  "**/tests/**",
  "**/__fixtures__/**"
]
```

resulting in `tests/` not being updated.

To reproduce the error I used `renovate` locally:
```
LOG_LEVEL=debug renovate --dry-run=true --token $MY_GH_TOKEN --ignore-paths '["**/node_modules/**", "**/target/**", "**/dist/**"]' hashintel/hash
```

## 🔗 Related links

- https://docs.renovatebot.com/configuration-options/#ignorepaths

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph