### PR TITLE
H-1608: Set correct permissions on org membership link

### DIFF
--- a/apps/hash-api/src/graph/knowledge/system-types/org-membership.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/org-membership.ts
@@ -1,4 +1,5 @@
 import { EntityTypeMismatchError } from "@local/hash-backend-utils/error";
+import { createOrgMembershipAuthorizationRelationships } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemLinkEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { IsMemberOfProperties } from "@local/hash-isomorphic-utils/system-types/shared";
 import {
@@ -79,28 +80,9 @@ export const createOrgMembership: ImpureGraphFunction<
       leftEntityId: userEntityId,
       rightEntityId: orgEntityId,
       properties: {},
-      relationships: [
-        {
-          relation: "setting",
-          subject: {
-            kind: "setting",
-            subjectId: "administratorFromWeb",
-          },
-        },
-        {
-          relation: "editor",
-          subject: {
-            kind: "account",
-            subjectId: userAccountId,
-          },
-        },
-        {
-          relation: "viewer",
-          subject: {
-            kind: "public",
-          },
-        },
-      ],
+      relationships: createOrgMembershipAuthorizationRelationships({
+        memberAccountId: userAccountId,
+      }),
     });
   } catch (error) {
     await ctx.graphApi.removeAccountGroupMember(

--- a/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -77,7 +77,15 @@ export const createEntityResolver: ResolverFn<
   MutationCreateEntityArgs
 > = async (
   _,
-  { ownedById, properties, entityTypeId, linkedEntities, linkData, draft },
+  {
+    ownedById,
+    properties,
+    entityTypeId,
+    linkedEntities,
+    linkData,
+    draft,
+    relationships,
+  },
   { dataSources, authentication, user },
 ) => {
   const context = dataSourcesToImpureGraphContext(dataSources);
@@ -114,7 +122,9 @@ export const createEntityResolver: ResolverFn<
       properties,
       linkEntityTypeId: entityTypeId,
       ownedById: ownedById ?? (user.accountId as OwnedById),
-      relationships: createDefaultAuthorizationRelationships(authentication),
+      relationships:
+        relationships ??
+        createDefaultAuthorizationRelationships(authentication),
       draft: draft ?? undefined,
     });
   } else {

--- a/apps/hash-frontend/src/graphql/queries/knowledge/entity.queries.ts
+++ b/apps/hash-frontend/src/graphql/queries/knowledge/entity.queries.ts
@@ -8,6 +8,7 @@ export const createEntityMutation = gql`
     $properties: EntityPropertiesObject!
     $linkData: LinkData
     $draft: Boolean
+    $relationships: [EntityRelationAndSubject!]
   ) {
     # This is a scalar, which has no selection.
     createEntity(
@@ -16,6 +17,7 @@ export const createEntityMutation = gql`
       properties: $properties
       linkData: $linkData
       draft: $draft
+      relationships: $relationships
     )
   }
 `;

--- a/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
@@ -129,7 +129,8 @@ export const fullTransactionTimeAxis: QueryTemporalAxesUnresolved = {
  * @param [options] configuration of the returned filter
  * @param [options.ignoreParents] don't check the type's parents for a match against the versionedUrl
  * @param [options.pathPrefix] the path to the thing to match the type of, if it's not the root of the query
- *     @example ["outgoingLinks", "rightEntity"] to filter query results to things with a linked entity of the given type
+ *     @example ["outgoingLinks", "rightEntity"] to filter query results to things with a linked entity of the given
+ *   type
  */
 export const generateVersionedUrlMatchingFilter = (
   versionedUrl: VersionedUrl,
@@ -225,6 +226,33 @@ export const createDefaultAuthorizationRelationships = (params: {
     subject: {
       kind: "setting",
       subjectId: "viewFromWeb",
+    },
+  },
+];
+
+export const createOrgMembershipAuthorizationRelationships = ({
+  memberAccountId,
+}: {
+  memberAccountId: AccountId;
+}): EntityRelationAndSubject[] => [
+  {
+    relation: "setting",
+    subject: {
+      kind: "setting",
+      subjectId: "administratorFromWeb", // web admins can edit the link
+    },
+  },
+  {
+    relation: "editor",
+    subject: {
+      kind: "account",
+      subjectId: memberAccountId, // so can the user
+    },
+  },
+  {
+    relation: "viewer",
+    subject: {
+      kind: "public", // everyone in the world can see it (until we allow restricting this)
     },
   },
 ];

--- a/libs/@local/hash-isomorphic-utils/src/graphql/scalar-mapping.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graphql/scalar-mapping.ts
@@ -31,6 +31,7 @@ export const scalars = {
   Entity: "@local/hash-subgraph#Entity",
   EntityRecordId: "@local/hash-subgraph#EntityRecordId",
   EntityMetadata: "@local/hash-subgraph#EntityMetadata",
+  EntityRelationAndSubject: "@local/hash-subgraph#EntityRelationAndSubject",
   EntityStructuralQuery: "@local/hash-graph-client#EntityStructuralQuery",
   EntityTemporalVersioningMetadata:
     "@local/hash-subgraph#EntityTemporalVersioningMetadata",

--- a/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/knowledge/entity.typedef.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/knowledge/entity.typedef.ts
@@ -6,6 +6,7 @@ export const entityTypedef = gql`
   scalar Entity
   scalar EntityPropertiesObject
   scalar EntityMetadata
+  scalar EntityRelationAndSubject
   scalar EntityStructuralQuery
   scalar LinkData
   scalar QueryOperationInput
@@ -204,6 +205,10 @@ export const entityTypedef = gql`
       Whether the created entity should be a draft
       """
       draft: Boolean
+      """
+      Set the permission relations on the entity
+      """
+      relationships: [EntityRelationAndSubject!]
     ): Entity!
 
     """


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR corrects a bug whereby adding an org member via the frontend would set the default permissions on the link between the member and the org, which is incorrect because:
1. The default permissions allow any member of the web (the org in this case) to edit the link, whereas it should be limited to org admins and the member the link refers to
2. The default permissions only permit web members to view the link, whereas org membership should be viewable by people outside the link (until we allow restricting that)

This PR fixes that by exposing the ability to specify custom permission relationships when creating an entity, and shares the org link permissions between the existing `createOrg` function in the backend, and the frontend.

An alternative solution would be to expose a `createOrgMembership` mutation, but since we plan to stop using the Node API as a middleman between the frontend and the Graph API at some point, introducing another mutation would be to increase the migration burden.
<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- Manual

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Log in as `alice@example.com`, create a new org
2. Add `instance-admin` to the org
3. In a separate incognito window, log in as `bob@example.com`
4. Visit `http://localhost:3000/@instance-admin` and confirm that membership of the new org is visible
5. If you remove `instance-admin` from the org, check out `main`, and repeat steps 2-4, the org membership will **not** be visible (the bug)
