### PR TITLE
H-1721: When adding a type for inference, add its linked types

### DIFF
--- a/apps/plugin-browser/src/pages/popup/popup-contents/action-center/automated/select-scope/rows-by-location.tsx
+++ b/apps/plugin-browser/src/pages/popup/popup-contents/action-center/automated/select-scope/rows-by-location.tsx
@@ -251,8 +251,14 @@ const RowByLocation = (
         <EntityTypeSelector
           inputHeight="auto"
           multiple
-          setTargetEntityTypeIds={(newTargetIds) => {
-            updateEntityTypeIds(newTargetIds);
+          setTargetEntityTypeIds={({
+            selectedEntityTypeIds,
+            linkedEntityTypeIds,
+          }) => {
+            updateEntityTypeIds([
+              ...selectedEntityTypeIds,
+              ...linkedEntityTypeIds,
+            ]);
           }}
           targetEntityTypeIds={entityTypeIds}
         />

--- a/apps/plugin-browser/src/pages/popup/popup-contents/action-center/one-off/infer-entities-action.tsx
+++ b/apps/plugin-browser/src/pages/popup/popup-contents/action-center/one-off/infer-entities-action.tsx
@@ -112,10 +112,16 @@ export const InferEntitiesAction = ({
           <EntityTypeSelector
             inputHeight="auto"
             multiple
-            setTargetEntityTypeIds={(newTargetIds) =>
+            setTargetEntityTypeIds={({
+              selectedEntityTypeIds,
+              linkedEntityTypeIds,
+            }) =>
               setManualInferenceConfig({
                 ...manualInferenceConfig,
-                targetEntityTypeIds: newTargetIds,
+                targetEntityTypeIds: [
+                  ...selectedEntityTypeIds,
+                  ...linkedEntityTypeIds,
+                ],
               })
             }
             targetEntityTypeIds={targetEntityTypeIds}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR introduces a convenience when configuring entity type inference in the browser plugin: when an entity type is added, it automatically adds any links from that type, plus their destination types (but no further).

This does not yet indicate which types are automatically added / inherited, or remove any linked types if a source type is removed. We will do more of this in follow-up.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies the browser plugin, which will need publishing once this is approved

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. `yarn dev` in the plugin's folder with the API running, try adding types which link to stuff

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

https://github.com/hashintel/hash/assets/37743469/3e9b39bb-20a2-4c99-b9f6-5f1339c1c7e7

