### PR TITLE
H-1472: Support loading entities into table block

### DIFF
--- a/apps/hash-frontend/src/components/hooks/block-protocol-functions/knowledge/knowledge-shim.ts
+++ b/apps/hash-frontend/src/components/hooks/block-protocol-functions/knowledge/knowledge-shim.ts
@@ -89,7 +89,10 @@ export type QueryEntitiesRequest = {
 export type QueryEntitiesMessageCallback = MessageCallback<
   QueryEntitiesRequest,
   null,
-  MessageReturn<Subgraph<EntityRootType>>,
+  MessageReturn<{
+    results: Subgraph<EntityRootType>;
+    operation: QueryOperationInput;
+  }>,
   ReadOrModifyResourceError
 >;
 

--- a/apps/hash-frontend/src/components/hooks/block-protocol-functions/knowledge/use-block-protocol-query-entities.ts
+++ b/apps/hash-frontend/src/components/hooks/block-protocol-functions/knowledge/use-block-protocol-query-entities.ts
@@ -72,7 +72,7 @@ export const useBlockProtocolQueryEntities = (): {
         response.queryEntities.subgraph,
       );
 
-      return { data: subgraph };
+      return { data: { results: subgraph, operation } };
     },
     [queryFn],
   );

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/query-editor-page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/query-editor-page.tsx
@@ -73,7 +73,7 @@ export const QueryEditorPage = (props: QueryEditorPageProps) => {
         throw new Error(res.errors?.[0]?.message ?? "Unknown error");
       }
 
-      return getRoots(res.data);
+      return getRoots(res.data.results);
     },
     [queryEntities],
   );

--- a/apps/hash-frontend/src/pages/settings/integrations/use-linear-integrations.ts
+++ b/apps/hash-frontend/src/pages/settings/integrations/use-linear-integrations.ts
@@ -28,7 +28,7 @@ export const useLinearIntegrations = () => {
 
   useEffect(() => {
     void (async () => {
-      const { data: subgraph } = await queryEntities({
+      const { data } = await queryEntities({
         data: {
           operation: {
             multiFilter: {
@@ -54,7 +54,9 @@ export const useLinearIntegrations = () => {
         },
       });
 
-      if (subgraph) {
+      if (data) {
+        const subgraph = data.results;
+
         const linearIntegrationEntities = getRoots(subgraph);
 
         setLinearIntegrations(

--- a/blocks/chart/package.json
+++ b/blocks/chart/package.json
@@ -64,7 +64,7 @@
       "entryPoint": "react"
     },
     "protocol": "0.3",
-    "blockEntityType": "https://blockprotocol.org/@hash/types/entity-type/chart/v/1",
+    "blockEntityType": "https://blockprotocol.org/@hash/types/entity-type/chart-block/v/1",
     "codegen": {
       "outputFolder": "src/types/generated",
       "targets": {

--- a/blocks/chart/src/app.tsx
+++ b/blocks/chart/src/app.tsx
@@ -125,13 +125,10 @@ export const App: BlockComponent<BlockEntity> = ({
         throw new Error("Could not fetch query entity results");
       }
 
-      /** @todo: figure out why `data` is typed wrong */
-      const subgraph = data as unknown as Subgraph<EntityRootType>;
-
       setFetchedQueryForLinkedQueryEditionId(
         queryEntity.metadata.recordId.editionId,
       );
-      setQueryResult(subgraph);
+      setQueryResult(data.results);
     },
     [graphModule],
   );

--- a/blocks/chart/src/types/generated/block-entity.ts
+++ b/blocks/chart/src/types/generated/block-entity.ts
@@ -4,29 +4,32 @@
 
 import { Entity, LinkData } from "@blockprotocol/graph";
 
-export type BlockEntity = Chart;
+export type BlockEntity = ChartBlock;
 
-export type BlockEntityOutgoingLinkAndTarget = ChartOutgoingLinkAndTarget;
+export type BlockEntityOutgoingLinkAndTarget = ChartBlockOutgoingLinkAndTarget;
 
-export type Chart = Entity<ChartProperties>;
+export type ChartBlock = Entity<ChartBlockProperties>;
+
+export type ChartBlockHasQueryLink = {
+  linkEntity: HasQuery;
+  rightEntity: Query;
+};
+
+export type ChartBlockOutgoingLinkAndTarget = ChartBlockHasQueryLink;
+
+export type ChartBlockOutgoingLinksByLinkEntityTypeId = {
+  "https://blockprotocol.org/@hash/types/entity-type/has-query/v/1": ChartBlockHasQueryLink;
+};
+
+export type ChartBlockProperties = {
+  "https://blockprotocol.org/@hash/types/property-type/chart-defintion/"?: ChartDefintionPropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/title/"?: TitlePropertyValue;
+};
 
 /**
  * The chart definition of something.
  */
 export type ChartDefintionPropertyValue = Object;
-
-export type ChartHasQueryLink = { linkEntity: HasQuery; rightEntity: Query };
-
-export type ChartOutgoingLinkAndTarget = ChartHasQueryLink;
-
-export type ChartOutgoingLinksByLinkEntityTypeId = {
-  "https://blockprotocol.org/@hash/types/entity-type/has-query/v/1": ChartHasQueryLink;
-};
-
-export type ChartProperties = {
-  "https://blockprotocol.org/@blockprotocol/types/property-type/title/"?: TitlePropertyValue;
-  "https://blockprotocol.org/@hash/types/property-type/chart-defintion/"?: ChartDefintionPropertyValue;
-};
 
 export type HasQuery = Entity<HasQueryProperties> & { linkData: LinkData };
 

--- a/blocks/table/package.json
+++ b/blocks/table/package.json
@@ -102,7 +102,7 @@
     "image": "public/block-preview.png",
     "name": "@hash/table",
     "protocol": "0.3",
-    "blockEntityType": "https://blockprotocol-fwu7vped4.stage.hash.ai/@yk_hash/types/entity-type/table-block/v/4",
+    "blockEntityType": "https://blockprotocol.org/@benwerner/types/entity-type/table-block/v/2",
     "codegen": {
       "outputFolder": "src/types/generated",
       "targets": {

--- a/blocks/table/package.json
+++ b/blocks/table/package.json
@@ -102,7 +102,7 @@
     "image": "public/block-preview.png",
     "name": "@hash/table",
     "protocol": "0.3",
-    "blockEntityType": "https://blockprotocol.org/@hash/types/entity-type/table/v/1",
+    "blockEntityType": "https://blockprotocol.org/@hash/types/entity-type/table-block/v/4",
     "codegen": {
       "outputFolder": "src/types/generated",
       "targets": {

--- a/blocks/table/package.json
+++ b/blocks/table/package.json
@@ -102,7 +102,7 @@
     "image": "public/block-preview.png",
     "name": "@hash/table",
     "protocol": "0.3",
-    "blockEntityType": "https://blockprotocol.org/@benwerner/types/entity-type/table-block/v/2",
+    "blockEntityType": "https://blockprotocol.org/@hash/types/entity-type/table/v/1",
     "codegen": {
       "outputFolder": "src/types/generated",
       "targets": {

--- a/blocks/table/src/app.tsx
+++ b/blocks/table/src/app.tsx
@@ -21,7 +21,7 @@ import {
 } from "./types/generated/block-entity";
 
 const titleKey: RootKey =
-  "https://blockprotocol-gkgdavns7.stage.hash.ai/@luisbett/types/property-type/title/";
+  "https://blockprotocol.org/@blockprotocol/types/property-type/title/";
 
 export const App: BlockComponent<BlockEntity> = ({
   graph: { blockEntitySubgraph, readonly },
@@ -34,9 +34,10 @@ export const App: BlockComponent<BlockEntity> = ({
     TableBlockOutgoingLinkAndTarget[]
   >(blockEntitySubgraph);
 
-  /** @todo use the real query object here, instead of the staging one */
-  const query = linkedEntities[0]?.rightEntity?.properties[
-    "https://blockprotocol-fwu7vped4.stage.hash.ai/@yk_hash/types/property-type/query-object/"
+  const linkedQueryEntity = linkedEntities[0]?.rightEntity;
+
+  const query = linkedQueryEntity?.properties[
+    "https://blockprotocol.org/@hash/types/property-type/query/"
   ] as MultiFilter | undefined;
 
   const {

--- a/blocks/table/src/app.tsx
+++ b/blocks/table/src/app.tsx
@@ -17,7 +17,7 @@ import { Table } from "./components/table/table";
 import { TableWithQuery } from "./components/table/table-with-query";
 import {
   BlockEntity,
-  TableOutgoingLinkAndTarget,
+  TableBlockOutgoingLinkAndTarget,
 } from "./types/generated/block-entity";
 
 const titleKey: RootKey =
@@ -31,7 +31,7 @@ export const App: BlockComponent<BlockEntity> = ({
 
   const { rootEntity: blockEntity, linkedEntities } = useEntitySubgraph<
     BlockEntity,
-    TableOutgoingLinkAndTarget[]
+    TableBlockOutgoingLinkAndTarget[]
   >(blockEntitySubgraph);
 
   const linkedQueryEntity = linkedEntities[0]?.rightEntity;

--- a/blocks/table/src/app.tsx
+++ b/blocks/table/src/app.tsx
@@ -17,7 +17,7 @@ import { Table } from "./components/table/table";
 import { TableWithQuery } from "./components/table/table-with-query";
 import {
   BlockEntity,
-  TableBlockOutgoingLinkAndTarget,
+  TableOutgoingLinkAndTarget,
 } from "./types/generated/block-entity";
 
 const titleKey: RootKey =
@@ -31,7 +31,7 @@ export const App: BlockComponent<BlockEntity> = ({
 
   const { rootEntity: blockEntity, linkedEntities } = useEntitySubgraph<
     BlockEntity,
-    TableBlockOutgoingLinkAndTarget[]
+    TableOutgoingLinkAndTarget[]
   >(blockEntitySubgraph);
 
   const linkedQueryEntity = linkedEntities[0]?.rightEntity;

--- a/blocks/table/src/components/settings-bar/settings-bar.tsx
+++ b/blocks/table/src/components/settings-bar/settings-bar.tsx
@@ -10,11 +10,11 @@ import { BlockEntity } from "../../types/generated/block-entity";
 import styles from "./styles.module.scss";
 
 const isStripedKey: RootKey =
-  "https://blockprotocol-fwu7vped4.stage.hash.ai/@yk_hash/types/property-type/table-rows-are-striped/";
+  "https://blockprotocol.org/@hash/types/property-type/table-rows-are-striped/";
 const hideHeaderRowKey: RootKey =
-  "https://blockprotocol-fwu7vped4.stage.hash.ai/@yk_hash/types/property-type/table-header-row-is-hidden/";
+  "https://blockprotocol.org/@hash/types/property-type/table-header-row-is-hidden/";
 const hideRowNumbersKey: RootKey =
-  "https://blockprotocol-fwu7vped4.stage.hash.ai/@yk_hash/types/property-type/table-row-numbers-are-hidden/";
+  "https://blockprotocol.org/@hash/types/property-type/table-row-numbers-are-hidden/";
 
 interface SettingSwitchProps {
   label: string;

--- a/blocks/table/src/components/table/table-with-query.tsx
+++ b/blocks/table/src/components/table/table-with-query.tsx
@@ -1,8 +1,10 @@
 import {
   Entity,
+  EntityRootType,
   GraphBlockHandler,
   JsonValue,
   MultiFilter,
+  Subgraph,
 } from "@blockprotocol/graph";
 import { getRoots } from "@blockprotocol/graph/stdlib";
 import {
@@ -18,11 +20,11 @@ import { BlockEntity } from "../../types/generated/block-entity";
 import { Grid, ROW_HEIGHT } from "../grid/grid";
 
 const isStripedKey: RootKey =
-  "https://blockprotocol-fwu7vped4.stage.hash.ai/@yk_hash/types/property-type/table-rows-are-striped/";
+  "https://blockprotocol.org/@hash/types/property-type/table-rows-are-striped/";
 const hideHeaderRowKey: RootKey =
-  "https://blockprotocol-fwu7vped4.stage.hash.ai/@yk_hash/types/property-type/table-header-row-is-hidden/";
+  "https://blockprotocol.org/@hash/types/property-type/table-header-row-is-hidden/";
 const hideRowNumbersKey: RootKey =
-  "https://blockprotocol-fwu7vped4.stage.hash.ai/@yk_hash/types/property-type/table-row-numbers-are-hidden/";
+  "https://blockprotocol.org/@hash/types/property-type/table-row-numbers-are-hidden/";
 
 interface TableProps {
   blockEntity: BlockEntity;
@@ -72,7 +74,9 @@ export const TableWithQuery = ({
         throw new Error(res.errors?.[0]?.message ?? "Unknown error");
       }
 
-      const roots = getRoots(res.data.results);
+      const subgraph = res.data as unknown as Subgraph<EntityRootType>;
+
+      const roots = getRoots(subgraph);
       setLoading(false);
 
       setEntities(roots);

--- a/blocks/table/src/components/table/table-with-query.tsx
+++ b/blocks/table/src/components/table/table-with-query.tsx
@@ -86,15 +86,19 @@ export const TableWithQuery = ({
   }, [graphModule, query]);
 
   const columns = useMemo<GridColumn[]>(() => {
-    const uniqueEntityTypeIds = new Set<string>(
+    const uniquePropertyTypeBaseUrls = new Set<string>(
       entities.flatMap(({ properties }) => Object.keys(properties)),
     );
 
-    return Array.from(uniqueEntityTypeIds).map((entityTypeId) => ({
-      id: entityTypeId,
-      title: entityTypeId.split("/").slice(-2)[0] ?? entityTypeId,
-      width: 200,
-    }));
+    return Array.from(uniquePropertyTypeBaseUrls).map(
+      (propertyTypeBaseUrl) => ({
+        id: propertyTypeBaseUrl,
+        /** @todo: fetch property type in query */
+        title:
+          propertyTypeBaseUrl.split("/").slice(-2)[0] ?? propertyTypeBaseUrl,
+        width: 200,
+      }),
+    );
   }, [entities]);
 
   const handleCellEdited: DataEditorProps["onCellEdited"] = (
@@ -106,15 +110,17 @@ export const TableWithQuery = ({
         if (index !== rowIndex) return entity;
 
         const column = columns[colIndex];
-        const propertyTypeId = column?.id;
+        const propertyTypeBaseUrl = column?.id;
 
-        if (!column || !propertyTypeId) throw new Error("Column not found");
+        if (!column || !propertyTypeBaseUrl) {
+          throw new Error("Column not found");
+        }
 
         const newPropertyValue = newValue.data as string;
 
         const newProperties = {
           ...entity.properties,
-          [propertyTypeId]: newPropertyValue,
+          [propertyTypeBaseUrl]: newPropertyValue,
         };
 
         void graphModule.updateEntity({

--- a/blocks/table/src/components/table/table-with-query.tsx
+++ b/blocks/table/src/components/table/table-with-query.tsx
@@ -80,8 +80,7 @@ export const TableWithQuery = ({
         throw new Error(res.errors?.[0]?.message ?? "Unknown error");
       }
 
-      /** @todo: fix the return type */
-      const fetchedSubgraph = res.data as unknown as Subgraph<EntityRootType>;
+      const fetchedSubgraph = res.data.results;
 
       setSubgraph(fetchedSubgraph);
       setEntities(getRoots(fetchedSubgraph));

--- a/blocks/table/src/components/table/table.tsx
+++ b/blocks/table/src/components/table/table.tsx
@@ -24,20 +24,20 @@ import { RowActions } from "./row-actions";
 import styles from "./table.module.scss";
 
 const localColumnsKey: RootKey =
-  "https://blockprotocol-hk4sbmd9k.stage.hash.ai/@yusuf123/types/property-type/table-local-column/";
+  "https://blockprotocol.org/@hash/types/property-type/table-local-column/";
 const localRowsKey: RootKey =
-  "https://blockprotocol-hk4sbmd9k.stage.hash.ai/@yusuf123/types/property-type/table-local-row/";
+  "https://blockprotocol.org/@hash/types/property-type/table-local-row/";
 const isStripedKey: RootKey =
-  "https://blockprotocol-fwu7vped4.stage.hash.ai/@yk_hash/types/property-type/table-rows-are-striped/";
+  "https://blockprotocol.org/@hash/types/property-type/table-rows-are-striped/";
 const hideHeaderRowKey: RootKey =
-  "https://blockprotocol-fwu7vped4.stage.hash.ai/@yk_hash/types/property-type/table-header-row-is-hidden/";
+  "https://blockprotocol.org/@hash/types/property-type/table-header-row-is-hidden/";
 const hideRowNumbersKey: RootKey =
-  "https://blockprotocol-fwu7vped4.stage.hash.ai/@yk_hash/types/property-type/table-row-numbers-are-hidden/";
+  "https://blockprotocol.org/@hash/types/property-type/table-row-numbers-are-hidden/";
 
 const columnTitleKey: ColumnKey =
-  "https://blockprotocol-gkgdavns7.stage.hash.ai/@luisbett/types/property-type/title/";
+  "https://blockprotocol.org/@blockprotocol/types/property-type/title/";
 const columnIdKey: ColumnKey =
-  "https://blockprotocol-gqpc30oin.stage.hash.ai/@nate/types/property-type/id/";
+  "https://blockprotocol.org/@hash/types/property-type/table-local-column-id/";
 
 interface TableProps {
   blockEntity: BlockEntity;

--- a/blocks/table/src/dev.tsx
+++ b/blocks/table/src/dev.tsx
@@ -14,38 +14,36 @@ const testEntity: BlockEntity = {
     entityTypeId: packageJson.blockprotocol.blockEntityType as VersionedUrl,
   },
   properties: {
-    "https://blockprotocol-gkgdavns7.stage.hash.ai/@luisbett/types/property-type/title/":
+    "https://blockprotocol.org/@blockprotocol/types/property-type/title/":
       "My Table",
-    "https://blockprotocol-hk4sbmd9k.stage.hash.ai/@yusuf123/types/property-type/table-local-column/":
-      [
-        {
-          "https://blockprotocol-gkgdavns7.stage.hash.ai/@luisbett/types/property-type/title/":
-            "Full Name",
-          "https://blockprotocol-gqpc30oin.stage.hash.ai/@nate/types/property-type/id/":
-            "fullName",
-        },
-        {
-          "https://blockprotocol-gkgdavns7.stage.hash.ai/@luisbett/types/property-type/title/":
-            "Role",
-          "https://blockprotocol-gqpc30oin.stage.hash.ai/@nate/types/property-type/id/":
-            "role",
-        },
-      ],
-    "https://blockprotocol-hk4sbmd9k.stage.hash.ai/@yusuf123/types/property-type/table-local-row/":
-      [
-        {
-          fullName: "John Johnson",
-          role: "Role 1",
-        },
-        {
-          fullName: "Bob Bobson",
-          role: "Role 2",
-        },
-        {
-          fullName: "Alice Aliceson",
-          role: "Role 3",
-        },
-      ],
+    "https://blockprotocol.org/@hash/types/property-type/table-local-column/": [
+      {
+        "https://blockprotocol.org/@blockprotocol/types/property-type/title/":
+          "Full Name",
+        "https://blockprotocol.org/@hash/types/property-type/table-local-column-id/":
+          "fullName",
+      },
+      {
+        "https://blockprotocol.org/@blockprotocol/types/property-type/title/":
+          "Role",
+        "https://blockprotocol.org/@hash/types/property-type/table-local-column-id/":
+          "role",
+      },
+    ],
+    "https://blockprotocol.org/@hash/types/property-type/table-local-row/": [
+      {
+        fullName: "John Johnson",
+        role: "Role 1",
+      },
+      {
+        fullName: "Bob Bobson",
+        role: "Role 2",
+      },
+      {
+        fullName: "Alice Aliceson",
+        role: "Role 3",
+      },
+    ],
   },
 };
 

--- a/blocks/table/src/types/generated/block-entity.ts
+++ b/blocks/table/src/types/generated/block-entity.ts
@@ -4,9 +4,9 @@
 
 import { Entity, LinkData } from "@blockprotocol/graph";
 
-export type BlockEntity = TableBlock;
+export type BlockEntity = Table;
 
-export type BlockEntityOutgoingLinkAndTarget = TableBlockOutgoingLinkAndTarget;
+export type BlockEntityOutgoingLinkAndTarget = TableOutgoingLinkAndTarget;
 
 /**
  * A True or False value
@@ -40,45 +40,55 @@ export type LinkProperties = {};
  */
 export type Object = {};
 
-export type Query = Entity<QueryProperties>;
+export type Table = Entity<TableProperties>;
 
-export type QueryOutgoingLinkAndTarget = never;
-
-export type QueryOutgoingLinksByLinkEntityTypeId = {};
-
-export type QueryProperties = {
-  "https://blockprotocol.org/@hash/types/property-type/query/": QueryPropertyValue;
-};
-
-/**
- * The query for something.
- */
-export type QueryPropertyValue = Object;
-
-export type TableBlock = Entity<TableBlockProperties>;
-
-export type TableBlockHasQueryLink = {
-  linkEntity: HasQuery;
-  rightEntity: Query;
-};
-
-export type TableBlockOutgoingLinkAndTarget = TableBlockHasQueryLink;
-
-export type TableBlockOutgoingLinksByLinkEntityTypeId = {
-  "https://blockprotocol.org/@hash/types/entity-type/has-query/v/1": TableBlockHasQueryLink;
-};
-
-export type TableBlockProperties = {
-  "https://blockprotocol.org/@blockprotocol/types/property-type/title/"?: TitlePropertyValue;
-  "https://blockprotocol.org/@hash/types/property-type/table-rows-are-striped/"?: TableRowsAreStripedPropertyValue;
-  "https://blockprotocol.org/@hash/types/property-type/table-header-row-is-hidden/"?: TableHeaderRowIsHiddenPropertyValue;
-  "https://blockprotocol.org/@hash/types/property-type/table-row-numbers-are-hidden/"?: TableRowNumbersAreHiddenPropertyValue;
-};
+export type TableHasQueryLink = { linkEntity: HasQuery; rightEntity: Entity };
 
 /**
  * Whether the table header row is hidden.
  */
 export type TableHeaderRowIsHiddenPropertyValue = Boolean;
+
+/**
+ * A unique identifier for a local column stored on the "Table" block.
+ */
+export type TableLocalColumnIDPropertyValue = Text;
+
+/**
+ * Local column stored on "Table" block.
+ */
+export type TableLocalColumnPropertyValue = {
+  "https://blockprotocol.org/@blockprotocol/types/property-type/title/"?: TitlePropertyValue;
+  "https://blockprotocol.org/@hash/types/property-type/table-local-column-id/": TableLocalColumnIDPropertyValue;
+};
+
+/**
+ * An object representing a local row stored on the "Table" block. The keys of this object must be one of the local column IDs.
+ *
+ * See: https://blockprotocol.org/@hash/types/property-type/table-local-column/
+ */
+export type TableLocalRowPropertyValue = Object;
+
+export type TableOutgoingLinkAndTarget = TableHasQueryLink;
+
+export type TableOutgoingLinksByLinkEntityTypeId = {
+  "https://blockprotocol.org/@hash/types/entity-type/has-query/v/1": TableHasQueryLink;
+};
+
+export type TableProperties = {
+  "https://blockprotocol.org/@hash/types/property-type/table-header-row-is-hidden/"?: TableHeaderRowIsHiddenPropertyValue;
+  /**
+   * @minItems 0
+   */
+  "https://blockprotocol.org/@hash/types/property-type/table-local-column/"?: TableLocalColumnPropertyValue[];
+  /**
+   * @minItems 0
+   */
+  "https://blockprotocol.org/@hash/types/property-type/table-local-row/"?: TableLocalRowPropertyValue[];
+  "https://blockprotocol.org/@hash/types/property-type/table-row-numbers-are-hidden/"?: TableRowNumbersAreHiddenPropertyValue;
+  "https://blockprotocol.org/@hash/types/property-type/table-rows-are-striped/"?: TableRowsAreStripedPropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/title/"?: TitlePropertyValue;
+};
 
 /**
  * Whether the table row numbers are hidden.

--- a/blocks/table/src/types/generated/block-entity.ts
+++ b/blocks/table/src/types/generated/block-entity.ts
@@ -4,9 +4,9 @@
 
 import { Entity, LinkData } from "@blockprotocol/graph";
 
-export type BlockEntity = Table;
+export type BlockEntity = TableBlock;
 
-export type BlockEntityOutgoingLinkAndTarget = TableOutgoingLinkAndTarget;
+export type BlockEntityOutgoingLinkAndTarget = TableBlockOutgoingLinkAndTarget;
 
 /**
  * A True or False value
@@ -40,9 +40,53 @@ export type LinkProperties = {};
  */
 export type Object = {};
 
-export type Table = Entity<TableProperties>;
+export type Query = Entity<QueryProperties>;
 
-export type TableHasQueryLink = { linkEntity: HasQuery; rightEntity: Entity };
+export type QueryOutgoingLinkAndTarget = never;
+
+export type QueryOutgoingLinksByLinkEntityTypeId = {};
+
+export type QueryProperties = {
+  "https://blockprotocol.org/@hash/types/property-type/query/": QueryPropertyValue;
+};
+
+/**
+ * The query for something.
+ */
+export type QueryPropertyValue = Object;
+
+export type TableBlock = Entity<TableBlockProperties>;
+
+export type TableBlockHasQueryLink = {
+  linkEntity: HasQuery;
+  rightEntity: Query;
+};
+
+export type TableBlockOutgoingLinkAndTarget = TableBlockHasQueryLink;
+
+export type TableBlockOutgoingLinksByLinkEntityTypeId = {
+  "https://blockprotocol.org/@hash/types/entity-type/has-query/v/1": TableBlockHasQueryLink;
+};
+
+/**
+ * The block entity of the "Table" block.
+ *
+ * See: https://blockprotocol.org/@hash/blocks/table
+ */
+export type TableBlockProperties = {
+  "https://blockprotocol.org/@blockprotocol/types/property-type/title/"?: TitlePropertyValue;
+  "https://blockprotocol.org/@hash/types/property-type/table-rows-are-striped/"?: TableRowsAreStripedPropertyValue;
+  "https://blockprotocol.org/@hash/types/property-type/table-row-numbers-are-hidden/"?: TableRowNumbersAreHiddenPropertyValue;
+  "https://blockprotocol.org/@hash/types/property-type/table-header-row-is-hidden/"?: TableHeaderRowIsHiddenPropertyValue;
+  /**
+   * @minItems 0
+   */
+  "https://blockprotocol.org/@hash/types/property-type/table-local-column/"?: TableLocalColumnPropertyValue[];
+  /**
+   * @minItems 0
+   */
+  "https://blockprotocol.org/@hash/types/property-type/table-local-row/"?: TableLocalRowPropertyValue[];
+};
 
 /**
  * Whether the table header row is hidden.
@@ -68,27 +112,6 @@ export type TableLocalColumnPropertyValue = {
  * See: https://blockprotocol.org/@hash/types/property-type/table-local-column/
  */
 export type TableLocalRowPropertyValue = Object;
-
-export type TableOutgoingLinkAndTarget = TableHasQueryLink;
-
-export type TableOutgoingLinksByLinkEntityTypeId = {
-  "https://blockprotocol.org/@hash/types/entity-type/has-query/v/1": TableHasQueryLink;
-};
-
-export type TableProperties = {
-  "https://blockprotocol.org/@hash/types/property-type/table-header-row-is-hidden/"?: TableHeaderRowIsHiddenPropertyValue;
-  /**
-   * @minItems 0
-   */
-  "https://blockprotocol.org/@hash/types/property-type/table-local-column/"?: TableLocalColumnPropertyValue[];
-  /**
-   * @minItems 0
-   */
-  "https://blockprotocol.org/@hash/types/property-type/table-local-row/"?: TableLocalRowPropertyValue[];
-  "https://blockprotocol.org/@hash/types/property-type/table-row-numbers-are-hidden/"?: TableRowNumbersAreHiddenPropertyValue;
-  "https://blockprotocol.org/@hash/types/property-type/table-rows-are-striped/"?: TableRowsAreStripedPropertyValue;
-  "https://blockprotocol.org/@blockprotocol/types/property-type/title/"?: TitlePropertyValue;
-};
 
 /**
  * Whether the table row numbers are hidden.

--- a/blocks/table/src/types/generated/block-entity.ts
+++ b/blocks/table/src/types/generated/block-entity.ts
@@ -13,10 +13,19 @@ export type BlockEntityOutgoingLinkAndTarget = TableBlockOutgoingLinkAndTarget;
  */
 export type Boolean = boolean;
 
+export type HasQuery = Entity<HasQueryProperties> & { linkData: LinkData };
+
+export type HasQueryOutgoingLinkAndTarget = never;
+
+export type HasQueryOutgoingLinksByLinkEntityTypeId = {};
+
 /**
- * An arbitrary ID
+ * The query that something has.
  */
-export type IDPropertyValue = Text;
+export type HasQueryProperties = HasQueryProperties1 & HasQueryProperties2;
+export type HasQueryProperties1 = LinkProperties;
+
+export type HasQueryProperties2 = {};
 
 export type Link = Entity<LinkProperties>;
 
@@ -26,23 +35,6 @@ export type LinkOutgoingLinksByLinkEntityTypeId = {};
 
 export type LinkProperties = {};
 
-export type LinkedQuery = Entity<LinkedQueryProperties> & {
-  linkData: LinkData;
-};
-
-export type LinkedQueryOutgoingLinkAndTarget = never;
-
-export type LinkedQueryOutgoingLinksByLinkEntityTypeId = {};
-
-/**
- * 123
- */
-export type LinkedQueryProperties = LinkedQueryProperties1 &
-  LinkedQueryProperties2;
-export type LinkedQueryProperties1 = LinkProperties;
-
-export type LinkedQueryProperties2 = {};
-
 /**
  * An opaque, untyped JSON object
  */
@@ -50,72 +42,51 @@ export type Object = {};
 
 export type Query = Entity<QueryProperties>;
 
-/**
- * 12312
- */
-export type QueryObjectPropertyValue = Object;
-
 export type QueryOutgoingLinkAndTarget = never;
 
 export type QueryOutgoingLinksByLinkEntityTypeId = {};
 
 export type QueryProperties = {
-  "https://blockprotocol-fwu7vped4.stage.hash.ai/@yk_hash/types/property-type/query-object/"?: QueryObjectPropertyValue;
-};
-
-export type TableBlock = Entity<TableBlockProperties>;
-
-export type TableBlockLinkedQueryLink = {
-  linkEntity: LinkedQuery;
-  rightEntity: Query;
-};
-
-export type TableBlockOutgoingLinkAndTarget = TableBlockLinkedQueryLink;
-
-export type TableBlockOutgoingLinksByLinkEntityTypeId = {
-  "https://blockprotocol-fwu7vped4.stage.hash.ai/@yk_hash/types/entity-type/linked-query/v/1": TableBlockLinkedQueryLink;
-};
-
-export type TableBlockProperties = {
-  "https://blockprotocol-fwu7vped4.stage.hash.ai/@yk_hash/types/property-type/table-header-row-is-hidden/"?: TableHeaderRowIsHiddenPropertyValue;
-  "https://blockprotocol-fwu7vped4.stage.hash.ai/@yk_hash/types/property-type/table-row-numbers-are-hidden/"?: TableRowNumbersAreHiddenPropertyValue;
-  "https://blockprotocol-fwu7vped4.stage.hash.ai/@yk_hash/types/property-type/table-rows-are-striped/"?: TableRowsAreStripedPropertyValue;
-  "https://blockprotocol-gkgdavns7.stage.hash.ai/@luisbett/types/property-type/title/"?: TitlePropertyValue;
-  /**
-   * @minItems 0
-   */
-  "https://blockprotocol-hk4sbmd9k.stage.hash.ai/@yusuf123/types/property-type/table-local-column/"?: TableLocalColumnPropertyValue[];
-  /**
-   * @minItems 0
-   */
-  "https://blockprotocol-hk4sbmd9k.stage.hash.ai/@yusuf123/types/property-type/table-local-row/"?: TableLocalRowPropertyValue[];
+  "https://blockprotocol.org/@hash/types/property-type/query/": QueryPropertyValue;
 };
 
 /**
- * 123
+ * The query for something.
+ */
+export type QueryPropertyValue = Object;
+
+export type TableBlock = Entity<TableBlockProperties>;
+
+export type TableBlockHasQueryLink = {
+  linkEntity: HasQuery;
+  rightEntity: Query;
+};
+
+export type TableBlockOutgoingLinkAndTarget = TableBlockHasQueryLink;
+
+export type TableBlockOutgoingLinksByLinkEntityTypeId = {
+  "https://blockprotocol.org/@hash/types/entity-type/has-query/v/1": TableBlockHasQueryLink;
+};
+
+export type TableBlockProperties = {
+  "https://blockprotocol.org/@blockprotocol/types/property-type/title/"?: TitlePropertyValue;
+  "https://blockprotocol.org/@hash/types/property-type/table-rows-are-striped/"?: TableRowsAreStripedPropertyValue;
+  "https://blockprotocol.org/@hash/types/property-type/table-header-row-is-hidden/"?: TableHeaderRowIsHiddenPropertyValue;
+  "https://blockprotocol.org/@hash/types/property-type/table-row-numbers-are-hidden/"?: TableRowNumbersAreHiddenPropertyValue;
+};
+
+/**
+ * Whether the table header row is hidden.
  */
 export type TableHeaderRowIsHiddenPropertyValue = Boolean;
 
 /**
- * Local column stored on "Table" block
- */
-export type TableLocalColumnPropertyValue = {
-  "https://blockprotocol-gkgdavns7.stage.hash.ai/@luisbett/types/property-type/title/"?: TitlePropertyValue;
-  "https://blockprotocol-gqpc30oin.stage.hash.ai/@nate/types/property-type/id/": IDPropertyValue;
-};
-
-/**
- * Local row stored on "Table" block
- */
-export type TableLocalRowPropertyValue = Object;
-
-/**
- * 123
+ * Whether the table row numbers are hidden.
  */
 export type TableRowNumbersAreHiddenPropertyValue = Boolean;
 
 /**
- * 123
+ * Whether the alternating table rows are zebra striped.
  */
 export type TableRowsAreStripedPropertyValue = Boolean;
 
@@ -125,6 +96,6 @@ export type TableRowsAreStripedPropertyValue = Boolean;
 export type Text = string;
 
 /**
- * The title of something
+ * The name given to something to identify it, generally associated with objects or inanimate things such as books, websites, songs, etc.
  */
 export type TitlePropertyValue = Text;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR allows for loading entities into the table block via the "Select data" modal.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-1472

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- updates the block to use `https://blockprotocol.org/@hash/types/entity-type/table/v/1` and related production types (previously it was using types created in a staging environment)
- adds the "Has Query" link to the block's type, so that the select data modal is displayed in the block's dropdown
- uses the property type's title to name columns, rather than using the slug from its base UrL
- cleaned up some misleading variable names

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

Manual testing.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Checkout the branch, and load the table block into a locally running instance of HASH
2. Try using the table block in its default mode, where data/columns are manually added
3. Try using the "Select data" modal via the block dropdown to select entities to be rendered in the table block. This should work for more entities of more than one type.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

https://github.com/hashintel/hash/assets/42802102/8ebeaf1b-05ef-415d-8683-5895798b8319



