### PR TITLE
H-1655: Update AI inference prompt to provide more context, encourage comprehensiveness

### DIFF
--- a/apps/hash-ai-worker-ts/src/workflows.ts
+++ b/apps/hash-ai-worker-ts/src/workflows.ts
@@ -4,7 +4,7 @@ import { proxyActivities } from "@temporalio/workflow";
 import { createAiActivities } from "./activities";
 
 const aiActivities = proxyActivities<ReturnType<typeof createAiActivities>>({
-  startToCloseTimeout: "600 second",
+  startToCloseTimeout: "1800 second",
   retry: {
     maximumAttempts: 1,
   },

--- a/apps/plugin-browser/src/scripts/background/infer-entities.ts
+++ b/apps/plugin-browser/src/scripts/background/infer-entities.ts
@@ -20,6 +20,8 @@ const inferEntitiesApiCall = async ({
   entityTypeIds,
   model,
   ownedById,
+  sourceTitle,
+  sourceUrl,
   textInput,
 }: {
   createAs: "draft" | "live";
@@ -27,6 +29,8 @@ const inferEntitiesApiCall = async ({
   textInput: string;
   entityTypeIds: VersionedUrl[];
   ownedById: OwnedById;
+  sourceTitle: string;
+  sourceUrl: string;
 }) => {
   const requestBody: InferEntitiesUserArguments = {
     createAs,
@@ -34,6 +38,8 @@ const inferEntitiesApiCall = async ({
     maxTokens: null,
     model,
     ownedById,
+    sourceTitle,
+    sourceUrl,
     textInput,
     temperature: 0,
   };
@@ -93,6 +99,8 @@ export const inferEntities = async (
       entityTypeIds,
       model,
       ownedById,
+      sourceTitle,
+      sourceUrl,
       textInput,
     });
 

--- a/libs/@local/hash-isomorphic-utils/src/temporal-types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/temporal-types.ts
@@ -37,6 +37,8 @@ export type InferEntitiesUserArguments = Subtype<
     maxTokens: number | null;
     model: InferenceModelName;
     ownedById: OwnedById;
+    sourceTitle: string;
+    sourceUrl: string;
     temperature: number;
     textInput: string;
   }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This updates the prompt and context in the AI Inference feature to address two common failures:
1. Failing to infer the most obvious entity of a requested type in a webpage – providing the page title and URL and a hint about focus seems to help here
2. Being 'lazy' in filling out properties for which there is information in the context – encouraging it to be comprehensive seems to help here

In local testing the 'comprehensive-bias' encouragement was so successful that I started getting `length` finish reasons. I want to see if it's possible to stitch together function call responses to make a bigger function argument than the completion token limit allows, but since each iteration of this takes 10 minutes+ to test and there are higher priorities right now I will come back to it in the next couple of days.

I've also upped the Temporal worker timeout from 10 minutes to 30 minutes because I hit 10 minutes waiting for just the second iteration of the call to OpenAI.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
