### PR TITLE
H-1937: Overhaul Read trait to allow returning Cursor

### DIFF
--- a/.env
+++ b/.env
@@ -49,7 +49,7 @@ HASH_TEMPORAL_VISIBILITY_PG_DATABASE=temporal_visibility
 HASH_GRAPH_PG_USER=graph
 HASH_GRAPH_PG_PASSWORD=graph
 HASH_GRAPH_PG_DATABASE=graph
-HASH_GRAPH_LOG_LEVEL=trace,h2=info,tokio_util=debug,tower=info,tonic=debug,hyper=info,tokio_postgres=debug,rustls=info,tarpc=warn
+HASH_GRAPH_LOG_LEVEL=trace,h2=info,tokio_util=debug,tower=info,tonic=debug,hyper=info,tokio_postgres=info,rustls=info,tarpc=warn
 
 HASH_GRAPH_TYPE_FETCHER_HOST=localhost
 HASH_GRAPH_TYPE_FETCHER_PORT=4444

--- a/.env
+++ b/.env
@@ -49,7 +49,7 @@ HASH_TEMPORAL_VISIBILITY_PG_DATABASE=temporal_visibility
 HASH_GRAPH_PG_USER=graph
 HASH_GRAPH_PG_PASSWORD=graph
 HASH_GRAPH_PG_DATABASE=graph
-HASH_GRAPH_LOG_LEVEL=trace,h2=info,tokio_util=debug,tower=info,tonic=debug,hyper=info,tokio_postgres=info,rustls=info,tarpc=warn
+HASH_GRAPH_LOG_LEVEL=trace,h2=info,tokio_util=debug,tower=info,tonic=debug,hyper=info,tokio_postgres=debug,rustls=info,tarpc=warn
 
 HASH_GRAPH_TYPE_FETCHER_HOST=localhost
 HASH_GRAPH_TYPE_FETCHER_PORT=4444

--- a/apps/hash-graph/libs/api/src/rest/data_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/data_type.rs
@@ -30,7 +30,10 @@ use graph::{
         error::VersionedUrlAlreadyExists, BaseUrlAlreadyExists, ConflictBehavior, DataTypeStore,
         OntologyVersionDoesNotExist, StorePool,
     },
-    subgraph::query::{DataTypeStructuralQuery, StructuralQuery},
+    subgraph::{
+        identifier::DataTypeVertexId,
+        query::{DataTypeStructuralQuery, StructuralQuery},
+    },
 };
 use graph_types::{
     ontology::{
@@ -377,7 +380,7 @@ async fn get_data_types_by_query<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
     authorization_api_pool: Extension<Arc<A>>,
-    Query(pagination): Query<Pagination<VersionedUrl>>,
+    Query(pagination): Query<Pagination<DataTypeVertexId>>,
     OriginalUri(uri): OriginalUri,
     Json(query): Json<serde_json::Value>,
 ) -> Result<(HeaderMap, Json<Subgraph>), Response>
@@ -402,7 +405,7 @@ where
             actor_id,
             &authorization_api,
             &query,
-            pagination.after.as_ref().map(|cursor| &cursor.0),
+            pagination.after.map(|cursor| cursor.0),
             pagination.limit,
         )
         .await

--- a/apps/hash-graph/libs/api/src/rest/data_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/data_type.rs
@@ -30,10 +30,7 @@ use graph::{
         error::VersionedUrlAlreadyExists, BaseUrlAlreadyExists, ConflictBehavior, DataTypeStore,
         OntologyVersionDoesNotExist, StorePool,
     },
-    subgraph::{
-        identifier::DataTypeVertexId,
-        query::{DataTypeStructuralQuery, StructuralQuery},
-    },
+    subgraph::query::{DataTypeStructuralQuery, StructuralQuery},
 };
 use graph_types::{
     ontology::{
@@ -380,7 +377,7 @@ async fn get_data_types_by_query<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
     authorization_api_pool: Extension<Arc<A>>,
-    Query(pagination): Query<Pagination<DataTypeVertexId>>,
+    Query(pagination): Query<Pagination<VersionedUrl>>,
     OriginalUri(uri): OriginalUri,
     Json(query): Json<serde_json::Value>,
 ) -> Result<(HeaderMap, Json<Subgraph>), Response>

--- a/apps/hash-graph/libs/api/src/rest/entity_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity_type.rs
@@ -31,10 +31,7 @@ use graph::{
         error::{BaseUrlAlreadyExists, OntologyVersionDoesNotExist, VersionedUrlAlreadyExists},
         ConflictBehavior, EntityTypeStore, StorePool,
     },
-    subgraph::{
-        identifier::EntityTypeVertexId,
-        query::{EntityTypeStructuralQuery, StructuralQuery},
-    },
+    subgraph::query::{EntityTypeStructuralQuery, StructuralQuery},
 };
 use graph_types::{
     ontology::{
@@ -690,7 +687,7 @@ async fn get_entity_types_by_query<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
     authorization_api_pool: Extension<Arc<A>>,
-    Query(pagination): Query<Pagination<EntityTypeVertexId>>,
+    Query(pagination): Query<Pagination<VersionedUrl>>,
     OriginalUri(uri): OriginalUri,
     Json(query): Json<serde_json::Value>,
 ) -> Result<(HeaderMap, Json<Subgraph>), Response>

--- a/apps/hash-graph/libs/api/src/rest/entity_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity_type.rs
@@ -31,7 +31,10 @@ use graph::{
         error::{BaseUrlAlreadyExists, OntologyVersionDoesNotExist, VersionedUrlAlreadyExists},
         ConflictBehavior, EntityTypeStore, StorePool,
     },
-    subgraph::query::{EntityTypeStructuralQuery, StructuralQuery},
+    subgraph::{
+        identifier::EntityTypeVertexId,
+        query::{EntityTypeStructuralQuery, StructuralQuery},
+    },
 };
 use graph_types::{
     ontology::{
@@ -687,7 +690,7 @@ async fn get_entity_types_by_query<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
     authorization_api_pool: Extension<Arc<A>>,
-    Query(pagination): Query<Pagination<VersionedUrl>>,
+    Query(pagination): Query<Pagination<EntityTypeVertexId>>,
     OriginalUri(uri): OriginalUri,
     Json(query): Json<serde_json::Value>,
 ) -> Result<(HeaderMap, Json<Subgraph>), Response>
@@ -713,7 +716,7 @@ where
             actor_id,
             &authorization_api,
             &query,
-            pagination.after.as_ref().map(|cursor| &cursor.0),
+            pagination.after.map(|cursor| cursor.0),
             pagination.limit,
         )
         .await

--- a/apps/hash-graph/libs/api/src/rest/property_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/property_type.rs
@@ -31,7 +31,10 @@ use graph::{
         error::VersionedUrlAlreadyExists, BaseUrlAlreadyExists, ConflictBehavior,
         OntologyVersionDoesNotExist, PropertyTypeStore, StorePool,
     },
-    subgraph::query::{PropertyTypeStructuralQuery, StructuralQuery},
+    subgraph::{
+        identifier::PropertyTypeVertexId,
+        query::{PropertyTypeStructuralQuery, StructuralQuery},
+    },
 };
 use graph_types::{
     ontology::{
@@ -383,7 +386,7 @@ async fn get_property_types_by_query<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
     authorization_api_pool: Extension<Arc<A>>,
-    Query(pagination): Query<Pagination<VersionedUrl>>,
+    Query(pagination): Query<Pagination<PropertyTypeVertexId>>,
     OriginalUri(uri): OriginalUri,
     Json(query): Json<serde_json::Value>,
 ) -> Result<(HeaderMap, Json<Subgraph>), Response>
@@ -408,7 +411,7 @@ where
             actor_id,
             &authorization_api,
             &query,
-            pagination.after.as_ref().map(|cursor| &cursor.0),
+            pagination.after.map(|cursor| cursor.0),
             pagination.limit,
         )
         .await

--- a/apps/hash-graph/libs/api/src/rest/property_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/property_type.rs
@@ -31,10 +31,7 @@ use graph::{
         error::VersionedUrlAlreadyExists, BaseUrlAlreadyExists, ConflictBehavior,
         OntologyVersionDoesNotExist, PropertyTypeStore, StorePool,
     },
-    subgraph::{
-        identifier::PropertyTypeVertexId,
-        query::{PropertyTypeStructuralQuery, StructuralQuery},
-    },
+    subgraph::query::{PropertyTypeStructuralQuery, StructuralQuery},
 };
 use graph_types::{
     ontology::{
@@ -386,7 +383,7 @@ async fn get_property_types_by_query<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
     authorization_api_pool: Extension<Arc<A>>,
-    Query(pagination): Query<Pagination<PropertyTypeVertexId>>,
+    Query(pagination): Query<Pagination<VersionedUrl>>,
     OriginalUri(uri): OriginalUri,
     Json(query): Json<serde_json::Value>,
 ) -> Result<(HeaderMap, Json<Subgraph>), Response>

--- a/apps/hash-graph/libs/graph/src/knowledge/query.rs
+++ b/apps/hash-graph/libs/graph/src/knowledge/query.rs
@@ -21,7 +21,7 @@ use crate::{
     },
 };
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub enum EntityQueryPath<'p> {
     /// The [`EntityUuid`] of the [`EntityId`] belonging to the [`Entity`].
     ///

--- a/apps/hash-graph/libs/graph/src/lib.rs
+++ b/apps/hash-graph/libs/graph/src/lib.rs
@@ -9,6 +9,7 @@
 #![feature(try_find)]
 #![feature(type_alias_impl_trait)]
 #![feature(hash_raw_entry)]
+#![feature(let_chains)]
 #![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
 #![cfg_attr(not(miri), doc(test(attr(deny(warnings, clippy::all)))))]
 #![expect(

--- a/apps/hash-graph/libs/graph/src/lib.rs
+++ b/apps/hash-graph/libs/graph/src/lib.rs
@@ -10,6 +10,7 @@
 #![feature(type_alias_impl_trait)]
 #![feature(hash_raw_entry)]
 #![feature(let_chains)]
+#![feature(never_type)]
 #![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
 #![cfg_attr(not(miri), doc(test(attr(deny(warnings, clippy::all)))))]
 #![expect(

--- a/apps/hash-graph/libs/graph/src/ontology/data_type.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/data_type.rs
@@ -22,7 +22,7 @@ use crate::{
 /// [`DataType`]: type_system::DataType
 // TODO: Adjust enum and docs when adding non-primitive data types
 //   see https://app.asana.com/0/1200211978612931/1202464168422955/f
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub enum DataTypeQueryPath<'p> {
     /// The [`BaseUrl`] of the [`DataType`].
     ///

--- a/apps/hash-graph/libs/graph/src/ontology/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/entity_type.rs
@@ -22,7 +22,7 @@ use crate::{
 /// A path to a [`EntityType`] field.
 ///
 /// [`EntityType`]: type_system::EntityType
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub enum EntityTypeQueryPath<'p> {
     /// The [`BaseUrl`] of the [`EntityType`].
     ///

--- a/apps/hash-graph/libs/graph/src/ontology/property_type.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/property_type.rs
@@ -18,7 +18,7 @@ use crate::{
 /// A path to a [`PropertyType`] field.
 ///
 /// [`PropertyType`]: type_system::PropertyType
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub enum PropertyTypeQueryPath<'p> {
     /// The [`BaseUrl`] of the [`PropertyType`].
     ///

--- a/apps/hash-graph/libs/graph/src/snapshot/entity/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/entity/batch.rs
@@ -227,16 +227,10 @@ impl<C: AsClient> WriteBatch<C> for EntityRowBatch {
             .change_context(InsertionError)?;
 
         if validation {
-            let entities = Read::<Entity>::read_vec(
-                postgres_client,
-                &Filter::All(Vec::new()),
-                None,
-                None,
-                None,
-                true,
-            )
-            .await
-            .change_context(InsertionError)?;
+            let entities =
+                Read::<Entity>::read_vec(postgres_client, &Filter::All(Vec::new()), None, true)
+                    .await
+                    .change_context(InsertionError)?;
 
             let schemas = postgres_client
                 .read_closed_schemas(&Filter::All(Vec::new()), None)

--- a/apps/hash-graph/libs/graph/src/snapshot/mod.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/mod.rs
@@ -54,7 +54,7 @@ use crate::{
     snapshot::{entity::EntitySnapshotRecord, restore::SnapshotRecordBatch},
     store::{
         crud::Read, query::Filter, AsClient, InsertionError, PostgresStore, PostgresStorePool,
-        StorePool,
+        Record, StorePool,
     },
 };
 
@@ -281,7 +281,7 @@ where
     ) -> Result<impl Stream<Item = Result<T, SnapshotDumpError>> + Send + 'pool, SnapshotDumpError>
     where
         <Self as StorePool>::Store<'pool>: Read<T>,
-        T: 'pool,
+        T: Record + 'pool,
     {
         Ok(Read::<T>::read(
             &self
@@ -289,8 +289,6 @@ where
                 .await
                 .change_context(SnapshotDumpError::Query)?,
             &Filter::All(vec![]),
-            None,
-            None,
             None,
             true,
         )

--- a/apps/hash-graph/libs/graph/src/store/crud.rs
+++ b/apps/hash-graph/libs/graph/src/store/crud.rs
@@ -202,7 +202,7 @@ pub trait ReadPaginated<R: Record, S: Sorting + Sync = VertexIdSorting<R>>: Read
         &self,
         filter: &Filter<'_, R>,
         temporal_axes: Option<&QueryTemporalAxes>,
-        sorting: Option<&S>,
+        sorting: &S,
         limit: Option<usize>,
         include_drafts: bool,
     ) -> Result<
@@ -217,7 +217,7 @@ pub trait ReadPaginated<R: Record, S: Sorting + Sync = VertexIdSorting<R>>: Read
         &self,
         filter: &Filter<'_, R>,
         temporal_axes: Option<&QueryTemporalAxes>,
-        sorting: Option<&S>,
+        sorting: &S,
         limit: Option<usize>,
         include_drafts: bool,
     ) -> Result<

--- a/apps/hash-graph/libs/graph/src/store/crud.rs
+++ b/apps/hash-graph/libs/graph/src/store/crud.rs
@@ -7,48 +7,167 @@
 //! [`Store`]: crate::store::Store
 
 use async_trait::async_trait;
-use error_stack::{ensure, Report, Result};
-use futures::TryStreamExt;
+use error_stack::Result;
+use futures::{Stream, TryStreamExt};
+use tokio_postgres::Row;
 
 use crate::{
     store::{query::Filter, QueryError, Record},
     subgraph::temporal_axes::QueryTemporalAxes,
 };
 
+pub trait QueryCompiler<'p> {
+    type ResultSet;
+}
+
+pub trait QueryRecordEncode {
+    type CompilationParameters<'p>: Send
+    where
+        Self: 'p;
+
+    fn encode(&self) -> Self::CompilationParameters<'_>;
+}
+
+pub trait QueryRecordDecode<Q> {
+    type CompilationArtifacts: Copy + Send + Sync + 'static;
+
+    fn decode(query_result: &Q, artifacts: Self::CompilationArtifacts) -> Self;
+}
+
+pub trait Cursor<'c, C>: QueryRecordEncode + QueryRecordDecode<C::ResultSet>
+where
+    C: QueryCompiler<'c>,
+{
+    fn compile<'p: 'c>(
+        compiler: &mut C,
+        parameters: Option<&'c Self::CompilationParameters<'p>>,
+        temporal_axes: &QueryTemporalAxes,
+    ) -> Self::CompilationArtifacts;
+}
+
+/// A record which is queried for.
+///
+/// To create a record, three steps are necessary:
+///
+///   1. As a preparation, the [`QueryRecord::parameters`] are retrieved. This is required as often
+///      the parameters are used for the compilation step but the parameters need to outlive
+///      compilation.
+///   2. Compiling the query using the [`CompilationParameters`] and the [`SelectCompiler`]. This
+///      results in [`CompilationArtifacts`], which are used later to decode the query result.
+///   3. After a query has been made, the query result is decoded using the [`CompilationArtifacts`]
+///      and the query result `Q`.
+///
+/// [`CompilationParameters`]: Self::CompilationParameters
+/// [`CompilationArtifacts`]: Self::CompilationArtifacts
+pub trait QueryRecord<'c, C>: Record + QueryRecordDecode<C::ResultSet>
+where
+    C: QueryCompiler<'c>,
+{
+    type CompilationParameters: Send + 'static;
+
+    fn parameters() -> Self::CompilationParameters;
+
+    fn compile<'p: 'c>(
+        compiler: &mut C,
+        paths: &'p Self::CompilationParameters,
+    ) -> Self::CompilationArtifacts;
+}
+
+pub trait QueryResult {
+    type Record;
+    type Cursor;
+
+    fn decode_record(&self) -> Self::Record;
+    fn decode_cursor(&self) -> Self::Cursor;
+}
+
+pub struct PostgresQueryResult<R, C>
+where
+    R: QueryRecordDecode<Row>,
+    C: QueryRecordDecode<Row>,
+{
+    pub query_result: Row,
+    pub record_artifacts: R::CompilationArtifacts,
+    pub cursor_artifacts: C::CompilationArtifacts,
+}
+
+impl<R, C> QueryResult for PostgresQueryResult<R, C>
+where
+    R: QueryRecordDecode<Row>,
+    C: QueryRecordDecode<Row>,
+{
+    type Cursor = C;
+    type Record = R;
+
+    fn decode_record(&self) -> Self::Record {
+        R::decode(&self.query_result, self.record_artifacts)
+    }
+
+    fn decode_cursor(&self) -> Self::Cursor {
+        C::decode(&self.query_result, self.cursor_artifacts)
+    }
+}
+
 /// Read access to a [`Store`].
 ///
 /// [`Store`]: crate::store::Store
-// TODO: Use queries, which are passed to the query-endpoint
-//   see https://app.asana.com/0/1202805690238892/1202979057056097/f
 #[async_trait]
-pub trait Read<R>: Sync {
-    type Record: Record;
-    type ReadStream: futures::Stream<Item = Result<R, QueryError>> + Send + Sync;
+pub trait ReadPaginated<R: Record, C = <R as Record>::VertexId>: Read<R> {
+    type QueryResultSet;
+    type QueryResult: QueryResult<Record = R, Cursor = C> + Send;
 
-    /// Returns a value from the [`Store`] specified by the passed `query`.
-    ///
-    /// [`Store`]: crate::store::Store
+    type ReadPaginatedStream: Stream<Item = Result<Self::QueryResult, QueryError>> + Send + Sync;
+
+    async fn read_paginated(
+        &self,
+        filter: &Filter<'_, R>,
+        temporal_axes: Option<&QueryTemporalAxes>,
+        cursor: Option<&C>,
+        limit: Option<usize>,
+        include_drafts: bool,
+    ) -> Result<Self::ReadPaginatedStream, QueryError>
+    where
+        C: QueryRecordDecode<Self::QueryResultSet> + Sync;
+
+    async fn read_paginated_vec(
+        &self,
+        filter: &Filter<'_, R>,
+        temporal_axes: Option<&QueryTemporalAxes>,
+        cursor: Option<&C>,
+        limit: Option<usize>,
+        include_drafts: bool,
+    ) -> Result<Vec<Self::QueryResult>, QueryError>
+    where
+        C: QueryRecordDecode<Self::QueryResultSet> + Sync,
+    {
+        self.read_paginated(filter, temporal_axes, cursor, limit, include_drafts)
+            .await?
+            .try_collect()
+            .await
+    }
+}
+
+/// Read access to a [`Store`].
+///
+/// [`Store`]: crate::store::Store
+#[async_trait]
+pub trait Read<R: Record>: Sync {
+    type ReadStream: Stream<Item = Result<R, QueryError>> + Send + Sync;
+
     async fn read(
         &self,
-        query: &Filter<Self::Record>,
+        filter: &Filter<'_, R>,
         temporal_axes: Option<&QueryTemporalAxes>,
-        after: Option<&<Self::Record as Record>::VertexId>,
-        limit: Option<usize>,
         include_drafts: bool,
     ) -> Result<Self::ReadStream, QueryError>;
 
     async fn read_vec(
         &self,
-        query: &Filter<Self::Record>,
+        filter: &Filter<'_, R>,
         temporal_axes: Option<&QueryTemporalAxes>,
-        after: Option<&<Self::Record as Record>::VertexId>,
-        limit: Option<usize>,
         include_drafts: bool,
-    ) -> Result<Vec<R>, QueryError>
-    where
-        R: Send,
-    {
-        self.read(query, temporal_axes, after, limit, include_drafts)
+    ) -> Result<Vec<R>, QueryError> {
+        self.read(filter, temporal_axes, include_drafts)
             .await?
             .try_collect()
             .await
@@ -56,29 +175,10 @@ pub trait Read<R>: Sync {
 
     async fn read_one(
         &self,
-        query: &Filter<Self::Record>,
+        filter: &Filter<'_, R>,
         temporal_axes: Option<&QueryTemporalAxes>,
         include_drafts: bool,
-    ) -> Result<R, QueryError>
-    where
-        R: Send,
-    {
-        let mut records = self
-            .read_vec(query, temporal_axes, None, None, include_drafts)
-            .await?;
-        ensure!(
-            records.len() <= 1,
-            Report::new(QueryError).attach_printable(format!(
-                "Expected exactly one record to be returned from the query but {} were returned",
-                records.len(),
-            ))
-        );
-        records.pop().ok_or_else(|| {
-            Report::new(QueryError).attach_printable(
-                "Expected exactly one record to be returned from the query but none was returned",
-            )
-        })
-    }
+    ) -> Result<R, QueryError>;
 }
 
-// TODO: Add remaining CRUD traits (but probably don't implement the `D`-part)
+// TODO: Add remaining CRUD traits

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -666,7 +666,6 @@ where
     }
 }
 
-#[async_trait]
 impl<I, A, R, S> ReadPaginated<R, S> for FetchingStore<I, A>
 where
     A: Send + Sync,

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -1098,7 +1098,6 @@ where
     }
 }
 
-#[async_trait]
 impl<S, A> EntityStore for FetchingStore<S, A>
 where
     S: DataTypeStore + PropertyTypeStore + EntityTypeStore + EntityStore + Send + Sync,
@@ -1262,7 +1261,7 @@ where
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut Au,
-        embeddings: impl IntoIterator<Item = EntityEmbedding<'_>> + Send,
+        embeddings: Vec<EntityEmbedding<'_>>,
         updated_at_transaction_time: Timestamp<TransactionTime>,
         updated_at_decision_time: Timestamp<DecisionTime>,
         reset: bool,

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -681,7 +681,7 @@ where
         &self,
         filter: &Filter<'_, R>,
         temporal_axes: Option<&QueryTemporalAxes>,
-        sorting: Option<&S>,
+        sorting: &S,
         limit: Option<usize>,
         include_drafts: bool,
     ) -> Result<

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -41,7 +41,7 @@ use validation::ValidationProfile;
 use crate::{
     ontology::domain_validator::DomainValidator,
     store::{
-        crud::{Read, ReadPaginated, Sorting},
+        crud::{QueryResult, Read, ReadPaginated, Sorting},
         knowledge::{EntityValidationType, ValidateEntityError},
         query::{Filter, OntologyQueryPath},
         AccountStore, ConflictBehavior, DataTypeStore, EntityStore, EntityTypeStore,
@@ -675,7 +675,6 @@ where
     S: Sorting + Sync,
 {
     type QueryResult = I::QueryResult;
-    type QueryResultSet = I::QueryResultSet;
     type ReadPaginatedStream = I::ReadPaginatedStream;
 
     async fn read_paginated(
@@ -685,7 +684,13 @@ where
         sorting: Option<&S>,
         limit: Option<usize>,
         include_drafts: bool,
-    ) -> Result<Self::ReadPaginatedStream, QueryError> {
+    ) -> Result<
+        (
+            Self::ReadPaginatedStream,
+            <Self::QueryResult as QueryResult<R, S>>::Artifacts,
+        ),
+        QueryError,
+    > {
         self.store
             .read_paginated(filter, temporal_axes, sorting, limit, include_drafts)
             .await

--- a/apps/hash-graph/libs/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/libs/graph/src/store/knowledge.rs
@@ -1,6 +1,5 @@
-use std::{error::Error, fmt};
+use std::{error::Error, fmt, future::Future};
 
-use async_trait::async_trait;
 use authorization::{schema::EntityRelationAndSubject, zanzibar::Consistency, AuthorizationApi};
 use error_stack::Result;
 use graph_types::{
@@ -41,7 +40,6 @@ impl Error for ValidateEntityError {}
 /// Describes the API of a store implementation for [Entities].
 ///
 /// [Entities]: Entity
-#[async_trait]
 pub trait EntityStore: crud::ReadPaginated<Entity, EntityVertexId> {
     /// Creates a new [`Entity`].
     ///
@@ -59,7 +57,7 @@ pub trait EntityStore: crud::ReadPaginated<Entity, EntityVertexId> {
         clippy::too_many_arguments,
         reason = "https://linear.app/hash/issue/H-1466"
     )]
-    async fn create_entity<A: AuthorizationApi + Send + Sync>(
+    fn create_entity<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut A,
@@ -73,7 +71,7 @@ pub trait EntityStore: crud::ReadPaginated<Entity, EntityVertexId> {
         properties: EntityProperties,
         link_data: Option<LinkData>,
         relationships: impl IntoIterator<Item = EntityRelationAndSubject> + Send,
-    ) -> Result<EntityMetadata, InsertionError>;
+    ) -> impl Future<Output = Result<EntityMetadata, InsertionError>> + Send;
 
     /// Validates an [`Entity`].
     ///
@@ -86,7 +84,7 @@ pub trait EntityStore: crud::ReadPaginated<Entity, EntityVertexId> {
         clippy::too_many_arguments,
         reason = "https://linear.app/hash/issue/H-1466"
     )]
-    async fn validate_entity<A: AuthorizationApi + Sync>(
+    fn validate_entity<A: AuthorizationApi + Sync>(
         &self,
         actor_id: AccountId,
         authorization_api: &A,
@@ -95,7 +93,7 @@ pub trait EntityStore: crud::ReadPaginated<Entity, EntityVertexId> {
         properties: &EntityProperties,
         link_data: Option<&LinkData>,
         profile: ValidationProfile,
-    ) -> Result<(), ValidateEntityError>;
+    ) -> impl Future<Output = Result<(), ValidateEntityError>> + Send;
 
     /// Inserts the entities with the specified [`EntityType`] into the `Store`.
     ///
@@ -114,7 +112,7 @@ pub trait EntityStore: crud::ReadPaginated<Entity, EntityVertexId> {
     /// - if an [`EntityUuid`] was supplied and already exists in the store
     ///
     /// [`EntityType`]: type_system::EntityType
-    async fn insert_entities_batched_by_type<A: AuthorizationApi + Send + Sync>(
+    fn insert_entities_batched_by_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut A,
@@ -129,21 +127,21 @@ pub trait EntityStore: crud::ReadPaginated<Entity, EntityVertexId> {
             IntoIter: Send,
         > + Send,
         entity_type_id: &VersionedUrl,
-    ) -> Result<Vec<EntityMetadata>, InsertionError>;
+    ) -> impl Future<Output = Result<Vec<EntityMetadata>, InsertionError>> + Send;
 
     /// Get the [`Subgraph`]s specified by the [`StructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`Entity`] doesn't exist
-    async fn get_entity<A: AuthorizationApi + Sync>(
+    fn get_entity<A: AuthorizationApi + Sync>(
         &self,
         actor_id: AccountId,
         authorization_api: &A,
         query: &StructuralQuery<'_, Entity>,
         after: Option<&EntityVertexId>,
         limit: Option<usize>,
-    ) -> Result<(Subgraph, Option<EntityVertexId>), QueryError>;
+    ) -> impl Future<Output = Result<(Subgraph, Option<EntityVertexId>), QueryError>> + Send;
 
     /// Update an existing [`Entity`].
     ///
@@ -163,7 +161,7 @@ pub trait EntityStore: crud::ReadPaginated<Entity, EntityVertexId> {
         clippy::too_many_arguments,
         reason = "https://linear.app/hash/issue/H-1466"
     )]
-    async fn update_entity<A: AuthorizationApi + Send + Sync>(
+    fn update_entity<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut A,
@@ -175,15 +173,15 @@ pub trait EntityStore: crud::ReadPaginated<Entity, EntityVertexId> {
         entity_type_id: VersionedUrl,
         properties: EntityProperties,
         link_order: EntityLinkOrder,
-    ) -> Result<EntityMetadata, UpdateError>;
+    ) -> impl Future<Output = Result<EntityMetadata, UpdateError>> + Send;
 
-    async fn update_entity_embeddings<A: AuthorizationApi + Send + Sync>(
+    fn update_entity_embeddings<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut A,
-        embeddings: impl IntoIterator<Item = EntityEmbedding<'_>> + Send,
+        embeddings: Vec<EntityEmbedding<'_>>,
         updated_at_transaction_time: Timestamp<TransactionTime>,
         updated_at_decision_time: Timestamp<DecisionTime>,
         reset: bool,
-    ) -> Result<(), UpdateError>;
+    ) -> impl Future<Output = Result<(), UpdateError>> + Send;
 }

--- a/apps/hash-graph/libs/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/libs/graph/src/store/knowledge.rs
@@ -40,7 +40,7 @@ impl Error for ValidateEntityError {}
 /// Describes the API of a store implementation for [Entities].
 ///
 /// [Entities]: Entity
-pub trait EntityStore: crud::ReadPaginated<Entity, EntityVertexId> {
+pub trait EntityStore: crud::ReadPaginated<Entity> {
     /// Creates a new [`Entity`].
     ///
     /// # Errors:

--- a/apps/hash-graph/libs/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/libs/graph/src/store/knowledge.rs
@@ -42,7 +42,7 @@ impl Error for ValidateEntityError {}
 ///
 /// [Entities]: Entity
 #[async_trait]
-pub trait EntityStore: crud::Read<Entity> {
+pub trait EntityStore: crud::ReadPaginated<Entity, EntityVertexId> {
     /// Creates a new [`Entity`].
     ///
     /// # Errors:
@@ -140,7 +140,7 @@ pub trait EntityStore: crud::Read<Entity> {
         &self,
         actor_id: AccountId,
         authorization_api: &A,
-        query: &StructuralQuery<Entity>,
+        query: &StructuralQuery<'_, Entity>,
         after: Option<&EntityVertexId>,
         limit: Option<usize>,
     ) -> Result<(Subgraph, Option<EntityVertexId>), QueryError>;

--- a/apps/hash-graph/libs/graph/src/store/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/mod.rs
@@ -23,7 +23,7 @@ pub use self::{
         BaseUrlAlreadyExists, InsertionError, OntologyVersionDoesNotExist, QueryError, StoreError,
         UpdateError,
     },
-    fetcher::{FetchingPool, TypeFetcher},
+    fetcher::{FetchingPool, FetchingStore, TypeFetcher},
     knowledge::{EntityStore, EntityValidationType},
     migration::{Migration, MigrationState, StoreMigration},
     ontology::{DataTypeStore, EntityTypeStore, PropertyTypeStore},

--- a/apps/hash-graph/libs/graph/src/store/ontology.rs
+++ b/apps/hash-graph/libs/graph/src/store/ontology.rs
@@ -1,6 +1,5 @@
-use std::iter;
+use std::{future::Future, iter};
 
-use async_trait::async_trait;
 use authorization::{
     schema::{
         DataTypeRelationAndSubject, EntityTypeRelationAndSubject, PropertyTypeRelationAndSubject,
@@ -22,17 +21,12 @@ use type_system::{
 };
 
 use crate::{
-    store::{crud, ConflictBehavior, InsertionError, QueryError, UpdateError},
-    subgraph::{
-        identifier::{DataTypeVertexId, EntityTypeVertexId, PropertyTypeVertexId},
-        query::StructuralQuery,
-        Subgraph,
-    },
+    store::{ConflictBehavior, InsertionError, QueryError, UpdateError},
+    subgraph::{query::StructuralQuery, Subgraph},
 };
 
 /// Describes the API of a store implementation for [`DataType`]s.
-#[async_trait]
-pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
+pub trait DataTypeStore {
     /// Creates a new [`DataType`].
     ///
     /// # Errors:
@@ -41,25 +35,30 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     /// - if the [`BaseUrl`] of the `data_type` already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    async fn create_data_type<A: AuthorizationApi + Send + Sync>(
+    fn create_data_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut A,
         schema: DataType,
         metadata: PartialDataTypeMetadata,
         relationships: impl IntoIterator<Item = DataTypeRelationAndSubject> + Send,
-    ) -> Result<DataTypeMetadata, InsertionError> {
-        Ok(self
-            .create_data_types(
-                actor_id,
-                authorization_api,
-                iter::once((schema, metadata)),
-                ConflictBehavior::Fail,
-                relationships,
-            )
-            .await?
-            .pop()
-            .expect("created exactly one data type"))
+    ) -> impl Future<Output = Result<DataTypeMetadata, InsertionError>> + Send
+    where
+        Self: Send,
+    {
+        async move {
+            Ok(self
+                .create_data_types(
+                    actor_id,
+                    authorization_api,
+                    iter::once((schema, metadata)),
+                    ConflictBehavior::Fail,
+                    relationships,
+                )
+                .await?
+                .pop()
+                .expect("created exactly one data type"))
+        }
     }
 
     /// Creates the provided [`DataType`]s.
@@ -70,70 +69,69 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     /// - if any [`BaseUrl`] of the data type already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    async fn create_data_types<A: AuthorizationApi + Send + Sync>(
+    fn create_data_types<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut A,
         data_types: impl IntoIterator<Item = (DataType, PartialDataTypeMetadata), IntoIter: Send> + Send,
         on_conflict: ConflictBehavior,
         relationships: impl IntoIterator<Item = DataTypeRelationAndSubject> + Send,
-    ) -> Result<Vec<DataTypeMetadata>, InsertionError>;
+    ) -> impl Future<Output = Result<Vec<DataTypeMetadata>, InsertionError>> + Send;
 
     /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`DataType`] doesn't exist.
-    async fn get_data_type<A: AuthorizationApi + Sync>(
+    fn get_data_type<A: AuthorizationApi + Sync>(
         &self,
         actor_id: AccountId,
         authorization_api: &A,
         query: &StructuralQuery<DataTypeWithMetadata>,
-        after: Option<&DataTypeVertexId>,
+        after: Option<&VersionedUrl>,
         limit: Option<usize>,
-    ) -> Result<Subgraph, QueryError>;
+    ) -> impl Future<Output = Result<Subgraph, QueryError>> + Send;
 
     /// Update the definition of an existing [`DataType`].
     ///
     /// # Errors
     ///
     /// - if the [`DataType`] doesn't exist.
-    async fn update_data_type<A: AuthorizationApi + Send + Sync>(
+    fn update_data_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut A,
         data_type: DataType,
         relationships: impl IntoIterator<Item = DataTypeRelationAndSubject> + Send,
-    ) -> Result<DataTypeMetadata, UpdateError>;
+    ) -> impl Future<Output = Result<DataTypeMetadata, UpdateError>> + Send;
 
     /// Archives the definition of an existing [`DataType`].
     ///
     /// # Errors
     ///
     /// - if the [`DataType`] doesn't exist.
-    async fn archive_data_type<A: AuthorizationApi + Send + Sync>(
+    fn archive_data_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut A,
         id: &VersionedUrl,
-    ) -> Result<OntologyTemporalMetadata, UpdateError>;
+    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
 
     /// Restores the definition of an existing [`DataType`].
     ///
     /// # Errors
     ///
     /// - if the [`DataType`] doesn't exist.
-    async fn unarchive_data_type<A: AuthorizationApi + Send + Sync>(
+    fn unarchive_data_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut A,
         id: &VersionedUrl,
-    ) -> Result<OntologyTemporalMetadata, UpdateError>;
+    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
 }
 
 /// Describes the API of a store implementation for [`PropertyType`]s.
-#[async_trait]
-pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
+pub trait PropertyTypeStore {
     /// Creates a new [`PropertyType`].
     ///
     /// # Errors:
@@ -142,25 +140,30 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     /// - if the [`BaseUrl`] of the `property_type` already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    async fn create_property_type<A: AuthorizationApi + Send + Sync>(
+    fn create_property_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut A,
         schema: PropertyType,
         metadata: PartialPropertyTypeMetadata,
         relationships: impl IntoIterator<Item = PropertyTypeRelationAndSubject> + Send,
-    ) -> Result<PropertyTypeMetadata, InsertionError> {
-        Ok(self
-            .create_property_types(
-                actor_id,
-                authorization_api,
-                iter::once((schema, metadata)),
-                ConflictBehavior::Fail,
-                relationships,
-            )
-            .await?
-            .pop()
-            .expect("created exactly one property type"))
+    ) -> impl Future<Output = Result<PropertyTypeMetadata, InsertionError>> + Send
+    where
+        Self: Send,
+    {
+        async move {
+            Ok(self
+                .create_property_types(
+                    actor_id,
+                    authorization_api,
+                    iter::once((schema, metadata)),
+                    ConflictBehavior::Fail,
+                    relationships,
+                )
+                .await?
+                .pop()
+                .expect("created exactly one property type"))
+        }
     }
 
     /// Creates the provided [`PropertyType`]s.
@@ -171,7 +174,7 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     /// - if any [`BaseUrl`] of the property type already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    async fn create_property_types<A: AuthorizationApi + Send + Sync>(
+    fn create_property_types<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut A,
@@ -181,63 +184,62 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
         > + Send,
         on_conflict: ConflictBehavior,
         relationships: impl IntoIterator<Item = PropertyTypeRelationAndSubject> + Send,
-    ) -> Result<Vec<PropertyTypeMetadata>, InsertionError>;
+    ) -> impl Future<Output = Result<Vec<PropertyTypeMetadata>, InsertionError>> + Send;
 
     /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`PropertyType`] doesn't exist.
-    async fn get_property_type<A: AuthorizationApi + Sync>(
+    fn get_property_type<A: AuthorizationApi + Sync>(
         &self,
         actor_id: AccountId,
         authorization_api: &A,
-        query: &StructuralQuery<PropertyTypeWithMetadata>,
-        after: Option<&PropertyTypeVertexId>,
+        query: &StructuralQuery<'_, PropertyTypeWithMetadata>,
+        after: Option<&VersionedUrl>,
         limit: Option<usize>,
-    ) -> Result<Subgraph, QueryError>;
+    ) -> impl Future<Output = Result<Subgraph, QueryError>> + Send;
 
     /// Update the definition of an existing [`PropertyType`].
     ///
     /// # Errors
     ///
     /// - if the [`PropertyType`] doesn't exist.
-    async fn update_property_type<A: AuthorizationApi + Send + Sync>(
+    fn update_property_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut A,
         property_type: PropertyType,
         relationships: impl IntoIterator<Item = PropertyTypeRelationAndSubject> + Send,
-    ) -> Result<PropertyTypeMetadata, UpdateError>;
+    ) -> impl Future<Output = Result<PropertyTypeMetadata, UpdateError>> + Send;
 
     /// Archives the definition of an existing [`PropertyType`].
     ///
     /// # Errors
     ///
     /// - if the [`PropertyType`] doesn't exist.
-    async fn archive_property_type<A: AuthorizationApi + Send + Sync>(
+    fn archive_property_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut A,
         id: &VersionedUrl,
-    ) -> Result<OntologyTemporalMetadata, UpdateError>;
+    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
 
     /// Restores the definition of an existing [`PropertyType`].
     ///
     /// # Errors
     ///
     /// - if the [`PropertyType`] doesn't exist.
-    async fn unarchive_property_type<A: AuthorizationApi + Send + Sync>(
+    fn unarchive_property_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut A,
         id: &VersionedUrl,
-    ) -> Result<OntologyTemporalMetadata, UpdateError>;
+    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
 }
 
 /// Describes the API of a store implementation for [`EntityType`]s.
-#[async_trait]
-pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
+pub trait EntityTypeStore {
     /// Creates a new [`EntityType`].
     ///
     /// # Errors:
@@ -246,25 +248,30 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     /// - if the [`BaseUrl`] of the `entity_type` already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    async fn create_entity_type<A: AuthorizationApi + Send + Sync>(
+    fn create_entity_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut A,
         schema: EntityType,
         metadata: PartialEntityTypeMetadata,
         relationships: impl IntoIterator<Item = EntityTypeRelationAndSubject> + Send,
-    ) -> Result<EntityTypeMetadata, InsertionError> {
-        Ok(self
-            .create_entity_types(
-                actor_id,
-                authorization_api,
-                iter::once((schema, metadata)),
-                ConflictBehavior::Fail,
-                relationships,
-            )
-            .await?
-            .pop()
-            .expect("created exactly one entity type"))
+    ) -> impl Future<Output = Result<EntityTypeMetadata, InsertionError>> + Send
+    where
+        Self: Send,
+    {
+        async move {
+            Ok(self
+                .create_entity_types(
+                    actor_id,
+                    authorization_api,
+                    iter::once((schema, metadata)),
+                    ConflictBehavior::Fail,
+                    relationships,
+                )
+                .await?
+                .pop()
+                .expect("created exactly one entity type"))
+        }
     }
 
     /// Creates the provided [`EntityType`]s.
@@ -275,7 +282,7 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     /// - if any [`BaseUrl`] of the entity type already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    async fn create_entity_types<A: AuthorizationApi + Send + Sync>(
+    fn create_entity_types<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut A,
@@ -283,28 +290,28 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
         + Send,
         on_conflict: ConflictBehavior,
         relationships: impl IntoIterator<Item = EntityTypeRelationAndSubject> + Send,
-    ) -> Result<Vec<EntityTypeMetadata>, InsertionError>;
+    ) -> impl Future<Output = Result<Vec<EntityTypeMetadata>, InsertionError>> + Send;
 
     /// Get the [`Subgraph`]s specified by the [`StructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`EntityType`] doesn't exist.
-    async fn get_entity_type<A: AuthorizationApi + Sync>(
+    fn get_entity_type<A: AuthorizationApi + Sync>(
         &self,
         actor_id: AccountId,
         authorization_api: &A,
-        query: &StructuralQuery<EntityTypeWithMetadata>,
-        after: Option<&EntityTypeVertexId>,
+        query: &StructuralQuery<'_, EntityTypeWithMetadata>,
+        after: Option<&VersionedUrl>,
         limit: Option<usize>,
-    ) -> Result<Subgraph, QueryError>;
+    ) -> impl Future<Output = Result<Subgraph, QueryError>> + Send;
 
     /// Update the definition of an existing [`EntityType`].
     ///
     /// # Errors
     ///
     /// - if the [`EntityType`] doesn't exist.
-    async fn update_entity_type<A: AuthorizationApi + Send + Sync>(
+    fn update_entity_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut A,
@@ -312,29 +319,29 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
         label_property: Option<BaseUrl>,
         icon: Option<String>,
         relationships: impl IntoIterator<Item = EntityTypeRelationAndSubject> + Send,
-    ) -> Result<EntityTypeMetadata, UpdateError>;
+    ) -> impl Future<Output = Result<EntityTypeMetadata, UpdateError>> + Send;
 
     /// Archives the definition of an existing [`EntityType`].
     ///
     /// # Errors
     ///
     /// - if the [`EntityType`] doesn't exist.
-    async fn archive_entity_type<A: AuthorizationApi + Send + Sync>(
+    fn archive_entity_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut A,
         id: &VersionedUrl,
-    ) -> Result<OntologyTemporalMetadata, UpdateError>;
+    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
 
     /// Restores the definition of an existing [`EntityType`].
     ///
     /// # Errors
     ///
     /// - if the [`EntityType`] doesn't exist.
-    async fn unarchive_entity_type<A: AuthorizationApi + Send + Sync>(
+    fn unarchive_entity_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
         authorization_api: &mut A,
         id: &VersionedUrl,
-    ) -> Result<OntologyTemporalMetadata, UpdateError>;
+    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
 }

--- a/apps/hash-graph/libs/graph/src/store/ontology.rs
+++ b/apps/hash-graph/libs/graph/src/store/ontology.rs
@@ -22,7 +22,11 @@ use type_system::{
 
 use crate::{
     store::{ConflictBehavior, InsertionError, QueryError, UpdateError},
-    subgraph::{query::StructuralQuery, Subgraph},
+    subgraph::{
+        identifier::{DataTypeVertexId, EntityTypeVertexId, PropertyTypeVertexId},
+        query::StructuralQuery,
+        Subgraph,
+    },
 };
 
 /// Describes the API of a store implementation for [`DataType`]s.
@@ -88,7 +92,7 @@ pub trait DataTypeStore {
         actor_id: AccountId,
         authorization_api: &A,
         query: &StructuralQuery<DataTypeWithMetadata>,
-        after: Option<&VersionedUrl>,
+        after: Option<DataTypeVertexId>,
         limit: Option<usize>,
     ) -> impl Future<Output = Result<Subgraph, QueryError>> + Send;
 
@@ -196,7 +200,7 @@ pub trait PropertyTypeStore {
         actor_id: AccountId,
         authorization_api: &A,
         query: &StructuralQuery<'_, PropertyTypeWithMetadata>,
-        after: Option<&VersionedUrl>,
+        after: Option<PropertyTypeVertexId>,
         limit: Option<usize>,
     ) -> impl Future<Output = Result<Subgraph, QueryError>> + Send;
 
@@ -302,7 +306,7 @@ pub trait EntityTypeStore {
         actor_id: AccountId,
         authorization_api: &A,
         query: &StructuralQuery<'_, EntityTypeWithMetadata>,
-        after: Option<&VersionedUrl>,
+        after: Option<EntityTypeVertexId>,
         limit: Option<usize>,
     ) -> impl Future<Output = Result<Subgraph, QueryError>> + Send;
 

--- a/apps/hash-graph/libs/graph/src/store/pool.rs
+++ b/apps/hash-graph/libs/graph/src/store/pool.rs
@@ -10,7 +10,7 @@ pub trait StorePool {
     type Error: Context;
 
     /// The store returned when acquiring.
-    type Store<'pool>: Store + Send;
+    type Store<'pool>: Store + Send + Sync;
 
     /// Retrieves a [`Store`] from the pool.
     async fn acquire(&self) -> Result<Self::Store<'_>, Self::Error>;

--- a/apps/hash-graph/libs/graph/src/store/postgres/crud.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/crud.rs
@@ -41,14 +41,11 @@ where
     }
 }
 
-#[async_trait]
 impl<Cl, R, S> ReadPaginated<R, S> for PostgresStore<Cl>
 where
     Cl: AsClient,
     for<'c> R: PostgresRecord<QueryPath<'c>: PostgresQueryPath>,
-    // TODO: figure out why `'s` is needed here, it should do nothing. It's likely because of
-    // `async_trait`
-    for<'s> S: PostgresSorting<R> + Sync + 's,
+    S: PostgresSorting<R> + Sync + 'static,
 {
     type QueryResult = Row;
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/crud.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/crud.rs
@@ -1,0 +1,161 @@
+use async_trait::async_trait;
+use error_stack::{Report, ResultExt};
+use futures::{Stream, StreamExt, TryStreamExt};
+use tokio_postgres::{GenericClient, Row};
+
+use crate::{
+    store::{
+        crud::{QueryRecordDecode, QueryResult, Read, ReadPaginated, Sorting},
+        postgres::query::{
+            PostgresQueryPath, PostgresRecord, PostgresSorting, QueryRecord, QueryRecordEncode,
+            SelectCompiler,
+        },
+        query::Filter,
+        AsClient, PostgresStore, QueryError,
+    },
+    subgraph::temporal_axes::QueryTemporalAxes,
+};
+
+pub struct PostgresQueryResult<R, S>
+where
+    R: QueryRecordDecode<Row>,
+    S: QueryRecordDecode<Row>,
+{
+    pub query_result: Row,
+    pub record_artifacts: R::CompilationArtifacts,
+    pub cursor_artifacts: S::CompilationArtifacts,
+}
+
+impl<R, S> QueryResult for PostgresQueryResult<R, S>
+where
+    R: QueryRecordDecode<Row, Output = R>,
+    S: Sorting + QueryRecordDecode<Row, Output = S::Cursor>,
+{
+    type Record = R;
+    type Sorting = S;
+
+    fn decode_record(&self) -> R {
+        R::decode(&self.query_result, self.record_artifacts)
+    }
+
+    fn decode_cursor(&self) -> S::Cursor {
+        S::decode(&self.query_result, self.cursor_artifacts)
+    }
+}
+
+#[async_trait]
+impl<Cl, R, S> ReadPaginated<R, S> for PostgresStore<Cl>
+where
+    Cl: AsClient,
+    for<'c> R: QueryRecord + PostgresRecord<QueryPath<'c>: PostgresQueryPath>,
+    S: PostgresSorting<R> + Send + Sync + 'static,
+    S::Cursor: QueryRecordEncode,
+{
+    type QueryResult = PostgresQueryResult<R, S>;
+    type QueryResultSet = Row;
+
+    type ReadPaginatedStream =
+        impl Stream<Item = Result<Self::QueryResult, Report<QueryError>>> + Send + Sync;
+
+    #[tracing::instrument(level = "info", skip(self, filter, sorting))]
+    async fn read_paginated(
+        &self,
+        filter: &Filter<'_, R>,
+        temporal_axes: Option<&QueryTemporalAxes>,
+        sorting: Option<&S>,
+        limit: Option<usize>,
+        include_drafts: bool,
+    ) -> Result<Self::ReadPaginatedStream, Report<QueryError>> {
+        let cursor_parameters = sorting
+            .and_then(Sorting::cursor)
+            .map(QueryRecordEncode::encode);
+
+        let mut compiler = SelectCompiler::new(temporal_axes, include_drafts);
+        if let Some(limit) = limit {
+            compiler.set_limit(limit);
+        }
+
+        let cursor_indices = S::compile(
+            &mut compiler,
+            #[allow(clippy::unwrap_used)]
+            cursor_parameters.as_ref(),
+            temporal_axes.expect("To use a cursor, temporal axes has to be specified"),
+        );
+
+        let record_artifacts = R::parameters();
+        let record_indices = R::compile(&mut compiler, &record_artifacts);
+
+        compiler.add_filter(filter);
+        let (statement, parameters) = compiler.compile();
+
+        let stream = self
+            .as_client()
+            .query_raw(&statement, parameters.iter().copied())
+            .await
+            .change_context(QueryError)?;
+
+        Ok(stream
+            .map(|row| row.change_context(QueryError))
+            .map_ok(move |row| PostgresQueryResult {
+                query_result: row,
+                record_artifacts: record_indices,
+                cursor_artifacts: cursor_indices,
+            }))
+    }
+}
+
+#[async_trait]
+impl<Cl, R> Read<R> for PostgresStore<Cl>
+where
+    Cl: AsClient,
+    for<'c> R: QueryRecord + PostgresRecord<QueryPath<'c>: PostgresQueryPath>,
+{
+    type ReadStream = impl Stream<Item = Result<R, Report<QueryError>>> + Send + Sync;
+
+    async fn read(
+        &self,
+        filter: &Filter<'_, R>,
+        temporal_axes: Option<&QueryTemporalAxes>,
+        include_drafts: bool,
+    ) -> Result<Self::ReadStream, Report<QueryError>> {
+        let mut compiler = SelectCompiler::new(temporal_axes, include_drafts);
+
+        let record_artifacts = R::parameters();
+        let record_indices = R::compile(&mut compiler, &record_artifacts);
+
+        compiler.add_filter(filter);
+        let (statement, parameters) = compiler.compile();
+
+        Ok(self
+            .as_client()
+            .query_raw(&statement, parameters.iter().copied())
+            .await
+            .change_context(QueryError)?
+            .map(|row| row.change_context(QueryError))
+            .map_ok(move |row| R::decode(&row, record_indices)))
+    }
+
+    #[tracing::instrument(level = "info", skip(self, filter))]
+    async fn read_one(
+        &self,
+        filter: &Filter<'_, R>,
+        temporal_axes: Option<&QueryTemporalAxes>,
+        include_drafts: bool,
+    ) -> Result<R, Report<QueryError>> {
+        let mut compiler = SelectCompiler::new(temporal_axes, include_drafts);
+
+        let record_artifacts = R::parameters();
+        let record_indices = R::compile(&mut compiler, &record_artifacts);
+
+        compiler.add_filter(filter);
+        let (statement, parameters) = compiler.compile();
+
+        let row = self
+            .as_client()
+            .query_one(&statement, parameters)
+            .await
+            .change_context(QueryError)?;
+
+        Ok(R::decode(&row, record_indices))
+    }
+}

--- a/apps/hash-graph/libs/graph/src/store/postgres/crud.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/crud.rs
@@ -7,8 +7,7 @@ use crate::{
     store::{
         crud::{QueryResult, Read, ReadPaginated, Sorting},
         postgres::query::{
-            PostgresQueryPath, PostgresRecord, PostgresSorting, QueryRecord, QueryRecordEncode,
-            SelectCompiler,
+            PostgresQueryPath, PostgresRecord, PostgresSorting, QueryRecordEncode, SelectCompiler,
         },
         query::Filter,
         AsClient, PostgresStore, QueryError,
@@ -48,9 +47,9 @@ where
 impl<Cl, R, S> ReadPaginated<R, S> for PostgresStore<Cl>
 where
     Cl: AsClient,
-    for<'c> R: QueryRecord + PostgresRecord<QueryPath<'c>: PostgresQueryPath>,
-    S: PostgresSorting<R> + Send + Sync + 'static,
-    S::Cursor: QueryRecordEncode,
+    for<'c> R: PostgresRecord<QueryPath<'c>: PostgresQueryPath>,
+    S: PostgresSorting<R> + Sync,
+    S::Cursor: QueryRecordEncode + 'static,
 {
     type QueryResult = Row;
 
@@ -108,7 +107,7 @@ where
 impl<Cl, R> Read<R> for PostgresStore<Cl>
 where
     Cl: AsClient,
-    for<'c> R: QueryRecord + PostgresRecord<QueryPath<'c>: PostgresQueryPath>,
+    for<'c> R: PostgresRecord<QueryPath<'c>: PostgresQueryPath>,
 {
     type ReadStream = impl Stream<Item = Result<R, Report<QueryError>>> + Send + Sync;
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -912,7 +912,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 self,
                 filter,
                 Some(&temporal_axes),
-                Some(&VertexIdSorting { cursor }),
+                &VertexIdSorting { cursor },
                 limit,
                 include_drafts,
             )

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -6,7 +6,6 @@ use std::{
     iter::once,
 };
 
-use async_trait::async_trait;
 use authorization::{
     backend::{ModifyRelationshipOperation, PermissionAssertion},
     schema::{
@@ -291,7 +290,6 @@ impl<C: AsClient> PostgresStore<C> {
     }
 }
 
-#[async_trait]
 impl<C: AsClient> EntityStore for PostgresStore<C> {
     #[tracing::instrument(
         level = "info",
@@ -1245,12 +1243,12 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         Ok(entity_metadata)
     }
 
-    #[tracing::instrument(level = "info", skip(self, _authorization_api, embeddings))]
+    #[tracing::instrument(level = "info", skip(self, embeddings))]
     async fn update_entity_embeddings<A: AuthorizationApi + Send + Sync>(
         &mut self,
-        _actor_id: AccountId,
-        _authorization_api: &mut A,
-        embeddings: impl IntoIterator<Item = EntityEmbedding<'_>> + Send,
+        _: AccountId,
+        _: &mut A,
+        embeddings: Vec<EntityEmbedding<'_>>,
         updated_at_transaction_time: Timestamp<TransactionTime>,
         updated_at_decision_time: Timestamp<DecisionTime>,
         reset: bool,

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/query.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/query.rs
@@ -21,10 +21,13 @@ use crate::{
     knowledge::EntityQueryPath,
     ontology::EntityTypeQueryPath,
     store::{
-        crud::{QueryRecordDecode, VertexIdSorting},
-        postgres::query::{
-            Distinctness, Expression, Function, Ordering, PostgresSorting, QueryRecord,
-            QueryRecordEncode, SelectCompiler,
+        crud::VertexIdSorting,
+        postgres::{
+            crud::QueryRecordDecode,
+            query::{
+                Distinctness, Expression, Function, Ordering, PostgresSorting, QueryRecord,
+                QueryRecordEncode, SelectCompiler,
+            },
         },
         query::Parameter,
     },
@@ -60,11 +63,11 @@ impl QueryRecordEncode for EntityVertexId {
     }
 }
 
-impl QueryRecordDecode<Row> for VertexIdSorting<Entity> {
+impl QueryRecordDecode for VertexIdSorting<Entity> {
     type CompilationArtifacts = EntityVertexIdIndices;
     type Output = EntityVertexId;
 
-    fn decode(row: &Row, indices: Self::CompilationArtifacts) -> Self::Output {
+    fn decode(row: &Row, indices: &Self::CompilationArtifacts) -> Self::Output {
         let ClosedTemporalBound::Inclusive(revision_id) = *row
             .get::<_, LeftClosedTemporalInterval<VariableAxis>>(indices.revision_id)
             .start();
@@ -199,11 +202,11 @@ impl Default for EntityRecordPaths<'_> {
     }
 }
 
-impl QueryRecordDecode<Row> for Entity {
+impl QueryRecordDecode for Entity {
     type CompilationArtifacts = EntityRecordRowIndices;
     type Output = Self;
 
-    fn decode(row: &Row, indices: Self::CompilationArtifacts) -> Self {
+    fn decode(row: &Row, indices: &Self::CompilationArtifacts) -> Self {
         let entity_type_id = VersionedUrl::from_str(row.get(indices.type_id))
             .expect("Malformed entity type ID returned from Postgres");
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/query.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/query.rs
@@ -1,0 +1,341 @@
+use std::{convert::identity, str::FromStr};
+
+use graph_types::{
+    knowledge::{
+        entity::{
+            Entity, EntityEditionProvenanceMetadata, EntityId, EntityMetadata,
+            EntityProvenanceMetadata, EntityRecordId, EntityUuid,
+        },
+        link::{EntityLinkOrder, LinkData},
+    },
+    owned_by_id::OwnedById,
+};
+use temporal_versioning::{
+    ClosedTemporalBound, LeftClosedTemporalInterval, TemporalTagged, TimeAxis,
+};
+use tokio_postgres::Row;
+use type_system::url::VersionedUrl;
+use uuid::Uuid;
+
+use crate::{
+    knowledge::EntityQueryPath,
+    ontology::EntityTypeQueryPath,
+    store::{
+        crud::{Cursor, QueryRecord, QueryRecordDecode, QueryRecordEncode},
+        postgres::query::{Distinctness, Expression, Function, Ordering, SelectCompiler},
+        query::Parameter,
+    },
+    subgraph::{
+        edges::{EdgeDirection, KnowledgeGraphEdgeKind, SharedEdgeKind},
+        identifier::EntityVertexId,
+        temporal_axes::{QueryTemporalAxes, VariableAxis},
+    },
+};
+
+#[derive(Debug, Copy, Clone)]
+pub struct EntityVertexIdIndices {
+    pub owned_by_id: usize,
+    pub entity_uuid: usize,
+    pub revision_id: usize,
+}
+
+pub struct EntityVertexIdCursorParameters<'p> {
+    owned_by_id: Parameter<'p>,
+    entity_uuid: Parameter<'p>,
+    revision_id: Parameter<'p>,
+}
+
+impl QueryRecordEncode for EntityVertexId {
+    type CompilationParameters<'p> = EntityVertexIdCursorParameters<'p>;
+
+    fn encode(&self) -> Self::CompilationParameters<'_> {
+        EntityVertexIdCursorParameters {
+            owned_by_id: Parameter::Uuid(self.base_id.owned_by_id.into_uuid()),
+            entity_uuid: Parameter::Uuid(self.base_id.entity_uuid.into_uuid()),
+            revision_id: Parameter::Timestamp(self.revision_id.cast()),
+        }
+    }
+}
+
+impl QueryRecordDecode<Row> for EntityVertexId {
+    type CompilationArtifacts = EntityVertexIdIndices;
+
+    fn decode(row: &Row, indices: Self::CompilationArtifacts) -> Self {
+        let ClosedTemporalBound::Inclusive(revision_id) = *row
+            .get::<_, LeftClosedTemporalInterval<VariableAxis>>(indices.revision_id)
+            .start();
+        Self {
+            base_id: EntityId {
+                owned_by_id: row.get(indices.owned_by_id),
+                entity_uuid: row.get(indices.entity_uuid),
+            },
+            revision_id,
+        }
+    }
+}
+
+impl<'c> Cursor<'c, SelectCompiler<'c, Entity>> for EntityVertexId {
+    fn compile<'p: 'c>(
+        compiler: &mut SelectCompiler<'c, Entity>,
+        parameters: Option<&'c Self::CompilationParameters<'p>>,
+        temporal_axes: &QueryTemporalAxes,
+    ) -> Self::CompilationArtifacts {
+        let revision_id_path = match temporal_axes.variable_time_axis() {
+            TimeAxis::TransactionTime => &EntityQueryPath::TransactionTime,
+            TimeAxis::DecisionTime => &EntityQueryPath::DecisionTime,
+        };
+
+        if let Some(parameters) = parameters {
+            // We already had a cursor, add them as parameters:
+            let owned_by_id_expression = compiler.compile_parameter(&parameters.owned_by_id).0;
+            let entity_uuid_expression = compiler.compile_parameter(&parameters.entity_uuid).0;
+            let revision_id_expression = compiler.compile_parameter(&parameters.revision_id).0;
+
+            EntityVertexIdIndices {
+                owned_by_id: compiler.add_cursor_selection(
+                    &EntityQueryPath::OwnedById,
+                    identity,
+                    owned_by_id_expression,
+                    Ordering::Ascending,
+                ),
+                entity_uuid: compiler.add_cursor_selection(
+                    &EntityQueryPath::Uuid,
+                    identity,
+                    entity_uuid_expression,
+                    Ordering::Ascending,
+                ),
+                revision_id: compiler.add_cursor_selection(
+                    revision_id_path,
+                    |column| Expression::Function(Function::Lower(Box::new(column))),
+                    revision_id_expression,
+                    Ordering::Descending,
+                ),
+            }
+        } else {
+            EntityVertexIdIndices {
+                owned_by_id: compiler.add_distinct_selection_with_ordering(
+                    &EntityQueryPath::OwnedById,
+                    Distinctness::Distinct,
+                    Some(Ordering::Ascending),
+                ),
+                entity_uuid: compiler.add_distinct_selection_with_ordering(
+                    &EntityQueryPath::Uuid,
+                    Distinctness::Distinct,
+                    Some(Ordering::Ascending),
+                ),
+                revision_id: compiler.add_distinct_selection_with_ordering(
+                    revision_id_path,
+                    Distinctness::Distinct,
+                    Some(Ordering::Descending),
+                ),
+            }
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct EntityRecordRowIndices {
+    pub owned_by_id: usize,
+    pub entity_uuid: usize,
+    pub transaction_time: usize,
+    pub decision_time: usize,
+
+    pub edition_id: usize,
+    pub type_id: usize,
+
+    pub properties: usize,
+
+    pub left_entity_uuid: usize,
+    pub left_entity_owned_by_id: usize,
+    pub right_entity_uuid: usize,
+    pub right_entity_owned_by_id: usize,
+    pub left_to_right_order: usize,
+    pub right_to_left_order: usize,
+
+    pub created_by_id: usize,
+    pub created_at_transaction_time: usize,
+    pub created_at_decision_time: usize,
+    pub edition_created_by_id: usize,
+
+    pub archived: usize,
+    pub draft: usize,
+}
+
+pub struct EntityRecordPaths<'q> {
+    pub left_entity_uuid: EntityQueryPath<'q>,
+    pub left_owned_by_id: EntityQueryPath<'q>,
+    pub right_entity_uuid: EntityQueryPath<'q>,
+    pub right_owned_by_id: EntityQueryPath<'q>,
+}
+
+impl Default for EntityRecordPaths<'_> {
+    fn default() -> Self {
+        Self {
+            left_entity_uuid: EntityQueryPath::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                path: Box::new(EntityQueryPath::Uuid),
+                direction: EdgeDirection::Outgoing,
+            },
+            left_owned_by_id: EntityQueryPath::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                path: Box::new(EntityQueryPath::OwnedById),
+                direction: EdgeDirection::Outgoing,
+            },
+            right_entity_uuid: EntityQueryPath::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
+                path: Box::new(EntityQueryPath::Uuid),
+                direction: EdgeDirection::Outgoing,
+            },
+            right_owned_by_id: EntityQueryPath::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
+                path: Box::new(EntityQueryPath::OwnedById),
+                direction: EdgeDirection::Outgoing,
+            },
+        }
+    }
+}
+
+impl QueryRecordDecode<Row> for Entity {
+    type CompilationArtifacts = EntityRecordRowIndices;
+
+    fn decode(row: &Row, indices: Self::CompilationArtifacts) -> Self {
+        let entity_type_id = VersionedUrl::from_str(row.get(indices.type_id))
+            .expect("Malformed entity type ID returned from Postgres");
+
+        let link_data = {
+            let left_owned_by_id: Option<Uuid> = row.get(indices.left_entity_owned_by_id);
+            let left_entity_uuid: Option<Uuid> = row.get(indices.left_entity_uuid);
+            let right_owned_by_id: Option<Uuid> = row.get(indices.right_entity_owned_by_id);
+            let right_entity_uuid: Option<Uuid> = row.get(indices.right_entity_uuid);
+            match (
+                left_owned_by_id,
+                left_entity_uuid,
+                right_owned_by_id,
+                right_entity_uuid,
+            ) {
+                (
+                    Some(left_owned_by_id),
+                    Some(left_entity_uuid),
+                    Some(right_owned_by_id),
+                    Some(right_entity_uuid),
+                ) => Some(LinkData {
+                    left_entity_id: EntityId {
+                        owned_by_id: OwnedById::new(left_owned_by_id),
+                        entity_uuid: EntityUuid::new(left_entity_uuid),
+                    },
+                    right_entity_id: EntityId {
+                        owned_by_id: OwnedById::new(right_owned_by_id),
+                        entity_uuid: EntityUuid::new(right_entity_uuid),
+                    },
+                    order: EntityLinkOrder {
+                        left_to_right: row.get(indices.left_to_right_order),
+                        right_to_left: row.get(indices.right_to_left_order),
+                    },
+                }),
+                (None, None, None, None) => None,
+                _ => unreachable!(
+                    "It's not possible to have a link entity with the left entityId or right \
+                     entityId unspecified"
+                ),
+            }
+        };
+
+        let entity_id = EntityId {
+            owned_by_id: row.get(indices.owned_by_id),
+            entity_uuid: row.get(indices.entity_uuid),
+        };
+
+        if let Ok(distance) = row.try_get::<_, f64>("distance") {
+            tracing::trace!(%entity_id, %distance, "Entity embedding was calculated");
+        }
+
+        Self {
+            properties: row.get(indices.properties),
+            link_data,
+            metadata: EntityMetadata {
+                record_id: EntityRecordId {
+                    entity_id,
+                    edition_id: row.get(indices.edition_id),
+                },
+                temporal_versioning: graph_types::knowledge::entity::EntityTemporalMetadata {
+                    decision_time: row.get(indices.decision_time),
+                    transaction_time: row.get(indices.transaction_time),
+                },
+                entity_type_id,
+                provenance: EntityProvenanceMetadata {
+                    created_by_id: row.get(indices.created_by_id),
+                    created_at_transaction_time: row.get(indices.created_at_transaction_time),
+                    created_at_decision_time: row.get(indices.created_at_decision_time),
+                    edition: EntityEditionProvenanceMetadata {
+                        created_by_id: row.get(indices.edition_created_by_id),
+                    },
+                },
+                archived: row.get(indices.archived),
+                draft: row.get(indices.draft),
+            },
+        }
+    }
+}
+
+impl<'c> QueryRecord<'c, SelectCompiler<'c, Self>> for Entity {
+    type CompilationParameters = EntityRecordPaths<'static>;
+
+    fn parameters() -> Self::CompilationParameters {
+        EntityRecordPaths::default()
+    }
+
+    fn compile<'p: 'c>(
+        compiler: &mut SelectCompiler<'c, Self>,
+        paths: &'p Self::CompilationParameters,
+    ) -> Self::CompilationArtifacts {
+        EntityRecordRowIndices {
+            owned_by_id: compiler.add_distinct_selection_with_ordering(
+                &EntityQueryPath::OwnedById,
+                Distinctness::Distinct,
+                None,
+            ),
+            entity_uuid: compiler.add_distinct_selection_with_ordering(
+                &EntityQueryPath::Uuid,
+                Distinctness::Distinct,
+                None,
+            ),
+            transaction_time: compiler.add_distinct_selection_with_ordering(
+                &EntityQueryPath::TransactionTime,
+                Distinctness::Distinct,
+                None,
+            ),
+            decision_time: compiler.add_distinct_selection_with_ordering(
+                &EntityQueryPath::DecisionTime,
+                Distinctness::Distinct,
+                None,
+            ),
+
+            edition_id: compiler.add_selection_path(&EntityQueryPath::EditionId),
+            type_id: compiler.add_selection_path(&EntityQueryPath::EntityTypeEdge {
+                edge_kind: SharedEdgeKind::IsOfType,
+                path: EntityTypeQueryPath::VersionedUrl,
+                inheritance_depth: Some(0),
+            }),
+
+            properties: compiler.add_selection_path(&EntityQueryPath::Properties(None)),
+
+            left_entity_uuid: compiler.add_selection_path(&paths.left_entity_uuid),
+            left_entity_owned_by_id: compiler.add_selection_path(&paths.left_owned_by_id),
+            right_entity_uuid: compiler.add_selection_path(&paths.right_entity_uuid),
+            right_entity_owned_by_id: compiler.add_selection_path(&paths.right_owned_by_id),
+            left_to_right_order: compiler.add_selection_path(&EntityQueryPath::LeftToRightOrder),
+            right_to_left_order: compiler.add_selection_path(&EntityQueryPath::RightToLeftOrder),
+
+            created_by_id: compiler.add_selection_path(&EntityQueryPath::CreatedById),
+            created_at_transaction_time: compiler
+                .add_selection_path(&EntityQueryPath::CreatedAtTransactionTime),
+            created_at_decision_time: compiler
+                .add_selection_path(&EntityQueryPath::CreatedAtDecisionTime),
+            edition_created_by_id: compiler
+                .add_selection_path(&EntityQueryPath::EditionCreatedById),
+
+            archived: compiler.add_selection_path(&EntityQueryPath::Archived),
+            draft: compiler.add_selection_path(&EntityQueryPath::Draft),
+        }
+    }
+}

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/query.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/query.rs
@@ -25,8 +25,8 @@ use crate::{
         postgres::{
             crud::QueryRecordDecode,
             query::{
-                Distinctness, Expression, Function, Ordering, PostgresSorting, QueryRecord,
-                QueryRecordEncode, SelectCompiler,
+                Distinctness, Expression, Function, Ordering, PostgresRecord, PostgresSorting,
+                QueryRecordEncode, SelectCompiler, Table,
             },
         },
         query::Parameter,
@@ -285,8 +285,12 @@ impl QueryRecordDecode for Entity {
     }
 }
 
-impl QueryRecord for Entity {
+impl PostgresRecord for Entity {
     type CompilationParameters = EntityRecordPaths<'static>;
+
+    fn base_table() -> Table {
+        Table::EntityTemporalMetadata
+    }
 
     fn parameters() -> Self::CompilationParameters {
         EntityRecordPaths::default()

--- a/apps/hash-graph/libs/graph/src/store/postgres/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/mod.rs
@@ -1,3 +1,4 @@
+mod crud;
 mod knowledge;
 mod ontology;
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
@@ -284,11 +284,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
             self,
             filter,
             Some(&temporal_axes),
-            cursor
-                .map(|cursor| VertexIdSorting {
-                    cursor: Some(cursor),
-                })
-                .as_ref(),
+            &VertexIdSorting { cursor },
             limit,
             include_drafts,
         )

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
@@ -34,7 +34,7 @@ use crate::{
         postgres::{
             crud::QueryRecordDecode,
             ontology::{OntologyId, PostgresOntologyTypeClassificationMetadata},
-            query::{Distinctness, QueryRecord, SelectCompiler},
+            query::{Distinctness, PostgresRecord, SelectCompiler, Table},
             TraversalContext,
         },
         AsClient, ConflictBehavior, DataTypeStore, InsertionError, PostgresStore, QueryError,
@@ -528,8 +528,12 @@ impl QueryRecordDecode for DataTypeWithMetadata {
     }
 }
 
-impl QueryRecord for DataTypeWithMetadata {
+impl PostgresRecord for DataTypeWithMetadata {
     type CompilationParameters = ();
+
+    fn base_table() -> Table {
+        Table::OntologyTemporalMetadata
+    }
 
     fn parameters() -> Self::CompilationParameters {}
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
@@ -42,7 +42,7 @@ use crate::{
                 read::OntologyTypeTraversalData, OntologyId,
                 PostgresOntologyTypeClassificationMetadata,
             },
-            query::{Distinctness, QueryRecord, ReferenceTable, SelectCompiler},
+            query::{Distinctness, PostgresRecord, ReferenceTable, SelectCompiler, Table},
             TraversalContext,
         },
         query::{Filter, FilterExpression, ParameterList},
@@ -902,8 +902,12 @@ impl QueryRecordDecode for EntityTypeWithMetadata {
     }
 }
 
-impl QueryRecord for EntityTypeWithMetadata {
+impl PostgresRecord for EntityTypeWithMetadata {
     type CompilationParameters = ();
+
+    fn base_table() -> Table {
+        Table::OntologyTemporalMetadata
+    }
 
     fn parameters() -> Self::CompilationParameters {}
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
@@ -3,7 +3,6 @@ use std::{
     iter::once,
 };
 
-use async_trait::async_trait;
 use authorization::{
     backend::ModifyRelationshipOperation,
     schema::{
@@ -23,7 +22,9 @@ use graph_types::{
         OntologyTypeRecordId, PartialEntityTypeMetadata,
     },
 };
+use postgres_types::Json;
 use temporal_versioning::RightBoundedTemporalInterval;
+use tokio_postgres::Row;
 use type_system::{
     url::{BaseUrl, VersionedUrl},
     EntityType,
@@ -33,11 +34,14 @@ use uuid::Uuid;
 use crate::{
     ontology::EntityTypeQueryPath,
     store::{
-        crud::Read,
+        crud::{QueryRecord, QueryRecordDecode, QueryResult, ReadPaginated},
         error::DeletionError,
         postgres::{
-            ontology::{read::OntologyTypeTraversalData, OntologyId},
-            query::ReferenceTable,
+            ontology::{
+                read::OntologyTypeTraversalData, OntologyId,
+                PostgresOntologyTypeClassificationMetadata,
+            },
+            query::{Distinctness, ReferenceTable, SelectCompiler},
             TraversalContext,
         },
         query::{Filter, FilterExpression, ParameterList},
@@ -408,7 +412,6 @@ pub struct EntityTypeInsertion {
     pub closed_schema: EntityType,
 }
 
-#[async_trait]
 impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
     #[tracing::instrument(
         level = "info",
@@ -572,8 +575,8 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         &self,
         actor_id: AccountId,
         authorization_api: &A,
-        query: &StructuralQuery<EntityTypeWithMetadata>,
-        after: Option<&EntityTypeVertexId>,
+        query: &StructuralQuery<'_, EntityTypeWithMetadata>,
+        after: Option<&VersionedUrl>,
         limit: Option<usize>,
     ) -> Result<Subgraph, QueryError> {
         let StructuralQuery {
@@ -590,25 +593,28 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         //   see https://linear.app/hash/issue/H-297
         let mut visited_ontology_ids = HashSet::new();
 
-        let entity_types = Read::<EntityTypeWithMetadata>::read_vec(
-            self,
-            filter,
-            Some(&temporal_axes),
-            after,
-            limit,
-            include_drafts,
-        )
-        .await?
-        .into_iter()
-        .filter_map(|entity_type| {
-            let id = EntityTypeId::from_url(entity_type.schema.id());
-            let vertex_id = entity_type.vertex_id(time_axis);
-            // The records are already sorted by time, so we can just take the first one
-            visited_ontology_ids
-                .insert(id)
-                .then_some((id, (vertex_id, entity_type)))
-        })
-        .collect::<Vec<_>>();
+        let entity_types =
+            ReadPaginated::<EntityTypeWithMetadata, VersionedUrl>::read_paginated_vec(
+                self,
+                filter,
+                Some(&temporal_axes),
+                after,
+                limit,
+                include_drafts,
+            )
+            .await?
+            .into_iter()
+            .filter_map(|entity_type_query| {
+                let cursor = entity_type_query.decode_cursor();
+                let entity_type = entity_type_query.decode_record();
+                let id = EntityTypeId::from_url(&cursor);
+                let vertex_id = entity_type.vertex_id(time_axis);
+                // The records are already sorted by time, so we can just take the first one
+                visited_ontology_ids
+                    .insert(id)
+                    .then_some((id, (vertex_id, entity_type)))
+            })
+            .collect::<Vec<_>>();
 
         let filtered_ids = entity_types
             .iter()
@@ -813,25 +819,118 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         }
     }
 
-    #[tracing::instrument(level = "info", skip(self, _authorization_api))]
-    async fn archive_entity_type<A: AuthorizationApi + Sync>(
+    #[tracing::instrument(level = "info", skip(self))]
+    async fn archive_entity_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        _authorization_api: &mut A,
+        _: &mut A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
         self.archive_ontology_type(id, EditionArchivedById::new(actor_id))
             .await
     }
 
-    #[tracing::instrument(level = "info", skip(self, _authorization_api))]
-    async fn unarchive_entity_type<A: AuthorizationApi + Sync>(
+    #[tracing::instrument(level = "info", skip(self))]
+    async fn unarchive_entity_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        _authorization_api: &mut A,
+        _: &mut A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
         self.unarchive_ontology_type(id, EditionCreatedById::new(actor_id))
             .await
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct EntityTypeRowIndices {
+    pub base_url: usize,
+    pub version: usize,
+    pub transaction_time: usize,
+
+    pub schema: usize,
+
+    pub edition_created_by_id: usize,
+    pub edition_archived_by_id: usize,
+    pub additional_metadata: usize,
+    pub label_property: usize,
+    pub icon: usize,
+}
+
+impl QueryRecordDecode<Row> for EntityTypeWithMetadata {
+    type CompilationArtifacts = EntityTypeRowIndices;
+
+    fn decode(row: &Row, indices: Self::CompilationArtifacts) -> Self {
+        Self {
+            schema: row.get::<_, Json<_>>(indices.schema).0,
+            metadata: EntityTypeMetadata {
+                record_id: OntologyTypeRecordId {
+                    base_url: BaseUrl::new(row.get(indices.base_url))
+                        .expect("invalid base URL returned from Postgres"),
+                    version: row.get(indices.version),
+                },
+                classification: row
+                    .get::<_, Json<PostgresOntologyTypeClassificationMetadata>>(
+                        indices.additional_metadata,
+                    )
+                    .0
+                    .into(),
+                temporal_versioning: OntologyTemporalMetadata {
+                    transaction_time: row.get(indices.transaction_time),
+                },
+                provenance: OntologyProvenanceMetadata {
+                    edition: OntologyEditionProvenanceMetadata {
+                        created_by_id: EditionCreatedById::new(
+                            row.get(indices.edition_created_by_id),
+                        ),
+                        archived_by_id: row.get(indices.edition_archived_by_id),
+                    },
+                },
+                label_property: row
+                    .get::<_, Option<String>>(indices.label_property)
+                    .map(BaseUrl::new)
+                    .transpose()
+                    .expect("label property returned from Postgres is not valid"),
+                icon: row.get(indices.icon),
+            },
+        }
+    }
+}
+
+impl<'c> QueryRecord<'c, SelectCompiler<'c, Self>> for EntityTypeWithMetadata {
+    type CompilationParameters = ();
+
+    fn parameters() -> Self::CompilationParameters {}
+
+    fn compile<'p: 'c>(
+        compiler: &mut SelectCompiler<'c, Self>,
+        _paths: &'p Self::CompilationParameters,
+    ) -> Self::CompilationArtifacts {
+        EntityTypeRowIndices {
+            base_url: compiler.add_distinct_selection_with_ordering(
+                &EntityTypeQueryPath::BaseUrl,
+                Distinctness::Distinct,
+                None,
+            ),
+            version: compiler.add_distinct_selection_with_ordering(
+                &EntityTypeQueryPath::Version,
+                Distinctness::Distinct,
+                None,
+            ),
+            transaction_time: compiler.add_distinct_selection_with_ordering(
+                &EntityTypeQueryPath::TransactionTime,
+                Distinctness::Distinct,
+                None,
+            ),
+            schema: compiler.add_selection_path(&EntityTypeQueryPath::Schema(None)),
+            edition_created_by_id: compiler
+                .add_selection_path(&EntityTypeQueryPath::EditionCreatedById),
+            edition_archived_by_id: compiler
+                .add_selection_path(&EntityTypeQueryPath::EditionArchivedById),
+            additional_metadata: compiler
+                .add_selection_path(&EntityTypeQueryPath::AdditionalMetadata),
+            label_property: compiler.add_selection_path(&EntityTypeQueryPath::LabelProperty),
+            icon: compiler.add_selection_path(&EntityTypeQueryPath::Icon),
+        }
     }
 }

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
@@ -598,11 +598,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
             self,
             filter,
             Some(&temporal_axes),
-            cursor
-                .map(|cursor| VertexIdSorting {
-                    cursor: Some(cursor),
-                })
-                .as_ref(),
+            &VertexIdSorting { cursor },
             limit,
             include_drafts,
         )

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/mod.rs
@@ -4,13 +4,36 @@ mod ontology_id;
 mod property_type;
 mod read;
 
+use std::{borrow::Cow, convert::identity};
+
 use error_stack::{Result, ResultExt};
-use graph_types::ontology::OntologyType;
-use tokio_postgres::Transaction;
-use type_system::{DataType, EntityType, PropertyType};
+use graph_types::{
+    ontology::{
+        DataTypeWithMetadata, EntityTypeWithMetadata, OntologyType,
+        OntologyTypeClassificationMetadata, OntologyTypeVersion, PropertyTypeWithMetadata,
+    },
+    owned_by_id::OwnedById,
+};
+use serde::Deserialize;
+use time::OffsetDateTime;
+use tokio_postgres::{Row, Transaction};
+use type_system::{
+    url::{BaseUrl, VersionedUrl},
+    DataType, EntityType, PropertyType,
+};
 
 pub use self::ontology_id::OntologyId;
-use crate::store::{error::DeletionError, AsClient, PostgresStore};
+use crate::{
+    ontology::{DataTypeQueryPath, EntityTypeQueryPath, PropertyTypeQueryPath},
+    store::{
+        crud::{Cursor, QueryRecordDecode, QueryRecordEncode},
+        error::DeletionError,
+        postgres::query::{Distinctness, Ordering, SelectCompiler},
+        query::Parameter,
+        AsClient, PostgresStore,
+    },
+    subgraph::temporal_axes::QueryTemporalAxes,
+};
 
 /// Provides an abstraction over elements of the Type System stored in the Database.
 ///
@@ -105,5 +128,113 @@ impl PostgresStore<Transaction<'_>> {
             .change_context(DeletionError)?;
 
         Ok(())
+    }
+}
+
+pub struct VersionedUrlCursorParameters<'p> {
+    base_url: Parameter<'p>,
+    version: Parameter<'p>,
+}
+
+impl QueryRecordEncode for VersionedUrl {
+    type CompilationParameters<'p> = VersionedUrlCursorParameters<'p>;
+
+    fn encode(&self) -> Self::CompilationParameters<'_> {
+        VersionedUrlCursorParameters {
+            base_url: Parameter::Text(Cow::Borrowed(self.base_url.as_str())),
+            version: Parameter::OntologyTypeVersion(OntologyTypeVersion::new(self.version)),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct VersionedUrlIndices {
+    pub base_url: usize,
+    pub version: usize,
+}
+
+impl QueryRecordDecode<Row> for VersionedUrl {
+    type CompilationArtifacts = VersionedUrlIndices;
+
+    fn decode(row: &Row, indices: Self::CompilationArtifacts) -> Self {
+        Self {
+            base_url: BaseUrl::new(row.get(indices.base_url))
+                .expect("invalid base URL returned from Postgres"),
+            version: row.get::<_, OntologyTypeVersion>(indices.version).inner(),
+        }
+    }
+}
+
+macro_rules! impl_cursor {
+    ($ty:ty, $query_path:ty) => {
+        impl<'c> Cursor<'c, SelectCompiler<'c, $ty>> for VersionedUrl {
+            fn compile<'p: 'c>(
+                compiler: &mut SelectCompiler<'c, $ty>,
+                parameters: Option<&'c Self::CompilationParameters<'p>>,
+                _temporal_axes: &QueryTemporalAxes,
+            ) -> Self::CompilationArtifacts {
+                if let Some(parameters) = parameters {
+                    let base_url_expression = compiler.compile_parameter(&parameters.base_url).0;
+                    let version_expression = compiler.compile_parameter(&parameters.version).0;
+
+                    VersionedUrlIndices {
+                        base_url: compiler.add_cursor_selection(
+                            &<$query_path>::BaseUrl,
+                            identity,
+                            base_url_expression,
+                            Ordering::Ascending,
+                        ),
+                        version: compiler.add_cursor_selection(
+                            &<$query_path>::Version,
+                            identity,
+                            version_expression,
+                            Ordering::Descending,
+                        ),
+                    }
+                } else {
+                    VersionedUrlIndices {
+                        base_url: compiler.add_distinct_selection_with_ordering(
+                            &<$query_path>::BaseUrl,
+                            Distinctness::Distinct,
+                            Some(Ordering::Ascending),
+                        ),
+                        version: compiler.add_distinct_selection_with_ordering(
+                            &<$query_path>::Version,
+                            Distinctness::Distinct,
+                            Some(Ordering::Descending),
+                        ),
+                    }
+                }
+            }
+        }
+    };
+}
+
+impl_cursor!(DataTypeWithMetadata, DataTypeQueryPath);
+impl_cursor!(PropertyTypeWithMetadata, PropertyTypeQueryPath);
+impl_cursor!(EntityTypeWithMetadata, EntityTypeQueryPath);
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum PostgresOntologyTypeClassificationMetadata {
+    Owned {
+        web_id: OwnedById,
+    },
+    External {
+        #[serde(with = "temporal_versioning::serde::time")]
+        fetched_at: OffsetDateTime,
+    },
+}
+
+impl From<PostgresOntologyTypeClassificationMetadata> for OntologyTypeClassificationMetadata {
+    fn from(value: PostgresOntologyTypeClassificationMetadata) -> Self {
+        match value {
+            PostgresOntologyTypeClassificationMetadata::Owned { web_id } => Self::Owned {
+                owned_by_id: web_id,
+            },
+            PostgresOntologyTypeClassificationMetadata::External { fetched_at } => {
+                Self::External { fetched_at }
+            }
+        }
     }
 }

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/mod.rs
@@ -23,10 +23,11 @@ pub use self::ontology_id::OntologyId;
 use crate::{
     ontology::{DataTypeQueryPath, EntityTypeQueryPath, PropertyTypeQueryPath},
     store::{
-        crud::{QueryRecordDecode, VertexIdSorting},
+        crud::VertexIdSorting,
         error::DeletionError,
-        postgres::query::{
-            Distinctness, Ordering, PostgresSorting, QueryRecordEncode, SelectCompiler,
+        postgres::{
+            crud::QueryRecordDecode,
+            query::{Distinctness, Ordering, PostgresSorting, QueryRecordEncode, SelectCompiler},
         },
         query::Parameter,
         AsClient, PostgresStore, Record,
@@ -154,11 +155,11 @@ macro_rules! impl_ontology_cursor {
             }
         }
 
-        impl QueryRecordDecode<Row> for VertexIdSorting<$ty> {
+        impl QueryRecordDecode for VertexIdSorting<$ty> {
             type CompilationArtifacts = VersionedUrlIndices;
             type Output = <$ty as Record>::VertexId;
 
-            fn decode(row: &Row, indices: Self::CompilationArtifacts) -> Self::Output {
+            fn decode(row: &Row, indices: &Self::CompilationArtifacts) -> Self::Output {
                 Self::Output {
                     base_id: BaseUrl::new(row.get(indices.base_url))
                         .expect("invalid base URL returned from Postgres"),

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/property_type.rs
@@ -3,7 +3,6 @@ use std::{
     iter::once,
 };
 
-use async_trait::async_trait;
 use authorization::{
     backend::ModifyRelationshipOperation,
     schema::{
@@ -22,16 +21,25 @@ use graph_types::{
         PropertyTypeMetadata, PropertyTypeWithMetadata,
     },
 };
+use postgres_types::Json;
 use temporal_versioning::RightBoundedTemporalInterval;
-use type_system::{url::VersionedUrl, PropertyType};
+use tokio_postgres::Row;
+use type_system::{
+    url::{BaseUrl, VersionedUrl},
+    PropertyType,
+};
 
 use crate::{
+    ontology::PropertyTypeQueryPath,
     store::{
-        crud::Read,
+        crud::{QueryRecord, QueryRecordDecode, QueryResult, ReadPaginated},
         error::DeletionError,
         postgres::{
-            ontology::{read::OntologyTypeTraversalData, OntologyId},
-            query::ReferenceTable,
+            ontology::{
+                read::OntologyTypeTraversalData, OntologyId,
+                PostgresOntologyTypeClassificationMetadata,
+            },
+            query::{Distinctness, ReferenceTable, SelectCompiler},
             TraversalContext,
         },
         AsClient, ConflictBehavior, InsertionError, PostgresStore, PropertyTypeStore, QueryError,
@@ -249,7 +257,6 @@ impl<C: AsClient> PostgresStore<C> {
     }
 }
 
-#[async_trait]
 impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
     #[tracing::instrument(
         level = "info",
@@ -394,8 +401,8 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         &self,
         actor_id: AccountId,
         authorization_api: &A,
-        query: &StructuralQuery<PropertyTypeWithMetadata>,
-        after: Option<&PropertyTypeVertexId>,
+        query: &StructuralQuery<'_, PropertyTypeWithMetadata>,
+        after: Option<&VersionedUrl>,
         limit: Option<usize>,
     ) -> Result<Subgraph, QueryError> {
         let StructuralQuery {
@@ -412,25 +419,28 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         //   see https://linear.app/hash/issue/H-297
         let mut visited_ontology_ids = HashSet::new();
 
-        let property_types = Read::<PropertyTypeWithMetadata>::read_vec(
-            self,
-            filter,
-            Some(&temporal_axes),
-            after,
-            limit,
-            include_drafts,
-        )
-        .await?
-        .into_iter()
-        .filter_map(|property_type| {
-            let id = PropertyTypeId::from_url(property_type.schema.id());
-            let vertex_id = property_type.vertex_id(time_axis);
-            // The records are already sorted by time, so we can just take the first one
-            visited_ontology_ids
-                .insert(id)
-                .then_some((id, (vertex_id, property_type)))
-        })
-        .collect::<Vec<_>>();
+        let property_types =
+            ReadPaginated::<PropertyTypeWithMetadata, VersionedUrl>::read_paginated_vec(
+                self,
+                filter,
+                Some(&temporal_axes),
+                after,
+                limit,
+                include_drafts,
+            )
+            .await?
+            .into_iter()
+            .filter_map(|property_type_query| {
+                let cursor = property_type_query.decode_cursor();
+                let property_type = property_type_query.decode_record();
+                let id = PropertyTypeId::from_url(&cursor);
+                let vertex_id = property_type.vertex_id(time_axis);
+                // The records are already sorted by time, so we can just take the first one
+                visited_ontology_ids
+                    .insert(id)
+                    .then_some((id, (vertex_id, property_type)))
+            })
+            .collect::<Vec<_>>();
 
         let filtered_ids = property_types
             .iter()
@@ -598,25 +608,108 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         }
     }
 
-    #[tracing::instrument(level = "info", skip(self, _authorization_api))]
-    async fn archive_property_type<A: AuthorizationApi + Sync>(
+    #[tracing::instrument(level = "info", skip(self))]
+    async fn archive_property_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        _authorization_api: &mut A,
+        _: &mut A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
         self.archive_ontology_type(id, EditionArchivedById::new(actor_id))
             .await
     }
 
-    #[tracing::instrument(level = "info", skip(self, _authorization_api))]
-    async fn unarchive_property_type<A: AuthorizationApi + Sync>(
+    #[tracing::instrument(level = "info", skip(self))]
+    async fn unarchive_property_type<A: AuthorizationApi + Send + Sync>(
         &mut self,
         actor_id: AccountId,
-        _authorization_api: &mut A,
+        _: &mut A,
         id: &VersionedUrl,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
         self.unarchive_ontology_type(id, EditionCreatedById::new(actor_id))
             .await
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct PropertyTypeRowIndices {
+    pub base_url: usize,
+    pub version: usize,
+    pub transaction_time: usize,
+
+    pub schema: usize,
+
+    pub edition_created_by_id: usize,
+    pub edition_archived_by_id: usize,
+    pub additional_metadata: usize,
+}
+
+impl QueryRecordDecode<Row> for PropertyTypeWithMetadata {
+    type CompilationArtifacts = PropertyTypeRowIndices;
+
+    fn decode(row: &Row, indices: Self::CompilationArtifacts) -> Self {
+        Self {
+            schema: row.get::<_, Json<_>>(indices.schema).0,
+            metadata: PropertyTypeMetadata {
+                record_id: OntologyTypeRecordId {
+                    base_url: BaseUrl::new(row.get(indices.base_url))
+                        .expect("invalid base URL returned from Postgres"),
+                    version: row.get(indices.version),
+                },
+                classification: row
+                    .get::<_, Json<PostgresOntologyTypeClassificationMetadata>>(
+                        indices.additional_metadata,
+                    )
+                    .0
+                    .into(),
+                temporal_versioning: OntologyTemporalMetadata {
+                    transaction_time: row.get(indices.transaction_time),
+                },
+                provenance: OntologyProvenanceMetadata {
+                    edition: OntologyEditionProvenanceMetadata {
+                        created_by_id: EditionCreatedById::new(
+                            row.get(indices.edition_created_by_id),
+                        ),
+                        archived_by_id: row.get(indices.edition_archived_by_id),
+                    },
+                },
+            },
+        }
+    }
+}
+
+impl<'c> QueryRecord<'c, SelectCompiler<'c, Self>> for PropertyTypeWithMetadata {
+    type CompilationParameters = ();
+
+    fn parameters() -> Self::CompilationParameters {}
+
+    fn compile<'p: 'c>(
+        compiler: &mut SelectCompiler<'c, Self>,
+        _paths: &'p Self::CompilationParameters,
+    ) -> Self::CompilationArtifacts {
+        PropertyTypeRowIndices {
+            base_url: compiler.add_distinct_selection_with_ordering(
+                &PropertyTypeQueryPath::BaseUrl,
+                Distinctness::Distinct,
+                None,
+            ),
+            version: compiler.add_distinct_selection_with_ordering(
+                &PropertyTypeQueryPath::Version,
+                Distinctness::Distinct,
+                None,
+            ),
+            transaction_time: compiler.add_distinct_selection_with_ordering(
+                &PropertyTypeQueryPath::TransactionTime,
+                Distinctness::Distinct,
+                None,
+            ),
+            schema: compiler.add_selection_path(&PropertyTypeQueryPath::Schema(None)),
+            edition_created_by_id: compiler
+                .add_selection_path(&PropertyTypeQueryPath::EditionCreatedById),
+            edition_archived_by_id: compiler
+                .add_selection_path(&PropertyTypeQueryPath::EditionArchivedById),
+            additional_metadata: compiler
+                .add_selection_path(&PropertyTypeQueryPath::AdditionalMetadata),
+        }
     }
 }

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/property_type.rs
@@ -40,7 +40,7 @@ use crate::{
                 read::OntologyTypeTraversalData, OntologyId,
                 PostgresOntologyTypeClassificationMetadata,
             },
-            query::{Distinctness, QueryRecord, ReferenceTable, SelectCompiler},
+            query::{Distinctness, PostgresRecord, ReferenceTable, SelectCompiler, Table},
             TraversalContext,
         },
         AsClient, ConflictBehavior, InsertionError, PostgresStore, PropertyTypeStore, QueryError,
@@ -683,8 +683,12 @@ impl QueryRecordDecode for PropertyTypeWithMetadata {
     }
 }
 
-impl QueryRecord for PropertyTypeWithMetadata {
+impl PostgresRecord for PropertyTypeWithMetadata {
     type CompilationParameters = ();
+
+    fn base_table() -> Table {
+        Table::OntologyTemporalMetadata
+    }
 
     fn parameters() -> Self::CompilationParameters {}
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/property_type.rs
@@ -424,11 +424,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
             self,
             filter,
             Some(&temporal_axes),
-            cursor
-                .map(|cursor| VertexIdSorting {
-                    cursor: Some(cursor),
-                })
-                .as_ref(),
+            &VertexIdSorting { cursor },
             limit,
             include_drafts,
         )

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/read.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/read.rs
@@ -1,23 +1,11 @@
-use std::{borrow::Cow, convert::identity};
+use std::borrow::Cow;
 
-use async_trait::async_trait;
 use authorization::schema::EntityTypeId;
 use error_stack::{Result, ResultExt};
-use futures::{Stream, StreamExt, TryStreamExt};
-use graph_types::{
-    account::EditionCreatedById,
-    ontology::{
-        DataTypeMetadata, DataTypeWithMetadata, EntityTypeMetadata, EntityTypeWithMetadata,
-        OntologyEditionProvenanceMetadata, OntologyProvenanceMetadata, OntologyTemporalMetadata,
-        OntologyTypeClassificationMetadata, OntologyTypeRecordId, OntologyTypeVersion,
-        PropertyTypeMetadata, PropertyTypeWithMetadata,
-    },
-    owned_by_id::OwnedById,
-};
+use futures::{Stream, StreamExt};
+use graph_types::ontology::{EntityTypeWithMetadata, OntologyTypeVersion};
 use postgres_types::Json;
-use serde::Deserialize;
 use temporal_versioning::RightBoundedTemporalInterval;
-use time::OffsetDateTime;
 use tokio_postgres::GenericClient;
 use type_system::{
     url::{BaseUrl, VersionedUrl},
@@ -25,419 +13,23 @@ use type_system::{
 };
 
 use crate::{
-    ontology::{DataTypeQueryPath, EntityTypeQueryPath, PropertyTypeQueryPath},
+    ontology::EntityTypeQueryPath,
     store::{
-        crud::Read,
         postgres::{
             ontology::OntologyId,
             query::{
-                Column, Distinctness, ForeignKeyReference, Ordering, ReferenceTable,
-                SelectCompiler, Table, Transpile,
+                Column, Distinctness, ForeignKeyReference, ReferenceTable, SelectCompiler, Table,
+                Transpile,
             },
         },
-        query::{Filter, Parameter},
-        AsClient, PostgresStore, QueryError, Record,
+        query::Filter,
+        AsClient, PostgresStore, QueryError,
     },
     subgraph::{
         edges::GraphResolveDepths,
         temporal_axes::{QueryTemporalAxes, VariableAxis},
     },
 };
-
-struct CursorParameters<'p> {
-    base_url: Parameter<'p>,
-    version: Parameter<'p>,
-}
-
-#[derive(Deserialize)]
-#[serde(untagged)]
-enum PostgresOntologyTypeClassificationMetadata {
-    Owned {
-        web_id: OwnedById,
-    },
-    External {
-        #[serde(with = "temporal_versioning::serde::time")]
-        fetched_at: OffsetDateTime,
-    },
-}
-
-impl From<PostgresOntologyTypeClassificationMetadata> for OntologyTypeClassificationMetadata {
-    fn from(value: PostgresOntologyTypeClassificationMetadata) -> Self {
-        match value {
-            PostgresOntologyTypeClassificationMetadata::Owned { web_id } => Self::Owned {
-                owned_by_id: web_id,
-            },
-            PostgresOntologyTypeClassificationMetadata::External { fetched_at } => {
-                Self::External { fetched_at }
-            }
-        }
-    }
-}
-
-#[async_trait]
-impl<C: AsClient> Read<DataTypeWithMetadata> for PostgresStore<C> {
-    type Record = DataTypeWithMetadata;
-
-    type ReadStream = impl Stream<Item = Result<DataTypeWithMetadata, QueryError>> + Send + Sync;
-
-    #[tracing::instrument(level = "info", skip(self, filter))]
-    async fn read(
-        &self,
-        filter: &Filter<Self::Record>,
-        temporal_axes: Option<&QueryTemporalAxes>,
-        after: Option<&<Self::Record as Record>::VertexId>,
-        limit: Option<usize>,
-        include_drafts: bool,
-    ) -> Result<Self::ReadStream, QueryError> {
-        let mut compiler = SelectCompiler::new(temporal_axes, include_drafts);
-        if let Some(limit) = limit {
-            compiler.set_limit(limit);
-        }
-
-        let cursor_parameters: Option<CursorParameters> = after.map(|cursor| CursorParameters {
-            base_url: Parameter::Text(Cow::Borrowed(cursor.base_id.as_str())),
-            version: Parameter::OntologyTypeVersion(cursor.revision_id),
-        });
-
-        let (base_url_index, version_index) = if let Some(cursor_parameters) = &cursor_parameters {
-            let base_url_expression = compiler.compile_parameter(&cursor_parameters.base_url).0;
-            let version_expression = compiler.compile_parameter(&cursor_parameters.version).0;
-
-            (
-                compiler.add_cursor_selection(
-                    &DataTypeQueryPath::BaseUrl,
-                    identity,
-                    base_url_expression,
-                    Ordering::Ascending,
-                ),
-                compiler.add_cursor_selection(
-                    &DataTypeQueryPath::Version,
-                    identity,
-                    version_expression,
-                    Ordering::Descending,
-                ),
-            )
-        } else {
-            // If we neither have `limit` nor `after` we don't need to sort
-            let maybe_ascending = limit.map(|_| Ordering::Ascending);
-            let maybe_descending = limit.map(|_| Ordering::Descending);
-            (
-                compiler.add_distinct_selection_with_ordering(
-                    &DataTypeQueryPath::BaseUrl,
-                    Distinctness::Distinct,
-                    maybe_ascending,
-                ),
-                compiler.add_distinct_selection_with_ordering(
-                    &DataTypeQueryPath::Version,
-                    Distinctness::Distinct,
-                    maybe_descending,
-                ),
-            )
-        };
-
-        // It's possible to have multiple records with the same transaction time. We order them
-        // descending so that the most recent record is returned first.
-        let transaction_time_index = compiler.add_distinct_selection_with_ordering(
-            &DataTypeQueryPath::TransactionTime,
-            Distinctness::Distinct,
-            Some(Ordering::Descending),
-        );
-        let schema_index = compiler.add_selection_path(&DataTypeQueryPath::Schema(None));
-        let edition_created_by_id_path_index =
-            compiler.add_selection_path(&DataTypeQueryPath::EditionCreatedById);
-        let edition_archived_by_id_path_index =
-            compiler.add_selection_path(&DataTypeQueryPath::EditionArchivedById);
-        let additional_metadata_index =
-            compiler.add_selection_path(&DataTypeQueryPath::AdditionalMetadata);
-
-        compiler.add_filter(filter);
-        let (statement, parameters) = compiler.compile();
-
-        let stream = self
-            .as_client()
-            .query_raw(&statement, parameters.iter().copied())
-            .await
-            .change_context(QueryError)?
-            .map(|row| row.change_context(QueryError))
-            .and_then(move |row| async move {
-                Ok(DataTypeWithMetadata {
-                    schema: row.get::<_, Json<_>>(schema_index).0,
-                    metadata: DataTypeMetadata {
-                        record_id: OntologyTypeRecordId {
-                            base_url: BaseUrl::new(row.get(base_url_index))
-                                .change_context(QueryError)?,
-                            version: row.get(version_index),
-                        },
-                        classification: row
-                            .get::<_, Json<PostgresOntologyTypeClassificationMetadata>>(
-                                additional_metadata_index,
-                            )
-                            .0
-                            .into(),
-                        temporal_versioning: OntologyTemporalMetadata {
-                            transaction_time: row.get(transaction_time_index),
-                        },
-                        provenance: OntologyProvenanceMetadata {
-                            edition: OntologyEditionProvenanceMetadata {
-                                created_by_id: EditionCreatedById::new(
-                                    row.get(edition_created_by_id_path_index),
-                                ),
-                                archived_by_id: row.get(edition_archived_by_id_path_index),
-                            },
-                        },
-                    },
-                })
-            });
-        Ok(stream)
-    }
-}
-
-#[async_trait]
-impl<C: AsClient> Read<PropertyTypeWithMetadata> for PostgresStore<C> {
-    type Record = PropertyTypeWithMetadata;
-
-    type ReadStream =
-        impl Stream<Item = Result<PropertyTypeWithMetadata, QueryError>> + Send + Sync;
-
-    #[tracing::instrument(level = "info", skip(self, filter))]
-    async fn read(
-        &self,
-        filter: &Filter<Self::Record>,
-        temporal_axes: Option<&QueryTemporalAxes>,
-        after: Option<&<Self::Record as Record>::VertexId>,
-        limit: Option<usize>,
-        include_drafts: bool,
-    ) -> Result<Self::ReadStream, QueryError> {
-        let mut compiler = SelectCompiler::new(temporal_axes, include_drafts);
-        if let Some(limit) = limit {
-            compiler.set_limit(limit);
-        }
-
-        let cursor_parameters: Option<CursorParameters> = after.map(|cursor| CursorParameters {
-            base_url: Parameter::Text(Cow::Borrowed(cursor.base_id.as_str())),
-            version: Parameter::OntologyTypeVersion(cursor.revision_id),
-        });
-
-        let (base_url_index, version_index) = if let Some(cursor_parameters) = &cursor_parameters {
-            let base_url_expression = compiler.compile_parameter(&cursor_parameters.base_url).0;
-            let version_expression = compiler.compile_parameter(&cursor_parameters.version).0;
-
-            (
-                compiler.add_cursor_selection(
-                    &PropertyTypeQueryPath::BaseUrl,
-                    identity,
-                    base_url_expression,
-                    Ordering::Ascending,
-                ),
-                compiler.add_cursor_selection(
-                    &PropertyTypeQueryPath::Version,
-                    identity,
-                    version_expression,
-                    Ordering::Descending,
-                ),
-            )
-        } else {
-            // If we neither have `limit` nor `after` we don't need to sort
-            let maybe_ascending = limit.map(|_| Ordering::Ascending);
-            let maybe_descending = limit.map(|_| Ordering::Descending);
-            (
-                compiler.add_distinct_selection_with_ordering(
-                    &PropertyTypeQueryPath::BaseUrl,
-                    Distinctness::Distinct,
-                    maybe_ascending,
-                ),
-                compiler.add_distinct_selection_with_ordering(
-                    &PropertyTypeQueryPath::Version,
-                    Distinctness::Distinct,
-                    maybe_descending,
-                ),
-            )
-        };
-
-        // It's possible to have multiple records with the same transaction time. We order them
-        // descending so that the most recent record is returned first.
-        let transaction_time_index = compiler.add_distinct_selection_with_ordering(
-            &PropertyTypeQueryPath::TransactionTime,
-            Distinctness::Distinct,
-            Some(Ordering::Descending),
-        );
-        let schema_index = compiler.add_selection_path(&PropertyTypeQueryPath::Schema(None));
-        let edition_created_by_id_path_index =
-            compiler.add_selection_path(&PropertyTypeQueryPath::EditionCreatedById);
-        let edition_archived_by_id_path_index =
-            compiler.add_selection_path(&PropertyTypeQueryPath::EditionArchivedById);
-        let additional_metadata_index =
-            compiler.add_selection_path(&PropertyTypeQueryPath::AdditionalMetadata);
-
-        compiler.add_filter(filter);
-        let (statement, parameters) = compiler.compile();
-
-        let stream = self
-            .as_client()
-            .query_raw(&statement, parameters.iter().copied())
-            .await
-            .change_context(QueryError)?
-            .map(|row| row.change_context(QueryError))
-            .and_then(move |row| async move {
-                Ok(PropertyTypeWithMetadata {
-                    schema: row.get::<_, Json<_>>(schema_index).0,
-                    metadata: PropertyTypeMetadata {
-                        record_id: OntologyTypeRecordId {
-                            base_url: BaseUrl::new(row.get(base_url_index))
-                                .change_context(QueryError)?,
-                            version: row.get(version_index),
-                        },
-                        classification: row
-                            .get::<_, Json<PostgresOntologyTypeClassificationMetadata>>(
-                                additional_metadata_index,
-                            )
-                            .0
-                            .into(),
-                        temporal_versioning: OntologyTemporalMetadata {
-                            transaction_time: row.get(transaction_time_index),
-                        },
-                        provenance: OntologyProvenanceMetadata {
-                            edition: OntologyEditionProvenanceMetadata {
-                                created_by_id: EditionCreatedById::new(
-                                    row.get(edition_created_by_id_path_index),
-                                ),
-                                archived_by_id: row.get(edition_archived_by_id_path_index),
-                            },
-                        },
-                    },
-                })
-            });
-        Ok(stream)
-    }
-}
-
-#[async_trait]
-impl<C: AsClient> Read<EntityTypeWithMetadata> for PostgresStore<C> {
-    type Record = EntityTypeWithMetadata;
-
-    type ReadStream = impl Stream<Item = Result<EntityTypeWithMetadata, QueryError>> + Send + Sync;
-
-    #[tracing::instrument(level = "info", skip(self, filter))]
-    async fn read(
-        &self,
-        filter: &Filter<Self::Record>,
-        temporal_axes: Option<&QueryTemporalAxes>,
-        after: Option<&<Self::Record as Record>::VertexId>,
-        limit: Option<usize>,
-        include_drafts: bool,
-    ) -> Result<Self::ReadStream, QueryError> {
-        let mut compiler = SelectCompiler::new(temporal_axes, include_drafts);
-        if let Some(limit) = limit {
-            compiler.set_limit(limit);
-        }
-
-        let cursor_parameters: Option<CursorParameters> = after.map(|cursor| CursorParameters {
-            base_url: Parameter::Text(Cow::Borrowed(cursor.base_id.as_str())),
-            version: Parameter::OntologyTypeVersion(cursor.revision_id),
-        });
-
-        let (base_url_index, version_index) = if let Some(cursor_parameters) = &cursor_parameters {
-            let base_url_expression = compiler.compile_parameter(&cursor_parameters.base_url).0;
-            let version_expression = compiler.compile_parameter(&cursor_parameters.version).0;
-
-            (
-                compiler.add_cursor_selection(
-                    &EntityTypeQueryPath::BaseUrl,
-                    identity,
-                    base_url_expression,
-                    Ordering::Ascending,
-                ),
-                compiler.add_cursor_selection(
-                    &EntityTypeQueryPath::Version,
-                    identity,
-                    version_expression,
-                    Ordering::Descending,
-                ),
-            )
-        } else {
-            // If we neither have `limit` nor `after` we don't need to sort
-            let maybe_ascending = limit.map(|_| Ordering::Ascending);
-            let maybe_descending = limit.map(|_| Ordering::Descending);
-            (
-                compiler.add_distinct_selection_with_ordering(
-                    &EntityTypeQueryPath::BaseUrl,
-                    Distinctness::Distinct,
-                    maybe_ascending,
-                ),
-                compiler.add_distinct_selection_with_ordering(
-                    &EntityTypeQueryPath::Version,
-                    Distinctness::Distinct,
-                    maybe_descending,
-                ),
-            )
-        };
-
-        // It's possible to have multiple records with the same transaction time. We order them
-        // descending so that the most recent record is returned first.
-        let transaction_time_index = compiler.add_distinct_selection_with_ordering(
-            &EntityTypeQueryPath::TransactionTime,
-            Distinctness::Distinct,
-            Some(Ordering::Descending),
-        );
-        let schema_index = compiler.add_selection_path(&EntityTypeQueryPath::Schema(None));
-        let edition_created_by_id_path_index =
-            compiler.add_selection_path(&EntityTypeQueryPath::EditionCreatedById);
-        let edition_archived_by_id_path_index =
-            compiler.add_selection_path(&EntityTypeQueryPath::EditionArchivedById);
-        let additional_metadata_index =
-            compiler.add_selection_path(&EntityTypeQueryPath::AdditionalMetadata);
-        let label_property_index = compiler.add_selection_path(&EntityTypeQueryPath::LabelProperty);
-        let icon_index = compiler.add_selection_path(&EntityTypeQueryPath::Icon);
-
-        compiler.add_filter(filter);
-        let (statement, parameters) = compiler.compile();
-
-        let stream = self
-            .as_client()
-            .query_raw(&statement, parameters.iter().copied())
-            .await
-            .change_context(QueryError)?
-            .map(|row| row.change_context(QueryError))
-            .and_then(move |row| async move {
-                let label_property = row
-                    .get::<_, Option<String>>(label_property_index)
-                    .map(BaseUrl::new)
-                    .transpose()
-                    .change_context(QueryError)?;
-
-                Ok(EntityTypeWithMetadata {
-                    schema: row.get::<_, Json<_>>(schema_index).0,
-                    metadata: EntityTypeMetadata {
-                        record_id: OntologyTypeRecordId {
-                            base_url: BaseUrl::new(row.get(base_url_index))
-                                .change_context(QueryError)?,
-                            version: row.get(version_index),
-                        },
-                        classification: row
-                            .get::<_, Json<PostgresOntologyTypeClassificationMetadata>>(
-                                additional_metadata_index,
-                            )
-                            .0
-                            .into(),
-                        temporal_versioning: OntologyTemporalMetadata {
-                            transaction_time: row.get(transaction_time_index),
-                        },
-                        provenance: OntologyProvenanceMetadata {
-                            edition: OntologyEditionProvenanceMetadata {
-                                created_by_id: EditionCreatedById::new(
-                                    row.get(edition_created_by_id_path_index),
-                                ),
-                                archived_by_id: row.get(edition_archived_by_id_path_index),
-                            },
-                        },
-                        label_property,
-                        icon: row.get(icon_index),
-                    },
-                })
-            });
-        Ok(stream)
-    }
-}
 
 #[derive(Debug, Default)]
 pub struct OntologyTypeTraversalData {
@@ -469,10 +61,10 @@ pub struct OntologyEdgeTraversal<L, R> {
 
 impl<C: AsClient> PostgresStore<C> {
     #[tracing::instrument(level = "trace", skip(self, filter))]
-    pub(crate) async fn read_closed_schemas(
+    pub(crate) async fn read_closed_schemas<'f>(
         &self,
-        filter: &Filter<'_, EntityTypeWithMetadata>,
-        temporal_axes: Option<&QueryTemporalAxes>,
+        filter: &Filter<'f, EntityTypeWithMetadata>,
+        temporal_axes: Option<&'f QueryTemporalAxes>,
     ) -> Result<impl Stream<Item = Result<(EntityTypeId, EntityType), QueryError>>, QueryError>
     {
         let mut compiler = SelectCompiler::new(temporal_axes, false);

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/compile.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/compile.rs
@@ -2,11 +2,9 @@ use std::collections::{HashMap, HashSet};
 
 use postgres_types::ToSql;
 use temporal_versioning::TimeAxis;
-use tokio_postgres::Row;
 
 use crate::{
     store::{
-        crud::QueryCompiler,
         postgres::query::{
             expression::GroupByExpression,
             table::{
@@ -50,10 +48,6 @@ pub struct SelectCompiler<'p, T: Record> {
     table_hooks: HashMap<Table, fn(&mut Self, Alias)>,
     selections:
         HashMap<&'p T::QueryPath<'p>, (AliasedColumn, usize, Distinctness, Option<Ordering>)>,
-}
-
-impl<'c, R: Record> QueryCompiler<'c> for SelectCompiler<'c, R> {
-    type ResultSet = Row;
 }
 
 impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/data_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/data_type.rs
@@ -1,7 +1,5 @@
 use std::iter::once;
 
-use graph_types::ontology::DataTypeWithMetadata;
-
 use crate::{
     ontology::DataTypeQueryPath,
     store::postgres::query::{
@@ -9,16 +7,10 @@ use crate::{
             Column, DataTypes, JsonField, OntologyAdditionalMetadata, OntologyIds,
             OntologyOwnedMetadata, OntologyTemporalMetadata, ReferenceTable, Relation,
         },
-        PostgresQueryPath, PostgresRecord, Table,
+        PostgresQueryPath,
     },
     subgraph::edges::{EdgeDirection, OntologyEdgeKind},
 };
-
-impl PostgresRecord for DataTypeWithMetadata {
-    fn base_table() -> Table {
-        Table::OntologyTemporalMetadata
-    }
-}
 
 impl PostgresQueryPath for DataTypeQueryPath<'_> {
     fn relations(&self) -> Vec<Relation> {

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/entity.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/entity.rs
@@ -1,7 +1,5 @@
 use std::iter::once;
 
-use graph_types::knowledge::entity::Entity;
-
 use crate::{
     knowledge::EntityQueryPath,
     store::postgres::query::{
@@ -9,16 +7,10 @@ use crate::{
             Column, EntityEditions, EntityEmbeddings, EntityHasLeftEntity, EntityHasRightEntity,
             EntityIds, EntityTemporalMetadata, JsonField, ReferenceTable, Relation,
         },
-        PostgresQueryPath, PostgresRecord, Table,
+        PostgresQueryPath,
     },
     subgraph::edges::{EdgeDirection, KnowledgeGraphEdgeKind, SharedEdgeKind},
 };
-
-impl PostgresRecord for Entity {
-    fn base_table() -> Table {
-        Table::EntityTemporalMetadata
-    }
-}
 
 impl PostgresQueryPath for EntityQueryPath<'_> {
     fn relations(&self) -> Vec<Relation> {

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/entity_type.rs
@@ -1,7 +1,5 @@
 use std::iter::once;
 
-use graph_types::ontology::EntityTypeWithMetadata;
-
 use crate::{
     ontology::EntityTypeQueryPath,
     store::postgres::query::{
@@ -9,16 +7,10 @@ use crate::{
             Column, EntityTypes, JsonField, OntologyAdditionalMetadata, OntologyIds,
             OntologyOwnedMetadata, OntologyTemporalMetadata, ReferenceTable, Relation,
         },
-        PostgresQueryPath, PostgresRecord, Table,
+        PostgresQueryPath,
     },
     subgraph::edges::{EdgeDirection, OntologyEdgeKind, SharedEdgeKind},
 };
-
-impl PostgresRecord for EntityTypeWithMetadata {
-    fn base_table() -> Table {
-        Table::OntologyTemporalMetadata
-    }
-}
 
 impl PostgresQueryPath for EntityTypeQueryPath<'_> {
     /// Returns the relations that are required to access the path.

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/mod.rs
@@ -35,9 +35,18 @@ use crate::{
     subgraph::temporal_axes::QueryTemporalAxes,
 };
 
-pub trait PostgresRecord: Record {
+pub trait PostgresRecord: Record + QueryRecordDecode<Output = Self> {
+    type CompilationParameters: Send + 'static;
+
     /// The [`Table`] used for this `Query`.
     fn base_table() -> Table;
+
+    fn parameters() -> Self::CompilationParameters;
+
+    fn compile<'c, 'p: 'c>(
+        compiler: &mut SelectCompiler<'c, Self>,
+        paths: &'p Self::CompilationParameters,
+    ) -> Self::CompilationArtifacts;
 }
 
 /// An absolute path inside of a query pointing to an attribute.
@@ -81,17 +90,6 @@ pub trait PostgresSorting<R: Record>:
         compiler: &mut SelectCompiler<'c, R>,
         parameters: Option<&'c <Self::Cursor as QueryRecordEncode>::CompilationParameters<'p>>,
         temporal_axes: &QueryTemporalAxes,
-    ) -> Self::CompilationArtifacts;
-}
-
-pub trait QueryRecord: Record + QueryRecordDecode<Output = Self> {
-    type CompilationParameters: Send + 'static;
-
-    fn parameters() -> Self::CompilationParameters;
-
-    fn compile<'c, 'p: 'c>(
-        compiler: &mut SelectCompiler<'c, Self>,
-        paths: &'p Self::CompilationParameters,
     ) -> Self::CompilationArtifacts;
 }
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/mod.rs
@@ -14,8 +14,6 @@ mod table;
 
 use std::fmt::{self, Display, Formatter};
 
-use tokio_postgres::Row;
-
 pub use self::{
     compile::SelectCompiler,
     condition::{Condition, EqualityOperator},
@@ -30,8 +28,8 @@ pub use self::{
 };
 use crate::{
     store::{
-        crud::{QueryRecordDecode, Sorting},
-        postgres::query::table::Relation,
+        crud::Sorting,
+        postgres::{crud::QueryRecordDecode, query::table::Relation},
         Record,
     },
     subgraph::temporal_axes::QueryTemporalAxes,
@@ -77,7 +75,7 @@ pub trait QueryRecordEncode {
 }
 
 pub trait PostgresSorting<R: Record>:
-    Sorting<Cursor: QueryRecordEncode> + QueryRecordDecode<Row, Output = Self::Cursor>
+    Sorting<Cursor: QueryRecordEncode> + QueryRecordDecode<Output = Self::Cursor>
 {
     fn compile<'c, 'p: 'c>(
         compiler: &mut SelectCompiler<'c, R>,
@@ -86,7 +84,7 @@ pub trait PostgresSorting<R: Record>:
     ) -> Self::CompilationArtifacts;
 }
 
-pub trait QueryRecord: Record + QueryRecordDecode<Row, Output = Self> {
+pub trait QueryRecord: Record + QueryRecordDecode<Output = Self> {
     type CompilationParameters: Send + 'static;
 
     fn parameters() -> Self::CompilationParameters;

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/property_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/property_type.rs
@@ -1,7 +1,5 @@
 use std::iter::once;
 
-use graph_types::ontology::PropertyTypeWithMetadata;
-
 use crate::{
     ontology::PropertyTypeQueryPath,
     store::postgres::query::{
@@ -9,16 +7,10 @@ use crate::{
             Column, JsonField, OntologyAdditionalMetadata, OntologyIds, OntologyOwnedMetadata,
             OntologyTemporalMetadata, PropertyTypes, ReferenceTable, Relation,
         },
-        PostgresQueryPath, PostgresRecord, Table,
+        PostgresQueryPath,
     },
     subgraph::edges::{EdgeDirection, OntologyEdgeKind},
 };
-
-impl PostgresRecord for PropertyTypeWithMetadata {
-    fn base_table() -> Table {
-        Table::OntologyTemporalMetadata
-    }
-}
 
 impl PostgresQueryPath for PropertyTypeQueryPath<'_> {
     fn relations(&self) -> Vec<Relation> {

--- a/apps/hash-graph/libs/graph/src/store/postgres/traversal_context.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/traversal_context.rs
@@ -37,8 +37,6 @@ impl<C: AsClient> PostgresStore<C> {
                 ParameterList::Uuid(&ids),
             ),
             Some(&subgraph.temporal_axes.resolved),
-            None,
-            None,
             false,
         )
         .await?
@@ -69,8 +67,6 @@ impl<C: AsClient> PostgresStore<C> {
                 ParameterList::Uuid(&ids),
             ),
             Some(&subgraph.temporal_axes.resolved),
-            None,
-            None,
             false,
         )
         .await?
@@ -101,8 +97,6 @@ impl<C: AsClient> PostgresStore<C> {
                 ParameterList::Uuid(&ids),
             ),
             Some(&subgraph.temporal_axes.resolved),
-            None,
-            None,
             false,
         )
         .await?
@@ -134,8 +128,6 @@ impl<C: AsClient> PostgresStore<C> {
                 ParameterList::Uuid(&ids),
             ),
             Some(&subgraph.temporal_axes.resolved),
-            None,
-            None,
             include_drafts,
         )
         .await?

--- a/apps/hash-graph/libs/graph/src/store/record.rs
+++ b/apps/hash-graph/libs/graph/src/store/record.rs
@@ -1,3 +1,5 @@
+use std::hash::Hash;
+
 use temporal_versioning::TimeAxis;
 
 use crate::{store::query::QueryPath, subgraph::identifier::VertexId};
@@ -9,7 +11,7 @@ use crate::{store::query::QueryPath, subgraph::identifier::VertexId};
 //   see https://linear.app/hash/issue/H-754
 pub trait Record: Sized + Send {
     type VertexId: VertexId<Record = Self> + Send + Sync;
-    type QueryPath<'p>: QueryPath + Send + Sync;
+    type QueryPath<'p>: QueryPath + Send + Sync + Eq + Hash;
 
     fn vertex_id(&self, time_axis: TimeAxis) -> Self::VertexId;
 }

--- a/apps/hash-graph/libs/graph/src/store/validation.rs
+++ b/apps/hash-graph/libs/graph/src/store/validation.rs
@@ -130,7 +130,7 @@ pub struct StoreProvider<'a, S, A> {
 
 impl<S, A> StoreProvider<'_, S, A>
 where
-    S: Read<DataTypeWithMetadata, Record = DataTypeWithMetadata>,
+    S: Read<DataTypeWithMetadata>,
     A: AuthorizationApi + Sync,
 {
     async fn authorize_data_type(&self, type_id: DataTypeId) -> Result<(), Report<QueryError>> {
@@ -154,7 +154,7 @@ where
 
 impl<S, A> OntologyTypeProvider<DataType> for StoreProvider<'_, S, A>
 where
-    S: Read<DataTypeWithMetadata, Record = DataTypeWithMetadata>,
+    S: Read<DataTypeWithMetadata>,
     A: AuthorizationApi + Sync,
 {
     #[expect(refining_impl_trait)]
@@ -176,7 +176,7 @@ where
         let schema = self
             .store
             .read_one(
-                &Filter::<S::Record>::for_versioned_url(type_id),
+                &Filter::for_versioned_url(type_id),
                 Some(
                     &QueryTemporalAxesUnresolved::DecisionTime {
                         pinned: PinnedTemporalAxisUnresolved::new(None),
@@ -197,7 +197,7 @@ where
 
 impl<S, A> StoreProvider<'_, S, A>
 where
-    S: Read<PropertyTypeWithMetadata, Record = PropertyTypeWithMetadata>,
+    S: Read<PropertyTypeWithMetadata>,
     A: AuthorizationApi + Sync,
 {
     async fn authorize_property_type(
@@ -224,7 +224,7 @@ where
 
 impl<S, A> OntologyTypeProvider<PropertyType> for StoreProvider<'_, S, A>
 where
-    S: Read<PropertyTypeWithMetadata, Record = PropertyTypeWithMetadata>,
+    S: Read<PropertyTypeWithMetadata>,
     A: AuthorizationApi + Sync,
 {
     #[expect(refining_impl_trait)]
@@ -246,7 +246,7 @@ where
         let schema = self
             .store
             .read_one(
-                &Filter::<S::Record>::for_versioned_url(type_id),
+                &Filter::for_versioned_url(type_id),
                 Some(
                     &QueryTemporalAxesUnresolved::DecisionTime {
                         pinned: PinnedTemporalAxisUnresolved::new(None),
@@ -402,7 +402,7 @@ where
 
 impl<S, A> EntityProvider for StoreProvider<'_, S, A>
 where
-    S: Read<Entity, Record = Entity>,
+    S: Read<Entity>,
     A: AuthorizationApi + Sync,
 {
     #[expect(refining_impl_trait)]
@@ -422,7 +422,7 @@ where
 
         self.store
             .read_one(
-                &Filter::<S::Record>::for_entity_by_entity_id(entity_id),
+                &Filter::for_entity_by_entity_id(entity_id),
                 Some(
                     &QueryTemporalAxesUnresolved::DecisionTime {
                         pinned: PinnedTemporalAxisUnresolved::new(None),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The current `Read` trait always returns `Self::Record`. This has the downsides that it's not possible to read data which is stored alongside the return value such as the distance or the cursor. Initially, this is required for root sorting but we will also require to dynamically choose the returned values for query methods, e.g. only returning the type of an entity instead of all information.

Generally, this will be required or at least very useful for:

- Root sorting        
- Selective return values
- Provenance

## 🔍 What does this change?

- Rewrite the `Read` trait:
    - Split into `Read` and `ReadPaginated` (as otherwise the generics would be empty)
    - Define the conversion of cursor and records on the records (and cursors) itself, not on the trait
    - This implies, that the `Read` trait is now only defined on two structs: `PostgresStore` and `FetchingStore`
    - This also imply a rather big diff as things were moved around. The underlying logic did not change much (besides the `cursor` is now exposed)
- Prepare interfaces to allow root sorting (H-1440)
- First step to use the builder pattern instead of passing all arguments (H-1466)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- The `Read` trait is split into two parts, this is suboptimal and may be revisited at some later point

## 🐾 Next steps

Implement root sorting (H-1440)

## 🛡 What tests cover this?

- This is an internal refactoring and every test which is using the Graph should go through these methods
- New tests are expected to be added later this week or early next week
