### PR TITLE
H-1845, H-1814, H-1815, H-1818: Fix entity editor crashes + other small improvements

### DIFF
--- a/apps/hash-frontend/src/pages/[shortname].page/pinned-entity-type-tab-contents.tsx
+++ b/apps/hash-frontend/src/pages/[shortname].page/pinned-entity-type-tab-contents.tsx
@@ -34,6 +34,7 @@ import {
 import { useAccountPages } from "../../components/hooks/use-account-pages";
 import { useCreatePage } from "../../components/hooks/use-create-page";
 import { Org, User } from "../../lib/user-and-org";
+import { useEntityTypesContextRequired } from "../../shared/entity-types-context/hooks/use-entity-types-context-required";
 import { ArrowDownAZRegularIcon } from "../../shared/icons/arrow-down-a-z-regular-icon";
 import { ArrowUpZARegularIcon } from "../../shared/icons/arrow-up-a-z-regular-icon";
 import { CanvasIcon } from "../../shared/icons/canvas-icon";
@@ -201,6 +202,12 @@ export const PinnedEntityTypeTabContents: FunctionComponent<{
   const isPagesTab =
     currentTab.entityTypeBaseUrl === systemEntityTypes.page.entityTypeBaseUrl;
 
+  const { isSpecialEntityTypeLookup } = useEntityTypesContextRequired();
+
+  const isLinkEntityType = currentTab.entityType
+    ? isSpecialEntityTypeLookup?.[currentTab.entityType.schema.$id]?.isLink
+    : undefined;
+
   return (
     <Box mb={6}>
       <Box display="flex" alignItems="center" columnGap={1.5} marginBottom={1}>
@@ -282,7 +289,7 @@ export const PinnedEntityTypeTabContents: FunctionComponent<{
                 No {currentTab.pluralTitle?.toLowerCase()} could be found in @
                 {profile.shortname}
               </Typography>
-              {isEditable ? (
+              {isEditable && !isLinkEntityType ? (
                 <Box marginTop={2}>
                   <Button
                     startIcon={<PlusRegularIcon />}

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-page-wrapper/entity-page-header.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-page-wrapper/entity-page-header.tsx
@@ -50,6 +50,7 @@ export const EntityPageHeader = ({
           {
             title: "Entities",
             id: "entities",
+            href: "/entities",
           },
           {
             title: entityLabel,

--- a/apps/hash-frontend/src/pages/new/entity.page.tsx
+++ b/apps/hash-frontend/src/pages/new/entity.page.tsx
@@ -1,25 +1,82 @@
-import { validateVersionedUrl } from "@blockprotocol/type-system";
+import { validateVersionedUrl, VersionedUrl } from "@blockprotocol/type-system";
+import { Container, Paper, Typography } from "@mui/material";
 import { useRouter } from "next/router";
-import { useContext } from "react";
+import { FunctionComponent, useContext, useMemo } from "react";
 
+import { useEntityTypesContextRequired } from "../../shared/entity-types-context/hooks/use-entity-types-context-required";
 import { getLayoutWithSidebar, NextPageWithLayout } from "../../shared/layout";
 import { CreateEntityPage } from "../[shortname]/entities/[entity-uuid].page/create-entity-page";
 import { EntityPageLoadingState } from "../[shortname]/entities/[entity-uuid].page/entity-page-loading-state";
 import { SelectEntityTypePage } from "../[shortname]/entities/[entity-uuid].page/select-entity-type-page";
 import { WorkspaceContext } from "../shared/workspace-context";
 
+const CreateLinkEntityError: FunctionComponent<{
+  linkEntityTypeId?: VersionedUrl;
+}> = ({ linkEntityTypeId }) => {
+  const { entityTypes } = useEntityTypesContextRequired();
+
+  const linkEntityType = useMemo(
+    () => entityTypes?.find(({ schema }) => schema.$id === linkEntityTypeId),
+    [entityTypes, linkEntityTypeId],
+  );
+
+  return (
+    <Container
+      sx={{ display: "flex", alignItems: "center", justifyContent: "center" }}
+    >
+      <Paper
+        sx={{
+          padding: 3,
+          marginTop: 3,
+          borderRadius: "6px",
+          width: "fit-content",
+        }}
+      >
+        <Typography variant="h3" gutterBottom textAlign="center">
+          Cannot create an entity of type{" "}
+          <strong>{linkEntityType?.schema.title}</strong>
+        </Typography>
+        <Typography textAlign="center">
+          Create links with type <strong>{linkEntityType?.schema.title}</strong>{" "}
+          by editing the source entity.
+        </Typography>
+      </Paper>
+    </Container>
+  );
+};
+
 const Page: NextPageWithLayout = () => {
   const router = useRouter();
+  const { isSpecialEntityTypeLookup } = useEntityTypesContextRequired();
+
   const queryEntityId = router.query["entity-type-id"]?.toString();
   const entityTypeId = !queryEntityId
     ? null
     : validateVersionedUrl(queryEntityId);
 
+  const isLinkEntity = useMemo(
+    () =>
+      entityTypeId && entityTypeId.type === "Ok"
+        ? isSpecialEntityTypeLookup?.[entityTypeId.inner]?.isLink
+        : undefined,
+    [entityTypeId, isSpecialEntityTypeLookup],
+  );
+
   const { activeWorkspace } = useContext(WorkspaceContext);
   const shouldBeCreatingEntity = entityTypeId?.type === "Ok";
 
-  if (!activeWorkspace) {
+  if (!activeWorkspace || typeof isLinkEntity === "undefined") {
     return <EntityPageLoadingState />;
+  }
+
+  if (isLinkEntity) {
+    return (
+      <CreateLinkEntityError
+        linkEntityTypeId={
+          entityTypeId?.type === "Ok" ? entityTypeId.inner : undefined
+        }
+      />
+    );
   }
 
   if (shouldBeCreatingEntity) {

--- a/apps/hash-frontend/src/pages/new/entity.page.tsx
+++ b/apps/hash-frontend/src/pages/new/entity.page.tsx
@@ -65,7 +65,10 @@ const Page: NextPageWithLayout = () => {
   const { activeWorkspace } = useContext(WorkspaceContext);
   const shouldBeCreatingEntity = entityTypeId?.type === "Ok";
 
-  if (!activeWorkspace || typeof isLinkEntity === "undefined") {
+  if (
+    !activeWorkspace ||
+    (entityTypeId?.type === "Ok" && typeof isLinkEntity === "undefined")
+  ) {
     return <EntityPageLoadingState />;
   }
 

--- a/apps/hash-frontend/src/pages/shared/entity-type-page/entity-type-tabs.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-page/entity-type-tabs.tsx
@@ -4,6 +4,7 @@ import { Box } from "@mui/material";
 import { useRouter } from "next/router";
 
 import { useEntityTypeEntitiesContext } from "../../../shared/entity-type-entities-context";
+import { useEntityTypesContextRequired } from "../../../shared/entity-types-context/hooks/use-entity-types-context-required";
 import { TabLink } from "../../../shared/ui/tab-link";
 import { Tabs } from "../../../shared/ui/tabs";
 import { useEntityType } from "./shared/entity-type-context";
@@ -25,6 +26,10 @@ export const EntityTypeTabs = ({
   const { entities, loading } = useEntityTypeEntitiesContext();
 
   const currentTab = useCurrentTab();
+
+  const { isSpecialEntityTypeLookup } = useEntityTypesContextRequired();
+
+  const isLinkEntityType = isSpecialEntityTypeLookup?.[entityType.$id]?.isLink;
 
   return (
     <Box display="flex">
@@ -53,43 +58,47 @@ export const EntityTypeTabs = ({
                 count={entities?.length ?? 0}
                 active={currentTab === "entities"}
               />,
-              <TabLink
-                key={isFile ? "upload" : "create"}
-                value={isFile ? "upload" : "create"}
-                href={
-                  isFile
-                    ? getTabUrl("upload")
-                    : `/new/entity?entity-type-id=${encodeURIComponent(
-                        entityType.$id,
-                      )}`
-                }
-                label={
-                  isFile
-                    ? `Add new ${isImage ? "image" : "file"}`
-                    : "Create new entity"
-                }
-                sx={(theme) => ({
-                  ml: "auto",
-                  color: "inherit",
-                  fill: theme.palette.blue[70],
-                  "&:hover": {
-                    color: theme.palette.primary.main,
-                    fill: theme.palette.blue[60],
-                  },
-                  mr: 0,
-                })}
-                icon={
-                  <FontAwesomeIcon
-                    icon={faPlus}
-                    sx={(theme) => ({
-                      ...theme.typography.smallTextLabels,
-                      fill: "inherit",
-                      ml: 1,
-                    })}
-                  />
-                }
-              />,
-            ]}
+              isLinkEntityType ? (
+                []
+              ) : (
+                <TabLink
+                  key={isFile ? "upload" : "create"}
+                  value={isFile ? "upload" : "create"}
+                  href={
+                    isFile
+                      ? getTabUrl("upload")
+                      : `/new/entity?entity-type-id=${encodeURIComponent(
+                          entityType.$id,
+                        )}`
+                  }
+                  label={
+                    isFile
+                      ? `Add new ${isImage ? "image" : "file"}`
+                      : "Create new entity"
+                  }
+                  sx={(theme) => ({
+                    ml: "auto",
+                    color: "inherit",
+                    fill: theme.palette.blue[70],
+                    "&:hover": {
+                      color: theme.palette.primary.main,
+                      fill: theme.palette.blue[60],
+                    },
+                    mr: 0,
+                  })}
+                  icon={
+                    <FontAwesomeIcon
+                      icon={faPlus}
+                      sx={(theme) => ({
+                        ...theme.typography.smallTextLabels,
+                        fill: "inherit",
+                        ml: 1,
+                      })}
+                    />
+                  }
+                />
+              ),
+            ].flat()}
       </Tabs>
     </Box>
   );

--- a/apps/hash-frontend/src/pages/shared/link-label-with-source-and-destination.tsx
+++ b/apps/hash-frontend/src/pages/shared/link-label-with-source-and-destination.tsx
@@ -1,5 +1,8 @@
 import { extractVersion } from "@blockprotocol/type-system";
-import { AsteriskRegularIcon } from "@hashintel/design-system";
+import {
+  AsteriskRegularIcon,
+  EyeSlashIconRegular,
+} from "@hashintel/design-system";
 import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import {
   Entity,
@@ -37,7 +40,7 @@ const ContentTypography = styled(Typography)(({ theme }) => ({
 }));
 
 const LeftOrRightEntity: FunctionComponent<{
-  entity: Entity;
+  entity?: Entity;
   subgraph: Subgraph<EntityRootType>;
   openInNew?: boolean;
   endAdornment?: ReactNode;
@@ -45,18 +48,25 @@ const LeftOrRightEntity: FunctionComponent<{
   sx?: BoxProps["sx"];
 }> = ({ subgraph, entity, endAdornment, sx, label, openInNew }) => {
   const entityLabel = useMemo(
-    () => generateEntityLabel(subgraph, entity),
+    () => (entity ? generateEntityLabel(subgraph, entity) : "Hidden entity"),
     [subgraph, entity],
   );
 
   const entityType = useMemo(
-    () => getEntityTypeById(subgraph, entity.metadata.entityTypeId)!,
+    () =>
+      entity
+        ? getEntityTypeById(subgraph, entity.metadata.entityTypeId)
+        : undefined,
     [subgraph, entity],
   );
 
   const getOwnerForEntity = useGetOwnerForEntity();
 
   const href = useMemo(() => {
+    if (!entity || entity.metadata.recordId.entityId.includes("draft")) {
+      return undefined;
+    }
+
     const { shortname: entityNamespace } = getOwnerForEntity(entity);
 
     return `/@${entityNamespace}/entities/${extractEntityUuidFromEntityId(
@@ -64,17 +74,55 @@ const LeftOrRightEntity: FunctionComponent<{
     )}`;
   }, [getOwnerForEntity, entity]);
 
+  const content = (
+    <Box
+      display="flex"
+      alignItems="center"
+      columnGap={1}
+      paddingX={1.5}
+      paddingY={0.75}
+      sx={[
+        {
+          borderRadius: "6px",
+          borderColor: ({ palette }) => palette.gray[30],
+          borderWidth: 1,
+          borderStyle: "solid",
+        },
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          svg: {
+            color: ({ palette }) => palette.gray[50],
+            fontSize: 16,
+            transition: ({ transitions }) => transitions.create("color"),
+          },
+        }}
+      >
+        {entityType ? (
+          entityType.metadata.icon ?? <AsteriskRegularIcon />
+        ) : (
+          <EyeSlashIconRegular />
+        )}
+      </Box>
+      <ContentTypography>{entityLabel}</ContentTypography>
+      {endAdornment}
+    </Box>
+  );
+
   return (
     <Box
       display="flex"
       flexDirection="column"
       sx={{
         minWidth: 0,
-        "&:first-of-type > a > div": {
+        "&:first-of-type > a > div, &:first-of-type > div": {
           borderTopRightRadius: 0,
           borderBottomRightRadius: 0,
         },
-        "&:last-of-type > a > div": {
+        "&:last-of-type > a > div, &:last-of-type > div": {
           borderTopLeftRadius: 0,
           borderBottomLeftRadius: 0,
         },
@@ -93,49 +141,24 @@ const LeftOrRightEntity: FunctionComponent<{
           {label}
         </Typography>
       ) : null}
-      <Link
-        openInNew={openInNew}
-        href={href}
-        noLinkStyle
-        sx={{
-          "&:hover": {
-            [`.${typographyClasses.root}, svg`]: {
-              color: ({ palette }) => palette.blue[70],
+      {href ? (
+        <Link
+          openInNew={openInNew}
+          href={href}
+          noLinkStyle
+          sx={{
+            "&:hover": {
+              [`.${typographyClasses.root}, svg`]: {
+                color: ({ palette }) => palette.blue[70],
+              },
             },
-          },
-        }}
-      >
-        <Box
-          display="flex"
-          alignItems="center"
-          columnGap={1}
-          paddingX={1.5}
-          paddingY={0.75}
-          sx={[
-            {
-              borderRadius: "6px",
-              borderColor: ({ palette }) => palette.gray[30],
-              borderWidth: 1,
-              borderStyle: "solid",
-            },
-            ...(Array.isArray(sx) ? sx : [sx]),
-          ]}
+          }}
         >
-          <Box display="flex">
-            {entityType.metadata.icon ?? (
-              <AsteriskRegularIcon
-                sx={{
-                  color: ({ palette }) => palette.gray[50],
-                  fontSize: 16,
-                  transition: ({ transitions }) => transitions.create("color"),
-                }}
-              />
-            )}
-          </Box>
-          <ContentTypography>{entityLabel}</ContentTypography>
-          {endAdornment}
-        </Box>
-      </Link>
+          {content}
+        </Link>
+      ) : (
+        content
+      )}
     </Box>
   );
 };
@@ -167,14 +190,11 @@ export const LinkLabelWithSourceAndDestination: FunctionComponent<{
         subgraph,
         linkEntity.metadata.entityTypeId,
       )!,
-      leftEntity: getEntityRevision(
-        subgraph,
-        linkEntity.linkData.leftEntityId,
-      )!,
+      leftEntity: getEntityRevision(subgraph, linkEntity.linkData.leftEntityId),
       rightEntity: getEntityRevision(
         subgraph,
         linkEntity.linkData.rightEntityId,
-      )!,
+      ),
     };
   }, [linkEntity, subgraph]);
 

--- a/apps/hash-frontend/src/pages/shared/link-label-with-source-and-destination.tsx
+++ b/apps/hash-frontend/src/pages/shared/link-label-with-source-and-destination.tsx
@@ -201,10 +201,21 @@ const LeftOrRightEntity: FunctionComponent<{
     >(
       (
         prev,
-        { linkEntity: linkEntityRevisions, rightEntity: rightEntityRevisions },
+        {
+          linkEntity: linkEntityRevisions,
+          /**
+           * @todo: figure out why this is typed as non-nullable when
+           * it can be nullable.
+           */
+          rightEntity: rightEntityRevisions = [],
+        },
       ) => {
-        const linkEntity = linkEntityRevisions[0]!;
-        const rightEntity = rightEntityRevisions[0]!;
+        const linkEntity = linkEntityRevisions[0];
+        const rightEntity = rightEntityRevisions[0];
+
+        if (!linkEntity || !rightEntity) {
+          return prev;
+        }
 
         const linkEntityTypeId = linkEntity.metadata.entityTypeId;
         const linkEntityType = getEntityTypeById(subgraph, linkEntityTypeId);

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list/entity-menu.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list/entity-menu.tsx
@@ -11,6 +11,7 @@ import { Box, Menu } from "@mui/material";
 import { bindMenu, PopupState } from "material-ui-popup-state/hooks";
 import { FunctionComponent } from "react";
 
+import { useEntityTypesContextRequired } from "../../../entity-types-context/hooks/use-entity-types-context-required";
 import { generateLinkParameters } from "../../../generate-link-parameters";
 import { EntityTypeMenuItem } from "./entity-type-menu-item";
 
@@ -29,14 +30,21 @@ export const EntityMenu: FunctionComponent<EntityTypeMenuProps> = ({
   popupState,
   title,
 }) => {
+  const { isSpecialEntityTypeLookup } = useEntityTypesContextRequired();
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const isLinkEntityType = isSpecialEntityTypeLookup?.[entityTypeId]?.isLink;
+
   return (
     <Menu {...bindMenu(popupState)}>
-      <EntityTypeMenuItem
-        title={`Create new ${pluralize.singular(title)}`}
-        icon={faAdd}
-        href={`/new/entity?entity-type-id=${entityTypeId}`}
-        popupState={popupState}
-      />
+      {isLinkEntityType ? null : (
+        <EntityTypeMenuItem
+          title={`Create new ${pluralize.singular(title)}`}
+          icon={faAdd}
+          href={`/new/entity?entity-type-id=${entityTypeId}`}
+          popupState={popupState}
+        />
+      )}
       <EntityTypeMenuItem
         title={`View all ${pluralize(title)}`}
         icon={faList}

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list/entity-type-menu.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list/entity-type-menu.tsx
@@ -6,6 +6,7 @@ import { Menu } from "@mui/material";
 import { bindMenu, PopupState } from "material-ui-popup-state/hooks";
 import { FunctionComponent, useState } from "react";
 
+import { useEntityTypesContextRequired } from "../../../entity-types-context/hooks/use-entity-types-context-required";
 import { useFrozenValue } from "../../../frozen";
 import { EntityTypeMenuItem } from "./entity-type-menu-item";
 
@@ -26,14 +27,21 @@ export const EntityTypeMenu: FunctionComponent<EntityTypeMenuProps> = ({
   const [copied, setCopied] = useState(false);
   const copiedFrozen = useFrozenValue(copied, !popupState.isOpen);
 
+  const { isSpecialEntityTypeLookup } = useEntityTypesContextRequired();
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const isLinkEntityType = isSpecialEntityTypeLookup?.[entityTypeId]?.isLink;
+
   return (
     <Menu {...bindMenu(popupState)}>
-      <EntityTypeMenuItem
-        title={`Create new ${pluralize.singular(title)}`}
-        icon={faAdd}
-        href={`/new/entity?entity-type-id=${entityTypeId}`}
-        popupState={popupState}
-      />
+      {isLinkEntityType ? null : (
+        <EntityTypeMenuItem
+          title={`Create new ${pluralize.singular(title)}`}
+          icon={faAdd}
+          href={`/new/entity?entity-type-id=${entityTypeId}`}
+          popupState={popupState}
+        />
+      )}
       <EntityTypeMenuItem
         title={copiedFrozen ? "Copied!" : `Copy link to ${title}`}
         icon={faLink}

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-page-list/account-page-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/account-page-list/account-page-list.tsx
@@ -410,7 +410,7 @@ export const AccountPageList: FunctionComponent<AccountPageListProps> = ({
           title="Pages"
           loading={loading}
           endAdornment={
-            <Tooltip title="Create new Page">
+            <Tooltip title="Create new page">
               <IconButton
                 size="small"
                 unpadded


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR prevents a crash in the entity editor when trying to create an entity with a link entity type, by displaying an error message instead. It also hides links to the "Create new entity" page when the entity type is a link entity.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-1845
- H-1814
- H-1815
- H-1818

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- lower-case "Page" in sidebar on hover (H-1818)
- make 'Entities' breadcrumb clickable (H-1815)
- display attributes (properties/outgoing links)of source/destination in tooltip link chips (H-1814)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

Manual testing.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Try creating a link on the "Create new entity" page, for example via `http://localhost:3000/new/entity?entity-type-id=https%3A%2F%2Fhash.ai%2F%40hash%2Ftypes%2Fentity-type%2Fauthored-by%2Fv%2F1`
2. View an existing link entity in the entity editor or a slideover, to view the new tooltip. You can also then check the "Entities" breadcrumb is clickable.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

Source/destination tooltips, and clickable "Entities" breadcrumb:

https://github.com/hashintel/hash/assets/42802102/6e7cc506-df0a-423e-8d32-36810572b011

Screen displayed if a user ends up on the "Create new entity" page for a link entity type:

<img width="1586" alt="image" src="https://github.com/hashintel/hash/assets/42802102/5b0dddbc-ebc2-47d7-9087-579bf104bfc9">

Lowercase "page" in the "Create new page" tooltip:

<img width="420" alt="image" src="https://github.com/hashintel/hash/assets/42802102/078180c0-55b3-4deb-a1ca-ef8215489d25">


