### PR TITLE
H-968, H-970: Adjust `hash-graph` to use entity validation

### DIFF
--- a/apps/hash-graph/Cargo.lock
+++ b/apps/hash-graph/Cargo.lock
@@ -671,6 +671,7 @@ checksum = "27a72baa257b5e0e2de241967bc5ee8f855d6072351042688621081d66b2a76b"
 dependencies = [
  "anyhow",
  "rustc_version",
+ "serde",
  "tracing-error",
 ]
 
@@ -899,6 +900,7 @@ dependencies = [
  "type-system",
  "utoipa",
  "uuid",
+ "validation",
 ]
 
 [[package]]
@@ -995,6 +997,7 @@ dependencies = [
  "type-fetcher",
  "type-system",
  "uuid",
+ "validation",
 ]
 
 [[package]]
@@ -3176,6 +3179,17 @@ dependencies = [
  "getrandom",
  "serde",
  "sha1_smol",
+]
+
+[[package]]
+name = "validation"
+version = "0.0.0"
+dependencies = [
+ "error-stack 0.4.1",
+ "graph-types",
+ "serde_json",
+ "thiserror",
+ "type-system",
 ]
 
 [[package]]

--- a/apps/hash-graph/Cargo.toml
+++ b/apps/hash-graph/Cargo.toml
@@ -21,12 +21,13 @@ graph-test-data = { path = "../../tests/hash-graph-test-data/rust" }
 # tested in CI if the dependency was changed.
 temporal-versioning = { path = "../../libs/@local/temporal-versioning" }
 graph-types = { path = "../../libs/@local/hash-graph-types/rust" }
+validation = { path = "../../libs/@local/hash-validation" }
 authorization = { path = "../../libs/@local/hash-authorization" }
 codec = { path = "../../libs/@local/codec" }
 
 type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "b63f923" }
 hash-status = { path = "../../libs/@local/status/rust" }
-error-stack = { version = "0.4.1", features = ["spantrace"] }
+error-stack = { version = "0.4.1", features = ["spantrace", "serde"] }
 
 tokio-util = { version = "0.7.10", default-features = false }
 bytes = "1.5.0"

--- a/apps/hash-graph/bin/cli/Cargo.toml
+++ b/apps/hash-graph/bin/cli/Cargo.toml
@@ -10,6 +10,7 @@ description = "The entity-graph query-layer for the HASH datastore"
 [dependencies]
 graph = { path = "../../lib/graph", features = ["clap"] }
 graph-types = { workspace = true }
+validation = { workspace = true }
 type-fetcher = { path = "../../lib/type-fetcher" }
 authorization = { workspace = true }
 codec = { workspace = true }

--- a/apps/hash-graph/bin/cli/src/main.rs
+++ b/apps/hash-graph/bin/cli/src/main.rs
@@ -15,6 +15,7 @@ use self::{args::Args, error::GraphError};
 
 fn main() -> Result<(), GraphError> {
     load_env(None);
+    validation::error::install_error_stack_hooks();
 
     let Args {
         sentry_dsn,

--- a/apps/hash-graph/lib/graph/Cargo.toml
+++ b/apps/hash-graph/lib/graph/Cargo.toml
@@ -7,6 +7,7 @@ description = "HASH Graph API"
 
 [dependencies]
 graph-types = { workspace = true, features = ["postgres", "utoipa"] }
+validation = { workspace = true }
 temporal-versioning = { workspace = true, features = ["postgres", "utoipa"] }
 type-fetcher = { path = "../type-fetcher" }
 authorization = { workspace = true, features = ["utoipa"] }

--- a/apps/hash-graph/lib/graph/src/api/rest/status.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/status.rs
@@ -1,20 +1,39 @@
 use std::fmt::Debug;
 
 use axum::{
-    http::StatusCode,
     response::{IntoResponse, Response},
     Json,
 };
-use hash_status::Status;
-use serde::{Deserialize, Serialize};
+use error_stack::{Context, Report};
+use hash_status::{Status, StatusCode};
+use serde::Serialize;
 
 pub fn status_to_response<T>(status: Status<T>) -> Response
 where
-    T: Serialize + for<'de> Deserialize<'de> + Send + Sync + Debug,
+    T: Serialize + Send + Sync + Debug,
 {
-    let status_code = StatusCode::from_u16(status.code().to_http_code())
+    let status_code = axum::http::StatusCode::from_u16(status.code().to_http_code())
         .expect("HASH Status code should map to a valid HTTP status code");
     let mut response = Json(status).into_response();
     *response.status_mut() = status_code;
     response
+}
+
+pub fn report_to_response<C>(report: Report<C>) -> Response
+where
+    C: Context,
+{
+    tracing::error!(error = ?report);
+    let status_code = report
+        .request_ref::<StatusCode>()
+        .next()
+        .copied()
+        .or_else(|| report.request_value::<StatusCode>().next())
+        .unwrap_or(StatusCode::Internal);
+
+    status_to_response(Status::new(
+        status_code,
+        Some(report.to_string()),
+        vec![report],
+    ))
 }

--- a/apps/hash-graph/lib/graph/src/store.rs
+++ b/apps/hash-graph/lib/graph/src/store.rs
@@ -9,6 +9,7 @@ mod migration;
 mod ontology;
 mod pool;
 mod record;
+mod validation;
 
 mod fetcher;
 mod postgres;

--- a/apps/hash-graph/lib/graph/src/store/pool.rs
+++ b/apps/hash-graph/lib/graph/src/store/pool.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use error_stack::Result;
+use error_stack::{Context, Result};
 
 use crate::store::Store;
 
@@ -7,7 +7,7 @@ use crate::store::Store;
 #[async_trait]
 pub trait StorePool {
     /// The error returned when acquiring a [`Store`].
-    type Error;
+    type Error: Context;
 
     /// The store returned when acquiring.
     type Store<'pool>: Store + Send;

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -1,5 +1,4 @@
 mod read;
-
 use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
@@ -22,11 +21,14 @@ use graph_types::{
     provenance::{OwnedById, ProvenanceMetadata, RecordCreatedById},
     web::WebId,
 };
+use hash_status::StatusCode;
+use postgres_types::Json;
 use temporal_versioning::{DecisionTime, RightBoundedTemporalInterval, Timestamp};
 #[cfg(hash_graph_test_environment)]
 use tokio_postgres::GenericClient;
-use type_system::url::VersionedUrl;
+use type_system::{raw, url::VersionedUrl, EntityType};
 use uuid::Uuid;
+use validation::Validate;
 
 #[cfg(hash_graph_test_environment)]
 use crate::store::error::DeletionError;
@@ -38,6 +40,7 @@ use crate::{
             knowledge::entity::read::EntityEdgeTraversalData, query::ReferenceTable,
             TraversalContext,
         },
+        validation::StoreProvider,
         AsClient, EntityStore, InsertionError, PostgresStore, QueryError, Record, UpdateError,
     },
     subgraph::{
@@ -300,7 +303,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 .await
                 .change_context(InsertionError)?
                 .assert_permission()
-                .change_context(InsertionError)?;
+                .change_context(InsertionError)
+                .attach(StatusCode::PermissionDenied)?;
         }
 
         let entity_id = EntityId {
@@ -373,13 +377,13 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             }
         };
 
-        let edition_id = transaction
+        let (edition_id, closed_schema) = transaction
             .insert_entity_edition(
                 RecordCreatedById::new(actor_id),
                 archived,
                 &entity_type_id,
-                properties,
-                link_order,
+                &properties,
+                &link_order,
             )
             .await?;
 
@@ -436,6 +440,27 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 .change_context(InsertionError)?
         };
 
+        let entity = Entity {
+            properties,
+            link_data,
+            metadata: EntityMetadata::new(
+                EntityRecordId {
+                    entity_id,
+                    edition_id,
+                },
+                EntityTemporalMetadata {
+                    decision_time: row.get(0),
+                    transaction_time: row.get(1),
+                },
+                entity_type_id,
+                ProvenanceMetadata {
+                    record_created_by_id: RecordCreatedById::new(actor_id),
+                    record_archived_by_id: None,
+                },
+                archived,
+            ),
+        };
+
         authorization_api
             .modify_entity_relations([(
                 ModifyRelationshipOperation::Create,
@@ -444,6 +469,19 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             )])
             .await
             .change_context(InsertionError)?;
+
+        let validator_provider = StoreProvider {
+            store: &transaction,
+            actor_id,
+            authorization_api,
+            consistency: Consistency::FullyConsistent,
+        };
+
+        entity
+            .validate(&closed_schema, &validator_provider)
+            .await
+            .change_context(InsertionError)
+            .attach(StatusCode::InvalidArgument)?;
 
         if let Err(mut error) = transaction.commit().await.change_context(InsertionError) {
             if let Err(auth_error) = authorization_api
@@ -462,22 +500,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
 
             Err(error)
         } else {
-            Ok(EntityMetadata::new(
-                EntityRecordId {
-                    entity_id,
-                    edition_id,
-                },
-                EntityTemporalMetadata {
-                    decision_time: row.get(0),
-                    transaction_time: row.get(1),
-                },
-                entity_type_id,
-                ProvenanceMetadata {
-                    record_created_by_id: RecordCreatedById::new(actor_id),
-                    record_archived_by_id: None,
-                },
-                archived,
-            ))
+            Ok(entity.metadata)
         }
     }
 
@@ -740,13 +763,13 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 .change_context(UpdateError));
         }
 
-        let edition_id = transaction
+        let (edition_id, closed_schema) = transaction
             .insert_entity_edition(
                 RecordCreatedById::new(actor_id),
                 archived,
                 &entity_type_id,
-                properties,
-                link_order,
+                &properties,
+                &link_order,
             )
             .await
             .change_context(UpdateError)?;
@@ -802,24 +825,45 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 .change_context(UpdateError)
         })?;
 
+        let entity = Entity {
+            properties,
+            // TODO: Use correct link data for validation
+            //   see https://linear.app/hash/issue/H-972
+            link_data: None,
+            metadata: EntityMetadata::new(
+                EntityRecordId {
+                    entity_id,
+                    edition_id,
+                },
+                EntityTemporalMetadata {
+                    decision_time: row.get(0),
+                    transaction_time: row.get(1),
+                },
+                entity_type_id,
+                ProvenanceMetadata {
+                    record_created_by_id: RecordCreatedById::new(actor_id),
+                    record_archived_by_id: None,
+                },
+                archived,
+            ),
+        };
+
+        let validator_provider = StoreProvider {
+            store: &transaction,
+            actor_id,
+            authorization_api,
+            consistency: Consistency::FullyConsistent,
+        };
+
+        entity
+            .validate(&closed_schema, &validator_provider)
+            .await
+            .change_context(UpdateError)
+            .attach(StatusCode::InvalidArgument)?;
+
         transaction.commit().await.change_context(UpdateError)?;
 
-        Ok(EntityMetadata::new(
-            EntityRecordId {
-                entity_id,
-                edition_id,
-            },
-            EntityTemporalMetadata {
-                decision_time: row.get(0),
-                transaction_time: row.get(1),
-            },
-            entity_type_id,
-            ProvenanceMetadata {
-                record_created_by_id: RecordCreatedById::new(actor_id),
-                record_archived_by_id: None,
-            },
-            archived,
-        ))
+        Ok(entity.metadata)
     }
 }
 
@@ -829,9 +873,9 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
         record_created_by_id: RecordCreatedById,
         archived: bool,
         entity_type_id: &VersionedUrl,
-        properties: EntityProperties,
-        link_order: EntityLinkOrder,
-    ) -> Result<EntityEditionId, InsertionError> {
+        properties: &EntityProperties,
+        link_order: &EntityLinkOrder,
+    ) -> Result<(EntityEditionId, EntityType), InsertionError> {
         let edition_id: EntityEditionId = self
             .as_client()
             .query_one(
@@ -876,6 +920,17 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
             .await
             .change_context(InsertionError)?;
 
-        Ok(edition_id)
+        let entity_schema: Json<raw::EntityType> = self
+            .as_client()
+            .query_one(
+                "SELECT closed_schema FROM entity_types WHERE ontology_id = $1;",
+                &[&entity_type_ontology_id],
+            )
+            .await
+            .change_context(InsertionError)?
+            .get(0);
+        let entity_type = EntityType::try_from(entity_schema.0).change_context(InsertionError)?;
+
+        Ok((edition_id, entity_type))
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/validation.rs
+++ b/apps/hash-graph/lib/graph/src/store/validation.rs
@@ -1,0 +1,88 @@
+use authorization::{
+    schema::{DataTypeId, DataTypePermission, PropertyTypeId, PropertyTypePermission},
+    zanzibar::Consistency,
+    AuthorizationApi,
+};
+use error_stack::{Report, ResultExt};
+use graph_types::{
+    account::AccountId,
+    ontology::{DataTypeWithMetadata, PropertyTypeWithMetadata},
+};
+use type_system::{url::VersionedUrl, DataType, PropertyType};
+use validation::OntologyTypeProvider;
+
+use crate::{
+    store::{crud::Read, query::Filter, QueryError},
+    subgraph::temporal_axes::QueryTemporalAxesUnresolved,
+};
+
+#[derive(Debug, Copy, Clone)]
+pub struct StoreProvider<'a, S, A> {
+    pub store: &'a S,
+    pub actor_id: AccountId,
+    pub authorization_api: &'a A,
+    pub consistency: Consistency<'static>,
+}
+
+impl<S, A> OntologyTypeProvider<DataType> for StoreProvider<'_, S, A>
+where
+    S: Read<DataTypeWithMetadata, Record = DataTypeWithMetadata>,
+    A: AuthorizationApi + Sync,
+{
+    #[expect(refining_impl_trait)]
+    async fn provide_type(&self, type_id: &VersionedUrl) -> Result<DataType, Report<QueryError>> {
+        let data_type_id = DataTypeId::from_url(type_id);
+        self.authorization_api
+            .check_data_type_permission(
+                self.actor_id,
+                DataTypePermission::View,
+                data_type_id,
+                self.consistency,
+            )
+            .await
+            .change_context(QueryError)?
+            .assert_permission()
+            .change_context(QueryError)?;
+
+        self.store
+            .read_one(
+                &Filter::<S::Record>::for_versioned_url(type_id),
+                Some(&QueryTemporalAxesUnresolved::default().resolve()),
+            )
+            .await
+            .map(|data_type| data_type.schema)
+    }
+}
+
+impl<S, A> OntologyTypeProvider<PropertyType> for StoreProvider<'_, S, A>
+where
+    S: Read<PropertyTypeWithMetadata, Record = PropertyTypeWithMetadata>,
+    A: AuthorizationApi + Sync,
+{
+    #[expect(refining_impl_trait)]
+    async fn provide_type(
+        &self,
+        type_id: &VersionedUrl,
+    ) -> Result<PropertyType, Report<QueryError>> {
+        let data_type_id = PropertyTypeId::from_url(type_id);
+        self.authorization_api
+            .check_property_type_permission(
+                self.actor_id,
+                PropertyTypePermission::View,
+                data_type_id,
+                self.consistency,
+            )
+            .await
+            .change_context(QueryError)?
+            .assert_permission()
+            .change_context(QueryError)?;
+
+        self.store
+            .read_one(
+                &Filter::<S::Record>::for_versioned_url(type_id),
+                Some(&QueryTemporalAxesUnresolved::default().resolve()),
+            )
+            .await
+            .map(|data_type| data_type.schema)
+    }
+}

--- a/apps/hash-graph/package.json
+++ b/apps/hash-graph/package.json
@@ -28,6 +28,7 @@
     "@local/codec-rs": "0.0.0-private",
     "@local/hash-authorization-rs": "0.0.0-private",
     "@local/hash-graph-types-rs": "0.0.0-private",
+    "@local/hash-validation-rs": "0.0.0-private",
     "@local/status-rust": "0.0.0-private",
     "@local/temporal-versioning-rs": "0.0.0-private",
     "ts-node": "10.9.1"

--- a/libs/@local/hash-authorization/src/api.rs
+++ b/libs/@local/hash-authorization/src/api.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, future::Future};
 
-use error_stack::Result;
+use error_stack::{Context, Result};
 use graph_types::{
     account::{AccountGroupId, AccountId},
     knowledge::entity::EntityId,
@@ -291,7 +291,7 @@ pub trait AuthorizationApi {
 /// Managed pool to keep track about [`AuthorizationApi`]s.
 pub trait AuthorizationApiPool {
     /// The error returned when acquiring an [`AuthorizationApi`].
-    type Error;
+    type Error: Context;
 
     /// The [`AuthorizationApi`] returned when acquiring.
     type Api<'pool>: AuthorizationApi + Send + Sync;

--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use error_stack::{Report, ResultExt};
-use graph_types::knowledge::entity::EntityProperties;
+use graph_types::knowledge::entity::{Entity, EntityProperties};
 use serde_json::Value as JsonValue;
 use thiserror::Error;
 use type_system::{url::BaseUrl, DataType, EntityType, Object, PropertyType};
@@ -49,6 +49,17 @@ where
 
     async fn validate(&self, schema: &EntityType, provider: &P) -> Result<(), Report<Self::Error>> {
         schema.validate_value(self.properties(), provider).await
+    }
+}
+
+impl<P> Validate<EntityType, P> for Entity
+where
+    P: OntologyTypeProvider<PropertyType> + OntologyTypeProvider<DataType> + Sync,
+{
+    type Error = EntityValidationError;
+
+    async fn validate(&self, schema: &EntityType, provider: &P) -> Result<(), Report<Self::Error>> {
+        self.properties.validate(schema, provider).await
     }
 }
 

--- a/libs/@local/status/rust/src/lib.rs
+++ b/libs/@local/status/rust/src/lib.rs
@@ -28,7 +28,7 @@ where
 
 impl<D> Status<D>
 where
-    D: Send + Sync + Debug + Serialize + for<'de> Deserialize<'de>,
+    D: Send + Sync + Debug + Serialize,
 {
     #[must_use]
     pub fn new(code: StatusCode, message: Option<String>, contents: Vec<D>) -> Self {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#3505 added the `validation` crate. This PR is responsible to use that functionality in the Graph.

## 🚫 Blocked by

- #3505 

## 🔍 What does this change?

- Validate entities on create/update
- Drive-by: Improve errors returned from `create_entity` and `update-entity` endpoints.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph