### PR TITLE
H-1331: add ability to count the incoming/outgoing links of an entity in a bar graph

### DIFF
--- a/apps/hash-frontend/package.json
+++ b/apps/hash-frontend/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@apollo/client": "3.6.9",
     "@blockprotocol/core": "0.1.2",
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "@blockprotocol/hook": "0.1.3",
     "@blockprotocol/service": "0.1.3",
     "@blockprotocol/type-system": "0.1.1",

--- a/blocks/address/package.json
+++ b/blocks/address/package.json
@@ -30,7 +30,7 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "@blockprotocol/service": "0.1.3",
     "@fortawesome/free-regular-svg-icons": "6.0.0",
     "@fortawesome/free-solid-svg-icons": "6.0.0",

--- a/blocks/ai-chat/package.json
+++ b/blocks/ai-chat/package.json
@@ -26,7 +26,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "@blockprotocol/hook": "0.1.3",
     "@blockprotocol/service": "0.1.3",
     "@hashintel/block-design-system": "0.0.1",

--- a/blocks/ai-image/package.json
+++ b/blocks/ai-image/package.json
@@ -30,7 +30,7 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "@blockprotocol/service": "0.1.3",
     "@hashintel/block-design-system": "0.0.1",
     "@hashintel/design-system": "0.0.7",

--- a/blocks/ai-text/package.json
+++ b/blocks/ai-text/package.json
@@ -26,7 +26,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "@blockprotocol/service": "0.1.3",
     "@hashintel/block-design-system": "0.0.1",
     "@hashintel/design-system": "0.0.7",

--- a/blocks/callout/package.json
+++ b/blocks/callout/package.json
@@ -26,7 +26,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "@blockprotocol/hook": "0.1.3"
   },
   "devDependencies": {

--- a/blocks/chart/package.json
+++ b/blocks/chart/package.json
@@ -26,7 +26,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "@hashintel/block-design-system": "0.0.1",
     "@hashintel/design-system": "0.0.7",
     "@mui/material": "5.14.11",
@@ -41,7 +41,7 @@
     "@local/eslint-config": "0.0.0-private",
     "@local/tsconfig": "0.0.0-private",
     "@types/lodash.debounce": "4.0.7",
-    "@types/pluralize": "0.0.29",
+    "@types/pluralize": "0.0.33",
     "@types/react-dom": "18.0.10",
     "@types/react-is": "18.2.0",
     "block-scripts": "0.3.1",

--- a/blocks/chart/src/app.tsx
+++ b/blocks/chart/src/app.tsx
@@ -23,9 +23,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { BarChart } from "./bar-chart";
 import { EditChartDefinition } from "./edit-chart-definition";
-import { generateInitialChartDefinition } from "./edit-chart-definition/bar-graph-definition-form/group-by-property-form";
+import { generateInitialChartDefinition as generateInitialCountLinkedEntitiesBarChartDefinition } from "./edit-chart-definition/bar-graph-definition-form/count-linked-entities-form";
+import { generateInitialChartDefinition as generateInitialGroupByPropertyBarChartDefinition } from "./edit-chart-definition/bar-graph-definition-form/group-by-property-form";
 import { EditableChartTitle } from "./edit-chart-title";
-import { ChartDefinition } from "./types/chart-definition";
+import {
+  BarChartDefinitionVariant,
+  ChartDefinition,
+} from "./types/chart-definition";
 import {
   BlockEntity,
   BlockEntityOutgoingLinkAndTarget,
@@ -190,10 +194,23 @@ export const App: BlockComponent<BlockEntity> = ({
   );
 
   useEffect(() => {
-    if (queryResult && !chartDefinition) {
-      const generatedChartDefinition = generateInitialChartDefinition({
-        queryResult,
-      });
+    if (
+      queryResult &&
+      (!chartDefinition ||
+        (Object.entries(chartDefinition).length === 1 &&
+          chartDefinition.kind === "bar-chart"))
+    ) {
+      let generatedChartDefinition: BarChartDefinitionVariant | undefined =
+        generateInitialGroupByPropertyBarChartDefinition({
+          queryResult,
+        });
+
+      if (!generatedChartDefinition) {
+        generatedChartDefinition =
+          generateInitialCountLinkedEntitiesBarChartDefinition({
+            queryResult,
+          });
+      }
 
       if (generatedChartDefinition) {
         void updateChartDefinition({

--- a/blocks/chart/src/app.tsx
+++ b/blocks/chart/src/app.tsx
@@ -23,9 +23,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { BarChart } from "./bar-chart";
 import { EditChartDefinition } from "./edit-chart-definition";
-import { generateInitialChartDefinition } from "./edit-chart-definition/bar-chart-definition-form";
+import { generateInitialChartDefinition } from "./edit-chart-definition/bar-graph-definition-form/group-by-property-form";
 import { EditableChartTitle } from "./edit-chart-title";
-import { ChartDefinition } from "./types/chart-definition";
+import {
+  BarChartCountLinkedEntitiesVariant,
+  ChartDefinition,
+} from "./types/chart-definition";
 import {
   BlockEntity,
   BlockEntityOutgoingLinkAndTarget,
@@ -39,7 +42,7 @@ export const App: BlockComponent<BlockEntity> = ({
   const { graphModule } = useGraphBlockModule(blockRootRef);
 
   const [displayEditChartDefinition, setDisplayEditChartDefinition] =
-    useState<boolean>(false);
+    useState<boolean>(true);
 
   const { rootEntity: blockEntity } = useEntitySubgraph<
     BlockEntity,
@@ -90,12 +93,12 @@ export const App: BlockComponent<BlockEntity> = ({
             isOfType: { outgoing: 1 },
             constrainsPropertiesOn: { outgoing: 255 },
             hasLeftEntity: {
-              outgoing: outgoingLinksDepth ?? 0,
-              incoming: incomingLinksDepth ?? 0,
-            },
-            hasRightEntity: {
               outgoing: incomingLinksDepth ?? 0,
               incoming: outgoingLinksDepth ?? 0,
+            },
+            hasRightEntity: {
+              outgoing: outgoingLinksDepth ?? 0,
+              incoming: incomingLinksDepth ?? 0,
             },
           },
         },
@@ -126,13 +129,25 @@ export const App: BlockComponent<BlockEntity> = ({
         chartDefinition?.kind === "graph-chart"
           ? (chartDefinition as ChartDefinition<"graph-chart">)
               .incomingLinksDepth
-          : undefined;
+          : chartDefinition?.kind === "bar-chart" &&
+              (chartDefinition as ChartDefinition<"bar-chart">).variant ===
+                "count-links" &&
+              (chartDefinition as BarChartCountLinkedEntitiesVariant)
+                .direction === "incoming"
+            ? 1
+            : undefined;
 
       const outgoingLinksDepth =
         chartDefinition?.kind === "graph-chart"
           ? (chartDefinition as ChartDefinition<"graph-chart">)
               .outgoingLinksDepth
-          : undefined;
+          : chartDefinition?.kind === "bar-chart" &&
+              (chartDefinition as ChartDefinition<"bar-chart">).variant ===
+                "count-links" &&
+              (chartDefinition as BarChartCountLinkedEntitiesVariant)
+                .direction === "outgoing"
+            ? 1
+            : undefined;
 
       void fetchQueryEntityResults({
         queryEntity: linkedQueryEntity,

--- a/blocks/chart/src/app.tsx
+++ b/blocks/chart/src/app.tsx
@@ -25,10 +25,7 @@ import { BarChart } from "./bar-chart";
 import { EditChartDefinition } from "./edit-chart-definition";
 import { generateInitialChartDefinition } from "./edit-chart-definition/bar-graph-definition-form/group-by-property-form";
 import { EditableChartTitle } from "./edit-chart-title";
-import {
-  BarChartCountLinkedEntitiesVariant,
-  ChartDefinition,
-} from "./types/chart-definition";
+import { ChartDefinition } from "./types/chart-definition";
 import {
   BlockEntity,
   BlockEntityOutgoingLinkAndTarget,
@@ -131,9 +128,7 @@ export const App: BlockComponent<BlockEntity> = ({
               .incomingLinksDepth
           : chartDefinition?.kind === "bar-chart" &&
               (chartDefinition as ChartDefinition<"bar-chart">).variant ===
-                "count-links" &&
-              (chartDefinition as BarChartCountLinkedEntitiesVariant)
-                .direction === "incoming"
+                "count-links"
             ? 1
             : undefined;
 
@@ -143,9 +138,7 @@ export const App: BlockComponent<BlockEntity> = ({
               .outgoingLinksDepth
           : chartDefinition?.kind === "bar-chart" &&
               (chartDefinition as ChartDefinition<"bar-chart">).variant ===
-                "count-links" &&
-              (chartDefinition as BarChartCountLinkedEntitiesVariant)
-                .direction === "outgoing"
+                "count-links"
             ? 1
             : undefined;
 

--- a/blocks/chart/src/app.tsx
+++ b/blocks/chart/src/app.tsx
@@ -127,22 +127,20 @@ export const App: BlockComponent<BlockEntity> = ({
   useEffect(() => {
     if (linkedQueryEntity) {
       const incomingLinksDepth =
-        chartDefinition?.kind === "graph-chart"
-          ? (chartDefinition as ChartDefinition<"graph-chart">)
-              .incomingLinksDepth
+        chartDefinition?.kind === "graph-chart" &&
+        chartDefinition.variant === "default"
+          ? chartDefinition.incomingLinksDepth
           : chartDefinition?.kind === "bar-chart" &&
-              (chartDefinition as ChartDefinition<"bar-chart">).variant ===
-                "count-links"
+              chartDefinition.variant === "count-links"
             ? 1
             : undefined;
 
       const outgoingLinksDepth =
-        chartDefinition?.kind === "graph-chart"
-          ? (chartDefinition as ChartDefinition<"graph-chart">)
-              .outgoingLinksDepth
+        chartDefinition?.kind === "graph-chart" &&
+        chartDefinition.variant === "default"
+          ? chartDefinition.outgoingLinksDepth
           : chartDefinition?.kind === "bar-chart" &&
-              (chartDefinition as ChartDefinition<"bar-chart">).variant ===
-                "count-links"
+              chartDefinition.variant === "count-links"
             ? 1
             : undefined;
 

--- a/blocks/chart/src/app.tsx
+++ b/blocks/chart/src/app.tsx
@@ -196,7 +196,10 @@ export const App: BlockComponent<BlockEntity> = ({
       });
 
       if (generatedChartDefinition) {
-        void updateChartDefinition(generatedChartDefinition);
+        void updateChartDefinition({
+          ...generatedChartDefinition,
+          kind: "bar-chart",
+        });
       }
     }
   }, [queryResult, updateChartDefinition, chartDefinition]);

--- a/blocks/chart/src/bar-chart.tsx
+++ b/blocks/chart/src/bar-chart.tsx
@@ -80,37 +80,34 @@ export const BarChart: FunctionComponent<{
       const { entityTypeId, labelPropertyTypeId, direction, linkEntityTypeId } =
         definition;
 
-      const numberOfLinkedEntitiesByEntity = queryResultsByType[entityTypeId]
-        ?.slice(0, 5)
-        .reduce<Record<string, number>>((prev, entity) => {
-          const entityId = entity.metadata.recordId.entityId;
+      const dataPoints = queryResultsByType[entityTypeId]?.reduce<
+        { label: string; value: number }[]
+      >((prev, entity) => {
+        const entityId = entity.metadata.recordId.entityId;
 
-          const links =
-            direction === "outgoing"
-              ? /** @todo: fix `getIncomingLinksForEntity` in the BP temporal package when passing non-temporal subgraphs */
-                getOutgoingLinkAndTargetEntities(queryResult, entityId).map(
-                  ({ linkEntity }) => linkEntity,
-                )
-              : getIncomingLinksForEntity(queryResult, entityId);
+        const links =
+          direction === "outgoing"
+            ? /** @todo: fix `getIncomingLinksForEntity` in the BP temporal package when passing non-temporal subgraphs */
+              getOutgoingLinkAndTargetEntities(queryResult, entityId).map(
+                ({ linkEntity }) => linkEntity,
+              )
+            : getIncomingLinksForEntity(queryResult, entityId);
 
-          const matchingLinks = links.filter(
-            ({ metadata }) => metadata.entityTypeId === linkEntityTypeId,
-          );
+        const matchingLinks = links.filter(
+          ({ metadata }) => metadata.entityTypeId === linkEntityTypeId,
+        );
 
-          const label = String(
-            entity.properties[extractBaseUrl(labelPropertyTypeId)] ?? "Unknown",
-          );
+        const label = String(
+          entity.properties[extractBaseUrl(labelPropertyTypeId)] ?? "Unknown",
+        );
 
-          return {
-            ...prev,
-            [label]: matchingLinks.length,
-          };
-        }, {});
+        return [...prev, { label, value: matchingLinks.length }];
+      }, []);
 
       return {
         xAxis: {
           type: "category",
-          data: Object.keys(numberOfLinkedEntitiesByEntity ?? {}),
+          data: dataPoints?.map(({ label }) => label) ?? [],
           name: definition.xAxisLabel,
           nameLocation: "middle",
           nameGap: 25,
@@ -122,9 +119,7 @@ export const BarChart: FunctionComponent<{
           nameGap: 25,
         },
         series: {
-          data: Object.values(numberOfLinkedEntitiesByEntity ?? {}).map(
-            (numberOfLinks) => numberOfLinks,
-          ),
+          data: dataPoints?.map(({ value }) => value) ?? [],
           type: "bar",
         },
       };

--- a/blocks/chart/src/bar-chart.tsx
+++ b/blocks/chart/src/bar-chart.tsx
@@ -5,11 +5,11 @@ import {
   Subgraph,
   VersionedUrl,
 } from "@blockprotocol/graph";
+import { getRoots } from "@blockprotocol/graph/stdlib";
 import {
   getIncomingLinksForEntity,
-  getOutgoingLinkAndTargetEntities,
-  getRoots,
-} from "@blockprotocol/graph/stdlib";
+  getOutgoingLinksForEntity,
+} from "@blockprotocol/graph/temporal/stdlib";
 import { EChart, ECOption } from "@hashintel/design-system";
 import { FunctionComponent, useMemo } from "react";
 
@@ -88,9 +88,7 @@ export const BarChart: FunctionComponent<{
         const links =
           direction === "outgoing"
             ? /** @todo: fix `getIncomingLinksForEntity` in the BP temporal package when passing non-temporal subgraphs */
-              getOutgoingLinkAndTargetEntities(queryResult, entityId).map(
-                ({ linkEntity }) => linkEntity,
-              )
+              getOutgoingLinksForEntity(queryResult, entityId)
             : getIncomingLinksForEntity(queryResult, entityId);
 
         const matchingLinks = links.filter(

--- a/blocks/chart/src/bar-chart.tsx
+++ b/blocks/chart/src/bar-chart.tsx
@@ -6,6 +6,8 @@ import {
   VersionedUrl,
 } from "@blockprotocol/graph";
 import { getRoots } from "@blockprotocol/graph/stdlib";
+import { Subgraph as TemporalSubgraph } from "@blockprotocol/graph/temporal";
+/** @todo: replace with the non-temporal equivalent methods */
 import {
   getIncomingLinksForEntity,
   getOutgoingLinksForEntity,
@@ -88,8 +90,14 @@ export const BarChart: FunctionComponent<{
         const links =
           direction === "outgoing"
             ? /** @todo: fix `getIncomingLinksForEntity` in the BP temporal package when passing non-temporal subgraphs */
-              getOutgoingLinksForEntity(queryResult, entityId)
-            : getIncomingLinksForEntity(queryResult, entityId);
+              getOutgoingLinksForEntity(
+                queryResult as unknown as TemporalSubgraph,
+                entityId,
+              )
+            : getIncomingLinksForEntity(
+                queryResult as unknown as TemporalSubgraph,
+                entityId,
+              );
 
         const matchingLinks = links.filter(
           ({ metadata }) => metadata.entityTypeId === linkEntityTypeId,

--- a/blocks/chart/src/bar-chart.tsx
+++ b/blocks/chart/src/bar-chart.tsx
@@ -5,13 +5,11 @@ import {
   Subgraph,
   VersionedUrl,
 } from "@blockprotocol/graph";
-import { getRoots } from "@blockprotocol/graph/stdlib";
-import { Subgraph as TemporalSubgraph } from "@blockprotocol/graph/temporal";
-/** @todo: replace with the non-temporal equivalent methods */
 import {
   getIncomingLinksForEntity,
   getOutgoingLinksForEntity,
-} from "@blockprotocol/graph/temporal/stdlib";
+  getRoots,
+} from "@blockprotocol/graph/stdlib";
 import { EChart, ECOption } from "@hashintel/design-system";
 import { FunctionComponent, useMemo } from "react";
 
@@ -89,15 +87,8 @@ export const BarChart: FunctionComponent<{
 
         const links =
           direction === "outgoing"
-            ? /** @todo: fix `getIncomingLinksForEntity` in the BP temporal package when passing non-temporal subgraphs */
-              getOutgoingLinksForEntity(
-                queryResult as unknown as TemporalSubgraph,
-                entityId,
-              )
-            : getIncomingLinksForEntity(
-                queryResult as unknown as TemporalSubgraph,
-                entityId,
-              );
+            ? getOutgoingLinksForEntity(queryResult, entityId)
+            : getIncomingLinksForEntity(queryResult, entityId);
 
         const matchingLinks = links.filter(
           ({ metadata }) => metadata.entityTypeId === linkEntityTypeId,

--- a/blocks/chart/src/edit-chart-definition.tsx
+++ b/blocks/chart/src/edit-chart-definition.tsx
@@ -9,13 +9,13 @@ import {
 import { FunctionComponent, useMemo } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
+import { BarChartDefinitionForm } from "./edit-chart-definition/bar-chart-definition-form";
 import {
-  BarChartDefinitionForm,
   generateXAxisLabel,
   generateYAxisLabel,
-  getEntityTypePropertyTypes,
-} from "./edit-chart-definition/bar-chart-definition-form";
+} from "./edit-chart-definition/bar-graph-definition-form/group-by-property-form";
 import { GraphChartDefinitionForm } from "./edit-chart-definition/graph-chart-definition-form";
+import { getEntityTypePropertyTypes } from "./edit-chart-definition/util";
 import { ChartDefinition } from "./types/chart-definition";
 
 const chartKindToLabel: Record<ChartDefinition["kind"], string> = {

--- a/blocks/chart/src/edit-chart-definition/bar-chart-definition-form.tsx
+++ b/blocks/chart/src/edit-chart-definition/bar-chart-definition-form.tsx
@@ -6,9 +6,11 @@ import { Controller, useFormContext } from "react-hook-form";
 import { ChartDefinition } from "../types/chart-definition";
 import {
   CountLinksForm,
+  generateInitialChartDefinition as generateInitialCountLinkedEntitiesChartDefinition,
   generateXAxisLabel as generateCountLinkedEntitiesXAxisLabel,
 } from "./bar-graph-definition-form/count-linked-entities-form";
 import {
+  generateInitialChartDefinition as generateInitialGroupByPropertyChartDefinition,
   generateYAxisLabel as generateGroupByPropertyYAxisLabel,
   GroupByPropertyForm,
 } from "./bar-graph-definition-form/group-by-property-form";
@@ -40,6 +42,49 @@ export const BarChartDefinitionForm: FunctionComponent<{
             <InputLabel id="bar-chart-variant">Bar Chart Variant</InputLabel>
             <Select
               {...field}
+              onChange={(event) => {
+                const updatedVariant = event.target
+                  .value as ChartDefinition<"bar-chart">["variant"];
+
+                if (updatedVariant === "group-by-property") {
+                  const initialDefinition =
+                    generateInitialGroupByPropertyChartDefinition({
+                      queryResult,
+                    });
+
+                  if (initialDefinition) {
+                    setValue("entityTypeId", initialDefinition.entityTypeId);
+                    setValue(
+                      "groupByPropertyTypeId",
+                      initialDefinition.groupByPropertyTypeId,
+                    );
+                    setValue("xAxisLabel", initialDefinition.xAxisLabel);
+                    setValue("yAxisLabel", initialDefinition.yAxisLabel);
+                  }
+                } else {
+                  const initialDefinition =
+                    generateInitialCountLinkedEntitiesChartDefinition({
+                      queryResult,
+                    });
+
+                  if (initialDefinition) {
+                    setValue("entityTypeId", initialDefinition.entityTypeId);
+                    setValue(
+                      "labelPropertyTypeId",
+                      initialDefinition.labelPropertyTypeId,
+                    );
+                    setValue("direction", initialDefinition.direction);
+                    setValue(
+                      "linkEntityTypeId",
+                      initialDefinition.linkEntityTypeId,
+                    );
+                    setValue("xAxisLabel", initialDefinition.xAxisLabel);
+                    setValue("yAxisLabel", initialDefinition.yAxisLabel);
+                  }
+                }
+
+                field.onChange(event);
+              }}
               labelId="bar-chart-variant"
               label="Bar Chart Variant"
               required

--- a/blocks/chart/src/edit-chart-definition/bar-chart-definition-form.tsx
+++ b/blocks/chart/src/edit-chart-definition/bar-chart-definition-form.tsx
@@ -4,9 +4,12 @@ import { FunctionComponent } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 
 import { ChartDefinition } from "../types/chart-definition";
-import { CountLinksForm } from "./bar-graph-definition-form/count-linked-entities-form";
 import {
-  generateYAxisLabel,
+  CountLinksForm,
+  generateXAxisLabel as generateCountLinkedEntitiesXAxisLabel,
+} from "./bar-graph-definition-form/count-linked-entities-form";
+import {
+  generateYAxisLabel as generateGroupByPropertyYAxisLabel,
   GroupByPropertyForm,
 } from "./bar-graph-definition-form/group-by-property-form";
 
@@ -65,12 +68,21 @@ export const BarChartDefinitionForm: FunctionComponent<{
                   );
 
                   if (selectedEntityType) {
-                    setValue(
-                      "yAxisLabel",
-                      generateYAxisLabel({
-                        entityType: selectedEntityType,
-                      }),
-                    );
+                    if (currentVariant === "group-by-property") {
+                      setValue(
+                        "yAxisLabel",
+                        generateGroupByPropertyYAxisLabel({
+                          entityType: selectedEntityType,
+                        }),
+                      );
+                    } else {
+                      setValue(
+                        "xAxisLabel",
+                        generateCountLinkedEntitiesXAxisLabel({
+                          entityType: selectedEntityType,
+                        }),
+                      );
+                    }
                   }
 
                   field.onChange(event);

--- a/blocks/chart/src/edit-chart-definition/bar-chart-definition-form.tsx
+++ b/blocks/chart/src/edit-chart-definition/bar-chart-definition-form.tsx
@@ -1,163 +1,55 @@
-import {
-  EntityRootType,
-  EntityType,
-  extractBaseUrl,
-  PropertyType,
-  Subgraph,
-  VersionedUrl,
-} from "@blockprotocol/graph";
-import {
-  getEntityTypeById,
-  getPropertyTypeById,
-  getRoots,
-} from "@blockprotocol/graph/stdlib";
-import {
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
-  TextField,
-} from "@mui/material";
-import pluralize from "pluralize";
-import { FunctionComponent, useMemo } from "react";
+import { EntityRootType, EntityType, Subgraph } from "@blockprotocol/graph";
+import { FormControl, InputLabel, MenuItem, Select } from "@mui/material";
+import { FunctionComponent } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 
 import { ChartDefinition } from "../types/chart-definition";
+import { CountLinksForm } from "./bar-graph-definition-form/count-linked-entities-form";
+import {
+  generateYAxisLabel,
+  GroupByPropertyForm,
+} from "./bar-graph-definition-form/group-by-property-form";
 
-export const getEntityTypePropertyTypes = (
-  subgraph: Subgraph,
-  entityType: EntityType,
-): PropertyType[] => {
-  const propertyTypeIds = Object.values(entityType.properties).map((value) =>
-    "$ref" in value ? value.$ref : value.items.$ref,
-  );
-
-  const propertyTypes = propertyTypeIds.map((propertyTypeId) => {
-    const propertyType = getPropertyTypeById(subgraph, propertyTypeId)?.schema;
-
-    if (!propertyType) {
-      throw new Error(
-        `Could not get property type from subgraph: ${propertyTypeId}`,
-      );
-    }
-
-    return propertyType;
-  });
-
-  return [
-    ...propertyTypes,
-    ...(entityType.allOf
-      ?.map(({ $ref }) => {
-        const inheritsFromEntityType = getEntityTypeById(subgraph, $ref)
-          ?.schema;
-
-        if (!inheritsFromEntityType) {
-          throw new Error(
-            `Could not get inherited entity type from subgraph: ${$ref}`,
-          );
-        }
-
-        return getEntityTypePropertyTypes(subgraph, inheritsFromEntityType);
-      })
-      .flat() ?? []),
-  ];
-};
-
-export const generateXAxisLabel = (params: {
-  entityType: EntityType;
-  groupByPropertyType: PropertyType;
-}) =>
-  `${
-    params.entityType.title
-  } ${params.groupByPropertyType.title.toLowerCase()}`;
-
-export const generateYAxisLabel = (params: { entityType: EntityType }) =>
-  `Number of ${pluralize(params.entityType.title.toLowerCase())}`;
-
-export const generateInitialChartDefinition = (params: {
-  queryResult: Subgraph<EntityRootType>;
-}): ChartDefinition | undefined => {
-  const { queryResult } = params;
-
-  const resultEntity = getRoots(queryResult)[0]!;
-
-  const entityType = getEntityTypeById(
-    queryResult,
-    resultEntity.metadata.entityTypeId,
-  )?.schema;
-
-  if (!entityType) {
-    return undefined;
-  }
-
-  const propertyTypes = getEntityTypePropertyTypes(queryResult, entityType);
-
-  const resultPropertyTypeWithTextValue = propertyTypes.find(
-    ({ $id, oneOf }) =>
-      Object.keys(resultEntity.properties).some(
-        (propertyTypeBaseUrl) => extractBaseUrl($id) === propertyTypeBaseUrl,
-      ) &&
-      oneOf.some(
-        (value) =>
-          "$ref" in value &&
-          value.$ref ===
-            "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
-      ),
-    [],
-  );
-
-  const groupByPropertyType =
-    resultPropertyTypeWithTextValue ?? propertyTypes[0];
-
-  if (!groupByPropertyType) {
-    return undefined;
-  }
-
-  return {
-    kind: "bar-chart",
-    variant: "group-by-property",
-    entityTypeId: entityType.$id,
-    groupByPropertyTypeId: groupByPropertyType.$id,
-    xAxisLabel: generateXAxisLabel({
-      entityType,
-      groupByPropertyType,
-    }),
-    yAxisLabel: generateYAxisLabel({
-      entityType,
-    }),
-  };
+const barChartVariantNames: Record<
+  ChartDefinition<"bar-chart">["variant"],
+  string
+> = {
+  "group-by-property": "Group by Property",
+  "count-links": "Count Links",
 };
 
 export const BarChartDefinitionForm: FunctionComponent<{
-  queryResult: Subgraph<EntityRootType>;
   entityTypes: EntityType[];
+  queryResult: Subgraph<EntityRootType>;
 }> = ({ entityTypes, queryResult }) => {
-  const { control, register, setValue, watch } =
+  const { control, setValue, watch } =
     useFormContext<ChartDefinition<"bar-chart">>();
 
-  const entityTypeId = watch("entityTypeId");
-
-  const entityType = useMemo(
-    () =>
-      /** @todo: figure out why react hook form makes this always defined */
-      (entityTypeId as VersionedUrl | "") !== ""
-        ? entityTypes.find(({ $id }) => $id === entityTypeId)
-        : undefined,
-    [entityTypes, entityTypeId],
-  );
-
-  const entityTypePropertyTypes = useMemo(() => {
-    if (!entityType) {
-      return undefined;
-    }
-
-    const propertyTypes = getEntityTypePropertyTypes(queryResult, entityType);
-
-    return propertyTypes;
-  }, [entityType, queryResult]);
+  const currentVariant = watch("variant");
 
   return (
     <>
+      <Controller
+        control={control}
+        name="variant"
+        render={({ field }) => (
+          <FormControl sx={{ minWidth: 200 }}>
+            <InputLabel id="bar-chart-variant">Bar Chart Variant</InputLabel>
+            <Select
+              {...field}
+              labelId="bar-chart-variant"
+              label="Bar Chart Variant"
+              required
+            >
+              {Object.entries(barChartVariantNames).map(([variant, label]) => (
+                <MenuItem key={variant} value={variant}>
+                  {label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
+      />
       {entityTypes.length > 0 ? (
         <Controller
           control={control}
@@ -175,7 +67,9 @@ export const BarChartDefinitionForm: FunctionComponent<{
                   if (selectedEntityType) {
                     setValue(
                       "yAxisLabel",
-                      generateYAxisLabel({ entityType: selectedEntityType }),
+                      generateYAxisLabel({
+                        entityType: selectedEntityType,
+                      }),
                     );
                   }
 
@@ -195,60 +89,14 @@ export const BarChartDefinitionForm: FunctionComponent<{
           )}
         />
       ) : null}
-      <Controller
-        control={control}
-        name="groupByPropertyTypeId"
-        disabled={!entityTypePropertyTypes}
-        render={({ field }) => (
-          <FormControl sx={{ minWidth: 200 }}>
-            <InputLabel id="group-by-property">Group by property</InputLabel>
-            <Select
-              {...field}
-              // prevent MUI from logging a warning
-              value={entityTypePropertyTypes ? field.value : ""}
-              onChange={(event) => {
-                const groupByPropertyType = entityTypePropertyTypes?.find(
-                  ({ $id }) => $id === event.target.value,
-                );
-
-                if (entityType && groupByPropertyType) {
-                  setValue(
-                    "xAxisLabel",
-                    generateXAxisLabel({ entityType, groupByPropertyType }),
-                  );
-                }
-
-                field.onChange(event);
-              }}
-              labelId="group-by-property"
-              label="Group by property"
-              required
-            >
-              {entityTypePropertyTypes?.map(({ $id, title }) => (
-                <MenuItem key={$id} value={$id}>
-                  {title}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        )}
-      />
-      <TextField
-        id="x-axis-label"
-        fullWidth
-        label="X Axis Label"
-        /** @todo: figure out why the label isn't shrinking when the value is updated programmatically */
-        InputLabelProps={{ shrink: true }}
-        {...register("xAxisLabel")}
-      />
-      <TextField
-        id="y-axis-label"
-        fullWidth
-        label="Y Axis Label"
-        /** @todo: figure out why the label isn't shrinking when the value is updated programmatically */
-        InputLabelProps={{ shrink: true }}
-        {...register("yAxisLabel")}
-      />
+      {currentVariant === "count-links" ? (
+        <CountLinksForm entityTypes={entityTypes} queryResult={queryResult} />
+      ) : (
+        <GroupByPropertyForm
+          entityTypes={entityTypes}
+          queryResult={queryResult}
+        />
+      )}
     </>
   );
 };

--- a/blocks/chart/src/edit-chart-definition/bar-graph-definition-form/count-linked-entities-form.tsx
+++ b/blocks/chart/src/edit-chart-definition/bar-graph-definition-form/count-linked-entities-form.tsx
@@ -1,0 +1,153 @@
+import {
+  EntityRootType,
+  EntityType,
+  ParseVersionedUrlError,
+  Subgraph,
+  VersionedUrl,
+} from "@blockprotocol/graph";
+import { getEntityTypeById } from "@blockprotocol/graph/stdlib";
+import { FormControl, InputLabel, MenuItem, Select } from "@mui/material";
+import { FunctionComponent, useMemo } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+
+import { ChartDefinition } from "../../types/chart-definition";
+import { getEntityTypePropertyTypes } from "../util";
+
+export const CountLinksForm: FunctionComponent<{
+  queryResult: Subgraph<EntityRootType>;
+  entityTypes: EntityType[];
+}> = ({ entityTypes, queryResult }) => {
+  const { control, watch } = useFormContext<ChartDefinition<"bar-chart">>();
+
+  const entityTypeId = watch("entityTypeId");
+
+  const entityType = useMemo(
+    () =>
+      /** @todo: figure out why react hook form makes this always defined */
+      (entityTypeId as ParseVersionedUrlError | "") !== ""
+        ? entityTypes.find(({ $id }) => $id === entityTypeId)
+        : undefined,
+    [entityTypes, entityTypeId],
+  );
+
+  const entityTypePropertyTypes = useMemo(() => {
+    if (!entityType) {
+      return undefined;
+    }
+
+    const propertyTypes = getEntityTypePropertyTypes(queryResult, entityType);
+
+    return propertyTypes;
+  }, [entityType, queryResult]);
+
+  const outgoingLinkEntityTypes = useMemo(() => {
+    if (entityType) {
+      const outgoingLinkEntityTypeIds = Object.keys(
+        entityType.links ?? {},
+      ) as VersionedUrl[];
+      /** @todo: account for inherited links */
+
+      return outgoingLinkEntityTypeIds
+        .map(
+          (linkEntityTypeId) =>
+            getEntityTypeById(queryResult, linkEntityTypeId)?.schema ?? [],
+        )
+        .flat();
+    }
+  }, [entityType, queryResult]);
+
+  const direction = watch("direction");
+
+  const linkEntityTypes =
+    direction === "incoming" ? [] : outgoingLinkEntityTypes;
+
+  return (
+    <>
+      <Controller
+        control={control}
+        name="labelPropertyTypeId"
+        disabled={!entityTypePropertyTypes}
+        render={({ field }) => (
+          <FormControl sx={{ minWidth: 200 }}>
+            <InputLabel id="label-property-type">
+              Label Property Type
+            </InputLabel>
+            <Select
+              {...field}
+              // prevent MUI from logging a warning
+              value={entityTypePropertyTypes ? field.value : ""}
+              labelId="label-property-type"
+              label="Label Property Type"
+              required
+            >
+              {entityTypePropertyTypes?.map(({ $id, title }) => (
+                <MenuItem key={$id} value={$id}>
+                  {title}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
+      />
+      <Controller
+        control={control}
+        name="direction"
+        render={({ field }) => (
+          <FormControl sx={{ minWidth: 200 }}>
+            <InputLabel id="link-direction">Link Direction</InputLabel>
+            <Select
+              {...field}
+              labelId="label-property-type"
+              label="Label Property Type"
+              required
+            >
+              <MenuItem value="incoming">Incoming</MenuItem>
+              <MenuItem value="outgoing">Outgoing</MenuItem>
+            </Select>
+          </FormControl>
+        )}
+      />
+      <Controller
+        control={control}
+        name="linkEntityTypeId"
+        disabled={!linkEntityTypes}
+        render={({ field }) => (
+          <FormControl sx={{ minWidth: 200 }}>
+            <InputLabel id="link-entity-type-id">
+              {direction === "incoming" ? "Incoming" : "Outgoing"} Link Entity
+              Type
+            </InputLabel>
+            <Select
+              {...field}
+              // prevent MUI from logging a warning
+              value={linkEntityTypes ? field.value : ""}
+              onChange={(event) => {
+                // const linkedEntityType = linkedEntityTypes?.find(
+                //   ({ $id }) => $id === event.target.value,
+                // );
+
+                // if (entityType && groupByPropertyType) {
+                //   setValue(
+                //     "xAxisLabel",
+                //     generateXAxisLabel({ entityType, groupByPropertyType }),
+                //   );
+                // }
+
+                field.onChange(event);
+              }}
+              labelId="link-entity-type-id"
+              label="Link Entity Type"
+              required
+            >
+              {linkEntityTypes?.map(({ $id, title }) => (
+                <MenuItem key={$id} value={$id}>
+                  {title}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
+      />
+    </>
+  );
+};

--- a/blocks/chart/src/edit-chart-definition/bar-graph-definition-form/count-linked-entities-form.tsx
+++ b/blocks/chart/src/edit-chart-definition/bar-graph-definition-form/count-linked-entities-form.tsx
@@ -6,10 +6,11 @@ import {
   Subgraph,
   VersionedUrl,
 } from "@blockprotocol/graph";
-import { getEntityTypeById, getRoots } from "@blockprotocol/graph/stdlib";
-import { Subgraph as TemporalSubgraph } from "@blockprotocol/graph/temporal";
-/** @todo: replace with the non-temporal equivalent method */
-import { getIncomingLinksForEntity } from "@blockprotocol/graph/temporal/stdlib";
+import {
+  getEntityTypeById,
+  getIncomingLinksForEntity,
+  getRoots,
+} from "@blockprotocol/graph/stdlib";
 import {
   FormControl,
   InputLabel,
@@ -64,10 +65,7 @@ const getIncomingLinkEntityTypes = (params: {
 
   return entities
     .map(({ metadata }) =>
-      getIncomingLinksForEntity(
-        queryResult as unknown as TemporalSubgraph,
-        metadata.recordId.entityId,
-      ),
+      getIncomingLinksForEntity(queryResult, metadata.recordId.entityId),
     )
     .flat()
     .map((linkEntity) => linkEntity.metadata.entityTypeId)

--- a/blocks/chart/src/edit-chart-definition/bar-graph-definition-form/count-linked-entities-form.tsx
+++ b/blocks/chart/src/edit-chart-definition/bar-graph-definition-form/count-linked-entities-form.tsx
@@ -13,13 +13,17 @@ import {
   Select,
   TextField,
 } from "@mui/material";
+import pluralize from "pluralize";
 import { FunctionComponent, useMemo } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 
 import { ChartDefinition } from "../../types/chart-definition";
 import { getEntityTypePropertyTypes } from "../util";
 
-const generateYAxisLabel = (params: { linkEntityType: EntityType }) =>
+export const generateXAxisLabel = (params: { entityType: EntityType }) =>
+  `${pluralize(params.entityType.title)}`;
+
+export const generateYAxisLabel = (params: { linkEntityType: EntityType }) =>
   `Number of ${params.linkEntityType.title.toLowerCase()} links`;
 
 export const CountLinksForm: FunctionComponent<{

--- a/blocks/chart/src/edit-chart-definition/bar-graph-definition-form/count-linked-entities-form.tsx
+++ b/blocks/chart/src/edit-chart-definition/bar-graph-definition-form/count-linked-entities-form.tsx
@@ -166,16 +166,12 @@ export const CountLinksForm: FunctionComponent<{
         id="x-axis-label"
         fullWidth
         label="X Axis Label"
-        /** @todo: figure out why the label isn't shrinking when the value is updated programmatically */
-        InputLabelProps={{ shrink: true }}
         {...register("xAxisLabel")}
       />
       <TextField
         id="y-axis-label"
         fullWidth
         label="Y Axis Label"
-        /** @todo: figure out why the label isn't shrinking when the value is updated programmatically */
-        InputLabelProps={{ shrink: true }}
         {...register("yAxisLabel")}
       />
     </>

--- a/blocks/chart/src/edit-chart-definition/bar-graph-definition-form/count-linked-entities-form.tsx
+++ b/blocks/chart/src/edit-chart-definition/bar-graph-definition-form/count-linked-entities-form.tsx
@@ -6,18 +6,28 @@ import {
   VersionedUrl,
 } from "@blockprotocol/graph";
 import { getEntityTypeById } from "@blockprotocol/graph/stdlib";
-import { FormControl, InputLabel, MenuItem, Select } from "@mui/material";
+import {
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+} from "@mui/material";
 import { FunctionComponent, useMemo } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 
 import { ChartDefinition } from "../../types/chart-definition";
 import { getEntityTypePropertyTypes } from "../util";
 
+const generateYAxisLabel = (params: { linkEntityType: EntityType }) =>
+  `Number of ${params.linkEntityType.title.toLowerCase()} links`;
+
 export const CountLinksForm: FunctionComponent<{
   queryResult: Subgraph<EntityRootType>;
   entityTypes: EntityType[];
 }> = ({ entityTypes, queryResult }) => {
-  const { control, watch } = useFormContext<ChartDefinition<"bar-chart">>();
+  const { control, watch, register, setValue } =
+    useFormContext<ChartDefinition<"bar-chart">>();
 
   const entityTypeId = watch("entityTypeId");
 
@@ -122,16 +132,16 @@ export const CountLinksForm: FunctionComponent<{
               // prevent MUI from logging a warning
               value={linkEntityTypes ? field.value : ""}
               onChange={(event) => {
-                // const linkedEntityType = linkedEntityTypes?.find(
-                //   ({ $id }) => $id === event.target.value,
-                // );
+                const linkEntityType = linkEntityTypes?.find(
+                  ({ $id }) => $id === event.target.value,
+                );
 
-                // if (entityType && groupByPropertyType) {
-                //   setValue(
-                //     "xAxisLabel",
-                //     generateXAxisLabel({ entityType, groupByPropertyType }),
-                //   );
-                // }
+                if (linkEntityType) {
+                  setValue(
+                    "yAxisLabel",
+                    generateYAxisLabel({ linkEntityType }),
+                  );
+                }
 
                 field.onChange(event);
               }}
@@ -147,6 +157,22 @@ export const CountLinksForm: FunctionComponent<{
             </Select>
           </FormControl>
         )}
+      />
+      <TextField
+        id="x-axis-label"
+        fullWidth
+        label="X Axis Label"
+        /** @todo: figure out why the label isn't shrinking when the value is updated programmatically */
+        InputLabelProps={{ shrink: true }}
+        {...register("xAxisLabel")}
+      />
+      <TextField
+        id="y-axis-label"
+        fullWidth
+        label="Y Axis Label"
+        /** @todo: figure out why the label isn't shrinking when the value is updated programmatically */
+        InputLabelProps={{ shrink: true }}
+        {...register("yAxisLabel")}
       />
     </>
   );

--- a/blocks/chart/src/edit-chart-definition/bar-graph-definition-form/count-linked-entities-form.tsx
+++ b/blocks/chart/src/edit-chart-definition/bar-graph-definition-form/count-linked-entities-form.tsx
@@ -6,6 +6,8 @@ import {
   VersionedUrl,
 } from "@blockprotocol/graph";
 import { getEntityTypeById, getRoots } from "@blockprotocol/graph/stdlib";
+import { Subgraph as TemporalSubgraph } from "@blockprotocol/graph/temporal";
+/** @todo: replace with the non-temporal equivalent method */
 import { getIncomingLinksForEntity } from "@blockprotocol/graph/temporal/stdlib";
 import {
   FormControl,
@@ -82,7 +84,10 @@ export const CountLinksForm: FunctionComponent<{
 
       return entities
         .map(({ metadata }) =>
-          getIncomingLinksForEntity(queryResult, metadata.recordId.entityId),
+          getIncomingLinksForEntity(
+            queryResult as unknown as TemporalSubgraph,
+            metadata.recordId.entityId,
+          ),
         )
         .flat()
         .map((linkEntity) => linkEntity.metadata.entityTypeId)

--- a/blocks/chart/src/edit-chart-definition/bar-graph-definition-form/group-by-property-form.tsx
+++ b/blocks/chart/src/edit-chart-definition/bar-graph-definition-form/group-by-property-form.tsx
@@ -1,0 +1,175 @@
+import {
+  EntityRootType,
+  EntityType,
+  extractBaseUrl,
+  PropertyType,
+  Subgraph,
+  VersionedUrl,
+} from "@blockprotocol/graph";
+import { getEntityTypeById, getRoots } from "@blockprotocol/graph/stdlib";
+import {
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+} from "@mui/material";
+import pluralize from "pluralize";
+import { FunctionComponent, useMemo } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+
+import { ChartDefinition } from "../../types/chart-definition";
+import { getEntityTypePropertyTypes } from "../util";
+
+export const generateXAxisLabel = (params: {
+  entityType: EntityType;
+  groupByPropertyType: PropertyType;
+}) =>
+  `${
+    params.entityType.title
+  } ${params.groupByPropertyType.title.toLowerCase()}`;
+
+export const generateYAxisLabel = (params: { entityType: EntityType }) =>
+  `Number of ${pluralize(params.entityType.title.toLowerCase())}`;
+
+export const generateInitialChartDefinition = (params: {
+  queryResult: Subgraph<EntityRootType>;
+}): ChartDefinition | undefined => {
+  const { queryResult } = params;
+
+  const resultEntity = getRoots(queryResult)[0]!;
+
+  const entityType = getEntityTypeById(
+    queryResult,
+    resultEntity.metadata.entityTypeId,
+  )?.schema;
+
+  if (!entityType) {
+    return undefined;
+  }
+
+  const propertyTypes = getEntityTypePropertyTypes(queryResult, entityType);
+
+  const resultPropertyTypeWithTextValue = propertyTypes.find(
+    ({ $id, oneOf }) =>
+      Object.keys(resultEntity.properties).some(
+        (propertyTypeBaseUrl) => extractBaseUrl($id) === propertyTypeBaseUrl,
+      ) &&
+      oneOf.some(
+        (value) =>
+          "$ref" in value &&
+          value.$ref ===
+            "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
+      ),
+    [],
+  );
+
+  const groupByPropertyType =
+    resultPropertyTypeWithTextValue ?? propertyTypes[0];
+
+  if (!groupByPropertyType) {
+    return undefined;
+  }
+
+  return {
+    kind: "bar-chart",
+    variant: "group-by-property",
+    entityTypeId: entityType.$id,
+    groupByPropertyTypeId: groupByPropertyType.$id,
+    xAxisLabel: generateXAxisLabel({
+      entityType,
+      groupByPropertyType,
+    }),
+    yAxisLabel: generateYAxisLabel({
+      entityType,
+    }),
+  };
+};
+
+export const GroupByPropertyForm: FunctionComponent<{
+  queryResult: Subgraph<EntityRootType>;
+  entityTypes: EntityType[];
+}> = ({ entityTypes, queryResult }) => {
+  const { control, register, watch, setValue } =
+    useFormContext<ChartDefinition>();
+
+  const entityTypeId = watch("entityTypeId");
+
+  const entityType = useMemo(
+    () =>
+      /** @todo: figure out why react hook form makes this always defined */
+      (entityTypeId as VersionedUrl | "") !== ""
+        ? entityTypes.find(({ $id }) => $id === entityTypeId)
+        : undefined,
+    [entityTypes, entityTypeId],
+  );
+
+  const entityTypePropertyTypes = useMemo(() => {
+    if (!entityType) {
+      return undefined;
+    }
+
+    const propertyTypes = getEntityTypePropertyTypes(queryResult, entityType);
+
+    return propertyTypes;
+  }, [entityType, queryResult]);
+
+  return (
+    <>
+      <Controller
+        control={control}
+        name="groupByPropertyTypeId"
+        disabled={!entityTypePropertyTypes}
+        render={({ field }) => (
+          <FormControl sx={{ minWidth: 200 }}>
+            <InputLabel id="group-by-property">Group by property</InputLabel>
+            <Select
+              {...field}
+              // prevent MUI from logging a warning
+              value={entityTypePropertyTypes ? field.value : ""}
+              onChange={(event) => {
+                const groupByPropertyType = entityTypePropertyTypes?.find(
+                  ({ $id }) => $id === event.target.value,
+                );
+
+                if (entityType && groupByPropertyType) {
+                  setValue(
+                    "xAxisLabel",
+                    generateXAxisLabel({ entityType, groupByPropertyType }),
+                  );
+                }
+
+                field.onChange(event);
+              }}
+              labelId="group-by-property"
+              label="Group by property"
+              required
+            >
+              {entityTypePropertyTypes?.map(({ $id, title }) => (
+                <MenuItem key={$id} value={$id}>
+                  {title}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
+      />
+      <TextField
+        id="x-axis-label"
+        fullWidth
+        label="X Axis Label"
+        /** @todo: figure out why the label isn't shrinking when the value is updated programmatically */
+        InputLabelProps={{ shrink: true }}
+        {...register("xAxisLabel")}
+      />
+      <TextField
+        id="y-axis-label"
+        fullWidth
+        label="Y Axis Label"
+        /** @todo: figure out why the label isn't shrinking when the value is updated programmatically */
+        InputLabelProps={{ shrink: true }}
+        {...register("yAxisLabel")}
+      />
+    </>
+  );
+};

--- a/blocks/chart/src/edit-chart-definition/bar-graph-definition-form/group-by-property-form.tsx
+++ b/blocks/chart/src/edit-chart-definition/bar-graph-definition-form/group-by-property-form.tsx
@@ -18,7 +18,10 @@ import pluralize from "pluralize";
 import { FunctionComponent, useMemo } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 
-import { ChartDefinition } from "../../types/chart-definition";
+import {
+  BarChartGroupByPropertyVariant,
+  ChartDefinition,
+} from "../../types/chart-definition";
 import { getEntityTypePropertyTypes } from "../util";
 
 export const generateXAxisLabel = (params: {
@@ -34,7 +37,7 @@ export const generateYAxisLabel = (params: { entityType: EntityType }) =>
 
 export const generateInitialChartDefinition = (params: {
   queryResult: Subgraph<EntityRootType>;
-}): ChartDefinition | undefined => {
+}): BarChartGroupByPropertyVariant | undefined => {
   const { queryResult } = params;
 
   const resultEntity = getRoots(queryResult)[0]!;
@@ -72,7 +75,6 @@ export const generateInitialChartDefinition = (params: {
   }
 
   return {
-    kind: "bar-chart",
     variant: "group-by-property",
     entityTypeId: entityType.$id,
     groupByPropertyTypeId: groupByPropertyType.$id,

--- a/blocks/chart/src/edit-chart-definition/bar-graph-definition-form/group-by-property-form.tsx
+++ b/blocks/chart/src/edit-chart-definition/bar-graph-definition-form/group-by-property-form.tsx
@@ -158,16 +158,12 @@ export const GroupByPropertyForm: FunctionComponent<{
         id="x-axis-label"
         fullWidth
         label="X Axis Label"
-        /** @todo: figure out why the label isn't shrinking when the value is updated programmatically */
-        InputLabelProps={{ shrink: true }}
         {...register("xAxisLabel")}
       />
       <TextField
         id="y-axis-label"
         fullWidth
         label="Y Axis Label"
-        /** @todo: figure out why the label isn't shrinking when the value is updated programmatically */
-        InputLabelProps={{ shrink: true }}
         {...register("yAxisLabel")}
       />
     </>

--- a/blocks/chart/src/edit-chart-definition/util.ts
+++ b/blocks/chart/src/edit-chart-definition/util.ts
@@ -1,0 +1,44 @@
+import { EntityType, PropertyType, Subgraph } from "@blockprotocol/graph";
+import {
+  getEntityTypeById,
+  getPropertyTypeById,
+} from "@blockprotocol/graph/stdlib";
+
+export const getEntityTypePropertyTypes = (
+  subgraph: Subgraph,
+  entityType: EntityType,
+): PropertyType[] => {
+  const propertyTypeIds = Object.values(entityType.properties).map((value) =>
+    "$ref" in value ? value.$ref : value.items.$ref,
+  );
+
+  const propertyTypes = propertyTypeIds.map((propertyTypeId) => {
+    const propertyType = getPropertyTypeById(subgraph, propertyTypeId)?.schema;
+
+    if (!propertyType) {
+      throw new Error(
+        `Could not get property type from subgraph: ${propertyTypeId}`,
+      );
+    }
+
+    return propertyType;
+  });
+
+  return [
+    ...propertyTypes,
+    ...(entityType.allOf
+      ?.map(({ $ref }) => {
+        const inheritsFromEntityType = getEntityTypeById(subgraph, $ref)
+          ?.schema;
+
+        if (!inheritsFromEntityType) {
+          throw new Error(
+            `Could not get inherited entity type from subgraph: ${$ref}`,
+          );
+        }
+
+        return getEntityTypePropertyTypes(subgraph, inheritsFromEntityType);
+      })
+      .flat() ?? []),
+  ];
+};

--- a/blocks/chart/src/edit-chart-title.tsx
+++ b/blocks/chart/src/edit-chart-title.tsx
@@ -42,6 +42,7 @@ export const EditableChartTitle: FunctionComponent<EditableChartTitleProps> = ({
           width: "100%",
           marginTop: 1,
         },
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- TODO why is this inferred as any?
         ...(Array.isArray(sx) ? sx : [sx]),
       ]}
     >

--- a/blocks/chart/src/types/chart-definition.ts
+++ b/blocks/chart/src/types/chart-definition.ts
@@ -23,6 +23,12 @@ export type BarChartDefinitionVariant =
   | BarChartGroupByPropertyVariant;
 
 export type GraphChartDefinitionVariant = {
+  /**
+   * Without this TS can't infer between the bar chart and graph chart variants
+   *
+   * @todo: figure out a better approach for structuring and typing the chart definition
+   */
+  variant: "default";
   incomingLinksDepth?: number;
   outgoingLinksDepth?: number;
 };

--- a/blocks/chart/src/types/chart-definition.ts
+++ b/blocks/chart/src/types/chart-definition.ts
@@ -1,12 +1,26 @@
 import { VersionedUrl } from "@blockprotocol/graph";
 
-export type BarChartDefinitionVariant = {
+export type BarChartCountLinkedEntitiesVariant = {
+  variant: "count-links";
+  entityTypeId: VersionedUrl;
+  labelPropertyTypeId: VersionedUrl;
+  direction: "incoming" | "outgoing";
+  linkEntityTypeId: VersionedUrl;
+  xAxisLabel?: string;
+  yAxisLabel?: string;
+};
+
+export type BarChartGroupByPropertyVariant = {
   variant: "group-by-property";
   entityTypeId: VersionedUrl;
   groupByPropertyTypeId: VersionedUrl;
   xAxisLabel?: string;
   yAxisLabel?: string;
 };
+
+export type BarChartDefinitionVariant =
+  | BarChartCountLinkedEntitiesVariant
+  | BarChartGroupByPropertyVariant;
 
 export type GraphChartDefinitionVariant = {
   incomingLinksDepth?: number;

--- a/blocks/chart/variants.json
+++ b/blocks/chart/variants.json
@@ -23,14 +23,16 @@
     "icon": "public/chart-network-regular.svg",
     "properties": {
       "https://blockprotocol.org/@hash/types/property-type/chart-defintion/": {
-        "kind": "graph-chart"
+        "kind": "graph-chart",
+        "variant": "default"
       }
     },
     "examples": [
       {
         "https://blockprotocol.org/@blockprotocol/types/property-type/title/": "Network Graph Chart Title",
         "https://blockprotocol.org/@hash/types/property-type/chart-defintion/": {
-          "kind": "graph-chart"
+          "kind": "graph-chart",
+          "variant": "default"
         }
       }
     ]

--- a/blocks/code/package.json
+++ b/blocks/code/package.json
@@ -26,7 +26,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "prismjs": "1.29.0"
   },
   "devDependencies": {

--- a/blocks/countdown/package.json
+++ b/blocks/countdown/package.json
@@ -26,7 +26,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "date-fns": "2.28.0",
     "react-datepicker": "4.7.0"
   },

--- a/blocks/divider/package.json
+++ b/blocks/divider/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@blockprotocol/core": "0.1.2",
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031"
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055"
   },
   "devDependencies": {
     "@local/eslint-config": "0.0.0-private",

--- a/blocks/faq/package.json
+++ b/blocks/faq/package.json
@@ -30,7 +30,7 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "@hashintel/block-design-system": "0.0.1",
     "@hashintel/design-system": "0.0.7",
     "@mui/material": "5.14.11",

--- a/blocks/heading/package.json
+++ b/blocks/heading/package.json
@@ -26,7 +26,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "@blockprotocol/hook": "0.1.3"
   },
   "devDependencies": {

--- a/blocks/how-to/package.json
+++ b/blocks/how-to/package.json
@@ -30,7 +30,7 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "@hashintel/block-design-system": "0.0.1",
     "@hashintel/design-system": "0.0.7",
     "@mui/material": "5.14.11",

--- a/blocks/image/package.json
+++ b/blocks/image/package.json
@@ -26,7 +26,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "@blockprotocol/hook": "0.1.3",
     "twind": "0.16.17"
   },

--- a/blocks/kanban-board/package.json
+++ b/blocks/kanban-board/package.json
@@ -29,7 +29,7 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "@dnd-kit/core": "6.0.8",
     "@dnd-kit/sortable": "7.0.2",
     "@dnd-kit/utilities": "3.2.1",

--- a/blocks/minesweeper/package.json
+++ b/blocks/minesweeper/package.json
@@ -20,7 +20,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "lit": "^2.4.1",
     "mine-sweeper-tag": "1.0.6"
   },

--- a/blocks/paragraph/package.json
+++ b/blocks/paragraph/package.json
@@ -26,7 +26,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "@blockprotocol/hook": "0.1.3"
   },
   "devDependencies": {

--- a/blocks/shuffle/package.json
+++ b/blocks/shuffle/package.json
@@ -26,7 +26,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "@dnd-kit/core": "6.0.8",
     "@dnd-kit/sortable": "7.0.2",
     "@dnd-kit/utilities": "3.2.1",

--- a/blocks/table/package.json
+++ b/blocks/table/package.json
@@ -30,7 +30,7 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "@glideapps/glide-data-grid": "5.2.1",
     "@hashintel/block-design-system": "0.0.1",
     "@mui/material": "5.14.11",

--- a/blocks/timer/package.json
+++ b/blocks/timer/package.json
@@ -26,7 +26,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "date-fns": "2.28.0",
     "duration-fns": "3.0.1"
   },

--- a/blocks/video/package.json
+++ b/blocks/video/package.json
@@ -26,7 +26,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "twind": "0.16.17"
   },
   "devDependencies": {

--- a/libs/@hashintel/design-system/package.json
+++ b/libs/@hashintel/design-system/package.json
@@ -36,7 +36,7 @@
     "postpublish": "PACKAGE_DIR=$(pwd) yarn workspace @local/repo-chores exe scripts/postpublish.ts"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "@blockprotocol/type-system": "0.1.1",
     "@fortawesome/free-regular-svg-icons": "6.0.0",
     "@fortawesome/free-solid-svg-icons": "6.0.0",

--- a/libs/@hashintel/query-editor/package.json
+++ b/libs/@hashintel/query-editor/package.json
@@ -19,7 +19,7 @@
     "postpublish": "PACKAGE_DIR=$(pwd) yarn workspace @local/repo-chores exe scripts/postpublish.ts"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "@fortawesome/free-regular-svg-icons": "6.0.0",
     "@fortawesome/free-solid-svg-icons": "6.0.0",
     "@hashintel/design-system": "0.0.7",

--- a/libs/@hashintel/type-editor/package.json
+++ b/libs/@hashintel/type-editor/package.json
@@ -19,7 +19,7 @@
     "postpublish": "PACKAGE_DIR=$(pwd) yarn workspace @local/repo-chores exe scripts/postpublish.ts"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "@blockprotocol/type-system": "0.1.1",
     "@fortawesome/free-regular-svg-icons": "6.0.0",
     "@fortawesome/free-solid-svg-icons": "6.0.0",

--- a/libs/@local/hash-isomorphic-utils/package.json
+++ b/libs/@local/hash-isomorphic-utils/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@apollo/client": "3.6.9",
     "@blockprotocol/core": "0.1.2",
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "@local/hash-graph-client": "0.0.0-private",
     "@local/hash-subgraph": "0.0.0-private",
     "@sentry/browser": "7.74.1",

--- a/libs/@local/hash-subgraph/package.json
+++ b/libs/@local/hash-subgraph/package.json
@@ -29,7 +29,7 @@
     "test:unit": "jest"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.3.1-canary-20231120181031",
+    "@blockprotocol/graph": "0.3.1-canary-20231207113055",
     "@blockprotocol/type-system": "0.1.1",
     "@local/advanced-types": "0.0.0-private",
     "@local/hash-graph-client": "0.0.0-private",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2321,10 +2321,10 @@
     node-fetch "^3.3.0"
     typescript "4.9.4"
 
-"@blockprotocol/graph@0.3.1-canary-20231120181031":
-  version "0.3.1-canary-20231120181031"
-  resolved "https://registry.yarnpkg.com/@blockprotocol/graph/-/graph-0.3.1-canary-20231120181031.tgz#bd75a617efb9eab3cc92c8a38b27705a8a7d7eab"
-  integrity sha512-9oypfKwOInP9OoSCEKnVxX2VxDaeyiHjJROyisr8qxcRIacK/LmAr8UkT/7bxF7JW3ga4D2BUPUpTHaEZ1eaZg==
+"@blockprotocol/graph@0.3.1-canary-20231207113055":
+  version "0.3.1-canary-20231207113055"
+  resolved "https://registry.yarnpkg.com/@blockprotocol/graph/-/graph-0.3.1-canary-20231207113055.tgz#a757a2a5cd7d3a40d0d912cbac14390f2748b657"
+  integrity sha512-Y9cyca+ztocsx08OcHTAw6Rof7lvznJIRFq/vJMS07t8IhlB9aA7PYemNAHuMA4kGkuP/CFZ54csA6RUUFGlBA==
   dependencies:
     "@blockprotocol/core" "0.1.2"
     "@blockprotocol/type-system" "0.1.1"
@@ -8082,11 +8082,6 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity "sha1-L4u0QUNNFjs1+4/9zNcTiSf/uMA= sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
-
-"@types/pluralize@0.0.29":
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/@types/pluralize/-/pluralize-0.0.29.tgz#6ffa33ed1fc8813c469b859681d09707eb40d03c"
-  integrity "sha1-b/oz7R/IgTxGm4WWgdCXB+tA0Dw= sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA=="
 
 "@types/pluralize@0.0.33":
   version "0.0.33"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR adds a "Count links" variant to the bar graph block, counting the incoming or outgoing links of a configurable link entity type of entities of a certain type.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-1331

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

- [x] merging https://github.com/hashintel/hash/pull/3658

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

See commits.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **block** that will need publishing via GitHub action once merged

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

- Currently the `getEntityIncomingLinks` and `getEntityOutgoingLinks` non-temporal methods break when they are passed a temporal subgraph (H-1522)

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

Manual testing.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Checkout the branch locally and run the block in development mode
2. Load the locally hosted block into a page, and add a data query which selects entities that have either incoming or outgoing links
3. Configure the "Count Links" bar chart variant and select the relevant linked entity type you'd like to count in the bar graph
4. Click "Update Chart", and observe the number of outgoing or incoming links being displayed in the chart

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->


https://github.com/hashintel/hash/assets/42802102/9b4788e3-2326-416d-b67d-96d6624f4a7b


