### PR TITLE
H-2171: Use Node API healthcheck in AWS

### DIFF
--- a/infra/docker/api/prod/Dockerfile
+++ b/infra/docker/api/prod/Dockerfile
@@ -50,4 +50,4 @@ RUN addgroup --system --gid 60000 hash \
 USER api:hash
 ENV NODE_ENV production
 
-HEALTHCHECK --interval=5s --timeout=3s --start-period=10s --retries=3 CMD curl -f http://localhost:5001 || exit 1
+HEALTHCHECK --interval=5s --timeout=3s --start-period=10s --retries=3 CMD curl -f http://localhost:5001/health-check || exit 1

--- a/infra/terraform/hash/hash_application/api.tf
+++ b/infra/terraform/hash/hash_application/api.tf
@@ -19,13 +19,19 @@ resource "aws_ssm_parameter" "api_env_vars" {
 
 locals {
   api_service_container_def = {
-    name         = "${local.api_prefix}container"
-    image        = "${var.api_image.url}:latest"
-    cpu          = 0 # let ECS divvy up the available CPU
-    mountPoints  = []
-    volumesFrom  = []
-    dependsOn    = [{ condition = "HEALTHY", containerName = local.graph_service_container_def.name }]
-    dependsOn    = [{ condition = "HEALTHY", containerName = local.kratos_service_container_def.name }]
+    name        = "${local.api_prefix}container"
+    image       = "${var.api_image.url}:latest"
+    cpu         = 0 # let ECS divvy up the available CPU
+    mountPoints = []
+    volumesFrom = []
+    dependsOn   = [{ condition = "HEALTHY", containerName = local.graph_service_container_def.name }]
+    dependsOn   = [{ condition = "HEALTHY", containerName = local.kratos_service_container_def.name }]
+    healthCheck = {
+      command  = ["CMD", "/bin/sh", "-c", "curl -f http://localhost:${local.api_container_port}/health-check || exit 1"]
+      retries  = 5
+      interval = 20
+      timeout  = 5
+    }
     portMappings = [
       {
         appProtocol   = "http"

--- a/infra/terraform/hash/hash_application/graph.tf
+++ b/infra/terraform/hash/hash_application/graph.tf
@@ -177,7 +177,6 @@ locals {
       retries  = 5
       interval = 20
       timeout  = 5
-
     }
     portMappings = [
       {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

ECS does not use the health-check defined in the Dockerfile. This sets the check manually.