### PR TITLE
H-580: Fix styling in link/property table, fix crash in entity editor

### DIFF
--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/file-preview-section.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/file-preview-section.tsx
@@ -158,6 +158,10 @@ export const FilePreviewSection = () => {
 
   const { isImage, url } = getFileUrlFromFileProperties(entity.properties);
 
+  if (!url) {
+    return null;
+  }
+
   const { description, displayName, fileName } = simplifyProperties(
     entity.properties as FileProperties,
   );
@@ -189,6 +193,7 @@ export const FilePreviewSection = () => {
           <>
             <ActionButtonsContainer>
               <Tooltip
+                placement="top"
                 title={
                   isDirty
                     ? "Save or discard your changes to replace the file"
@@ -204,7 +209,7 @@ export const FilePreviewSection = () => {
                   </GrayToBlueIconButton>
                 </Box>
               </Tooltip>
-              <Tooltip title="Download">
+              <Tooltip placement="top" title="Download">
                 <Box
                   component="a"
                   href={url}

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/shared/get-image-url-from-properties.ts
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/shared/get-image-url-from-properties.ts
@@ -24,10 +24,6 @@ export const getFileUrlFromFileProperties = (
     | string
     | undefined;
 
-  if (!url) {
-    throw new Error("Entity does not have a defined File URL property");
-  }
-
   const mimeType = properties[extractBaseUrl(mimeTypePropertyTypeUrl)] as
     | string
     | undefined;

--- a/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/definition-tab.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/definition-tab.tsx
@@ -81,6 +81,7 @@ export const DefinitionTab = ({
       customization={{ onNavigateToType }}
       entityType={entityTypeAndPropertyTypes.entityType}
       entityTypeOptions={entityTypeOptions}
+      key={entityTypeAndPropertyTypes.entityType.$id} // Reset state when switching entity types, helps avoid state mismatch issues
       ontologyFunctions={ontologyFunctions}
       propertyTypeOptions={propertyTypeOptions}
       readonly={readonly}

--- a/libs/@hashintel/type-editor/src/entity-type-editor/link-list-card.tsx
+++ b/libs/@hashintel/type-editor/src/entity-type-editor/link-list-card.tsx
@@ -169,7 +169,14 @@ const LinkTypeRow = ({
       <EntityTypeTableRow flash={flash}>
         <TableCell>
           <EntityTypeTableTitleCellText>
-            <Link href={link.$id} style={{ color: "inherit", fontWeight: 600 }}>
+            <Link
+              href={link.$id}
+              style={{
+                color: "inherit",
+                fontWeight: 600,
+                whiteSpace: "nowrap",
+              }}
+            >
               {link.title}
             </Link>
             {currentVersion !== latestVersion && !isReadonly ? (

--- a/libs/@hashintel/type-editor/src/entity-type-editor/property-list-card/property-title-cell.tsx
+++ b/libs/@hashintel/type-editor/src/entity-type-editor/property-list-card/property-title-cell.tsx
@@ -77,6 +77,7 @@ export const PropertyTitleCell = ({
             expanded !== undefined && depth === 0
               ? "translateX(-20px)"
               : "none",
+          whiteSpace: "nowrap",
         }}
       >
         <Collapse


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A few small fixes:
1. H-580: Stop the link/property titles wrapping in the type editor, i.e. stop this
![image](https://github.com/hashintel/hash/assets/37743469/bcbeb70b-a159-4b12-948a-649bc8d39b15)
2. Fix a crash when viewing the entity editor for non-file entities (introduced in #3216)
3. Adjust tooltip placement on file preview to stop tooltips covering the adjacent button
4. Reset entity type editor state when switching types (fixes a crash I noticed while testing the above)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


## ⚠️ Known issues

- I noticed another crash in the type editor tracked in H-846

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. For wrapping, you need to create a type which has a non-latest property or link type
2. Visit entity editor for non-file entity to confirm no crash
3. Check tooltip placement on file preview

