### PR TITLE
H-1841: Trigger embedding creation workflow when entity was created/updated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,6 +1078,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tarpc",
+ "temporal-client 0.0.0",
  "temporal-versioning",
  "time",
  "tokio",

--- a/apps/hash-graph/libs/api/src/rest/entity.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity.rs
@@ -46,6 +46,7 @@ use graph_types::{
     Embedding,
 };
 use serde::Deserialize;
+use temporal_client::TemporalClient;
 use temporal_versioning::{DecisionTime, Timestamp, TransactionTime};
 use type_system::url::VersionedUrl;
 use utoipa::{OpenApi, ToSchema};
@@ -201,6 +202,7 @@ async fn create_entity<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
     authorization_api_pool: Extension<Arc<A>>,
+    temporal_client: Extension<Option<Arc<TemporalClient>>>,
     body: Json<CreateEntityRequest>,
 ) -> Result<Json<EntityMetadata>, Response>
 where
@@ -227,6 +229,7 @@ where
         .create_entity(
             actor_id,
             &mut authorization_api,
+            temporal_client.as_deref(),
             owned_by_id,
             entity_uuid,
             None,
@@ -469,6 +472,7 @@ async fn update_entity<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
     authorization_api_pool: Extension<Arc<A>>,
+    temporal_client: Extension<Option<Arc<TemporalClient>>>,
     body: Json<UpdateEntityRequest>,
 ) -> Result<Json<EntityMetadata>, Response>
 where
@@ -494,6 +498,7 @@ where
         .update_entity(
             actor_id,
             &mut authorization_api,
+            temporal_client.as_deref(),
             entity_id,
             None,
             archived,

--- a/apps/hash-graph/libs/graph/Cargo.toml
+++ b/apps/hash-graph/libs/graph/Cargo.toml
@@ -9,6 +9,7 @@ description = "HASH Graph API"
 graph-types = { workspace = true, features = ["postgres", "utoipa"] }
 validation = { workspace = true }
 temporal-versioning = { workspace = true, features = ["postgres", "utoipa"] }
+temporal-client = { workspace = true }
 type-fetcher = { workspace = true }
 authorization = { workspace = true, features = ["utoipa"] }
 codec = { workspace = true }

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -27,6 +27,7 @@ use graph_types::{
     owned_by_id::OwnedById,
 };
 use tarpc::context;
+use temporal_client::TemporalClient;
 use temporal_versioning::{DecisionTime, Timestamp, TransactionTime};
 use tokio::net::ToSocketAddrs;
 use tokio_serde::formats::Json;
@@ -1065,6 +1066,7 @@ where
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut Au,
+        temporal_client: Option<&TemporalClient>,
         owned_by_id: OwnedById,
         entity_uuid: Option<EntityUuid>,
         decision_time: Option<Timestamp<DecisionTime>>,
@@ -1090,6 +1092,7 @@ where
             .create_entity(
                 actor_id,
                 authorization_api,
+                temporal_client,
                 owned_by_id,
                 entity_uuid,
                 decision_time,
@@ -1175,6 +1178,7 @@ where
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut Au,
+        temporal_client: Option<&TemporalClient>,
         entity_id: EntityId,
         decision_time: Option<Timestamp<DecisionTime>>,
         archived: bool,
@@ -1199,6 +1203,7 @@ where
             .update_entity(
                 actor_id,
                 authorization_api,
+                temporal_client,
                 entity_id,
                 decision_time,
                 archived,

--- a/apps/hash-graph/libs/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/libs/graph/src/store/knowledge.rs
@@ -11,6 +11,7 @@ use graph_types::{
     },
     owned_by_id::OwnedById,
 };
+use temporal_client::TemporalClient;
 use temporal_versioning::{DecisionTime, Timestamp, TransactionTime};
 use type_system::{url::VersionedUrl, EntityType};
 use validation::ValidationProfile;
@@ -62,6 +63,7 @@ pub trait EntityStore: crud::Read<Entity> {
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut A,
+        temporal_client: Option<&TemporalClient>,
         owned_by_id: OwnedById,
         entity_uuid: Option<EntityUuid>,
         decision_time: Option<Timestamp<DecisionTime>>,
@@ -165,6 +167,7 @@ pub trait EntityStore: crud::Read<Entity> {
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut A,
+        temporal_client: Option<&TemporalClient>,
         entity_id: EntityId,
         decision_time: Option<Timestamp<DecisionTime>>,
         archived: bool,

--- a/libs/@local/temporal-client/src/ai.rs
+++ b/libs/@local/temporal-client/src/ai.rs
@@ -1,0 +1,64 @@
+use std::collections::HashMap;
+
+use error_stack::{Report, ResultExt};
+use graph_types::{account::AccountId, knowledge::entity::Entity};
+use serde::Serialize;
+use temporal_io_client::{WorkflowClientTrait, WorkflowOptions};
+use temporal_io_sdk_core_protos::{
+    temporal::api::common::v1::Payload, ENCODING_PAYLOAD_KEY, JSON_ENCODING_VAL,
+};
+use uuid::Uuid;
+
+use crate::{TemporalClient, WorkflowError};
+
+impl TemporalClient {
+    /// Starts a workflow to update the embeddings for the provided entity.
+    ///
+    /// Returns the run ID of the workflow.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the workflow fails to start.
+    pub async fn start_update_entity_embeddings_workflow(
+        &self,
+        actor_id: AccountId,
+        entity: Entity,
+    ) -> Result<String, Report<WorkflowError>> {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct AuthenticationContext {
+            actor_id: AccountId,
+        }
+
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct UpdateEntityEmbeddingsParams {
+            authentication: AuthenticationContext,
+            entity: Entity,
+        }
+
+        Ok(self
+            .client
+            .start_workflow(
+                vec![Payload {
+                    metadata: HashMap::from([(
+                        ENCODING_PAYLOAD_KEY.to_owned(),
+                        JSON_ENCODING_VAL.as_bytes().to_vec(),
+                    )]),
+                    data: serde_json::to_vec(&UpdateEntityEmbeddingsParams {
+                        authentication: AuthenticationContext { actor_id },
+                        entity,
+                    })
+                    .change_context(WorkflowError("updateEntityEmbeddings"))?,
+                }],
+                "ai".to_owned(),
+                Uuid::new_v4().to_string(),
+                "updateEntityEmbeddings".to_owned(),
+                None,
+                WorkflowOptions::default(),
+            )
+            .await
+            .change_context(WorkflowError("updateEntityEmbeddings"))?
+            .run_id)
+    }
+}

--- a/libs/@local/temporal-client/src/error.rs
+++ b/libs/@local/temporal-client/src/error.rs
@@ -7,3 +7,7 @@ pub struct ConfigError;
 #[derive(Debug, Error)]
 #[error("Could not connect to Temporal.io Server")]
 pub struct ConnectionError;
+
+#[derive(Debug, Error)]
+#[error("Workflow execution of job {0} failed")]
+pub struct WorkflowError(pub &'static str);

--- a/libs/@local/temporal-client/src/lib.rs
+++ b/libs/@local/temporal-client/src/lib.rs
@@ -1,6 +1,9 @@
-#![feature(lint_reasons, impl_trait_in_assoc_type)]
+#![feature(impl_trait_in_assoc_type)]
 
-pub mod error;
+pub use self::error::{ConfigError, ConnectionError, WorkflowError};
+
+mod ai;
+mod error;
 
 use std::future::{Future, IntoFuture};
 
@@ -8,11 +11,8 @@ use error_stack::{Report, ResultExt};
 use temporal_io_client::{Client, ClientOptions, ClientOptionsBuilder, RetryClient};
 use url::Url;
 
-use self::error::{ConfigError, ConnectionError};
-
 #[derive(Debug)]
 pub struct TemporalClient {
-    #[expect(dead_code)]
     client: RetryClient<Client>,
 }
 

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -514,6 +514,7 @@ impl DatabaseApi<'_> {
             .create_entity(
                 self.account_id,
                 &mut NoAuthorization,
+                None,
                 OwnedById::new(self.account_id.into_uuid()),
                 entity_uuid,
                 Some(generate_decision_time()),
@@ -627,6 +628,7 @@ impl DatabaseApi<'_> {
             .update_entity(
                 self.account_id,
                 &mut NoAuthorization,
+                None,
                 entity_id,
                 Some(generate_decision_time()),
                 false,
@@ -650,6 +652,7 @@ impl DatabaseApi<'_> {
             .create_entity(
                 self.account_id,
                 &mut NoAuthorization,
+                None,
                 OwnedById::new(self.account_id.into_uuid()),
                 entity_uuid,
                 None,
@@ -830,6 +833,7 @@ impl DatabaseApi<'_> {
             .update_entity(
                 self.account_id,
                 &mut NoAuthorization,
+                None,
                 entity_id,
                 None,
                 true,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

After an entity was created/updated, the workflow to update the entity embeddings should be triggered. This PR implements that.

## 🚫 Blocked by

- #3855
- #3861 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph