### PR TITLE
H-1443: Implement caching when validating entities in snapshots

### DIFF
--- a/apps/hash-graph/lib/graph/src/snapshot/entity/batch.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/entity/batch.rs
@@ -17,7 +17,10 @@ use crate::{
         entity::{EntityEditionRow, EntityIdRow, EntityLinkEdgeRow, EntityTemporalMetadataRow},
         WriteBatch,
     },
-    store::{crud::Read, query::Filter, AsClient, InsertionError, PostgresStore, StoreProvider},
+    store::{
+        crud::Read, query::Filter, AsClient, InsertionError, PostgresStore, StoreCache,
+        StoreProvider,
+    },
 };
 
 pub enum EntityRowBatch {
@@ -221,6 +224,7 @@ impl<C: AsClient> WriteBatch<C> for EntityRowBatch {
 
         let validator_provider = StoreProvider::<_, NoAuthorization> {
             store: postgres_client,
+            cache: StoreCache::new(),
             authorization: None,
         };
 

--- a/apps/hash-graph/lib/graph/src/snapshot/entity/batch.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/entity/batch.rs
@@ -224,7 +224,7 @@ impl<C: AsClient> WriteBatch<C> for EntityRowBatch {
 
         let validator_provider = StoreProvider::<_, NoAuthorization> {
             store: postgres_client,
-            cache: StoreCache::new(),
+            cache: StoreCache::default(),
             authorization: None,
         };
 

--- a/apps/hash-graph/lib/graph/src/store.rs
+++ b/apps/hash-graph/lib/graph/src/store.rs
@@ -30,7 +30,7 @@ pub use self::{
     pool::StorePool,
     postgres::{AsClient, PostgresStore, PostgresStorePool},
     record::Record,
-    validation::StoreProvider,
+    validation::{StoreCache, StoreProvider},
 };
 
 /// Describes the API of a store implementation.

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -48,7 +48,8 @@ use crate::{
         },
         query::{Filter, FilterExpression, Parameter},
         validation::StoreProvider,
-        AsClient, EntityStore, InsertionError, PostgresStore, QueryError, Record, UpdateError,
+        AsClient, EntityStore, InsertionError, PostgresStore, QueryError, Record, StoreCache,
+        UpdateError,
     },
     subgraph::{
         edges::{EdgeDirection, GraphResolveDepths, KnowledgeGraphEdgeKind, SharedEdgeKind},
@@ -608,6 +609,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
 
         let validator_provider = StoreProvider {
             store: self,
+            cache: StoreCache::new(),
             authorization: Some((authorization_api, actor_id, Consistency::FullyConsistent)),
         };
 
@@ -1012,6 +1014,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 &closed_schema,
                 &StoreProvider {
                     store: &transaction,
+                    cache: StoreCache::new(),
                     authorization: Some((
                         authorization_api,
                         actor_id,

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -609,7 +609,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
 
         let validator_provider = StoreProvider {
             store: self,
-            cache: StoreCache::new(),
+            cache: StoreCache::default(),
             authorization: Some((authorization_api, actor_id, Consistency::FullyConsistent)),
         };
 
@@ -1014,7 +1014,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 &closed_schema,
                 &StoreProvider {
                     store: &transaction,
-                    cache: StoreCache::new(),
+                    cache: StoreCache::default(),
                     authorization: Some((
                         authorization_api,
                         actor_id,

--- a/apps/hash-graph/lib/graph/src/store/validation.rs
+++ b/apps/hash-graph/lib/graph/src/store/validation.rs
@@ -55,11 +55,10 @@ where
 {
     async fn get(&self, key: &K) -> Option<Result<Arc<V>, Report<QueryError>>> {
         let guard = self.inner.read().await;
-        let access = guard.get(key)?.clone();
-        drop(guard);
+        let access = guard.get(key)?;
 
         match access {
-            Access::Granted(value) => Some(Ok(value)),
+            Access::Granted(value) => Some(Ok(Arc::clone(value))),
             Access::Denied => Some(Err(
                 Report::new(PermissionAssertion).change_context(QueryError)
             )),

--- a/apps/hash-graph/lib/graph/src/store/validation.rs
+++ b/apps/hash-graph/lib/graph/src/store/validation.rs
@@ -38,17 +38,17 @@ enum Access<T> {
 impl<T> Access<T> {
     fn map<U>(self, f: impl FnOnce(T) -> U) -> Access<U> {
         match self {
-            Access::Granted(value) => Access::Granted(f(value)),
-            Access::Denied => Access::Denied,
-            Access::Malformed => Access::Malformed,
+            Self::Granted(value) => Access::Granted(f(value)),
+            Self::Denied => Access::Denied,
+            Self::Malformed => Access::Malformed,
         }
     }
 
-    fn as_ref(&self) -> Access<&T> {
+    const fn as_ref(&self) -> Access<&T> {
         match self {
-            Access::Granted(value) => Access::Granted(value),
-            Access::Denied => Access::Denied,
-            Access::Malformed => Access::Malformed,
+            Self::Granted(value) => Access::Granted(value),
+            Self::Denied => Access::Denied,
+            Self::Malformed => Access::Malformed,
         }
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

While trying to insert a snapshot from <insert place here>, I found that the restore times were not tolerable. One of the problems encountered seems to be the repeated fetching of the same types thousands of times, leading to massive slowdowns (we're talking about down to multiple hours).

This tries to remedy it by only querying SpiceDB and Postgres once and saving the result in an intermediate cache.

@TimDiekmann, any guidance on how to best write a test case for this?

## 🔍 What does this change?

- Naive caching strategy for types (not entities).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

