### PR TITLE
H-1131, H-1333, H-1335, H-1348: Add Sentry to Node API, improve error handling in frontend

### DIFF
--- a/apps/hash-api/README.md
+++ b/apps/hash-api/README.md
@@ -8,7 +8,7 @@ The HASH Backend API service is configured using the following environment varia
   default logging levels and output formatting.
 - `PORT`: the port number the API will listen on.
 - `SELF_HOSTED_HASH`: if `"true"` forces self-hosted behavior, which e.g. loads system types as external types.
-- `NODE_SENTRY_DSN`: the Sentry DSN to use for error reporting and tracing
+- `NODE_API_SENTRY_DSN`: the Sentry DSN to use for error reporting and tracing
 - `AWS_REGION`: the AWS region to use (for the Simple Email Service (SES) provider, and as a fallback for other AWS services)
 - `FILE_UPLOAD_PROVIDER`: where to store user file uploads. Currently supported values are:
   - `LOCAL_FILE_SYSTEM`: (default) use the local filesystem for file uploads – **not recommended for production use**

--- a/apps/hash-api/README.md
+++ b/apps/hash-api/README.md
@@ -8,6 +8,7 @@ The HASH Backend API service is configured using the following environment varia
   default logging levels and output formatting.
 - `PORT`: the port number the API will listen on.
 - `SELF_HOSTED_HASH`: if `"true"` forces self-hosted behavior, which e.g. loads system types as external types.
+- `NODE_SENTRY_DSN`: the Sentry DSN to use for error reporting and tracing
 - `AWS_REGION`: the AWS region to use (for the Simple Email Service (SES) provider, and as a fallback for other AWS services)
 - `FILE_UPLOAD_PROVIDER`: where to store user file uploads. Currently supported values are:
   - `LOCAL_FILE_SYSTEM`: (default) use the local filesystem for file uploads – **not recommended for production use**

--- a/apps/hash-api/package.json
+++ b/apps/hash-api/package.json
@@ -45,6 +45,7 @@
     "@ory/client": "1.1.41",
     "@ory/kratos-client": "0.13.1",
     "@rudderstack/rudder-sdk-node": "2.0.3",
+    "@sentry/node": "7.81.0",
     "@snowplow/node-tracker": "3.3.1",
     "@temporalio/client": "1.8.1",
     "agentkeepalive": "4.2.1",

--- a/apps/hash-api/src/sentry.ts
+++ b/apps/hash-api/src/sentry.ts
@@ -2,7 +2,7 @@ import * as Sentry from "@sentry/node";
 
 import { isProdEnv } from "./lib/env-config";
 
-const sentryDsn = process.env.NODE_SENTRY_DSN;
+const sentryDsn = process.env.NODE_API_SENTRY_DSN;
 
 export const initSentry = () => {
   Sentry.init({

--- a/apps/hash-api/src/sentry.ts
+++ b/apps/hash-api/src/sentry.ts
@@ -1,0 +1,20 @@
+import * as Sentry from "@sentry/node";
+
+import { isProdEnv } from "./lib/env-config";
+
+const sentryDsn = process.env.NODE_SENTRY_DSN;
+
+export const initSentry = () => {
+  Sentry.init({
+    dsn: sentryDsn,
+    enabled: !!sentryDsn,
+    environment: isProdEnv ? "production" : "development",
+    /**
+     * Sentry's ApolloServer integration does not yet work when constructing the ApolloServer with a 'schema' property
+     * @see https://github.com/getsentry/sentry-javascript/issues/8227
+     */
+    integrations: [new Sentry.Integrations.Http({ tracing: true })],
+
+    tracesSampleRate: 0.2,
+  });
+};

--- a/apps/hash-frontend/sentry.client.config.ts
+++ b/apps/hash-frontend/sentry.client.config.ts
@@ -13,7 +13,7 @@ import {
 Sentry.init({
   dsn: SENTRY_DSN,
   enabled: !!SENTRY_DSN,
-  environment: VERCEL_ENV,
+  environment: VERCEL_ENV || "development",
   integrations: [new Sentry.Replay({ stickySession: true })],
   release: buildStamp,
   replaysOnErrorSampleRate: 1,

--- a/apps/hash-frontend/sentry.edge.config.ts
+++ b/apps/hash-frontend/sentry.edge.config.ts
@@ -6,7 +6,7 @@ import { SENTRY_DSN, VERCEL_ENV } from "./src/lib/public-env";
 Sentry.init({
   dsn: SENTRY_DSN,
   enabled: !!SENTRY_DSN,
-  environment: VERCEL_ENV,
+  environment: VERCEL_ENV || "development",
   release: buildStamp,
   // release is set in next.config.js in the Sentry webpack plugin
   /** @todo reduce perf sample rate from 100% when we have more traffic */

--- a/apps/hash-frontend/sentry.server.config.ts
+++ b/apps/hash-frontend/sentry.server.config.ts
@@ -6,7 +6,7 @@ import { SENTRY_DSN, VERCEL_ENV } from "./src/lib/public-env";
 Sentry.init({
   dsn: SENTRY_DSN,
   enabled: !!SENTRY_DSN,
-  environment: VERCEL_ENV,
+  environment: VERCEL_ENV || "development",
   release: buildStamp,
   // release is set in next.config.js in the Sentry webpack plugin
   /** @todo reduce perf sample rate from 100% when we have more traffic */

--- a/apps/hash-frontend/src/components/hooks/use-snackbar.ts
+++ b/apps/hash-frontend/src/components/hooks/use-snackbar.ts
@@ -44,13 +44,21 @@ const generateSnackbarVariants = (
   return Object.fromEntries(entries) as SnackbarVariants;
 };
 
-export const useSnackbar = () => {
-  const { enqueueSnackbar } = useLibSnackbar();
+export type SnackbarManager = {
+  closeSnackbar: (key: string) => void;
+  triggerSnackbar: SnackbarVariants;
+};
 
-  const snackbar = useMemo(
+export const useSnackbar = (): SnackbarManager => {
+  const { closeSnackbar, enqueueSnackbar } = useLibSnackbar();
+
+  const triggerSnackbar = useMemo(
     () => generateSnackbarVariants(enqueueSnackbar),
     [enqueueSnackbar],
   );
 
-  return snackbar;
+  return useMemo(
+    () => ({ closeSnackbar, triggerSnackbar }),
+    [closeSnackbar, triggerSnackbar],
+  );
 };

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor-page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor-page.tsx
@@ -37,7 +37,7 @@ export const EntityEditorPage = ({
   ...entityEditorProps
 }: EntityEditorPageProps) => {
   const [shouldShowQueryEditor, setShouldShowQueryEditor] = useState(true);
-  const snackbar = useSnackbar();
+  const { triggerSnackbar } = useSnackbar();
 
   return (
     <>
@@ -60,7 +60,7 @@ export const EntityEditorPage = ({
             await handleSaveChanges(properties);
 
             if (!isDraft) {
-              snackbar.success("Changes saved successfully");
+              triggerSnackbar.success("Changes saved successfully");
             }
           }}
           entityLabel={entityLabel}

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/select-entity-type-page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/select-entity-type-page.tsx
@@ -22,7 +22,7 @@ import { PropertiesSectionEmptyState } from "./shared/properties-section-empty-s
 
 export const SelectEntityTypePage = () => {
   const router = useRouter();
-  const snackbar = useSnackbar();
+  const { triggerSnackbar } = useSnackbar();
   const [isSelectingType, setIsSelectingType] = useState(false);
   const [loading, setLoading] = useState(false);
 
@@ -109,7 +109,7 @@ export const SelectEntityTypePage = () => {
                         )}`,
                       );
                     } catch (error: any) {
-                      snackbar.error(error.message);
+                      triggerSnackbar.error(error.message);
                     } finally {
                       setLoading(false);
                     }

--- a/apps/hash-frontend/src/pages/_app.page/error-fallback.tsx
+++ b/apps/hash-frontend/src/pages/_app.page/error-fallback.tsx
@@ -26,8 +26,7 @@ const CopyableMonospace = ({ text }: { text: string }) => {
           sx={({ palette }) => ({
             background: palette.gray[20],
             border: `1px solid ${palette.gray[50]}`,
-            color: palette.gray[90],
-            fontFamily: "monospace",
+            maxWidth: "100%",
             minHeight: 0,
             py: 0.5,
             px: 1.5,
@@ -36,7 +35,19 @@ const CopyableMonospace = ({ text }: { text: string }) => {
             },
           })}
         >
-          {text}
+          <Typography
+            component="span"
+            sx={({ palette }) => ({
+              color: palette.gray[90],
+              fontFamily: "monospace",
+              fontSize: "0.8rem",
+              maxWidth: "100%",
+              textAlign: "left",
+              whiteSpace: "pre-wrap",
+            })}
+          >
+            {text}
+          </Typography>
         </Button>
       </Tooltip>
     </Box>
@@ -93,6 +104,10 @@ export const ErrorFallback: FallbackRender = ({
           <Box mt={2}>
             <Typography variant="smallCaps">Error message</Typography>
             <CopyableMonospace text={error.message} />
+          </Box>
+          <Box mt={2}>
+            <Typography variant="smallCaps">Stack trace</Typography>
+            <CopyableMonospace text={error.stack ?? ""} />
           </Box>
         </Box>
       </Collapse>

--- a/apps/hash-frontend/src/pages/shared/block-collection/block-collection.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/block-collection.tsx
@@ -9,6 +9,7 @@ import { FunctionComponent, useLayoutEffect, useRef } from "react";
 import { useLocalstorageState } from "rooks";
 
 import { useUserBlocks } from "../../../blocks/user-blocks";
+import { useSnackbar } from "../../../components/hooks/use-snackbar";
 import { BlockCollectionContentItem } from "../../../graphql/api-types.gen";
 import { Button } from "../../../shared/ui";
 import { usePortals } from "./block-portals";
@@ -70,6 +71,8 @@ export const BlockCollection: FunctionComponent<BlockCollectionProps> = ({
 
   const { pageTitleRef, setEditorContext } = pageContext ?? {};
 
+  const snackbarManager = useSnackbar();
+
   /**
    * This effect runs once and just sets up the prosemirror instance. It is not
    * responsible for setting the contents of the prosemirror document
@@ -84,18 +87,19 @@ export const BlockCollection: FunctionComponent<BlockCollectionProps> = ({
      * child
      */
     const { view, connection, manager } = createEditorView({
-      renderNode: node,
-      renderPortal,
-      ownedById,
-      pageEntityId: entityId,
+      autoFocus,
+      client,
       getBlocksMap: () => currentBlocks.current,
-      readonly,
-      pageTitleRef,
       getLastSavedValue: () =>
         currentContents.current.map((contentItem) => contentItem.rightEntity),
-      client,
       isCommentingEnabled: enableCommenting,
-      autoFocus,
+      ownedById,
+      pageEntityId: entityId,
+      pageTitleRef,
+      readonly,
+      renderNode: node,
+      renderPortal,
+      snackbarManager,
     });
 
     if (setEditorContext) {
@@ -134,6 +138,7 @@ export const BlockCollection: FunctionComponent<BlockCollectionProps> = ({
     client,
     enableCommenting,
     autoFocus,
+    snackbarManager,
   ]);
 
   return (

--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -269,7 +269,7 @@ module "application" {
 #    { name = "LINEAR_CLIENT_ID", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["linear_client_id"]) },
 #    { name = "LINEAR_CLIENT_SECRET", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["linear_client_secret"]) },
     { name = "LINEAR_WEBHOOK_SECRET", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["linear_webhook_secret"]) },
-    { name = "NODE_SENTRY_DSN", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["node_sentry_dsn"]) }
+    { name = "NODE_API_SENTRY_DSN", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["node_api_sentry_dsn"]) }
   ])
   temporal_worker_ai_ts_image = module.temporal_worker_ai_ts_ecr
   temporal_worker_ai_ts_env_vars = [

--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -269,6 +269,7 @@ module "application" {
 #    { name = "LINEAR_CLIENT_ID", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["linear_client_id"]) },
 #    { name = "LINEAR_CLIENT_SECRET", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["linear_client_secret"]) },
     { name = "LINEAR_WEBHOOK_SECRET", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["linear_webhook_secret"]) },
+    { name = "NODE_SENTRY_DSN", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["node_sentry_dsn"]) }
   ])
   temporal_worker_ai_ts_image = module.temporal_worker_ai_ts_ecr
   temporal_worker_ai_ts_env_vars = [

--- a/libs/@local/hash-isomorphic-utils/src/create-apollo-client.ts
+++ b/libs/@local/hash-isomorphic-utils/src/create-apollo-client.ts
@@ -20,13 +20,20 @@ const errorLink = onError(({ graphQLErrors, operation }) => {
   if (graphQLErrors) {
     for (const { message, extensions, path } of graphQLErrors) {
       Sentry.withScope((scope) => {
+        if (extensions.code === "FORBIDDEN") {
+          return;
+        }
+
         const error = new Error(
           `GraphQL Error: ${path?.[0]?.toString() ?? "?"}`,
         );
         scope.setExtra("Exception", extensions.exception);
         scope.setExtra("Location", path);
         scope.setExtra("Query", operation.query.loc?.source.body);
-        scope.setExtra("Variables", operation.variables);
+        scope.setExtra(
+          "Variables",
+          JSON.stringify(operation.variables, undefined, 2),
+        );
         error.message = `GraphQL error - ${
           path?.[0]?.toString() ?? "undefined"
         } - ${message}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5333,6 +5333,15 @@
     "@sentry/types" "7.77.0"
     "@sentry/utils" "7.77.0"
 
+"@sentry-internal/tracing@7.81.0":
+  version "7.81.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.81.0.tgz#bf63b817f8471462432fcfe466d3e021e84aef1f"
+  integrity sha512-mc3tdOEvAE6kaCvT3BpMwCgfTT2yfXjWpC7g+3N8U/yuQEmQSCDZA/ut7EkzU0DyhG3t8HzT0c+CAG3HtilEAQ==
+  dependencies:
+    "@sentry/core" "7.81.0"
+    "@sentry/types" "7.81.0"
+    "@sentry/utils" "7.81.0"
+
 "@sentry/browser@7.74.1":
   version "7.74.1"
   resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.74.1.tgz#9302d440bbdcb018abd5fee5959dab4b2fe97383"
@@ -5411,6 +5420,14 @@
     "@sentry/types" "7.77.0"
     "@sentry/utils" "7.77.0"
 
+"@sentry/core@7.81.0":
+  version "7.81.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.81.0.tgz#e72e02dcb175ada154a71cf89599287f9393e787"
+  integrity sha512-FCAKlqo9Z6fku69bkahw1AN+eBfAgRgOL1RpBLZgyG7YBW12vtSkHb5SDvZZTkm541Fo3hhepUTLtX0qmpA4yw==
+  dependencies:
+    "@sentry/types" "7.81.0"
+    "@sentry/utils" "7.81.0"
+
 "@sentry/integrations@7.77.0":
   version "7.77.0"
   resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.77.0.tgz#f2717e05cb7c69363316ccd34096b2ea07ae4c59"
@@ -5440,7 +5457,7 @@
     rollup "2.78.0"
     stacktrace-parser "^0.1.10"
 
-"@sentry/node@7.77.0", "@sentry/node@^7.60.0":
+"@sentry/node@7.77.0":
   version "7.77.0"
   resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.77.0.tgz#a247452779a5bcb55724457707286e3e4a29dbbe"
   integrity sha512-Ob5tgaJOj0OYMwnocc6G/CDLWC7hXfVvKX/ofkF98+BbN/tQa5poL+OwgFn9BA8ud8xKzyGPxGU6LdZ8Oh3z/g==
@@ -5449,6 +5466,17 @@
     "@sentry/core" "7.77.0"
     "@sentry/types" "7.77.0"
     "@sentry/utils" "7.77.0"
+    https-proxy-agent "^5.0.0"
+
+"@sentry/node@7.81.0", "@sentry/node@^7.60.0":
+  version "7.81.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.81.0.tgz#b911a4eb03bcd230f89da9e2ee3825a311ad5c78"
+  integrity sha512-hFfDxKGB+JhkhpZtM1ntyZDZoMlS8rMsynCSQcqJS39iYcCgdvgy9zOb34mXrX9kXOJNhWWmoloBZGA+KKFTdg==
+  dependencies:
+    "@sentry-internal/tracing" "7.81.0"
+    "@sentry/core" "7.81.0"
+    "@sentry/types" "7.81.0"
+    "@sentry/utils" "7.81.0"
     https-proxy-agent "^5.0.0"
 
 "@sentry/react@7.74.1":
@@ -5501,6 +5529,11 @@
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.77.0.tgz#c5d00fe547b89ccde59cdea59143bf145cee3144"
   integrity sha512-nfb00XRJVi0QpDHg+JkqrmEBHsqBnxJu191Ded+Cs1OJ5oPXEW6F59LVcBScGvMqe+WEk1a73eH8XezwfgrTsA==
 
+"@sentry/types@7.81.0":
+  version "7.81.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.81.0.tgz#a093286c4016a2ff58aa8408ff873b7952a9386f"
+  integrity sha512-rbYNYSSrrnwNndC7S+eVT84GRLEyCZNh9oXUQqzgSD6ngXCZ0xFJW6si75uv/XQBWIw4rkj9xfRcy8DU0Tj4fg==
+
 "@sentry/utils@7.74.1":
   version "7.74.1"
   resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.74.1.tgz#e9a8453c954d02ebed2fd3dbe7588483d8f6d3cb"
@@ -5509,12 +5542,19 @@
     "@sentry/types" "7.74.1"
     tslib "^2.4.1 || ^1.9.3"
 
-"@sentry/utils@7.77.0", "@sentry/utils@^7.60.0":
+"@sentry/utils@7.77.0":
   version "7.77.0"
   resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.77.0.tgz#1f88501f0b8777de31b371cf859d13c82ebe1379"
   integrity sha512-NmM2kDOqVchrey3N5WSzdQoCsyDkQkiRxExPaNI2oKQ/jMWHs9yt0tSy7otPBcXs0AP59ihl75Bvm1tDRcsp5g==
   dependencies:
     "@sentry/types" "7.77.0"
+
+"@sentry/utils@7.81.0", "@sentry/utils@^7.60.0":
+  version "7.81.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.81.0.tgz#b874664ebc5647eed2d3492ac4171819267262cb"
+  integrity sha512-yC9IvfeVbG4dygi4b+iUUMHp9xeHJfCn6XLbqjJVfq3xjAzBGHgfrpw6fYPNyTljXKb6CTiSXSqaNaQJE4CkPA==
+  dependencies:
+    "@sentry/types" "7.81.0"
 
 "@sentry/vercel-edge@7.77.0":
   version "7.77.0"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A few things to help in error capturing and in giving more information about errors to users:
- H-1131: Stop errors being sent to Sentry from the frontend where they relate to a user not being logged in – this is juust spam
- H-1333: Show a snackbar when page contents are not being saved for whatever reason (see demo) – this uses an existing snackbar implementation which we can add custom styling to in a later task (designs [here](https://www.figma.com/file/gydVGka9FjNEg9E2STwhi2/HASH?type=design&node-id=552%3A30695&mode=design&t=v3gy5C2e2Z17yCCu-1))
- H-1335: Add Sentry to the Node API
- H-1348: Include the stack trace information in the ErrorFallback component

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->
Get the appropriate DSNs for the projects from Sentry.

1. H-1131: Add a `SENTRY_DSN` with the frontend's DSN to your `.env.local`. Visit the frontend in an incognito window and confirm that the error doesn't reach Sentry. Check that another error _does_ reach Sentry.
2. H-1333: Kill the backend or throw an error from the `updateBlockContents` resolver to check that the error appears
3. H-1335: Add a `NODE_SENTRY_DSN` to your `.env.local` and make some GraphQL request that errors, confirm it reaches Sentry
4. H-1348: Throw an error during a React component's render and check the stack trace appears in the fallback

## 📹 Demo

Demo of toast when page fails to save:

https://github.com/hashintel/hash/assets/37743469/bf31e24d-4488-4db8-991e-03dc28b65e56

