### PR TITLE
H-1421, H-1474, H-1509: Page loading and quick notes improvements

### DIFF
--- a/apps/hash-api/src/graph/knowledge/system-types/org.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/org.ts
@@ -189,6 +189,7 @@ export const getOrgByShortname: ImpureGraphFunction<
         all: [
           generateVersionedUrlMatchingFilter(
             systemEntityTypes.organization.entityTypeId,
+            { ignoreParents: true },
           ),
           {
             equal: [

--- a/apps/hash-api/src/graph/knowledge/system-types/page.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/page.ts
@@ -1,12 +1,10 @@
 import { sortBlockCollectionLinks } from "@local/hash-isomorphic-utils/block-collection";
-import { paragraphBlockComponentId } from "@local/hash-isomorphic-utils/blocks";
 import { getFirstEntityRevision } from "@local/hash-isomorphic-utils/entity";
 import {
   currentTimeInstantTemporalAxes,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import {
-  blockProtocolPropertyTypes,
   systemEntityTypes,
   systemLinkEntityTypes,
   systemPropertyTypes,
@@ -59,12 +57,7 @@ import {
   createLinkEntity,
   getLinkEntityRightEntity,
 } from "../primitive/link-entity";
-import {
-  Block,
-  createBlock,
-  getBlockComments,
-  getBlockFromEntity,
-} from "./block";
+import { Block, getBlockComments, getBlockFromEntity } from "./block";
 import { addBlockToBlockCollection } from "./block-collection";
 import { Comment } from "./comment";
 import { getUserById, User } from "./user";

--- a/apps/hash-api/src/graph/knowledge/system-types/page.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/page.ts
@@ -163,26 +163,7 @@ export const createPage: ImpureGraphFunction<
 
   const page = getPageFromEntity({ entity });
 
-  const initialBlocks =
-    params.initialBlocks && params.initialBlocks.length > 0
-      ? params.initialBlocks
-      : [
-          await createBlock(ctx, authentication, {
-            ownedById,
-            componentId: paragraphBlockComponentId,
-            blockData: await createEntity(ctx, authentication, {
-              ownedById,
-              properties: {
-                [extractBaseUrl(
-                  blockProtocolPropertyTypes.textualContent.propertyTypeId,
-                )]: [],
-              },
-              entityTypeId: systemEntityTypes.text.entityTypeId,
-            }),
-          }),
-        ];
-
-  for (const block of initialBlocks) {
+  for (const block of params.initialBlocks ?? []) {
     await addBlockToBlockCollection(ctx, authentication, {
       blockCollectionEntityId: page.entity.metadata.recordId.entityId,
       block,

--- a/apps/hash-frontend/src/components/block-loader/block-loader.tsx
+++ b/apps/hash-frontend/src/components/block-loader/block-loader.tsx
@@ -352,14 +352,12 @@ export const BlockLoader: FunctionComponent<BlockLoaderProps> = ({
     });
   }, [
     blockEntityId,
-    blockCollectionSubgraph,
     blockEntityTypeId,
     blockSubgraph,
     fallbackBlockProperties,
     fetchBlockSubgraph,
     setBlockSubgraph,
     setUserPermissions,
-    userPermissionsOnEntities,
   ]);
 
   const refetchSubgraph = useCallback(async () => {

--- a/apps/hash-frontend/src/components/hooks/shared/get-page-refetch-queries.ts
+++ b/apps/hash-frontend/src/components/hooks/shared/get-page-refetch-queries.ts
@@ -1,9 +1,13 @@
 import { getEntityQuery } from "@local/hash-isomorphic-utils/graphql/queries/entity.queries";
-import { EntityId, extractOwnedByIdFromEntityId } from "@local/hash-subgraph";
+import {
+  EntityId,
+  extractEntityUuidFromEntityId,
+  extractOwnedByIdFromEntityId,
+} from "@local/hash-subgraph";
 import { useCallback } from "react";
 
 import { structuralQueryEntitiesQuery } from "../../../graphql/queries/knowledge/entity.queries";
-import { blockCollectionContentsStaticVariables } from "../../../pages/shared/block-collection-contents";
+import { getBlockCollectionContentsStructuralQueryVariables } from "../../../pages/shared/block-collection-contents";
 import { getAccountPagesVariables } from "../../../shared/account-pages-variables";
 
 /**
@@ -33,12 +37,10 @@ export const useGetPageRefetchQueries = () =>
         }),
       },
       {
-        query: getEntityQuery,
-        variables: {
-          // The query for the page's own page
-          entityId: pageEntityId,
-          ...blockCollectionContentsStaticVariables,
-        },
+        query: structuralQueryEntitiesQuery,
+        variables: getBlockCollectionContentsStructuralQueryVariables(
+          extractEntityUuidFromEntityId(pageEntityId),
+        ),
       },
     ],
     [],

--- a/apps/hash-frontend/src/components/hooks/use-archive-page.ts
+++ b/apps/hash-frontend/src/components/hooks/use-archive-page.ts
@@ -1,6 +1,10 @@
 import { useMutation } from "@apollo/client";
 import { getEntityQuery } from "@local/hash-isomorphic-utils/graphql/queries/entity.queries";
-import { EntityId, extractOwnedByIdFromEntityId } from "@local/hash-subgraph";
+import {
+  EntityId,
+  extractEntityUuidFromEntityId,
+  extractOwnedByIdFromEntityId,
+} from "@local/hash-subgraph";
 import { useCallback, useContext } from "react";
 
 import {
@@ -9,7 +13,7 @@ import {
 } from "../../graphql/api-types.gen";
 import { structuralQueryEntitiesQuery } from "../../graphql/queries/knowledge/entity.queries";
 import { updatePage } from "../../graphql/queries/page.queries";
-import { blockCollectionContentsStaticVariables } from "../../pages/shared/block-collection-contents";
+import { getBlockCollectionContentsStructuralQueryVariables } from "../../pages/shared/block-collection-contents";
 import { getAccountPagesVariables } from "../../shared/account-pages-variables";
 import { EntityTypeEntitiesContext } from "../../shared/entity-type-entities-context";
 
@@ -35,12 +39,12 @@ export const useArchivePage = () => {
         query: structuralQueryEntitiesQuery,
         variables: getAccountPagesVariables({ ownedById }),
       },
+
       {
-        query: getEntityQuery,
-        variables: {
-          entityId: pageEntityId,
-          ...blockCollectionContentsStaticVariables,
-        },
+        query: structuralQueryEntitiesQuery,
+        variables: getBlockCollectionContentsStructuralQueryVariables(
+          extractEntityUuidFromEntityId(pageEntityId),
+        ),
       },
     ];
   }, []);

--- a/apps/hash-frontend/src/components/hooks/use-page-comments.ts
+++ b/apps/hash-frontend/src/components/hooks/use-page-comments.ts
@@ -38,7 +38,7 @@ export const usePageComments = (pageEntityId?: EntityId): PageCommentsInfo => {
     GetPageCommentsQueryVariables
   >(getPageComments, {
     variables: { entityId: pageEntityId! },
-    pollInterval: 5_000,
+    pollInterval: 10_000,
     skip: !pageEntityId,
   });
 

--- a/apps/hash-frontend/src/components/hooks/use-page-comments.ts
+++ b/apps/hash-frontend/src/components/hooks/use-page-comments.ts
@@ -32,13 +32,14 @@ export type PageCommentsInfo = {
 
 const emptyComments: PageThread[] = [];
 
-export const usePageComments = (pageEntityId: EntityId): PageCommentsInfo => {
+export const usePageComments = (pageEntityId?: EntityId): PageCommentsInfo => {
   const { data, loading } = useQuery<
     GetPageCommentsQuery,
     GetPageCommentsQueryVariables
   >(getPageComments, {
-    variables: { entityId: pageEntityId },
+    variables: { entityId: pageEntityId! },
     pollInterval: 5_000,
+    skip: !pageEntityId,
   });
 
   return { data: data?.pageComments ?? emptyComments, loading };

--- a/apps/hash-frontend/src/pages/[shortname].page/profile-bio.tsx
+++ b/apps/hash-frontend/src/pages/[shortname].page/profile-bio.tsx
@@ -20,7 +20,7 @@ import { GlobeRegularIcon } from "../../shared/icons/globe-regular-icon";
 import { ProfileSectionHeading } from "../[shortname]/shared/profile-section-heading";
 import { BlockCollection } from "../shared/block-collection/block-collection";
 import {
-  blockCollectionContentsStaticVariables,
+  blockCollectionContentsGetEntityVariables,
   getBlockCollectionContents,
   isBlockCollectionContentsEmpty,
 } from "../shared/block-collection-contents";
@@ -42,7 +42,7 @@ export const ProfileBio: FunctionComponent<{
   >(getEntityQuery, {
     variables: {
       entityId: profile.hasBio?.profileBioEntity.metadata.recordId.entityId!,
-      ...blockCollectionContentsStaticVariables,
+      ...blockCollectionContentsGetEntityVariables,
     },
     skip: !profile.hasBio,
   });

--- a/apps/hash-frontend/src/pages/[shortname]/[page-slug].page/canvas-page/block-creation-dialog.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/[page-slug].page/canvas-page/block-creation-dialog.tsx
@@ -3,7 +3,7 @@ import { VersionedUrl } from "@blockprotocol/type-system/dist/cjs-slim/index-sli
 import { HashBlockMeta } from "@local/hash-isomorphic-utils/blocks";
 import { updateBlockCollectionContents } from "@local/hash-isomorphic-utils/graphql/queries/block-collection.queries";
 import { getEntityQuery } from "@local/hash-isomorphic-utils/graphql/queries/entity.queries";
-import { OwnedById } from "@local/hash-subgraph";
+import { extractEntityUuidFromEntityId, OwnedById } from "@local/hash-subgraph";
 import { useApp } from "@tldraw/editor";
 import { DialogProps } from "@tldraw/tldraw";
 import { useCallback, useState } from "react";
@@ -12,9 +12,10 @@ import {
   UpdateBlockCollectionContentsMutation,
   UpdateBlockCollectionContentsMutationVariables,
 } from "../../../../graphql/api-types.gen";
+import { structuralQueryEntitiesQuery } from "../../../../graphql/queries/knowledge/entity.queries";
 import { BlockSuggester } from "../../../shared/block-collection/create-suggester/block-suggester";
 import { usePageContext } from "../../../shared/block-collection/page-context";
-import { blockCollectionContentsStaticVariables } from "../../../shared/block-collection-contents";
+import { getBlockCollectionContentsStructuralQueryVariables } from "../../../shared/block-collection-contents";
 import { useRouteNamespace } from "../../shared/use-route-namespace";
 import { BlockShape } from "./block-shape";
 import { defaultBlockHeight, defaultBlockWidth } from "./shared";
@@ -83,11 +84,10 @@ export const BlockCreationDialog = ({ onClose }: DialogProps) => {
         // temporary hack to keep page data consistent, in the absence of proper data subscriptions
         refetchQueries: [
           {
-            query: getEntityQuery,
-            variables: {
-              entityId: pageEntityId,
-              ...blockCollectionContentsStaticVariables,
-            },
+            query: structuralQueryEntitiesQuery,
+            variables: getBlockCollectionContentsStructuralQueryVariables(
+              extractEntityUuidFromEntityId(pageEntityId),
+            ),
           },
         ],
       });

--- a/apps/hash-frontend/src/pages/[shortname]/[page-slug].page/canvas-page/block-shape.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/[page-slug].page/canvas-page/block-shape.tsx
@@ -5,7 +5,7 @@ import {
 import { updateBlockCollectionContents } from "@local/hash-isomorphic-utils/graphql/queries/block-collection.queries";
 import { getEntityQuery } from "@local/hash-isomorphic-utils/graphql/queries/entity.queries";
 import { HasSpatiallyPositionedContentProperties } from "@local/hash-isomorphic-utils/system-types/canvas";
-import { EntityId } from "@local/hash-subgraph";
+import { EntityId, extractEntityUuidFromEntityId } from "@local/hash-subgraph";
 import { toDomPrecision } from "@tldraw/primitives";
 import {
   defineShape,
@@ -17,9 +17,10 @@ import {
 } from "@tldraw/tldraw";
 
 import { BlockLoader } from "../../../../components/block-loader/block-loader";
+import { structuralQueryEntitiesQuery } from "../../../../graphql/queries/knowledge/entity.queries";
 import { apolloClient } from "../../../../lib/apollo-client";
 import { BlockContextProvider } from "../../../shared/block-collection/block-context";
-import { blockCollectionContentsStaticVariables } from "../../../shared/block-collection-contents";
+import { getBlockCollectionContentsStructuralQueryVariables } from "../../../shared/block-collection-contents";
 import { BlockCollectionContext } from "../../../shared/block-collection-context";
 import {
   defaultBlockHeight,
@@ -65,12 +66,12 @@ const persistBlockPosition = ({
     },
     mutation: updateBlockCollectionContents,
     refetchQueries: [
+      // Refetch the page
       {
-        query: getEntityQuery,
-        variables: {
-          entityId: pageEntityId,
-          ...blockCollectionContentsStaticVariables,
-        },
+        query: structuralQueryEntitiesQuery,
+        variables: getBlockCollectionContentsStructuralQueryVariables(
+          extractEntityUuidFromEntityId(pageEntityId),
+        ),
       },
     ],
   });

--- a/apps/hash-frontend/src/pages/_app.page.tsx
+++ b/apps/hash-frontend/src/pages/_app.page.tsx
@@ -47,7 +47,6 @@ import { RoutePageInfoProvider } from "../shared/routing";
 import { ErrorFallback } from "./_app.page/error-fallback";
 import { AppPage, redirectInGetInitialProps } from "./shared/_app.util";
 import { AuthInfoProvider, useAuthInfo } from "./shared/auth-info-context";
-import { fetchKratosSession } from "./shared/ory-kratos";
 import { setSentryUser } from "./shared/sentry";
 import { WorkspaceContextProvider } from "./shared/workspace-context";
 

--- a/apps/hash-frontend/src/pages/_app.page.tsx
+++ b/apps/hash-frontend/src/pages/_app.page.tsx
@@ -227,20 +227,15 @@ AppWithTypeSystemContextProvider.getInitialProps = async (appContext) => {
    *   on subsequent loads it will be cached so long as the cookie value remains the same.
    * We leave it up to the client to re-fetch the user as necessary in response to user-initiated actions.
    */
-  const [initialAuthenticatedUserSubgraph, kratosSession] = await Promise.all([
-    apolloClient
-      .query<MeQuery>({
-        query: meQuery,
-        context: { headers: { cookie } },
-      })
-      .then(({ data }) =>
-        mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
-          data.me.subgraph,
-        ),
-      )
-      .catch(() => undefined),
-    fetchKratosSession(cookie),
-  ]);
+  const initialAuthenticatedUserSubgraph = await apolloClient
+    .query<MeQuery>({
+      query: meQuery,
+      context: { headers: { cookie } },
+    })
+    .then(({ data }) =>
+      mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(data.me.subgraph),
+    )
+    .catch(() => undefined);
 
   const userEntity = initialAuthenticatedUserSubgraph
     ? (getRoots<EntityRootType>(initialAuthenticatedUserSubgraph)[0] as
@@ -249,7 +244,7 @@ AppWithTypeSystemContextProvider.getInitialProps = async (appContext) => {
     : undefined;
 
   /** @todo: make additional pages publicly accessible */
-  if (!userEntity || !kratosSession) {
+  if (!userEntity) {
     // If the user is logged out and not on a page that should be publicly accessible...
     if (!publiclyAccessiblePagePathnames.includes(pathname)) {
       // ...redirect them to the login page

--- a/apps/hash-frontend/src/pages/notes.page.tsx
+++ b/apps/hash-frontend/src/pages/notes.page.tsx
@@ -65,6 +65,7 @@ const NotesPage: NextPageWithLayout = () => {
           all: [
             generateVersionedUrlMatchingFilter(
               systemEntityTypes.quickNote.entityTypeId,
+              { ignoreParents: true },
             ),
             {
               equal: [

--- a/apps/hash-frontend/src/pages/notes.page/timestamp-column.tsx
+++ b/apps/hash-frontend/src/pages/notes.page/timestamp-column.tsx
@@ -29,6 +29,7 @@ export const TimestampColumn: FunctionComponent<{
   <Box
     sx={{
       width: timestampColumnWidth,
+      minWidth: timestampColumnWidth,
       display: "flex",
       flexDirection: "column",
       alignItems: "flex-end",

--- a/apps/hash-frontend/src/pages/shared/auth-info-context.tsx
+++ b/apps/hash-frontend/src/pages/shared/auth-info-context.tsx
@@ -34,7 +34,6 @@ import {
   isEntityUserEntity,
   User,
 } from "../../lib/user-and-org";
-import { fetchKratosSession } from "./ory-kratos";
 
 type RefetchAuthInfoFunction = () => Promise<{
   authenticatedUser?: User;
@@ -126,20 +125,17 @@ export const AuthInfoProvider: FunctionComponent<AuthInfoProviderProps> = ({
 
   const fetchAuthenticatedUser =
     useCallback<RefetchAuthInfoFunction>(async () => {
-      const [subgraph, kratosSession] = await Promise.all([
-        getMe()
-          .then(({ data }) =>
-            data
-              ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
-                  data.me.subgraph,
-                )
-              : undefined,
-          )
-          .catch(() => undefined),
-        fetchKratosSession(),
-      ]);
+      const subgraph = await getMe()
+        .then(({ data }) =>
+          data
+            ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
+                data.me.subgraph,
+              )
+            : undefined,
+        )
+        .catch(() => undefined);
 
-      if (!subgraph || !kratosSession) {
+      if (!subgraph) {
         setAuthenticatedUserSubgraph(undefined);
         return {};
       }

--- a/apps/hash-frontend/src/pages/shared/block-collection-contents.ts
+++ b/apps/hash-frontend/src/pages/shared/block-collection-contents.ts
@@ -1,5 +1,9 @@
+import { EntityStructuralQuery } from "@local/hash-graph-client";
 import { sortBlockCollectionLinks } from "@local/hash-isomorphic-utils/block-collection";
-import { zeroedGraphResolveDepths } from "@local/hash-isomorphic-utils/graph-queries";
+import {
+  currentTimeInstantTemporalAxes,
+  zeroedGraphResolveDepths,
+} from "@local/hash-isomorphic-utils/graph-queries";
 import {
   blockProtocolPropertyTypes,
   systemEntityTypes,
@@ -15,6 +19,7 @@ import {
   Entity,
   EntityId,
   EntityRootType,
+  EntityUuid,
   GraphResolveDepths,
   Subgraph,
 } from "@local/hash-subgraph";
@@ -27,7 +32,10 @@ import {
   LinkEntity,
 } from "@local/hash-subgraph/type-system-patch";
 
-import { BlockCollectionContentItem } from "../../graphql/api-types.gen";
+import {
+  BlockCollectionContentItem,
+  StructuralQueryEntitiesQueryVariables,
+} from "../../graphql/api-types.gen";
 
 /**
  * The depths required to fetch the contents for blocks to render, rooted at a BlockCollection
@@ -52,10 +60,33 @@ export const blockCollectionContentsDepths: GraphResolveDepths = {
   hasRightEntity: { incoming: 4, outgoing: 4 },
 };
 
-export const blockCollectionContentsStaticVariables = {
+export const blockCollectionContentsGetEntityVariables = {
   ...blockCollectionContentsDepths,
   includePermissions: true,
 };
+
+export const getBlockCollectionContentsStructuralQueryVariables = (
+  pageEntityUuid: EntityUuid,
+): StructuralQueryEntitiesQueryVariables => ({
+  includePermissions: true,
+  query: {
+    filter: {
+      all: [
+        {
+          equal: [
+            { path: ["uuid"] },
+            {
+              parameter: pageEntityUuid,
+            },
+          ],
+        },
+      ],
+    },
+    graphResolveDepths: blockCollectionContentsDepths,
+    includeDrafts: false,
+    temporalAxes: currentTimeInstantTemporalAxes,
+  },
+});
 
 export const isBlockCollectionContentsEmpty = (params: {
   contents: BlockCollectionContentItem[];

--- a/apps/hash-frontend/src/pages/shared/ory-kratos.ts
+++ b/apps/hash-frontend/src/pages/shared/ory-kratos.ts
@@ -31,15 +31,6 @@ export const oryKratosClient = new FrontendApi(
   }),
 );
 
-export const fetchKratosSession = async (cookie?: string) => {
-  const kratosSession = await oryKratosClient
-    .toSession({ cookie })
-    .then(({ data }) => data)
-    .catch(() => undefined);
-
-  return kratosSession;
-};
-
 /**
  * A helper type representing the traits defined by the kratos identity schema at `apps/hash-external-services/kratos/identity.schema.json`
  */


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Makes some improvements to page loading times by:
- On page creation, don't bother creating an initial empty block in the API (the frontend code will handle it) – saves two sequential creations (H-1509)
- When loading blocks in a page, set the initial data from the page's subgraph on first render, not in an effect
- Don't bother converting the page's shortname into an `ownedById` before loading a page, we can identify the page without it – this speeds up the loading of `/@[shortname]/[page-uuid]` pages
- Don't fetch the Kratos session on the server prior to each page load – this speeds up all navigation, server or client-side
- Ignore parents when retrieving quick notes (checking type inheritance slows down the query) – speeds up quick notes loading

Also fixes a bug where the quick note container could become wider as the user typed (H-1421).

Page loading, particuarly quick notes, is still slow first time round. At least locally navigating between pages can still also be randomly slow. Create page, for example, seems to take a few seconds after a refresh and then is instant beyond that. Will see how production behaves after deployment.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Check that pages still load, see how pages/notes load on first render and then navigating between pages
