### PR TITLE
H-1461: Hide share button on page

### DIFF
--- a/apps/hash-frontend/src/pages/shared/top-context-bar.tsx
+++ b/apps/hash-frontend/src/pages/shared/top-context-bar.tsx
@@ -183,7 +183,7 @@ export const TopContextBar = ({
           ) : null}
         </Box>
         <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-          {item && !isItemEntityType(item) && (
+          {item && !isItemEntityType(item) && !isEntityPageEntity(item) && (
             <ShareDropdownMenu entity={item} />
           )}
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The 'share' button on a page (a document or canvas) only shares the page entity itself with other users (or the public), not the entities it contains. This PR hides the button on a page until this is fixed (involves figuring out how to cascade permissions from the page to entities it might need to display, and warn the user about what's happening).

The button remains on an individual entity's page.
## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Check that the 'Share' button does not appear on a document page, but does on the entity editor for an individual entity
