### PR TITLE
H-1339: Remove delay on making new blocks editable, fix block re-ordering

### DIFF
--- a/libs/@local/hash-isomorphic-utils/src/save.ts
+++ b/libs/@local/hash-isomorphic-utils/src/save.ts
@@ -280,8 +280,8 @@ const calculateSaveActions = (
     const previousFractionalIndex = oldValue?.[1]?.fractionalIndex;
     if (
       previousFractionalIndex &&
-      (i < 0 || previousFractionalIndex > newFractionalIndexSeries[i - 1]!) &&
-      (i >= newFractionalIndexSeries.length ||
+      (i === 0 || previousFractionalIndex > newFractionalIndexSeries[i - 1]!) &&
+      (i + 1 >= newFractionalIndexSeries.length ||
         previousFractionalIndex < newFractionalIndexSeries[i + 1]!)
     ) {
       // No moving action required


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fix two bugs:
1. H-1339: A delay in making new text blocks editable was introduced by #3422, which this fixes
2. The logic for detecting if a block needs reassigning was broken for the first and last blocks in a collection

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Try adding a new paragraph in a page and check it can be edited immediately
2. Check that the calls to `updateBlockCollectionContents` when editing a page does not include any move actions, unless a block has actually been moved from its current position

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
