### PR TITLE
H-1436: Remove deprecated OpenAI models from model list in AI blocks

### DIFF
--- a/blocks/ai-text/src/app/generate-text/model-selector.tsx
+++ b/blocks/ai-text/src/app/generate-text/model-selector.tsx
@@ -25,35 +25,6 @@ const MODELS_BY_GROUP: GroupedOptions = {
         description:
           "The best model for many use cases; faster and 10x cheaper than Davinci",
       },
-      {
-        id: "text-davinci-003",
-        icon: <AbstractAiIcon sx={{ fontSize: "inherit" }} />,
-        title: "GPT-3 Davinci",
-        helperText: "text-davinci-003",
-        description:
-          "Great at writing long-form text, complex intent, cause and effect, summarization",
-      },
-      {
-        id: "text-curie-001",
-        icon: <AbstractAiIcon sx={{ fontSize: "inherit" }} />,
-        title: "GPT-3 Curie",
-        helperText: "text-curie-001",
-        description: "Good at language translation, Q&A",
-      },
-      {
-        id: "text-babbage-001",
-        icon: <AbstractAiIcon sx={{ fontSize: "inherit" }} />,
-        title: "GPT-3 Babbage",
-        helperText: "text-babbage-001",
-        description: "Good at moderate classification tasks",
-      },
-      {
-        id: "text-ada-001",
-        icon: <AbstractAiIcon sx={{ fontSize: "inherit" }} />,
-        title: "GPT-3 Ada",
-        helperText: "text-ada-001",
-        description: "Good at parsing, correction, keywords",
-      },
     ],
   },
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR removes the ability to use `Davinci`, `Curie`, `Babbage` and `Ada` in the AI Text block, which are models that [will stop working on 2024-01-04l](https://platform.openai.com/docs/deprecations/instructgpt-models).

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-1436

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **block** that will need publishing via GitHub action once merged

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

- Add support for other models (such as GPT-4) in the service methods, so that the dropdown in the AI text block displays more than one option again

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

Manual testing

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Checkout the branch, and run the AI text block locally
2. Ensure that only GPT-3.5 Turbo can selected

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

https://github.com/hashintel/hash/assets/42802102/1e888936-f23e-4ee1-bbb1-902209c425da



