### PR TITLE
H-653: Support creation and deletion of relations without erroring on conflicts

### DIFF
--- a/apps/hash-graph/lib/authorization/src/backend.rs
+++ b/apps/hash-graph/lib/authorization/src/backend.rs
@@ -43,6 +43,18 @@ pub trait ZanzibarBackend {
     where
         T: Tuple + Send + Sync;
 
+    /// Creates a new relation specified by the [`Tuple`] but does not error if it already exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the relation could not be created.
+    fn touch_relations<T>(
+        &mut self,
+        tuples: impl IntoIterator<Item = T, IntoIter: Send> + Send,
+    ) -> impl Future<Output = Result<CreateRelationResponse, Report<CreateRelationError>>> + Send
+    where
+        T: Tuple + Send + Sync;
+
     /// Deletes the relation specified by the [`Tuple`].
     ///
     /// # Errors

--- a/apps/hash-graph/lib/authorization/src/backend/spicedb/api.rs
+++ b/apps/hash-graph/lib/authorization/src/backend/spicedb/api.rs
@@ -237,6 +237,23 @@ impl ZanzibarBackend for SpiceDbOpenApi {
         clippy::missing_errors_doc,
         reason = "False positive, documented on trait"
     )]
+    async fn touch_relations<T>(
+        &mut self,
+        tuples: impl IntoIterator<Item = T, IntoIter: Send> + Send,
+    ) -> Result<CreateRelationResponse, Report<CreateRelationError>>
+    where
+        T: Tuple + Send + Sync,
+    {
+        self.modify_relations(repeat(model::RelationshipUpdateOperation::Touch).zip(tuples))
+            .await
+            .map(|written_at| CreateRelationResponse { written_at })
+            .change_context(CreateRelationError)
+    }
+
+    #[expect(
+        clippy::missing_errors_doc,
+        reason = "False positive, documented on trait"
+    )]
     async fn delete_relations<T>(
         &mut self,
         tuples: impl IntoIterator<Item = T, IntoIter: Send> + Send,

--- a/apps/hash-graph/lib/authorization/src/backend/spicedb/model.rs
+++ b/apps/hash-graph/lib/authorization/src/backend/spicedb/model.rs
@@ -153,7 +153,6 @@ pub enum RelationshipUpdateOperation {
     Create,
     /// Upsert the relationship, and will not error if it already exists.
     #[serde(rename = "OPERATION_TOUCH")]
-    #[expect(dead_code, reason = "Not yet exposed")]
     Touch,
     /// Delete the relationship. If the relationship does not exist, this operation will no-op.
     #[serde(rename = "OPERATION_DELETE")]

--- a/apps/hash-graph/lib/authorization/tests/api.rs
+++ b/apps/hash-graph/lib/authorization/tests/api.rs
@@ -64,6 +64,16 @@ impl ZanzibarBackend for TestApi {
         self.client.create_relations(tuples).await
     }
 
+    async fn touch_relations<T>(
+        &mut self,
+        tuples: impl IntoIterator<Item = T, IntoIter: Send> + Send,
+    ) -> Result<CreateRelationResponse, Report<CreateRelationError>>
+    where
+        T: Tuple + Send + Sync,
+    {
+        self.client.touch_relations(tuples).await
+    }
+
     async fn delete_relations<T>(
         &mut self,
         tuples: impl IntoIterator<Item = T, IntoIter: Send> + Send,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Snapshots do not now previous entries, thus, it's not possible to check if a relation already existed in the database. This adds a method to create relations without erroring on duplicates.

## 🚫 Blocked by

- #3210 
- #3211 
- #3223
- ~#3224~
- ~#3243~
## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph