### PR TITLE
H-1846: Use the default `/var/lib/postgresql/data` for PGDATA

### DIFF
--- a/apps/hash-external-services/docker-compose.yml
+++ b/apps/hash-external-services/docker-compose.yml
@@ -38,7 +38,6 @@ services:
       restart_policy:
         condition: on-failure
     environment:
-      PGDATA: /data/pgdata
       POSTGRES_USER: "${POSTGRES_USER}"
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
       HASH_KRATOS_PG_USER: "${HASH_KRATOS_PG_USER}"
@@ -54,7 +53,7 @@ services:
       HASH_GRAPH_REALTIME_PG_USER: "${HASH_GRAPH_REALTIME_PG_USER}"
       HASH_GRAPH_REALTIME_PG_PASSWORD: "${HASH_GRAPH_REALTIME_PG_PASSWORD}"
     volumes:
-      - hash-postgres-data:/data/pgdata
+      - hash-postgres-data:/var/lib/postgresql/data
       - ./postgres/postgresql.conf:/etc/postgresql/postgresql.conf:ro
       - ./postgres/init-user-db.sh:/docker-entrypoint-initdb.d/init-user-db.sh:ro
     healthcheck:

--- a/apps/hash-external-services/postgres/Dockerfile
+++ b/apps/hash-external-services/postgres/Dockerfile
@@ -12,5 +12,3 @@ RUN apk add --no-cache --virtual .build-deps gcc clang15 llvm15 git make musl-de
     && rm -rf wal2json ppgvector \
     && apk del .build-deps \
     && mkdir -p /etc/postgresql/
-
-COPY postgresql.conf /etc/postgresql

--- a/apps/hash-external-services/postgres/Dockerfile
+++ b/apps/hash-external-services/postgres/Dockerfile
@@ -11,7 +11,6 @@ RUN apk add --no-cache --virtual .build-deps gcc clang15 llvm15 git make musl-de
     && (cd /pgvector && make && make install) \
     && rm -rf wal2json ppgvector \
     && apk del .build-deps \
-    && echo "local  postgres  postgres  trust" >> /var/lib/postgresql/data/pg_hba.conf \
     && mkdir -p /etc/postgresql/
 
 COPY postgresql.conf /etc/postgresql


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently encounter a lot of CI failures when starting the Postgres external service. It seems to be fixed when removing the `echo` from `postgres/Dockerfile` and use the desired `PGDATA` directory for the volume. I don’t see why we have that `echo` in the first place as it’s outputting to a directory which is supposed to be unused as `PGDATA` is manually set.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph