### PR TITLE
H-925: Enable authorization on `hash.ai`

### DIFF
--- a/apps/hash-graph/docker/Dockerfile
+++ b/apps/hash-graph/docker/Dockerfile
@@ -44,7 +44,7 @@ WORKDIR /usr/local/src/apps/hash-graph
 
 ARG PROFILE=production
 ARG ENABLE_TEST_SERVER=no
-ARG ENABLE_AUTHORIZATION=no
+ARG ENABLE_AUTHORIZATION=yes
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \

--- a/apps/hash-graph/package.json
+++ b/apps/hash-graph/package.json
@@ -12,10 +12,10 @@
     }
   },
   "scripts": {
-    "build:docker": "docker buildx build --build-arg PROFILE=dev --build-arg ENABLE_AUTHORIZATION=yes --tag hash-graph --file docker/Dockerfile ../../",
-    "build:docker:offline": "docker buildx build --build-arg PROFILE=dev --build-arg ENABLE_AUTHORIZATION=yes --build-arg ENABLE_TYPE_FETCHER=no --tag hash-graph --file docker/Dockerfile ../../",
+    "build:docker": "docker buildx build --build-arg PROFILE=dev --tag hash-graph --file docker/Dockerfile ../../",
+    "build:docker:offline": "docker buildx build --build-arg PROFILE=dev --build-arg ENABLE_TYPE_FETCHER=no --tag hash-graph --file docker/Dockerfile ../../",
     "build:docker:prod": "docker buildx build --build-arg PROFILE=production --tag hash-graph --tag hash-graph:prod --file docker/Dockerfile ../../",
-    "build:docker:test": "docker buildx build --build-arg PROFILE=dev --build-arg ENABLE_AUTHORIZATION=yes --build-arg ENABLE_TEST_SERVER=yes --tag hash-graph --tag hash-graph:test --file docker/Dockerfile ../../",
+    "build:docker:test": "docker buildx build --build-arg PROFILE=dev --build-arg ENABLE_TEST_SERVER=yes --tag hash-graph --tag hash-graph:test --file docker/Dockerfile ../../",
     "codegen:generate-openapi-specs": "just generate-openapi-specs",
     "exe": "ts-node",
     "fix:clippy": "just clippy --fix",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Enables authorization by default when building the docker image without parameters

## 🔗 Related links

- H-925

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

- [ ] H-756
- [ ] H-921

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- ...

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- do not affect the execution graph