### PR TITLE
H-1711: Allow inserting custom data types as web admin

### DIFF
--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -141,22 +141,15 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 
 {
   "ownedById": "{{account_id}}",
-  "schema": [
-    {
-      "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
-      "kind": "dataType",
-      "$id": "http://localhost:3000/@alice/types/data-type/text/v/1",
-      "title": "Text",
-      "type": "string"
-    },
-    {
-      "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
-      "kind": "dataType",
-      "$id": "http://localhost:3000/@alice/types/data-type/number/v/1",
-      "title": "Number",
-      "type": "number"
-    }
-  ],
+  "schema":
+  {
+    "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
+    "kind": "dataType",
+    "$id": "http://localhost:3000/@alice/types/data-type/meter/v/1",
+    "title": "Meter",
+    "type": "number",
+    "minimum": 0
+  },
   "relationships": [{
     "relation": "viewer",
     "subject": {
@@ -167,8 +160,9 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 
 > {%
     client.test("status", function() {
-        client.assert(response.status === 403, "Response status is not 200");
+        client.assert(response.status === 200, "Response status is not 200");
     });
+    client.global.set("meter_data_type_id", `${response.body.recordId.baseUrl}v/${response.body.recordId.version}`);
 %}
 
 ### Insert external data types
@@ -272,20 +266,21 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     });
 %}
 
-### Update Text data type
+### Update Meter data type
 PUT http://127.0.0.1:4000/data-types
 Content-Type: application/json
 Accept: application/json
 X-Authenticated-User-Actor-Id: {{account_id}}
 
 {
-  "typeToUpdate": "http://localhost:3000/@alice/types/data-type/text/v/1",
+  "typeToUpdate": "{{meter_data_type_id}}",
   "schema": {
     "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
     "kind": "dataType",
-    "title": "Text",
-    "description": "An ordered sequence of characters",
-    "type": "string"
+    "title": "Meter",
+    "type": "number",
+    "description": "A unit of length equal to 100 centimeters",
+    "minimum": 0
   },
   "relationships": [{
     "relation": "viewer",
@@ -297,8 +292,9 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 
 > {%
     client.test("status", function() {
-        client.assert(response.status === 403, "Response status is not 200");
+        client.assert(response.status === 200, "Response status is not 200");
     });
+    client.global.set("meter_data_type_id", `${response.body.recordId.baseUrl}v/${response.body.recordId.version}`);
 %}
 
 ### Insert Name property type
@@ -334,6 +330,41 @@ X-Authenticated-User-Actor-Id: {{account_id}}
         client.assert(response.status === 200, "Response status is not 200");
     });
     client.global.set("person_property_type_id", `${response.body.recordId.baseUrl}v/${response.body.recordId.version}`);
+%}
+
+### Insert height property type
+POST http://127.0.0.1:4000/property-types
+Content-Type: application/json
+Accept: application/json
+X-Authenticated-User-Actor-Id: {{account_id}}
+
+{
+  "ownedById": "{{account_id}}",
+  "schema": {
+    "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type",
+    "kind": "propertyType",
+    "$id": "http://localhost:3000/@alice/types/property-type/height/v/1",
+    "title": "Height",
+    "oneOf": [
+      {
+        "$ref": "{{meter_data_type_id}}"
+      }
+    ]
+  },
+  "relationships": [{
+    "relation": "setting",
+    "subject": {
+      "kind": "setting",
+      "subjectId": "updateFromWeb"
+    }
+  }]
+}
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+    });
+    client.global.set("height_property_type_id", `${response.body.recordId.baseUrl}v/${response.body.recordId.version}`);
 %}
 
 ### Get Name property type
@@ -501,7 +532,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
-        client.assert(response.body.roots.length === 1, "Unexpected number of property types");
+        client.assert(response.body.roots.length === 2, "Unexpected number of property types");
     });
 %}
 
@@ -799,6 +830,9 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     "properties": {
       "http://localhost:3000/@alice/types/property-type/name/": {
         "$ref": "http://localhost:3000/@alice/types/property-type/name/v/2"
+      },
+      "http://localhost:3000/@alice/types/property-type/height/": {
+        "$ref": "http://localhost:3000/@alice/types/property-type/height/v/1"
       }
     },
     "links": {
@@ -1553,7 +1587,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 {
   "ownedById": "{{account_id}}",
   "properties": {
-    "http://localhost:3000/@alice/types/property-type/name/": "Bob"
+    "http://localhost:3000/@alice/types/property-type/name/": "Bob",
+    "http://localhost:3000/@alice/types/property-type/height/": 1.8
   },
   "administrator": "{{account_id}}",
   "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/2",

--- a/libs/@local/hash-authorization/schemas/v1__initial_schema.zed
+++ b/libs/@local/hash-authorization/schemas/v1__initial_schema.zed
@@ -53,8 +53,8 @@ definition graph/web {
 	// Data types
 	relation level_00_data_type_viewer: graph/account:*
 
-	permission create_data_type = administrator - administrator
-	permission update_data_type = administrator - administrator
+	permission create_data_type = administrator
+	permission update_data_type = administrator
 	permission view_data_type = update_data_type + level_00_data_type_viewer
 }
 

--- a/tests/hash-backend-integration/src/tests/graph/ontology/primitive/data-type.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/ontology/primitive/data-type.test.ts
@@ -1,12 +1,17 @@
 import { deleteKratosIdentity } from "@apps/hash-api/src/auth/ory-kratos";
 import { ImpureGraphContext } from "@apps/hash-api/src/graph/context-types";
 import { ensureSystemGraphIsInitialized } from "@apps/hash-api/src/graph/ensure-system-graph-is-initialized";
-import { User } from "@apps/hash-api/src/graph/knowledge/system-types/user";
+import { Org } from "@apps/hash-api/src/graph/knowledge/system-types/org";
+import {
+  joinOrg,
+  User,
+} from "@apps/hash-api/src/graph/knowledge/system-types/user";
 import {
   createDataType,
   getDataTypeById,
   updateDataType,
 } from "@apps/hash-api/src/graph/ontology/primitive/data-type";
+import { modifyWebAuthorizationRelationships } from "@apps/hash-api/src/graph/ontology/primitive/util";
 import { TypeSystemInitializer } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
 import { ConstructDataTypeParams } from "@local/hash-isomorphic-utils/types";
@@ -19,6 +24,7 @@ import {
 import { resetGraph } from "../../../test-server";
 import {
   createTestImpureGraphContext,
+  createTestOrg,
   createTestUser,
   textDataTypeId,
 } from "../../../util";
@@ -33,6 +39,7 @@ const logger = new Logger({
 
 const graphContext: ImpureGraphContext = createTestImpureGraphContext();
 
+let testOrg: Org;
 let testUser: User;
 let testUser2: User;
 
@@ -47,6 +54,37 @@ beforeAll(async () => {
 
   testUser = await createTestUser(graphContext, "data-type-test-1", logger);
   testUser2 = await createTestUser(graphContext, "data-type-test-2", logger);
+
+  const authentication = { actorId: testUser.accountId };
+
+  testOrg = await createTestOrg(
+    graphContext,
+    authentication,
+    "propertytestorg",
+    logger,
+  );
+  await joinOrg(graphContext, authentication, {
+    userEntityId: testUser2.entity.metadata.recordId.entityId,
+    orgEntityId: testOrg.entity.metadata.recordId.entityId,
+  });
+
+  // Currently, full access permissions are required to update a data type
+  await modifyWebAuthorizationRelationships(graphContext, authentication, [
+    {
+      relationship: {
+        resource: {
+          kind: "web",
+          resourceId: testOrg.accountGroupId as OwnedById,
+        },
+        relation: "owner",
+        subject: {
+          kind: "account",
+          subjectId: testUser2.accountId,
+        },
+      },
+      operation: "create",
+    },
+  ]);
 });
 
 afterAll(async () => {
@@ -63,11 +101,11 @@ afterAll(async () => {
 describe("Data type CRU", () => {
   let createdDataType: DataTypeWithMetadata;
 
-  it.skip("can create a data type", async () => {
+  it("can create a data type", async () => {
     const authentication = { actorId: testUser.accountId };
 
     createdDataType = await createDataType(graphContext, authentication, {
-      ownedById: testUser.accountId as OwnedById,
+      ownedById: testOrg.accountGroupId as OwnedById,
       schema: dataTypeSchema,
       relationships: [{ relation: "viewer", subject: { kind: "public" } }],
     });
@@ -88,7 +126,7 @@ describe("Data type CRU", () => {
   });
 
   const updatedTitle = "New text!";
-  it.skip("can update a data type", async () => {
+  it("can update a data type", async () => {
     expect(
       isOwnedOntologyElementMetadata(createdDataType.metadata) &&
         createdDataType.metadata.custom.provenance.recordCreatedById,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We don't expose the functionality in the frontend but we need to allow web admins to insert new data types.

## 🔍 What does this change?

- Allow `administrator` relations to insert/update data types
- Adjust HTTP and BE tests

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph