### PR TITLE
H-1808: Fix mention bugs, editor crash on property object arrays, and page content reloading

### DIFF
--- a/apps/hash-frontend/src/blocks/use-fetch-block-subgraph.ts
+++ b/apps/hash-frontend/src/blocks/use-fetch-block-subgraph.ts
@@ -73,7 +73,7 @@ export const useFetchBlockSubgraph = (): ((
         const placeholderEntity: Entity = {
           metadata: {
             recordId: {
-              entityId: "placeholder-account%entity-id-not-set" as EntityId,
+              entityId: "placeholder-account~entity-id-not-set" as EntityId,
               editionId: now,
             },
             entityTypeId: blockEntityTypeId,

--- a/apps/hash-frontend/src/pages/[shortname]/[page-slug].page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/[page-slug].page.tsx
@@ -199,6 +199,7 @@ const Page: NextPageWithLayout<PageProps> = () => {
   >(structuralQueryEntitiesQuery, {
     variables:
       getBlockCollectionContentsStructuralQueryVariables(pageEntityUuid),
+    fetchPolicy: "cache-and-network",
   });
 
   const pageHeaderRef = useRef<HTMLElement>();

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/use-rows/generate-property-rows-from-entity.ts
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/use-rows/generate-property-rows-from-entity.ts
@@ -23,9 +23,10 @@ export const generatePropertyRowsFromEntity = (
 
   return entityTypeAndAncestors.flatMap((entityType) =>
     Object.keys(entityType.schema.properties).map((propertyTypeBaseUrl) => {
-      const propertyRef = entityType.schema.properties[propertyTypeBaseUrl];
+      const propertyRefSchema =
+        entityType.schema.properties[propertyTypeBaseUrl];
 
-      if (!propertyRef) {
+      if (!propertyRefSchema) {
         throw new Error("Property not found");
       }
 
@@ -35,7 +36,7 @@ export const generatePropertyRowsFromEntity = (
         entity,
         entitySubgraph,
         requiredPropertyTypes,
-        propertyOnEntityTypeSchema: propertyRef,
+        propertyRefSchema,
       });
     }),
   );

--- a/apps/hash-frontend/src/pages/shared/block-collection/mention-view/mention-display.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/mention-view/mention-display.tsx
@@ -45,6 +45,7 @@ export const MentionDisplay: FunctionComponent<MentionDisplayProps> = ({
     graphResolveDepths: {
       ...zeroedGraphResolveDepths,
       isOfType: { outgoing: 1 },
+      inheritsFrom: { outgoing: 255 },
       hasLeftEntity: { incoming: 1, outgoing: 0 },
       hasRightEntity: { incoming: 0, outgoing: 1 },
     },

--- a/apps/hash-frontend/src/pages/shared/block-collection/mention-view/mention-display.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/mention-view/mention-display.tsx
@@ -252,14 +252,20 @@ export const MentionDisplay: FunctionComponent<MentionDisplayProps> = ({
   );
 
   const tooltip =
-    mention.kind === "property-value"
-      ? `The value for ${propertyType?.schema.title} of ${entityLabel}`
-      : `The target of a ${outgoingLinkType?.schema
-          .title} link from ${entityLabel}${
-          rawTitle === inaccessibleTargetEntityLabel
-            ? ", which is in draft, archived, or you do not have permission to view."
-            : ""
-        }`;
+    mention.kind === "property-value" ? (
+      <>
+        The value for <strong>{propertyType?.schema.title}</strong> of{" "}
+        <strong>{entityLabel}</strong>
+      </>
+    ) : (
+      <>
+        The target of a <strong>{outgoingLinkType?.schema.title}</strong> link
+        from <strong>{entityLabel}</strong>
+        {rawTitle === inaccessibleTargetEntityLabel
+          ? ", which is in draft, archived, or you do not have permission to view."
+          : ""}
+      </>
+    );
 
   const content = (
     <>

--- a/apps/hash-frontend/src/pages/shared/block-collection/shared/mention-suggester.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/shared/mention-suggester.tsx
@@ -8,7 +8,10 @@ import {
   mapGqlSubgraphFieldsFragmentToSubgraph,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
-import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
+import {
+  systemEntityTypes,
+  systemLinkEntityTypes,
+} from "@local/hash-isomorphic-utils/ontology-type-ids";
 import {
   isPageEntityTypeId,
   pageEntityTypeIds,
@@ -50,6 +53,7 @@ import { isEntityPageEntity } from "../../../../shared/is-of-type";
 import { usePropertyTypes } from "../../../../shared/property-types-context";
 import { useScrollLock } from "../../../../shared/use-scroll-lock";
 import { useAuthenticatedUser } from "../../auth-info-context";
+import { hiddenEntityTypeIds } from "../../hidden-types";
 import { fuzzySearchBy } from "./fuzzy-search-by";
 import {
   MentionSuggesterEntity,
@@ -226,8 +230,15 @@ export const MentionSuggester: FunctionComponent<MentionSuggesterProps> = ({
             ?.reduce(
               (prev, currentEntity) => {
                 if (
-                  isEntityPageEntity(currentEntity) &&
-                  isPageArchived(currentEntity)
+                  (isEntityPageEntity(currentEntity) &&
+                    isPageArchived(currentEntity)) ||
+                  hiddenEntityTypeIds.includes(
+                    currentEntity.metadata.entityTypeId,
+                  ) ||
+                  Object.values(systemLinkEntityTypes).some(
+                    ({ linkEntityTypeId }) =>
+                      linkEntityTypeId === currentEntity.metadata.entityTypeId,
+                  )
                 ) {
                   return prev;
                 }

--- a/apps/hash-frontend/src/pages/shared/block-collection/shared/mention-suggester.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/shared/mention-suggester.tsx
@@ -378,8 +378,6 @@ export const MentionSuggester: FunctionComponent<MentionSuggesterProps> = ({
 
             if (!linkEntity) {
               throw new Error("Link entity not found");
-            } else if (!rightEntity) {
-              throw new Error("Right entity not found");
             }
 
             const linkEntityType = getEntityTypeById(
@@ -392,10 +390,9 @@ export const MentionSuggester: FunctionComponent<MentionSuggesterProps> = ({
               linkEntity,
               linkEntityType,
               targetEntity: rightEntity,
-              targetEntityLabel: generateEntityLabel(
-                entitiesSubgraph,
-                rightEntity,
-              ),
+              targetEntityLabel: rightEntity
+                ? generateEntityLabel(entitiesSubgraph, rightEntity)
+                : "",
             };
           },
         );

--- a/apps/hash-frontend/src/pages/shared/block-collection/shared/mention-suggester/mention-suggester-entity.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/shared/mention-suggester/mention-suggester-entity.tsx
@@ -75,8 +75,8 @@ export type SubMenuItem =
       kind: "outgoing-link";
       linkEntity: Entity;
       linkEntityType: EntityTypeWithMetadata;
-      targetEntity: Entity;
-      targetEntityLabel: string;
+      targetEntity?: Entity;
+      targetEntityLabel?: string;
     };
 
 export const MentionSuggesterEntity = forwardRef<

--- a/apps/hash-frontend/src/pages/shared/hidden-types.ts
+++ b/apps/hash-frontend/src/pages/shared/hidden-types.ts
@@ -17,6 +17,5 @@ export const hiddenEntityTypeIds: VersionedUrl[] = [
   systemEntityTypes.twitterAccount.entityTypeId,
   systemEntityTypes.tiktokAccount.entityTypeId,
   systemEntityTypes.machine.entityTypeId,
-  systemEntityTypes.user.entityTypeId,
   systemEntityTypes.usageRecord.entityTypeId,
 ];

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-entities-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-entities-list.tsx
@@ -1,5 +1,6 @@
 import { IconButton } from "@hashintel/design-system";
 import { blockProtocolHubOrigin } from "@local/hash-isomorphic-utils/blocks";
+import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import {
   isOwnedOntologyElementMetadata,
   OwnedById,
@@ -71,8 +72,10 @@ export const AccountEntitiesList: FunctionComponent<
           // Filter out external types from blockprotocol.org, except the Address type.
           (!root.schema.$id.startsWith(blockProtocolHubOrigin) ||
             root.schema.$id.includes("/address/")) &&
+          // Filter out link types and some system types
           !isSpecialEntityTypeLookup?.[root.schema.$id]?.isLink &&
-          !hiddenEntityTypeIds.includes(root.schema.$id),
+          !hiddenEntityTypeIds.includes(root.schema.$id) &&
+          root.schema.$id !== systemEntityTypes.user.entityTypeId,
       );
     }
 

--- a/libs/@local/hash-isomorphic-utils/src/text.ts
+++ b/libs/@local/hash-isomorphic-utils/src/text.ts
@@ -71,7 +71,7 @@ export const textBlockNodeToTextTokens = (node: ComponentNode): TextToken[] => {
           mentionType: child.attrs.mentionType,
           entityId: child.attrs.entityId,
           propertyTypeBaseUrl: child.attrs.propertyTypeBaseUrl,
-          linkEntityTypeBaseUrl: child.attrs.linkEntityTypeId,
+          linkEntityTypeBaseUrl: child.attrs.linkEntityTypeBaseUrl,
         });
         break;
       }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The PR started off to fix the `@mention` suggester crashing, and fixed a few other things along the way:
1. Handle missing target entities of links in the mention suggester. 
    - the cause of the original crash – the mention suggester doesn't look for draft entities, and so it picks up 'live' notification entities which point to draft entities, which aren't available
2. Save the `linkEntityTypeBaseUrl` when inserting a mention of the target of a link (this information was not being saved before, meaning the link type wasn't available when returning to the page)
3. Handle type inheritance in the mention display
4. Hide some system types from the mention suggester

Things I fixed in passing because I noticed them when trying to test this:
1. The entity editor was crashing when viewing entities with an array of property objects (e.g. Service Feature entities) – there's no UI implemented for arrays of objects so I'm just taking the first for now (to be addressed as part of H-1785)
2. The page fetching query wasn't set to `cache-and-network`, meaning it didn't update properly when navigating away and back to a page

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- None currently – there is still an issue with the page-related tests which I need to fix in a follow-up.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. To test handling of missing right entities the easiest thing to do is to use the plugin to create a draft (or create one in the API and link to it) and temporarily stop filtering out the notification entities.
2. Other mention types can be tested by just trying to insert them and checking they appear correctly across a refresh.


