### PR TITLE
H-1414: Add loading skeletons for the entities + type section in sidebar

### DIFF
--- a/apps/hash-frontend/src/shared/entity-types-context/hooks.ts
+++ b/apps/hash-frontend/src/shared/entity-types-context/hooks.ts
@@ -27,7 +27,7 @@ export const useLatestEntityTypesOptional = (params?: {
 }) => {
   const { includeArchived = false } = params ?? {};
 
-  const { entityTypes, isSpecialEntityTypeLookup } =
+  const { entityTypes, isSpecialEntityTypeLookup, loading } =
     useEntityTypesContextRequired();
 
   const latestEntityTypes = useMemo(() => {
@@ -60,7 +60,7 @@ export const useLatestEntityTypesOptional = (params?: {
         );
   }, [entityTypes, includeArchived]);
 
-  return { latestEntityTypes, isSpecialEntityTypeLookup };
+  return { latestEntityTypes, isSpecialEntityTypeLookup, loading };
 };
 
 /**

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list.tsx
@@ -18,6 +18,7 @@ import {
   SortType,
 } from "./account-entity-type-list/sort-actions-dropdown";
 import { NavLink } from "./nav-link";
+import { LoadingSkeleton } from "./shared/loading-skeleton";
 import { ViewAllLink } from "./view-all-link";
 
 type AccountEntityTypeListProps = {
@@ -36,7 +37,7 @@ export const AccountEntityTypeList: FunctionComponent<
     popupId: "type-sort-actions-menu",
   });
 
-  const { latestEntityTypes } = useLatestEntityTypesOptional();
+  const { latestEntityTypes, loading } = useLatestEntityTypesOptional();
 
   const accountEntityTypes = useMemo(() => {
     if (latestEntityTypes) {
@@ -128,13 +129,17 @@ export const AccountEntityTypeList: FunctionComponent<
         }
       >
         <Box component="ul">
-          <TransitionGroup>
-            {filteredEntityTypes.map((root) => (
-              <Collapse key={root.schema.$id}>
-                <EntityTypeItem entityType={root} variant="entity-type" />
-              </Collapse>
-            ))}
-          </TransitionGroup>
+          {loading ? (
+            <LoadingSkeleton />
+          ) : (
+            <TransitionGroup>
+              {filteredEntityTypes.map((root) => (
+                <Collapse key={root.schema.$id}>
+                  <EntityTypeItem entityType={root} variant="entity-type" />
+                </Collapse>
+              ))}
+            </TransitionGroup>
+          )}
           <Box
             tabIndex={0}
             component="li"

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-page-list/account-page-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-page-list/account-page-list.tsx
@@ -43,10 +43,10 @@ import { useUserOrOrgShortnameByOwnedById } from "../../../../components/hooks/u
 import { constructPageRelativeUrl } from "../../../../lib/routes";
 import { PlusRegularIcon } from "../../../icons/plus-regular";
 import { NavLink } from "../nav-link";
+import { LoadingSkeleton } from "../shared/loading-skeleton";
 import { ViewAllLink } from "../view-all-link";
 import { AccountPageListItem } from "./account-page-list-item";
 import { IDENTATION_WIDTH } from "./page-tree-item";
-import { PagesLoadingState } from "./pages-loading-state";
 import {
   getLastIndex,
   getProjection,
@@ -427,7 +427,7 @@ export const AccountPageList: FunctionComponent<AccountPageListProps> = ({
           }
         >
           {pagesLoading ? (
-            <PagesLoadingState />
+            <LoadingSkeleton page />
           ) : (
             <Box sx={{ marginX: 0.75 }} data-testid="pages-tree">
               {renderPageTree(treeItems)}

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/acount-entities-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/acount-entities-list.tsx
@@ -19,6 +19,7 @@ import {
   SortType,
 } from "./account-entity-type-list/sort-actions-dropdown";
 import { NavLink } from "./nav-link";
+import { LoadingSkeleton } from "./shared/loading-skeleton";
 import { ViewAllLink } from "./view-all-link";
 
 type AccountEntitiesListProps = {
@@ -37,7 +38,7 @@ export const AccountEntitiesList: FunctionComponent<
 
   const { activeWorkspace } = useActiveWorkspace();
 
-  const { latestEntityTypes } = useLatestEntityTypesOptional();
+  const { latestEntityTypes, loading } = useLatestEntityTypesOptional();
 
   const pinnedEntityTypes = useMemo(() => {
     const { pinnedEntityTypeBaseUrls } = activeWorkspace ?? {};
@@ -132,19 +133,24 @@ export const AccountEntitiesList: FunctionComponent<
         }
       >
         <Box component="ul">
-          <TransitionGroup>
-            {sortedEntityTypes.map((root) => (
-              <Collapse key={root.schema.$id}>
-                <EntityTypeItem
-                  entityType={root}
-                  href={`/entities?entityTypeIdOrBaseUrl=${extractBaseUrl(
-                    root.schema.$id,
-                  )}`}
-                  variant="entity"
-                />
-              </Collapse>
-            ))}
-          </TransitionGroup>
+          {loading ? (
+            <LoadingSkeleton />
+          ) : (
+            <TransitionGroup>
+              {sortedEntityTypes.map((root) => (
+                <Collapse key={root.schema.$id}>
+                  <EntityTypeItem
+                    entityType={root}
+                    href={`/entities?entityTypeIdOrBaseUrl=${extractBaseUrl(
+                      root.schema.$id,
+                    )}`}
+                    variant="entity"
+                  />
+                </Collapse>
+              ))}
+            </TransitionGroup>
+          )}
+
           <Box marginLeft={1} marginTop={0.5}>
             <ViewAllLink href="/entities">View all entities</ViewAllLink>
           </Box>

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/shared/loading-skeleton.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/shared/loading-skeleton.tsx
@@ -25,8 +25,8 @@ const LoadingLine = () => {
   );
 };
 
-export const PagesLoadingState = () => (
-  <Box mx={0.75} px={3.5}>
+export const LoadingSkeleton = ({ page = false }: { page?: boolean }) => (
+  <Box mx={0.75} pl={page ? 3.5 : 1.5} pr={6}>
     <LoadingLine />
     <LoadingLine />
     <LoadingLine />


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

It adds loading skeletons for the entities + type section in sidebar, although since the latter is collapsed by default it will only be visible if someone quickly expands it on page load.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change
-
### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Reload the page

## 📹 Demo

https://github.com/hashintel/hash/assets/37743469/f4529da8-da38-4a0e-a178-0bb6b2b5b296

