### PR TITLE
H-1759, H-1793: Handle incomplete users in plugin, fix entity labelling bug

### DIFF
--- a/apps/hash-api/src/index.ts
+++ b/apps/hash-api/src/index.ts
@@ -367,6 +367,19 @@ const main = async () => {
     })(req, res, next);
   });
 
+  app.use((req, _res, next) => {
+    if (req.path !== "/graphql") {
+      if (!req.user?.isAccountSignupComplete) {
+        /**
+         * Only GraphQL requests need to be provided with incomplete users, to allow them to complete signup
+         *   – otherwise they should be treated as anonymous requests.
+         */
+        delete req.user;
+      }
+    }
+    next();
+  });
+
   // Integrations
   app.get("/oauth/linear", rateLimiter, oAuthLinear);
   app.get("/oauth/linear/callback", rateLimiter, oAuthLinearCallback);

--- a/apps/hash-frontend/src/blocks/use-fetch-block-subgraph.ts
+++ b/apps/hash-frontend/src/blocks/use-fetch-block-subgraph.ts
@@ -73,7 +73,7 @@ export const useFetchBlockSubgraph = (): ((
         const placeholderEntity: Entity = {
           metadata: {
             recordId: {
-              entityId: "placeholder-account%entity-id-not-set" as EntityId,
+              entityId: "placeholder-account~entity-id-not-set" as EntityId,
               editionId: now,
             },
             entityTypeId: blockEntityTypeId,

--- a/apps/plugin-browser/package.json
+++ b/apps/plugin-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apps/plugin-browser",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "description": "A browser extension for gathering info from the web into your HASH account.",
   "repository": {

--- a/apps/plugin-browser/src/pages/options/options-contents.tsx
+++ b/apps/plugin-browser/src/pages/options/options-contents.tsx
@@ -68,8 +68,7 @@ export const OptionsContents = () => {
                       fontSize: 20,
                     }}
                   >
-                    Welcome,{" "}
-                    {user.properties.preferredName ?? user.properties.email}!
+                    Welcome, {user.properties.preferredName}
                   </Typography>
                   <Typography
                     sx={{

--- a/apps/plugin-browser/src/pages/popup/popup-contents.tsx
+++ b/apps/plugin-browser/src/pages/popup/popup-contents.tsx
@@ -45,8 +45,6 @@ export const PopupContents = () => {
 
   const loading = userLoading || !popupTabLoaded;
 
-  console.log({ userLoading });
-
   return (
     <ThemeProvider theme={theme}>
       <Box

--- a/apps/plugin-browser/src/pages/popup/popup-contents.tsx
+++ b/apps/plugin-browser/src/pages/popup/popup-contents.tsx
@@ -45,6 +45,8 @@ export const PopupContents = () => {
 
   const loading = userLoading || !popupTabLoaded;
 
+  console.log({ userLoading });
+
   return (
     <ThemeProvider theme={theme}>
       <Box

--- a/apps/plugin-browser/src/pages/popup/popup-contents/action-center.tsx
+++ b/apps/plugin-browser/src/pages/popup/popup-contents/action-center.tsx
@@ -141,8 +141,7 @@ export const ActionCenter = ({
               ? `${FRONTEND_ORIGIN}/@${user.properties.shortname}`
               : undefined
           }
-          // @todo handle users who haven't signed up
-          name={user.properties.preferredName ?? "?"}
+          name={user.properties.preferredName}
         />
       </Stack>
       <Box sx={{ maxHeight: 545, overflowY: "scroll" }}>

--- a/apps/plugin-browser/src/pages/popup/popup-contents/action-center/shared/select-web-target/web-selector.tsx
+++ b/apps/plugin-browser/src/pages/popup/popup-contents/action-center/shared/select-web-target/web-selector.tsx
@@ -63,12 +63,12 @@ export const WebSelector = ({
         // Creating the component here reduces loading state in the dropdown
         <Avatar
           avatar={user.avatar}
-          name={user.properties.preferredName ?? "?"}
+          name={user.properties.preferredName}
           size={16}
         />
       ),
       label: "My web",
-      name: user.properties.preferredName ?? "?",
+      name: user.properties.preferredName,
       value: user.webOwnedById,
     },
     ...user.orgs.map((org) => ({

--- a/apps/plugin-browser/src/pages/shared/sentry.ts
+++ b/apps/plugin-browser/src/pages/shared/sentry.ts
@@ -1,6 +1,6 @@
-import { Simplified } from "@local/hash-isomorphic-utils/simplify-properties";
-import { User } from "@local/hash-isomorphic-utils/system-types/shared";
 import * as Sentry from "@sentry/browser";
+
+import { LocalStorage } from "../../shared/storage";
 
 /**
  * Initialize Sentry. Run this as early as possible in the app.
@@ -21,7 +21,7 @@ export const initializeSentry = () =>
     tracesSampleRate: 1.0, // Capture 100% of the transactions
   });
 
-export const setSentryUser = (user?: Simplified<User> | null) => {
+export const setSentryUser = (user?: LocalStorage["user"] | null) => {
   Sentry.configureScope((scope) => {
     const sentryUser = scope.getUser();
     if (!user && sentryUser) {

--- a/apps/plugin-browser/src/shared/get-user.ts
+++ b/apps/plugin-browser/src/shared/get-user.ts
@@ -64,6 +64,15 @@ export const getUser = (): Promise<LocalStorage["user"] | null> => {
 
       const user = getRoots(subgraph)[0];
 
+      const { email, shortname, preferredName } = simplifyProperties(
+        user.properties as UserProperties,
+      );
+
+      if (!shortname || !preferredName) {
+        // User has not completed signup
+        return null;
+      }
+
       const userAvatar = getAvatarForEntity(
         subgraph,
         user.metadata.recordId.entityId,
@@ -101,7 +110,11 @@ export const getUser = (): Promise<LocalStorage["user"] | null> => {
         ...user,
         avatar: userAvatar,
         orgs,
-        properties: simplifyProperties(user.properties as UserProperties),
+        properties: {
+          email,
+          preferredName,
+          shortname,
+        },
         webOwnedById: getOwnedByIdFromEntityId(user.metadata.recordId.entityId),
       };
     })

--- a/apps/plugin-browser/src/shared/storage.ts
+++ b/apps/plugin-browser/src/shared/storage.ts
@@ -3,7 +3,10 @@ import type {
   InferenceModelName,
   InferEntitiesReturn,
 } from "@local/hash-isomorphic-utils/ai-inference-types";
-import type { Simplified } from "@local/hash-isomorphic-utils/simplify-properties";
+import type {
+  SimpleProperties,
+  Simplified,
+} from "@local/hash-isomorphic-utils/simplify-properties";
 import type {
   ImageProperties,
   OrganizationProperties,
@@ -49,7 +52,16 @@ export type PageEntityInference = InferenceStatus & {
   trigger: "passive" | "user";
 };
 
-type UserAndLinkedData = Simplified<Entity<UserProperties>> & {
+type SimplifiedUser = Entity & {
+  properties: Required<
+    Pick<
+      SimpleProperties<UserProperties>,
+      "email" | "preferredName" | "shortname"
+    >
+  >;
+};
+
+type UserAndLinkedData = SimplifiedUser & {
   avatar?: Entity<ImageProperties>;
   orgs: (Simplified<Entity<OrganizationProperties>> & {
     avatar?: Entity<ImageProperties>;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

H-1759: 
- Account for users who haven't completed signup in the plugin, and the AI inference websocket, by treating them as non-users

H-1793:
- Fix bug when labelling entities with a placeholder entity id by correcting the delimiter in the placeholder id. This bug was exposed by the additional of `generateEntityLabel` to the entity editor modal in #3759. The modal component (at least the wrapper) is mounted as long as an entity subgraph is present, but the subgraph might contain a placeholder entity, for new paragraph blocks. This was crashing because the `extractEntityUuidFromEntityId` function expects the entity id to have a `~` delimiter, and the placeholder id for new block entiites still used the old `%` delimiter (between the ownedById and uuid).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] requires publishing a new test version of the plugin, but https://itero.plasmo.com is currently crashing (reported on Discord)

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Labelling crash: check that you can insert a new block in a page without it crashing
Incomplete users: set `USER_EMAIL_ALLOW_LIST=[]`, create an incomplete user, check plugin shows 'not logged in' screen
