### PR TITLE
H-2074: Use turbo version from `package.json` in CI

### DIFF
--- a/.github/actions/install-turbo/action.yml
+++ b/.github/actions/install-turbo/action.yml
@@ -1,0 +1,9 @@
+name: Install turbo
+description: "Installs `turbo` as specified in `package.json`"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install turbo
+      shell: bash
+      run: yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"

--- a/.github/actions/prune-repository/action.yml
+++ b/.github/actions/prune-repository/action.yml
@@ -9,8 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: Install turbo
-      shell: bash
-      run: yarn global add turbo
+      uses: ./.github/actions/install-turbo
 
     - name: Prune repository
       shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 2
 
       - name: Install turbo
-        run: yarn global add turbo
+        uses: ./.github/actions/install-turbo
 
       - name: Determine changed packages
         id: packages
@@ -56,7 +56,7 @@ jobs:
           fetch-depth: 2
 
       - name: Install turbo
-        run: yarn global add turbo
+        uses: ./.github/actions/install-turbo
 
       - name: Find lint steps to run
         id: lints

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 2
 
       - name: Install turbo
-        run: yarn global add turbo
+        uses: ./.github/actions/install-turbo
 
       - name: Determine changed packages
         id: packages
@@ -128,7 +128,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Install turbo
-        run: yarn global add turbo
+        uses: ./.github/actions/install-turbo
 
       - name: Find test steps to run
         id: tests
@@ -242,7 +242,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Install turbo
-        run: yarn global add turbo
+        uses: ./.github/actions/install-turbo
 
       - name: Prune repository
         uses: ./.github/actions/prune-repository
@@ -382,7 +382,7 @@ jobs:
         run: mkdir -p var/logs
 
       - name: Install turbo
-        run: yarn global add turbo
+        uses: ./.github/actions/install-turbo
 
       - name: Find test steps to run
         id: tests

--- a/apps/hash-ai-worker-ts/docker/Dockerfile
+++ b/apps/hash-ai-worker-ts/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM node:18.15-slim AS base
 WORKDIR /app
 
 COPY package.json .
-RUN yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"
+RUN apk add --no-cache jq && yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"
 COPY . .
 RUN turbo prune --scope='@apps/hash-ai-worker-ts' --docker
 

--- a/apps/hash-ai-worker-ts/docker/Dockerfile
+++ b/apps/hash-ai-worker-ts/docker/Dockerfile
@@ -3,7 +3,10 @@ FROM node:18.15-slim AS base
 WORKDIR /app
 
 COPY package.json .
-RUN apk add --no-cache jq && yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends jq && \
+    rm -rf /var/lib/apt/lists/* && \
+    yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"
 COPY . .
 RUN turbo prune --scope='@apps/hash-ai-worker-ts' --docker
 

--- a/apps/hash-ai-worker-ts/docker/Dockerfile
+++ b/apps/hash-ai-worker-ts/docker/Dockerfile
@@ -2,7 +2,8 @@ FROM node:18.15-slim AS base
 
 WORKDIR /app
 
-RUN yarn global add turbo
+COPY package.json .
+RUN yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"
 COPY . .
 RUN turbo prune --scope='@apps/hash-ai-worker-ts' --docker
 

--- a/apps/hash-frontend/vercel-install.sh
+++ b/apps/hash-frontend/vercel-install.sh
@@ -25,7 +25,7 @@ curl https://zyedidia.github.io/eget.sh | sh
 # Setup TurboRepo and get a pruned src folder and lockfile
 
 echo "Installing turbo"
-yarn global add turbo
+yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"
 
 # TODO: investigate why producing a pruned repo results in a broken Vercel build
 #   update: Probably due to missing `patches/` folder, needs investigation

--- a/apps/hash-graph/docker/Dockerfile
+++ b/apps/hash-graph/docker/Dockerfile
@@ -4,7 +4,8 @@ FROM node:20-alpine3.18 AS base
 
 WORKDIR /app
 
-RUN yarn global add turbo && apk add --no-cache yq
+COPY package.json .
+RUN yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)" && apk add --no-cache yq
 COPY . .
 # `turbo prune` does not include Cargo workspaces, so we create dummy projects for each workspace member
 RUN turbo prune --scope='@apps/hash-graph' --docker && \

--- a/apps/hash-graph/docker/Dockerfile
+++ b/apps/hash-graph/docker/Dockerfile
@@ -5,7 +5,7 @@ FROM node:20-alpine3.18 AS base
 WORKDIR /app
 
 COPY package.json .
-RUN yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)" && apk add --no-cache yq
+RUN apk add --no-cache jq yq && yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"
 COPY . .
 # `turbo prune` does not include Cargo workspaces, so we create dummy projects for each workspace member
 RUN turbo prune --scope='@apps/hash-graph' --docker && \

--- a/apps/hash-integration-worker/docker/Dockerfile
+++ b/apps/hash-integration-worker/docker/Dockerfile
@@ -2,7 +2,8 @@ FROM node:18.15-slim AS base
 
 WORKDIR /app
 
-RUN yarn global add turbo
+COPY package.json .
+RUN yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"
 COPY . .
 RUN turbo prune --scope='@apps/hash-integration-worker' --docker
 

--- a/apps/hash-integration-worker/docker/Dockerfile
+++ b/apps/hash-integration-worker/docker/Dockerfile
@@ -3,7 +3,10 @@ FROM node:18.15-slim AS base
 WORKDIR /app
 
 COPY package.json .
-RUN apk add --no-cache jq && yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends jq && \
+    rm -rf /var/lib/apt/lists/* && \
+    yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"
 COPY . .
 RUN turbo prune --scope='@apps/hash-integration-worker' --docker
 

--- a/apps/hash-integration-worker/docker/Dockerfile
+++ b/apps/hash-integration-worker/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM node:18.15-slim AS base
 WORKDIR /app
 
 COPY package.json .
-RUN yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"
+RUN apk add --no-cache jq && yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"
 COPY . .
 RUN turbo prune --scope='@apps/hash-integration-worker' --docker
 

--- a/infra/docker/api/prod/Dockerfile
+++ b/infra/docker/api/prod/Dockerfile
@@ -2,7 +2,8 @@ FROM node:18.15-alpine AS builder
 
 WORKDIR /app
 
-RUN yarn global add turbo
+COPY package.json .
+RUN yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"
 COPY . .
 RUN turbo prune --scope='@apps/hash-api' --docker
 # Turbo isn't aware of our patches by default (it would be if we use Yarn 2+ or pnpm).

--- a/infra/docker/api/prod/Dockerfile
+++ b/infra/docker/api/prod/Dockerfile
@@ -3,7 +3,7 @@ FROM node:18.15-alpine AS builder
 WORKDIR /app
 
 COPY package.json .
-RUN yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"
+RUN apk add --no-cache jq && yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"
 COPY . .
 RUN turbo prune --scope='@apps/hash-api' --docker
 # Turbo isn't aware of our patches by default (it would be if we use Yarn 2+ or pnpm).

--- a/infra/docker/frontend/prod/Dockerfile
+++ b/infra/docker/frontend/prod/Dockerfile
@@ -3,7 +3,7 @@ FROM node:18.15-alpine AS builder
 WORKDIR /app
 
 COPY package.json .
-RUN yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"
+RUN apk add --no-cache jq && yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"
 COPY . .
 RUN turbo prune --scope='@apps/hash-frontend' --docker
 # Turbo isn't aware of our patches by default (it would be if we use Yarn 2+ or pnpm).

--- a/infra/docker/frontend/prod/Dockerfile
+++ b/infra/docker/frontend/prod/Dockerfile
@@ -2,7 +2,8 @@ FROM node:18.15-alpine AS builder
 
 WORKDIR /app
 
-RUN yarn global add turbo
+COPY package.json .
+RUN yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"
 COPY . .
 RUN turbo prune --scope='@apps/hash-frontend' --docker
 # Turbo isn't aware of our patches by default (it would be if we use Yarn 2+ or pnpm).


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The current CI fails because `turbo@1.12` behaves differently from `turbo@1.11`. This changes the CI to use the same version as specified in `package.json` so we can pin the version.