### PR TITLE
H-936: Add file upload S3 bucket to Terraform config

### DIFF
--- a/infra/terraform/hash/hash_application/main.tf
+++ b/infra/terraform/hash/hash_application/main.tf
@@ -339,6 +339,18 @@ resource "aws_iam_role" "task_role" {
           ],
           Effect   = "Allow",
           Resource = "*"
+        },
+        # Enable read/write access to file upload bucket
+        {
+          Action = [
+            "s3:GetObject",
+            "s3:PutObject",
+            "s3:PutObjectAcl",
+          ]
+          Effect   = "Allow"
+          Resource = [
+            "${aws_s3_bucket.uploads.arn}/*",
+          ]
         }
       ]
     })

--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -247,7 +247,6 @@ module "application" {
   api_image = module.api_ecr
   api_env_vars = concat(var.hash_api_env_vars, [
     { name = "AWS_REGION", secret = false, value = local.region },
-    { name = "AWS_S3_UPLOADS_BUCKET", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["aws_s3_uploads_bucket"]) },
     { name = "SYSTEM_USER_PASSWORD", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_system_user_password"]) },
     { name = "BLOCK_PROTOCOL_API_KEY", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_block_protocol_api_key"]) },
     { name = "KRATOS_API_KEY", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["kratos_api_key"]) },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds Terraform configuration for creating an S3 bucket for user file uploads, and assign read/write access to the task role.

Supersedes #3327.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

1. Check file uploads work in the remote deployment

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. For now, we can only check Terraform plan
