### PR TITLE
H-1663: Fix linear integration

### DIFF
--- a/apps/hash-api/src/integrations/sync-back-watcher.ts
+++ b/apps/hash-api/src/integrations/sync-back-watcher.ts
@@ -81,8 +81,12 @@ export const createIntegrationSyncBackWatcher = async (
            * The linear bot may not have access to the entity, which means
            * it it's probably not an entity that should be processed.
            *
-           * @todo figure out what the permission model should be for the sync-back watcher
-           * so that it can be used for other integrations.
+           * @todo we probably want to avoid fetching the entity in the sync
+           * back watcher entirely, as we don't want to have a single actor
+           * that can read all entities in the graph. One way of avoiding this
+           * would be passing the `entityTypeId` of the modified entity so that
+           * the correct integration processor can be called based on the entity's
+           * type.
            *
            * @see https://linear.app/hash/issue/H-756
            */


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR makes several fixes to the linear integration following the recent introduction of the linear bot machine user:

- Refactors the `oAuthLinearCallback` to ignore the `ownedById` it receives in the OAuth state, and just create the linear integration in the user's web. It also no longer gives the linear bot access to the web, as in this point in the flow we don't yet know which web the user is trying to sync linear with.
- Refactors the `syncLinearIntegrationWithWorkspacesMutation` resolver to ensure the linear bot has access to the webs the user is trying to sync linear data with. This now works for both org and user webs.
- Refactors the sync back watcher to use the linear bot to try and fetch any entity that has changed. We probably want to change this so that the sync back watcher no longer needs to be able to fetch the entity from the datastore, and is able to determine which integration processor to call based on the information it receives (e.g. via the entity's `entityTypeId`)

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-1663

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

See description

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

Manual testing.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Setup the linear webhook via `ngrok http 5001`
2. Setup the linear integration at `/settings/integrations` and sync it to a user or org's web (or both)
3. Verify that syncing to linear and vice versa is working

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

https://github.com/hashintel/hash/assets/42802102/8a811e6e-f3f2-4c3d-99cc-8f0cbd0fb8ac

