### PR TITLE
H-1888: Don't filter out draft entities when create embeddings via a filter

### DIFF
--- a/apps/hash-ai-worker-ts/src/workflows.ts
+++ b/apps/hash-ai-worker-ts/src/workflows.ts
@@ -75,7 +75,7 @@ export const updateEntityEmbeddings = async (
           hasRightEntity: { incoming: 0, outgoing: 0 },
         },
         temporalAxes,
-        includeDrafts: false,
+        includeDrafts: true,
       },
     });
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Embeddings are also generated for drafts and when using a filter the behavior should be the same.