### PR TITLE
H-1656: Show more precise timestamps than the day in the `Inbox > Notifications` table

### DIFF
--- a/apps/hash-frontend/src/pages/inbox.page.tsx
+++ b/apps/hash-frontend/src/pages/inbox.page.tsx
@@ -220,14 +220,14 @@ const NotificationRow: FunctionComponent<Notification> = (notification) => {
     const numberOfDaysAgo = differenceInDays(now, createdAt);
 
     if (numberOfDaysAgo < 7) {
-      return format(createdAt, "iiii"); // "Monday"
+      return format(createdAt, "h:mma iiii"); // "12:00AM Monday"
     }
 
     if (isThisYear(createdAt)) {
-      return format(createdAt, "MMMM do"); // "October 27th"
+      return format(createdAt, "h:mma MMMM do"); // "12:00AM October 27th"
     }
 
-    return format(createdAt, "MMMM do, yyyy"); // "December 24th, 2022"
+    return format(createdAt, "h:mma MMMM do, yyyy"); // "12:00AM December 24th, 2022"
   }, [createdAt]);
 
   return (

--- a/apps/hash-frontend/src/shared/notifications-context.tsx
+++ b/apps/hash-frontend/src/shared/notifications-context.tsx
@@ -260,7 +260,9 @@ export const NotificationsContextProvider: FunctionComponent<
   const previouslyFetchedNotificationsRef = useRef<Notification[] | null>(null);
 
   const notifications = useMemo<Notification[] | undefined>(() => {
-    if (
+    if (notificationEntities && notificationEntities.length === 0) {
+      return [];
+    } else if (
       !outgoingLinksSubgraph ||
       !notificationEntities ||
       !notificationRevisionsData ||


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR adds the time of day to the nearest minute when a notification was created to the notification timestamp, when the notification was created more than a day ago.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-1656

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- fixes the empty state of the notifications page (previously was loading indefinitely when there are 0 notifications)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

Manual testing.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Easiest way to test this is to uncomment the various conditions that determine how the timestamp is formatted for an existing notification.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

When the notification has been created less than a minute ago, displays:

![image](https://github.com/hashintel/hash/assets/42802102/1c10e9e7-452a-42bf-a84c-5d815aff8750)


More than a minute ago (will include hours if more than an hour ago):

![image](https://github.com/hashintel/hash/assets/42802102/637630a5-570b-46cd-a6b9-40638cc2b2dc)

More than a day ago:

![image](https://github.com/hashintel/hash/assets/42802102/c027e777-6478-4047-b5ec-6745e41c5a78)

More than 7 days ago:

![image](https://github.com/hashintel/hash/assets/42802102/81f76b68-212f-4bcc-874a-12c50958dcb9)

More than a year ago:
![image](https://github.com/hashintel/hash/assets/42802102/84b9d1dc-e346-4c2e-ae46-6724d13138a2)

