### PR TITLE
GEN-109, GEN-110: Fix CI jobs not determined correctly

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -97,7 +97,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.lints) }}
       fail-fast: false
-    if: always()
+    if: needs.setup.outputs.lint != '{}'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -221,7 +221,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.units) }}
       fail-fast: false
-    if: always()
+    if: needs.setup.outputs.units != '{}'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -260,6 +260,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.dockers) }}
       fail-fast: false
+    if: needs.setup.outputs.dockers != '{}'
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -279,7 +280,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.integrations) }}
       fail-fast: false
-    if: always()
+    if: needs.setup.outputs.integrations != '{}'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -365,7 +366,7 @@ jobs:
           [[ ${{ needs.setup.result }} = success ]]
       - name: Check lint results
         run: |
-          [[ ${{ needs.lint.result }} = success ]]
+          [[ ${{ needs.lint.result }} =~ success|skipped ]]
       - name: Check unit tests
         run: |
           [[ ${{ needs.unit.result }} =~ success|skipped ]]

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -97,7 +97,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.lints) }}
       fail-fast: false
-    if: needs.setup.outputs.lint != '{}'
+    if: needs.setup.outputs.lints != '{"package":[],"include":[]}'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -221,7 +221,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.units) }}
       fail-fast: false
-    if: needs.setup.outputs.units != '{}'
+    if: needs.setup.outputs.units != '{"package":[],"include":[]}'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -260,7 +260,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.dockers) }}
       fail-fast: false
-    if: needs.setup.outputs.dockers != '{}'
+    if: needs.setup.outputs.dockers != '{"include":[]}'
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -280,7 +280,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.integrations) }}
       fail-fast: false
-    if: needs.setup.outputs.integrations != '{}'
+    if: needs.setup.outputs.integrations != '{"package":[],"include":[]}'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -111,35 +111,36 @@ jobs:
       - name: Find lint steps to run
         id: lints
         run: |
-          ESLINT=$(turbo run lint:eslint --filter '${{ matrix.package }}...[HEAD^]' --dry-run=json \
+          set -x
+          ESLINT=$(turbo run lint:eslint --filter '${{ matrix.package }}' --dry-run=json \
             | jq '[.tasks[] | select(.task == "lint:eslint" and .command != "<NONEXISTENT>")] != []' || echo 'false')
           echo "eslint=$ESLINT" >> $GITHUB_OUTPUT
 
-          TSC=$(turbo run lint:tsc --filter '${{ matrix.package }}...[HEAD^]' --dry-run=json \
+          TSC=$(turbo run lint:tsc --filter '${{ matrix.package }}' --dry-run=json \
             | jq '[.tasks[] | select(.task == "lint:tsc" and .command != "<NONEXISTENT>")] != []' || echo 'false')
           echo "tsc=$TSC" >> $GITHUB_OUTPUT
 
           HAS_PYTHON=$(test -f "${{ matrix.directory }}/pyproject.toml" && echo 'true' || echo 'false')
           echo "has-python=$HAS_PYTHON" >> $GITHUB_OUTPUT
-          if [[ -f "${{ matrix.directory }}/pyproject.toml" ]]; then
+          if [[ $HAS_PYTHON = 'true' ]]; then
             echo "python-version=$(cat "${{ matrix.directory }}/pyproject.toml" | yq -p toml '.tool.poetry.dependencies.python')" >> $GITHUB_OUTPUT
           else
             echo "python-version=^3.11" >> $GITHUB_OUTPUT
           fi
 
-          HAS_POETRY_DEPS=$(turbo run poetry:install --filter '${{ matrix.package }}...[HEAD^]' --dry-run=json \
+          HAS_POETRY_DEPS=$(turbo run poetry:install --dry-run=json \
             | jq '[.tasks[] | select(.task == "poetry:install" and .command != "<NONEXISTENT>")] != []' || echo 'false')
           echo "has-poetry-deps=$HAS_POETRY_DEPS" >> $GITHUB_OUTPUT
 
-          BLACK=$(turbo run lint:black --filter '${{ matrix.package }}...[HEAD^]' --dry-run=json \
+          BLACK=$(turbo run lint:black --filter '${{ matrix.package }}' --dry-run=json \
             | jq '[.tasks[] | select(.task == "lint:black" and .command != "<NONEXISTENT>")] != []' || echo 'false')
           echo "black=$BLACK" >> $GITHUB_OUTPUT
 
-          RUFF=$(turbo run lint:ruff --filter '${{ matrix.package }}...[HEAD^]' --dry-run=json \
+          RUFF=$(turbo run lint:ruff --filter '${{ matrix.package }}' --dry-run=json \
             | jq '[.tasks[] | select(.task == "lint:ruff" and .command != "<NONEXISTENT>")] != []' || echo 'false')
           echo "ruff=$RUFF" >> $GITHUB_OUTPUT
 
-          MYPY=$(turbo run lint:mypy --filter '${{ matrix.package }}...[HEAD^]' --dry-run=json \
+          MYPY=$(turbo run lint:mypy --filter '${{ matrix.package }}' --dry-run=json \
             | jq '[.tasks[] | select(.task == "lint:mypy" and .command != "<NONEXISTENT>")] != []' || echo 'false')
           echo "mypy=$MYPY" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -128,7 +128,7 @@ jobs:
             echo "python-version=^3.11" >> $GITHUB_OUTPUT
           fi
 
-          HAS_POETRY_DEPS=$(turbo run poetry:install --dry-run=json \
+          HAS_POETRY_DEPS=$(turbo run poetry:install --filter '${{ matrix.package }}...' --dry-run=json \
             | jq '[.tasks[] | select(.task == "poetry:install" and .command != "<NONEXISTENT>")] != []' || echo 'false')
           echo "has-poetry-deps=$HAS_POETRY_DEPS" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -37,7 +37,7 @@ jobs:
         id: packages
         run: |
           UNIT_PACKAGES=$(turbo run test \
-              --filter '!@tests/*...[HEAD^]' \
+              --filter '!@tests/*' --filter '...[HEAD^]' \
               --dry-run=json \
             | jq '.tasks[]' \
             | jq 'select(.task == "test" and .command != "<NONEXISTENT>")' \

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -50,7 +50,7 @@ jobs:
             | jq 'select(.task == "test" and .command != "<NONEXISTENT>")' \
             | jq --compact-output --slurp '{ package: [.[].package] | unique, include: [( .[] | {package: .package, directory: .directory })] | unique }')
 
-          LINT_PACKAGES=$(turbo run lint --dry-run=json \
+          LINT_PACKAGES=$(turbo run lint --dry-run=json --filter '...[HEAD^]' \
             | jq '.tasks[]' \
             | jq --compact-output --slurp '{ package: [.[].package] | unique, include: [( .[] | {package: .package, directory: .directory })] | unique }')
 

--- a/turbo.json
+++ b/turbo.json
@@ -29,7 +29,7 @@
   },
   "globalDependencies": [
     "**/turbo.json",
-    ".github/workflows/**",
+    ".github/workflows/*.yml",
     ".github/actions/**",
     ".env*",
     ".justfile",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

GEN-99 added a new CI approach. That CI changed `turbo.json` which implies that all CI jobs are running anyway so wrongly used `[HEAD^]` filters were not noticed. This PR (hopefully) fixes the issues.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph