### PR TITLE
H-913: Add non-exhaustive outline of unpublished libraries

### DIFF
--- a/libs/README.md
+++ b/libs/README.md
@@ -42,8 +42,6 @@ Although published to package managers, the following libraries were developed f
 | [@hashintel/design-system]       | TypeScript  | [npm](https://www.npmjs.com/package/@hashintel/design-system)       | To be written | A collection of styleguide-aligned reusable UI primitives for [HASH] and our [hash.ai] website       |
 | [@hashintel/block-design-system] | TypeScript  | [npm](https://www.npmjs.com/package/@hashintel/block-design-system) | To be written | A relatively unopinionated set of reusable UI primitives for use in building [Block Protocol] blocks |
 
-## Internal unpublished libraries
-
 The packages inside of [`@local`](./@local) are libraries used inside this repository which are **not** published to package managers. All of these libraries may be subject to breaking changes. External consumers should be especially careful when using or upgrading these.
 
 The following list is a non-exhaustive list of packages in `@local`:

--- a/libs/README.md
+++ b/libs/README.md
@@ -42,7 +42,7 @@ Although published to package managers, the following libraries were developed f
 | [@hashintel/design-system]       | TypeScript  | [npm](https://www.npmjs.com/package/@hashintel/design-system)       | To be written | A collection of styleguide-aligned reusable UI primitives for [HASH] and our [hash.ai] website       |
 | [@hashintel/block-design-system] | TypeScript  | [npm](https://www.npmjs.com/package/@hashintel/block-design-system) | To be written | A relatively unopinionated set of reusable UI primitives for use in building [Block Protocol] blocks |
 
-The packages inside of [`@local`](./@local) are libraries used inside this repository which are **not** published to package managers. All of these libraries may be subject to breaking changes. External consumers should be especially careful when using or upgrading these.
+Those packages inside of [`@local`](./@local) are libraries used inside this repository which are **not** published to package managers. All of these libraries may be subject to breaking changes. External consumers should be especially careful when using or upgrading these.
 
 The following list is a non-exhaustive list of packages in `@local`:
 

--- a/libs/README.md
+++ b/libs/README.md
@@ -44,17 +44,17 @@ Although published to package managers, the following libraries were developed f
 
 ## Internal unpublished libraries
 
-The packages inside of [`@local`](./@local) are libraries used inside the repository and are not published to package managers. all of these libraries may be subject to breaking changes. External consumers should be especially careful when using or upgrading these.
+The packages inside of [`@local`](./@local) are libraries used inside this repository which are **not** published to package managers. All of these libraries may be subject to breaking changes. External consumers should be especially careful when using or upgrading these.
 
 The following list is a non-exhaustive list of packages in `@local`:
 
 | Package                                                         | Language(s) | Docs URL      | Description                                                                                                       |
 | --------------------------------------------------------------- | ----------- | ------------- | ----------------------------------------------------------------------------------------------------------------- |
 | [@local/codec-rs](@local/codec)                                 | Rust        | Not hosted    | Implementation of different `serde` or byte codes used in HASH                                                    |
-| [@local/hash-authorization-rs](@local/hash-authorization)       | Rust        | Not hosted    | Provides the Authorization interface and logic used in the Graph                                                  |
-| [@local/hash-graph-client](@local/hash-graph-client/typescript) | Typescript  | To be written | A generator to create a TypeScript/JavaScript client for the Graph API                                            |
+| [@local/hash-authorization-rs](@local/hash-authorization)       | Rust        | Not hosted    | Provides the authorization interface and logic used in the Graph                                                  |
+| [@local/hash-graph-client](@local/hash-graph-client/typescript) | TypeScript  | To be written | A generator to create a TypeScript/JavaScript client for the Graph API                                            |
 | [@local/hash-graph-client-py](@local/hash-graph-client/python)  | Python      | To be written | A generator to create a Python client for the Graph API                                                           |
-| [@local/hash-graph-sdk-py](@local/hash-graph-sdk/python)        | Python      | To be written | A High-level interface for the HASH Graph API, providing several convenience methods for interacting with the API |
+| [@local/hash-graph-sdk-py](@local/hash-graph-sdk/python)        | Python      | To be written | A high-level interface for the HASH Graph API, providing several convenience methods for interacting with the API |
 | [@local/hash-graph-types-rs](@local/hash-graph-types/rust)      | Rust        | Not hosted    | Types used inside of the Graph API                                                                                |
 | [@local/hash-graph-types-py](@local/hash-graph-types/python)    | Python      | To be written | Utility library to convert Block Protocol ontology schemas to Python Pydantic models.                             |
 | [@local/temporal-versioning-rs](@local/temporal-versioning)     | Rust        | Not hosted    | Implementation of temporal versioning                                                                             |

--- a/libs/README.md
+++ b/libs/README.md
@@ -42,6 +42,23 @@ Although published to package managers, the following libraries were developed f
 | [@hashintel/design-system]       | TypeScript  | [npm](https://www.npmjs.com/package/@hashintel/design-system)       | To be written | A collection of styleguide-aligned reusable UI primitives for [HASH] and our [hash.ai] website       |
 | [@hashintel/block-design-system] | TypeScript  | [npm](https://www.npmjs.com/package/@hashintel/block-design-system) | To be written | A relatively unopinionated set of reusable UI primitives for use in building [Block Protocol] blocks |
 
+## Internal unpublished libraries
+
+The packages inside of [`@local`](./@local) are libraries used inside the repository and are not published to package managers. all of these libraries may be subject to breaking changes. External consumers should be especially careful when using or upgrading these.
+
+The following list is a non-exhaustive list of packages in `@local`:
+
+| Package                                                         | Language(s) | Docs URL      | Description                                                                                                       |
+| --------------------------------------------------------------- | ----------- | ------------- | ----------------------------------------------------------------------------------------------------------------- |
+| [@local/codec-rs](@local/codec)                                 | Rust        | Not hosted    | Implementation of different `serde` or byte codes used in HASH                                                    |
+| [@local/hash-authorization-rs](@local/hash-authorization)       | Rust        | Not hosted    | Provides the Authorization interface and logic used in the Graph                                                  |
+| [@local/hash-graph-client](@local/hash-graph-client/typescript) | Typescript  | To be written | A generator to create a TypeScript/JavaScript client for the Graph API                                            |
+| [@local/hash-graph-client-py](@local/hash-graph-client/python)  | Python      | To be written | A generator to create a Python client for the Graph API                                                           |
+| [@local/hash-graph-sdk-py](@local/hash-graph-sdk/python)        | Python      | To be written | A High-level interface for the HASH Graph API, providing several convenience methods for interacting with the API |
+| [@local/hash-graph-types-rs](@local/hash-graph-types/rust)      | Rust        | Not hosted    | Types used inside of the Graph API                                                                                |
+| [@local/hash-graph-types-py](@local/hash-graph-types/python)    | Python      | To be written | Utility library to convert Block Protocol ontology schemas to Python Pydantic models.                             |
+| [@local/temporal-versioning-rs](@local/temporal-versioning)     | Rust        | Not hosted    | Implementation of temporal versioning                                                                             |
+
 ## Contributing
 
 See [CONTRIBUTING.md](../.github/CONTRIBUTING.md).


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To easier see what libraries exist this starts a section on unpublished libraries in the `libs/` folder. I purposefully did that in `libs/` not in `libs/@local` so every library going to be listed in a single file which makes searching for a specific library easier.