### PR TITLE
H-1591: Provide a `--skip-validation` flag to snapshot restoration

### DIFF
--- a/apps/hash-graph/libs/graph/src/api/rest/test_server.rs
+++ b/apps/hash-graph/libs/graph/src/api/rest/test_server.rs
@@ -119,6 +119,7 @@ where
             ),
             &mut authorization_api,
             10_000,
+            true,
         )
         .await
         .map_err(|report| {

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/data_type/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/data_type/batch.rs
@@ -81,7 +81,10 @@ impl<C: AsClient> WriteBatch<C> for DataTypeRowBatch {
         Ok(())
     }
 
-    async fn commit(postgres_client: &PostgresStore<C>) -> Result<(), InsertionError> {
+    async fn commit(
+        postgres_client: &PostgresStore<C>,
+        _validation: bool,
+    ) -> Result<(), InsertionError> {
         postgres_client
             .as_client()
             .client()

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/entity_type/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/entity_type/batch.rs
@@ -190,7 +190,10 @@ impl<C: AsClient> WriteBatch<C> for EntityTypeRowBatch {
     }
 
     #[expect(clippy::too_many_lines, reason = "TODO: Move out common parts")]
-    async fn commit(postgres_client: &PostgresStore<C>) -> Result<(), InsertionError> {
+    async fn commit(
+        postgres_client: &PostgresStore<C>,
+        _validation: bool,
+    ) -> Result<(), InsertionError> {
         // Insert types which don't need updating so they are available in the graph for the resolve
         // step below.
         postgres_client

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/metadata/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/metadata/batch.rs
@@ -133,7 +133,10 @@ impl<C: AsClient> WriteBatch<C> for OntologyTypeMetadataRowBatch {
         Ok(())
     }
 
-    async fn commit(postgres_client: &PostgresStore<C>) -> Result<(), InsertionError> {
+    async fn commit(
+        postgres_client: &PostgresStore<C>,
+        _validation: bool,
+    ) -> Result<(), InsertionError> {
         postgres_client
             .as_client()
             .client()

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/property_type/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/property_type/batch.rs
@@ -135,7 +135,10 @@ impl<C: AsClient> WriteBatch<C> for PropertyTypeRowBatch {
         Ok(())
     }
 
-    async fn commit(postgres_client: &PostgresStore<C>) -> Result<(), InsertionError> {
+    async fn commit(
+        postgres_client: &PostgresStore<C>,
+        _validation: bool,
+    ) -> Result<(), InsertionError> {
         postgres_client
             .as_client()
             .client()

--- a/apps/hash-graph/libs/graph/src/snapshot/owner/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/owner/batch.rs
@@ -91,7 +91,10 @@ impl<C: AsClient> WriteBatch<C> for AccountRowBatch {
         Ok(())
     }
 
-    async fn commit(postgres_client: &PostgresStore<C>) -> Result<(), InsertionError> {
+    async fn commit(
+        postgres_client: &PostgresStore<C>,
+        _validation: bool,
+    ) -> Result<(), InsertionError> {
         postgres_client
             .as_client()
             .client()

--- a/apps/hash-graph/libs/graph/src/snapshot/restore/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/restore/batch.rs
@@ -61,14 +61,17 @@ impl<C: AsClient> WriteBatch<C> for SnapshotRecordBatch {
         }
     }
 
-    async fn commit(postgres_client: &PostgresStore<C>) -> Result<(), InsertionError> {
-        AccountRowBatch::commit(postgres_client).await?;
-        WebBatch::commit(postgres_client).await?;
-        OntologyTypeMetadataRowBatch::commit(postgres_client).await?;
-        DataTypeRowBatch::commit(postgres_client).await?;
-        PropertyTypeRowBatch::commit(postgres_client).await?;
-        EntityTypeRowBatch::commit(postgres_client).await?;
-        EntityRowBatch::commit(postgres_client).await?;
+    async fn commit(
+        postgres_client: &PostgresStore<C>,
+        validation: bool,
+    ) -> Result<(), InsertionError> {
+        AccountRowBatch::commit(postgres_client, validation).await?;
+        WebBatch::commit(postgres_client, validation).await?;
+        OntologyTypeMetadataRowBatch::commit(postgres_client, validation).await?;
+        DataTypeRowBatch::commit(postgres_client, validation).await?;
+        PropertyTypeRowBatch::commit(postgres_client, validation).await?;
+        EntityTypeRowBatch::commit(postgres_client, validation).await?;
+        EntityRowBatch::commit(postgres_client, validation).await?;
         Ok(())
     }
 }

--- a/apps/hash-graph/libs/graph/src/snapshot/web/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/web/batch.rs
@@ -67,7 +67,10 @@ impl<C: AsClient> WriteBatch<C> for WebBatch {
         Ok(())
     }
 
-    async fn commit(postgres_client: &PostgresStore<C>) -> Result<(), InsertionError> {
+    async fn commit(
+        postgres_client: &PostgresStore<C>,
+        _validation: bool,
+    ) -> Result<(), InsertionError> {
         postgres_client
             .as_client()
             .client()


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Snapshot restoration can be a very time consuming task currently if every entity is validated. This is especially the case if the database is on a remote server. As the validation could happen on a separate step, this provides the functionality to bypass validation