### PR TITLE
GEN-132: Update `error-stack` blog posts with link to docs

### DIFF
--- a/apps/hashdotdev/src/_pages/blog/0004_announcing-error-stack.mdx
+++ b/apps/hashdotdev/src/_pages/blog/0004_announcing-error-stack.mdx
@@ -13,7 +13,11 @@ categories:
 ---
 
 <Callout>
-  This is an old blog post and may contain code which does not compile with the current `error-stack` version. Please check out the [latest documentation](https://docs.rs/error-stack) and [examples](https://github.com/hashintel/hash/tree/main/libs/error-stack/examples) for more information.
+  This is an old blog post and may contain code which does not compile with the
+  current `error-stack` version. Please check out the [latest
+  documentation](https://docs.rs/error-stack) and
+  [examples](https://github.com/hashintel/hash/tree/main/libs/error-stack/examples)
+  for more information.
 </Callout>
 
 We are proud to announce a new error library for Rust: `error-stack` - a context-aware error library with arbitrary attached user data.
@@ -136,9 +140,9 @@ This was clearly not ideal, and we ended up with a weird mixture of well-defined
 
 We really love the Rust ecosystem, and although there are many great error crates out there, we struggled to find one that aligned with our needs, and which worked well with some of our project's inherent complexity. The closest error crate we could find was [`anyhow`](https://crates.io/crates/anyhow) (or its fork [`eyre`](https://crates.io/crates/eyre)), however, we had some additional wants:
 
-1.  encourage the user to provide a new error type if the scope is changed, usually by crossing module/crate boundaries (for example, a `ConfigParseError` when parsing a configuration file vs. an `IoError` when reading a file from disk)
-1.  be able to use those error types within return types, without needing to handle difficult `From` logic
-1.  be able to attach _any_ data to an error _without a lot of configuration [1]_, not just string-like types, which then can be requested when handling the error.
+1. encourage the user to provide a new error type if the scope is changed, usually by crossing module/crate boundaries (for example, a `ConfigParseError` when parsing a configuration file vs. an `IoError` when reading a file from disk)
+1. be able to use those error types within return types, without needing to handle difficult `From` logic
+1. be able to attach _any_ data to an error _without a lot of configuration [1]_, not just string-like types, which then can be requested when handling the error.
 
 Based on our experiences outlined above, we made a few additional design decisions that differentiated our approach to error handling from those existing crates designed to facilitate it. Generally speaking, these decisions were made to force developers to be more explicit when creating or chaining errors, but most importantly, we don't supply in-built support for creating errors from strings. While it is convenient, we want to encourage developers to think more about their errors by building concrete error types like `std::io::Error` or `std::num::ParseIntError`
 
@@ -156,8 +160,8 @@ Based on our experiences outlined above, we made a few additional design decisio
 
 This `Report` on the error is made-up of a combination of two main concepts:
 
-1.  Contexts
-1.  Attachments
+1. Contexts
+1. Attachments
 
 A `Report` is organized as a stack, where you push contexts and attachments. We call this the `Frame` stack as each context and attachment is contained in a `Frame` alongside the code location of where it was created. The `Report` is able to iterate through the `Frame` stack from the most recent one to the root (on a 'Last In, First Out' basis).
 

--- a/apps/hashdotdev/src/_pages/blog/0004_announcing-error-stack.mdx
+++ b/apps/hashdotdev/src/_pages/blog/0004_announcing-error-stack.mdx
@@ -12,6 +12,10 @@ categories:
   - error-stack
 ---
 
+<Callout>
+  This is an old blog post and may contain code which does not compile with the current `error-stack` version. Please check out the [latest documentation](https://docs.rs/error-stack) and [examples](https://github.com/hashintel/hash/tree/main/libs/error-stack/examples) for more information.
+</Callout>
+
 We are proud to announce a new error library for Rust: `error-stack` - a context-aware error library with arbitrary attached user data.
 
 - [View the crate on GitHub >](https://github.com/hashintel/hash/tree/main/libs/error-stack)

--- a/apps/hashdotdev/src/_pages/blog/0010_error-stack-update-0-2.mdx
+++ b/apps/hashdotdev/src/_pages/blog/0010_error-stack-update-0-2.mdx
@@ -12,6 +12,10 @@ categories:
   - error-stack
 ---
 
+<Callout>
+  This is an old blog post and may contain code which does not compile with the current `error-stack` version. Please check out the [latest documentation](https://docs.rs/error-stack) and [examples](https://github.com/hashintel/hash/tree/main/libs/error-stack/examples) for more information.
+</Callout>
+
 Back in June [we announced the initial public release](https://hash.dev/blog/announcing-error-stack) of `error-stack`, our context-aware Rust error library. We developed this to help address a lot of challenges we encountered when implementing error handling in our [simulation engine]. In the time since then we’ve started using it in our entity-graph query layer that we’re building as a datastore for [HASH]. Across that development we’ve learned a lot of lessons, and in joint efforts with open-source contributors we’re ready to release a new version of the library.
 
 - [View the crate on GitHub >](https://github.com/hashintel/hash/tree/main/libs/error-stack)

--- a/apps/hashdotdev/src/_pages/blog/0010_error-stack-update-0-2.mdx
+++ b/apps/hashdotdev/src/_pages/blog/0010_error-stack-update-0-2.mdx
@@ -13,7 +13,11 @@ categories:
 ---
 
 <Callout>
-  This is an old blog post and may contain code which does not compile with the current `error-stack` version. Please check out the [latest documentation](https://docs.rs/error-stack) and [examples](https://github.com/hashintel/hash/tree/main/libs/error-stack/examples) for more information.
+  This is an old blog post and may contain code which does not compile with the
+  current `error-stack` version. Please check out the [latest
+  documentation](https://docs.rs/error-stack) and
+  [examples](https://github.com/hashintel/hash/tree/main/libs/error-stack/examples)
+  for more information.
 </Callout>
 
 Back in June [we announced the initial public release](https://hash.dev/blog/announcing-error-stack) of `error-stack`, our context-aware Rust error library. We developed this to help address a lot of challenges we encountered when implementing error handling in our [simulation engine]. In the time since then we’ve started using it in our entity-graph query layer that we’re building as a datastore for [HASH]. Across that development we’ve learned a lot of lessons, and in joint efforts with open-source contributors we’re ready to release a new version of the library.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@TODO.1": "Upgrade or remove these blocks and remove the --ignore-package options (also @TODO.2)",
     "fix:dependency-version-consistency": "check-dependency-version-consistency --fix . --ignore-package=@apps/hashdotdev --ignore-package=@blocks/embed --ignore-package=@blocks/person",
     "fix:eslint": "turbo --continue fix:eslint --",
-    "fix:lock-files": "turbo fix:lock-files",
     "fix:markdownlint": "markdownlint --dot --fix .",
     "fix:prettier": "prettier --write  --ignore-unknown .",
     "fix:yarn-deduplicate": "yarn install && yarn-deduplicate --strategy=fewer && yarn install",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Following concern expressed in #3740, this PR adds callouts to the top of our original `error-stack` announcement posts notifying users that the code snippets within may be out-of-date, and directing them to the up-to-date docs and examples for current best practice.

Fixes #3740.