### PR TITLE
GEN-110: Fix CI running too many jobs

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -52,6 +52,7 @@ jobs:
 
           LINT_PACKAGES=$(turbo run lint --dry-run=json --filter '...[HEAD^]' \
             | jq '.tasks[]' \
+            | jq 'select(.task == "lint")' \
             | jq --compact-output --slurp '{ package: [.[].package] | unique, include: [( .[] | {package: .package, directory: .directory })] | unique }')
 
           REQUIRES_GRAPH=$(turbo run build --filter '@apps/hash-graph...[HEAD^]' --dry-run=json | jq '.packages != []')


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Jobs are not filtered, this hotfixes that.