### PR TITLE
H-1350: Set a default variable for the sentry environment in `graph`

### DIFF
--- a/apps/hash-graph/bin/cli/src/args.rs
+++ b/apps/hash-graph/bin/cli/src/args.rs
@@ -1,11 +1,23 @@
+use std::fmt;
+
 use clap::{Parser, ValueEnum};
 
 use crate::{parser::OptionalSentryDsnParser, subcommand::Subcommand};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum SentryEnvironment {
+    #[default]
     Development,
     Production,
+}
+
+impl fmt::Display for SentryEnvironment {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Development => fmt.write_str("development"),
+            Self::Production => fmt.write_str("production"),
+        }
+    }
 }
 
 /// Arguments passed to the program.
@@ -17,8 +29,12 @@ pub struct Args {
     #[arg(long, env = "HASH_GRAPH_SENTRY_DSN", value_parser = OptionalSentryDsnParser, default_value = "")]
     pub sentry_dsn: core::option::Option<sentry::types::Dsn>,
 
-    #[arg(long, env = "HASH_GRAPH_SENTRY_ENVIRONMENT")]
-    pub sentry_environment: Option<SentryEnvironment>,
+    #[arg(
+        long,
+        env = "HASH_GRAPH_SENTRY_ENVIRONMENT",
+        default_value_t = SentryEnvironment::default(),
+    )]
+    pub sentry_environment: SentryEnvironment,
 
     /// Specify a subcommand to run.
     #[command(subcommand)]

--- a/apps/hash-graph/bin/cli/src/main.rs
+++ b/apps/hash-graph/bin/cli/src/main.rs
@@ -12,7 +12,6 @@ use error_stack::Result;
 use graph::load_env;
 
 use self::{args::Args, error::GraphError};
-use crate::args::SentryEnvironment;
 
 fn main() -> Result<(), GraphError> {
     load_env(None);
@@ -40,12 +39,7 @@ fn main() -> Result<(), GraphError> {
                 1.0
             }
         })),
-        environment: sentry_environment.map(|env| {
-            Cow::Borrowed(match env {
-                SentryEnvironment::Development => "development",
-                SentryEnvironment::Production => "production",
-            })
-        }),
+        environment: Some(Cow::Owned(sentry_environment.to_string())),
 
         ..Default::default()
     });


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To avoid passing no sentry environment a default environment is provided.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph