### PR TITLE
H-886: Don't restrict token count by default

### DIFF
--- a/apps/hash-ai-worker-py/app/encoding.py
+++ b/apps/hash-ai-worker-py/app/encoding.py
@@ -36,7 +36,7 @@ class PydanticJSONPayloadConverter(JSONPlainPayloadConverter):
 
         def encoder(obj: Any) -> Any:  # noqa: ANN401
             if isinstance(obj, BaseModel):
-                return obj.model_dump(by_alias=True, exclude_none=True)
+                return obj.model_dump(by_alias=True)
 
             return pydantic_encoder(obj)
 

--- a/apps/hash-ai-worker-py/app/infer/entities/__init__.py
+++ b/apps/hash-ai-worker-py/app/infer/entities/__init__.py
@@ -40,7 +40,7 @@ class InferEntitiesWorkflowParameter(BaseModel, extra=Extra.forbid):
     text_input: str = Field(..., alias="textInput")
     entity_type_ids: list[str] = Field(..., alias="entityTypeIds")
     model: str = "gpt-4-0613"
-    max_tokens: int = Field(4096, alias="maxTokens")
+    max_tokens: int | None = Field(None, alias="maxTokens")
     allow_empty_results: bool = Field(True, alias="allowEmptyResults")  # noqa: FBT003
     validation: EntityValidation = Field(EntityValidation.full)
 
@@ -51,6 +51,6 @@ class InferEntitiesActivityParameter(BaseModel, extra=Extra.forbid):
     text_input: str = Field(..., alias="textInput")
     entity_types: list[dict[str, Any]] = Field(..., alias="entityTypes")
     model: str
-    max_tokens: int = Field(..., alias="maxTokens")
+    max_tokens: int | None = Field(..., alias="maxTokens")
     allow_empty_results: bool = Field(..., alias="allowEmptyResults")
     validation: EntityValidation


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently pass a maximum completion token number of 4096 by default. This changes the default behavior that does not pass any explicit limit to the AI. The model will use it's internal limit and an sensible error will be returned if this is reached. An example status when the maximum token count is reached:
```json
[
  {
    "code": "INVALID_ARGUMENT",
    "contents": [],
    "message": "The maximum amount of tokens was reached."
  }
]
```

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph