### PR TITLE
H-1408: Add an `entityCreator` relationship for webs

### DIFF
--- a/apps/hash-graph/lib/graph/src/api/rest/web.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/web.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use authorization::{
     backend::{ModifyRelationshipOperation, PermissionAssertion},
-    schema::{WebOwnerSubject, WebPermission, WebRelationAndSubject},
+    schema::{WebEntityCreatorSubject, WebOwnerSubject, WebPermission, WebRelationAndSubject},
     zanzibar::Consistency,
     AuthorizationApi, AuthorizationApiPool,
 };
@@ -43,6 +43,7 @@ use crate::{
             WebRelationAndSubject,
             WebPermission,
             WebOwnerSubject,
+            WebEntityCreatorSubject,
             ModifyWebAuthorizationRelationship,
         ),
     ),

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -5080,6 +5080,49 @@
           }
         }
       },
+      "WebEntityCreatorSubject": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "subjectId",
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "account"
+                ]
+              },
+              "subjectId": {
+                "$ref": "#/components/schemas/AccountId"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "subjectId",
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "accountGroup"
+                ]
+              },
+              "subjectId": {
+                "$ref": "#/components/schemas/AccountGroupId"
+              }
+            }
+          }
+        ],
+        "discriminator": {
+          "propertyName": "kind"
+        }
+      },
       "WebOwnerSubject": {
         "oneOf": [
           {
@@ -5150,6 +5193,24 @@
               },
               "subject": {
                 "$ref": "#/components/schemas/WebOwnerSubject"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "subject",
+              "relation"
+            ],
+            "properties": {
+              "relation": {
+                "type": "string",
+                "enum": [
+                  "entityCreator"
+                ]
+              },
+              "subject": {
+                "$ref": "#/components/schemas/WebEntityCreatorSubject"
               }
             }
           }

--- a/libs/@local/hash-authorization/schemas/v1__initial_schema.zed
+++ b/libs/@local/hash-authorization/schemas/v1__initial_schema.zed
@@ -21,10 +21,11 @@ definition graph/entity {
 
 definition graph/web {
 	relation level_00_owner: graph/account | graph/account_group#member
+	relation level_00_entity_creator: graph/account | graph/account_group#member
 
 	permission update = level_00_owner
 
-	permission create_entity = level_00_owner
+	permission create_entity = level_00_owner + level_00_entity_creator
 	permission create_entity_type = level_00_owner
 	permission create_property_type = level_00_owner
 	permission create_data_type = level_00_owner - level_00_owner

--- a/libs/@local/hash-authorization/src/schema.rs
+++ b/libs/@local/hash-authorization/src/schema.rs
@@ -35,7 +35,7 @@ pub use self::{
         PropertyTypeSubjectId, PropertyTypeSubjectSet, PropertyTypeViewerSubject,
     },
     web::{
-        WebNamespace, WebOwnerSubject, WebPermission, WebRelationAndSubject, WebResourceRelation,
-        WebSubject, WebSubjectId, WebSubjectSet,
+        WebEntityCreatorSubject, WebNamespace, WebOwnerSubject, WebPermission,
+        WebRelationAndSubject, WebResourceRelation, WebSubject, WebSubjectId, WebSubjectSet,
     },
 };

--- a/libs/@local/hash-authorization/src/schema/web.rs
+++ b/libs/@local/hash-authorization/src/schema/web.rs
@@ -44,7 +44,7 @@ impl Resource for WebId {
 #[serde(rename_all = "snake_case")]
 pub enum WebResourceRelation {
     Owner,
-    Editor,
+    EntityCreator,
 }
 
 impl Relation<WebId> for WebResourceRelation {}
@@ -196,7 +196,7 @@ impl Relationship for (WebId, WebRelationAndSubject) {
                         return Err(InvalidRelationship::invalid_subject_set(parts));
                     }
                 },
-                WebResourceRelation::Editor => match (parts.subject, parts.subject_set) {
+                WebResourceRelation::EntityCreator => match (parts.subject, parts.subject_set) {
                     (WebSubject::Account(id), None) => WebRelationAndSubject::EntityCreator {
                         subject: WebEntityCreatorSubject::Account { id },
                         level: parts.relation.level,
@@ -235,7 +235,7 @@ impl Relationship for (WebId, WebRelationAndSubject) {
             ),
             WebRelationAndSubject::EntityCreator { subject, level } => (
                 LeveledRelation {
-                    name: WebResourceRelation::Editor,
+                    name: WebResourceRelation::EntityCreator,
                     level,
                 },
                 match subject {

--- a/libs/@local/hash-graph-client/python/graph_client/models.py
+++ b/libs/@local/hash-graph-client/python/graph_client/models.py
@@ -391,6 +391,20 @@ class ValidationOperation(RootModel[Literal['all']]):
     model_config = ConfigDict(populate_by_name=True)
     root: Literal['all']
 
+class WebEntityCreatorSubjectItem(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    kind: Literal['account']
+    subject_id: AccountId = Field(..., alias='subjectId')
+
+class WebEntityCreatorSubjectItem1(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    kind: Literal['accountGroup']
+    subject_id: AccountGroupId = Field(..., alias='subjectId')
+
+class WebEntityCreatorSubject(RootModel[WebEntityCreatorSubjectItem | WebEntityCreatorSubjectItem1]):
+    model_config = ConfigDict(populate_by_name=True)
+    root: WebEntityCreatorSubjectItem | WebEntityCreatorSubjectItem1 = Field(..., discriminator='kind')
+
 class WebOwnerSubjectItem(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     kind: Literal['account']
@@ -417,9 +431,14 @@ class WebRelationAndSubjectItem(BaseModel):
     relation: Literal['owner']
     subject: WebOwnerSubject
 
-class WebRelationAndSubject(RootModel[WebRelationAndSubjectItem]):
+class WebRelationAndSubjectItem1(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
-    root: WebRelationAndSubjectItem = Field(..., discriminator='relation')
+    relation: Literal['entityCreator']
+    subject: WebEntityCreatorSubject
+
+class WebRelationAndSubject(RootModel[WebRelationAndSubjectItem | WebRelationAndSubjectItem1]):
+    model_config = ConfigDict(populate_by_name=True)
+    root: WebRelationAndSubjectItem | WebRelationAndSubjectItem1 = Field(..., discriminator='relation')
 
 class UpdateDataType(BaseModel):
     """


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To allow the system user to create linear entities in a web, a relationship has to be created. As the system user should not be the owner of the web, a new relationship type is added.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph