### PR TITLE
H-1886: Store embeddings in snapshot

### DIFF
--- a/apps/hash-graph/libs/graph/src/knowledge/query.rs
+++ b/apps/hash-graph/libs/graph/src/knowledge/query.rs
@@ -13,7 +13,7 @@ use crate::{
     ontology::{EntityTypeQueryPath, EntityTypeQueryPathVisitor},
     store::{
         query::{parse_query_token, JsonPath, ParameterType, PathToken, QueryPath},
-        Record,
+        QueryRecord, SubgraphRecord,
     },
     subgraph::{
         edges::{EdgeDirection, KnowledgeGraphEdgeKind, SharedEdgeKind},
@@ -738,8 +738,11 @@ impl<'de: 'p, 'p> EntityQueryPath<'p> {
     }
 }
 
-impl Record for Entity {
+impl QueryRecord for Entity {
     type QueryPath<'p> = EntityQueryPath<'p>;
+}
+
+impl SubgraphRecord for Entity {
     type VertexId = EntityVertexId;
 
     #[must_use]

--- a/apps/hash-graph/libs/graph/src/knowledge/query.rs
+++ b/apps/hash-graph/libs/graph/src/knowledge/query.rs
@@ -387,7 +387,7 @@ pub enum EntityQueryPath<'p> {
     /// # use serde_json::json;
     /// # use graph::knowledge::EntityQueryPath;
     /// let path = EntityQueryPath::deserialize(json!(["embedding"]))?;
-    /// assert_eq!(path, EntityQueryPath::Embedding,);
+    /// assert_eq!(path, EntityQueryPath::Embedding);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     Embedding,

--- a/apps/hash-graph/libs/graph/src/ontology/mod.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/mod.rs
@@ -24,7 +24,7 @@ pub use self::{
     property_type::{PropertyTypeQueryPath, PropertyTypeQueryPathVisitor, PropertyTypeQueryToken},
 };
 use crate::{
-    store::Record,
+    store::{QueryRecord, SubgraphRecord},
     subgraph::identifier::{DataTypeVertexId, EntityTypeVertexId, PropertyTypeVertexId},
 };
 
@@ -85,8 +85,11 @@ where
     serde_json::from_value(value).change_context(PatchAndParseError)
 }
 
-impl Record for DataTypeWithMetadata {
+impl QueryRecord for DataTypeWithMetadata {
     type QueryPath<'p> = DataTypeQueryPath<'p>;
+}
+
+impl SubgraphRecord for DataTypeWithMetadata {
     type VertexId = DataTypeVertexId;
 
     #[must_use]
@@ -99,8 +102,11 @@ impl Record for DataTypeWithMetadata {
     }
 }
 
-impl Record for PropertyTypeWithMetadata {
+impl QueryRecord for PropertyTypeWithMetadata {
     type QueryPath<'p> = PropertyTypeQueryPath<'p>;
+}
+
+impl SubgraphRecord for PropertyTypeWithMetadata {
     type VertexId = PropertyTypeVertexId;
 
     #[must_use]
@@ -113,8 +119,11 @@ impl Record for PropertyTypeWithMetadata {
     }
 }
 
-impl Record for EntityTypeWithMetadata {
+impl QueryRecord for EntityTypeWithMetadata {
     type QueryPath<'p> = EntityTypeQueryPath<'p>;
+}
+
+impl SubgraphRecord for EntityTypeWithMetadata {
     type VertexId = EntityTypeVertexId;
 
     #[must_use]

--- a/apps/hash-graph/libs/graph/src/snapshot/entity/channel.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/entity/channel.rs
@@ -6,7 +6,7 @@ use std::{
 use authorization::schema::EntityRelationAndSubject;
 use error_stack::{Report, ResultExt};
 use futures::{
-    channel::mpsc::{self, Sender},
+    channel::mpsc::{self, Receiver, Sender},
     stream::{select_all, BoxStream, SelectAll},
     Sink, SinkExt, Stream, StreamExt,
 };
@@ -14,7 +14,7 @@ use graph_types::{knowledge::entity::EntityUuid, ontology::OntologyTypeVersion};
 
 use crate::snapshot::{
     entity::{
-        record::EntityRelationRecord, EntityEditionRow, EntityIdRow, EntityLinkEdgeRow,
+        table::EntityEmbeddingRow, EntityEditionRow, EntityIdRow, EntityLinkEdgeRow,
         EntityRowBatch, EntityTemporalMetadataRow,
     },
     EntitySnapshotRecord, SnapshotRestoreError,
@@ -154,51 +154,6 @@ impl Sink<EntitySnapshotRecord> for EntitySender {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct EntityRelationSender {
-    relations: Sender<(EntityUuid, EntityRelationAndSubject)>,
-}
-
-impl Sink<EntityRelationRecord> for EntityRelationSender {
-    type Error = Report<SnapshotRestoreError>;
-
-    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        ready!(self.relations.poll_ready_unpin(cx))
-            .change_context(SnapshotRestoreError::Read)
-            .attach_printable("could not poll entity relations sender")?;
-
-        Poll::Ready(Ok(()))
-    }
-
-    fn start_send(
-        mut self: Pin<&mut Self>,
-        record: EntityRelationRecord,
-    ) -> Result<(), Self::Error> {
-        self.relations
-            .start_send_unpin((record.entity_uuid, record.relation))
-            .change_context(SnapshotRestoreError::Read)
-            .attach_printable("could not send entity relations")?;
-
-        Ok(())
-    }
-
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        ready!(self.relations.poll_flush_unpin(cx))
-            .change_context(SnapshotRestoreError::Read)
-            .attach_printable("could not flush entity relations sender")?;
-
-        Poll::Ready(Ok(()))
-    }
-
-    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        ready!(self.relations.poll_close_unpin(cx))
-            .change_context(SnapshotRestoreError::Read)
-            .attach_printable("could not close entity relations sender")?;
-
-        Poll::Ready(Ok(()))
-    }
-}
-
 /// A stream to emit [`EntityRowBatch`]es.
 ///
 /// An [`EntitySender`] with the corresponding `EntityReceiver` are created using the [`channel`]
@@ -221,12 +176,15 @@ impl Stream for EntityReceiver {
 ///
 /// The `chunk_size` parameter determines the number of rows that are sent in a single
 /// [`EntityRowBatch`].
-pub fn channel(chunk_size: usize) -> (EntitySender, EntityRelationSender, EntityReceiver) {
+pub fn channel(
+    chunk_size: usize,
+    relation_rx: Receiver<(EntityUuid, EntityRelationAndSubject)>,
+    embedding_rx: Receiver<EntityEmbeddingRow>,
+) -> (EntitySender, EntityReceiver) {
     let (id_tx, id_rx) = mpsc::channel(chunk_size);
     let (edition_tx, edition_rx) = mpsc::channel(chunk_size);
     let (temporal_metadata_tx, temporal_metadata_rx) = mpsc::channel(chunk_size);
     let (left_entity_tx, left_entity_rx) = mpsc::channel(chunk_size);
-    let (relation_tx, relation_rx) = mpsc::channel(chunk_size);
 
     (
         EntitySender {
@@ -234,9 +192,6 @@ pub fn channel(chunk_size: usize) -> (EntitySender, EntityRelationSender, Entity
             edition: edition_tx,
             temporal_metadata: temporal_metadata_tx,
             links: left_entity_tx,
-        },
-        EntityRelationSender {
-            relations: relation_tx,
         },
         EntityReceiver {
             stream: select_all([
@@ -259,6 +214,10 @@ pub fn channel(chunk_size: usize) -> (EntitySender, EntityRelationSender, Entity
                 relation_rx
                     .ready_chunks(chunk_size)
                     .map(EntityRowBatch::Relations)
+                    .boxed(),
+                embedding_rx
+                    .ready_chunks(chunk_size)
+                    .map(EntityRowBatch::Embeddings)
                     .boxed(),
             ]),
         },

--- a/apps/hash-graph/libs/graph/src/snapshot/entity/mod.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/entity/mod.rs
@@ -5,7 +5,10 @@ mod table;
 
 pub use self::{
     batch::EntityRowBatch,
-    channel::{channel, EntityReceiver, EntityRelationSender, EntitySender},
-    record::{EntityRelationRecord, EntitySnapshotRecord},
-    table::{EntityEditionRow, EntityIdRow, EntityLinkEdgeRow, EntityTemporalMetadataRow},
+    channel::{channel, EntityReceiver, EntitySender},
+    record::{EntityEmbeddingRecord, EntityRelationRecord, EntitySnapshotRecord},
+    table::{
+        EntityEditionRow, EntityEmbeddingRow, EntityIdRow, EntityLinkEdgeRow,
+        EntityTemporalMetadataRow,
+    },
 };

--- a/apps/hash-graph/libs/graph/src/snapshot/entity/record.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/entity/record.rs
@@ -1,9 +1,14 @@
 use authorization::schema::EntityRelationAndSubject;
-use graph_types::knowledge::{
-    entity::{EntityMetadata, EntityProperties, EntityUuid},
-    link::LinkData,
+use graph_types::{
+    knowledge::{
+        entity::{EntityId, EntityMetadata, EntityProperties, EntityUuid},
+        link::LinkData,
+    },
+    Embedding,
 };
 use serde::{Deserialize, Serialize};
+use temporal_versioning::{DecisionTime, Timestamp, TransactionTime};
+use type_system::url::BaseUrl;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -19,4 +24,14 @@ pub struct EntitySnapshotRecord {
 pub struct EntityRelationRecord {
     pub entity_uuid: EntityUuid,
     pub relation: EntityRelationAndSubject,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityEmbeddingRecord {
+    pub entity_id: EntityId,
+    pub embedding: Embedding<'static>,
+    pub property: Option<BaseUrl>,
+    pub updated_at_transaction_time: Timestamp<TransactionTime>,
+    pub updated_at_decision_time: Timestamp<DecisionTime>,
 }

--- a/apps/hash-graph/libs/graph/src/snapshot/entity/table.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/entity/table.rs
@@ -6,6 +6,7 @@ use graph_types::{
     },
     ontology::OntologyTypeVersion,
     owned_by_id::OwnedById,
+    Embedding,
 };
 use postgres_types::ToSql;
 use temporal_versioning::{DecisionTime, LeftClosedTemporalInterval, Timestamp, TransactionTime};
@@ -53,4 +54,15 @@ pub struct EntityLinkEdgeRow {
     pub left_entity_uuid: EntityUuid,
     pub right_web_id: OwnedById,
     pub right_entity_uuid: EntityUuid,
+}
+
+#[derive(Debug, ToSql)]
+#[postgres(name = "entity_embeddings_tmp")]
+pub struct EntityEmbeddingRow {
+    pub web_id: OwnedById,
+    pub entity_uuid: EntityUuid,
+    pub property: Option<String>,
+    pub embedding: Embedding<'static>,
+    pub updated_at_transaction_time: Timestamp<TransactionTime>,
+    pub updated_at_decision_time: Timestamp<DecisionTime>,
 }

--- a/apps/hash-graph/libs/graph/src/snapshot/mod.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/mod.rs
@@ -39,7 +39,7 @@ use futures::{
 };
 use graph_types::{
     account::{AccountGroupId, AccountId},
-    knowledge::entity::{Entity, EntityUuid},
+    knowledge::entity::{Entity, EntityId, EntityUuid},
     ontology::{DataTypeWithMetadata, EntityTypeWithMetadata, PropertyTypeWithMetadata},
     owned_by_id::OwnedById,
 };
@@ -51,10 +51,13 @@ use tokio_postgres::{
     tls::{MakeTlsConnect, TlsConnect},
     Socket,
 };
-use type_system::url::VersionedUrl;
+use type_system::url::{BaseUrl, VersionedUrl};
 
 use crate::{
-    snapshot::{entity::EntitySnapshotRecord, restore::SnapshotRecordBatch},
+    snapshot::{
+        entity::{EntityEmbeddingRecord, EntitySnapshotRecord},
+        restore::SnapshotRecordBatch,
+    },
     store::{
         crud::Read, query::Filter, AsClient, InsertionError, PostgresStore, PostgresStorePool,
         QueryRecord, StorePool,
@@ -100,6 +103,7 @@ pub enum SnapshotEntry {
     PropertyType(PropertyTypeSnapshotRecord),
     EntityType(EntityTypeSnapshotRecord),
     Entity(EntitySnapshotRecord),
+    EntityEmbedding(EntityEmbeddingRecord),
     Relation(AuthorizationRelation),
 }
 
@@ -171,6 +175,18 @@ impl SnapshotEntry {
                 if context.alternate() {
                     if let Ok(json) = serde_json::to_string_pretty(relation) {
                         context.push_appendix(format!("{id}:\n{json}"));
+                    }
+                }
+            }
+            Self::EntityEmbedding(embedding) => {
+                context.push_body(format!(
+                    "entity embedding: {}",
+                    embedding.entity_id.entity_uuid
+                ));
+                if context.alternate() {
+                    if let Ok(json) = serde_json::to_string_pretty(embedding) {
+                        context
+                            .push_appendix(format!("{}:\n{json}", embedding.entity_id.entity_uuid));
                     }
                 }
             }
@@ -324,6 +340,48 @@ where
         .map_err(|stream_error| stream_error.change_context(SnapshotDumpError::Read)))
     }
 
+    /// Convenience function to create a stream of snapshot entries.
+    async fn create_entity_embedding_stream(
+        &self,
+    ) -> Result<
+        impl Stream<Item = Result<SnapshotEntry, SnapshotDumpError>> + Send,
+        SnapshotDumpError,
+    > {
+        Ok(self
+            .acquire()
+            .await
+            .change_context(SnapshotDumpError::Query)?
+            .as_client()
+            .query_raw(
+                "SELECT
+                    web_id,
+                    entity_uuid,
+                    property,
+                    embedding,
+                    updated_at_decision_time,
+                    updated_at_transaction_time
+                 FROM entity_embeddings",
+                [] as [&(dyn ToSql + Sync); 0],
+            )
+            .await
+            .change_context(SnapshotDumpError::Query)?
+            .map(|result| result.change_context(SnapshotDumpError::Query))
+            .map_ok(|row| {
+                SnapshotEntry::EntityEmbedding(EntityEmbeddingRecord {
+                    entity_id: EntityId {
+                        owned_by_id: OwnedById::new(row.get(0)),
+                        entity_uuid: row.get(1),
+                    },
+                    property: row.get::<_, Option<String>>(2).map(|property| {
+                        BaseUrl::new(property).expect("Invalid property URL returned from Postgres")
+                    }),
+                    embedding: row.get(3),
+                    updated_at_decision_time: row.get(4),
+                    updated_at_transaction_time: row.get(5),
+                })
+            }))
+    }
+
     /// Reads the snapshot from the store into the given sink.
     ///
     /// The sink is expected to be a `futures::Sink` that can be used to write the snapshot entries
@@ -465,6 +523,12 @@ where
                             metadata: entity.metadata,
                         }))
                     })
+                    .forward(snapshot_record_tx.clone()),
+            );
+
+            scope.spawn(
+                self.create_entity_embedding_stream()
+                    .try_flatten_stream()
                     .forward(snapshot_record_tx.clone()),
             );
 

--- a/apps/hash-graph/libs/graph/src/snapshot/mod.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/mod.rs
@@ -57,7 +57,7 @@ use crate::{
     snapshot::{entity::EntitySnapshotRecord, restore::SnapshotRecordBatch},
     store::{
         crud::Read, query::Filter, AsClient, InsertionError, PostgresStore, PostgresStorePool,
-        Record, StorePool,
+        QueryRecord, StorePool,
     },
 };
 
@@ -308,7 +308,7 @@ where
     ) -> Result<impl Stream<Item = Result<T, SnapshotDumpError>> + Send + 'pool, SnapshotDumpError>
     where
         <Self as StorePool>::Store<'pool>: Read<T>,
-        T: Record + 'pool,
+        T: QueryRecord + 'pool,
     {
         Ok(Read::<T>::read(
             &self

--- a/apps/hash-graph/libs/graph/src/snapshot/restore/channel.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/restore/channel.rs
@@ -4,15 +4,17 @@ use std::{
     task::{ready, Context, Poll},
 };
 
+use authorization::schema::EntityRelationAndSubject;
 use error_stack::{Report, ResultExt};
 use futures::{
-    channel::mpsc::{self, UnboundedReceiver, UnboundedSender},
+    channel::mpsc::{self, Sender, UnboundedReceiver, UnboundedSender},
     stream::{select_all, BoxStream, SelectAll},
     Sink, SinkExt, Stream, StreamExt,
 };
+use graph_types::knowledge::entity::EntityUuid;
 
 use crate::snapshot::{
-    entity::{self, EntityRelationRecord, EntityRelationSender, EntitySender},
+    entity::{self, EntityEmbeddingRow, EntitySender},
     ontology::{self, DataTypeSender, EntityTypeSender, PropertyTypeSender},
     owner,
     owner::{Owner, OwnerSender},
@@ -31,7 +33,8 @@ pub struct SnapshotRecordSender {
     property_type: PropertyTypeSender,
     entity_type: EntityTypeSender,
     entity: EntitySender,
-    entity_relation: EntityRelationSender,
+    entity_relation: Sender<(EntityUuid, EntityRelationAndSubject)>,
+    entity_embedding: Sender<EntityEmbeddingRow>,
 }
 
 impl Sink<SnapshotEntry> for SnapshotRecordSender {
@@ -57,7 +60,11 @@ impl Sink<SnapshotEntry> for SnapshotRecordSender {
         ready!(self.entity.poll_ready_unpin(cx))
             .attach_printable("could not poll entity sender")?;
         ready!(self.entity_relation.poll_ready_unpin(cx))
+            .change_context(SnapshotRestoreError::Read)
             .attach_printable("could not poll entity relation sender")?;
+        ready!(self.entity_embedding.poll_ready_unpin(cx))
+            .change_context(SnapshotRestoreError::Read)
+            .attach_printable("could not poll entity embedding sender")?;
 
         Poll::Ready(Ok(()))
     }
@@ -103,11 +110,21 @@ impl Sink<SnapshotEntry> for SnapshotRecordSender {
                 relationship: relation,
             }) => self
                 .entity_relation
-                .start_send_unpin(EntityRelationRecord {
-                    entity_uuid,
-                    relation,
-                })
+                .start_send_unpin((entity_uuid, relation))
+                .change_context(SnapshotRestoreError::Read)
                 .attach_printable("could not send entity relation"),
+            SnapshotEntry::EntityEmbedding(embedding) => self
+                .entity_embedding
+                .start_send_unpin(EntityEmbeddingRow {
+                    web_id: embedding.entity_id.owned_by_id,
+                    entity_uuid: embedding.entity_id.entity_uuid,
+                    property: embedding.property.as_ref().map(ToString::to_string),
+                    embedding: embedding.embedding,
+                    updated_at_transaction_time: embedding.updated_at_transaction_time,
+                    updated_at_decision_time: embedding.updated_at_decision_time,
+                })
+                .change_context(SnapshotRestoreError::Read)
+                .attach_printable("could not send entity embedding"),
         }
     }
 
@@ -131,7 +148,11 @@ impl Sink<SnapshotEntry> for SnapshotRecordSender {
         ready!(self.entity.poll_flush_unpin(cx))
             .attach_printable("could not flush entity sender")?;
         ready!(self.entity_relation.poll_flush_unpin(cx))
+            .change_context(SnapshotRestoreError::Read)
             .attach_printable("could not flush entity relation sender")?;
+        ready!(self.entity_embedding.poll_flush_unpin(cx))
+            .change_context(SnapshotRestoreError::Read)
+            .attach_printable("could not flush entity embedding sender")?;
 
         Poll::Ready(Ok(()))
     }
@@ -156,7 +177,11 @@ impl Sink<SnapshotEntry> for SnapshotRecordSender {
         ready!(self.entity.poll_close_unpin(cx))
             .attach_printable("could not close entity sender")?;
         ready!(self.entity_relation.poll_close_unpin(cx))
+            .change_context(SnapshotRestoreError::Read)
             .attach_printable("could not close entity relation sender")?;
+        ready!(self.entity_embedding.poll_close_unpin(cx))
+            .change_context(SnapshotRestoreError::Read)
+            .attach_printable("could not close entity embedding sender")?;
 
         Poll::Ready(Ok(()))
     }
@@ -192,7 +217,10 @@ pub fn channel(
         ontology::property_type_channel(chunk_size, ontology_metadata_tx.clone());
     let (entity_type_tx, entity_type_rx) =
         ontology::entity_type_channel(chunk_size, ontology_metadata_tx);
-    let (entity_tx, entity_relation_tx, entity_rx) = entity::channel(chunk_size);
+    let (entity_relation_tx, entity_relation_rx) = mpsc::channel(chunk_size);
+    let (entity_embedding_tx, entity_embedding_rx) = mpsc::channel(chunk_size);
+    let (entity_tx, entity_rx) =
+        entity::channel(chunk_size, entity_relation_rx, entity_embedding_rx);
 
     (
         SnapshotRecordSender {
@@ -204,6 +232,7 @@ pub fn channel(
             entity_type: entity_type_tx,
             entity: entity_tx,
             entity_relation: entity_relation_tx,
+            entity_embedding: entity_embedding_tx,
         },
         SnapshotRecordReceiver {
             stream: select_all(vec![

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -47,7 +47,8 @@ use crate::{
         },
         query::{Filter, OntologyQueryPath},
         AccountStore, ConflictBehavior, DataTypeStore, EntityStore, EntityTypeStore,
-        InsertionError, PropertyTypeStore, QueryError, Record, StoreError, StorePool, UpdateError,
+        InsertionError, PropertyTypeStore, QueryError, QueryRecord, StoreError, StorePool,
+        SubgraphRecord, UpdateError,
     },
     subgraph::{
         edges::GraphResolveDepths,
@@ -222,7 +223,7 @@ where
     ) -> Result<bool, StoreError> {
         fn create_query<'u, T>(versioned_url: &'u VersionedUrl) -> StructuralQuery<'u, T>
         where
-            T: Record<QueryPath<'u>: OntologyQueryPath>,
+            T: SubgraphRecord<QueryPath<'u>: OntologyQueryPath>,
             T::VertexId: VertexId<BaseId = BaseUrl, RevisionId = OntologyTypeVersion>,
         {
             StructuralQuery {
@@ -670,7 +671,7 @@ impl<I, A, R, S> ReadPaginated<R, S> for FetchingStore<I, A>
 where
     A: Send + Sync,
     I: ReadPaginated<R, S> + Send,
-    R: Record,
+    R: QueryRecord,
     S: Sorting + Sync,
 {
     type QueryResult = I::QueryResult;
@@ -701,7 +702,7 @@ impl<S, A, R> Read<R> for FetchingStore<S, A>
 where
     A: Send + Sync,
     S: Read<R> + Send,
-    R: Record,
+    R: QueryRecord,
 {
     type ReadStream = S::ReadStream;
 

--- a/apps/hash-graph/libs/graph/src/store/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/mod.rs
@@ -35,7 +35,7 @@ pub use self::{
     ontology::{DataTypeStore, EntityTypeStore, PropertyTypeStore},
     pool::StorePool,
     postgres::{AsClient, PostgresStore, PostgresStorePool},
-    record::Record,
+    record::{QueryRecord, SubgraphRecord},
     validation::{StoreCache, StoreProvider},
 };
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -53,8 +53,8 @@ use crate::{
         },
         query::{Filter, FilterExpression, Parameter},
         validation::StoreProvider,
-        AsClient, EntityStore, InsertionError, PostgresStore, QueryError, Record, StoreCache,
-        UpdateError,
+        AsClient, EntityStore, InsertionError, PostgresStore, QueryError, StoreCache,
+        SubgraphRecord, UpdateError,
     },
     subgraph::{
         edges::{EdgeDirection, GraphResolveDepths, KnowledgeGraphEdgeKind, SharedEdgeKind},

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
@@ -38,7 +38,7 @@ use crate::{
             TraversalContext,
         },
         AsClient, ConflictBehavior, DataTypeStore, InsertionError, PostgresStore, QueryError,
-        Record, UpdateError,
+        SubgraphRecord, UpdateError,
     },
     subgraph::{
         edges::GraphResolveDepths, identifier::DataTypeVertexId, query::StructuralQuery,

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
@@ -47,7 +47,7 @@ use crate::{
         },
         query::{Filter, FilterExpression, ParameterList},
         AsClient, ConflictBehavior, EntityTypeStore, InsertionError, PostgresStore, QueryError,
-        Record, UpdateError,
+        SubgraphRecord, UpdateError,
     },
     subgraph::{
         edges::{EdgeDirection, GraphResolveDepths, OntologyEdgeKind},

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/mod.rs
@@ -30,7 +30,7 @@ use crate::{
             query::{Distinctness, PostgresSorting, SelectCompiler},
         },
         query::Parameter,
-        AsClient, Ordering, PostgresStore, Record,
+        AsClient, Ordering, PostgresStore, SubgraphRecord,
     },
     subgraph::temporal_axes::QueryTemporalAxes,
 };
@@ -146,7 +146,7 @@ macro_rules! impl_ontology_cursor {
     ($ty:ty, $query_path:ty) => {
         impl QueryRecordDecode for VertexIdSorting<$ty> {
             type CompilationArtifacts = VersionedUrlIndices;
-            type Output = <$ty as Record>::VertexId;
+            type Output = <$ty as SubgraphRecord>::VertexId;
 
             fn decode(row: &Row, indices: &Self::CompilationArtifacts) -> Self::Output {
                 Self::Output {

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/property_type.rs
@@ -44,7 +44,7 @@ use crate::{
             TraversalContext,
         },
         AsClient, ConflictBehavior, InsertionError, PostgresStore, PropertyTypeStore, QueryError,
-        Record, UpdateError,
+        SubgraphRecord, UpdateError,
     },
     subgraph::{
         edges::{EdgeDirection, GraphResolveDepths, OntologyEdgeKind},

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/compile.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/compile.rs
@@ -17,7 +17,7 @@ use crate::{
             WhereExpression, WindowStatement, WithExpression,
         },
         query::{Filter, FilterExpression, Parameter, ParameterList, ParameterType},
-        NullOrdering, Ordering, Record,
+        NullOrdering, Ordering, QueryRecord,
     },
     subgraph::temporal_axes::QueryTemporalAxes,
 };
@@ -48,7 +48,7 @@ struct PathSelection {
     ordering: Option<(Ordering, Option<NullOrdering>)>,
 }
 
-pub struct SelectCompiler<'p, 'q: 'p, T: Record> {
+pub struct SelectCompiler<'p, 'q: 'p, T: QueryRecord> {
     statement: SelectStatement,
     artifacts: CompilerArtifacts<'p>,
     temporal_axes: Option<&'p QueryTemporalAxes>,

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/mod.rs
@@ -47,12 +47,12 @@ use crate::{
         knowledge::{EntityQueryCursor, EntityQuerySorting},
         postgres::{crud::QueryRecordDecode, query::table::Relation},
         query::ParameterConversionError,
-        Record,
+        QueryRecord,
     },
     subgraph::temporal_axes::QueryTemporalAxes,
 };
 
-pub trait PostgresRecord: Record + QueryRecordDecode<Output = Self> {
+pub trait PostgresRecord: QueryRecord + QueryRecordDecode<Output = Self> {
     type CompilationParameters: Send + 'static;
 
     /// The [`Table`] used for this `Query`.
@@ -92,7 +92,7 @@ pub trait Transpile: 'static {
     }
 }
 
-pub trait PostgresSorting<'s, R: Record>:
+pub trait PostgresSorting<'s, R: QueryRecord>:
     Sorting + QueryRecordDecode<Output = Self::Cursor>
 {
     type CompilationParameters: Send;

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/table.rs
@@ -710,6 +710,9 @@ pub enum EntityEmbeddings {
     WebId,
     EntityUuid,
     Embedding,
+    Property,
+    UpdatedAtTransactionTime,
+    UpdatedAtDecisionTime,
     Distance,
 }
 
@@ -719,6 +722,9 @@ impl EntityEmbeddings {
             Self::WebId => "web_id",
             Self::EntityUuid => "entity_uuid",
             Self::Embedding => "embedding",
+            Self::Property => "property",
+            Self::UpdatedAtDecisionTime => "updated_at_decision_time",
+            Self::UpdatedAtTransactionTime => "updated_at_transaction_time",
             Self::Distance => "distance",
         };
         table.transpile(fmt)?;
@@ -729,6 +735,10 @@ impl EntityEmbeddings {
         match self {
             Self::WebId | Self::EntityUuid => ParameterType::Uuid,
             Self::Embedding => ParameterType::Vector,
+            Self::Property => ParameterType::BaseUrl,
+            Self::UpdatedAtTransactionTime | Self::UpdatedAtDecisionTime => {
+                ParameterType::Timestamp
+            }
             Self::Distance => ParameterType::F64,
         }
     }

--- a/apps/hash-graph/libs/graph/src/store/postgres/traversal_context.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/traversal_context.rs
@@ -14,7 +14,7 @@ use crate::{
         crud::Read,
         postgres::ontology::OntologyId,
         query::{Filter, FilterExpression, ParameterList},
-        AsClient, PostgresStore, QueryError, Record,
+        AsClient, PostgresStore, QueryError, SubgraphRecord,
     },
     subgraph::{edges::GraphResolveDepths, temporal_axes::VariableAxis, Subgraph},
 };

--- a/apps/hash-graph/libs/graph/src/store/query/filter.rs
+++ b/apps/hash-graph/libs/graph/src/store/query/filter.rs
@@ -17,7 +17,7 @@ use crate::{
     knowledge::EntityQueryPath,
     store::{
         query::{OntologyQueryPath, ParameterType, QueryPath},
-        Record,
+        QueryRecord, SubgraphRecord,
     },
     subgraph::identifier::VertexId,
 };
@@ -32,7 +32,7 @@ use crate::{
     rename_all = "camelCase",
     bound = "'de: 'p, R::QueryPath<'p>: Deserialize<'de>"
 )]
-pub enum Filter<'p, R: Record + ?Sized> {
+pub enum Filter<'p, R: QueryRecord + ?Sized> {
     All(Vec<Self>),
     Any(Vec<Self>),
     Not(Box<Self>),
@@ -58,7 +58,7 @@ pub enum Filter<'p, R: Record + ?Sized> {
 
 impl<'p, R> Filter<'p, R>
 where
-    R: Record<QueryPath<'p>: OntologyQueryPath>,
+    R: SubgraphRecord<QueryPath<'p>: OntologyQueryPath>,
     R::VertexId: VertexId<BaseId = BaseUrl, RevisionId = OntologyTypeVersion>,
 {
     /// Creates a `Filter` to search for a specific ontology type of kind `R`, identified by its
@@ -103,7 +103,7 @@ impl<'p> Filter<'p, Entity> {
     }
 }
 
-impl<'p, R: Record> Filter<'p, R>
+impl<'p, R: QueryRecord> Filter<'p, R>
 where
     R::QueryPath<'p>: fmt::Display,
 {
@@ -177,7 +177,7 @@ where
     rename_all = "camelCase",
     bound = "'de: 'p, R::QueryPath<'p>: Deserialize<'de>"
 )]
-pub enum FilterExpression<'p, R: Record + ?Sized> {
+pub enum FilterExpression<'p, R: QueryRecord + ?Sized> {
     Path(R::QueryPath<'p>),
     Parameter(Parameter<'p>),
 }
@@ -452,7 +452,7 @@ mod tests {
 
     fn test_filter_representation<'de, R>(actual: &Filter<'de, R>, expected: &'de serde_json::Value)
     where
-        R: Record<QueryPath<'de>: fmt::Debug + fmt::Display + PartialEq + Deserialize<'de>>,
+        R: QueryRecord<QueryPath<'de>: fmt::Debug + fmt::Display + PartialEq + Deserialize<'de>>,
     {
         let mut expected =
             Filter::<R>::deserialize(expected).expect("Could not deserialize filter");

--- a/apps/hash-graph/libs/graph/src/store/record.rs
+++ b/apps/hash-graph/libs/graph/src/store/record.rs
@@ -4,14 +4,17 @@ use temporal_versioning::TimeAxis;
 
 use crate::{store::query::QueryPath, subgraph::identifier::VertexId};
 
+pub trait QueryRecord: Sized + Send {
+    type QueryPath<'p>: QueryPath + Send + Sync + Eq + Hash;
+}
+
 /// A record persisted in the [`store`].
 ///
 /// [`store`]: crate::store
 // TODO: Split trait into subgraph part and query part
 //   see https://linear.app/hash/issue/H-754
-pub trait Record: Sized + Send {
+pub trait SubgraphRecord: QueryRecord {
     type VertexId: VertexId<Record = Self> + Send + Sync;
-    type QueryPath<'p>: QueryPath + Send + Sync + Eq + Hash;
 
     fn vertex_id(&self, time_axis: TimeAxis) -> Self::VertexId;
 }

--- a/apps/hash-graph/libs/graph/src/subgraph/mod.rs
+++ b/apps/hash-graph/libs/graph/src/subgraph/mod.rs
@@ -16,7 +16,7 @@ use self::{
     vertices::Vertices,
 };
 use crate::{
-    store::Record,
+    store::SubgraphRecord,
     subgraph::{
         edges::{EdgeDirection, EdgeKind},
         identifier::{EdgeEndpoint, VertexId},
@@ -51,18 +51,18 @@ impl Subgraph {
         }
     }
 
-    fn vertex_entry_mut<R: Record>(
+    fn vertex_entry_mut<R: SubgraphRecord>(
         &mut self,
         vertex_id: &R::VertexId,
     ) -> RawEntryMut<R::VertexId, R, RandomState> {
         vertex_id.subgraph_entry_mut(&mut self.vertices)
     }
 
-    pub fn get_vertex<R: Record>(&self, vertex_id: &R::VertexId) -> Option<&R> {
+    pub fn get_vertex<R: SubgraphRecord>(&self, vertex_id: &R::VertexId) -> Option<&R> {
         vertex_id.subgraph_entry(&self.vertices)
     }
 
-    pub fn insert_vertex<R: Record>(&mut self, vertex_id: R::VertexId, record: R)
+    pub fn insert_vertex<R: SubgraphRecord>(&mut self, vertex_id: R::VertexId, record: R)
     where
         R::VertexId: Eq + Hash,
     {

--- a/apps/hash-graph/libs/graph/src/subgraph/query.rs
+++ b/apps/hash-graph/libs/graph/src/subgraph/query.rs
@@ -43,6 +43,8 @@ use crate::{
 /// see the documentation on the implementation of [`QueryRecord::QueryPath`] for the valid paths
 /// for each type.
 ///
+/// [`QueryRecord::QueryPath`]: crate::store::QueryRecord::QueryPath
+///
 /// # Depth
 ///
 /// The depth of a query determines how many edges the query will follow from the root vertices. For

--- a/apps/hash-graph/libs/graph/src/subgraph/query.rs
+++ b/apps/hash-graph/libs/graph/src/subgraph/query.rs
@@ -14,7 +14,7 @@ use utoipa::{
 };
 
 use crate::{
-    store::{query::Filter, Record},
+    store::{query::Filter, SubgraphRecord},
     subgraph::{edges::GraphResolveDepths, temporal_axes::QueryTemporalAxesUnresolved},
 };
 
@@ -40,8 +40,8 @@ use crate::{
 /// as a root vertex.
 ///
 /// Depending on the type of the [`StructuralQuery`], different [`RecordPath`]s are valid. Please
-/// see the documentation on the implementation of [`Record::QueryPath`] for the valid paths for
-/// each type.
+/// see the documentation on the implementation of [`QueryRecord::QueryPath`] for the valid paths
+/// for each type.
 ///
 /// # Depth
 ///
@@ -161,7 +161,7 @@ use crate::{
 #[derive(Deserialize, Derivative)]
 #[derivative(Debug(bound = "R::QueryPath<'p>: Debug, R::VertexId: Debug"))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
-pub struct StructuralQuery<'p, R: Record> {
+pub struct StructuralQuery<'p, R: SubgraphRecord> {
     #[serde(bound = "'de: 'p, R::QueryPath<'p>: Deserialize<'de>")]
     pub filter: Filter<'p, R>,
     pub graph_resolve_depths: GraphResolveDepths,
@@ -170,7 +170,7 @@ pub struct StructuralQuery<'p, R: Record> {
 }
 
 #[cfg(feature = "utoipa")]
-impl<'p, R: Record> StructuralQuery<'p, R>
+impl<'p, R: SubgraphRecord> StructuralQuery<'p, R>
 where
     R::VertexId: ToSchema<'static>,
 {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To avoid regenerating embeddings, this adds the embeddings to the Snapshots as well.

## 🚫 Blocked by

- #3973 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

As snapshots are stored as JSON and embeddings contains many numbers the snapshot can grow pretty big. To mitigate this it's possible to pipe the snapshot from/to `gzip`. Later, we probably want to allow splitting the snapshots, either by number of records or by type. Ideally, it's possible to specify the format as well so a more efficient format can be used instead.