### PR TITLE
H-1211: Support reading Entity and `EntityType` from validation

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/validation.rs
+++ b/apps/hash-graph/lib/graph/src/store/validation.rs
@@ -1,18 +1,23 @@
 use authorization::{
-    schema::{DataTypeId, DataTypePermission, PropertyTypeId, PropertyTypePermission},
+    schema::{
+        DataTypeId, DataTypePermission, EntityPermission, EntityTypeId, EntityTypePermission,
+        PropertyTypeId, PropertyTypePermission,
+    },
     zanzibar::Consistency,
     AuthorizationApi,
 };
 use error_stack::{Report, ResultExt};
 use graph_types::{
     account::AccountId,
-    ontology::{DataTypeWithMetadata, PropertyTypeWithMetadata},
+    knowledge::entity::{Entity, EntityId},
+    ontology::{DataTypeWithMetadata, EntityTypeWithMetadata, PropertyTypeWithMetadata},
 };
-use type_system::{url::VersionedUrl, DataType, PropertyType};
-use validation::OntologyTypeProvider;
+use tokio_postgres::GenericClient;
+use type_system::{url::VersionedUrl, DataType, EntityType, PropertyType};
+use validation::{EntityProvider, EntityTypeProvider, OntologyTypeProvider};
 
 use crate::{
-    store::{crud::Read, query::Filter, QueryError},
+    store::{crud::Read, query::Filter, AsClient, PostgresStore, QueryError},
     subgraph::temporal_axes::QueryTemporalAxesUnresolved,
 };
 
@@ -84,5 +89,95 @@ where
             )
             .await
             .map(|data_type| data_type.schema)
+    }
+}
+
+impl<S, A> OntologyTypeProvider<EntityType> for StoreProvider<'_, S, A>
+where
+    S: Read<EntityTypeWithMetadata, Record = EntityTypeWithMetadata>,
+    A: AuthorizationApi + Sync,
+{
+    #[expect(refining_impl_trait)]
+    async fn provide_type(&self, type_id: &VersionedUrl) -> Result<EntityType, Report<QueryError>> {
+        let entity_type_id = EntityTypeId::from_url(type_id);
+        self.authorization_api
+            .check_entity_type_permission(
+                self.actor_id,
+                EntityTypePermission::View,
+                entity_type_id,
+                self.consistency,
+            )
+            .await
+            .change_context(QueryError)?
+            .assert_permission()
+            .change_context(QueryError)?;
+
+        self.store
+            .read_one(
+                &Filter::<S::Record>::for_versioned_url(type_id),
+                Some(&QueryTemporalAxesUnresolved::default().resolve()),
+            )
+            .await
+            .map(|entity_type| entity_type.schema)
+    }
+}
+
+impl<C, A> EntityTypeProvider for StoreProvider<'_, PostgresStore<C>, A>
+where
+    C: AsClient,
+    A: AuthorizationApi + Sync,
+{
+    #[expect(refining_impl_trait)]
+    async fn is_parent_of(
+        &self,
+        child: &VersionedUrl,
+        parent: &VersionedUrl,
+    ) -> Result<bool, Report<QueryError>> {
+        let client = self.store.as_client().client();
+        let child_id = EntityTypeId::from_url(child);
+        let parent_id = EntityTypeId::from_url(parent);
+
+        Ok(client
+            .query_one(
+                "
+                    SELECT EXISTS (
+                        SELECT 1 FROM closed_entity_type_inherits_from
+                        WHERE source_entity_type_ontology_id = $1
+                          AND target_entity_type_ontology_id = $2
+                    );
+                ",
+                &[child_id.as_uuid(), parent_id.as_uuid()],
+            )
+            .await
+            .change_context(QueryError)?
+            .get(0))
+    }
+}
+
+impl<S, A> EntityProvider for StoreProvider<'_, S, A>
+where
+    S: Read<Entity, Record = Entity>,
+    A: AuthorizationApi + Sync,
+{
+    #[expect(refining_impl_trait)]
+    async fn provide_entity(&self, entity_id: EntityId) -> Result<Entity, Report<QueryError>> {
+        self.authorization_api
+            .check_entity_permission(
+                self.actor_id,
+                EntityPermission::View,
+                entity_id,
+                self.consistency,
+            )
+            .await
+            .change_context(QueryError)?
+            .assert_permission()
+            .change_context(QueryError)?;
+
+        self.store
+            .read_one(
+                &Filter::<S::Record>::for_entity_by_entity_id(entity_id),
+                Some(&QueryTemporalAxesUnresolved::default().resolve()),
+            )
+            .await
     }
 }

--- a/libs/@local/hash-graph-types/rust/src/knowledge/entity.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/entity.rs
@@ -160,7 +160,7 @@ impl EntityMetadata {
 
 /// A record of an [`Entity`] that has been persisted in the datastore, with its associated
 /// metadata.
-#[derive(Debug, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[cfg_attr(feature = "utoipa", derive(ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct Entity {

--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -69,6 +69,7 @@ mod tests {
 
     #[tokio::test]
     async fn address() {
+        let entity_types = [];
         let property_types = [
             graph_test_data::property_type::ADDRESS_LINE_1_V1,
             graph_test_data::property_type::POSTCODE_NUMBER_V1,
@@ -79,6 +80,7 @@ mod tests {
         validate_entity(
             graph_test_data::entity::ADDRESS_V1,
             graph_test_data::entity_type::UK_ADDRESS_V1,
+            entity_types,
             property_types,
             data_types,
         )
@@ -88,12 +90,14 @@ mod tests {
 
     #[tokio::test]
     async fn block() {
+        let entity_types = [];
         let property_types = [graph_test_data::property_type::NAME_V1];
         let data_types = [graph_test_data::data_type::TEXT_V1];
 
         validate_entity(
             graph_test_data::entity::BLOCK_V1,
             graph_test_data::entity_type::BLOCK_V1,
+            entity_types,
             property_types,
             data_types,
         )
@@ -106,6 +110,7 @@ mod tests {
         validate_entity(
             graph_test_data::entity::BOOK_V1,
             graph_test_data::entity_type::BOOK_V1,
+            [],
             [
                 graph_test_data::property_type::NAME_V1,
                 graph_test_data::property_type::BLURB_V1,
@@ -119,12 +124,14 @@ mod tests {
 
     #[tokio::test]
     async fn building() {
+        let entity_types = [];
         let property_types = [];
         let data_types = [];
 
         validate_entity(
             graph_test_data::entity::BUILDING_V1,
             graph_test_data::entity_type::BUILDING_V1,
+            entity_types,
             property_types,
             data_types,
         )
@@ -134,12 +141,14 @@ mod tests {
 
     #[tokio::test]
     async fn organization() {
+        let entity_types = [];
         let property_types = [graph_test_data::property_type::NAME_V1];
         let data_types = [graph_test_data::data_type::TEXT_V1];
 
         validate_entity(
             graph_test_data::entity::ORGANIZATION_V1,
             graph_test_data::entity_type::ORGANIZATION_V1,
+            entity_types,
             property_types,
             data_types,
         )
@@ -149,12 +158,14 @@ mod tests {
 
     #[tokio::test]
     async fn page() {
+        let entity_types = [];
         let property_types = [graph_test_data::property_type::TEXT_V1];
         let data_types = [graph_test_data::data_type::TEXT_V1];
 
         validate_entity(
             graph_test_data::entity::PAGE_V1,
             graph_test_data::entity_type::PAGE_V1,
+            entity_types,
             property_types,
             data_types,
         )
@@ -164,6 +175,7 @@ mod tests {
         validate_entity(
             graph_test_data::entity::PAGE_V2,
             graph_test_data::entity_type::PAGE_V2,
+            entity_types,
             property_types,
             data_types,
         )
@@ -173,12 +185,14 @@ mod tests {
 
     #[tokio::test]
     async fn person() {
+        let entity_types = [];
         let property_types = [graph_test_data::property_type::NAME_V1];
         let data_types = [graph_test_data::data_type::TEXT_V1];
 
         validate_entity(
             graph_test_data::entity::PERSON_ALICE_V1,
             graph_test_data::entity_type::PERSON_V1,
+            entity_types,
             property_types,
             data_types,
         )
@@ -188,6 +202,7 @@ mod tests {
         validate_entity(
             graph_test_data::entity::PERSON_BOB_V1,
             graph_test_data::entity_type::PERSON_V1,
+            entity_types,
             property_types,
             data_types,
         )
@@ -197,6 +212,7 @@ mod tests {
         validate_entity(
             graph_test_data::entity::PERSON_CHARLES_V1,
             graph_test_data::entity_type::PERSON_V1,
+            entity_types,
             property_types,
             data_types,
         )
@@ -206,12 +222,14 @@ mod tests {
 
     #[tokio::test]
     async fn playlist() {
+        let entity_types = [];
         let property_types = [graph_test_data::property_type::NAME_V1];
         let data_types = [graph_test_data::data_type::TEXT_V1];
 
         validate_entity(
             graph_test_data::entity::PLAYLIST_V1,
             graph_test_data::entity_type::PLAYLIST_V1,
+            entity_types,
             property_types,
             data_types,
         )
@@ -221,12 +239,14 @@ mod tests {
 
     #[tokio::test]
     async fn song() {
+        let entity_types = [];
         let property_types = [graph_test_data::property_type::NAME_V1];
         let data_types = [graph_test_data::data_type::TEXT_V1];
 
         validate_entity(
             graph_test_data::entity::SONG_V1,
             graph_test_data::entity_type::SONG_V1,
+            entity_types,
             property_types,
             data_types,
         )

--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -69,6 +69,7 @@ mod tests {
 
     #[tokio::test]
     async fn address() {
+        let entities = [];
         let entity_types = [];
         let property_types = [
             graph_test_data::property_type::ADDRESS_LINE_1_V1,
@@ -80,6 +81,7 @@ mod tests {
         validate_entity(
             graph_test_data::entity::ADDRESS_V1,
             graph_test_data::entity_type::UK_ADDRESS_V1,
+            entities,
             entity_types,
             property_types,
             data_types,
@@ -90,6 +92,7 @@ mod tests {
 
     #[tokio::test]
     async fn block() {
+        let entities = [];
         let entity_types = [];
         let property_types = [graph_test_data::property_type::NAME_V1];
         let data_types = [graph_test_data::data_type::TEXT_V1];
@@ -97,6 +100,7 @@ mod tests {
         validate_entity(
             graph_test_data::entity::BLOCK_V1,
             graph_test_data::entity_type::BLOCK_V1,
+            entities,
             entity_types,
             property_types,
             data_types,
@@ -107,16 +111,22 @@ mod tests {
 
     #[tokio::test]
     async fn book() {
+        let entities = [];
+        let entity_types = [];
+        let property_types = [
+            graph_test_data::property_type::NAME_V1,
+            graph_test_data::property_type::BLURB_V1,
+            graph_test_data::property_type::PUBLISHED_ON_V1,
+        ];
+        let data_types = [graph_test_data::data_type::TEXT_V1];
+
         validate_entity(
             graph_test_data::entity::BOOK_V1,
             graph_test_data::entity_type::BOOK_V1,
-            [],
-            [
-                graph_test_data::property_type::NAME_V1,
-                graph_test_data::property_type::BLURB_V1,
-                graph_test_data::property_type::PUBLISHED_ON_V1,
-            ],
-            [graph_test_data::data_type::TEXT_V1],
+            entities,
+            entity_types,
+            property_types,
+            data_types,
         )
         .await
         .expect("validation failed");
@@ -124,6 +134,7 @@ mod tests {
 
     #[tokio::test]
     async fn building() {
+        let entities = [];
         let entity_types = [];
         let property_types = [];
         let data_types = [];
@@ -131,6 +142,7 @@ mod tests {
         validate_entity(
             graph_test_data::entity::BUILDING_V1,
             graph_test_data::entity_type::BUILDING_V1,
+            entities,
             entity_types,
             property_types,
             data_types,
@@ -141,6 +153,7 @@ mod tests {
 
     #[tokio::test]
     async fn organization() {
+        let entities = [];
         let entity_types = [];
         let property_types = [graph_test_data::property_type::NAME_V1];
         let data_types = [graph_test_data::data_type::TEXT_V1];
@@ -148,6 +161,7 @@ mod tests {
         validate_entity(
             graph_test_data::entity::ORGANIZATION_V1,
             graph_test_data::entity_type::ORGANIZATION_V1,
+            entities,
             entity_types,
             property_types,
             data_types,
@@ -158,6 +172,7 @@ mod tests {
 
     #[tokio::test]
     async fn page() {
+        let entities = [];
         let entity_types = [];
         let property_types = [graph_test_data::property_type::TEXT_V1];
         let data_types = [graph_test_data::data_type::TEXT_V1];
@@ -165,6 +180,7 @@ mod tests {
         validate_entity(
             graph_test_data::entity::PAGE_V1,
             graph_test_data::entity_type::PAGE_V1,
+            entities.to_vec(),
             entity_types,
             property_types,
             data_types,
@@ -175,6 +191,7 @@ mod tests {
         validate_entity(
             graph_test_data::entity::PAGE_V2,
             graph_test_data::entity_type::PAGE_V2,
+            entities,
             entity_types,
             property_types,
             data_types,
@@ -185,6 +202,7 @@ mod tests {
 
     #[tokio::test]
     async fn person() {
+        let entities = [];
         let entity_types = [];
         let property_types = [graph_test_data::property_type::NAME_V1];
         let data_types = [graph_test_data::data_type::TEXT_V1];
@@ -192,6 +210,7 @@ mod tests {
         validate_entity(
             graph_test_data::entity::PERSON_ALICE_V1,
             graph_test_data::entity_type::PERSON_V1,
+            entities.to_vec(),
             entity_types,
             property_types,
             data_types,
@@ -202,6 +221,7 @@ mod tests {
         validate_entity(
             graph_test_data::entity::PERSON_BOB_V1,
             graph_test_data::entity_type::PERSON_V1,
+            entities.to_vec(),
             entity_types,
             property_types,
             data_types,
@@ -212,6 +232,7 @@ mod tests {
         validate_entity(
             graph_test_data::entity::PERSON_CHARLES_V1,
             graph_test_data::entity_type::PERSON_V1,
+            entities,
             entity_types,
             property_types,
             data_types,
@@ -222,6 +243,7 @@ mod tests {
 
     #[tokio::test]
     async fn playlist() {
+        let entities = [];
         let entity_types = [];
         let property_types = [graph_test_data::property_type::NAME_V1];
         let data_types = [graph_test_data::data_type::TEXT_V1];
@@ -229,6 +251,7 @@ mod tests {
         validate_entity(
             graph_test_data::entity::PLAYLIST_V1,
             graph_test_data::entity_type::PLAYLIST_V1,
+            entities,
             entity_types,
             property_types,
             data_types,
@@ -239,6 +262,7 @@ mod tests {
 
     #[tokio::test]
     async fn song() {
+        let entities = [];
         let entity_types = [];
         let property_types = [graph_test_data::property_type::NAME_V1];
         let data_types = [graph_test_data::data_type::TEXT_V1];
@@ -246,6 +270,7 @@ mod tests {
         validate_entity(
             graph_test_data::entity::SONG_V1,
             graph_test_data::entity_type::SONG_V1,
+            entities,
             entity_types,
             property_types,
             data_types,

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -112,7 +112,6 @@ mod tests {
         error::install_error_stack_hooks, property_type::PropertyValidationError,
     };
 
-    #[expect(clippy::struct_field_names)]
     struct Provider {
         entities: HashMap<EntityId, Entity>,
         entity_types: HashMap<VersionedUrl, EntityType>,
@@ -174,10 +173,10 @@ mod tests {
         async fn provide_entity(
             &self,
             entity_id: EntityId,
-        ) -> Result<&Entity, Report<InvalidPropertyType>> {
+        ) -> Result<&Entity, Report<InvalidEntity>> {
             self.entities
-                .get(entity_id)
-                .ok_or_else(|| Report::new(InvalidPropertyType { id: *entity_id }))
+                .get(&entity_id)
+                .ok_or_else(|| Report::new(InvalidEntity { id: entity_id }))
         }
     }
 
@@ -240,6 +239,7 @@ mod tests {
     pub(crate) async fn validate_entity(
         entity: &'static str,
         entity_type: &'static str,
+        entities: impl IntoIterator<Item = Entity> + Send,
         entity_types: impl IntoIterator<Item = &'static str> + Send,
         property_types: impl IntoIterator<Item = &'static str> + Send,
         data_types: impl IntoIterator<Item = &'static str> + Send,
@@ -247,6 +247,7 @@ mod tests {
         install_error_stack_hooks();
 
         let provider = Provider::new(
+            entities,
             entity_types.into_iter().map(|entity_type_id| {
                 let raw_entity_type = serde_json::from_str::<raw::EntityType>(entity_type_id)
                     .expect("failed to read entity type string");
@@ -284,6 +285,7 @@ mod tests {
         install_error_stack_hooks();
 
         let provider = Provider::new(
+            [],
             [],
             property_types.into_iter().map(|property_type_id| {
                 let raw_property_type = serde_json::from_str::<raw::PropertyType>(property_type_id)

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -185,7 +185,7 @@ mod tests {
             &self,
             child: &VersionedUrl,
             parent: &VersionedUrl,
-        ) -> Result<bool, Report<InvalidPropertyType>> {
+        ) -> Result<bool, Report<InvalidEntityType>> {
             Ok(
                 OntologyTypeProvider::<EntityType>::provide_type(self, child)
                     .await?
@@ -201,9 +201,9 @@ mod tests {
         async fn provide_type(
             &self,
             type_id: &VersionedUrl,
-        ) -> Result<&EntityType, Report<InvalidPropertyType>> {
+        ) -> Result<&EntityType, Report<InvalidEntityType>> {
             self.entity_types.get(type_id).ok_or_else(|| {
-                Report::new(InvalidPropertyType {
+                Report::new(InvalidEntityType {
                     id: type_id.clone(),
                 })
             })

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -19,7 +19,8 @@ mod property_type;
 use std::{borrow::Borrow, future::Future};
 
 use error_stack::{Context, Report};
-use type_system::url::VersionedUrl;
+use graph_types::knowledge::entity::{Entity, EntityId};
+use type_system::{url::VersionedUrl, EntityType};
 
 trait Schema<V: ?Sized, P: Sync> {
     type Error: Context;
@@ -82,11 +83,25 @@ pub trait OntologyTypeProvider<O> {
     ) -> impl Future<Output = Result<impl Borrow<O> + Send, Report<impl Context>>> + Send;
 }
 
+pub trait EntityTypeProvider: OntologyTypeProvider<EntityType> {
+    fn is_parent_of(
+        &self,
+        child: &VersionedUrl,
+        parent: &VersionedUrl,
+    ) -> impl Future<Output = Result<bool, Report<impl Context>>> + Send;
+}
+pub trait EntityProvider {
+    fn provide_entity(
+        &self,
+        entity_id: EntityId,
+    ) -> impl Future<Output = Result<impl Borrow<Entity> + Send, Report<impl Context>>> + Send;
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
 
-    use graph_types::knowledge::entity::EntityProperties;
+    use graph_types::knowledge::entity::{EntityId, EntityProperties};
     use serde_json::Value as JsonValue;
     use thiserror::Error;
     use type_system::{raw, DataType, EntityType, PropertyType};
@@ -97,16 +112,29 @@ mod tests {
         error::install_error_stack_hooks, property_type::PropertyValidationError,
     };
 
+    #[expect(clippy::struct_field_names)]
     struct Provider {
+        entities: HashMap<EntityId, Entity>,
+        entity_types: HashMap<VersionedUrl, EntityType>,
         property_types: HashMap<VersionedUrl, PropertyType>,
         data_types: HashMap<VersionedUrl, DataType>,
     }
     impl Provider {
         fn new(
+            entities: impl IntoIterator<Item = Entity>,
+            entity_types: impl IntoIterator<Item = EntityType>,
             property_types: impl IntoIterator<Item = PropertyType>,
             data_types: impl IntoIterator<Item = DataType>,
         ) -> Self {
             Self {
+                entities: entities
+                    .into_iter()
+                    .map(|entity| (entity.metadata.record_id().entity_id, entity))
+                    .collect(),
+                entity_types: entity_types
+                    .into_iter()
+                    .map(|schema| (schema.id().clone(), schema))
+                    .collect(),
                 property_types: property_types
                     .into_iter()
                     .map(|schema| (schema.id().clone(), schema))
@@ -120,6 +148,18 @@ mod tests {
     }
 
     #[derive(Debug, Error)]
+    #[error("entity was not found: `{id}`")]
+    struct InvalidEntity {
+        id: EntityId,
+    }
+
+    #[derive(Debug, Error)]
+    #[error("entity type was not found: `{id}`")]
+    struct InvalidEntityType {
+        id: VersionedUrl,
+    }
+
+    #[derive(Debug, Error)]
     #[error("property type was not found: `{id}`")]
     struct InvalidPropertyType {
         id: VersionedUrl,
@@ -128,6 +168,47 @@ mod tests {
     #[error("data type was not found: `{id}`")]
     struct InvalidDataType {
         id: VersionedUrl,
+    }
+
+    impl EntityProvider for Provider {
+        async fn provide_entity(
+            &self,
+            entity_id: EntityId,
+        ) -> Result<&Entity, Report<InvalidPropertyType>> {
+            self.entities
+                .get(entity_id)
+                .ok_or_else(|| Report::new(InvalidPropertyType { id: *entity_id }))
+        }
+    }
+
+    impl EntityTypeProvider for Provider {
+        async fn is_parent_of(
+            &self,
+            child: &VersionedUrl,
+            parent: &VersionedUrl,
+        ) -> Result<bool, Report<InvalidPropertyType>> {
+            Ok(
+                OntologyTypeProvider::<EntityType>::provide_type(self, child)
+                    .await?
+                    .inherits_from()
+                    .all_of()
+                    .iter()
+                    .any(|id| id.url() == parent),
+            )
+        }
+    }
+
+    impl OntologyTypeProvider<EntityType> for Provider {
+        async fn provide_type(
+            &self,
+            type_id: &VersionedUrl,
+        ) -> Result<&EntityType, Report<InvalidPropertyType>> {
+            self.entity_types.get(type_id).ok_or_else(|| {
+                Report::new(InvalidPropertyType {
+                    id: type_id.clone(),
+                })
+            })
+        }
     }
 
     impl OntologyTypeProvider<PropertyType> for Provider {
@@ -159,12 +240,18 @@ mod tests {
     pub(crate) async fn validate_entity(
         entity: &'static str,
         entity_type: &'static str,
+        entity_types: impl IntoIterator<Item = &'static str> + Send,
         property_types: impl IntoIterator<Item = &'static str> + Send,
         data_types: impl IntoIterator<Item = &'static str> + Send,
     ) -> Result<(), Report<EntityValidationError>> {
         install_error_stack_hooks();
 
         let provider = Provider::new(
+            entity_types.into_iter().map(|entity_type_id| {
+                let raw_entity_type = serde_json::from_str::<raw::EntityType>(entity_type_id)
+                    .expect("failed to read entity type string");
+                EntityType::try_from(raw_entity_type).expect("failed to parse entity type")
+            }),
             property_types.into_iter().map(|property_type_id| {
                 let raw_property_type = serde_json::from_str::<raw::PropertyType>(property_type_id)
                     .expect("failed to read property type string");
@@ -197,6 +284,7 @@ mod tests {
         install_error_stack_hooks();
 
         let provider = Provider::new(
+            [],
             property_types.into_iter().map(|property_type_id| {
                 let raw_property_type = serde_json::from_str::<raw::PropertyType>(property_type_id)
                     .expect("failed to read property type string");


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To validate links it's required that entity types and entities can be seen from the validation. This adds the functionality to access these. Also, a function is added to detect if an entity type is inheriting from another type.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing
### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph