### PR TITLE
H-1064: Allow specifying the owner of an entity on creation

### DIFF
--- a/apps/hash-api/src/graph/knowledge/primitive/entity.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity.ts
@@ -45,6 +45,7 @@ export type CreateEntityParams = {
   properties: EntityPropertiesObject;
   entityTypeId: VersionedUrl;
   entityUuid?: EntityUuid;
+  owner?: AccountId | AccountGroupId;
 };
 
 /** @todo: potentially directly export this from the subgraph package */
@@ -75,6 +76,7 @@ export const createEntity: ImpureGraphFunction<
     entityTypeId,
     properties,
     entityUuid: overrideEntityUuid,
+    owner: params.owner ?? ownedById,
   });
 
   return {

--- a/apps/hash-api/src/graph/knowledge/primitive/link-entity.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/link-entity.ts
@@ -1,4 +1,6 @@
 import {
+  AccountGroupId,
+  AccountId,
   Entity,
   EntityId,
   EntityMetadata,
@@ -17,6 +19,7 @@ export type CreateLinkEntityParams = {
   ownedById: OwnedById;
   properties?: EntityPropertiesObject;
   linkEntityType: EntityTypeWithMetadata;
+  owner?: AccountId | AccountGroupId;
   leftEntityId: EntityId;
   leftToRightOrder?: number;
   rightEntityId: EntityId;
@@ -77,6 +80,7 @@ export const createLinkEntity: ImpureGraphFunction<
       linkData,
       entityTypeId: linkEntityType.schema.$id,
       properties,
+      owner: params.owner ?? authentication.actorId,
     },
   );
 

--- a/apps/hash-graph/lib/graph/src/snapshot.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot.rs
@@ -308,13 +308,13 @@ where
                 match relation {
                     WebRelation::DirectOwner => Ok(Web {
                         id,
-                        owners: vec![OwnerId::AccountGroup(account_group)],
+                        owners: vec![OwnerId::AccountGroupMembers(account_group)],
                         editors: Vec::new(),
                     }),
                     WebRelation::DirectEditor => Ok(Web {
                         id,
                         owners: Vec::new(),
-                        editors: vec![OwnerId::AccountGroup(account_group)],
+                        editors: vec![OwnerId::AccountGroupMembers(account_group)],
                     }),
                 }
             });

--- a/apps/hash-graph/lib/graph/src/snapshot/web/channel.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/web/channel.rs
@@ -63,7 +63,7 @@ impl Sink<Web> for WebSender {
                     .start_send_unpin((item.id, relation, account_id))
                     .change_context(SnapshotRestoreError::Read)
                     .attach_printable("could not send web account relation owner")?,
-                OwnerId::AccountGroup(account_group_id) => self
+                OwnerId::AccountGroupMembers(account_group_id) => self
                     .web_account_group_relation
                     .start_send_unpin((
                         item.id,

--- a/apps/hash-graph/lib/graph/src/store.rs
+++ b/apps/hash-graph/lib/graph/src/store.rs
@@ -16,7 +16,7 @@ mod postgres;
 use async_trait::async_trait;
 
 pub use self::{
-    account::{AccountOrAccountGroup, AccountStore},
+    account::AccountStore,
     config::{DatabaseConnectionInfo, DatabaseType},
     error::{
         BaseUrlAlreadyExists, InsertionError, OntologyVersionDoesNotExist, QueryError, StoreError,

--- a/apps/hash-graph/lib/graph/src/store/account.rs
+++ b/apps/hash-graph/lib/graph/src/store/account.rs
@@ -1,11 +1,10 @@
 use async_trait::async_trait;
-use authorization::{schema::OwnerId, AuthorizationApi, EntitySubject};
+use authorization::{schema::OwnerId, AuthorizationApi};
 use error_stack::Result;
 use graph_types::{
     account::{AccountGroupId, AccountId},
     provenance::OwnedById,
 };
-use serde::Serialize;
 
 use crate::store::{InsertionError, QueryError};
 
@@ -42,37 +41,5 @@ pub trait AccountStore {
     ///
     /// - if the [`OwnedById`] does not exist
     /// - if the [`OwnedById`] exists but is both, an [`AccountId`] and an [`AccountGroupId`]
-    async fn identify_owned_by_id(
-        &self,
-        owned_by_id: OwnedById,
-    ) -> Result<AccountOrAccountGroup, QueryError>;
-}
-
-#[derive(Debug, Copy, Clone, Serialize)]
-#[serde(untagged)]
-pub enum AccountOrAccountGroup {
-    Account(AccountId),
-    AccountGroup(AccountGroupId),
-}
-
-impl From<AccountOrAccountGroup> for EntitySubject {
-    fn from(id: AccountOrAccountGroup) -> Self {
-        match id {
-            AccountOrAccountGroup::Account(account_id) => Self::Account(account_id),
-            AccountOrAccountGroup::AccountGroup(account_group_id) => {
-                Self::AccountGroupMembers(account_group_id)
-            }
-        }
-    }
-}
-
-impl From<AccountOrAccountGroup> for OwnerId {
-    fn from(id: AccountOrAccountGroup) -> Self {
-        match id {
-            AccountOrAccountGroup::Account(account_id) => Self::Account(account_id),
-            AccountOrAccountGroup::AccountGroup(account_group_id) => {
-                Self::AccountGroup(account_group_id)
-            }
-        }
-    }
+    async fn identify_owned_by_id(&self, owned_by_id: OwnedById) -> Result<OwnerId, QueryError>;
 }

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashSet, mem};
 
 use async_trait::async_trait;
-use authorization::AuthorizationApi;
+use authorization::{schema::OwnerId, AuthorizationApi};
 use error_stack::{Report, Result, ResultExt};
 use graph_types::{
     account::{AccountGroupId, AccountId},
@@ -32,9 +32,8 @@ use crate::{
     store::{
         crud::Read,
         query::{Filter, OntologyQueryPath},
-        AccountOrAccountGroup, AccountStore, ConflictBehavior, DataTypeStore, EntityStore,
-        EntityTypeStore, InsertionError, PropertyTypeStore, QueryError, Record, StoreError,
-        StorePool, UpdateError,
+        AccountStore, ConflictBehavior, DataTypeStore, EntityStore, EntityTypeStore,
+        InsertionError, PropertyTypeStore, QueryError, Record, StoreError, StorePool, UpdateError,
     },
     subgraph::{
         edges::GraphResolveDepths,
@@ -603,10 +602,7 @@ where
             .await
     }
 
-    async fn identify_owned_by_id(
-        &self,
-        owned_by_id: OwnedById,
-    ) -> Result<AccountOrAccountGroup, QueryError> {
+    async fn identify_owned_by_id(&self, owned_by_id: OwnedById) -> Result<OwnerId, QueryError> {
         self.store.identify_owned_by_id(owned_by_id).await
     }
 }
@@ -865,6 +861,7 @@ where
         actor_id: AccountId,
         authorization_api: &mut Au,
         owned_by_id: OwnedById,
+        owner: OwnerId,
         entity_uuid: Option<EntityUuid>,
         decision_time: Option<Timestamp<DecisionTime>>,
         archived: bool,
@@ -887,6 +884,7 @@ where
                 actor_id,
                 authorization_api,
                 owned_by_id,
+                owner,
                 entity_uuid,
                 decision_time,
                 archived,

--- a/apps/hash-graph/lib/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/lib/graph/src/store/knowledge.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use authorization::AuthorizationApi;
+use authorization::{schema::OwnerId, AuthorizationApi};
 use error_stack::Result;
 use graph_types::{
     account::AccountId,
@@ -38,6 +38,7 @@ pub trait EntityStore: crud::Read<Entity> {
         actor_id: AccountId,
         authorization_api: &mut A,
         owned_by_id: OwnedById,
+        owner: OwnerId,
         entity_uuid: Option<EntityUuid>,
         decision_time: Option<Timestamp<DecisionTime>>,
         archived: bool,

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -292,7 +292,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
 
         transaction
             .as_client()
-            .query_one(
+            .query(
                 "
                     INSERT INTO entity_ids (owned_by_id, entity_uuid)
                     VALUES ($1, $2);

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -10,7 +10,7 @@ use authorization::{
 };
 use error_stack::{Report, Result, ResultExt};
 use graph_types::{
-    account::{AccountGroupId, AccountId},
+    account::AccountId,
     knowledge::{
         entity::{
             Entity, EntityEditionId, EntityId, EntityMetadata, EntityProperties, EntityRecordId,
@@ -266,6 +266,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         actor_id: AccountId,
         authorization_api: &mut A,
         owned_by_id: OwnedById,
+        owner: OwnerId,
         entity_uuid: Option<EntityUuid>,
         decision_time: Option<Timestamp<DecisionTime>>,
         archived: bool,
@@ -289,33 +290,17 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
 
         let transaction = self.transaction().await.change_context(InsertionError)?;
 
-        let is_account_group: bool = transaction
+        transaction
             .as_client()
             .query_one(
                 "
-                    WITH inserted_owners AS (
-                        INSERT INTO entity_ids (owned_by_id, entity_uuid)
-                        VALUES ($1, $2)
-                        RETURNING owned_by_id
-                    )
-                    SELECT EXISTS (
-                        SELECT 1
-                        FROM account_groups
-                        JOIN inserted_owners ON account_group_id = inserted_owners.owned_by_id
-                    );
+                    INSERT INTO entity_ids (owned_by_id, entity_uuid)
+                    VALUES ($1, $2);
                 ",
                 &[&entity_id.owned_by_id, &entity_id.entity_uuid],
             )
             .await
-            .change_context(InsertionError)?
-            .get(0);
-
-        let owned_by_uuid = owned_by_id.into_uuid();
-        let visibility_scope = if is_account_group {
-            OwnerId::AccountGroup(AccountGroupId::new(owned_by_uuid))
-        } else {
-            OwnerId::Account(AccountId::new(owned_by_uuid))
-        };
+            .change_context(InsertionError)?;
 
         let link_order = if let Some(link_data) = link_data {
             transaction
@@ -432,13 +417,13 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         };
 
         authorization_api
-            .add_entity_owner(visibility_scope, entity_id)
+            .add_entity_owner(owner, entity_id)
             .await
             .change_context(InsertionError)?;
 
         if let Err(mut error) = transaction.commit().await.change_context(InsertionError) {
             if let Err(auth_error) = authorization_api
-                .remove_entity_owner(visibility_scope, entity_id)
+                .remove_entity_owner(owner, entity_id)
                 .await
                 .change_context(InsertionError)
             {

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -1986,7 +1986,8 @@
         "required": [
           "properties",
           "entityTypeId",
-          "ownedById"
+          "ownedById",
+          "owner"
         ],
         "properties": {
           "entityTypeId": {
@@ -2007,6 +2008,9 @@
             ]
           },
           "ownedById": {
+            "$ref": "#/components/schemas/OwnedById"
+          },
+          "owner": {
             "$ref": "#/components/schemas/OwnedById"
           },
           "properties": {

--- a/apps/hash-graph/tests/circular-links.http
+++ b/apps/hash-graph/tests/circular-links.http
@@ -59,6 +59,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "ownedById": "{{account_id}}",
   "properties": {},
   "entityTypeId": "http://localhost:3000/@snapshot/types/entity-type/object/v/1",
+  "owner": "{{account_id}}",
   "entityUuid": "0000000A-0001-0000-0000-000000000000"
 }
 
@@ -79,6 +80,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "ownedById": "{{account_id}}",
   "properties": {},
   "entityTypeId": "http://localhost:3000/@snapshot/types/entity-type/object/v/1",
+  "owner": "{{account_id}}",
   "entityUuid": "0000000B-0001-0000-0000-000000000000"
 }
 
@@ -99,6 +101,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "ownedById": "{{account_id}}",
   "properties": {},
   "entityTypeId": "http://localhost:3000/@snapshot/types/entity-type/object/v/1",
+  "owner": "{{account_id}}",
   "entityUuid": "0000000C-0001-0000-0000-000000000000"
 }
 
@@ -119,6 +122,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "ownedById": "{{account_id}}",
   "properties": {},
   "entityTypeId": "http://localhost:3000/@snapshot/types/entity-type/object/v/1",
+  "owner": "{{account_id}}",
   "entityUuid": "0000000D-0001-0000-0000-000000000000"
 }
 
@@ -140,6 +144,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "properties": {},
   "entityTypeId": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1",
   "entityUuid": "000000AB-0001-0000-0000-000000000000",
+  "owner": "{{account_id}}",
   "linkData": {
     "leftEntityId": "{{entity_a}}",
     "rightEntityId": "{{entity_b}}"
@@ -163,6 +168,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "properties": {},
   "entityTypeId": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1",
   "entityUuid": "000000BC-0001-0000-0000-000000000000",
+  "owner": "{{account_id}}",
   "linkData": {
     "leftEntityId": "{{entity_b}}",
     "rightEntityId": "{{entity_c}}"
@@ -186,6 +192,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "properties": {},
   "entityTypeId": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1",
   "entityUuid": "000000CD-0001-0000-0000-000000000000",
+  "owner": "{{account_id}}",
   "linkData": {
     "leftEntityId": "{{entity_c}}",
     "rightEntityId": "{{entity_d}}"
@@ -209,6 +216,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "properties": {},
   "entityTypeId": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1",
   "entityUuid": "000000DA-0001-0000-0000-000000000000",
+  "owner": "{{account_id}}",
   "linkData": {
     "leftEntityId": "{{entity_d}}",
     "rightEntityId": "{{entity_a}}"
@@ -233,6 +241,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "properties": {},
   "entityTypeId": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1",
   "entityUuid": "000000BA-0001-0000-0000-000000000000",
+  "owner": "{{account_id}}",
   "linkData": {
     "leftEntityId": "{{entity_b}}",
     "rightEntityId": "{{entity_a}}"
@@ -258,6 +267,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "properties": {},
   "entityTypeId": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1",
   "entityUuid": "000000CB-0001-0000-0000-000000000000",
+  "owner": "{{account_id}}",
   "linkData": {
     "leftEntityId": "{{entity_c}}",
     "rightEntityId": "{{entity_b}}"
@@ -283,6 +293,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "properties": {},
   "entityTypeId": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1",
   "entityUuid": "000000DC-0001-0000-0000-000000000000",
+  "owner": "{{account_id}}",
   "linkData": {
     "leftEntityId": "{{entity_d}}",
     "rightEntityId": "{{entity_c}}"
@@ -308,6 +319,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "properties": {},
   "entityTypeId": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1",
   "entityUuid": "000000AD-0001-0000-0000-000000000000",
+  "owner": "{{account_id}}",
   "linkData": {
     "leftEntityId": "{{entity_a}}",
     "rightEntityId": "{{entity_d}}"

--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -1137,6 +1137,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "properties": {
     "http://localhost:3000/@alice/types/property-type/name/": "Alice"
   },
+  "owner": "{{account_id}}",
   "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/1"
 }
 
@@ -1265,6 +1266,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "properties": {
     "http://localhost:3000/@alice/types/property-type/name/": "Bob"
   },
+  "owner": "{{account_id}}",
   "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/1"
 }
 
@@ -1349,6 +1351,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "ownedById": "{{account_id}}",
   "properties": {},
   "entityTypeId": "{{friendship_link_entity_type_id}}",
+  "owner": "{{account_id}}",
   "linkData": {
     "leftEntityId": "{{person_a_entity_id}}",
     "rightEntityId": "{{person_b_entity_id}}"

--- a/apps/hash-integration-worker/src/activities.ts
+++ b/apps/hash-integration-worker/src/activities.ts
@@ -127,6 +127,7 @@ const createOrUpdateHashEntity = async (params: {
   if (entities.length === 0 && params.workspaceOwnedById) {
     await params.graphApiClient.createEntity(params.authentication.actorId, {
       ownedById: params.workspaceOwnedById,
+      owner: params.workspaceOwnedById,
       ...params.entity,
     });
   }

--- a/libs/@local/hash-authorization/src/api.rs
+++ b/libs/@local/hash-authorization/src/api.rs
@@ -28,6 +28,17 @@ pub enum EntitySubject {
     AccountGroupMembers(AccountGroupId),
 }
 
+impl From<OwnerId> for EntitySubject {
+    fn from(id: OwnerId) -> Self {
+        match id {
+            OwnerId::Account(account_id) => Self::Account(account_id),
+            OwnerId::AccountGroupMembers(account_group_id) => {
+                Self::AccountGroupMembers(account_group_id)
+            }
+        }
+    }
+}
+
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum AccountOrPublic {

--- a/libs/@local/hash-authorization/src/schema/web.rs
+++ b/libs/@local/hash-authorization/src/schema/web.rs
@@ -12,19 +12,7 @@ use crate::zanzibar::{Affiliation, Permission, Relation, Resource};
 #[serde(rename_all = "camelCase", tag = "type", content = "id")]
 pub enum OwnerId {
     Account(AccountId),
-    AccountGroup(AccountGroupId),
-}
-
-impl From<AccountId> for OwnerId {
-    fn from(account_id: AccountId) -> Self {
-        Self::Account(account_id)
-    }
-}
-
-impl From<AccountGroupId> for OwnerId {
-    fn from(account_group_id: AccountGroupId) -> Self {
-        Self::AccountGroup(account_group_id)
-    }
+    AccountGroupMembers(AccountGroupId),
 }
 
 impl Resource for WebId {

--- a/libs/@local/hash-authorization/src/zanzibar/api.rs
+++ b/libs/@local/hash-authorization/src/zanzibar/api.rs
@@ -95,7 +95,7 @@ where
                     .create_relations([(web, WebRelation::DirectOwner, account)])
                     .await
             }
-            OwnerId::AccountGroup(account_group) => {
+            OwnerId::AccountGroupMembers(account_group) => {
                 self.backend
                     .create_relations([(
                         web,
@@ -121,7 +121,7 @@ where
                     .delete_relations([(web, WebRelation::DirectOwner, account)])
                     .await
             }
-            OwnerId::AccountGroup(account_group) => {
+            OwnerId::AccountGroupMembers(account_group) => {
                 self.backend
                     .delete_relations([(
                         web,
@@ -147,7 +147,7 @@ where
                     .create_relations([(web, WebRelation::DirectEditor, account)])
                     .await
             }
-            OwnerId::AccountGroup(account_group) => {
+            OwnerId::AccountGroupMembers(account_group) => {
                 self.backend
                     .create_relations([(
                         web,
@@ -173,7 +173,7 @@ where
                     .delete_relations([(web, WebRelation::DirectEditor, account)])
                     .await
             }
-            OwnerId::AccountGroup(account_group) => {
+            OwnerId::AccountGroupMembers(account_group) => {
                 self.backend
                     .delete_relations([(
                         web,
@@ -307,7 +307,7 @@ where
                     .create_relations([(entity.entity_uuid, EntityRelation::DirectOwner, account)])
                     .await
             }
-            OwnerId::AccountGroup(account_group) => {
+            OwnerId::AccountGroupMembers(account_group) => {
                 self.backend
                     .create_relations([(
                         entity.entity_uuid,
@@ -333,7 +333,7 @@ where
                     .delete_relations([(entity.entity_uuid, EntityRelation::DirectOwner, account)])
                     .await
             }
-            OwnerId::AccountGroup(account_group) => {
+            OwnerId::AccountGroupMembers(account_group) => {
                 self.backend
                     .delete_relations([(
                         entity.entity_uuid,
@@ -359,7 +359,7 @@ where
                     .create_relations([(entity.entity_uuid, EntityRelation::DirectEditor, account)])
                     .await
             }
-            OwnerId::AccountGroup(account_group) => {
+            OwnerId::AccountGroupMembers(account_group) => {
                 self.backend
                     .create_relations([(
                         entity.entity_uuid,
@@ -385,7 +385,7 @@ where
                     .delete_relations([(entity.entity_uuid, EntityRelation::DirectEditor, account)])
                     .await
             }
-            OwnerId::AccountGroup(account_group) => {
+            OwnerId::AccountGroupMembers(account_group) => {
                 self.backend
                     .delete_relations([(
                         entity.entity_uuid,

--- a/libs/@local/hash-graph-client/python/graph_client/models.py
+++ b/libs/@local/hash-graph-client/python/graph_client/models.py
@@ -817,6 +817,7 @@ class CreateEntityRequest(BaseModel):
     entity_uuid: EntityUuid | None = Field(None, alias="entityUuid")
     link_data: LinkData | None = Field(None, alias="linkData")
     owned_by_id: OwnedById = Field(..., alias="ownedById")
+    owner: OwnedById
     properties: EntityProperties
 
 

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -13,7 +13,7 @@ mod property_type;
 
 use std::{borrow::Cow, str::FromStr};
 
-use authorization::NoAuthorization;
+use authorization::{schema::OwnerId, NoAuthorization};
 use error_stack::Result;
 use graph::{
     knowledge::EntityQueryPath,
@@ -419,6 +419,7 @@ impl DatabaseApi<'_> {
                 self.account_id,
                 &mut NoAuthorization,
                 OwnedById::new(self.account_id.into_uuid()),
+                OwnerId::Account(self.account_id),
                 entity_uuid,
                 Some(generate_decision_time()),
                 false,
@@ -543,6 +544,7 @@ impl DatabaseApi<'_> {
                 self.account_id,
                 &mut NoAuthorization,
                 OwnedById::new(self.account_id.into_uuid()),
+                OwnerId::Account(self.account_id),
                 entity_uuid,
                 None,
                 false,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For thinks like comments it's desired that the `ownedById` is not the same as the owner (we're going to rename `ownedById` at some later point).

## 🔗 Related links

- H-1064

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph