### PR TITLE
H-1668: Change global allocator to `mimalloc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,6 +1087,7 @@ dependencies = [
  "graph",
  "graph-api",
  "graph-types",
+ "mimalloc",
  "regex",
  "reqwest",
  "semver",
@@ -1431,6 +1432,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1496,6 +1507,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/apps/hash-graph/bins/cli/Cargo.toml
+++ b/apps/hash-graph/bins/cli/Cargo.toml
@@ -22,6 +22,7 @@ type-system = { workspace = true }
 axum = "0.7.2"
 clap = { version = "4.4.11", features = ["cargo", "derive", "env", "wrap_help"] }
 clap_complete = "4.4.4"
+mimalloc = { version = "0.1.39", default-features = false }
 futures = { version = "0.3.29" }
 regex = "1.10.2"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }

--- a/apps/hash-graph/bins/cli/src/main.rs
+++ b/apps/hash-graph/bins/cli/src/main.rs
@@ -18,6 +18,9 @@ use graph::load_env;
 
 use self::{args::Args, error::GraphError};
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() -> Result<(), GraphError> {
     load_env(None);
     validation::error::install_error_stack_hooks();


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We encountered a memory leak in our application. After endless debugging and false positives one solution which seems to work is switching out the global allocator. I'm not going into the details why this could solve this, but the TL;DR is that different allocators handle certain scenarios differently.

## 🔍 What does this change?

- Make `mimalloc` the global allocator