### PR TITLE
H-1792: Generate `systemDataTypes` type ids

### DIFF
--- a/apps/hash-api/src/generate-ontology-type-ids.ts
+++ b/apps/hash-api/src/generate-ontology-type-ids.ts
@@ -209,6 +209,7 @@ const generateOntologyIds = async () => {
   const [
     hashEntityTypes,
     hashPropertyTypes,
+    hashDataTypes,
     linearEntityTypes,
     linearPropertyTypes,
     blockProtocolEntityTypes,
@@ -220,6 +221,9 @@ const generateOntologyIds = async () => {
       query: getLatestTypesInOrganizationQuery({ organization: hashOrg }),
     }).then((subgraph) => getRoots(subgraph)),
     getPropertyTypes(graphContext, authentication, {
+      query: getLatestTypesInOrganizationQuery({ organization: hashOrg }),
+    }).then((subgraph) => getRoots(subgraph)),
+    getDataTypes(graphContext, authentication, {
       query: getLatestTypesInOrganizationQuery({ organization: hashOrg }),
     }).then((subgraph) => getRoots(subgraph)),
     // Linear types
@@ -252,6 +256,7 @@ const generateOntologyIds = async () => {
       serializeTypes({ graphApi }, authentication, {
         entityTypes: hashEntityTypes,
         propertyTypes: hashPropertyTypes,
+        dataTypes: hashDataTypes,
         /** @todo: change this to "hash"? */
         prefix: "system",
       }),

--- a/libs/@local/hash-isomorphic-utils/src/ontology-type-ids.ts
+++ b/libs/@local/hash-isomorphic-utils/src/ontology-type-ids.ts
@@ -559,6 +559,70 @@ export const systemPropertyTypes = {
   },
 } as const;
 
+export const systemDataTypes = {
+  centimeters: {
+    dataTypeId: "https://hash.ai/@hash/types/data-type/centimeters/v/1",
+    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/centimeters/",
+    title: "Centimeters",
+    description:
+      "A unit of length in the International System of Units (SI), equal to one hundredth of a meter.",
+  },
+  date: {
+    dataTypeId: "https://hash.ai/@hash/types/data-type/date/v/1",
+    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/date/",
+    title: "Date",
+    description:
+      "A reference to a particular day represented within a calendar system, in the format YYYY-MM-DD.",
+  },
+  datetime: {
+    dataTypeId: "https://hash.ai/@hash/types/data-type/datetime/v/1",
+    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/datetime/",
+    title: "DateTime",
+    description: "A reference to a particular date and time.",
+  },
+  email: {
+    dataTypeId: "https://hash.ai/@hash/types/data-type/email/v/1",
+    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/email/",
+    title: "Email",
+    description:
+      "An identifier for an email box to which messages are delivered.",
+  },
+  kilometers: {
+    dataTypeId: "https://hash.ai/@hash/types/data-type/kilometers/v/1",
+    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/kilometers/",
+    title: "Kilometers",
+    description:
+      "A unit of length in the International System of Units (SI), equal to one thousand meters.",
+  },
+  meters: {
+    dataTypeId: "https://hash.ai/@hash/types/data-type/meters/v/1",
+    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/meters/",
+    title: "Meters",
+    description:
+      "The base unit of length in the International System of Units (SI).",
+  },
+  miles: {
+    dataTypeId: "https://hash.ai/@hash/types/data-type/miles/v/1",
+    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/miles/",
+    title: "Miles",
+    description:
+      "An imperial unit of length, equivalent to 1,609.344 meters in the International System of Units (SI).",
+  },
+  millimeters: {
+    dataTypeId: "https://hash.ai/@hash/types/data-type/millimeters/v/1",
+    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/millimeters/",
+    title: "Millimeters",
+    description:
+      "A unit of length in the International System of Units (SI), equal to one thousandth of a meter.",
+  },
+  uri: {
+    dataTypeId: "https://hash.ai/@hash/types/data-type/uri/v/1",
+    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/uri/",
+    title: "URI",
+    description: "A unique identifier for a resource (e.g. a URL, or URN).",
+  },
+} as const;
+
 export const linearEntityTypes = {
   attachment: {
     entityTypeId: "https://hash.ai/@linear/types/entity-type/attachment/v/1",
@@ -1020,10 +1084,22 @@ export const blockProtocolEntityTypes = {
     entityTypeBaseUrl:
       "https://blockprotocol.org/@blockprotocol/types/entity-type/link/",
   },
+  paragraphBlock: {
+    entityTypeId:
+      "https://blockprotocol.org/@hash/types/entity-type/paragraph-block/v/3",
+    entityTypeBaseUrl:
+      "https://blockprotocol.org/@hash/types/entity-type/paragraph-block/",
+  },
   query: {
     entityTypeId: "https://blockprotocol.org/@hash/types/entity-type/query/v/1",
     entityTypeBaseUrl:
       "https://blockprotocol.org/@hash/types/entity-type/query/",
+  },
+  tableBlock: {
+    entityTypeId:
+      "https://blockprotocol.org/@hash/types/entity-type/table-block/v/4",
+    entityTypeBaseUrl:
+      "https://blockprotocol.org/@hash/types/entity-type/table-block/",
   },
   thing: {
     entityTypeId:
@@ -1115,11 +1191,53 @@ export const blockProtocolPropertyTypes = {
     propertyTypeBaseUrl:
       "https://blockprotocol.org/@hash/types/property-type/query/",
   },
+  tableHeaderRowIsHidden: {
+    propertyTypeId:
+      "https://blockprotocol.org/@hash/types/property-type/table-header-row-is-hidden/v/1",
+    propertyTypeBaseUrl:
+      "https://blockprotocol.org/@hash/types/property-type/table-header-row-is-hidden/",
+  },
+  tableLocalColumn: {
+    propertyTypeId:
+      "https://blockprotocol.org/@hash/types/property-type/table-local-column/v/1",
+    propertyTypeBaseUrl:
+      "https://blockprotocol.org/@hash/types/property-type/table-local-column/",
+  },
+  tableLocalColumnId: {
+    propertyTypeId:
+      "https://blockprotocol.org/@hash/types/property-type/table-local-column-id/v/1",
+    propertyTypeBaseUrl:
+      "https://blockprotocol.org/@hash/types/property-type/table-local-column-id/",
+  },
+  tableLocalRow: {
+    propertyTypeId:
+      "https://blockprotocol.org/@hash/types/property-type/table-local-row/v/1",
+    propertyTypeBaseUrl:
+      "https://blockprotocol.org/@hash/types/property-type/table-local-row/",
+  },
+  tableRowNumbersAreHidden: {
+    propertyTypeId:
+      "https://blockprotocol.org/@hash/types/property-type/table-row-numbers-are-hidden/v/1",
+    propertyTypeBaseUrl:
+      "https://blockprotocol.org/@hash/types/property-type/table-row-numbers-are-hidden/",
+  },
+  tableRowsAreStriped: {
+    propertyTypeId:
+      "https://blockprotocol.org/@hash/types/property-type/table-rows-are-striped/v/1",
+    propertyTypeBaseUrl:
+      "https://blockprotocol.org/@hash/types/property-type/table-rows-are-striped/",
+  },
   textualContent: {
     propertyTypeId:
       "https://blockprotocol.org/@blockprotocol/types/property-type/textual-content/v/2",
     propertyTypeBaseUrl:
       "https://blockprotocol.org/@blockprotocol/types/property-type/textual-content/",
+  },
+  title: {
+    propertyTypeId:
+      "https://blockprotocol.org/@blockprotocol/types/property-type/title/v/1",
+    propertyTypeBaseUrl:
+      "https://blockprotocol.org/@blockprotocol/types/property-type/title/",
   },
 } as const;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR adds the system data types (the data types in the HASH org) to the generated `ontology-type-ids.ts` file.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-1792

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Check the `ontology-type-ids.ts` file in this PR contains the expected data types.
