### PR TITLE
H-1072: Fix environment variable for authorization

### DIFF
--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -233,7 +233,7 @@ module "application" {
     { name = "HASH_GRAPH_PG_HOST", secret = false, value = module.postgres.pg_host },
     { name = "HASH_GRAPH_PG_PORT", secret = false, value = module.postgres.pg_port },
     { name = "HASH_GRAPH_PG_DATABASE", secret = false, value = "graph" },
-    { name = "HASH_SPICEDB_HOST", secret = false, value = "127.0.0.1" },
+    { name = "HASH_SPICEDB_HOST", secret = false, value = "http://127.0.0.1" },
     { name = "HASH_SPICEDB_HTTP_PORT", secret = false, value = "8443" },
     { name = "HASH_SPICEDB_GRPC_PRESHARED_KEY", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["spicedb_grpc_preshared_key"]) },
   ])

--- a/libs/@local/hash-authorization/src/backend/spicedb/api.rs
+++ b/libs/@local/hash-authorization/src/backend/spicedb/api.rs
@@ -67,12 +67,14 @@ impl SpiceDbOpenApi {
         path: &'static str,
         body: &(impl Serialize + Sync),
     ) -> Result<Response, Report<InvocationError>> {
+        let url = format!("{}{}", self.base_path, path);
         let request = self
             .client
-            .post(format!("{}{}", self.base_path, path))
+            .post(&url)
             .json(&body)
             .build()
-            .change_context(InvocationError::Request)?;
+            .change_context(InvocationError::Request)
+            .attach_printable(url)?;
 
         let response = self
             .client


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

While testing if authorization works in prod I noticed a minor issue with an environment variable. To have a better error output I attached the URL on error.

## 🔗 Related links

- H-1072


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph