### PR TITLE
H-1894, H-1895: Associate Node and Rust Sentry spans and improve Context information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,6 +1055,7 @@ dependencies = [
  "graph",
  "graph-types",
  "hash-status",
+ "hash-tracing",
  "http-body-util",
  "hyper 1.1.0",
  "include_dir",

--- a/apps/hash-api/src/sentry.ts
+++ b/apps/hash-api/src/sentry.ts
@@ -1,19 +1,31 @@
 import * as Sentry from "@sentry/node";
+import { Router } from "express";
 
 import { isProdEnv } from "./lib/env-config";
 
 const sentryDsn = process.env.NODE_API_SENTRY_DSN;
 
-export const initSentry = () => {
+export const initSentry = (app: Router) => {
+  // TODO: Sentry's integration does not work properly. There are several circumstances where spans are not created
+  //       properly. This implies that the same TraceID is used for different transactions and spans. This is a problem
+  //       because it means that the spans are not correctly linked to the transaction and the transaction is not
+  //       correctly linked to the parent transaction.
+  //   see https://linear.app/hash/issue/H-1916
   Sentry.init({
     dsn: sentryDsn,
     enabled: !!sentryDsn,
     environment: isProdEnv ? "production" : "development",
-    /**
-     * Sentry's ApolloServer integration does not yet work when constructing the ApolloServer with a 'schema' property
-     * @see https://github.com/getsentry/sentry-javascript/issues/8227
-     */
-    integrations: [new Sentry.Integrations.Http({ tracing: true })],
+    integrations: [
+      // Listen to routes specified in `app`
+      new Sentry.Integrations.Express({ app }),
+      // Hooks into Node's internal http module
+      new Sentry.Integrations.Http({ tracing: true }),
+      // Create spans for resolvers
+      // TODO: Sentry's ApolloServer integration does not yet work when constructing the ApolloServer with a 'schema'
+      //       property
+      //   see https://github.com/getsentry/sentry-javascript/issues/8227
+      // new Sentry.Integrations.Apollo({ useNestjs: true }),
+    ],
 
     tracesSampleRate: 0.2,
   });

--- a/apps/hash-api/src/sentry.ts
+++ b/apps/hash-api/src/sentry.ts
@@ -27,6 +27,6 @@ export const initSentry = (app: Router) => {
       // new Sentry.Integrations.Apollo({ useNestjs: true }),
     ],
 
-    tracesSampleRate: 0.2,
+    tracesSampleRate: 1.0,
   });
 };

--- a/apps/hash-graph/libs/api/Cargo.toml
+++ b/apps/hash-graph/libs/api/Cargo.toml
@@ -10,6 +10,7 @@ description = "HASH Graph API"
 hash-status = { workspace = true }
 graph = { workspace = true, features = ["utoipa"] }
 graph-types = { workspace = true }
+hash-tracing = { workspace = true }
 temporal-client = { workspace = true }
 temporal-versioning = { workspace = true }
 authorization = { workspace = true }

--- a/libs/@local/tracing/src/logging.rs
+++ b/libs/@local/tracing/src/logging.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt::{Display, Formatter},
     io,
-    io::Stderr,
+    io::{IsTerminal, Stderr},
     path::{Path, PathBuf},
 };
 
@@ -201,7 +201,7 @@ where
         LogFormat::Compact => OutputFormatter::Compact(formatter.compact()),
     };
 
-    let ansi_output = log_format != LogFormat::Json;
+    let ansi_output = io::stderr().is_terminal() && log_format != LogFormat::Json;
     if !ansi_output {
         Report::set_color_mode(ColorMode::None);
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To make Sentry more useful (or useful at all) the spans between the projects should be connected. Also, the current information stored on Rust events could have been improved. The most important fix this PR is providing that (hopefully) all GraphQL requests get a unique trace ID so they are actually distinguishable in Sentry.

## 🔍 What does this change?

- Rewrite Apollo server setup to use new Sentry API
- Enable integrations for Sentry and Express and use the tracing plugin to create a sentry transaction per GraphQL request
- Add a `capture_report` function to capture an `error_stack::Report`. Currently, this only captures it as a message but also tries to read the surrounding lines in the file.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

I had several issues around the trace IDs. Especially some traces bleeds into other traces when multiple requests were issued. The current approach and combination of plugins/setup seems to work pretty stable but this is something we need to improve. For more information see H-1916.

## 📹 Demo

<img width="1010" alt="image" src="https://github.com/hashintel/hash/assets/21277928/cb82f540-ecbf-47be-87be-fb6d512d0b5b">
<img width="1269" alt="image" src="https://github.com/hashintel/hash/assets/21277928/d3e7805b-5972-44d8-a089-f0375d6d06c3">
<img width="1257" alt="image" src="https://github.com/hashintel/hash/assets/21277928/d059f642-97bc-424f-bc4b-6d2ce26a80bf">
<img width="1299" alt="image" src="https://github.com/hashintel/hash/assets/21277928/f0e73513-cba3-4bc6-a83a-f17d48890f5b">

