### PR TITLE
H-1736: Run CI if the root package changed

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,8 @@ jobs:
       - name: Determine changed packages
         id: packages
         run: |
-          PACKAGES=$(turbo run lint --dry-run=json --filter '...[HEAD^]' \
+          FILTER=$(turbo run lint --dry-run=json --filter '...[HEAD^]' | jq -e '.packages | contains(["//"])' > /dev/null && echo '' || echo '--filter ...[HEAD^]')
+          PACKAGES=$(sh -c "turbo run lint --dry-run=json $FILTER" \
             | jq '.tasks[]' \
             | jq 'select(.task == "lint")' \
             | jq --compact-output --slurp '{ package: [.[].package] | unique, include: [( .[] | {package: .package, directory: .directory })] | unique }')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,17 +37,20 @@ jobs:
       - name: Determine changed packages
         id: packages
         run: |
-          UNIT_TEST_PACKAGES=$(turbo run test:unit --dry-run=json --filter '...[HEAD^]' \
+          UNIT_TEST_FILTER=$(turbo run test:unit --dry-run=json --filter '...[HEAD^]' | jq -e '.packages | contains(["//"])' > /dev/null && echo '' || echo '--filter ...[HEAD^]')
+          UNIT_TEST_PACKAGES=$(sh -c "turbo run test:unit --dry-run=json $UNIT_TEST_FILTER" \
             | jq '.tasks[]' \
             | jq 'select(.task == "test:unit" and .command != "<NONEXISTENT>")' \
             | jq --compact-output --slurp '{ package: [.[].package] | unique, include: [( .[] | {package: .package, directory: .directory })] | unique }')
 
-          INTEGRATION_TEST_TASKS=$(turbo run test:integration --dry-run=json --filter '...[HEAD^]' | jq -c '.tasks[]')
+          INTEGRATION_TEST_FILTER=$(turbo run test:integration --dry-run=json --filter '...[HEAD^]' | jq -e '.packages | contains(["//"])' > /dev/null && echo '' || echo '--filter ...[HEAD^]')
+          INTEGRATION_TEST_TASKS=$(sh -c "turbo run test:integration --dry-run=json $INTEGRATION_TEST_FILTER" | jq -c '.tasks[]')
           INTEGRATION_TEST_PACKAGES=$(echo "$INTEGRATION_TEST_TASKS" \
             | jq 'select(.task == "test:integration" and .command != "<NONEXISTENT>")' \
             | jq --compact-output --slurp '{ package: [.[].package] | unique, include: [( .[] | {package: .package, directory: .directory })] | unique }')
 
-          SYSTEM_TEST_PACKAGES=$(turbo run test:system --dry-run=json --filter '...[HEAD^]' \
+          SYSTEM_TEST_FILTER=$(turbo run test:system --dry-run=json --filter '...[HEAD^]' | jq -e '.packages | contains(["//"])' > /dev/null && echo '' || echo '--filter ...[HEAD^]')
+          SYSTEM_TEST_PACKAGES=$(sh -c "turbo run test:system --dry-run=json $SYSTEM_TEST_FILTER" \
             | jq '.tasks[]' \
             | jq 'select(.task == "test:system" and .command != "<NONEXISTENT>")' \
             | jq --compact-output --slurp '{ package: [.[].package] | unique, include: [( .[] | {package: .package, directory: .directory })] | unique }')


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

If a global file changed, the CI does not run. As `turbo` does not recognize changes in `globalDependencies`, this only filters CI runs if the root package did not change.

If the CI of this PR runs we're good.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this