### PR TITLE
H-60, H-1262: Retain text when swapping between blocks. Fix block permissions

### DIFF
--- a/apps/hash-frontend/src/components/block-loader/block-loader.tsx
+++ b/apps/hash-frontend/src/components/block-loader/block-loader.tsx
@@ -5,12 +5,10 @@ import {
 } from "@blockprotocol/graph/temporal";
 import { getRoots } from "@blockprotocol/graph/temporal/stdlib";
 import { VersionedUrl } from "@blockprotocol/type-system/slim";
-import {
-  TextToken,
-  UserPermissionsOnEntities,
-} from "@local/hash-graphql-shared/graphql/types";
+import { UserPermissionsOnEntities } from "@local/hash-graphql-shared/graphql/types";
 import { HashBlockMeta } from "@local/hash-isomorphic-utils/blocks";
 import { textualContentPropertyTypeBaseUrl } from "@local/hash-isomorphic-utils/entity-store";
+import { TextualContentPropertyValue } from "@local/hash-isomorphic-utils/system-types/shared";
 import {
   Entity,
   EntityId,
@@ -280,9 +278,9 @@ export const BlockLoader: FunctionComponent<BlockLoaderProps> = ({
 
     const textTokens = rootEntity.properties[
       textualContentPropertyTypeBaseUrl
-    ] as TextToken[] | undefined;
+    ] as TextualContentPropertyValue | undefined;
 
-    if (textTokens) {
+    if (textTokens && typeof textTokens !== "string") {
       newProperties[textualContentPropertyTypeBaseUrl] = textTokens
         .map((token) =>
           "text" in token ? token.text : "hardBreak" in token ? "\n" : "",

--- a/blocks/code/package.json
+++ b/blocks/code/package.json
@@ -65,7 +65,7 @@
       }
     ],
     "protocol": "0.3",
-    "blockEntityType": "https://blockprotocol.org/@hash/types/entity-type/code-block/v/2",
+    "blockEntityType": "https://blockprotocol.org/@hash/types/entity-type/code-block/v/3",
     "codegen": {
       "outputFolder": "src/types/generated",
       "targets": {

--- a/blocks/code/src/app.tsx
+++ b/blocks/code/src/app.tsx
@@ -89,7 +89,9 @@ export const App: BlockComponent<BlockEntity> = ({
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- account for old browsers
       if (navigator.clipboard) {
         await navigator.clipboard.writeText(
-          localData[propertyIds.content] ?? "",
+          typeof localData[propertyIds.content] === "string"
+            ? (localData[propertyIds.content] as string)
+            : "",
         );
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
@@ -170,7 +172,11 @@ export const App: BlockComponent<BlockEntity> = ({
           </div>
         </div>
         <Editor
-          content={localData[propertyIds.content] ?? ""}
+          content={
+            typeof localData[propertyIds.content] === "string"
+              ? (localData[propertyIds.content] as string)
+              : ""
+          }
           setContent={(text) =>
             updateLocalData({ [propertyIds.content]: text })
           }

--- a/blocks/code/src/types/generated/block-entity.ts
+++ b/blocks/code/src/types/generated/block-entity.ts
@@ -40,6 +40,11 @@ export type CodeBlockProperties = {
 };
 
 /**
+ * An opaque, untyped JSON object
+ */
+export type Object = {};
+
+/**
  * An ordered sequence of characters
  */
 export type Text = string;
@@ -47,4 +52,4 @@ export type Text = string;
 /**
  * The text material, information, or body, that makes up the content of this thing.
  */
-export type TextualContentPropertyValue = Text;
+export type TextualContentPropertyValue = Text | Object[];

--- a/blocks/heading/variants.json
+++ b/blocks/heading/variants.json
@@ -46,8 +46,13 @@
     "description": "For small section headings",
     "icon": "public/h4.svg",
     "properties": {
-      "https://blockprotocol.org/@blockprotocol/types/property-type/html-heading-level/": 4,
-      "https://blockprotocol.org/@blockprotocol/types/property-type/textual-content/": "I'm a small heading!"
-    }
+      "https://blockprotocol.org/@blockprotocol/types/property-type/html-heading-level/": 4
+    },
+    "examples": [
+      {
+        "https://blockprotocol.org/@blockprotocol/types/property-type/html-heading-level/": 4,
+        "https://blockprotocol.org/@blockprotocol/types/property-type/textual-content/": "I'm a small heading!"
+      }
+    ]
   }
 ]

--- a/libs/@local/hash-isomorphic-utils/src/blocks.ts
+++ b/libs/@local/hash-isomorphic-utils/src/blocks.ts
@@ -232,10 +232,15 @@ export const componentIdBase = `https://blockprotocol${
 
 export const paragraphBlockComponentId = `${componentIdBase}/blocks/hash/paragraph`;
 
-const textBlockComponentIds = new Set([
+const richTextBlockComponentIds = new Set([
   paragraphBlockComponentId,
   `${componentIdBase}/blocks/hash/heading`,
   `${componentIdBase}/blocks/hash/callout`,
+]);
+
+const componentIdsWithTextualContentProperty = new Set([
+  ...Array.from(richTextBlockComponentIds),
+  `${componentIdBase}/blocks/hash/code`,
 ]);
 
 /**
@@ -247,7 +252,7 @@ const textBlockComponentIds = new Set([
  *    we currently store this in localStorage - see UserBlocksProvider.
  */
 export const defaultBlockComponentIds = [
-  ...Array.from(textBlockComponentIds),
+  ...Array.from(richTextBlockComponentIds),
   `${componentIdBase}/blocks/hash/person`,
   `${componentIdBase}/blocks/hash/image`,
   `${componentIdBase}/blocks/hash/table`,
@@ -262,7 +267,10 @@ export const defaultBlockComponentIds = [
  * text block to another
  */
 export const isHashTextBlock = (componentId: string) =>
-  textBlockComponentIds.has(componentId);
+  richTextBlockComponentIds.has(componentId);
+
+export const isBlockWithTextualContentProperty = (componentId: string) =>
+  componentIdsWithTextualContentProperty.has(componentId);
 
 /**
  * In some places, we need to know if the current component and a target
@@ -278,5 +286,5 @@ export const areComponentsCompatible = (
   currentComponentId &&
   targetComponentId &&
   (currentComponentId === targetComponentId ||
-    (isHashTextBlock(currentComponentId) &&
-      isHashTextBlock(targetComponentId)));
+    (isBlockWithTextualContentProperty(currentComponentId) &&
+      isBlockWithTextualContentProperty(targetComponentId)));

--- a/libs/@local/hash-isomorphic-utils/src/prosemirror-manager.ts
+++ b/libs/@local/hash-isomorphic-utils/src/prosemirror-manager.ts
@@ -1,4 +1,6 @@
 import { BlockVariant, JsonObject } from "@blockprotocol/core";
+import { TextToken } from "@local/hash-graphql-shared/graphql/types";
+import { TextualContentPropertyValue } from "@local/hash-isomorphic-utils/system-types/shared";
 import { EntityId, OwnedById } from "@local/hash-subgraph";
 import { Node, Schema } from "prosemirror-model";
 import { EditorState, Transaction } from "prosemirror-state";
@@ -343,10 +345,10 @@ export class ProsemirrorManager {
 
         // Retain any text from the old entity if we have some and we know it accepts textual-content
         if (isBlockWithTextualContentProperty(targetComponentId)) {
-          const existingTextContent =
-            blockEntity.blockChildEntity?.properties[
-              textualContentPropertyTypeBaseUrl
-            ];
+          const existingTextContent = blockEntity.blockChildEntity?.properties[
+            textualContentPropertyTypeBaseUrl
+          ] as TextualContentPropertyValue | undefined;
+
           const newTextContent =
             newBlockProperties[textualContentPropertyTypeBaseUrl];
 
@@ -355,8 +357,15 @@ export class ProsemirrorManager {
             (!newTextContent ||
               (Array.isArray(newTextContent) && !newTextContent[0]))
           ) {
+            const textAsTokens =
+              typeof existingTextContent === "string"
+                ? ([
+                    { tokenType: "text", text: existingTextContent },
+                  ] satisfies TextToken[])
+                : existingTextContent;
+
             newBlockProperties[textualContentPropertyTypeBaseUrl] =
-              existingTextContent;
+              textAsTokens;
           }
         }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes a couple of bugs related to blocks:
1. Restore the ability to swap between blocks that accept a text property, and retain the text (H-60)
2. Handle blocks created mid-session properly (fetch their permissions and subgraph, don't rely on it being in the page subgraph)
3. Upgrade the code block's schema to use the new text property type
4. Fix variant properties in header level 4

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **block** that will need publishing via GitHub action once merged


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

There are still several bugs to do with text editing:
1. Header levels do not set consistently (H-1276)
2. Swapping between header levels via the context menu does not work (H-1276)
3. The code block needs a blur to save, it should save periodically (H-1281)
4. Loading jank for blocks (H-1282)

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Try swapping between blocks that have a `textual-content` property – ideally we would generate this list automatically from the system types
2. Note that swapping **to** the Code block will crash until we have published the new block version, because its schema doesn't accept text tokens.

## 📹 Demo

<!-- Add a screenshot or video s

https://github.com/hashintel/hash/assets/37743469/0c86d5e0-22d5-4692-a2fa-48bdf91ec368

howcasing your work -->
