### PR TITLE
H-1349: Fix snapshots not storing account groups when restoring

### DIFF
--- a/apps/hash-graph/lib/graph/src/snapshot/owner/channel.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/owner/channel.rs
@@ -65,6 +65,12 @@ impl Sink<Owner> for OwnerSender {
                 .change_context(SnapshotRestoreError::Read)
                 .attach_printable("could not send account"),
             Owner::AccountGroup(account_group) => {
+                self.account_group_id
+                    .start_send_unpin(AccountGroupRow {
+                        account_group_id: account_group.id,
+                    })
+                    .change_context(SnapshotRestoreError::Read)
+                    .attach_printable("could not send account group")?;
                 for relation in account_group.relations {
                     self.account_group_relations
                         .start_send_unpin((account_group.id, relation))


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The relations are stored in the database but not the account group.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph