### PR TITLE
H-893: Update issue creation links to the `/choose` page

### DIFF
--- a/libs/antsi/README.md
+++ b/libs/antsi/README.md
@@ -41,7 +41,7 @@ O no! <span style="color: red;">mainframe breach <s>(from an unknown user)</s> h
 
 ## Contributors
 
-`antsi` was created by [Bilal Mahmoud](https://github.com/indietyp) for use in [`error-stack`](https://github.com/hashintel/hash/tree/main/libs/error-stack). It is being developed in conjunction with [HASH](https://hash.dev/) as an open-source project. We gratefully accept external contributions and have published a [contributing guide](https://github.com/hashintel/hash/blob/main/.github/CONTRIBUTING.md) that outlines the process. If you have questions, please reach out to us on our [Discord server](https://hash.ai/discord?utm_medium=organic&utm_source=github_readme_hash-repo_libs-antsi-readme). You can also report bugs [directly on the GitHub repo](https://github.com/hashintel/hash/issues/new?assignees=Alfred-Mountfield%2CTimDiekmann%2Cindietyp&labels=A-antsi%2CC-bug&template=bug-report-antsi.yml).
+`antsi` was created by [Bilal Mahmoud](https://github.com/indietyp) for use in [`error-stack`](https://github.com/hashintel/hash/tree/main/libs/error-stack). It is being developed in conjunction with [HASH](https://hash.dev/) as an open-source project. We gratefully accept external contributions and have published a [contributing guide](https://github.com/hashintel/hash/blob/main/.github/CONTRIBUTING.md) that outlines the process. If you have questions, please reach out to us on our [Discord server](https://hash.ai/discord?utm_medium=organic&utm_source=github_readme_hash-repo_libs-antsi-readme). You can also report bugs [directly on the GitHub repo](https://github.com/hashintel/hash/issues/new/choose).
 
 ## License
 

--- a/libs/deer/README.md
+++ b/libs/deer/README.md
@@ -108,7 +108,7 @@ Instead of strictly deserializing types, one might prefer to deserialize while c
 
 ## Contributors
 
-`deer` was created by [Bilal Mahmoud](https://github.com/indietyp). It is being developed in conjunction with [HASH](https://hash.dev/). As an open-source project, we gratefully accept external contributions and have published a [contributing guide](https://github.com/hashintel/hash/blob/main/.github/CONTRIBUTING.md) that outlines the process. If you have questions, please reach out to us on our [Discord server](https://hash.ai/discord?utm_medium=organic&utm_source=github_readme_hash-repo_libs-deer-readme). You can also report bugs [directly on the GitHub repo](https://github.com/hashintel/hash/issues/new?assignees=Alfred-Mountfield%2CTimDiekmann%2Cindietyp&labels=A-deer%2CC-bug&template=bug-report-deer.yml).
+`deer` was created by [Bilal Mahmoud](https://github.com/indietyp). It is being developed in conjunction with [HASH](https://hash.dev/). As an open-source project, we gratefully accept external contributions and have published a [contributing guide](https://github.com/hashintel/hash/blob/main/.github/CONTRIBUTING.md) that outlines the process. If you have questions, please reach out to us on our [Discord server](https://hash.ai/discord?utm_medium=organic&utm_source=github_readme_hash-repo_libs-deer-readme). You can also report bugs [directly on the GitHub repo](https://github.com/hashintel/hash/issues/new/choose).
 
 ## License
 

--- a/libs/deer/json/README.md
+++ b/libs/deer/json/README.md
@@ -8,7 +8,7 @@
 
 ## Contributors
 
-`deer` was created by [Bilal Mahmoud](https://github.com/indietyp). It is being developed in conjunction with [HASH](https://hash.dev/). As an open-source project, we gratefully accept external contributions and have published a [contributing guide](https://github.com/hashintel/hash/blob/main/.github/CONTRIBUTING.md) that outlines the process. If you have questions, please reach out to us on our [Discord server](https://hash.ai/discord). You can also report bugs [directly on the GitHub repo](https://github.com/hashintel/hash/issues/new?assignees=Alfred-Mountfield%2CTimDiekmann%2Cindietyp&labels=A-deer%2CC-bug&template=bug-report-deer.yml).
+`deer` was created by [Bilal Mahmoud](https://github.com/indietyp). It is being developed in conjunction with [HASH](https://hash.dev/). As an open-source project, we gratefully accept external contributions and have published a [contributing guide](https://github.com/hashintel/hash/blob/main/.github/CONTRIBUTING.md) that outlines the process. If you have questions, please reach out to us on our [Discord server](https://hash.ai/discord). You can also report bugs [directly on the GitHub repo](https://github.com/hashintel/hash/issues/new/choose).
 
 ## License
 

--- a/libs/deer/macros/README.md
+++ b/libs/deer/macros/README.md
@@ -8,7 +8,7 @@
 
 ## Contributors
 
-`deer` was created by [Bilal Mahmoud](https://github.com/indietyp). It is being developed in conjunction with [HASH](https://hash.dev/). As an open-source project, we gratefully accept external contributions and have published a [contributing guide](https://github.com/hashintel/hash/blob/main/.github/CONTRIBUTING.md) that outlines the process. If you have questions, please reach out to us on our [Discord server](https://hash.ai/discord). You can also report bugs [directly on the GitHub repo](https://github.com/hashintel/hash/issues/new?assignees=Alfred-Mountfield%2CTimDiekmann%2Cindietyp&labels=A-deer%2CC-bug&template=bug-report-deer.yml).
+`deer` was created by [Bilal Mahmoud](https://github.com/indietyp). It is being developed in conjunction with [HASH](https://hash.dev/). As an open-source project, we gratefully accept external contributions and have published a [contributing guide](https://github.com/hashintel/hash/blob/main/.github/CONTRIBUTING.md) that outlines the process. If you have questions, please reach out to us on our [Discord server](https://hash.ai/discord). You can also report bugs [directly on the GitHub repo](https://github.com/hashintel/hash/issues/new/choose).
 
 ## License
 

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -621,7 +621,7 @@ impl<C> Report<C> {
             // is a valid context, it's guaranteed that the context is available.
             unreachable!(
                 "Report does not contain a context. This is considered a bug and should be \
-                reported to https://github.com/hashintel/hash/issues/new"
+                reported to https://github.com/hashintel/hash/issues/new/choose"
             );
         })
     }

--- a/libs/sarif/README.md
+++ b/libs/sarif/README.md
@@ -22,7 +22,7 @@
 
 ## Contributors
 
-`sarif` was created by [Tim Diekmann](https://github.com/TimDiekmann) and [Bilal Mahmoud](https://github.com/indietyp) to be used to improve DX around creating Pull Requests. It is being developed in conjunction with [HASH](https://hash.dev/) as an open-source project. We gratefully accept external contributions and have published a [contributing guide](https://github.com/hashintel/hash/blob/main/.github/CONTRIBUTING.md) that outlines the process. If you have questions, please reach out to us on our [Discord server][discord]. You can also report bugs [directly on the GitHub repo](https://github.com/hashintel/hash/issues/new?assignees=TimDiekmann%2Cindietyp&labels=A-sarif%2CC-bug&template=bug-report-sarif.yml).
+`sarif` was created by [Tim Diekmann](https://github.com/TimDiekmann) and [Bilal Mahmoud](https://github.com/indietyp) to be used to improve DX around creating Pull Requests. It is being developed in conjunction with [HASH](https://hash.dev/) as an open-source project. We gratefully accept external contributions and have published a [contributing guide](https://github.com/hashintel/hash/blob/main/.github/CONTRIBUTING.md) that outlines the process. If you have questions, please reach out to us on our [Discord server][discord]. You can also report bugs [directly on the GitHub repo](https://github.com/hashintel/hash/issues/new/choose).
 
 ## License
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Many README files contain a link to file an issue. The link is hard-coded and outdated as the template may change over time. This changes the link to the [`/choose` page](https://github.com/hashintel/hash/issues/new/choose). This is not as precise as before but always up-to-date and it's better to show all options in any case.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph