### PR TITLE
H-1136: Fix Test CI passing when a build-step fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -610,7 +610,7 @@ jobs:
 
   passed:
     name: Tests passed
-    needs: [setup, unit-tests, integration-tests, system-tests, publish]
+    needs: [setup, unit-tests, build, integration-tests, system-tests, publish]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -620,6 +620,9 @@ jobs:
       - name: Check unit tests
         run: |
           [[ ${{ needs.unit-tests.result }} =~ success|skipped ]]
+      - name: Check builds
+        run: |
+          [[ ${{ needs.build.result }} =~ success|skipped ]]
       - name: Check integration tests
         run: |
           [[ ${{ needs.integration-tests.result }} =~ success|skipped ]]

--- a/turbo.json
+++ b/turbo.json
@@ -39,7 +39,6 @@
   },
   "globalDependencies": [
     "**/turbo.json",
-    ".github/workflows/**.yml",
     ".github/actions/**",
     ".env*",
     ".justfile",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The CI is allowed to pass if a build step is failing as next steps will be skipped and skipped tests count as passed.