### PR TITLE
H-1546: Update schema in blocks using file uploads

### DIFF
--- a/blocks/address/package.json
+++ b/blocks/address/package.json
@@ -70,7 +70,7 @@
     "image": "public/block-preview.png",
     "name": "@hash/address",
     "protocol": "0.3",
-    "blockEntityType": "https://blockprotocol.org/@hash/types/entity-type/address-block/v/3",
+    "blockEntityType": "https://blockprotocol.org/@hash/types/entity-type/address-block/v/4",
     "codegen": {
       "outputFolder": "src/types/generated",
       "targets": {

--- a/blocks/address/src/types/generated/block-entity.ts
+++ b/blocks/address/src/types/generated/block-entity.ts
@@ -15,7 +15,7 @@ export type AddressBlockHasAddressLink = {
 
 export type AddressBlockHasMapImageLink = {
   linkEntity: HasMapImage;
-  rightEntity: RemoteFile;
+  rightEntity: Image;
 };
 
 export type AddressBlockOutgoingLinkAndTarget =
@@ -78,14 +78,92 @@ export type BlockEntityOutgoingLinkAndTarget =
   AddressBlockOutgoingLinkAndTarget;
 
 /**
+ * A True or False value
+ */
+export type Boolean = boolean;
+
+/**
  * A piece of text that tells you about something or someone. This can include explaining what they look like, what its purpose is for, what they’re like, etc.
  */
 export type DescriptionPropertyValue = Text;
 
 /**
+ * A human-friendly display name for something
+ */
+export type DisplayNamePropertyValue = Text;
+
+export type File = Entity<FileProperties>;
+
+/**
+ * A unique signature derived from a file's contents
+ */
+export type FileHashPropertyValue = Text;
+
+/**
  * The name of a file.
  */
 export type FileNamePropertyValue = Text;
+
+export type FileOutgoingLinkAndTarget = never;
+
+export type FileOutgoingLinksByLinkEntityTypeId = {};
+
+/**
+ * A file hosted at a URL
+ */
+export type FileProperties = {
+  "https://blockprotocol.org/@blockprotocol/types/property-type/description/"?: DescriptionPropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/display-name/"?: DisplayNamePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/file-hash/"?: FileHashPropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/file-name/"?: FileNamePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/file-size/"?: FileSizePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/file-url/": FileURLPropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/mime-type/"?: MIMETypePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/original-file-name/"?: OriginalFileNamePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/original-source/"?: OriginalSourcePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/original-url/"?: OriginalURLPropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-bucket/"?: FileStorageBucketPropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-endpoint/"?: FileStorageEndpointPropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-force-path-style/"?: FileStorageForcePathStylePropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-key/"?: FileStorageKeyPropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-provider/"?: FileStorageProviderPropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-region/"?: FileStorageRegionPropertyValue;
+};
+
+/**
+ * The size of a file
+ */
+export type FileSizePropertyValue = Number;
+
+/**
+ * The bucket in which a file is stored.
+ */
+export type FileStorageBucketPropertyValue = Text;
+
+/**
+ * The endpoint for making requests to a file storage provider.
+ */
+export type FileStorageEndpointPropertyValue = Text;
+
+/**
+ * Whether to force path style for requests to a file storage provider (vs virtual host style).
+ */
+export type FileStorageForcePathStylePropertyValue = Boolean;
+
+/**
+ * The key identifying a file in storage.
+ */
+export type FileStorageKeyPropertyValue = Text;
+
+/**
+ * The provider of a file storage service.
+ */
+export type FileStorageProviderPropertyValue = Text;
+
+/**
+ * The region in which a file is stored.
+ */
+export type FileStorageRegionPropertyValue = Text;
 
 /**
  * A URL that serves a file.
@@ -129,6 +207,20 @@ export type HasMapImageProperties2 = {
   "https://blockprotocol.org/@blockprotocol/types/property-type/mapbox-address-id/"?: MapboxAddressIDPropertyValue;
 };
 
+export type Image = Entity<ImageProperties>;
+
+export type ImageOutgoingLinkAndTarget = never;
+
+export type ImageOutgoingLinksByLinkEntityTypeId = {};
+
+/**
+ * An image file hosted at a URL
+ */
+export type ImageProperties = ImageProperties1 & ImageProperties2;
+export type ImageProperties1 = FileProperties;
+
+export type ImageProperties2 = {};
+
 export type Link = Entity<LinkProperties>;
 
 export type LinkOutgoingLinkAndTarget = never;
@@ -171,6 +263,21 @@ export type MapboxStaticImageZoomLevelPropertyValue = Number;
 export type Number = number;
 
 /**
+ * The original name of a file
+ */
+export type OriginalFileNamePropertyValue = Text;
+
+/**
+ * The original source of something
+ */
+export type OriginalSourcePropertyValue = Text;
+
+/**
+ * The original URL something was hosted at
+ */
+export type OriginalURLPropertyValue = Text;
+
+/**
  * The postal code of an address.
  *
  * This should conform to the standards of the area the code is from, for example
@@ -180,22 +287,6 @@ export type Number = number;
  * - a US ZIP code might look like: “20500”
  */
 export type PostalCodePropertyValue = Text;
-
-export type RemoteFile = Entity<RemoteFileProperties>;
-
-export type RemoteFileOutgoingLinkAndTarget = never;
-
-export type RemoteFileOutgoingLinksByLinkEntityTypeId = {};
-
-/**
- * Information about a file hosted at a remote URL.
- */
-export type RemoteFileProperties = {
-  "https://blockprotocol.org/@blockprotocol/types/property-type/description/"?: DescriptionPropertyValue;
-  "https://blockprotocol.org/@blockprotocol/types/property-type/file-url/": FileURLPropertyValue;
-  "https://blockprotocol.org/@blockprotocol/types/property-type/mime-type/": MIMETypePropertyValue;
-  "https://blockprotocol.org/@blockprotocol/types/property-type/file-name/": FileNamePropertyValue;
-};
 
 /**
  * The first line of street information of an address.

--- a/blocks/ai-image/package.json
+++ b/blocks/ai-image/package.json
@@ -68,7 +68,7 @@
     "image": "public/block-preview.png",
     "name": "@hash/ai-image",
     "protocol": "0.3",
-    "blockEntityType": "https://blockprotocol.org/@hash/types/entity-type/ai-image-block/v/2",
+    "blockEntityType": "https://blockprotocol.org/@hash/types/entity-type/ai-image-block/v/3",
     "codegen": {
       "outputFolder": "src/types/generated",
       "targets": {

--- a/blocks/ai-image/src/types/generated/block-entity.ts
+++ b/blocks/ai-image/src/types/generated/block-entity.ts
@@ -8,7 +8,7 @@ export type AIImageBlock = Entity<AIImageBlockProperties>;
 
 export type AIImageBlockGeneratedLink = {
   linkEntity: Generated;
-  rightEntity: RemoteFile;
+  rightEntity: Image;
 };
 
 export type AIImageBlockOutgoingLinkAndTarget = AIImageBlockGeneratedLink;
@@ -32,14 +32,92 @@ export type BlockEntityOutgoingLinkAndTarget =
   AIImageBlockOutgoingLinkAndTarget;
 
 /**
+ * A True or False value
+ */
+export type Boolean = boolean;
+
+/**
  * A piece of text that tells you about something or someone. This can include explaining what they look like, what its purpose is for, what they’re like, etc.
  */
 export type DescriptionPropertyValue = Text;
 
 /**
+ * A human-friendly display name for something
+ */
+export type DisplayNamePropertyValue = Text;
+
+export type File = Entity<FileProperties>;
+
+/**
+ * A unique signature derived from a file's contents
+ */
+export type FileHashPropertyValue = Text;
+
+/**
  * The name of a file.
  */
 export type FileNamePropertyValue = Text;
+
+export type FileOutgoingLinkAndTarget = never;
+
+export type FileOutgoingLinksByLinkEntityTypeId = {};
+
+/**
+ * A file hosted at a URL
+ */
+export type FileProperties = {
+  "https://blockprotocol.org/@blockprotocol/types/property-type/description/"?: DescriptionPropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/display-name/"?: DisplayNamePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/file-hash/"?: FileHashPropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/file-name/"?: FileNamePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/file-size/"?: FileSizePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/file-url/": FileURLPropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/mime-type/"?: MIMETypePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/original-file-name/"?: OriginalFileNamePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/original-source/"?: OriginalSourcePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/original-url/"?: OriginalURLPropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-bucket/"?: FileStorageBucketPropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-endpoint/"?: FileStorageEndpointPropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-force-path-style/"?: FileStorageForcePathStylePropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-key/"?: FileStorageKeyPropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-provider/"?: FileStorageProviderPropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-region/"?: FileStorageRegionPropertyValue;
+};
+
+/**
+ * The size of a file
+ */
+export type FileSizePropertyValue = Number;
+
+/**
+ * The bucket in which a file is stored.
+ */
+export type FileStorageBucketPropertyValue = Text;
+
+/**
+ * The endpoint for making requests to a file storage provider.
+ */
+export type FileStorageEndpointPropertyValue = Text;
+
+/**
+ * Whether to force path style for requests to a file storage provider (vs virtual host style).
+ */
+export type FileStorageForcePathStylePropertyValue = Boolean;
+
+/**
+ * The key identifying a file in storage.
+ */
+export type FileStorageKeyPropertyValue = Text;
+
+/**
+ * The provider of a file storage service.
+ */
+export type FileStorageProviderPropertyValue = Text;
+
+/**
+ * The region in which a file is stored.
+ */
+export type FileStorageRegionPropertyValue = Text;
 
 /**
  * A URL that serves a file.
@@ -60,6 +138,20 @@ export type GeneratedProperties1 = LinkProperties;
 
 export type GeneratedProperties2 = {};
 
+export type Image = Entity<ImageProperties>;
+
+export type ImageOutgoingLinkAndTarget = never;
+
+export type ImageOutgoingLinksByLinkEntityTypeId = {};
+
+/**
+ * An image file hosted at a URL
+ */
+export type ImageProperties = ImageProperties1 & ImageProperties2;
+export type ImageProperties1 = FileProperties;
+
+export type ImageProperties2 = {};
+
 export type Link = Entity<LinkProperties>;
 
 export type LinkOutgoingLinkAndTarget = never;
@@ -76,27 +168,31 @@ export type LinkProperties = {};
 export type MIMETypePropertyValue = Text;
 
 /**
+ * An arithmetical value (in the Real number system)
+ */
+export type Number = number;
+
+/**
  * The prompt provided as an input to an OpenAI-model capable of generating images.
  *
  * See: https://blockprotocol.org/docs/spec/service-module
  */
 export type OpenAIImageModelPromptPropertyValue = Text;
 
-export type RemoteFile = Entity<RemoteFileProperties>;
-
-export type RemoteFileOutgoingLinkAndTarget = never;
-
-export type RemoteFileOutgoingLinksByLinkEntityTypeId = {};
+/**
+ * The original name of a file
+ */
+export type OriginalFileNamePropertyValue = Text;
 
 /**
- * Information about a file hosted at a remote URL.
+ * The original source of something
  */
-export type RemoteFileProperties = {
-  "https://blockprotocol.org/@blockprotocol/types/property-type/description/"?: DescriptionPropertyValue;
-  "https://blockprotocol.org/@blockprotocol/types/property-type/file-url/": FileURLPropertyValue;
-  "https://blockprotocol.org/@blockprotocol/types/property-type/mime-type/": MIMETypePropertyValue;
-  "https://blockprotocol.org/@blockprotocol/types/property-type/file-name/": FileNamePropertyValue;
-};
+export type OriginalSourcePropertyValue = Text;
+
+/**
+ * The original URL something was hosted at
+ */
+export type OriginalURLPropertyValue = Text;
 
 /**
  * An ordered sequence of characters

--- a/blocks/image/package.json
+++ b/blocks/image/package.json
@@ -61,7 +61,7 @@
       {}
     ],
     "protocol": "0.3",
-    "blockEntityType": "https://blockprotocol.org/@hash/types/entity-type/image-block/v/2",
+    "blockEntityType": "https://blockprotocol.org/@hash/types/entity-type/image-block/v/3",
     "codegen": {
       "outputFolder": "src/types/generated",
       "targets": {

--- a/blocks/image/src/types/generated/block-entity.ts
+++ b/blocks/image/src/types/generated/block-entity.ts
@@ -9,6 +9,11 @@ export type BlockEntity = ImageBlock;
 export type BlockEntityOutgoingLinkAndTarget = ImageBlockOutgoingLinkAndTarget;
 
 /**
+ * A True or False value
+ */
+export type Boolean = boolean;
+
+/**
  * A brief explanation or accompanying message.
  */
 export type CaptionPropertyValue = Text;
@@ -17,6 +22,11 @@ export type CaptionPropertyValue = Text;
  * A piece of text that tells you about something or someone. This can include explaining what they look like, what its purpose is for, what they’re like, etc.
  */
 export type DescriptionPropertyValue = Text;
+
+/**
+ * A human-friendly display name for something
+ */
+export type DisplayNamePropertyValue = Text;
 
 export type DisplaysMediaFile = Entity<DisplaysMediaFileProperties> & {
   linkData: LinkData;
@@ -35,21 +45,91 @@ export type DisplaysMediaFileProperties1 = LinkProperties;
 
 export type DisplaysMediaFileProperties2 = {};
 
+export type File = Entity<FileProperties>;
+
+/**
+ * A unique signature derived from a file's contents
+ */
+export type FileHashPropertyValue = Text;
+
 /**
  * The name of a file.
  */
 export type FileNamePropertyValue = Text;
+
+export type FileOutgoingLinkAndTarget = never;
+
+export type FileOutgoingLinksByLinkEntityTypeId = {};
+
+/**
+ * A file hosted at a URL
+ */
+export type FileProperties = {
+  "https://blockprotocol.org/@blockprotocol/types/property-type/description/"?: DescriptionPropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/display-name/"?: DisplayNamePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/file-hash/"?: FileHashPropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/file-name/"?: FileNamePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/file-size/"?: FileSizePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/file-url/": FileURLPropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/mime-type/"?: MIMETypePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/original-file-name/"?: OriginalFileNamePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/original-source/"?: OriginalSourcePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/original-url/"?: OriginalURLPropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-bucket/"?: FileStorageBucketPropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-endpoint/"?: FileStorageEndpointPropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-force-path-style/"?: FileStorageForcePathStylePropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-key/"?: FileStorageKeyPropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-provider/"?: FileStorageProviderPropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-region/"?: FileStorageRegionPropertyValue;
+};
+
+/**
+ * The size of a file
+ */
+export type FileSizePropertyValue = Number;
+
+/**
+ * The bucket in which a file is stored.
+ */
+export type FileStorageBucketPropertyValue = Text;
+
+/**
+ * The endpoint for making requests to a file storage provider.
+ */
+export type FileStorageEndpointPropertyValue = Text;
+
+/**
+ * Whether to force path style for requests to a file storage provider (vs virtual host style).
+ */
+export type FileStorageForcePathStylePropertyValue = Boolean;
+
+/**
+ * The key identifying a file in storage.
+ */
+export type FileStorageKeyPropertyValue = Text;
+
+/**
+ * The provider of a file storage service.
+ */
+export type FileStorageProviderPropertyValue = Text;
+
+/**
+ * The region in which a file is stored.
+ */
+export type FileStorageRegionPropertyValue = Text;
 
 /**
  * A URL that serves a file.
  */
 export type FileURLPropertyValue = Text;
 
+export type Image = Entity<ImageProperties>;
+
 export type ImageBlock = Entity<ImageBlockProperties>;
 
 export type ImageBlockDisplaysMediaFileLink = {
   linkEntity: DisplaysMediaFile;
-  rightEntity: RemoteFile;
+  rightEntity: Image;
 };
 
 export type ImageBlockOutgoingLinkAndTarget = ImageBlockDisplaysMediaFileLink;
@@ -67,6 +147,18 @@ export type ImageBlockProperties = {
   "https://blockprotocol.org/@blockprotocol/types/property-type/caption/"?: CaptionPropertyValue;
   "https://blockprotocol.org/@blockprotocol/types/property-type/width-in-pixels/"?: WidthInPixelsPropertyValue;
 };
+
+export type ImageOutgoingLinkAndTarget = never;
+
+export type ImageOutgoingLinksByLinkEntityTypeId = {};
+
+/**
+ * An image file hosted at a URL
+ */
+export type ImageProperties = ImageProperties1 & ImageProperties2;
+export type ImageProperties1 = FileProperties;
+
+export type ImageProperties2 = {};
 
 export type Link = Entity<LinkProperties>;
 
@@ -88,21 +180,20 @@ export type MIMETypePropertyValue = Text;
  */
 export type Number = number;
 
-export type RemoteFile = Entity<RemoteFileProperties>;
-
-export type RemoteFileOutgoingLinkAndTarget = never;
-
-export type RemoteFileOutgoingLinksByLinkEntityTypeId = {};
+/**
+ * The original name of a file
+ */
+export type OriginalFileNamePropertyValue = Text;
 
 /**
- * Information about a file hosted at a remote URL.
+ * The original source of something
  */
-export type RemoteFileProperties = {
-  "https://blockprotocol.org/@blockprotocol/types/property-type/description/"?: DescriptionPropertyValue;
-  "https://blockprotocol.org/@blockprotocol/types/property-type/file-url/": FileURLPropertyValue;
-  "https://blockprotocol.org/@blockprotocol/types/property-type/mime-type/": MIMETypePropertyValue;
-  "https://blockprotocol.org/@blockprotocol/types/property-type/file-name/": FileNamePropertyValue;
-};
+export type OriginalSourcePropertyValue = Text;
+
+/**
+ * The original URL something was hosted at
+ */
+export type OriginalURLPropertyValue = Text;
 
 /**
  * An ordered sequence of characters

--- a/blocks/video/package.json
+++ b/blocks/video/package.json
@@ -60,7 +60,7 @@
       {}
     ],
     "protocol": "0.3",
-    "blockEntityType": "https://blockprotocol.org/@hash/types/entity-type/video-block/v/2",
+    "blockEntityType": "https://blockprotocol.org/@hash/types/entity-type/video-block/v/3",
     "codegen": {
       "outputFolder": "src/types/generated",
       "targets": {

--- a/blocks/video/src/types/generated/block-entity.ts
+++ b/blocks/video/src/types/generated/block-entity.ts
@@ -9,6 +9,11 @@ export type BlockEntity = VideoBlock;
 export type BlockEntityOutgoingLinkAndTarget = VideoBlockOutgoingLinkAndTarget;
 
 /**
+ * A True or False value
+ */
+export type Boolean = boolean;
+
+/**
  * A brief explanation or accompanying message.
  */
 export type CaptionPropertyValue = Text;
@@ -17,6 +22,11 @@ export type CaptionPropertyValue = Text;
  * A piece of text that tells you about something or someone. This can include explaining what they look like, what its purpose is for, what they’re like, etc.
  */
 export type DescriptionPropertyValue = Text;
+
+/**
+ * A human-friendly display name for something
+ */
+export type DisplayNamePropertyValue = Text;
 
 export type DisplaysMediaFile = Entity<DisplaysMediaFileProperties> & {
   linkData: LinkData;
@@ -35,15 +45,97 @@ export type DisplaysMediaFileProperties1 = LinkProperties;
 
 export type DisplaysMediaFileProperties2 = {};
 
+export type File = Entity<FileProperties>;
+
+/**
+ * A unique signature derived from a file's contents
+ */
+export type FileHashPropertyValue = Text;
+
 /**
  * The name of a file.
  */
 export type FileNamePropertyValue = Text;
 
+export type FileOutgoingLinkAndTarget = never;
+
+export type FileOutgoingLinksByLinkEntityTypeId = {};
+
+/**
+ * A file hosted at a URL
+ */
+export type FileProperties = {
+  "https://blockprotocol.org/@blockprotocol/types/property-type/description/"?: DescriptionPropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/display-name/"?: DisplayNamePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/file-hash/"?: FileHashPropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/file-name/"?: FileNamePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/file-size/"?: FileSizePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/file-url/": FileURLPropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/mime-type/"?: MIMETypePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/original-file-name/"?: OriginalFileNamePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/original-source/"?: OriginalSourcePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/original-url/"?: OriginalURLPropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-bucket/"?: FileStorageBucketPropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-endpoint/"?: FileStorageEndpointPropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-force-path-style/"?: FileStorageForcePathStylePropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-key/"?: FileStorageKeyPropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-provider/"?: FileStorageProviderPropertyValue;
+  "https://hash.ai/@hash/types/property-type/file-storage-region/"?: FileStorageRegionPropertyValue;
+};
+
+/**
+ * The size of a file
+ */
+export type FileSizePropertyValue = Number;
+
+/**
+ * The bucket in which a file is stored.
+ */
+export type FileStorageBucketPropertyValue = Text;
+
+/**
+ * The endpoint for making requests to a file storage provider.
+ */
+export type FileStorageEndpointPropertyValue = Text;
+
+/**
+ * Whether to force path style for requests to a file storage provider (vs virtual host style).
+ */
+export type FileStorageForcePathStylePropertyValue = Boolean;
+
+/**
+ * The key identifying a file in storage.
+ */
+export type FileStorageKeyPropertyValue = Text;
+
+/**
+ * The provider of a file storage service.
+ */
+export type FileStorageProviderPropertyValue = Text;
+
+/**
+ * The region in which a file is stored.
+ */
+export type FileStorageRegionPropertyValue = Text;
+
 /**
  * A URL that serves a file.
  */
 export type FileURLPropertyValue = Text;
+
+export type Image = Entity<ImageProperties>;
+
+export type ImageOutgoingLinkAndTarget = never;
+
+export type ImageOutgoingLinksByLinkEntityTypeId = {};
+
+/**
+ * An image file hosted at a URL
+ */
+export type ImageProperties = ImageProperties1 & ImageProperties2;
+export type ImageProperties1 = FileProperties;
+
+export type ImageProperties2 = {};
 
 export type Link = Entity<LinkProperties>;
 
@@ -60,21 +152,25 @@ export type LinkProperties = {};
  */
 export type MIMETypePropertyValue = Text;
 
-export type RemoteFile = Entity<RemoteFileProperties>;
-
-export type RemoteFileOutgoingLinkAndTarget = never;
-
-export type RemoteFileOutgoingLinksByLinkEntityTypeId = {};
+/**
+ * An arithmetical value (in the Real number system)
+ */
+export type Number = number;
 
 /**
- * Information about a file hosted at a remote URL.
+ * The original name of a file
  */
-export type RemoteFileProperties = {
-  "https://blockprotocol.org/@blockprotocol/types/property-type/description/"?: DescriptionPropertyValue;
-  "https://blockprotocol.org/@blockprotocol/types/property-type/file-url/": FileURLPropertyValue;
-  "https://blockprotocol.org/@blockprotocol/types/property-type/mime-type/": MIMETypePropertyValue;
-  "https://blockprotocol.org/@blockprotocol/types/property-type/file-name/": FileNamePropertyValue;
-};
+export type OriginalFileNamePropertyValue = Text;
+
+/**
+ * The original source of something
+ */
+export type OriginalSourcePropertyValue = Text;
+
+/**
+ * The original URL something was hosted at
+ */
+export type OriginalURLPropertyValue = Text;
 
 /**
  * An ordered sequence of characters
@@ -85,7 +181,7 @@ export type VideoBlock = Entity<VideoBlockProperties>;
 
 export type VideoBlockDisplaysMediaFileLink = {
   linkEntity: DisplaysMediaFile;
-  rightEntity: RemoteFile;
+  rightEntity: Image;
 };
 
 export type VideoBlockOutgoingLinkAndTarget = VideoBlockDisplaysMediaFileLink;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We have a few blocks which upload files and create links to those files.

Their schemas previously specified that the link destination should be of type `blockprotocol.org/@blockprotocol/remote-file`, but we actually upload files in HASH with an id of `hash.ai/@hash/file` (or `@hash/image` which inherits from `file`). This means that the image blocks are creating invalid links.

Although updating the schemas to point to the new file type id fixes the issue, this highlights an issue with specifying that link destinations are constrained by the exact type of entity they point to (by identity of the type) rather than simply that the destination entity is of a structurally compatible type, which is all the block needs. Ideally we'd be able to constrain link destinations on structural compatibility rather than an exact identity match of the type.

## 🔍 What does this change?

- Regenerates types for blocks, after I updated the block's schemas in blockprotocol.org

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **block** that will need publishing via GitHub action once merged


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

Publish the blocks

