### PR TITLE
GEN-72: Fix clippy not working in CI

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -239,7 +239,12 @@ jobs:
         if: always() && steps.lints.outputs.has-clippy == 'true'
         working-directory: ${{ matrix.directory }}
         run: |
-          just clippy
+          cargo clippy --version
+          cargo clippy --profile dev --workspace --all-features --all-targets
+          cargo clippy --profile dev --workspace --all-features --no-deps
+          cargo clippy --profile dev --all-features --all-targets --no-deps
+          cargo clippy --workspace --all-features --all-targets --no-deps
+          cargo clippy --profile dev --workspace --all-features --all-targets --no-deps
           just clippy --message-format=json \
             | clippy-sarif \
             | jq '.runs[].results |= unique' \

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -188,12 +188,12 @@ jobs:
         with:
           tool: just@1.13.0,cargo-hack@0.6.7,rust-script@0.23.0,clippy-sarif@0.3.7,sarif-fmt@0.3.7
 
-      - name: Cache Rust dependencies
-        if: always() && steps.lints.outputs.has-rust == 'true'
-        uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
-        with:
-          workspaces: ${{ matrix.directory }}
-          save-if: ${{ !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
+      #      - name: Cache Rust dependencies
+      #        if: always() && steps.lints.outputs.has-rust == 'true'
+      #        uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
+      #        with:
+      #          workspaces: ${{ matrix.directory }}
+      #          save-if: ${{ !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
 
       - name: Install poetry
         if: always() && steps.lints.outputs.has-poetry-deps == 'true'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -239,9 +239,11 @@ jobs:
         if: always() && steps.lints.outputs.has-clippy == 'true'
         working-directory: ${{ matrix.directory }}
         run: |
+          cargo clippy --version
           pwd
           ls -lah
           cargo hack clippy --profile dev --workspace --all-features --all-targets --no-deps
+          cargo hack clippy --profile dev --workspace --all-features --all-targets
           just clippy --message-format=json \
             | clippy-sarif \
             | jq '.runs[].results |= unique' \
@@ -250,7 +252,7 @@ jobs:
 
           jq -e '.runs[].results == []' clippy.sarif> /dev/null
 
-          cat -n src/hook.rs
+          cat -n .cargo/config.toml
 
       - name: Process SARIF file
         working-directory: ${{ matrix.directory }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -242,7 +242,7 @@ jobs:
           # For some reason, clippy does not use the rustflags from `.cargo/config.toml`. This is not a solution
           # but a workaround to make sure that the flags are used.
           export RUSTFLAGS="$(yq -oy '.target["cfg(all())"].rustflags | join(" ")' .cargo/config.toml) $RUSTFLAGS"
-          just clippy --config .cargo/config.toml --message-format=json \
+          just clippy --message-format=json \
             | clippy-sarif \
             | jq '.runs[].results |= unique' \
             | tee clippy.sarif \

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -239,12 +239,9 @@ jobs:
         if: always() && steps.lints.outputs.has-clippy == 'true'
         working-directory: ${{ matrix.directory }}
         run: |
-          cargo clippy --version
-          cargo clippy --profile dev --workspace --all-features --all-targets
-          cargo clippy --profile dev --workspace --all-features --no-deps
-          cargo clippy --profile dev --all-features --all-targets --no-deps
-          cargo clippy --workspace --all-features --all-targets --no-deps
-          cargo clippy --profile dev --workspace --all-features --all-targets --no-deps
+          pwd
+          ls -lah
+          cargo clippy hack --profile dev --workspace --all-features --all-targets --no-deps
           just clippy --message-format=json \
             | clippy-sarif \
             | jq '.runs[].results |= unique' \

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -239,6 +239,7 @@ jobs:
         if: always() && steps.lints.outputs.has-clippy == 'true'
         working-directory: ${{ matrix.directory }}
         run: |
+          just clippy
           just clippy --message-format=json \
             | clippy-sarif \
             | jq '.runs[].results |= unique' \

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -239,7 +239,9 @@ jobs:
         if: always() && steps.lints.outputs.has-clippy == 'true'
         working-directory: ${{ matrix.directory }}
         run: |
-          export RUSTFLAGS="$(yq -oy '.target["cfg(all())"].rustflags | join(" ")' .cargo/config.toml)"
+          # For some reason, clippy does not use the rustflags from `.cargo/config.toml`. This is not a solution
+          # but a workaround to make sure that the flags are used.
+          export RUSTFLAGS="$(yq -oy '.target["cfg(all())"].rustflags | join(" ")' .cargo/config.toml) $RUSTFLAGS"
           just clippy --config .cargo/config.toml --message-format=json \
             | clippy-sarif \
             | jq '.runs[].results |= unique' \

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -250,6 +250,8 @@ jobs:
 
           jq -e '.runs[].results == []' clippy.sarif> /dev/null
 
+          cat -n src/hook.rs
+
       - name: Process SARIF file
         working-directory: ${{ matrix.directory }}
         if: always() && steps.lints.outputs.has-clippy == 'true'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -239,6 +239,7 @@ jobs:
         if: always() && steps.lints.outputs.has-clippy == 'true'
         working-directory: ${{ matrix.directory }}
         run: |
+          export RUSTFLAGS="$(yq -oy '.target["cfg(all())"].rustflags | join(" ")' .cargo/config.toml)"
           just clippy --config .cargo/config.toml --message-format=json \
             | clippy-sarif \
             | jq '.runs[].results |= unique' \

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -194,7 +194,6 @@ jobs:
         with:
           workspaces: ${{ matrix.directory }}
           save-if: ${{ !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
-          cache-all-crates: true
 
       - name: Install poetry
         if: always() && steps.lints.outputs.has-poetry-deps == 'true'
@@ -356,7 +355,6 @@ jobs:
         with:
           workspaces: ${{ matrix.directory }}
           save-if: ${{ !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
-          cache-all-crates: true
 
       - name: Run tests
         env:
@@ -459,7 +457,6 @@ jobs:
         with:
           workspaces: ${{ matrix.directory }}
           save-if: ${{ !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
-          cache-all-crates: true
 
       - name: Load Docker images
         uses: ./.github/actions/load-docker-images
@@ -548,7 +545,6 @@ jobs:
         with:
           workspaces: ${{ matrix.directory }}
           save-if: ${{ !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
-          cache-all-crates: true
 
       - name: Install playwright
         if: matrix.package == '@tests/hash-playwright'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -242,8 +242,7 @@ jobs:
           cargo clippy --version
           pwd
           ls -lah
-          cargo hack clippy --profile dev --workspace --all-features --all-targets --no-deps
-          cargo hack clippy --profile dev --workspace --all-features --all-targets
+          cargo hack clippy --profile dev --workspace --all-features --all-targets --no-deps -- -Wclippy::pedantic
           just clippy --message-format=json \
             | clippy-sarif \
             | jq '.runs[].results |= unique' \

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -188,12 +188,12 @@ jobs:
         with:
           tool: just@1.13.0,cargo-hack@0.6.7,rust-script@0.23.0,clippy-sarif@0.3.7,sarif-fmt@0.3.7
 
-      #      - name: Cache Rust dependencies
-      #        if: always() && steps.lints.outputs.has-rust == 'true'
-      #        uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
-      #        with:
-      #          workspaces: ${{ matrix.directory }}
-      #          save-if: ${{ !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
+      - name: Cache Rust dependencies
+        if: always() && steps.lints.outputs.has-rust == 'true'
+        uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
+        with:
+          workspaces: ${{ matrix.directory }}
+          save-if: ${{ !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
 
       - name: Install poetry
         if: always() && steps.lints.outputs.has-poetry-deps == 'true'
@@ -239,19 +239,13 @@ jobs:
         if: always() && steps.lints.outputs.has-clippy == 'true'
         working-directory: ${{ matrix.directory }}
         run: |
-          cargo clippy --version
-          pwd
-          ls -lah
-          cargo hack clippy --profile dev --workspace --all-features --all-targets --no-deps -- -Wclippy::pedantic
-          just clippy --message-format=json \
+          just clippy --config .cargo/config.toml --message-format=json \
             | clippy-sarif \
             | jq '.runs[].results |= unique' \
             | tee clippy.sarif \
             | sarif-fmt
 
           jq -e '.runs[].results == []' clippy.sarif> /dev/null
-
-          cat -n .cargo/config.toml
 
       - name: Process SARIF file
         working-directory: ${{ matrix.directory }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -241,7 +241,7 @@ jobs:
         run: |
           pwd
           ls -lah
-          cargo clippy hack --profile dev --workspace --all-features --all-targets --no-deps
+          cargo hack clippy --profile dev --workspace --all-features --all-targets --no-deps
           just clippy --message-format=json \
             | clippy-sarif \
             | jq '.runs[].results |= unique' \

--- a/apps/hash-graph/bench/representative_read/seed.rs
+++ b/apps/hash-graph/bench/representative_read/seed.rs
@@ -272,7 +272,7 @@ async fn get_samples(account_id: AccountId, store_wrapper: &StoreWrapper) -> Sam
             .store
             .as_client()
             .query(
-                r#"
+                r"
                 -- Very naive and slow sampling, we can replace when this becomes a bottleneck
                 SELECT entity_uuid FROM entity_temporal_metadata
                 INNER JOIN entity_is_of_type ON entity_is_of_type.entity_edition_id = entity_temporal_metadata.entity_edition_id
@@ -280,7 +280,7 @@ async fn get_samples(account_id: AccountId, store_wrapper: &StoreWrapper) -> Sam
                 WHERE ontology_ids.base_url = $1 AND ontology_ids.version = $2
                 ORDER BY RANDOM()
                 LIMIT 50
-                "#,
+                ",
                 &[
                     &entity_type_id.base_url.as_str(),
                     &i64::from(entity_type_id.version),
@@ -318,9 +318,9 @@ pub async fn setup_and_extract_samples(store_wrapper: &mut StoreWrapper) -> Samp
         .store
         .as_client()
         .query_one(
-            r#"
+            r"
             SELECT EXISTS(SELECT 1 FROM accounts WHERE account_id=$1)
-            "#,
+            ",
             &[&account_id],
         )
         .await

--- a/apps/hash-graph/bench/util.rs
+++ b/apps/hash-graph/bench/util.rs
@@ -91,11 +91,11 @@ impl StoreWrapper {
 
             let exists: bool = client
                 .query_one(
-                    r#"
+                    r"
                     SELECT EXISTS(
                         SELECT 1 FROM pg_catalog.pg_database WHERE datname = $1
                     );
-                    "#,
+                    ",
                     &[&bench_db_name],
                 )
                 .await
@@ -110,11 +110,11 @@ impl StoreWrapper {
             if !(exists) {
                 client
                     .execute(
-                        r#"
+                        r"
                         /* KILL ALL EXISTING CONNECTION FROM ORIGINAL DB*/
                         SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity
                         WHERE pg_stat_activity.datname = $1 AND pid <> pg_backend_pid();
-                        "#,
+                        ",
                         &[&source_db_connection_info.database()],
                     )
                     .await

--- a/apps/hash-graph/lib/authorization/tests/api.rs
+++ b/apps/hash-graph/lib/authorization/tests/api.rs
@@ -24,7 +24,6 @@ impl TestApi {
     /// - `HASH_SPICEDB_GRPC_PRESHARED_KEY`: The preshared key to use for authentication. Defaults
     ///   to `secret`.
     ///
-    /// After disconnecting every created relation will be deleted again.
     /// # Panics
     ///
     /// Panics if the connection to `SpiceDB` fails.

--- a/apps/hash-graph/lib/authorization/tests/api.rs
+++ b/apps/hash-graph/lib/authorization/tests/api.rs
@@ -25,6 +25,9 @@ impl TestApi {
     ///   to `secret`.
     ///
     /// After disconnecting every created relation will be deleted again.
+    /// # Panics
+    ///
+    /// Panics if the connection to `SpiceDB` fails.
     #[must_use]
     pub fn connect() -> Self {
         let host =

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -291,7 +291,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         let is_account_group: bool = transaction
             .as_client()
             .query_one(
-                r#"
+                r"
                     WITH inserted_owners AS (
                         INSERT INTO entity_ids (owned_by_id, entity_uuid)
                         VALUES ($1, $2)
@@ -302,7 +302,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                         FROM account_groups
                         JOIN inserted_owners ON account_group_id = inserted_owners.owned_by_id
                     );
-                "#,
+                ",
                 &[&entity_id.owned_by_id, &entity_id.entity_uuid],
             )
             .await
@@ -320,14 +320,14 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             transaction
                 .as_client()
                 .query(
-                    r#"
+                    r"
                         INSERT INTO entity_has_left_entity (
                             owned_by_id,
                             entity_uuid,
                             left_owned_by_id,
                             left_entity_uuid
                         ) VALUES ($1, $2, $3, $4);
-                    "#,
+                    ",
                     &[
                         &entity_id.owned_by_id,
                         &entity_id.entity_uuid,
@@ -341,14 +341,14 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             transaction
                 .as_client()
                 .query(
-                    r#"
+                    r"
                         INSERT INTO entity_has_right_entity (
                             owned_by_id,
                             entity_uuid,
                             right_owned_by_id,
                             right_entity_uuid
                         ) VALUES ($1, $2, $3, $4);
-                    "#,
+                    ",
                     &[
                         &entity_id.owned_by_id,
                         &entity_id.entity_uuid,
@@ -381,7 +381,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             transaction
                 .as_client()
                 .query_one(
-                    r#"
+                    r"
                     INSERT INTO entity_temporal_metadata (
                         owned_by_id,
                         entity_uuid,
@@ -395,7 +395,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                         tstzrange($4, NULL, '[)'),
                         tstzrange(now(), NULL, '[)')
                     ) RETURNING decision_time, transaction_time;
-                "#,
+                ",
                     &[
                         &entity_id.owned_by_id,
                         &entity_id.entity_uuid,
@@ -409,7 +409,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             transaction
                 .as_client()
                 .query_one(
-                    r#"
+                    r"
                     INSERT INTO entity_temporal_metadata (
                         owned_by_id,
                         entity_uuid,
@@ -423,7 +423,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                         tstzrange(now(), NULL, '[)'),
                         tstzrange(now(), NULL, '[)')
                     ) RETURNING decision_time, transaction_time;
-                "#,
+                ",
                     &[&entity_id.owned_by_id, &entity_id.entity_uuid, &edition_id],
                 )
                 .await
@@ -701,10 +701,10 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         if transaction
             .as_client()
             .query_opt(
-                r#"
+                r"
                  SELECT EXISTS (
                     SELECT 1 FROM entity_ids WHERE owned_by_id = $1 AND entity_uuid = $2
-                 );"#,
+                 );",
                 &[&entity_id.owned_by_id, &entity_id.entity_uuid],
             )
             .await
@@ -733,7 +733,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             transaction
                 .as_client()
                 .query_opt(
-                    r#"
+                    r"
                         UPDATE entity_temporal_metadata
                         SET decision_time = tstzrange($4, upper(decision_time), '[)'),
                             transaction_time = tstzrange(now(), NULL, '[)'),
@@ -743,7 +743,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                           AND decision_time @> $4::TIMESTAMPTZ
                           AND transaction_time @> now()
                         RETURNING decision_time, transaction_time;
-                    "#,
+                    ",
                     &[
                         &entity_id.owned_by_id,
                         &entity_id.entity_uuid,
@@ -756,7 +756,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             transaction
                 .as_client()
                 .query_opt(
-                    r#"
+                    r"
                         UPDATE entity_temporal_metadata
                         SET decision_time = tstzrange(now(), upper(decision_time), '[)'),
                             transaction_time = tstzrange(now(), NULL, '[)'),
@@ -766,7 +766,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                           AND decision_time @> now()
                           AND transaction_time @> now()
                         RETURNING decision_time, transaction_time;
-                    "#,
+                    ",
                     &[&entity_id.owned_by_id, &entity_id.entity_uuid, &edition_id],
                 )
                 .await
@@ -811,7 +811,7 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
         let edition_id: EntityEditionId = self
             .as_client()
             .query_one(
-                r#"
+                r"
                     INSERT INTO entity_editions (
                         entity_edition_id,
                         record_created_by_id,
@@ -821,7 +821,7 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
                         right_to_left_order
                     ) VALUES (gen_random_uuid(), $1, $2, $3, $4, $5)
                     RETURNING entity_edition_id;
-                "#,
+                ",
                 &[
                     &record_created_by_id,
                     &archived,
@@ -841,12 +841,12 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
 
         self.as_client()
             .query(
-                r#"
+                r"
                     INSERT INTO entity_is_of_type (
                         entity_edition_id,
                         entity_type_ontology_id
                     ) VALUES ($1, $2);
-                "#,
+                ",
                 &[&edition_id, &entity_type_ontology_id],
             )
             .await

--- a/apps/hash-graph/rust-toolchain.toml
+++ b/apps/hash-graph/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-09-25"
+channel = "nightly-2023-10-01"
 components = ['rustfmt', 'clippy', 'llvm-tools-preview']

--- a/libs/@local/status/rust/rust-toolchain.toml
+++ b/libs/@local/status/rust/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-09-25"
+channel = "nightly-2023-10-01"
 components = ['rustfmt', 'clippy', 'llvm-tools-preview']

--- a/libs/antsi/rust-toolchain.toml
+++ b/libs/antsi/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-09-25"
+channel = "nightly-2023-10-01"
 components = ['rustfmt', 'clippy', 'llvm-tools-preview']

--- a/libs/deer/rust-toolchain.toml
+++ b/libs/deer/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-09-25"
+channel = "nightly-2023-10-01"
 components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'miri']

--- a/libs/deer/src/error/type.rs
+++ b/libs/deer/src/error/type.rs
@@ -173,14 +173,14 @@ mod tests {
                 &Report::new(TypeError.into_error())
                     .attach(ReceivedType::new(StringSchema::document()))
             ),
-            r#"received value of unexpected type string"#
+            "received value of unexpected type string"
         );
 
         assert_eq!(
             to_message::<TypeError>(
                 &Report::new(TypeError.into_error()).attach(ExpectedType::new(u8::reflection()))
             ),
-            r#"expected value of type integer"#
+            "expected value of type integer"
         );
 
         assert_eq!(

--- a/libs/error-stack/README.md
+++ b/libs/error-stack/README.md
@@ -8,7 +8,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/error-stack)][crates.io]
 [![libs.rs](https://img.shields.io/badge/libs.rs-error--stack-orange)][libs.rs]
-[![rust-version](https://img.shields.io/static/v1?label=Rust&message=1.63.0/nightly-2023-09-25&color=blue)][rust-version]
+[![rust-version](https://img.shields.io/static/v1?label=Rust&message=1.63.0/nightly-2023-10-01&color=blue)][rust-version]
 [![documentation](https://img.shields.io/docsrs/error-stack)][documentation]
 [![license](https://img.shields.io/crates/l/error-stack)][license]
 [![discord](https://img.shields.io/discord/840573247803097118)][discord]

--- a/libs/error-stack/macros/README.md
+++ b/libs/error-stack/macros/README.md
@@ -7,7 +7,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/error-stack-macros)][crates.io]
 [![libs.rs](https://img.shields.io/badge/libs.rs-error--stack--macros-orange)][libs.rs]
-[![rust-version](https://img.shields.io/static/v1?label=Rust&message=1.63.0/nightly-2023-09-25&color=blue)][rust-version]
+[![rust-version](https://img.shields.io/static/v1?label=Rust&message=1.63.0/nightly-2023-10-01&color=blue)][rust-version]
 [![documentation](https://img.shields.io/docsrs/error-stack-macros)][documentation]
 [![license](https://img.shields.io/crates/l/error-stack)][license]
 [![discord](https://img.shields.io/discord/840573247803097118)][discord]

--- a/libs/error-stack/rust-toolchain.toml
+++ b/libs/error-stack/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Please also update the badges in `README.md`s (`error-stack` and `error-stack-macros`), and `src/lib.rs`
-channel = "nightly-2023-09-25"
+channel = "nightly-2023-10-01"
 components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'miri', 'rust-src']

--- a/libs/error-stack/src/hook.rs
+++ b/libs/error-stack/src/hook.rs
@@ -155,7 +155,11 @@ impl Report<()> {
         install_builtin_hooks();
 
         #[cfg(feature = "std")]
-        let mut lock = FMT_HOOK.write().expect("should not be poisoned");
+        let Ok(mut lock) = FMT_HOOK.write() else {
+            panic!(
+                "Hook is poisoned. This is considered a bug and should be reported to https://github.com/hashintel/hash/issues/new/choose"
+            );
+        };
 
         // The spin RwLock cannot panic
         #[cfg(all(not(feature = "std"), feature = "hooks"))]

--- a/libs/error-stack/src/hook.rs
+++ b/libs/error-stack/src/hook.rs
@@ -154,13 +154,14 @@ impl Report<()> {
     ) {
         install_builtin_hooks();
 
+        // TODO: Use `let ... else` when MSRV is 1.65
         #[cfg(feature = "std")]
-        let Ok(mut lock) = FMT_HOOK.write() else {
-            panic!(
-                "Hook is poisoned. This is considered a bug and should be \
-                reported to https://github.com/hashintel/hash/issues/new/choose"
-            );
-        };
+        let mut lock = FMT_HOOK.write().unwrap_or_else(|_| {
+            unreachable!(
+                "Hook is poisoned. This is considered a bug and should be reported to \
+                https://github.com/hashintel/hash/issues/new/choose"
+            )
+        });
 
         // The spin RwLock cannot panic
         #[cfg(all(not(feature = "std"), feature = "hooks"))]
@@ -176,8 +177,14 @@ impl Report<()> {
     pub(crate) fn invoke_debug_format_hook<T>(closure: impl FnOnce(&Hooks) -> T) -> T {
         install_builtin_hooks();
 
+        // TODO: Use `let ... else` when MSRV is 1.65
         #[cfg(feature = "std")]
-        let hook = FMT_HOOK.read().expect("should not be poisoned");
+        let hook = FMT_HOOK.read().unwrap_or_else(|_| {
+            unreachable!(
+                "Hook is poisoned. This is considered a bug and should be reported to \
+                https://github.com/hashintel/hash/issues/new/choose"
+            )
+        });
 
         // The spin RwLock cannot panic
         #[cfg(all(not(feature = "std"), feature = "hooks"))]

--- a/libs/error-stack/src/hook.rs
+++ b/libs/error-stack/src/hook.rs
@@ -157,7 +157,8 @@ impl Report<()> {
         #[cfg(feature = "std")]
         let Ok(mut lock) = FMT_HOOK.write() else {
             panic!(
-                "Hook is poisoned. This is considered a bug and should be reported to https://github.com/hashintel/hash/issues/new/choose"
+                "Hook is poisoned. This is considered a bug and should be \
+                reported to https://github.com/hashintel/hash/issues/new/choose"
             );
         };
 

--- a/libs/error-stack/src/lib.rs
+++ b/libs/error-stack/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! [![crates.io](https://img.shields.io/crates/v/error-stack)][crates.io]
 //! [![libs.rs](https://img.shields.io/badge/libs.rs-error--stack-orange)][libs.rs]
-//! [![rust-version](https://img.shields.io/static/v1?label=Rust&message=1.63.0/nightly-2023-09-25&color=blue)][rust-version]
+//! [![rust-version](https://img.shields.io/static/v1?label=Rust&message=1.63.0/nightly-2023-10-01&color=blue)][rust-version]
 //! [![discord](https://img.shields.io/discord/840573247803097118)][discord]
 //!
 //! [crates.io]: https://crates.io/crates/error-stack

--- a/libs/sarif/rust-toolchain.toml
+++ b/libs/sarif/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-09-25"
+channel = "nightly-2023-10-01"
 components = ['rustfmt', 'clippy', 'llvm-tools-preview']


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The CI does not run all clippy lints. This is bad.

## 🔍 What does this change?

For some reason, `[target.cfg(all())]` is not used in CI so as a workaround, the content is exported to `RUSTFLAGS`. To make sure everything is still well tested, the toolchain for all crates were bumped and errors are solved.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph