### PR TITLE
H-2042: Add code ownership for Postgres migrations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,6 @@
 LICENSE @hashintel/legal
 LICENSE.txt @hashintel/legal
 LICENSE.md @hashintel/legal
+
+# Database migrations
+/apps/hash-graph/postgres_migrations/ @hashintel/db-admins


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We formerly had this: https://github.com/hashintel/hash/pull/2112