### PR TITLE
H-1028: Disable realtime service by default

### DIFF
--- a/.env
+++ b/.env
@@ -78,6 +78,9 @@ SYSTEM_USER_EMAIL_ADDRESS=system-user@example.com
 
 API_ORIGIN=http://localhost:5001
 
+# Whether or not the realtime service and things depending on it are enabled (e.g. integration 2-way sync)
+ENABLE_REALTIME_SYNC=false
+
 # Optional usage telemetry for HASH
 HASH_TELEMETRY_ENABLED=false
 # Currently our endpoint doesn't have HTTPS so this is set to false

--- a/apps/hash-api/src/index.ts
+++ b/apps/hash-api/src/index.ts
@@ -5,6 +5,7 @@ import { promisify } from "node:util";
 import { TypeSystemInitializer } from "@blockprotocol/type-system";
 import {
   monorepoRootDir,
+  realtimeSyncEnabled,
   waitOnResource,
 } from "@local/hash-backend-utils/environment";
 import { OpenSearch } from "@local/hash-backend-utils/search/opensearch";
@@ -367,15 +368,17 @@ const main = async () => {
     });
   });
 
-  const integrationSyncBackWatcher =
-    await createIntegrationSyncBackWatcher(graphApi);
+  if (realtimeSyncEnabled) {
+    const integrationSyncBackWatcher =
+      await createIntegrationSyncBackWatcher(graphApi);
 
-  void integrationSyncBackWatcher.start();
+    void integrationSyncBackWatcher.start();
 
-  shutdown.addCleanup(
-    "Integration sync back watcher",
-    integrationSyncBackWatcher.stop,
-  );
+    shutdown.addCleanup(
+      "Integration sync back watcher",
+      integrationSyncBackWatcher.stop,
+    );
+  }
 };
 
 void main().catch(async (err) => {

--- a/apps/hash-realtime/src/index.ts
+++ b/apps/hash-realtime/src/index.ts
@@ -5,6 +5,7 @@ import * as http from "node:http";
 
 import {
   getRequiredEnv,
+  realtimeSyncEnabled,
   waitOnResource,
 } from "@local/hash-backend-utils/environment";
 import { Logger } from "@local/hash-backend-utils/logger";
@@ -20,6 +21,14 @@ import {
 import { sql } from "slonik";
 
 import { generateQueues, MONITOR_TABLES } from "./config";
+
+if (!realtimeSyncEnabled) {
+  // eslint-disable-next-line no-console
+  console.log(
+    "*********** Realtime sync is not enabled – exiting. ***********",
+  );
+  process.exit();
+}
 
 // The number of milliseconds between queries to the replication slot
 const POLL_INTERVAL_MILLIS = 250;

--- a/libs/@local/hash-backend-utils/src/environment.ts
+++ b/libs/@local/hash-backend-utils/src/environment.ts
@@ -34,4 +34,4 @@ export const waitOnResource = async (
   logger?.debug(`${resource} is ready`);
 };
 
-export const realtimeSyncEnabled = !!process.env.ENABLE_REALTIME_SYNC;
+export const realtimeSyncEnabled = process.env.ENABLE_REALTIME_SYNC === "true";

--- a/libs/@local/hash-backend-utils/src/environment.ts
+++ b/libs/@local/hash-backend-utils/src/environment.ts
@@ -33,3 +33,5 @@ export const waitOnResource = async (
 
   logger?.debug(`${resource} is ready`);
 };
+
+export const realtimeSyncEnabled = !!process.env.ENABLE_REALTIME_SYNC;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `realtime` service reads database changes from a replica slot and adds them to a Redis queue, which can be subscribed to by other services which need to react to changes in the database. Previously, this included the collaborative editing ("collab") service, but currently it is only the service which syncs data changes in HASH back to external integrations.

With the introduction of authorization we need to figure out the permissions for this service. Until we do so, and until we return to developing external integrations, this PR disables `realtime` and the integration syncing function by default (it can be enabled by environment variable).

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


