### PR TITLE
Remove unused policy rule from hash terraform

### DIFF
--- a/infra/terraform/hash/hash_application/main.tf
+++ b/infra/terraform/hash/hash_application/main.tf
@@ -284,13 +284,6 @@ resource "aws_iam_role" "execution_role" {
             flatten([for def in local.task_defs : [for _, env_var in def.env_vars : env_var.arn]])
           )
         }],
-        [{
-          Effect = "Allow"
-          Action = ["ssm:GetParameters"]
-          Resource = concat(
-            flatten([for def in local.worker_task_defs : [for _, env_var in def.env_vars : env_var.arn]])
-          )
-        }],
       ])
     })
   }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With the removal of the AI Python worker (#3644), there are no secrets among the `worker_task_defs`. 

This PR removes a redundant rule allowing the ECS Task Execution role to get secrets from SSM that don't exist.
