### PR TITLE
H-1070: Fix Graph API crash when attempting to remove entity owner

### DIFF
--- a/apps/hash-graph/Cargo.lock
+++ b/apps/hash-graph/Cargo.lock
@@ -120,6 +120,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tokio",
  "tokio-util",
  "utoipa",
 ]

--- a/libs/@local/hash-authorization/Cargo.toml
+++ b/libs/@local/hash-authorization/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = { version = "1.0.107" }
 
 reqwest = { version = "0.11.22", default-features = false, features = ["json", "stream"] }
 tokio-util = { version ="0.7.9", features = ["io"] }
+tokio = { version = "1.33.0", default-features = false }
 
 utoipa = { version = "4.0.0", optional = true }
 

--- a/libs/@local/hash-authorization/src/backend/spicedb/api.rs
+++ b/libs/@local/hash-authorization/src/backend/spicedb/api.rs
@@ -4,6 +4,7 @@ use error_stack::{Report, ResultExt};
 use futures::{Stream, StreamExt, TryStreamExt};
 use reqwest::Response;
 use serde::{de::DeserializeOwned, ser::SerializeStruct, Deserialize, Serialize, Serializer};
+use tokio::time::sleep;
 use tokio_util::{codec::FramedRead, io::StreamReader};
 
 use crate::{
@@ -170,22 +171,42 @@ impl SpiceDbOpenApi {
             written_at: model::ZedToken,
         }
 
-        let response = self
-            .call::<RequestResponse>(
-                "/v1/relationships/write",
-                &RequestBody {
-                    updates: operations
-                        .into_iter()
-                        .map(|(operation, tuple)| RelationshipUpdate::<T> {
-                            operation,
-                            relationship: model::Relationship(tuple),
-                        })
-                        .collect(),
-                },
-            )
-            .await?;
+        let request_body = RequestBody {
+            updates: operations
+                .into_iter()
+                .map(|(operation, tuple)| RelationshipUpdate::<T> {
+                    operation,
+                    relationship: model::Relationship(tuple),
+                })
+                .collect(),
+        };
 
-        Ok(response.written_at.into())
+        let max_attempts = 3_u32;
+        let mut attempt = 0;
+        loop {
+            let invocation = self
+                .call::<RequestResponse>("/v1/relationships/write", &request_body)
+                .await;
+
+            match invocation {
+                Ok(response) => return Ok(response.written_at.into()),
+                Err(report) => match report.current_context() {
+                    InvocationError::Api(RpcError { code: 2, .. }) => {
+                        if attempt == max_attempts {
+                            return Err(report);
+                        }
+
+                        attempt += 1;
+                        // TODO: Use a more customizable backoff
+                        //       current: 10ms, 40ms, 90ms
+                        sleep(std::time::Duration::from_millis(10) * attempt * attempt).await;
+
+                        continue;
+                    }
+                    _ => return Err(report),
+                },
+            }
+        }
     }
 }
 

--- a/libs/@local/hash-authorization/src/backend/spicedb/api.rs
+++ b/libs/@local/hash-authorization/src/backend/spicedb/api.rs
@@ -193,17 +193,15 @@ impl SpiceDbOpenApi {
                 Err(report) => match report.current_context() {
                     InvocationError::Api(RpcError { code: 2, .. }) => {
                         if attempt == max_attempts {
-                            return Err(report);
+                            break Err(report);
                         }
 
                         attempt += 1;
                         // TODO: Use a more customizable backoff
                         //       current: 10ms, 40ms, 90ms
                         sleep(std::time::Duration::from_millis(10) * attempt * attempt).await;
-
-                        continue;
                     }
-                    _ => return Err(report),
+                    _ => break Err(report),
                 },
             }
         }

--- a/libs/@local/hash-authorization/src/backend/spicedb/model.rs
+++ b/libs/@local/hash-authorization/src/backend/spicedb/model.rs
@@ -10,7 +10,7 @@ use crate::zanzibar::{self, Resource, Tuple};
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct RpcError {
-    code: i32,
+    pub(crate) code: i32,
     message: String,
     #[serde(default)]
     #[expect(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With too many write operations at the same time a data race may happen. To avoid this, this adds a very primitive retry solution which attempts to retry the request three times.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph