### PR TITLE
H-1121: Define modify-relationship-API on trait level

### DIFF
--- a/apps/hash-graph/lib/graph/src/snapshot/entity/batch.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/entity/batch.rs
@@ -143,7 +143,7 @@ impl<C: AsClient> WriteBatch<C> for EntityRowBatch {
             }
             Self::Relations(relations) => {
                 authorization_api
-                    .touch_relations(relations)
+                    .touch_relationships(relations)
                     .await
                     .change_context(InsertionError)?;
             }

--- a/apps/hash-graph/lib/graph/src/snapshot/owner/batch.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/owner/batch.rs
@@ -83,7 +83,7 @@ impl<C: AsClient> WriteBatch<C> for AccountRowBatch {
             }
             Self::AccountGroupAccountRelations(relations) => {
                 authorization_api
-                    .touch_relations(relations)
+                    .touch_relationships(relations)
                     .await
                     .change_context(InsertionError)?;
             }

--- a/apps/hash-graph/lib/graph/src/snapshot/web/batch.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/web/batch.rs
@@ -33,13 +33,13 @@ impl<C: AsClient> WriteBatch<C> for WebBatch {
         match self {
             Self::Accounts(accounts) => {
                 authorization_api
-                    .touch_relations(accounts)
+                    .touch_relationships(accounts)
                     .await
                     .change_context(InsertionError)?;
             }
             Self::AccountGroups(account_groups) => {
                 authorization_api
-                    .touch_relations(account_groups)
+                    .touch_relationships(account_groups)
                     .await
                     .change_context(InsertionError)?;
             }

--- a/libs/@local/hash-authorization/src/backend/spicedb/model.rs
+++ b/libs/@local/hash-authorization/src/backend/spicedb/model.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, fmt};
 
 use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
 
-use crate::zanzibar;
+use crate::{backend::ModifyRelationshipOperation, zanzibar};
 
 /// Error response returned from the API
 #[derive(Debug, Deserialize)]
@@ -72,18 +72,24 @@ impl From<ZedToken> for zanzibar::Zookie<'static> {
     }
 }
 
-/// Used for mutating a single relationship within the service.
 #[derive(Debug, Copy, Clone, Serialize)]
 pub(crate) enum RelationshipUpdateOperation {
-    /// Create the relationship only if it doesn't exist, and error otherwise.
     #[serde(rename = "OPERATION_CREATE")]
     Create,
-    /// Upsert the relationship, and will not error if it already exists.
     #[serde(rename = "OPERATION_TOUCH")]
     Touch,
-    /// Delete the relationship. If the relationship does not exist, this operation will no-op.
     #[serde(rename = "OPERATION_DELETE")]
     Delete,
+}
+
+impl From<ModifyRelationshipOperation> for RelationshipUpdateOperation {
+    fn from(operation: ModifyRelationshipOperation) -> Self {
+        match operation {
+            ModifyRelationshipOperation::Create => Self::Create,
+            ModifyRelationshipOperation::Touch => Self::Touch,
+            ModifyRelationshipOperation::Delete => Self::Delete,
+        }
+    }
 }
 
 /// Represents a reference to a caveat to be used by caveated relationships.

--- a/libs/@local/hash-authorization/src/zanzibar/api.rs
+++ b/libs/@local/hash-authorization/src/zanzibar/api.rs
@@ -52,7 +52,7 @@ where
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(self
             .backend
-            .create_relations([(account_group, AccountGroupRelation::DirectOwner, member)])
+            .create_relationships([(account_group, AccountGroupRelation::DirectOwner, member)])
             .await
             .change_context(ModifyRelationError)?
             .written_at)
@@ -65,10 +65,10 @@ where
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(self
             .backend
-            .delete_relations([(account_group, AccountGroupRelation::DirectOwner, member)])
+            .delete_relationships([(account_group, AccountGroupRelation::DirectOwner, member)])
             .await
             .change_context(ModifyRelationError)?
-            .deleted_at)
+            .written_at)
     }
 
     async fn add_account_group_admin(
@@ -78,7 +78,7 @@ where
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(self
             .backend
-            .create_relations([(account_group, AccountGroupRelation::DirectAdmin, member)])
+            .create_relationships([(account_group, AccountGroupRelation::DirectAdmin, member)])
             .await
             .change_context(ModifyRelationError)?
             .written_at)
@@ -91,10 +91,10 @@ where
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(self
             .backend
-            .delete_relations([(account_group, AccountGroupRelation::DirectAdmin, member)])
+            .delete_relationships([(account_group, AccountGroupRelation::DirectAdmin, member)])
             .await
             .change_context(ModifyRelationError)?
-            .deleted_at)
+            .written_at)
     }
 
     async fn add_account_group_member(
@@ -104,7 +104,7 @@ where
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(self
             .backend
-            .create_relations([(account_group, AccountGroupRelation::DirectMember, member)])
+            .create_relationships([(account_group, AccountGroupRelation::DirectMember, member)])
             .await
             .change_context(ModifyRelationError)?
             .written_at)
@@ -117,10 +117,10 @@ where
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(self
             .backend
-            .delete_relations([(account_group, AccountGroupRelation::DirectMember, member)])
+            .delete_relationships([(account_group, AccountGroupRelation::DirectMember, member)])
             .await
             .change_context(ModifyRelationError)?
-            .deleted_at)
+            .written_at)
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -146,12 +146,12 @@ where
         Ok(match owner {
             OwnerId::Account(account) => {
                 self.backend
-                    .create_relations([(web, WebRelation::DirectOwner, account)])
+                    .create_relationships([(web, WebRelation::DirectOwner, account)])
                     .await
             }
             OwnerId::AccountGroupMembers(account_group) => {
                 self.backend
-                    .create_relations([(
+                    .create_relationships([(
                         web,
                         WebRelation::DirectOwner,
                         (account_group, AccountGroupPermission::Member),
@@ -171,12 +171,12 @@ where
         Ok(match owner {
             OwnerId::Account(account) => {
                 self.backend
-                    .delete_relations([(web, WebRelation::DirectOwner, account)])
+                    .delete_relationships([(web, WebRelation::DirectOwner, account)])
                     .await
             }
             OwnerId::AccountGroupMembers(account_group) => {
                 self.backend
-                    .delete_relations([(
+                    .delete_relationships([(
                         web,
                         WebRelation::DirectOwner,
                         (account_group, AccountGroupPermission::Member),
@@ -185,7 +185,7 @@ where
             }
         }
         .change_context(ModifyRelationError)?
-        .deleted_at)
+        .written_at)
     }
 
     async fn add_web_editor(
@@ -196,12 +196,12 @@ where
         Ok(match editor {
             OwnerId::Account(account) => {
                 self.backend
-                    .create_relations([(web, WebRelation::DirectEditor, account)])
+                    .create_relationships([(web, WebRelation::DirectEditor, account)])
                     .await
             }
             OwnerId::AccountGroupMembers(account_group) => {
                 self.backend
-                    .create_relations([(
+                    .create_relationships([(
                         web,
                         WebRelation::DirectEditor,
                         (account_group, AccountGroupPermission::Member),
@@ -221,12 +221,12 @@ where
         Ok(match editor {
             OwnerId::Account(account) => {
                 self.backend
-                    .delete_relations([(web, WebRelation::DirectEditor, account)])
+                    .delete_relationships([(web, WebRelation::DirectEditor, account)])
                     .await
             }
             OwnerId::AccountGroupMembers(account_group) => {
                 self.backend
-                    .delete_relations([(
+                    .delete_relationships([(
                         web,
                         WebRelation::DirectEditor,
                         (account_group, AccountGroupPermission::Member),
@@ -235,7 +235,7 @@ where
             }
         }
         .change_context(ModifyRelationError)?
-        .deleted_at)
+        .written_at)
     }
 
     async fn add_entity_relation(
@@ -245,7 +245,7 @@ where
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(self
             .backend
-            .create_relations([(entity.entity_uuid, relationship)])
+            .create_relationships([(entity.entity_uuid, relationship)])
             .await
             .change_context(ModifyRelationError)?
             .written_at)
@@ -258,10 +258,10 @@ where
     ) -> Result<Zookie<'static>, ModifyRelationError> {
         Ok(self
             .backend
-            .delete_relations([(entity.entity_uuid, relationship)])
+            .delete_relationships([(entity.entity_uuid, relationship)])
             .await
             .change_context(ModifyRelationError)?
-            .deleted_at)
+            .written_at)
     }
 
     async fn check_entity_permission(

--- a/libs/@local/hash-authorization/tests/simple.rs
+++ b/libs/@local/hash-authorization/tests/simple.rs
@@ -41,7 +41,7 @@ async fn plain_permissions() -> Result<(), Box<dyn Error>> {
         .await?;
 
     let token = api
-        .touch_relations([
+        .touch_relationships([
             (ENTITY_A, EntityObjectRelation::DirectOwner, ALICE),
             (ENTITY_A, EntityObjectRelation::DirectViewer, BOB),
             (ENTITY_B, EntityObjectRelation::DirectOwner, BOB),
@@ -164,9 +164,9 @@ async fn plain_permissions() -> Result<(), Box<dyn Error>> {
     );
 
     let token = api
-        .delete_relations([(ENTITY_A, EntityObjectRelation::DirectViewer, BOB)])
+        .delete_relationships([(ENTITY_A, EntityObjectRelation::DirectViewer, BOB)])
         .await?
-        .deleted_at;
+        .written_at;
 
     assert!(
         !api.check(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently define three convenient methods to modify a relationship. To avoid updating multiple places, this should be implemented on a trait level

## 🔗 Related links

- H-1121

## 🚫 Blocked by

- #3403 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph