### PR TITLE
H-697: Migrate from S3 to Cloudflare R2 for file object storage

### DIFF
--- a/apps/hash-api/src/graphql/resolvers/knowledge/file/request-file-upload.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/file/request-file-upload.ts
@@ -28,7 +28,7 @@ export const requestFileUpload: ResolverFn<
 ) => {
   const context = dataSourcesToImpureGraphContext(dataSources);
 
-  const { presignedPost, entity } = await createFileFromUploadRequest(
+  const { presignedPut, entity } = await createFileFromUploadRequest(
     context,
     authentication,
     {
@@ -42,7 +42,7 @@ export const requestFileUpload: ResolverFn<
   );
 
   return {
-    presignedPost,
+    presignedPut,
     entity: entity as unknown as Entity,
   };
 };

--- a/apps/hash-api/src/lib/aws-config.ts
+++ b/apps/hash-api/src/lib/aws-config.ts
@@ -5,10 +5,12 @@ export const getAwsRegion = (): string => getRequiredEnv("AWS_REGION");
 
 export const getAwsS3Config = (): AwsS3StorageProviderConstructorArgs => {
   return {
-    credentials: {
-      accessKeyId: getRequiredEnv("AWS_S3_UPLOADS_ACCESS_KEY_ID"),
-      secretAccessKey: getRequiredEnv("AWS_S3_UPLOADS_SECRET_ACCESS_KEY"),
-    },
+    credentials: process.env.AWS_S3_UPLOADS_ACCESS_KEY_ID
+      ? {
+          accessKeyId: process.env.AWS_S3_UPLOADS_ACCESS_KEY_ID,
+          secretAccessKey: getRequiredEnv("AWS_S3_UPLOADS_SECRET_ACCESS_KEY"),
+        }
+      : undefined, // authorization may be provided by other means, e.g. IAM role for API task
     bucket: getRequiredEnv("AWS_S3_UPLOADS_BUCKET"),
     region: process.env.AWS_S3_REGION ?? getAwsRegion(),
   };

--- a/apps/hash-api/src/lib/aws-config.ts
+++ b/apps/hash-api/src/lib/aws-config.ts
@@ -1,9 +1,14 @@
+import { AwsS3StorageProviderConstructorArgs } from "../storage";
 import { getRequiredEnv } from "../util";
 
 export const getAwsRegion = (): string => getRequiredEnv("AWS_REGION");
 
-export const getAwsS3Config = () => {
+export const getAwsS3Config = (): AwsS3StorageProviderConstructorArgs => {
   return {
+    credentials: {
+      accessKeyId: getRequiredEnv("AWS_S3_UPLOADS_ACCESS_KEY_ID"),
+      secretAccessKey: getRequiredEnv("AWS_S3_UPLOADS_SECRET_ACCESS_KEY"),
+    },
     bucket: getRequiredEnv("AWS_S3_UPLOADS_BUCKET"),
     region: process.env.AWS_S3_REGION ?? getAwsRegion(),
   };

--- a/apps/hash-api/src/storage/aws-s3-storage-provider.ts
+++ b/apps/hash-api/src/storage/aws-s3-storage-provider.ts
@@ -1,4 +1,4 @@
-import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { GetObjectCommand, S3Client, S3ClientConfig } from "@aws-sdk/client-s3";
 import { createPresignedPost } from "@aws-sdk/s3-presigned-post";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
@@ -12,21 +12,33 @@ import {
 } from "./storage-provider";
 
 export interface AwsS3StorageProviderConstructorArgs {
+  credentials: S3ClientConfig["credentials"];
   /** Name of the S3 bucket */
   bucket: string;
   /** S3 region */
   region: string;
 }
-/** Inplementation of the storage provider for AWS S3. Uploads all files to a single bucket */
+/** Implementation of the storage provider for AWS S3. Uploads all files to a single bucket */
 export class AwsS3StorageProvider implements UploadableStorageProvider {
   /** The S3 client is created in the constructor and kept as long as the instance lives */
   private client: S3Client;
   private bucket: string;
   public storageType: StorageType = StorageType.AwsS3;
 
-  constructor({ bucket, region }: AwsS3StorageProviderConstructorArgs) {
+  constructor({
+    bucket,
+    credentials,
+    region,
+  }: AwsS3StorageProviderConstructorArgs) {
+    // optional environment variable if using a non-AWS S3 compatible service
+    const bucketEndpoint = process.env.AWS_S3_UPLOADS_ENDPOINT;
+
     this.bucket = bucket;
-    this.client = new S3Client({ region });
+    this.client = new S3Client({
+      endpoint: bucketEndpoint,
+      credentials,
+      region,
+    });
   }
 
   async presignUpload(

--- a/apps/hash-api/src/storage/aws-s3-storage-provider.ts
+++ b/apps/hash-api/src/storage/aws-s3-storage-provider.ts
@@ -60,10 +60,7 @@ export class AwsS3StorageProvider implements UploadableStorageProvider {
       signableHeaders: new Set(["content-length", "content-type"]),
     });
 
-    console.log({ presignedPutUrl });
-
     return {
-      headers: {},
       url: presignedPutUrl,
     };
   }

--- a/apps/hash-api/src/storage/local-file-storage.ts
+++ b/apps/hash-api/src/storage/local-file-storage.ts
@@ -9,7 +9,7 @@ import multer, { Multer, StorageEngine } from "multer";
 import {
   GetFileEntityStorageKeyParams,
   PresignedDownloadRequest,
-  PresignedPostUpload,
+  PresignedPutUpload,
   PresignedStorageRequest,
   StorageProvider,
   StorageType,
@@ -60,14 +60,11 @@ export class LocalFileSystemStorageProvider implements StorageProvider {
 
   async presignUpload(
     params: PresignedStorageRequest,
-  ): Promise<PresignedPostUpload> {
-    const presignedPost = {
+  ): Promise<PresignedPutUpload> {
+    const presignedPut = {
       url: new URL(UPLOAD_BASE_URL, this.apiOrigin).href,
-      fields: {
-        key: params.key,
-      },
     };
-    return presignedPost;
+    return presignedPut;
   }
 
   async presignDownload(params: PresignedDownloadRequest): Promise<string> {

--- a/apps/hash-api/src/storage/local-file-storage.ts
+++ b/apps/hash-api/src/storage/local-file-storage.ts
@@ -10,7 +10,6 @@ import {
   GetFileEntityStorageKeyParams,
   PresignedDownloadRequest,
   PresignedPutUpload,
-  PresignedStorageRequest,
   StorageProvider,
   StorageType,
 } from "./storage-provider";
@@ -58,9 +57,7 @@ export class LocalFileSystemStorageProvider implements StorageProvider {
     this.setupExpressRoutes(app);
   }
 
-  async presignUpload(
-    params: PresignedStorageRequest,
-  ): Promise<PresignedPutUpload> {
+  async presignUpload(): Promise<PresignedPutUpload> {
     const presignedPut = {
       url: new URL(UPLOAD_BASE_URL, this.apiOrigin).href,
     };

--- a/apps/hash-api/src/storage/storage-provider.ts
+++ b/apps/hash-api/src/storage/storage-provider.ts
@@ -28,9 +28,9 @@ export interface GetFileEntityStorageKeyParams {
 
 export interface UploadableStorageProvider extends StorageProvider, DataSource {
   /** Presigns a file upload request for a client to later upload a file
-   * @return {Promise<PresignedPostUpload>} Object containing the data and url needed to POST the file
+   * @return {Promise<PresignedPutUpload>} Object containing the data and url needed to POST the file
    */
-  presignUpload(params: PresignedStorageRequest): Promise<PresignedPostUpload>;
+  presignUpload(params: PresignedStorageRequest): Promise<PresignedPutUpload>;
   /** For a given file upload request, generates the path/key to store the file. This method
    * needs to be defined by each storage provider, as different storage providers might want to store files in different paths
    */
@@ -41,9 +41,10 @@ export interface UploadableStorageProvider extends StorageProvider, DataSource {
 export interface PresignedStorageRequest {
   /** Key (or path) of the file in the storage */
   key: string;
-  /** Custom parameter fields to add to the storage request (currently used by S3) */
-  fields: {
-    [key: string]: string;
+  /** Headers to add to the storage request (currently used by S3-compatible storage providers) */
+  headers?: {
+    "content-type"?: string;
+    "content-length"?: number;
   };
   /** Expiry delay for the upload authorisation. The client needs to upload a file before that time */
   expiresInSeconds: number;
@@ -57,14 +58,12 @@ export interface PresignedDownloadRequest {
   expiresInSeconds: number;
 }
 
-/** Data returned for a client
- * to be able to send a POST request to upload a file */
-export interface PresignedPostUpload {
-  /** URL to send the upload request to */
+/**
+ * Data returned for a client to be able to send a PUT request to upload a file
+ * PUT rather than POST is used for R2 compatibility
+ * @see https://developers.cloudflare.com/r2/api/s3/presigned-urls
+ */
+export interface PresignedPutUpload {
+  /** PUT URL to send the upload request to, including any headers */
   url: string;
-  /** form-data fields that must be appended to the POST data
-   * when uploading the file */
-  fields: {
-    [key: string]: string;
-  };
 }

--- a/apps/hash-frontend/src/components/hooks/block-protocol-functions/knowledge/use-block-protocol-file-upload.ts
+++ b/apps/hash-frontend/src/components/hooks/block-protocol-functions/knowledge/use-block-protocol-file-upload.ts
@@ -125,10 +125,10 @@ export const useBlockProtocolFileUpload = (
        * Upload file with presignedPost data to storage provider
        */
       const {
-        requestFileUpload: { presignedPost, entity: uploadedFileEntity },
+        requestFileUpload: { presignedPut, entity: uploadedFileEntity },
       } = data;
 
-      await uploadFileToStorageProvider(presignedPost, file);
+      await uploadFileToStorageProvider(presignedPut, file);
 
       return { data: uploadedFileEntity as unknown as FileEntityType };
     },

--- a/apps/hash-frontend/src/graphql/queries/knowledge/file.queries.ts
+++ b/apps/hash-frontend/src/graphql/queries/knowledge/file.queries.ts
@@ -19,7 +19,6 @@ export const requestFileUpload = gql`
     ) {
       presignedPut {
         url
-        headers
       }
       entity
     }

--- a/apps/hash-frontend/src/graphql/queries/knowledge/file.queries.ts
+++ b/apps/hash-frontend/src/graphql/queries/knowledge/file.queries.ts
@@ -17,9 +17,9 @@ export const requestFileUpload = gql`
       fileEntityCreationInput: $fileEntityCreationInput
       fileEntityUpdateInput: $fileEntityUpdateInput
     ) {
-      presignedPost {
+      presignedPut {
         url
-        fields
+        headers
       }
       entity
     }

--- a/apps/hash-frontend/src/shared/file-upload-context.tsx
+++ b/apps/hash-frontend/src/shared/file-upload-context.tsx
@@ -25,7 +25,7 @@ import {
   CreateEntityMutationVariables,
   CreateFileFromUrlMutation,
   CreateFileFromUrlMutationVariables,
-  PresignedFormPost,
+  PresignedPut,
   RequestFileUploadMutation,
   RequestFileUploadMutationVariables,
 } from "../graphql/api-types.gen";
@@ -90,7 +90,7 @@ type FileCreatingFileEntity = FileUploadVariant<{
 
 type FileUploadUploading = FileUploadVariant<{
   createdEntities: Pick<FileUploadEntities, "fileEntity">;
-  presignedPostForm: PresignedFormPost;
+  presignedPut: PresignedPut;
   status: "uploading-file-locally";
 }>;
 
@@ -108,7 +108,7 @@ type FileUploadError = FileUploadVariant<{
   createdEntities?: Pick<FileUploadEntities, "fileEntity">;
   errorMessage: string;
   failedStep: FileUploadStatus;
-  presignedPostForm?: PresignedFormPost;
+  presignedPut?: PresignedPut;
   status: "error";
 }>;
 
@@ -282,8 +282,8 @@ export const FileUploadsProvider = ({ children }: PropsWithChildren) => {
         existingUpload?.failedStep !== "creating-link-entity" &&
         existingUpload?.failedStep !== "archiving-link-entity"
       ) {
-        let presignedPostForm: PresignedFormPost | undefined =
-          "presignedPostForm" in upload ? upload.presignedPostForm : undefined;
+        let presignedPut: PresignedPut | undefined =
+          "presignedPut" in upload ? upload.presignedPut : undefined;
 
         try {
           if (!fileEntity) {
@@ -312,21 +312,21 @@ export const FileUploadsProvider = ({ children }: PropsWithChildren) => {
             fileEntity = data.requestFileUpload
               .entity as unknown as FileEntityType;
 
-            presignedPostForm = data.requestFileUpload.presignedPost;
+            presignedPut = data.requestFileUpload.presignedPut;
 
             const updatedUpload: FileUpload = {
               ...upload,
               createdEntities: { fileEntity },
-              presignedPostForm,
+              presignedPut,
               status: "uploading-file-locally",
             };
             updateUpload(updatedUpload);
           }
 
-          if (!presignedPostForm) {
+          if (!presignedPut) {
             // We should never get here as we should have the presigned form from an existing upload or the requestFileUploadFn call above
             throw new Error(
-              `No presignedPostForm found for requestId ${requestId}, cannot upload file`,
+              `No presignedPut found for requestId ${requestId}, cannot upload file`,
             );
           }
 
@@ -334,7 +334,7 @@ export const FileUploadsProvider = ({ children }: PropsWithChildren) => {
            * Upload file with presignedPost data to storage provider
            */
           await uploadFileToStorageProvider(
-            presignedPostForm,
+            presignedPut,
             fileData.file,
             (progress) => {
               setUploadsProgress((prevProgress) => ({

--- a/apps/hash-frontend/src/shared/upload-to-storage-provider.ts
+++ b/apps/hash-frontend/src/shared/upload-to-storage-provider.ts
@@ -1,22 +1,15 @@
 import { RequestFileUploadResponse } from "../graphql/api-types.gen";
 
 export const uploadFileToStorageProvider = async (
-  presignedPostData: RequestFileUploadResponse["presignedPost"],
+  presignedPutData: RequestFileUploadResponse["presignedPut"],
   file: File,
   onProgress?: (progress: number) => void,
 ) => {
-  const formData = new FormData();
-  const { url, fields } = presignedPostData;
-
-  for (const [key, val] of Object.entries(fields)) {
-    formData.append(key, val as string);
-  }
-
-  formData.append("file", file);
+  const { url } = presignedPutData;
 
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
-    xhr.open("POST", url, true);
+    xhr.open("PUT", url, true);
 
     if (onProgress) {
       xhr.upload.addEventListener("progress", (event) => {
@@ -39,6 +32,6 @@ export const uploadFileToStorageProvider = async (
       reject(new Error(xhr.statusText || "Network error."));
     };
 
-    xhr.send(formData);
+    xhr.send(file);
   });
 };

--- a/infra/terraform/hash/hash_application/main.tf
+++ b/infra/terraform/hash/hash_application/main.tf
@@ -340,18 +340,6 @@ resource "aws_iam_role" "task_role" {
           Effect   = "Allow",
           Resource = "*"
         },
-        # Enable read/write access to file upload bucket
-        {
-          Action = [
-            "s3:GetObject",
-            "s3:PutObject",
-            "s3:PutObjectAcl",
-          ]
-          Effect   = "Allow"
-          Resource = [
-            "${aws_s3_bucket.uploads.arn}/*",
-          ]
-        }
       ]
     })
   }

--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -247,6 +247,9 @@ module "application" {
   api_image = module.api_ecr
   api_env_vars = concat(var.hash_api_env_vars, [
     { name = "AWS_REGION", secret = false, value = local.region },
+    { name = "AWS_S3_UPLOADS_ACCESS_KEY_ID", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["aws_s3_uploads_access_key_id" ]) },
+    { name = "AWS_S3_UPLOADS_BUCKET", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["aws_s3_uploads_bucket" ]) },
+    { name = "AWS_S3_UPLOADS_SECRET_ACCESS_KEY", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["aws_s3_uploads_secret_access_key" ]) },
     { name = "SYSTEM_USER_PASSWORD", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_system_user_password"]) },
     { name = "BLOCK_PROTOCOL_API_KEY", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_block_protocol_api_key"]) },
     { name = "KRATOS_API_KEY", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["kratos_api_key"]) },

--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -249,6 +249,7 @@ module "application" {
     { name = "AWS_REGION", secret = false, value = local.region },
     { name = "AWS_S3_UPLOADS_ACCESS_KEY_ID", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["aws_s3_uploads_access_key_id" ]) },
     { name = "AWS_S3_UPLOADS_BUCKET", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["aws_s3_uploads_bucket" ]) },
+    { name = "AWS_S3_UPLOADS_ENDPOINT", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["aws_s3_uploads_endpoint" ]) },
     { name = "AWS_S3_UPLOADS_SECRET_ACCESS_KEY", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["aws_s3_uploads_secret_access_key" ]) },
     { name = "SYSTEM_USER_PASSWORD", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_system_user_password"]) },
     { name = "BLOCK_PROTOCOL_API_KEY", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_block_protocol_api_key"]) },

--- a/libs/@local/hash-graphql-shared/src/graphql/type-defs/knowledge/file.typedef.ts
+++ b/libs/@local/hash-graphql-shared/src/graphql/type-defs/knowledge/file.typedef.ts
@@ -14,17 +14,12 @@ export const fileTypedef = gql`
 
   """
   Presigned data to send a PUT request to upload a file
-  The fields object contains form parameters that need to be sent with the POST request to upload a file
   """
   type PresignedPut {
     """
     url to POST the file to
     """
     url: String!
-    """
-    Headers that need to be sent with the request when uploading
-    """
-    headers: JSONObject!
   }
 
   input FileEntityCreationInput {

--- a/libs/@local/hash-graphql-shared/src/graphql/type-defs/knowledge/file.typedef.ts
+++ b/libs/@local/hash-graphql-shared/src/graphql/type-defs/knowledge/file.typedef.ts
@@ -3,9 +3,9 @@ import { gql } from "apollo-server-express";
 export const fileTypedef = gql`
   type RequestFileUploadResponse {
     """
-    Presigned post object containing the info needed to send a POST request
+    Presigned object containing the info needed to send a PUT request
     """
-    presignedPost: PresignedFormPost!
+    presignedPut: PresignedPut!
     """
     The file Entity
     """
@@ -13,18 +13,18 @@ export const fileTypedef = gql`
   }
 
   """
-  Presigned data to send a POST request to upload a file
+  Presigned data to send a PUT request to upload a file
   The fields object contains form parameters that need to be sent with the POST request to upload a file
   """
-  type PresignedFormPost {
+  type PresignedPut {
     """
     url to POST the file to
     """
     url: String!
     """
-    form-data fields that need to be appended to the POST request when uploading
+    Headers that need to be sent with the request when uploading
     """
-    fields: JSONObject!
+    headers: JSONObject!
   }
 
   input FileEntityCreationInput {

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/file.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/file.test.ts
@@ -59,9 +59,7 @@ describe("File", () => {
     graphContext.uploadProvider = {
       getFileEntityStorageKey: jest.fn(() => fileKey),
       presignDownload: jest.fn(() => Promise.resolve(downloadUrl)),
-      presignUpload: jest.fn(() =>
-        Promise.resolve({ url: uploadUrl, fields: {} }),
-      ),
+      presignUpload: jest.fn(() => Promise.resolve({ url: uploadUrl })),
       storageType: StorageType.LocalFileSystem,
     };
 
@@ -75,7 +73,7 @@ describe("File", () => {
       },
     );
 
-    expect(file.presignedPost.url).toEqual(uploadUrl);
+    expect(file.presignedPut.url).toEqual(uploadUrl);
 
     expect(
       file.entity.properties[


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Changes where we store files from S3 to R2.

## 🔍 What does this change?

- Adds environment variables for connecting to R2 (we were previously relying on the AWS IAM role for the API task having authorization)
- Update the file upload request from a presigned POST (not supported in R2) to a PUT
- Validate that the content type and length are as originally requested (this currently simply ensures that the type/length requested by the user for upload, which could be anything, are the same as what they actually upload, but at some point we could reject requests for upload with certain types/sizes, if we wanted)
- Remove Terraform config for S3 bucket


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

We probably want to change how we proxy file downloads to address the following: 
1. Currently, if the storage provider of a HASH Instance is changed, previously uploaded files will not be accessible (since retrieving them uses the current file storage provider configuration) – H-1010
2. It is possible to download files without being authorized to do so, if the file's URL is known (cannot be guessed but once known provides indefinite access to the file) – also H-1010
3. Allow for using a custom domain – H-1011

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- None really. There's a file test but it doesn't test upload, it mocks it.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. You would need to set the environment variables in `.env.local`, including `FILE_UPLOAD_PROVIDER=AWS_S3`.

