### PR TITLE
H-1625, H-1561: Fix bugs related to machine notifications, link to original page from plugin request

### DIFF
--- a/apps/hash-frontend/src/pages/drafts.page/draft-entities.tsx
+++ b/apps/hash-frontend/src/pages/drafts.page/draft-entities.tsx
@@ -206,8 +206,8 @@ export const DraftEntities: FunctionComponent<{ sortOrder: SortOrder }> = ({
                     generateEntityLabel(draftEntitiesSubgraph, b.entity),
                   )
                 : sortOrder === "created-at-asc"
-                ? a.createdAt.getTime() - b.createdAt.getTime()
-                : b.createdAt.getTime() - a.createdAt.getTime(),
+                  ? a.createdAt.getTime() - b.createdAt.getTime()
+                  : b.createdAt.getTime() - a.createdAt.getTime(),
             )
         : undefined,
     [

--- a/apps/hash-frontend/src/pages/drafts.page/draft-entities.tsx
+++ b/apps/hash-frontend/src/pages/drafts.page/draft-entities.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@apollo/client";
+import { getRoots } from "@blockprotocol/graph/temporal/stdlib";
 import { Skeleton } from "@hashintel/design-system";
 import {
   fullDecisionTimeAxis,
@@ -108,7 +109,13 @@ export const DraftEntities: FunctionComponent<{ sortOrder: SortOrder }> = ({
   );
 
   const accountIds = useMemo(() => {
-    if (!draftEntities || !draftEntityHistoriesSubgraph) {
+    if (
+      !draftEntities ||
+      !draftEntityHistoriesSubgraph ||
+      // We may have a stale subgraph that doesn't contain the revisions for all of the draft entities yet
+      getRoots(draftEntityHistoriesSubgraph as any).length !==
+        draftEntities.length
+    ) {
       return undefined;
     }
 

--- a/apps/hash-frontend/src/pages/drafts.page/draft-entities.tsx
+++ b/apps/hash-frontend/src/pages/drafts.page/draft-entities.tsx
@@ -109,7 +109,7 @@ export const DraftEntities: FunctionComponent<{ sortOrder: SortOrder }> = ({
     [draftEntityHistoriesData, previouslyFetchedDraftEntityHistoriesData],
   );
 
-  const accountIds = useMemo(() => {
+  const creatorAccountIds = useMemo(() => {
     if (
       !draftEntities ||
       !draftEntityHistoriesSubgraph ||
@@ -130,7 +130,7 @@ export const DraftEntities: FunctionComponent<{ sortOrder: SortOrder }> = ({
     });
   }, [draftEntities, draftEntityHistoriesSubgraph]);
 
-  const { actors } = useActors({ accountIds });
+  const { actors } = useActors({ accountIds: creatorAccountIds });
 
   const draftEntitiesWithCreatedAtAndCreators = useMemo(() => {
     if (!draftEntities || !draftEntityHistoriesSubgraph || !actors) {
@@ -206,8 +206,8 @@ export const DraftEntities: FunctionComponent<{ sortOrder: SortOrder }> = ({
                     generateEntityLabel(draftEntitiesSubgraph, b.entity),
                   )
                 : sortOrder === "created-at-asc"
-                  ? a.createdAt.getTime() - b.createdAt.getTime()
-                  : b.createdAt.getTime() - a.createdAt.getTime(),
+                ? a.createdAt.getTime() - b.createdAt.getTime()
+                : b.createdAt.getTime() - a.createdAt.getTime(),
             )
         : undefined,
     [

--- a/apps/hash-frontend/src/pages/drafts.page/draft-entities/draft-entities-filters.tsx
+++ b/apps/hash-frontend/src/pages/drafts.page/draft-entities/draft-entities-filters.tsx
@@ -367,44 +367,46 @@ export const DraftEntitiesFilters: FunctionComponent<{
       </Box>
       <Box>
         <FilterSectionHeading>Source</FilterSectionHeading>
-        {sources?.map((source) => {
-          const label =
-            authenticatedUser.accountId === source.accountId
-              ? "Me"
-              : "preferredName" in source
-                ? source.preferredName
-                : "displayName" in source
-                  ? source.displayName
-                  : "Unknown";
-          return (
-            <CheckboxFilter
-              key={source.accountId}
-              label={
-                <>
-                  <UserIcon />
-                  {label}
-                </>
-              }
-              checked={
-                !!filterState?.sourceAccountIds.includes(source.accountId)
-              }
-              onChange={(checked) =>
-                setFilterState((prev) =>
-                  prev
-                    ? {
-                        ...prev,
-                        sourceAccountIds: checked
-                          ? [...prev.sourceAccountIds, source.accountId]
-                          : prev.sourceAccountIds.filter(
-                              (accountId) => accountId !== source.accountId,
-                            ),
-                      }
-                    : undefined,
-                )
-              }
-            />
-          );
-        })}
+        <Box display="flex" flexDirection="column">
+          {sources?.map((source) => {
+            const label =
+              authenticatedUser.accountId === source.accountId
+                ? "Me"
+                : "preferredName" in source
+                  ? source.preferredName
+                  : "displayName" in source
+                    ? source.displayName
+                    : "Unknown";
+            return (
+              <CheckboxFilter
+                key={source.accountId}
+                label={
+                  <>
+                    <UserIcon />
+                    {label}
+                  </>
+                }
+                checked={
+                  !!filterState?.sourceAccountIds.includes(source.accountId)
+                }
+                onChange={(checked) =>
+                  setFilterState((prev) =>
+                    prev
+                      ? {
+                          ...prev,
+                          sourceAccountIds: checked
+                            ? [...prev.sourceAccountIds, source.accountId]
+                            : prev.sourceAccountIds.filter(
+                                (accountId) => accountId !== source.accountId,
+                              ),
+                        }
+                      : undefined,
+                  )
+                }
+              />
+            );
+          })}
+        </Box>
       </Box>
       <Box>
         <FilterSectionHeading>Last edited</FilterSectionHeading>

--- a/apps/hash-frontend/src/pages/drafts.page/draft-entities/draft-entities-filters.tsx
+++ b/apps/hash-frontend/src/pages/drafts.page/draft-entities/draft-entities-filters.tsx
@@ -368,16 +368,33 @@ export const DraftEntitiesFilters: FunctionComponent<{
       <Box>
         <FilterSectionHeading>Source</FilterSectionHeading>
         <Box display="flex" flexDirection="column">
-          {sources?.map((source) => {
-            const label =
-              authenticatedUser.accountId === source.accountId
-                ? "Me"
-                : "preferredName" in source
-                  ? source.preferredName
-                  : "displayName" in source
-                    ? source.displayName
-                    : "Unknown";
-            return (
+          {sources
+            ?.map((source) => {
+              const label =
+                authenticatedUser.accountId === source.accountId
+                  ? "Me"
+                  : "preferredName" in source
+                    ? source.preferredName!
+                    : "displayName" in source
+                      ? source.displayName
+                      : "Unknown";
+
+              return { label, source };
+            })
+            .sort(
+              (
+                { label: labelA, source: sourceA },
+                { label: labelB, source: sourceB },
+              ) => {
+                if (authenticatedUser.accountId === sourceA.accountId) {
+                  return -1;
+                } else if (authenticatedUser.accountId === sourceB.accountId) {
+                  return 1;
+                }
+                return labelA.localeCompare(labelB);
+              },
+            )
+            .map(({ source, label }) => (
               <CheckboxFilter
                 key={source.accountId}
                 label={
@@ -404,8 +421,7 @@ export const DraftEntitiesFilters: FunctionComponent<{
                   )
                 }
               />
-            );
-          })}
+            ))}
         </Box>
       </Box>
       <Box>

--- a/apps/hash-frontend/src/pages/inbox.page.tsx
+++ b/apps/hash-frontend/src/pages/inbox.page.tsx
@@ -101,19 +101,19 @@ const GraphChangeNotificationContent = ({
   handleNotificationClick: () => void;
   targetHref?: string;
 }) => {
-  const { entityLabel, entity, operation } = notification;
+  const { occurredInEntityLabel, occurredInEntity, operation } = notification;
 
   return (
     <Typography component="span">
-      A {entity.metadata.draft ? "draft" : "live"} entity,{" "}
+      HASH AI {operation}d{" "}
       <Link
         href={targetHref ?? ""}
         noLinkStyle
         onClick={handleNotificationClick}
       >
-        {entityLabel}
-      </Link>
-      , was {operation}d
+        {occurredInEntityLabel}
+      </Link>{" "}
+      {occurredInEntity.metadata.draft ? "as draft" : ""}
     </Typography>
   );
 };
@@ -182,7 +182,9 @@ const NotificationRow: FunctionComponent<Notification> = (notification) => {
     }
 
     if (kind === "graph-change") {
-      return `/${entityOwningShortname}/entities/${occurredInEntity.metadata.recordId.entityId}`;
+      return `/@${entityOwningShortname}/entities/${extractEntityUuidFromEntityId(
+        occurredInEntity.metadata.recordId.entityId,
+      )}`;
     }
 
     const { occurredInBlock } = notification;

--- a/apps/hash-frontend/src/shared/notifications-context.tsx
+++ b/apps/hash-frontend/src/shared/notifications-context.tsx
@@ -98,8 +98,8 @@ export type GraphChangeNotification = {
   createdAt: Date;
   entity: Entity<GraphChangeNotificationProperties>;
   kind: "graph-change";
-  entityEditionTimestamp: string | undefined;
-  entityLabel: string;
+  occurredInEntityEditionTimestamp: string | undefined;
+  occurredInEntityLabel: string;
   occurredInEntity: Entity;
   operation: string;
 } & SimpleProperties<NotificationProperties>;
@@ -435,14 +435,14 @@ export const NotificationsContextProvider: FunctionComponent<
               );
             }
 
-            const entityEditionTimestamp = (
+            const occurredInEntityEditionTimestamp = (
               occurredInEntityLink
                 .linkEntity[0] as Entity<OccurredInEntityProperties>
             ).properties[
               "https://hash.ai/@hash/types/property-type/entity-edition-id/"
             ];
 
-            if (!entityEditionTimestamp) {
+            if (!occurredInEntityEditionTimestamp) {
               throw new Error(
                 `Graph change notification "${entityId}" Occurred In Entity link is missing required entityEditionId property`,
               );
@@ -450,9 +450,8 @@ export const NotificationsContextProvider: FunctionComponent<
 
             const occurredInEntity = occurredInEntityLink.rightEntity[0];
             if (!occurredInEntity) {
-              throw new Error(
-                `Graph change notification "${entityId}" is missing right entity to Occurred In Entity link`,
-              );
+              // @todo archive the notification when the entity it occurred in is archived
+              return null;
             }
 
             const graphChangeEntity =
@@ -460,10 +459,13 @@ export const NotificationsContextProvider: FunctionComponent<
 
             return {
               kind: "graph-change",
-              createdAt: new Date(entityEditionTimestamp),
+              createdAt: new Date(occurredInEntityEditionTimestamp),
               entity: graphChangeEntity,
-              entityLabel: generateEntityLabel(outgoingLinksSubgraph, entity),
-              entityEditionTimestamp,
+              occurredInEntityLabel: generateEntityLabel(
+                outgoingLinksSubgraph,
+                occurredInEntity,
+              ),
+              occurredInEntityEditionTimestamp,
               occurredInEntity,
               operation:
                 graphChangeEntity.properties[
@@ -473,6 +475,10 @@ export const NotificationsContextProvider: FunctionComponent<
           }
           throw new Error(`Notification of type "${entityTypeId}" not handled`);
         })
+        .filter(
+          (notification): notification is NonNullable<typeof notification> =>
+            !!notification,
+        )
         /**
          * Order the notifications by when their revisions were created
          *

--- a/apps/hash-frontend/src/shared/notifications-context.tsx
+++ b/apps/hash-frontend/src/shared/notifications-context.tsx
@@ -258,7 +258,7 @@ export const NotificationsContextProvider: FunctionComponent<
 
           const firstRevision = getFirstEntityRevision(
             revisionsSubgraph,
-            entity.metadata.recordId.entityId,
+            entityId,
           );
 
           const createdAt = new Date(

--- a/apps/hash-frontend/src/shared/use-actors.ts
+++ b/apps/hash-frontend/src/shared/use-actors.ts
@@ -49,7 +49,10 @@ export const useActors = (params: {
           any: (params.accountIds ?? []).map((accountId) => ({
             all: [
               {
-                equal: [{ path: ["uuid"] }, { parameter: accountId }],
+                equal: [
+                  { path: ["recordCreatedById"] },
+                  { parameter: accountId },
+                ],
               },
               generateVersionedUrlMatchingFilter(
                 systemEntityTypes.machine.entityTypeId,

--- a/apps/plugin-browser/src/pages/popup/popup-contents/action-center/log/inference-request.tsx
+++ b/apps/plugin-browser/src/pages/popup/popup-contents/action-center/log/inference-request.tsx
@@ -1,6 +1,6 @@
 import { pluralize } from "@local/hash-isomorphic-utils/pluralize";
 import type { InferEntitiesReturn } from "@local/hash-isomorphic-utils/temporal-types";
-import { Box, Skeleton, Stack, Typography } from "@mui/material";
+import { Box, Link, Skeleton, Stack, Typography } from "@mui/material";
 import { useMemo, useState } from "react";
 
 import type {
@@ -14,16 +14,27 @@ import {
 import { useEntityTypes } from "../../../../shared/use-entity-types";
 import { InferredEntity } from "./inference-request/inferred-entity";
 
+const metadataFontSize = 12;
+
 const MetadataItem = ({ label, value }: { label: string; value: string }) => (
   <Stack
     component="span"
     direction="row"
     sx={{ "&:not(:last-child)": { mr: 1.5 } }}
   >
-    <Typography sx={{ fontSize: 12, fontWeight: 600, opacity: 0.5, mr: 0.3 }}>
+    <Typography
+      sx={{
+        fontSize: metadataFontSize,
+        fontWeight: 600,
+        opacity: 0.5,
+        mr: 0.3,
+      }}
+    >
       {label}:
     </Typography>
-    <Typography sx={{ fontSize: 12, opacity: 0.6 }}>{value}</Typography>
+    <Typography sx={{ fontSize: metadataFontSize, opacity: 0.6 }}>
+      {value}
+    </Typography>
   </Stack>
 );
 
@@ -44,18 +55,15 @@ export const InferenceRequest = ({
       entityTypeIds.some((typeId) => typeId === type.schema.$id),
     );
 
-    return entityTypes.reduce(
-      (acc, type) => {
-        acc[type.schema.$id] =
-          status === "complete"
-            ? request.data.contents[0].results.filter(
-                (result) => result.entityTypeId === type.schema.$id,
-              )
-            : [];
-        return acc;
-      },
-      {} as Record<string, InferEntitiesReturn["contents"][0]["results"]>,
-    );
+    return entityTypes.reduce((acc, type) => {
+      acc[type.schema.$id] =
+        status === "complete"
+          ? request.data.contents[0].results.filter(
+              (result) => result.entityTypeId === type.schema.$id,
+            )
+          : [];
+      return acc;
+    }, {} as Record<string, InferEntitiesReturn["contents"][0]["results"]>);
   }, [allEntityTypes, entityTypeIds, request, status]);
 
   if (status === "pending" || status === "not-started") {
@@ -168,7 +176,28 @@ export const InferenceRequest = ({
           );
         },
       )}
-      <Stack direction="row" justifyContent="flex-end">
+      <Stack alignItems="center" direction="row" justifyContent="flex-end">
+        <Box
+          component="a"
+          href={request.sourceUrl}
+          sx={({ palette, transitions }) => ({
+            color: palette.blue[70],
+            textDecoration: "none",
+            fontSize: metadataFontSize,
+            fontWeight: 600,
+            lineHeight: 1.5,
+            marginBottom: "1px",
+            mr: 1.5,
+            opacity: 0.7,
+            transition: transitions.create("opacity"),
+            "&:hover": {
+              opacity: 1,
+            },
+          })}
+          target="blank"
+        >
+          Visit page
+        </Box>
         <MetadataItem label="Model" value={request.model} />
         {usage && <MetadataItem label="Tokens used" value={usage.toString()} />}
       </Stack>

--- a/apps/plugin-browser/src/pages/popup/popup-contents/action-center/log/inference-request.tsx
+++ b/apps/plugin-browser/src/pages/popup/popup-contents/action-center/log/inference-request.tsx
@@ -55,15 +55,18 @@ export const InferenceRequest = ({
       entityTypeIds.some((typeId) => typeId === type.schema.$id),
     );
 
-    return entityTypes.reduce((acc, type) => {
-      acc[type.schema.$id] =
-        status === "complete"
-          ? request.data.contents[0].results.filter(
-              (result) => result.entityTypeId === type.schema.$id,
-            )
-          : [];
-      return acc;
-    }, {} as Record<string, InferEntitiesReturn["contents"][0]["results"]>);
+    return entityTypes.reduce(
+      (acc, type) => {
+        acc[type.schema.$id] =
+          status === "complete"
+            ? request.data.contents[0].results.filter(
+                (result) => result.entityTypeId === type.schema.$id,
+              )
+            : [];
+        return acc;
+      },
+      {} as Record<string, InferEntitiesReturn["contents"][0]["results"]>,
+    );
   }, [allEntityTypes, entityTypeIds, request, status]);
 
   if (status === "pending" || status === "not-started") {

--- a/apps/plugin-browser/src/pages/popup/popup-contents/action-center/log/inference-request.tsx
+++ b/apps/plugin-browser/src/pages/popup/popup-contents/action-center/log/inference-request.tsx
@@ -1,6 +1,6 @@
 import { pluralize } from "@local/hash-isomorphic-utils/pluralize";
 import type { InferEntitiesReturn } from "@local/hash-isomorphic-utils/temporal-types";
-import { Box, Link, Skeleton, Stack, Typography } from "@mui/material";
+import { Box, Skeleton, Stack, Typography } from "@mui/material";
 import { useMemo, useState } from "react";
 
 import type {

--- a/apps/plugin-browser/src/pages/popup/popup-contents/action-center/one-off/infer-entities-action.tsx
+++ b/apps/plugin-browser/src/pages/popup/popup-contents/action-center/one-off/infer-entities-action.tsx
@@ -129,10 +129,9 @@ export const InferEntitiesAction = ({
               borderStyle: "solid",
               borderWidth: 1,
               ...borderColors,
-              mb: 1.5,
             }}
           >
-            <Typography sx={{ fontSize: 14, fontWeight: 600, mb: 1 }}>
+            <Typography sx={{ fontSize: 14, fontWeight: 600, pb: 1 }}>
               Choose inference engine to use
             </Typography>
             <ModelSelector
@@ -145,7 +144,7 @@ export const InferEntitiesAction = ({
               }
             />
 
-            <Typography sx={{ fontSize: 14, fontWeight: 600, mb: 1, mt: 2 }}>
+            <Typography sx={{ fontSize: 14, fontWeight: 600, pb: 1, pt: 2 }}>
               When entities are found...
             </Typography>
             <SelectWebTarget
@@ -167,7 +166,7 @@ export const InferEntitiesAction = ({
             />
           </Box>
         </Collapse>
-        <Stack alignItems="center" direction="row">
+        <Stack alignItems="center" direction="row" mt={1.5}>
           <Button
             disabled={pendingInferenceRequest || targetEntityTypeIds.length < 1}
             size="small"

--- a/apps/plugin-browser/webpack.config.js
+++ b/apps/plugin-browser/webpack.config.js
@@ -222,7 +222,7 @@ const options = {
       chunks: ["popup"],
       cache: false,
     }),
-    env.SENTRY_AUTH_TOKEN && env.SENTRY_DSN
+    env.SENTRY_AUTH_TOKEN && env.SENTRY_DSN && !isDevelopment
       ? sentryWebpackPlugin({
           authToken: env.SENTRY_AUTH_TOKEN,
           org: "hashintel",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes a few bugs related to the notifications / draft page following the introduction of machine actors (H-1625):
- Account for potential mismatches between the contents of the `draftEntities` and `draftEntityHistoriesSubgraph`s (fixes crash when a draft is created with the page open)
- Look for machine actors as draft creators in the `DraftEntityChip`
- Better copy for machine-inferred entity notifications
- Fix link to entities in machine-inferred entity notifications
- Filter out notifications linked to archived entities
- Correct the query for machine actors

Separately:
- Stop uploading plugin source maps to Sentry in development
- H-1561: Have a link to the inference source in the plugin `Log` tab

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


## ⚠️ Known issues

Rather than filtering out notifications related to archived entities, we should archive them when the entities are archived.
<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Try using the plugin with the drafts page open
2. Discard a draft and check notifications page doesn't crash
3. Check notifications and draft chips for machine-inferred entities

