### PR TITLE
H-1708: Fix SpiceDB migration not working in prod

### DIFF
--- a/infra/terraform/hash/hash_application/main.tf
+++ b/infra/terraform/hash/hash_application/main.tf
@@ -5,7 +5,7 @@ locals {
   task_defs = [
     {
       task_def = local.spicedb_migration_container_def
-      env_vars = aws_ssm_parameter.spicedb_env_vars
+      env_vars = aws_ssm_parameter.spicedb_migration_env_vars
     },
     {
       task_def = local.spicedb_service_container_def

--- a/infra/terraform/hash/hash_application/spicedb.tf
+++ b/infra/terraform/hash/hash_application/spicedb.tf
@@ -6,11 +6,11 @@ locals {
 }
 
 
-resource "aws_ssm_parameter" "spicedb_env_vars" {
+resource "aws_ssm_parameter" "spicedb_migration_env_vars" {
   # Only put secrets into SSM
-  for_each = {for env_var in var.spicedb_env_vars : env_var.name => env_var if env_var.secret}
+  for_each = {for env_var in var.spicedb_migration_env_vars : env_var.name => env_var if env_var.secret}
 
-  name      = "${local.spicedb_param_prefix}/${each.value.name}"
+  name      = "${local.spicedb_param_prefix}/migration/${each.value.name}"
   # Still supports non-secret values
   type      = each.value.secret ? "SecureString" : "String"
   value     = each.value.secret ? sensitive(each.value.value) : each.value.value
@@ -18,9 +18,9 @@ resource "aws_ssm_parameter" "spicedb_env_vars" {
   tags      = {}
 }
 
-resource "aws_ssm_parameter" "spicedb_migration_env_vars" {
+resource "aws_ssm_parameter" "spicedb_env_vars" {
   # Only put secrets into SSM
-  for_each = {for env_var in var.spicedb_migration_env_vars : env_var.name => env_var if env_var.secret}
+  for_each = {for env_var in var.spicedb_env_vars : env_var.name => env_var if env_var.secret}
 
   name      = "${local.spicedb_param_prefix}/${each.value.name}"
   # Still supports non-secret values


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Last time when we updated SpiceDB the migration failed due to the wrong connection URI. This was because the migration connection URI was overwritten by the default URI.