### PR TITLE
H-946: `@mention` people in Slack on github action failure

### DIFF
--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -448,6 +448,8 @@ jobs:
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@b24d75fe0e728a4bf9fc42ee217caa686d141ee8
         env:
+          SLACK_LINK_NAMES: true
+          SLACK_MESSAGE: "Error deploying the HASH backend <@U0143NL4GMP> <@U027NPY8Y3X> <@U02NLJY0FGX>"
           SLACK_TITLE: Backend deployment failed
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_USERNAME: GitHub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
         uses: rtCamp/action-slack-notify@b24d75fe0e728a4bf9fc42ee217caa686d141ee8
         if: ${{ failure() }}
         env:
+          SLACK_LINK_NAMES: true
+          SLACK_MESSAGE: "Error releasing NPM packages <@U0143NL4GMP> <@U027NPY8Y3X>"
           SLACK_TITLE: Package release failed
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_USERNAME: GitHub

--- a/.github/workflows/tf-apply-hash.yml
+++ b/.github/workflows/tf-apply-hash.yml
@@ -66,6 +66,8 @@ jobs:
         uses: rtCamp/action-slack-notify@b24d75fe0e728a4bf9fc42ee217caa686d141ee8
         if: ${{ failure() }}
         env:
+          SLACK_LINK_NAMES: true
+          SLACK_MESSAGE: "Error applying Terraform configuration <@U0143NL4GMP> <@U027NPY8Y3X> <@U02NLJY0FGX>"
           SLACK_TITLE: Terraform apply failed
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_USERNAME: GitHub


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds `@mention`ing of people in Slack when a GitHub action failures to make it more likely the warning is picked up.
## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. On merge to `main` the Terraform apply should fail (unrelated issue I am working on), and we will see if this works. 
