### PR TITLE
GEN-114: Add example to disable location printing

### DIFF
--- a/libs/error-stack/src/hook.rs
+++ b/libs/error-stack/src/hook.rs
@@ -147,6 +147,49 @@ impl Report<()> {
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/hook__debug_hook_provide.snap"))]
     /// </pre>
     ///
+    /// `error-stack` comes with some built-in hooks which can be overwritten. This is useful if you
+    /// want to change the output of the built-in hooks, or if you want to add additional
+    /// information to the output. For example, you can override the built-in hook for [`Location`]
+    /// to hide the file path:
+    ///
+    /// ```rust
+    /// # // we only test the snapshot on nightly, therefore report is unused (so is render)
+    /// # #![cfg_attr(not(nightly), allow(dead_code, unused_variables, unused_imports))]
+    /// use std::{
+    ///     io::{Error, ErrorKind},
+    ///     panic::Location,
+    /// };
+    ///
+    /// error_stack::Report::install_debug_hook::<Location>(|_location, _context| {
+    ///     // Intentionally left empty so nothing will be printed
+    /// });
+    ///
+    /// let report = error_stack::report!(Error::from(ErrorKind::InvalidInput));
+    ///
+    /// # error_stack::Report::set_color_mode(error_stack::fmt::ColorMode::Emphasis);
+    /// # fn render(value: String) -> String {
+    /// #     let backtrace = regex::Regex::new(r"backtrace no\. (\d+)\n(?:  .*\n)*  .*").unwrap();
+    /// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
+    /// #
+    /// #     let value = backtrace.replace_all(&value, "backtrace no. $1\n  [redacted]");
+    /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
+    /// #
+    /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
+    /// # }
+    /// #
+    /// # #[cfg(nightly)]
+    /// # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/hook__location_hook.snap")].assert_eq(&render(format!("{report:?}")));
+    /// #
+    /// println!("{report:?}");
+    /// ```
+    ///
+    /// Which will result in something like:
+    ///
+    /// <pre>
+    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/hook__location_hook.snap"))]
+    /// </pre>
+    ///
+    /// [`Location`]: std::panic::Location
     /// [`Error::provide`]: std::error::Error::provide
     #[cfg(any(feature = "std", feature = "hooks"))]
     pub fn install_debug_hook<T: Send + Sync + 'static>(

--- a/libs/error-stack/tests/snapshots/doc/hook__location_hook.snap
+++ b/libs/error-stack/tests/snapshots/doc/hook__location_hook.snap
@@ -1,0 +1,7 @@
+<b>invalid input parameter</b>
+╰╴backtrace (1)
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+backtrace no. 1
+  [redacted]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The feature to disable the location is available since `0.2.4` but it was not properly documented.

## 🔗 Related links

- #3353
- #1215

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph