### PR TITLE
H-838: Expose function to check if a user can update an entity

### DIFF
--- a/apps/hash-graph/lib/graph/src/api/rest.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest.rs
@@ -40,6 +40,7 @@ use graph_types::{
 };
 use include_dir::{include_dir, Dir};
 use sentry::integrations::tower::{NewSentryLayer, SentryHttpLayer};
+use serde::Serialize;
 use temporal_versioning::{
     ClosedTemporalBound, DecisionTime, LeftClosedTemporalInterval, LimitedTemporalBound,
     OpenTemporalBound, RightBoundedTemporalInterval, TemporalBound, Timestamp, TransactionTime,
@@ -105,6 +106,11 @@ impl<S> FromRequestParts<S> for AuthenticatedUserHeader {
             ))
         }
     }
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PermissionResponse {
+    has_permission: bool,
 }
 
 #[async_trait]
@@ -270,6 +276,8 @@ async fn serve_static_schema(Path(path): Path<String>) -> Result<Response, Statu
     ),
     components(
         schemas(
+            PermissionResponse,
+
             OwnedById,
             RecordCreatedById,
             RecordArchivedById,

--- a/apps/hash-graph/lib/graph/src/api/rest/entity.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity.rs
@@ -5,7 +5,12 @@ use std::sync::Arc;
 use authorization::{
     zanzibar::Consistency, AuthorizationApi, AuthorizationApiPool, VisibilityScope,
 };
-use axum::{extract::Path, http::StatusCode, routing::post, Extension, Router};
+use axum::{
+    extract::Path,
+    http::StatusCode,
+    routing::{get, post},
+    Extension, Router,
+};
 use graph_types::{
     knowledge::{
         entity::{
@@ -23,7 +28,7 @@ use utoipa::{OpenApi, ToSchema};
 use crate::{
     api::rest::{
         api_resource::RoutedResource, json::Json, report_to_status_code,
-        utoipa_typedef::subgraph::Subgraph, AuthenticatedUserHeader,
+        utoipa_typedef::subgraph::Subgraph, AuthenticatedUserHeader, PermissionResponse,
     },
     knowledge::EntityQueryToken,
     store::{
@@ -38,9 +43,11 @@ use crate::{
     paths(
         create_entity,
         get_entities_by_query,
+        can_update_entity,
         update_entity,
         make_entity_public,
         make_entity_private,
+
     ),
     components(
         schemas(
@@ -81,9 +88,14 @@ impl RoutedResource for EntityResource {
             "/entities",
             Router::new()
                 .route("/", post(create_entity::<S, A>).put(update_entity::<S, A>))
-                .route(
-                    "/:entity_id/public",
-                    post(make_entity_public::<A>).delete(make_entity_private::<A>),
+                .nest(
+                    "/:entity_id",
+                    Router::new()
+                        .route(
+                            "/public",
+                            post(make_entity_public::<A>).delete(make_entity_private::<A>),
+                        )
+                        .route("/update", get(can_update_entity::<A>)),
                 )
                 .route("/query", post(get_entities_by_query::<S, A>)),
         )
@@ -225,6 +237,50 @@ where
         })?;
 
     Ok(Json(subgraph.into()))
+}
+
+#[utoipa::path(
+    get,
+    path = "/entities/{entity_id}/update",
+    tag = "Entity",
+    params(
+        ("X-Authenticated-User-Actor-Id" = AccountId, Header, description = "The ID of the actor which is used to authorize the request"),
+        ("entity_id" = EntityId, Path, description = "The entity ID to check if the actor can update"),
+    ),
+    responses(
+        (status = 200, body = PermissionResponse, description = "Information if the actor can update the entity"),
+
+        (status = 500, description = "Internal error occurred"),
+    )
+)]
+#[tracing::instrument(level = "info", skip(authorization_api_pool))]
+async fn can_update_entity<A>(
+    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    Path(entity_id): Path<EntityId>,
+    authorization_api_pool: Extension<Arc<A>>,
+) -> Result<Json<PermissionResponse>, StatusCode>
+where
+    A: AuthorizationApiPool + Send + Sync,
+{
+    Ok(Json(PermissionResponse {
+        has_permission: authorization_api_pool
+            .acquire()
+            .await
+            .map_err(|error| {
+                tracing::error!(?error, "Could not acquire access to the authorization API");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?
+            .can_update_entity(actor_id, entity_id, Consistency::FullyConsistent)
+            .await
+            .map_err(|error| {
+                tracing::error!(
+                    ?error,
+                    "Could not check if account group member can be removed"
+                );
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?
+            .has_permission,
+    }))
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]

--- a/apps/hash-graph/lib/graph/src/api/rest/entity.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity.rs
@@ -89,7 +89,7 @@ impl RoutedResource for EntityResource {
             Router::new()
                 .route("/", post(create_entity::<S, A>).put(update_entity::<S, A>))
                 .nest(
-                    "/:entity_id",
+                    "/:entity_id/permissions",
                     Router::new()
                         .route(
                             "/public",
@@ -241,7 +241,7 @@ where
 
 #[utoipa::path(
     get,
-    path = "/entities/{entity_id}/update",
+    path = "/entities/{entity_id}/permissions/update",
     tag = "Entity",
     params(
         ("X-Authenticated-User-Actor-Id" = AccountId, Header, description = "The ID of the actor which is used to authorize the request"),

--- a/apps/hash-graph/lib/graph/src/api/rest/entity.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity.rs
@@ -89,13 +89,13 @@ impl RoutedResource for EntityResource {
             Router::new()
                 .route("/", post(create_entity::<S, A>).put(update_entity::<S, A>))
                 .nest(
-                    "/:entity_id/permissions",
+                    "/:entity_id",
                     Router::new()
                         .route(
                             "/public",
                             post(make_entity_public::<A>).delete(make_entity_private::<A>),
                         )
-                        .route("/update", get(can_update_entity::<A>)),
+                        .route("/permissions/update", get(can_update_entity::<A>)),
                 )
                 .route("/query", post(get_entities_by_query::<S, A>)),
         )

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -825,6 +825,50 @@
         }
       }
     },
+    "/entities/{entity_id}/permissions/update": {
+      "get": {
+        "tags": [
+          "Graph",
+          "Entity"
+        ],
+        "operationId": "can_update_entity",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          },
+          {
+            "name": "entity_id",
+            "in": "path",
+            "description": "The entity ID to check if the actor can update",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/EntityId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Information if the actor can update the entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error occurred"
+          }
+        }
+      }
+    },
     "/entities/{entity_id}/public": {
       "post": {
         "tags": [
@@ -893,50 +937,6 @@
           },
           "403": {
             "description": "Permission denied"
-          }
-        }
-      }
-    },
-    "/entities/{entity_id}/update": {
-      "get": {
-        "tags": [
-          "Graph",
-          "Entity"
-        ],
-        "operationId": "can_update_entity",
-        "parameters": [
-          {
-            "name": "X-Authenticated-User-Actor-Id",
-            "in": "header",
-            "description": "The ID of the actor which is used to authorize the request",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/AccountId"
-            }
-          },
-          {
-            "name": "entity_id",
-            "in": "path",
-            "description": "The entity ID to check if the actor can update",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/EntityId"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Information if the actor can update the entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PermissionResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal error occurred"
           }
         }
       }

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -897,6 +897,50 @@
         }
       }
     },
+    "/entities/{entity_id}/update": {
+      "get": {
+        "tags": [
+          "Graph",
+          "Entity"
+        ],
+        "operationId": "can_update_entity",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          },
+          {
+            "name": "entity_id",
+            "in": "path",
+            "description": "The entity ID to check if the actor can update",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/EntityId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Information if the actor can update the entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error occurred"
+          }
+        }
+      }
+    },
     "/entity-types": {
       "post": {
         "tags": [
@@ -2883,6 +2927,17 @@
       "OwnedById": {
         "type": "string",
         "format": "uuid"
+      },
+      "PermissionResponse": {
+        "type": "object",
+        "required": [
+          "has_permission"
+        ],
+        "properties": {
+          "has_permission": {
+            "type": "boolean"
+          }
+        }
       },
       "PropertyTypeQueryToken": {
         "type": "string",

--- a/libs/@local/hash-graph-client/python/graph_client/models.py
+++ b/libs/@local/hash-graph-client/python/graph_client/models.py
@@ -177,6 +177,11 @@ class OwnedById(RootModel):
     root: UUID
 
 
+class PermissionResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    has_permission: bool
+
+
 class PropertyTypeQueryToken(Enum):
     """
     A single token in a [`DataTypeQueryPath`].


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To check if a user will be able to update an entity, a function is required to be exposed for that. The first thing where this is used is to determine if the user can edit the instance settings.

## 🚫 Blocked by

- #3200
- #3204 
- #3210 
- #3211 


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph