### PR TITLE
H-1220: Fix environment variable for allowed domain pattern

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@ DUMMY_EMAIL_TRANSPORTER_FILE_PATH=var/api/dummy-email-transporter/email-dumps.ym
 DUMMY_EMAIL_TRANSPORTER_USE_CLIPBOARD=true
 
 FRONTEND_URL=http://localhost:3000
-HASH_GRAPH_ALLOWED_URL_DOMAIN_PATTERN="(?:http://localhost:3000|https://hash\.ai)/@(?P<shortname>[\w-]+)/types/(?P<kind>(?:data-type)|(?:property-type)|(?:entity-type))/[\w\-_%]+/"
+HASH_GRAPH_ALLOWED_URL_DOMAIN_PATTERN="(?:http://localhost:3000|https://hash\\.ai)/@(?P<shortname>[\\w-]+)/types/(?P<kind>(?:data-type)|(?:property-type)|(?:entity-type))/[\\w\\-_%]+/"
 
 HASH_INTEGRATION_QUEUE_NAME=integration
 HASH_EMAIL_TRANSPORTER=dummy

--- a/.env.test
+++ b/.env.test
@@ -2,4 +2,4 @@ HASH_KRATOS_PG_DATABASE=test_kratos
 HASH_TEMPORAL_PG_DATABASE=test_temporal
 HASH_TEMPORAL_VISIBILITY_PG_DATABASE=test_temporal_visibility
 HASH_GRAPH_PG_DATABASE=test_graph
-HASH_GRAPH_ALLOWED_URL_DOMAIN_PATTERN="(?:http://localhost:3000|https://hash\.ai)/@(?P<shortname>[\w-]+)/types/(?P<kind>(?:data-type)|(?:property-type)|(?:entity-type))/[\w\-_%]+/"
+HASH_GRAPH_ALLOWED_URL_DOMAIN_PATTERN="(?:http://localhost:3000|https://hash\\.ai)/@(?P<shortname>[\\w-]+)/types/(?P<kind>(?:data-type)|(?:property-type)|(?:entity-type))/[\\w\\-_%]+/"

--- a/apps/hash-graph/bin/cli/src/subcommand/server.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/server.rs
@@ -98,14 +98,14 @@ pub struct ServerArgs {
     /// - be in the standard format accepted by Rust's `regex` crate.
     ///
     /// - contain a capture group named "shortname" to identify a user's shortname, e.g.
-    ///   `(?P<shortname>[\w|-]+)`
+    ///   `(?P<shortname>[\w-]+)`
     ///
     /// - contain a capture group named "kind" to identify the slug of the kind of ontology type
     ///   being hosted (data-type, property-type, entity-type, link-type), e.g.
-    ///   `(?P<kind>(?:data-type)|(?:property-type)|(?:entity-type)|(?:link-type))`
+    ///   `(?P<kind>(?:data-type)|(?:property-type)|(?:entity-type))`
     #[clap(
         long,
-        default_value_t = Regex::new(r"http://localhost:3000/@(?P<shortname>[\w-]+)/types/(?P<kind>(?:data-type)|(?:property-type)|(?:entity-type)|(?:link-type))/[\w\-_%]+/").unwrap(),
+        default_value_t = Regex::new(r"http://localhost:3000/@(?P<shortname>[\w-]+)/types/(?P<kind>(?:data-type)|(?:property-type)|(?:entity-type))/[\w\-_%]+/").unwrap(),
         env = "HASH_GRAPH_ALLOWED_URL_DOMAIN_PATTERN",
     )]
     pub allowed_url_domain: Regex,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Without the backslashes `\` escaped in the environment file the Graph fails to load all variables. This also drives-by a fix for the default value to exclude the old `link-type`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph