### PR TITLE
H-1630: Make instantiators public for some system types

### DIFF
--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/001-create-hash-system-types.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/001-create-hash-system-types.migration.ts
@@ -832,7 +832,7 @@ const migrate: MigrationFunction = async ({
       },
       webShortname: "hash",
       migrationState,
-      instantiator: null,
+      instantiator: anyUserInstantiator,
     },
   );
 
@@ -1449,7 +1449,7 @@ const migrate: MigrationFunction = async ({
       },
       webShortname: "hash",
       migrationState,
-      instantiator: null,
+      instantiator: anyUserInstantiator,
     },
   );
 
@@ -1566,7 +1566,7 @@ const migrate: MigrationFunction = async ({
       },
       webShortname: "hash",
       migrationState,
-      instantiator: null,
+      instantiator: anyUserInstantiator,
     });
 
   /** Comment Notification entity type */
@@ -1636,7 +1636,7 @@ const migrate: MigrationFunction = async ({
       },
       webShortname: "hash",
       migrationState,
-      instantiator: null,
+      instantiator: anyUserInstantiator,
     });
 
   return migrationState;

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/004-create-machines-update-users.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/004-create-machines-update-users.migration.ts
@@ -5,6 +5,7 @@ import { getEntityTypeById } from "../../../ontology/primitive/entity-type";
 import { systemAccountId } from "../../../system-account";
 import { MigrationFunction } from "../types";
 import {
+  anyUserInstantiator,
   createSystemEntityTypeIfNotExists,
   createSystemPropertyTypeIfNotExists,
   getCurrentHashSystemEntityTypeId,
@@ -189,7 +190,7 @@ const migrate: MigrationFunction = async ({
     },
     webShortname: "hash",
     migrationState,
-    instantiator: null,
+    instantiator: anyUserInstantiator,
   });
 
   /** Step 6: Update the dependencies of entity types which we've updated above */

--- a/apps/hash-api/src/graph/knowledge/system-types/hash-instance.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/hash-instance.ts
@@ -21,6 +21,7 @@ import {
 
 import { createAccountGroup } from "../../account-permission-management";
 import { ImpureGraphFunction, PureGraphFunction } from "../../context-types";
+import { modifyEntityTypeAuthorizationRelationships } from "../../ontology/primitive/entity-type";
 import { createEntity } from "../primitive/entity";
 import { getOrgByShortname } from "./org";
 import { User } from "./user";
@@ -161,6 +162,23 @@ export const createHashInstance: ImpureGraphFunction<
       },
     ],
   });
+
+  await modifyEntityTypeAuthorizationRelationships(ctx, authentication, [
+    {
+      operation: "touch",
+      relationship: {
+        relation: "instantiator",
+        subject: {
+          kind: "accountGroup",
+          subjectId: hashInstanceAdminsAccountGroupId,
+        },
+        resource: {
+          kind: "entityType",
+          resourceId: systemEntityTypes.hashInstance.entityTypeId,
+        },
+      },
+    },
+  ]);
 
   return getHashInstanceFromEntity({ entity });
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#3714 limited the `instantiator` permission on some system entity types, which is intended to restrict who can create entities of a certain type. But at the moment `instantiator` also restricts who can _update_ entities of those types, which was not the intention of the restrictions and isn't currently workable (e.g. users need to be able to edit their own record, at least parts of it, and to archive/mark notifications as read).

This PR therefore makes those system types have an 'anyone' instantiator again, until we change the restriction to apply only to entity creation and not update.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. You would have to rebuild the app and check that a user can mark a notification as read
