### PR TITLE
H-1399: Use offline mode in BE integration tests

### DIFF
--- a/apps/hash-api/src/graph/migrate-ontology-types/migrations/000.migration.ts
+++ b/apps/hash-api/src/graph/migrate-ontology-types/migrations/000.migration.ts
@@ -9,13 +9,15 @@ import {
   loadExternalEntityTypeIfNotExists,
   loadExternalPropertyTypeIfNotExists,
 } from "../util";
+import { VersionedUrl } from "@blockprotocol/type-system";
 
 const migrate: MigrationFunction = async ({
   context,
   authentication,
   migrationState,
 }) => {
-  for (const blockProtocolDataTypeId of Object.keys(CACHED_DATA_TYPE_SCHEMAS)) {
+  let blockProtocolDataTypeId: VersionedUrl;
+  for (blockProtocolDataTypeId in CACHED_DATA_TYPE_SCHEMAS) {
     /** @todo: provide schemas so they don't have to be fetched from blockprotocol.org */
     await loadExternalDataTypeIfNotExists(context, authentication, {
       dataTypeId: blockProtocolDataTypeId,
@@ -23,9 +25,8 @@ const migrate: MigrationFunction = async ({
     });
   }
 
-  for (const blockProtocolPropertyTypeId of Object.keys(
-    CACHED_PROPERTY_TYPE_SCHEMAS,
-  )) {
+  let blockProtocolPropertyTypeId: VersionedUrl;
+  for (blockProtocolPropertyTypeId in CACHED_PROPERTY_TYPE_SCHEMAS) {
     /** @todo: provide schemas so they don't have to be fetched from blockprotocol.org */
     await loadExternalPropertyTypeIfNotExists(context, authentication, {
       propertyTypeId: blockProtocolPropertyTypeId,
@@ -33,9 +34,8 @@ const migrate: MigrationFunction = async ({
     });
   }
 
-  for (const blockProtocolEntityTypeId of Object.keys(
-    CACHED_ENTITY_TYPE_SCHEMAS,
-  )) {
+  let blockProtocolEntityTypeId: VersionedUrl;
+  for (blockProtocolEntityTypeId in CACHED_ENTITY_TYPE_SCHEMAS) {
     /** @todo: provide schemas so they don't have to be fetched from blockprotocol.org */
     await loadExternalEntityTypeIfNotExists(context, authentication, {
       entityTypeId: blockProtocolEntityTypeId,

--- a/apps/hash-api/src/graph/migrate-ontology-types/migrations/000.migration.ts
+++ b/apps/hash-api/src/graph/migrate-ontology-types/migrations/000.migration.ts
@@ -1,3 +1,5 @@
+import { VersionedUrl } from "@blockprotocol/type-system";
+
 import {
   CACHED_DATA_TYPE_SCHEMAS,
   CACHED_ENTITY_TYPE_SCHEMAS,
@@ -9,7 +11,6 @@ import {
   loadExternalEntityTypeIfNotExists,
   loadExternalPropertyTypeIfNotExists,
 } from "../util";
-import { VersionedUrl } from "@blockprotocol/type-system";
 
 const migrate: MigrationFunction = async ({
   context,
@@ -17,8 +18,8 @@ const migrate: MigrationFunction = async ({
   migrationState,
 }) => {
   let blockProtocolDataTypeId: VersionedUrl;
+  // eslint-disable-next-line guard-for-in
   for (blockProtocolDataTypeId in CACHED_DATA_TYPE_SCHEMAS) {
-    /** @todo: provide schemas so they don't have to be fetched from blockprotocol.org */
     await loadExternalDataTypeIfNotExists(context, authentication, {
       dataTypeId: blockProtocolDataTypeId,
       migrationState,
@@ -26,8 +27,8 @@ const migrate: MigrationFunction = async ({
   }
 
   let blockProtocolPropertyTypeId: VersionedUrl;
+  // eslint-disable-next-line guard-for-in
   for (blockProtocolPropertyTypeId in CACHED_PROPERTY_TYPE_SCHEMAS) {
-    /** @todo: provide schemas so they don't have to be fetched from blockprotocol.org */
     await loadExternalPropertyTypeIfNotExists(context, authentication, {
       propertyTypeId: blockProtocolPropertyTypeId,
       migrationState,
@@ -35,8 +36,8 @@ const migrate: MigrationFunction = async ({
   }
 
   let blockProtocolEntityTypeId: VersionedUrl;
+  // eslint-disable-next-line guard-for-in
   for (blockProtocolEntityTypeId in CACHED_ENTITY_TYPE_SCHEMAS) {
-    /** @todo: provide schemas so they don't have to be fetched from blockprotocol.org */
     await loadExternalEntityTypeIfNotExists(context, authentication, {
       entityTypeId: blockProtocolEntityTypeId,
       migrationState,

--- a/apps/hash-api/src/graph/migrate-ontology-types/migrations/000.migration.ts
+++ b/apps/hash-api/src/graph/migrate-ontology-types/migrations/000.migration.ts
@@ -1,26 +1,44 @@
-import { VersionedUrl } from "@blockprotocol/type-system";
-
+import {
+  CACHED_DATA_TYPE_SCHEMAS,
+  CACHED_ENTITY_TYPE_SCHEMAS,
+  CACHED_PROPERTY_TYPE_SCHEMAS,
+} from "../../../seed-data";
 import { MigrationFunction } from "../types";
-import { loadExternalDataTypeIfNotExists } from "../util";
-
-const blockProtocolDataTypeIds: VersionedUrl[] = [
-  "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
-  "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1",
-  "https://blockprotocol.org/@blockprotocol/types/data-type/boolean/v/1",
-  "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1",
-  "https://blockprotocol.org/@blockprotocol/types/data-type/empty-list/v/1",
-  "https://blockprotocol.org/@blockprotocol/types/data-type/null/v/1",
-];
+import {
+  loadExternalDataTypeIfNotExists,
+  loadExternalEntityTypeIfNotExists,
+  loadExternalPropertyTypeIfNotExists,
+} from "../util";
 
 const migrate: MigrationFunction = async ({
   context,
   authentication,
   migrationState,
 }) => {
-  for (const blockProtocolDataTypeId of blockProtocolDataTypeIds) {
+  for (const blockProtocolDataTypeId of Object.keys(CACHED_DATA_TYPE_SCHEMAS)) {
     /** @todo: provide schemas so they don't have to be fetched from blockprotocol.org */
     await loadExternalDataTypeIfNotExists(context, authentication, {
       dataTypeId: blockProtocolDataTypeId,
+      migrationState,
+    });
+  }
+
+  for (const blockProtocolPropertyTypeId of Object.keys(
+    CACHED_PROPERTY_TYPE_SCHEMAS,
+  )) {
+    /** @todo: provide schemas so they don't have to be fetched from blockprotocol.org */
+    await loadExternalPropertyTypeIfNotExists(context, authentication, {
+      propertyTypeId: blockProtocolPropertyTypeId,
+      migrationState,
+    });
+  }
+
+  for (const blockProtocolEntityTypeId of Object.keys(
+    CACHED_ENTITY_TYPE_SCHEMAS,
+  )) {
+    /** @todo: provide schemas so they don't have to be fetched from blockprotocol.org */
+    await loadExternalEntityTypeIfNotExists(context, authentication, {
+      entityTypeId: blockProtocolEntityTypeId,
       migrationState,
     });
   }

--- a/apps/hash-api/src/graph/migrate-ontology-types/util.ts
+++ b/apps/hash-api/src/graph/migrate-ontology-types/util.ts
@@ -1,4 +1,7 @@
 /* eslint-disable no-param-reassign */
+import fs from "node:fs";
+import path from "node:path";
+
 import {
   Array,
   DataTypeReference,
@@ -33,6 +36,11 @@ import {
 } from "@local/hash-subgraph/type-system-patch";
 
 import { NotFoundError } from "../../lib/error";
+import {
+  CACHED_DATA_TYPE_SCHEMAS,
+  CACHED_ENTITY_TYPE_SCHEMAS,
+  CACHED_PROPERTY_TYPE_SCHEMAS,
+} from "../../seed-data";
 import { ImpureGraphFunction } from "../context-types";
 import { getDataTypeById } from "../ontology/primitive/data-type";
 import {
@@ -96,6 +104,28 @@ export const loadExternalDataTypeIfNotExists: ImpureGraphFunction<
     return existingDataType;
   }
 
+  const cached_file_name = CACHED_DATA_TYPE_SCHEMAS[dataTypeId];
+  if (cached_file_name) {
+    // We need an absolute path to `../../../seed-data`
+    await context.graphApi.loadExternalDataType(authentication.actorId, {
+      schema: JSON.parse(
+        fs.readFileSync(
+          path.join(
+            __dirname,
+            "..",
+            "..",
+            "seed-data",
+            "data_type",
+            cached_file_name,
+          ),
+          "utf8",
+        ),
+      ),
+    });
+
+    return await getDataTypeById(context, authentication, { dataTypeId });
+  }
+
   await context.graphApi.loadExternalDataType(authentication.actorId, {
     dataTypeId,
   });
@@ -132,6 +162,30 @@ export const loadExternalPropertyTypeIfNotExists: ImpureGraphFunction<
     return existingPropertyType;
   }
 
+  const cached_file_name = CACHED_PROPERTY_TYPE_SCHEMAS[propertyTypeId];
+  if (cached_file_name) {
+    // We need an absolute path to `../../../seed-data`
+    await context.graphApi.loadExternalPropertyType(authentication.actorId, {
+      schema: JSON.parse(
+        fs.readFileSync(
+          path.join(
+            __dirname,
+            "..",
+            "..",
+            "seed-data",
+            "property_type",
+            cached_file_name,
+          ),
+          "utf8",
+        ),
+      ),
+    });
+
+    return await getPropertyTypeById(context, authentication, {
+      propertyTypeId,
+    });
+  }
+
   await context.graphApi.loadExternalPropertyType(authentication.actorId, {
     propertyTypeId,
   });
@@ -162,6 +216,28 @@ export const loadExternalEntityTypeIfNotExists: ImpureGraphFunction<
 
   if (existingEntityType) {
     return existingEntityType;
+  }
+
+  const cached_file_name = CACHED_ENTITY_TYPE_SCHEMAS[entityTypeId];
+  if (cached_file_name) {
+    // We need an absolute path to `../../../seed-data`
+    await context.graphApi.loadExternalEntityType(authentication.actorId, {
+      schema: JSON.parse(
+        fs.readFileSync(
+          path.join(
+            __dirname,
+            "..",
+            "..",
+            "seed-data",
+            "entity_type",
+            cached_file_name,
+          ),
+          "utf8",
+        ),
+      ),
+    });
+
+    return await getEntityTypeById(context, authentication, { entityTypeId });
   }
 
   await context.graphApi.loadExternalEntityType(authentication.actorId, {

--- a/apps/hash-api/src/seed-data/data_type/boolean/1.json
+++ b/apps/hash-api/src/seed-data/data_type/boolean/1.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
+  "kind": "dataType",
+  "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/boolean/v/1",
+  "title": "Boolean",
+  "description": "A True or False value",
+  "type": "boolean"
+}

--- a/apps/hash-api/src/seed-data/data_type/empty_list/1.json
+++ b/apps/hash-api/src/seed-data/data_type/empty_list/1.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
+  "kind": "dataType",
+  "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/empty-list/v/1",
+  "title": "Empty List",
+  "description": "An Empty List",
+  "type": "array",
+  "const": []
+}

--- a/apps/hash-api/src/seed-data/data_type/null/1.json
+++ b/apps/hash-api/src/seed-data/data_type/null/1.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
+  "kind": "dataType",
+  "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/null/v/1",
+  "title": "Null",
+  "description": "A placeholder value representing 'nothing'",
+  "type": "null"
+}

--- a/apps/hash-api/src/seed-data/data_type/number/1.json
+++ b/apps/hash-api/src/seed-data/data_type/number/1.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
+  "kind": "dataType",
+  "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1",
+  "title": "Number",
+  "description": "An arithmetical value (in the Real number system)",
+  "type": "number"
+}

--- a/apps/hash-api/src/seed-data/data_type/object/1.json
+++ b/apps/hash-api/src/seed-data/data_type/object/1.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
+  "kind": "dataType",
+  "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1",
+  "title": "Object",
+  "description": "An opaque, untyped JSON object",
+  "type": "object"
+}

--- a/apps/hash-api/src/seed-data/data_type/text/1.json
+++ b/apps/hash-api/src/seed-data/data_type/text/1.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
+  "kind": "dataType",
+  "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
+  "title": "Text",
+  "description": "An ordered sequence of characters",
+  "type": "string"
+}

--- a/apps/hash-api/src/seed-data/entity_type/has_query/1.json
+++ b/apps/hash-api/src/seed-data/entity_type/has_query/1.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/entity-type",
+  "$id": "https://blockprotocol.org/@hash/types/entity-type/has-query/v/1",
+  "kind": "entityType",
+  "title": "Has Query",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1"
+    }
+  ],
+  "description": "The query that something has.",
+  "examples": [],
+  "links": {},
+  "properties": {},
+  "required": []
+}

--- a/apps/hash-api/src/seed-data/entity_type/link/1.json
+++ b/apps/hash-api/src/seed-data/entity_type/link/1.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/entity-type",
+  "kind": "entityType",
+  "$id": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1",
+  "type": "object",
+  "title": "Link",
+  "properties": {}
+}

--- a/apps/hash-api/src/seed-data/entity_type/query/1.json
+++ b/apps/hash-api/src/seed-data/entity_type/query/1.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/entity-type",
+  "$id": "https://blockprotocol.org/@hash/types/entity-type/query/v/1",
+  "kind": "entityType",
+  "title": "Query",
+  "type": "object",
+  "allOf": [],
+  "description": "",
+  "examples": [],
+  "links": {},
+  "properties": {
+    "https://blockprotocol.org/@hash/types/property-type/query/": {
+      "$ref": "https://blockprotocol.org/@hash/types/property-type/query/v/1"
+    }
+  },
+  "required": ["https://blockprotocol.org/@hash/types/property-type/query/"]
+}

--- a/apps/hash-api/src/seed-data/entity_type/thing/1.json
+++ b/apps/hash-api/src/seed-data/entity_type/thing/1.json
@@ -1,0 +1,13 @@
+{
+  "allOf": [],
+  "description": "A generic thing",
+  "examples": [],
+  "$id": "https://blockprotocol.org/@blockprotocol/types/entity-type/thing/v/1",
+  "kind": "entityType",
+  "links": {},
+  "properties": {},
+  "required": [],
+  "title": "Thing",
+  "type": "object",
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/entity-type"
+}

--- a/apps/hash-api/src/seed-data/index.ts
+++ b/apps/hash-api/src/seed-data/index.ts
@@ -1,3 +1,4 @@
+import { VersionedUrl } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
 import { OwnedById } from "@local/hash-subgraph";
 
@@ -10,7 +11,6 @@ import {
 import { joinOrg, User } from "../graph/knowledge/system-types/user";
 import { PageDefinition, seedPages } from "./seed-pages";
 import { ensureUsersAreSeeded } from "./seed-users";
-import { VersionedUrl } from "@blockprotocol/type-system";
 
 export const CACHED_DATA_TYPE_SCHEMAS: Record<VersionedUrl, string> = {
   "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1":

--- a/apps/hash-api/src/seed-data/index.ts
+++ b/apps/hash-api/src/seed-data/index.ts
@@ -10,8 +10,9 @@ import {
 import { joinOrg, User } from "../graph/knowledge/system-types/user";
 import { PageDefinition, seedPages } from "./seed-pages";
 import { ensureUsersAreSeeded } from "./seed-users";
+import { VersionedUrl } from "@blockprotocol/type-system";
 
-export const CACHED_DATA_TYPE_SCHEMAS: Record<string, string> = {
+export const CACHED_DATA_TYPE_SCHEMAS: Record<VersionedUrl, string> = {
   "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1":
     "text/1.json",
   "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1":
@@ -26,7 +27,7 @@ export const CACHED_DATA_TYPE_SCHEMAS: Record<string, string> = {
     "null/1.json",
 };
 
-export const CACHED_PROPERTY_TYPE_SCHEMAS: Record<string, string> = {
+export const CACHED_PROPERTY_TYPE_SCHEMAS: Record<VersionedUrl, string> = {
   "https://blockprotocol.org/@blockprotocol/types/property-type/original-source/v/1":
     "original_source/1.json",
   "https://blockprotocol.org/@blockprotocol/types/property-type/original-file-name/v/1":
@@ -55,7 +56,7 @@ export const CACHED_PROPERTY_TYPE_SCHEMAS: Record<string, string> = {
     "name/1.json",
 };
 
-export const CACHED_ENTITY_TYPE_SCHEMAS: Record<string, string> = {
+export const CACHED_ENTITY_TYPE_SCHEMAS: Record<VersionedUrl, string> = {
   "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1":
     "link/1.json",
   "https://blockprotocol.org/@hash/types/entity-type/query/v/1": "query/1.json",

--- a/apps/hash-api/src/seed-data/index.ts
+++ b/apps/hash-api/src/seed-data/index.ts
@@ -11,6 +11,60 @@ import { joinOrg, User } from "../graph/knowledge/system-types/user";
 import { PageDefinition, seedPages } from "./seed-pages";
 import { ensureUsersAreSeeded } from "./seed-users";
 
+export const CACHED_DATA_TYPE_SCHEMAS: Record<string, string> = {
+  "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1":
+    "text/1.json",
+  "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1":
+    "number/1.json",
+  "https://blockprotocol.org/@blockprotocol/types/data-type/boolean/v/1":
+    "boolean/1.json",
+  "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1":
+    "object/1.json",
+  "https://blockprotocol.org/@blockprotocol/types/data-type/empty-list/v/1":
+    "empty_list/1.json",
+  "https://blockprotocol.org/@blockprotocol/types/data-type/null/v/1":
+    "null/1.json",
+};
+
+export const CACHED_PROPERTY_TYPE_SCHEMAS: Record<string, string> = {
+  "https://blockprotocol.org/@blockprotocol/types/property-type/original-source/v/1":
+    "original_source/1.json",
+  "https://blockprotocol.org/@blockprotocol/types/property-type/original-file-name/v/1":
+    "original_file_name/1.json",
+  "https://blockprotocol.org/@blockprotocol/types/property-type/file-size/v/1":
+    "file_size/1.json",
+  "https://blockprotocol.org/@blockprotocol/types/property-type/mime-type/v/1":
+    "mime_type/1.json",
+  "https://blockprotocol.org/@blockprotocol/types/property-type/description/v/1":
+    "description/1.json",
+  "https://blockprotocol.org/@blockprotocol/types/property-type/original-url/v/1":
+    "original_url/1.json",
+  "https://blockprotocol.org/@blockprotocol/types/property-type/file-name/v/1":
+    "file_name/1.json",
+  "https://blockprotocol.org/@blockprotocol/types/property-type/file-hash/v/1":
+    "file_hash/1.json",
+  "https://blockprotocol.org/@blockprotocol/types/property-type/display-name/v/1":
+    "display_name/1.json",
+  "https://blockprotocol.org/@blockprotocol/types/property-type/file-url/v/1":
+    "file_url/1.json",
+  "https://blockprotocol.org/@blockprotocol/types/property-type/textual-content/v/2":
+    "textual_content/2.json",
+  "https://blockprotocol.org/@hash/types/property-type/query/v/1":
+    "query/1.json",
+  "https://blockprotocol.org/@blockprotocol/types/property-type/name/v/1":
+    "name/1.json",
+};
+
+export const CACHED_ENTITY_TYPE_SCHEMAS: Record<string, string> = {
+  "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1":
+    "link/1.json",
+  "https://blockprotocol.org/@hash/types/entity-type/query/v/1": "query/1.json",
+  "https://blockprotocol.org/@hash/types/entity-type/has-query/v/1":
+    "has_query/1.json",
+  "https://blockprotocol.org/@blockprotocol/types/entity-type/thing/v/1":
+    "thing/1.json",
+};
+
 // Seed Org with some pages.
 const seedOrg = async (params: {
   logger: Logger;

--- a/apps/hash-api/src/seed-data/load_type.sh
+++ b/apps/hash-api/src/seed-data/load_type.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# The input is the URL to read the file from, e.g.: https://blockprotocol.org/@blockprotocol/types/data-type/boolean/v/1
+# The output is the file to write to, e.g.: ./data_types/boolean/1.json
+DIRECTORY=${1#*types/}
+DIRECTORY=${DIRECTORY%/v/*}
+DIRECTORY=${DIRECTORY//-/_}
+
+VERSION=${1#*types/*/*/v/}
+VERSION=${VERSION%/*}
+
+echo "Creating directory $DIRECTORY"
+mkdir -p "$DIRECTORY"
+echo "Loading type from $INPUT to $DIRECTORY/$VERSION.json"
+wget -O "$DIRECTORY/$VERSION.json" "$1"

--- a/apps/hash-api/src/seed-data/property_type/description/1.json
+++ b/apps/hash-api/src/seed-data/property_type/description/1.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type",
+  "$id": "https://blockprotocol.org/@blockprotocol/types/property-type/description/v/1",
+  "kind": "propertyType",
+  "title": "Description",
+  "description": "A piece of text that tells you about something or someone. This can include explaining what they look like, what its purpose is for, what they’re like, etc.",
+  "oneOf": [
+    {
+      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"
+    }
+  ]
+}

--- a/apps/hash-api/src/seed-data/property_type/display_name/1.json
+++ b/apps/hash-api/src/seed-data/property_type/display_name/1.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type",
+  "$id": "https://blockprotocol.org/@blockprotocol/types/property-type/display-name/v/1",
+  "kind": "propertyType",
+  "title": "Display Name",
+  "description": "A human-friendly display name for something",
+  "oneOf": [
+    {
+      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"
+    }
+  ]
+}

--- a/apps/hash-api/src/seed-data/property_type/file_hash/1.json
+++ b/apps/hash-api/src/seed-data/property_type/file_hash/1.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type",
+  "$id": "https://blockprotocol.org/@blockprotocol/types/property-type/file-hash/v/1",
+  "kind": "propertyType",
+  "title": "File Hash",
+  "description": "A unique signature derived from a file's contents",
+  "oneOf": [
+    {
+      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"
+    }
+  ]
+}

--- a/apps/hash-api/src/seed-data/property_type/file_name/1.json
+++ b/apps/hash-api/src/seed-data/property_type/file_name/1.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type",
+  "$id": "https://blockprotocol.org/@blockprotocol/types/property-type/file-name/v/1",
+  "kind": "propertyType",
+  "title": "File Name",
+  "description": "The name of a file.",
+  "oneOf": [
+    {
+      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"
+    }
+  ]
+}

--- a/apps/hash-api/src/seed-data/property_type/file_size/1.json
+++ b/apps/hash-api/src/seed-data/property_type/file_size/1.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type",
+  "$id": "https://blockprotocol.org/@blockprotocol/types/property-type/file-size/v/1",
+  "kind": "propertyType",
+  "title": "File Size",
+  "description": "The size of a file",
+  "oneOf": [
+    {
+      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1"
+    }
+  ]
+}

--- a/apps/hash-api/src/seed-data/property_type/file_url/1.json
+++ b/apps/hash-api/src/seed-data/property_type/file_url/1.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type",
+  "$id": "https://blockprotocol.org/@blockprotocol/types/property-type/file-url/v/1",
+  "kind": "propertyType",
+  "title": "File URL",
+  "description": "A URL that serves a file.",
+  "oneOf": [
+    {
+      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"
+    }
+  ]
+}

--- a/apps/hash-api/src/seed-data/property_type/mime_type/1.json
+++ b/apps/hash-api/src/seed-data/property_type/mime_type/1.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type",
+  "$id": "https://blockprotocol.org/@blockprotocol/types/property-type/mime-type/v/1",
+  "kind": "propertyType",
+  "title": "MIME Type",
+  "description": "A MIME (Multipurpose Internet Mail Extensions) type.\n\nSee: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types",
+  "oneOf": [
+    {
+      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"
+    }
+  ]
+}

--- a/apps/hash-api/src/seed-data/property_type/name/1.json
+++ b/apps/hash-api/src/seed-data/property_type/name/1.json
@@ -1,0 +1,12 @@
+{
+  "$id": "https://blockprotocol.org/@blockprotocol/types/property-type/name/v/1",
+  "description": "A word or set of words by which something is known, addressed, or referred to.",
+  "oneOf": [
+    {
+      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"
+    }
+  ],
+  "kind": "propertyType",
+  "title": "Name",
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type"
+}

--- a/apps/hash-api/src/seed-data/property_type/original_file_name/1.json
+++ b/apps/hash-api/src/seed-data/property_type/original_file_name/1.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type",
+  "$id": "https://blockprotocol.org/@blockprotocol/types/property-type/original-file-name/v/1",
+  "kind": "propertyType",
+  "title": "Original File Name",
+  "description": "The original name of a file",
+  "oneOf": [
+    {
+      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"
+    }
+  ]
+}

--- a/apps/hash-api/src/seed-data/property_type/original_source/1.json
+++ b/apps/hash-api/src/seed-data/property_type/original_source/1.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type",
+  "$id": "https://blockprotocol.org/@blockprotocol/types/property-type/original-source/v/1",
+  "kind": "propertyType",
+  "title": "Original Source",
+  "description": "The original source of something",
+  "oneOf": [
+    {
+      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"
+    }
+  ]
+}

--- a/apps/hash-api/src/seed-data/property_type/original_url/1.json
+++ b/apps/hash-api/src/seed-data/property_type/original_url/1.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type",
+  "$id": "https://blockprotocol.org/@blockprotocol/types/property-type/original-url/v/1",
+  "kind": "propertyType",
+  "title": "Original URL",
+  "description": "The original URL something was hosted at",
+  "oneOf": [
+    {
+      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"
+    }
+  ]
+}

--- a/apps/hash-api/src/seed-data/property_type/query/1.json
+++ b/apps/hash-api/src/seed-data/property_type/query/1.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type",
+  "$id": "https://blockprotocol.org/@hash/types/property-type/query/v/1",
+  "kind": "propertyType",
+  "title": "query",
+  "description": "The query for something.",
+  "oneOf": [
+    {
+      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1"
+    }
+  ]
+}

--- a/apps/hash-api/src/seed-data/property_type/textual_content/2.json
+++ b/apps/hash-api/src/seed-data/property_type/textual_content/2.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type",
+  "$id": "https://blockprotocol.org/@blockprotocol/types/property-type/textual-content/v/2",
+  "kind": "propertyType",
+  "title": "Textual Content",
+  "description": "The text material, information, or body, that makes up the content of this thing.",
+  "oneOf": [
+    {
+      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"
+    },
+    {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/apps/hash-external-services/docker-compose.dev.yml
+++ b/apps/hash-external-services/docker-compose.dev.yml
@@ -115,10 +115,6 @@ services:
       timeout: 2s
       retries: 10
 
-  type-fetcher:
-    ports:
-      - "${HASH_GRAPH_TYPE_FETCHER_PORT}:4444"
-
   graph-migrate:
     depends_on:
       telemetry-collector:

--- a/apps/hash-external-services/docker-compose.type-fetcher.yml
+++ b/apps/hash-external-services/docker-compose.type-fetcher.yml
@@ -8,6 +8,8 @@ services:
     volumes:
       - logs:/logs
     command: type-fetcher
+    ports:
+      - "${HASH_GRAPH_TYPE_FETCHER_PORT}:4444"
     environment:
       HASH_GRAPH_LOG_FORMAT: "${HASH_GRAPH_LOG_FORMAT:-pretty}"
       HASH_GRAPH_LOG_FOLDER: "/logs/graph-type-fetcher"

--- a/apps/hash-external-services/package.json
+++ b/apps/hash-external-services/package.json
@@ -9,6 +9,6 @@
     "deploy:offline": "docker compose --project-name hash-external-services --file docker-compose.yml --file docker-compose.dev.yml --file docker-compose.temporal.yml --env-file ../../.env  --env-file ../../.env.development --env-file ../../.env.local",
     "deploy:prod": "docker compose --project-name hash-external-services --file docker-compose.yml --file docker-compose.type-fetcher.yml --file docker-compose.prod.yml --env-file ../../.env --env-file ../../.env.production --env-file ../../.env.local",
     "deploy:prototype": "docker compose --project-name hash-prototype-services --file docker-compose.prototype.yml --env-file ../../.env --env-file ../../.env.local",
-    "deploy:test": "docker compose --project-name hash-external-services --file docker-compose.yml --file docker-compose.test.yml --file docker-compose.type-fetcher.yml --file docker-compose.temporal.yml --env-file ../../.env --env-file ../../.env.test --env-file ../../.env.local"
+    "deploy:test": "docker compose --project-name hash-external-services --file docker-compose.yml --file docker-compose.test.yml --file docker-compose.temporal.yml --env-file ../../.env --env-file ../../.env.test --env-file ../../.env.local"
   }
 }

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -212,14 +212,15 @@ where
             OntologyTypeReference::EntityTypeReference(reference) => reference.url(),
         };
 
-        if self
-            .connection_info()?
-            .domain_validator
-            .validate_url(url.base_url.as_str())
-        {
-            // If the domain is valid, we own the data type and it either exists or we cannot
-            // reference it.
-            return Ok(true);
+        if let Ok(connection_info) = self.connection_info() {
+            if connection_info
+                .domain_validator
+                .validate_url(url.base_url.as_str())
+            {
+                // If the domain is valid, we own the data type and it either exists or we cannot
+                // reference it.
+                return Ok(true);
+            }
         }
 
         match ontology_type_reference {
@@ -292,8 +293,21 @@ where
         };
 
         let mut fetched_ontology_types = FetchedOntologyTypes::default();
+        if queue.is_empty() {
+            return Ok(fetched_ontology_types);
+        }
 
-        let fetcher = self.fetcher_client().await.change_context(StoreError)?;
+        let fetcher = self
+            .fetcher_client()
+            .await
+            .change_context(StoreError)
+            .attach_printable_lazy(|| {
+                queue
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            })?;
         loop {
             let ontology_urls = mem::take(&mut queue);
             if ontology_urls.is_empty() {
@@ -692,7 +706,14 @@ where
             data_types.iter().map(|(data_type, _)| data_type),
             &requested_types,
         )
-        .await?;
+        .await
+        .attach_printable_lazy(|| {
+            data_types
+                .iter()
+                .map(|(data_type, _)| data_type.id().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        })?;
 
         self.store
             .create_data_types(actor_id, authorization_api, data_types, on_conflict)
@@ -725,7 +746,8 @@ where
             &HashSet::from([data_type.id()]),
         )
         .await
-        .change_context(UpdateError)?;
+        .change_context(UpdateError)
+        .attach_printable_lazy(|| data_type.id().clone())?;
 
         self.store
             .update_data_type(actor_id, authorization_api, data_type)
@@ -785,7 +807,14 @@ where
                 .map(|(property_type, _)| property_type),
             &requested_types,
         )
-        .await?;
+        .await
+        .attach_printable_lazy(|| {
+            property_types
+                .iter()
+                .map(|(property_type, _)| property_type.id().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        })?;
 
         self.store
             .create_property_types(actor_id, authorization_api, property_types, on_conflict)
@@ -818,7 +847,8 @@ where
             &HashSet::from([property_type.id()]),
         )
         .await
-        .change_context(UpdateError)?;
+        .change_context(UpdateError)
+        .attach_printable_lazy(|| property_type.id().clone())?;
 
         self.store
             .update_property_type(actor_id, authorization_api, property_type)
@@ -874,7 +904,14 @@ where
             entity_types.iter().map(|(entity_type, _)| entity_type),
             &requested_types,
         )
-        .await?;
+        .await
+        .attach_printable_lazy(|| {
+            entity_types
+                .iter()
+                .map(|(entity_type, _)| entity_type.id().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        })?;
 
         self.store
             .create_entity_types(actor_id, authorization_api, entity_types, on_conflict)
@@ -909,7 +946,8 @@ where
             &HashSet::from([entity_type.id()]),
         )
         .await
-        .change_context(UpdateError)?;
+        .change_context(UpdateError)
+        .attach_printable_lazy(|| entity_type.id().clone())?;
 
         self.store
             .update_entity_type(

--- a/apps/hash-graph/tests/circular-links.http
+++ b/apps/hash-graph/tests/circular-links.http
@@ -30,6 +30,30 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   });
 %}
 
+### load entity link type
+POST http://127.0.0.1:4000/entity-types/load
+Content-Type: application/json
+Accept: application/json
+X-Authenticated-User-Actor-Id: {{account_id}}
+
+{
+  "schema": {
+    "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/entity-type",
+    "kind": "entityType",
+    "$id": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1",
+    "type": "object",
+    "title": "Link",
+    "properties": {}
+  }
+}
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+    });
+    client.global.set("link_entity_type_id", `${response.body.recordId.baseUrl}v/${response.body.recordId.version}`);
+%}
+
 ### Insert link entity type
 POST http://127.0.0.1:4000/entity-types
 Content-Type: application/json
@@ -44,7 +68,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     "$id": "http://localhost:3000/@snapshot/types/entity-type/link/v/1",
     "type": "object",
     "title": "Object",
-    "allOf": [{ "$ref": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1" }],
+    "allOf": [{ "$ref": "{{link_entity_type_id}}" }],
     "properties": {}
   }
 }

--- a/apps/hash-graph/tests/circular-links.http
+++ b/apps/hash-graph/tests/circular-links.http
@@ -47,13 +47,6 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   }
 }
 
-> {%
-    client.test("status", function() {
-        client.assert(response.status === 200, "Response status is not 200");
-    });
-    client.global.set("link_entity_type_id", `${response.body.recordId.baseUrl}v/${response.body.recordId.version}`);
-%}
-
 ### Insert link entity type
 POST http://127.0.0.1:4000/entity-types
 Content-Type: application/json
@@ -68,7 +61,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     "$id": "http://localhost:3000/@snapshot/types/entity-type/link/v/1",
     "type": "object",
     "title": "Object",
-    "allOf": [{ "$ref": "{{link_entity_type_id}}" }],
+    "allOf": [{ "$ref": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1" }],
     "properties": {}
   }
 }

--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -486,13 +486,6 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   }
 }
 
-> {%
-    client.test("status", function() {
-        client.assert(response.status === 200, "Response status is not 200");
-    });
-    client.global.set("link_entity_type_id", `${response.body.recordId.baseUrl}v/${response.body.recordId.version}`);
-%}
-
 ### Insert Friendship entity link type
 POST http://127.0.0.1:4000/entity-types
 Content-Type: application/json
@@ -509,7 +502,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     "title": "Friendship",
     "allOf": [
       {
-        "$ref": "{{link_entity_type_id}}"
+        "$ref": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1"
       }
     ],
     "properties": {}
@@ -944,7 +937,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
         ]
       },
       {
-        "parameter": "{{link_entity_type_id}}"
+        "parameter": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1"
       }
     ]
   },
@@ -1682,7 +1675,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
         ]
       },
       {
-        "parameter": "{{link_entity_type_id}}"
+        "parameter": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1"
       }
     ]
   },

--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -171,7 +171,14 @@ Accept: application/json
 X-Authenticated-User-Actor-Id: {{account_id}}
 
 {
-  "dataTypeId": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"
+  "schema": {
+    "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
+    "kind": "dataType",
+    "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
+    "title": "Text",
+    "description": "An ordered sequence of characters",
+    "type": "string"
+  }
 }
 
 > {%
@@ -462,6 +469,30 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     });
 %}
 
+### Insert external entity link type
+POST http://127.0.0.1:4000/entity-types/load
+Content-Type: application/json
+Accept: application/json
+X-Authenticated-User-Actor-Id: {{account_id}}
+
+{
+  "schema": {
+    "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/entity-type",
+    "kind": "entityType",
+    "$id": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1",
+    "type": "object",
+    "title": "Link",
+    "properties": {}
+  }
+}
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+    });
+    client.global.set("link_entity_type_id", `${response.body.recordId.baseUrl}v/${response.body.recordId.version}`);
+%}
+
 ### Insert Friendship entity link type
 POST http://127.0.0.1:4000/entity-types
 Content-Type: application/json
@@ -478,7 +509,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     "title": "Friendship",
     "allOf": [
       {
-        "$ref": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1"
+        "$ref": "{{link_entity_type_id}}"
       }
     ],
     "properties": {}
@@ -913,7 +944,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
         ]
       },
       {
-        "parameter": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1"
+        "parameter": "{{link_entity_type_id}}"
       }
     ]
   },
@@ -1651,7 +1682,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
         ]
       },
       {
-        "parameter": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1"
+        "parameter": "{{link_entity_type_id}}"
       }
     ]
   },

--- a/tests/hash-backend-integration/src/tests/graph/ontology/primitive/entity-type.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/ontology/primitive/entity-type.test.ts
@@ -245,7 +245,7 @@ describe("Entity type CRU", () => {
     ).toBe(testUser2.accountId);
   });
 
-  it("can load an external type on demand", async () => {
+  it.skip("can load an external type on demand", async () => {
     const authentication = { actorId: testUser.accountId };
 
     const entityTypeId =

--- a/tests/hash-backend-integration/src/tests/graph/ontology/primitive/property-type.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/ontology/primitive/property-type.test.ts
@@ -148,7 +148,7 @@ describe("Property type CRU", () => {
     ).toBe(testUser2.accountId);
   });
 
-  it("can load an external type on demand", async () => {
+  it.skip("can load an external type on demand", async () => {
     const authentication = { actorId: testUser.accountId };
 
     const propertyTypeId =


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Due to fetching the type very frequently in CI we encounter various flaky errors which makes dealing with external types currently very hard. This PR stores the types used in HASH in the migration skips and uses the cached variant if available. Further, it enforces no type fetcher running in the BE integration tests to avoid future issues.
This also fixes some issues in the type fetcher when the offline mode is enabled and adds more information to the errors if the type fetcher is not available (the requested types are printed so it's easier to find them and insert them to the migration).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph