### PR TITLE
H-1338: Add Sentry to/enable in prod for the Graph

### DIFF
--- a/apps/hash-graph/bin/cli/src/args.rs
+++ b/apps/hash-graph/bin/cli/src/args.rs
@@ -1,8 +1,12 @@
-use std::borrow::Cow;
-
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 
 use crate::{parser::OptionalSentryDsnParser, subcommand::Subcommand};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum SentryEnvironment {
+    Development,
+    Production,
+}
 
 /// Arguments passed to the program.
 #[derive(Debug, Parser)]
@@ -14,7 +18,7 @@ pub struct Args {
     pub sentry_dsn: core::option::Option<sentry::types::Dsn>,
 
     #[arg(long, env = "HASH_GRAPH_SENTRY_ENVIRONMENT")]
-    pub sentry_environment: Option<Cow<'static, str>>,
+    pub sentry_environment: Option<SentryEnvironment>,
 
     /// Specify a subcommand to run.
     #[command(subcommand)]

--- a/apps/hash-graph/bin/cli/src/args.rs
+++ b/apps/hash-graph/bin/cli/src/args.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use clap::Parser;
 
 use crate::{parser::OptionalSentryDsnParser, subcommand::Subcommand};
@@ -10,6 +12,9 @@ pub struct Args {
     // the `value_parser` on the internal `sentry::types::Dsn`, failing.
     #[arg(long, env = "HASH_GRAPH_SENTRY_DSN", value_parser = OptionalSentryDsnParser, default_value = "")]
     pub sentry_dsn: core::option::Option<sentry::types::Dsn>,
+
+    #[arg(long, env = "HASH_GRAPH_SENTRY_ENVIRONMENT")]
+    pub sentry_environment: Option<Cow<'static, str>>,
 
     /// Specify a subcommand to run.
     #[command(subcommand)]

--- a/apps/hash-graph/bin/cli/src/main.rs
+++ b/apps/hash-graph/bin/cli/src/main.rs
@@ -19,6 +19,7 @@ fn main() -> Result<(), GraphError> {
 
     let Args {
         sentry_dsn,
+        sentry_environment,
         subcommand,
     } = Args::parse_args();
 
@@ -38,6 +39,7 @@ fn main() -> Result<(), GraphError> {
                 1.0
             }
         })),
+        environment: sentry_environment,
         ..Default::default()
     });
 

--- a/apps/hash-graph/bin/cli/src/main.rs
+++ b/apps/hash-graph/bin/cli/src/main.rs
@@ -6,12 +6,13 @@ mod error;
 mod parser;
 mod subcommand;
 
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use error_stack::Result;
 use graph::load_env;
 
 use self::{args::Args, error::GraphError};
+use crate::args::SentryEnvironment;
 
 fn main() -> Result<(), GraphError> {
     load_env(None);
@@ -39,7 +40,13 @@ fn main() -> Result<(), GraphError> {
                 1.0
             }
         })),
-        environment: sentry_environment,
+        environment: sentry_environment.map(|env| {
+            Cow::Borrowed(match env {
+                SentryEnvironment::Development => "development",
+                SentryEnvironment::Production => "production",
+            })
+        }),
+
         ..Default::default()
     });
 

--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -236,6 +236,8 @@ module "application" {
     { name = "HASH_SPICEDB_HOST", secret = false, value = "http://127.0.0.1" },
     { name = "HASH_SPICEDB_HTTP_PORT", secret = false, value = "8443" },
     { name = "HASH_SPICEDB_GRPC_PRESHARED_KEY", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["spicedb_grpc_preshared_key"]) },
+    { name = "HASH_GRAPH_SENTRY_DSN", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["graph_sentry_dsn"]) },
+    { name = "HASH_GRAPH_SENTRY_ENVIRONMENT", secret = false, value = "production" },
   ])
   # The type fetcher uses the same image as the graph right now
   type_fetcher_image = module.graph_ecr


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds Sentry to the production instance.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

Set the `HASH_GRAPH_SENTRY_DSN` to the Graph DSN and `HASH_GRAPH_SENTRY_ENVIRONMENT` to `development` and run the Graph with an error (e.g. by not starting the Database service)

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
