### PR TITLE
H-1459: Use different error for `validate_entity`

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -35,7 +35,7 @@ use crate::{
     ontology::domain_validator::DomainValidator,
     store::{
         crud::Read,
-        knowledge::EntityValidationType,
+        knowledge::{EntityValidationError, EntityValidationType},
         query::{Filter, OntologyQueryPath},
         AccountStore, ConflictBehavior, DataTypeStore, EntityStore, EntityTypeStore,
         InsertionError, PropertyTypeStore, QueryError, Record, StoreError, StorePool, UpdateError,
@@ -969,7 +969,7 @@ where
         entity_type: EntityValidationType<'_>,
         properties: &EntityProperties,
         link_data: Option<&LinkData>,
-    ) -> Result<(), QueryError> {
+    ) -> Result<(), EntityValidationError> {
         self.store
             .validate_entity(
                 actor_id,

--- a/apps/hash-graph/lib/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/lib/graph/src/store/knowledge.rs
@@ -1,3 +1,5 @@
+use std::{error::Error, fmt};
+
 use async_trait::async_trait;
 use authorization::{schema::EntityOwnerSubject, zanzibar::Consistency, AuthorizationApi};
 use error_stack::Result;
@@ -22,6 +24,17 @@ pub enum EntityValidationType<'a> {
     Schema(&'a EntityType),
     Id(&'a VersionedUrl),
 }
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct EntityValidationError;
+
+impl fmt::Display for EntityValidationError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_str("Entity validation failed")
+    }
+}
+
+impl Error for EntityValidationError {}
 
 /// Describes the API of a store implementation for [Entities].
 ///
@@ -66,7 +79,7 @@ pub trait EntityStore: crud::Read<Entity> {
         entity_type: EntityValidationType<'_>,
         properties: &EntityProperties,
         link_data: Option<&LinkData>,
-    ) -> Result<(), QueryError>;
+    ) -> Result<(), EntityValidationError>;
 
     /// Inserts the entities with the specified [`EntityType`] into the `Store`.
     ///

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -32,7 +32,7 @@ use temporal_versioning::{DecisionTime, RightBoundedTemporalInterval, Timestamp}
 use tokio_postgres::GenericClient;
 use type_system::{url::VersionedUrl, EntityType};
 use uuid::Uuid;
-use validation::{EntityValidationError, Validate};
+use validation::Validate;
 
 #[cfg(hash_graph_test_environment)]
 use crate::store::error::DeletionError;
@@ -41,7 +41,7 @@ use crate::{
     store::{
         crud::Read,
         error::{EntityDoesNotExist, RaceConditionOnUpdate},
-        knowledge::EntityValidationType,
+        knowledge::{EntityValidationError, EntityValidationType},
         postgres::{
             knowledge::entity::read::EntityEdgeTraversalData, query::ReferenceTable,
             TraversalContext,
@@ -537,7 +537,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         entity_type: EntityValidationType<'_>,
         properties: &EntityProperties,
         link_data: Option<&LinkData>,
-    ) -> Result<(), QueryError> {
+    ) -> Result<(), EntityValidationError> {
         enum MaybeBorrowed<'a, T> {
             Borrowed(&'a T),
             Owned(T),
@@ -556,9 +556,9 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                         consistency,
                     )
                     .await
-                    .change_context(QueryError)?
+                    .change_context(EntityValidationError)?
                     .assert_permission()
-                    .change_context(QueryError)
+                    .change_context(EntityValidationError)
                     .attach(StatusCode::PermissionDenied)?;
 
                 let mut closed_schemas = self
@@ -578,21 +578,22 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                         ),
                     )
                     .await
-                    .change_context(QueryError)?
+                    .change_context(EntityValidationError)?
                     .map_ok(|(_, raw_type)| raw_type)
                     .try_collect::<Vec<EntityType>>()
-                    .await?;
+                    .await
+                    .change_context(EntityValidationError)?;
 
                 ensure!(
                     closed_schemas.len() <= 1,
-                    Report::new(QueryError).attach_printable(format!(
+                    Report::new(EntityValidationError).attach_printable(format!(
                         "Expected exactly one closed schema to be returned from the query but {} \
                          were returned",
                         closed_schemas.len(),
                     ))
                 );
                 MaybeBorrowed::Owned(closed_schemas.pop().ok_or_else(|| {
-                    Report::new(QueryError).attach_printable(
+                    Report::new(EntityValidationError).attach_printable(
                         "Expected exactly one closed schema to be returned from the query but \
                          none was returned",
                     )
@@ -605,7 +606,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             MaybeBorrowed::Owned(schema) => schema,
         };
 
-        let mut status: Result<(), EntityValidationError> = Ok(());
+        let mut status: Result<(), validation::EntityValidationError> = Ok(());
 
         let validator_provider = StoreProvider {
             store: self,
@@ -630,7 +631,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         }
 
         status
-            .change_context(QueryError)
+            .change_context(EntityValidationError)
             .attach(StatusCode::InvalidArgument)
     }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The error message on `validate_entity` is confusing

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph