### PR TITLE
H-917: Fix wrongly inferred entity type id if another type was not inferred

### DIFF
--- a/apps/hash-ai-worker-py/app/infer/entities/activity.py
+++ b/apps/hash-ai-worker-py/app/infer/entities/activity.py
@@ -315,7 +315,9 @@ async def infer_entities(  # noqa: PLR0911, PLR0912, PLR0915, C901
                                 entity_id = len(entities)
                                 entities.append(
                                     ProposedEntity(
-                                        entityTypeId=entity_type_map[function_call["name"]],
+                                        entityTypeId=entity_type_map[
+                                            function_call["name"],
+                                        ],
                                         entityId=entity_id,
                                         properties=deepcopy(entity),
                                     ),

--- a/apps/hash-ai-worker-py/app/infer/entities/activity.py
+++ b/apps/hash-ai-worker-py/app/infer/entities/activity.py
@@ -189,6 +189,7 @@ async def infer_entities(  # noqa: PLR0911, PLR0912, PLR0915, C901
         {"role": "user", "content": params.text_input.strip()},
     ]
     entities: list[ProposedEntity] = []
+    entity_type_map: dict[str, str] = {}
     try:
         for i, entity_type in enumerate([*params.entity_types, *params.link_types]):
             if i < len(params.entity_types) - 1:
@@ -214,20 +215,22 @@ async def infer_entities(  # noqa: PLR0911, PLR0912, PLR0915, C901
                 exclude_none=True,
             )
 
+            function = Function.openai(
+                entity_type,
+                is_link_type=current_state
+                in [
+                    InferenceState.links,
+                    InferenceState.last_link,
+                ],
+            )
+            entity_type_map[function.name] = entity_type["$id"]
             completion = await openai.ChatCompletion.acreate(
                 model=params.model,
                 temperature=params.temperature,
                 max_tokens=params.max_tokens,
                 messages=messages,
                 functions=[
-                    Function.openai(
-                        entity_type,
-                        is_link_type=current_state
-                        in [
-                            InferenceState.links,
-                            InferenceState.last_link,
-                        ],
-                    ).model_dump(
+                    function.model_dump(
                         by_alias=True,
                         exclude_none=True,
                     ),
@@ -289,15 +292,13 @@ async def infer_entities(  # noqa: PLR0911, PLR0912, PLR0915, C901
                     # until all entities have been inferred. To create links the AI
                     # needs to know the IDs of the entities. We therefore update the
                     # entities.
-                    entity_type_index = 0
                     for message in messages:
                         if (
                             message["role"] == "assistant"
                             and "function_call" in message
                         ):
-                            arguments = json.loads(
-                                message["function_call"]["arguments"],
-                            )
+                            function_call = message["function_call"]
+                            arguments = json.loads(function_call["arguments"])
 
                             for entity in arguments["entities"]:
                                 if not isinstance(entity, dict):
@@ -314,16 +315,12 @@ async def infer_entities(  # noqa: PLR0911, PLR0912, PLR0915, C901
                                 entity_id = len(entities)
                                 entities.append(
                                     ProposedEntity(
-                                        entityTypeId=params.entity_types[
-                                            entity_type_index
-                                        ]["$id"],
+                                        entityTypeId=entity_type_map[function_call["name"]],
                                         entityId=entity_id,
                                         properties=deepcopy(entity),
                                     ),
                                 )
                                 entity["entityId"] = entity_id
-
-                            entity_type_index += 1
 
                             message["function_call"]["arguments"] = json.dumps(
                                 arguments,

--- a/apps/hash-ai-worker-py/app/infer/entities/activity.py
+++ b/apps/hash-ai-worker-py/app/infer/entities/activity.py
@@ -313,11 +313,10 @@ async def infer_entities(  # noqa: PLR0911, PLR0912, PLR0915, C901
                                     continue
 
                                 entity_id = len(entities)
+                                function_name: str = function_call["name"]
                                 entities.append(
                                     ProposedEntity(
-                                        entityTypeId=entity_type_map[
-                                            function_call["name"],
-                                        ],
+                                        entityTypeId=entity_type_map[function_name],
                                         entityId=entity_id,
                                         properties=deepcopy(entity),
                                     ),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When no entities were inferred but multiple entity type ids are provided the ids may be assigned wrongly

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph