### PR TITLE
H-1846: Use correct volume for `vault`

### DIFF
--- a/apps/hash-external-services/docker-compose.dev.yml
+++ b/apps/hash-external-services/docker-compose.dev.yml
@@ -138,7 +138,7 @@ services:
     ports:
       - "${HASH_VAULT_PORT}:8200"
     volumes:
-      - hash-postgres-data:/vault/file:rw
+      - hash-vault-data:/vault/file:rw
       # - ./vault/config:/vault/config:rw - for when we need a config file
     cap_add:
       - IPC_LOCK


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The volume for `vault` is wrong and uses the same volume as for `postgres`. As the result `postgres` will fail to start if `vault` was started earlier.