### PR TITLE
H-1227: Comment out unused vault variables

### DIFF
--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -1,6 +1,6 @@
 /*
-  This module contains the configuration for standing up a HASH instance in 
-  AWS using ECS Fargate. 
+  This module contains the configuration for standing up a HASH instance in
+  AWS using ECS Fargate.
 */
 
 module "variables_hash" {
@@ -266,8 +266,8 @@ module "application" {
     { name = "HASH_TEMPORAL_SERVER_HOST", secret = false, value = module.temporal.host },
     { name = "HASH_TEMPORAL_SERVER_PORT", secret = false, value = module.temporal.temporal_port },
     { name = "HASH_INTEGRATION_QUEUE_NAME", secret = false, value = "integration" },
-    { name = "LINEAR_CLIENT_ID", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["linear_client_id"]) },
-    { name = "LINEAR_CLIENT_SECRET", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["linear_client_secret"]) },
+#    { name = "LINEAR_CLIENT_ID", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["linear_client_id"]) },
+#    { name = "LINEAR_CLIENT_SECRET", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["linear_client_secret"]) },
     { name = "LINEAR_WEBHOOK_SECRET", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["linear_webhook_secret"]) },
   ])
   temporal_worker_ai_ts_image = module.temporal_worker_ai_ts_ecr


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We removed the client ID and client secret variable to prevent seeding linear types until they are updated. To avoid breaking TF, this removes them from the environment as well.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph