### PR TITLE
H-1245: Ensure mention attribute chips automatically update when underlying data changes

### DIFF
--- a/apps/hash-frontend/src/components/hooks/use-entity-by-id.ts
+++ b/apps/hash-frontend/src/components/hooks/use-entity-by-id.ts
@@ -22,10 +22,12 @@ export const useEntityById = ({
   entityId,
   graphResolveDepths,
   includePermissions = false,
+  pollInterval,
 }: {
   entityId: EntityId;
   graphResolveDepths?: GraphResolveDepths;
   includePermissions?: boolean;
+  pollInterval?: number;
 }): {
   loading: boolean;
   entitySubgraph?: Subgraph<EntityRootType>;
@@ -41,6 +43,7 @@ export const useEntityById = ({
         includePermissions,
       },
       fetchPolicy: "cache-and-network",
+      pollInterval,
     },
   );
 

--- a/apps/hash-frontend/src/components/hooks/use-entity-by-id.ts
+++ b/apps/hash-frontend/src/components/hooks/use-entity-by-id.ts
@@ -40,6 +40,7 @@ export const useEntityById = ({
         entityId,
         includePermissions,
       },
+      fetchPolicy: "cache-and-network",
     },
   );
 

--- a/apps/hash-frontend/src/pages/shared/block-collection/mention-view/mention-display.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/mention-view/mention-display.tsx
@@ -48,6 +48,8 @@ export const MentionDisplay: FunctionComponent<MentionDisplayProps> = ({
       hasLeftEntity: { incoming: 1, outgoing: 0 },
       hasRightEntity: { incoming: 0, outgoing: 1 },
     },
+    // Poll for the latest version every 5 seconds
+    pollInterval: 5_000,
   });
   const contentRef = useRef<HTMLDivElement>(null);
   const { propertyTypes } = usePropertyTypes({ latestOnly: true });


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR fixes the property mention chip to not re-use cached results when navigating to the page without a hard refresh, and polling for the latest version of the entity every 5 seconds.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-1245

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- adds an optional `pollInterval` parameter to the `useEntityById` hook
- sets `fetchPolicy: "cache-and-network"` for the `useQuery` method in `useEntityById`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing 

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change 

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph 

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Run HASH locally or view the deployment
2. Create a property mention on a page
3. Update the value of the property in the underlying entity
4. Ensure the property mention is automatically updated after no longer than 5 seconds, or immediately when navigating away and back to the page via the sidebar

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

https://github.com/hashintel/hash/assets/42802102/366bbd64-d3e6-45f6-94f0-f0a981589443



