### PR TITLE
H-1626: Enable cancelling inference jobs from the browser plugin

### DIFF
--- a/apps/hash-ai-worker-ts/package.json
+++ b/apps/hash-ai-worker-ts/package.json
@@ -41,6 +41,7 @@
     "@local/hash-subgraph": "0.0.0-private",
     "@local/status": "0.0.0-private",
     "@temporalio/activity": "1.8.1",
+    "@temporalio/common": "1.8.1",
     "@temporalio/worker": "1.8.1",
     "@temporalio/workflow": "1.8.1",
     "dedent": "0.7.0",

--- a/apps/hash-ai-worker-ts/src/activities.ts
+++ b/apps/hash-ai-worker-ts/src/activities.ts
@@ -21,29 +21,25 @@ export const createAiActivities = ({
   graphApiClient,
 }: {
   graphApiClient: GraphApi;
-}) => {
-  return {
-    async inferEntitiesActivity(
-      params: InferEntitiesCallerParams,
-    ): Promise<InferEntitiesReturn> {
-      const status = await inferEntitiesActivity({ ...params, graphApiClient });
-      if (status.code !== StatusCode.Ok) {
-        throw new ApplicationFailure(status.message, status.code, true, [
-          status,
-        ]);
-      }
+}) => ({
+  async inferEntitiesActivity(
+    params: InferEntitiesCallerParams,
+  ): Promise<InferEntitiesReturn> {
+    const status = await inferEntitiesActivity({ ...params, graphApiClient });
+    if (status.code !== StatusCode.Ok) {
+      throw new ApplicationFailure(status.message, status.code, true, [status]);
+    }
 
-      return status;
-    },
+    return status;
+  },
 
-    async createEmbeddingsActivity(params: {
-      entityProperties: EntityPropertiesObject;
-      propertyTypes: PropertyTypeWithMetadata[];
-    }): Promise<{
-      embeddings: { property?: BaseUrl; embedding: number[] }[];
-      usage: CreateEmbeddingResponse.Usage;
-    }> {
-      return createEmbeddings(params);
-    },
-  };
-};
+  async createEmbeddingsActivity(params: {
+    entityProperties: EntityPropertiesObject;
+    propertyTypes: PropertyTypeWithMetadata[];
+  }): Promise<{
+    embeddings: { property?: BaseUrl; embedding: number[] }[];
+    usage: CreateEmbeddingResponse.Usage;
+  }> {
+    return createEmbeddings(params);
+  },
+});

--- a/apps/hash-ai-worker-ts/src/activities.ts
+++ b/apps/hash-ai-worker-ts/src/activities.ts
@@ -13,7 +13,7 @@ import { ApplicationFailure } from "@temporalio/activity";
 import { CreateEmbeddingResponse } from "openai/resources";
 
 import { createEmbeddings } from "./activities/embeddings";
-import { inferEntities } from "./activities/infer-entities";
+import { inferEntitiesActivity } from "./activities/infer-entities";
 
 export { createGraphActivities } from "./activities/graph";
 
@@ -21,25 +21,29 @@ export const createAiActivities = ({
   graphApiClient,
 }: {
   graphApiClient: GraphApi;
-}) => ({
-  async inferEntitiesActivity(
-    params: InferEntitiesCallerParams,
-  ): Promise<InferEntitiesReturn> {
-    const status = await inferEntities({ ...params, graphApiClient });
-    if (status.code !== StatusCode.Ok) {
-      throw new ApplicationFailure(status.message, status.code, true, [status]);
-    }
+}) => {
+  return {
+    async inferEntitiesActivity(
+      params: InferEntitiesCallerParams,
+    ): Promise<InferEntitiesReturn> {
+      const status = await inferEntitiesActivity({ ...params, graphApiClient });
+      if (status.code !== StatusCode.Ok) {
+        throw new ApplicationFailure(status.message, status.code, true, [
+          status,
+        ]);
+      }
 
-    return status;
-  },
+      return status;
+    },
 
-  async createEmbeddingsActivity(params: {
-    entityProperties: EntityPropertiesObject;
-    propertyTypes: PropertyTypeWithMetadata[];
-  }): Promise<{
-    embeddings: { property?: BaseUrl; embedding: number[] }[];
-    usage: CreateEmbeddingResponse.Usage;
-  }> {
-    return createEmbeddings(params);
-  },
-});
+    async createEmbeddingsActivity(params: {
+      entityProperties: EntityPropertiesObject;
+      propertyTypes: PropertyTypeWithMetadata[];
+    }): Promise<{
+      embeddings: { property?: BaseUrl; embedding: number[] }[];
+      usage: CreateEmbeddingResponse.Usage;
+    }> {
+      return createEmbeddings(params);
+    },
+  };
+};

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities.ts
@@ -518,8 +518,8 @@ export const inferEntitiesActivity = async ({
    * If an inference job has no usage and no results, it was probably cancelled basically immediately,
    * and there's no point creating empty usage records that have no tokens and link to nothing.
    *
-   * In theory usage should be sufficient to check, because there should be no results without usage,
-   * but in case somehow there are results with no usage we should log them.
+   * In theory checking that 'usage.length > 0' should be sufficient, as there shouldn't be results without usage logged,
+   * but we check both in case there is somehow results without usage.
    */
   if (results.length !== 0 || usage.length !== 0) {
     // We act as the HASH AI machine actor to create these entities
@@ -605,7 +605,7 @@ export const inferEntitiesActivity = async ({
 
   /**
    * This must be a cancellation, throw it. We pass the results back to the workflow as details inside the cancellation error.
-   * We could just return the results, but we have to throw this error for Temporal to categorise the workflow as cancelled.
+   * We could just return the results, but we have to throw this error for Temporal to categorise the activity as cancelled.
    */
   throw new CancelledFailure(
     "Activity cancelled",

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/get-results-from-inference-state.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/get-results-from-inference-state.ts
@@ -1,0 +1,9 @@
+import { InferredEntityChangeResult } from "@local/hash-isomorphic-utils/ai-inference-types";
+
+import { InferenceState } from "./inference-types";
+
+export const getResultsFromInferenceState = (inferenceState: InferenceState) =>
+  Object.values(inferenceState.resultsByTemporaryId).filter(
+    (result): result is InferredEntityChangeResult =>
+      result.status !== "update-candidate",
+  );

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/shared/get-open-ai-response.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/shared/get-open-ai-response.ts
@@ -80,10 +80,6 @@ export const getOpenAiResponse = async (
         ...openAiPayload,
         stream: false,
       },
-      /**
-       * Note that if the model has started generating, it will
-       * so this only saves tokens if
-       */
       { signal: Context.current().cancellationSignal },
     );
 

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/shared/get-open-ai-response.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/shared/get-open-ai-response.ts
@@ -1,4 +1,5 @@
 import { Status, StatusCode } from "@local/status";
+import { Context } from "@temporalio/activity";
 import OpenAI from "openai";
 import { promptTokensEstimate } from "openai-chat-tokens";
 
@@ -74,10 +75,17 @@ export const getOpenAiResponse = async (
 
   let data: OpenAI.ChatCompletion;
   try {
-    data = await openai.chat.completions.create({
-      ...openAiPayload,
-      stream: false,
-    });
+    data = await openai.chat.completions.create(
+      {
+        ...openAiPayload,
+        stream: false,
+      },
+      /**
+       * Note that if the model has started generating, it will
+       * so this only saves tokens if
+       */
+      { signal: Context.current().cancellationSignal },
+    );
 
     log(`Response from AI received: ${stringify(data)}.`);
   } catch (err) {

--- a/apps/hash-ai-worker-ts/src/workflows.ts
+++ b/apps/hash-ai-worker-ts/src/workflows.ts
@@ -41,9 +41,14 @@ export const inferEntities = async (params: InferEntitiesCallerParams) => {
         err.cause.details[0] !== null &&
         "code" in err.cause.details[0]
       ) {
-        // We've been given a cancellation failure with the return in the cause's details, return it
-        const details = err.cause.details[0];
-        throw new CancelledFailure("Cancelled", [details]);
+        /**
+         * We've been given a cancellation failure with the return in the cause's details, return it.
+         *
+         * Ideally we'd throw the `CancelledFailure` error here, so that Temporal treats it as a cancellation,
+         * but the client doesn't see the `details` if we do that for some reason.
+         * @see https://temporalio.slack.com/archives/C01DKSMU94L/p1705927971571849
+         */
+        return err.cause.details[0];
       }
     }
     throw err;

--- a/apps/hash-api/src/ai/infer-entities-websocket/handle-cancel-infer-entities-request.ts
+++ b/apps/hash-api/src/ai/infer-entities-websocket/handle-cancel-infer-entities-request.ts
@@ -1,0 +1,44 @@
+import {
+  CancelInferEntitiesRequestMessage,
+  InferEntitiesResponseMessage,
+} from "@local/hash-isomorphic-utils/ai-inference-types";
+import { StatusCode } from "@local/status";
+import type { Client } from "@temporalio/client";
+import type { WebSocket } from "ws";
+
+import { User } from "../../graph/knowledge/system-types/user";
+
+export const handleCancelInferEntitiesRequest = async ({
+  socket,
+  temporalClient,
+  message,
+  user,
+}: {
+  socket: WebSocket;
+  temporalClient: Client;
+  message: Omit<CancelInferEntitiesRequestMessage, "cookie">;
+  user: User;
+}) => {
+  const { requestUuid } = message;
+
+  const workflowHandle = temporalClient.workflow.getHandle(requestUuid);
+
+  const description = await workflowHandle.describe();
+
+  if (description.memo?.userAccountId !== user.accountId) {
+    const responseMessage: InferEntitiesResponseMessage = {
+      payload: {
+        code: StatusCode.InvalidArgument,
+        contents: [],
+        message: `User has no request with id ${requestUuid}`,
+      },
+      requestUuid,
+      status: "bad-request",
+      type: "inference-response",
+    };
+    socket.send(JSON.stringify(responseMessage));
+    return;
+  }
+
+  void workflowHandle.cancel();
+};

--- a/apps/hash-api/src/ai/infer-entities-websocket/handle-infer-entities-request.ts
+++ b/apps/hash-api/src/ai/infer-entities-websocket/handle-infer-entities-request.ts
@@ -1,0 +1,120 @@
+import {
+  inferenceModelNames,
+  InferEntitiesCallerParams,
+  InferEntitiesRequestMessage,
+  InferEntitiesResponseMessage,
+  InferEntitiesReturn,
+  inferEntitiesUserArgumentKeys,
+} from "@local/hash-isomorphic-utils/ai-inference-types";
+import { StatusCode } from "@local/status";
+import type {
+  ApplicationFailure,
+  Client,
+  WorkflowFailedError,
+} from "@temporalio/client";
+import type { WebSocket } from "ws";
+
+import { User } from "../../graph/knowledge/system-types/user";
+
+export const handleInferEntitiesRequest = async ({
+  socket,
+  temporalClient,
+  message,
+  user,
+}: {
+  socket: WebSocket;
+  temporalClient: Client;
+  message: Omit<InferEntitiesRequestMessage, "cookie">;
+  user: User;
+}) => {
+  const { requestUuid, payload: userArguments } = message;
+
+  const sendResponse = (
+    payload: InferEntitiesReturn,
+    status: "bad-request" | "complete",
+  ) => {
+    const responseMessage: InferEntitiesResponseMessage = {
+      payload,
+      requestUuid,
+      status,
+      type: "inference-response",
+    };
+    socket.send(JSON.stringify(responseMessage));
+  };
+
+  if (inferEntitiesUserArgumentKeys.some((key) => !(key in userArguments))) {
+    sendResponse(
+      {
+        code: StatusCode.InvalidArgument,
+        contents: [],
+        message: `Invalid request body – expected an object containing all of ${inferEntitiesUserArgumentKeys.join(
+          ", ",
+        )}`,
+      },
+      "bad-request",
+    );
+    return;
+  }
+
+  if (!inferenceModelNames.includes(userArguments.model)) {
+    sendResponse(
+      {
+        code: StatusCode.InvalidArgument,
+        contents: [],
+        message: `Invalid request body – expected 'model' to be one of ${inferenceModelNames.join(
+          ", ",
+        )}`,
+      },
+      "bad-request",
+    );
+    return;
+  }
+
+  try {
+    const status = await temporalClient.workflow.execute<
+      (params: InferEntitiesCallerParams) => Promise<InferEntitiesReturn>
+    >("inferEntities", {
+      taskQueue: "ai",
+      args: [
+        {
+          authentication: { actorId: user.accountId },
+          requestUuid,
+          userArguments,
+        },
+      ],
+      memo: {
+        userAccountId: user.accountId,
+      },
+      workflowId: requestUuid,
+      retry: {
+        maximumAttempts: 1,
+      },
+    });
+
+    sendResponse(status, "complete");
+  } catch (err) {
+    console.log(JSON.stringify(err, null, 2));
+    const errorCause = (err as WorkflowFailedError).cause?.cause as
+      | ApplicationFailure
+      | undefined;
+
+    const errorDetails = errorCause?.details?.[0] as
+      | InferEntitiesReturn
+      | undefined;
+
+    if (errorDetails) {
+      sendResponse(errorDetails, "complete");
+    } else {
+      sendResponse(
+        {
+          code: StatusCode.Internal,
+          contents: [],
+          message: `Unexpected error from Infer Entities workflow: ${
+            (err as Error).message
+          }`,
+        },
+        "complete",
+      );
+    }
+  }
+};

--- a/apps/hash-api/src/ai/infer-entities-websocket/handle-infer-entities-request.ts
+++ b/apps/hash-api/src/ai/infer-entities-websocket/handle-infer-entities-request.ts
@@ -31,7 +31,7 @@ export const handleInferEntitiesRequest = async ({
 
   const sendResponse = (
     payload: InferEntitiesReturn,
-    status: "bad-request" | "complete",
+    status: InferEntitiesResponseMessage["status"],
   ) => {
     const responseMessage: InferEntitiesResponseMessage = {
       payload,
@@ -91,9 +91,11 @@ export const handleInferEntitiesRequest = async ({
       },
     });
 
-    sendResponse(status, "complete");
+    sendResponse(
+      status,
+      status.code === "CANCELLED" ? "user-cancelled" : "complete",
+    );
   } catch (err) {
-    console.log(JSON.stringify(err, null, 2));
     const errorCause = (err as WorkflowFailedError).cause?.cause as
       | ApplicationFailure
       | undefined;

--- a/apps/hash-api/src/storage/aws-s3-storage-provider.ts
+++ b/apps/hash-api/src/storage/aws-s3-storage-provider.ts
@@ -128,7 +128,6 @@ export class AwsS3StorageProvider implements UploadableStorageProvider {
     const url = await getSignedUrl(client, command, {
       expiresIn: params.expiresInSeconds,
     });
-
     return url;
   }
 

--- a/apps/hash-api/src/storage/aws-s3-storage-provider.ts
+++ b/apps/hash-api/src/storage/aws-s3-storage-provider.ts
@@ -128,6 +128,7 @@ export class AwsS3StorageProvider implements UploadableStorageProvider {
     const url = await getSignedUrl(client, command, {
       expiresIn: params.expiresInSeconds,
     });
+
     return url;
   }
 

--- a/apps/plugin-browser/src/pages/popup/popup-contents/action-center/log/inference-request.tsx
+++ b/apps/plugin-browser/src/pages/popup/popup-contents/action-center/log/inference-request.tsx
@@ -96,7 +96,26 @@ const InferenceMetadata = ({ request }: { request: PageEntityInference }) => {
         ) : null}
         <MetadataItem label="Time" value={timeElapsed} />
       </Stack>
-      <CopyableRequestId requestId={request.requestUuid} />
+      <Stack
+        alignItems="center"
+        direction="row"
+        justifyContent="space-between"
+        mt={0.8}
+      >
+        <Box>
+          {request.status === "user-cancelled" && (
+            <Typography
+              sx={{
+                color: ({ palette }) => palette.red[80],
+                fontSize: metadataFontSize,
+              }}
+            >
+              Cancelled
+            </Typography>
+          )}
+        </Box>
+        <CopyableRequestId requestId={request.requestUuid} />
+      </Stack>
     </Box>
   );
 };
@@ -121,9 +140,11 @@ export const InferenceRequest = ({
     return entityTypes.reduce(
       (acc, type) => {
         acc[type.schema.$id] =
-          status === "complete"
+          status === "complete" || status === "user-cancelled"
             ? request.data.contents[0]?.results.filter(
-                (result) => result.entityTypeId === type.schema.$id,
+                (result) =>
+                  result.entityTypeId === type.schema.$id &&
+                  result.status === "success",
               ) ?? []
             : [];
         return acc;

--- a/apps/plugin-browser/src/pages/popup/popup-contents/action-center/log/inference-request.tsx
+++ b/apps/plugin-browser/src/pages/popup/popup-contents/action-center/log/inference-request.tsx
@@ -91,7 +91,9 @@ const InferenceMetadata = ({ request }: { request: PageEntityInference }) => {
           View source page
         </Link>
         <MetadataItem label="Model" value={request.model} />
-        {usage && <MetadataItem label="Tokens" value={usage.toString()} />}
+        {usage ? (
+          <MetadataItem label="Tokens" value={usage.toString()} />
+        ) : null}
         <MetadataItem label="Time" value={timeElapsed} />
       </Stack>
       <CopyableRequestId requestId={request.requestUuid} />

--- a/apps/plugin-browser/src/pages/popup/popup-contents/action-center/log/inference-request/copyable-request-id.tsx
+++ b/apps/plugin-browser/src/pages/popup/popup-contents/action-center/log/inference-request/copyable-request-id.tsx
@@ -10,7 +10,6 @@ export const CopyableRequestId = ({ requestId }: { requestId: string }) => {
       alignItems="center"
       direction="row"
       justifyContent="flex-end"
-      mt={0.8}
     >
       <Typography
         sx={{

--- a/apps/plugin-browser/src/pages/popup/popup-contents/action-center/log/inference-requests.tsx
+++ b/apps/plugin-browser/src/pages/popup/popup-contents/action-center/log/inference-requests.tsx
@@ -37,14 +37,15 @@ const InferenceRequestContainer = ({
   request: PageEntityInference;
   user: NonNullable<LocalStorage["user"]>;
 }) => {
-  const isUnproductiveSuccessfulRequest =
-    request.status === "complete" &&
-    (!request.data.contents[0]?.results?.length ||
-      request.data.contents[0].results.every(
-        (result) => result.operation === "already-exists-as-proposed",
-      ));
-
   const [cancellationRequested, setCancellationRequested] = useState(false);
+
+  const isUnproductiveSuccessfulRequest =
+    request.status === "complete" ||
+    (request.status === "user-cancelled" &&
+      (!request.data.contents[0]?.results?.length ||
+        request.data.contents[0].results.every(
+          (result) => result.operation === "already-exists-as-proposed",
+        )));
 
   const cancelRequest = (event: MouseEvent) => {
     event.stopPropagation();
@@ -112,7 +113,13 @@ const InferenceRequestContainer = ({
         </Stack>
         {request.status === "pending" ? (
           <Stack alignItems="center" direction="row">
-            {!cancellationRequested && (
+            {cancellationRequested ? (
+              <CircularProgress
+                variant="indeterminate"
+                size={13}
+                sx={{ mr: 1, color: ({ palette }) => palette.red[70] }}
+              />
+            ) : (
               <IconButton
                 onClick={cancelRequest}
                 title="Cancel request"
@@ -137,7 +144,8 @@ const InferenceRequestContainer = ({
               sx={{ mr: 1 }}
             />
           </Stack>
-        ) : request.status === "complete" ? (
+        ) : request.status === "complete" ||
+          request.status === "user-cancelled" ? (
           isUnproductiveSuccessfulRequest ? (
             <DashIcon
               sx={{ height: 16, fill: ({ palette }) => palette.gray[40] }}

--- a/apps/plugin-browser/src/scripts/background.ts
+++ b/apps/plugin-browser/src/scripts/background.ts
@@ -13,7 +13,10 @@ import {
   getSetFromLocalStorageValue,
   setInLocalStorage,
 } from "../shared/storage";
-import { inferEntities } from "./background/infer-entities";
+import {
+  cancelInferEntities,
+  inferEntities,
+} from "./background/infer-entities";
 
 /**
  * This is the service worker for the extension.
@@ -42,6 +45,8 @@ browser.runtime.onMessage.addListener((message: Message, sender) => {
 
   if (message.type === "infer-entities") {
     void inferEntities(message, "user");
+  } else if (message.type === "cancel-infer-entities") {
+    void cancelInferEntities(message);
   }
 });
 

--- a/apps/plugin-browser/src/scripts/background/infer-entities.ts
+++ b/apps/plugin-browser/src/scripts/background/infer-entities.ts
@@ -1,12 +1,9 @@
-import type { VersionedUrl } from "@blockprotocol/graph";
 import type {
-  InferenceModelName,
   InferEntitiesRequestMessage,
   InferEntitiesResponseMessage,
   InferEntitiesReturn,
   InferEntitiesUserArguments,
 } from "@local/hash-isomorphic-utils/ai-inference-types";
-import { OwnedById } from "@local/hash-subgraph";
 import type { Status } from "@local/status";
 import { v4 as uuid } from "uuid";
 import browser from "webextension-polyfill";

--- a/apps/plugin-browser/src/shared/messages.ts
+++ b/apps/plugin-browser/src/shared/messages.ts
@@ -13,6 +13,11 @@ export type InferEntitiesRequest = {
   textInput: string;
 };
 
+export type CancelInferEntitiesRequest = {
+  type: "cancel-infer-entities";
+  requestUuid: string;
+};
+
 export type GetSiteContentRequest = {
   type: "get-site-content";
 };
@@ -23,4 +28,7 @@ export type GetSiteContentReturn = {
   pageUrl: string;
 };
 
-export type Message = InferEntitiesRequest | GetSiteContentRequest;
+export type Message =
+  | InferEntitiesRequest
+  | CancelInferEntitiesRequest
+  | GetSiteContentRequest;

--- a/apps/plugin-browser/src/shared/storage.ts
+++ b/apps/plugin-browser/src/shared/storage.ts
@@ -34,6 +34,11 @@ type InferenceErrorStatus = {
   status: "error";
 };
 
+type InferenceCancelledStatus = {
+  data: InferEntitiesReturn;
+  status: "user-cancelled";
+};
+
 type InferenceCompleteStatus = {
   data: InferEntitiesReturn;
   status: "complete";
@@ -44,6 +49,7 @@ export type InferenceStatus =
       status: "not-started" | "pending";
     }
   | InferenceErrorStatus
+  | InferenceCancelledStatus
   | InferenceCompleteStatus;
 
 export type PageEntityInference = InferenceStatus & {

--- a/libs/@local/hash-isomorphic-utils/package.json
+++ b/libs/@local/hash-isomorphic-utils/package.json
@@ -55,6 +55,7 @@
     "@graphql-codegen/typescript-operations": "2.5.12",
     "@local/eslint-config": "0.0.0-private",
     "@local/tsconfig": "0.0.0-private",
+    "@temporalio/workflow": "1.8.1",
     "@types/lodash": "4.14.188",
     "@types/node": "18.15.13",
     "@types/node-fetch": "^2.6.2",

--- a/libs/@local/hash-isomorphic-utils/src/ai-inference-types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/ai-inference-types.ts
@@ -152,8 +152,19 @@ export type InferEntitiesRequestMessage = {
   requestUuid: string;
 };
 
+export type CancelInferEntitiesRequestMessage = {
+  cookie: string;
+  type: "cancel-inference-request";
+  requestUuid: string;
+};
+
+export type InferenceWebsocketRequestMessage =
+  | InferEntitiesRequestMessage
+  | CancelInferEntitiesRequestMessage;
+
 export type InferEntitiesResponseMessage = {
   payload: InferEntitiesReturn;
   requestUuid: string;
+  status: "complete" | "user-cancelled" | "bad-request";
   type: "inference-response";
 };

--- a/libs/@local/hash-isomorphic-utils/src/ai-inference-types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/ai-inference-types.ts
@@ -8,6 +8,7 @@ import {
   OwnedById,
 } from "@local/hash-subgraph";
 import type { Status } from "@local/status";
+import type { QueryDefinition } from "@temporalio/workflow";
 
 export const inferEntitiesUserArgumentKeys = [
   "entityTypeIds",
@@ -168,3 +169,9 @@ export type InferEntitiesResponseMessage = {
   status: "complete" | "user-cancelled" | "bad-request";
   type: "inference-response";
 };
+
+export type GetResultsFromCancelledInferenceRequestQuery = QueryDefinition<
+  InferEntitiesReturn,
+  never,
+  "getResultsFromCancelledInference"
+>;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds a button to inference jobs on the browser plugin allowing the user to cancel them early, receiving whatever entity creations/updates (if any) had been processed up to that point.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

- [x] ~I haven't been able to throw a `CancellationFailure` from the workflow _and_ get partial results back to the client. I have asked on the Temporal Slack as to how best to deal with getting partial results back from a cancelled workflow (see comments in diff).~ I have [updated the PR](https://github.com/hashintel/hash/pull/3922/commits/f94e7109252d33e42fa4ff5699760783bdc7cdc6) to allow for querying for partial results from the client. I suspect the `details` not appearing in the error thrown to the client is a bug, and ideally we would be able to capture them so they're attached to the Temporal job, but this isn't important until we are using the Temporal event history for something.

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Adds a button to pending inference requests allowing them to be cancelled (see demo)
  - jobs which are cancelled are marked by red 'Cancelled' text in the inference details
  - they otherwise appear as completed jobs, i.e. a gray dash if they resulted in no changes, and a green tick if they resulted in some changes. We could alternatively use a different icon for 'Cancelled', but it would mean the user would not know if it resulted in any graph changes or not.
- Handle cancellations in the AI inference websocket, and the Temporal activity/workflow
  - a lot of the diff is moving the existing 'handle AI inference request' into its own file, and adding a new file for handling a cancellation request 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies the plugin, which I'll publish after this PR is merged as I have no other immediately pending tasks updating it

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- Manual

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Stop the Temporal worker in Docker and run it locally
2. `yarn dev` in the plugin folder
3. Try starting and cancelling a job, both immediately, and then once the AI worker has had a chance to do something.

## 📹 Demo

https://github.com/hashintel/hash/assets/37743469/c72e4e31-f988-4231-b6a0-12c898aca7e8

