### PR TITLE
H-1649: Support `Vector` type in Structural Queries

### DIFF
--- a/apps/hash-graph/libs/api/src/rest/mod.rs
+++ b/apps/hash-graph/libs/api/src/rest/mod.rs
@@ -655,6 +655,42 @@ impl Modify for FilterSchemaAddon {
                         )
                         .item(
                             ObjectBuilder::new()
+                                .title(Some("L2DistanceFilter"))
+                                .property(
+                                    "l2Distance",
+                                    ArrayBuilder::new()
+                                        .items(Ref::from_schema_name("FilterExpression"))
+                                        .min_items(Some(3))
+                                        .max_items(Some(3)),
+                                )
+                                .required("l2Distance"),
+                        )
+                        .item(
+                            ObjectBuilder::new()
+                                .title(Some("CosineDistanceFilter"))
+                                .property(
+                                    "cosineDistance",
+                                    ArrayBuilder::new()
+                                        .items(Ref::from_schema_name("FilterExpression"))
+                                        .min_items(Some(3))
+                                        .max_items(Some(3)),
+                                )
+                                .required("cosineDistance"),
+                        )
+                        .item(
+                            ObjectBuilder::new()
+                                .title(Some("InnerProductFilter"))
+                                .property(
+                                    "innerProduct",
+                                    ArrayBuilder::new()
+                                        .items(Ref::from_schema_name("FilterExpression"))
+                                        .min_items(Some(3))
+                                        .max_items(Some(3)),
+                                )
+                                .required("innerProduct"),
+                        )
+                        .item(
+                            ObjectBuilder::new()
                                 .title(Some("StartsWithFilter"))
                                 .property(
                                     "startsWith",

--- a/apps/hash-graph/libs/api/src/rest/mod.rs
+++ b/apps/hash-graph/libs/api/src/rest/mod.rs
@@ -655,18 +655,6 @@ impl Modify for FilterSchemaAddon {
                         )
                         .item(
                             ObjectBuilder::new()
-                                .title(Some("L2DistanceFilter"))
-                                .property(
-                                    "l2Distance",
-                                    ArrayBuilder::new()
-                                        .items(Ref::from_schema_name("FilterExpression"))
-                                        .min_items(Some(3))
-                                        .max_items(Some(3)),
-                                )
-                                .required("l2Distance"),
-                        )
-                        .item(
-                            ObjectBuilder::new()
                                 .title(Some("CosineDistanceFilter"))
                                 .property(
                                     "cosineDistance",
@@ -676,18 +664,6 @@ impl Modify for FilterSchemaAddon {
                                         .max_items(Some(3)),
                                 )
                                 .required("cosineDistance"),
-                        )
-                        .item(
-                            ObjectBuilder::new()
-                                .title(Some("InnerProductFilter"))
-                                .property(
-                                    "innerProduct",
-                                    ArrayBuilder::new()
-                                        .items(Ref::from_schema_name("FilterExpression"))
-                                        .min_items(Some(3))
-                                        .max_items(Some(3)),
-                                )
-                                .required("innerProduct"),
                         )
                         .item(
                             ObjectBuilder::new()

--- a/apps/hash-graph/libs/graph/src/knowledge/query.rs
+++ b/apps/hash-graph/libs/graph/src/knowledge/query.rs
@@ -384,7 +384,7 @@ impl QueryPath for EntityQueryPath<'_> {
             }
             Self::DecisionTime | Self::TransactionTime => ParameterType::TimeInterval,
             Self::Properties(_) => ParameterType::Any,
-            Self::LeftToRightOrder | Self::RightToLeftOrder => ParameterType::Number,
+            Self::LeftToRightOrder | Self::RightToLeftOrder => ParameterType::I32,
             Self::Archived | Self::Draft => ParameterType::Boolean,
             Self::EntityTypeEdge { path, .. } => path.expected_type(),
             Self::EntityEdge { path, .. } => path.expected_type(),

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/compile.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/compile.rs
@@ -366,6 +366,21 @@ impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {
                 rhs.as_ref()
                     .map(|expression| self.compile_filter_expression(expression).0),
             ),
+            Filter::L2Distance(lhs, rhs, max) => Condition::L2Distance(
+                self.compile_filter_expression(lhs).0,
+                self.compile_filter_expression(rhs).0,
+                self.compile_filter_expression(max).0,
+            ),
+            Filter::CosineDistance(lhs, rhs, max) => Condition::CosineDistance(
+                self.compile_filter_expression(lhs).0,
+                self.compile_filter_expression(rhs).0,
+                self.compile_filter_expression(max).0,
+            ),
+            Filter::InnerProduct(lhs, rhs, max) => Condition::InnerProduct(
+                self.compile_filter_expression(lhs).0,
+                self.compile_filter_expression(rhs).0,
+                self.compile_filter_expression(max).0,
+            ),
             Filter::In(lhs, rhs) => Condition::In(
                 self.compile_filter_expression(lhs).0,
                 self.compile_parameter_list(rhs).0,
@@ -566,9 +581,13 @@ impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {
         parameter: &'p Parameter<'f>,
     ) -> (Expression, ParameterType) {
         let parameter_type = match parameter {
-            Parameter::Number(number) => {
+            Parameter::I32(number) => {
                 self.artifacts.parameters.push(number);
-                ParameterType::Number
+                ParameterType::I32
+            }
+            Parameter::F64(number) => {
+                self.artifacts.parameters.push(number);
+                ParameterType::F64
             }
             Parameter::Text(text) => {
                 self.artifacts.parameters.push(text);
@@ -577,6 +596,10 @@ impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {
             Parameter::Boolean(bool) => {
                 self.artifacts.parameters.push(bool);
                 ParameterType::Boolean
+            }
+            Parameter::Vector(vector) => {
+                self.artifacts.parameters.push(vector);
+                ParameterType::Vector
             }
             Parameter::Any(json) => {
                 self.artifacts.parameters.push(json);

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/compile.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/compile.rs
@@ -366,17 +366,7 @@ impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {
                 rhs.as_ref()
                     .map(|expression| self.compile_filter_expression(expression).0),
             ),
-            Filter::L2Distance(lhs, rhs, max) => Condition::L2Distance(
-                self.compile_filter_expression(lhs).0,
-                self.compile_filter_expression(rhs).0,
-                self.compile_filter_expression(max).0,
-            ),
             Filter::CosineDistance(lhs, rhs, max) => Condition::CosineDistance(
-                self.compile_filter_expression(lhs).0,
-                self.compile_filter_expression(rhs).0,
-                self.compile_filter_expression(max).0,
-            ),
-            Filter::InnerProduct(lhs, rhs, max) => Condition::InnerProduct(
                 self.compile_filter_expression(lhs).0,
                 self.compile_filter_expression(rhs).0,
                 self.compile_filter_expression(max).0,

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/condition.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/condition.rs
@@ -16,6 +16,9 @@ pub enum Condition {
     LessOrEqual(Expression, Expression),
     Greater(Expression, Expression),
     GreaterOrEqual(Expression, Expression),
+    L2Distance(Expression, Expression, Expression),
+    CosineDistance(Expression, Expression, Expression),
+    InnerProduct(Expression, Expression, Expression),
     In(Expression, Expression),
     TimeIntervalContainsTimestamp(Expression, Expression),
     Overlap(Expression, Expression),
@@ -86,6 +89,33 @@ impl Transpile for Condition {
                 lhs.transpile(fmt)?;
                 fmt.write_str(" != ")?;
                 rhs.transpile(fmt)
+            }
+            Self::L2Distance(lhs, rhs, max) => {
+                fmt.write_char('(')?;
+                lhs.transpile(fmt)?;
+                fmt.write_str(" <-> ")?;
+                rhs.transpile(fmt)?;
+                fmt.write_str(" <= ")?;
+                max.transpile(fmt)?;
+                fmt.write_char(')')
+            }
+            Self::CosineDistance(lhs, rhs, max) => {
+                fmt.write_char('(')?;
+                lhs.transpile(fmt)?;
+                fmt.write_str(" <=> ")?;
+                rhs.transpile(fmt)?;
+                fmt.write_str(" <= ")?;
+                max.transpile(fmt)?;
+                fmt.write_char(')')
+            }
+            Self::InnerProduct(lhs, rhs, max) => {
+                fmt.write_char('(')?;
+                lhs.transpile(fmt)?;
+                fmt.write_str(" <#> ")?;
+                rhs.transpile(fmt)?;
+                fmt.write_str(" <= ")?;
+                max.transpile(fmt)?;
+                fmt.write_char(')')
             }
             Self::Less(lhs, rhs) => {
                 lhs.transpile(fmt)?;
@@ -256,7 +286,7 @@ mod tests {
                 ),
                 Filter::Equal(
                     Some(FilterExpression::Path(DataTypeQueryPath::Version)),
-                    Some(FilterExpression::Parameter(Parameter::Number(1))),
+                    Some(FilterExpression::Parameter(Parameter::I32(1))),
                 ),
             ]),
             r#"("ontology_ids_0_1_0"."base_url" = $1) AND ("ontology_ids_0_1_0"."version" = $2)"#,
@@ -290,7 +320,7 @@ mod tests {
                 ),
                 Filter::Equal(
                     Some(FilterExpression::Path(DataTypeQueryPath::Version)),
-                    Some(FilterExpression::Parameter(Parameter::Number(1))),
+                    Some(FilterExpression::Parameter(Parameter::I32(1))),
                 ),
             ]),
             r#"(("ontology_ids_0_1_0"."base_url" = $1) OR ("ontology_ids_0_1_0"."version" = $2))"#,

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/condition.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/condition.rs
@@ -16,9 +16,7 @@ pub enum Condition {
     LessOrEqual(Expression, Expression),
     Greater(Expression, Expression),
     GreaterOrEqual(Expression, Expression),
-    L2Distance(Expression, Expression, Expression),
     CosineDistance(Expression, Expression, Expression),
-    InnerProduct(Expression, Expression, Expression),
     In(Expression, Expression),
     TimeIntervalContainsTimestamp(Expression, Expression),
     Overlap(Expression, Expression),
@@ -90,28 +88,10 @@ impl Transpile for Condition {
                 fmt.write_str(" != ")?;
                 rhs.transpile(fmt)
             }
-            Self::L2Distance(lhs, rhs, max) => {
-                fmt.write_char('(')?;
-                lhs.transpile(fmt)?;
-                fmt.write_str(" <-> ")?;
-                rhs.transpile(fmt)?;
-                fmt.write_str(" <= ")?;
-                max.transpile(fmt)?;
-                fmt.write_char(')')
-            }
             Self::CosineDistance(lhs, rhs, max) => {
                 fmt.write_char('(')?;
                 lhs.transpile(fmt)?;
                 fmt.write_str(" <=> ")?;
-                rhs.transpile(fmt)?;
-                fmt.write_str(" <= ")?;
-                max.transpile(fmt)?;
-                fmt.write_char(')')
-            }
-            Self::InnerProduct(lhs, rhs, max) => {
-                fmt.write_char('(')?;
-                lhs.transpile(fmt)?;
-                fmt.write_str(" <#> ")?;
                 rhs.transpile(fmt)?;
                 fmt.write_str(" <= ")?;
                 max.transpile(fmt)?;

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/expression/where_clause.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/expression/where_clause.rs
@@ -84,7 +84,7 @@ mod tests {
             ),
             Filter::Equal(
                 Some(FilterExpression::Path(DataTypeQueryPath::Version)),
-                Some(FilterExpression::Parameter(Parameter::Number(1))),
+                Some(FilterExpression::Parameter(Parameter::I32(1))),
             ),
         ]);
         where_clause.add_condition(compiler.compile_filter(&filter_b));

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/statement/select.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/statement/select.rs
@@ -230,7 +230,7 @@ mod tests {
             ),
             Filter::Equal(
                 Some(FilterExpression::Path(DataTypeQueryPath::Version)),
-                Some(FilterExpression::Parameter(Parameter::Number(1))),
+                Some(FilterExpression::Parameter(Parameter::I32(1))),
             ),
         ]);
         compiler.add_filter(&filter);
@@ -367,7 +367,7 @@ mod tests {
                         path: DataTypeQueryPath::Version,
                     },
                 )),
-                Some(FilterExpression::Parameter(Parameter::Number(1))),
+                Some(FilterExpression::Parameter(Parameter::I32(1))),
             ),
         ]);
         compiler.add_filter(&filter);
@@ -752,7 +752,7 @@ mod tests {
                 }),
                 direction: EdgeDirection::Incoming,
             })),
-            Some(FilterExpression::Parameter(Parameter::Number(10))),
+            Some(FilterExpression::Parameter(Parameter::I32(10))),
         );
         compiler.add_filter(&filter);
 
@@ -801,7 +801,7 @@ mod tests {
                 }),
                 direction: EdgeDirection::Incoming,
             })),
-            Some(FilterExpression::Parameter(Parameter::Number(10))),
+            Some(FilterExpression::Parameter(Parameter::I32(10))),
         );
         compiler.add_filter(&filter);
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/table.rs
@@ -734,7 +734,7 @@ impl EntityEditions<'static> {
         match self {
             Self::EditionId | Self::RecordCreatedById => ParameterType::Uuid,
             Self::Properties(_) => ParameterType::Any,
-            Self::LeftToRightOrder | Self::RightToLeftOrder => ParameterType::Number,
+            Self::LeftToRightOrder | Self::RightToLeftOrder => ParameterType::I32,
             Self::Archived | Self::Draft => ParameterType::Boolean,
         }
     }
@@ -761,7 +761,7 @@ impl EntityIsOfType {
     pub const fn parameter_type(self) -> ParameterType {
         match self {
             Self::EntityEditionId | Self::EntityTypeOntologyId => ParameterType::Uuid,
-            Self::InheritanceDepth => ParameterType::Number,
+            Self::InheritanceDepth => ParameterType::I32,
         }
     }
 }
@@ -906,7 +906,7 @@ impl EntityTypeConstrainsPropertiesOn {
             Self::SourceEntityTypeOntologyId | Self::TargetPropertyTypeOntologyId => {
                 ParameterType::Uuid
             }
-            Self::InheritanceDepth => ParameterType::Number,
+            Self::InheritanceDepth => ParameterType::I32,
         }
     }
 }
@@ -937,7 +937,7 @@ impl EntityTypeInheritsFrom {
             Self::SourceEntityTypeOntologyId | Self::TargetEntityTypeOntologyId => {
                 ParameterType::Uuid
             }
-            Self::InheritanceDepth => ParameterType::Number,
+            Self::InheritanceDepth => ParameterType::I32,
         }
     }
 }
@@ -968,7 +968,7 @@ impl EntityTypeConstrainsLinksOn {
             Self::SourceEntityTypeOntologyId | Self::TargetEntityTypeOntologyId => {
                 ParameterType::Uuid
             }
-            Self::InheritanceDepth => ParameterType::Number,
+            Self::InheritanceDepth => ParameterType::I32,
         }
     }
 }
@@ -999,7 +999,7 @@ impl EntityTypeConstrainsLinkDestinationsOn {
             Self::SourceEntityTypeOntologyId | Self::TargetEntityTypeOntologyId => {
                 ParameterType::Uuid
             }
-            Self::InheritanceDepth => ParameterType::Number,
+            Self::InheritanceDepth => ParameterType::I32,
         }
     }
 }

--- a/apps/hash-graph/libs/graph/src/store/query/filter.rs
+++ b/apps/hash-graph/libs/graph/src/store/query/filter.rs
@@ -44,17 +44,7 @@ pub enum Filter<'p, R: Record + ?Sized> {
         Option<FilterExpression<'p, R>>,
         Option<FilterExpression<'p, R>>,
     ),
-    L2Distance(
-        FilterExpression<'p, R>,
-        FilterExpression<'p, R>,
-        FilterExpression<'p, R>,
-    ),
     CosineDistance(
-        FilterExpression<'p, R>,
-        FilterExpression<'p, R>,
-        FilterExpression<'p, R>,
-    ),
-    InnerProduct(
         FilterExpression<'p, R>,
         FilterExpression<'p, R>,
         FilterExpression<'p, R>,
@@ -139,9 +129,7 @@ where
                 ) => parameter.convert_to_parameter_type(path.expected_type())?,
                 (..) => {}
             },
-            Self::L2Distance(lhs, rhs, max)
-            | Self::CosineDistance(lhs, rhs, max)
-            | Self::InnerProduct(lhs, rhs, max) => {
+            Self::CosineDistance(lhs, rhs, max) => {
                 if let FilterExpression::Parameter(parameter) = max {
                     parameter.convert_to_parameter_type(ParameterType::F64)?;
                 }

--- a/apps/hash-graph/libs/graph/src/store/query/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/query/mod.rs
@@ -52,9 +52,11 @@ pub fn parse_query_token<'de, T: Deserialize<'de>, E: de::Error>(
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum ParameterType {
     Boolean,
-    Number,
+    I32,
+    F64,
     OntologyTypeVersion,
     Text,
+    Vector,
     Uuid,
     BaseUrl,
     VersionedUrl,
@@ -68,9 +70,11 @@ impl fmt::Display for ParameterType {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Boolean => fmt.write_str("boolean"),
-            Self::Number => fmt.write_str("number"),
+            Self::I32 => fmt.write_str("signed 32 bit integral number"),
+            Self::F64 => fmt.write_str("64 bit floating point number"),
             Self::OntologyTypeVersion => fmt.write_str("ontology type version"),
             Self::Text => fmt.write_str("text"),
+            Self::Vector => fmt.write_str("vector"),
             Self::Uuid => fmt.write_str("UUID"),
             Self::BaseUrl => fmt.write_str("base URL"),
             Self::VersionedUrl => fmt.write_str("versioned URL"),

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -3876,6 +3876,57 @@
           },
           {
             "type": "object",
+            "title": "L2DistanceFilter",
+            "required": [
+              "l2Distance"
+            ],
+            "properties": {
+              "l2Distance": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FilterExpression"
+                },
+                "maxItems": 3,
+                "minItems": 3
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "CosineDistanceFilter",
+            "required": [
+              "cosineDistance"
+            ],
+            "properties": {
+              "cosineDistance": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FilterExpression"
+                },
+                "maxItems": 3,
+                "minItems": 3
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "InnerProductFilter",
+            "required": [
+              "innerProduct"
+            ],
+            "properties": {
+              "innerProduct": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FilterExpression"
+                },
+                "maxItems": 3,
+                "minItems": 3
+              }
+            }
+          },
+          {
+            "type": "object",
             "title": "StartsWithFilter",
             "required": [
               "startsWith"

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -3910,40 +3910,6 @@
           },
           {
             "type": "object",
-            "title": "InnerProductFilter",
-            "required": [
-              "innerProduct"
-            ],
-            "properties": {
-              "innerProduct": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/FilterExpression"
-                },
-                "maxItems": 3,
-                "minItems": 3
-              }
-            }
-          },
-          {
-            "type": "object",
-            "title": "StartsWithFilter",
-            "required": [
-              "startsWith"
-            ],
-            "properties": {
-              "startsWith": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/FilterExpression"
-                },
-                "maxItems": 2,
-                "minItems": 2
-              }
-            }
-          },
-          {
-            "type": "object",
             "title": "EndsWithFilter",
             "required": [
               "endsWith"

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -3876,23 +3876,6 @@
           },
           {
             "type": "object",
-            "title": "L2DistanceFilter",
-            "required": [
-              "l2Distance"
-            ],
-            "properties": {
-              "l2Distance": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/FilterExpression"
-                },
-                "maxItems": 3,
-                "minItems": 3
-              }
-            }
-          },
-          {
-            "type": "object",
             "title": "CosineDistanceFilter",
             "required": [
               "cosineDistance"
@@ -3905,6 +3888,23 @@
                 },
                 "maxItems": 3,
                 "minItems": 3
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "StartsWithFilter",
+            "required": [
+              "startsWith"
+            ],
+            "properties": {
+              "startsWith": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FilterExpression"
+                },
+                "maxItems": 2,
+                "minItems": 2
               }
             }
           },

--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -2120,9 +2120,10 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 
 {
   "filter": {
-    "containsSegment": [
-      { "path": ["properties", "http://localhost:3000/@alice/types/property-type/name/"] },
-      { "parameter": "Alice" }
+    "cosineDistance": [
+      { "path": ["embedding"] },
+      { "parameter": [10, 20, 30, 40] },
+      { "parameter": 10.0 }
     ]
   },
   "graphResolveDepths": {

--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -2120,10 +2120,9 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 
 {
   "filter": {
-    "cosineDistance": [
-      { "path": ["embedding"] },
-      { "parameter": [10, 20, 30, 40] },
-      { "parameter": 10.0 }
+    "containsSegment": [
+      { "path": ["properties", "http://localhost:3000/@alice/types/property-type/name/"] },
+      { "parameter": "Alice" }
     ]
   },
   "graphResolveDepths": {

--- a/libs/@local/hash-graph-types/rust/src/embedding.rs
+++ b/libs/@local/hash-graph-types/rust/src/embedding.rs
@@ -1,4 +1,6 @@
-use std::{borrow::Cow, error::Error};
+use std::borrow::Cow;
+#[cfg(feature = "postgres")]
+use std::error::Error;
 
 #[cfg(feature = "postgres")]
 use bytes::{BufMut, BytesMut};

--- a/libs/@local/hash-graph-types/rust/src/embedding.rs
+++ b/libs/@local/hash-graph-types/rust/src/embedding.rs
@@ -1,0 +1,106 @@
+use std::{borrow::Cow, error::Error};
+
+#[cfg(feature = "postgres")]
+use bytes::{BufMut, BytesMut};
+#[cfg(feature = "postgres")]
+use postgres_types::{FromSql, IsNull, ToSql, Type};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(transparent)]
+pub struct Embedding<'v>(Cow<'v, [f32]>);
+
+impl Embedding<'_> {
+    pub const DIM: usize = 1536;
+
+    pub fn iter(&self) -> impl Iterator<Item = f32> + '_ {
+        self.0.iter().copied()
+    }
+
+    #[must_use]
+    pub fn into_owned(self) -> Embedding<'static> {
+        Embedding(Cow::Owned(self.0.into_owned()))
+    }
+
+    #[must_use]
+    pub fn to_owned(&self) -> Embedding<'static> {
+        match self.0 {
+            Cow::Borrowed(slice) => Embedding(Cow::Owned(slice.to_owned())),
+            Cow::Owned(ref vec) => Embedding(Cow::Owned(vec.clone())),
+        }
+    }
+}
+
+impl FromIterator<f32> for Embedding<'_> {
+    fn from_iter<T: IntoIterator<Item = f32>>(iter: T) -> Self {
+        Self(Cow::Owned(iter.into_iter().collect()))
+    }
+}
+
+impl From<Vec<f32>> for Embedding<'_> {
+    fn from(vector: Vec<f32>) -> Self {
+        Self(Cow::Owned(vector))
+    }
+}
+
+impl<'v> From<&'v [f32]> for Embedding<'v> {
+    fn from(vector: &'v [f32]) -> Self {
+        Self(Cow::Borrowed(vector))
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl ToSql for Embedding<'_> {
+    postgres_types::to_sql_checked!();
+
+    fn to_sql(&self, _ty: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        let dim = self.0.len();
+        w.put_u16(dim.try_into()?);
+        w.put_u16(0);
+
+        for v in self.0.as_ref() {
+            w.put_f32(*v);
+        }
+
+        Ok(IsNull::No)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        ty.name() == "vector"
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl<'v> FromSql<'v> for Embedding<'_> {
+    #[expect(
+        clippy::big_endian_bytes,
+        reason = "Postgres always returns big endian"
+    )]
+    #[expect(
+        clippy::missing_asserts_for_indexing,
+        reason = "We error if the buffer is too small"
+    )]
+    fn from_sql(_ty: &Type, buf: &'v [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        if buf.len() < 4 {
+            return Err("expected at least 4 bytes".into());
+        }
+        let dim = u16::from_be_bytes(buf[0..2].try_into()?) as usize;
+        let unused = u16::from_be_bytes(buf[2..4].try_into()?);
+        if unused != 0 {
+            return Err("expected unused to be 0".into());
+        }
+
+        let mut vec = Vec::with_capacity(dim);
+        for i in 0..dim {
+            let s = 4 + 4 * i;
+            vec.push(f32::from_be_bytes(buf[s..s + 4].try_into()?));
+        }
+
+        Ok(Self(Cow::Owned(vec)))
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        ty.name() == "vector"
+    }
+}

--- a/libs/@local/hash-graph-types/rust/src/lib.rs
+++ b/libs/@local/hash-graph-types/rust/src/lib.rs
@@ -1,6 +1,12 @@
+#![feature(lint_reasons)]
+
 pub mod knowledge;
 pub mod ontology;
 
 pub mod provenance;
 
 pub mod account;
+
+pub use self::embedding::Embedding;
+
+mod embedding;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To allow querying by embeddings it's required that a Vector type is available in structural queries


## 🔍 What does this change?

- Rename `Parameter::Number` to `Parameter::I32`
- Add `Parameter::F64` and `Parameter::Vector`
- Add an `Embedding` type and allow converting it to/from Postgres
- Add filter for L2 distance, cosine distance, and inner product

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph