### PR TITLE
H-1089: Fix Postgres data not have a dedicated volume

### DIFF
--- a/apps/hash-external-services/docker-compose.yml
+++ b/apps/hash-external-services/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       HASH_GRAPH_REALTIME_PG_USER: "${HASH_GRAPH_REALTIME_PG_USER}"
       HASH_GRAPH_REALTIME_PG_PASSWORD: "${HASH_GRAPH_REALTIME_PG_PASSWORD}"
     volumes:
-      - hash-postgres-data:/var/lib/postgresql/data
+      - hash-postgres-data:/data/pgdata
       - ./postgres/postgresql.conf:/etc/postgresql/postgresql.conf:ro
       - ./postgres/init-user-db.sh:/docker-entrypoint-initdb.d/init-user-db.sh:ro
     healthcheck:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The volume set for postgres data is erroneous, pointing to a directory that isn't used at all. This is a remnant of the old `docker-compose.yml`. The correct setting was previously set in `docker-compose.prod.yml`. 

This corrects the issue.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


## ⚠️ Known issues

Because we change where the volume points to (and the directory), your current database will most likely get wiped! To circumvent this you must first `pg_dump` in the container itself, before any rebuild happens.


