### PR TITLE
H-1764: Allow `label` property on data types

### DIFF
--- a/libs/@local/hash-validation/src/data_type.rs
+++ b/libs/@local/hash-validation/src/data_type.rs
@@ -332,6 +332,9 @@ impl<P: Sync> Schema<JsonValue, P> for DataType {
                 "minimum" | "maximum" | "exclusiveMinimum" | "exclusiveMaximum" | "multipleOf"
                     if self.json_type() == "integer" || self.json_type() == "number" => {}
                 "format" if self.json_type() == "string" => {}
+                "label" => {
+                    // Label does not have to be validated
+                }
                 _ => bail!(
                     Report::new(DataTypeConstraint::UnknownConstraint {
                         key: additional_key.to_owned(),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `label` property on data type does not have to be validated