### PR TITLE
H-1148: `hash-graph`: remove check if DSN is valid

### DIFF
--- a/apps/hash-graph/Cargo.lock
+++ b/apps/hash-graph/Cargo.lock
@@ -2550,18 +2550,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/apps/hash-graph/bin/cli/src/error.rs
+++ b/apps/hash-graph/bin/cli/src/error.rs
@@ -28,18 +28,3 @@ impl fmt::Display for HealthcheckError {
 }
 
 impl Context for HealthcheckError {}
-
-#[derive(Debug)]
-pub enum SentryError {
-    InvalidDsn,
-}
-
-impl fmt::Display for SentryError {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::InvalidDsn => fmt.write_str("invalid Sentry DSN"),
-        }
-    }
-}
-
-impl Context for SentryError {}

--- a/apps/hash-graph/bin/cli/src/main.rs
+++ b/apps/hash-graph/bin/cli/src/main.rs
@@ -22,17 +22,6 @@ fn main() -> Result<(), GraphError> {
         subcommand,
     } = Args::parse_args();
 
-    if let Some(dsn) = &sentry_dsn {
-        let client = sentry::Client::from_config(dsn);
-
-        ensure!(
-            client.is_enabled(),
-            Report::new(SentryError::InvalidDsn)
-                .attach_printable(dsn.clone())
-                .change_context(GraphError)
-        );
-    }
-
     // Initialize Sentry
     // When initializing Sentry, a `Drop` guard is returned, once dropped any remaining events are
     // flushed. This means we need to keep the guard around for the entire lifetime of the program.

--- a/apps/hash-graph/bin/cli/src/main.rs
+++ b/apps/hash-graph/bin/cli/src/main.rs
@@ -8,11 +8,10 @@ mod subcommand;
 
 use std::sync::Arc;
 
-use error_stack::{ensure, Report, Result};
+use error_stack::Result;
 use graph::load_env;
 
 use self::{args::Args, error::GraphError};
-use crate::error::SentryError;
 
 fn main() -> Result<(), GraphError> {
     load_env(None);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

It seems that in a recent version the sentry-rust `Transport` has been changed, in a way where it is no longer possible to know if a connection was successful (or maybe I this never worked, who knows 🤷). After some more investigation, there doesn't seem to be an official way of verifying that the DSN is correct, so I have removed it for now.

## 🔗 Related links

- https://github.com/getsentry/sentry-python/issues/1033

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

We no longer can verify if a DSN is correct, only that it is of a valid format.
