### PR TITLE
H-1147: Explicitly load images into Docker

### DIFF
--- a/apps/hash-ai-worker-py/package.json
+++ b/apps/hash-ai-worker-py/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "A Python 'AI' worker for HASH",
   "scripts": {
-    "build:docker": "docker buildx build --tag hash-ai-worker-py --file docker/Dockerfile ../../",
+    "build:docker": "docker buildx build --tag hash-ai-worker-py --file docker/Dockerfile ../../ --load",
     "dev": "poetry run python -m worker",
     "fix:black": "poetry run black .",
     "fix:lock-files": "poetry lock --no-update",

--- a/apps/hash-ai-worker-ts/package.json
+++ b/apps/hash-ai-worker-ts/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "build": "tsc --build && yarn exe ./scripts/bundle-workflow-code.ts",
-    "build:docker": "docker buildx build --tag hash-ai-worker-ts --file ./docker/Dockerfile ../../",
+    "build:docker": "docker buildx build --tag hash-ai-worker-ts --file ./docker/Dockerfile ../../ --load",
     "dev": "node --max-old-space-size=2048 ./node_modules/.bin/ts-node-dev --respawn --transpile-only ./src/main.ts",
     "exe": "ts-node --transpile-only",
     "fix:eslint": "eslint --fix .",

--- a/apps/hash-graph/package.json
+++ b/apps/hash-graph/package.json
@@ -12,10 +12,10 @@
     }
   },
   "scripts": {
-    "build:docker": "docker buildx build --build-arg PROFILE=dev --tag hash-graph --file docker/Dockerfile ../../",
-    "build:docker:offline": "docker buildx build --build-arg PROFILE=dev --build-arg ENABLE_TYPE_FETCHER=no --tag hash-graph --file docker/Dockerfile ../../",
-    "build:docker:prod": "docker buildx build --build-arg PROFILE=production --tag hash-graph --tag hash-graph:prod --file docker/Dockerfile ../../",
-    "build:docker:test": "docker buildx build --build-arg PROFILE=dev --build-arg ENABLE_TEST_SERVER=yes --tag hash-graph --tag hash-graph:test --file docker/Dockerfile ../../",
+    "build:docker": "docker buildx build --build-arg PROFILE=dev --tag hash-graph --file docker/Dockerfile ../../ --load",
+    "build:docker:offline": "docker buildx build --build-arg PROFILE=dev --build-arg ENABLE_TYPE_FETCHER=no --tag hash-graph --file docker/Dockerfile ../../ --load",
+    "build:docker:prod": "docker buildx build --build-arg PROFILE=production --tag hash-graph --tag hash-graph:prod --file docker/Dockerfile ../../ --load",
+    "build:docker:test": "docker buildx build --build-arg PROFILE=dev --build-arg ENABLE_TEST_SERVER=yes --tag hash-graph --tag hash-graph:test --file docker/Dockerfile ../../ --load",
     "codegen:generate-openapi-specs": "just generate-openapi-specs",
     "dev": "RUST_LOG=info cargo run --all-features -- server",
     "exe": "ts-node",

--- a/apps/hash-integration-worker/package.json
+++ b/apps/hash-integration-worker/package.json
@@ -6,7 +6,7 @@
   "license": "AGPL-3.0",
   "scripts": {
     "build": "tsc --build && yarn exe ./scripts/bundle-workflow-code.ts",
-    "build:docker": "docker buildx build --tag hash-integration-worker --file ./docker/Dockerfile ../../",
+    "build:docker": "docker buildx build --tag hash-integration-worker --file ./docker/Dockerfile ../../ --load",
     "dev": "node --max-old-space-size=2048 ./node_modules/.bin/ts-node-dev --respawn --transpile-only ./src/main.ts",
     "exe": "ts-node --transpile-only",
     "fix:eslint": "eslint --fix .",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This adds `--load` to the `buildx` command to explicitly force `buildx` to load the image into docker. This is needed as there are multiple different "drivers" for building images: `docker`, `docker-container`, `kubernetes` and `remote`. Only `docker` supports automatically loading the image, but some setups use `docker-container` (like mine) instead, and need an explicit `--load` argument.

This fixes it by adding the argument.

Fun fact: you can see what your default driver is via: `docker buildx ls` (the `*` indicates the default)

## 🔗 Related links

- https://docs.docker.com/build/drivers/

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
