### PR TITLE
H-1735: Validate more custom data types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,6 +655,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "email_address"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2153bd83ebc09db15bcbdc3e2194d901804952e3dc96967e1cd3b0c5c32d112"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3376,6 +3382,7 @@ dependencies = [
 name = "validation"
 version = "0.0.0"
 dependencies = [
+ "email_address",
  "error-stack",
  "graph-test-data",
  "graph-types",
@@ -3383,6 +3390,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "type-system",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "b
 
 # Shared third-party dependencies
 bytes = "1.5.0"
+email_address = { version = "0.2.4", default-features = false }
 futures = { version = "0.3.29", default-features = false }
 postgres-types = { version = "0.2.6", default-features = false }
 serde = { version = "1.0.193", default-features = false }
@@ -56,6 +57,7 @@ tokio = { version = "1.35.0", default-features = false }
 tokio-util = { version = "0.7.10", default-features = false }
 tracing = "0.1.40"
 utoipa = "4.1.0"
+url = { version = "2.5.0", default-features = false }
 uuid = { version = "1.6.1", default-features = false }
 
 [profile.production]

--- a/libs/@local/hash-validation/Cargo.toml
+++ b/libs/@local/hash-validation/Cargo.toml
@@ -13,6 +13,8 @@ type-system.workspace = true
 
 thiserror = "1.0.51"
 serde_json = { version = "1.0.108" }
+url = { workspace = true }
+email_address = { workspace = true }
 
 [dev-dependencies]
 graph-test-data.workspace = true

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -315,7 +315,7 @@ mod tests {
 
     pub(crate) async fn validate_data(
         data: JsonValue,
-        data_type: &'static str,
+        data_type: &str,
         profile: ValidationProfile,
     ) -> Result<(), Report<DataValidationError>> {
         install_error_stack_hooks();


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Add support for some more data type validations:
- `minimum`
- `maximum`
- `exclusiveMinimum`
- `exclusiveMaximum`
- `multipleOf`
- `format = "uri"`
- `format = "email"`