### PR TITLE
H-886: Bump `max_tokens` for `gpt-4-0613` model

### DIFF
--- a/apps/hash-ai-worker-py/app/infer/entities/__init__.py
+++ b/apps/hash-ai-worker-py/app/infer/entities/__init__.py
@@ -29,7 +29,7 @@ class InferEntitiesWorkflowParameter(BaseModel, extra=Extra.forbid):
     text_input: str = Field(..., alias="textInput")
     entity_type_ids: list[str] = Field(..., alias="entityTypeIds")
     model: str = "gpt-4-0613"
-    max_tokens: int = Field(4096, alias="maxTokens")
+    max_tokens: int = Field(8192, alias="maxTokens")
     allow_empty_results: bool = Field(True, alias="allowEmptyResults")  # noqa: FBT003
 
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`gpt-4-0612` has an 8k (not 4k) context window.

## 🔍 What does this change?

This changes `max_tokens` in the `hash-ai-worker-py`'s entity inference workflow.

## 🐾 Next steps

Ideally we'd define the `max_tokens` accepted for each model statically elsewhere (likely alongside pricing information in the internal API) so we don't have to update this in multiple places.

It would still be useful to maintain `max_tokens` inline here separately here, allowing for capping of overall input sizes.