### PR TITLE
H-994: Expose entity validation to the Node API

### DIFF
--- a/apps/hash-api/src/graph/knowledge/primitive/entity.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity.ts
@@ -857,3 +857,17 @@ export const getEntityAuthorizationRelationships: ImpureGraphFunction<
           }) as EntityAuthorizationRelationship,
       ),
     );
+
+export const validateEntity: ImpureGraphFunction<
+  {
+    entityTypeId: VersionedUrl;
+    properties: Entity["properties"];
+    linkData?: Entity["linkData"];
+  },
+  Promise<void>
+> = async ({ graphApi }, { actorId }, params) => {
+  await graphApi.validateEntity(actorId, {
+    operations: new Set(["all"]),
+    ...params,
+  });
+};

--- a/apps/hash-graph/lib/graph/src/store.rs
+++ b/apps/hash-graph/lib/graph/src/store.rs
@@ -24,7 +24,7 @@ pub use self::{
         UpdateError,
     },
     fetcher::{FetchingPool, TypeFetcher},
-    knowledge::EntityStore,
+    knowledge::{EntityStore, EntityValidationType},
     migration::{Migration, MigrationState, StoreMigration},
     ontology::{DataTypeStore, EntityTypeStore, PropertyTypeStore},
     pool::StorePool,

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -3,6 +3,7 @@ use std::{collections::HashSet, mem};
 use async_trait::async_trait;
 use authorization::{
     schema::{EntityOwnerSubject, WebOwnerSubject, WebSubject},
+    zanzibar::Consistency,
     AuthorizationApi,
 };
 use error_stack::{Report, Result, ResultExt};
@@ -34,6 +35,7 @@ use crate::{
     ontology::domain_validator::DomainValidator,
     store::{
         crud::Read,
+        knowledge::EntityValidationType,
         query::{Filter, OntologyQueryPath},
         AccountStore, ConflictBehavior, DataTypeStore, EntityStore, EntityTypeStore,
         InsertionError, PropertyTypeStore, QueryError, Record, StoreError, StorePool, UpdateError,
@@ -959,6 +961,27 @@ where
                 decision_time,
                 archived,
                 entity_type_id,
+                properties,
+                link_data,
+            )
+            .await
+    }
+
+    async fn validate_entity<Au: AuthorizationApi + Sync>(
+        &self,
+        actor_id: AccountId,
+        authorization_api: &Au,
+        consistency: Consistency<'static>,
+        entity_type: EntityValidationType<'_>,
+        properties: &EntityProperties,
+        link_data: Option<&LinkData>,
+    ) -> Result<(), QueryError> {
+        self.store
+            .validate_entity(
+                actor_id,
+                authorization_api,
+                consistency,
+                entity_type,
                 properties,
                 link_data,
             )

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -51,7 +51,10 @@ use crate::{
         edges::{EdgeDirection, GraphResolveDepths, OntologyEdgeKind},
         identifier::{EntityTypeVertexId, PropertyTypeVertexId},
         query::StructuralQuery,
-        temporal_axes::{QueryTemporalAxesUnresolved, VariableAxis},
+        temporal_axes::{
+            PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved, VariableAxis,
+            VariableTemporalAxisUnresolved,
+        },
         Subgraph,
     },
 };
@@ -376,7 +379,13 @@ impl<C: AsClient> PostgresStore<C> {
                     FilterExpression::Path(EntityTypeQueryPath::OntologyId),
                     ParameterList::Uuid(&parent_entity_type_ids),
                 ),
-                Some(&QueryTemporalAxesUnresolved::default().resolve()),
+                Some(
+                    &QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    }
+                    .resolve(),
+                ),
             )
             .await?
             .map_ok(|(id, schema)| (EntityTypeId::from(id), schema))

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -499,13 +499,10 @@ impl<C: AsClient> PostgresStore<C> {
             .query_raw(&statement, parameters.iter().copied())
             .await
             .change_context(QueryError)?
-            .map(|row| row.change_context(QueryError))
-            .and_then(move |row| async move {
-                Ok((
-                    row.get(ontology_id_index),
-                    serde_json::from_value(row.get(closed_schema_index))
-                        .change_context(QueryError)?,
-                ))
+            .map(move |row| {
+                let row = row.change_context(QueryError)?;
+                let Json(schema) = row.get(closed_schema_index);
+                Ok((row.get(ontology_id_index), schema))
             }))
     }
 

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -868,6 +868,50 @@
         }
       }
     },
+    "/entities/validate": {
+      "post": {
+        "tags": [
+          "Graph",
+          "Entity"
+        ],
+        "operationId": "validate_entity",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ValidateEntityRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "The validation passed"
+          },
+          "400": {
+            "description": "The entity validation failed"
+          },
+          "404": {
+            "description": "Entity Type URL was not found"
+          },
+          "500": {
+            "description": "Store error occurred"
+          }
+        }
+      }
+    },
     "/entities/{entity_id}/editors/{editor}": {
       "post": {
         "tags": [
@@ -4972,6 +5016,43 @@
             "$ref": "./models/shared.json#/definitions/VersionedUrl"
           }
         }
+      },
+      "ValidateEntityRequest": {
+        "type": "object",
+        "required": [
+          "entityTypeId",
+          "properties",
+          "operations"
+        ],
+        "properties": {
+          "entityTypeId": {
+            "$ref": "./models/shared.json#/definitions/VersionedUrl"
+          },
+          "linkData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LinkData"
+              }
+            ],
+            "nullable": true
+          },
+          "operations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidationOperation"
+            },
+            "uniqueItems": true
+          },
+          "properties": {
+            "$ref": "#/components/schemas/EntityProperties"
+          }
+        }
+      },
+      "ValidationOperation": {
+        "type": "string",
+        "enum": [
+          "all"
+        ]
       },
       "Vertex": {
         "oneOf": [

--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -1251,7 +1251,7 @@ Content-Type: application/json
 X-Authenticated-User-Actor-Id: {{account_id}}
 
 {
-  "entityTypeId": "https://hash.ai/@hash/types/entity-type/user/v/1",
+  "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/1",
   "properties": {
     "http://localhost:3000/@alice/types/property-type/name/": "Alice"
   },
@@ -1276,7 +1276,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     "http://localhost:3000/@alice/types/property-type/name/": "Alice"
   },
   "owner": "{{account_id}}",
-  "entityTypeId": "https://hash.ai/@hash/types/entity-type/user/v/1"
+  "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/1"
 }
 
 > {%

--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -1245,6 +1245,25 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     });
 %}
 
+### Validate person entity to insert
+POST http://127.0.0.1:4000/entities/validate
+Content-Type: application/json
+X-Authenticated-User-Actor-Id: {{account_id}}
+
+{
+  "entityTypeId": "https://hash.ai/@hash/types/entity-type/user/v/1",
+  "properties": {
+    "http://localhost:3000/@alice/types/property-type/name/": "Alice"
+  },
+  "operations": ["all"]
+}
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 204, "Response status is not 204");
+    });
+%}
+
 ### Insert Person entity
 POST http://127.0.0.1:4000/entities
 Content-Type: application/json
@@ -1257,7 +1276,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     "http://localhost:3000/@alice/types/property-type/name/": "Alice"
   },
   "owner": "{{account_id}}",
-  "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/1"
+  "entityTypeId": "https://hash.ai/@hash/types/entity-type/user/v/1"
 }
 
 > {%
@@ -1350,6 +1369,26 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.roots.length === 1, "Unexpected number of entities");
+    });
+%}
+
+
+### Validate person entity to update
+POST http://127.0.0.1:4000/entities/validate
+Content-Type: application/json
+X-Authenticated-User-Actor-Id: {{account_id}}
+
+{
+  "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/2",
+  "properties": {
+    "http://localhost:3000/@alice/types/property-type/name/": "Alice Allison"
+  },
+  "operations": ["all"]
+}
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 204, "Response status is not 204");
     });
 %}
 
@@ -1453,6 +1492,27 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.roots.length === 2, "Unexpected number of entities");
+    });
+%}
+
+### Validate link to insert between persons
+POST http://127.0.0.1:4000/entities/validate
+Content-Type: application/json
+X-Authenticated-User-Actor-Id: {{account_id}}
+
+{
+  "entityTypeId": "{{friendship_link_entity_type_id}}",
+  "properties": {},
+  "linkData": {
+    "leftEntityId": "{{person_a_entity_id}}",
+    "rightEntityId": "{{person_b_entity_id}}"
+  },
+  "operations": ["all"]
+}
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 204, "Response status is not 204");
     });
 %}
 

--- a/libs/@local/hash-graph-client/python/graph_client/models.py
+++ b/libs/@local/hash-graph-client/python/graph_client/models.py
@@ -387,6 +387,10 @@ class TransactionTime(RootModel[Literal['transactionTime']]):
     model_config = ConfigDict(populate_by_name=True)
     root: Literal['transactionTime'] = Field(..., description='Time axis for the transaction time.\n\nThis is used as the generic argument to time-related structs and can be used as tag value.')
 
+class ValidationOperation(RootModel[Literal['all']]):
+    model_config = ConfigDict(populate_by_name=True)
+    root: Literal['all']
+
 class WebOwnerSubjectItem(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     kind: Literal['account']
@@ -759,6 +763,13 @@ class UpdateEntityRequest(EntityLinkOrder):
     archived: bool
     entity_id: EntityId = Field(..., alias='entityId')
     entity_type_id: VersionedURL = Field(..., alias='entityTypeId')
+    properties: EntityProperties
+
+class ValidateEntityRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    entity_type_id: VersionedURL = Field(..., alias='entityTypeId')
+    link_data: LinkData | None = Field(None, alias='linkData')
+    operations: list[ValidationOperation]
     properties: EntityProperties
 
 class PropertyTypeObjectItem(BaseModel):

--- a/libs/@local/hash-validation/src/property_type.rs
+++ b/libs/@local/hash-validation/src/property_type.rs
@@ -306,8 +306,8 @@ where
         let mut status: Result<(), Report<Self::Error>> = Ok(());
 
         for (key, property) in value {
-            if let Some(object_schema) = self.properties().get(key) {
-                if let Err(report) = object_schema.validate_value(property, provider).await {
+            if let Some(property_schema) = self.properties().get(key) {
+                if let Err(report) = property_schema.validate_value(property, provider).await {
                     extend_report!(status, report);
                 }
             } else {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To allow the frontend and entity inference to validate entities using the Graph, the functionality has to be exposed.

## 🔍 What does this change?

- Adds a new `EntityStore` method `validate_entity` which is used by the `create_entity` and `update_entity` methods. The function will read the closed schema from the Graph if required (but does not invoke the type fetcher)
- Expose the above function to the REST API
- Add a small wrapper function in the Node API

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Three example invocations are added to the HTTP tests