### PR TITLE
Set manual schedule for updating `taiki-e/install-action`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,6 +35,14 @@
       "dependencyDashboardApproval": false
     },
     {
+      "packageRules": [
+        {
+          "matchPackageNames": ["taiki-e/install-action"],
+          "schedule": ["after 9pm on sunday"]
+        }
+      ]
+    },
+    {
       "matchManagers": ["docker-compose", "dockerfile"],
       "commitMessageTopic": "Docker tag `{{depName}}`",
       "additionalBranchPrefix": "docker/"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

That package is automatically bump every time a new version of a tool is available. We don't need that frequency.