### PR TITLE
H-1454: Adjust snapshots to support draft entities

### DIFF
--- a/apps/hash-graph/lib/graph/src/snapshot.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot.rs
@@ -440,6 +440,7 @@ where
                                 custom: CustomEntityMetadata {
                                     provenance: entity.metadata.provenance(),
                                     archived: entity.metadata.archived(),
+                                    draft: entity.metadata.draft(),
                                 },
                             },
                             link_data: entity.link_data,

--- a/apps/hash-graph/lib/graph/src/snapshot/entity/channel.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/entity/channel.rs
@@ -85,9 +85,7 @@ impl Sink<EntitySnapshotRecord> for EntitySender {
                     .and_then(|link_data| link_data.order.right_to_left),
                 record_created_by_id: entity.metadata.custom.provenance.record_created_by_id,
                 archived: entity.metadata.custom.archived,
-                // TODO: Adjust snapshots to support draft entities
-                //   see https://linear.app/hash/issue/H-1454
-                draft: false,
+                draft: entity.metadata.custom.draft,
                 entity_type_base_url: entity.metadata.entity_type_id.base_url.as_str().to_owned(),
                 entity_type_version: OntologyTypeVersion::new(
                     entity.metadata.entity_type_id.version,

--- a/apps/hash-graph/lib/graph/src/snapshot/entity/record.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/entity/record.rs
@@ -9,11 +9,21 @@ use graph_types::{
 use serde::{Deserialize, Serialize};
 use type_system::url::VersionedUrl;
 
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "Used in procedural macros"
+)]
+fn is_false(b: &bool) -> bool {
+    !b
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct CustomEntityMetadata {
     pub provenance: ProvenanceMetadata,
     pub archived: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub draft: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adjusts the subgraph logic to also dump/restore drafts. If an entity is not a draft, that field will be omitted.

## 🚫 Blocked by

- #3640 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph