### PR TITLE
H-1397: Better logging, error handling in the Node API

### DIFF
--- a/apps/hash-api/src/graphql/create-apollo-server.ts
+++ b/apps/hash-api/src/graphql/create-apollo-server.ts
@@ -99,14 +99,7 @@ export const createApolloServer = ({
             executionDidStart: async ({ request }) => {
               const scope = Sentry.getCurrentScope();
 
-              const user: Express.Request["user"] = ctx.context.user;
-              scope.setUser({
-                id: ctx.context.authentication.actorId,
-                email: user?.emails[0],
-                username: user?.shortname ?? "public",
-              });
-
-              scope.setExtras({
+              scope.setContext("graphql", {
                 query: request.query,
                 variables: request.variables,
               });

--- a/apps/hash-api/src/index.ts
+++ b/apps/hash-api/src/index.ts
@@ -154,6 +154,23 @@ const main = async () => {
   );
   app.use(cors(CORS_CONFIG));
 
+  // Add logging of requests
+  app.use((req, res, next) => {
+    const requestId = nanoid();
+    res.set("x-hash-request-id", requestId);
+    logger.info({
+      requestId,
+      method: req.method,
+      ip: req.ip,
+      path: req.path,
+      message: "request",
+      userAgent: req.headers["user-agent"],
+      graphqlClient: req.headers["apollographql-client-name"],
+    });
+
+    next();
+  });
+
   const redisHost = getRequiredEnv("HASH_REDIS_HOST");
   const redisPort = parseInt(getRequiredEnv("HASH_REDIS_PORT"), 10);
 

--- a/apps/hash-api/src/storage/aws-s3-storage-provider.ts
+++ b/apps/hash-api/src/storage/aws-s3-storage-provider.ts
@@ -116,6 +116,7 @@ export class AwsS3StorageProvider implements UploadableStorageProvider {
         forcePathStyle: fileStorageForcePathStyle,
         region: fileStorageRegion,
       });
+      // eslint-disable-next-line no-console -- temporary debug log
       console.log("Constructed new client");
     }
 

--- a/apps/hash-api/src/storage/aws-s3-storage-provider.ts
+++ b/apps/hash-api/src/storage/aws-s3-storage-provider.ts
@@ -116,6 +116,7 @@ export class AwsS3StorageProvider implements UploadableStorageProvider {
         forcePathStyle: fileStorageForcePathStyle,
         region: fileStorageRegion,
       });
+      console.log("Constructed new client");
     }
 
     const command = new GetObjectCommand({

--- a/apps/hash-api/src/storage/index.ts
+++ b/apps/hash-api/src/storage/index.ts
@@ -211,6 +211,8 @@ export const setupFileDownloadProxyHandler = (
       },
     );
 
+    console.log({ fileEntity });
+
     if (!fileEntity) {
       res.status(404).json({
         error: `Could not find file entity ${entityId} with edition timestamp ${editionTimestamp}, either it does not exist or you do not have permission to access it.`,
@@ -266,6 +268,8 @@ export const setupFileDownloadProxyHandler = (
         }
       }
 
+      console.log({ storageProvider });
+
       presignUrl = await storageProvider.presignDownload({
         entity: fileEntity,
         key: fileStorageKey,
@@ -289,6 +293,8 @@ export const setupFileDownloadProxyHandler = (
         );
       }
     }
+
+    console.log({ presignUrl });
 
     res.redirect(presignUrl);
   });

--- a/apps/hash-api/src/storage/index.ts
+++ b/apps/hash-api/src/storage/index.ts
@@ -211,6 +211,7 @@ export const setupFileDownloadProxyHandler = (
       },
     );
 
+    // eslint-disable-next-line no-console -- temporary debug log
     console.log({ fileEntity });
 
     if (!fileEntity) {
@@ -267,7 +268,7 @@ export const setupFileDownloadProxyHandler = (
           return;
         }
       }
-
+      // eslint-disable-next-line no-console -- temporary debug log
       console.log({ storageProvider });
 
       presignUrl = await storageProvider.presignDownload({
@@ -294,6 +295,7 @@ export const setupFileDownloadProxyHandler = (
       }
     }
 
+    // eslint-disable-next-line no-console -- temporary debug log
     console.log({ presignUrl });
 
     res.redirect(presignUrl);

--- a/infra/terraform/hash/prod-usea1.tfvars
+++ b/infra/terraform/hash/prod-usea1.tfvars
@@ -47,7 +47,7 @@ hash_api_env_vars = [
   { name = "FRONTEND_URL", secret = false, value = "https://app.hash.ai" },
   { name = "API_ORIGIN", secret = false, value = "https://app-api.hash.ai" },
 
-  { name = "LOG_LEVEL", secret = false, value = "debug" },
+  { name = "LOG_LEVEL", secret = false, value = "info" },
 
   { name = "FILE_UPLOAD_PROVIDER", secret = false, value = "AWS_S3" },
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This improves logging and error handling in the API by:
1. Moving the request logging middleware to before the routes it is supposed to apply to, so that it works
2. Similarly moving the Sentry tracing middleware up above the request routes
3. Setting the request context consistently between GraphQL and non-GraphQL requests
4. Clear the scope and breadcrumbs in each request, since otherwise Sentry has breadcrumbs / scope from other requests (this should not be required so there is still something wrong somehow)
5. Add a fallback error handler for non-GraphQL requests
6. Change the Node API's log level in production from `debug` to `info`

It also **adds some temporary debug logs** to try and figure out why file retrieval is not working in production, which I will remove after looking at them. This relates to H-1943.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

1. Scope should not be bleeding across requests in the first place, clearing it might be hiding other issues
2. Non-GraphQL requests get the full headers object added automatically, but GraphQL requests don't get this.

Both of these issues might be solved by using the Sentry ApolloServer integration, once it works for ApolloServers constructed by passing a `schema` argument (it currently does not).

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- Existing / manual

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. With `SENTRY_DSN` set for the Node API, throw an error in both a non-Sentry route (e.g. `/health-check`) and in the GraphQL playground (just pass any bad query)

