### PR TITLE
H-1491: Version consistency for types which refer to themselves

### DIFF
--- a/apps/hash-frontend/src/pages/shared/entity-type-page.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-page.tsx
@@ -1,4 +1,7 @@
-import { extractVersion } from "@blockprotocol/type-system";
+import {
+  EntityTypeReference,
+  extractVersion,
+} from "@blockprotocol/type-system";
 import { VersionedUrl } from "@blockprotocol/type-system/dist/cjs-slim/index-slim";
 import { EntityType } from "@blockprotocol/type-system/slim";
 import {
@@ -13,12 +16,17 @@ import {
   getSchemaFromFormData,
   useEntityTypeForm,
 } from "@hashintel/type-editor";
+import { typedEntries } from "@local/advanced-types/typed-entries";
 import {
   AccountId,
   BaseUrl,
   linkEntityTypeUrl,
   OwnedById,
 } from "@local/hash-subgraph";
+import {
+  componentsFromVersionedUrl,
+  versionedUrlFromComponents,
+} from "@local/hash-subgraph/type-system-patch";
 import { Box, Container, Theme, Typography } from "@mui/material";
 import { GlobalStyles } from "@mui/system";
 import { useRouter } from "next/router";
@@ -155,10 +163,52 @@ export const EntityTypePage = ({
       );
       reset(data);
     } else {
+      /**
+       * If an entity type refers to itself as a link destination, e.g. a Company may have a Parent which is a Company,
+       * we want the version specified as the link target in the schema to be the same as the version of the entity type.
+       * This rewriting of the schema ensures that by looking for self references and giving them the expected next version.
+       * If we don't do this, creating a new version of Company means the new version will have a link to the previous version.
+       */
+      const linkRecordWithConsistentSelfReferences = {
+        ...entityTypeSchema,
+        links: typedEntries(entityTypeSchema.links).reduce<
+          NonNullable<EntityType["links"]>
+        >((accumulator, [linkTypeId, linkSchema]) => {
+          const currentEntityTypeId = entityType?.$id;
+          if (!currentEntityTypeId) {
+            throw new Error(
+              "Cannot update entity type without existing entityType schema",
+            );
+          }
+
+          const schemaWithConsistentSelfReferences = {
+            ...linkSchema,
+            items: {
+              ...linkSchema.items,
+              oneOf: linkSchema.items.oneOf.map((item) => {
+                const isSelfReference = item.$ref === currentEntityTypeId;
+                if (isSelfReference) {
+                  const { baseUrl, version: currentVersion } =
+                    componentsFromVersionedUrl(currentEntityTypeId);
+                  return {
+                    $ref: versionedUrlFromComponents(
+                      baseUrl,
+                      currentVersion + 1,
+                    ),
+                  };
+                }
+                return item;
+              }) as [EntityTypeReference, ...EntityTypeReference[]],
+            },
+          };
+
+          accumulator[linkTypeId] = schemaWithConsistentSelfReferences;
+          return accumulator;
+        }, {}),
+      };
+
       const res = await updateEntityType(
-        {
-          ...entityTypeSchema,
-        },
+        linkRecordWithConsistentSelfReferences,
         { icon: data.icon },
       );
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

An entity type may have a link where the expected type linked to is itself.

E.g . a `Company` may be a `Subsidiary of` `Company`, or `Company` may have `Invested In` `Company`.

Previously, it was impossible to have the versions of `Company` involved consistent via the UI, because there was no way of setting a link destination to be 'the next version of this thing', and creating a new version of the type would increment its version, meaning the version of the link destination was one step behind.

This PR keeps them consistent automatically by amending the schema to make the version of any 'self' link destinations the same as the type's next version.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Create a type which links to itself
2. Check that the version of the type and the link destination are the same

