### PR TITLE
H-1441: Fix Graph API client types for `validateEntity`

### DIFF
--- a/apps/hash-api/src/graph/knowledge/primitive/entity.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity.ts
@@ -867,7 +867,7 @@ export const validateEntity: ImpureGraphFunction<
   Promise<void>
 > = async ({ graphApi }, { actorId }, params) => {
   await graphApi.validateEntity(actorId, {
-    operations: new Set(["all"]),
+    operations: ["all"],
     ...params,
   });
 };

--- a/apps/hash-graph/lib/graph/src/api/rest/entity.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity.rs
@@ -250,6 +250,7 @@ struct ValidateEntityRequest {
     properties: EntityProperties,
     #[serde(default)]
     link_data: Option<LinkData>,
+    #[schema(value_type = Vec<ValidationOperation>)]
     operations: HashSet<ValidationOperation>,
 }
 

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -5040,8 +5040,7 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ValidationOperation"
-            },
-            "uniqueItems": true
+            }
           },
           "properties": {
             "$ref": "#/components/schemas/EntityProperties"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Then OpenAPI client generator uses the wrong type (The serialization of `Set` does not result in an array, so `Set` is wrong in this situation).


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change
### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph