### PR TITLE
H-1457: Fix SpiceDB failing when inserting more than 1000 relationships

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -443,30 +443,38 @@ where
             .await
             .change_context(InsertionError)?;
 
-        self.store
-            .create_data_types(
-                actor_id,
-                authorization_api,
-                fetched_ontology_types.data_types,
-                ConflictBehavior::Skip,
-            )
-            .await?;
-        self.store
-            .create_property_types(
-                actor_id,
-                authorization_api,
-                fetched_ontology_types.property_types,
-                ConflictBehavior::Skip,
-            )
-            .await?;
-        self.store
-            .create_entity_types(
-                actor_id,
-                authorization_api,
-                fetched_ontology_types.entity_types,
-                ConflictBehavior::Skip,
-            )
-            .await?;
+        if !fetched_ontology_types.data_types.is_empty() {
+            self.store
+                .create_data_types(
+                    actor_id,
+                    authorization_api,
+                    fetched_ontology_types.data_types,
+                    ConflictBehavior::Skip,
+                )
+                .await?;
+        }
+
+        if !fetched_ontology_types.property_types.is_empty() {
+            self.store
+                .create_property_types(
+                    actor_id,
+                    authorization_api,
+                    fetched_ontology_types.property_types,
+                    ConflictBehavior::Skip,
+                )
+                .await?;
+        }
+
+        if !fetched_ontology_types.entity_types.is_empty() {
+            self.store
+                .create_entity_types(
+                    actor_id,
+                    authorization_api,
+                    fetched_ontology_types.entity_types,
+                    ConflictBehavior::Skip,
+                )
+                .await?;
+        }
 
         Ok(())
     }
@@ -497,33 +505,44 @@ where
                 .await
                 .change_context(InsertionError)?;
 
-            let created_data_types = self
-                .store
-                .create_data_types(
-                    actor_id,
-                    authorization_api,
-                    fetched_ontology_types.data_types,
-                    ConflictBehavior::Skip,
-                )
-                .await?;
-            let created_property_types = self
-                .store
-                .create_property_types(
-                    actor_id,
-                    authorization_api,
-                    fetched_ontology_types.property_types,
-                    ConflictBehavior::Skip,
-                )
-                .await?;
-            let created_entity_types = self
-                .store
-                .create_entity_types(
-                    actor_id,
-                    authorization_api,
-                    fetched_ontology_types.entity_types,
-                    ConflictBehavior::Skip,
-                )
-                .await?;
+            let created_data_types = if fetched_ontology_types.data_types.is_empty() {
+                Vec::new()
+            } else {
+                self.store
+                    .create_data_types(
+                        actor_id,
+                        authorization_api,
+                        fetched_ontology_types.data_types,
+                        ConflictBehavior::Skip,
+                    )
+                    .await?
+            };
+
+            let created_property_types = if fetched_ontology_types.property_types.is_empty() {
+                Vec::new()
+            } else {
+                self.store
+                    .create_property_types(
+                        actor_id,
+                        authorization_api,
+                        fetched_ontology_types.property_types,
+                        ConflictBehavior::Skip,
+                    )
+                    .await?
+            };
+
+            let created_entity_types = if fetched_ontology_types.entity_types.is_empty() {
+                Vec::new()
+            } else {
+                self.store
+                    .create_entity_types(
+                        actor_id,
+                        authorization_api,
+                        fetched_ontology_types.entity_types,
+                        ConflictBehavior::Skip,
+                    )
+                    .await?
+            };
 
             Ok(created_data_types
                 .into_iter()

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -455,6 +455,14 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
                 closed_schema,
             } = insertion;
 
+            relationships.push((
+                EntityTypeId::from_url(schema.id()),
+                EntityTypeRelationAndSubject::Viewer {
+                    subject: EntityTypeViewerSubject::Public,
+                    level: 0,
+                },
+            ));
+
             if let Some((ontology_id, transaction_time, owner)) = transaction
                 .create_ontology_metadata(
                     provenance.record_created_by_id,
@@ -479,14 +487,6 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
                     metadata,
                     provenance,
                     transaction_time,
-                ));
-
-                relationships.push((
-                    EntityTypeId::from(ontology_id),
-                    EntityTypeRelationAndSubject::Viewer {
-                        subject: EntityTypeViewerSubject::Public,
-                        level: 0,
-                    },
                 ));
 
                 if let Some(owner) = owner {

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -290,6 +290,14 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                     .change_context(InsertionError)?;
             }
 
+            relationships.push((
+                PropertyTypeId::from_url(schema.id()),
+                PropertyTypeRelationAndSubject::Viewer {
+                    subject: PropertyTypeViewerSubject::Public,
+                    level: 0,
+                },
+            ));
+
             if let Some((ontology_id, transaction_time, owner)) = transaction
                 .create_ontology_metadata(
                     provenance.record_created_by_id,
@@ -308,13 +316,6 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                     transaction_time,
                 ));
 
-                relationships.push((
-                    PropertyTypeId::from(ontology_id),
-                    PropertyTypeRelationAndSubject::Viewer {
-                        subject: PropertyTypeViewerSubject::Public,
-                        level: 0,
-                    },
-                ));
                 if let Some(owner) = owner {
                     match owner {
                         OntologyTypeSubject::Account { id } => relationships.push((


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

SpiceDB is configured to fail if more than 1000 relationships are being updated. This is a sensible default and we should chunk the requests instead.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph