### PR TITLE
H-849: Make `codec` module a crate

### DIFF
--- a/apps/hash-graph/Cargo.lock
+++ b/apps/hash-graph/Cargo.lock
@@ -371,6 +371,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
+name = "codec"
+version = "0.0.0"
+dependencies = [
+ "derive-where",
+ "error-stack",
+ "serde",
+ "serde_json",
+ "tokio-util",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +535,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146398d62142a0f35248a608f17edf0dde57338354966d6e41d0eb2d16980ccb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -799,6 +821,7 @@ dependencies = [
  "bb8-postgres",
  "bytes",
  "clap",
+ "codec",
  "criterion",
  "derivative",
  "dotenv-flow",
@@ -936,6 +959,7 @@ dependencies = [
  "axum",
  "clap",
  "clap_complete",
+ "codec",
  "error-stack",
  "futures",
  "graph",

--- a/apps/hash-graph/Cargo.toml
+++ b/apps/hash-graph/Cargo.toml
@@ -22,11 +22,13 @@ graph-test-data = { path = "tests/test_data" }
 temporal-versioning = { path = "lib/temporal-versioning" }
 graph-types = { path = "lib/graph-types" }
 authorization = { path = "lib/authorization" }
+codec = { path = "lib/codec" }
 
 type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "cdde49" }
 hash-status = { path = "../../libs/@local/status/crate" }
 error-stack = { git = "https://github.com/hashintel/hash", rev = "0829935", features = ["spantrace"] }
 
+tokio-util = { version = "0.7.9", default-features = false }
 bytes = "1.5.0"
 utoipa = "3.5.0"
 uuid = { version = "1.4.1", default-features = false }

--- a/apps/hash-graph/bin/cli/Cargo.toml
+++ b/apps/hash-graph/bin/cli/Cargo.toml
@@ -12,6 +12,7 @@ graph = { path = "../../lib/graph", features = ["clap"] }
 graph-types = { workspace = true }
 type-fetcher = { path = "../../lib/type-fetcher" }
 authorization = { workspace = true }
+codec = { workspace = true }
 
 error-stack = { workspace = true }
 type-system = { workspace = true }
@@ -30,7 +31,7 @@ time = "0.3.28"
 tokio = { workspace = true }
 tokio-postgres = { version = "0.7.10", default-features = false }
 tokio-serde = { version = "0.8", features = ["json"] }
-tokio-util = { version = "0.7.9", default-features = false, features = ["codec"] }
+tokio-util = { workspace = true, features = ["codec"] }
 tracing = "0.1.37"
 uuid = "1.4.1"
 

--- a/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use error_stack::{Result, ResultExt};
 use graph::{
     logging::{init_logger, LoggingArgs},
-    snapshot::{codec, SnapshotEntry, SnapshotStore},
+    snapshot::{SnapshotEntry, SnapshotStore},
     store::{DatabaseConnectionInfo, PostgresStorePool, StorePool},
 };
 use tokio::io;
@@ -53,7 +53,7 @@ pub async fn snapshot(args: SnapshotArgs) -> Result<(), GraphError> {
             pool.dump_snapshot(
                 FramedWrite::new(
                     io::BufWriter::new(io::stdout()),
-                    codec::JsonLinesEncoder::default(),
+                    codec::bytes::JsonLinesEncoder::default(),
                 ),
                 10_000,
             )
@@ -72,7 +72,7 @@ pub async fn snapshot(args: SnapshotArgs) -> Result<(), GraphError> {
             .restore_snapshot(
                 FramedRead::new(
                     io::BufReader::new(io::stdin()),
-                    codec::JsonLinesDecoder::default(),
+                    codec::bytes::JsonLinesDecoder::default(),
                 ),
                 10_000,
             )

--- a/apps/hash-graph/lib/codec/Cargo.toml
+++ b/apps/hash-graph/lib/codec/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "codec"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+error-stack = { workspace = true }
+
+derive-where = { version = "1.2.5", default-features = false, features = ["nightly"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio-util = { workspace = true, features = ["codec"] }

--- a/apps/hash-graph/lib/codec/src/bytes.rs
+++ b/apps/hash-graph/lib/codec/src/bytes.rs
@@ -3,29 +3,17 @@ use std::{
     marker::PhantomData,
 };
 
-use bytes::{BufMut, BytesMut};
-use derivative::Derivative;
+use derive_where::derive_where;
 use error_stack::{Report, ResultExt};
 use serde::{de::DeserializeOwned, Serialize};
-use tokio_util::codec::{Decoder, Encoder, LinesCodec};
+use tokio_util::{
+    bytes::{BufMut, BytesMut},
+    codec::{Decoder, Encoder, LinesCodec},
+};
 
-#[derive(Derivative)]
-#[derivative(
-    Debug(bound = ""),
-    Default(bound = ""),
-    Copy(bound = ""),
-    Eq(bound = ""),
-    PartialEq(bound = ""),
-    Hash(bound = "")
-)]
+#[derive_where(Debug, Default, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct JsonLinesEncoder<T> {
     _marker: PhantomData<fn() -> T>,
-}
-
-impl<T> Clone for JsonLinesEncoder<T> {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 
 impl<T: Serialize + Send + Sync + 'static> Encoder<T> for JsonLinesEncoder<T> {
@@ -41,15 +29,7 @@ impl<T: Serialize + Send + Sync + 'static> Encoder<T> for JsonLinesEncoder<T> {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(
-    Debug(bound = ""),
-    Default(bound = ""),
-    Clone(bound = ""),
-    Eq(bound = ""),
-    PartialEq(bound = ""),
-    Hash(bound = "")
-)]
+#[derive_where(Debug, Default, Clone, PartialEq, Eq, Hash)]
 pub struct JsonLinesDecoder<T> {
     lines: LinesCodec,
     current_line: usize,
@@ -73,6 +53,11 @@ impl<T> JsonLinesDecoder<T> {
             current_line: 0,
             _marker: PhantomData,
         }
+    }
+
+    #[must_use]
+    pub fn max_length(&self) -> usize {
+        self.lines.max_length()
     }
 }
 

--- a/apps/hash-graph/lib/codec/src/lib.rs
+++ b/apps/hash-graph/lib/codec/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod bytes;

--- a/apps/hash-graph/lib/graph/Cargo.toml
+++ b/apps/hash-graph/lib/graph/Cargo.toml
@@ -10,6 +10,7 @@ graph-types = { workspace = true, features = ["postgres", "utoipa"] }
 temporal-versioning = { workspace = true, features = ["postgres", "utoipa"] }
 type-fetcher = { path = "../type-fetcher" }
 authorization = { workspace = true }
+codec = { workspace = true }
 
 error-stack = { workspace = true }
 hash-status = { workspace = true }
@@ -44,7 +45,7 @@ time = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 tokio-postgres = { version = "0.7.10", default-features = false }
 tokio-serde = { version = "0.8", features = ["json"] }
-tokio-util = { version = "0.7.9", default-features = false, features = ["codec", "io"] }
+tokio-util = { workspace = true, features = ["io"] }
 tonic = "0.9.2"
 tower = "0.4.13"
 tower-http = { version = "0.4.4", features = ["trace"] }

--- a/apps/hash-graph/lib/graph/src/api/rest/test_server.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/test_server.rs
@@ -24,7 +24,7 @@ use crate::{
             status::status_to_response,
         },
     },
-    snapshot::{codec, SnapshotStore},
+    snapshot::SnapshotStore,
     store::{PostgresStorePool, StorePool},
 };
 
@@ -78,7 +78,7 @@ async fn restore_snapshot(
                 StreamReader::new(
                     snapshot.map_err(|err| io::Error::new(io::ErrorKind::Other, err)),
                 ),
-                codec::JsonLinesDecoder::default(),
+                codec::bytes::JsonLinesDecoder::default(),
             ),
             10_000,
         )

--- a/apps/hash-graph/lib/graph/src/snapshot.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot.rs
@@ -1,4 +1,3 @@
-pub mod codec;
 pub mod entity;
 pub mod owner;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `JsonLineDecoderis` is required in multiple locations in the repository. It should be moved to a separate crate.

In the future, I expect more codecs to be implemented here, such as how (de-)serialization is implemented (e.g. the current temporal_versioning::serde module).


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
