### PR TITLE
H-1621, H-1714, H-1717: Split SpiceDB tasks into another service

### DIFF
--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -392,7 +392,7 @@ jobs:
           AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
           AWS_REGION: ${{ env.AWS_REGION }}
 
-      - name: Redeploy HASH backend service
+      - name: Redeploy HASH graph service
         run: |
           aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_GRAPH_SERVICE_NAME }} --force-new-deployment 1> /dev/null
 

--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -36,6 +36,7 @@ env:
 
   HASH_ECS_CLUSTER_NAME: h-hash-prod-usea1-ecs
   HASH_APP_SERVICE_NAME: h-hash-prod-usea1-appsvc
+  HASH_GRAPH_SERVICE_NAME: h-hash-prod-usea1-graph
   HASH_WORKER_SERVICE_NAME: h-hash-prod-usea1-appworker-svc
 
   HASH_TEMPORAL_ECS_CLUSTER_NAME: h-temporal-prod-usea1-ecs
@@ -322,6 +323,7 @@ jobs:
     name: Deploy HASH app images
     runs-on: ubuntu-latest
     needs:
+      - build-ts-worker
       - build-graph
       - build-api
       - build-kratos
@@ -357,11 +359,47 @@ jobs:
         run: |
           aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_APP_SERVICE_NAME }} --force-new-deployment 1> /dev/null
 
+  deploy-graph:
+    name: Deploy HASH graph images
+    runs-on: ubuntu-latest
+    needs:
+      - build-graph
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Authenticate Vault
+        id: secrets
+        uses: hashicorp/vault-action@affa6f04da5c2d55e6e115b7d1b044a6b1af8c74 # v2.7.4
+        with:
+          exportToken: true
+          url: ${{ env.VAULT_ADDR }}
+          method: jwt
+          role: prod
+          # Even though it could look like separate calls to fetch the secrets
+          # the responses here are cached, so we're only issuing a single set of credentials
+          secrets: |
+            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+
+      - uses: ./.github/actions/docker-ecr-login
+        with:
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+
+      - name: Redeploy HASH backend service
+        run: |
+          aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_GRAPH_SERVICE_NAME }} --force-new-deployment 1> /dev/null
+
   deploy-workers:
     name: Deploy HASH worker images
     runs-on: ubuntu-latest
     needs:
-      - build-ts-worker
       - build-integration-worker
     permissions:
       id-token: write
@@ -437,6 +475,8 @@ jobs:
     name: Notify Slack on failure
     needs:
       - deploy-app
+      - deploy-graph
+      - deploy-workers
       - deploy-temporal
     runs-on: ubuntu-latest
     if: ${{ failure() }}

--- a/infra/terraform/hash/hash_application/api.tf
+++ b/infra/terraform/hash/hash_application/api.tf
@@ -7,9 +7,9 @@ locals {
 
 resource "aws_ssm_parameter" "api_env_vars" {
   # Only put secrets into SSM
-  for_each = { for env_var in var.api_env_vars : env_var.name => env_var if env_var.secret }
+  for_each = {for env_var in var.api_env_vars : env_var.name => env_var if env_var.secret}
 
-  name = "${local.api_param_prefix}/${each.value.name}"
+  name      = "${local.api_param_prefix}/${each.value.name}"
   # Still supports non-secret values
   type      = each.value.secret ? "SecureString" : "String"
   value     = each.value.secret ? sensitive(each.value.value) : each.value.value
@@ -19,35 +19,43 @@ resource "aws_ssm_parameter" "api_env_vars" {
 
 locals {
   api_service_container_def = {
-    name        = "${local.api_prefix}container"
-    image       = "${var.api_image.url}:latest"
-    cpu         = 0 # let ECS divvy up the available CPU
-    mountPoints = []
-    volumesFrom = []
-    dependsOn   = [{ condition = "HEALTHY", containerName = local.graph_service_container_def.name }]
-    dependsOn   = [{ condition = "HEALTHY", containerName = local.kratos_service_container_def.name }]
-    portMappings = [{
-      appProtocol   = "http"
-      containerPort = local.api_container_port
-      hostPort      = local.api_container_port
-      protocol      = "tcp"
-    }]
+    name         = "${local.api_prefix}container"
+    image        = "${var.api_image.url}:latest"
+    cpu          = 0 # let ECS divvy up the available CPU
+    mountPoints  = []
+    volumesFrom  = []
+    dependsOn    = [{ condition = "HEALTHY", containerName = local.graph_service_container_def.name }]
+    dependsOn    = [{ condition = "HEALTHY", containerName = local.kratos_service_container_def.name }]
+    portMappings = [
+      {
+        appProtocol   = "http"
+        containerPort = local.api_container_port
+        hostPort      = local.api_container_port
+        protocol      = "tcp"
+      }
+    ]
     logConfiguration = {
       logDriver = "awslogs"
-      options = {
+      options   = {
         "awslogs-create-group"  = "true"
         "awslogs-group"         = local.log_group_name
         "awslogs-stream-prefix" = local.api_service_name
         "awslogs-region"        = var.region
       }
     }
-    Environment = [
+    Environment = concat([
       for env_var in var.api_env_vars :
       { name = env_var.name, value = env_var.value } if !env_var.secret
-    ]
+    ],
+      [
+        { name = "HASH_GRAPH_API_HOST", value = local.graph_container_port_dns },
+        { name = "HASH_GRAPH_API_PORT", value = tostring(local.graph_container_port) },
+      ])
 
-    secrets = [for env_name, ssm_param in aws_ssm_parameter.api_env_vars :
-    { name = env_name, valueFrom = ssm_param.arn }]
+    secrets = [
+      for env_name, ssm_param in aws_ssm_parameter.api_env_vars :
+      { name = env_name, valueFrom = ssm_param.arn }
+    ]
 
     essential = true
   }

--- a/infra/terraform/hash/hash_application/graph.tf
+++ b/infra/terraform/hash/hash_application/graph.tf
@@ -1,16 +1,18 @@
 locals {
-  graph_service_name   = "graph"
-  graph_prefix         = "${var.prefix}-${local.graph_service_name}"
-  graph_param_prefix   = "${local.param_prefix}/${local.graph_service_name}"
-  graph_container_port = 4000
+  graph_service_name        = "graph"
+  graph_prefix              = "${var.prefix}-${local.graph_service_name}"
+  graph_param_prefix        = "${local.param_prefix}/${local.graph_service_name}"
+  graph_container_port      = 4000
+  graph_container_port_name = local.graph_service_name
+  graph_container_port_dns  = "${local.graph_container_port_name}.${aws_service_discovery_private_dns_namespace.app.name}"
 }
 
 
 resource "aws_ssm_parameter" "graph_env_vars" {
   # Only put secrets into SSM
-  for_each = { for env_var in var.graph_env_vars : env_var.name => env_var if env_var.secret }
+  for_each = {for env_var in var.graph_env_vars : env_var.name => env_var if env_var.secret}
 
-  name = "${local.graph_param_prefix}/${each.value.name}"
+  name      = "${local.graph_param_prefix}/${each.value.name}"
   # Still supports non-secret values
   type      = each.value.secret ? "SecureString" : "String"
   value     = each.value.secret ? sensitive(each.value.value) : each.value.value
@@ -18,39 +20,135 @@ resource "aws_ssm_parameter" "graph_env_vars" {
   tags      = {}
 }
 
+resource "aws_security_group" "graph" {
+  name   = local.graph_prefix
+  vpc_id = var.vpc.id
+
+  egress {
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    description     = "Allow Fargate to pull images from the private registry"
+    prefix_list_ids = [data.aws_vpc_endpoint.s3.prefix_list_id]
+  }
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    description = "Fargate tasks must have outbound access to allow outgoing traffic and access Amazon ECS endpoints."
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    description = "Allow connections to Postgres within the VPC"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+  egress {
+    from_port   = 4444
+    to_port     = 4444
+    protocol    = "tcp"
+    description = "Allow connections with the type fetcher"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  egress {
+    from_port   = local.spicedb_container_http_port
+    to_port     = local.spicedb_container_http_port
+    protocol    = "tcp"
+    description = "Allow communication to SpiceDB"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  ingress {
+    from_port   = local.graph_container_port
+    to_port     = local.graph_container_port
+    protocol    = "tcp"
+    description = "Allow communication with the graph"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+}
+
+resource "aws_ecs_task_definition" "graph" {
+  family                   = local.graph_prefix
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.cpu
+  memory                   = var.memory
+  network_mode             = "awsvpc"
+  execution_role_arn       = aws_iam_role.execution_role.arn
+  task_role_arn            = aws_iam_role.task_role.arn
+  container_definitions    = jsonencode([for task_def in local.graph_task_defs : task_def.task_def])
+  tags                     = {}
+}
+
+resource "aws_ecs_service" "graph" {
+  depends_on             = [aws_iam_role.task_role]
+  name                   = local.graph_prefix
+  cluster                = data.aws_ecs_cluster.ecs.arn
+  task_definition        = aws_ecs_task_definition.graph.arn
+  enable_execute_command = true
+  desired_count          = 1
+  launch_type            = "FARGATE"
+
+  network_configuration {
+    subnets          = var.subnets
+    assign_public_ip = true
+    security_groups  = [
+      aws_security_group.graph.id,
+    ]
+  }
+
+  service_connect_configuration {
+    enabled   = true
+    namespace = aws_service_discovery_private_dns_namespace.app.arn
+
+    service {
+      port_name = local.graph_container_port_name
+
+      client_alias {
+        port = local.graph_container_port
+      }
+    }
+  }
+}
+
 locals {
   graph_migration_container_def = {
-    name        = "${local.graph_prefix}-migration"
-    image       = "${var.graph_image.url}:latest"
-    cpu         = 0 # let ECS divvy up the available CPU
-    mountPoints = []
-    volumesFrom = []
-    command     = ["migrate"]
+    name             = "${local.graph_prefix}-migration"
+    image            = "${var.graph_image.url}:latest"
+    cpu              = 0 # let ECS divvy up the available CPU
+    mountPoints      = []
+    volumesFrom      = []
+    command          = ["migrate"]
     logConfiguration = {
       logDriver = "awslogs"
-      options = {
+      options   = {
         "awslogs-create-group"  = "true"
         "awslogs-group"         = local.log_group_name
         "awslogs-stream-prefix" = local.graph_service_name
         "awslogs-region"        = var.region
       }
     }
-    Environment = [for env_var in var.graph_env_vars :
-      { name = env_var.name, value = env_var.value } if !env_var.secret]
+    Environment = [
+      for env_var in var.graph_env_vars :
+      { name = env_var.name, value = env_var.value } if !env_var.secret
+    ]
 
-    secrets = [for env_name, ssm_param in aws_ssm_parameter.graph_env_vars :
-      { name = env_name, valueFrom = ssm_param.arn }]
+    secrets = [
+      for env_name, ssm_param in aws_ssm_parameter.graph_env_vars :
+      { name = env_name, valueFrom = ssm_param.arn }
+    ]
 
     essential = false
   }
   graph_service_container_def = {
-    name        = "${local.graph_prefix}container"
+    name        = local.graph_prefix
     image       = "${var.graph_image.url}:latest"
     cpu         = 0 # let ECS divvy up the available CPU
     mountPoints = []
     volumesFrom = []
     dependsOn   = [
-      { condition = "HEALTHY", containerName = local.type_fetcher_service_container_def.name },
       { condition = "SUCCESS", containerName = local.graph_migration_container_def.name },
     ]
     command     = ["server"]
@@ -61,31 +159,41 @@ locals {
       timeout  = 5
 
     }
-    portMappings = [{
-      appProtocol   = "http"
-      containerPort = local.graph_container_port
-      hostPort      = local.graph_container_port
-      protocol      = "tcp"
-    }]
+    portMappings = [
+      {
+        name          = local.graph_container_port_name
+        appProtocol   = "http"
+        containerPort = local.graph_container_port
+        protocol      = "tcp"
+      }
+    ]
     logConfiguration = {
       logDriver = "awslogs"
-      options = {
+      options   = {
         "awslogs-create-group"  = "true"
         "awslogs-group"         = local.log_group_name
         "awslogs-stream-prefix" = local.graph_service_name
         "awslogs-region"        = var.region
       }
     }
-    Environment = concat([for env_var in var.graph_env_vars :
-    { name = env_var.name, value = env_var.value } if !env_var.secret],
+    Environment = concat([
+      for env_var in var.graph_env_vars :
+      { name = env_var.name, value = env_var.value } if !env_var.secret
+    ],
       [
+        { name = "HASH_GRAPH_API_HOST", value = "0.0.0.0" },
+        { name = "HASH_GRAPH_API_PORT", value = tostring(local.graph_container_port) },
+        { name = "HASH_GRAPH_TYPE_FETCHER_HOST", value = local.type_fetcher_container_port_dns },
+        { name = "HASH_GRAPH_TYPE_FETCHER_PORT", value = tostring(local.type_fetcher_container_port) },
         { name = "HASH_SPICEDB_HOST", value = "http://${local.spicedb_container_http_port_dns}" },
         { name = "HASH_SPICEDB_HTTP_PORT", value = tostring(local.spicedb_container_http_port) },
       ]
     )
 
-    secrets = [for env_name, ssm_param in aws_ssm_parameter.graph_env_vars :
-    { name = env_name, valueFrom = ssm_param.arn }]
+    secrets = [
+      for env_name, ssm_param in aws_ssm_parameter.graph_env_vars :
+      { name = env_name, valueFrom = ssm_param.arn }
+    ]
 
     essential = true
   }

--- a/infra/terraform/hash/hash_application/graph.tf
+++ b/infra/terraform/hash/hash_application/graph.tf
@@ -51,7 +51,6 @@ locals {
     volumesFrom = []
     dependsOn   = [
       { condition = "HEALTHY", containerName = local.type_fetcher_service_container_def.name },
-      { condition = "HEALTHY", containerName = local.spicedb_service_container_def.name },
       { condition = "SUCCESS", containerName = local.graph_migration_container_def.name },
     ]
     command     = ["server"]
@@ -77,8 +76,13 @@ locals {
         "awslogs-region"        = var.region
       }
     }
-    Environment = [for env_var in var.graph_env_vars :
-    { name = env_var.name, value = env_var.value } if !env_var.secret]
+    Environment = concat([for env_var in var.graph_env_vars :
+    { name = env_var.name, value = env_var.value } if !env_var.secret],
+      [
+        { name = "HASH_SPICEDB_HOST", value = "http://${local.spicedb_container_http_port_dns}" },
+        { name = "HASH_SPICEDB_HTTP_PORT", value = tostring(local.spicedb_container_http_port) },
+      ]
+    )
 
     secrets = [for env_name, ssm_param in aws_ssm_parameter.graph_env_vars :
     { name = env_name, valueFrom = ssm_param.arn }]

--- a/infra/terraform/hash/hash_application/main.tf
+++ b/infra/terraform/hash/hash_application/main.tf
@@ -1,7 +1,7 @@
 locals {
-  prefix         = "${var.prefix}-app"
-  log_group_name = "${local.prefix}log"
-  param_prefix   = "${var.param_prefix}/app"
+  prefix            = "${var.prefix}-app"
+  log_group_name    = "${local.prefix}log"
+  param_prefix      = "${var.param_prefix}/app"
   spicedb_task_defs = [
     {
       task_def = local.spicedb_migration_container_def
@@ -12,7 +12,7 @@ locals {
       env_vars = aws_ssm_parameter.spicedb_env_vars
     },
   ]
-  task_defs = [
+  graph_task_defs = [
     {
       task_def = local.graph_migration_container_def
       env_vars = aws_ssm_parameter.graph_env_vars
@@ -25,9 +25,11 @@ locals {
     },
     {
       task_def = local.type_fetcher_service_container_def
-      env_vars = aws_ssm_parameter.type_fetcher_env_vars
+      env_vars = []
       ecr_arn  = var.type_fetcher_image.ecr_arn
     },
+  ]
+  task_defs = [
     {
       task_def = local.kratos_migration_container_def
       env_vars = aws_ssm_parameter.kratos_env_vars
@@ -55,7 +57,7 @@ locals {
   worker_task_defs = [
     {
       task_def = local.temporal_worker_integration_service_container_def
-      env_vars = aws_ssm_parameter.temporal_worker_integration_env_vars
+      env_vars = []
       ecr_arn  = var.temporal_worker_integration_image.ecr_arn
     }
   ]
@@ -118,6 +120,22 @@ resource "aws_security_group" "alb_sg" {
     cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
+
+  ingress {
+    from_port   = 4444
+    to_port     = 4444
+    protocol    = "tcp"
+    description = "Allow connections with the type fetcher"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  egress {
+    from_port   = local.graph_container_port
+    to_port     = local.graph_container_port
+    protocol    = "tcp"
+    description = "Allow communication with the graph"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
 }
 
 resource "aws_lb" "app_alb" {
@@ -128,7 +146,7 @@ resource "aws_lb" "app_alb" {
 
   security_groups = [aws_security_group.alb_sg.id]
   # Timeout is set to allow collab to use long polling and not closing after default 60 seconds.
-  idle_timeout = 4000
+  idle_timeout    = 4000
 }
 
 resource "aws_lb_target_group" "app_tg" {
@@ -146,7 +164,7 @@ resource "aws_lb_target_group" "app_tg" {
     timeout             = 10
     unhealthy_threshold = 3
   }
-  slow_start = 30
+  slow_start           = 30
   # Time between demoting state from 'draining' to 'unused'.
   # The default, 300s, makes it so we have multiple services running for 5 whole minutes.
   deregistration_delay = 30
@@ -177,7 +195,7 @@ resource "aws_lb" "kratos_alb" {
 
   security_groups = [aws_security_group.alb_sg.id]
   # Timeout is set to allow collab to use long polling and not closing after default 60 seconds.
-  idle_timeout = 4000
+  idle_timeout    = 4000
 }
 
 resource "aws_lb_target_group" "kratos_tg" {
@@ -195,7 +213,7 @@ resource "aws_lb_target_group" "kratos_tg" {
     timeout             = 10
     unhealthy_threshold = 3
   }
-  slow_start = 30
+  slow_start           = 30
   # Time between demoting state from 'draining' to 'unused'.
   # The default, 300s, makes it so we have multiple services running for 5 whole minutes.
   deregistration_delay = 30
@@ -258,13 +276,13 @@ resource "aws_lb_listener" "kratos_https" {
 
 # IAM role which allows ECS to pull the API Docker image from ECR
 resource "aws_iam_role" "execution_role" {
-  name = "${local.prefix}exerole"
+  name               = "${local.prefix}exerole"
   assume_role_policy = jsonencode({
-    Version = "2012-10-17"
+    Version   = "2012-10-17"
     Statement = [
       {
-        Action = "sts:AssumeRole"
-        Effect = "Allow"
+        Action    = "sts:AssumeRole"
+        Effect    = "Allow"
         Principal = {
           Service = "ecs-tasks.amazonaws.com"
         }
@@ -272,10 +290,10 @@ resource "aws_iam_role" "execution_role" {
     ]
   })
   inline_policy {
-    name = "policy"
+    name   = "policy"
     # Allow fetching images from ECR, publishing logs and getting secrets
     policy = jsonencode({
-      Version = "2012-10-17"
+      Version   = "2012-10-17"
       Statement = flatten([
         [
           {
@@ -284,20 +302,33 @@ resource "aws_iam_role" "execution_role" {
             Resource = ["*"]
           }
         ],
-        [{
-          Effect = "Allow"
-          Action = ["ssm:GetParameters"]
-          Resource = concat(
-            flatten([for def in local.task_defs : [for _, env_var in def.env_vars : env_var.arn]])
-          )
-        }],
-        [{
-          Effect = "Allow"
-          Action = ["ssm:GetParameters"]
-          Resource = concat(
-            flatten([for def in local.spicedb_task_defs : [for _, env_var in def.env_vars : env_var.arn]])
-          )
-        }],
+        [
+          {
+            Effect   = "Allow"
+            Action   = ["ssm:GetParameters"]
+            Resource = concat(
+              flatten([for def in local.task_defs : [for _, env_var in def.env_vars : env_var.arn]])
+            )
+          }
+        ],
+        [
+          {
+            Effect   = "Allow"
+            Action   = ["ssm:GetParameters"]
+            Resource = concat(
+              flatten([for def in local.spicedb_task_defs : [for _, env_var in def.env_vars : env_var.arn]])
+            )
+          }
+        ],
+        [
+          {
+            Effect   = "Allow"
+            Action   = ["ssm:GetParameters"]
+            Resource = concat(
+              flatten([for def in local.graph_task_defs : [for _, env_var in def.env_vars : env_var.arn]])
+            )
+          }
+        ],
       ])
     })
   }
@@ -320,13 +351,13 @@ resource "aws_iam_role_policy_attachment" "execution_role_exe" {
 
 # IAM role for the running task
 resource "aws_iam_role" "task_role" {
-  name = "${local.prefix}taskrole"
+  name               = "${local.prefix}taskrole"
   assume_role_policy = jsonencode({
-    Version = "2012-10-17"
+    Version   = "2012-10-17"
     Statement = [
       {
-        Action = "sts:AssumeRole"
-        Effect = "Allow"
+        Action    = "sts:AssumeRole"
+        Effect    = "Allow"
         Principal = {
           Service = "ecs-tasks.amazonaws.com"
         }
@@ -334,9 +365,9 @@ resource "aws_iam_role" "task_role" {
     ]
   })
   inline_policy {
-    name = "policy"
+    name   = "policy"
     policy = jsonencode({
-      Version = "2012-10-17"
+      Version   = "2012-10-17"
       Statement = [
         {
           # @todo: we can restrict the FROM address and more
@@ -401,7 +432,7 @@ resource "aws_ecs_service" "svc" {
   network_configuration {
     subnets          = var.subnets
     assign_public_ip = true
-    security_groups = [
+    security_groups  = [
       aws_security_group.app_sg.id,
     ]
   }
@@ -419,7 +450,7 @@ resource "aws_ecs_service" "svc" {
   }
 
   service_connect_configuration {
-    enabled = true
+    enabled   = true
     namespace = aws_service_discovery_private_dns_namespace.app.arn
   }
 
@@ -438,9 +469,14 @@ resource "aws_ecs_service" "worker" {
   network_configuration {
     subnets          = var.subnets
     assign_public_ip = true
-    security_groups = [
+    security_groups  = [
       aws_security_group.app_sg.id,
     ]
+  }
+
+  service_connect_configuration {
+    enabled   = true
+    namespace = aws_service_discovery_private_dns_namespace.app.arn
   }
 
   tags = { Service = "${local.prefix}worker-svc" }
@@ -510,11 +546,11 @@ resource "aws_security_group" "app_sg" {
   }
 
   egress {
-    from_port       = local.spicedb_container_http_port
-    to_port         = local.spicedb_container_http_port
-    protocol        = "tcp"
-    description     = "Allow communication to SpiceDB"
-    cidr_blocks     = [var.vpc.cidr_block]
+    from_port   = local.graph_container_port
+    to_port     = local.graph_container_port
+    protocol    = "tcp"
+    description = "Allow connections to the graph"
+    cidr_blocks = [var.vpc.cidr_block]
   }
 
   ingress {

--- a/infra/terraform/hash/hash_application/main.tf
+++ b/infra/terraform/hash/hash_application/main.tf
@@ -5,7 +5,7 @@ locals {
   task_defs = [
     {
       task_def = local.spicedb_migration_container_def
-      env_vars = aws_ssm_parameter.spicedb_env_vars
+      env_vars = aws_ssm_parameter.spicedb_migration_env_vars
     },
     {
       task_def = local.spicedb_service_container_def

--- a/infra/terraform/hash/hash_application/spicedb.tf
+++ b/infra/terraform/hash/hash_application/spicedb.tf
@@ -6,11 +6,11 @@ locals {
 }
 
 
-resource "aws_ssm_parameter" "spicedb_env_vars" {
+resource "aws_ssm_parameter" "spicedb_migration_env_vars" {
   # Only put secrets into SSM
-  for_each = {for env_var in var.spicedb_env_vars : env_var.name => env_var if env_var.secret}
+  for_each = {for env_var in var.spicedb_migration_env_vars : env_var.name => env_var if env_var.secret}
 
-  name      = "${local.spicedb_param_prefix}/${each.value.name}"
+  name      = "${local.spicedb_param_prefix}/migration/${each.value.name}"
   # Still supports non-secret values
   type      = each.value.secret ? "SecureString" : "String"
   value     = each.value.secret ? sensitive(each.value.value) : each.value.value
@@ -18,9 +18,9 @@ resource "aws_ssm_parameter" "spicedb_env_vars" {
   tags      = {}
 }
 
-resource "aws_ssm_parameter" "spicedb_migration_env_vars" {
+resource "aws_ssm_parameter" "spicedb_env_vars" {
   # Only put secrets into SSM
-  for_each = {for env_var in var.spicedb_migration_env_vars : env_var.name => env_var if env_var.secret}
+  for_each = {for env_var in var.spicedb_env_vars : env_var.name => env_var if env_var.secret}
 
   name      = "${local.spicedb_param_prefix}/${each.value.name}"
   # Still supports non-secret values

--- a/infra/terraform/hash/hash_application/spicedb.tf
+++ b/infra/terraform/hash/hash_application/spicedb.tf
@@ -37,39 +37,11 @@ resource "aws_security_group" "spicedb" {
   vpc_id = var.vpc.id
 
   egress {
-    from_port       = 443
-    to_port         = 443
-    protocol        = "tcp"
-    description     = "Allow Fargate to pull images from the private registry"
-    prefix_list_ids = [data.aws_vpc_endpoint.s3.prefix_list_id]
-  }
-  egress {
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    description = "Allow endpoint connections"
-    cidr_blocks = [var.vpc.cidr_block]
-  }
-  egress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    description = "Allow outgoing requests to fetch types"
+    description = "Fargate tasks must have outbound access to allow outgoing traffic and access Amazon ECS endpoints."
     cidr_blocks = ["0.0.0.0/0"]
-  }
-  egress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    description = "Allow outgoing requests to fetch types"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-  egress {
-    from_port   = 587
-    to_port     = 587
-    protocol    = "tcp"
-    description = "Allow connections AWS SES"
-    cidr_blocks = [var.vpc.cidr_block]
   }
 
   egress {
@@ -81,11 +53,11 @@ resource "aws_security_group" "spicedb" {
   }
 
   ingress {
-    from_port       = local.spicedb_container_http_port
-    to_port         = local.spicedb_container_http_port
-    protocol        = "tcp"
-    description     = "Allow communication via HTTP"
-    cidr_blocks     = [var.vpc.cidr_block]
+    from_port   = local.spicedb_container_http_port
+    to_port     = local.spicedb_container_http_port
+    protocol    = "tcp"
+    description = "Allow communication via HTTP"
+    cidr_blocks = [var.vpc.cidr_block]
   }
 }
 
@@ -113,13 +85,13 @@ resource "aws_ecs_service" "spicedb" {
   network_configuration {
     subnets          = var.subnets
     assign_public_ip = true
-    security_groups = [
+    security_groups  = [
       aws_security_group.spicedb.id,
     ]
   }
 
   service_connect_configuration {
-    enabled = true
+    enabled   = true
     namespace = aws_service_discovery_private_dns_namespace.app.arn
 
     service {

--- a/infra/terraform/hash/hash_application/temporal_worker_ai_ts.tf
+++ b/infra/terraform/hash/hash_application/temporal_worker_ai_ts.tf
@@ -40,11 +40,13 @@ locals {
       }
     }
     Environment = concat(
+      [for env_var in var.temporal_worker_ai_ts_env_vars : { name = env_var.name, value = env_var.value } if !env_var.secret],
       [
         { name = "HASH_TEMPORAL_HOST", value = var.temporal_host },
         { name = "HASH_TEMPORAL_PORT", value = var.temporal_port },
+        { name = "HASH_GRAPH_API_HOST", value = local.graph_container_port_dns },
+        { name = "HASH_GRAPH_API_PORT", value = tostring(local.graph_container_port) },
       ],
-      [for env_var in var.temporal_worker_ai_ts_env_vars : { name = env_var.name, value = env_var.value } if !env_var.secret]
     )
 
     secrets = [for env_name, ssm_param in aws_ssm_parameter.temporal_worker_ai_ts_env_vars :

--- a/infra/terraform/hash/hash_application/temporal_worker_integration.tf
+++ b/infra/terraform/hash/hash_application/temporal_worker_integration.tf
@@ -1,27 +1,15 @@
 locals {
-  temporal_worker_integration_service_name   = "worker-integration"
-  temporal_worker_integration_prefix         = "${var.prefix}-${local.temporal_worker_integration_service_name}"
-  temporal_worker_integration_param_prefix   = "${local.param_prefix}/worker/integration"
-}
-
-resource "aws_ssm_parameter" "temporal_worker_integration_env_vars" {
-  # Only put secrets into SSM
-  for_each = { for env_var in var.temporal_worker_integration_env_vars : env_var.name => env_var if env_var.secret }
-
-  name = "${local.temporal_worker_integration_param_prefix}/${each.value.name}"
-  # Still supports non-secret values
-  type      = each.value.secret ? "SecureString" : "String"
-  value     = each.value.secret ? sensitive(each.value.value) : each.value.value
-  overwrite = true
-  tags      = {}
+  temporal_worker_integration_service_name = "worker-integration"
+  temporal_worker_integration_prefix       = "${var.prefix}-${local.temporal_worker_integration_service_name}"
+  temporal_worker_integration_param_prefix = "${local.param_prefix}/worker/integration"
 }
 
 locals {
   temporal_worker_integration_service_container_def = {
-    essential = true
-    name      = local.temporal_worker_integration_prefix
-    image     = "${var.temporal_worker_integration_image.url}:latest"
-    cpu       = 0 # let ECS divvy up the available CPU
+    essential   = true
+    name        = local.temporal_worker_integration_prefix
+    image       = "${var.temporal_worker_integration_image.url}:latest"
+    cpu         = 0 # let ECS divvy up the available CPU
     healthCheck = {
       command     = ["CMD", "/bin/sh", "-c", "curl -f http://localhost:4300/health || exit 1"]
       startPeriod = 10
@@ -32,7 +20,7 @@ locals {
 
     logConfiguration = {
       logDriver = "awslogs"
-      options = {
+      options   = {
         "awslogs-create-group"  = "true"
         "awslogs-group"         = local.log_group_name
         "awslogs-stream-prefix" = local.temporal_worker_integration_service_name
@@ -43,12 +31,10 @@ locals {
       [
         { name = "HASH_TEMPORAL_HOST", value = var.temporal_host },
         { name = "HASH_TEMPORAL_PORT", value = var.temporal_port },
+        { name = "HASH_GRAPH_API_HOST", value = local.graph_container_port_dns },
+        { name = "HASH_GRAPH_API_PORT", value = tostring(local.graph_container_port) },
       ],
-      [for env_var in var.temporal_worker_integration_env_vars : { name = env_var.name, value = env_var.value } if !env_var.secret]
     )
-
-    secrets = [for env_name, ssm_param in aws_ssm_parameter.temporal_worker_integration_env_vars :
-      { name = env_name, valueFrom = ssm_param.arn }]
 
     essential = true
   }

--- a/infra/terraform/hash/hash_application/variables.tf
+++ b/infra/terraform/hash/hash_application/variables.tf
@@ -82,15 +82,6 @@ variable "type_fetcher_image" {
   description = "URL of the docker image for the type fetcher service"
 }
 
-variable "type_fetcher_env_vars" {
-  type = list(object({
-    name   = string,
-    secret = bool,
-    value  = string
-  }))
-  description = "A list of environment variables to save as system parameters and inject into the type fetcher service"
-}
-
 variable "kratos_image" {
   type = object({
     url     = string
@@ -151,15 +142,6 @@ variable "temporal_worker_integration_image" {
   description = "URL of the docker image for the Temporal integration worker"
 }
 
-variable "temporal_worker_integration_env_vars" {
-  type = list(object({
-    name   = string,
-    secret = bool,
-    value  = string
-  }))
-  description = "A list of environment variables to save as system parameters and inject into the Temporal integration worker"
-}
-
 variable "ses_verified_domain_identity" {
   type        = string
   description = "A verified AWS SES identity to use for email sending in the application."
@@ -201,4 +183,3 @@ variable "spicedb_env_vars" {
   }))
   description = "A list of environment variables to save as system parameters and inject into the SpiceDB service"
 }
-

--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -38,7 +38,7 @@ provider "vault" {
 data "vault_kv_secret_v2" "secrets" {
   mount = "automation"
   # Remove leading and trailing slashes from the path so we ensure it's a path and not a file
-  name = "${trim(var.vault_kvv2_secret_path, "/ ")}/${local.env}"
+  name  = "${trim(var.vault_kvv2_secret_path, "/ ")}/${local.env}"
 }
 
 module "vault_aws_auth" {
@@ -95,28 +95,28 @@ module "postgres" {
 }
 
 module "temporal" {
-  depends_on            = [module.networking, module.postgres]
-  source                = "./temporal"
-  prefix                = module.variables_temporal.prefix
-  param_prefix          = module.variables_temporal.param_prefix
-  subnets               = module.networking.snpub
-  vpc                   = module.networking.vpc
-  env                   = local.env
-  region                = local.region
-  cpu                   = 256
-  memory                = 512
+  depends_on          = [module.networking, module.postgres]
+  source              = "./temporal"
+  prefix              = module.variables_temporal.prefix
+  param_prefix        = module.variables_temporal.param_prefix
+  subnets             = module.networking.snpub
+  vpc                 = module.networking.vpc
+  env                 = local.env
+  region              = local.region
+  cpu                 = 256
+  memory              = 512
   # TODO: provide by the HASH variables.tf
-  temporal_version      = "1.21.0.0"
-  temporal_ui_version   = "2.16.2"
+  temporal_version    = "1.21.0.0"
+  temporal_ui_version = "2.16.2"
 
-  postgres_host = module.postgres.pg_host
-  postgres_port = module.postgres.pg_port
-  postgres_db = "temporal"
+  postgres_host          = module.postgres.pg_host
+  postgres_port          = module.postgres.pg_port
+  postgres_db            = "temporal"
   postgres_visibility_db = "temporal_visibility"
-  postgres_user = "temporal"
-  postgres_password  = sensitive(data.vault_kv_secret_v2.secrets.data["pg_temporal_user_password_raw"])
+  postgres_user          = "temporal"
+  postgres_password      = sensitive(data.vault_kv_secret_v2.secrets.data["pg_temporal_user_password_raw"])
 
-  postgres_superuser = "superuser"
+  postgres_superuser          = "superuser"
   postgres_superuser_password = sensitive(data.vault_kv_secret_v2.secrets.data["pg_superuser_password"])
 }
 
@@ -149,10 +149,10 @@ module "postgres_roles" {
   pg_superuser_username = "superuser"
   pg_superuser_password = data.vault_kv_secret_v2.secrets.data["pg_superuser_password"]
 
-  pg_kratos_user_password_hash = data.vault_kv_secret_v2.secrets.data["pg_kratos_user_password_hash"]
-  pg_graph_user_password_hash  = data.vault_kv_secret_v2.secrets.data["pg_graph_user_password_hash"]
+  pg_kratos_user_password_hash   = data.vault_kv_secret_v2.secrets.data["pg_kratos_user_password_hash"]
+  pg_graph_user_password_hash    = data.vault_kv_secret_v2.secrets.data["pg_graph_user_password_hash"]
   pg_temporal_user_password_hash = data.vault_kv_secret_v2.secrets.data["pg_temporal_user_password_hash"]
-  pg_spicedb_user_password_hash = data.vault_kv_secret_v2.secrets.data["pg_spicedb_user_password_hash"]
+  pg_spicedb_user_password_hash  = data.vault_kv_secret_v2.secrets.data["pg_spicedb_user_password_hash"]
 }
 
 module "redis" {
@@ -219,83 +219,129 @@ module "application" {
   worker_memory                = 512
   ses_verified_domain_identity = var.ses_verified_domain_identity
   graph_image                  = module.graph_ecr
-  graph_env_vars = concat(var.hash_graph_env_vars, [
-    { name = "HASH_GRAPH_TYPE_FETCHER_HOST", secret = false, value = "127.0.0.1" },
-    { name = "HASH_GRAPH_TYPE_FETCHER_PORT", secret = false, value = "4444" },
+  graph_env_vars               = concat(var.hash_graph_env_vars, [
     { name = "HASH_GRAPH_PG_USER", secret = false, value = "graph" },
-    { name = "HASH_GRAPH_PG_PASSWORD", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["pg_graph_user_password_raw"]) },
+    {
+      name  = "HASH_GRAPH_PG_PASSWORD", secret = true,
+      value = sensitive(data.vault_kv_secret_v2.secrets.data["pg_graph_user_password_raw"])
+    },
     { name = "HASH_GRAPH_PG_HOST", secret = false, value = module.postgres.pg_host },
     { name = "HASH_GRAPH_PG_PORT", secret = false, value = module.postgres.pg_port },
     { name = "HASH_GRAPH_PG_DATABASE", secret = false, value = "graph" },
-    { name = "HASH_SPICEDB_HOST", secret = false, value = "http://127.0.0.1" },
-    { name = "HASH_SPICEDB_HTTP_PORT", secret = false, value = "8443" },
-    { name = "HASH_SPICEDB_GRPC_PRESHARED_KEY", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["spicedb_grpc_preshared_key"]) },
-    { name = "HASH_GRAPH_SENTRY_DSN", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["graph_sentry_dsn"]) },
+    {
+      name  = "HASH_SPICEDB_GRPC_PRESHARED_KEY", secret = true,
+      value = sensitive(data.vault_kv_secret_v2.secrets.data["spicedb_grpc_preshared_key"])
+    },
+    {
+      name  = "HASH_GRAPH_SENTRY_DSN", secret = true,
+      value = sensitive(data.vault_kv_secret_v2.secrets.data["graph_sentry_dsn"])
+    },
     { name = "HASH_GRAPH_SENTRY_ENVIRONMENT", secret = false, value = "production" },
   ])
   # The type fetcher uses the same image as the graph right now
   type_fetcher_image = module.graph_ecr
-  # we reuse the same non-secret env vars as the graph. Stuff like logging
-  type_fetcher_env_vars = concat(var.hash_graph_env_vars, [
-    { name = "HASH_GRAPH_TYPE_FETCHER_HOST", secret = false, value = "127.0.0.1" },
-    { name = "HASH_GRAPH_TYPE_FETCHER_PORT", secret = false, value = "4444" },
+  kratos_image       = module.kratos_ecr
+  kratos_env_vars    = concat(var.kratos_env_vars, [
+    {
+      name  = "SECRETS_COOKIE", secret = true,
+      value = sensitive(data.vault_kv_secret_v2.secrets.data["kratos_secrets_cookie"])
+    },
+    {
+      name  = "SECRETS_CIPHER", secret = true,
+      value = sensitive(data.vault_kv_secret_v2.secrets.data["kratos_secrets_cipher"])
+    },
+    {
+      name  = "DSN", secret = true,
+      value = "postgres://kratos:${sensitive(data.vault_kv_secret_v2.secrets.data["pg_kratos_user_password_raw"])}@${module.postgres.pg_host}:${module.postgres.pg_port}/kratos"
+    },
   ])
-  kratos_image = module.kratos_ecr
-  kratos_env_vars = concat(var.kratos_env_vars, [
-    { name = "SECRETS_COOKIE", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["kratos_secrets_cookie"]) },
-    { name = "SECRETS_CIPHER", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["kratos_secrets_cipher"]) },
-    { name = "DSN", secret = true, value = "postgres://kratos:${sensitive(data.vault_kv_secret_v2.secrets.data["pg_kratos_user_password_raw"])}@${module.postgres.pg_host}:${module.postgres.pg_port}/kratos" },
-  ])
-  api_image = module.api_ecr
+  api_image    = module.api_ecr
   api_env_vars = concat(var.hash_api_env_vars, [
     { name = "AWS_REGION", secret = false, value = local.region },
-    { name = "AWS_S3_UPLOADS_ACCESS_KEY_ID", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["aws_s3_uploads_access_key_id" ]) },
-    { name = "AWS_S3_UPLOADS_BUCKET", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["aws_s3_uploads_bucket" ]) },
-    { name = "AWS_S3_UPLOADS_ENDPOINT", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["aws_s3_uploads_endpoint" ]) },
-    { name = "AWS_S3_UPLOADS_SECRET_ACCESS_KEY", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["aws_s3_uploads_secret_access_key" ]) },
-    { name = "BLOCK_PROTOCOL_API_KEY", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_block_protocol_api_key"]) },
-    { name = "KRATOS_API_KEY", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["kratos_api_key"]) },
-    { name = "HASH_API_RUDDERSTACK_KEY", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_api_rudderstack_key"]) },
-    { name = "HASH_SEED_USERS", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_seed_users"]) },
+    {
+      name  = "AWS_S3_UPLOADS_ACCESS_KEY_ID", secret = true,
+      value = sensitive(data.vault_kv_secret_v2.secrets.data["aws_s3_uploads_access_key_id"])
+    },
+    {
+      name  = "AWS_S3_UPLOADS_BUCKET", secret = true,
+      value = sensitive(data.vault_kv_secret_v2.secrets.data["aws_s3_uploads_bucket"])
+    },
+    {
+      name  = "AWS_S3_UPLOADS_ENDPOINT", secret = true,
+      value = sensitive(data.vault_kv_secret_v2.secrets.data["aws_s3_uploads_endpoint"])
+    },
+    {
+      name  = "AWS_S3_UPLOADS_SECRET_ACCESS_KEY", secret = true,
+      value = sensitive(data.vault_kv_secret_v2.secrets.data["aws_s3_uploads_secret_access_key"])
+    },
+    {
+      name  = "BLOCK_PROTOCOL_API_KEY", secret = true,
+      value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_block_protocol_api_key"])
+    },
+    {
+      name  = "KRATOS_API_KEY", secret = true,
+      value = sensitive(data.vault_kv_secret_v2.secrets.data["kratos_api_key"])
+    },
+    {
+      name  = "HASH_API_RUDDERSTACK_KEY", secret = true,
+      value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_api_rudderstack_key"])
+    },
+    {
+      name  = "HASH_SEED_USERS", secret = true,
+      value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_seed_users"])
+    },
     { name = "HASH_REDIS_HOST", secret = false, value = module.redis.node.address },
     { name = "HASH_REDIS_PORT", secret = false, value = module.redis.node.port },
     { name = "HASH_TEMPORAL_SERVER_HOST", secret = false, value = module.temporal.host },
     { name = "HASH_TEMPORAL_SERVER_PORT", secret = false, value = module.temporal.temporal_port },
     { name = "HASH_INTEGRATION_QUEUE_NAME", secret = false, value = "integration" },
-#    { name = "LINEAR_CLIENT_ID", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["linear_client_id"]) },
-#    { name = "LINEAR_CLIENT_SECRET", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["linear_client_secret"]) },
-    { name = "LINEAR_WEBHOOK_SECRET", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["linear_webhook_secret"]) },
-    { name = "NODE_API_SENTRY_DSN", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["node_api_sentry_dsn"]) }
+    #    { name = "LINEAR_CLIENT_ID", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["linear_client_id"]) },
+    #    { name = "LINEAR_CLIENT_SECRET", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["linear_client_secret"]) },
+    {
+      name  = "LINEAR_WEBHOOK_SECRET", secret = true,
+      value = sensitive(data.vault_kv_secret_v2.secrets.data["linear_webhook_secret"])
+    },
+    {
+      name  = "NODE_API_SENTRY_DSN", secret = true,
+      value = sensitive(data.vault_kv_secret_v2.secrets.data["node_api_sentry_dsn"])
+    }
   ])
-  temporal_worker_ai_ts_image = module.temporal_worker_ai_ts_ecr
+  temporal_worker_ai_ts_image    = module.temporal_worker_ai_ts_ecr
   temporal_worker_ai_ts_env_vars = [
-    { name = "OPENAI_API_KEY", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_openai_api_key"]) },
-    { name = "HASH_GRAPH_API_HOST", secret = false, value = "localhost" },
-    { name = "HASH_GRAPH_API_PORT", secret = false, value = "4000" },
+    {
+      name  = "OPENAI_API_KEY", secret = true,
+      value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_openai_api_key"])
+    },
   ]
   temporal_worker_integration_image = module.temporal_worker_integration_ecr
-  temporal_worker_integration_env_vars = [
-    { name = "HASH_GRAPH_API_HOST", secret = false, value = "localhost" },
-    { name = "HASH_GRAPH_API_PORT", secret = false, value = "4000" },
-  ]
-  temporal_host = module.temporal.host
-  temporal_port = module.temporal.temporal_port
-  spicedb_image = {
-    name = "authzed/spicedb"
+  temporal_host                     = module.temporal.host
+  temporal_port                     = module.temporal.temporal_port
+  spicedb_image                     = {
+    name    = "authzed/spicedb"
     version = "1.28.0"
   }
   spicedb_migration_env_vars = [
     { name = "SPICEDB_LOG_FORMAT", secret = false, value = "console" },
     { name = "SPICEDB_DATASTORE_ENGINE", secret = false, value = "postgres" },
-    { name = "SPICEDB_DATASTORE_CONN_URI", secret = true, value = sensitive("postgres://superuser:${data.vault_kv_secret_v2.secrets.data["pg_superuser_password"]}@${module.postgres.pg_host}:${module.postgres.pg_port}/spicedb") },
+    {
+      name  = "SPICEDB_DATASTORE_CONN_URI", secret = true,
+      value = sensitive("postgres://superuser:${data.vault_kv_secret_v2.secrets.data["pg_superuser_password"]}@${module.postgres.pg_host}:${module.postgres.pg_port}/spicedb")
+    },
   ]
   spicedb_env_vars = [
     { name = "SPICEDB_LOG_FORMAT", secret = false, value = "console" },
     { name = "SPICEDB_DATASTORE_ENGINE", secret = false, value = "postgres" },
-    { name = "SPICEDB_DATASTORE_CONN_URI", secret = true, value = sensitive("postgres://spicedb:${data.vault_kv_secret_v2.secrets.data["pg_spicedb_user_password_raw"]}@${module.postgres.pg_host}:${module.postgres.pg_port}/spicedb?plan_cache_mode=force_custom_plan") },
+    {
+      name  = "SPICEDB_DATASTORE_CONN_URI", secret = true,
+      value = sensitive("postgres://spicedb:${data.vault_kv_secret_v2.secrets.data["pg_spicedb_user_password_raw"]}@${module.postgres.pg_host}:${module.postgres.pg_port}/spicedb?plan_cache_mode=force_custom_plan")
+    },
     { name = "SPICEDB_HTTP_ENABLED", secret = false, value = "True" },
     { name = "SPICEDB_SCHEMA_PREFIXES_REQUIRED", secret = false, value = "True" },
     { name = "SPICEDB_TELEMETRY_ENDPOINT", secret = false, value = "" },
-    { name = "SPICEDB_GRPC_PRESHARED_KEY", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["spicedb_grpc_preshared_key"]) },
+    { name = "SPICEDB_DATASTORE_GC_WINDOW", secret = false, value = "2m0s" },
+    {
+      name  = "SPICEDB_GRPC_PRESHARED_KEY", secret = true,
+      value = sensitive(data.vault_kv_secret_v2.secrets.data["spicedb_grpc_preshared_key"])
+    },
   ]
 }

--- a/infra/terraform/hash/prod-usea1.tfvars
+++ b/infra/terraform/hash/prod-usea1.tfvars
@@ -10,12 +10,16 @@ kratos_env_vars = [
   { name = "COOKIES_DOMAIN", secret = false, value = "hash.ai" },
   { name = "COOKIES_SAME_SITE", secret = false, value = "Lax" },
   { name = "SERVE_PUBLIC_BASE_URL", secret = false, value = "https://kratos.hash.ai" },
-  { name = "SERVE_PUBLIC_CORS_ALLOWED_HEADERS", secret = false, value = "Authorization,Content-Type,X-Session-Token,X-CSRF-Token" },
+  { name  = "SERVE_PUBLIC_CORS_ALLOWED_HEADERS", secret = false,
+    value = "Authorization,Content-Type,X-Session-Token,X-CSRF-Token"
+  },
   { name = "SERVE_PUBLIC_CORS_ALLOWED_ORIGINS", secret = false, value = "https://app.hash.ai" },
   { name = "SELFSERVICE_DEFAULT_BROWSER_RETURN_URL", secret = false, value = "https://app.hash.ai/" },
   { name = "SELFSERVICE_ALLOWED_RETURN_URLS", secret = false, value = "https://app.hash.ai" },
   { name = "SELFSERVICE_FLOWS_ERROR_UI_URL", secret = false, value = "https://app.hash.ai/error" },
-  { name = "SELFSERVICE_FLOWS_LOGOUT_AFTER_DEFAULT_BROWSER_RETURN_URL", secret = false, value = "https://app.hash.ai/login" },
+  { name  = "SELFSERVICE_FLOWS_LOGOUT_AFTER_DEFAULT_BROWSER_RETURN_URL", secret = false,
+    value = "https://app.hash.ai/login"
+  },
   { name = "SELFSERVICE_FLOWS_LOGIN_UI_URL", secret = false, value = "https://app.hash.ai/login" },
   { name = "SELFSERVICE_FLOWS_REGISTRATION_UI_URL", secret = false, value = "https://app.hash.ai/signup" },
   { name = "SELFSERVICE_METHODS_LINK_CONFIG_BASE_URL", secret = false, value = "https://app.hash.ai/api/ory" },
@@ -28,9 +32,12 @@ kratos_env_vars = [
 ]
 
 hash_graph_env_vars = [
-  { name = "HASH_GRAPH_ALLOWED_URL_DOMAIN_PATTERN", secret = false, value = "(?:https://hash\\.ai|https://app\\.hash\\.ai)/@(?P<shortname>[\\w-]+)/types/(?P<kind>(?:data-type)|(?:property-type)|(?:entity-type))/[\\w\\-_%]+/" },
+  { name  = "HASH_GRAPH_ALLOWED_URL_DOMAIN_PATTERN", secret = false,
+    value = "(?:https://hash\\.ai|https://app\\.hash\\.ai)/@(?P<shortname>[\\w-]+)/types/(?P<kind>(?:data-type)|(?:property-type)|(?:entity-type))/[\\w\\-_%]+/"
+  },
   { name = "HASH_GRAPH_LOG_FORMAT", secret = false, value = "pretty" },
-  { name = "RUST_LOG", secret = false, value = "graph=info,hash-graph=info,tokio_postgres=info,hash_type_fetcher=info" },
+  { name  = "RUST_LOG", secret = false, value = "graph=info,hash-graph=info,tokio_postgres=info,hash_type_fetcher=info"
+  },
   { name = "RUST_BACKTRACE", secret = false, value = "1" }
 ]
 
@@ -38,11 +45,9 @@ hash_api_env_vars = [
   { name = "FRONTEND_URL", secret = false, value = "https://app.hash.ai" },
   { name = "API_ORIGIN", secret = false, value = "https://app-api.hash.ai" },
 
-  { name = "HASH_GRAPH_API_HOST", secret = false, value = "localhost" },
-  { name = "HASH_GRAPH_API_PORT", secret = false, value = "4000" },
   { name = "LOG_LEVEL", secret = false, value = "debug" },
 
-  { name = "FILE_UPLOAD_PROVIDER", secret = false, value = "AWS_S3"},
+  { name = "FILE_UPLOAD_PROVIDER", secret = false, value = "AWS_S3" },
 
   { name = "HASH_OPENSEARCH_ENABLED", secret = false, value = "false" },
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Addresses H-1714 and H-1717 (children of H-96). To have finer control over resources and a better traffic health check this moves SpiceDB and the Graph into separate services. Also fixes H-1621 in drive-by. 

## 🔍 What does this change?

- Create a task definition, a service, and a security group for SpiceDB, the Graph and the type fetcher
- Use AWS Service Connect to connect the Graph with SpiceDB
- Update CD to restart the graph service as well

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- `egress` rules can probably be reduced
- Currently, it's using 2 CPUs and 4 GB memory, this probably can be reduced