### PR TITLE
H-1225: Fix user being created without web

### DIFF
--- a/apps/hash-api/src/graph/account-permission-management.ts
+++ b/apps/hash-api/src/graph/account-permission-management.ts
@@ -1,6 +1,7 @@
-import { AccountGroupId, AccountId } from "@local/hash-subgraph";
+import { AccountGroupId, AccountId, OwnedById } from "@local/hash-subgraph";
 
 import { ImpureGraphFunction } from "./context-types";
+import { WebOwnerSubject } from "@local/hash-graph-client";
 
 export const addAccountGroupMember: ImpureGraphFunction<
   { accountId: AccountId; accountGroupId: AccountGroupId },
@@ -43,8 +44,8 @@ export const createAccountGroup: ImpureGraphFunction<
     .then(({ data }) => data as AccountGroupId);
 
 export const createWeb: ImpureGraphFunction<
-  { owner: AccountId | AccountGroupId },
+  { ownedById: OwnedById; owner: WebOwnerSubject },
   Promise<void>
 > = async ({ graphApi }, { actorId }, params) => {
-  await graphApi.createWeb(actorId, params.owner);
+  await graphApi.createWeb(actorId, params);
 };

--- a/apps/hash-api/src/graph/account-permission-management.ts
+++ b/apps/hash-api/src/graph/account-permission-management.ts
@@ -1,7 +1,7 @@
+import { WebOwnerSubject } from "@local/hash-graph-client";
 import { AccountGroupId, AccountId, OwnedById } from "@local/hash-subgraph";
 
 import { ImpureGraphFunction } from "./context-types";
-import { WebOwnerSubject } from "@local/hash-graph-client";
 
 export const addAccountGroupMember: ImpureGraphFunction<
   { accountId: AccountId; accountGroupId: AccountGroupId },

--- a/apps/hash-api/src/graph/knowledge/system-types/hash-instance.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/hash-instance.ts
@@ -129,7 +129,10 @@ export const createHashInstance: ImpureGraphFunction<
   }
 
   const hashInstanceAdmins = await createAccountGroup(ctx, authentication, {});
-  await createWeb(ctx, authentication, { owner: hashInstanceAdmins });
+  await createWeb(ctx, authentication, {
+    ownedById: hashInstanceAdmins as OwnedById,
+    owner: { kind: "accountGroup", subjectId: hashInstanceAdmins },
+  });
 
   const entity = await createEntity(ctx, authentication, {
     ownedById: hashInstanceAdmins as OwnedById,

--- a/apps/hash-api/src/graph/knowledge/system-types/org.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/org.ts
@@ -131,7 +131,10 @@ export const createOrg: ImpureGraphFunction<
     orgAccountGroupId = params.orgAccountGroupId;
   } else {
     orgAccountGroupId = await createAccountGroup(ctx, authentication, {});
-    await createWeb(ctx, authentication, { owner: orgAccountGroupId });
+    await createWeb(ctx, authentication, {
+      ownedById: orgAccountGroupId as OwnedById,
+      owner: { kind: "accountGroup", subjectId: orgAccountGroupId },
+    });
   }
 
   const properties: EntityPropertiesObject = {

--- a/apps/hash-api/src/graph/knowledge/system-types/user.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user.ts
@@ -28,6 +28,7 @@ import {
 import { EntityTypeMismatchError } from "../../../lib/error";
 import { createAccount, createWeb } from "../../account-permission-management";
 import { ImpureGraphFunction, PureGraphFunction } from "../../context-types";
+import { systemAccountId } from "../../system-account";
 import { SYSTEM_TYPES } from "../../system-types";
 import {
   checkEntityPermission,
@@ -49,8 +50,6 @@ import {
   getOrgMembershipOrg,
   OrgMembership,
 } from "./org-membership";
-import { systemAccountId } from "../../system-account";
-import { modifyWebAuthorizationRelationships } from "../../ontology/primitive/util";
 
 export type User = {
   accountId: AccountId;

--- a/apps/hash-api/src/graph/ontology/primitive/util.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/util.ts
@@ -65,6 +65,7 @@ export const getWebAuthorizationRelationships: ImpureGraphFunction<
           }) as WebAuthorizationRelationship,
       ),
     );
+    
 export const modifyWebAuthorizationRelationships: ImpureGraphFunction<
   {
     operation: ModifyRelationshipOperation;

--- a/apps/hash-api/src/graph/ontology/primitive/util.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/util.ts
@@ -1,13 +1,21 @@
 import {
   entityIdFromOwnedByIdAndEntityUuid,
+  EntityTypeAuthorizationRelationship,
   EntityUuid,
   OwnedById,
   Uuid,
+  WebAuthorizationRelationship,
 } from "@local/hash-subgraph";
 
 import { ImpureGraphFunction } from "../../context-types";
 import { getOrgById } from "../../knowledge/system-types/org";
 import { getUserById } from "../../knowledge/system-types/user";
+import { VersionedUrl } from "@blockprotocol/type-system";
+import {
+  EntityTypePermission,
+  ModifyRelationshipOperation,
+  WebPermission,
+} from "@local/hash-graph-client";
 
 /**
  * Get the web shortname of an account or account group by its id
@@ -41,3 +49,43 @@ export const getWebShortname: ImpureGraphFunction<
 
   return namespace;
 };
+
+export const getWebAuthorizationRelationships: ImpureGraphFunction<
+  { ownedById: OwnedById },
+  Promise<WebAuthorizationRelationship[]>
+> = async ({ graphApi }, { actorId }, params) =>
+  graphApi
+    .getWebAuthorizationRelationships(actorId, params.ownedById)
+    .then(({ data }) =>
+      data.map(
+        (relationship) =>
+          ({
+            resource: { kind: "web", resourceId: params.ownedById },
+            ...relationship,
+          }) as WebAuthorizationRelationship,
+      ),
+    );
+export const modifyWebAuthorizationRelationships: ImpureGraphFunction<
+  {
+    operation: ModifyRelationshipOperation;
+    relationship: WebAuthorizationRelationship;
+  }[],
+  Promise<void>
+> = async ({ graphApi }, { actorId }, params) => {
+  await graphApi.modifyWebAuthorizationRelationships(
+    actorId,
+    params.map(({ operation, relationship }) => ({
+      operation,
+      resource: relationship.resource.resourceId,
+      relationAndSubject: relationship,
+    })),
+  );
+};
+
+export const checkWebPermission: ImpureGraphFunction<
+  { ownedById: OwnedById; permission: WebPermission },
+  Promise<boolean>
+> = async ({ graphApi }, { actorId }, params) =>
+  graphApi
+    .checkWebPermission(actorId, params.ownedById, params.permission)
+    .then(({ data }) => data.has_permission);

--- a/apps/hash-api/src/graph/ontology/primitive/util.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/util.ts
@@ -1,6 +1,9 @@
 import {
+  ModifyRelationshipOperation,
+  WebPermission,
+} from "@local/hash-graph-client";
+import {
   entityIdFromOwnedByIdAndEntityUuid,
-  EntityTypeAuthorizationRelationship,
   EntityUuid,
   OwnedById,
   Uuid,
@@ -10,12 +13,6 @@ import {
 import { ImpureGraphFunction } from "../../context-types";
 import { getOrgById } from "../../knowledge/system-types/org";
 import { getUserById } from "../../knowledge/system-types/user";
-import { VersionedUrl } from "@blockprotocol/type-system";
-import {
-  EntityTypePermission,
-  ModifyRelationshipOperation,
-  WebPermission,
-} from "@local/hash-graph-client";
 
 /**
  * Get the web shortname of an account or account group by its id
@@ -65,7 +62,7 @@ export const getWebAuthorizationRelationships: ImpureGraphFunction<
           }) as WebAuthorizationRelationship,
       ),
     );
-    
+
 export const modifyWebAuthorizationRelationships: ImpureGraphFunction<
   {
     operation: ModifyRelationshipOperation;

--- a/apps/hash-api/src/graph/util.ts
+++ b/apps/hash-api/src/graph/util.ts
@@ -107,7 +107,10 @@ const getOrCreateOwningAccountGroupId = async (
   // The systemAccountId will automatically be assigned as an owner of the account group since it creates it
   const accountGroupId = await createAccountGroup(context, authentication, {});
 
-  await createWeb(context, authentication, { owner: accountGroupId });
+  await createWeb(context, authentication, {
+    ownedById: accountGroupId as OwnedById,
+    owner: { kind: "accountGroup", subjectId: accountGroupId },
+  });
 
   owningWebs[webShortname].accountGroupId = accountGroupId;
 

--- a/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -18,7 +18,6 @@ import {
 } from "apollo-server-express";
 
 import { publicUserAccountId } from "../../../../auth/public-user-account-id";
-import { createWeb } from "../../../../graph/account-permission-management";
 import {
   addEntityEditor,
   addEntityOwner,
@@ -40,6 +39,8 @@ import {
   updateLinkEntity,
 } from "../../../../graph/knowledge/primitive/link-entity";
 import { getEntityTypeById } from "../../../../graph/ontology/primitive/entity-type";
+import { modifyWebAuthorizationRelationships } from "../../../../graph/ontology/primitive/util";
+import { systemAccountId } from "../../../../graph/system-account";
 import { SYSTEM_TYPES } from "../../../../graph/system-types";
 import { genId } from "../../../../util";
 import {
@@ -70,8 +71,6 @@ import { GraphQLContext, LoggedInGraphQLContext } from "../../../context";
 import { dataSourcesToImpureGraphContext } from "../../util";
 import { mapEntityToGQL } from "../graphql-mapping";
 import { createSubgraphAndPermissionsReturn } from "../shared/create-subgraph-and-permissions-return";
-import { modifyWebAuthorizationRelationships } from "../../../../graph/ontology/primitive/util";
-import { systemAccountId } from "../../../../graph/system-account";
 
 export const createEntityResolver: ResolverFn<
   Promise<Entity>,

--- a/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -328,7 +328,8 @@ export const updateEntityResolver: ResolverFn<
       SYSTEM_TYPES.propertyType.preferredName.metadata.recordId.baseUrl
     ]
   ) {
-    // Now that the user has completed signup, we can create their web, allowing them to create/edit entities
+    // Now that the user has completed signup, we can transfer the ownership of the web
+    // allowing them to create entities and types.
     await modifyWebAuthorizationRelationships(
       context,
       { actorId: systemAccountId },

--- a/apps/hash-external-services/docker-compose.test.yml
+++ b/apps/hash-external-services/docker-compose.test.yml
@@ -80,6 +80,10 @@ services:
       timeout: 2s
       retries: 10
 
+  redis:
+    ports:
+      - "6379:6379"
+
   graph:
     depends_on:
       graph-test-server:

--- a/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
@@ -1,6 +1,6 @@
 use std::{iter::repeat, str::FromStr};
 
-use authorization::NoAuthorization;
+use authorization::{schema::WebOwnerSubject, NoAuthorization};
 use criterion::{BatchSize::SmallInput, Bencher, BenchmarkId, Criterion, SamplingMode};
 use criterion_macro::criterion;
 use graph::{
@@ -64,6 +64,7 @@ async fn seed_db(
             account_id,
             &mut NoAuthorization,
             OwnedById::new(account_id.into_uuid()),
+            WebOwnerSubject::Account { id: account_id },
         )
         .await
         .expect("could not create web id");

--- a/apps/hash-graph/bench/read_scaling/knowledge/linkless/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/linkless/entity.rs
@@ -1,6 +1,6 @@
 use std::{iter::repeat, str::FromStr};
 
-use authorization::NoAuthorization;
+use authorization::{schema::WebOwnerSubject, NoAuthorization};
 use criterion::{BatchSize::SmallInput, Bencher, BenchmarkId, Criterion};
 use criterion_macro::criterion;
 use graph::{
@@ -53,6 +53,7 @@ async fn seed_db(
             account_id,
             &mut NoAuthorization,
             OwnedById::new(account_id.into_uuid()),
+            WebOwnerSubject::Account { id: account_id },
         )
         .await
         .expect("could not create web id");

--- a/apps/hash-graph/bench/representative_read/seed.rs
+++ b/apps/hash-graph/bench/representative_read/seed.rs
@@ -4,7 +4,7 @@ use std::{
     str::FromStr,
 };
 
-use authorization::NoAuthorization;
+use authorization::{schema::WebOwnerSubject, NoAuthorization};
 use graph::store::{AccountStore, AsClient, EntityStore};
 use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::{
@@ -136,6 +136,7 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
             account_id,
             &mut NoAuthorization,
             OwnedById::new(account_id.into_uuid()),
+            WebOwnerSubject::Account { id: account_id },
         )
         .await
         .expect("could not create web id");

--- a/apps/hash-graph/lib/graph/src/api/rest/web.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/web.rs
@@ -5,20 +5,26 @@
 use std::sync::Arc;
 
 use authorization::{
-    schema::WebPermission, zanzibar::Consistency, AuthorizationApi, AuthorizationApiPool,
+    backend::{ModifyRelationshipOperation, PermissionAssertion},
+    schema::{WebOwnerSubject, WebPermission, WebRelationAndSubject},
+    zanzibar::Consistency,
+    AuthorizationApi, AuthorizationApiPool,
 };
 use axum::{
     extract::Path,
     http::StatusCode,
+    response::Response,
     routing::{get, post},
     Extension, Json, Router,
 };
+use error_stack::Report;
 use graph_types::{provenance::OwnedById, web::WebId};
-use utoipa::OpenApi;
+use serde::Deserialize;
+use utoipa::{OpenApi, ToSchema};
 
 use super::api_resource::RoutedResource;
 use crate::{
-    api::rest::{AuthenticatedUserHeader, PermissionResponse},
+    api::rest::{status::report_to_response, AuthenticatedUserHeader, PermissionResponse},
     store::{AccountStore, StorePool},
 };
 
@@ -27,10 +33,17 @@ use crate::{
     paths(
         create_web,
         check_web_permission,
+        modify_web_authorization_relationships,
+        get_web_authorization_relationships,
     ),
     components(
         schemas(
+            CreateWebRequest,
+
+            WebRelationAndSubject,
             WebPermission,
+            WebOwnerSubject,
+            ModifyWebAuthorizationRelationship,
         ),
     ),
     tags(
@@ -47,21 +60,40 @@ impl RoutedResource for WebResource {
         A: AuthorizationApiPool + Send + Sync + 'static,
     {
         Router::new().nest(
-            "/webs/:web_id",
+            "/webs",
             Router::new()
+                .route(
+                    "/relationships",
+                    post(modify_web_authorization_relationships::<A>),
+                )
                 .route("/", post(create_web::<S, A>))
-                .route("/permissions/:permission", get(check_web_permission::<A>)),
+                .nest(
+                    "/:web_id",
+                    Router::new()
+                        .route("/permissions/:permission", get(check_web_permission::<A>))
+                        .route(
+                            "/relationships",
+                            get(get_web_authorization_relationships::<A>),
+                        ),
+                ),
         )
     }
 }
 
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct CreateWebRequest {
+    owned_by_id: OwnedById,
+    owner: WebOwnerSubject,
+}
+
 #[utoipa::path(
     post,
-    path = "/webs/{web_id}",
+    path = "/webs",
+    request_body = CreateWebRequest,
     tag = "Web",
     params(
         ("X-Authenticated-User-Actor-Id" = AccountId, Header, description = "The ID of the actor which is used to authorize the request"),
-        ("web_id" = OwnedById, Path, description = "The ID of the account group to add the owner to"),
     ),
     responses(
         (status = 204, content_type = "application/json", description = "The web was created successfully"),
@@ -74,12 +106,14 @@ async fn create_web<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     authorization_api_pool: Extension<Arc<A>>,
     store_pool: Extension<Arc<S>>,
-    Path(owned_by_id): Path<OwnedById>,
+    Json(body): Json<CreateWebRequest>,
 ) -> Result<StatusCode, StatusCode>
 where
     S: StorePool + Send + Sync,
     A: AuthorizationApiPool + Send + Sync,
 {
+    let CreateWebRequest { owned_by_id, owner } = body;
+
     let mut store = store_pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
         StatusCode::INTERNAL_SERVER_ERROR
@@ -91,7 +125,7 @@ where
     })?;
 
     store
-        .insert_web_id(actor_id, &mut authorization_api, owned_by_id)
+        .insert_web_id(actor_id, &mut authorization_api, owned_by_id, owner)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not create web id");
@@ -145,4 +179,122 @@ where
             })?
             .has_permission,
     }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/webs/{web_id}/relationships",
+    tag = "Web",
+    params(
+        ("X-Authenticated-User-Actor-Id" = AccountId, Header, description = "The ID of the actor which is used to authorize the request"),
+        ("web_id" = OwnedById, Path, description = "The web to read the relations for"),
+    ),
+    responses(
+        (status = 200, description = "The relations of the web", body = [WebRelationAndSubject]),
+
+        (status = 403, description = "Permission denied"),
+    )
+)]
+#[tracing::instrument(level = "info", skip(authorization_api_pool))]
+async fn get_web_authorization_relationships<A>(
+    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    Path(web_id): Path<OwnedById>,
+    authorization_api_pool: Extension<Arc<A>>,
+) -> Result<Json<Vec<WebRelationAndSubject>>, Response>
+where
+    A: AuthorizationApiPool + Send + Sync,
+{
+    let authorization_api = authorization_api_pool
+        .acquire()
+        .await
+        .map_err(report_to_response)?;
+
+    Ok(Json(
+        authorization_api
+            .get_web_relations(WebId::new(web_id.into_uuid()), Consistency::FullyConsistent)
+            .await
+            .map_err(report_to_response)?,
+    ))
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct ModifyWebAuthorizationRelationship {
+    operation: ModifyRelationshipOperation,
+    resource: OwnedById,
+    relation_and_subject: WebRelationAndSubject,
+}
+
+#[utoipa::path(
+    post,
+    path = "/webs/relationships",
+    tag = "Web",
+    request_body = [ModifyWebAuthorizationRelationship],
+    params(
+        ("X-Authenticated-User-Actor-Id" = AccountId, Header, description = "The ID of the actor which is used to authorize the request"),
+    ),
+    responses(
+        (status = 204, description = "The relationship was modified for the web"),
+
+        (status = 403, description = "Permission denied"),
+    )
+)]
+#[tracing::instrument(level = "info", skip(authorization_api_pool))]
+async fn modify_web_authorization_relationships<A>(
+    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    authorization_api_pool: Extension<Arc<A>>,
+    relationships: Json<Vec<ModifyWebAuthorizationRelationship>>,
+) -> Result<StatusCode, Response>
+where
+    A: AuthorizationApiPool + Send + Sync,
+{
+    let mut authorization_api = authorization_api_pool
+        .acquire()
+        .await
+        .map_err(report_to_response)?;
+
+    let (webs, operations): (Vec<_>, Vec<_>) = relationships
+        .0
+        .into_iter()
+        .map(|request| {
+            let web_id = WebId::new(request.resource.into_uuid());
+            (
+                web_id,
+                (request.operation, web_id, request.relation_and_subject),
+            )
+        })
+        .unzip();
+
+    let (permissions, _zookie) = authorization_api
+        .check_webs_permission(
+            actor_id,
+            WebPermission::Update,
+            webs,
+            Consistency::FullyConsistent,
+        )
+        .await
+        .map_err(report_to_response)?;
+
+    let mut failed = false;
+    // TODO: Change interface for `check_webs_permission` to avoid this loop
+    for (web_id, has_permission) in permissions {
+        if !has_permission {
+            tracing::error!("Insufficient permissions to modify relationship for web `{web_id}`");
+            failed = true;
+        }
+    }
+
+    if failed {
+        return Err(report_to_response(
+            Report::new(PermissionAssertion).attach(hash_status::StatusCode::PermissionDenied),
+        ));
+    }
+
+    // for request in relationships.0 {
+    authorization_api
+        .modify_web_relations(operations)
+        .await
+        .map_err(report_to_response)?;
+
+    Ok(StatusCode::NO_CONTENT)
 }

--- a/apps/hash-graph/lib/graph/src/store/account.rs
+++ b/apps/hash-graph/lib/graph/src/store/account.rs
@@ -1,5 +1,8 @@
 use async_trait::async_trait;
-use authorization::{schema::WebSubject, AuthorizationApi};
+use authorization::{
+    schema::{WebOwnerSubject, WebSubject},
+    AuthorizationApi,
+};
 use error_stack::Result;
 use graph_types::{
     account::{AccountGroupId, AccountId},
@@ -45,6 +48,7 @@ pub trait AccountStore {
         actor_id: AccountId,
         authorization_api: &mut A,
         owned_by_id: OwnedById,
+        owner: WebOwnerSubject,
     ) -> Result<(), InsertionError>;
 
     /// Returns if the [`AccountId`] exists in the database.

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, mem};
 
 use async_trait::async_trait;
 use authorization::{
-    schema::{EntityOwnerSubject, WebSubject},
+    schema::{EntityOwnerSubject, WebOwnerSubject, WebSubject},
     AuthorizationApi,
 };
 use error_stack::{Report, Result, ResultExt};
@@ -614,9 +614,10 @@ where
         actor_id: AccountId,
         authorization_api: &mut Au,
         owned_by_id: OwnedById,
+        owner: WebOwnerSubject,
     ) -> Result<(), InsertionError> {
         self.store
-            .insert_web_id(actor_id, authorization_api, owned_by_id)
+            .insert_web_id(actor_id, authorization_api, owned_by_id, owner)
             .await
     }
 

--- a/apps/hash-graph/lib/graph/src/store/postgres.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres.rs
@@ -10,7 +10,7 @@ use authorization::{
     backend::ModifyRelationshipOperation,
     schema::{
         AccountGroupOwnerSubject, AccountGroupRelationAndSubject, WebOwnerSubject,
-        WebRelationAndSubject, WebSubject, WebSubjectSet,
+        WebRelationAndSubject, WebSubject,
     },
     AuthorizationApi,
 };
@@ -1315,21 +1315,9 @@ impl<C: AsClient> AccountStore for PostgresStore<C> {
         _actor_id: AccountId,
         authorization_api: &mut A,
         owned_by_id: OwnedById,
+        owner: WebOwnerSubject,
     ) -> Result<(), InsertionError> {
         let transaction = self.transaction().await.change_context(InsertionError)?;
-
-        let web_subject = transaction
-            .identify_owned_by_id(owned_by_id)
-            .await
-            .change_context(InsertionError)?;
-
-        let owner = match web_subject {
-            WebSubject::Account(id) => WebOwnerSubject::Account { id },
-            WebSubject::AccountGroup(id) => WebOwnerSubject::AccountGroup {
-                id,
-                set: WebSubjectSet::Member,
-            },
-        };
 
         transaction
             .as_client()

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -2086,7 +2086,7 @@
         }
       }
     },
-    "/webs/{web_id}": {
+    "/webs": {
       "post": {
         "tags": [
           "Graph",
@@ -2102,23 +2102,65 @@
             "schema": {
               "$ref": "#/components/schemas/AccountId"
             }
-          },
-          {
-            "name": "web_id",
-            "in": "path",
-            "description": "The ID of the account group to add the owner to",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/OwnedById"
-            }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateWebRequest"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "204": {
             "description": "The web was created successfully"
           },
           "500": {
             "description": "Store error occurred"
+          }
+        }
+      }
+    },
+    "/webs/relationships": {
+      "post": {
+        "tags": [
+          "Graph",
+          "Web"
+        ],
+        "operationId": "modify_web_authorization_relationships",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ModifyWebAuthorizationRelationship"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "The relationship was modified for the web"
+          },
+          "403": {
+            "description": "Permission denied"
           }
         }
       }
@@ -2172,6 +2214,53 @@
           },
           "500": {
             "description": "Internal error occurred"
+          }
+        }
+      }
+    },
+    "/webs/{web_id}/relationships": {
+      "get": {
+        "tags": [
+          "Graph",
+          "Web"
+        ],
+        "operationId": "get_web_authorization_relationships",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          },
+          {
+            "name": "web_id",
+            "in": "path",
+            "description": "The web to read the relations for",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/OwnedById"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The relations of the web",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WebRelationAndSubject"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied"
           }
         }
       }
@@ -2369,6 +2458,21 @@
                 }
               }
             ]
+          }
+        }
+      },
+      "CreateWebRequest": {
+        "type": "object",
+        "required": [
+          "ownedById",
+          "owner"
+        ],
+        "properties": {
+          "ownedById": {
+            "$ref": "#/components/schemas/OwnedById"
+          },
+          "owner": {
+            "$ref": "#/components/schemas/WebOwnerSubject"
           }
         }
       },
@@ -3846,6 +3950,25 @@
           "delete"
         ]
       },
+      "ModifyWebAuthorizationRelationship": {
+        "type": "object",
+        "required": [
+          "operation",
+          "resource",
+          "relationAndSubject"
+        ],
+        "properties": {
+          "operation": {
+            "$ref": "#/components/schemas/ModifyRelationshipOperation"
+          },
+          "relationAndSubject": {
+            "$ref": "#/components/schemas/WebRelationAndSubject"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/OwnedById"
+          }
+        }
+      },
       "NullableTimestamp": {
         "type": "string",
         "format": "date-time",
@@ -4800,14 +4923,83 @@
           }
         }
       },
+      "WebOwnerSubject": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "subjectId",
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "account"
+                ]
+              },
+              "subjectId": {
+                "$ref": "#/components/schemas/AccountId"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "subjectId",
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "accountGroup"
+                ]
+              },
+              "subjectId": {
+                "$ref": "#/components/schemas/AccountGroupId"
+              }
+            }
+          }
+        ],
+        "discriminator": {
+          "propertyName": "kind"
+        }
+      },
       "WebPermission": {
         "type": "string",
         "enum": [
+          "update",
           "create_entity",
           "create_entity_type",
           "create_property_type",
           "create_data_type"
         ]
+      },
+      "WebRelationAndSubject": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "subject",
+              "relation"
+            ],
+            "properties": {
+              "relation": {
+                "type": "string",
+                "enum": [
+                  "owner"
+                ]
+              },
+              "subject": {
+                "$ref": "#/components/schemas/WebOwnerSubject"
+              }
+            }
+          }
+        ],
+        "discriminator": {
+          "propertyName": "relation"
+        }
       }
     }
   },

--- a/apps/hash-graph/tests/circular-links.http
+++ b/apps/hash-graph/tests/circular-links.http
@@ -12,8 +12,17 @@ X-Authenticated-User-Actor-Id: 00000000-0000-0000-0000-000000000000
 %}
 
 ### Create account web
-POST http://127.0.0.1:4000/webs/{{account_id}}
+POST http://127.0.0.1:4000/webs
+Content-Type: application/json
 X-Authenticated-User-Actor-Id: {{account_id}}
+
+{
+   "ownedById": "{{account_id}}",
+   "owner": {
+       "kind": "account",
+       "subjectId": "{{account_id}}"
+    }
+}
 
 > {%
   client.test("status", function() {

--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -12,8 +12,17 @@ X-Authenticated-User-Actor-Id: 00000000-0000-0000-0000-000000000000
 %}
 
 ### Create account web
-POST http://127.0.0.1:4000/webs/{{account_id}}
+POST http://127.0.0.1:4000/webs
+Content-Type: application/json
 X-Authenticated-User-Actor-Id: {{account_id}}
+
+{
+   "ownedById": "{{account_id}}",
+   "owner": {
+       "kind": "account",
+       "subjectId": "{{account_id}}"
+    }
+}
 
 > {%
     client.test("status", function() {
@@ -33,8 +42,17 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 %}
 
 ### Create account group web
-POST http://127.0.0.1:4000/webs/{{account_group_id}}
+POST http://127.0.0.1:4000/webs
+Content-Type: application/json
 X-Authenticated-User-Actor-Id: {{account_id}}
+
+{
+   "ownedById": "{{account_group_id}}",
+   "owner": {
+       "kind": "accountGroup",
+       "subjectId": "{{account_group_id}}"
+    }
+}
 
 > {%
   client.test("status", function() {

--- a/libs/@local/hash-authorization/schemas/v1__initial_schema.zed
+++ b/libs/@local/hash-authorization/schemas/v1__initial_schema.zed
@@ -22,6 +22,8 @@ definition graph/entity {
 definition graph/web {
 	relation level_00_owner: graph/account | graph/account_group#member
 
+	permission update = level_00_owner
+
 	permission create_entity = level_00_owner
 	permission create_entity_type = level_00_owner
 	permission create_property_type = level_00_owner

--- a/libs/@local/hash-authorization/src/lib.rs
+++ b/libs/@local/hash-authorization/src/lib.rs
@@ -88,6 +88,14 @@ impl AuthorizationApi for NoAuthorization {
         Ok(Zookie::empty())
     }
 
+    async fn get_web_relations(
+        &self,
+        _web: WebId,
+        _consistency: Consistency<'static>,
+    ) -> Result<Vec<WebRelationAndSubject>, ReadError> {
+        Ok(Vec::new())
+    }
+
     async fn check_entity_permission(
         &self,
         _actor: AccountId,

--- a/libs/@local/hash-authorization/src/schema/web.rs
+++ b/libs/@local/hash-authorization/src/schema/web.rs
@@ -52,6 +52,8 @@ impl Relation<WebId> for WebResourceRelation {}
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum WebPermission {
+    Update,
+
     CreateEntity,
     CreateEntityType,
     CreatePropertyType,

--- a/libs/@local/hash-authorization/src/zanzibar/api.rs
+++ b/libs/@local/hash-authorization/src/zanzibar/api.rs
@@ -105,6 +105,24 @@ where
             .written_at)
     }
 
+    async fn get_web_relations(
+        &self,
+        web: WebId,
+        consistency: Consistency<'static>,
+    ) -> Result<Vec<WebRelationAndSubject>, ReadError> {
+        Ok(self
+            .backend
+            .read_relations::<(WebId, WebRelationAndSubject)>(
+                RelationshipFilter::from_resource(web),
+                consistency,
+            )
+            .await
+            .change_context(ReadError)?
+            .into_iter()
+            .map(|(_, relation)| relation)
+            .collect())
+    }
+
     async fn modify_entity_relations(
         &mut self,
         relationships: impl IntoIterator<

--- a/libs/@local/hash-graph-client/python/graph_client/models.py
+++ b/libs/@local/hash-graph-client/python/graph_client/models.py
@@ -363,11 +363,35 @@ class TransactionTime(RootModel[Literal['transactionTime']]):
     model_config = ConfigDict(populate_by_name=True)
     root: Literal['transactionTime'] = Field(..., description='Time axis for the transaction time.\n\nThis is used as the generic argument to time-related structs and can be used as tag value.')
 
+class WebOwnerSubjectItem(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    kind: Literal['account']
+    subject_id: AccountId = Field(..., alias='subjectId')
+
+class WebOwnerSubjectItem1(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    kind: Literal['accountGroup']
+    subject_id: AccountGroupId = Field(..., alias='subjectId')
+
+class WebOwnerSubject(RootModel[WebOwnerSubjectItem | WebOwnerSubjectItem1]):
+    model_config = ConfigDict(populate_by_name=True)
+    root: WebOwnerSubjectItem | WebOwnerSubjectItem1 = Field(..., discriminator='kind')
+
 class WebPermission(Enum):
+    update = 'update'
     create_entity = 'create_entity'
     create_entity_type = 'create_entity_type'
     create_property_type = 'create_property_type'
     create_data_type = 'create_data_type'
+
+class WebRelationAndSubjectItem(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    relation: Literal['owner']
+    subject: WebOwnerSubject
+
+class WebRelationAndSubject(RootModel[WebRelationAndSubjectItem]):
+    model_config = ConfigDict(populate_by_name=True)
+    root: WebRelationAndSubjectItem = Field(..., discriminator='relation')
 
 class UpdateDataType(BaseModel):
     """
@@ -512,6 +536,11 @@ class CreateDataTypeRequest(BaseModel):
     owned_by_id: OwnedById = Field(..., alias='ownedById')
     schema_: DataType | list[DataType] = Field(..., alias='schema')
 
+class CreateWebRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    owned_by_id: OwnedById = Field(..., alias='ownedById')
+    owner: WebOwnerSubject
+
 class DataTypeRelationAndSubjectItem1(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     relation: Literal['viewer']
@@ -635,6 +664,12 @@ class ModifyEntityTypeAuthorizationRelationship(BaseModel):
     operation: ModifyRelationshipOperation
     relation_and_subject: EntityTypeRelationAndSubject = Field(..., alias='relationAndSubject')
     resource: VersionedURL
+
+class ModifyWebAuthorizationRelationship(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    operation: ModifyRelationshipOperation
+    relation_and_subject: WebRelationAndSubject = Field(..., alias='relationAndSubject')
+    resource: OwnedById
 
 class OpenTemporalBound(RootModel[ExclusiveBound | UnboundedBound]):
     model_config = ConfigDict(populate_by_name=True)

--- a/libs/@local/hash-subgraph/src/types/shared/branded.ts
+++ b/libs/@local/hash-subgraph/src/types/shared/branded.ts
@@ -9,6 +9,7 @@ import {
   EntityRelationAndSubject,
   EntityTypeRelationAndSubject,
   PropertyTypeRelationAndSubject,
+  WebRelationAndSubject,
 } from "@local/hash-graph-client";
 import { validate as validateUuid } from "uuid";
 
@@ -116,6 +117,13 @@ type BrandSubject<T extends object> = T extends { kind: "account" }
 type BrandRelationship<T extends { subject: object }> = {
   [K in keyof T]: K extends "subject" ? BrandSubject<T[K]> : T[K];
 };
+
+export type WebAuthorizationRelationship = {
+  resource: {
+    kind: "web";
+    resourceId: OwnedById;
+  };
+} & BrandRelationship<WebRelationAndSubject>;
 
 export type EntityAuthorizationRelationship = {
   resource: {

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -13,7 +13,10 @@ mod property_type;
 
 use std::{borrow::Cow, str::FromStr};
 
-use authorization::{schema::EntityOwnerSubject, NoAuthorization};
+use authorization::{
+    schema::{EntityOwnerSubject, WebOwnerSubject},
+    NoAuthorization,
+};
 use error_stack::Result;
 use graph::{
     knowledge::EntityQueryPath,
@@ -132,6 +135,7 @@ impl DatabaseTestWrapper {
                 account_id,
                 &mut NoAuthorization,
                 OwnedById::new(account_id.into_uuid()),
+                WebOwnerSubject::Account { id: account_id },
             )
             .await
             .expect("could not create web id");


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This changes the way a user is created. As a web is required to create the user entity, a web is created first, but the owner is set to the system account. After the registration is completed, the ownership is transferred to the user.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph