### PR TITLE
H-1150: Allow bulk deletion of relationships

### DIFF
--- a/libs/@local/hash-authorization/src/backend.rs
+++ b/libs/@local/hash-authorization/src/backend.rs
@@ -185,6 +185,23 @@ pub trait ZanzibarBackend {
                 Subject: Resource<Kind: Deserialize<'de>, Id: Deserialize<'de>>,
                 SubjectSet: Deserialize<'de>,
             > + Send;
+
+    /// Deletes all relationships matching the given filter
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the deletion could not be performed.
+    fn delete_relations(
+        &mut self,
+        filter: RelationshipFilter<
+            impl Serialize + Send + Sync,
+            impl Serialize + Send + Sync,
+            impl Serialize + Send + Sync,
+            impl Serialize + Send + Sync,
+            impl Serialize + Send + Sync,
+            impl Serialize + Send + Sync,
+        >,
+    ) -> impl Future<Output = Result<DeleteRelationshipResponse, Report<DeleteRelationshipError>>> + Send;
 }
 
 impl ZanzibarBackend for NoAuthorization {
@@ -243,6 +260,22 @@ impl ZanzibarBackend for NoAuthorization {
     ) -> Result<Vec<R>, Report<ReadError>> {
         Ok(Vec::new())
     }
+
+    async fn delete_relations(
+        &mut self,
+        _filter: RelationshipFilter<
+            impl Serialize + Send + Sync,
+            impl Serialize + Send + Sync,
+            impl Serialize + Send + Sync,
+            impl Serialize + Send + Sync,
+            impl Serialize + Send + Sync,
+            impl Serialize + Send + Sync,
+        >,
+    ) -> Result<DeleteRelationshipResponse, Report<DeleteRelationshipError>> {
+        Ok(DeleteRelationshipResponse {
+            deleted_at: Zookie::empty(),
+        })
+    }
 }
 
 /// Return value for [`ZanzibarBackend::import_schema`].
@@ -298,11 +331,30 @@ pub struct ModifyRelationshipError;
 
 impl fmt::Display for ModifyRelationshipError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.write_str("failed to modify relations")
+        fmt.write_str("failed to modify relationships")
     }
 }
 
 impl Error for ModifyRelationshipError {}
+
+/// Return value for [`ZanzibarBackend::delete_relationships`].
+#[derive(Debug)]
+pub struct DeleteRelationshipResponse {
+    /// A token to determine the time at which the relation was created.
+    pub deleted_at: Zookie<'static>,
+}
+
+/// Error returned from [`ZanzibarBackend::delete_relationships`].
+#[derive(Debug)]
+pub struct DeleteRelationshipError;
+
+impl fmt::Display for DeleteRelationshipError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_str("failed to delete relationships")
+    }
+}
+
+impl Error for DeleteRelationshipError {}
 
 /// Return value for [`ZanzibarBackend::check`].
 #[derive(Debug)]

--- a/libs/@local/hash-authorization/src/schema.rs
+++ b/libs/@local/hash-authorization/src/schema.rs
@@ -12,9 +12,9 @@ pub use self::{
         AccountGroupSubject, AccountGroupSubjectId,
     },
     entity::{
-        EntityGeneralEditorSubject, EntityGeneralViewerSubject, EntityOwnerSubject,
-        EntityPermission, EntityRelationAndSubject, EntityResourceRelation, EntitySubject,
-        EntitySubjectId, EntitySubjectSet,
+        EntityGeneralEditorSubject, EntityGeneralViewerSubject, EntityNamespace,
+        EntityOwnerSubject, EntityPermission, EntityRelationAndSubject, EntityResourceRelation,
+        EntitySubject, EntitySubjectId, EntitySubjectSet,
     },
     web::{
         WebNamespace, WebOwnerSubject, WebPermission, WebRelationAndSubject, WebResourceRelation,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For entities it didn't hurt if more relationships were stored than required (it was annoying though), for ontology types this will break the BE test suite.

## 🚫 Blocked by

- #3442
- #3443
- #3458

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph