### PR TITLE
H-1413: Validate link source and target by BaseURL on creation/update

### DIFF
--- a/apps/hash-graph/libs/graph/src/store/validation.rs
+++ b/apps/hash-graph/libs/graph/src/store/validation.rs
@@ -18,7 +18,10 @@ use graph_types::{
 };
 use tokio::sync::RwLock;
 use tokio_postgres::GenericClient;
-use type_system::{url::VersionedUrl, DataType, EntityType, PropertyType};
+use type_system::{
+    url::{BaseUrl, VersionedUrl},
+    DataType, EntityType, PropertyType,
+};
 use validation::{EntityProvider, EntityTypeProvider, OntologyTypeProvider};
 
 use crate::{
@@ -370,10 +373,10 @@ where
     A: AuthorizationApi + Sync,
 {
     #[expect(refining_impl_trait)]
-    async fn type_matches_base_url(
+    async fn is_parent_of(
         &self,
         child: &VersionedUrl,
-        parent: &VersionedUrl,
+        parent: &BaseUrl,
     ) -> Result<bool, Report<QueryError>> {
         let client = self.store.as_client().client();
         let child_id = EntityTypeId::from_url(child);
@@ -389,7 +392,7 @@ where
                           AND ontology_ids.base_url = $2
                     );
                 ",
-                &[child_id.as_uuid(), &parent.base_url.as_str()],
+                &[child_id.as_uuid(), &parent.as_str()],
             )
             .await
             .change_context(QueryError)?

--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -109,7 +109,7 @@ where
         let mut status: Result<(), Report<EntityValidationError>> = Ok(());
 
         let is_link = provider
-            .is_parent_of(
+            .type_matches_base_url(
                 schema.id(),
                 // TODO: The link type should be a const but the type system crate does not allow
                 //       to make this a `const` variable.
@@ -192,6 +192,7 @@ where
 
     // TODO: validate link data
     //   see https://linear.app/hash/issue/H-972
+    #[expect(clippy::too_many_lines)]
     async fn validate_value<'a>(
         &'a self,
         link_data: &'a LinkData,
@@ -218,7 +219,7 @@ where
             .map_err(|error| extend_report!(status, error))
             .ok();
 
-        let _right_entity_type_id = right_entity.as_ref().map(|entity| {
+        let right_entity_type_id = right_entity.as_ref().map(|entity| {
             if profile == ValidationProfile::Full && entity.borrow().metadata.draft() {
                 extend_report!(
                     status,
@@ -241,85 +242,91 @@ where
                 );
             }
 
-            // let left_entity_type = provider
-            //     .provide_type(left_entity.borrow().metadata.entity_type_id())
-            //     .await
-            //     .change_context_lazy(|| EntityValidationError::EntityTypeRetrieval {
-            //         id: left_entity.borrow().metadata.entity_type_id().clone(),
-            //     })
-            //     .map_err(|error| extend_report!(status, error))
-            //     .ok();
-            //
-            // if let Some(left_entity_type) = left_entity_type {
-            //     let mut maybe_allowed_targets = left_entity_type.borrow().links().get(self.id());
-            //     if maybe_allowed_targets.is_none() {
-            //         // No exact match found, so we look up parent types
-            //         for (link_type, allowed_targets) in left_entity_type.borrow().links() {
-            //             if provider
-            //                 .is_parent_of(self.id(), link_type)
-            //                 .await
-            //                 .change_context_lazy(|| EntityValidationError::EntityTypeRetrieval {
-            //                     id: self.id().clone(),
-            //                 })
-            //                 .map_err(|error| extend_report!(status, error))
-            //                 .unwrap_or(false)
-            //             {
-            //                 maybe_allowed_targets = Some(allowed_targets);
-            //                 break;
-            //             }
-            //         }
-            //     }
-            //
-            //     if let Some(maybe_allowed_targets) = maybe_allowed_targets {
-            //         if let (Some(allowed_targets), Some(right_entity_type_id)) =
-            //             (maybe_allowed_targets.array().items(), right_entity_type_id)
-            //         {
-            //             let mut found_match = false;
-            //             for allowed_target in allowed_targets.one_of() {
-            //                 // We test exact matches first to avoid looking up parent types
-            //                 if allowed_target.url() == right_entity_type_id {
-            //                     found_match = true;
-            //                     break;
-            //                 }
-            //             }
-            //             if !found_match {
-            //                 // No exact match found, so we look up parent types
-            //                 for allowed_target in allowed_targets.one_of() {
-            //                     if provider
-            //                         .is_parent_of(right_entity_type_id, allowed_target.url())
-            //                         .await
-            //                         .change_context_lazy(|| {
-            //                             EntityValidationError::EntityTypeRetrieval {
-            //                                 id: right_entity_type_id.clone(),
-            //                             }
-            //                         })
-            //                         .map_err(|error| extend_report!(status, error))
-            //                         .unwrap_or(false)
-            //                     {
-            //                         found_match = true;
-            //                         break;
-            //                     }
-            //                 }
-            //             }
-            //
-            //             if !found_match {
-            //                 extend_report!(
-            //                     status,
-            //                     EntityValidationError::InvalidLinkTargetId {
-            //                         target_type: right_entity_type_id.clone(),
-            //                     }
-            //                 );
-            //             }
-            //         }
-            //     } else {
-            //         extend_report!(
-            //             status,
-            //             EntityValidationError::InvalidLinkTypeId {
-            //                 link_type: self.id().clone(),
-            //             }
-            //         );
-            //     }
-            // }
+            let left_entity_type = provider
+                .provide_type(left_entity.borrow().metadata.entity_type_id())
+                .await
+                .change_context_lazy(|| EntityValidationError::EntityTypeRetrieval {
+                    id: left_entity.borrow().metadata.entity_type_id().clone(),
+                })
+                .map_err(|error| extend_report!(status, error))
+                .ok();
+
+            if let Some(left_entity_type) = left_entity_type {
+                let mut maybe_allowed_targets = left_entity_type.borrow().links().get(self.id());
+                if maybe_allowed_targets.is_none() {
+                    // No exact match found, so we look up parent types
+                    for (link_type, allowed_targets) in left_entity_type.borrow().links() {
+                        if self.id().base_url == link_type.base_url
+                            || provider
+                                .type_matches_base_url(self.id(), link_type)
+                                .await
+                                .change_context_lazy(|| {
+                                    EntityValidationError::EntityTypeRetrieval {
+                                        id: self.id().clone(),
+                                    }
+                                })
+                                .map_err(|error| extend_report!(status, error))
+                                .unwrap_or(false)
+                        {
+                            maybe_allowed_targets = Some(allowed_targets);
+                            break;
+                        }
+                    }
+                }
+
+                if let Some(maybe_allowed_targets) = maybe_allowed_targets {
+                    if let (Some(allowed_targets), Some(right_entity_type_id)) =
+                        (maybe_allowed_targets.array().items(), right_entity_type_id)
+                    {
+                        let mut found_match = false;
+                        for allowed_target in allowed_targets.one_of() {
+                            // We test exact matches first to avoid looking up parent types
+                            if allowed_target.url().base_url == right_entity_type_id.base_url {
+                                found_match = true;
+                                break;
+                            }
+                        }
+                        if !found_match {
+                            // No exact match found, so we look up parent types
+                            for allowed_target in allowed_targets.one_of() {
+                                if provider
+                                    .type_matches_base_url(
+                                        right_entity_type_id,
+                                        allowed_target.url(),
+                                    )
+                                    .await
+                                    .change_context_lazy(|| {
+                                        EntityValidationError::EntityTypeRetrieval {
+                                            id: right_entity_type_id.clone(),
+                                        }
+                                    })
+                                    .map_err(|error| extend_report!(status, error))
+                                    .unwrap_or(false)
+                                {
+                                    found_match = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if !found_match {
+                            extend_report!(
+                                status,
+                                EntityValidationError::InvalidLinkTargetId {
+                                    target_type: right_entity_type_id.clone(),
+                                }
+                            );
+                        }
+                    }
+                } else {
+                    extend_report!(
+                        status,
+                        EntityValidationError::InvalidLinkTypeId {
+                            link_type: self.id().clone(),
+                        }
+                    );
+                }
+            }
         }
 
         status

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -97,7 +97,7 @@ pub trait OntologyTypeProvider<O> {
 }
 
 pub trait EntityTypeProvider: OntologyTypeProvider<EntityType> {
-    fn is_parent_of(
+    fn type_matches_base_url(
         &self,
         child: &VersionedUrl,
         parent: &VersionedUrl,
@@ -196,7 +196,7 @@ mod tests {
     }
 
     impl EntityTypeProvider for Provider {
-        async fn is_parent_of(
+        async fn type_matches_base_url(
             &self,
             child: &VersionedUrl,
             parent: &VersionedUrl,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When a link is updated, the source and target entities should be validated at the current timestamp for the base URL

We also want to change validation on link creation to only check the base URL also

## 🔍 What does this change?

- Change link validation to search for matching BaseURL instead of Versioned URLs (including parents)
- Enable link validation on create/update