### PR TITLE
H-1631: Archive notification when discarding a draft entity

### DIFF
--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
@@ -799,6 +799,9 @@ export const updateSystemEntityType: ImpureGraphFunction<
     await getEntityTypeById(context, authentication, {
       entityTypeId: nextEntityTypeId,
     });
+
+    migrationState.entityTypeVersions[baseUrl] = version + 1;
+
     return { updatedEntityTypeId: nextEntityTypeId };
   } catch {
     // the next version doesn't exist, continue to create it

--- a/apps/hash-frontend/src/pages/drafts.page/draft-entity.tsx
+++ b/apps/hash-frontend/src/pages/drafts.page/draft-entity.tsx
@@ -42,7 +42,11 @@ export const DraftEntity: FunctionComponent<{
 
   return (
     <Box paddingY={4.5} paddingX={3.25}>
-      <Box display="flex" justifyContent="space-between">
+      <Box
+        display="flex"
+        justifyContent="space-between"
+        alignItems="flex-start"
+      >
         {/* @todo: open in a slide-over instead of redirecting */}
         <Link
           noLinkStyle

--- a/apps/hash-frontend/src/pages/drafts.page/draft-entity/draft-entity-action-buttons.tsx
+++ b/apps/hash-frontend/src/pages/drafts.page/draft-entity/draft-entity-action-buttons.tsx
@@ -358,7 +358,7 @@ export const DraftEntityActionButtons: FunctionComponent<{
           />
         </AlertModal>
       )}
-      <Box display="flex" columnGap={1}>
+      <Box marginLeft={1} display="flex" columnGap={1}>
         <Button
           onClick={handleIgnore}
           size="xs"

--- a/apps/hash-frontend/src/shared/use-actors.ts
+++ b/apps/hash-frontend/src/shared/use-actors.ts
@@ -71,6 +71,9 @@ export const useActors = (params: {
   });
 
   const actors = useMemo(() => {
+    if (accountIds && accountIds.length === 0) {
+      return [];
+    }
     if (!machineActorsData || !userActors) {
       return;
     }
@@ -90,7 +93,7 @@ export const useActors = (params: {
     });
 
     return [...machineActors, ...userActors];
-  }, [userActors, machineActorsData]);
+  }, [userActors, machineActorsData, accountIds]);
 
   return {
     actors,

--- a/libs/@local/hash-isomorphic-utils/src/ontology-types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/ontology-types.ts
@@ -97,7 +97,13 @@ export const generateLinkMapWithConsistentSelfReferences = (
       const schemaWithConsistentSelfReferences = {
         ...linkSchema,
         items:
-          "oneOf" in linkSchema.items
+          /**
+           * @todo remove array check when it's no longer possible for  the value of
+           * `oneOf` to be `{}`
+           *
+           * @see TODO
+           */
+          "oneOf" in linkSchema.items && Array.isArray(linkSchema.items.oneOf)
             ? {
                 oneOf: linkSchema.items.oneOf.map((item) => {
                   const isSelfReference = item.$ref === currentEntityTypeId;

--- a/libs/@local/hash-isomorphic-utils/src/ontology-types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/ontology-types.ts
@@ -101,7 +101,7 @@ export const generateLinkMapWithConsistentSelfReferences = (
            * @todo remove array check when it's no longer possible for  the value of
            * `oneOf` to be `{}`
            *
-           * @see TODO
+           * @see https://linear.app/hash/issue/BP-74/omit-emtpy-oneof-and-allof-in-types
            */
           "oneOf" in linkSchema.items && Array.isArray(linkSchema.items.oneOf)
             ? {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR archives notifications related to draft entities when they are discarded on the `/drafts` page.

In addition it:

- fixes a bug in a migration utility function which meant the migration state was not updated with the up-to-date version of a type
- fixes the empty state on the `/drafts` page (currently it just hangs on the loading state)
- fixes an issue where we weren't accounting for `oneOf: {}`, not relevant to the diff in this PR but was uncovered in some other changes I originally made

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-1631

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

See description.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

Manual testing.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Create a draft entity via the browser plugin
2. Check a notification and a draft entity was created
3. Discard the draft entity, and ensure the notification has been archived

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->


https://github.com/hashintel/hash/assets/42802102/694f438b-5428-4cba-b40a-7037f96a0fc5


