### PR TITLE
H-1185: Fix wrong permission passed to the Graph API

### DIFF
--- a/apps/hash-graph/lib/graph/src/api/rest/account.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/account.rs
@@ -194,7 +194,7 @@ where
 
 #[utoipa::path(
     get,
-    path = "/account_groups/{account_group_id}/permissions/add_owner",
+    path = "/account_groups/{account_group_id}/permissions/{permission}",
     tag = "Account Group",
     params(
         ("X-Authenticated-User-Actor-Id" = AccountId, Header, description = "The ID of the actor which is used to authorize the request"),

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -140,7 +140,7 @@
         }
       }
     },
-    "/account_groups/{account_group_id}/permissions/add_owner": {
+    "/account_groups/{account_group_id}/permissions/{permission}": {
       "get": {
         "tags": [
           "Graph",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The pass in the `utoipa` attribute was wrong so the Node API hard-coded the `add_owner` permission, which does not even exist.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph