### PR TITLE
H-1449: Relax constraints on entity validation for draft entities

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/create-entities.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/create-entities.ts
@@ -58,6 +58,7 @@ export const createEntities = async ({
               entityTypeId,
               operations: ["all"],
               properties,
+              draft: false,
             });
 
             const { data: createdEntityMetadata } =
@@ -191,6 +192,7 @@ export const createEntities = async ({
               operations: ["all"],
               linkData,
               properties,
+              draft: false,
             });
 
             const { data: createdEntityMetadata } =

--- a/apps/hash-api/src/graph/knowledge/primitive/entity.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity.ts
@@ -868,6 +868,7 @@ export const validateEntity: ImpureGraphFunction<
     entityTypeId: VersionedUrl;
     properties: Entity["properties"];
     linkData?: Entity["linkData"];
+    draft: boolean;
   },
   Promise<void>
 > = async ({ graphApi }, { actorId }, params) => {

--- a/apps/hash-graph/lib/graph/src/api/rest/entity.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity.rs
@@ -34,6 +34,7 @@ use graph_types::{
 use serde::Deserialize;
 use type_system::url::VersionedUrl;
 use utoipa::{OpenApi, ToSchema};
+use validation::ValidationProfile;
 
 use crate::{
     api::rest::{
@@ -264,6 +265,7 @@ struct ValidateEntityRequest {
     link_data: Option<LinkData>,
     #[schema(value_type = Vec<ValidationOperation>)]
     operations: HashSet<ValidationOperation>,
+    draft: bool,
 }
 
 #[utoipa::path(
@@ -298,6 +300,7 @@ where
         properties,
         link_data,
         operations,
+        draft,
     }) = body;
 
     if operations.contains(&ValidationOperation::All) {
@@ -315,6 +318,11 @@ where
                 EntityValidationType::Id(&entity_type_id),
                 &properties,
                 link_data.as_ref(),
+                if draft {
+                    ValidationProfile::Draft
+                } else {
+                    ValidationProfile::Full
+                },
             )
             .await
             .attach(hash_status::StatusCode::InvalidArgument)

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -36,7 +36,7 @@ use crate::{
     ontology::domain_validator::DomainValidator,
     store::{
         crud::Read,
-        knowledge::{EntityValidationError, EntityValidationType},
+        knowledge::{EntityValidationType, ValidateEntityError},
         query::{Filter, OntologyQueryPath},
         AccountStore, ConflictBehavior, DataTypeStore, EntityStore, EntityTypeStore,
         InsertionError, PropertyTypeStore, QueryError, Record, StoreError, StorePool, UpdateError,
@@ -1002,7 +1002,7 @@ where
         properties: &EntityProperties,
         link_data: Option<&LinkData>,
         profile: ValidationProfile,
-    ) -> Result<(), EntityValidationError> {
+    ) -> Result<(), ValidateEntityError> {
         self.store
             .validate_entity(
                 actor_id,

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -30,6 +30,7 @@ use type_system::{
     url::{BaseUrl, VersionedUrl},
     DataType, EntityType, EntityTypeReference, PropertyType,
 };
+use validation::ValidationProfile;
 
 use crate::{
     ontology::domain_validator::DomainValidator,
@@ -1000,6 +1001,7 @@ where
         entity_type: EntityValidationType<'_>,
         properties: &EntityProperties,
         link_data: Option<&LinkData>,
+        profile: ValidationProfile,
     ) -> Result<(), EntityValidationError> {
         self.store
             .validate_entity(
@@ -1009,6 +1011,7 @@ where
                 entity_type,
                 properties,
                 link_data,
+                profile,
             )
             .await
     }

--- a/apps/hash-graph/lib/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/lib/graph/src/store/knowledge.rs
@@ -27,15 +27,15 @@ pub enum EntityValidationType<'a> {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct EntityValidationError;
+pub struct ValidateEntityError;
 
-impl fmt::Display for EntityValidationError {
+impl fmt::Display for ValidateEntityError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.write_str("Entity validation failed")
     }
 }
 
-impl Error for EntityValidationError {}
+impl Error for ValidateEntityError {}
 
 /// Describes the API of a store implementation for [Entities].
 ///
@@ -93,7 +93,7 @@ pub trait EntityStore: crud::Read<Entity> {
         properties: &EntityProperties,
         link_data: Option<&LinkData>,
         profile: ValidationProfile,
-    ) -> Result<(), EntityValidationError>;
+    ) -> Result<(), ValidateEntityError>;
 
     /// Inserts the entities with the specified [`EntityType`] into the `Store`.
     ///

--- a/apps/hash-graph/lib/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/lib/graph/src/store/knowledge.rs
@@ -13,6 +13,7 @@ use graph_types::{
 };
 use temporal_versioning::{DecisionTime, Timestamp};
 use type_system::{url::VersionedUrl, EntityType};
+use validation::ValidationProfile;
 
 use crate::{
     store::{crud, InsertionError, QueryError, UpdateError},
@@ -53,8 +54,10 @@ pub trait EntityStore: crud::Read<Entity> {
     /// [`EntityType`]: type_system::EntityType
     // TODO: Revisit creation parameter to avoid too many parameters, especially as the parameters
     //       are booleans/optionals and can be easily confused
-    //   see https://linear.app/hash/issue/H-1466
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "https://linear.app/hash/issue/H-1466"
+    )]
     async fn create_entity<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
@@ -75,6 +78,12 @@ pub trait EntityStore: crud::Read<Entity> {
     /// # Errors:
     ///
     /// - if the validation failed
+    // TODO: Revisit parameter to avoid too many parameters, especially as the parameters are
+    //       booleans/optionals and can be easily confused
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "https://linear.app/hash/issue/H-1466"
+    )]
     async fn validate_entity<A: AuthorizationApi + Sync>(
         &self,
         actor_id: AccountId,
@@ -83,6 +92,7 @@ pub trait EntityStore: crud::Read<Entity> {
         entity_type: EntityValidationType<'_>,
         properties: &EntityProperties,
         link_data: Option<&LinkData>,
+        profile: ValidationProfile,
     ) -> Result<(), EntityValidationError>;
 
     /// Inserts the entities with the specified [`EntityType`] into the `Store`.
@@ -145,12 +155,14 @@ pub trait EntityStore: crud::Read<Entity> {
     /// - if the account referred to by `actor_id` does not exist
     ///
     /// [`EntityType`]: type_system::EntityType
-    // TODO: Revisit creation parameter to avoid too many parameters, especially as the parameters
-    //       are booleans/optionals and can be easily confused
-    //   see https://linear.app/hash/issue/H-1466
     // TODO: Allow partial updates to avoid setting the `draft` and `archived` state here
     //   see https://linear.app/hash/issue/H-1455
-    #[expect(clippy::too_many_arguments)]
+    // TODO: Revisit creation parameter to avoid too many parameters, especially as the parameters
+    //       are booleans/optionals and can be easily confused
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "https://linear.app/hash/issue/H-1466"
+    )]
     async fn update_entity<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -5151,9 +5151,13 @@
         "required": [
           "entityTypeId",
           "properties",
-          "operations"
+          "operations",
+          "draft"
         ],
         "properties": {
+          "draft": {
+            "type": "boolean"
+          },
           "entityTypeId": {
             "$ref": "./models/shared.json#/definitions/VersionedUrl"
           },

--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -1255,7 +1255,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "properties": {
     "http://localhost:3000/@alice/types/property-type/name/": "Alice"
   },
-  "operations": ["all"]
+  "operations": ["all"],
+  "draft": false
 }
 
 > {%
@@ -1384,7 +1385,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "properties": {
     "http://localhost:3000/@alice/types/property-type/name/": "Alice Allison"
   },
-  "operations": ["all"]
+  "operations": ["all"],
+  "draft": false
 }
 
 > {%
@@ -1510,7 +1512,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     "leftEntityId": "{{person_a_entity_id}}",
     "rightEntityId": "{{person_b_entity_id}}"
   },
-  "operations": ["all"]
+  "operations": ["all"],
+  "draft": false
 }
 
 > {%

--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -14,7 +14,7 @@ use type_system::{
 
 use crate::{
     error::{Actual, Expected},
-    EntityProvider, EntityTypeProvider, OntologyTypeProvider, Schema, Validate,
+    EntityProvider, EntityTypeProvider, OntologyTypeProvider, Schema, Validate, ValidationProfile,
 };
 
 macro_rules! extend_report {
@@ -54,6 +54,7 @@ where
     async fn validate_value<'a>(
         &'a self,
         value: &'a HashMap<BaseUrl, serde_json::Value>,
+        profile: ValidationProfile,
         provider: &'a P,
     ) -> Result<(), Report<EntityValidationError>> {
         // TODO: Distinguish between format validation and content validation so it's possible
@@ -61,7 +62,7 @@ where
         //   see https://linear.app/hash/issue/BP-33
         Object::<_, 0>::new(self.properties().clone(), self.required().to_vec())
             .expect("`Object` was already validated")
-            .validate_value(value, provider)
+            .validate_value(value, profile, provider)
             .await
             .change_context(EntityValidationError::InvalidProperties)
             .attach_lazy(|| Expected::EntityType(self.clone()))
@@ -75,8 +76,15 @@ where
 {
     type Error = EntityValidationError;
 
-    async fn validate(&self, schema: &EntityType, provider: &P) -> Result<(), Report<Self::Error>> {
-        schema.validate_value(self.properties(), provider).await
+    async fn validate(
+        &self,
+        schema: &EntityType,
+        profile: ValidationProfile,
+        provider: &P,
+    ) -> Result<(), Report<Self::Error>> {
+        schema
+            .validate_value(self.properties(), profile, provider)
+            .await
     }
 }
 
@@ -90,7 +98,12 @@ where
 {
     type Error = EntityValidationError;
 
-    async fn validate(&self, schema: &EntityType, provider: &P) -> Result<(), Report<Self::Error>> {
+    async fn validate(
+        &self,
+        schema: &EntityType,
+        profile: ValidationProfile,
+        provider: &P,
+    ) -> Result<(), Report<Self::Error>> {
         let mut status: Result<(), Report<EntityValidationError>> = Ok(());
 
         let is_link = provider
@@ -124,7 +137,7 @@ where
                 extend_report!(status, EntityValidationError::UnexpectedLinkData);
             }
 
-            if let Err(error) = schema.validate_value(*link_data, provider).await {
+            if let Err(error) = schema.validate_value(*link_data, profile, provider).await {
                 extend_report!(status, error);
             }
         } else if is_link {
@@ -145,13 +158,23 @@ where
 {
     type Error = EntityValidationError;
 
-    async fn validate(&self, schema: &EntityType, provider: &P) -> Result<(), Report<Self::Error>> {
+    async fn validate(
+        &self,
+        schema: &EntityType,
+        profile: ValidationProfile,
+        provider: &P,
+    ) -> Result<(), Report<Self::Error>> {
         let mut status: Result<(), Report<EntityValidationError>> = Ok(());
 
-        if let Err(error) = self.properties.validate(schema, provider).await {
+        if let Err(error) = self.properties.validate(schema, profile, provider).await {
             extend_report!(status, error);
         }
-        if let Err(error) = self.link_data.as_ref().validate(schema, provider).await {
+        if let Err(error) = self
+            .link_data
+            .as_ref()
+            .validate(schema, profile, provider)
+            .await
+        {
             extend_report!(status, error);
         }
 
@@ -170,6 +193,7 @@ where
     async fn validate_value<'a>(
         &'a self,
         link_data: &'a LinkData,
+        _profile: ValidationProfile,
         provider: &'a P,
     ) -> Result<(), Report<EntityValidationError>> {
         let mut status: Result<(), Report<EntityValidationError>> = Ok(());
@@ -284,7 +308,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::validate_entity;
+    use crate::{tests::validate_entity, ValidationProfile};
 
     #[tokio::test]
     async fn address() {
@@ -304,6 +328,7 @@ mod tests {
             entity_types,
             property_types,
             data_types,
+            ValidationProfile::Full,
         )
         .await
         .expect("validation failed");
@@ -323,6 +348,7 @@ mod tests {
             entity_types,
             property_types,
             data_types,
+            ValidationProfile::Full,
         )
         .await
         .expect("validation failed");
@@ -346,6 +372,7 @@ mod tests {
             entity_types,
             property_types,
             data_types,
+            ValidationProfile::Full,
         )
         .await
         .expect("validation failed");
@@ -365,6 +392,7 @@ mod tests {
             entity_types,
             property_types,
             data_types,
+            ValidationProfile::Full,
         )
         .await
         .expect("validation failed");
@@ -384,6 +412,7 @@ mod tests {
             entity_types,
             property_types,
             data_types,
+            ValidationProfile::Full,
         )
         .await
         .expect("validation failed");
@@ -403,6 +432,7 @@ mod tests {
             entity_types,
             property_types,
             data_types,
+            ValidationProfile::Full,
         )
         .await
         .expect("validation failed");
@@ -414,6 +444,7 @@ mod tests {
             entity_types,
             property_types,
             data_types,
+            ValidationProfile::Full,
         )
         .await
         .expect("validation failed");
@@ -433,6 +464,7 @@ mod tests {
             entity_types,
             property_types,
             data_types,
+            ValidationProfile::Full,
         )
         .await
         .expect("validation failed");
@@ -444,6 +476,7 @@ mod tests {
             entity_types,
             property_types,
             data_types,
+            ValidationProfile::Full,
         )
         .await
         .expect("validation failed");
@@ -455,6 +488,7 @@ mod tests {
             entity_types,
             property_types,
             data_types,
+            ValidationProfile::Full,
         )
         .await
         .expect("validation failed");
@@ -474,6 +508,7 @@ mod tests {
             entity_types,
             property_types,
             data_types,
+            ValidationProfile::Full,
         )
         .await
         .expect("validation failed");
@@ -493,6 +528,7 @@ mod tests {
             entity_types,
             property_types,
             data_types,
+            ValidationProfile::Full,
         )
         .await
         .expect("validation failed");


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When creating draft entities, the validation constraints should be lifted.

## 🚫 Blocked by

- #3640 
- #3646 

## 🔍 What does this change?

- Allow to pass either `ValidationProfile::Draft` or `ValidationProfile::Full` to any validation function
- Don't check for required properties if profile is `Draft`
- Don't check for min/max items on arrays if profile is `Draft`
- Add a `draft` parameter to the `validateEntity` endpoint

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph