### PR TITLE
H-900: Add HASH Browser Extension to tech tree

### DIFF
--- a/apps/hashdotdev/src/pages/roadmap/technology-tree-data.tsx
+++ b/apps/hashdotdev/src/pages/roadmap/technology-tree-data.tsx
@@ -968,4 +968,13 @@ export const technologyTreeData: TechnologyTreeNodeData[] = [
     useCases: ["general"],
     variant: "infrastructure",
   },
+  {
+    id: "97",
+    heading: "Browser Extension",
+    body: "Find, use and create entities as you browse",
+    parentIds: ["30"],
+    status: "in-progress",
+    useCases: ["general", "knowledge-management", "data-management"],
+    variant: "feature",
+  },
 ];


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds the HASH Browser Extension to tech tree.

## Testing instructions

Check the absolute bottom row of the hash.dev/roadmap tech tree.