### PR TITLE
H-1904: Avoid duplicated entries when querying by distance

### DIFF
--- a/.env
+++ b/.env
@@ -49,7 +49,7 @@ HASH_TEMPORAL_VISIBILITY_PG_DATABASE=temporal_visibility
 HASH_GRAPH_PG_USER=graph
 HASH_GRAPH_PG_PASSWORD=graph
 HASH_GRAPH_PG_DATABASE=graph
-HASH_GRAPH_LOG_LEVEL=trace,h2=info,tokio_util=debug,tower=info,tonic=debug,hyper=info,tokio_postgres=info
+HASH_GRAPH_LOG_LEVEL=trace,h2=info,tokio_util=debug,tower=info,tonic=debug,hyper=info,tokio_postgres=info,rustls=info
 
 HASH_GRAPH_TYPE_FETCHER_HOST=localhost
 HASH_GRAPH_TYPE_FETCHER_PORT=4444

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/read.rs
@@ -264,15 +264,21 @@ impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
                     }
                 };
 
+                let entity_id = EntityId {
+                    owned_by_id: row.get(owned_by_id_index),
+                    entity_uuid: row.get(entity_uuid_index),
+                };
+
+                if let Ok(distance) = row.try_get::<_, f64>("distance") {
+                    tracing::trace!(%entity_id, %distance, "Entity embedding was calculated");
+                }
+
                 Ok(Entity {
                     properties: row.get(properties_index),
                     link_data,
                     metadata: EntityMetadata {
                         record_id: EntityRecordId {
-                            entity_id: EntityId {
-                                owned_by_id: row.get(owned_by_id_index),
-                                entity_uuid: row.get(entity_uuid_index),
-                            },
+                            entity_id,
                             edition_id: row.get(edition_id_index),
                         },
                         temporal_versioning: EntityTemporalMetadata {

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/compile.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/compile.rs
@@ -6,6 +6,7 @@ use temporal_versioning::TimeAxis;
 use crate::{
     store::{
         postgres::query::{
+            expression::GroupByExpression,
             table::{
                 EntityEditions, EntityEmbeddings, EntityTemporalMetadata, OntologyIds,
                 OntologyTemporalMetadata,
@@ -75,6 +76,7 @@ impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {
                 joins: Vec::new(),
                 where_expression: WhereExpression::default(),
                 order_by_expression: OrderByExpression::default(),
+                group_by_expression: GroupByExpression::default(),
                 limit: None,
             },
             artifacts: CompilerArtifacts {
@@ -411,12 +413,27 @@ impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {
                             with: WithExpression::default(),
                             distinct: vec![],
                             selects: vec![
-                                SelectExpression::new(Expression::Asterisk, None),
                                 SelectExpression::new(
-                                    Expression::CosineDistance(
-                                        Box::new(Expression::Column(embeddings_column)),
-                                        Box::new(parameter_expression),
+                                    Expression::Column(
+                                        Column::EntityEmbeddings(EntityEmbeddings::WebId)
+                                            .aliased(table.alias),
                                     ),
+                                    None,
+                                ),
+                                SelectExpression::new(
+                                    Expression::Column(
+                                        Column::EntityEmbeddings(EntityEmbeddings::EntityUuid)
+                                            .aliased(table.alias),
+                                    ),
+                                    None,
+                                ),
+                                SelectExpression::new(
+                                    Expression::Function(Function::Min(Box::new(
+                                        Expression::CosineDistance(
+                                            Box::new(Expression::Column(embeddings_column)),
+                                            Box::new(parameter_expression),
+                                        ),
+                                    ))),
                                     Some("distance"),
                                 ),
                             ],
@@ -424,6 +441,14 @@ impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {
                             joins: vec![],
                             where_expression: WhereExpression::default(),
                             order_by_expression: OrderByExpression::default(),
+                            group_by_expression: GroupByExpression {
+                                columns: vec![
+                                    Column::EntityEmbeddings(EntityEmbeddings::WebId)
+                                        .aliased(table.alias),
+                                    Column::EntityEmbeddings(EntityEmbeddings::EntityUuid)
+                                        .aliased(table.alias),
+                                ],
+                            },
                             limit: None,
                         });
                     }
@@ -554,6 +579,7 @@ impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {
                 joins: vec![],
                 where_expression: WhereExpression::default(),
                 order_by_expression: OrderByExpression::default(),
+                group_by_expression: GroupByExpression::default(),
                 limit: None,
             },
         );

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/expression/group_by_clause.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/expression/group_by_clause.rs
@@ -1,0 +1,59 @@
+use std::fmt;
+
+use crate::store::postgres::query::{AliasedColumn, Transpile};
+
+#[derive(Debug, Default, PartialEq, Eq, Hash)]
+pub struct GroupByExpression {
+    pub columns: Vec<AliasedColumn>,
+}
+
+impl Transpile for GroupByExpression {
+    fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        if self.columns.is_empty() {
+            return Ok(());
+        }
+
+        fmt.write_str("GROUP BY ")?;
+        for (idx, column) in self.columns.iter().enumerate() {
+            if idx > 0 {
+                fmt.write_str(", ")?;
+            }
+            column.transpile(fmt)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        knowledge::EntityQueryPath,
+        store::postgres::query::{Alias, PostgresQueryPath},
+    };
+
+    #[test]
+    fn order_one() {
+        let order_by_expression = GroupByExpression {
+            columns: vec![
+                EntityQueryPath::OwnedById
+                    .terminating_column()
+                    .aliased(Alias {
+                        condition_index: 1,
+                        chain_depth: 2,
+                        number: 3,
+                    }),
+                EntityQueryPath::Uuid.terminating_column().aliased(Alias {
+                    condition_index: 4,
+                    chain_depth: 5,
+                    number: 6,
+                }),
+            ],
+        };
+        assert_eq!(
+            order_by_expression.transpile_to_string(),
+            r#"GROUP BY "entity_temporal_metadata_1_2_3"."web_id", "entity_temporal_metadata_4_5_6"."entity_uuid""#
+        );
+    }
+}

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/expression/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/expression/mod.rs
@@ -1,4 +1,5 @@
 mod conditional;
+mod group_by_clause;
 mod join_clause;
 mod order_clause;
 mod select_clause;
@@ -7,6 +8,7 @@ mod with_clause;
 
 pub use self::{
     conditional::{Constant, Expression, Function},
+    group_by_clause::GroupByExpression,
     join_clause::JoinExpression,
     order_clause::{OrderByExpression, Ordering},
     select_clause::SelectExpression,

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/expression/with_clause.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/expression/with_clause.rs
@@ -55,7 +55,7 @@ impl Transpile for WithExpression {
 mod tests {
     use super::*;
     use crate::store::postgres::query::{
-        expression::OrderByExpression,
+        expression::{GroupByExpression, OrderByExpression},
         test_helper::{max_version_expression, trim_whitespace},
         Alias, Expression, SelectExpression, SelectStatement, Table, WhereExpression,
     };
@@ -82,6 +82,7 @@ mod tests {
                 joins: vec![],
                 where_expression: WhereExpression::default(),
                 order_by_expression: OrderByExpression::default(),
+                group_by_expression: GroupByExpression::default(),
                 limit: None,
             },
         );
@@ -108,6 +109,7 @@ mod tests {
                 joins: vec![],
                 where_expression: WhereExpression::default(),
                 order_by_expression: OrderByExpression::default(),
+                group_by_expression: GroupByExpression::default(),
                 limit: None,
             },
         );


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

There might be the different embeddings for the same entity and as the entities are sorted by the distance it's not guaranteed, that an entity is only returned once.

## 🔍 What does this change?

- Add a `GROUP BY` statement to the distance filter
- Tweak logging to (a) not print `rustle` debug/trace infos and (b) print tracing info about the calculated embedding distance of an entity

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph