### PR TITLE
H-1598: Fix handling of links to externally-hosted types

### DIFF
--- a/apps/hash-api/src/graph/ontology/primitive/util.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/util.ts
@@ -20,6 +20,7 @@ export const isExternalTypeId = (typeId: VersionedUrl) =>
   !typeId.startsWith(frontendUrl) &&
   // To be removed in H-1172: Temporary provision to serve types with a https://hash.ai URL from https://app.hash.ai
   !(
+    process.env.NEXT_PUBLIC_SELF_HOSTED_HASH !== "true" &&
     ["https://app.hash.ai", "http://localhost:3000"].includes(frontendUrl) &&
     new URL(typeId).hostname === "hash.ai"
   );

--- a/apps/hash-frontend/next.config.js
+++ b/apps/hash-frontend/next.config.js
@@ -36,6 +36,8 @@ process.env.NEXT_PUBLIC_SENTRY_DSN = process.env.SENTRY_DSN ?? "";
 process.env.NEXT_PUBLIC_SENTRY_REPLAY_SESSION_SAMPLE_RATE =
   process.env.SENTRY_REPLAY_SESSION_SAMPLE_RATE ?? 1;
 
+process.env.NEXT_PUBLIC_SELF_HOSTED_HASH = process.env.SELF_HOSTED_HASH ?? "";
+
 const apiUrl = process.env.NEXT_PUBLIC_API_ORIGIN ?? "http://localhost:5001";
 
 const apiDomain = new URL(apiUrl).hostname;

--- a/apps/hash-frontend/src/shared/generate-link-parameters.ts
+++ b/apps/hash-frontend/src/shared/generate-link-parameters.ts
@@ -72,7 +72,9 @@ export const generateLinkParameters = (
          * The exceptions are the /contact and /discord routes which actually reside at https://hash.ai
          * @todo when implementing H-1172, just use the href here
          */
-        pathname.startsWith("/discord") || pathname.startsWith("/contact")
+        isExternal ||
+        pathname.startsWith("/discord") ||
+        pathname.startsWith("/contact")
           ? href
           : `${pathname}${paramsString ? `?${paramsString}` : ""}`,
     };

--- a/apps/hash-frontend/src/shared/generate-link-parameters.ts
+++ b/apps/hash-frontend/src/shared/generate-link-parameters.ts
@@ -50,8 +50,8 @@ export const generateLinkParameters = (
     sanitizedHref.split("?")[0]!.match(typeUrlRegExp) ?? [];
 
   if (typeBaseUrl) {
-    if (isExternal) {
-      // If it's an external type, use the type route for loading external types
+    if (isExternal && typeBaseUrl.includes("/entity-type/")) {
+      // If it's an external entity type, use the type route for loading external types
       const base64EncodedBaseUrl = btoa(typeBaseUrl);
       return {
         isExternal: false, // it's an external type but we're using an internal route

--- a/apps/hash-frontend/src/shared/is-href-external.ts
+++ b/apps/hash-frontend/src/shared/is-href-external.ts
@@ -9,6 +9,7 @@ export const isHrefExternal = (href: string) =>
   !href.startsWith(frontendUrl) &&
   // To be removed in H-1172: Temporary provision to serve types with a https://hash.ai URL from https://app.hash.ai
   !(
+    process.env.NEXT_PUBLIC_SELF_HOSTED_HASH !== "true" &&
     ["https://app.hash.ai", "http://localhost:3000"].includes(frontendUrl) &&
     (href.startsWith("#") ||
       href.startsWith("/") ||


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes a couple of bugs related to links to external types, i.e. types which originate from instances of HASH other than the one running:
1. Respect `SELF_HOSTED_HASH` environment variable in the frontend, if it is set (rather than always treating a `localhost:3000` origin as being HASH prime). This allows testing of self-hosted instance frontends locally
2. Only use the special external type page for entity types (since there is no dedicated page for property or data types, whether external or not)
## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Set `SELF_HOSTED_HASH=true` in `.env.local` and run the app (don't need to reseed)
2. Visit `/types`
3. Click on a HASH entity type, check it loads in the external route
4. Click on a HASH property type, check that the JSON is loaded rather than the external route
