### PR TITLE
H-1126: Don't create Linear integration org if integration not enabled

### DIFF
--- a/apps/hash-api/src/graph/util.ts
+++ b/apps/hash-api/src/graph/util.ts
@@ -27,6 +27,7 @@ import {
   PropertyTypeWithMetadata,
 } from "@local/hash-subgraph";
 
+import { enabledIntegrations } from "../integrations/enabled-integrations";
 import { NotFoundError } from "../lib/error";
 import { logger } from "../logger";
 import { createAccountGroup, createWeb } from "./account-permission-management";
@@ -55,15 +56,18 @@ const owningWebs: Record<
   SystemTypeWebShortname,
   {
     accountGroupId?: AccountGroupId;
+    enabled: boolean;
     name: string;
     website: string;
   }
 > = {
   hash: {
+    enabled: true,
     name: "HASH",
     website: "https://hash.ai",
   },
   linear: {
+    enabled: enabledIntegrations.linear,
     name: "Linear",
     website: "https://linear.app",
   },
@@ -125,7 +129,13 @@ export const ensureAccountGroupOrgsExist = async (params: {
 
   logger.debug("Ensuring account group organization entities exist");
 
-  for (const [webShortname, { name, website }] of Object.entries(owningWebs)) {
+  for (const [webShortname, { enabled, name, website }] of Object.entries(
+    owningWebs,
+  )) {
+    if (!enabled) {
+      continue;
+    }
+
     const authentication = { actorId: systemAccountId };
     const foundOrg = await getOrgByShortname(context, authentication, {
       shortname: webShortname,

--- a/apps/hash-api/src/index.ts
+++ b/apps/hash-api/src/index.ts
@@ -35,6 +35,7 @@ import { User } from "./graph/knowledge/system-types/user";
 import { ensureLinearTypesExist } from "./graph/linear-types";
 import { createApolloServer } from "./graphql/create-apollo-server";
 import { registerOpenTelemetryTracing } from "./graphql/opentelemetry";
+import { enabledIntegrations } from "./integrations/enabled-integrations";
 import { oAuthLinear, oAuthLinearCallback } from "./integrations/linear/oauth";
 import { linearWebhook } from "./integrations/linear/webhook";
 import { createIntegrationSyncBackWatcher } from "./integrations/sync-back-watcher";
@@ -161,7 +162,7 @@ const main = async () => {
 
   await ensureSystemGraphIsInitialized({ logger, context });
 
-  if (process.env.LINEAR_CLIENT_ID) {
+  if (enabledIntegrations.linear) {
     await ensureLinearTypesExist({ logger, context });
   }
 

--- a/apps/hash-api/src/integrations/enabled-integrations.ts
+++ b/apps/hash-api/src/integrations/enabled-integrations.ts
@@ -1,0 +1,3 @@
+export const enabledIntegrations = {
+  linear: !!process.env.LINEAR_CLIENT_ID,
+} as const satisfies Record<string, boolean>;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We were creating the Linear system types conditional on a Linear client ID being present, but creating the Linear org unconditionally. We should only create it if the Linear integration is enabled.

A better approach would be either 
(a) to have one check for Linear being enabled, and create the types and org if so, or
(b) check which system types exist, and only create the orgs for the webs they belong to

but this will do for now – we can make it better when we introduce another integration.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-1226

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
