### PR TITLE
H-1837: Downgrade `actions/download-artifact` to `v3`

### DIFF
--- a/.github/actions/build-docker-images/action.yml
+++ b/.github/actions/build-docker-images/action.yml
@@ -81,7 +81,7 @@ runs:
 
     - name: Upload artifact
       if: ${{ (success() || failure()) && inputs.hash-graph == 'true' }}
-      uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: hash-graph
         path: /tmp/hash-graph.tar
@@ -106,7 +106,7 @@ runs:
 
     - name: Upload artifact
       if: ${{ (success() || failure()) && inputs.hash-ai-worker-ts == 'true' }}
-      uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: hash-ai-worker-ts
         path: /tmp/hash-ai-worker-ts.tar
@@ -131,7 +131,7 @@ runs:
 
     - name: Upload artifact
       if: ${{ (success() || failure()) && inputs.hash-integration-worker == 'true' }}
-      uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: hash-integration-worker
         path: /tmp/hash-integration-worker.tar

--- a/.github/actions/load-docker-images/action.yml
+++ b/.github/actions/load-docker-images/action.yml
@@ -44,21 +44,21 @@ runs:
 
     - name: Download hash-graph image
       if: inputs.hash-graph == 'true'
-      uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: hash-graph
         path: /tmp
 
     - name: Download hash-ai-worker-ts image
       if: inputs.hash-ai-worker-ts == 'true'
-      uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: hash-ai-worker-ts
         path: /tmp
 
     - name: Download hash-integration-worker image
       if: inputs.hash-integration-worker == 'true'
-      uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: hash-integration-worker
         path: /tmp

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -45,8 +45,10 @@
     {
       "packageRules": [
         {
-          "matchPackageNames": ["actions/download-artifact"],
-          "$comment": "Remove when https://github.com/orgs/community/discussions/81413 is fixed",
+          "matchPackageNames": [
+            "actions/download-artifact",
+            "actions/upload-artifact"
+          ],
           "dependencyDashboardApproval": true
         }
       ]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -43,6 +43,15 @@
       ]
     },
     {
+      "packageRules": [
+        {
+          "matchPackageNames": ["actions/download-artifact"],
+          "$comment": "Remove when https://github.com/orgs/community/discussions/81413 is fixed",
+          "dependencyDashboardApproval": true
+        }
+      ]
+    },
+    {
       "matchManagers": ["docker-compose", "dockerfile"],
       "commitMessageTopic": "Docker tag `{{depName}}`",
       "additionalBranchPrefix": "docker/"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Version 4 of `actions/download-artifacts` frequently fails to download an artifact. Until this issue is fixed we're pinning the version to v3.

## 🔗 Related links

- https://github.com/orgs/community/discussions/81413
## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph