### PR TITLE
H-1465: Add graph visualization to `/entities` page

### DIFF
--- a/apps/hash-frontend/next.config.js
+++ b/apps/hash-frontend/next.config.js
@@ -119,6 +119,8 @@ module.exports = withSentryConfig(
         "@blockprotocol/type-system",
         "@emotion/server",
         "@hashintel/design-system",
+        "echarts",
+        "zrender",
         "@hashintel/block-design-system",
         "@hashintel/type-editor",
         "@hashintel/query-editor",

--- a/apps/hash-frontend/src/pages/[shortname].page/pinned-entity-type-tab-contents.tsx
+++ b/apps/hash-frontend/src/pages/[shortname].page/pinned-entity-type-tab-contents.tsx
@@ -1,5 +1,6 @@
 import { faCaretDown } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon, Select, SelectProps } from "@hashintel/design-system";
+import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { isPageEntityTypeId } from "@local/hash-isomorphic-utils/page-entity-type-ids";
 import {
@@ -38,7 +39,6 @@ import {
 
 import { useAccountPages } from "../../components/hooks/use-account-pages";
 import { useCreatePage } from "../../components/hooks/use-create-page";
-import { generateEntityLabel } from "../../lib/entities";
 import { Org, User } from "../../lib/user-and-org";
 import { ArrowDownAZRegularIcon } from "../../shared/icons/arrow-down-a-z-regular-icon";
 import { ArrowUpZARegularIcon } from "../../shared/icons/arrow-up-a-z-regular-icon";

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page.tsx
@@ -1,4 +1,5 @@
 import { useLazyQuery } from "@apollo/client";
+import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import { mapGqlSubgraphFieldsFragmentToSubgraph } from "@local/hash-isomorphic-utils/graph-queries";
 import { getEntityQuery } from "@local/hash-isomorphic-utils/graphql/queries/entity.queries";
 import { blockProtocolEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
@@ -23,7 +24,6 @@ import {
   GetEntityQuery,
   GetEntityQueryVariables,
 } from "../../../graphql/api-types.gen";
-import { generateEntityLabel } from "../../../lib/entities";
 import {
   getLayoutWithSidebar,
   NextPageWithLayout,

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/create-entity-page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/create-entity-page.tsx
@@ -1,4 +1,5 @@
 import { VersionedUrl } from "@blockprotocol/type-system";
+import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import { blockProtocolEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import {
   EntityPropertiesObject,
@@ -10,7 +11,6 @@ import { useContext, useState } from "react";
 
 import { useBlockProtocolCreateEntity } from "../../../../components/hooks/block-protocol-functions/knowledge/use-block-protocol-create-entity";
 import { PageErrorState } from "../../../../components/page-error-state";
-import { generateEntityLabel } from "../../../../lib/entities";
 import { WorkspaceContext } from "../../../shared/workspace-context";
 import { EditBar } from "../../shared/edit-bar";
 import { EntityEditorPage } from "./entity-editor-page";

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/file-preview-section.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/file-preview-section.tsx
@@ -5,6 +5,7 @@ import {
   ImageWithCheckedBackground,
   RotateIconRegular,
 } from "@hashintel/design-system";
+import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
 import { FileProperties } from "@local/hash-isomorphic-utils/system-types/shared";
 import { extractOwnedByIdFromEntityId } from "@local/hash-subgraph";
@@ -18,7 +19,6 @@ import {
 } from "@mui/material";
 import { PropsWithChildren, useState } from "react";
 
-import { generateEntityLabel } from "../../../../../lib/entities";
 import {
   useFileUploads,
   useFileUploadsProgress,

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/linked-with-cell.ts
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/linked-with-cell.ts
@@ -4,6 +4,7 @@ import {
   GridCellKind,
 } from "@glideapps/glide-data-grid";
 import { customColors } from "@hashintel/design-system/theme";
+import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import { EntityId } from "@local/hash-subgraph";
 
 import {
@@ -14,7 +15,6 @@ import { drawCellFadeOutGradient } from "../../../../../../../../components/grid
 import { drawChipWithIcon } from "../../../../../../../../components/grid/utils/draw-chip-with-icon";
 import { InteractableManager } from "../../../../../../../../components/grid/utils/interactable-manager";
 import { Interactable } from "../../../../../../../../components/grid/utils/interactable-manager/types";
-import { generateEntityLabel } from "../../../../../../../../lib/entities";
 import { getImageUrlFromEntityProperties } from "../../../../../../../shared/get-image-url-from-properties";
 import { LinkRow } from "../types";
 import { LinkedWithCellEditor } from "./linked-with-cell/linked-with-cell-editor";

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/linked-with-cell/entity-selector.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/linked-with-cell/entity-selector.tsx
@@ -5,6 +5,7 @@ import {
   SelectorAutocomplete,
 } from "@hashintel/design-system";
 import { GRID_CLICK_IGNORE_CLASS } from "@hashintel/design-system/constants";
+import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import {
   Entity,
   EntityId,
@@ -24,7 +25,6 @@ import {
 } from "react";
 
 import { useQueryEntities } from "../../../../../../../../../components/hooks/use-query-entities";
-import { generateEntityLabel } from "../../../../../../../../../lib/entities";
 import { useEntityTypesContextRequired } from "../../../../../../../../../shared/entity-types-context/hooks/use-entity-types-context-required";
 import { useFileUploads } from "../../../../../../../../../shared/file-upload-context";
 import { Button } from "../../../../../../../../../shared/ui/button";

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/linked-with-cell/linked-entity-list-editor.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/linked-with-cell/linked-entity-list-editor.tsx
@@ -1,5 +1,6 @@
 import { VersionedUrl } from "@blockprotocol/type-system";
 import { ProvideEditorComponent } from "@glideapps/glide-data-grid";
+import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import {
   Entity,
   EntityId,
@@ -13,7 +14,6 @@ import { Box } from "@mui/material";
 import produce from "immer";
 import { useMemo, useState } from "react";
 
-import { generateEntityLabel } from "../../../../../../../../../lib/entities";
 import { getImageUrlFromEntityProperties } from "../../../../../../../../shared/get-image-url-from-properties";
 import { useMarkLinkEntityToArchive } from "../../../../../shared/use-mark-link-entity-to-archive";
 import { useEntityEditor } from "../../../../entity-editor-context";

--- a/apps/hash-frontend/src/pages/shared/block-collection/block-context-menu/load-entity-menu-content.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/block-context-menu/load-entity-menu-content.tsx
@@ -7,6 +7,7 @@ import {
   TextField,
 } from "@hashintel/design-system";
 import { EntityStoreType } from "@local/hash-isomorphic-utils/entity-store";
+import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import { mapGqlSubgraphFieldsFragmentToSubgraph } from "@local/hash-isomorphic-utils/graph-queries";
 import { Entity, EntityId, EntityRootType } from "@local/hash-subgraph";
 import { getRoots } from "@local/hash-subgraph/stdlib";
@@ -32,7 +33,6 @@ import {
   QueryEntitiesQueryVariables,
 } from "../../../../graphql/api-types.gen";
 import { queryEntitiesQuery } from "../../../../graphql/queries/knowledge/entity.queries";
-import { generateEntityLabel } from "../../../../lib/entities";
 import { entityHasEntityTypeByBaseUrlFilter } from "../../../../shared/filters";
 import { MenuItem } from "../../../../shared/ui";
 import { useBlockView } from "../block-view";

--- a/apps/hash-frontend/src/pages/shared/block-collection/mention-view/mention-display.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/mention-view/mention-display.tsx
@@ -1,3 +1,4 @@
+import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import { zeroedGraphResolveDepths } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
@@ -16,7 +17,6 @@ import { Box, Popover, styled, Tooltip, Typography } from "@mui/material";
 import { FunctionComponent, useMemo, useRef, useState } from "react";
 
 import { useEntityById } from "../../../../components/hooks/use-entity-by-id";
-import { generateEntityLabel } from "../../../../lib/entities";
 import { constructPageRelativeUrl } from "../../../../lib/routes";
 import { useEntityTypesContextRequired } from "../../../../shared/entity-types-context/hooks/use-entity-types-context-required";
 import { ArrowUpRightRegularIcon } from "../../../../shared/icons/arrow-up-right-regular-icon";

--- a/apps/hash-frontend/src/pages/shared/block-collection/shared/mention-suggester.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/shared/mention-suggester.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@apollo/client";
 import { VersionedUrl } from "@blockprotocol/type-system";
 import { LoadingSpinner } from "@hashintel/design-system";
+import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import {
   currentTimeInstantTemporalAxes,
   generateVersionedUrlMatchingFilter,
@@ -44,7 +45,6 @@ import {
   StructuralQueryEntitiesQueryVariables,
 } from "../../../../graphql/api-types.gen";
 import { structuralQueryEntitiesQuery } from "../../../../graphql/queries/knowledge/entity.queries";
-import { generateEntityLabel } from "../../../../lib/entities";
 import { isPageArchived } from "../../../../shared/is-archived";
 import { isEntityPageEntity } from "../../../../shared/is-of-type";
 import { usePropertyTypes } from "../../../../shared/property-types-context";

--- a/apps/hash-frontend/src/pages/shared/block-collection/shared/mention-suggester/mention-suggester-entity.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/shared/mention-suggester/mention-suggester-entity.tsx
@@ -1,4 +1,5 @@
 import { AsteriskRegularIcon, IconButton } from "@hashintel/design-system";
+import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import {
   Entity,
   EntityPropertyValue,
@@ -21,7 +22,6 @@ import {
 } from "@mui/material";
 import { forwardRef, useEffect, useRef } from "react";
 
-import { generateEntityLabel } from "../../../../../lib/entities";
 import { ArrowDownArrowUpRegularIcon } from "../../../../../shared/icons/arrow-down-arrow-up-regular-icon";
 import { ChevronRightRegularIcon } from "../../../../../shared/icons/chevron-right-regular-icon";
 import { LinkRegularIcon } from "../../../../../shared/icons/link-regular-icon";

--- a/apps/hash-frontend/src/pages/shared/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table.tsx
@@ -327,6 +327,14 @@ export const EntitiesTable: FunctionComponent<{
             entityTypeBaseUrl ??
             (entityTypeId ? extractBaseUrl(entityTypeId) : undefined)
           }
+          sx={{
+            background: ({ palette }) => palette.common.white,
+            height: `calc(100vh - (${
+              HEADER_HEIGHT + TOP_CONTEXT_BAR_HEIGHT + 179 + tableHeaderHeight
+            }px + ${theme.spacing(5)} + ${theme.spacing(5)}))`,
+            borderBottomRightRadius: 6,
+            borderBottomLeftRadius: 6,
+          }}
           subgraph={subgraph}
         />
       ) : (

--- a/apps/hash-frontend/src/pages/shared/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table.tsx
@@ -12,7 +12,14 @@ import {
   extractOwnedByIdFromEntityId,
 } from "@local/hash-subgraph";
 import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
-import { Box, useTheme } from "@mui/material";
+import {
+  Box,
+  ToggleButton,
+  toggleButtonClasses,
+  ToggleButtonGroup,
+  Tooltip,
+  useTheme,
+} from "@mui/material";
 import { useRouter } from "next/router";
 import {
   FunctionComponent,
@@ -30,6 +37,8 @@ import {
 } from "../../components/grid/grid";
 import { BlankCell, blankCell } from "../../components/grid/utils";
 import { useEntityTypeEntities } from "../../shared/entity-type-entities-context";
+import { ChartNetworkRegularIcon } from "../../shared/icons/chart-network-regular-icon";
+import { ListRegularIcon } from "../../shared/icons/list-regular-icon";
 import { HEADER_HEIGHT } from "../../shared/layout/layout-with-header/page-header";
 import {
   FilterState,
@@ -251,6 +260,61 @@ export const EntitiesTable: FunctionComponent<{
               ({ entityId }) => entity.metadata.recordId.entityId === entityId,
             ),
           ) ?? []
+        }
+        endAdornment={
+          <ToggleButtonGroup
+            value={view}
+            exclusive
+            onChange={(_, updatedView) => {
+              if (updatedView) {
+                setView(updatedView);
+              }
+            }}
+            aria-label="view"
+            size="small"
+            sx={{
+              [`.${toggleButtonClasses.root}`]: {
+                backgroundColor: ({ palette }) => palette.common.white,
+                "&:not(:last-of-type)": {
+                  borderRightColor: ({ palette }) => palette.gray[20],
+                  borderRightStyle: "solid",
+                  borderRightWidth: 2,
+                },
+                "&:hover": {
+                  backgroundColor: ({ palette }) => palette.common.white,
+                  svg: {
+                    color: ({ palette }) => palette.gray[80],
+                  },
+                },
+                [`&.${toggleButtonClasses.selected}`]: {
+                  backgroundColor: ({ palette }) => palette.common.white,
+                  svg: {
+                    color: ({ palette }) => palette.gray[90],
+                  },
+                },
+                svg: {
+                  transition: ({ transitions }) => transitions.create("color"),
+                  color: ({ palette }) => palette.gray[50],
+                  fontSize: 18,
+                },
+              },
+            }}
+          >
+            <ToggleButton disableRipple value="table" aria-label="table">
+              <Tooltip title="Table view" placement="top">
+                <Box sx={{ lineHeight: 0 }}>
+                  <ListRegularIcon />
+                </Box>
+              </Tooltip>
+            </ToggleButton>
+            <ToggleButton disableRipple value="graph" aria-label="graph">
+              <Tooltip title="Graph view" placement="top">
+                <Box sx={{ lineHeight: 0 }}>
+                  <ChartNetworkRegularIcon />
+                </Box>
+              </Tooltip>
+            </ToggleButton>
+          </ToggleButtonGroup>
         }
         filterState={filterState}
         setFilterState={setFilterState}

--- a/apps/hash-frontend/src/pages/shared/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table.tsx
@@ -45,7 +45,7 @@ import {
 } from "../../components/grid/grid";
 import { BlankCell, blankCell } from "../../components/grid/utils";
 import { useGetOwnerForEntity } from "../../components/hooks/use-get-owner-for-entity";
-import { useEntityTypeEntities } from "../../shared/entity-type-entities-context";
+import { useEntityTypeEntitiesContext } from "../../shared/entity-type-entities-context";
 import { ChartNetworkRegularIcon } from "../../shared/icons/chart-network-regular-icon";
 import { ListRegularIcon } from "../../shared/icons/list-regular-icon";
 import { HEADER_HEIGHT } from "../../shared/layout/layout-with-header/page-header";
@@ -54,6 +54,7 @@ import {
   TableHeader,
   tableHeaderHeight,
 } from "../../shared/table-header";
+import { useEntityTypeEntities } from "../../shared/use-entity-type-entities";
 import { useAuthenticatedUser } from "./auth-info-context";
 import { renderChipCell } from "./chip-cell";
 import {
@@ -79,7 +80,7 @@ export const EntitiesTable: FunctionComponent<{
   });
   const [showSearch, setShowSearch] = useState<boolean>(false);
 
-  const [view, setView] = useState<"table" | "graph">("graph");
+  const [view, setView] = useState<"table" | "graph">("table");
 
   const {
     entityTypeBaseUrl,
@@ -89,8 +90,25 @@ export const EntitiesTable: FunctionComponent<{
     hadCachedContent,
     loading,
     propertyTypes,
-    subgraph,
-  } = useEntityTypeEntities();
+    subgraph: subgraphWithoutLinkedEntities,
+  } = useEntityTypeEntitiesContext();
+
+  const { subgraph: subgraphWithLinkedEntities } = useEntityTypeEntities({
+    entityTypeBaseUrl,
+    entityTypeId,
+    graphResolveDepths: {
+      constrainsLinksOn: { outgoing: 255 },
+      constrainsLinkDestinationsOn: { outgoing: 255 },
+      constrainsPropertiesOn: { outgoing: 255 },
+      constrainsValuesOn: { outgoing: 255 },
+      inheritsFrom: { outgoing: 255 },
+      isOfType: { outgoing: 1 },
+      hasLeftEntity: { outgoing: 1, incoming: 1 },
+      hasRightEntity: { outgoing: 1, incoming: 1 },
+    },
+  });
+
+  const subgraph = subgraphWithLinkedEntities ?? subgraphWithoutLinkedEntities;
 
   const entities = useMemo(
     /**

--- a/apps/hash-frontend/src/pages/shared/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table.tsx
@@ -318,7 +318,7 @@ export const EntitiesTable: FunctionComponent<{
         }
         filterState={filterState}
         setFilterState={setFilterState}
-        toggleSearch={() => setShowSearch(true)}
+        toggleSearch={view === "table" ? () => setShowSearch(true) : undefined}
         onBulkActionCompleted={() => setSelectedRows([])}
       />
       {view === "graph" ? (

--- a/apps/hash-frontend/src/pages/shared/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table.tsx
@@ -47,7 +47,7 @@ import {
 } from "../../shared/table-header";
 import { useAuthenticatedUser } from "./auth-info-context";
 import { renderChipCell } from "./chip-cell";
-import { EntitiesGraph } from "./entities-table/entities-graph";
+import { EntitiesGraphChart } from "./entities-table/entities-graph-chart";
 import {
   createRenderTextIconCell,
   TextIconCell,
@@ -322,7 +322,7 @@ export const EntitiesTable: FunctionComponent<{
         onBulkActionCompleted={() => setSelectedRows([])}
       />
       {view === "graph" ? (
-        <EntitiesGraph
+        <EntitiesGraphChart
           primaryEntityTypeBaseUrl={
             entityTypeBaseUrl ??
             (entityTypeId ? extractBaseUrl(entityTypeId) : undefined)

--- a/apps/hash-frontend/src/pages/shared/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table.tsx
@@ -8,6 +8,7 @@ import { isPageEntityTypeId } from "@local/hash-isomorphic-utils/page-entity-typ
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
 import { PageProperties } from "@local/hash-isomorphic-utils/system-types/shared";
 import {
+  Entity,
   extractEntityUuidFromEntityId,
   extractOwnedByIdFromEntityId,
 } from "@local/hash-subgraph";
@@ -36,6 +37,7 @@ import {
   gridRowHeight,
 } from "../../components/grid/grid";
 import { BlankCell, blankCell } from "../../components/grid/utils";
+import { useGetOwnerForEntity } from "../../components/hooks/use-get-owner-for-entity";
 import { useEntityTypeEntities } from "../../shared/entity-type-entities-context";
 import { ChartNetworkRegularIcon } from "../../shared/icons/chart-network-regular-icon";
 import { ListRegularIcon } from "../../shared/icons/list-regular-icon";
@@ -248,6 +250,25 @@ export const EntitiesTable: FunctionComponent<{
 
   const theme = useTheme();
 
+  const getOwnerForEntity = useGetOwnerForEntity();
+
+  const handleEntityClick = useCallback(
+    (entity: Entity) => {
+      const { shortname: entityNamespace } = getOwnerForEntity(entity);
+
+      if (entityNamespace === "") {
+        return;
+      }
+
+      void router.push(
+        `/@${entityNamespace}/entities/${extractEntityUuidFromEntityId(
+          entity.metadata.recordId.entityId,
+        )}`,
+      );
+    },
+    [router, getOwnerForEntity],
+  );
+
   return (
     <Box>
       <TableHeader
@@ -336,6 +357,7 @@ export const EntitiesTable: FunctionComponent<{
                   ),
                 )
           }
+          onEntityClick={handleEntityClick}
           sx={{
             background: ({ palette }) => palette.common.white,
             height: `calc(100vh - (${

--- a/apps/hash-frontend/src/pages/shared/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table.tsx
@@ -4,6 +4,7 @@ import {
   Item,
   TextCell,
 } from "@glideapps/glide-data-grid";
+import { EntitiesGraphChart } from "@hashintel/design-system";
 import { isPageEntityTypeId } from "@local/hash-isomorphic-utils/page-entity-type-ids";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
 import { PageProperties } from "@local/hash-isomorphic-utils/system-types/shared";
@@ -49,7 +50,6 @@ import {
 } from "../../shared/table-header";
 import { useAuthenticatedUser } from "./auth-info-context";
 import { renderChipCell } from "./chip-cell";
-import { EntitiesGraphChart } from "./entities-table/entities-graph-chart";
 import {
   createRenderTextIconCell,
   TextIconCell,

--- a/apps/hash-frontend/src/pages/shared/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table.tsx
@@ -327,6 +327,15 @@ export const EntitiesTable: FunctionComponent<{
             entityTypeBaseUrl ??
             (entityTypeId ? extractBaseUrl(entityTypeId) : undefined)
           }
+          filterEntity={(entity) =>
+            filterState.includeGlobal
+              ? true
+              : internalWebIds.includes(
+                  extractOwnedByIdFromEntityId(
+                    entity.metadata.recordId.entityId,
+                  ),
+                )
+          }
           sx={{
             background: ({ palette }) => palette.common.white,
             height: `calc(100vh - (${

--- a/apps/hash-frontend/src/pages/shared/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table.tsx
@@ -1,15 +1,21 @@
 import {
+  Entity as BpEntity,
+  EntityRootType as BpEntityRootType,
+  Subgraph as BpSubgraph,
+} from "@blockprotocol/graph";
+import {
   CustomCell,
   GridCellKind,
   Item,
   TextCell,
 } from "@glideapps/glide-data-grid";
-import { EntitiesGraphChart } from "@hashintel/design-system";
+import { EntitiesGraphChart } from "@hashintel/block-design-system";
 import { isPageEntityTypeId } from "@local/hash-isomorphic-utils/page-entity-type-ids";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
 import { PageProperties } from "@local/hash-isomorphic-utils/system-types/shared";
 import {
   Entity,
+  EntityId,
   extractEntityUuidFromEntityId,
   extractOwnedByIdFromEntityId,
 } from "@local/hash-subgraph";
@@ -253,8 +259,10 @@ export const EntitiesTable: FunctionComponent<{
   const getOwnerForEntity = useGetOwnerForEntity();
 
   const handleEntityClick = useCallback(
-    (entity: Entity) => {
-      const { shortname: entityNamespace } = getOwnerForEntity(entity);
+    (entity: BpEntity) => {
+      const { shortname: entityNamespace } = getOwnerForEntity(
+        entity as Entity,
+      );
 
       if (entityNamespace === "") {
         return;
@@ -262,7 +270,7 @@ export const EntitiesTable: FunctionComponent<{
 
       void router.push(
         `/@${entityNamespace}/entities/${extractEntityUuidFromEntityId(
-          entity.metadata.recordId.entityId,
+          entity.metadata.recordId.entityId as EntityId,
         )}`,
       );
     },
@@ -353,7 +361,7 @@ export const EntitiesTable: FunctionComponent<{
               ? true
               : internalWebIds.includes(
                   extractOwnedByIdFromEntityId(
-                    entity.metadata.recordId.entityId,
+                    entity.metadata.recordId.entityId as EntityId,
                   ),
                 )
           }
@@ -366,7 +374,7 @@ export const EntitiesTable: FunctionComponent<{
             borderBottomRightRadius: 6,
             borderBottomLeftRadius: 6,
           }}
-          subgraph={subgraph}
+          subgraph={subgraph as unknown as BpSubgraph<BpEntityRootType>}
         />
       ) : (
         <Grid

--- a/apps/hash-frontend/src/pages/shared/entities-table/entities-graph-chart.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table/entities-graph-chart.tsx
@@ -19,7 +19,7 @@ import { FunctionComponent, useEffect, useMemo, useState } from "react";
 import { useGetOwnerForEntity } from "../../../components/hooks/use-get-owner-for-entity";
 import { generateEntityLabel } from "../../../lib/entities";
 
-export const EntitiesGraph: FunctionComponent<{
+export const EntitiesGraphChart: FunctionComponent<{
   filterEntity?: (entity: Entity) => boolean;
   primaryEntityTypeBaseUrl?: BaseUrl;
   subgraph?: Subgraph<EntityRootType>;

--- a/apps/hash-frontend/src/pages/shared/entities-table/entities-graph-chart.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table/entities-graph-chart.tsx
@@ -14,7 +14,7 @@ import {
 } from "@local/hash-subgraph/type-system-patch";
 import { BoxProps } from "@mui/material";
 import { useRouter } from "next/router";
-import { FunctionComponent, useEffect, useMemo, useState } from "react";
+import { FunctionComponent, useEffect, useMemo, useRef, useState } from "react";
 
 import { useGetOwnerForEntity } from "../../../components/hooks/use-get-owner-for-entity";
 import { generateEntityLabel } from "../../../lib/entities";
@@ -102,6 +102,8 @@ export const EntitiesGraphChart: FunctionComponent<{
       chart?.off("click");
     };
   }, [chart, entities, router, getOwnerForEntity]);
+
+  const chartInitialized = useRef(false);
 
   const eChartOptions = useMemo<ECOption>(() => {
     return {
@@ -199,7 +201,8 @@ export const EntitiesGraphChart: FunctionComponent<{
         })),
         type: "graph",
         layout: "force",
-        zoom: 5,
+        // Hack for only setting the zoom if the chart hasn't already been initialized
+        ...(chartInitialized.current ? {} : { zoom: 5 }),
       },
     };
   }, [
@@ -213,7 +216,10 @@ export const EntitiesGraphChart: FunctionComponent<{
   return (
     <EChart
       sx={sx}
-      onChartInitialized={(initializedChart) => setChart(initializedChart)}
+      onChartInitialized={(initializedChart) => {
+        setChart(initializedChart);
+        chartInitialized.current = true;
+      }}
       options={eChartOptions}
     />
   );

--- a/apps/hash-frontend/src/pages/shared/entities-table/entities-graph.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table/entities-graph.tsx
@@ -1,0 +1,143 @@
+import { BaseUrl } from "@blockprotocol/type-system";
+import { EChart, ECOption } from "@hashintel/design-system";
+import { EntityRootType, Subgraph } from "@local/hash-subgraph";
+import { getEntities, getEntityTypeById } from "@local/hash-subgraph/stdlib";
+import {
+  extractBaseUrl,
+  LinkEntity,
+} from "@local/hash-subgraph/type-system-patch";
+import { FunctionComponent, useMemo } from "react";
+
+import { generateEntityLabel } from "../../../lib/entities";
+
+export const EntitiesGraph: FunctionComponent<{
+  primaryEntityTypeBaseUrl?: BaseUrl;
+  subgraph?: Subgraph<EntityRootType>;
+}> = ({ primaryEntityTypeBaseUrl, subgraph }) => {
+  const eChartOptions = useMemo<ECOption>(() => {
+    const entities = subgraph ? getEntities(subgraph, true) : undefined;
+
+    const linkEntities = entities?.filter(
+      (entity): entity is LinkEntity => "linkData" in entity,
+    );
+
+    const nonLinkEntities = entities?.filter((entity) => !entity.linkData);
+
+    return {
+      tooltip: {
+        show: true,
+        trigger: "item",
+        formatter: (params) => {
+          const id = (params as any).data.id as string;
+
+          if ((params as any).dataType === "edge") {
+            const linkEntity = linkEntities?.find(
+              ({ metadata }) => metadata.recordId.entityId === id,
+            );
+
+            if (linkEntity) {
+              const leftEntity = entities?.find(
+                ({ metadata }) =>
+                  metadata.recordId.entityId ===
+                  linkEntity.linkData.leftEntityId,
+              );
+
+              const leftEntityTypeTitle = getEntityTypeById(
+                subgraph!,
+                leftEntity!.metadata.entityTypeId,
+              )?.schema.title;
+
+              const rightEntity = entities?.find(
+                ({ metadata }) =>
+                  metadata.recordId.entityId ===
+                  linkEntity.linkData.rightEntityId,
+              );
+
+              const rightEntityTypeTitle = getEntityTypeById(
+                subgraph!,
+                rightEntity!.metadata.entityTypeId,
+              )?.schema.title;
+
+              const linkEntityTypeTitle = getEntityTypeById(
+                subgraph!,
+                linkEntity.metadata.entityTypeId,
+              )?.schema.title;
+
+              return [
+                leftEntityTypeTitle,
+                `<strong>${generateEntityLabel(
+                  subgraph!,
+                  leftEntity,
+                )}</strong>`,
+                linkEntityTypeTitle?.toLowerCase(),
+                rightEntityTypeTitle,
+                `<strong>${generateEntityLabel(
+                  subgraph!,
+                  rightEntity,
+                )}</strong>`,
+              ].join(" ");
+            }
+          } else {
+            const entity = entities?.find(
+              ({ metadata }) => metadata.recordId.entityId === id,
+            );
+
+            if (entity) {
+              const entityType = getEntityTypeById(
+                subgraph!,
+                entity.metadata.entityTypeId,
+              );
+
+              return entityType?.schema.title;
+            }
+          }
+        },
+      },
+      series: {
+        roam: true,
+        data: nonLinkEntities?.map((entity) => ({
+          name: generateEntityLabel(subgraph!, entity),
+          id: entity.metadata.recordId.entityId,
+          label: {
+            show: true,
+          },
+          itemStyle: primaryEntityTypeBaseUrl
+            ? {
+                opacity:
+                  extractBaseUrl(entity.metadata.entityTypeId) ===
+                  primaryEntityTypeBaseUrl
+                    ? 1
+                    : 0.8,
+              }
+            : undefined,
+        })),
+        edges: linkEntities?.map((linkEntity) => ({
+          /** @todo: figure out why the right entity is the source and not the target */
+          source: linkEntity.linkData.leftEntityId,
+          target: linkEntity.linkData.rightEntityId,
+          id: linkEntity.metadata.recordId.entityId,
+          label: {
+            show: true,
+            formatter: () =>
+              getEntityTypeById(subgraph!, linkEntity.metadata.entityTypeId)
+                ?.schema.title ?? "Unknown",
+          },
+          symbol: ["none", "arrow"],
+          name: linkEntity.metadata.entityTypeId,
+        })),
+        type: "graph",
+        layout: "force",
+        zoom: 5,
+      },
+    };
+  }, [subgraph, primaryEntityTypeBaseUrl]);
+
+  return (
+    <EChart
+      sx={{
+        background: ({ palette }) => palette.common.white,
+      }}
+      options={eChartOptions}
+    />
+  );
+};

--- a/apps/hash-frontend/src/pages/shared/entities-table/entities-graph.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table/entities-graph.tsx
@@ -64,6 +64,9 @@ export const EntitiesGraph: FunctionComponent<{
         }
       });
     }
+    return () => {
+      chart?.off("click");
+    };
   }, [chart, entities, router, getOwnerForEntity]);
 
   const eChartOptions = useMemo<ECOption>(() => {
@@ -147,6 +150,7 @@ export const EntitiesGraph: FunctionComponent<{
       },
       series: {
         roam: true,
+        draggable: true,
         data: nonLinkEntities?.map((entity) => ({
           name: generateEntityLabel(subgraph!, entity),
           id: entity.metadata.recordId.entityId,

--- a/apps/hash-frontend/src/pages/shared/entities-table/entities-graph.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table/entities-graph.tsx
@@ -11,6 +11,7 @@ import {
   extractBaseUrl,
   LinkEntity,
 } from "@local/hash-subgraph/type-system-patch";
+import { BoxProps } from "@mui/material";
 import { useRouter } from "next/router";
 import { FunctionComponent, useEffect, useMemo, useState } from "react";
 
@@ -20,7 +21,8 @@ import { generateEntityLabel } from "../../../lib/entities";
 export const EntitiesGraph: FunctionComponent<{
   primaryEntityTypeBaseUrl?: BaseUrl;
   subgraph?: Subgraph<EntityRootType>;
-}> = ({ primaryEntityTypeBaseUrl, subgraph }) => {
+  sx?: BoxProps["sx"];
+}> = ({ primaryEntityTypeBaseUrl, subgraph, sx }) => {
   const router = useRouter();
   const [chart, setChart] = useState<Chart>();
 
@@ -190,9 +192,7 @@ export const EntitiesGraph: FunctionComponent<{
 
   return (
     <EChart
-      sx={{
-        background: ({ palette }) => palette.common.white,
-      }}
+      sx={sx}
       onChartInitialized={(initializedChart) => setChart(initializedChart)}
       options={eChartOptions}
     />

--- a/apps/hash-frontend/src/pages/shared/entities-table/entities-graph.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table/entities-graph.tsx
@@ -97,21 +97,11 @@ export const EntitiesGraph: FunctionComponent<{
                   linkEntity.linkData.leftEntityId,
               );
 
-              const leftEntityTypeTitle = getEntityTypeById(
-                subgraph!,
-                leftEntity!.metadata.entityTypeId,
-              )?.schema.title;
-
               const rightEntity = entities?.find(
                 ({ metadata }) =>
                   metadata.recordId.entityId ===
                   linkEntity.linkData.rightEntityId,
               );
-
-              const rightEntityTypeTitle = getEntityTypeById(
-                subgraph!,
-                rightEntity!.metadata.entityTypeId,
-              )?.schema.title;
 
               const linkEntityTypeTitle = getEntityTypeById(
                 subgraph!,
@@ -119,13 +109,11 @@ export const EntitiesGraph: FunctionComponent<{
               )?.schema.title;
 
               return [
-                leftEntityTypeTitle,
                 `<strong>${generateEntityLabel(
                   subgraph!,
                   leftEntity,
                 )}</strong>`,
                 linkEntityTypeTitle?.toLowerCase(),
-                rightEntityTypeTitle,
                 `<strong>${generateEntityLabel(
                   subgraph!,
                   rightEntity,

--- a/apps/hash-frontend/src/pages/shared/entities-table/use-entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table/use-entities-table.tsx
@@ -4,6 +4,7 @@ import {
   PropertyType,
 } from "@blockprotocol/type-system";
 import { SizedGridColumn } from "@glideapps/glide-data-grid";
+import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import { isPageEntityTypeId } from "@local/hash-isomorphic-utils/page-entity-type-ids";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
 import { PageProperties } from "@local/hash-isomorphic-utils/system-types/shared";
@@ -20,7 +21,6 @@ import { useMemo } from "react";
 
 import { useGetOwnerForEntity } from "../../../components/hooks/use-get-owner-for-entity";
 import { useUsers } from "../../../components/hooks/use-users";
-import { generateEntityLabel } from "../../../lib/entities";
 import { MinimalUser } from "../../../lib/user-and-org";
 
 export interface TypeEntitiesRow {

--- a/apps/hash-frontend/src/pages/shared/entity-type-page/entities-tab.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-page/entities-tab.tsx
@@ -4,7 +4,7 @@ import { extractOwnedByIdFromEntityId } from "@local/hash-subgraph";
 import { Box, Paper } from "@mui/material";
 import { FunctionComponent, useContext, useMemo } from "react";
 
-import { useEntityTypeEntities } from "../../../shared/entity-type-entities-context";
+import { useEntityTypeEntitiesContext } from "../../../shared/entity-type-entities-context";
 import { SectionEmptyState } from "../../[shortname]/shared/section-empty-state";
 import { SectionWrapper } from "../../[shortname]/shared/section-wrapper";
 import { EntitiesTable } from "../entities-table";
@@ -12,7 +12,7 @@ import { WorkspaceContext } from "../workspace-context";
 import { useEntityType } from "./shared/entity-type-context";
 
 export const EntitiesTab: FunctionComponent = () => {
-  const { entities, loading } = useEntityTypeEntities();
+  const { entities, loading } = useEntityTypeEntitiesContext();
 
   const { activeWorkspaceOwnedById } = useContext(WorkspaceContext);
 

--- a/apps/hash-frontend/src/pages/shared/entity-type-page/entity-type-tabs.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-page/entity-type-tabs.tsx
@@ -3,7 +3,7 @@ import { FontAwesomeIcon } from "@hashintel/design-system";
 import { Box } from "@mui/material";
 import { useRouter } from "next/router";
 
-import { useEntityTypeEntities } from "../../../shared/entity-type-entities-context";
+import { useEntityTypeEntitiesContext } from "../../../shared/entity-type-entities-context";
 import { TabLink } from "../../../shared/ui/tab-link";
 import { Tabs } from "../../../shared/ui/tabs";
 import { useEntityType } from "./shared/entity-type-context";
@@ -22,7 +22,7 @@ export const EntityTypeTabs = ({
 
   const entityType = useEntityType();
 
-  const { entities, loading } = useEntityTypeEntities();
+  const { entities, loading } = useEntityTypeEntitiesContext();
 
   const currentTab = useCurrentTab();
 

--- a/apps/hash-frontend/src/shared/entity-type-entities-context.ts
+++ b/apps/hash-frontend/src/shared/entity-type-entities-context.ts
@@ -1,11 +1,22 @@
 import { ApolloQueryResult } from "@apollo/client";
-import { EntityType, PropertyType } from "@blockprotocol/type-system";
-import { Entity, EntityRootType, Subgraph } from "@local/hash-subgraph";
+import {
+  EntityType,
+  PropertyType,
+  VersionedUrl,
+} from "@blockprotocol/type-system";
+import {
+  BaseUrl,
+  Entity,
+  EntityRootType,
+  Subgraph,
+} from "@local/hash-subgraph";
 import { createContext, useContext } from "react";
 
 import { QueryEntitiesQuery } from "../graphql/api-types.gen";
 
 export type EntityTypeEntitiesContextValue = {
+  entityTypeId?: VersionedUrl;
+  entityTypeBaseUrl?: BaseUrl;
   entities?: Entity[];
   entityTypes?: EntityType[];
   // Whether or not cached content was available immediately for the context data

--- a/apps/hash-frontend/src/shared/entity-type-entities-context.ts
+++ b/apps/hash-frontend/src/shared/entity-type-entities-context.ts
@@ -35,7 +35,7 @@ export type EntityTypeEntitiesContextValue = {
 export const EntityTypeEntitiesContext =
   createContext<null | EntityTypeEntitiesContextValue>(null);
 
-export const useEntityTypeEntities = () => {
+export const useEntityTypeEntitiesContext = () => {
   const entityTypeEntitiesContext = useContext(EntityTypeEntitiesContext);
 
   if (!entityTypeEntitiesContext) {

--- a/apps/hash-frontend/src/shared/entity-type-entities-context/use-entity-type-entities-context-value.tsx
+++ b/apps/hash-frontend/src/shared/entity-type-entities-context/use-entity-type-entities-context-value.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from "@apollo/client";
 import {
-  BaseUrl,
   EntityType,
   PropertyType,
   VersionedUrl,
@@ -9,7 +8,7 @@ import {
   mapGqlSubgraphFieldsFragmentToSubgraph,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
-import { EntityRootType } from "@local/hash-subgraph";
+import { BaseUrl, EntityRootType } from "@local/hash-subgraph";
 import {
   getEntityTypeAndParentsById,
   getPropertyTypeById,
@@ -64,6 +63,8 @@ export const useEntityTypeEntitiesContextValue = (params: {
       constrainsValuesOn: { outgoing: 255 },
       inheritsFrom: { outgoing: 255 },
       isOfType: { outgoing: 1 },
+      hasLeftEntity: { outgoing: 1, incoming: 1 },
+      hasRightEntity: { outgoing: 1, incoming: 1 },
       includePermissions: false,
     }),
     [entityTypeBaseUrl, entityTypeId],
@@ -129,6 +130,8 @@ export const useEntityTypeEntitiesContextValue = (params: {
   }, [subgraph]);
 
   return {
+    entityTypeBaseUrl,
+    entityTypeId,
     entities,
     entityTypes,
     hadCachedContent,

--- a/apps/hash-frontend/src/shared/entity-type-entities-context/use-entity-type-entities-context-value.tsx
+++ b/apps/hash-frontend/src/shared/entity-type-entities-context/use-entity-type-entities-context-value.tsx
@@ -1,28 +1,17 @@
-import { useQuery } from "@apollo/client";
 import {
   EntityType,
   PropertyType,
   VersionedUrl,
 } from "@blockprotocol/type-system";
-import {
-  mapGqlSubgraphFieldsFragmentToSubgraph,
-  zeroedGraphResolveDepths,
-} from "@local/hash-isomorphic-utils/graph-queries";
-import { BaseUrl, EntityRootType } from "@local/hash-subgraph";
+import { BaseUrl } from "@local/hash-subgraph";
 import {
   getEntityTypeAndParentsById,
   getPropertyTypeById,
-  getRoots,
 } from "@local/hash-subgraph/stdlib";
 import { useMemo } from "react";
 
-import {
-  QueryEntitiesQuery,
-  QueryEntitiesQueryVariables,
-} from "../../graphql/api-types.gen";
-import { queryEntitiesQuery } from "../../graphql/queries/knowledge/entity.queries";
-import { apolloClient } from "../../lib/apollo-client";
 import { EntityTypeEntitiesContextValue } from "../entity-type-entities-context";
+import { useEntityTypeEntities } from "../use-entity-type-entities";
 
 export const useEntityTypeEntitiesContextValue = (params: {
   entityTypeBaseUrl?: BaseUrl;
@@ -30,74 +19,27 @@ export const useEntityTypeEntitiesContextValue = (params: {
 }): EntityTypeEntitiesContextValue => {
   const { entityTypeBaseUrl, entityTypeId } = params;
 
-  const variables = useMemo<QueryEntitiesQueryVariables>(
-    () => ({
-      operation: {
-        multiFilter: {
-          filters: [
-            ...(entityTypeBaseUrl
-              ? [
-                  {
-                    field: ["metadata", "entityTypeBaseUrl"],
-                    operator: "EQUALS" as const,
-                    value: entityTypeBaseUrl,
-                  },
-                ]
-              : entityTypeId
-                ? [
-                    {
-                      field: ["metadata", "entityTypeId"],
-                      operator: "EQUALS" as const,
-                      value: entityTypeId,
-                    },
-                  ]
-                : []),
-          ],
-          operator: "AND",
-        },
+  const { subgraph, entities, hadCachedContent, loading, refetch } =
+    useEntityTypeEntities({
+      entityTypeBaseUrl,
+      entityTypeId,
+      graphResolveDepths: {
+        constrainsLinksOn: { outgoing: 255 },
+        constrainsLinkDestinationsOn: { outgoing: 255 },
+        constrainsPropertiesOn: { outgoing: 255 },
+        constrainsValuesOn: { outgoing: 255 },
+        inheritsFrom: { outgoing: 255 },
+        isOfType: { outgoing: 1 },
       },
-      ...zeroedGraphResolveDepths,
-      constrainsLinksOn: { outgoing: 255 },
-      constrainsLinkDestinationsOn: { outgoing: 255 },
-      constrainsPropertiesOn: { outgoing: 255 },
-      constrainsValuesOn: { outgoing: 255 },
-      inheritsFrom: { outgoing: 255 },
-      isOfType: { outgoing: 1 },
-      hasLeftEntity: { outgoing: 1, incoming: 1 },
-      hasRightEntity: { outgoing: 1, incoming: 1 },
-      includePermissions: false,
-    }),
-    [entityTypeBaseUrl, entityTypeId],
-  );
+    });
 
-  const { data, loading, refetch } = useQuery<
-    QueryEntitiesQuery,
-    QueryEntitiesQueryVariables
-  >(queryEntitiesQuery, {
-    fetchPolicy: "cache-and-network",
-    variables,
-  });
-
-  const hadCachedContent = useMemo(
-    () => !!apolloClient.readQuery({ query: queryEntitiesQuery, variables }),
-    [variables],
-  );
-
-  const subgraph = data?.queryEntities.subgraph
-    ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
-        data.queryEntities.subgraph,
-      )
-    : undefined;
-
-  const [entities, entityTypes, propertyTypes] = useMemo(() => {
-    if (!subgraph) {
+  const [entityTypes, propertyTypes] = useMemo(() => {
+    if (!subgraph || !entities) {
       return [];
     }
 
-    const relevantEntities = getRoots(subgraph);
-
     const relevantTypesMap = new Map<string, EntityType>();
-    for (const { metadata } of relevantEntities) {
+    for (const { metadata } of entities) {
       if (!relevantTypesMap.has(metadata.entityTypeId)) {
         const types = getEntityTypeAndParentsById(
           subgraph,
@@ -126,8 +68,8 @@ export const useEntityTypeEntitiesContextValue = (params: {
     }
     const relevantProperties = Array.from(relevantPropertiesMap.values());
 
-    return [relevantEntities, relevantTypes, relevantProperties];
-  }, [subgraph]);
+    return [relevantTypes, relevantProperties];
+  }, [subgraph, entities]);
 
   return {
     entityTypeBaseUrl,

--- a/apps/hash-frontend/src/shared/icons/list-regular-icon.tsx
+++ b/apps/hash-frontend/src/shared/icons/list-regular-icon.tsx
@@ -1,0 +1,10 @@
+import { SvgIcon, SvgIconProps } from "@mui/material";
+import { FunctionComponent } from "react";
+
+export const ListRegularIcon: FunctionComponent<SvgIconProps> = (props) => {
+  return (
+    <SvgIcon {...props} viewBox="0 0 512 512" fill="none">
+      <path d="M40 48C26.7 48 16 58.7 16 72v48c0 13.3 10.7 24 24 24H88c13.3 0 24-10.7 24-24V72c0-13.3-10.7-24-24-24H40zM184 72c-13.3 0-24 10.7-24 24s10.7 24 24 24H488c13.3 0 24-10.7 24-24s-10.7-24-24-24H184zm0 160c-13.3 0-24 10.7-24 24s10.7 24 24 24H488c13.3 0 24-10.7 24-24s-10.7-24-24-24H184zm0 160c-13.3 0-24 10.7-24 24s10.7 24 24 24H488c13.3 0 24-10.7 24-24s-10.7-24-24-24H184zM16 232v48c0 13.3 10.7 24 24 24H88c13.3 0 24-10.7 24-24V232c0-13.3-10.7-24-24-24H40c-13.3 0-24 10.7-24 24zM40 368c-13.3 0-24 10.7-24 24v48c0 13.3 10.7 24 24 24H88c13.3 0 24-10.7 24-24V392c0-13.3-10.7-24-24-24H40z" />
+    </SvgIcon>
+  );
+};

--- a/apps/hash-frontend/src/shared/table-header.tsx
+++ b/apps/hash-frontend/src/shared/table-header.tsx
@@ -32,6 +32,7 @@ import {
 import {
   Dispatch,
   FunctionComponent,
+  ReactNode,
   SetStateAction,
   useMemo,
   useState,
@@ -117,6 +118,7 @@ type TableHeaderProps = {
     | DataTypeWithMetadata
   )[];
   filterState: FilterState;
+  endAdornment?: ReactNode;
   setFilterState: Dispatch<SetStateAction<FilterState>>;
   toggleSearch?: () => void;
   onBulkActionCompleted?: () => void;
@@ -134,6 +136,7 @@ export const TableHeader: FunctionComponent<TableHeaderProps> = ({
   items,
   selectedItems,
   filterState,
+  endAdornment,
   setFilterState,
   toggleSearch,
   onBulkActionCompleted,
@@ -266,84 +269,88 @@ export const TableHeader: FunctionComponent<TableHeaderProps> = ({
           </IconButton>
         ) : null}
       </Box>
-      <Box
-        sx={{
-          display: "flex",
-          justifyContent: "flex-end",
-          background: ({ palette }) =>
-            displayFilters || Object.values(filterState).some((value) => value)
-              ? palette.common.white
-              : "transparent",
-          transition: ({ transitions }) => transitions.create("background"),
-          borderRadius: 15,
-        }}
-      >
-        <Button
-          variant="tertiary_quiet"
-          onClick={() => setDisplayFilters(!displayFilters)}
-          startIcon={<FilterListIcon />}
-          sx={{
-            py: 0.25,
-            px: 2,
-            borderRadius: 15,
-            background: "transparent",
-            minHeight: "unset",
-            minWidth: "unset",
-            fontWeight: 500,
-            fontSize: 13,
-            color: ({ palette }) => palette.gray[70],
-            [`.${buttonClasses.startIcon}`]: {
-              color: ({ palette }) => palette.gray[70],
-            },
-            ":hover": {
-              color: ({ palette }) => palette.gray[90],
-              background: ({ palette }) => palette.gray[30],
-              [`.${buttonClasses.startIcon}`]: {
-                color: ({ palette }) => palette.gray[90],
-              },
-            },
-          }}
-        >
-          Filter
-        </Button>
+      <Box display="flex" columnGap={1}>
         <Box
           sx={{
-            transition: ({ transitions }) => transitions.create("max-width"),
-            maxWidth: displayFilters ? 500 : 0,
-            overflow: "hidden",
+            display: "flex",
+            justifyContent: "flex-end",
+            background: ({ palette }) =>
+              displayFilters ||
+              Object.values(filterState).some((value) => value)
+                ? palette.common.white
+                : "transparent",
+            transition: ({ transitions }) => transitions.create("background"),
+            borderRadius: 15,
           }}
         >
-          <Box
-            display="flex"
-            flexWrap="nowrap"
-            alignItems="center"
-            height="100%"
-            paddingRight={2}
+          <Button
+            variant="tertiary_quiet"
+            onClick={() => setDisplayFilters(!displayFilters)}
+            startIcon={<FilterListIcon />}
+            sx={{
+              py: 0.25,
+              px: 2,
+              borderRadius: 15,
+              background: "transparent",
+              minHeight: "unset",
+              minWidth: "unset",
+              fontWeight: 500,
+              fontSize: 13,
+              color: ({ palette }) => palette.gray[70],
+              [`.${buttonClasses.startIcon}`]: {
+                color: ({ palette }) => palette.gray[70],
+              },
+              ":hover": {
+                color: ({ palette }) => palette.gray[90],
+                background: ({ palette }) => palette.gray[30],
+                [`.${buttonClasses.startIcon}`]: {
+                  color: ({ palette }) => palette.gray[90],
+                },
+              },
+            }}
           >
-            {filterState.includeArchived !== undefined ? (
+            Filter
+          </Button>
+          <Box
+            sx={{
+              transition: ({ transitions }) => transitions.create("max-width"),
+              maxWidth: displayFilters ? 500 : 0,
+              overflow: "hidden",
+            }}
+          >
+            <Box
+              display="flex"
+              flexWrap="nowrap"
+              alignItems="center"
+              height="100%"
+              paddingRight={2}
+            >
+              {filterState.includeArchived !== undefined ? (
+                <CheckboxFilter
+                  label="Include archived"
+                  checked={filterState.includeArchived}
+                  onChange={(checked) =>
+                    setFilterState((prev) => ({
+                      ...prev,
+                      includeArchived: checked,
+                    }))
+                  }
+                />
+              ) : null}
               <CheckboxFilter
-                label="Include archived"
-                checked={filterState.includeArchived}
+                label="Include external"
+                checked={filterState.includeGlobal}
                 onChange={(checked) =>
                   setFilterState((prev) => ({
                     ...prev,
-                    includeArchived: checked,
+                    includeGlobal: checked,
                   }))
                 }
               />
-            ) : null}
-            <CheckboxFilter
-              label="Include external"
-              checked={filterState.includeGlobal}
-              onChange={(checked) =>
-                setFilterState((prev) => ({
-                  ...prev,
-                  includeGlobal: checked,
-                }))
-              }
-            />
+            </Box>
           </Box>
         </Box>
+        {endAdornment}
       </Box>
     </Box>
   );

--- a/apps/hash-frontend/src/shared/use-entity-type-entities.tsx
+++ b/apps/hash-frontend/src/shared/use-entity-type-entities.tsx
@@ -1,0 +1,96 @@
+import { useQuery } from "@apollo/client";
+import { VersionedUrl } from "@blockprotocol/type-system";
+import {
+  mapGqlSubgraphFieldsFragmentToSubgraph,
+  zeroedGraphResolveDepths,
+} from "@local/hash-isomorphic-utils/graph-queries";
+import {
+  BaseUrl,
+  EntityRootType,
+  GraphResolveDepths,
+} from "@local/hash-subgraph";
+import { getRoots } from "@local/hash-subgraph/stdlib";
+import { useMemo } from "react";
+
+import {
+  QueryEntitiesQuery,
+  QueryEntitiesQueryVariables,
+} from "../graphql/api-types.gen";
+import { queryEntitiesQuery } from "../graphql/queries/knowledge/entity.queries";
+import { apolloClient } from "../lib/apollo-client";
+import { EntityTypeEntitiesContextValue } from "./entity-type-entities-context";
+
+export const useEntityTypeEntities = (params: {
+  entityTypeBaseUrl?: BaseUrl;
+  entityTypeId?: VersionedUrl;
+  graphResolveDepths?: Partial<GraphResolveDepths>;
+}): EntityTypeEntitiesContextValue => {
+  const { entityTypeBaseUrl, entityTypeId, graphResolveDepths } = params;
+
+  const variables = useMemo<QueryEntitiesQueryVariables>(
+    () => ({
+      operation: {
+        multiFilter: {
+          filters: [
+            ...(entityTypeBaseUrl
+              ? [
+                  {
+                    field: ["metadata", "entityTypeBaseUrl"],
+                    operator: "EQUALS" as const,
+                    value: entityTypeBaseUrl,
+                  },
+                ]
+              : entityTypeId
+                ? [
+                    {
+                      field: ["metadata", "entityTypeId"],
+                      operator: "EQUALS" as const,
+                      value: entityTypeId,
+                    },
+                  ]
+                : []),
+          ],
+          operator: "AND",
+        },
+      },
+      ...zeroedGraphResolveDepths,
+      ...graphResolveDepths,
+      includePermissions: false,
+    }),
+    [entityTypeBaseUrl, graphResolveDepths, entityTypeId],
+  );
+
+  const { data, loading, refetch } = useQuery<
+    QueryEntitiesQuery,
+    QueryEntitiesQueryVariables
+  >(queryEntitiesQuery, {
+    fetchPolicy: "cache-and-network",
+    variables,
+  });
+
+  const hadCachedContent = useMemo(
+    () => !!apolloClient.readQuery({ query: queryEntitiesQuery, variables }),
+    [variables],
+  );
+
+  const subgraph = data?.queryEntities.subgraph
+    ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
+        data.queryEntities.subgraph,
+      )
+    : undefined;
+
+  const entities = useMemo(
+    () => (subgraph ? getRoots(subgraph) : undefined),
+    [subgraph],
+  );
+
+  return {
+    entityTypeBaseUrl,
+    entityTypeId,
+    entities,
+    hadCachedContent,
+    loading,
+    refetch,
+    subgraph,
+  };
+};

--- a/blocks/chart/package.json
+++ b/blocks/chart/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@hashintel/design-system": "0.0.7",
     "@mui/material": "5.14.11",
     "echarts": "^5.3.2",
     "lodash.debounce": "4.0.8",

--- a/blocks/chart/package.json
+++ b/blocks/chart/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@blockprotocol/graph": "0.3.1-canary-20231120181031",
-    "@hashintel/design-system": "0.0.7",
+    "@hashintel/block-design-system": "0.0.1",
     "@mui/material": "5.14.11",
     "echarts": "^5.3.2",
     "lodash.debounce": "4.0.8",

--- a/blocks/chart/src/bar-chart.tsx
+++ b/blocks/chart/src/bar-chart.tsx
@@ -7,9 +7,9 @@ import {
   VersionedUrl,
 } from "@blockprotocol/graph/temporal";
 import { getRoots } from "@blockprotocol/graph/temporal/stdlib";
+import { EChart, ECOption } from "@hashintel/design-system";
 import { FunctionComponent, useMemo } from "react";
 
-import { EChart, ECOption } from "./e-chart";
 import { ChartDefinition } from "./types/chart-definition";
 
 export const BarChart: FunctionComponent<{

--- a/blocks/chart/src/types/generated/block-entity.ts
+++ b/blocks/chart/src/types/generated/block-entity.ts
@@ -2,117 +2,80 @@
  * This file was automatically generated – do not edit it.
  */
 
-import { Entity, LinkData } from "@blockprotocol/graph"
+import { Entity, LinkData } from "@blockprotocol/graph";
 
+export type BlockEntity = Chart;
 
+export type BlockEntityOutgoingLinkAndTarget = ChartOutgoingLinkAndTarget;
 
-
-
-export type BlockEntity = Chart
-
-
-
-export type BlockEntityOutgoingLinkAndTarget = ChartOutgoingLinkAndTarget
-
-
-
-export type Chart = Entity<ChartProperties>
-
+export type Chart = Entity<ChartProperties>;
 
 /**
  * The chart definition of something.
  */
-export type ChartDefintionPropertyValue = Object
+export type ChartDefintionPropertyValue = Object;
 
+export type ChartHasQueryLink = { linkEntity: HasQuery; rightEntity: Query };
 
+export type ChartOutgoingLinkAndTarget = ChartHasQueryLink;
 
-export type ChartHasQueryLink = { linkEntity: HasQuery; rightEntity: Query }
-
-export type ChartOutgoingLinkAndTarget = ChartHasQueryLink
-
-export type ChartOutgoingLinksByLinkEntityTypeId = { "https://blockprotocol.org/@hash/types/entity-type/has-query/v/1": ChartHasQueryLink }
-
-
-
+export type ChartOutgoingLinksByLinkEntityTypeId = {
+  "https://blockprotocol.org/@hash/types/entity-type/has-query/v/1": ChartHasQueryLink;
+};
 
 export type ChartProperties = {
-"https://blockprotocol.org/@blockprotocol/types/property-type/title/"?: TitlePropertyValue
-"https://blockprotocol.org/@hash/types/property-type/chart-defintion/"?: ChartDefintionPropertyValue
-}
+  "https://blockprotocol.org/@blockprotocol/types/property-type/title/"?: TitlePropertyValue;
+  "https://blockprotocol.org/@hash/types/property-type/chart-defintion/"?: ChartDefintionPropertyValue;
+};
 
+export type HasQuery = Entity<HasQueryProperties> & { linkData: LinkData };
 
+export type HasQueryOutgoingLinkAndTarget = never;
 
-export type HasQuery = Entity<HasQueryProperties> & { linkData: LinkData }
-
-
-export type HasQueryOutgoingLinkAndTarget = never
-
-export type HasQueryOutgoingLinksByLinkEntityTypeId = {  }
+export type HasQueryOutgoingLinksByLinkEntityTypeId = {};
 
 /**
  * The query that something has.
  */
-export type HasQueryProperties = (HasQueryProperties1 & HasQueryProperties2)
-export type HasQueryProperties1 = LinkProperties
+export type HasQueryProperties = HasQueryProperties1 & HasQueryProperties2;
+export type HasQueryProperties1 = LinkProperties;
 
+export type HasQueryProperties2 = {};
 
-export type HasQueryProperties2 = {
+export type Link = Entity<LinkProperties>;
 
-}
+export type LinkOutgoingLinkAndTarget = never;
 
+export type LinkOutgoingLinksByLinkEntityTypeId = {};
 
-
-export type Link = Entity<LinkProperties>
-
-
-export type LinkOutgoingLinkAndTarget = never
-
-export type LinkOutgoingLinksByLinkEntityTypeId = {  }
-
-export type LinkProperties = {
-
-}
-
+export type LinkProperties = {};
 
 /**
  * An opaque, untyped JSON object
  */
-export type Object = {
+export type Object = {};
 
-}
+export type Query = Entity<QueryProperties>;
 
+export type QueryOutgoingLinkAndTarget = never;
 
-
-export type Query = Entity<QueryProperties>
-
-
-export type QueryOutgoingLinkAndTarget = never
-
-export type QueryOutgoingLinksByLinkEntityTypeId = {  }
-
-
+export type QueryOutgoingLinksByLinkEntityTypeId = {};
 
 export type QueryProperties = {
-"https://blockprotocol.org/@hash/types/property-type/query/": QueryPropertyValue
-}
-
+  "https://blockprotocol.org/@hash/types/property-type/query/": QueryPropertyValue;
+};
 
 /**
  * The query for something.
  */
-export type QueryPropertyValue = Object
-
-
+export type QueryPropertyValue = Object;
 
 /**
  * An ordered sequence of characters
  */
-export type Text = string
-
+export type Text = string;
 
 /**
  * The name given to something to identify it, generally associated with objects or inanimate things such as books, websites, songs, etc.
  */
-export type TitlePropertyValue = Text
-
-
+export type TitlePropertyValue = Text;

--- a/blocks/chart/src/types/generated/block-entity.ts
+++ b/blocks/chart/src/types/generated/block-entity.ts
@@ -2,80 +2,117 @@
  * This file was automatically generated – do not edit it.
  */
 
-import { Entity, LinkData } from "@blockprotocol/graph";
+import { Entity, LinkData } from "@blockprotocol/graph"
 
-export type BlockEntity = Chart;
 
-export type BlockEntityOutgoingLinkAndTarget = ChartOutgoingLinkAndTarget;
 
-export type Chart = Entity<ChartProperties>;
+
+
+export type BlockEntity = Chart
+
+
+
+export type BlockEntityOutgoingLinkAndTarget = ChartOutgoingLinkAndTarget
+
+
+
+export type Chart = Entity<ChartProperties>
+
 
 /**
  * The chart definition of something.
  */
-export type ChartDefintionPropertyValue = Object;
+export type ChartDefintionPropertyValue = Object
 
-export type ChartHasQueryLink = { linkEntity: HasQuery; rightEntity: Query };
 
-export type ChartOutgoingLinkAndTarget = ChartHasQueryLink;
 
-export type ChartOutgoingLinksByLinkEntityTypeId = {
-  "https://blockprotocol.org/@hash/types/entity-type/has-query/v/1": ChartHasQueryLink;
-};
+export type ChartHasQueryLink = { linkEntity: HasQuery; rightEntity: Query }
+
+export type ChartOutgoingLinkAndTarget = ChartHasQueryLink
+
+export type ChartOutgoingLinksByLinkEntityTypeId = { "https://blockprotocol.org/@hash/types/entity-type/has-query/v/1": ChartHasQueryLink }
+
+
+
 
 export type ChartProperties = {
-  "https://blockprotocol.org/@blockprotocol/types/property-type/title/"?: TitlePropertyValue;
-  "https://blockprotocol.org/@hash/types/property-type/chart-defintion/"?: ChartDefintionPropertyValue;
-};
+"https://blockprotocol.org/@blockprotocol/types/property-type/title/"?: TitlePropertyValue
+"https://blockprotocol.org/@hash/types/property-type/chart-defintion/"?: ChartDefintionPropertyValue
+}
 
-export type HasQuery = Entity<HasQueryProperties> & { linkData: LinkData };
 
-export type HasQueryOutgoingLinkAndTarget = never;
 
-export type HasQueryOutgoingLinksByLinkEntityTypeId = {};
+export type HasQuery = Entity<HasQueryProperties> & { linkData: LinkData }
+
+
+export type HasQueryOutgoingLinkAndTarget = never
+
+export type HasQueryOutgoingLinksByLinkEntityTypeId = {  }
 
 /**
  * The query that something has.
  */
-export type HasQueryProperties = HasQueryProperties1 & HasQueryProperties2;
-export type HasQueryProperties1 = LinkProperties;
+export type HasQueryProperties = (HasQueryProperties1 & HasQueryProperties2)
+export type HasQueryProperties1 = LinkProperties
 
-export type HasQueryProperties2 = {};
 
-export type Link = Entity<LinkProperties>;
+export type HasQueryProperties2 = {
 
-export type LinkOutgoingLinkAndTarget = never;
+}
 
-export type LinkOutgoingLinksByLinkEntityTypeId = {};
 
-export type LinkProperties = {};
+
+export type Link = Entity<LinkProperties>
+
+
+export type LinkOutgoingLinkAndTarget = never
+
+export type LinkOutgoingLinksByLinkEntityTypeId = {  }
+
+export type LinkProperties = {
+
+}
+
 
 /**
  * An opaque, untyped JSON object
  */
-export type Object = {};
+export type Object = {
 
-export type Query = Entity<QueryProperties>;
+}
 
-export type QueryOutgoingLinkAndTarget = never;
 
-export type QueryOutgoingLinksByLinkEntityTypeId = {};
+
+export type Query = Entity<QueryProperties>
+
+
+export type QueryOutgoingLinkAndTarget = never
+
+export type QueryOutgoingLinksByLinkEntityTypeId = {  }
+
+
 
 export type QueryProperties = {
-  "https://blockprotocol.org/@hash/types/property-type/query/": QueryPropertyValue;
-};
+"https://blockprotocol.org/@hash/types/property-type/query/": QueryPropertyValue
+}
+
 
 /**
  * The query for something.
  */
-export type QueryPropertyValue = Object;
+export type QueryPropertyValue = Object
+
+
 
 /**
  * An ordered sequence of characters
  */
-export type Text = string;
+export type Text = string
+
 
 /**
  * The name given to something to identify it, generally associated with objects or inanimate things such as books, websites, songs, etc.
  */
-export type TitlePropertyValue = Text;
+export type TitlePropertyValue = Text
+
+

--- a/blocks/chart/theme-override.d.ts
+++ b/blocks/chart/theme-override.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../../libs/@hashintel/design-system/theme-override.d.ts" />

--- a/blocks/chart/tsconfig.json
+++ b/blocks/chart/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@local/tsconfig/block.json",
-  "include": ["src"],
+  "include": ["src", "theme-override.d.ts"],
   "exclude": ["node_modules"]
 }

--- a/libs/@hashintel/block-design-system/package.json
+++ b/libs/@hashintel/block-design-system/package.json
@@ -25,7 +25,9 @@
     "postpublish": "PACKAGE_DIR=$(pwd) yarn workspace @local/repo-chores exe scripts/postpublish.ts"
   },
   "dependencies": {
+    "@blockprotocol/type-system": "0.1.1",
     "@hashintel/design-system": "0.0.7",
+    "@local/hash-isomorphic-utils": "0.0.0-private",
     "lowlight": "2.8.1",
     "react-syntax-highlighter": "15.5.0",
     "react-type-animation": "3.0.1"

--- a/libs/@hashintel/block-design-system/src/entities-graph-chart.tsx
+++ b/libs/@hashintel/block-design-system/src/entities-graph-chart.tsx
@@ -1,20 +1,25 @@
-/* eslint-disable no-restricted-imports */
-import { BaseUrl } from "@blockprotocol/type-system";
-import { Chart, EChart, ECOption } from "@hashintel/design-system";
-import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import {
   Entity,
   EntityId,
   EntityRootType,
   Subgraph,
-} from "@local/hash-subgraph";
-import { getEntities, getEntityTypeById } from "@local/hash-subgraph/stdlib";
-import {
-  extractBaseUrl,
-  LinkEntity,
-} from "@local/hash-subgraph/type-system-patch";
+} from "@blockprotocol/graph";
+import { getEntities, getEntityTypeById } from "@blockprotocol/graph/stdlib";
+import { BaseUrl } from "@blockprotocol/type-system";
+import { extractBaseUrl } from "@blockprotocol/type-system/slim";
+import { Chart, EChart, ECOption } from "@hashintel/design-system";
+// eslint-disable-next-line no-restricted-imports
+import { generateEntityLabel as hashGenerateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import { BoxProps } from "@mui/material";
 import { FunctionComponent, useEffect, useMemo, useRef, useState } from "react";
+
+const generateEntityLabel = (
+  subgraph: Subgraph<EntityRootType>,
+  entity: Entity,
+) => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  return hashGenerateEntityLabel(subgraph as any, entity as any);
+};
 
 export const EntitiesGraphChart: FunctionComponent<{
   filterEntity?: (entity: Entity) => boolean;
@@ -32,7 +37,7 @@ export const EntitiesGraphChart: FunctionComponent<{
   const [chart, setChart] = useState<Chart>();
 
   const entities = useMemo(
-    () => (subgraph ? getEntities(subgraph, true) : undefined),
+    () => (subgraph ? getEntities(subgraph) : undefined),
     [subgraph],
   );
 
@@ -49,7 +54,11 @@ export const EntitiesGraphChart: FunctionComponent<{
     () =>
       entities && nonLinkEntities
         ? entities.filter(
-            (entity): entity is LinkEntity =>
+            (
+              entity,
+            ): entity is Entity & {
+              linkData: NonNullable<Entity["linkData"]>;
+            } =>
               !!entity.linkData &&
               nonLinkEntities.some(
                 (nonLinkEntity) =>
@@ -133,12 +142,12 @@ export const EntitiesGraphChart: FunctionComponent<{
               return [
                 `<strong>${generateEntityLabel(
                   subgraph!,
-                  leftEntity,
+                  leftEntity!,
                 )}</strong>`,
                 linkEntityTypeTitle?.toLowerCase(),
                 `<strong>${generateEntityLabel(
                   subgraph!,
-                  rightEntity,
+                  rightEntity!,
                 )}</strong>`,
               ].join(" ");
             }

--- a/libs/@hashintel/block-design-system/src/main.ts
+++ b/libs/@hashintel/block-design-system/src/main.ts
@@ -4,6 +4,7 @@ export * from "./block-prompt-input";
 export * from "./block-settings-button";
 export * from "./dropdown-selector";
 export * from "./editable-field";
+export * from "./entities-graph-chart";
 export * from "./get-help-link";
 export * from "./icons/icons";
 export { theme } from "@hashintel/design-system/theme";

--- a/libs/@hashintel/design-system/package.json
+++ b/libs/@hashintel/design-system/package.json
@@ -41,6 +41,7 @@
     "@fortawesome/free-regular-svg-icons": "6.0.0",
     "@fortawesome/free-solid-svg-icons": "6.0.0",
     "clsx": "1.2.1",
+    "echarts": "^5.3.2",
     "react-loading-skeleton": "3.2.0"
   },
   "devDependencies": {

--- a/libs/@hashintel/design-system/src/components.ts
+++ b/libs/@hashintel/design-system/src/components.ts
@@ -7,7 +7,6 @@ export * from "./callout";
 export * from "./chip";
 export * from "./chip-group";
 export * from "./e-chart";
-export * from "./entities-graph-chart";
 export * from "./fa-icons/icons";
 export * from "./fontawesome-icon";
 export * from "./form-inline";

--- a/libs/@hashintel/design-system/src/components.ts
+++ b/libs/@hashintel/design-system/src/components.ts
@@ -6,6 +6,7 @@ export * from "./button";
 export * from "./callout";
 export * from "./chip";
 export * from "./chip-group";
+export * from "./e-chart";
 export * from "./fa-icons/icons";
 export * from "./fontawesome-icon";
 export * from "./form-inline";

--- a/libs/@hashintel/design-system/src/components.ts
+++ b/libs/@hashintel/design-system/src/components.ts
@@ -7,6 +7,7 @@ export * from "./callout";
 export * from "./chip";
 export * from "./chip-group";
 export * from "./e-chart";
+export * from "./entities-graph-chart";
 export * from "./fa-icons/icons";
 export * from "./fontawesome-icon";
 export * from "./form-inline";

--- a/libs/@hashintel/design-system/src/e-chart.tsx
+++ b/libs/@hashintel/design-system/src/e-chart.tsx
@@ -1,11 +1,14 @@
 import {
   BarChart,
   BarSeriesOption,
+  GraphChart,
+  GraphSeriesOption,
   LineChart,
   LineSeriesOption,
   ScatterChart,
   ScatterSeriesOption,
 } from "echarts/charts";
+// eslint-disable-next-line no-restricted-imports
 import { GridComponent } from "echarts/components";
 import * as echarts from "echarts/core";
 import { SVGRenderer } from "echarts/renderers";
@@ -14,13 +17,21 @@ import { FunctionComponent, useEffect, useRef, useState } from "react";
 export type SeriesOption =
   | LineSeriesOption
   | ScatterSeriesOption
-  | BarSeriesOption;
+  | BarSeriesOption
+  | GraphSeriesOption;
 
 // Combine an Option type with only required components and charts via ComposeOption
 export type ECOption = echarts.ComposeOption<SeriesOption>;
 
 // Register the required components
-echarts.use([LineChart, BarChart, ScatterChart, GridComponent, SVGRenderer]);
+echarts.use([
+  LineChart,
+  BarChart,
+  ScatterChart,
+  GraphChart,
+  GridComponent,
+  SVGRenderer,
+]);
 
 type GraphProps = {
   options: ECOption;

--- a/libs/@hashintel/design-system/src/e-chart.tsx
+++ b/libs/@hashintel/design-system/src/e-chart.tsx
@@ -19,6 +19,8 @@ import * as echarts from "echarts/core";
 import { SVGRenderer } from "echarts/renderers";
 import { FunctionComponent, useEffect, useRef, useState } from "react";
 
+export type Chart = echarts.ECharts;
+
 export type SeriesOption =
   | LineSeriesOption
   | ScatterSeriesOption
@@ -43,19 +45,30 @@ echarts.use([
 
 type GraphProps = {
   options: ECOption;
+  onChartInitialized?: (chart: Chart) => void;
   sx?: BoxProps["sx"];
 };
 
-export const EChart: FunctionComponent<GraphProps> = ({ options, sx }) => {
+export const EChart: FunctionComponent<GraphProps> = ({
+  options,
+  sx,
+  onChartInitialized,
+}) => {
   const wrapperRef = useRef<HTMLDivElement>(null);
 
-  const [chart, setChart] = useState<echarts.ECharts>();
+  const [chart, setChart] = useState<Chart>();
 
   useEffect(() => {
     if (wrapperRef.current) {
       setChart(echarts.init(wrapperRef.current));
     }
   }, [wrapperRef]);
+
+  useEffect(() => {
+    if (chart) {
+      onChartInitialized?.(chart);
+    }
+  }, [chart, onChartInitialized]);
 
   useEffect(() => {
     if (chart) {

--- a/libs/@hashintel/design-system/src/e-chart.tsx
+++ b/libs/@hashintel/design-system/src/e-chart.tsx
@@ -72,7 +72,7 @@ export const EChart: FunctionComponent<GraphProps> = ({
 
   useEffect(() => {
     if (chart) {
-      chart.setOption(options, { notMerge: true });
+      chart.setOption(options);
     }
   }, [chart, options]);
 

--- a/libs/@hashintel/design-system/src/e-chart.tsx
+++ b/libs/@hashintel/design-system/src/e-chart.tsx
@@ -1,3 +1,4 @@
+import { Box, BoxProps } from "@mui/material";
 import {
   BarChart,
   BarSeriesOption,
@@ -9,7 +10,11 @@ import {
   ScatterSeriesOption,
 } from "echarts/charts";
 // eslint-disable-next-line no-restricted-imports
-import { GridComponent } from "echarts/components";
+import {
+  GridComponent,
+  TooltipComponent,
+  TooltipComponentOption,
+} from "echarts/components";
 import * as echarts from "echarts/core";
 import { SVGRenderer } from "echarts/renderers";
 import { FunctionComponent, useEffect, useRef, useState } from "react";
@@ -21,7 +26,9 @@ export type SeriesOption =
   | GraphSeriesOption;
 
 // Combine an Option type with only required components and charts via ComposeOption
-export type ECOption = echarts.ComposeOption<SeriesOption>;
+export type ECOption = echarts.ComposeOption<
+  SeriesOption | TooltipComponentOption
+>;
 
 // Register the required components
 echarts.use([
@@ -31,13 +38,15 @@ echarts.use([
   GraphChart,
   GridComponent,
   SVGRenderer,
+  TooltipComponent,
 ]);
 
 type GraphProps = {
   options: ECOption;
+  sx?: BoxProps["sx"];
 };
 
-export const EChart: FunctionComponent<GraphProps> = ({ options }) => {
+export const EChart: FunctionComponent<GraphProps> = ({ options, sx }) => {
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   const [chart, setChart] = useState<echarts.ECharts>();
@@ -54,5 +63,10 @@ export const EChart: FunctionComponent<GraphProps> = ({ options }) => {
     }
   }, [chart, options]);
 
-  return <div style={{ width: "100%", height: 500 }} ref={wrapperRef} />;
+  return (
+    <Box
+      sx={[{ width: "100%", height: 500 }, ...(Array.isArray(sx) ? sx : [sx])]}
+      ref={wrapperRef}
+    />
+  );
 };

--- a/libs/@hashintel/design-system/src/e-chart.tsx
+++ b/libs/@hashintel/design-system/src/e-chart.tsx
@@ -76,6 +76,20 @@ export const EChart: FunctionComponent<GraphProps> = ({
     }
   }, [chart, options]);
 
+  useEffect(() => {
+    if (chart && wrapperRef.current) {
+      const resizeObserver = new ResizeObserver(() => {
+        chart.resize();
+      });
+
+      resizeObserver.observe(wrapperRef.current);
+
+      return () => {
+        resizeObserver.disconnect();
+      };
+    }
+  }, [chart]);
+
   return (
     <Box
       sx={[{ width: "100%", height: 500 }, ...(Array.isArray(sx) ? sx : [sx])]}

--- a/libs/@hashintel/design-system/src/entities-graph-chart.tsx
+++ b/libs/@hashintel/design-system/src/entities-graph-chart.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-imports */
 import { BaseUrl } from "@blockprotocol/type-system";
 import { Chart, EChart, ECOption } from "@hashintel/design-system";
 import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
@@ -73,6 +74,8 @@ export const EntitiesGraphChart: FunctionComponent<{
           params.seriesType === "graph"
         ) {
           if (params.dataType === "node" || params.dataType === "edge") {
+            /** @todo: improve typing */
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             const entityId = (params.data as any).id as EntityId;
 
             const entity = entities?.find(
@@ -99,8 +102,11 @@ export const EntitiesGraphChart: FunctionComponent<{
         show: true,
         trigger: "item",
         formatter: (params) => {
+          /** @todo: improve typing */
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           const id = (params as any).data.id as string;
 
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           if ((params as any).dataType === "edge") {
             const linkEntity = linkEntities?.find(
               ({ metadata }) => metadata.recordId.entityId === id,

--- a/libs/@local/hash-isomorphic-utils/src/generate-entity-label.ts
+++ b/libs/@local/hash-isomorphic-utils/src/generate-entity-label.ts
@@ -67,10 +67,12 @@ export const generateEntityLabel = (
       );
 
       entityType = entityTypeAndAncestors[0];
-    } catch (err) {
+    } catch (error) {
       // eslint-disable-next-line no-console -- prefer not to crash here but still have some feedback that there's an issue
       console.error(
-        `Error looking for entity type and ancestors in provided subgraph: ${err}}`,
+        `Error looking for entity type and ancestors in provided subgraph: ${
+          (error as Error).message
+        }}`,
       );
     }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR adds a graph visualization to the `/entities` page.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-1465

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Moves the `EChart` component out of the `Chart` block and into the shared design-system package. Technically we should therefore republish the block, but as in follow up we are adding the `Graph` chart variant we can republish the block then.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

- Sometimes when switching between filters the graph hard resets. I'm not sure which of the properties is causing this, and why it only happens sometimes.

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->


## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Go to the `/entities` page to see the graph with all entities
2. Go to the `/entities?entityTypeIdOrBaseUrl=https://hash.ai/@hash/types/entity-type/user/` to view all `User` entities and their linked entities, or try out a different type

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->


https://github.com/hashintel/hash/assets/42802102/d2f2795b-04d9-4769-92ad-44030c1b04b6


