### PR TITLE
H-941: Set FILE_UPLOAD_PROVIDER in prod hash config

### DIFF
--- a/.github/actions/terraform-exec/action.yml
+++ b/.github/actions/terraform-exec/action.yml
@@ -24,6 +24,9 @@ runs:
   using: composite
   steps:
     - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+      with:
+        # pin until https://github.com/cyrilgdn/terraform-provider-postgresql/issues/357 is fixed
+        terraform_version: 1.5.7
 
     - name: Authenticate Vault
       id: secrets

--- a/infra/terraform/hash/prod-usea1.tfvars
+++ b/infra/terraform/hash/prod-usea1.tfvars
@@ -46,6 +46,8 @@ hash_api_env_vars = [
   { name = "HASH_GRAPH_API_PORT", secret = false, value = "4000" },
   { name = "LOG_LEVEL", secret = false, value = "debug" },
 
+  { name = "FILE_UPLOAD_PROVIDER", secret = false, value = "AWS_S3"},
+
   { name = "HASH_OPENSEARCH_ENABLED", secret = false, value = "false" },
 
   { name = "ORY_KRATOS_PUBLIC_URL", secret = false, value = "http://localhost:4433" },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Another variable required following #3327 to enable s3 object storage.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

