### PR TITLE
H-1854: Fix health status for Docker compose setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -331,7 +331,7 @@ jobs:
           fi
 
           echo "Running services: $SERVICES"
-          yarn workspace @apps/hash-external-services deploy:test up $SERVICES --detach
+          yarn workspace @apps/hash-external-services deploy:test up $SERVICES --wait
 
       - name: Show disk usage
         run: df -h
@@ -452,7 +452,7 @@ jobs:
       - name: Launch external services
         run: |
           turbo codegen --filter '@apps/hash-external-services'
-          yarn workspace @apps/hash-external-services deploy up --detach
+          yarn workspace @apps/hash-external-services deploy up --wait
 
       - name: Launch HASH-API
         run: |

--- a/apps/hash-external-services/docker-compose.dev.yml
+++ b/apps/hash-external-services/docker-compose.dev.yml
@@ -2,35 +2,6 @@ volumes:
   hash-vault-data:
 
 services:
-  hash-dev-opensearch:
-    deploy:
-      restart_policy:
-        condition: on-failure
-    environment:
-      HASH_OPENSEARCH_ENABLED: "${HASH_OPENSEARCH_ENABLED}"
-      ## Tell OpenSearch that it's operating in single-node mode
-      discovery.type: single-node
-      ## Disable the security module for development so we can connect over plain HTTP
-      plugins.security.disabled: true
-      ## Docker volumes are ~10GB by default which is typically much smaller than the
-      ## host's drive size. This can cause OpenSearch to shutdown if it thinks disk
-      ## space is running low. Set the disk high watermark to 100% to ignore this.
-      cluster.routing.allocation.disk.watermark.high: 100%
-      cluster.routing.allocation.disk.watermark.flood_stage: 100%
-    build:
-      context: ./opensearch
-    ports:
-      - "9200:9200"
-    ulimits:
-      nofile:
-        soft: 65536
-        hard: 65536
-    ## Mounting open search data to a local directory may lead to java.nio.file.AccessDeniedException.
-    ## Details: https://github.com/opensearch-project/OpenSearch/issues/1579.
-    ## We can revisit the setup after upgrading base image or by fixing permissions in a custom image.
-    # volumes:
-    #   - ../../var/hash-external-service/opensearch/data:/usr/share/opensearch/data
-
   postgres:
     environment:
       HASH_SPICEDB_PG_USER: "${HASH_SPICEDB_PG_USER}"
@@ -84,8 +55,6 @@ services:
   spicedb:
     image: authzed/spicedb:v${HASH_SPICEDB_VERSION}
     depends_on:
-      postgres:
-        condition: service_healthy
       spicedb-migrate:
         condition: service_completed_successfully
       telemetry-collector:
@@ -163,31 +132,6 @@ services:
   redis:
     ports:
       - "6379:6379"
-
-  temporal-migrate:
-    build:
-      context: ./temporal
-      dockerfile: migrate.Dockerfile
-      args:
-        TEMPORAL_VERSION: "${HASH_TEMPORAL_VERSION}"
-    read_only: true
-    depends_on:
-      postgres:
-        condition: service_healthy
-    environment:
-      # This sets configuration values in
-      # https://github.com/temporalio/temporal/blob/master/docker/config_template.yaml
-      # posgres12 for v12+ of postgres.
-      DB: "postgres12"
-      DBNAME: "${HASH_TEMPORAL_PG_DATABASE}"
-      VISIBILITY_DBNAME: "${HASH_TEMPORAL_VISIBILITY_PG_DATABASE}"
-      DB_PORT: "5432"
-      # Intentionally use the POSTGRES user as it's the "superadmin" which has access to schema
-      POSTGRES_USER: "${POSTGRES_USER}"
-      POSTGRES_PWD: "${POSTGRES_PASSWORD}"
-      POSTGRES_SEEDS: "postgres" # the hostname of the postgres container
-    security_opt:
-      - no-new-privileges:true
 
   vault:
     image: hashicorp/vault

--- a/apps/hash-external-services/docker-compose.opensearch.yml
+++ b/apps/hash-external-services/docker-compose.opensearch.yml
@@ -1,0 +1,29 @@
+services:
+  hash-dev-opensearch:
+    deploy:
+      restart_policy:
+        condition: on-failure
+    environment:
+      HASH_OPENSEARCH_ENABLED: "${HASH_OPENSEARCH_ENABLED}"
+      ## Tell OpenSearch that it's operating in single-node mode
+      discovery.type: single-node
+      ## Disable the security module for development so we can connect over plain HTTP
+      plugins.security.disabled: true
+      ## Docker volumes are ~10GB by default which is typically much smaller than the
+      ## host's drive size. This can cause OpenSearch to shutdown if it thinks disk
+      ## space is running low. Set the disk high watermark to 100% to ignore this.
+      cluster.routing.allocation.disk.watermark.high: 100%
+      cluster.routing.allocation.disk.watermark.flood_stage: 100%
+    build:
+      context: ./opensearch
+    ports:
+      - "9200:9200"
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
+    ## Mounting open search data to a local directory may lead to java.nio.file.AccessDeniedException.
+    ## Details: https://github.com/opensearch-project/OpenSearch/issues/1579.
+    ## We can revisit the setup after upgrading base image or by fixing permissions in a custom image.
+    # volumes:
+    #   - ../../var/hash-external-service/opensearch/data:/usr/share/opensearch/data

--- a/apps/hash-external-services/docker-compose.temporal.yml
+++ b/apps/hash-external-services/docker-compose.temporal.yml
@@ -38,8 +38,6 @@ services:
         condition: service_healthy
       temporal-migrate:
         condition: service_completed_successfully
-      hash-dev-opensearch:
-        condition: service_started
     healthcheck:
       test:
         [
@@ -107,6 +105,8 @@ services:
     depends_on:
       temporal:
         condition: service_healthy
+      temporal-setup:
+        condition: service_completed_successfully
     environment:
       TEMPORAL_ADDRESS: temporal:7233
       TEMPORAL_CORS_ORIGINS: http://localhost:3000
@@ -114,6 +114,11 @@ services:
       - no-new-privileges:true
     ports:
       - "${HASH_TEMPORAL_UI_PORT}:8080"
+    healthcheck:
+      test: ["CMD", "/bin/sh", "-c", "nc -z $(hostname) 8080"]
+      interval: 2s
+      timeout: 2s
+      retries: 10
 
   hash-temporal-worker-ts:
     image: hash-ai-worker-ts

--- a/apps/hash-external-services/docker-compose.yml
+++ b/apps/hash-external-services/docker-compose.yml
@@ -4,33 +4,6 @@ volumes:
   logs:
 
 services:
-  hash-dev-opensearch:
-    deploy:
-      restart_policy:
-        condition: on-failure
-    environment:
-      HASH_OPENSEARCH_ENABLED: "${HASH_OPENSEARCH_ENABLED}"
-      ## Tell OpenSearch that it's operating in single-node mode
-      discovery.type: single-node
-      ## Disable the security module for development so we can connect over plain HTTP
-      plugins.security.disabled: true
-      ## Docker volumes are ~10GB by default which is typically much smaller than the
-      ## host's drive size. This can cause OpenSearch to shutdown if it thinks disk
-      ## space is running low. Set the disk high watermark to 100% to ignore this.
-      cluster.routing.allocation.disk.watermark.high: 100%
-      cluster.routing.allocation.disk.watermark.flood_stage: 100%
-    build:
-      context: ./opensearch
-    ulimits:
-      nofile:
-        soft: 65536
-        hard: 65536
-    ## Mounting open search data to a local directory may lead to java.nio.file.AccessDeniedException.
-    ## Details: https://github.com/opensearch-project/OpenSearch/issues/1579.
-    ## We can revisit the setup after upgrading base image or by fixing permissions in a custom image.
-    # volumes:
-    #   - ../../var/hash-external-service/opensearch/data:/usr/share/opensearch/data
-
   postgres:
     build:
       context: ./postgres


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For our dev-setup for Docker we don't rely on health checks because they were not set up for Temporal-UI and OpenSearch.

## 🔍 What does this change?

- Move OpenSearch container into unused file
- Remove the duplicated `temporal-migrate` service in the `.dev.yaml`
- Add health check for Temporal-UI
- Ensure that `temporal-setup` finished be fore starting the UI
- Use `--wait` instead of `--detach` in CI

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph