### PR TITLE
H-1159: Fix check for isUserOrOrg

### DIFF
--- a/apps/hash-frontend/src/lib/user-and-org.ts
+++ b/apps/hash-frontend/src/lib/user-and-org.ts
@@ -383,7 +383,7 @@ export const constructUser = (params: {
 
     if (!isEntityOrgEntity(orgEntity)) {
       throw new Error(
-        `Entity with type ${orgEntity.metadata.entityTypeId} is not a user entity`,
+        `Entity with type ${orgEntity.metadata.entityTypeId} is not an org entity`,
       );
     }
 

--- a/apps/hash-frontend/src/shared/table-header.tsx
+++ b/apps/hash-frontend/src/shared/table-header.tsx
@@ -204,7 +204,7 @@ export const TableHeader: FunctionComponent<TableHeaderProps> = ({
                     }}
                   />
                 }
-                label={`${numberOfUserWebItems} in your webs`}
+                label={`${numberOfUserWebItems ?? "-"} in your webs`}
                 sx={{
                   ...commonChipSx,
                   [`.${chipClasses.label}`]: {
@@ -249,7 +249,7 @@ export const TableHeader: FunctionComponent<TableHeaderProps> = ({
                     <EarthAmericasRegularIcon />
                   )
                 }
-                label={`${numberOfGlobalItems} others`}
+                label={`${numberOfGlobalItems ?? "-"} others`}
                 sx={({ palette }) => ({
                   ...commonChipSx,
                   [`.${chipClasses.label}`]: {

--- a/apps/hash-frontend/src/shared/use-user-or-org.ts
+++ b/apps/hash-frontend/src/shared/use-user-or-org.ts
@@ -101,8 +101,8 @@ export const useUserOrOrg = (
         ).reduce<Entity<OrgProperties> | Entity<UserProperties> | undefined>(
           (prev, currentEntity) => {
             if (
-              !isEntityUserEntity(currentEntity) ||
-              isEntityOrgEntity(currentEntity)
+              !isEntityUserEntity(currentEntity) &&
+              !isEntityOrgEntity(currentEntity)
             ) {
               throw new Error(
                 `Entity with type ${currentEntity.metadata.entityTypeId} is not a user or an org entity`,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

1. Fixes a check for 'is this an user or org'
2. Driveby: have a fallback for table headers to avoid 'undefined in your webs' table header

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Not entirely sure what brings the crash about as I haven't experienced it, so I can't confirm that the fix works – maybe @TimDiekmann can once it's deployed
