### PR TITLE
H-1384: Stop full-page refresh after submitting the entity type form

### DIFF
--- a/apps/hash-frontend/src/pages/shared/entity-type-page.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-page.tsx
@@ -29,6 +29,7 @@ import { PageErrorState } from "../../components/page-error-state";
 import { EntityTypeEntitiesContext } from "../../shared/entity-type-entities-context";
 import { useEntityTypeEntitiesContextValue } from "../../shared/entity-type-entities-context/use-entity-type-entities-context-value";
 import { useIsSpecialEntityType } from "../../shared/entity-types-context/hooks";
+import { generateLinkParameters } from "../../shared/generate-link-parameters";
 import { isTypeArchived } from "../../shared/is-archived";
 import { isHrefExternal } from "../../shared/is-href-external";
 import { ArchiveMenuItem } from "../[shortname]/shared/archive-menu-item";
@@ -146,7 +147,7 @@ export const EntityTypePage = ({
       });
 
       if (!res.errors?.length && res.data) {
-        void router.push(res.data.schema.$id);
+        void router.push(generateLinkParameters(res.data.schema.$id).href);
       } else {
         throw new Error("Could not publish changes");
       }
@@ -193,7 +194,7 @@ export const EntityTypePage = ({
     });
 
     if (!res.errors?.length && res.data) {
-      void router.push(res.data.schema.$id);
+      void router.push(generateLinkParameters(res.data.schema.$id).href);
     } else {
       throw new Error("Could not publish changes");
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In the remote deployment, types are given a `https//hash.ai` origin for their ids, but are hosted on `https://app.hash.ai`, in anticipation of the frontend being moved to `https://hash.ai`. This involves a number of temporary workarounds when users click on links with `https://hash.ai` URLs to actually treat them as internal – introduced in #3485.

One place where a workaround is required was missed – where users are sent to after submitting the type form. This means after submission users were sent to `https://hash.ai`, and redirected back to the same page, resulting in a full refresh (and the time taken to process the redirect). This PR fixes that.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Only possible in production, since the workaround depends on the frontend running on `https://app.hash.ai` – but the logic alone should make sense.
