### PR TITLE
H-1937: Fix various lifetime issues and start implementing `CustomSorting`

### DIFF
--- a/apps/hash-graph/libs/graph/src/store/crud.rs
+++ b/apps/hash-graph/libs/graph/src/store/crud.rs
@@ -48,21 +48,13 @@ impl<R: Record> Sorting for VertexIdSorting<R> {
     }
 }
 
-#[expect(
-    dead_code,
-    reason = "https://linear.app/hash/issue/H-1440/implement-sorting-for-subgraph-roots"
-)]
 pub struct CustomSorting<'p, R: Record> {
-    keys: Vec<R::QueryPath<'p>>,
-    cursor: Option<CustomCursor>,
+    pub paths: Vec<R::QueryPath<'p>>,
+    pub cursor: Option<CustomCursor>,
 }
 
-#[expect(
-    dead_code,
-    reason = "https://linear.app/hash/issue/H-1440/implement-sorting-for-subgraph-roots"
-)]
 pub struct CustomCursor {
-    values: Vec<serde_json::Value>,
+    pub values: Vec<serde_json::Value>,
 }
 
 impl<R: Record> Sorting for CustomSorting<'_, R> {
@@ -137,7 +129,7 @@ impl<'f, R: Record, S> ReadParameter<'f, R, S> {
             temporal_axes: self.temporal_axes,
             include_drafts: self.include_drafts,
             sorting: Some(CustomSorting {
-                keys: keys.into_iter().collect(),
+                paths: keys.into_iter().collect(),
                 cursor: None,
             }),
             limit: self.limit,

--- a/apps/hash-graph/libs/graph/src/store/postgres/crud.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/crud.rs
@@ -45,7 +45,7 @@ impl<Cl, R, S> ReadPaginated<R, S> for PostgresStore<Cl>
 where
     Cl: AsClient,
     for<'c> R: PostgresRecord<QueryPath<'c>: PostgresQueryPath>,
-    S: PostgresSorting<R> + Sync + 'static,
+    for<'s> S: PostgresSorting<'s, R> + Sync + 'static,
 {
     type QueryResult = Row;
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
@@ -533,9 +533,9 @@ impl PostgresRecord for DataTypeWithMetadata {
 
     fn parameters() -> Self::CompilationParameters {}
 
-    fn compile<'c, 'p: 'c>(
-        compiler: &mut SelectCompiler<'c, Self>,
-        _paths: &'p Self::CompilationParameters,
+    fn compile<'p, 'q: 'p>(
+        compiler: &mut SelectCompiler<'p, 'q, Self>,
+        _paths: &Self::CompilationParameters,
     ) -> Self::CompilationArtifacts {
         DataTypeRowIndices {
             base_url: compiler.add_distinct_selection_with_ordering(

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
@@ -907,9 +907,9 @@ impl PostgresRecord for EntityTypeWithMetadata {
 
     fn parameters() -> Self::CompilationParameters {}
 
-    fn compile<'c, 'p: 'c>(
-        compiler: &mut SelectCompiler<'c, Self>,
-        _paths: &'p Self::CompilationParameters,
+    fn compile<'p, 'q: 'p>(
+        compiler: &mut SelectCompiler<'p, 'q, Self>,
+        _paths: &Self::CompilationParameters,
     ) -> Self::CompilationArtifacts {
         EntityTypeRowIndices {
             base_url: compiler.add_distinct_selection_with_ordering(

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/property_type.rs
@@ -688,9 +688,9 @@ impl PostgresRecord for PropertyTypeWithMetadata {
 
     fn parameters() -> Self::CompilationParameters {}
 
-    fn compile<'c, 'p: 'c>(
-        compiler: &mut SelectCompiler<'c, Self>,
-        _paths: &'p Self::CompilationParameters,
+    fn compile<'p, 'q: 'p>(
+        compiler: &mut SelectCompiler<'p, 'q, Self>,
+        _paths: &Self::CompilationParameters,
     ) -> Self::CompilationArtifacts {
         PropertyTypeRowIndices {
             base_url: compiler.add_distinct_selection_with_ordering(

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/compile.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/compile.rs
@@ -41,16 +41,16 @@ pub struct CompilerArtifacts<'p> {
     uses_cursor: bool,
 }
 
-pub struct SelectCompiler<'p, T: Record> {
+pub struct SelectCompiler<'p, 'q: 'p, T: Record> {
     statement: SelectStatement,
     artifacts: CompilerArtifacts<'p>,
     temporal_axes: Option<&'p QueryTemporalAxes>,
     table_hooks: HashMap<Table, fn(&mut Self, Alias)>,
     selections:
-        HashMap<&'p T::QueryPath<'p>, (AliasedColumn, usize, Distinctness, Option<Ordering>)>,
+        HashMap<&'p T::QueryPath<'q>, (AliasedColumn, usize, Distinctness, Option<Ordering>)>,
 }
 
-impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {
+impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
     /// Creates a new, empty compiler.
     pub fn new(temporal_axes: Option<&'p QueryTemporalAxes>, include_drafts: bool) -> Self {
         let mut table_hooks = HashMap::<_, fn(&mut Self, Alias)>::new();
@@ -260,9 +260,9 @@ impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {
     ///
     /// Optionally, the added selection can be distinct or ordered by providing [`Distinctness`]
     /// and [`Ordering`].
-    pub fn add_selection_path(&mut self, path: &'p R::QueryPath<'p>) -> usize
+    pub fn add_selection_path(&mut self, path: &'p R::QueryPath<'q>) -> usize
     where
-        R::QueryPath<'p>: PostgresQueryPath,
+        R::QueryPath<'q>: PostgresQueryPath,
     {
         self.add_distinct_selection_with_ordering(path, Distinctness::Indistinct, None)
     }
@@ -273,12 +273,12 @@ impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {
     /// and [`Ordering`].
     pub fn add_distinct_selection_with_ordering(
         &mut self,
-        path: &'p R::QueryPath<'p>,
+        path: &'p R::QueryPath<'q>,
         distinctness: Distinctness,
         ordering: Option<Ordering>,
     ) -> usize
     where
-        R::QueryPath<'p>: PostgresQueryPath,
+        R::QueryPath<'q>: PostgresQueryPath,
     {
         if let Some((column, index, stored_distinctness, stored_ordering)) =
             self.selections.get_mut(path)
@@ -319,13 +319,13 @@ impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {
     /// Adds a new path to the selection which can be used as cursor.
     pub fn add_cursor_selection(
         &mut self,
-        path: &'p R::QueryPath<'p>,
+        path: &'p R::QueryPath<'q>,
         lhs: impl FnOnce(Expression) -> Expression,
         rhs: Expression,
         ordering: Ordering,
     ) -> usize
     where
-        R::QueryPath<'p>: PostgresQueryPath,
+        R::QueryPath<'q>: PostgresQueryPath,
     {
         let column = self.compile_path_column(path);
         self.statement
@@ -336,9 +336,9 @@ impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {
     }
 
     /// Adds a new filter to the selection.
-    pub fn add_filter<'f: 'p>(&mut self, filter: &'p Filter<'f, R>)
+    pub fn add_filter(&mut self, filter: &'p Filter<'q, R>)
     where
-        R::QueryPath<'f>: PostgresQueryPath,
+        R::QueryPath<'q>: PostgresQueryPath,
     {
         let condition = self.compile_filter(filter);
         self.artifacts.condition_index += 1;
@@ -355,9 +355,9 @@ impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {
 
     /// Compiles a [`Filter`] to a `Condition`.
     #[expect(clippy::too_many_lines)]
-    pub fn compile_filter<'f: 'p>(&mut self, filter: &'p Filter<'f, R>) -> Condition
+    pub fn compile_filter(&mut self, filter: &'p Filter<'q, R>) -> Condition
     where
-        R::QueryPath<'f>: PostgresQueryPath,
+        R::QueryPath<'q>: PostgresQueryPath,
     {
         if let Some(condition) = self.compile_special_filter(filter) {
             return condition;
@@ -553,7 +553,7 @@ impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {
     //          statement to ensure compatibility
     // TODO: Remove CTE to allow limit or cursor selection
     //   see https://linear.app/hash/issue/H-1442
-    fn compile_latest_ontology_version_filter<'q>(
+    fn compile_latest_ontology_version_filter(
         &mut self,
         path: &R::QueryPath<'q>,
         operator: EqualityOperator,
@@ -624,9 +624,9 @@ impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {
     ///
     /// The following [`Filter`]s will be special cased:
     /// - Comparing the `"version"` field on [`Table::OntologyIds`] with `"latest"` for equality.
-    fn compile_special_filter<'f: 'p>(&mut self, filter: &Filter<'f, R>) -> Option<Condition>
+    fn compile_special_filter(&mut self, filter: &'p Filter<'q, R>) -> Option<Condition>
     where
-        R::QueryPath<'f>: PostgresQueryPath,
+        R::QueryPath<'q>: PostgresQueryPath,
     {
         match filter {
             Filter::Equal(lhs, rhs) | Filter::NotEqual(lhs, rhs) => match (lhs, rhs) {
@@ -660,7 +660,7 @@ impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {
         }
     }
 
-    pub fn compile_path_column<'q>(&mut self, path: &'p R::QueryPath<'q>) -> AliasedColumn
+    pub fn compile_path_column(&mut self, path: &'p R::QueryPath<'q>) -> AliasedColumn
     where
         R::QueryPath<'q>: PostgresQueryPath,
     {
@@ -730,12 +730,12 @@ impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {
         )
     }
 
-    pub fn compile_filter_expression<'f: 'p>(
+    pub fn compile_filter_expression(
         &mut self,
-        expression: &'p FilterExpression<'f, R>,
+        expression: &'p FilterExpression<'q, R>,
     ) -> (Expression, ParameterType)
     where
-        R::QueryPath<'f>: PostgresQueryPath,
+        R::QueryPath<'q>: PostgresQueryPath,
     {
         match expression {
             FilterExpression::Path(path) => {
@@ -769,7 +769,7 @@ impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {
     /// compiled, each subsequent call will result in a new join-chain.
     ///
     /// [`Relation`]: super::table::Relation
-    fn add_join_statements<'q>(&mut self, path: &R::QueryPath<'q>) -> Alias
+    fn add_join_statements(&mut self, path: &R::QueryPath<'q>) -> Alias
     where
         R::QueryPath<'q>: PostgresQueryPath,
     {

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/statement/select.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/statement/select.rs
@@ -114,8 +114,8 @@ mod tests {
         },
     };
 
-    fn test_compilation<'p, T: PostgresRecord + 'static>(
-        compiler: &SelectCompiler<'p, T>,
+    fn test_compilation<'p, 'q: 'p, T: PostgresRecord + 'static>(
+        compiler: &SelectCompiler<'p, 'q, T>,
         expected_statement: &'static str,
         expected_parameters: &[&'p dyn ToSql],
     ) {

--- a/apps/hash-graph/libs/graph/src/store/query/filter.rs
+++ b/apps/hash-graph/libs/graph/src/store/query/filter.rs
@@ -204,8 +204,78 @@ pub enum ParameterList<'p> {
     Uuid(&'p [Uuid]),
 }
 
-impl Parameter<'_> {
-    fn to_owned(&self) -> Parameter<'static> {
+impl<'p> Parameter<'p> {
+    /// Creates a `Parameter` from a JSON value.
+    ///
+    /// # Errors
+    ///
+    /// - Returns [`ParameterConversionError`] if conversion fails.
+    pub fn from_value(
+        value: &'p serde_json::Value,
+        ty: ParameterType,
+    ) -> Result<Self, ParameterConversionError> {
+        match ty {
+            ParameterType::Boolean => {
+                value
+                    .as_bool()
+                    .map(Parameter::Boolean)
+                    .ok_or_else(|| ParameterConversionError {
+                        actual: ActualParameterType::Value(value.clone()),
+                        expected: ty,
+                    })
+            }
+            ParameterType::I32 => value
+                .as_i64()
+                .and_then(|number| Some(Parameter::I32(number.try_into().ok()?)))
+                .ok_or_else(|| ParameterConversionError {
+                    actual: ActualParameterType::Value(value.clone()),
+                    expected: ty,
+                }),
+            ParameterType::F64 => {
+                value
+                    .as_f64()
+                    .map(Parameter::F64)
+                    .ok_or_else(|| ParameterConversionError {
+                        actual: ActualParameterType::Value(value.clone()),
+                        expected: ty,
+                    })
+            }
+            ParameterType::OntologyTypeVersion => value
+                .as_i64()
+                .and_then(|number| {
+                    Some(Parameter::OntologyTypeVersion(OntologyTypeVersion::new(
+                        number.try_into().ok()?,
+                    )))
+                })
+                .ok_or_else(|| ParameterConversionError {
+                    actual: ActualParameterType::Value(value.clone()),
+                    expected: ty,
+                }),
+            ParameterType::Text | ParameterType::BaseUrl | ParameterType::VersionedUrl => value
+                .as_str()
+                .map(|text| Parameter::Text(Cow::Borrowed(text)))
+                .ok_or_else(|| ParameterConversionError {
+                    actual: ActualParameterType::Value(value.clone()),
+                    expected: ty,
+                }),
+            ParameterType::Vector => todo!("Converting vectors is not yet supported"),
+            ParameterType::Uuid => value
+                .as_str()
+                .and_then(|text| Uuid::from_str(text).ok())
+                .map(Parameter::Uuid)
+                .ok_or_else(|| ParameterConversionError {
+                    actual: ActualParameterType::Value(value.clone()),
+                    expected: ty,
+                }),
+            ParameterType::TimeInterval => todo!("Converting time intervals is not yet supported"),
+            ParameterType::Timestamp => todo!("Converting timestamps is not yet supported"),
+            ParameterType::Object => todo!("Converting objects is not yet supported"),
+            ParameterType::Any => Ok(Parameter::Any(value.clone())),
+        }
+    }
+
+    #[must_use]
+    pub fn to_owned(&self) -> Parameter<'static> {
         match self {
             Parameter::Boolean(bool) => Parameter::Boolean(*bool),
             Parameter::I32(number) => Parameter::I32(*number),
@@ -221,30 +291,58 @@ impl Parameter<'_> {
 }
 
 #[derive(Debug)]
+enum ActualParameterType {
+    Parameter(Parameter<'static>),
+    Value(serde_json::Value),
+}
+
+impl From<Parameter<'static>> for ActualParameterType {
+    fn from(value: Parameter<'static>) -> Self {
+        Self::Parameter(value)
+    }
+}
+
+impl From<serde_json::Value> for ActualParameterType {
+    fn from(value: serde_json::Value) -> Self {
+        Self::Value(value)
+    }
+}
+
+#[derive(Debug)]
 #[must_use]
 pub struct ParameterConversionError {
-    actual: Parameter<'static>,
+    actual: ActualParameterType,
     expected: ParameterType,
 }
 
 impl fmt::Display for ParameterConversionError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         let actual = match &self.actual {
-            Parameter::Any(Value::Null) => "null".to_owned(),
-            Parameter::Boolean(boolean) | Parameter::Any(Value::Bool(boolean)) => {
-                boolean.to_string()
-            }
-            Parameter::I32(number) => number.to_string(),
-            Parameter::F64(number) => number.to_string(),
-            Parameter::Any(Value::Number(number)) => number.to_string(),
-            Parameter::Text(text) => text.to_string(),
-            Parameter::Vector(_) => "vector".to_owned(),
-            Parameter::Any(Value::String(string)) => string.clone(),
-            Parameter::Uuid(uuid) => uuid.to_string(),
-            Parameter::OntologyTypeVersion(version) => version.inner().to_string(),
-            Parameter::Timestamp(timestamp) => timestamp.to_string(),
-            Parameter::Any(Value::Object(_)) => "object".to_owned(),
-            Parameter::Any(Value::Array(_)) => "array".to_owned(),
+            ActualParameterType::Parameter(parameter) => match parameter {
+                Parameter::Any(Value::Null) => "null".to_owned(),
+                Parameter::Boolean(boolean) | Parameter::Any(Value::Bool(boolean)) => {
+                    boolean.to_string()
+                }
+                Parameter::I32(number) => number.to_string(),
+                Parameter::F64(number) => number.to_string(),
+                Parameter::Any(Value::Number(number)) => number.to_string(),
+                Parameter::Text(text) => text.to_string(),
+                Parameter::Vector(_) => "vector".to_owned(),
+                Parameter::Any(Value::String(string)) => string.clone(),
+                Parameter::Uuid(uuid) => uuid.to_string(),
+                Parameter::OntologyTypeVersion(version) => version.inner().to_string(),
+                Parameter::Timestamp(timestamp) => timestamp.to_string(),
+                Parameter::Any(Value::Object(_)) => "object".to_owned(),
+                Parameter::Any(Value::Array(_)) => "array".to_owned(),
+            },
+            ActualParameterType::Value(value) => match value {
+                Value::Null => "null".to_owned(),
+                Value::Bool(boolean) => boolean.to_string(),
+                Value::Number(number) => number.to_string(),
+                Value::String(string) => string.clone(),
+                Value::Array(_) => "array".to_owned(),
+                Value::Object(_) => "object".to_owned(),
+            },
         };
 
         write!(fmt, "could not convert {actual} to {}", self.expected)
@@ -287,13 +385,13 @@ impl Parameter<'_> {
             (Parameter::Any(Value::Number(number)), ParameterType::I32) => {
                 let number = number.as_i64().ok_or_else(|| {
                     Report::new(ParameterConversionError {
-                        actual: self.to_owned(),
+                        actual: self.to_owned().into(),
                         expected,
                     })
                 })?;
                 *self = Parameter::I32(i32::try_from(number).change_context_lazy(|| {
                     ParameterConversionError {
-                        actual: self.to_owned(),
+                        actual: self.to_owned().into(),
                         expected: ParameterType::OntologyTypeVersion,
                     }
                 })?);
@@ -301,7 +399,7 @@ impl Parameter<'_> {
             (Parameter::I32(number), ParameterType::OntologyTypeVersion) => {
                 *self = Parameter::OntologyTypeVersion(OntologyTypeVersion::new(
                     u32::try_from(*number).change_context_lazy(|| ParameterConversionError {
-                        actual: self.to_owned(),
+                        actual: self.to_owned().into(),
                         expected: ParameterType::OntologyTypeVersion,
                     })?,
                 ));
@@ -315,7 +413,7 @@ impl Parameter<'_> {
                 *self = Parameter::Any(Value::Number(Number::from_f64(*number).ok_or_else(
                     || {
                         Report::new(ParameterConversionError {
-                            actual: self.to_owned(),
+                            actual: self.to_owned().into(),
                             expected,
                         })
                     },
@@ -324,7 +422,7 @@ impl Parameter<'_> {
             (Parameter::Any(Value::Number(number)), ParameterType::F64) => {
                 *self = Parameter::F64(number.as_f64().ok_or_else(|| {
                     Report::new(ParameterConversionError {
-                        actual: self.to_owned(),
+                        actual: self.to_owned().into(),
                         expected,
                     })
                 })?);
@@ -348,7 +446,7 @@ impl Parameter<'_> {
             (Parameter::Text(text), ParameterType::Uuid) => {
                 *self = Parameter::Uuid(Uuid::from_str(&*text).change_context_lazy(|| {
                     ParameterConversionError {
-                        actual: self.to_owned(),
+                        actual: self.to_owned().into(),
                         expected: ParameterType::Uuid,
                     }
                 })?);
@@ -363,7 +461,7 @@ impl Parameter<'_> {
                             Number::from_f64(f64::from(value))
                                 .ok_or_else(|| {
                                     Report::new(ParameterConversionError {
-                                        actual: Parameter::Vector(vector.to_owned()),
+                                        actual: Parameter::Vector(vector.to_owned()).into(),
                                         expected,
                                     })
                                 })
@@ -385,7 +483,7 @@ impl Parameter<'_> {
                                 .as_f64()
                                 .ok_or_else(|| {
                                     Report::new(ParameterConversionError {
-                                        actual: self.to_owned(),
+                                        actual: self.to_owned().into(),
                                         expected,
                                     })
                                 })
@@ -398,7 +496,7 @@ impl Parameter<'_> {
             // Fallback
             (actual, expected) => {
                 bail!(ParameterConversionError {
-                    actual: actual.to_owned(),
+                    actual: actual.to_owned().into(),
                     expected
                 });
             }

--- a/apps/hash-graph/libs/graph/src/store/query/filter.rs
+++ b/apps/hash-graph/libs/graph/src/store/query/filter.rs
@@ -210,6 +210,10 @@ impl<'p> Parameter<'p> {
     /// # Errors
     ///
     /// - Returns [`ParameterConversionError`] if conversion fails.
+    #[expect(
+        clippy::todo,
+        reason = "https://linear.app/hash/issue/H-2005/allow-reading-arbitrary-values-from-postgres"
+    )]
     pub fn from_value(
         value: &'p serde_json::Value,
         ty: ParameterType,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Generically passing custom paths to the query compiler came with various issues. The `CustomSorting` struct is supposed to do exactly this, so this was an issue. This PR solves various lifetime errors to allow passing `QueryPath<'static>` to the `SelectCompiler`. 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- It's currently not possible to pass a generic `CustomSorting<'s, R: Record>` to the `ReadPaginated` trait. Using `'s` instead of `'static` implies some errors about the struct not being generic enough and using `R` instead of `Entity` came with various other lifetime issues. For the initial use case, `CustomSorting<'static, Entity>` is enough, but this suggest various other issues in the query logic itself, mainly because it grew over time and all different features/components greatly increased in complexity
- It's not yet possible to load a custom cursor from Postgres as `serde_json::Value` is not a type which can be used for that. This is subject to a follow-up PR.

## 🐾 Next steps

- H-2005

## 🛡 What tests cover this?

No runtime tests were added but the implementation of `CustomSorting` covered many compile time tests around lifetimes and trait implementations.