### PR TITLE
H-1762: Retain order returned from Postgres in `roots`

### DIFF
--- a/apps/hash-graph/libs/api/src/rest/utoipa_typedef/subgraph/mod.rs
+++ b/apps/hash-graph/libs/api/src/rest/utoipa_typedef/subgraph/mod.rs
@@ -29,7 +29,7 @@ pub(crate) struct Subgraph {
 impl From<graph::subgraph::Subgraph> for Subgraph {
     fn from(subgraph: graph::subgraph::Subgraph) -> Self {
         Self {
-            roots: subgraph.roots.into_iter().collect(),
+            roots: subgraph.roots,
             vertices: subgraph.vertices.into(),
             edges: subgraph.edges.into(),
             depths: subgraph.depths,

--- a/apps/hash-graph/libs/graph/src/subgraph/mod.rs
+++ b/apps/hash-graph/libs/graph/src/subgraph/mod.rs
@@ -5,10 +5,7 @@ pub mod temporal_axes;
 pub mod vertices;
 
 use std::{
-    collections::{
-        hash_map::{RandomState, RawEntryMut},
-        HashSet,
-    },
+    collections::hash_map::{RandomState, RawEntryMut},
     hash::Hash,
 };
 
@@ -28,7 +25,7 @@ use crate::{
 
 #[derive(Debug)]
 pub struct Subgraph {
-    pub roots: HashSet<GraphElementVertexId>,
+    pub roots: Vec<GraphElementVertexId>,
     pub vertices: Vertices,
     pub edges: Edges,
     pub depths: GraphResolveDepths,
@@ -43,7 +40,7 @@ impl Subgraph {
         resolved_temporal_axes: QueryTemporalAxes,
     ) -> Self {
         Self {
-            roots: HashSet::new(),
+            roots: Vec::new(),
             vertices: Vertices::default(),
             edges: Edges::default(),
             depths,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Even if we sort the returned values in Postgres the roots in the subgraph are unordered. This means that any sorting is pointless and results in unexpected values when using pagination.

## 🔍 What does this change?

- retain the order

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph