### PR TITLE
H-1199: fetch latest version of blocks once per page load

### DIFF
--- a/apps/hash-frontend/src/blocks/user-blocks.tsx
+++ b/apps/hash-frontend/src/blocks/user-blocks.tsx
@@ -75,7 +75,7 @@ export const UserBlocksProvider: FunctionComponent<{
              * @todo consider mechanisms for migrating existing blocks
              * to new versions if there are breaking changes
              */
-            bustCache: true,
+            useCachedData: false,
           });
 
           const blockSchema = await fetchBlockSchema({

--- a/apps/hash-frontend/src/blocks/user-blocks.tsx
+++ b/apps/hash-frontend/src/blocks/user-blocks.tsx
@@ -66,7 +66,17 @@ export const UserBlocksProvider: FunctionComponent<{
 
       const apiBlocksWithSchema = await Promise.all(
         data.getBlockProtocolBlocks.map(async ({ componentId }) => {
-          const fetchedBlock = await fetchBlock(componentId);
+          const fetchedBlock = await fetchBlock(componentId, {
+            /**
+             * We want to avoid using the `blockCache` here as we want to
+             * fetch the latest version of the block once per page-load,
+             * incase there's been an update.
+             *
+             * @todo consider mechanisms for migrating existing blocks
+             * to new versions if there are breaking changes
+             */
+            bustCache: true,
+          });
 
           const blockSchema = await fetchBlockSchema({
             schemaId: fetchedBlock.meta.schema,

--- a/apps/hash-frontend/src/pages/[shortname]/[page-slug].page/canvas-page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/[page-slug].page/canvas-page.tsx
@@ -54,7 +54,9 @@ export const CanvasPageBlock = ({
       contents.map(async ({ rightEntity }) => {
         const { componentId } = rightEntity;
         if (!blocksMap[componentId]) {
-          blocksMap[componentId] = await fetchBlock(componentId);
+          blocksMap[componentId] = await fetchBlock(componentId, {
+            useCachedData: true,
+          });
         }
       }),
     ).then(() => {

--- a/libs/@local/hash-isomorphic-utils/src/blocks.ts
+++ b/libs/@local/hash-isomorphic-utils/src/blocks.ts
@@ -154,14 +154,16 @@ export const prepareBlockCache = (
 // @todo deal with errors, loading, abort etc.
 export const fetchBlock = async (
   componentId: string,
-  options?: { bustCache: boolean },
+  options: { useCachedData: boolean },
 ): Promise<HashBlock> => {
   const baseUrl = componentIdToUrl(componentId);
 
-  if (options?.bustCache) {
-    blockCache.delete(baseUrl);
+  const cachedPromise = blockCache.get(baseUrl);
+
+  if (options.useCachedData && cachedPromise) {
+    return cachedPromise;
   } else if (blockCache.has(baseUrl)) {
-    return blockCache.get(baseUrl)!;
+    blockCache.delete(baseUrl);
   }
 
   const promise = (async () => {

--- a/libs/@local/hash-isomorphic-utils/src/prosemirror-manager.ts
+++ b/libs/@local/hash-isomorphic-utils/src/prosemirror-manager.ts
@@ -115,7 +115,7 @@ export class ProsemirrorManager {
     options?: { bustCache: boolean },
   ): Promise<HashBlock> {
     const block = await fetchBlock(componentId, {
-      bustCache: !!options?.bustCache,
+      useCachedData: !options?.bustCache,
     });
 
     this.defineBlock(block);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR modifies the `useUserBlocks` method to fetch the latest version of the blocks reliably once per page-load, updating the block metadata stored in local storage if there's been any changes.

Previously to get the latest versions of the blocks users would've been forced to manually clear their local storage.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-1199


## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- adds the `bustCache` parameter to the `fetchBlock` call in `useUserBlocks`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

- When an updated version of the block has breaking changes, there is currently no mechanism for migrating previous versions of the block to the newer version.

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

Manual testing

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

If you haven't cleared local storage since the last block update, run the HASH App locally with these changes and the latest versions of the blocks should be loaded.
