### PR TITLE
H-1737: Make sure Backend is deployed when it changed

### DIFF
--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -12,9 +12,7 @@ on:
       - "apps/hash-api/**"
       - "apps/hash-external-services/temporal/**"
       - "apps/hash-external-services/kratos/**"
-      - "libs/@local/hash-backend-utils-utils/**"
-      - "libs/@local/hash-isomorphic-utils/**"
-      - "libs/@local/status/**"
+      - "libs/@local/**"
       - "infra/docker/api/prod/**"
 
 env:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The BE deployment is not necessarily executed on pushes, this adds more possible paths to the CD.