### PR TITLE
H-1528: Increase CPU and memory for AWS instance

### DIFF
--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -213,8 +213,8 @@ module "application" {
   vpc                          = module.networking.vpc
   prefix                       = local.prefix
   param_prefix                 = local.param_prefix
-  cpu                          = 512
-  memory                       = 2048
+  cpu                          = 2048
+  memory                       = 4096
   worker_cpu                   = 256
   worker_memory                = 512
   ses_verified_domain_identity = var.ses_verified_domain_identity


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We want to raise the number of CPUs to 2 and the memory to 4 GB.