### PR TITLE
H-835: Don't run Rust CI if something else than workflows changed in `.github/`

### DIFF
--- a/.github/scripts/rust/setup.py
+++ b/.github/scripts/rust/setup.py
@@ -19,7 +19,7 @@ from pygit2 import Repository, Commit
 CWD = Path.cwd()
 
 # All jobs for all crates will run if any of these paths change
-ALWAYS_RUN_PATTERNS = [".github/**", ".config/**", ".cargo/**"]
+ALWAYS_RUN_PATTERNS = [".github/workflows/**", ".github/actions/**", ".github/scripts/rust/**", ".config/**", ".cargo/**"]
 
 # Toolchains used for the specified crates in addition to the toolchain which is defined in
 # rust-toolchain.toml


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The only real reason to run Rust CI when `.github` change is when the actual workflow changes.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing
### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph