### PR TITLE
H-1548: Fix setting unconstrained links on an entity type

### DIFF
--- a/apps/hash-frontend/src/pages/shared/entity-type-page.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-page.tsx
@@ -1,6 +1,8 @@
 import {
   EntityTypeReference,
   extractVersion,
+  MaybeOneOfEntityTypeReference,
+  MaybeOrderedArray,
 } from "@blockprotocol/type-system";
 import { VersionedUrl } from "@blockprotocol/type-system/dist/cjs-slim/index-slim";
 import { EntityType } from "@blockprotocol/type-system/slim";
@@ -183,23 +185,25 @@ export const EntityTypePage = ({
 
           const schemaWithConsistentSelfReferences = {
             ...linkSchema,
-            items: {
-              ...linkSchema.items,
-              oneOf: linkSchema.items.oneOf.map((item) => {
-                const isSelfReference = item.$ref === currentEntityTypeId;
-                if (isSelfReference) {
-                  const { baseUrl, version: currentVersion } =
-                    componentsFromVersionedUrl(currentEntityTypeId);
-                  return {
-                    $ref: versionedUrlFromComponents(
-                      baseUrl,
-                      currentVersion + 1,
-                    ),
-                  };
-                }
-                return item;
-              }) as [EntityTypeReference, ...EntityTypeReference[]],
-            },
+            items:
+              "oneOf" in linkSchema.items
+                ? {
+                    oneOf: linkSchema.items.oneOf.map((item) => {
+                      const isSelfReference = item.$ref === currentEntityTypeId;
+                      if (isSelfReference) {
+                        const { baseUrl, version: currentVersion } =
+                          componentsFromVersionedUrl(currentEntityTypeId);
+                        return {
+                          $ref: versionedUrlFromComponents(
+                            baseUrl,
+                            currentVersion + 1,
+                          ),
+                        };
+                      }
+                      return item;
+                    }) as [EntityTypeReference, ...EntityTypeReference[]],
+                  }
+                : {},
           };
 
           accumulator[linkTypeId] = schemaWithConsistentSelfReferences;

--- a/apps/hash-frontend/src/pages/shared/entity-type-page.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-page.tsx
@@ -1,8 +1,6 @@
 import {
   EntityTypeReference,
   extractVersion,
-  MaybeOneOfEntityTypeReference,
-  MaybeOrderedArray,
 } from "@blockprotocol/type-system";
 import { VersionedUrl } from "@blockprotocol/type-system/dist/cjs-slim/index-slim";
 import { EntityType } from "@blockprotocol/type-system/slim";

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list.tsx
@@ -129,7 +129,7 @@ export const AccountEntityTypeList: FunctionComponent<
         }
       >
         <Box component="ul">
-          {loading ? (
+          {loading && filteredEntityTypes.length === 0 ? (
             <LoadingSkeleton />
           ) : (
             <TransitionGroup>

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/acount-entities-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/acount-entities-list.tsx
@@ -133,7 +133,7 @@ export const AccountEntitiesList: FunctionComponent<
         }
       >
         <Box component="ul">
-          {loading ? (
+          {loading && sortedEntityTypes.length === 0 ? (
             <LoadingSkeleton />
           ) : (
             <TransitionGroup>

--- a/patches/@blockprotocol+type-system+0.1.1.patch
+++ b/patches/@blockprotocol+type-system+0.1.1.patch
@@ -1,0 +1,18 @@
+diff --git a/node_modules/@blockprotocol/type-system/dist/wasm/type-system.d.ts b/node_modules/@blockprotocol/type-system/dist/wasm/type-system.d.ts
+index b25b9d7..77fb40a 100644
+--- a/node_modules/@blockprotocol/type-system/dist/wasm/type-system.d.ts
++++ b/node_modules/@blockprotocol/type-system/dist/wasm/type-system.d.ts
+@@ -116,7 +116,12 @@ export interface EntityType extends AllOf<EntityTypeReference>, Object<ValueOrAr
+     examples?: Record<BaseUrl, any>[];
+ }
+ 
+-export type MaybeOneOfEntityTypeReference = OneOf<EntityTypeReference> | Record<string, never>;
++/**
++ * PATCHED BECAUSE:
++ * Using Record<string, never> means that the TS compiler doesn't pick up that items.oneOf in a link schema might be undefined
++ * @todo reconsider these types in the @blockprotocol/type-system package
++ */
++export type MaybeOneOfEntityTypeReference = OneOf<EntityTypeReference> | {};
+ 
+ export type ParseVersionedUrlError = { reason: "IncorrectFormatting" } | { reason: "MissingVersion" } | { reason: "InvalidVersion"; inner: [string, string] } | { reason: "AdditionalEndContent"; inner: string } | { reason: "InvalidBaseUrl"; inner: ParseBaseUrlError } | { reason: "TooLong" };
+ 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes a bug introduced by #3683 where attempting to add a link to an entity type without constraining its destination would cause a crash. This crept in because the TS compiler for some reason doesn't flag that something which is `T | Record<string, never>` might be `Record<string, never>` and not `T`. I've patched the type locally to use `{}` instead.

As a drive-by I also noticed that the loading state in the sidebar introduced in #3677 would show when the data was refetching, which I've stopped.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
