### PR TITLE
H-1783: Use superuser permissions to migrate graph database

### DIFF
--- a/infra/terraform/hash/hash_application/main.tf
+++ b/infra/terraform/hash/hash_application/main.tf
@@ -15,7 +15,7 @@ locals {
   graph_task_defs = [
     {
       task_def = local.graph_migration_container_def
-      env_vars = aws_ssm_parameter.graph_env_vars
+      env_vars = aws_ssm_parameter.graph_migration_env_vars
       ecr_arn  = var.graph_image.ecr_arn
     },
     {

--- a/infra/terraform/hash/hash_application/variables.tf
+++ b/infra/terraform/hash/hash_application/variables.tf
@@ -65,6 +65,15 @@ variable "graph_image" {
   description = "URL of the docker image for the Graph service"
 }
 
+variable "graph_migration_env_vars" {
+  type = list(object({
+    name   = string,
+    secret = bool,
+    value  = string
+  }))
+  description = "A list of environment variables to save as system parameters and inject into the Graph migration script"
+}
+
 variable "graph_env_vars" {
   type = list(object({
     name   = string,

--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -219,6 +219,21 @@ module "application" {
   worker_memory                = 512
   ses_verified_domain_identity = var.ses_verified_domain_identity
   graph_image                  = module.graph_ecr
+  graph_migration_env_vars               = concat(var.hash_graph_env_vars, [
+    { name = "HASH_GRAPH_PG_USER", secret = false, value = "superuser" },
+    {
+      name  = "HASH_GRAPH_PG_PASSWORD", secret = true,
+      value = sensitive(data.vault_kv_secret_v2.secrets.data["pg_superuser_password"])
+    },
+    { name = "HASH_GRAPH_PG_HOST", secret = false, value = module.postgres.pg_host },
+    { name = "HASH_GRAPH_PG_PORT", secret = false, value = module.postgres.pg_port },
+    { name = "HASH_GRAPH_PG_DATABASE", secret = false, value = "graph" },
+    {
+      name  = "HASH_GRAPH_SENTRY_DSN", secret = true,
+      value = sensitive(data.vault_kv_secret_v2.secrets.data["graph_sentry_dsn"])
+    },
+    { name = "HASH_GRAPH_SENTRY_ENVIRONMENT", secret = false, value = "production" },
+  ])
   graph_env_vars               = concat(var.hash_graph_env_vars, [
     { name = "HASH_GRAPH_PG_USER", secret = false, value = "graph" },
     {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Migration script require admin permissions, e.g. when creating extensions. This will change the AWS instance to use the `superuser` for migration instead of the default user.

## 🔍 What does this change?

- Use a new set of environment variables for the migration container

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing
### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change
### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph