### PR TITLE
H-980: Return all users and relations for a given entity

### DIFF
--- a/.github/actions/load-docker-images/action.yml
+++ b/.github/actions/load-docker-images/action.yml
@@ -42,6 +42,10 @@ runs:
         set -x
         echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
 
+    - name: Clean docker system
+      shell: bash
+      run: docker system prune --force
+
     - name: Download hash-graph image
       if: inputs.hash-graph == 'true'
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2

--- a/.github/actions/load-docker-images/action.yml
+++ b/.github/actions/load-docker-images/action.yml
@@ -44,7 +44,7 @@ runs:
 
     - name: Clean docker system
       shell: bash
-      run: docker system prune --force
+      run: docker system prune --force --all
 
     - name: Download hash-graph image
       if: inputs.hash-graph == 'true'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -241,6 +241,9 @@ jobs:
         if: always() && steps.lints.outputs.has-poetry-deps == 'true'
         run: turbo run poetry:install
 
+      - name: Show disk usage
+        run: df -h
+
       - name: Run codegen
         if: always() && steps.lints.outputs.codegen == 'true'
         run: |
@@ -252,6 +255,9 @@ jobs:
               git --no-pager diff --exit-code --color -- "${{ matrix.directory }}/$line"
             fi
           done <<< "$(cat ${{ matrix.directory }}/turbo.json | grep -v '^ *//' | jq -r '.pipeline.codegen.outputs | if . == null then "." else .[] end')"
+
+      - name: Show disk usage
+        run: df -h
 
       - name: Run ESLint
         if: always() && steps.lints.outputs.eslint == 'true'
@@ -333,6 +339,9 @@ jobs:
       - name: Run MyPy
         if: always() && steps.lints.outputs.mypy == 'true'
         run: turbo run lint:mypy --filter "${{ matrix.package }}"
+
+      - name: Show disk usage
+        run: df -h
 
   unit-tests:
     name: Unit Tests
@@ -421,12 +430,18 @@ jobs:
         if: always() && steps.tests.outputs.has-poetry-deps == 'true'
         run: turbo run poetry:install
 
+      - name: Show disk usage
+        run: df -h
+
       - name: Run tests
         env:
           TEST_COVERAGE: ${{ github.event_name != 'merge_group' }}
         run: |
           turbo run test:unit --filter "${{ matrix.package }}"
           echo "TRIMMED_PACKAGE_NAME=$(echo "${{ matrix.package }}" | sed 's|@||g' | sed 's|/|.|g')" >> $GITHUB_ENV
+
+      - name: Show disk usage
+        run: df -h
 
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
         name: Upload coverage to https://app.codecov.io/gh/hashintel/hash
@@ -561,6 +576,9 @@ jobs:
         if: always() && steps.tests.outputs.has-poetry-deps == 'true'
         run: turbo run poetry:install
 
+      - name: Show disk usage
+        run: df -h
+
       - name: Load Docker images
         uses: ./.github/actions/load-docker-images
         with:
@@ -568,6 +586,9 @@ jobs:
           hash-ai-worker-ts: ${{ steps.tests.outputs.external-service-ai-worker-ts == 'true' }}
           hash-ai-worker-py: ${{ steps.tests.outputs.external-service-ai-worker-py == 'true' }}
           hash-integration-worker: ${{ steps.tests.outputs.external-service-worker-integration == 'true' }}
+
+      - name: Show disk usage
+        run: df -h
 
       - name: Launch external services
         run: |
@@ -591,10 +612,16 @@ jobs:
           echo "Running services: $SERVICES"
           yarn workspace @apps/hash-external-services deploy:test up $SERVICES --detach
 
+      - name: Show disk usage
+        run: df -h
+
       - name: Run tests
         run: |
           turbo run test:integration --filter "${{ matrix.package }}"
           echo "TRIMMED_PACKAGE_NAME=$(echo "${{ matrix.package }}" | sed 's|@||g' | sed 's|/|.|g')" >> $GITHUB_ENV
+
+      - name: Show disk usage
+        run: df -h
 
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
         name: Upload coverage to https://app.codecov.io/gh/hashintel/hash
@@ -678,6 +705,9 @@ jobs:
           shell: bash
           command: npx playwright install --with-deps chromium
 
+      - name: Show disk usage
+        run: df -h
+
       - name: Load Docker images
         uses: ./.github/actions/load-docker-images
         with:
@@ -705,9 +735,15 @@ jobs:
           yarn workspace @apps/hash-frontend start &
           yarn wait-on --timeout 30000 http://0.0.0.0:3000
 
+      - name: Show disk usage
+        run: df -h
+
       - name: Run tests
         run: |
           turbo run test:system --filter "${{ matrix.package }}"
+
+      - name: Show disk usage
+        run: df -h
 
       - name: Show container logs
         if: ${{ success() || failure() }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -686,6 +686,9 @@ jobs:
           hash-ai-worker-py: true
           hash-integration-worker: true
 
+      - name: Show disk usage
+        run: df -h
+
       - name: Launch external services
         run: |
           turbo codegen --filter '@apps/hash-external-services'

--- a/apps/hash-api/src/graph/knowledge/primitive/entity.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity.ts
@@ -1,10 +1,8 @@
 import { VersionedUrl } from "@blockprotocol/type-system";
 import {
-  EntityRelation,
   EntityStructuralQuery,
   Filter,
   GraphResolveDepths,
-  VisibilityScope,
 } from "@local/hash-graph-client";
 import {
   currentTimeInstantTemporalAxes,
@@ -15,6 +13,7 @@ import {
   AccountId,
   BaseUrl,
   Entity,
+  EntityAuthorizationRelationship,
   EntityId,
   EntityMetadata,
   EntityPropertiesObject,
@@ -722,10 +721,15 @@ export const isEntityPublic: ImpureGraphFunction<
 > = async (ctx, _, params) =>
   canViewEntity(ctx, { actorId: publicUserAccountId }, params);
 
-export const getEntityRelations: ImpureGraphFunction<
+export const getEntityAuthorizationRelationships: ImpureGraphFunction<
   { entityId: EntityId },
-  Promise<{ relation: EntityRelation; scope: VisibilityScope }[]>
+  Promise<EntityAuthorizationRelationship[]>
 > = async ({ graphApi }, { actorId }, params) =>
   graphApi
-    .getEntityRelations(actorId, params.entityId)
-    .then(({ data }) => data.relations);
+    .getEntityAuthorizationRelationships(actorId, params.entityId)
+    .then(({ data }) =>
+      data.map((relationship) => ({
+        object: params.entityId,
+        ...relationship,
+      })),
+    );

--- a/apps/hash-api/src/graph/knowledge/primitive/entity.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity.ts
@@ -1,8 +1,10 @@
 import { VersionedUrl } from "@blockprotocol/type-system";
 import {
+  EntityRelation,
   EntityStructuralQuery,
   Filter,
   GraphResolveDepths,
+  VisibilityScope,
 } from "@local/hash-graph-client";
 import {
   currentTimeInstantTemporalAxes,
@@ -719,3 +721,11 @@ export const isEntityPublic: ImpureGraphFunction<
   Promise<boolean>
 > = async (ctx, _, params) =>
   canViewEntity(ctx, { actorId: publicUserAccountId }, params);
+
+export const getEntityRelations: ImpureGraphFunction<
+  { entityId: EntityId },
+  Promise<{ relation: EntityRelation; scope: VisibilityScope }[]>
+> = async ({ graphApi }, { actorId }, params) =>
+  graphApi
+    .getEntityRelations(actorId, params.entityId)
+    .then(({ data }) => data.relations);

--- a/apps/hash-graph/Cargo.lock
+++ b/apps/hash-graph/Cargo.lock
@@ -121,6 +121,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio-util",
+ "utoipa",
 ]
 
 [[package]]

--- a/apps/hash-graph/docker/Dockerfile
+++ b/apps/hash-graph/docker/Dockerfile
@@ -45,7 +45,6 @@ WORKDIR /usr/local/src/apps/hash-graph
 ARG PROFILE=production
 ARG ENABLE_TEST_SERVER=no
 ARG ENABLE_AUTHORIZATION=no
-ARG TRIM_DEBUG_SYMBOLS=yes
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
@@ -58,8 +57,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     if [[ ${ENABLE_AUTHORIZATION^^} == Y* || ${ENABLE_AUTHORIZATION^^} == T* || $ENABLE_AUTHORIZATION == 1 ]]; then \
       FEATURES+=("authorization"); \
     fi; \
-    if [[ ${TRIM_DEBUG_SYMBOLS^^} == Y* || ${TRIM_DEBUG_SYMBOLS^^} == T* || $TRIM_DEBUG_SYMBOLS == 1 ]]; then \
-        export RUSTFLAGS="$RUSTFLAGS -C link-arg=-s"; \
+    if [[ ${PROFILE} == dev ]]; then \
+        export RUSTFLAGS="$RUSTFLAGS -C debuginfo=line-tables-only"; \
     fi; \
     FEATURES=${FEATURES[@]}; \
     cargo install --path bin/cli --features "${FEATURES// /,}" --profile $PROFILE --locked;

--- a/apps/hash-graph/docker/Dockerfile
+++ b/apps/hash-graph/docker/Dockerfile
@@ -45,6 +45,7 @@ WORKDIR /usr/local/src/apps/hash-graph
 ARG PROFILE=production
 ARG ENABLE_TEST_SERVER=no
 ARG ENABLE_AUTHORIZATION=no
+ARG TRIM_DEBUG_SYMBOLS=yes
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
@@ -56,6 +57,9 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     fi; \
     if [[ ${ENABLE_AUTHORIZATION^^} == Y* || ${ENABLE_AUTHORIZATION^^} == T* || $ENABLE_AUTHORIZATION == 1 ]]; then \
       FEATURES+=("authorization"); \
+    fi; \
+    if [[ ${TRIM_DEBUG_SYMBOLS^^} == Y* || ${TRIM_DEBUG_SYMBOLS^^} == T* || $TRIM_DEBUG_SYMBOLS == 1 ]]; then \
+        export RUSTFLAGS="$RUSTFLAGS -C link-arg=-s"; \
     fi; \
     FEATURES=${FEATURES[@]}; \
     cargo install --path bin/cli --features "${FEATURES// /,}" --profile $PROFILE --locked;

--- a/apps/hash-graph/lib/graph/Cargo.toml
+++ b/apps/hash-graph/lib/graph/Cargo.toml
@@ -9,7 +9,7 @@ description = "HASH Graph API"
 graph-types = { workspace = true, features = ["postgres", "utoipa"] }
 temporal-versioning = { workspace = true, features = ["postgres", "utoipa"] }
 type-fetcher = { path = "../type-fetcher" }
-authorization = { workspace = true }
+authorization = { workspace = true, features = ["utoipa"] }
 codec = { workspace = true }
 
 error-stack = { workspace = true }

--- a/apps/hash-graph/lib/graph/src/snapshot.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot.rs
@@ -22,7 +22,7 @@ use authorization::{
     backend::ZanzibarBackend,
     schema::{AccountGroupPermission, AccountGroupRelation, EntityRelation, OwnerId, WebRelation},
     zanzibar::Consistency,
-    AccountOrPublic, VisibilityScope,
+    AccountOrPublic, EntitySubject,
 };
 use error_stack::{ensure, Context, Report, Result, ResultExt};
 use futures::{
@@ -442,13 +442,13 @@ where
                         {
                             match relation {
                                 EntityRelation::DirectOwner => {
-                                    owners.push(VisibilityScope::from(account));
+                                    owners.push(EntitySubject::from(account));
                                 }
                                 EntityRelation::DirectEditor => {
-                                    editors.push(VisibilityScope::from(account));
+                                    editors.push(EntitySubject::from(account));
                                 }
                                 EntityRelation::DirectViewer => {
-                                    viewers.push(VisibilityScope::from(account));
+                                    viewers.push(EntitySubject::from(account));
                                 }
                             }
                         }
@@ -467,13 +467,13 @@ where
                             if account_group_permission == Some(AccountGroupPermission::Member){
                                 match relation {
                                     EntityRelation::DirectOwner => {
-                                        owners.push(VisibilityScope::AccountGroup(account_group));
+                                        owners.push(EntitySubject::AccountGroupMembers(account_group));
                                     }
                                     EntityRelation::DirectEditor => {
-                                        editors.push(VisibilityScope::AccountGroup(account_group));
+                                        editors.push(EntitySubject::AccountGroupMembers(account_group));
                                     }
                                     EntityRelation::DirectViewer => {
-                                        viewers.push(VisibilityScope::AccountGroup(account_group));
+                                        viewers.push(EntitySubject::AccountGroupMembers(account_group));
                                     }
                                 }
                             } else {

--- a/apps/hash-graph/lib/graph/src/snapshot/entity/channel.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/entity/channel.rs
@@ -5,7 +5,7 @@ use std::{
 
 use authorization::{
     schema::{AccountGroupPermission, EntityRelation},
-    VisibilityScope,
+    EntitySubject,
 };
 use error_stack::{Report, ResultExt};
 use futures::{
@@ -169,18 +169,19 @@ impl Sink<EntitySnapshotRecord> for EntitySender {
         let mut public_account_relations = Vec::new();
         for (scope, relation) in owners.chain(editors).chain(viewers) {
             match scope {
-                VisibilityScope::Account(account_id) => account_relations.push((
+                EntitySubject::Account(account_id) => account_relations.push((
                     entity.metadata.record_id.entity_id.entity_uuid,
                     relation,
                     account_id,
                 )),
-                VisibilityScope::AccountGroup(account_group_id) => account_group_relations.push((
-                    entity.metadata.record_id.entity_id.entity_uuid,
-                    relation,
-                    account_group_id,
-                    AccountGroupPermission::Member,
-                )),
-                VisibilityScope::Public => public_account_relations
+                EntitySubject::AccountGroupMembers(account_group_id) => account_group_relations
+                    .push((
+                        entity.metadata.record_id.entity_id.entity_uuid,
+                        relation,
+                        account_group_id,
+                        AccountGroupPermission::Member,
+                    )),
+                EntitySubject::Public => public_account_relations
                     .push((entity.metadata.record_id.entity_id.entity_uuid, relation)),
             }
         }

--- a/apps/hash-graph/lib/graph/src/snapshot/entity/record.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/entity/record.rs
@@ -1,4 +1,4 @@
-use authorization::VisibilityScope;
+use authorization::EntitySubject;
 use graph_types::{
     knowledge::{
         entity::{EntityProperties, EntityRecordId, EntityTemporalMetadata},
@@ -34,9 +34,9 @@ pub struct EntitySnapshotRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub link_data: Option<LinkData>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub owners: Vec<VisibilityScope>,
+    pub owners: Vec<EntitySubject>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub editors: Vec<VisibilityScope>,
+    pub editors: Vec<EntitySubject>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub viewers: Vec<VisibilityScope>,
+    pub viewers: Vec<EntitySubject>,
 }

--- a/apps/hash-graph/lib/graph/src/store/account.rs
+++ b/apps/hash-graph/lib/graph/src/store/account.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use authorization::{schema::OwnerId, AuthorizationApi, VisibilityScope};
+use authorization::{schema::OwnerId, AuthorizationApi, EntitySubject};
 use error_stack::Result;
 use graph_types::{
     account::{AccountGroupId, AccountId},
@@ -55,12 +55,12 @@ pub enum AccountOrAccountGroup {
     AccountGroup(AccountGroupId),
 }
 
-impl From<AccountOrAccountGroup> for VisibilityScope {
+impl From<AccountOrAccountGroup> for EntitySubject {
     fn from(id: AccountOrAccountGroup) -> Self {
         match id {
             AccountOrAccountGroup::Account(account_id) => Self::Account(account_id),
             AccountOrAccountGroup::AccountGroup(account_group_id) => {
-                Self::AccountGroup(account_group_id)
+                Self::AccountGroupMembers(account_group_id)
             }
         }
     }

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -1093,13 +1093,13 @@
         }
       }
     },
-    "/entities/{entity_id}/relations": {
+    "/entities/{entity_id}/relationships": {
       "get": {
         "tags": [
           "Graph",
           "Entity"
         ],
-        "operationId": "get_entity_relations",
+        "operationId": "get_entity_authorization_relationships",
         "parameters": [
           {
             "name": "X-Authenticated-User-Actor-Id",
@@ -1126,7 +1126,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/EntityRelations"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EntityAuthorizationRelationship"
+                  }
                 }
               }
             }
@@ -2244,6 +2247,21 @@
           }
         }
       },
+      "EntityAuthorizationRelationship": {
+        "type": "object",
+        "required": [
+          "relation",
+          "subject"
+        ],
+        "properties": {
+          "relation": {
+            "$ref": "#/components/schemas/EntityRelation"
+          },
+          "subject": {
+            "$ref": "#/components/schemas/EntitySubject"
+          }
+        }
+      },
       "EntityEditionId": {
         "type": "string",
         "format": "uuid"
@@ -2359,35 +2377,6 @@
           "direct_viewer"
         ]
       },
-      "EntityRelationScope": {
-        "type": "object",
-        "required": [
-          "relation",
-          "scope"
-        ],
-        "properties": {
-          "relation": {
-            "$ref": "#/components/schemas/EntityRelation"
-          },
-          "scope": {
-            "$ref": "#/components/schemas/VisibilityScope"
-          }
-        }
-      },
-      "EntityRelations": {
-        "type": "object",
-        "required": [
-          "relations"
-        ],
-        "properties": {
-          "relations": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/EntityRelationScope"
-            }
-          }
-        }
-      },
       "EntityStructuralQuery": {
         "type": "object",
         "required": [
@@ -2405,6 +2394,66 @@
           "temporalAxes": {
             "$ref": "#/components/schemas/QueryTemporalAxesUnresolved"
           }
+        }
+      },
+      "EntitySubject": {
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "PublicSubject",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "public"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "AccountSubject",
+            "required": [
+              "type",
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "$ref": "#/components/schemas/AccountId"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "account"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "AccountGroupMembersSubject",
+            "required": [
+              "type",
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "$ref": "#/components/schemas/AccountGroupId"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "accountGroupMembers"
+                ]
+              }
+            }
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type"
         }
       },
       "EntityTemporalMetadata": {
@@ -3864,66 +3913,6 @@
             "$ref": "#/components/schemas/OwnedById"
           }
         ]
-      },
-      "VisibilityScope": {
-        "oneOf": [
-          {
-            "type": "object",
-            "title": "PublicScope",
-            "required": [
-              "type"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "public"
-                ]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "title": "AccountScope",
-            "required": [
-              "type",
-              "id"
-            ],
-            "properties": {
-              "id": {
-                "$ref": "#/components/schemas/AccountId"
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "account"
-                ]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "title": "AccountGroupScope",
-            "required": [
-              "type",
-              "id"
-            ],
-            "properties": {
-              "id": {
-                "$ref": "#/components/schemas/AccountGroupId"
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "accountGroup"
-                ]
-              }
-            }
-          }
-        ],
-        "discriminator": {
-          "propertyName": "type"
-        }
       }
     }
   },

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -1093,6 +1093,50 @@
         }
       }
     },
+    "/entities/{entity_id}/relations": {
+      "get": {
+        "tags": [
+          "Graph",
+          "Entity"
+        ],
+        "operationId": "get_entity_relations",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          },
+          {
+            "name": "entity_id",
+            "in": "path",
+            "description": "The Entity to read the relations for",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/EntityId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The relations of the entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityRelations"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied"
+          }
+        }
+      }
+    },
     "/entities/{entity_id}/viewers/{viewer}": {
       "post": {
         "tags": [
@@ -2304,6 +2348,43 @@
           },
           "entityId": {
             "$ref": "#/components/schemas/EntityId"
+          }
+        }
+      },
+      "EntityRelation": {
+        "type": "string",
+        "enum": [
+          "direct_owner",
+          "direct_editor",
+          "direct_viewer"
+        ]
+      },
+      "EntityRelationScope": {
+        "type": "object",
+        "required": [
+          "relation",
+          "scope"
+        ],
+        "properties": {
+          "relation": {
+            "$ref": "#/components/schemas/EntityRelation"
+          },
+          "scope": {
+            "$ref": "#/components/schemas/VisibilityScope"
+          }
+        }
+      },
+      "EntityRelations": {
+        "type": "object",
+        "required": [
+          "relations"
+        ],
+        "properties": {
+          "relations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityRelationScope"
+            }
           }
         }
       },
@@ -3783,6 +3864,66 @@
             "$ref": "#/components/schemas/OwnedById"
           }
         ]
+      },
+      "VisibilityScope": {
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "PublicScope",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "public"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "AccountScope",
+            "required": [
+              "type",
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "$ref": "#/components/schemas/AccountId"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "account"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "AccountGroupScope",
+            "required": [
+              "type",
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "$ref": "#/components/schemas/AccountGroupId"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "accountGroup"
+                ]
+              }
+            }
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type"
+        }
       }
     }
   },

--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -1743,9 +1743,3 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     client.assert(response.body.roots.length === 2, "Unexpected number of entity types");
   });
 %}
-
-
-
-### Get a
-GET http://127.0.0.1:4000/entities/f77dc95b-03e7-4704-bf04-240d261b0435~cb6d1a8f-cd2a-454e-8e3f-9556528cf080/relations
-X-Authenticated-User-Actor-Id: {{account_id}}

--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -1743,3 +1743,9 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     client.assert(response.body.roots.length === 2, "Unexpected number of entity types");
   });
 %}
+
+
+
+### Get a
+GET http://127.0.0.1:4000/entities/f77dc95b-03e7-4704-bf04-240d261b0435~cb6d1a8f-cd2a-454e-8e3f-9556528cf080/relations
+X-Authenticated-User-Actor-Id: {{account_id}}

--- a/libs/@local/hash-authorization/Cargo.toml
+++ b/libs/@local/hash-authorization/Cargo.toml
@@ -16,6 +16,12 @@ serde_json = { version = "1.0.107" }
 reqwest = { version = "0.11.22", default-features = false, features = ["json", "stream"] }
 tokio-util = { version ="0.7.9", features = ["io"] }
 
+utoipa = { version = "4.0.0", optional = true }
+
 [dev-dependencies]
 uuid =  { version = "1.4.1", default-features = false }
 tokio = { version = "1.33.0", default-features = false , features = ["macros", "rt-multi-thread"] }
+
+[features]
+utoipa = ["dep:utoipa"]
+

--- a/libs/@local/hash-authorization/src/api.rs
+++ b/libs/@local/hash-authorization/src/api.rs
@@ -19,13 +19,13 @@ use crate::{
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", tag = "type", content = "id")]
-pub enum VisibilityScope {
-    #[cfg_attr(feature = "utoipa", schema(title = "PublicScope"))]
+pub enum EntitySubject {
+    #[cfg_attr(feature = "utoipa", schema(title = "PublicSubject"))]
     Public,
-    #[cfg_attr(feature = "utoipa", schema(title = "AccountScope"))]
+    #[cfg_attr(feature = "utoipa", schema(title = "AccountSubject"))]
     Account(AccountId),
-    #[cfg_attr(feature = "utoipa", schema(title = "AccountGroupScope"))]
-    AccountGroup(AccountGroupId),
+    #[cfg_attr(feature = "utoipa", schema(title = "AccountGroupMembersSubject"))]
+    AccountGroupMembers(AccountGroupId),
 }
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
@@ -35,7 +35,7 @@ pub enum AccountOrPublic {
     Account(AccountId),
 }
 
-impl From<AccountOrPublic> for VisibilityScope {
+impl From<AccountOrPublic> for EntitySubject {
     fn from(account_or_public: AccountOrPublic) -> Self {
         match account_or_public {
             AccountOrPublic::Public(_) => Self::Public,
@@ -202,12 +202,12 @@ pub trait AuthorizationApi {
 
     fn add_entity_viewer(
         &mut self,
-        scope: VisibilityScope,
+        scope: EntitySubject,
         entity: EntityId,
     ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
     fn remove_entity_viewer(
         &mut self,
-        scope: VisibilityScope,
+        scope: EntitySubject,
         entity: EntityId,
     ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
 
@@ -253,7 +253,7 @@ pub trait AuthorizationApi {
         &self,
         entity: EntityId,
         consistency: Consistency<'static>,
-    ) -> impl Future<Output = Result<Vec<(VisibilityScope, EntityRelation)>, ReadError>> + Send;
+    ) -> impl Future<Output = Result<Vec<(EntitySubject, EntityRelation)>, ReadError>> + Send;
 }
 
 /// Managed pool to keep track about [`AuthorizationApi`]s.

--- a/libs/@local/hash-authorization/src/lib.rs
+++ b/libs/@local/hash-authorization/src/lib.rs
@@ -22,8 +22,8 @@ use graph_types::{
 };
 
 use crate::{
-    backend::{CheckError, CheckResponse, ModifyRelationError},
-    schema::OwnerId,
+    backend::{CheckError, CheckResponse, ModifyRelationError, ReadError},
+    schema::{EntityRelation, OwnerId},
     zanzibar::{Consistency, Zookie},
 };
 
@@ -265,6 +265,14 @@ impl AuthorizationApi for NoAuthorization {
             has_permission: true,
             checked_at: Zookie::empty(),
         })
+    }
+
+    async fn get_entity_relations(
+        &self,
+        _entity: EntityId,
+        _consistency: Consistency<'static>,
+    ) -> Result<Vec<(VisibilityScope, EntityRelation)>, ReadError> {
+        Ok(Vec::new())
     }
 }
 

--- a/libs/@local/hash-authorization/src/lib.rs
+++ b/libs/@local/hash-authorization/src/lib.rs
@@ -10,7 +10,7 @@ pub mod backend;
 pub mod schema;
 pub mod zanzibar;
 
-pub use self::api::{AccountOrPublic, AuthorizationApi, AuthorizationApiPool, VisibilityScope};
+pub use self::api::{AccountOrPublic, AuthorizationApi, AuthorizationApiPool, EntitySubject};
 
 mod api;
 
@@ -217,7 +217,7 @@ impl AuthorizationApi for NoAuthorization {
 
     async fn add_entity_viewer(
         &mut self,
-        _scope: VisibilityScope,
+        _scope: EntitySubject,
         _entity: EntityId,
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(Zookie::empty())
@@ -225,7 +225,7 @@ impl AuthorizationApi for NoAuthorization {
 
     async fn remove_entity_viewer(
         &mut self,
-        _scope: VisibilityScope,
+        _scope: EntitySubject,
         _entity: EntityId,
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(Zookie::empty())
@@ -271,7 +271,7 @@ impl AuthorizationApi for NoAuthorization {
         &self,
         _entity: EntityId,
         _consistency: Consistency<'static>,
-    ) -> Result<Vec<(VisibilityScope, EntityRelation)>, ReadError> {
+    ) -> Result<Vec<(EntitySubject, EntityRelation)>, ReadError> {
         Ok(Vec::new())
     }
 }

--- a/libs/@local/hash-authorization/src/schema/entity.rs
+++ b/libs/@local/hash-authorization/src/schema/entity.rs
@@ -18,6 +18,7 @@ impl Resource for EntityUuid {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum EntityRelation {
     DirectOwner,

--- a/libs/@local/hash-authorization/src/zanzibar/api.rs
+++ b/libs/@local/hash-authorization/src/zanzibar/api.rs
@@ -12,7 +12,7 @@ use crate::{
         PublicAccess, WebPermission, WebRelation,
     },
     zanzibar::{Consistency, Zookie},
-    AccountOrPublic, AuthorizationApi, VisibilityScope,
+    AccountOrPublic, AuthorizationApi, EntitySubject,
 };
 
 #[derive(Debug, Clone)]
@@ -402,11 +402,11 @@ where
 
     async fn add_entity_viewer(
         &mut self,
-        scope: VisibilityScope,
+        scope: EntitySubject,
         entity: EntityId,
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(match scope {
-            VisibilityScope::Public => {
+            EntitySubject::Public => {
                 self.backend
                     .create_relations([(
                         entity.entity_uuid,
@@ -415,12 +415,12 @@ where
                     )])
                     .await
             }
-            VisibilityScope::Account(account) => {
+            EntitySubject::Account(account) => {
                 self.backend
                     .create_relations([(entity.entity_uuid, EntityRelation::DirectViewer, account)])
                     .await
             }
-            VisibilityScope::AccountGroup(account_group) => {
+            EntitySubject::AccountGroupMembers(account_group) => {
                 self.backend
                     .create_relations([(
                         entity.entity_uuid,
@@ -437,11 +437,11 @@ where
 
     async fn remove_entity_viewer(
         &mut self,
-        scope: VisibilityScope,
+        scope: EntitySubject,
         entity: EntityId,
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(match scope {
-            VisibilityScope::Public => {
+            EntitySubject::Public => {
                 self.backend
                     .delete_relations([(
                         entity.entity_uuid,
@@ -450,12 +450,12 @@ where
                     )])
                     .await
             }
-            VisibilityScope::Account(account) => {
+            EntitySubject::Account(account) => {
                 self.backend
                     .delete_relations([(entity.entity_uuid, EntityRelation::DirectViewer, account)])
                     .await
             }
-            VisibilityScope::AccountGroup(account_group) => {
+            EntitySubject::AccountGroupMembers(account_group) => {
                 self.backend
                     .delete_relations([(
                         entity.entity_uuid,
@@ -516,7 +516,7 @@ where
         &self,
         entity: EntityId,
         consistency: Consistency<'static>,
-    ) -> Result<Vec<(VisibilityScope, EntityRelation)>, ReadError> {
+    ) -> Result<Vec<(EntitySubject, EntityRelation)>, ReadError> {
         let accounts = self
             .backend
             .read_relations::<EntityUuid, EntityRelation, AccountOrPublic, ()>(
@@ -532,7 +532,7 @@ where
             .map(|(entity_uuid, relation, account, account_relation)| {
                 debug_assert_eq!(entity_uuid, entity.entity_uuid);
                 assert!(account_relation.is_none());
-                (VisibilityScope::from(account), relation)
+                (EntitySubject::from(account), relation)
             });
 
         let account_groups = self
@@ -550,7 +550,7 @@ where
             .map(|(entity_uuid, relation, account_group, account_relation)| {
                 debug_assert_eq!(entity_uuid, entity.entity_uuid);
                 assert_eq!(account_relation, Some(AccountGroupPermission::Member));
-                (VisibilityScope::AccountGroup(account_group), relation)
+                (EntitySubject::AccountGroupMembers(account_group), relation)
             });
 
         Ok(accounts.chain(account_groups).collect())

--- a/libs/@local/hash-authorization/tests/simple.rs
+++ b/libs/@local/hash-authorization/tests/simple.rs
@@ -41,7 +41,7 @@ async fn plain_permissions() -> Result<(), Box<dyn Error>> {
         .await?;
 
     let token = api
-        .create_relations([
+        .touch_relations([
             (ENTITY_A, EntityRelation::DirectOwner, ALICE),
             (ENTITY_A, EntityRelation::DirectViewer, BOB),
             (ENTITY_B, EntityRelation::DirectOwner, BOB),

--- a/libs/@local/hash-graph-client/python/graph_client/models.py
+++ b/libs/@local/hash-graph-client/python/graph_client/models.py
@@ -96,6 +96,12 @@ class EntityRecordId(BaseModel):
     entity_id: EntityId = Field(..., alias="entityId")
 
 
+class EntityRelation(Enum):
+    direct_owner = "direct_owner"
+    direct_editor = "direct_editor"
+    direct_viewer = "direct_viewer"
+
+
 class EntityTypeQueryToken(Enum):
     """
     A single token in a [`EntityTypeQueryPath`].
@@ -251,6 +257,30 @@ class TransactionTime(RootModel[Literal["transactionTime"]]):
 class Viewer(RootModel[Literal["public"] | OwnedById]):
     model_config = ConfigDict(populate_by_name=True)
     root: Literal["public"] | OwnedById
+
+
+class PublicScope(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    type: Literal["public"]
+
+
+class AccountScope(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    id: AccountId
+    type: Literal["account"]
+
+
+class AccountGroupScope(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    id: AccountGroupId
+    type: Literal["accountGroup"]
+
+
+class VisibilityScope(RootModel[PublicScope | AccountScope | AccountGroupScope]):
+    model_config = ConfigDict(populate_by_name=True)
+    root: PublicScope | AccountScope | AccountGroupScope = Field(
+        ..., discriminator="type"
+    )
 
 
 class UpdateDataType(BaseModel):
@@ -543,6 +573,17 @@ class EntityLinkOrder(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     left_to_right_order: LinkOrder | None = Field(None, alias="leftToRightOrder")
     right_to_left_order: LinkOrder | None = Field(None, alias="rightToLeftOrder")
+
+
+class EntityRelationScope(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    relation: EntityRelation
+    scope: VisibilityScope
+
+
+class EntityRelations(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    relations: list[EntityRelationScope]
 
 
 class EntityTypeVertexId(BaseModel):

--- a/libs/@local/hash-graph-client/python/graph_client/models.py
+++ b/libs/@local/hash-graph-client/python/graph_client/models.py
@@ -102,6 +102,32 @@ class EntityRelation(Enum):
     direct_viewer = "direct_viewer"
 
 
+class PublicSubject(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    type: Literal["public"]
+
+
+class AccountSubject(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    id: AccountId
+    type: Literal["account"]
+
+
+class AccountGroupMembersSubject(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    id: AccountGroupId
+    type: Literal["accountGroupMembers"]
+
+
+class EntitySubject(
+    RootModel[PublicSubject | AccountSubject | AccountGroupMembersSubject]
+):
+    model_config = ConfigDict(populate_by_name=True)
+    root: PublicSubject | AccountSubject | AccountGroupMembersSubject = Field(
+        ..., discriminator="type"
+    )
+
+
 class EntityTypeQueryToken(Enum):
     """
     A single token in a [`EntityTypeQueryPath`].
@@ -257,30 +283,6 @@ class TransactionTime(RootModel[Literal["transactionTime"]]):
 class Viewer(RootModel[Literal["public"] | OwnedById]):
     model_config = ConfigDict(populate_by_name=True)
     root: Literal["public"] | OwnedById
-
-
-class PublicScope(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
-    type: Literal["public"]
-
-
-class AccountScope(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
-    id: AccountId
-    type: Literal["account"]
-
-
-class AccountGroupScope(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
-    id: AccountGroupId
-    type: Literal["accountGroup"]
-
-
-class VisibilityScope(RootModel[PublicScope | AccountScope | AccountGroupScope]):
-    model_config = ConfigDict(populate_by_name=True)
-    root: PublicScope | AccountScope | AccountGroupScope = Field(
-        ..., discriminator="type"
-    )
 
 
 class UpdateDataType(BaseModel):
@@ -569,21 +571,16 @@ class DataTypeVertexId(BaseModel):
     revision_id: OntologyTypeVersion = Field(..., alias="revisionId")
 
 
+class EntityAuthorizationRelationship(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    relation: EntityRelation
+    subject: EntitySubject
+
+
 class EntityLinkOrder(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     left_to_right_order: LinkOrder | None = Field(None, alias="leftToRightOrder")
     right_to_left_order: LinkOrder | None = Field(None, alias="rightToLeftOrder")
-
-
-class EntityRelationScope(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
-    relation: EntityRelation
-    scope: VisibilityScope
-
-
-class EntityRelations(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
-    relations: list[EntityRelationScope]
 
 
 class EntityTypeVertexId(BaseModel):

--- a/libs/@local/hash-subgraph/src/types/shared/branded.ts
+++ b/libs/@local/hash-subgraph/src/types/shared/branded.ts
@@ -4,6 +4,7 @@ import {
 } from "@blockprotocol/type-system/slim";
 import { Brand } from "@local/advanced-types/brand";
 import { validate as validateUuid } from "uuid";
+import { EntityRelation, EntitySubject } from "@local/hash-graph-client";
 
 export type BaseUrl = Brand<BaseUrlBp, "BaseUrl">;
 
@@ -89,3 +90,15 @@ export const extractAccountGroupId = extractEntityUuidFromEntityId as (
   entityId: AccountGroupEntityId,
   // The type cannot be cast directly to `AccountGroupId`, so we do it over two casts, but without `unknown`
 ) => string as (entityId: AccountGroupEntityId) => AccountGroupId;
+
+export type AuthorizationRelationship<O, R, S> = {
+  object: O;
+  relation: R;
+  subject: S;
+};
+
+export type EntityAuthorizationRelationship = AuthorizationRelationship<
+  EntityId,
+  EntityRelation,
+  EntitySubject
+>;

--- a/libs/@local/hash-subgraph/src/types/shared/branded.ts
+++ b/libs/@local/hash-subgraph/src/types/shared/branded.ts
@@ -3,8 +3,8 @@ import {
   validateBaseUrl,
 } from "@blockprotocol/type-system/slim";
 import { Brand } from "@local/advanced-types/brand";
-import { validate as validateUuid } from "uuid";
 import { EntityRelation, EntitySubject } from "@local/hash-graph-client";
+import { validate as validateUuid } from "uuid";
 
 export type BaseUrl = Brand<BaseUrlBp, "BaseUrl">;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Provides an interface to read all users and relations for the requested entity.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

This is not how I want to implement reading relationships in the first place. This approach is very inflexible and lengthy. In addition, this will not work when introducing more features such as attribute-based permissions (caveats) which are required for more fine-grained permissions. Also, this approach does not scale well and is rather slow. However, the functionality is required for the share menu, so I decided to provide a function that is working.
The approach I wanted to use did not work out fully but can be extended. It's available in [this branch](https://github.com/hashintel/hash/tree/t/h-980-return-all-users-relations-for-a-given-entity-experiment).
