### PR TITLE
H-1212: Allow prevention to update certain properties

### DIFF
--- a/apps/hash-api/src/graph/util.ts
+++ b/apps/hash-api/src/graph/util.ts
@@ -190,6 +190,7 @@ export const propertyTypeInitializer = (
           return await createPropertyType(context, authentication, {
             ownedById: systemUserAccountId as OwnedById,
             schema: propertyTypeSchema,
+            instantiators: [{ kind: "public" }],
           }).catch((createError) => {
             logger.warn(`Failed to create property type: ${params.title}`);
             throw createError;

--- a/apps/hash-api/src/graphql/resolvers/ontology/property-type.ts
+++ b/apps/hash-api/src/graphql/resolvers/ontology/property-type.ts
@@ -46,6 +46,7 @@ export const createPropertyTypeResolver: ResolverFn<
     {
       ownedById: (ownedById ?? user.accountId) as OwnedById,
       schema: propertyType,
+      instantiators: [{ kind: "public" }],
     },
   );
 
@@ -151,6 +152,7 @@ export const updatePropertyTypeResolver: ResolverFn<
     {
       propertyTypeId: params.propertyTypeId,
       schema: params.updatedPropertyType,
+      instantiators: [{ kind: "public" }],
     },
   );
 

--- a/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use authorization::{
     backend::{ModifyRelationshipOperation, PermissionAssertion},
     schema::{
-        PropertyTypeGeneralViewerSubject, PropertyTypeId, PropertyTypeOwnerSubject,
-        PropertyTypePermission, PropertyTypeRelationAndSubject,
+        PropertyTypeGeneralViewerSubject, PropertyTypeId, PropertyTypeInstantiatorSubject,
+        PropertyTypeOwnerSubject, PropertyTypePermission, PropertyTypeRelationAndSubject,
     },
     zanzibar::Consistency,
     AuthorizationApi, AuthorizationApiPool,
@@ -75,6 +75,7 @@ use crate::{
 
             PropertyTypeGeneralViewerSubject,
             PropertyTypeOwnerSubject,
+            PropertyTypeInstantiatorSubject,
             PropertyTypePermission,
             PropertyTypeRelationAndSubject,
             ModifyPropertyTypeAuthorizationRelationship,

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -394,6 +394,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             )
             .await?;
 
+        #[expect(clippy::needless_collect, reason = "Higher ranked lifetime error")]
         let has_permission = authorization_api
             .check_property_types_permission(
                 actor_id,
@@ -831,8 +832,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                         .properties
                         .properties()
                         .get(base_url)
-                        .map(|old_value| old_value != *value)
-                        .unwrap_or(true)
+                        .map_or(true, |old_value| old_value != *value)
                 })
                 .chain(previous_entity.properties.properties().iter().filter(
                     |(base_url, _valuevalue)| properties.properties().get(base_url).is_none(),

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -4,9 +4,9 @@ use async_trait::async_trait;
 use authorization::{
     backend::ModifyRelationshipOperation,
     schema::{
-        PropertyTypeGeneralViewerSubject, PropertyTypeId, PropertyTypeOwnerSubject,
-        PropertyTypePermission, PropertyTypeRelationAndSubject, PropertyTypeSubjectSet,
-        WebPermission,
+        PropertyTypeGeneralViewerSubject, PropertyTypeId, PropertyTypeInstantiatorSubject,
+        PropertyTypeOwnerSubject, PropertyTypePermission, PropertyTypeRelationAndSubject,
+        PropertyTypeSubjectSet, WebPermission,
     },
     zanzibar::{Consistency, Zookie},
     AuthorizationApi,
@@ -316,6 +316,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                         subject: PropertyTypeGeneralViewerSubject::Public,
                     },
                 ));
+
                 if let Some(owner) = owner {
                     match owner {
                         OntologyTypeSubject::Account { id } => relationships.push((
@@ -334,6 +335,13 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                             },
                         )),
                     }
+                } else {
+                    relationships.push((
+                        PropertyTypeId::from(ontology_id),
+                        PropertyTypeRelationAndSubject::Instantiator {
+                            subject: PropertyTypeInstantiatorSubject::Public,
+                        },
+                    ));
                 }
             }
         }

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -4126,6 +4126,63 @@
           }
         ]
       },
+      "PropertyTypeInstantiatorSubject": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "subjectId",
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "account"
+                ]
+              },
+              "subjectId": {
+                "$ref": "#/components/schemas/AccountId"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "subjectId",
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "accountGroup"
+                ]
+              },
+              "subjectId": {
+                "$ref": "#/components/schemas/AccountGroupId"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "public"
+                ]
+              }
+            }
+          }
+        ],
+        "discriminator": {
+          "propertyName": "kind"
+        }
+      },
       "PropertyTypeOwnerSubject": {
         "oneOf": [
           {
@@ -4173,7 +4230,8 @@
         "type": "string",
         "enum": [
           "update",
-          "view"
+          "view",
+          "instantiate"
         ]
       },
       "PropertyTypeQueryToken": {
@@ -4227,6 +4285,24 @@
               },
               "subject": {
                 "$ref": "#/components/schemas/PropertyTypeGeneralViewerSubject"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "subject",
+              "relation"
+            ],
+            "properties": {
+              "relation": {
+                "type": "string",
+                "enum": [
+                  "instantiator"
+                ]
+              },
+              "subject": {
+                "$ref": "#/components/schemas/PropertyTypeInstantiatorSubject"
               }
             }
           }

--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -284,6 +284,27 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     client.global.set("person_property_type_id", `${response.body.recordId.baseUrl}v/${response.body.recordId.version}`);
 %}
 
+
+### Allow the name property type to be instantiated by the account
+POST http://127.0.0.1:4000/property-types/relationships
+Content-Type: application/json
+Accept: application/json
+X-Authenticated-User-Actor-Id: {{account_id}}
+
+[
+  {
+    "operation": "create",
+    "resource": "{{person_property_type_id}}",
+    "relationAndSubject": {
+      "relation": "instantiator",
+      "subject": {
+        "kind": "account",
+        "subjectId": "{{account_id}}"
+      }
+    }
+  }
+]
+
 ### Get Name property type
 POST http://127.0.0.1:4000/property-types/query
 Content-Type: application/json
@@ -372,7 +393,29 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
+    client.global.set("person_property_type_id_2", `${response.body.recordId.baseUrl}v/${response.body.recordId.version}`);
 %}
+
+
+### Allow the name property type to be instantiated by the account
+POST http://127.0.0.1:4000/property-types/relationships
+Content-Type: application/json
+Accept: application/json
+X-Authenticated-User-Actor-Id: {{account_id}}
+
+[
+  {
+    "operation": "create",
+    "resource": "{{person_property_type_id_2}}",
+    "relationAndSubject": {
+      "relation": "instantiator",
+      "subject": {
+        "kind": "account",
+        "subjectId": "{{account_id}}"
+      }
+    }
+  }
+]
 
 ### Get all latest property types
 POST http://127.0.0.1:4000/property-types/query
@@ -1284,7 +1327,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
  "entityId": "{{person_a_entity_id}}",
  "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/2",
  "properties": {
-   "http://localhost:3000/@alice/types/property-type/name/": "Alice Allison"
+   "http://localhost:3000/@alice/types/property-type/name/": "Alice Allisons"
  },
  "archived": false
 }

--- a/libs/@local/hash-authorization/schemas/v1__initial_schema.zed
+++ b/libs/@local/hash-authorization/schemas/v1__initial_schema.zed
@@ -38,9 +38,11 @@ definition graph/entity_type {
 
 definition graph/property_type {
 	relation level_00_owner: graph/account | graph/account_group#member
+	relation level_00_instantiator: graph/account | graph/account_group#member | graph/account:*
 	relation level_00_viewer: graph/account:*
 
 	permission update = level_00_owner
+    permission instantiate = level_00_instantiator
 	permission view = level_00_viewer + update
 }
 

--- a/libs/@local/hash-authorization/src/schema.rs
+++ b/libs/@local/hash-authorization/src/schema.rs
@@ -30,10 +30,10 @@ pub use self::{
         EntityTypeSubject, EntityTypeSubjectId, EntityTypeSubjectSet,
     },
     property_type::{
-        PropertyTypeGeneralViewerSubject, PropertyTypeId, PropertyTypeNamespace,
-        PropertyTypeOwnerSubject, PropertyTypePermission, PropertyTypeRelationAndSubject,
-        PropertyTypeResourceRelation, PropertyTypeSubject, PropertyTypeSubjectId,
-        PropertyTypeSubjectSet,
+        PropertyTypeGeneralViewerSubject, PropertyTypeId, PropertyTypeInstantiatorSubject,
+        PropertyTypeNamespace, PropertyTypeOwnerSubject, PropertyTypePermission,
+        PropertyTypeRelationAndSubject, PropertyTypeResourceRelation, PropertyTypeSubject,
+        PropertyTypeSubjectId, PropertyTypeSubjectSet,
     },
     web::{
         WebNamespace, WebOwnerSubject, WebPermission, WebRelationAndSubject, WebResourceRelation,

--- a/libs/@local/hash-graph-client/python/graph_client/models.py
+++ b/libs/@local/hash-graph-client/python/graph_client/models.py
@@ -318,6 +318,24 @@ class PropertyTypeGeneralViewerSubject(RootModel[PropertyTypeGeneralViewerSubjec
     model_config = ConfigDict(populate_by_name=True)
     root: PropertyTypeGeneralViewerSubjectItem
 
+class PropertyTypeInstantiatorSubjectItem(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    kind: Literal['account']
+    subject_id: AccountId = Field(..., alias='subjectId')
+
+class PropertyTypeInstantiatorSubjectItem1(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    kind: Literal['accountGroup']
+    subject_id: AccountGroupId = Field(..., alias='subjectId')
+
+class PropertyTypeInstantiatorSubjectItem2(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    kind: Literal['public']
+
+class PropertyTypeInstantiatorSubject(RootModel[PropertyTypeInstantiatorSubjectItem | PropertyTypeInstantiatorSubjectItem1 | PropertyTypeInstantiatorSubjectItem2]):
+    model_config = ConfigDict(populate_by_name=True)
+    root: PropertyTypeInstantiatorSubjectItem | PropertyTypeInstantiatorSubjectItem1 | PropertyTypeInstantiatorSubjectItem2 = Field(..., discriminator='kind')
+
 class PropertyTypeOwnerSubjectItem(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     kind: Literal['account']
@@ -335,6 +353,7 @@ class PropertyTypeOwnerSubject(RootModel[PropertyTypeOwnerSubjectItem | Property
 class PropertyTypePermission(Enum):
     update = 'update'
     view = 'view'
+    instantiate = 'instantiate'
 
 class PropertyTypeQueryToken(Enum):
     """
@@ -361,9 +380,14 @@ class PropertyTypeRelationAndSubjectItem1(BaseModel):
     relation: Literal['generalViewer']
     subject: PropertyTypeGeneralViewerSubject
 
-class PropertyTypeRelationAndSubject(RootModel[PropertyTypeRelationAndSubjectItem | PropertyTypeRelationAndSubjectItem1]):
+class PropertyTypeRelationAndSubjectItem2(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
-    root: PropertyTypeRelationAndSubjectItem | PropertyTypeRelationAndSubjectItem1 = Field(..., discriminator='relation')
+    relation: Literal['instantiator']
+    subject: PropertyTypeInstantiatorSubject
+
+class PropertyTypeRelationAndSubject(RootModel[PropertyTypeRelationAndSubjectItem | PropertyTypeRelationAndSubjectItem1 | PropertyTypeRelationAndSubjectItem2]):
+    model_config = ConfigDict(populate_by_name=True)
+    root: PropertyTypeRelationAndSubjectItem | PropertyTypeRelationAndSubjectItem1 | PropertyTypeRelationAndSubjectItem2 = Field(..., discriminator='relation')
 
 class PinnedDecisionAxis(BaseModel):
     model_config = ConfigDict(populate_by_name=True)

--- a/libs/@local/hash-subgraph/src/types/shared/branded.ts
+++ b/libs/@local/hash-subgraph/src/types/shared/branded.ts
@@ -8,6 +8,7 @@ import {
   DataTypeRelationAndSubject,
   EntityRelationAndSubject,
   EntityTypeRelationAndSubject,
+  PropertyTypeInstantiatorSubject as PropertyTypeInstantiatorSubjectGraph,
   PropertyTypeRelationAndSubject,
 } from "@local/hash-graph-client";
 import { validate as validateUuid } from "uuid";
@@ -137,6 +138,8 @@ export type PropertyTypeAuthorizationRelationship = {
     resourceId: VersionedUrl;
   };
 } & BrandRelationship<PropertyTypeRelationAndSubject>;
+export type PropertyTypeInstantiatorSubject =
+  BrandSubject<PropertyTypeInstantiatorSubjectGraph>;
 
 export type DataTypeAuthorizationRelationship = {
   resource: {

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/primitive/entity.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/primitive/entity.test.ts
@@ -110,6 +110,7 @@ describe("Entity CRU", () => {
           title: "Favorite Book",
           oneOf: [{ $ref: textDataTypeId }],
         },
+        instantiators: [{ kind: "public" }],
       })
         .then((val) => {
           favoriteBookPropertyType = val;
@@ -124,6 +125,7 @@ describe("Entity CRU", () => {
           title: "Name",
           oneOf: [{ $ref: textDataTypeId }],
         },
+        instantiators: [{ kind: "public" }],
       })
         .then((val) => {
           namePropertyType = val;

--- a/tests/hash-backend-integration/src/tests/graph/ontology/primitive/entity-type.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/ontology/primitive/entity-type.test.ts
@@ -111,6 +111,7 @@ beforeAll(async () => {
         title: "Favorite Book",
         oneOf: [{ $ref: textDataTypeId }],
       },
+      instantiators: [{ kind: "public" }],
     }).then((val) => {
       favoriteBookPropertyType = val;
     }),
@@ -120,6 +121,7 @@ beforeAll(async () => {
         title: "Name",
         oneOf: [{ $ref: textDataTypeId }],
       },
+      instantiators: [{ kind: "public" }],
     }).then((val) => {
       namePropertyType = val;
     }),

--- a/tests/hash-backend-integration/src/tests/graph/ontology/primitive/property-type.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/ontology/primitive/property-type.test.ts
@@ -108,6 +108,7 @@ describe("Property type CRU", () => {
       {
         ownedById: testOrg.accountGroupId as OwnedById,
         schema: propertyTypeSchema,
+        instantiators: [{ kind: "public" }],
       },
     );
   });
@@ -145,6 +146,7 @@ describe("Property type CRU", () => {
           ...propertyTypeSchema,
           title: updatedTitle,
         },
+        instantiators: [{ kind: "public" }],
       },
     ).catch((err) => Promise.reject(err.data));
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

As an easy/fast solution to prevent users from updating types such as EMail and Shortname the permission to do so can globally restricted. While users may want to use these types on their own entity types, this is the quickest solution to achieve that forbids updating these properties.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph