### PR TITLE
H-590, H-1753, H-1678, H-1679: Style cleanup around the expected link types table on the entity types page + other minor tweaks

### DIFF
--- a/apps/hash-frontend/src/pages/shared/entity-type-page/type-slide-over-stack/type-slide-over-slide.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-page/type-slide-over-stack/type-slide-over-slide.tsx
@@ -33,28 +33,34 @@ import { useEntityTypeValue } from "../use-entity-type-value";
 const CopyableOntologyChip: FunctionComponent<{
   entityType: EntityTypeWithMetadata;
 }> = ({ entityType }) => {
+  const [tooltipTitle, setTooltipTitle] = useState("Copy type URL");
+
   const [copyTooltipIsOpen, setCopyTooltipIsOpen] = useState(false);
-  const [copiedEntityTypeUrl, setCopiedEntityTypeUrl] = useState(false);
 
   const ontology = parseUrlForOntologyChip(entityType.schema.$id);
 
-  const handleCopyEntityTypeUrl = useCallback(() => {
-    void navigator.clipboard.writeText(entityType.schema.$id);
-    setCopiedEntityTypeUrl(true);
-    setTimeout(() => {
-      setCopyTooltipIsOpen(false);
-
+  const handleCopyEntityTypeUrl = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(entityType.schema.$id);
+      setTooltipTitle("Copied type URL!");
+    } catch {
+      setTooltipTitle("Not allowed to copy to clipboard");
+    } finally {
       setTimeout(() => {
-        setCopiedEntityTypeUrl(false);
-      }, 300);
-    }, 500);
+        setCopyTooltipIsOpen(false);
+
+        setTimeout(() => {
+          setTooltipTitle("Copy type URL");
+        }, 300);
+      }, 500);
+    }
   }, [entityType]);
 
   return (
     <Box display="flex" alignItems="center" columnGap={1}>
       <Tooltip
         open={copyTooltipIsOpen}
-        title={copiedEntityTypeUrl ? "Copied type URL!" : "Copy type URL"}
+        title={tooltipTitle}
         placement="top"
         slotProps={{
           tooltip: {

--- a/apps/hash-frontend/src/pages/shared/entity-type-page/type-slide-over-stack/type-slide-over-slide.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-page/type-slide-over-stack/type-slide-over-slide.tsx
@@ -14,12 +14,14 @@ import {
   getFormDataFromSchema,
   useEntityTypeForm,
 } from "@hashintel/type-editor";
+import { EntityTypeWithMetadata } from "@local/hash-subgraph";
 import { componentsFromVersionedUrl } from "@local/hash-subgraph/type-system-patch";
-import { Box, Slide, Tooltip } from "@mui/material";
+import { Box, ButtonBase, Slide, Tooltip } from "@mui/material";
 import { FunctionComponent, useCallback, useMemo, useState } from "react";
 
 import { useEntityTypesContextRequired } from "../../../../shared/entity-types-context/hooks/use-entity-types-context-required";
 import { ArrowRightIcon } from "../../../../shared/icons/arrow-right";
+import { ArrowUpRightRegularFromSquareIcon } from "../../../../shared/icons/arrow-up-right-from-square-regular-icon";
 import { Link } from "../../../../shared/ui";
 import { useRouteNamespace } from "../../../[shortname]/shared/use-route-namespace";
 import { useDataTypesContext } from "../../data-types-context";
@@ -27,6 +29,70 @@ import { EntityTypeContext } from "../shared/entity-type-context";
 import { EntityTypeHeader } from "../shared/entity-type-header";
 import { getTypesWithoutMetadata } from "../shared/get-types-without-metadata";
 import { useEntityTypeValue } from "../use-entity-type-value";
+
+const CopyableOntologyChip: FunctionComponent<{
+  entityType: EntityTypeWithMetadata;
+}> = ({ entityType }) => {
+  const [copyTooltipIsOpen, setCopyTooltipIsOpen] = useState(false);
+  const [copiedEntityTypeUrl, setCopiedEntityTypeUrl] = useState(false);
+
+  const ontology = parseUrlForOntologyChip(entityType.schema.$id);
+
+  const handleCopyEntityTypeUrl = useCallback(() => {
+    void navigator.clipboard.writeText(entityType.schema.$id);
+    setCopiedEntityTypeUrl(true);
+    setTimeout(() => {
+      setCopyTooltipIsOpen(false);
+
+      setTimeout(() => {
+        setCopiedEntityTypeUrl(false);
+      }, 300);
+    }, 500);
+  }, [entityType]);
+
+  return (
+    <Box display="flex" alignItems="center" columnGap={1}>
+      <Tooltip
+        open={copyTooltipIsOpen}
+        title={copiedEntityTypeUrl ? "Copied type URL!" : "Copy type URL"}
+        placement="top"
+        slotProps={{
+          tooltip: {
+            sx: {
+              maxWidth: "unset",
+              textWrap: "no-wrap",
+            },
+          },
+        }}
+      >
+        <ButtonBase
+          onClick={handleCopyEntityTypeUrl}
+          onMouseEnter={() => setCopyTooltipIsOpen(true)}
+          onMouseLeave={() => setCopyTooltipIsOpen(false)}
+        >
+          <OntologyChip {...ontology} />
+        </ButtonBase>
+      </Tooltip>
+      <Link href={entityType.schema.$id} target="_blank">
+        <IconButton
+          sx={{
+            padding: 0,
+            transition: ({ transitions }) => transitions.create("color"),
+            "&:hover": {
+              background: "transparent",
+              color: ({ palette }) => palette.blue[70],
+            },
+            svg: {
+              fontSize: 14,
+            },
+          }}
+        >
+          <ArrowUpRightRegularFromSquareIcon />
+        </IconButton>
+      </Link>
+    </Box>
+  );
+};
 
 const SLIDE_WIDTH = 1000;
 
@@ -77,10 +143,6 @@ export const TypeSlideOverSlide: FunctionComponent<TypeSlideOverSlideProps> = ({
   const [animateOut, setAnimateOut] = useState(false);
 
   const entityTypesContext = useEntityTypesContextRequired();
-
-  const ontology = remoteEntityType
-    ? parseUrlForOntologyChip(remoteEntityType.schema.$id)
-    : undefined;
 
   const entityTypeOptions = useMemo(
     () =>
@@ -163,10 +225,7 @@ export const TypeSlideOverSlide: FunctionComponent<TypeSlideOverSlideProps> = ({
             </IconButton>
           </Tooltip>
         </Box>
-        {loadingNamespace ||
-        loadingRemoteEntityType ||
-        !remoteEntityType ||
-        !ontology ? (
+        {loadingNamespace || loadingRemoteEntityType || !remoteEntityType ? (
           <Box
             sx={{
               display: "flex",
@@ -192,13 +251,7 @@ export const TypeSlideOverSlide: FunctionComponent<TypeSlideOverSlideProps> = ({
                     ]?.isFile
                   }
                   ontologyChip={
-                    <Link
-                      href={remoteEntityType.schema.$id}
-                      target="_blank"
-                      style={{ textDecoration: "none" }}
-                    >
-                      <OntologyChip {...ontology} />
-                    </Link>
+                    <CopyableOntologyChip entityType={remoteEntityType} />
                   }
                   entityType={remoteEntityType.schema}
                   isReadonly

--- a/apps/hash-frontend/src/shared/icons/arrow-up-right-from-square-regular-icon.tsx
+++ b/apps/hash-frontend/src/shared/icons/arrow-up-right-from-square-regular-icon.tsx
@@ -1,0 +1,18 @@
+import { SvgIcon, SvgIconProps } from "@mui/material";
+import { FunctionComponent } from "react";
+
+export const ArrowUpRightRegularFromSquareIcon: FunctionComponent<
+  SvgIconProps
+> = (props) => {
+  return (
+    <SvgIcon
+      {...props}
+      height="16"
+      width="16"
+      viewBox="0 0 512 512"
+      fill="none"
+    >
+      <path d="M304 24c0 13.3 10.7 24 24 24H430.1L207 271c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l223-223V184c0 13.3 10.7 24 24 24s24-10.7 24-24V24c0-13.3-10.7-24-24-24H328c-13.3 0-24 10.7-24 24zM72 32C32.2 32 0 64.2 0 104V440c0 39.8 32.2 72 72 72H408c39.8 0 72-32.2 72-72V312c0-13.3-10.7-24-24-24s-24 10.7-24 24V440c0 13.3-10.7 24-24 24H72c-13.3 0-24-10.7-24-24V104c0-13.3 10.7-24 24-24H200c13.3 0 24-10.7 24-24s-10.7-24-24-24H72z" />
+    </SvgIcon>
+  );
+};

--- a/apps/hash-frontend/src/shared/layout/layout-with-header/notifications-dropdown.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-header/notifications-dropdown.tsx
@@ -24,7 +24,6 @@ export const NotificationsDropdown: FunctionComponent = () => {
     <Link noLinkStyle href="/inbox">
       <HeaderIconButton
         sx={{
-          fontSize: theme.spacing(2),
           width: hasNotifications ? "auto" : "32px",
           px: hasNotifications ? 1.5 : "unset",
           height: "32px",
@@ -74,6 +73,7 @@ export const NotificationsDropdown: FunctionComponent = () => {
           <>
             <Typography
               sx={{
+                fontSize: 14,
                 fontWeight: 600,
                 lineHeight: theme.spacing(2),
                 color: "purple",

--- a/libs/@hashintel/type-editor/src/entity-type-editor/link-list-card/anything-chip.tsx
+++ b/libs/@hashintel/type-editor/src/entity-type-editor/link-list-card/anything-chip.tsx
@@ -5,6 +5,7 @@ import { TypeChipLabel } from "./type-chip-label";
 export const AnythingChip = () => (
   <Chip
     color="blue"
+    sx={{ m: 0.25 }}
     variant="outlined"
     label={<TypeChipLabel>Anything</TypeChipLabel>}
   />


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR makes some minor styling/functionality improvements, including:

- copying the URL of an entity type in the entity type slideover when the URL chip is clicked (H-1678), and allowing the type to be opened in a new tab via an icon (H-1679)
- fixes the font size of the notification counter in the header (H-1753)
- fixes height inconsistencies between the "Anything" chip and other entity type chips (as part of H-590)


## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-590, H-1753, H-1678, H-1679


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

Manual testing.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

View the relevant pages in the deployment to view the styling changes.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

Updated font size for notification counter:

<img width="1355" alt="image" src="https://github.com/hashintel/hash/assets/42802102/374abb19-af62-40ac-b134-6975b8b1fc49">

Consistent height for "Anything" and other type chips:

<img width="244" alt="image" src="https://github.com/hashintel/hash/assets/42802102/8c18928a-99a8-4c13-a63f-6e5314b727f2">

<img width="482" alt="image" src="https://github.com/hashintel/hash/assets/42802102/a771a6f6-b6e6-426b-9565-66fafa8fb0a6">

<img width="495" alt="image" src="https://github.com/hashintel/hash/assets/42802102/5099d5b3-2336-4307-8eee-fce7c0fcaa5c">

Allow for copying type URL via the chip in the slideover:


https://github.com/hashintel/hash/assets/42802102/9a8f2d3a-2c37-47f6-bdb8-00082ba5c7fb
