### PR TITLE
H-1278: Add 'Entities' section to sidebar

### DIFF
--- a/apps/hash-frontend/src/pages/[shortname].page/edit-pinned-entity-types-modal.tsx
+++ b/apps/hash-frontend/src/pages/[shortname].page/edit-pinned-entity-types-modal.tsx
@@ -56,6 +56,7 @@ import { entityTypeIcons } from "../../shared/use-entity-icon";
 import { ProfileSectionHeading } from "../[shortname]/shared/profile-section-heading";
 import { useAuthenticatedUser } from "../shared/auth-info-context";
 import { EntityTypeSelector } from "../shared/entity-type-selector";
+import { useActiveWorkspace } from "../shared/workspace-context";
 
 /** @see https://github.com/atlassian/react-beautiful-dnd/issues/128#issuecomment-1010053365 */
 const useDraggableInPortal = () => {
@@ -143,6 +144,8 @@ export const EditPinnedEntityTypesModal: FunctionComponent<
     name: "pinnedEntityTypes",
   });
 
+  const { activeWorkspace, refetchActiveWorkspace } = useActiveWorkspace();
+
   const innerSubmit = handleSubmit(async (data) => {
     const { pinnedEntityTypes } = data;
 
@@ -166,8 +169,14 @@ export const EditPinnedEntityTypesModal: FunctionComponent<
     /** @todo: error handling */
 
     void refetchProfile();
-
-    reset({ pinnedEntityTypes });
+    // Display the updated pinned entity types in the sidebar
+    if (
+      activeWorkspace &&
+      activeWorkspace.entity.metadata.recordId.entityId ===
+        profile.entity.metadata.recordId.entityId
+    ) {
+      void refetchActiveWorkspace();
+    }
     onClose();
   });
 

--- a/apps/hash-frontend/src/pages/shared/workspace-context.tsx
+++ b/apps/hash-frontend/src/pages/shared/workspace-context.tsx
@@ -20,11 +20,13 @@ export type WorkspaceContextValue = {
   updateActiveWorkspaceOwnedById: (
     updatedActiveWorkspaceAccountId: OwnedById,
   ) => void;
+  refetchActiveWorkspace: () => Promise<void>;
 };
 
 const defaultWorkspaceContextValue: WorkspaceContextValue = {
   updateActiveWorkspaceOwnedById: (_updateActiveWorkspaceOwnedById: string) =>
     undefined,
+  refetchActiveWorkspace: () => Promise.resolve(),
 };
 
 export const WorkspaceContext = createContext<WorkspaceContextValue>(
@@ -38,7 +40,7 @@ export const useActiveWorkspace = () => {
 export const WorkspaceContextProvider: FunctionComponent<{
   children: ReactElement;
 }> = ({ children }) => {
-  const { authenticatedUser } = useAuthInfo();
+  const { authenticatedUser, refetch } = useAuthInfo();
 
   const [activeWorkspaceOwnedById, setActiveWorkspaceOwnedById] =
     useState<OwnedById>();
@@ -105,11 +107,13 @@ export const WorkspaceContextProvider: FunctionComponent<{
       activeWorkspace,
       activeWorkspaceOwnedById,
       updateActiveWorkspaceOwnedById,
+      refetchActiveWorkspace: () => refetch().then(() => undefined),
     };
   }, [
     authenticatedUser,
     activeWorkspaceOwnedById,
     updateActiveWorkspaceOwnedById,
+    refetch,
   ]);
 
   return (

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list/entity-type-item.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list/entity-type-item.tsx
@@ -49,9 +49,13 @@ const Container = styled((props: BoxProps & { selected: boolean }) => (
   },
 }));
 
-export const EntityTypeItem: FunctionComponent<EntityTypeWithMetadata> = ({
+export const EntityTypeItem: FunctionComponent<
+  EntityTypeWithMetadata & { href?: string; hideOptionsMenu?: boolean }
+> = ({
   metadata: { icon },
   schema: { title, $id: entityTypeId },
+  href,
+  hideOptionsMenu,
 }) => {
   const entityMenuTriggerRef = useRef(null);
   const popupState = usePopupState({
@@ -74,8 +78,14 @@ export const EntityTypeItem: FunctionComponent<EntityTypeWithMetadata> = ({
   const { isLink } = isSpecialEntityTypeLookup?.[entityTypeId] ?? {};
 
   return (
-    <Container component="li" tabIndex={0} selected={selected}>
-      <Link tabIndex={-1} sx={{ flex: 1 }} noLinkStyle href={baseUrl} flex={1}>
+    <Container component="li" tabIndex={0} selected={selected} minHeight={32}>
+      <Link
+        tabIndex={-1}
+        sx={{ flex: 1 }}
+        noLinkStyle
+        href={href ?? baseUrl}
+        flex={1}
+      >
         <Typography
           variant="smallTextLabels"
           sx={{
@@ -109,30 +119,34 @@ export const EntityTypeItem: FunctionComponent<EntityTypeWithMetadata> = ({
           {title}
         </Typography>
       </Link>
-      <Tooltip title="Options" sx={{ left: 5 }}>
-        <IconButton
-          ref={entityMenuTriggerRef}
-          className="entity-menu-trigger"
-          {...bindTrigger(popupState)}
-          size="medium"
-          unpadded
-          sx={({ palette }) => ({
-            color: [selected ? palette.gray[80] : "transparent"],
-            "&:focus-visible, &:hover": {
-              backgroundColor: palette.gray[selected ? 40 : 30],
-              color: palette.gray[selected ? 80 : 40],
-            },
-          })}
-        >
-          <EllipsisRegularIcon />
-        </IconButton>
-      </Tooltip>
-      <EntityTypeMenu
-        entityTypeId={entityTypeId}
-        popupState={popupState}
-        title={title}
-        url={baseUrl}
-      />
+      {hideOptionsMenu ? null : (
+        <>
+          <Tooltip title="Options" sx={{ left: 5 }}>
+            <IconButton
+              ref={entityMenuTriggerRef}
+              className="entity-menu-trigger"
+              {...bindTrigger(popupState)}
+              size="medium"
+              unpadded
+              sx={({ palette }) => ({
+                color: [selected ? palette.gray[80] : "transparent"],
+                "&:focus-visible, &:hover": {
+                  backgroundColor: palette.gray[selected ? 40 : 30],
+                  color: palette.gray[selected ? 80 : 40],
+                },
+              })}
+            >
+              <EllipsisRegularIcon />
+            </IconButton>
+          </Tooltip>
+          <EntityTypeMenu
+            entityTypeId={entityTypeId}
+            popupState={popupState}
+            title={title}
+            url={baseUrl}
+          />
+        </>
+      )}
     </Container>
   );
 };

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/acount-entities-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/acount-entities-list.tsx
@@ -1,0 +1,132 @@
+import { IconButton } from "@hashintel/design-system";
+import { isOwnedOntologyElementMetadata } from "@local/hash-subgraph";
+import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
+import { Box, Collapse, Tooltip } from "@mui/material";
+import { orderBy } from "lodash";
+import { bindTrigger, usePopupState } from "material-ui-popup-state/hooks";
+import { FunctionComponent, useMemo, useState } from "react";
+import { TransitionGroup } from "react-transition-group";
+
+import { useLatestEntityTypesOptional } from "../../entity-types-context/hooks";
+import { ArrowDownAZRegularIcon } from "../../icons/arrow-down-a-z-regular-icon";
+import { ArrowUpZARegularIcon } from "../../icons/arrow-up-a-z-regular-icon";
+import { PlusRegularIcon } from "../../icons/plus-regular";
+import { Link } from "../../ui";
+import { EntityTypeItem } from "./account-entity-type-list/entity-type-item";
+import {
+  SortActionsDropdown,
+  SortType,
+} from "./account-entity-type-list/sort-actions-dropdown";
+import { NavLink } from "./nav-link";
+import { ViewAllLink } from "./view-all-link";
+
+type AccountEntitiesListProps = {
+  ownedById: string;
+};
+
+export const AccountEntitiesList: FunctionComponent<
+  AccountEntitiesListProps
+> = ({ ownedById }) => {
+  const [sortType, setSortType] = useState<SortType>("asc");
+  const sortActionsPopupState = usePopupState({
+    variant: "popover",
+    popupId: "type-sort-actions-menu",
+  });
+
+  const { latestEntityTypes } = useLatestEntityTypesOptional();
+
+  const accountEntityTypes = useMemo(() => {
+    if (latestEntityTypes) {
+      return latestEntityTypes.filter(
+        (root) =>
+          isOwnedOntologyElementMetadata(root.metadata) &&
+          root.metadata.custom.ownedById === ownedById,
+      );
+    }
+
+    return null;
+  }, [latestEntityTypes, ownedById]);
+
+  const sortedEntityTypes = useMemo(
+    () =>
+      orderBy(accountEntityTypes, (root) => root.schema.title.toLowerCase(), [
+        sortType === "asc" || sortType === "desc" ? sortType : "asc",
+      ]),
+    [accountEntityTypes, sortType],
+  );
+
+  return (
+    <Box>
+      <NavLink
+        title="Entities"
+        endAdornment={
+          <Box display="flex" gap={1}>
+            <Tooltip title="Sort types" placement="top">
+              <IconButton
+                {...bindTrigger(sortActionsPopupState)}
+                size="small"
+                unpadded
+                rounded
+                sx={({ palette }) => ({
+                  color: palette.gray[80],
+                  ...(sortActionsPopupState.isOpen && {
+                    backgroundColor: palette.gray[30],
+                  }),
+                  svg: {
+                    fontSize: 13,
+                  },
+                })}
+              >
+                {sortType === "asc" ? (
+                  <ArrowDownAZRegularIcon />
+                ) : (
+                  <ArrowUpZARegularIcon />
+                )}
+              </IconButton>
+            </Tooltip>
+            <SortActionsDropdown
+              popupState={sortActionsPopupState}
+              setSortType={setSortType}
+              activeSortType={sortType}
+            />
+            <Link tabIndex={-1} href="/new/entity" noLinkStyle>
+              <Tooltip title="Create new entity " sx={{ left: 5 }}>
+                <IconButton
+                  data-testid="create-entity-type-btn"
+                  size="small"
+                  unpadded
+                  rounded
+                  className="end-adornment-button"
+                  sx={({ palette }) => ({
+                    color: palette.gray[80],
+                  })}
+                >
+                  <PlusRegularIcon />
+                </IconButton>
+              </Tooltip>
+            </Link>
+          </Box>
+        }
+      >
+        <Box component="ul">
+          <TransitionGroup>
+            {sortedEntityTypes.map((root) => (
+              <Collapse key={root.schema.$id}>
+                <EntityTypeItem
+                  {...root}
+                  href={`/entities?entityTypeIdOrBaseUrl=${extractBaseUrl(
+                    root.schema.$id,
+                  )}`}
+                  hideOptionsMenu
+                />
+              </Collapse>
+            ))}
+          </TransitionGroup>
+          <Box marginLeft={1} marginTop={0.5}>
+            <ViewAllLink href="/entities">View all entities</ViewAllLink>
+          </Box>
+        </Box>
+      </NavLink>
+    </Box>
+  );
+};

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/acount-entities-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/acount-entities-list.tsx
@@ -7,6 +7,7 @@ import { bindTrigger, usePopupState } from "material-ui-popup-state/hooks";
 import { FunctionComponent, useMemo, useState } from "react";
 import { TransitionGroup } from "react-transition-group";
 
+import { useActiveWorkspace } from "../../../pages/shared/workspace-context";
 import { useLatestEntityTypesOptional } from "../../entity-types-context/hooks";
 import { ArrowDownAZRegularIcon } from "../../icons/arrow-down-a-z-regular-icon";
 import { ArrowUpZARegularIcon } from "../../icons/arrow-up-a-z-regular-icon";
@@ -33,7 +34,19 @@ export const AccountEntitiesList: FunctionComponent<
     popupId: "type-sort-actions-menu",
   });
 
+  const { activeWorkspace } = useActiveWorkspace();
+
   const { latestEntityTypes } = useLatestEntityTypesOptional();
+
+  const pinnedEntityTypes = useMemo(() => {
+    const { pinnedEntityTypeBaseUrls } = activeWorkspace ?? {};
+
+    return pinnedEntityTypeBaseUrls
+      ? latestEntityTypes?.filter(({ metadata }) =>
+          pinnedEntityTypeBaseUrls.includes(metadata.recordId.baseUrl),
+        )
+      : [];
+  }, [activeWorkspace, latestEntityTypes]);
 
   const accountEntityTypes = useMemo(() => {
     if (latestEntityTypes) {
@@ -47,12 +60,17 @@ export const AccountEntitiesList: FunctionComponent<
     return null;
   }, [latestEntityTypes, ownedById]);
 
+  const sidebarEntityTypes = useMemo(
+    () => [...(pinnedEntityTypes ?? []), ...(accountEntityTypes ?? [])],
+    [pinnedEntityTypes, accountEntityTypes],
+  );
+
   const sortedEntityTypes = useMemo(
     () =>
-      orderBy(accountEntityTypes, (root) => root.schema.title.toLowerCase(), [
+      orderBy(sidebarEntityTypes, (root) => root.schema.title.toLowerCase(), [
         sortType === "asc" || sortType === "desc" ? sortType : "asc",
       ]),
-    [accountEntityTypes, sortType],
+    [sidebarEntityTypes, sortType],
   );
 
   return (

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar.tsx
@@ -14,6 +14,7 @@ import { useRoutePageInfo } from "../../routing";
 import { HEADER_HEIGHT } from "../layout-with-header/page-header";
 import { AccountEntityTypeList } from "./account-entity-type-list";
 import { AccountPageList } from "./account-page-list/account-page-list";
+import { AccountEntitiesList } from "./acount-entities-list";
 import { useSidebarContext } from "./sidebar-context";
 import { TopNavLink } from "./top-nav-link";
 import { WorkspaceSwitcher } from "./workspace-switcher";
@@ -126,6 +127,8 @@ export const PageSidebar: FunctionComponent = () => {
                 ownedById={activeWorkspaceOwnedById}
               />
             ) : null}
+            {/* ENTITIES */}
+            <AccountEntitiesList ownedById={activeWorkspaceOwnedById} />
             {/* TYPES */}
             <AccountEntityTypeList ownedById={activeWorkspaceOwnedById} />
           </>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR adds an `Entities` section to the sidebar, which displays the entity types in the current web and the pinned entity types of the user.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-1278

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

View the sidebar in the deployment or a locally running instance of HASH. You can add pinned entity types in the profile menu, or create new types in the active web to display them in the sidebar.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->


https://github.com/hashintel/hash/assets/42802102/0c207f84-b1f8-40b0-9dc5-3d9682ab1aa6


