### PR TITLE
H-1669: Fix creating some link entities in AI inference

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/infer-entities.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities.ts
@@ -7,7 +7,10 @@ import {
   getWebMachineActorId,
 } from "@local/hash-backend-utils/machine-actors";
 import { createGraphChangeNotification } from "@local/hash-backend-utils/notifications";
-import type { GraphApi } from "@local/hash-graph-client";
+import type {
+  Entity as GraphApiEntity,
+  GraphApi,
+} from "@local/hash-graph-client";
 import {
   currentTimeInstantTemporalAxes,
   zeroedGraphResolveDepths,
@@ -17,12 +20,8 @@ import type {
   InferenceTokenUsage,
   InferEntitiesCallerParams,
   InferEntitiesReturn,
-  InferredEntityUpdateSuccess,
 } from "@local/hash-isomorphic-utils/temporal-types";
-import {
-  InferredEntityChangeResult,
-  InferredEntityCreationSuccess,
-} from "@local/hash-isomorphic-utils/temporal-types";
+import { InferredEntityChangeResult } from "@local/hash-isomorphic-utils/temporal-types";
 import type {
   AccountId,
   Entity,
@@ -108,6 +107,7 @@ const requestEntityInference = async (params: {
     OpenAI.ChatCompletionCreateParams,
     "stream" | "tools" | "model"
   > & { model: SpecificModel };
+  entitiesForLinks: Record<number, { entity: GraphApiEntity }>;
   entityTypes: DereferencedEntityTypesByTypeId;
   iterationCount: number;
   graphApiClient: GraphApi;
@@ -120,6 +120,7 @@ const requestEntityInference = async (params: {
     authentication,
     completionPayload,
     createAs,
+    entitiesForLinks,
     entityTypes,
     iterationCount,
     graphApiClient,
@@ -465,28 +466,21 @@ const requestEntityInference = async (params: {
           }
 
           try {
-            const { creationSuccesses, creationFailures, updateCandidates } =
-              await createEntities({
-                actorId: authentication.machineActorId,
-                createAsDraft: createAs === "draft",
-                graphApiClient,
-                log,
-                ownedById,
-                previousSuccesses: results.reduce<
-                  Record<
-                    number,
-                    InferredEntityCreationSuccess | InferredEntityUpdateSuccess
-                  >
-                >((acc, result) => {
-                  if (result.status === "success") {
-                    acc[result.proposedEntity.entityId] = result;
-                  }
-
-                  return acc;
-                }, {}),
-                proposedEntitiesByType,
-                requestedEntityTypes: entityTypes,
-              });
+            const {
+              creationSuccesses,
+              creationFailures,
+              updateCandidates,
+              unchangedEntities,
+            } = await createEntities({
+              actorId: authentication.machineActorId,
+              createAsDraft: createAs === "draft",
+              graphApiClient,
+              log,
+              ownedById,
+              previousSuccesses: entitiesForLinks,
+              proposedEntitiesByType,
+              requestedEntityTypes: entityTypes,
+            });
 
             log(`Creation successes: ${stringify(creationSuccesses)}`);
             log(`Creation failures: ${stringify(creationFailures)}`);
@@ -495,6 +489,16 @@ const requestEntityInference = async (params: {
             const successes = Object.values(creationSuccesses);
             const failures = Object.values(creationFailures);
             const updates = Object.values(updateCandidates);
+            const unchangeds = Object.values(unchangedEntities);
+
+            for (const unchanged of unchangeds) {
+              entitiesForLinks[unchanged.proposedEntity.entityId] = {
+                entity: unchanged.existingEntity,
+              };
+            }
+            for (const success of successes) {
+              entitiesForLinks[success.proposedEntity.entityId] = success;
+            }
 
             for (const success of successes) {
               void createInferredEntityNotification({
@@ -918,6 +922,7 @@ export const inferEntities = async ({
     },
     createAs,
     entityTypes,
+    entitiesForLinks: {},
     graphApiClient,
     iterationCount: 1,
     ownedById,

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/create-entities.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/create-entities.ts
@@ -5,7 +5,6 @@ import { generateVersionedUrlMatchingFilter } from "@local/hash-isomorphic-utils
 import type {
   InferredEntityCreationFailure,
   InferredEntityCreationSuccess,
-  InferredEntityUpdateSuccess,
   ProposedEntity,
 } from "@local/hash-isomorphic-utils/temporal-types";
 import type {
@@ -37,9 +36,7 @@ type StatusByTemporaryId<T> = Record<number, T>;
 type EntityStatusMap = {
   creationSuccesses: StatusByTemporaryId<InferredEntityCreationSuccess>;
   creationFailures: StatusByTemporaryId<InferredEntityCreationFailure>;
-  previousSuccesses: StatusByTemporaryId<
-    InferredEntityCreationSuccess | InferredEntityUpdateSuccess
-  >;
+  previousSuccesses: StatusByTemporaryId<{ entity: Entity }>;
   updateCandidates: StatusByTemporaryId<UpdateCandidate>;
   unchangedEntities: StatusByTemporaryId<UpdateCandidate>;
 };
@@ -57,9 +54,7 @@ export const createEntities = async ({
   createAsDraft: boolean;
   graphApiClient: GraphApi;
   log: (message: string) => void;
-  previousSuccesses: StatusByTemporaryId<
-    InferredEntityCreationSuccess | InferredEntityUpdateSuccess
-  >;
+  previousSuccesses: StatusByTemporaryId<{ entity: Entity }>;
   proposedEntitiesByType: ProposedEntityCreationsByType;
   requestedEntityTypes: Record<
     VersionedUrl,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In the AI inference logic we don't bother to create entities or ask the AI to update them if the model suggests an entity that is _identical_ to one that already exists (same type, properties).

There was a bug whereby if the AI had suggested a link involving one such entity in a _subsequent_ iteration, the link could not be created because we didn't preserve information on those entities across iterations (there was no record of them in future iterations).

This PR fixes that by tracking entities which were not created because they are identical to existing entities, so that they are available in subsequent iterations.
 
## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
