### PR TITLE
H-888: Implement loading skeleton when Glide table is loading

### DIFF
--- a/apps/hash-frontend/src/pages/shared/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table.tsx
@@ -98,16 +98,15 @@ export const EntitiesTable: FunctionComponent<{
     [entities, filterState, activeWorkspaceOwnedById],
   );
 
-  const { columns, rows } =
-    useEntitiesTable({
-      entities: filteredEntities,
-      entityTypes,
-      propertyTypes,
-      subgraph,
-      hideEntityTypeVersionColumn,
-      hidePropertiesColumns,
-      isViewingPages,
-    }) ?? {};
+  const { columns, rows } = useEntitiesTable({
+    entities: filteredEntities,
+    entityTypes,
+    propertyTypes,
+    subgraph,
+    hideEntityTypeVersionColumn,
+    hidePropertiesColumns,
+    isViewingPages,
+  });
 
   const [selectedRows, setSelectedRows] = useState<TypeEntitiesRow[]>([]);
 
@@ -118,7 +117,7 @@ export const EntitiesTable: FunctionComponent<{
         | TextCell
         | BlankCell
         | CustomCell => {
-        const columnId = columns?.[colIndex]?.id;
+        const columnId = columns[colIndex]?.id;
         if (columnId) {
           const row = entityRows[rowIndex];
 
@@ -231,36 +230,34 @@ export const EntitiesTable: FunctionComponent<{
         toggleSearch={() => setShowSearch(true)}
         onBulkActionCompleted={() => setSelectedRows([])}
       />
-      {columns && rows ? (
-        <Grid
-          showSearch={showSearch}
-          onSearchClose={() => setShowSearch(false)}
-          columns={columns}
-          rows={rows}
-          enableCheckboxSelection
-          selectedRows={selectedRows}
-          onSelectedRowsChange={(updatedSelectedRows) =>
-            setSelectedRows(updatedSelectedRows)
-          }
-          firstColumnLeftPadding={16}
-          height={`
+      <Grid
+        showSearch={showSearch}
+        onSearchClose={() => setShowSearch(false)}
+        columns={columns}
+        rows={rows}
+        enableCheckboxSelection
+        selectedRows={selectedRows}
+        onSelectedRowsChange={(updatedSelectedRows) =>
+          setSelectedRows(updatedSelectedRows)
+        }
+        firstColumnLeftPadding={16}
+        height={`
             min(
               calc(100vh - (${
                 HEADER_HEIGHT + TOP_CONTEXT_BAR_HEIGHT + 179 + tableHeaderHeight
               }px + ${theme.spacing(5)} + ${theme.spacing(5)})),
              calc(
               ${gridHeaderHeightWithBorder}px +
-              (${rows.length} * ${gridRowHeight}px) +
+              (${rows ? rows.length : 1} * ${gridRowHeight}px) +
               ${gridHorizontalScrollbarHeight}px)
             )`}
-          createGetCellContent={createGetCellContent}
-          customRenderers={[
-            createRenderTextIconCell({ firstColumnLeftPadding: 16 }),
-            renderChipCell,
-          ]}
-          freezeColumns={1}
-        />
-      ) : null}
+        createGetCellContent={createGetCellContent}
+        customRenderers={[
+          createRenderTextIconCell({ firstColumnLeftPadding: 16 }),
+          renderChipCell,
+        ]}
+        freezeColumns={1}
+      />
     </Box>
   );
 };

--- a/apps/hash-frontend/src/pages/types/[[...type-kind]].page.tsx
+++ b/apps/hash-frontend/src/pages/types/[[...type-kind]].page.tsx
@@ -136,12 +136,12 @@ const TypesPage: NextPageWithLayout<TypesPageProps> = ({ currentTab }) => {
       currentTab === "all"
         ? allTypes
         : currentTab === "entity-type"
-        ? latestNonLinkEntityTypes ?? []
+        ? latestNonLinkEntityTypes
         : currentTab === "link-type"
-        ? latestLinkEntityTypes ?? []
+        ? latestLinkEntityTypes
         : currentTab === "property-type"
-        ? latestPropertyTypes ?? []
-        : latestDataTypes ?? [],
+        ? latestPropertyTypes
+        : latestDataTypes,
     [
       currentTab,
       allTypes,
@@ -210,7 +210,7 @@ const TypesPage: NextPageWithLayout<TypesPageProps> = ({ currentTab }) => {
         </Container>
       </Box>
       <Container sx={{ paddingTop: 5, maxWidth: { lg: contentMaxWidth } }}>
-        <TypesTable kind={currentTab} types={currentTypes ?? []} />
+        <TypesTable kind={currentTab} types={currentTypes} />
       </Container>
     </>
   );

--- a/apps/hash-frontend/src/pages/types/[[...type-kind]].page/types-table.tsx
+++ b/apps/hash-frontend/src/pages/types/[[...type-kind]].page/types-table.tsx
@@ -69,7 +69,7 @@ type TypesTableRow = {
 };
 
 export const TypesTable: FunctionComponent<{
-  types: (
+  types?: (
     | EntityTypeWithMetadata
     | PropertyTypeWithMetadata
     | DataTypeWithMetadata
@@ -130,10 +130,10 @@ export const TypesTable: FunctionComponent<{
     [users, orgs],
   );
 
-  const filteredRows = useMemo<TypesTableRow[]>(
+  const filteredRows = useMemo<TypesTableRow[] | undefined>(
     () =>
       types
-        .map((type) => {
+        ?.map((type) => {
           const isExternal = isExternalOntologyElementMetadata(type.metadata)
             ? true
             : type.metadata.custom.ownedById !== activeWorkspaceOwnedById;
@@ -254,7 +254,7 @@ export const TypesTable: FunctionComponent<{
         items={types}
         filterState={filterState}
         setFilterState={setFilterState}
-        selectedItems={types.filter((type) =>
+        selectedItems={types?.filter((type) =>
           selectedRows.some(({ typeId }) => type.schema.$id === typeId),
         )}
         onBulkActionCompleted={() => setSelectedRows([])}
@@ -280,7 +280,7 @@ export const TypesTable: FunctionComponent<{
             }px + ${theme.spacing(5)}) - ${theme.spacing(5)}),
             calc(
               ${gridHeaderHeightWithBorder}px +
-              (${filteredRows.length} * ${gridRowHeight}px) +
+              (${filteredRows ? filteredRows.length : 1} * ${gridRowHeight}px) +
               ${gridHorizontalScrollbarHeight}px
             )
           )`}

--- a/apps/hash-frontend/src/shared/table-header.tsx
+++ b/apps/hash-frontend/src/shared/table-header.tsx
@@ -102,13 +102,13 @@ export type FilterState = {
 
 type TableHeaderProps = {
   itemLabelPlural: "entities" | "pages" | "types";
-  items: (
+  items?: (
     | Entity
     | EntityTypeWithMetadata
     | PropertyTypeWithMetadata
     | DataTypeWithMetadata
   )[];
-  selectedItems: (
+  selectedItems?: (
     | Entity
     | EntityTypeWithMetadata
     | PropertyTypeWithMetadata
@@ -150,7 +150,7 @@ export const TableHeader: FunctionComponent<TableHeaderProps> = ({
 
   const numberOfUserWebItems = useMemo(
     () =>
-      items.filter(({ metadata }) =>
+      items?.filter(({ metadata }) =>
         "entityTypeId" in metadata
           ? userWebIds.includes(
               extractOwnedByIdFromEntityId(metadata.recordId.entityId),
@@ -162,7 +162,10 @@ export const TableHeader: FunctionComponent<TableHeaderProps> = ({
     [items, userWebIds],
   );
 
-  const numberOfGlobalItems = items.length - numberOfUserWebItems;
+  const numberOfGlobalItems =
+    items && typeof numberOfUserWebItems !== "undefined"
+      ? items.length - numberOfUserWebItems
+      : undefined;
 
   return (
     <Box
@@ -182,7 +185,7 @@ export const TableHeader: FunctionComponent<TableHeaderProps> = ({
       }}
     >
       <Box display="flex" gap={1.5} alignItems="center">
-        {selectedItems.length ? (
+        {selectedItems && selectedItems.length ? (
           <BulkActionsDropdown
             selectedItems={selectedItems}
             onBulkActionCompleted={onBulkActionCompleted}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR adds a loading state to the `Grid` component, when the provided `rows` are set to `undefined`. This loading state is now displayed for the entities and types tables whilst the rows are loading (so on the `/entities`, `/pages` and `/types` pages).

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-888

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Go to the `/entities` page in the deployment, and observe the loading state.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->


https://github.com/hashintel/hash/assets/42802102/d317e0ab-adf4-4d7d-9a41-045ab8d434c0


