### PR TITLE
H-985: Allow checking if an entity is public

### DIFF
--- a/apps/hash-api/src/graph/knowledge/primitive/entity.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity.ts
@@ -33,6 +33,7 @@ import {
   EntityDefinition,
   LinkedEntityDefinition,
 } from "../../../graphql/api-types.gen";
+import { publicUserAccountId } from "../../../graphql/context";
 import { linkedTreeFlatten } from "../../../util";
 import { ImpureGraphFunction } from "../..";
 import { getEntityTypeById } from "../../ontology/primitive/entity-type";
@@ -682,3 +683,25 @@ export const removeEntityViewer: ImpureGraphFunction<
 > = async ({ graphApi }, { actorId }, params) => {
   await graphApi.removeEntityViewer(actorId, params.entityId, params.viewer);
 };
+
+export const canViewEntity: ImpureGraphFunction<
+  { entityId: EntityId },
+  Promise<boolean>
+> = async ({ graphApi }, { actorId }, params) =>
+  graphApi
+    .canViewEntity(actorId, params.entityId)
+    .then(({ data }) => data.has_permission);
+
+export const canUpdateEntity: ImpureGraphFunction<
+  { entityId: EntityId },
+  Promise<boolean>
+> = async ({ graphApi }, { actorId }, params) =>
+  graphApi
+    .canUpdateEntity(actorId, params.entityId)
+    .then(({ data }) => data.has_permission);
+
+export const isEntityPublic: ImpureGraphFunction<
+  { entityId: EntityId },
+  Promise<boolean>
+> = async (ctx, _, params) =>
+  canViewEntity(ctx, { actorId: publicUserAccountId }, params);

--- a/apps/hash-api/src/graph/knowledge/system-types/user.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user.ts
@@ -28,6 +28,7 @@ import { ImpureGraphFunction, PureGraphFunction } from "../..";
 import { SYSTEM_TYPES } from "../../system-types";
 import {
   addEntityViewer,
+  canUpdateEntity,
   createEntity,
   CreateEntityParams,
   getEntityOutgoingLinks,
@@ -456,12 +457,13 @@ export const isUserMemberOfOrg: ImpureGraphFunction<
 export const isUserHashInstanceAdmin: ImpureGraphFunction<
   { user: User },
   Promise<boolean>
-> = async (ctx, authentication, params) => {
-  const hashInstance = await getHashInstance(ctx, authentication, {});
-  return ctx.graphApi
-    .canUpdateEntity(
-      params.user.accountId,
-      hashInstance.entity.metadata.recordId.entityId,
-    )
-    .then(({ data: { has_permission } }) => has_permission);
-};
+> = async (ctx, authentication, { user }) =>
+  getHashInstance(ctx, authentication, {}).then((hashInstance) =>
+    canUpdateEntity(
+      ctx,
+      { actorId: user.accountId },
+      {
+        entityId: hashInstance.entity.metadata.recordId.entityId,
+      },
+    ),
+  );

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -959,6 +959,50 @@
         }
       }
     },
+    "/entities/{entity_id}/permissions/view": {
+      "get": {
+        "tags": [
+          "Graph",
+          "Entity"
+        ],
+        "operationId": "can_view_entity",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          },
+          {
+            "name": "entity_id",
+            "in": "path",
+            "description": "The entity ID to check if the actor can view",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/EntityId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Information if the actor can view the entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error occurred"
+          }
+        }
+      }
+    },
     "/entities/{entity_id}/viewers/{viewer}": {
       "post": {
         "tags": [


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The node API should have an easy way to tell if an entity can be viewed/is public.

## 🚫 Blocked by

- #3337

## 🔍 What does this change?

- Expose `canViewEntity` from Rust to Node
- Add `isEntityPublic` to Node API by checking if the public user can read an entity

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph