### PR TITLE
H-1450: Restrict non-draft links to non-draft entities

### DIFF
--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -43,6 +43,8 @@ pub enum EntityValidationError {
     InvalidLinkTypeId { link_type: VersionedUrl },
     #[error("The link target `{target_type}` is not allowed")]
     InvalidLinkTargetId { target_type: VersionedUrl },
+    #[error("Linking to a draft is only allowed for draft entities")]
+    LinksToDraft { id: EntityId },
 }
 
 impl<P> Schema<HashMap<BaseUrl, JsonValue>, P> for EntityType
@@ -190,10 +192,11 @@ where
 
     // TODO: validate link data
     //   see https://linear.app/hash/issue/H-972
+    #[expect(clippy::too_many_lines)]
     async fn validate_value<'a>(
         &'a self,
         link_data: &'a LinkData,
-        _profile: ValidationProfile,
+        profile: ValidationProfile,
         provider: &'a P,
     ) -> Result<(), Report<EntityValidationError>> {
         let mut status: Result<(), Report<EntityValidationError>> = Ok(());
@@ -216,11 +219,29 @@ where
             .map_err(|error| extend_report!(status, error))
             .ok();
 
-        let right_entity_type_id = right_entity
-            .as_ref()
-            .map(|entity| entity.borrow().metadata.entity_type_id());
+        let right_entity_type_id = right_entity.as_ref().map(|entity| {
+            if profile == ValidationProfile::Full && entity.borrow().metadata.draft() {
+                extend_report!(
+                    status,
+                    EntityValidationError::LinksToDraft {
+                        id: entity.borrow().metadata.record_id().entity_id
+                    }
+                );
+            }
+
+            entity.borrow().metadata.entity_type_id()
+        });
 
         if let Some(left_entity) = left_entity {
+            if profile == ValidationProfile::Full && left_entity.borrow().metadata.draft() {
+                extend_report!(
+                    status,
+                    EntityValidationError::LinksToDraft {
+                        id: left_entity.borrow().metadata.record_id().entity_id
+                    }
+                );
+            }
+
             let left_entity_type = provider
                 .provide_type(left_entity.borrow().metadata.entity_type_id())
                 .await


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

If a link is not a draft it must not link to any draft entity.


## 🚫 Blocked by

- #3640 
- #3646 
- #3649

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph