### PR TITLE
H-1034: Fix keyboard shortcuts firing when they shouldn't

### DIFF
--- a/apps/hash-frontend/src/pages/_app.page.tsx
+++ b/apps/hash-frontend/src/pages/_app.page.tsx
@@ -34,6 +34,7 @@ import { apolloClient } from "../lib/apollo-client";
 import { constructMinimalUser } from "../lib/user-and-org";
 import { EntityTypesContextProvider } from "../shared/entity-types-context/provider";
 import { FileUploadsProvider } from "../shared/file-upload-context";
+import { KeyboardShortcutsContextProvider } from "../shared/keyboard-shortcuts-context";
 import {
   getLayoutWithSidebar,
   getPlainLayout,
@@ -141,30 +142,32 @@ const App: FunctionComponent<AppProps> = ({
             <CssBaseline />
             <RoutePageInfoProvider>
               <WorkspaceContextProvider>
-                <SnackbarProvider maxSnack={3}>
-                  <NotificationsContextProvider>
-                    <EntityTypesContextProvider>
-                      <PropertyTypesContextProvider includeArchived>
-                        <FileUploadsProvider>
-                          <SidebarContextProvider>
-                            <ErrorBoundary
-                              beforeCapture={(scope) => {
-                                scope.setTag("error-boundary", "_app");
-                              }}
-                              fallback={(props) =>
-                                getLayoutWithSidebar(
-                                  <ErrorFallback {...props} />,
-                                )
-                              }
-                            >
-                              {getLayout(<Component {...pageProps} />)}
-                            </ErrorBoundary>
-                          </SidebarContextProvider>
-                        </FileUploadsProvider>
-                      </PropertyTypesContextProvider>
-                    </EntityTypesContextProvider>
-                  </NotificationsContextProvider>
-                </SnackbarProvider>
+                <KeyboardShortcutsContextProvider>
+                  <SnackbarProvider maxSnack={3}>
+                    <NotificationsContextProvider>
+                      <EntityTypesContextProvider>
+                        <PropertyTypesContextProvider includeArchived>
+                          <FileUploadsProvider>
+                            <SidebarContextProvider>
+                              <ErrorBoundary
+                                beforeCapture={(scope) => {
+                                  scope.setTag("error-boundary", "_app");
+                                }}
+                                fallback={(props) =>
+                                  getLayoutWithSidebar(
+                                    <ErrorFallback {...props} />,
+                                  )
+                                }
+                              >
+                                {getLayout(<Component {...pageProps} />)}
+                              </ErrorBoundary>
+                            </SidebarContextProvider>
+                          </FileUploadsProvider>
+                        </PropertyTypesContextProvider>
+                      </EntityTypesContextProvider>
+                    </NotificationsContextProvider>
+                  </SnackbarProvider>
+                </KeyboardShortcutsContextProvider>
               </WorkspaceContextProvider>
             </RoutePageInfoProvider>
           </ThemeProvider>

--- a/apps/hash-frontend/src/pages/notes.page/create-quick-note.tsx
+++ b/apps/hash-frontend/src/pages/notes.page/create-quick-note.tsx
@@ -14,10 +14,13 @@ import {
   useRef,
   useState,
 } from "react";
-import { useKeys } from "rooks";
 
 import { useBlockProtocolGetEntity } from "../../components/hooks/block-protocol-functions/knowledge/use-block-protocol-get-entity";
 import { ArrowTurnDownLeftRegularIcon } from "../../shared/icons/arrow-turn-down-left-regular-icon";
+import {
+  useSetKeyboardShortcuts,
+  useUnsetKeyboardShortcuts,
+} from "../../shared/keyboard-shortcuts-context";
 import { Button } from "../../shared/ui";
 import { useAuthenticatedUser } from "../shared/auth-info-context";
 import { useCreateBlockCollection } from "../shared/use-create-block-collection";
@@ -123,8 +126,25 @@ export const CreateQuickNote: FunctionComponent<{
     }
   }, [isFocused, handleCreateNew, creatingNewQuickNote]);
 
-  useKeys(["Meta", "Enter"], handleCommandEnter);
-  useKeys(["Control", "Enter"], handleCommandEnter);
+  const setKeyboardShortcuts = useSetKeyboardShortcuts();
+  const unsetKeyboardShortcuts = useUnsetKeyboardShortcuts();
+
+  useEffect(() => {
+    const shortcuts = [
+      {
+        keys: ["Meta", "Enter"],
+        callback: handleCommandEnter,
+      },
+      {
+        keys: ["Control", "Enter"],
+        callback: handleCommandEnter,
+      },
+    ];
+
+    setKeyboardShortcuts(shortcuts);
+
+    return () => unsetKeyboardShortcuts(shortcuts);
+  }, [handleCommandEnter, setKeyboardShortcuts, unsetKeyboardShortcuts]);
 
   const quickNoteEntityWithCreatedAt = useMemo(
     () =>

--- a/apps/hash-frontend/src/shared/command-bar/cheat-sheet.tsx
+++ b/apps/hash-frontend/src/shared/command-bar/cheat-sheet.tsx
@@ -11,7 +11,7 @@ export const CheatSheet = () => {
   const [showAll, setShowAll] = useState(false);
 
   useEffect(() => {
-    const unsubscribe = menu.addListener(forceRender);
+    const unsubscribe = menu.addUpdateListener(forceRender);
 
     return () => {
       unsubscribe();
@@ -32,24 +32,32 @@ export const CheatSheet = () => {
   );
 
   /**
-   * @todo reinstate this
-   * when doing so, check if https://github.com/imbhargav5/rooks/issues/1730 has been fixed
-   * if it has, upgrade rooks. if not, either implement our own version of useKeys (command-bar has one) or patch rooks
+   * @todo reinstate this when we have enough shortcuts for a cheatsheet, and style it properly
    */
-  // useKeys(
-  //   ["?"],
-  //   (evt) => {
-  //     // Hack to detect if pressed inside an input or textarea
-  //     if (
-  //       evt.target &&
-  //       !("defaultValue" in evt.target) &&
-  //       !(evt.target as HTMLElement).isContentEditable
-  //     ) {
-  //       setOpen(true);
-  //     }
-  //   },
-  //   {},
-  // );
+  // const setKeyboardShortcuts = useSetKeyboardShortcuts();
+  // const unsetKeyboardShortcuts = useUnsetKeyboardShortcuts();
+  //
+  // useEffect(() => {
+  //   const shortcut = {
+  //     keys: ["?"],
+  //     callback: (evt: KeyboardEvent) => {
+  //       // Hack to detect if pressed inside an input or textarea
+  //       if (
+  //         evt.target &&
+  //         !("defaultValue" in evt.target) &&
+  //         !(evt.target as HTMLElement).isContentEditable
+  //       ) {
+  //         setOpen(true);
+  //       }
+  //     },
+  //   };
+  //
+  //   setKeyboardShortcuts([shortcut]);
+  //
+  //   return () => {
+  //     unsetKeyboardShortcuts([shortcut]);
+  //   };
+  // }, [setKeyboardShortcuts, unsetKeyboardShortcuts]);
 
   return (
     <Modal open={open} onClose={() => setOpen(false)}>

--- a/apps/hash-frontend/src/shared/command-bar/command-bar-options.ts
+++ b/apps/hash-frontend/src/shared/command-bar/command-bar-options.ts
@@ -84,7 +84,7 @@ class CommandBarMenu {
     return option;
   }
 
-  addListener(listener: () => void) {
+  addUpdateListener(listener: () => void) {
     this.root.listeners.push(listener);
 
     return () => {

--- a/apps/hash-frontend/src/shared/keyboard-shortcuts-context.tsx
+++ b/apps/hash-frontend/src/shared/keyboard-shortcuts-context.tsx
@@ -62,6 +62,13 @@ export const KeyboardShortcutsContextProvider: FunctionComponent<
   const setKeyboardShortcuts: SetKeyboardShortcutsFunction = useCallback(
     (shortcutsToRegister) => {
       setKeyboardShortcutsState((currentShortcuts) => {
+        /**
+         * This approach means that if Shortcut A's key combination is overridden in some context by Shortcut B,
+         * and then Shortcut B is unset, Shortcut A will no longer be in the list of shortcuts either.
+         * If we ever need to introduce shortcuts with duplicate keys we should change this, and figure out
+         * a way of setting the priority of shortcuts with duplicate keys.
+         * Similarly, {@link unsetKeyboardShortcuts} would need updating to not wipe out all shortcuts for the given keys.
+         */
         const currentShortcutsWithoutDuplicates = currentShortcuts.filter(
           (existingShortcut) =>
             !shortcutsToRegister.some(
@@ -134,9 +141,9 @@ export const KeyboardShortcutsContextProvider: FunctionComponent<
  * - CANNOT handle shortcuts which involve multiple non-modifier keys being pressed (e.g. K + P, W + 1, I + ;)
  *
  * An alternative approach would be to maintain a manual mapping of which keys have been held down or released,
- * which could distinguish between modifier keys, but JavaScript execution can be interrupted by OS shortcuts / actions.
- * and therefore are situations in which the manual keyup handler will not fire, and therefore may still record
- * a modifier as being pressed when it is not.
+ * which could distinguish between modifier keys, but OS shortcuts / actions can take window focus without triggering
+ * 'keyup' or 'blur' event listeners, and therefore there are situations in which the manual keyup handler will not fire,
+ * and any manual map may still record a key as being pressed when it is not.
  *
  * If it is ever important that we handle shortcuts which cannot be detected from a single KeyboardEvent, we should:
  * - manually maintain a mapping of which keys are currently pressed based on keydown and keyup handlers

--- a/apps/hash-frontend/src/shared/keyboard-shortcuts-context.tsx
+++ b/apps/hash-frontend/src/shared/keyboard-shortcuts-context.tsx
@@ -1,0 +1,173 @@
+import {
+  createContext,
+  FunctionComponent,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+export type KeyboardShortcut = {
+  keys: string[];
+  callback: (event: KeyboardEvent) => void;
+};
+
+type SetKeyboardShortcutsFunction = (shortcuts: KeyboardShortcut[]) => void;
+
+type UnsetKeyboardShortcutsFunction = (
+  shortcutsToUnset: { keys: string[] }[],
+) => void;
+
+type KeyboardShortcutsContextValue = {
+  setKeyboardShortcuts: SetKeyboardShortcutsFunction;
+  unsetKeyboardShortcuts: UnsetKeyboardShortcutsFunction;
+};
+
+export const KeyboardShortcutsContext =
+  createContext<null | KeyboardShortcutsContextValue>(null);
+
+const modKeyToKeyboardEventProperty: Record<string, keyof KeyboardEvent> = {
+  Alt: "altKey",
+  Meta: "metaKey",
+  Control: "ctrlKey",
+  Shift: "shiftKey",
+};
+
+/**
+ * We detect which keys are pressed based on a single KeyboardEvent.
+ *
+ * See limitations described on {@link useSetKeyboardShortcuts}
+ */
+const areAllKeysPressed = (event: KeyboardEvent, keys: string[]) => {
+  for (const key of keys) {
+    const modifierProperty = modKeyToKeyboardEventProperty[key];
+
+    if (event.key !== key && (!modifierProperty || !event[modifierProperty])) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+export const KeyboardShortcutsContextProvider: FunctionComponent<
+  PropsWithChildren
+> = ({ children }) => {
+  const [keyboardShortcutsState, setKeyboardShortcutsState] = useState<
+    KeyboardShortcut[]
+  >([]);
+
+  const setKeyboardShortcuts: SetKeyboardShortcutsFunction = useCallback(
+    (shortcutsToRegister) => {
+      setKeyboardShortcutsState((currentShortcuts) => {
+        const currentShortcutsWithoutDuplicates = currentShortcuts.filter(
+          (existingShortcut) =>
+            !shortcutsToRegister.some(
+              (newShortcut) =>
+                newShortcut.keys.length === existingShortcut.keys.length &&
+                existingShortcut.keys.every((key) =>
+                  newShortcut.keys.includes(key),
+                ),
+            ),
+        );
+
+        return [...currentShortcutsWithoutDuplicates, ...shortcutsToRegister];
+      });
+    },
+    [],
+  );
+
+  const unsetKeyboardShortcuts: UnsetKeyboardShortcutsFunction = useCallback(
+    (shortcutsKeysToRemove) => {
+      setKeyboardShortcutsState((currentShortcuts) =>
+        currentShortcuts.filter(
+          (currentShortcut) =>
+            !shortcutsKeysToRemove.some(
+              ({ keys: keysToRemove }) =>
+                currentShortcut.keys.length !== keysToRemove.length ||
+                !currentShortcut.keys.every((key) =>
+                  keysToRemove.includes(key),
+                ),
+            ),
+        ),
+      );
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const shortcut = keyboardShortcutsState.find(({ keys }) =>
+        areAllKeysPressed(event, keys),
+      );
+
+      if (shortcut) {
+        event.preventDefault();
+        shortcut.callback(event);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [keyboardShortcutsState]);
+
+  const value = useMemo(
+    () => ({ setKeyboardShortcuts, unsetKeyboardShortcuts }),
+    [setKeyboardShortcuts, unsetKeyboardShortcuts],
+  );
+
+  return (
+    <KeyboardShortcutsContext.Provider value={value}>
+      {children}
+    </KeyboardShortcutsContext.Provider>
+  );
+};
+
+/**
+ * Set a keyboard shortcut that will trigger the given callback when the given keys are pressed.
+ *
+ * This is limited by the information available on a single KeyboardEvent, and therefore
+ * - CANNOT distinguish between left/right modifier keys. Pass 'Meta', 'Control', 'Alt', 'Shift', NOT 'MetaLeft' etc
+ * - CANNOT handle shortcuts which involve multiple non-modifier keys being pressed (e.g. K + P, W + 1, I + ;)
+ *
+ * An alternative approach would be to maintain a manual mapping of which keys have been held down or released,
+ * which could distinguish between modifier keys, but JavaScript execution can be interrupted by OS shortcuts / actions.
+ * and therefore are situations in which the manual keyup handler will not fire, and therefore may still record
+ * a modifier as being pressed when it is not.
+ *
+ * If it is ever important that we handle shortcuts which cannot be detected from a single KeyboardEvent, we should:
+ * - manually maintain a mapping of which keys are currently pressed based on keydown and keyup handlers
+ * - add an event listener for `"blur"` on `window` to clear the map if the window loses focus
+ *   NOTE: this does not work for all events that may trigger the browser losing focus, e.g. MacOS screenshot shortcut
+ * - add an interval to clear the key map if the window is not focused to handle situations not covered by the 'blur' listener
+ * - know that this will not be able to detect key combinations if a key is pressed and held while the window is not focused.
+ *
+ * The 'single KeyboardEvent' approach is taken for now because it is simpler and more reliable, and there is no current
+ * use case for the different key combinations that the more complex and less reliable approach enables.
+ */
+export const useSetKeyboardShortcuts = (): SetKeyboardShortcutsFunction => {
+  const context = useContext(KeyboardShortcutsContext);
+
+  if (!context) {
+    throw new Error(
+      "useSetKeyboardShortcut must be used within a KeyboardShortcutsContextProvider",
+    );
+  }
+
+  return context.setKeyboardShortcuts;
+};
+
+export const useUnsetKeyboardShortcuts = (): UnsetKeyboardShortcutsFunction => {
+  const context = useContext(KeyboardShortcutsContext);
+
+  if (!context) {
+    throw new Error(
+      "useUnsetKeyboardShortcut must be used within a KeyboardShortcutsContextProvider",
+    );
+  }
+
+  return context.unsetKeyboardShortcuts;
+};

--- a/apps/hash-frontend/src/shared/layout/layout-with-header/search-bar/search-input.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-header/search-bar/search-input.tsx
@@ -87,16 +87,28 @@ export const SearchInput: FunctionComponent<{
   const inputRef = useRef<HTMLInputElement>(null);
 
   /**
-   * @todo reinstate this
-   * when doing so, check if https://github.com/imbhargav5/rooks/issues/1730 has been fixed
-   * if it has, upgrade rooks. if not, either implement our own version of useKeys (command-bar has one) or patch rooks
+   * @todo reinstate this when search functionality is restored
    */
-  // useKeys(["ControlLeft", "KeyP"], (event) => {
-  //   event.preventDefault();
-  //   if (!isMac) {
-  //     inputRef.current?.focus();
-  //   }
-  // });
+  // const setKeyboardShortcuts = useSetKeyboardShortcuts();
+  // const unsetKeyboardShortcuts = useUnsetKeyboardShortcuts();
+  //
+  // useEffect(() => {
+  //   const shortcut = {
+  //     keys: ["Control", "p"],
+  //     callback: (evt: KeyboardEvent) => {
+  //      event.preventDefault();
+  //      if (!isMac) {
+  //        inputRef.current?.focus();
+  //      }
+  //     },
+  //   };
+  //
+  //   setKeyboardShortcuts([shortcut]);
+  //
+  //   return () => {
+  //     unsetKeyboardShortcuts([shortcut]);
+  //   };
+  // }, [setKeyboardShortcuts, unsetKeyboardShortcuts]);
 
   useEffect(() => {
     function checkSearchKey(event: KeyboardEvent) {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To handle keyboard actions involving multiple key presses we were using either `useKeys` from [rooks](https://github.com/imbhargav5/rooks) or an approach adapted from it, both of which rely on manually maintaining which keys have been held by the user. This approach is unreliable because it relies on the `keyup` handler being fired in order to wipe the key map.

A previous attempt to fix this in #2983 involving also wiping the key map on `blur` does not work for some OS-level actions, for example screen capture shortcuts on MacOS (`cmd` + `shift` + `5`).

This PR introduces an approach which relies solely on the `KeyboardEvent`, removing the need for maintaining a manual map. This does mean we cannot support some key combinations, as described in a comment in the diff, but in the absence of any particular need to do so this approach is more reliable.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Run the HASH app
2. Check that shortcuts still work as expected (E.g. cmd + K for command bar, cmd + E for new entity)
3. Press cmd + shift + 5
4. Return to HASH app, press E
5. Confirm that new entity page is not opened
