### PR TITLE
H-1920: Fix authorization relationship updates on circular types

### DIFF
--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
@@ -151,7 +151,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
             },
         };
 
-        let mut relationships = Vec::new();
+        let mut relationships = HashSet::new();
 
         let mut inserted_data_type_metadata = Vec::new();
         for (schema, metadata) in data_types {
@@ -171,7 +171,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
                     .assert_permission()
                     .change_context(InsertionError)?;
 
-                relationships.push((
+                relationships.insert((
                     data_type_id,
                     DataTypeRelationAndSubject::Owner {
                         subject: DataTypeOwnerSubject::Web { id: *owned_by_id },

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
@@ -437,7 +437,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
             },
         };
 
-        let mut relationships = Vec::new();
+        let mut relationships = HashSet::new();
 
         let mut inserted_entity_types = Vec::new();
         let mut inserted_entity_type_metadata =
@@ -466,7 +466,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
                     .assert_permission()
                     .change_context(InsertionError)?;
 
-                relationships.push((
+                relationships.insert((
                     entity_type_id,
                     EntityTypeRelationAndSubject::Owner {
                         subject: EntityTypeOwnerSubject::Web { id: *owned_by_id },

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/property_type.rs
@@ -277,7 +277,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
             },
         };
 
-        let mut relationships = Vec::new();
+        let mut relationships = HashSet::new();
 
         let mut inserted_property_types = Vec::new();
         let mut inserted_property_type_metadata =
@@ -300,7 +300,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                     .assert_permission()
                     .change_context(InsertionError)?;
 
-                relationships.push((
+                relationships.insert((
                     property_type_id,
                     PropertyTypeRelationAndSubject::Owner {
                         subject: PropertyTypeOwnerSubject::Web { id: *owned_by_id },

--- a/libs/@local/hash-authorization/src/schema/account.rs
+++ b/libs/@local/hash-authorization/src/schema/account.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::zanzibar::types::{Resource, Subject};
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum AccountNamespace {
     #[serde(rename = "graph/account")]
     Account,
@@ -47,7 +47,7 @@ impl Subject for AccountId {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum PublicAccess {
     #[serde(rename = "*")]
     Public,

--- a/libs/@local/hash-authorization/src/schema/data_type.rs
+++ b/libs/@local/hash-authorization/src/schema/data_type.rs
@@ -16,7 +16,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum DataTypeNamespace {
     #[serde(rename = "graph/data_type")]
     DataType,
@@ -71,7 +71,7 @@ impl Resource for DataTypeId {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DataTypeResourceRelation {
     Owner,
@@ -80,7 +80,7 @@ pub enum DataTypeResourceRelation {
 
 impl Relation<DataTypeId> for DataTypeResourceRelation {}
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum DataTypePermission {
@@ -90,14 +90,14 @@ pub enum DataTypePermission {
 
 impl Permission<DataTypeId> for DataTypePermission {}
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "type", content = "id")]
 pub enum DataTypeSubject {
     Web(OwnedById),
     Public,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum DataTypeSubjectNamespace {
     #[serde(rename = "graph/web")]
     Web,
@@ -105,7 +105,7 @@ pub enum DataTypeSubjectNamespace {
     Account,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DataTypeSubjectId {
     Uuid(Uuid),
@@ -149,7 +149,7 @@ impl Resource for DataTypeSubject {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", tag = "kind", deny_unknown_fields)]
 pub enum DataTypeOwnerSubject {
@@ -159,14 +159,14 @@ pub enum DataTypeOwnerSubject {
     },
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", tag = "kind", deny_unknown_fields)]
 pub enum DataTypeViewerSubject {
     Public,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", tag = "relation")]
 pub enum DataTypeRelationAndSubject {

--- a/libs/@local/hash-authorization/src/schema/entity_type.rs
+++ b/libs/@local/hash-authorization/src/schema/entity_type.rs
@@ -97,14 +97,14 @@ pub enum EntityTypePermission {
 
 impl Permission<EntityTypeId> for EntityTypePermission {}
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub enum EntityTypeSetting {
     UpdateFromWeb,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "type", content = "id")]
 pub enum EntityTypeSubject {
     Web(OwnedById),
@@ -114,7 +114,7 @@ pub enum EntityTypeSubject {
     AccountGroup(AccountGroupId),
 }
 
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EntityTypeSubjectSet {
     #[default]
@@ -207,7 +207,7 @@ impl Resource for EntityTypeSubject {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", tag = "kind", deny_unknown_fields)]
 pub enum EntityTypeOwnerSubject {
@@ -217,7 +217,7 @@ pub enum EntityTypeOwnerSubject {
     },
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", tag = "kind", deny_unknown_fields)]
 pub enum EntityTypeSettingSubject {
@@ -227,7 +227,7 @@ pub enum EntityTypeSettingSubject {
     },
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", tag = "kind", deny_unknown_fields)]
 pub enum EntityTypeEditorSubject {
@@ -243,14 +243,14 @@ pub enum EntityTypeEditorSubject {
     },
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", tag = "kind", deny_unknown_fields)]
 pub enum EntityTypeViewerSubject {
     Public,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", tag = "kind", deny_unknown_fields)]
 pub enum EntityTypeInstantiatorSubject {
@@ -267,7 +267,7 @@ pub enum EntityTypeInstantiatorSubject {
     },
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", tag = "relation")]
 pub enum EntityTypeRelationAndSubject {

--- a/libs/@local/hash-authorization/src/schema/property_type.rs
+++ b/libs/@local/hash-authorization/src/schema/property_type.rs
@@ -19,7 +19,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum PropertyTypeNamespace {
     #[serde(rename = "graph/property_type")]
     PropertyType,
@@ -74,7 +74,7 @@ impl Resource for PropertyTypeId {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PropertyTypeResourceRelation {
     Owner,
@@ -85,7 +85,7 @@ pub enum PropertyTypeResourceRelation {
 
 impl Relation<PropertyTypeId> for PropertyTypeResourceRelation {}
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum PropertyTypePermission {
@@ -95,14 +95,14 @@ pub enum PropertyTypePermission {
 
 impl Permission<PropertyTypeId> for PropertyTypePermission {}
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub enum PropertyTypeSetting {
     UpdateFromWeb,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "type", content = "id")]
 pub enum PropertyTypeSubject {
     Web(OwnedById),
@@ -112,7 +112,7 @@ pub enum PropertyTypeSubject {
     AccountGroup(AccountGroupId),
 }
 
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PropertyTypeSubjectSet {
     #[default]
@@ -121,7 +121,7 @@ pub enum PropertyTypeSubjectSet {
 
 impl Relation<PropertyTypeSubject> for PropertyTypeSubjectSet {}
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum PropertyTypeSubjectNamespace {
     #[serde(rename = "graph/web")]
     Web,
@@ -133,7 +133,7 @@ pub enum PropertyTypeSubjectNamespace {
     AccountGroup,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum PropertyTypeSubjectId {
     Uuid(Uuid),
@@ -205,7 +205,7 @@ impl Resource for PropertyTypeSubject {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", tag = "kind", deny_unknown_fields)]
 pub enum PropertyTypeOwnerSubject {
@@ -215,7 +215,7 @@ pub enum PropertyTypeOwnerSubject {
     },
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", tag = "kind", deny_unknown_fields)]
 pub enum PropertyTypeSettingSubject {
@@ -225,7 +225,7 @@ pub enum PropertyTypeSettingSubject {
     },
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", tag = "kind", deny_unknown_fields)]
 pub enum PropertyTypeEditorSubject {
@@ -241,14 +241,14 @@ pub enum PropertyTypeEditorSubject {
     },
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", tag = "kind", deny_unknown_fields)]
 pub enum PropertyTypeViewerSubject {
     Public,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", tag = "relation")]
 pub enum PropertyTypeRelationAndSubject {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When fetching an external type with circular dependencies the relationships to be inserted may have duplicates, which is not allowed.