### PR TITLE
H-1276: Fix swapping between block variants, header levels

### DIFF
--- a/apps/hash-frontend/src/blocks/use-fetch-block-subgraph.ts
+++ b/apps/hash-frontend/src/blocks/use-fetch-block-subgraph.ts
@@ -5,6 +5,7 @@ import { getEntityQuery } from "@local/hash-isomorphic-utils/graphql/queries/ent
 import {
   Entity,
   EntityId,
+  EntityPropertiesObject,
   EntityRevisionId,
   EntityRootType,
   GraphResolveDepths,
@@ -24,6 +25,7 @@ import {
 export const useFetchBlockSubgraph = (): ((
   blockEntityTypeId: VersionedUrl,
   blockEntityId?: EntityId,
+  fallbackBlockProperties?: EntityPropertiesObject,
 ) => Promise<
   Omit<SubgraphAndPermissions, "subgraph"> & {
     subgraph: Subgraph<EntityRootType>;
@@ -37,7 +39,11 @@ export const useFetchBlockSubgraph = (): ((
   );
 
   const fetchBlockSubgraph = useCallback(
-    async (blockEntityTypeId: VersionedUrl, blockEntityId?: EntityId) => {
+    async (
+      blockEntityTypeId: VersionedUrl,
+      blockEntityId?: EntityId,
+      fallbackBlockProperties?: EntityPropertiesObject,
+    ) => {
       const depths: GraphResolveDepths = {
         constrainsValuesOn: { outgoing: 255 },
         constrainsPropertiesOn: { outgoing: 255 },
@@ -93,7 +99,7 @@ export const useFetchBlockSubgraph = (): ((
               recordCreatedById: "placeholder-account" as RecordCreatedById,
             },
           },
-          properties: {},
+          properties: fallbackBlockProperties ?? {},
         } as const;
 
         const subgraphTemporalAxes = {

--- a/apps/hash-frontend/src/components/block-loader/block-loader.tsx
+++ b/apps/hash-frontend/src/components/block-loader/block-loader.tsx
@@ -197,7 +197,7 @@ export const BlockLoader: FunctionComponent<BlockLoaderProps> = ({
         : null;
 
       const draftEntityEditionTimestamp =
-        entityInStore?.metadata.temporalVersioning?.decisionTime.start.limit;
+        entityInStore?.metadata.temporalVersioning.decisionTime.start.limit;
 
       const draftEntityIsNewer =
         draftEntityEditionTimestamp &&

--- a/apps/hash-frontend/src/pages/shared/block-collection/block-context-menu/block-context-menu-item.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/block-context-menu/block-context-menu-item.tsx
@@ -21,6 +21,7 @@ import {
 import { MenuItem } from "../../../../shared/ui";
 
 type BlockContextMenuItemProps = {
+  closeMenu: () => void;
   itemKey: string;
   onClick?: () => void;
   icon: ReactElement;
@@ -32,88 +33,96 @@ type BlockContextMenuItemProps = {
 export const BlockContextMenuItem = forwardRef<
   HTMLLIElement,
   BlockContextMenuItemProps
->(({ onClick, icon, title, itemKey, subMenu, subMenuWidth }, ref) => {
-  const subMenuPopupState = usePopupState({
-    variant: "popper",
-    popupId: `${itemKey}-submenu`,
-  });
-  const [subMenuOffsetTop, setSubmenuOffsetTop] = useState<
-    number | undefined
-  >();
-  const localRef = useRef<HTMLLIElement>(null);
-  // @todo this doesn't handle when ref is a function and can break when trying to
-  // access offsetTop in the useLayoutEffect. Consider using an library to handle merging refs
-  // @see https://github.com/gregberge/react-merge-refs, or better still, use the
-  // useForkRef exported by MUI
-  const menuItemRef = (ref ?? localRef) as RefObject<HTMLLIElement>;
+>(
+  (
+    { closeMenu, onClick, icon, title, itemKey, subMenu, subMenuWidth },
+    ref,
+  ) => {
+    const subMenuPopupState = usePopupState({
+      variant: "popper",
+      popupId: `${itemKey}-submenu`,
+    });
+    const [subMenuOffsetTop, setSubmenuOffsetTop] = useState<
+      number | undefined
+    >();
+    const localRef = useRef<HTMLLIElement>(null);
+    // @todo this doesn't handle when ref is a function and can break when trying to
+    // access offsetTop in the useLayoutEffect. Consider using an library to handle merging refs
+    // @see https://github.com/gregberge/react-merge-refs, or better still, use the
+    // useForkRef exported by MUI
+    const menuItemRef = (ref ?? localRef) as RefObject<HTMLLIElement>;
 
-  useLayoutEffect(() => {
-    if (subMenu && !subMenuOffsetTop && menuItemRef.current) {
-      setSubmenuOffsetTop(menuItemRef.current.offsetTop);
-    }
-  }, [subMenu, subMenuOffsetTop, menuItemRef]);
+    useLayoutEffect(() => {
+      if (subMenu && !subMenuOffsetTop && menuItemRef.current) {
+        setSubmenuOffsetTop(menuItemRef.current.offsetTop);
+      }
+    }, [subMenu, subMenuOffsetTop, menuItemRef]);
 
-  return (
-    <MenuItem
-      ref={menuItemRef}
-      {...(subMenu
-        ? {
-            ...bindHover(subMenuPopupState),
-            ...bindFocus(subMenuPopupState),
-          }
-        : {
-            onClick,
-          })}
-      sx={{
-        position: "relative",
-        boxShadow: "none !important",
-
-        "&:active": {
-          backgroundColor: ({ palette }) =>
-            `${palette.primary.main} !important`,
-        },
-
-        ...(subMenuPopupState.isOpen && {
-          backgroundColor: ({ palette }) => `${palette.gray[20]} !important`,
-        }),
-      }}
-    >
-      <ListItemIcon>{icon}</ListItemIcon>
-      <ListItemText primary={title} />
-      {subMenu ? (
-        <>
-          <FontAwesomeIcon
-            icon={faChevronRight}
-            sx={({ palette }) => ({
-              ml: "auto",
-              color: palette.gray[50],
-              fontSize: 12,
+    return (
+      <MenuItem
+        ref={menuItemRef}
+        {...(subMenu
+          ? {
+              ...bindHover(subMenuPopupState),
+              ...bindFocus(subMenuPopupState),
+            }
+          : {
+              onClick,
             })}
-          />
-          <HoverPopover
-            {...bindPopover(subMenuPopupState)}
-            elevation={4}
-            anchorOrigin={{
-              horizontal: "right",
-              vertical: subMenuOffsetTop ? -subMenuOffsetTop : "top",
-            }}
-            transformOrigin={{
-              horizontal: "left",
-              vertical: "top",
-            }}
-            PaperProps={{
-              sx: {
-                height: 300,
-                width: subMenuWidth,
-                ml: 1,
-                py: 0.5,
-              },
-            }}
-          >
-            {cloneElement(subMenu, { popupState: subMenuPopupState })}
-          </HoverPopover>
-        </>
-      ) : null}
-    </MenuItem>
-  );
-});
+        sx={{
+          position: "relative",
+          boxShadow: "none !important",
+
+          "&:active": {
+            backgroundColor: ({ palette }) =>
+              `${palette.primary.main} !important`,
+          },
+
+          ...(subMenuPopupState.isOpen && {
+            backgroundColor: ({ palette }) => `${palette.gray[20]} !important`,
+          }),
+        }}
+      >
+        <ListItemIcon>{icon}</ListItemIcon>
+        <ListItemText primary={title} />
+        {subMenu ? (
+          <>
+            <FontAwesomeIcon
+              icon={faChevronRight}
+              sx={({ palette }) => ({
+                ml: "auto",
+                color: palette.gray[50],
+                fontSize: 12,
+              })}
+            />
+            <HoverPopover
+              {...bindPopover(subMenuPopupState)}
+              elevation={4}
+              anchorOrigin={{
+                horizontal: "right",
+                vertical: subMenuOffsetTop ? -subMenuOffsetTop : "top",
+              }}
+              transformOrigin={{
+                horizontal: "left",
+                vertical: "top",
+              }}
+              PaperProps={{
+                sx: {
+                  height: 300,
+                  width: subMenuWidth,
+                  ml: 1,
+                  py: 0.5,
+                },
+              }}
+            >
+              {cloneElement(subMenu, {
+                closeMenu,
+                popupState: subMenuPopupState,
+              })}
+            </HoverPopover>
+          </>
+        ) : null}
+      </MenuItem>
+    );
+  },
+);

--- a/apps/hash-frontend/src/pages/shared/block-collection/block-context-menu/block-context-menu.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/block-context-menu/block-context-menu.tsx
@@ -314,6 +314,7 @@ const BlockContextMenu: ForwardRefRenderFunction<
                 title={title}
                 itemKey={key}
                 icon={icon}
+                closeMenu={() => popupState.close()}
                 onClick={() => {
                   onClick?.();
                   popupState.close();

--- a/apps/hash-frontend/src/pages/shared/block-collection/block-context-menu/block-list-menu-content.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/block-context-menu/block-list-menu-content.tsx
@@ -17,13 +17,14 @@ import { useBlockView } from "../block-view";
 import { useFilteredBlocks } from "../shared/use-filtered-blocks";
 
 type BlockListMenuContentProps = {
+  closeMenu?: () => void;
   popupState?: PopupState;
   compatibleBlocks: HashBlock[];
 };
 
 export const BlockListMenuContent: FunctionComponent<
   BlockListMenuContentProps
-> = ({ compatibleBlocks, popupState }) => {
+> = ({ closeMenu, compatibleBlocks, popupState }) => {
   const [searchQuery, setSearchQuery] = useState("");
   const searchInputRef = useRef<HTMLInputElement>(null);
   const blocks = useFilteredBlocks(searchQuery, compatibleBlocks);
@@ -79,7 +80,10 @@ export const BlockListMenuContent: FunctionComponent<
       )}
       {blocks.map((option) => (
         <MenuItem
-          onClick={() => blockView.onBlockChange(option.variant, option.meta)}
+          onClick={() => {
+            blockView.onBlockChange(option.variant, option.meta);
+            closeMenu?.();
+          }}
           key={`${option.meta.componentId}/${option.variant.name}`}
         >
           <ListItemIcon>

--- a/apps/hash-frontend/src/pages/shared/block-collection/component-view.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/component-view.tsx
@@ -199,7 +199,6 @@ export class ComponentView implements NodeView {
               <BlockCollectionContext.Consumer>
                 {(collectionContext) => (
                   <BlockLoader
-                    key={entityId} // reset the component state when the entity changes
                     blockCollectionSubgraph={
                       collectionContext?.blockCollectionSubgraph
                     }
@@ -210,9 +209,11 @@ export class ComponentView implements NodeView {
                     } // @todo make this always defined
                     blockEntityTypeId={this.block.meta.schema as VersionedUrl}
                     blockMetadata={this.block.meta}
+                    entityStore={this.store}
                     // @todo uncomment this when sandbox is fixed
                     // shouldSandbox={!this.editable}
                     editableRef={this.editableRef}
+                    fallbackBlockProperties={childEntity?.properties}
                     wrappingEntityId={entityId}
                     onBlockLoaded={this.onBlockLoaded}
                     readonly={this.readonly}

--- a/libs/@local/hash-isomorphic-utils/src/entity-store-plugin.ts
+++ b/libs/@local/hash-isomorphic-utils/src/entity-store-plugin.ts
@@ -649,15 +649,22 @@ class ProsemirrorStateChangeHandler {
       // Check if the next entity node's child is a component node
       isComponentNode(node.firstChild.firstChild)
     ) {
-      const nextProps = textBlockNodeToEntityProperties(node.firstChild);
+      const nextTextProperties = textBlockNodeToEntityProperties(
+        node.firstChild,
+      );
 
-      if (!isEqual(childEntity.properties, nextProps)) {
+      if (
+        !isEqual(
+          childEntity.properties[textualContentPropertyTypeBaseUrl],
+          nextTextProperties[textualContentPropertyTypeBaseUrl],
+        )
+      ) {
         addEntityStoreAction(this.state, this.tr, {
           type: "updateEntityProperties",
           payload: {
-            merge: false,
+            merge: true,
             draftId: childEntity.draftId,
-            properties: nextProps,
+            properties: nextTextProperties,
           },
         });
       }

--- a/libs/@local/hash-isomorphic-utils/src/entity-store-plugin.ts
+++ b/libs/@local/hash-isomorphic-utils/src/entity-store-plugin.ts
@@ -24,6 +24,7 @@ import {
   getDraftEntityByEntityId,
   isBlockEntity,
   isDraftBlockEntity,
+  textualContentPropertyTypeBaseUrl,
 } from "./entity-store";
 import {
   ComponentNode,
@@ -209,11 +210,7 @@ const setBlockChildEntity = (
       targetEntity.metadata.recordId.entityId,
     );
     targetDraftEntity = {
-      metadata: {
-        recordId: {
-          entityId: targetEntity.metadata.recordId.entityId,
-        },
-      },
+      metadata: targetEntity.metadata,
       draftId: targetEntityDraftId,
       properties: targetEntity.properties,
       /** @todo use the actual updated date here https://app.asana.com/0/0/1203099452204542/f */
@@ -375,10 +372,34 @@ const entityStoreReducer = (
           draftState.trackedActions.push({ action, id: uuid() });
         }
 
+        const now = new Date().toISOString();
+
         draftState.store.draft[action.payload.draftId] = {
           metadata: {
+            archived: false,
             recordId: {
               entityId: action.payload.entityId,
+              editionId: now,
+            },
+            temporalVersioning: {
+              decisionTime: {
+                start: {
+                  kind: "inclusive",
+                  limit: now as Timestamp,
+                },
+                end: {
+                  kind: "unbounded",
+                },
+              },
+              transactionTime: {
+                start: {
+                  kind: "inclusive",
+                  limit: now as Timestamp,
+                },
+                end: {
+                  kind: "unbounded",
+                },
+              },
             },
           },
           draftId: action.payload.draftId,

--- a/libs/@local/hash-isomorphic-utils/src/entity-store.ts
+++ b/libs/@local/hash-isomorphic-utils/src/entity-store.ts
@@ -3,7 +3,6 @@ import {
   EntityId,
   EntityMetadata,
   EntityPropertiesObject,
-  EntityRevisionId,
   EntityTemporalVersioningMetadata,
   LinkData,
 } from "@local/hash-subgraph";
@@ -22,13 +21,14 @@ export const textualContentPropertyTypeBaseUrl = extractBaseUrl(
 
 export type DraftEntity<Type extends EntityStoreType = EntityStoreType> = {
   metadata: {
+    archived: boolean;
     recordId: {
       entityId: EntityId | null;
-      revisionId?: EntityRevisionId;
+      editionId: string;
     };
     entityTypeId?: VersionedUrl | null;
     provenance?: EntityMetadata["provenance"];
-    temporalVersioning?: EntityTemporalVersioningMetadata;
+    temporalVersioning: EntityTemporalVersioningMetadata;
   };
   /** @todo properly type this part of the DraftEntity type https://app.asana.com/0/0/1203099452204542/f */
   blockChildEntity?: Type & { draftId?: string };
@@ -182,12 +182,12 @@ export const createEntityStore = (
            */
           if (
             new Date(
-              draftData[draftId]!.metadata.temporalVersioning?.decisionTime
-                .start.limit ?? 0,
+              draftData[
+                draftId
+              ]!.metadata.temporalVersioning.decisionTime.start.limit,
             ).getTime() >
             new Date(
-              draftEntity.metadata.temporalVersioning?.decisionTime.start
-                .limit ?? 0,
+              draftEntity.metadata.temporalVersioning.decisionTime.start.limit,
             ).getTime()
           ) {
             Object.assign(draftEntity, draftData[draftId]);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes a few bugs related to setting variants of blocks. The visible effect of this is that when inserting a header of a specific level, or swapping between headers of specific levels, they will appear at the correct size (rather than defaulting to H1).

The key underlying issue is that when creating a new block with specific properties, or updating the properties on an existing entity via the context menu, what is actually happening is that the ProseMirror code is updating a local entity store which only it uses, which is periodically persisted to the API. The changes in this PR are to ensure that properties set in this way are used in the block loading code, which was previously relying on data from the API. We'd be better off having a single entity store which manages interaction with the API, rather than these piecemeal patches – see H-1351.

The PR also fixes the block swapping menu not closing when switching between the same block, which happens when switching between variants or if the clicks on the exact block that's already selected

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Fixes `block-loader` to 
  - add entities from the draft entity store into the block's subgraph where appropriate
  - accept a `fallbackBlockProperties` prop for newly created block entities, so that properties aren't empty while waiting for the entity to be saved in the API
- Explicitly close the block swapper menu when the same block is selected (it only happened to work when switching to different blocks because a new instance of the block and its context buttons is created when doing so)
- Fix some inconsistencies in the type of entities in the EntityStore vs everywhere else
- Stop non-text properties being lost when updating text in some places in the entity store code

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

- We should have a single entity store instead of having to do this patch work – H-1351
- Typing e.g. `/h3` in an empty para inserts the new block below, rather than replacing the empty block. It should replace it instead – H-1266

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- Manual

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Try inserting headers at different levels, swapping between them,

## 📹 Demo

https://github.com/hashintel/hash/assets/37743469/20b255d1-918d-4d84-9a6e-87d743dbfab3


<!-- Add a screenshot or video showcasing your work -->
