### PR TITLE
H-841: Support parallel processing for snapshot dumping

### DIFF
--- a/apps/hash-graph/Cargo.lock
+++ b/apps/hash-graph/Cargo.lock
@@ -87,6 +87,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "async-scoped"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7a6a57c8aeb40da1ec037f5d455836852f7a57e69e1b1ad3d8f38ac1d6cadf"
+dependencies = [
+ "futures",
+ "pin-project",
+ "slab",
+ "tokio",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,6 +792,7 @@ dependencies = [
 name = "graph"
 version = "0.0.0"
 dependencies = [
+ "async-scoped",
  "async-trait",
  "authorization",
  "axum",

--- a/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
@@ -1,6 +1,5 @@
 use clap::Parser;
 use error_stack::{Result, ResultExt};
-use futures::{SinkExt, StreamExt, TryStreamExt};
 use graph::{
     logging::{init_logger, LoggingArgs},
     snapshot::{codec, SnapshotEntry, SnapshotStore},
@@ -51,24 +50,15 @@ pub async fn snapshot(args: SnapshotArgs) -> Result<(), GraphError> {
 
     match args.command {
         SnapshotCommand::Dump(_) => {
-            pool.dump_snapshot()
-                .map_err(|report| {
-                    report
-                        .change_context(GraphError)
-                        .attach_printable("Failed to produce snapshot dump")
-                })
-                .forward(
-                    FramedWrite::new(
-                        io::BufWriter::new(io::stdout()),
-                        codec::JsonLinesEncoder::default(),
-                    )
-                    .sink_map_err(|report| {
-                        report
-                            .change_context(GraphError)
-                            .attach_printable("Failed to write snapshot dump")
-                    }),
-                )
-                .await?;
+            pool.dump_snapshot(
+                FramedWrite::new(
+                    io::BufWriter::new(io::stdout()),
+                    codec::JsonLinesEncoder::default(),
+                ),
+                10_000,
+            )
+            .change_context(GraphError)
+            .attach_printable("Failed to produce snapshot dump")?;
 
             tracing::info!("Snapshot dumped successfully");
         }

--- a/apps/hash-graph/lib/graph/Cargo.toml
+++ b/apps/hash-graph/lib/graph/Cargo.toml
@@ -21,6 +21,7 @@ utoipa = { workspace = true, features = ["uuid"] }
 tracing = { workspace = true }
 
 async-trait = "0.1.73"
+async-scoped = { version = "0.7.1", features = ["use-tokio"] }
 axum = "0.6.20"
 bb8-postgres = "0.8.1"
 bytes = { workspace = true }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The current implementation to dump a stream does not allow processing multiple records simultaneously as only a single connection to Postgres is possible. A change to the design is needed so a pool is used to create new connections on demand. This makes it possible to dump multiple records in parallel. 

When performance becomes an issue when dumping big datasets, dumping can be chunked. While the database connection can process large batches we need a post-processing step for records to read permission data from another source and this will be a lot slower.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph