### PR TITLE
H-1179: Allow reading/writing ontology type relationships/permissions

### DIFF
--- a/apps/hash-api/src/graph/knowledge/primitive/entity.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity.ts
@@ -862,7 +862,7 @@ export const getEntityAuthorizationRelationships: ImpureGraphFunction<
         (relationship) =>
           ({
             resource: { kind: "entity", resourceId: params.entityId },
-            ...relationship.relationAndSubject,
+            ...relationship,
           }) as EntityAuthorizationRelationship,
       ),
     );

--- a/apps/hash-api/src/graph/ontology/primitive/data-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/data-type.ts
@@ -3,7 +3,9 @@ import {
   VersionedUrl,
 } from "@blockprotocol/type-system";
 import {
+  DataTypePermission,
   DataTypeStructuralQuery,
+  ModifyRelationshipOperation,
   OntologyTemporalMetadata,
 } from "@local/hash-graph-client";
 import { ConstructDataTypeParams } from "@local/hash-graphql-shared/graphql/types";
@@ -14,6 +16,7 @@ import {
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { generateTypeId } from "@local/hash-isomorphic-utils/ontology-types";
 import {
+  DataTypeAuthorizationRelationship,
   DataTypeRootType,
   DataTypeWithMetadata,
   OntologyElementMetadata,
@@ -252,3 +255,44 @@ export const unarchiveDataType: ImpureGraphFunction<
 
   return temporalMetadata;
 };
+
+export const getDataTypeAuthorizationRelationships: ImpureGraphFunction<
+  { dataTypeId: VersionedUrl },
+  Promise<DataTypeAuthorizationRelationship[]>
+> = async ({ graphApi }, { actorId }, params) =>
+  graphApi
+    .getDataTypeAuthorizationRelationships(actorId, params.dataTypeId)
+    .then(({ data }) =>
+      data.map(
+        (relationship) =>
+          ({
+            resource: { kind: "dataType", resourceId: params.dataTypeId },
+            ...relationship,
+          }) as DataTypeAuthorizationRelationship,
+      ),
+    );
+
+export const modifyDataTypeAuthorizationRelationships: ImpureGraphFunction<
+  {
+    operation: ModifyRelationshipOperation;
+    relationship: DataTypeAuthorizationRelationship;
+  }[],
+  Promise<void>
+> = async ({ graphApi }, { actorId }, params) => {
+  await graphApi.modifyDataTypeAuthorizationRelationships(
+    actorId,
+    params.map(({ operation, relationship }) => ({
+      operation,
+      resource: relationship.resource.resourceId,
+      relationAndSubject: relationship,
+    })),
+  );
+};
+
+export const checkDataTypePermission: ImpureGraphFunction<
+  { dataTypeId: VersionedUrl; permission: DataTypePermission },
+  Promise<boolean>
+> = async ({ graphApi }, { actorId }, params) =>
+  graphApi
+    .checkDataTypePermission(actorId, params.dataTypeId, params.permission)
+    .then(({ data }) => data.has_permission);

--- a/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
@@ -5,7 +5,9 @@ import {
 } from "@blockprotocol/type-system";
 import {
   EntityType,
+  EntityTypePermission,
   EntityTypeStructuralQuery,
+  ModifyRelationshipOperation,
   OntologyTemporalMetadata,
   UpdateEntityTypeRequest,
 } from "@local/hash-graph-client";
@@ -17,6 +19,7 @@ import {
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { generateTypeId } from "@local/hash-isomorphic-utils/ontology-types";
 import {
+  EntityTypeAuthorizationRelationship,
   EntityTypeMetadata,
   EntityTypeRootType,
   EntityTypeWithMetadata,
@@ -300,3 +303,43 @@ export const unarchiveEntityType: ImpureGraphFunction<
 
   return temporalMetadata;
 };
+
+export const getEntityTypeAuthorizationRelationships: ImpureGraphFunction<
+  { entityTypeId: VersionedUrl },
+  Promise<EntityTypeAuthorizationRelationship[]>
+> = async ({ graphApi }, { actorId }, params) =>
+  graphApi
+    .getEntityTypeAuthorizationRelationships(actorId, params.entityTypeId)
+    .then(({ data }) =>
+      data.map(
+        (relationship) =>
+          ({
+            resource: { kind: "entityType", resourceId: params.entityTypeId },
+            ...relationship,
+          }) as EntityTypeAuthorizationRelationship,
+      ),
+    );
+export const modifyEntityTypeAuthorizationRelationships: ImpureGraphFunction<
+  {
+    operation: ModifyRelationshipOperation;
+    relationship: EntityTypeAuthorizationRelationship;
+  }[],
+  Promise<void>
+> = async ({ graphApi }, { actorId }, params) => {
+  await graphApi.modifyEntityTypeAuthorizationRelationships(
+    actorId,
+    params.map(({ operation, relationship }) => ({
+      operation,
+      resource: relationship.resource.resourceId,
+      relationAndSubject: relationship,
+    })),
+  );
+};
+
+export const checkEntityTypePermission: ImpureGraphFunction<
+  { entityTypeId: VersionedUrl; permission: EntityTypePermission },
+  Promise<boolean>
+> = async ({ graphApi }, { actorId }, params) =>
+  graphApi
+    .checkEntityTypePermission(actorId, params.entityTypeId, params.permission)
+    .then(({ data }) => data.has_permission);

--- a/apps/hash-api/src/graph/ontology/primitive/property-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/property-type.ts
@@ -3,7 +3,9 @@ import {
   VersionedUrl,
 } from "@blockprotocol/type-system";
 import {
+  ModifyRelationshipOperation,
   OntologyTemporalMetadata,
+  PropertyTypePermission,
   PropertyTypeStructuralQuery,
   UpdatePropertyTypeRequest,
 } from "@local/hash-graph-client";
@@ -19,6 +21,7 @@ import {
   OntologyTypeRecordId,
   ontologyTypeRecordIdToVersionedUrl,
   OwnedById,
+  PropertyTypeAuthorizationRelationship,
   PropertyTypeRootType,
   PropertyTypeWithMetadata,
   Subgraph,
@@ -256,3 +259,51 @@ export const unarchivePropertyType: ImpureGraphFunction<
 
   return temporalMetadata;
 };
+
+export const getPropertyTypeAuthorizationRelationships: ImpureGraphFunction<
+  { propertyTypeId: VersionedUrl },
+  Promise<PropertyTypeAuthorizationRelationship[]>
+> = async ({ graphApi }, { actorId }, params) =>
+  graphApi
+    .getPropertyTypeAuthorizationRelationships(actorId, params.propertyTypeId)
+    .then(({ data }) =>
+      data.map(
+        (relationship) =>
+          ({
+            resource: {
+              kind: "propertyType",
+              resourceId: params.propertyTypeId,
+            },
+            ...relationship,
+          }) as PropertyTypeAuthorizationRelationship,
+      ),
+    );
+
+export const modifyPropertyTypeAuthorizationRelationships: ImpureGraphFunction<
+  {
+    operation: ModifyRelationshipOperation;
+    relationship: PropertyTypeAuthorizationRelationship;
+  }[],
+  Promise<void>
+> = async ({ graphApi }, { actorId }, params) => {
+  await graphApi.modifyPropertyTypeAuthorizationRelationships(
+    actorId,
+    params.map(({ operation, relationship }) => ({
+      operation,
+      resource: relationship.resource.resourceId,
+      relationAndSubject: relationship,
+    })),
+  );
+};
+
+export const checkPropertyTypePermission: ImpureGraphFunction<
+  { propertyTypeId: VersionedUrl; permission: PropertyTypePermission },
+  Promise<boolean>
+> = async ({ graphApi }, { actorId }, params) =>
+  graphApi
+    .checkPropertyTypePermission(
+      actorId,
+      params.propertyTypeId,
+      params.permission,
+    )
+    .then(({ data }) => data.has_permission);

--- a/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
@@ -4,12 +4,23 @@
 
 use std::sync::Arc;
 
-use authorization::{backend::PermissionAssertion, AuthorizationApiPool};
+use authorization::{
+    backend::{ModifyRelationshipOperation, PermissionAssertion},
+    schema::{
+        DataTypeGeneralViewerSubject, DataTypeId, DataTypeOwnerSubject, DataTypePermission,
+        DataTypeRelationAndSubject,
+    },
+    zanzibar::Consistency,
+    AuthorizationApi, AuthorizationApiPool,
+};
 use axum::{
+    extract::Path,
     http::StatusCode,
-    routing::{post, put},
+    response::Response,
+    routing::{get, post, put},
     Extension, Router,
 };
+use error_stack::Report;
 use graph_types::{
     ontology::{
         DataTypeWithMetadata, OntologyElementMetadata, OntologyTemporalMetadata,
@@ -26,8 +37,9 @@ use crate::{
     api::rest::{
         json::Json,
         report_to_status_code,
+        status::report_to_response,
         utoipa_typedef::{subgraph::Subgraph, ListOrValue, MaybeListOfDataType},
-        AuthenticatedUserHeader, RestApiStore,
+        AuthenticatedUserHeader, PermissionResponse, RestApiStore,
     },
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
@@ -43,6 +55,10 @@ use crate::{
 #[derive(OpenApi)]
 #[openapi(
     paths(
+        get_data_type_authorization_relationships,
+        modify_data_type_authorization_relationships,
+        check_data_type_permission,
+
         create_data_type,
         load_external_data_type,
         get_data_types_by_query,
@@ -53,6 +69,12 @@ use crate::{
     components(
         schemas(
             DataTypeWithMetadata,
+
+            DataTypeGeneralViewerSubject,
+            DataTypeOwnerSubject,
+            DataTypePermission,
+            DataTypeRelationAndSubject,
+            ModifyDataTypeAuthorizationRelationship,
 
             CreateDataTypeRequest,
             LoadExternalDataTypeRequest,
@@ -84,6 +106,22 @@ impl RoutedResource for DataTypeResource {
                 .route(
                     "/",
                     post(create_data_type::<S, A>).put(update_data_type::<S, A>),
+                )
+                .route(
+                    "/relationships",
+                    post(modify_data_type_authorization_relationships::<A>),
+                )
+                .nest(
+                    "/:data_type_id",
+                    Router::new()
+                        .route(
+                            "/relationships",
+                            get(get_data_type_authorization_relationships::<A>),
+                        )
+                        .route(
+                            "/permissions/:permission",
+                            get(check_data_type_permission::<A>),
+                        ),
                 )
                 .route("/query", post(get_data_types_by_query::<S, A>))
                 .route("/load", post(load_external_data_type::<S, A>))
@@ -534,4 +572,166 @@ where
             StatusCode::INTERNAL_SERVER_ERROR
         })
         .map(Json)
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct ModifyDataTypeAuthorizationRelationship {
+    operation: ModifyRelationshipOperation,
+    resource: VersionedUrl,
+    relation_and_subject: DataTypeRelationAndSubject,
+}
+
+#[utoipa::path(
+    post,
+    path = "/data-types/relationships",
+    tag = "DataType",
+    request_body = [ModifyDataTypeAuthorizationRelationship],
+    params(
+        ("X-Authenticated-User-Actor-Id" = AccountId, Header, description = "The ID of the actor which is used to authorize the request"),
+    ),
+    responses(
+        (status = 204, description = "The relationship was modified for the data"),
+
+        (status = 403, description = "Permission denied"),
+    )
+)]
+#[tracing::instrument(level = "info", skip(authorization_api_pool))]
+async fn modify_data_type_authorization_relationships<A>(
+    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    authorization_api_pool: Extension<Arc<A>>,
+    relationships: Json<Vec<ModifyDataTypeAuthorizationRelationship>>,
+) -> Result<StatusCode, Response>
+where
+    A: AuthorizationApiPool + Send + Sync,
+{
+    let mut authorization_api = authorization_api_pool
+        .acquire()
+        .await
+        .map_err(report_to_response)?;
+
+    let (data_types, operations): (Vec<_>, Vec<_>) = relationships
+        .0
+        .into_iter()
+        .map(|request| {
+            let resource = DataTypeId::from_url(&request.resource);
+            (
+                resource,
+                (request.operation, resource, request.relation_and_subject),
+            )
+        })
+        .unzip();
+
+    let (permissions, _zookie) = authorization_api
+        .check_data_types_permission(
+            actor_id,
+            DataTypePermission::Update,
+            data_types,
+            Consistency::FullyConsistent,
+        )
+        .await
+        .map_err(report_to_response)?;
+
+    let mut failed = false;
+    // TODO: Change interface for `check_data_types_permission` to avoid this loop
+    for (_data_type_id, has_permission) in permissions {
+        if !has_permission {
+            tracing::error!("Insufficient permissions to modify relationship for data type");
+            failed = true;
+        }
+    }
+
+    if failed {
+        return Err(report_to_response(
+            Report::new(PermissionAssertion).attach(hash_status::StatusCode::PermissionDenied),
+        ));
+    }
+
+    // for request in relationships.0 {
+    authorization_api
+        .modify_data_type_relations(operations)
+        .await
+        .map_err(report_to_response)?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[utoipa::path(
+    get,
+    path = "/data-types/{data_type_id}/relationships",
+    tag = "DataType",
+    params(
+        ("X-Authenticated-User-Actor-Id" = AccountId, Header, description = "The ID of the actor which is used to authorize the request"),
+        ("data_type_id" = VersionedUrl, Path, description = "The Data type to read the relations for"),
+    ),
+    responses(
+        (status = 200, description = "The relations of the data type", body = [DataTypeRelationAndSubject]),
+
+        (status = 403, description = "Permission denied"),
+    )
+)]
+#[tracing::instrument(level = "info", skip(authorization_api_pool))]
+async fn get_data_type_authorization_relationships<A>(
+    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    Path(data_type_id): Path<VersionedUrl>,
+    authorization_api_pool: Extension<Arc<A>>,
+) -> Result<Json<Vec<DataTypeRelationAndSubject>>, Response>
+where
+    A: AuthorizationApiPool + Send + Sync,
+{
+    let authorization_api = authorization_api_pool
+        .acquire()
+        .await
+        .map_err(report_to_response)?;
+
+    Ok(Json(
+        authorization_api
+            .get_data_type_relations(
+                DataTypeId::from_url(&data_type_id),
+                Consistency::FullyConsistent,
+            )
+            .await
+            .map_err(report_to_response)?,
+    ))
+}
+
+#[utoipa::path(
+    get,
+    path = "/data-types/{data_type_id}/permissions/{permission}",
+    tag = "DataType",
+    params(
+        ("X-Authenticated-User-Actor-Id" = AccountId, Header, description = "The ID of the actor which is used to authorize the request"),
+        ("data_type_id" = VersionedUrl, Path, description = "The data type ID to check if the actor has the permission"),
+        ("permission" = DataTypePermission, Path, description = "The permission to check for"),
+    ),
+    responses(
+        (status = 200, body = PermissionResponse, description = "Information if the actor has the permission for the data type"),
+
+        (status = 500, description = "Internal error occurred"),
+    )
+)]
+#[tracing::instrument(level = "info", skip(authorization_api_pool))]
+async fn check_data_type_permission<A>(
+    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    Path((data_type_id, permission)): Path<(VersionedUrl, DataTypePermission)>,
+    authorization_api_pool: Extension<Arc<A>>,
+) -> Result<Json<PermissionResponse>, Response>
+where
+    A: AuthorizationApiPool + Send + Sync,
+{
+    Ok(Json(PermissionResponse {
+        has_permission: authorization_api_pool
+            .acquire()
+            .await
+            .map_err(report_to_response)?
+            .check_data_type_permission(
+                actor_id,
+                permission,
+                DataTypeId::from_url(&data_type_id),
+                Consistency::FullyConsistent,
+            )
+            .await
+            .map_err(report_to_response)?
+            .has_permission,
+    }))
 }

--- a/apps/hash-graph/lib/graph/src/api/rest/entity.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity.rs
@@ -2,10 +2,10 @@
 
 #![expect(clippy::str_to_string)]
 
-use std::{iter::once, sync::Arc};
+use std::sync::Arc;
 
 use authorization::{
-    backend::ModifyRelationshipOperation,
+    backend::{ModifyRelationshipOperation, PermissionAssertion},
     schema::{
         EntityGeneralEditorSubject, EntityGeneralViewerSubject, EntityOwnerSubject,
         EntityPermission, EntityRelationAndSubject, EntitySubjectSet, WebSubject,
@@ -20,7 +20,7 @@ use axum::{
     routing::{get, post},
     Extension, Router,
 };
-use error_stack::ResultExt;
+use error_stack::{Report, ResultExt};
 use graph_types::{
     knowledge::{
         entity::{
@@ -33,7 +33,7 @@ use graph_types::{
 };
 use serde::{Deserialize, Serialize};
 use type_system::url::VersionedUrl;
-use utoipa::{openapi, OpenApi, ToSchema};
+use utoipa::{OpenApi, ToSchema};
 
 use crate::{
     api::rest::{
@@ -77,7 +77,6 @@ use crate::{
             EntityOwnerSubject,
             EntityGeneralEditorSubject,
             EntityGeneralViewerSubject,
-            EntityAuthorizationRelationship,
             ModifyEntityAuthorizationRelationship,
             ModifyRelationshipOperation,
 
@@ -93,8 +92,6 @@ use crate::{
             EntityQueryToken,
             LinkData,
             LinkOrder,
-
-            Viewer,
         )
     ),
     tags(
@@ -255,7 +252,7 @@ async fn check_entity_permission<A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     Path((entity_id, permission)): Path<(EntityId, EntityPermission)>,
     authorization_api_pool: Extension<Arc<A>>,
-) -> Result<Json<PermissionResponse>, StatusCode>
+) -> Result<Json<PermissionResponse>, Response>
 where
     A: AuthorizationApiPool + Send + Sync,
 {
@@ -263,10 +260,7 @@ where
         has_permission: authorization_api_pool
             .acquire()
             .await
-            .map_err(|error| {
-                tracing::error!(?error, "Could not acquire access to the authorization API");
-                StatusCode::INTERNAL_SERVER_ERROR
-            })?
+            .map_err(report_to_response)?
             .check_entity_permission(
                 actor_id,
                 permission,
@@ -274,13 +268,7 @@ where
                 Consistency::FullyConsistent,
             )
             .await
-            .map_err(|error| {
-                tracing::error!(
-                    ?error,
-                    "Could not check if permission on entity is granted to the specified actor"
-                );
-                StatusCode::INTERNAL_SERVER_ERROR
-            })?
+            .map_err(report_to_response)?
             .has_permission,
     }))
 }
@@ -418,41 +406,6 @@ where
         .map(Json)
 }
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum PublicTag {
-    Public,
-}
-
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum Viewer {
-    Public(PublicTag),
-    Owner(OwnedById),
-}
-
-impl<'s> ToSchema<'s> for Viewer {
-    fn schema() -> (&'static str, openapi::RefOr<openapi::Schema>) {
-        (
-            "Viewer",
-            openapi::OneOfBuilder::new()
-                .item(openapi::schema::Schema::from(
-                    openapi::schema::ObjectBuilder::new()
-                        .schema_type(openapi::SchemaType::String)
-                        .enum_values(Some(once(serde_json::Value::String("public".to_owned())))),
-                ))
-                .item(openapi::schema::Ref::from_schema_name("OwnedById"))
-                .into(),
-        )
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
-#[serde(rename_all = "camelCase")]
-struct EntityAuthorizationRelationship {
-    relation_and_subject: EntityRelationAndSubject,
-}
-
 #[utoipa::path(
     get,
     path = "/entities/{entity_id}/relationships",
@@ -462,7 +415,7 @@ struct EntityAuthorizationRelationship {
         ("entity_id" = EntityId, Path, description = "The Entity to read the relations for"),
     ),
     responses(
-        (status = 200, description = "The relations of the entity", body = [EntityAuthorizationRelationship]),
+        (status = 200, description = "The relations of the entity", body = [EntityRelationAndSubject]),
 
         (status = 403, description = "Permission denied"),
     )
@@ -472,28 +425,20 @@ async fn get_entity_authorization_relationships<A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     Path(entity_id): Path<EntityId>,
     authorization_api_pool: Extension<Arc<A>>,
-) -> Result<Json<Vec<EntityAuthorizationRelationship>>, StatusCode>
+) -> Result<Json<Vec<EntityRelationAndSubject>>, Response>
 where
     A: AuthorizationApiPool + Send + Sync,
 {
-    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
-        tracing::error!(?error, "Could not acquire access to the authorization API");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let authorization_api = authorization_api_pool
+        .acquire()
+        .await
+        .map_err(report_to_response)?;
 
     Ok(Json(
         authorization_api
             .get_entity_relations(entity_id, Consistency::FullyConsistent)
             .await
-            .map_err(|error| {
-                tracing::error!(?error, "Could not add entity owner");
-                StatusCode::INTERNAL_SERVER_ERROR
-            })?
-            .into_iter()
-            .map(|relation| EntityAuthorizationRelationship {
-                relation_and_subject: relation,
-            })
-            .collect(),
+            .map_err(report_to_response)?,
     ))
 }
 
@@ -524,14 +469,14 @@ async fn modify_entity_authorization_relationships<A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     authorization_api_pool: Extension<Arc<A>>,
     relationships: Json<Vec<ModifyEntityAuthorizationRelationship>>,
-) -> Result<StatusCode, StatusCode>
+) -> Result<StatusCode, Response>
 where
     A: AuthorizationApiPool + Send + Sync,
 {
-    let mut authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
-        tracing::error!(?error, "Could not acquire access to the authorization API");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let mut authorization_api = authorization_api_pool
+        .acquire()
+        .await
+        .map_err(report_to_response)?;
 
     let (entities, operations): (Vec<_>, Vec<_>) = relationships
         .0
@@ -556,13 +501,7 @@ where
             Consistency::FullyConsistent,
         )
         .await
-        .map_err(|error| {
-            tracing::error!(
-                ?error,
-                "Could not check if relationship can be modified for entity"
-            );
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+        .map_err(report_to_response)?;
 
     let mut failed = false;
     // TODO: Change interface for `check_entities_permission` to avoid this loop
@@ -576,18 +515,16 @@ where
     }
 
     if failed {
-        return Err(StatusCode::FORBIDDEN);
+        return Err(report_to_response(
+            Report::new(PermissionAssertion).attach(hash_status::StatusCode::PermissionDenied),
+        ));
     }
 
     // for request in relationships.0 {
     authorization_api
         .modify_entity_relations(operations)
         .await
-        .map_err(|error| {
-            tracing::error!(?error, "Could not add entity relationship");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-    // }
+        .map_err(report_to_response)?;
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -683,7 +620,7 @@ where
     params(
         ("X-Authenticated-User-Actor-Id" = AccountId, Header, description = "The ID of the actor which is used to authorize the request"),
         ("entity_id" = EntityId, Path, description = "The Entity to remove the owner from"),
-        ("owner" = Viewer, Path, description = "The owner to remove from the entity"),
+        ("owner" = OwnedById, Path, description = "The owner to remove from the entity"),
     ),
     responses(
         (status = 204, description = "The owner was removed from the entity"),

--- a/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
@@ -4,12 +4,23 @@
 
 use std::sync::Arc;
 
-use authorization::{backend::PermissionAssertion, AuthorizationApiPool};
+use authorization::{
+    backend::{ModifyRelationshipOperation, PermissionAssertion},
+    schema::{
+        PropertyTypeGeneralViewerSubject, PropertyTypeId, PropertyTypeOwnerSubject,
+        PropertyTypePermission, PropertyTypeRelationAndSubject,
+    },
+    zanzibar::Consistency,
+    AuthorizationApi, AuthorizationApiPool,
+};
 use axum::{
+    extract::Path,
     http::StatusCode,
-    routing::{post, put},
+    response::Response,
+    routing::{get, post, put},
     Extension, Router,
 };
+use error_stack::Report;
 use graph_types::{
     ontology::{
         OntologyElementMetadata, OntologyTemporalMetadata, OntologyTypeReference,
@@ -26,8 +37,9 @@ use crate::{
     api::rest::{
         json::Json,
         report_to_status_code,
+        status::report_to_response,
         utoipa_typedef::{subgraph::Subgraph, ListOrValue, MaybeListOfPropertyType},
-        AuthenticatedUserHeader, RestApiStore,
+        AuthenticatedUserHeader, PermissionResponse, RestApiStore,
     },
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
@@ -43,6 +55,10 @@ use crate::{
 #[derive(OpenApi)]
 #[openapi(
     paths(
+        get_property_type_authorization_relationships,
+        modify_property_type_authorization_relationships,
+        check_property_type_permission,
+
         create_property_type,
         load_external_property_type,
         get_property_types_by_query,
@@ -53,6 +69,12 @@ use crate::{
     components(
         schemas(
             PropertyTypeWithMetadata,
+
+            PropertyTypeGeneralViewerSubject,
+            PropertyTypeOwnerSubject,
+            PropertyTypePermission,
+            PropertyTypeRelationAndSubject,
+            ModifyPropertyTypeAuthorizationRelationship,
 
             CreatePropertyTypeRequest,
             LoadExternalPropertyTypeRequest,
@@ -84,6 +106,22 @@ impl RoutedResource for PropertyTypeResource {
                 .route(
                     "/",
                     post(create_property_type::<S, A>).put(update_property_type::<S, A>),
+                )
+                .route(
+                    "/relationships",
+                    post(modify_property_type_authorization_relationships::<A>),
+                )
+                .nest(
+                    "/:property_type_id",
+                    Router::new()
+                        .route(
+                            "/relationships",
+                            get(get_property_type_authorization_relationships::<A>),
+                        )
+                        .route(
+                            "/permissions/:permission",
+                            get(check_property_type_permission::<A>),
+                        ),
                 )
                 .route("/query", post(get_property_types_by_query::<S, A>))
                 .route("/load", post(load_external_property_type::<S, A>))
@@ -535,4 +573,166 @@ where
             StatusCode::INTERNAL_SERVER_ERROR
         })
         .map(Json)
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct ModifyPropertyTypeAuthorizationRelationship {
+    operation: ModifyRelationshipOperation,
+    resource: VersionedUrl,
+    relation_and_subject: PropertyTypeRelationAndSubject,
+}
+
+#[utoipa::path(
+    post,
+    path = "/property-types/relationships",
+    tag = "PropertyType",
+    request_body = [ModifyPropertyTypeAuthorizationRelationship],
+    params(
+        ("X-Authenticated-User-Actor-Id" = AccountId, Header, description = "The ID of the actor which is used to authorize the request"),
+    ),
+    responses(
+        (status = 204, description = "The relationship was modified for the property"),
+
+        (status = 403, description = "Permission denied"),
+    )
+)]
+#[tracing::instrument(level = "info", skip(authorization_api_pool))]
+async fn modify_property_type_authorization_relationships<A>(
+    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    authorization_api_pool: Extension<Arc<A>>,
+    relationships: Json<Vec<ModifyPropertyTypeAuthorizationRelationship>>,
+) -> Result<StatusCode, Response>
+where
+    A: AuthorizationApiPool + Send + Sync,
+{
+    let mut authorization_api = authorization_api_pool
+        .acquire()
+        .await
+        .map_err(report_to_response)?;
+
+    let (property_types, operations): (Vec<_>, Vec<_>) = relationships
+        .0
+        .into_iter()
+        .map(|request| {
+            let resource = PropertyTypeId::from_url(&request.resource);
+            (
+                resource,
+                (request.operation, resource, request.relation_and_subject),
+            )
+        })
+        .unzip();
+
+    let (permissions, _zookie) = authorization_api
+        .check_property_types_permission(
+            actor_id,
+            PropertyTypePermission::Update,
+            property_types,
+            Consistency::FullyConsistent,
+        )
+        .await
+        .map_err(report_to_response)?;
+
+    let mut failed = false;
+    // TODO: Change interface for `check_property_types_permission` to avoid this loop
+    for (_property_type_id, has_permission) in permissions {
+        if !has_permission {
+            tracing::error!("Insufficient permissions to modify relationship for property type");
+            failed = true;
+        }
+    }
+
+    if failed {
+        return Err(report_to_response(
+            Report::new(PermissionAssertion).attach(hash_status::StatusCode::PermissionDenied),
+        ));
+    }
+
+    // for request in relationships.0 {
+    authorization_api
+        .modify_property_type_relations(operations)
+        .await
+        .map_err(report_to_response)?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[utoipa::path(
+    get,
+    path = "/property-types/{property_type_id}/relationships",
+    tag = "PropertyType",
+    params(
+        ("X-Authenticated-User-Actor-Id" = AccountId, Header, description = "The ID of the actor which is used to authorize the request"),
+        ("property_type_id" = VersionedUrl, Path, description = "The Property type to read the relations for"),
+    ),
+    responses(
+        (status = 200, description = "The relations of the property type", body = [PropertyTypeRelationAndSubject]),
+
+        (status = 403, description = "Permission denied"),
+    )
+)]
+#[tracing::instrument(level = "info", skip(authorization_api_pool))]
+async fn get_property_type_authorization_relationships<A>(
+    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    Path(property_type_id): Path<VersionedUrl>,
+    authorization_api_pool: Extension<Arc<A>>,
+) -> Result<Json<Vec<PropertyTypeRelationAndSubject>>, Response>
+where
+    A: AuthorizationApiPool + Send + Sync,
+{
+    let authorization_api = authorization_api_pool
+        .acquire()
+        .await
+        .map_err(report_to_response)?;
+
+    Ok(Json(
+        authorization_api
+            .get_property_type_relations(
+                PropertyTypeId::from_url(&property_type_id),
+                Consistency::FullyConsistent,
+            )
+            .await
+            .map_err(report_to_response)?,
+    ))
+}
+
+#[utoipa::path(
+    get,
+    path = "/property-types/{property_type_id}/permissions/{permission}",
+    tag = "PropertyType",
+    params(
+        ("X-Authenticated-User-Actor-Id" = AccountId, Header, description = "The ID of the actor which is used to authorize the request"),
+        ("property_type_id" = VersionedUrl, Path, description = "The property type ID to check if the actor has the permission"),
+        ("permission" = PropertyTypePermission, Path, description = "The permission to check for"),
+    ),
+    responses(
+        (status = 200, body = PermissionResponse, description = "Information if the actor has the permission for the property type"),
+
+        (status = 500, description = "Internal error occurred"),
+    )
+)]
+#[tracing::instrument(level = "info", skip(authorization_api_pool))]
+async fn check_property_type_permission<A>(
+    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    Path((property_type_id, permission)): Path<(VersionedUrl, PropertyTypePermission)>,
+    authorization_api_pool: Extension<Arc<A>>,
+) -> Result<Json<PermissionResponse>, Response>
+where
+    A: AuthorizationApiPool + Send + Sync,
+{
+    Ok(Json(PermissionResponse {
+        has_permission: authorization_api_pool
+            .acquire()
+            .await
+            .map_err(report_to_response)?
+            .check_property_type_permission(
+                actor_id,
+                permission,
+                PropertyTypeId::from_url(&property_type_id),
+                Consistency::FullyConsistent,
+            )
+            .await
+            .map_err(report_to_response)?
+            .has_permission,
+    }))
 }

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -481,6 +481,47 @@
         }
       }
     },
+    "/data-types/relationships": {
+      "post": {
+        "tags": [
+          "Graph",
+          "DataType"
+        ],
+        "operationId": "modify_data_type_authorization_relationships",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ModifyDataTypeAuthorizationRelationship"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "The relationship was modified for the data"
+          },
+          "403": {
+            "description": "Permission denied"
+          }
+        }
+      }
+    },
     "/data-types/unarchive": {
       "put": {
         "tags": [
@@ -531,6 +572,106 @@
           },
           "500": {
             "description": "Store error occurred"
+          }
+        }
+      }
+    },
+    "/data-types/{data_type_id}/permissions/{permission}": {
+      "get": {
+        "tags": [
+          "Graph",
+          "DataType"
+        ],
+        "operationId": "check_data_type_permission",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          },
+          {
+            "name": "data_type_id",
+            "in": "path",
+            "description": "The data type ID to check if the actor has the permission",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/VersionedUrl"
+            }
+          },
+          {
+            "name": "permission",
+            "in": "path",
+            "description": "The permission to check for",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DataTypePermission"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Information if the actor has the permission for the data type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error occurred"
+          }
+        }
+      }
+    },
+    "/data-types/{data_type_id}/relationships": {
+      "get": {
+        "tags": [
+          "Graph",
+          "DataType"
+        ],
+        "operationId": "get_data_type_authorization_relationships",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          },
+          {
+            "name": "data_type_id",
+            "in": "path",
+            "description": "The Data type to read the relations for",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/VersionedUrl"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The relations of the data type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DataTypeRelationAndSubject"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied"
           }
         }
       }
@@ -893,7 +1034,7 @@
             "description": "The owner to remove from the entity",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/Viewer"
+              "$ref": "#/components/schemas/OwnedById"
             }
           }
         ],
@@ -995,7 +1136,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/EntityAuthorizationRelationship"
+                    "$ref": "#/components/schemas/EntityRelationAndSubject"
                   }
                 }
               }
@@ -1302,6 +1443,47 @@
         }
       }
     },
+    "/entity-types/relationships": {
+      "post": {
+        "tags": [
+          "Graph",
+          "EntityType"
+        ],
+        "operationId": "modify_entity_type_authorization_relationships",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ModifyEntityTypeAuthorizationRelationship"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "The relationship was modified for the entity"
+          },
+          "403": {
+            "description": "Permission denied"
+          }
+        }
+      }
+    },
     "/entity-types/unarchive": {
       "put": {
         "tags": [
@@ -1352,6 +1534,106 @@
           },
           "500": {
             "description": "Store error occurred"
+          }
+        }
+      }
+    },
+    "/entity-types/{entity_type_id}/permissions/{permission}": {
+      "get": {
+        "tags": [
+          "Graph",
+          "EntityType"
+        ],
+        "operationId": "check_entity_type_permission",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          },
+          {
+            "name": "entity_type_id",
+            "in": "path",
+            "description": "The entity type ID to check if the actor has the permission",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/VersionedUrl"
+            }
+          },
+          {
+            "name": "permission",
+            "in": "path",
+            "description": "The permission to check for",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/EntityTypePermission"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Information if the actor has the permission for the entity type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error occurred"
+          }
+        }
+      }
+    },
+    "/entity-types/{entity_type_id}/relationships": {
+      "get": {
+        "tags": [
+          "Graph",
+          "EntityType"
+        ],
+        "operationId": "get_entity_type_authorization_relationships",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          },
+          {
+            "name": "entity_type_id",
+            "in": "path",
+            "description": "The Entity type to read the relations for",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/VersionedUrl"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The relations of the entity type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EntityTypeRelationAndSubject"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied"
           }
         }
       }
@@ -1609,6 +1891,47 @@
         }
       }
     },
+    "/property-types/relationships": {
+      "post": {
+        "tags": [
+          "Graph",
+          "PropertyType"
+        ],
+        "operationId": "modify_property_type_authorization_relationships",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ModifyPropertyTypeAuthorizationRelationship"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "The relationship was modified for the property"
+          },
+          "403": {
+            "description": "Permission denied"
+          }
+        }
+      }
+    },
     "/property-types/unarchive": {
       "put": {
         "tags": [
@@ -1659,6 +1982,106 @@
           },
           "500": {
             "description": "Store error occurred"
+          }
+        }
+      }
+    },
+    "/property-types/{property_type_id}/permissions/{permission}": {
+      "get": {
+        "tags": [
+          "Graph",
+          "PropertyType"
+        ],
+        "operationId": "check_property_type_permission",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          },
+          {
+            "name": "property_type_id",
+            "in": "path",
+            "description": "The property type ID to check if the actor has the permission",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/VersionedUrl"
+            }
+          },
+          {
+            "name": "permission",
+            "in": "path",
+            "description": "The permission to check for",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropertyTypePermission"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Information if the actor has the permission for the property type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error occurred"
+          }
+        }
+      }
+    },
+    "/property-types/{property_type_id}/relationships": {
+      "get": {
+        "tags": [
+          "Graph",
+          "PropertyType"
+        ],
+        "operationId": "get_property_type_authorization_relationships",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          },
+          {
+            "name": "property_type_id",
+            "in": "path",
+            "description": "The Property type to read the relations for",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/VersionedUrl"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The relations of the property type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PropertyTypeRelationAndSubject"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied"
           }
         }
       }
@@ -1993,6 +2416,74 @@
           }
         ]
       },
+      "DataTypeGeneralViewerSubject": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "public"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "DataTypeOwnerSubject": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "subjectId",
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "account"
+                ]
+              },
+              "subjectId": {
+                "$ref": "#/components/schemas/AccountId"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "subjectId",
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "accountGroup"
+                ]
+              },
+              "subjectId": {
+                "$ref": "#/components/schemas/AccountGroupId"
+              }
+            }
+          }
+        ],
+        "discriminator": {
+          "propertyName": "kind"
+        }
+      },
+      "DataTypePermission": {
+        "type": "string",
+        "enum": [
+          "update",
+          "view"
+        ]
+      },
       "DataTypeQueryToken": {
         "type": "string",
         "description": "A single token in a [`DataTypeQueryPath`].",
@@ -2007,6 +2498,49 @@
           "description",
           "type"
         ]
+      },
+      "DataTypeRelationAndSubject": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "relation",
+              "subject"
+            ],
+            "properties": {
+              "relation": {
+                "type": "string",
+                "enum": [
+                  "owner"
+                ]
+              },
+              "subject": {
+                "$ref": "#/components/schemas/DataTypeOwnerSubject"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "relation",
+              "subject"
+            ],
+            "properties": {
+              "relation": {
+                "type": "string",
+                "enum": [
+                  "generalViewer"
+                ]
+              },
+              "subject": {
+                "$ref": "#/components/schemas/DataTypeGeneralViewerSubject"
+              }
+            }
+          }
+        ],
+        "discriminator": {
+          "propertyName": "relation"
+        }
       },
       "DataTypeStructuralQuery": {
         "type": "object",
@@ -2122,17 +2656,6 @@
           },
           "properties": {
             "$ref": "#/components/schemas/EntityProperties"
-          }
-        }
-      },
-      "EntityAuthorizationRelationship": {
-        "type": "object",
-        "required": [
-          "relationAndSubject"
-        ],
-        "properties": {
-          "relationAndSubject": {
-            "$ref": "#/components/schemas/EntityRelationAndSubject"
           }
         }
       },
@@ -2488,6 +3011,24 @@
           }
         }
       },
+      "EntityTypeGeneralViewerSubject": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "public"
+                ]
+              }
+            }
+          }
+        ]
+      },
       "EntityTypeMetadata": {
         "type": "object",
         "required": [
@@ -2515,6 +3056,56 @@
           }
         }
       },
+      "EntityTypeOwnerSubject": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "subjectId",
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "account"
+                ]
+              },
+              "subjectId": {
+                "$ref": "#/components/schemas/AccountId"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "subjectId",
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "accountGroup"
+                ]
+              },
+              "subjectId": {
+                "$ref": "#/components/schemas/AccountGroupId"
+              }
+            }
+          }
+        ],
+        "discriminator": {
+          "propertyName": "kind"
+        }
+      },
+      "EntityTypePermission": {
+        "type": "string",
+        "enum": [
+          "update",
+          "view"
+        ]
+      },
       "EntityTypeQueryToken": {
         "type": "string",
         "description": "A single token in a [`EntityTypeQueryPath`].",
@@ -2536,6 +3127,49 @@
           "inheritsFrom",
           "children"
         ]
+      },
+      "EntityTypeRelationAndSubject": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "relation",
+              "subject"
+            ],
+            "properties": {
+              "relation": {
+                "type": "string",
+                "enum": [
+                  "owner"
+                ]
+              },
+              "subject": {
+                "$ref": "#/components/schemas/EntityTypeOwnerSubject"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "relation",
+              "subject"
+            ],
+            "properties": {
+              "relation": {
+                "type": "string",
+                "enum": [
+                  "generalViewer"
+                ]
+              },
+              "subject": {
+                "$ref": "#/components/schemas/EntityTypeGeneralViewerSubject"
+              }
+            }
+          }
+        ],
+        "discriminator": {
+          "propertyName": "relation"
+        }
       },
       "EntityTypeStructuralQuery": {
         "type": "object",
@@ -3075,6 +3709,25 @@
           }
         ]
       },
+      "ModifyDataTypeAuthorizationRelationship": {
+        "type": "object",
+        "required": [
+          "operation",
+          "resource",
+          "relationAndSubject"
+        ],
+        "properties": {
+          "operation": {
+            "$ref": "#/components/schemas/ModifyRelationshipOperation"
+          },
+          "relationAndSubject": {
+            "$ref": "#/components/schemas/DataTypeRelationAndSubject"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/VersionedUrl"
+          }
+        }
+      },
       "ModifyEntityAuthorizationRelationship": {
         "type": "object",
         "required": [
@@ -3091,6 +3744,44 @@
           },
           "resource": {
             "$ref": "#/components/schemas/EntityId"
+          }
+        }
+      },
+      "ModifyEntityTypeAuthorizationRelationship": {
+        "type": "object",
+        "required": [
+          "operation",
+          "resource",
+          "relationAndSubject"
+        ],
+        "properties": {
+          "operation": {
+            "$ref": "#/components/schemas/ModifyRelationshipOperation"
+          },
+          "relationAndSubject": {
+            "$ref": "#/components/schemas/EntityTypeRelationAndSubject"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/VersionedUrl"
+          }
+        }
+      },
+      "ModifyPropertyTypeAuthorizationRelationship": {
+        "type": "object",
+        "required": [
+          "operation",
+          "resource",
+          "relationAndSubject"
+        ],
+        "properties": {
+          "operation": {
+            "$ref": "#/components/schemas/ModifyRelationshipOperation"
+          },
+          "relationAndSubject": {
+            "$ref": "#/components/schemas/PropertyTypeRelationAndSubject"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/VersionedUrl"
           }
         }
       },
@@ -3365,6 +4056,74 @@
           }
         }
       },
+      "PropertyTypeGeneralViewerSubject": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "public"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "PropertyTypeOwnerSubject": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "subjectId",
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "account"
+                ]
+              },
+              "subjectId": {
+                "$ref": "#/components/schemas/AccountId"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "subjectId",
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "accountGroup"
+                ]
+              },
+              "subjectId": {
+                "$ref": "#/components/schemas/AccountGroupId"
+              }
+            }
+          }
+        ],
+        "discriminator": {
+          "propertyName": "kind"
+        }
+      },
+      "PropertyTypePermission": {
+        "type": "string",
+        "enum": [
+          "update",
+          "view"
+        ]
+      },
       "PropertyTypeQueryToken": {
         "type": "string",
         "description": "A single token in a [`DataTypeQueryPath`].",
@@ -3380,6 +4139,49 @@
           "dataTypes",
           "propertyTypes"
         ]
+      },
+      "PropertyTypeRelationAndSubject": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "relation",
+              "subject"
+            ],
+            "properties": {
+              "relation": {
+                "type": "string",
+                "enum": [
+                  "owner"
+                ]
+              },
+              "subject": {
+                "$ref": "#/components/schemas/PropertyTypeOwnerSubject"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "relation",
+              "subject"
+            ],
+            "properties": {
+              "relation": {
+                "type": "string",
+                "enum": [
+                  "generalViewer"
+                ]
+              },
+              "subject": {
+                "$ref": "#/components/schemas/PropertyTypeGeneralViewerSubject"
+              }
+            }
+          }
+        ],
+        "discriminator": {
+          "propertyName": "relation"
+        }
       },
       "PropertyTypeStructuralQuery": {
         "type": "object",
@@ -3945,19 +4747,6 @@
             ]
           }
         }
-      },
-      "Viewer": {
-        "oneOf": [
-          {
-            "type": "string",
-            "enum": [
-              "public"
-            ]
-          },
-          {
-            "$ref": "#/components/schemas/OwnedById"
-          }
-        ]
       },
       "WebPermission": {
         "type": "string",

--- a/libs/@local/hash-graph-client/python/graph_client/models.py
+++ b/libs/@local/hash-graph-client/python/graph_client/models.py
@@ -18,6 +18,32 @@ class AccountId(RootModel[UUID]):
     model_config = ConfigDict(populate_by_name=True)
     root: UUID
 
+class DataTypeGeneralViewerSubjectItem(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    kind: Literal['public']
+
+class DataTypeGeneralViewerSubject(RootModel[DataTypeGeneralViewerSubjectItem]):
+    model_config = ConfigDict(populate_by_name=True)
+    root: DataTypeGeneralViewerSubjectItem
+
+class DataTypeOwnerSubjectItem(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    kind: Literal['account']
+    subject_id: AccountId = Field(..., alias='subjectId')
+
+class DataTypeOwnerSubjectItem1(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    kind: Literal['accountGroup']
+    subject_id: AccountGroupId = Field(..., alias='subjectId')
+
+class DataTypeOwnerSubject(RootModel[DataTypeOwnerSubjectItem | DataTypeOwnerSubjectItem1]):
+    model_config = ConfigDict(populate_by_name=True)
+    root: DataTypeOwnerSubjectItem | DataTypeOwnerSubjectItem1 = Field(..., discriminator='kind')
+
+class DataTypePermission(Enum):
+    update = 'update'
+    view = 'view'
+
 class DataTypeQueryToken(Enum):
     """
     A single token in a [`DataTypeQueryPath`].
@@ -31,6 +57,20 @@ class DataTypeQueryToken(Enum):
     title = 'title'
     description = 'description'
     type = 'type'
+
+class DataTypeRelationAndSubjectItem(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    relation: Literal['owner']
+    subject: DataTypeOwnerSubject
+
+class DataTypeRelationAndSubjectItem1(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    relation: Literal['generalViewer']
+    subject: DataTypeGeneralViewerSubject
+
+class DataTypeRelationAndSubject(RootModel[DataTypeRelationAndSubjectItem | DataTypeRelationAndSubjectItem1]):
+    model_config = ConfigDict(populate_by_name=True)
+    root: DataTypeRelationAndSubjectItem | DataTypeRelationAndSubjectItem1 = Field(..., discriminator='relation')
 
 class DecisionTime(RootModel[Literal['decisionTime']]):
     model_config = ConfigDict(populate_by_name=True)
@@ -149,6 +189,32 @@ class EntityRelationAndSubject(RootModel[EntityRelationAndSubjectItem | EntityRe
     model_config = ConfigDict(populate_by_name=True)
     root: EntityRelationAndSubjectItem | EntityRelationAndSubjectItem1 | EntityRelationAndSubjectItem2 = Field(..., discriminator='relation')
 
+class EntityTypeGeneralViewerSubjectItem(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    kind: Literal['public']
+
+class EntityTypeGeneralViewerSubject(RootModel[EntityTypeGeneralViewerSubjectItem]):
+    model_config = ConfigDict(populate_by_name=True)
+    root: EntityTypeGeneralViewerSubjectItem
+
+class EntityTypeOwnerSubjectItem(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    kind: Literal['account']
+    subject_id: AccountId = Field(..., alias='subjectId')
+
+class EntityTypeOwnerSubjectItem1(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    kind: Literal['accountGroup']
+    subject_id: AccountGroupId = Field(..., alias='subjectId')
+
+class EntityTypeOwnerSubject(RootModel[EntityTypeOwnerSubjectItem | EntityTypeOwnerSubjectItem1]):
+    model_config = ConfigDict(populate_by_name=True)
+    root: EntityTypeOwnerSubjectItem | EntityTypeOwnerSubjectItem1 = Field(..., discriminator='kind')
+
+class EntityTypePermission(Enum):
+    update = 'update'
+    view = 'view'
+
 class EntityTypeQueryToken(Enum):
     """
     A single token in a [`EntityTypeQueryPath`].
@@ -169,6 +235,20 @@ class EntityTypeQueryToken(Enum):
     links = 'links'
     inherits_from = 'inheritsFrom'
     children = 'children'
+
+class EntityTypeRelationAndSubjectItem(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    relation: Literal['owner']
+    subject: EntityTypeOwnerSubject
+
+class EntityTypeRelationAndSubjectItem1(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    relation: Literal['generalViewer']
+    subject: EntityTypeGeneralViewerSubject
+
+class EntityTypeRelationAndSubject(RootModel[EntityTypeRelationAndSubjectItem | EntityTypeRelationAndSubjectItem1]):
+    model_config = ConfigDict(populate_by_name=True)
+    root: EntityTypeRelationAndSubjectItem | EntityTypeRelationAndSubjectItem1 = Field(..., discriminator='relation')
 
 class EntityUuid(RootModel[UUID]):
     model_config = ConfigDict(populate_by_name=True)
@@ -230,6 +310,32 @@ class PermissionResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     has_permission: bool
 
+class PropertyTypeGeneralViewerSubjectItem(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    kind: Literal['public']
+
+class PropertyTypeGeneralViewerSubject(RootModel[PropertyTypeGeneralViewerSubjectItem]):
+    model_config = ConfigDict(populate_by_name=True)
+    root: PropertyTypeGeneralViewerSubjectItem
+
+class PropertyTypeOwnerSubjectItem(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    kind: Literal['account']
+    subject_id: AccountId = Field(..., alias='subjectId')
+
+class PropertyTypeOwnerSubjectItem1(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    kind: Literal['accountGroup']
+    subject_id: AccountGroupId = Field(..., alias='subjectId')
+
+class PropertyTypeOwnerSubject(RootModel[PropertyTypeOwnerSubjectItem | PropertyTypeOwnerSubjectItem1]):
+    model_config = ConfigDict(populate_by_name=True)
+    root: PropertyTypeOwnerSubjectItem | PropertyTypeOwnerSubjectItem1 = Field(..., discriminator='kind')
+
+class PropertyTypePermission(Enum):
+    update = 'update'
+    view = 'view'
+
 class PropertyTypeQueryToken(Enum):
     """
     A single token in a [`DataTypeQueryPath`].
@@ -244,6 +350,20 @@ class PropertyTypeQueryToken(Enum):
     description = 'description'
     data_types = 'dataTypes'
     property_types = 'propertyTypes'
+
+class PropertyTypeRelationAndSubjectItem(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    relation: Literal['owner']
+    subject: PropertyTypeOwnerSubject
+
+class PropertyTypeRelationAndSubjectItem1(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    relation: Literal['generalViewer']
+    subject: PropertyTypeGeneralViewerSubject
+
+class PropertyTypeRelationAndSubject(RootModel[PropertyTypeRelationAndSubjectItem | PropertyTypeRelationAndSubjectItem1]):
+    model_config = ConfigDict(populate_by_name=True)
+    root: PropertyTypeRelationAndSubjectItem | PropertyTypeRelationAndSubjectItem1 = Field(..., discriminator='relation')
 
 class PinnedDecisionAxis(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
@@ -278,10 +398,6 @@ class Timestamp(RootModel[datetime]):
 class TransactionTime(RootModel[Literal['transactionTime']]):
     model_config = ConfigDict(populate_by_name=True)
     root: Literal['transactionTime'] = Field(..., description='Time axis for the transaction time.\n\nThis is used as the generic argument to time-related structs and can be used as tag value.')
-
-class Viewer(RootModel[Literal['public'] | OwnedById]):
-    model_config = ConfigDict(populate_by_name=True)
-    root: Literal['public'] | OwnedById
 
 class WebPermission(Enum):
     create_entity = 'create_entity'
@@ -437,10 +553,6 @@ class DataTypeVertexId(BaseModel):
     base_id: BaseURL = Field(..., alias='baseId')
     revision_id: OntologyTypeVersion = Field(..., alias='revisionId')
 
-class EntityAuthorizationRelationship(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
-    relation_and_subject: EntityRelationAndSubject = Field(..., alias='relationAndSubject')
-
 class EntityLinkOrder(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     left_to_right_order: LinkOrder | None = Field(None, alias='leftToRightOrder')
@@ -507,11 +619,29 @@ class LoadExternalPropertyTypeRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     property_type_id: VersionedURL = Field(..., alias='propertyTypeId')
 
+class ModifyDataTypeAuthorizationRelationship(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    operation: ModifyRelationshipOperation
+    relation_and_subject: DataTypeRelationAndSubject = Field(..., alias='relationAndSubject')
+    resource: VersionedURL
+
 class ModifyEntityAuthorizationRelationship(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     operation: ModifyRelationshipOperation
     relation_subject: EntityRelationAndSubject = Field(..., alias='relationSubject')
     resource: EntityId
+
+class ModifyEntityTypeAuthorizationRelationship(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    operation: ModifyRelationshipOperation
+    relation_and_subject: EntityTypeRelationAndSubject = Field(..., alias='relationAndSubject')
+    resource: VersionedURL
+
+class ModifyPropertyTypeAuthorizationRelationship(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    operation: ModifyRelationshipOperation
+    relation_and_subject: PropertyTypeRelationAndSubject = Field(..., alias='relationAndSubject')
+    resource: VersionedURL
 
 class OpenTemporalBound(RootModel[ExclusiveBound | UnboundedBound]):
     model_config = ConfigDict(populate_by_name=True)

--- a/libs/@local/hash-subgraph/src/types/shared/branded.ts
+++ b/libs/@local/hash-subgraph/src/types/shared/branded.ts
@@ -1,9 +1,15 @@
 import {
   BaseUrl as BaseUrlBp,
   validateBaseUrl,
+  VersionedUrl,
 } from "@blockprotocol/type-system/slim";
 import { Brand } from "@local/advanced-types/brand";
-import { EntityRelationAndSubject } from "@local/hash-graph-client";
+import {
+  DataTypeRelationAndSubject,
+  EntityRelationAndSubject,
+  EntityTypeRelationAndSubject,
+  PropertyTypeRelationAndSubject,
+} from "@local/hash-graph-client";
 import { validate as validateUuid } from "uuid";
 
 export type BaseUrl = Brand<BaseUrlBp, "BaseUrl">;
@@ -117,3 +123,24 @@ export type EntityAuthorizationRelationship = {
     resourceId: EntityId;
   };
 } & BrandRelationship<EntityRelationAndSubject>;
+
+export type EntityTypeAuthorizationRelationship = {
+  resource: {
+    kind: "entityType";
+    resourceId: VersionedUrl;
+  };
+} & BrandRelationship<EntityTypeRelationAndSubject>;
+
+export type PropertyTypeAuthorizationRelationship = {
+  resource: {
+    kind: "propertyType";
+    resourceId: VersionedUrl;
+  };
+} & BrandRelationship<PropertyTypeRelationAndSubject>;
+
+export type DataTypeAuthorizationRelationship = {
+  resource: {
+    kind: "dataType";
+    resourceId: VersionedUrl;
+  };
+} & BrandRelationship<DataTypeRelationAndSubject>;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To fully control ontology types this adds three endpoints for all ontology types:
- read relationships
- write relationships
- read permissions


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph