### PR TITLE
H-1453: Expose draft entity interface to the Node API

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/create-entities.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/create-entities.ts
@@ -66,6 +66,7 @@ export const createEntities = async ({
                 ownedById,
                 owner: ownedById,
                 properties,
+                draft: false,
               });
 
             createdEntitiesByTemporaryId[proposedEntity.entityId] = {
@@ -199,6 +200,7 @@ export const createEntities = async ({
                 ownedById,
                 owner: ownedById,
                 properties,
+                draft: false,
               });
 
             createdEntitiesByTemporaryId[proposedEntity.entityId] = {

--- a/apps/hash-api/src/graph/knowledge/primitive/entity.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity.ts
@@ -63,6 +63,7 @@ export type CreateEntityParams = {
   outgoingLinks?: Omit<CreateLinkEntityParams, "leftEntityId">[];
   entityUuid?: EntityUuid;
   owner?: AccountId | AccountGroupId;
+  draft?: boolean;
 };
 
 /** @todo: potentially directly export this from the subgraph package */
@@ -87,6 +88,7 @@ export const createEntity: ImpureGraphFunction<
     properties,
     outgoingLinks,
     entityUuid: overrideEntityUuid,
+    draft = false,
   } = params;
 
   const { graphApi } = context;
@@ -98,6 +100,7 @@ export const createEntity: ImpureGraphFunction<
     properties,
     entityUuid: overrideEntityUuid,
     owner: params.owner ?? ownedById,
+    draft,
   });
 
   const entity = { properties, metadata: metadata as EntityMetadata };
@@ -392,6 +395,7 @@ export const updateEntity: ImpureGraphFunction<
      * */
     entityTypeId: entityTypeId ?? entity.metadata.entityTypeId,
     archived: entity.metadata.archived,
+    draft: entity.metadata.draft,
     properties,
   });
 
@@ -423,6 +427,7 @@ export const archiveEntity: ImpureGraphFunction<
   await graphApi.updateEntity(actorId, {
     entityId: entity.metadata.recordId.entityId,
     archived: true,
+    draft: entity.metadata.draft,
     /**
      * @todo: these fields shouldn't be required when archiving an entity
      *

--- a/apps/hash-api/src/graph/knowledge/primitive/link-entity.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/link-entity.ts
@@ -24,6 +24,7 @@ export type CreateLinkEntityParams = {
   properties?: EntityPropertiesObject;
   linkEntityTypeId: VersionedUrl;
   owner?: AccountId | AccountGroupId;
+  draft?: boolean;
   leftEntityId: EntityId;
   leftToRightOrder?: number;
   rightEntityId: EntityId;
@@ -56,6 +57,7 @@ export const createLinkEntity: ImpureGraphFunction<
     rightEntityId,
     rightToLeftOrder,
     properties = {},
+    draft = false,
   } = params;
 
   const linkEntityType = await getEntityTypeById(context, authentication, {
@@ -93,6 +95,7 @@ export const createLinkEntity: ImpureGraphFunction<
       entityTypeId: linkEntityType.schema.$id,
       properties,
       owner: params.owner ?? ownedById,
+      draft,
     },
   );
 
@@ -142,6 +145,7 @@ export const updateLinkEntity: ImpureGraphFunction<
     entityTypeId: linkEntity.metadata.entityTypeId,
     properties,
     archived: linkEntity.metadata.archived,
+    draft: linkEntity.metadata.draft,
     leftToRightOrder,
     rightToLeftOrder,
   });

--- a/apps/hash-frontend/src/blocks/use-fetch-block-subgraph.ts
+++ b/apps/hash-frontend/src/blocks/use-fetch-block-subgraph.ts
@@ -95,6 +95,7 @@ export const useFetchBlockSubgraph = (): ((
               },
             },
             archived: false,
+            draft: false,
             provenance: {
               recordCreatedById: "placeholder-account" as RecordCreatedById,
             },

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/linked-with-cell/linked-entity-list-editor.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/linked-with-cell/linked-entity-list-editor.tsx
@@ -29,6 +29,7 @@ import { MaxItemsReached } from "./linked-entity-list-editor/max-items-reached";
  * @todo - This is unsafe, and should be refactored to return a new type `DraftEntity`, so that we aren't
  *   breaking invariants and constraints. Having a disjoint type will let us rely on `tsc` properly and avoid casts
  *   and empty placeholder values below
+ *   see https://linear.app/hash/issue/H-1083/draft-entities
  */
 export const createDraftLinkEntity = ({
   rightEntityId,
@@ -44,6 +45,9 @@ export const createDraftLinkEntity = ({
     linkData: { rightEntityId, leftEntityId },
     metadata: {
       archived: false,
+      // @todo use the Graph to create draft entities
+      //   see https://linear.app/hash/issue/H-1083/draft-entities
+      draft: false,
       recordId: { editionId: "", entityId: `draft~${Date.now()}` as EntityId },
       entityTypeId: linkEntityTypeId,
       provenance: { recordCreatedById: "" as RecordCreatedById },

--- a/apps/hash-frontend/src/pages/shared/block-collection/component-view.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/component-view.tsx
@@ -43,7 +43,7 @@ const getChildEntity = (
 ): DraftEntity<BlockEntity["blockChildEntity"]> | null => {
   if (entity && entity.blockChildEntity) {
     if (!isDraftBlockEntity(entity)) {
-      throw new Error("Cannot prepare non-block entity for prosemirrior");
+      throw new Error("Cannot prepare non-block entity for ProseMirror");
     }
 
     return entity.blockChildEntity as DraftEntity;

--- a/apps/hash-graph/lib/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/lib/graph/src/store/knowledge.rs
@@ -51,6 +51,9 @@ pub trait EntityStore: crud::Read<Entity> {
     /// - if an [`EntityUuid`] was supplied and already exists in the store
     ///
     /// [`EntityType`]: type_system::EntityType
+    // TODO: Revisit creation parameter to avoid too many parameters, especially as the parameters
+    //       are booleans/optionals and can be easily confused
+    //   see https://linear.app/hash/issue/H-1466
     #[expect(clippy::too_many_arguments)]
     async fn create_entity<A: AuthorizationApi + Send + Sync>(
         &mut self,
@@ -142,6 +145,11 @@ pub trait EntityStore: crud::Read<Entity> {
     /// - if the account referred to by `actor_id` does not exist
     ///
     /// [`EntityType`]: type_system::EntityType
+    // TODO: Revisit creation parameter to avoid too many parameters, especially as the parameters
+    //       are booleans/optionals and can be easily confused
+    //   see https://linear.app/hash/issue/H-1466
+    // TODO: Allow partial updates to avoid setting the `draft` and `archived` state here
+    //   see https://linear.app/hash/issue/H-1455
     #[expect(clippy::too_many_arguments)]
     async fn update_entity<A: AuthorizationApi + Send + Sync>(
         &mut self,

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -2533,9 +2533,13 @@
           "properties",
           "entityTypeId",
           "ownedById",
-          "owner"
+          "owner",
+          "draft"
         ],
         "properties": {
+          "draft": {
+            "type": "boolean"
+          },
           "entityTypeId": {
             "$ref": "./models/shared.json#/definitions/VersionedUrl"
           },
@@ -3015,10 +3019,14 @@
           "temporalVersioning",
           "entityTypeId",
           "provenance",
-          "archived"
+          "archived",
+          "draft"
         ],
         "properties": {
           "archived": {
+            "type": "boolean"
+          },
+          "draft": {
             "type": "boolean"
           },
           "entityTypeId": {
@@ -5078,10 +5086,14 @@
               "properties",
               "entityId",
               "entityTypeId",
-              "archived"
+              "archived",
+              "draft"
             ],
             "properties": {
               "archived": {
+                "type": "boolean"
+              },
+              "draft": {
                 "type": "boolean"
               },
               "entityId": {

--- a/apps/hash-graph/tests/circular-links.http
+++ b/apps/hash-graph/tests/circular-links.http
@@ -146,7 +146,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "properties": {},
   "entityTypeId": "http://localhost:3000/@snapshot/types/entity-type/object/v/1",
   "owner": "{{account_id}}",
-  "entityUuid": "0000000A-0001-0000-0000-000000000000"
+  "entityUuid": "0000000A-0001-0000-0000-000000000000",
+  "draft": false
 }
 
 > {%
@@ -167,7 +168,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "properties": {},
   "entityTypeId": "http://localhost:3000/@snapshot/types/entity-type/object/v/1",
   "owner": "{{account_id}}",
-  "entityUuid": "0000000B-0001-0000-0000-000000000000"
+  "entityUuid": "0000000B-0001-0000-0000-000000000000",
+  "draft": false
 }
 
 > {%
@@ -188,7 +190,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "properties": {},
   "entityTypeId": "http://localhost:3000/@snapshot/types/entity-type/object/v/1",
   "owner": "{{account_id}}",
-  "entityUuid": "0000000C-0001-0000-0000-000000000000"
+  "entityUuid": "0000000C-0001-0000-0000-000000000000",
+  "draft": false
 }
 
 > {%
@@ -209,7 +212,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "properties": {},
   "entityTypeId": "http://localhost:3000/@snapshot/types/entity-type/object/v/1",
   "owner": "{{account_id}}",
-  "entityUuid": "0000000D-0001-0000-0000-000000000000"
+  "entityUuid": "0000000D-0001-0000-0000-000000000000",
+  "draft": false
 }
 
 > {%
@@ -234,7 +238,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "linkData": {
     "leftEntityId": "{{entity_a}}",
     "rightEntityId": "{{entity_b}}"
-  }
+  },
+  "draft": false
 }
 
 > {%
@@ -258,7 +263,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "linkData": {
     "leftEntityId": "{{entity_b}}",
     "rightEntityId": "{{entity_c}}"
-  }
+  },
+  "draft": false
 }
 
 > {%
@@ -282,7 +288,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "linkData": {
     "leftEntityId": "{{entity_c}}",
     "rightEntityId": "{{entity_d}}"
-  }
+  },
+  "draft": false
 }
 
 > {%
@@ -306,7 +313,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "linkData": {
     "leftEntityId": "{{entity_d}}",
     "rightEntityId": "{{entity_a}}"
-  }
+  },
+  "draft": false
 }
 
 > {%
@@ -331,7 +339,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "linkData": {
     "leftEntityId": "{{entity_b}}",
     "rightEntityId": "{{entity_a}}"
-  }
+  },
+  "draft": false
 }
 
 > {%
@@ -357,7 +366,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "linkData": {
     "leftEntityId": "{{entity_c}}",
     "rightEntityId": "{{entity_b}}"
-  }
+  },
+  "draft": false
 }
 
 > {%
@@ -383,7 +393,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "linkData": {
     "leftEntityId": "{{entity_d}}",
     "rightEntityId": "{{entity_c}}"
-  }
+  },
+  "draft": false
 }
 
 > {%
@@ -409,7 +420,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "linkData": {
     "leftEntityId": "{{entity_a}}",
     "rightEntityId": "{{entity_d}}"
-  }
+  },
+  "draft": false
 }
 
 > {%

--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -1276,7 +1276,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     "http://localhost:3000/@alice/types/property-type/name/": "Alice"
   },
   "owner": "{{account_id}}",
-  "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/1"
+  "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/1",
+  "draft": false
 }
 
 > {%
@@ -1399,12 +1400,13 @@ Accept: application/json
 X-Authenticated-User-Actor-Id: {{account_id}}
 
 {
- "entityId": "{{person_a_entity_id}}",
- "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/2",
- "properties": {
-   "http://localhost:3000/@alice/types/property-type/name/": "Alice Allison"
- },
- "archived": false
+  "entityId": "{{person_a_entity_id}}",
+  "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/2",
+  "properties": {
+    "http://localhost:3000/@alice/types/property-type/name/": "Alice Allison"
+  },
+  "archived": false,
+  "draft": false
 }
 
 > {%
@@ -1425,7 +1427,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     "http://localhost:3000/@alice/types/property-type/name/": "Bob"
   },
   "owner": "{{account_id}}",
-  "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/2"
+  "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/2",
+  "draft": false
 }
 
 > {%
@@ -1534,7 +1537,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "linkData": {
     "leftEntityId": "{{person_a_entity_id}}",
     "rightEntityId": "{{person_b_entity_id}}"
-  }
+  },
+  "draft": false
 }
 
 > {%
@@ -1709,12 +1713,13 @@ Accept: application/json
 X-Authenticated-User-Actor-Id: {{account_id}}
 
 {
- "entityId": "{{person_b_entity_id}}",
- "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/1",
- "properties": {
-   "http://localhost:3000/@alice/types/property-type/name/": "Bob"
- },
- "archived": true
+  "entityId": "{{person_b_entity_id}}",
+  "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/1",
+  "properties": {
+    "http://localhost:3000/@alice/types/property-type/name/": "Bob"
+  },
+  "archived": true,
+  "draft": false
 }
 
 > {%

--- a/apps/hash-integration-worker/src/activities.ts
+++ b/apps/hash-integration-worker/src/activities.ts
@@ -37,6 +37,7 @@ const createHashEntity = async (params: {
     {
       ownedById,
       owner: ownedById,
+      draft: false,
       ...params.partialEntity,
     },
   );
@@ -52,6 +53,7 @@ const createHashEntity = async (params: {
         },
         entityTypeId: linkEntityTypeId,
         properties: {},
+        draft: false,
       }),
     ),
   );
@@ -131,6 +133,7 @@ const createOrUpdateHashEntity = async (params: {
           properties: {},
           ownedById: params.ownedById,
           owner: params.ownedById,
+          draft: false,
         }),
       ),
     ]);
@@ -166,6 +169,7 @@ const createOrUpdateHashEntity = async (params: {
       entityId: existingEntity.metadata.recordId.entityId,
       entityTypeId: existingEntity.metadata.entityTypeId,
       properties: mergedProperties,
+      draft: existingEntity.metadata.draft,
     });
   }
 

--- a/apps/hash-integration-worker/src/activities/graph-requests.ts
+++ b/apps/hash-integration-worker/src/activities/graph-requests.ts
@@ -192,5 +192,6 @@ export const archiveEntity = async (params: {
      * */
     entityTypeId: entity.metadata.entityTypeId,
     properties: entity.properties,
+    draft: false,
   });
 };

--- a/libs/@local/hash-graph-types/rust/src/knowledge/entity.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/entity.rs
@@ -112,9 +112,6 @@ pub struct EntityMetadata {
     entity_type_id: VersionedUrl,
     provenance: ProvenanceMetadata,
     archived: bool,
-    // TODO: Expose draft entity interface to the Node API
-    //   see https://linear.app/hash/issue/H-1453
-    #[serde(skip)]
     draft: bool,
 }
 

--- a/libs/@local/hash-graph-types/rust/src/knowledge/link.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/link.rs
@@ -44,6 +44,8 @@ pub struct EntityLinkOrder {
 pub struct LinkData {
     pub left_entity_id: EntityId,
     pub right_entity_id: EntityId,
+    // TODO: Remove link ordering
+    //   see https://linear.app/hash/issue/H-162
     #[serde(flatten)]
     pub order: EntityLinkOrder,
 }

--- a/libs/@local/hash-isomorphic-utils/src/entity-store-plugin.ts
+++ b/libs/@local/hash-isomorphic-utils/src/entity-store-plugin.ts
@@ -377,6 +377,9 @@ const entityStoreReducer = (
         draftState.store.draft[action.payload.draftId] = {
           metadata: {
             archived: false,
+            // @todo use the Graph to create draft entities
+            //   see https://linear.app/hash/issue/H-1083/draft-entities
+            draft: false,
             recordId: {
               entityId: action.payload.entityId,
               editionId: now,

--- a/libs/@local/hash-isomorphic-utils/src/entity-store.ts
+++ b/libs/@local/hash-isomorphic-utils/src/entity-store.ts
@@ -22,6 +22,9 @@ export const textualContentPropertyTypeBaseUrl = extractBaseUrl(
 export type DraftEntity<Type extends EntityStoreType = EntityStoreType> = {
   metadata: {
     archived: boolean;
+    // @todo use the Graph API to create draft entities
+    //   see https://linear.app/hash/issue/H-1083/draft-entities
+    draft: boolean;
     recordId: {
       entityId: EntityId | null;
       editionId: string;

--- a/libs/@local/hash-subgraph/src/types/element/knowledge.ts
+++ b/libs/@local/hash-subgraph/src/types/element/knowledge.ts
@@ -91,6 +91,7 @@ export type EntityMetadata = Subtype<
     entityTypeId: VersionedUrl;
     temporalVersioning: EntityTemporalVersioningMetadata;
     archived: boolean;
+    draft: boolean;
     provenance: ProvenanceMetadata;
   }
 >;

--- a/libs/@local/hash-subgraph/tests/compatibility.test/map-vertices.ts
+++ b/libs/@local/hash-subgraph/tests/compatibility.test/map-vertices.ts
@@ -282,6 +282,7 @@ const mapEntityMetadata = (
     ),
     provenance: mapProvenanceMetadata(metadata.provenance),
     archived: metadata.archived,
+    draft: metadata.draft,
   };
 };
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Even though drafts are not fully implemented, yet, this exposes the functionality to the node API. Exposing it implies it's that it's available as OpenAPI so it's far easier to test functionality via plain http requests.

## 🚫 Blocked by

- #3640 

## 🔍 What does this change?

- Expose the `draft` field on `EntityMetadata` and on create/update requests
- Return an error if a draft is about to be created via the Node API

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- The functionality which is exposed does not work yet and will always error with a permission-denied error.
- In the Node API there is already a struct `DraftEntity`, which we probably want to rename.