### PR TITLE
H-1908: Return archived types when JSON is requested

### DIFF
--- a/apps/hash-api/package.json
+++ b/apps/hash-api/package.json
@@ -6,7 +6,7 @@
   "license": "AGPL-3.0",
   "scripts": {
     "codegen": "rimraf './src/**/*.gen.*'; graphql-codegen --config codegen.config.ts",
-    "dev": "NODE_ENV=development NODE_OPTIONS=--max-old-space-size=2048 tsx watch ./src/index.ts",
+    "dev": "NODE_ENV=development NODE_OPTIONS=--max-old-space-size=2048 tsx watch --clear-screen=false ./src/index.ts",
     "fix:eslint": "eslint --fix .",
     "generate-ontology-type-ids": "tsx ./src/generate-ontology-type-ids.ts; yarn prettier --write ../../libs/@local/hash-isomorphic-utils/src/ontology-type-ids.ts",
     "lint:eslint": "eslint --report-unused-disable-directives .",

--- a/apps/hash-api/src/graphql/resolvers/ontology/data-type.ts
+++ b/apps/hash-api/src/graphql/resolvers/ontology/data-type.ts
@@ -1,5 +1,6 @@
 import {
   currentTimeInstantTemporalAxes,
+  fullTransactionTimeAxis,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { DataTypeRootType, Subgraph } from "@local/hash-subgraph";
@@ -19,7 +20,11 @@ export const queryDataTypes: ResolverFn<
   {},
   LoggedInGraphQLContext,
   QueryQueryDataTypesArgs
-> = async (_, { constrainsValuesOn }, { dataSources, authentication }) => {
+> = async (
+  _,
+  { constrainsValuesOn, includeArchived },
+  { dataSources, authentication },
+) => {
   const { graphApi } = dataSources;
 
   const { data } = await graphApi.getDataTypesByQuery(authentication.actorId, {
@@ -30,7 +35,9 @@ export const queryDataTypes: ResolverFn<
       ...zeroedGraphResolveDepths,
       constrainsValuesOn,
     },
-    temporalAxes: currentTimeInstantTemporalAxes,
+    temporalAxes: includeArchived
+      ? fullTransactionTimeAxis
+      : currentTimeInstantTemporalAxes,
     includeDrafts: false,
   });
 
@@ -46,7 +53,7 @@ export const getDataType: ResolverFn<
   QueryGetDataTypeArgs
 > = async (
   _,
-  { dataTypeId, constrainsValuesOn },
+  { dataTypeId, constrainsValuesOn, includeArchived },
   { dataSources, authentication },
 ) =>
   getDataTypeSubgraphById(
@@ -59,6 +66,8 @@ export const getDataType: ResolverFn<
         ...zeroedGraphResolveDepths,
         constrainsValuesOn,
       },
-      temporalAxes: currentTimeInstantTemporalAxes,
+      temporalAxes: includeArchived
+        ? fullTransactionTimeAxis
+        : currentTimeInstantTemporalAxes,
     },
   );

--- a/apps/hash-api/src/graphql/resolvers/ontology/entity-type.ts
+++ b/apps/hash-api/src/graphql/resolvers/ontology/entity-type.ts
@@ -1,6 +1,7 @@
 import { OntologyTemporalMetadata } from "@local/hash-graph-client";
 import {
   currentTimeInstantTemporalAxes,
+  fullTransactionTimeAxis,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import {
@@ -108,21 +109,7 @@ export const queryEntityTypesResolver: ResolverFn<
         inheritsFrom,
       },
       temporalAxes: includeArchived
-        ? {
-            pinned: {
-              axis: "decisionTime",
-              timestamp: null,
-            },
-            variable: {
-              axis: "transactionTime",
-              interval: {
-                start: {
-                  kind: "unbounded",
-                },
-                end: null,
-              },
-            },
-          }
+        ? fullTransactionTimeAxis
         : currentTimeInstantTemporalAxes,
       includeDrafts: false,
     },
@@ -147,6 +134,7 @@ export const getEntityTypeResolver: ResolverFn<
     constrainsLinksOn,
     constrainsLinkDestinationsOn,
     inheritsFrom,
+    includeArchived,
   },
   { dataSources, authentication },
   __,
@@ -164,7 +152,9 @@ export const getEntityTypeResolver: ResolverFn<
         constrainsLinkDestinationsOn,
         inheritsFrom,
       },
-      temporalAxes: currentTimeInstantTemporalAxes,
+      temporalAxes: includeArchived
+        ? fullTransactionTimeAxis
+        : currentTimeInstantTemporalAxes,
     },
   );
 

--- a/apps/hash-api/src/graphql/resolvers/ontology/property-type.ts
+++ b/apps/hash-api/src/graphql/resolvers/ontology/property-type.ts
@@ -1,6 +1,7 @@
 import { OntologyTemporalMetadata } from "@local/hash-graph-client";
 import {
   currentTimeInstantTemporalAxes,
+  fullTransactionTimeAxis,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import {
@@ -105,21 +106,7 @@ export const queryPropertyTypesResolver: ResolverFn<
         constrainsPropertiesOn,
       },
       temporalAxes: includeArchived
-        ? {
-            pinned: {
-              axis: "decisionTime",
-              timestamp: null,
-            },
-            variable: {
-              axis: "transactionTime",
-              interval: {
-                start: {
-                  kind: "unbounded",
-                },
-                end: null,
-              },
-            },
-          }
+        ? fullTransactionTimeAxis
         : currentTimeInstantTemporalAxes,
       includeDrafts: false,
     },
@@ -137,7 +124,12 @@ export const getPropertyTypeResolver: ResolverFn<
   QueryGetPropertyTypeArgs
 > = async (
   _,
-  { propertyTypeId, constrainsValuesOn, constrainsPropertiesOn },
+  {
+    propertyTypeId,
+    constrainsValuesOn,
+    constrainsPropertiesOn,
+    includeArchived,
+  },
   { dataSources, authentication },
   __,
 ) =>
@@ -151,7 +143,9 @@ export const getPropertyTypeResolver: ResolverFn<
         constrainsValuesOn,
         constrainsPropertiesOn,
       },
-      temporalAxes: currentTimeInstantTemporalAxes,
+      temporalAxes: includeArchived
+        ? fullTransactionTimeAxis
+        : currentTimeInstantTemporalAxes,
     },
   );
 

--- a/apps/hash-frontend/src/graphql/queries/ontology/data-type.queries.ts
+++ b/apps/hash-frontend/src/graphql/queries/ontology/data-type.queries.ts
@@ -5,10 +5,12 @@ export const getDataTypeQuery = gql`
   query getDataType(
     $dataTypeId: VersionedUrl!
     $constrainsValuesOn: OutgoingEdgeResolveDepthInput!
+    $includeArchived: Boolean = false
   ) {
     getDataType(
       dataTypeId: $dataTypeId
       constrainsValuesOn: $constrainsValuesOn
+      includeArchived: $includeArchived
     ) {
       ...SubgraphFields
     }
@@ -17,8 +19,14 @@ export const getDataTypeQuery = gql`
 `;
 
 export const queryDataTypesQuery = gql`
-  query queryDataTypes($constrainsValuesOn: OutgoingEdgeResolveDepthInput!) {
-    queryDataTypes(constrainsValuesOn: $constrainsValuesOn) {
+  query queryDataTypes(
+    $constrainsValuesOn: OutgoingEdgeResolveDepthInput!
+    $includeArchived: Boolean = false
+  ) {
+    queryDataTypes(
+      constrainsValuesOn: $constrainsValuesOn
+      includeArchived: $includeArchived
+    ) {
       ...SubgraphFields
     }
   }

--- a/apps/hash-frontend/src/graphql/queries/ontology/entity-type.queries.ts
+++ b/apps/hash-frontend/src/graphql/queries/ontology/entity-type.queries.ts
@@ -9,6 +9,7 @@ export const getEntityTypeQuery = gql`
     $constrainsLinksOn: OutgoingEdgeResolveDepthInput!
     $constrainsLinkDestinationsOn: OutgoingEdgeResolveDepthInput!
     $inheritsFrom: OutgoingEdgeResolveDepthInput!
+    $includeArchived: Boolean = false
   ) {
     getEntityType(
       entityTypeId: $entityTypeId
@@ -17,6 +18,7 @@ export const getEntityTypeQuery = gql`
       constrainsLinksOn: $constrainsLinksOn
       constrainsLinkDestinationsOn: $constrainsLinkDestinationsOn
       inheritsFrom: $inheritsFrom
+      includeArchived: $includeArchived
     ) {
       ...SubgraphFields
     }

--- a/apps/hash-frontend/src/graphql/queries/ontology/property-type.queries.ts
+++ b/apps/hash-frontend/src/graphql/queries/ontology/property-type.queries.ts
@@ -6,11 +6,13 @@ export const getPropertyTypeQuery = gql`
     $propertyTypeId: VersionedUrl!
     $constrainsValuesOn: OutgoingEdgeResolveDepthInput!
     $constrainsPropertiesOn: OutgoingEdgeResolveDepthInput!
+    $includeArchived: Boolean = false
   ) {
     getPropertyType(
       propertyTypeId: $propertyTypeId
       constrainsValuesOn: $constrainsValuesOn
       constrainsPropertiesOn: $constrainsPropertiesOn
+      includeArchived: $includeArchived
     ) {
       ...SubgraphFields
     }

--- a/apps/hash-frontend/src/middleware/return-types-as-json/generate-query-args.ts
+++ b/apps/hash-frontend/src/middleware/return-types-as-json/generate-query-args.ts
@@ -44,6 +44,7 @@ export const generateQueryArgs = (
         variables: {
           dataTypeId: versionedUrl,
           constrainsValuesOn: zeroDepth,
+          includeArchived: true,
         },
       };
     case "entity-type":
@@ -56,6 +57,7 @@ export const generateQueryArgs = (
           constrainsPropertiesOn: zeroDepth,
           constrainsValuesOn: zeroDepth,
           inheritsFrom: zeroDepth,
+          includeArchived: true,
         },
       };
     case "property-type":
@@ -65,6 +67,7 @@ export const generateQueryArgs = (
           constrainsValuesOn: zeroDepth,
           constrainsPropertiesOn: zeroDepth,
           propertyTypeId: versionedUrl,
+          includeArchived: true,
         },
       };
   }

--- a/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
@@ -100,6 +100,29 @@ export const fullDecisionTimeAxis: QueryTemporalAxesUnresolved = {
 };
 
 /**
+ * According to the database's most up-to-date knowledge (transaction time),
+ * return the full history of entities and the times at which those decisions
+ * were made.
+ *
+ * Used to be passed as `temporalAxes` to structural queries.
+ */
+export const fullTransactionTimeAxis: QueryTemporalAxesUnresolved = {
+  pinned: {
+    axis: "decisionTime",
+    timestamp: null,
+  },
+  variable: {
+    axis: "transactionTime",
+    interval: {
+      start: {
+        kind: "unbounded",
+      },
+      end: null,
+    },
+  },
+};
+
+/**
  * Generates a query filter to match a type, given its versionedUrl.
  *
  * @param versionedUrl

--- a/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
@@ -100,11 +100,11 @@ export const fullDecisionTimeAxis: QueryTemporalAxesUnresolved = {
 };
 
 /**
- * According to the database's most up-to-date knowledge (transaction time),
- * return the full history of entities and the times at which those decisions
- * were made.
+ * Return the full history of records according to their transaction time
  *
- * Used to be passed as `temporalAxes` to structural queries.
+ * This is specifically useful for:
+ * 1. Returning archived types – types currently are archived by setting an upper bound on their transaction time
+ * 2. [Future] audit purposes, to check the transaction history of records
  */
 export const fullTransactionTimeAxis: QueryTemporalAxesUnresolved = {
   pinned: {

--- a/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/ontology/data-type.typedef.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/ontology/data-type.typedef.ts
@@ -11,6 +11,7 @@ export const dataTypeTypedef = gql`
     """
     queryDataTypes(
       constrainsValuesOn: OutgoingEdgeResolveDepthInput!
+      includeArchived: Boolean = false
     ): Subgraph!
 
     """
@@ -19,6 +20,7 @@ export const dataTypeTypedef = gql`
     getDataType(
       dataTypeId: VersionedUrl!
       constrainsValuesOn: OutgoingEdgeResolveDepthInput!
+      includeArchived: Boolean = false
     ): Subgraph!
   }
 

--- a/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/ontology/entity-type.typedef.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/ontology/entity-type.typedef.ts
@@ -29,6 +29,7 @@ export const entityTypeTypedef = gql`
       constrainsLinksOn: OutgoingEdgeResolveDepthInput!
       constrainsLinkDestinationsOn: OutgoingEdgeResolveDepthInput!
       inheritsFrom: OutgoingEdgeResolveDepthInput!
+      includeArchived: Boolean = false
     ): Subgraph!
   }
 

--- a/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/ontology/property-type.typedef.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/ontology/property-type.typedef.ts
@@ -23,6 +23,7 @@ export const propertyTypeTypedef = gql`
       propertyTypeId: VersionedUrl!
       constrainsValuesOn: OutgoingEdgeResolveDepthInput!
       constrainsPropertiesOn: OutgoingEdgeResolveDepthInput!
+      includeArchived: Boolean = false
     ): Subgraph!
   }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When a type's URL is requested outside a browser contet (when there's no `text/html` in the `accept` header), we return JSON instead.

The logic for doing so was excluding archived types. Type archival is meant to remove types from being discovered, but not from being used if they are already being relied on. 

This PR fixes the 'return types as JSON' logic to return an archived type if its URL is requested.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- Manual

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Create a property type and archive it
2. `curl [its-id]` and check the JSON is returned
3. in `main` this will not work
