### PR TITLE
H-945: Set vault variables to blank for Slack notification job

### DIFF
--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -451,3 +451,5 @@ jobs:
           SLACK_TITLE: Backend deployment failed
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_USERNAME: GitHub
+          VAULT_ADDR: ""
+          VAULT_TOKEN: ""

--- a/.github/workflows/tf-apply-hash.yml
+++ b/.github/workflows/tf-apply-hash.yml
@@ -69,3 +69,5 @@ jobs:
           SLACK_TITLE: Terraform apply failed
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_USERNAME: GitHub
+          VAULT_ADDR: ""
+          VAULT_TOKEN: ""


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The Slack notification job introduced in #3339 is [failing](https://github.com/hashintel/hash/actions/runs/6423979071/job/17443644852) because the [action](https://github.com/rtCamp/action-slack-notify) we are using supports storing the webhook URL in Vault, by setting `VAULT_ADDR` and `VAULT_TOKEN` environment variables. Because we use these environment variables for other things in some jobs it assumes the webhook URL can be found there, when it can't.

This PR overwrites those variables for the Slack job. I'm not sure how secret inheritance/overwriting works in GitHub actions so this might not work. If it doesn't we can always add the webhook URL to vault, but that would also mean adding the Vault environment variables to jobs that don't currently need them, just for the webhook URL.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
