### PR TITLE
H-57, H-894: Adjust GraphQL endpoints to support links and more configuration parameters

### DIFF
--- a/apps/hash-ai-worker-py/app/infer/entities/__init__.py
+++ b/apps/hash-ai-worker-py/app/infer/entities/__init__.py
@@ -51,11 +51,11 @@ class InferEntitiesWorkflowParameter(BaseModel, extra=Extra.forbid):
     authentication: AuthenticationContext
     text_input: str = Field(..., alias="textInput")
     entity_type_ids: list[str] = Field(..., alias="entityTypeIds")
-    model: str = "gpt-4-0613"
-    max_tokens: int | None = Field(None, alias="maxTokens")
-    allow_empty_results: bool = Field(True, alias="allowEmptyResults")  # noqa: FBT003
-    validation: EntityValidation = Field(EntityValidation.full)
-    temperature: float = 0.0
+    model: str
+    max_tokens: int | None = Field(..., alias="maxTokens")
+    allow_empty_results: bool = Field(..., alias="allowEmptyResults")
+    validation: EntityValidation
+    temperature: float
 
 
 # Keep this in sync with the InferEntitiesResult type in the GraphQL definition

--- a/apps/hash-ai-worker-py/app/infer/entities/__init__.py
+++ b/apps/hash-ai-worker-py/app/infer/entities/__init__.py
@@ -14,11 +14,11 @@ with workflow.unsafe.imports_passed_through():
 class EntityValidation(str, enum.Enum):
     """The validation status of an entity."""
 
-    full = "full"
+    full = "FULL"
     """The inferred entities are fully validated."""
-    partial = "partial"
+    partial = "PARTIAL"
     """Full validation except the `required` field."""
-    none = "none"
+    none = "NONE"
     """No validation performed."""
 
 

--- a/apps/hash-ai-worker-py/app/infer/entities/__init__.py
+++ b/apps/hash-ai-worker-py/app/infer/entities/__init__.py
@@ -22,6 +22,7 @@ class EntityValidation(str, enum.Enum):
     """No validation performed."""
 
 
+# Keep this in sync with the ProposedLinkData type in the GraphQL definition
 class LinkData(BaseModel, extra=Extra.forbid):
     """Link data for an entity."""
 
@@ -29,6 +30,7 @@ class LinkData(BaseModel, extra=Extra.forbid):
     right_entity_id: int = Field(..., alias="rightEntityId")
 
 
+# Keep this in sync with the ProposedEntity type in the GraphQL definition
 class ProposedEntity(BaseModel, extra=Extra.forbid):
     """An entity proposed by AI."""
 
@@ -42,6 +44,7 @@ class ProposedEntity(BaseModel, extra=Extra.forbid):
         entity_type(**self.properties)
 
 
+# Keep this in sync with the inferEntities mutation in the GraphQL definition
 class InferEntitiesWorkflowParameter(BaseModel, extra=Extra.forbid):
     """Parameters for entity inference workflow."""
 
@@ -53,6 +56,13 @@ class InferEntitiesWorkflowParameter(BaseModel, extra=Extra.forbid):
     allow_empty_results: bool = Field(True, alias="allowEmptyResults")  # noqa: FBT003
     validation: EntityValidation = Field(EntityValidation.full)
     temperature: float = 0.0
+
+
+# Keep this in sync with the InferEntitiesResult type in the GraphQL definition
+class InferEntitiesWorkflowResult(BaseModel, extra=Extra.forbid):
+    """Result of entity inference workflow."""
+
+    entities: list[ProposedEntity]
 
 
 class InferEntitiesActivityParameter(BaseModel, extra=Extra.forbid):

--- a/apps/hash-ai-worker-py/app/infer/entities/workflow.py
+++ b/apps/hash-ai-worker-py/app/infer/entities/workflow.py
@@ -22,6 +22,7 @@ with workflow.unsafe.imports_passed_through():
         EntityValidation,
         InferEntitiesActivityParameter,
         InferEntitiesWorkflowParameter,
+        InferEntitiesWorkflowResult,
         ProposedEntity,
     )
 
@@ -38,7 +39,7 @@ class InferEntitiesWorkflow:
     async def infer_entities(  # noqa: PLR0912, C901
         self,
         params: InferEntitiesWorkflowParameter,
-    ) -> Status[ProposedEntity | ErrorDetails]:
+    ) -> Status[InferEntitiesWorkflowResult | ErrorDetails]:
         """Infer entities from the provided text input."""
         try:
             entity_types: dict[str, type[EntityType]] = {
@@ -140,4 +141,8 @@ class InferEntitiesWorkflow:
                         f" `{proposed_entity.entity_type_id}`"
                     ),
                 )
-        return status
+        return Status(
+            code=StatusCode.OK,
+            message="success",
+            contents=[InferEntitiesWorkflowResult(entities=proposed_entities)],
+        )

--- a/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -332,14 +332,14 @@ export const inferEntitiesResolver: ResolverFn<
   null,
   LoggedInGraphQLContext,
   MutationInferEntitiesArgs
-> = async (_, { textInput, entityTypeIds }, { authentication, temporal }) => {
+> = async (_, args, { authentication, temporal }) => {
   if (!temporal) {
     throw new Error("Temporal client not available");
   }
 
   const status = await temporal.workflow.execute("inferEntities", {
     taskQueue: "aipy",
-    args: [{ authentication, textInput, entityTypeIds }],
+    args: [{ authentication, ...args }],
     workflowId: `inferEntities-${genId()}`,
   });
 

--- a/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -339,7 +339,13 @@ export const inferEntitiesResolver: ResolverFn<
 
   const status = await temporal.workflow.execute("inferEntities", {
     taskQueue: "aipy",
-    args: [{ authentication, ...args }],
+    args: [
+      {
+        authentication,
+        ...args,
+        maxTokens: args.maxTokens === 0 ? null : args.maxTokens,
+      },
+    ],
     workflowId: `inferEntities-${genId()}`,
   });
 

--- a/libs/@local/hash-graphql-shared/src/graphql/type-defs/knowledge/entity.typedef.ts
+++ b/libs/@local/hash-graphql-shared/src/graphql/type-defs/knowledge/entity.typedef.ts
@@ -230,28 +230,25 @@ export const entityTypedef = gql`
       """
       entityTypeIds: [VersionedUrl!]!
       """
-      The model to use for inference. Defaults to "gpt-4-0613".
+      The model to use for inference.
       """
-      model: String
+      model: String!
       """
-      The maximum amount of tokens to generate. If not specified, no limit is applied.
+      The maximum amount of tokens to generate. '0' means that the model's limit will be used.
       """
-      maxTokens: Int
+      maxTokens: Int!
       """
-      Whether to allow empty results. Defaults to true.
+      Whether to allow empty results.
       """
-      allowEmptyResults: Boolean
+      allowEmptyResults: Boolean!
       """
-      The validation to apply to the inferred entities. Defaults to full. Possible values are:
-      - full: All entities must be valid.
-      - partial: Entity properties has to be valid but the "required" condition is omitted
-      - none: No validation is applied.
+      The validation to apply to the inferred entities.
       """
-      validation: EntityValidation
+      validation: EntityValidation!
       """
-      The temperature to use for inference. Defaults to 0.0.
+      The temperature to use for inference.
       """
-      temperature: Float
+      temperature: Float!
     ): InferEntitiesResult!
   }
 `;

--- a/libs/@local/hash-graphql-shared/src/graphql/type-defs/knowledge/entity.typedef.ts
+++ b/libs/@local/hash-graphql-shared/src/graphql/type-defs/knowledge/entity.typedef.ts
@@ -78,9 +78,34 @@ export const entityTypedef = gql`
     linkData: ProposedLinkData
   }
 
+  """
+  The result of an entity inference.
+  """
   type InferEntitiesResult {
     # Keep this in sync with the InferEntitiesWorkflowResult type in apps/hash-ai-worker-py
+    """
+    The proposed entities.
+    """
     entities: [ProposedEntity!]!
+  }
+
+  """
+  The level of validation to apply to the inferred entities.
+  """
+  enum EntityValidation {
+    # Keep this in sync with the EntityValidation type in apps/hash-ai-worker-py
+    """
+    The inferred entities are fully validated.
+    """
+    FULL
+    """
+    Full validation except the \`required\` field.
+    """
+    PARTIAL
+    """
+    No validation performed.
+    """
+    NONE
   }
 
   extend type Query {
@@ -222,7 +247,7 @@ export const entityTypedef = gql`
       - partial: Entity properties has to be valid but the "required" condition is omitted
       - none: No validation is applied.
       """
-      validation: String
+      validation: EntityValidation
       """
       The temperature to use for inference. Defaults to 0.0.
       """

--- a/libs/@local/hash-graphql-shared/src/graphql/type-defs/knowledge/entity.typedef.ts
+++ b/libs/@local/hash-graphql-shared/src/graphql/type-defs/knowledge/entity.typedef.ts
@@ -41,9 +41,29 @@ export const entityTypedef = gql`
   }
 
   """
+  The link metadata of a proposed entity.
+  """
+  type ProposedLinkData {
+    # Keep this in sync with the LinkData type in apps/hash-ai-worker-py
+    """
+    The left entity id of the proposed link entity.
+    """
+    leftEntityId: Int!
+    """
+    The right entity id of the proposed link entity.
+    """
+    rightEntityId: Int!
+  }
+
+  """
   An entity proposed for creation. The suggested data can be used in further calls, e.g. to createEntity
   """
   type ProposedEntity {
+    # Keep this in sync with the ProposedEntity type in apps/hash-ai-worker-py
+    """
+    The entity identifier.
+    """
+    entityId: EntityId!
     """
     The type of the proposed entity.
     """
@@ -55,10 +75,11 @@ export const entityTypedef = gql`
     """
     The link metadata of the entity, if this is proposed as a link entity
     """
-    linkData: LinkData
+    linkData: ProposedLinkData
   }
 
   type InferEntitiesResult {
+    # Keep this in sync with the InferEntitiesWorkflowResult type in apps/hash-ai-worker-py
     entities: [ProposedEntity!]!
   }
 
@@ -174,6 +195,7 @@ export const entityTypedef = gql`
     Does NOT persist the entities – callers are responsible for doing something with the proposed entities.
     """
     inferEntities(
+      # Keep this in sync with the InferEntitiesWorkflowParameter type in apps/hash-ai-worker-py
       """
       A string of text to infer entities from, e.g. a page of text.
       """
@@ -182,6 +204,29 @@ export const entityTypedef = gql`
       The ids of the possible entity types that inferred entities may be of.
       """
       entityTypeIds: [VersionedUrl!]!
+      """
+      The model to use for inference. Defaults to "gpt-4-0613".
+      """
+      model: String
+      """
+      The maximum amount of tokens to generate. If not specified, no limit is applied.
+      """
+      maxTokens: Int
+      """
+      Whether to allow empty results. Defaults to true.
+      """
+      allowEmptyResults: Boolean
+      """
+      The validation to apply to the inferred entities. Defaults to full. Possible values are:
+      - full: All entities must be valid.
+      - partial: Entity properties has to be valid but the "required" condition is omitted
+      - none: No validation is applied.
+      """
+      validation: String
+      """
+      The temperature to use for inference. Defaults to 0.0.
+      """
+      temperature: Float
     ): InferEntitiesResult!
   }
 `;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
The GraphQL endpoints currently do not return the entity id and has a wrong `LinkData` associated (it's not possible to infer the correct entity ID from AI).

With this PR the GraphQL endpoint has all capabilities to infer entities as required for H-57.

## 🔍 What does this change?

Synchronize the parameters/results of GraphQL and the Python worker

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph