### PR TITLE
H-2133: Fix CI not erroring if Rust docs contains invalid links

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -156,7 +156,9 @@ clippy *arguments: install-cargo-hack install-rust-script
 # Creates the documentation for the crate
 [no-cd]
 doc *arguments:
-  cargo doc --all-features --no-deps -Zunstable-options -Zrustdoc-scrape-examples {{arguments}}
+  @just not-in-pr RUSTDOCFLAGS=-Dwarnings cargo doc --all-features --workspace --no-deps -Zunstable-options -Zrustdoc-scrape-examples {{arguments}}
+  @just in-pr cargo doc --all-features --workspace --no-deps -Zunstable-options -Zrustdoc-scrape-examples {{arguments}}
+
 
 # Builds the crate
 [no-cd]

--- a/.justfile
+++ b/.justfile
@@ -156,8 +156,8 @@ clippy *arguments: install-cargo-hack install-rust-script
 # Creates the documentation for the crate
 [no-cd]
 doc *arguments:
-  @just not-in-pr RUSTDOCFLAGS=-Dwarnings cargo doc --all-features --workspace --no-deps -Zunstable-options -Zrustdoc-scrape-examples {{arguments}}
-  @just in-pr cargo doc --all-features --workspace --no-deps -Zunstable-options -Zrustdoc-scrape-examples {{arguments}}
+  @just in-pr RUSTDOCFLAGS=-Dwarnings cargo doc --all-features --workspace --no-deps -Zunstable-options -Zrustdoc-scrape-examples {{arguments}}
+  @just not-in-pr cargo doc --all-features --workspace --no-deps -Zunstable-options -Zrustdoc-scrape-examples {{arguments}}
 
 
 # Builds the crate

--- a/apps/hash-graph/libs/graph/src/knowledge/query.rs
+++ b/apps/hash-graph/libs/graph/src/knowledge/query.rs
@@ -156,8 +156,8 @@ pub enum EntityQueryPath<'p> {
     /// [`EditionCreatedById`]: graph_types::account::EditionCreatedById
     /// [`EntityProvenanceMetadata`]: graph_types::knowledge::entity::EntityProvenanceMetadata
     EditionCreatedById,
-    /// The [`RecordCreatedById`] of the [`ProvenanceMetadata`] belonging to the [`Entity`] when
-    /// it was _first inserted_ into the database.
+    /// The [`CreatedById`] of the [`EntityProvenanceMetadata`] belonging to the [`Entity`]
+    /// when it was _first inserted_ into the database.
     ///
     /// This does not take into account if the [`Entity`] was updated with an earlier decision
     /// time.
@@ -171,8 +171,8 @@ pub enum EntityQueryPath<'p> {
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     ///
-    /// [`RecordCreatedById`]: graph_types::provenance::RecordCreatedById
-    /// [`ProvenanceMetadata`]: graph_types::provenance::ProvenanceMetadata
+    /// [`CreatedById`]: graph_types::account::CreatedById
+    /// [`EntityProvenanceMetadata`]: graph_types::knowledge::entity::EntityProvenanceMetadata
     CreatedById,
     /// An edge from this [`Entity`] to it's [`EntityType`] using a [`SharedEdgeKind`].
     ///


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`-Dwarnings` is not specified in CI.