### PR TITLE
H-1128: Rename task definition name for AI worker

### DIFF
--- a/infra/terraform/hash/hash_application/main.tf
+++ b/infra/terraform/hash/hash_application/main.tf
@@ -365,7 +365,7 @@ resource "aws_iam_role" "task_role" {
 }
 
 resource "aws_ecs_task_definition" "task" {
-  family                   = "${local.prefix}taskdef"
+  family                   = "${local.prefix}-app-taskdef"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.cpu
   memory                   = var.memory
@@ -377,7 +377,7 @@ resource "aws_ecs_task_definition" "task" {
 }
 
 resource "aws_ecs_task_definition" "worker_task" {
-  family                   = "${local.prefix}taskdef"
+  family                   = "${local.prefix}-worker-taskdef"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.worker_cpu
   memory                   = var.worker_memory


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Using the same task definition name for two definitions causes conflicts

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph