### PR TITLE
H-1797: Improve entity graph

### DIFF
--- a/apps/hash-frontend/src/pages/shared/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table.tsx
@@ -376,7 +376,7 @@ export const EntitiesTable: FunctionComponent<{
                 entityTypeBaseUrl
               : entityTypeId
                 ? entityTypeId === entity.metadata.entityTypeId
-                : false
+                : true
           }
           filterEntity={(entity) =>
             filterState.includeGlobal

--- a/libs/@hashintel/block-design-system/src/entities-graph-chart.tsx
+++ b/libs/@hashintel/block-design-system/src/entities-graph-chart.tsx
@@ -9,7 +9,7 @@ import { Chart, EChart, ECOption } from "@hashintel/design-system";
 // eslint-disable-next-line no-restricted-imports
 import { generateEntityLabel as hashGenerateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import { BoxProps, useTheme } from "@mui/material";
-import { FunctionComponent, useEffect, useMemo, useRef, useState } from "react";
+import { FunctionComponent, useEffect, useMemo, useState } from "react";
 
 const generateEntityLabel = (
   subgraph: Subgraph<EntityRootType>,
@@ -95,7 +95,7 @@ export const EntitiesGraphChart: FunctionComponent<{
     };
   }, [chart, entities, onEntityClick]);
 
-  const chartInitialized = useRef(false);
+  const chartInitialized = !!chart;
 
   const theme = useTheme();
 
@@ -167,6 +167,9 @@ export const EntitiesGraphChart: FunctionComponent<{
       series: {
         roam: true,
         draggable: true,
+        force: {
+          layoutAnimation: chartInitialized,
+        },
         data: nonLinkEntities?.map((entity) => ({
           name: generateEntityLabel(subgraph!, entity),
           id: entity.metadata.recordId.entityId,
@@ -201,7 +204,7 @@ export const EntitiesGraphChart: FunctionComponent<{
         type: "graph",
         layout: "force",
         // Hack for only setting the zoom if the chart hasn't already been initialized
-        ...(chartInitialized.current ? {} : { zoom: 5 }),
+        ...(chartInitialized ? {} : { zoom: 5 }),
       },
     };
   }, [
@@ -211,6 +214,7 @@ export const EntitiesGraphChart: FunctionComponent<{
     nonLinkEntities,
     isPrimaryEntity,
     theme,
+    chartInitialized,
   ]);
 
   return (
@@ -218,7 +222,6 @@ export const EntitiesGraphChart: FunctionComponent<{
       sx={sx}
       onChartInitialized={(initializedChart) => {
         setChart(initializedChart);
-        chartInitialized.current = true;
       }}
       options={eChartOptions}
     />

--- a/libs/@hashintel/design-system/src/e-chart.tsx
+++ b/libs/@hashintel/design-system/src/e-chart.tsx
@@ -72,7 +72,7 @@ export const EChart: FunctionComponent<GraphProps> = ({
 
   useEffect(() => {
     if (chart) {
-      chart.setOption(options);
+      chart.setOption(options, false);
     }
   }, [chart, options]);
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR makes some small improvements to the entities graph:

- prevents initial animation from playing by disabling `layoutAnimation` on the initial echarts configuration, and subsequently setting `layoutAnimation` back to `true`
- on the `/entities` page render all nodes as primary nodes (no reduced opacity)

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-1797

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **block** that will need publishing via GitHub action once merged

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

- republish `Graph` block to account for changes in the entities graph component
- hide node/edge labels when zooming out of the entities graph (H-1803)


## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

Manual testing

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Go to the `/entities` page, and look at the graph visualisation.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

<details>
  <summary>Previously</summary>

  https://github.com/hashintel/hash/assets/42802102/81c40ed7-b095-478d-8c4e-b8cb13fea7f6

</details>


<details>
  <summary>Now</summary>

  https://github.com/hashintel/hash/assets/42802102/9c972e02-9d39-4690-a74b-648dc7a95fb4

</details>






