### PR TITLE
BP-70: Directly use `(de)serialize` on ontology types

### DIFF
--- a/apps/hash-graph/Cargo.lock
+++ b/apps/hash-graph/Cargo.lock
@@ -933,7 +933,6 @@ name = "graph-types"
 version = "0.0.0"
 dependencies = [
  "bytes",
- "error-stack 0.4.1",
  "postgres-types",
  "serde",
  "serde_json",
@@ -3074,7 +3073,7 @@ dependencies = [
 [[package]]
 name = "type-system"
 version = "0.0.0"
-source = "git+https://github.com/blockprotocol/blockprotocol?rev=b63f923#b63f923ee1c931c8213d4c9e37ac84c6a4966ca7"
+source = "git+https://github.com/blockprotocol/blockprotocol?rev=d199607#d199607aedaaf44d99f4fb0261b4c4949b12d752"
 dependencies = [
  "console_error_panic_hook",
  "serde",

--- a/apps/hash-graph/Cargo.lock
+++ b/apps/hash-graph/Cargo.lock
@@ -3073,7 +3073,7 @@ dependencies = [
 [[package]]
 name = "type-system"
 version = "0.0.0"
-source = "git+https://github.com/blockprotocol/blockprotocol?rev=d199607#d199607aedaaf44d99f4fb0261b4c4949b12d752"
+source = "git+https://github.com/blockprotocol/blockprotocol?rev=b87db85#b87db85fe4ae2a448aafeaf44d2fca6ec15ce772"
 dependencies = [
  "console_error_panic_hook",
  "serde",

--- a/apps/hash-graph/Cargo.toml
+++ b/apps/hash-graph/Cargo.toml
@@ -25,7 +25,7 @@ validation = { path = "../../libs/@local/hash-validation" }
 authorization = { path = "../../libs/@local/hash-authorization" }
 codec = { path = "../../libs/@local/codec" }
 
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "b63f923" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "d199607" }
 hash-status = { path = "../../libs/@local/status/rust" }
 error-stack = { version = "0.4.1", features = ["spantrace", "serde"] }
 

--- a/apps/hash-graph/Cargo.toml
+++ b/apps/hash-graph/Cargo.toml
@@ -25,7 +25,7 @@ validation = { path = "../../libs/@local/hash-validation" }
 authorization = { path = "../../libs/@local/hash-authorization" }
 codec = { path = "../../libs/@local/codec" }
 
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "d199607" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "b87db85" }
 hash-status = { path = "../../libs/@local/status/rust" }
 error-stack = { version = "0.4.1", features = ["spantrace", "serde"] }
 

--- a/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
@@ -26,7 +26,7 @@ use graph_types::{
 use rand::{prelude::IteratorRandom, thread_rng};
 use temporal_versioning::TemporalBound;
 use tokio::runtime::Runtime;
-use type_system::{raw, EntityType};
+use type_system::EntityType;
 use uuid::Uuid;
 
 use crate::util::{seed, setup, Store, StoreWrapper};
@@ -90,12 +90,9 @@ async fn seed_db(
 
     let properties: EntityProperties =
         serde_json::from_str(entity::BOOK_V1).expect("could not parse entity");
-    let entity_type_repr: raw::EntityType = serde_json::from_str(entity_type::BOOK_V1)
-        .expect("could not parse entity type representation");
-    let entity_type_id = EntityType::try_from(entity_type_repr)
-        .expect("could not parse entity type")
-        .id()
-        .clone();
+    let entity_type: EntityType =
+        serde_json::from_str(entity_type::BOOK_V1).expect("could not parse entity type");
+    let entity_type_id = entity_type.id().clone();
 
     let owned_by_id = OwnedById::new(account_id.into_uuid());
 

--- a/apps/hash-graph/bench/read_scaling/knowledge/linkless/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/linkless/entity.rs
@@ -23,7 +23,7 @@ use graph_types::{
 use rand::{prelude::IteratorRandom, thread_rng};
 use temporal_versioning::TemporalBound;
 use tokio::runtime::Runtime;
-use type_system::{raw, EntityType};
+use type_system::EntityType;
 use uuid::Uuid;
 
 use crate::util::{seed, setup, Store, StoreWrapper};
@@ -79,12 +79,9 @@ async fn seed_db(
 
     let properties: EntityProperties =
         serde_json::from_str(entity::BOOK_V1).expect("could not parse entity");
-    let entity_type_repr: raw::EntityType = serde_json::from_str(entity_type::BOOK_V1)
-        .expect("could not parse entity type representation");
-    let entity_type_id = EntityType::try_from(entity_type_repr)
-        .expect("could not parse entity type")
-        .id()
-        .clone();
+    let entity_type: EntityType =
+        serde_json::from_str(entity_type::BOOK_V1).expect("could not parse entity type");
+    let entity_type_id = entity_type.id().clone();
 
     let entity_metadata_list = transaction
         .insert_entities_batched_by_type(

--- a/apps/hash-graph/bench/representative_read/seed.rs
+++ b/apps/hash-graph/bench/representative_read/seed.rs
@@ -15,7 +15,7 @@ use graph_types::{
     },
     provenance::OwnedById,
 };
-use type_system::{raw, url::VersionedUrl, EntityType};
+use type_system::{url::VersionedUrl, EntityType};
 use uuid::Uuid;
 
 use crate::util::{seed, StoreWrapper};
@@ -156,12 +156,9 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
     for (entity_type_str, entity_str, quantity) in SEED_ENTITIES {
         let properties: EntityProperties =
             serde_json::from_str(entity_str).expect("could not parse entity");
-        let entity_type_repr: raw::EntityType = serde_json::from_str(entity_type_str)
-            .expect("could not parse entity type representation");
-        let entity_type_id = EntityType::try_from(entity_type_repr)
-            .expect("could not parse entity type")
-            .id()
-            .clone();
+        let entity_type: EntityType =
+            serde_json::from_str(entity_type_str).expect("could not parse entity type");
+        let entity_type_id = entity_type.id().clone();
 
         let uuids = transaction
             .insert_entities_batched_by_type(
@@ -185,12 +182,9 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
     }
 
     for (entity_type_str, left_entity_index, right_entity_index) in SEED_LINKS {
-        let entity_type_repr: raw::EntityType = serde_json::from_str(entity_type_str)
-            .expect("could not parse entity type representation");
-        let entity_type_id = EntityType::try_from(entity_type_repr)
-            .expect("could not parse entity type")
-            .id()
-            .clone();
+        let entity_type: EntityType =
+            serde_json::from_str(entity_type_str).expect("could not parse entity type");
+        let entity_type_id = entity_type.id().clone();
 
         let uuids = transaction
             .insert_entities_batched_by_type(
@@ -249,12 +243,9 @@ async fn get_samples(account_id: AccountId, store_wrapper: &StoreWrapper) -> Sam
         SEED_ENTITY_TYPES
             .into_iter()
             .map(|entity_type_str| {
-                let entity_type_repr: raw::EntityType = serde_json::from_str(entity_type_str)
-                    .expect("could not parse entity type representation");
-                EntityType::try_from(entity_type_repr)
-                    .expect("could not parse entity type")
-                    .id()
-                    .clone()
+                let entity_type: EntityType =
+                    serde_json::from_str(entity_type_str).expect("could not parse entity type");
+                entity_type.id().clone()
             })
             .collect(),
     );
@@ -270,12 +261,9 @@ async fn get_samples(account_id: AccountId, store_wrapper: &StoreWrapper) -> Sam
         .expect("could not get sample map");
 
     for entity_type_id in SEED_ENTITIES.map(|(entity_type_str, ..)| {
-        let entity_type_repr: raw::EntityType = serde_json::from_str(entity_type_str)
-            .expect("could not parse entity type representation");
-        EntityType::try_from(entity_type_repr)
-            .expect("could not parse entity type")
-            .id()
-            .clone()
+        let entity_type: EntityType =
+            serde_json::from_str(entity_type_str).expect("could not parse entity type");
+        entity_type.id().clone()
     }) {
         // For now we'll just pick a sample of 50 entities.
         let sample_entity_uuids = store_wrapper

--- a/apps/hash-graph/bench/util.rs
+++ b/apps/hash-graph/bench/util.rs
@@ -18,7 +18,7 @@ use graph_types::{
 };
 use tokio::runtime::Runtime;
 use tokio_postgres::NoTls;
-use type_system::{raw, DataType, EntityType, PropertyType};
+use type_system::{DataType, EntityType, PropertyType};
 
 type Pool = PostgresStorePool<NoTls>;
 pub type Store = <Pool as StorePool>::Store<'static>;
@@ -196,7 +196,6 @@ impl Drop for StoreWrapper {
     }
 }
 
-#[expect(clippy::too_many_lines)]
 pub async fn seed<D, P, E, C>(
     store: &mut PostgresStore<C>,
     account_id: AccountId,
@@ -210,9 +209,8 @@ pub async fn seed<D, P, E, C>(
     C: AsClient,
 {
     for data_type_str in data_types {
-        let data_type_repr: raw::DataType =
-            serde_json::from_str(data_type_str).expect("could not parse data type representation");
-        let data_type = DataType::try_from(data_type_repr).expect("could not parse data type");
+        let data_type: DataType =
+            serde_json::from_str(data_type_str).expect("could not parse data type");
 
         match store
             .create_data_type(
@@ -243,10 +241,8 @@ pub async fn seed<D, P, E, C>(
     }
 
     for property_type_str in property_types {
-        let property_typee_repr: raw::PropertyType = serde_json::from_str(property_type_str)
-            .expect("could not parse property type representation");
-        let property_type =
-            PropertyType::try_from(property_typee_repr).expect("could not parse property type");
+        let property_type: PropertyType =
+            serde_json::from_str(property_type_str).expect("could not parse property type");
 
         match store
             .create_property_type(
@@ -277,10 +273,8 @@ pub async fn seed<D, P, E, C>(
     }
 
     for entity_type_str in entity_types {
-        let entity_type_repr: raw::EntityType = serde_json::from_str(entity_type_str)
-            .expect("could not parse entity type representation");
-        let entity_type =
-            EntityType::try_from(entity_type_repr).expect("could not parse entity type");
+        let entity_type: EntityType =
+            serde_json::from_str(entity_type_str).expect("could not parse entity type");
 
         match store
             .create_entity_type(

--- a/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef.rs
@@ -2,7 +2,7 @@ pub mod subgraph;
 
 use graph_types::ontology::{EntityTypeMetadata, OntologyElementMetadata};
 use serde::{Deserialize, Serialize};
-use type_system::raw;
+use type_system::{DataType, EntityType, PropertyType};
 use utoipa::{
     openapi::{OneOfBuilder, Ref, RefOr, Schema},
     ToSchema,
@@ -57,7 +57,7 @@ impl ToSchema<'_> for MaybeListOfEntityTypeMetadata {
     }
 }
 
-pub type MaybeListOfDataType = ListOrValue<raw::DataType>;
+pub type MaybeListOfDataType = ListOrValue<DataType>;
 impl ToSchema<'_> for MaybeListOfDataType {
     fn schema() -> (&'static str, RefOr<Schema>) {
         (
@@ -67,7 +67,7 @@ impl ToSchema<'_> for MaybeListOfDataType {
     }
 }
 
-pub type MaybeListOfPropertyType = ListOrValue<raw::PropertyType>;
+pub type MaybeListOfPropertyType = ListOrValue<PropertyType>;
 impl ToSchema<'_> for MaybeListOfPropertyType {
     fn schema() -> (&'static str, RefOr<Schema>) {
         (
@@ -77,7 +77,7 @@ impl ToSchema<'_> for MaybeListOfPropertyType {
     }
 }
 
-pub type MaybeListOfEntityType = ListOrValue<raw::EntityType>;
+pub type MaybeListOfEntityType = ListOrValue<EntityType>;
 impl ToSchema<'_> for MaybeListOfEntityType {
     fn schema() -> (&'static str, RefOr<Schema>) {
         (

--- a/apps/hash-graph/lib/graph/src/snapshot/entity/batch.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/entity/batch.rs
@@ -10,7 +10,6 @@ use error_stack::{Result, ResultExt};
 use futures::TryStreamExt;
 use graph_types::knowledge::entity::{Entity, EntityUuid};
 use tokio_postgres::GenericClient;
-use type_system::EntityType;
 use validation::Validate;
 
 use crate::{
@@ -216,15 +215,6 @@ impl<C: AsClient> WriteBatch<C> for EntityRowBatch {
             .read_closed_schemas(&Filter::All(Vec::new()), None)
             .await
             .change_context(InsertionError)?
-            .map_ok(|(id, schema)| {
-                // TODO: Distinguish between format validation and content validation so it's
-                //       possible to directly use the correct type.
-                //   see https://linear.app/hash/issue/BP-33
-                let entity_type = EntityType::try_from(schema).expect(
-                    "could not convert raw entity type to entity type from schema in database",
-                );
-                (id, entity_type)
-            })
             .try_collect::<HashMap<_, _>>()
             .await
             .change_context(InsertionError)?;

--- a/apps/hash-graph/lib/graph/src/snapshot/ontology/record.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/ontology/record.rs
@@ -9,13 +9,12 @@ use type_system::{DataType, EntityType, PropertyType};
 #[serde(
     rename_all = "camelCase",
     bound(
-        serialize = "T::Representation: Serialize, T::Metadata: Serialize, R: Serialize",
-        deserialize = "T::Representation: Deserialize<'de>, T::Metadata: Deserialize<'de>, R: \
-                       Deserialize<'de>"
+        serialize = "T: Serialize, T::Metadata: Serialize, R: Serialize",
+        deserialize = "T: Deserialize<'de>, T::Metadata: Deserialize<'de>, R: Deserialize<'de>"
     )
 )]
 pub struct OntologyTypeSnapshotRecord<T: OntologyType, R> {
-    pub schema: T::Representation,
+    pub schema: T,
     pub metadata: T::Metadata,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub relations: Vec<R>,

--- a/apps/hash-graph/lib/graph/src/snapshot/ontology/table.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/ontology/table.rs
@@ -5,7 +5,7 @@ use graph_types::{
 use postgres_types::{Json, ToSql};
 use temporal_versioning::{LeftClosedTemporalInterval, TransactionTime};
 use time::OffsetDateTime;
-use type_system::raw;
+use type_system::{DataType, EntityType, PropertyType};
 use uuid::Uuid;
 
 #[derive(Debug, ToSql)]
@@ -43,14 +43,14 @@ pub struct OntologyTemporalMetadataRow {
 #[postgres(name = "data_types")]
 pub struct DataTypeRow {
     pub ontology_id: Uuid,
-    pub schema: Json<raw::DataType>,
+    pub schema: Json<DataType>,
 }
 
 #[derive(Debug, ToSql)]
 #[postgres(name = "property_types")]
 pub struct PropertyTypeRow {
     pub ontology_id: Uuid,
-    pub schema: Json<raw::PropertyType>,
+    pub schema: Json<PropertyType>,
 }
 
 #[derive(Debug, ToSql)]
@@ -73,8 +73,8 @@ pub struct PropertyTypeConstrainsPropertiesOnRow {
 #[postgres(name = "entity_types")]
 pub struct EntityTypeRow {
     pub ontology_id: Uuid,
-    pub schema: Json<raw::EntityType>,
-    pub closed_schema: Json<raw::EntityType>,
+    pub schema: Json<EntityType>,
+    pub closed_schema: Json<EntityType>,
     pub label_property: Option<String>,
     pub icon: Option<String>,
 }

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -25,7 +25,7 @@ use tarpc::context;
 use temporal_versioning::{DecisionTime, Timestamp};
 use tokio::net::ToSocketAddrs;
 use tokio_serde::formats::Json;
-use type_fetcher::fetcher::{FetcherClient, OntologyTypeRepr};
+use type_fetcher::fetcher::{FetchedOntologyType, FetcherClient};
 use type_system::{
     url::{BaseUrl, VersionedUrl},
     DataType, EntityType, EntityTypeReference, PropertyType,
@@ -305,7 +305,7 @@ where
 
             for (ontology_type, fetched_at) in ontology_types {
                 match ontology_type {
-                    OntologyTypeRepr::DataType(data_type) => {
+                    FetchedOntologyType::DataType(data_type) => {
                         let metadata = PartialOntologyElementMetadata {
                             record_id: data_type.id().clone().into(),
                             custom: PartialCustomOntologyMetadata::External { fetched_at },
@@ -331,7 +331,7 @@ where
                             .data_types
                             .push((data_type, metadata));
                     }
-                    OntologyTypeRepr::PropertyType(property_type) => {
+                    FetchedOntologyType::PropertyType(property_type) => {
                         let metadata = PartialOntologyElementMetadata {
                             record_id: property_type.id().clone().into(),
                             custom: PartialCustomOntologyMetadata::External { fetched_at },
@@ -357,7 +357,7 @@ where
                             .property_types
                             .push((property_type, metadata));
                     }
-                    OntologyTypeRepr::EntityType(entity_type) => {
+                    FetchedOntologyType::EntityType(entity_type) => {
                         let metadata = PartialOntologyElementMetadata {
                             record_id: entity_type.id().clone().into(),
                             custom: PartialCustomOntologyMetadata::External { fetched_at },

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -305,9 +305,7 @@ where
 
             for (ontology_type, fetched_at) in ontology_types {
                 match ontology_type {
-                    OntologyTypeRepr::DataType(data_type_repr) => {
-                        let data_type =
-                            DataType::try_from(data_type_repr).change_context(StoreError)?;
+                    OntologyTypeRepr::DataType(data_type) => {
                         let metadata = PartialOntologyElementMetadata {
                             record_id: data_type.id().clone().into(),
                             custom: PartialCustomOntologyMetadata::External { fetched_at },
@@ -334,8 +332,6 @@ where
                             .push((data_type, metadata));
                     }
                     OntologyTypeRepr::PropertyType(property_type) => {
-                        let property_type =
-                            PropertyType::try_from(property_type).change_context(StoreError)?;
                         let metadata = PartialOntologyElementMetadata {
                             record_id: property_type.id().clone().into(),
                             custom: PartialCustomOntologyMetadata::External { fetched_at },
@@ -362,8 +358,6 @@ where
                             .push((property_type, metadata));
                     }
                     OntologyTypeRepr::EntityType(entity_type) => {
-                        let entity_type =
-                            EntityType::try_from(entity_type).change_context(StoreError)?;
                         let metadata = PartialOntologyElementMetadata {
                             record_id: entity_type.id().clone().into(),
                             custom: PartialCustomOntologyMetadata::External { fetched_at },

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -30,7 +30,7 @@ use postgres_types::Json;
 use temporal_versioning::{DecisionTime, RightBoundedTemporalInterval, Timestamp};
 #[cfg(hash_graph_test_environment)]
 use tokio_postgres::GenericClient;
-use type_system::{raw, url::VersionedUrl, EntityType};
+use type_system::{url::VersionedUrl, EntityType};
 use uuid::Uuid;
 use validation::{EntityValidationError, Validate};
 
@@ -578,12 +578,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                     )
                     .await
                     .change_context(QueryError)?
-                    .and_then(|(_, raw_type)| async move {
-                        // TODO: Distinguish between format validation and content validation so
-                        //       it's possible to directly use the correct type.
-                        //   see https://linear.app/hash/issue/BP-33
-                        EntityType::try_from(raw_type).change_context(QueryError)
-                    })
+                    .map_ok(|(_, raw_type)| raw_type)
                     .try_collect::<Vec<EntityType>>()
                     .await?;
 
@@ -1097,7 +1092,7 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
             .await
             .change_context(InsertionError)?;
 
-        let entity_schema: Json<raw::EntityType> = self
+        let Json(entity_type) = self
             .as_client()
             .query_one(
                 "SELECT closed_schema FROM entity_types WHERE ontology_id = $1;",
@@ -1106,7 +1101,6 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
             .await
             .change_context(InsertionError)?
             .get(0);
-        let entity_type = EntityType::try_from(entity_schema.0).change_context(InsertionError)?;
 
         Ok((edition_id, entity_type))
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -177,9 +177,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
                 )
                 .await?
             {
-                transaction
-                    .insert_with_id(ontology_id, schema.clone())
-                    .await?;
+                transaction.insert_with_id(ontology_id, &schema).await?;
                 inserted_data_type_metadata.push(OntologyElementMetadata::from_partial(
                     metadata,
                     provenance,
@@ -375,7 +373,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
         let transaction = self.transaction().await.change_context(UpdateError)?;
 
         let (ontology_id, metadata, owner) = transaction
-            .update::<DataType>(data_type, RecordCreatedById::new(actor_id))
+            .update::<DataType>(&data_type, RecordCreatedById::new(actor_id))
             .await?;
 
         let owner = match owner {

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -299,9 +299,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                 )
                 .await?
             {
-                transaction
-                    .insert_with_id(ontology_id, schema.clone())
-                    .await?;
+                transaction.insert_with_id(ontology_id, &schema).await?;
 
                 inserted_property_types.push((ontology_id, schema));
                 inserted_property_type_metadata.push(OntologyElementMetadata::from_partial(
@@ -517,7 +515,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         // We can only insert them after the type has been created, and so we currently extract them
         // after as well. See `insert_property_type_references` taking `&property_type`
         let (ontology_id, metadata, owner) = transaction
-            .update::<PropertyType>(property_type.clone(), RecordCreatedById::new(actor_id))
+            .update::<PropertyType>(&property_type, RecordCreatedById::new(actor_id))
             .await?;
 
         transaction

--- a/apps/hash-graph/lib/graph/src/store/validation.rs
+++ b/apps/hash-graph/lib/graph/src/store/validation.rs
@@ -140,16 +140,12 @@ where
                 schemas.len(),
             ))
         );
-        let schema = schemas.pop().ok_or_else(|| {
+        schemas.pop().ok_or_else(|| {
             Report::new(QueryError).attach_printable(
                 "Expected exactly one closed schema to be returned from the query but none was \
                  returned",
             )
-        })?;
-        // TODO: Distinguish between format validation and content validation so it's possible
-        //       to directly use the correct type.
-        //   see https://linear.app/hash/issue/BP-33
-        EntityType::try_from(schema).change_context(QueryError)
+        })
     }
 }
 

--- a/apps/hash-graph/lib/type-fetcher/src/fetcher.rs
+++ b/apps/hash-graph/lib/type-fetcher/src/fetcher.rs
@@ -28,7 +28,7 @@ impl fmt::Display for FetcherError {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum OntologyTypeRepr {
+pub enum FetchedOntologyType {
     DataType(DataType),
     PropertyType(PropertyType),
     EntityType(EntityType),
@@ -39,5 +39,5 @@ pub trait Fetcher {
     /// Fetch a list of ontology types identified by their [`VersionedUrl]` and returns them.
     async fn fetch_ontology_types(
         ontology_type_urls: Vec<VersionedUrl>,
-    ) -> Result<Vec<(OntologyTypeRepr, OffsetDateTime)>, FetcherError>;
+    ) -> Result<Vec<(FetchedOntologyType, OffsetDateTime)>, FetcherError>;
 }

--- a/apps/hash-graph/lib/type-fetcher/src/fetcher.rs
+++ b/apps/hash-graph/lib/type-fetcher/src/fetcher.rs
@@ -2,7 +2,7 @@ use std::{error::Error, fmt};
 
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
-use type_system::{raw, url::VersionedUrl};
+use type_system::{url::VersionedUrl, DataType, EntityType, PropertyType};
 
 // We would really like to use error-stack for this. It's not possible because
 // we need Serialize and Deserialize for `Report`
@@ -29,9 +29,9 @@ impl fmt::Display for FetcherError {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum OntologyTypeRepr {
-    DataType(raw::DataType),
-    PropertyType(raw::PropertyType),
-    EntityType(raw::EntityType),
+    DataType(DataType),
+    PropertyType(PropertyType),
+    EntityType(EntityType),
 }
 
 #[tarpc::service]

--- a/apps/hash-graph/lib/type-fetcher/src/fetcher_server.rs
+++ b/apps/hash-graph/lib/type-fetcher/src/fetcher_server.rs
@@ -9,7 +9,7 @@ use tarpc::context::Context;
 use time::OffsetDateTime;
 use type_system::url::VersionedUrl;
 
-use crate::fetcher::{Fetcher, FetcherError, OntologyTypeRepr};
+use crate::fetcher::{FetchedOntologyType, Fetcher, FetcherError};
 
 #[derive(Clone)]
 pub struct FetchServer {
@@ -22,7 +22,7 @@ impl Fetcher for FetchServer {
         self,
         _context: Context,
         ontology_type_urls: Vec<VersionedUrl>,
-    ) -> Result<Vec<(OntologyTypeRepr, OffsetDateTime)>, FetcherError> {
+    ) -> Result<Vec<(FetchedOntologyType, OffsetDateTime)>, FetcherError> {
         let client = Client::new();
         stream::iter(ontology_type_urls)
             .map(|url| {
@@ -39,7 +39,7 @@ impl Fetcher for FetchServer {
                             tracing::error!(error=?err, %url, "Could not fetch ontology type");
                             FetcherError::NetworkError(format!("Error fetching {url}: {err:?}"))
                         })?
-                        .json::<OntologyTypeRepr>()
+                        .json::<FetchedOntologyType>()
                         .await
                         .map_err(|err| {
                             tracing::error!(error=?err, %url, "Could not deserialize response");

--- a/libs/@local/hash-authorization/Cargo.toml
+++ b/libs/@local/hash-authorization/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 error-stack = { version = "0.4.1", features = ["spantrace"] }
 graph-types = { path = "../hash-graph-types/rust" }
 codec = { path = "../codec" }
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "b63f923" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "d199607" }
 
 derive-where = { version = "1.2.5", default-features = false, features = ["nightly"] }
 futures = { version = "0.3.29", default-features = false }

--- a/libs/@local/hash-authorization/Cargo.toml
+++ b/libs/@local/hash-authorization/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 error-stack = { version = "0.4.1", features = ["spantrace"] }
 graph-types = { path = "../hash-graph-types/rust" }
 codec = { path = "../codec" }
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "d199607" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "b87db85" }
 
 derive-where = { version = "1.2.5", default-features = false, features = ["nightly"] }
 futures = { version = "0.3.29", default-features = false }

--- a/libs/@local/hash-graph-types/rust/Cargo.toml
+++ b/libs/@local/hash-graph-types/rust/Cargo.toml
@@ -5,8 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-error-stack = { version = "0.4.1", features = ["spantrace"] }
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "b63f923" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "d199607" }
 temporal-versioning = { path = "../../temporal-versioning" }
 
 bytes = { version = "1.5.0" }

--- a/libs/@local/hash-graph-types/rust/Cargo.toml
+++ b/libs/@local/hash-graph-types/rust/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "d199607" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "b87db85" }
 temporal-versioning = { path = "../../temporal-versioning" }
 
 bytes = { version = "1.5.0" }

--- a/libs/@local/hash-graph-types/rust/src/ontology/data_type.rs
+++ b/libs/@local/hash-graph-types/rust/src/ontology/data_type.rs
@@ -1,4 +1,4 @@
-use type_system::{raw, url::VersionedUrl, DataType, ParseDataTypeError};
+use type_system::{url::VersionedUrl, DataType};
 #[cfg(feature = "utoipa")]
 use utoipa::{
     openapi::{schema, Ref, RefOr, Schema},
@@ -10,9 +10,7 @@ use crate::ontology::{
 };
 
 impl OntologyType for DataType {
-    type ConversionError = ParseDataTypeError;
     type Metadata = OntologyElementMetadata;
-    type Representation = raw::DataType;
 
     fn id(&self) -> &VersionedUrl {
         self.id()

--- a/libs/@local/hash-graph-types/rust/src/ontology/entity_type.rs
+++ b/libs/@local/hash-graph-types/rust/src/ontology/entity_type.rs
@@ -3,9 +3,8 @@ use std::iter::once;
 use serde::{Deserialize, Serialize};
 use temporal_versioning::{LeftClosedTemporalInterval, TransactionTime};
 use type_system::{
-    raw,
     url::{BaseUrl, VersionedUrl},
-    EntityType, ParseEntityTypeError,
+    EntityType,
 };
 #[cfg(feature = "utoipa")]
 use utoipa::{
@@ -84,9 +83,7 @@ impl From<EntityTypeMetadata> for OntologyElementMetadata {
 }
 
 impl OntologyType for EntityType {
-    type ConversionError = ParseEntityTypeError;
     type Metadata = EntityTypeMetadata;
-    type Representation = raw::EntityType;
 
     fn id(&self) -> &VersionedUrl {
         self.id()

--- a/libs/@local/hash-graph-types/rust/src/ontology/property_type.rs
+++ b/libs/@local/hash-graph-types/rust/src/ontology/property_type.rs
@@ -1,4 +1,4 @@
-use type_system::{raw, url::VersionedUrl, ParsePropertyTypeError, PropertyType};
+use type_system::{url::VersionedUrl, PropertyType};
 #[cfg(feature = "utoipa")]
 use utoipa::{
     openapi::{schema, Ref, RefOr, Schema},
@@ -10,9 +10,7 @@ use crate::ontology::{
 };
 
 impl OntologyType for PropertyType {
-    type ConversionError = ParsePropertyTypeError;
     type Metadata = OntologyElementMetadata;
-    type Representation = raw::PropertyType;
 
     fn id(&self) -> &VersionedUrl {
         self.id()

--- a/libs/@local/hash-validation/Cargo.toml
+++ b/libs/@local/hash-validation/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 error-stack = { version = "0.4.1", features = ["spantrace"] }
 graph-types = { path = "../hash-graph-types/rust" }
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "b63f923" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "d199607" }
 thiserror = "1.0.50"
 serde_json = { version = "1.0.108" }
 

--- a/libs/@local/hash-validation/Cargo.toml
+++ b/libs/@local/hash-validation/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 error-stack = { version = "0.4.1", features = ["spantrace"] }
 graph-types = { path = "../hash-graph-types/rust" }
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "d199607" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "b87db85" }
 thiserror = "1.0.50"
 serde_json = { version = "1.0.108" }
 

--- a/libs/@local/hash-validation/src/error.rs
+++ b/libs/@local/hash-validation/src/error.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use error_stack::Report;
 use graph_types::knowledge::entity::EntityProperties;
 use serde_json::Value as JsonValue;
-use type_system::{raw, url::VersionedUrl, DataType, EntityType, PropertyType};
+use type_system::{url::VersionedUrl, DataType, EntityType, PropertyType};
 
 pub fn install_error_stack_hooks() {
     Report::install_debug_hook::<Actual>(|actual, context| match actual {
@@ -30,15 +30,9 @@ pub fn install_error_stack_hooks() {
 
         if attach {
             let json = match expected {
-                Expected::EntityType(entity_type) => {
-                    serde_json::to_value(raw::EntityType::from(entity_type.clone()))
-                }
-                Expected::PropertyType(property_type) => {
-                    serde_json::to_value(raw::PropertyType::from(property_type.clone()))
-                }
-                Expected::DataType(data_type) => {
-                    serde_json::to_value(raw::DataType::from(data_type.clone()))
-                }
+                Expected::EntityType(entity_type) => serde_json::to_value(entity_type),
+                Expected::PropertyType(property_type) => serde_json::to_value(property_type),
+                Expected::DataType(data_type) => serde_json::to_value(data_type.clone()),
             };
             if let Ok(json) = json {
                 context.push_appendix(format!("{id}\n{json:#}"));

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -104,7 +104,7 @@ mod tests {
     use graph_types::knowledge::entity::{EntityId, EntityProperties};
     use serde_json::Value as JsonValue;
     use thiserror::Error;
-    use type_system::{raw, DataType, EntityType, PropertyType};
+    use type_system::{DataType, EntityType, PropertyType};
 
     use super::*;
     use crate::{
@@ -248,27 +248,19 @@ mod tests {
 
         let provider = Provider::new(
             entities,
-            entity_types.into_iter().map(|entity_type_id| {
-                let raw_entity_type = serde_json::from_str::<raw::EntityType>(entity_type_id)
-                    .expect("failed to read entity type string");
-                EntityType::try_from(raw_entity_type).expect("failed to parse entity type")
+            entity_types.into_iter().map(|entity_type| {
+                serde_json::from_str(entity_type).expect("failed to parse entity type")
             }),
-            property_types.into_iter().map(|property_type_id| {
-                let raw_property_type = serde_json::from_str::<raw::PropertyType>(property_type_id)
-                    .expect("failed to read property type string");
-                PropertyType::try_from(raw_property_type).expect("failed to parse property type")
+            property_types.into_iter().map(|property_type| {
+                serde_json::from_str(property_type).expect("failed to parse property type")
             }),
-            data_types.into_iter().map(|data_type_id| {
-                let raw_data_type = serde_json::from_str::<raw::DataType>(data_type_id)
-                    .expect("failed to read data type string");
-                DataType::try_from(raw_data_type).expect("failed to parse data type")
+            data_types.into_iter().map(|data_type| {
+                serde_json::from_str(data_type).expect("failed to parse data type")
             }),
         );
 
-        let raw_entity_type = serde_json::from_str::<raw::EntityType>(entity_type)
-            .expect("failed to read entity type string");
-        let entity_type =
-            EntityType::try_from(raw_entity_type).expect("failed to parse entity type");
+        let entity_type: EntityType =
+            serde_json::from_str(entity_type).expect("failed to parse entity type");
 
         let entity =
             serde_json::from_str::<EntityProperties>(entity).expect("failed to read entity string");
@@ -287,22 +279,16 @@ mod tests {
         let provider = Provider::new(
             [],
             [],
-            property_types.into_iter().map(|property_type_id| {
-                let raw_property_type = serde_json::from_str::<raw::PropertyType>(property_type_id)
-                    .expect("failed to read property type string");
-                PropertyType::try_from(raw_property_type).expect("failed to parse property type")
+            property_types.into_iter().map(|property_type| {
+                serde_json::from_str(property_type).expect("failed to parse property type")
             }),
-            data_types.into_iter().map(|data_type_id| {
-                let raw_data_type = serde_json::from_str::<raw::DataType>(data_type_id)
-                    .expect("failed to read data type string");
-                DataType::try_from(raw_data_type).expect("failed to parse data type")
+            data_types.into_iter().map(|data_type| {
+                serde_json::from_str(data_type).expect("failed to parse data type")
             }),
         );
 
-        let raw_property_type = serde_json::from_str::<raw::PropertyType>(property_type)
-            .expect("failed to read property type string");
-        let property_type =
-            PropertyType::try_from(raw_property_type).expect("failed to parse property type");
+        let property_type: PropertyType =
+            serde_json::from_str(property_type).expect("failed to parse property type");
 
         property.validate(&property_type, &provider).await
     }
@@ -313,9 +299,8 @@ mod tests {
     ) -> Result<(), Report<DataValidationError>> {
         install_error_stack_hooks();
 
-        let raw_data_type = serde_json::from_str::<raw::DataType>(data_type)
-            .expect("failed to read data type string");
-        let data_type = DataType::try_from(raw_data_type).expect("failed to parse data type");
+        let data_type: DataType =
+            serde_json::from_str(data_type).expect("failed to parse data type");
 
         data.validate(&data_type, &()).await
     }

--- a/tests/hash-graph-integration/Cargo.toml
+++ b/tests/hash-graph-integration/Cargo.toml
@@ -12,7 +12,7 @@ temporal-versioning = { path = "../../libs/@local/temporal-versioning" }
 authorization = { path = "../../libs/@local/hash-authorization" }
 
 error-stack = { version = "0.4.1", features = ["spantrace"] }
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "b63f923" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "d199607" }
 
 futures = { version = "0.3.29", default-features = false }
 rand = "0.8.5"

--- a/tests/hash-graph-integration/Cargo.toml
+++ b/tests/hash-graph-integration/Cargo.toml
@@ -12,7 +12,7 @@ temporal-versioning = { path = "../../libs/@local/temporal-versioning" }
 authorization = { path = "../../libs/@local/hash-authorization" }
 
 error-stack = { version = "0.4.1", features = ["spantrace"] }
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "d199607" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "b87db85" }
 
 futures = { version = "0.3.29", default-features = false }
 rand = "0.8.5"

--- a/tests/hash-graph-integration/postgres/data_type.rs
+++ b/tests/hash-graph-integration/postgres/data_type.rs
@@ -2,16 +2,14 @@ use graph::store::{
     error::{OntologyTypeIsNotOwned, OntologyVersionDoesNotExist, VersionedUrlAlreadyExists},
     BaseUrlAlreadyExists,
 };
-use type_system::{raw, DataType};
+use type_system::DataType;
 
 use crate::DatabaseTestWrapper;
 
 #[tokio::test]
 async fn insert() {
-    let data_type_repr: raw::DataType =
-        serde_json::from_str(graph_test_data::data_type::BOOLEAN_V1)
-            .expect("could not parse data type representation");
-    let boolean_dt = DataType::try_from(data_type_repr).expect("could not parse data type");
+    let boolean_dt: DataType = serde_json::from_str(graph_test_data::data_type::BOOLEAN_V1)
+        .expect("could not parse data type representation");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database
@@ -26,10 +24,8 @@ async fn insert() {
 
 #[tokio::test]
 async fn query() {
-    let data_type_repr: raw::DataType =
-        serde_json::from_str(graph_test_data::data_type::EMPTY_LIST_V1)
-            .expect("could not parse data type representation");
-    let empty_list_dt = DataType::try_from(data_type_repr).expect("could not parse data type");
+    let empty_list_dt: DataType = serde_json::from_str(graph_test_data::data_type::EMPTY_LIST_V1)
+        .expect("could not parse data type representation");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database
@@ -51,15 +47,11 @@ async fn query() {
 
 #[tokio::test]
 async fn update() {
-    let object_dt_v1_repr: raw::DataType =
-        serde_json::from_str(graph_test_data::data_type::OBJECT_V1)
-            .expect("could not parse data type representation");
-    let object_dt_v1 = DataType::try_from(object_dt_v1_repr).expect("could not parse data type");
+    let object_dt_v1: DataType = serde_json::from_str(graph_test_data::data_type::OBJECT_V1)
+        .expect("could not parse data type representation");
 
-    let object_dt_v2_repr: raw::DataType =
-        serde_json::from_str(graph_test_data::data_type::OBJECT_V2)
-            .expect("could not parse data type representation");
-    let object_dt_v2 = DataType::try_from(object_dt_v2_repr).expect("could not parse data type");
+    let object_dt_v2: DataType = serde_json::from_str(graph_test_data::data_type::OBJECT_V2)
+        .expect("could not parse data type representation");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database
@@ -94,15 +86,11 @@ async fn update() {
 
 #[tokio::test]
 async fn insert_same_base_url() {
-    let object_dt_v1_repr: raw::DataType =
-        serde_json::from_str(graph_test_data::data_type::OBJECT_V1)
-            .expect("could not parse data type representation");
-    let object_dt_v1 = DataType::try_from(object_dt_v1_repr).expect("could not parse data type");
+    let object_dt_v1: DataType = serde_json::from_str(graph_test_data::data_type::OBJECT_V1)
+        .expect("could not parse data type representation");
 
-    let object_dt_v2_repr: raw::DataType =
-        serde_json::from_str(graph_test_data::data_type::OBJECT_V2)
-            .expect("could not parse data type representation");
-    let object_dt_v2 = DataType::try_from(object_dt_v2_repr).expect("could not parse data type");
+    let object_dt_v2: DataType = serde_json::from_str(graph_test_data::data_type::OBJECT_V2)
+        .expect("could not parse data type representation");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database
@@ -153,15 +141,11 @@ async fn insert_same_base_url() {
 
 #[tokio::test]
 async fn wrong_update_order() {
-    let object_dt_v1_repr: raw::DataType =
-        serde_json::from_str(graph_test_data::data_type::OBJECT_V1)
-            .expect("could not parse data type representation");
-    let object_dt_v1 = DataType::try_from(object_dt_v1_repr).expect("could not parse data type");
+    let object_dt_v1: DataType = serde_json::from_str(graph_test_data::data_type::OBJECT_V1)
+        .expect("could not parse data type representation");
 
-    let object_dt_v2_repr: raw::DataType =
-        serde_json::from_str(graph_test_data::data_type::OBJECT_V2)
-            .expect("could not parse data type representation");
-    let object_dt_v2 = DataType::try_from(object_dt_v2_repr).expect("could not parse data type");
+    let object_dt_v2: DataType = serde_json::from_str(graph_test_data::data_type::OBJECT_V2)
+        .expect("could not parse data type representation");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database
@@ -207,15 +191,11 @@ async fn wrong_update_order() {
 
 #[tokio::test]
 async fn update_external_with_owned() {
-    let object_dt_v1_repr: raw::DataType =
-        serde_json::from_str(graph_test_data::data_type::OBJECT_V1)
-            .expect("could not parse data type representation");
-    let object_dt_v1 = DataType::try_from(object_dt_v1_repr).expect("could not parse data type");
+    let object_dt_v1: DataType = serde_json::from_str(graph_test_data::data_type::OBJECT_V1)
+        .expect("could not parse data type representation");
 
-    let object_dt_v2_repr: raw::DataType =
-        serde_json::from_str(graph_test_data::data_type::OBJECT_V2)
-            .expect("could not parse data type representation");
-    let object_dt_v2 = DataType::try_from(object_dt_v2_repr).expect("could not parse data type");
+    let object_dt_v2: DataType = serde_json::from_str(graph_test_data::data_type::OBJECT_V2)
+        .expect("could not parse data type representation");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database

--- a/tests/hash-graph-integration/postgres/entity_type.rs
+++ b/tests/hash-graph-integration/postgres/entity_type.rs
@@ -1,13 +1,12 @@
 use graph_test_data::{data_type, entity_type, property_type};
-use type_system::{raw, EntityType};
+use type_system::EntityType;
 
 use crate::DatabaseTestWrapper;
 
 #[tokio::test]
 async fn insert() {
-    let person_et_repr: raw::EntityType = serde_json::from_str(entity_type::PERSON_V1)
+    let person_et: EntityType = serde_json::from_str(entity_type::PERSON_V1)
         .expect("could not parse entity type representation");
-    let person_et = EntityType::try_from(person_et_repr).expect("could not parse entity type");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database
@@ -26,10 +25,8 @@ async fn insert() {
 
 #[tokio::test]
 async fn query() {
-    let organization_et_repr: raw::EntityType = serde_json::from_str(entity_type::ORGANIZATION_V1)
+    let organization_et: EntityType = serde_json::from_str(entity_type::ORGANIZATION_V1)
         .expect("could not parse entity type representation");
-    let organization_et =
-        EntityType::try_from(organization_et_repr).expect("could not parse entity type");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database
@@ -51,13 +48,11 @@ async fn query() {
 
 #[tokio::test]
 async fn update() {
-    let page_et_v1_repr: raw::EntityType = serde_json::from_str(entity_type::PAGE_V1)
+    let page_et_v1: EntityType = serde_json::from_str(entity_type::PAGE_V1)
         .expect("could not parse entity type representation");
-    let page_et_v1 = EntityType::try_from(page_et_v1_repr).expect("could not parse entity type");
 
-    let page_et_v2_repr: raw::EntityType = serde_json::from_str(entity_type::PAGE_V2)
+    let page_et_v2: EntityType = serde_json::from_str(entity_type::PAGE_V2)
         .expect("could not parse entity type representation");
-    let page_et_v2 = EntityType::try_from(page_et_v2_repr).expect("could not parse entity type");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -57,7 +57,7 @@ use graph_types::{
 use temporal_versioning::{DecisionTime, LimitedTemporalBound, TemporalBound, Timestamp};
 use time::{format_description::well_known::Iso8601, Duration, OffsetDateTime};
 use tokio_postgres::{NoTls, Transaction};
-use type_system::{raw, url::VersionedUrl, DataType, EntityType, PropertyType};
+use type_system::{url::VersionedUrl, DataType, EntityType, PropertyType};
 use uuid::Uuid;
 
 pub struct DatabaseTestWrapper {
@@ -141,9 +141,8 @@ impl DatabaseTestWrapper {
             .expect("could not create web id");
 
         let data_types_iter = propertys.into_iter().map(|data_type_str| {
-            let data_type_repr: raw::DataType = serde_json::from_str(data_type_str)
+            let data_type: DataType = serde_json::from_str(data_type_str)
                 .expect("could not parse data type representation");
-            let data_type = DataType::try_from(data_type_repr).expect("could not parse data type");
 
             let metadata = PartialOntologyElementMetadata {
                 record_id: data_type.id().clone().into(),
@@ -164,10 +163,8 @@ impl DatabaseTestWrapper {
             .await?;
 
         let property_types_iter = property_types.into_iter().map(|property_type_str| {
-            let property_type_repr: raw::PropertyType = serde_json::from_str(property_type_str)
+            let property_type: PropertyType = serde_json::from_str(property_type_str)
                 .expect("could not parse property type representation");
-            let property_type =
-                PropertyType::try_from(property_type_repr).expect("could not parse property type");
 
             let metadata = PartialOntologyElementMetadata {
                 record_id: property_type.id().clone().into(),
@@ -188,10 +185,8 @@ impl DatabaseTestWrapper {
             .await?;
 
         let entity_types_iter = entity_types.into_iter().map(|entity_type_str| {
-            let entity_type_repr: raw::EntityType = serde_json::from_str(entity_type_str)
+            let entity_type: EntityType = serde_json::from_str(entity_type_str)
                 .expect("could not parse entity type representation");
-            let entity_type =
-                EntityType::try_from(entity_type_repr).expect("could not parse entity type");
 
             let metadata = PartialEntityTypeMetadata {
                 record_id: entity_type.id().clone().into(),

--- a/tests/hash-graph-integration/postgres/property_type.rs
+++ b/tests/hash-graph-integration/postgres/property_type.rs
@@ -1,13 +1,12 @@
 use graph_test_data::{data_type, property_type};
-use type_system::{raw, PropertyType};
+use type_system::PropertyType;
 
 use crate::DatabaseTestWrapper;
 
 #[tokio::test]
 async fn insert() {
-    let age_pt_repr: raw::PropertyType = serde_json::from_str(property_type::AGE_V1)
-        .expect("could not parse property type representation");
-    let age_pt = PropertyType::try_from(age_pt_repr).expect("could not parse property type");
+    let age_pt: PropertyType =
+        serde_json::from_str(property_type::AGE_V1).expect("could not parse property type");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database
@@ -22,11 +21,8 @@ async fn insert() {
 
 #[tokio::test]
 async fn query() {
-    let favorite_quote_pt_repr: raw::PropertyType =
-        serde_json::from_str(property_type::FAVORITE_QUOTE_V1)
-            .expect("could not parse property type representation");
-    let favorite_quote_pt =
-        PropertyType::try_from(favorite_quote_pt_repr).expect("could not parse property type");
+    let favorite_quote_pt: PropertyType = serde_json::from_str(property_type::FAVORITE_QUOTE_V1)
+        .expect("could not parse property type representation");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database
@@ -48,15 +44,11 @@ async fn query() {
 
 #[tokio::test]
 async fn update() {
-    let user_id_pt_v1_repr: raw::PropertyType = serde_json::from_str(property_type::USER_ID_V1)
+    let user_id_pt_v1: PropertyType = serde_json::from_str(property_type::USER_ID_V1)
         .expect("could not parse property type representation");
-    let user_id_pt_v1 =
-        PropertyType::try_from(user_id_pt_v1_repr).expect("could not parse property type");
 
-    let user_id_pt_v2_repr: raw::PropertyType = serde_json::from_str(property_type::USER_ID_V2)
+    let user_id_pt_v2: PropertyType = serde_json::from_str(property_type::USER_ID_V2)
         .expect("could not parse property type representation");
-    let user_id_pt_v2 =
-        PropertyType::try_from(user_id_pt_v2_repr).expect("could not parse property type");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

As a quick solution to distinguish between format validation and content validation, the raw module should be made private and the serde implementation should use that internally. This greatly improves the DX around the types.
The amount of code which can be removed because of this speaks for itself.

## 🔍 What does this change?

- Avoid the steady back and forth casting between `raw::` and normal representation

## 🚫 Blocked by

- https://github.com/blockprotocol/blockprotocol/pull/1350

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph