### PR TITLE
H-886: Revert "H-886: Bump `max_tokens` for `gpt-4-0613` model"

### DIFF
--- a/apps/hash-ai-worker-py/app/infer/entities/__init__.py
+++ b/apps/hash-ai-worker-py/app/infer/entities/__init__.py
@@ -40,7 +40,7 @@ class InferEntitiesWorkflowParameter(BaseModel, extra=Extra.forbid):
     text_input: str = Field(..., alias="textInput")
     entity_type_ids: list[str] = Field(..., alias="entityTypeIds")
     model: str = "gpt-4-0613"
-    max_tokens: int = Field(8192, alias="maxTokens")
+    max_tokens: int = Field(4096, alias="maxTokens")
     allow_empty_results: bool = Field(True, alias="allowEmptyResults")  # noqa: FBT003
     validation: EntityValidation = Field(EntityValidation.full)
 


### PR DESCRIPTION
Reverts hashintel/hash#3291

I'll figure out another way to solve this, but for now it's more important that entity inference is working.

The PR actually broke entity inference with the following status as an example returned:
```json
[
  {
    "code": "UNKNOWN",
    "contents": [],
    "message": "Unable to infer entities: This model's maximum context length is 8192 tokens. However, you requested 8777 tokens (478 in the messages, 107 in the functions, and 8192 in the completion). Please reduce the length of the messages, functions, or completion."
  }
]
```