### PR TITLE
H-2166: Add workflow to update all type embeddings

### DIFF
--- a/apps/hash-ai-worker-ts/src/workflows.ts
+++ b/apps/hash-ai-worker-ts/src/workflows.ts
@@ -475,6 +475,66 @@ export const updateEntityEmbeddings = async (
   return usage;
 };
 
+export const updateAllDataTypeEmbeddings =
+  async (): Promise<CreateEmbeddingResponse.Usage> =>
+    await updateDataTypeEmbeddings({
+      authentication: {
+        actorId: "00000000-0000-0000-0000-000000000000" as AccountId,
+      },
+      filter: {
+        all: [
+          {
+            // @ts-expect-error -- Support null in Path parameter in structural queries in Node
+            //                     see https://linear.app/hash/issue/H-1207
+            equal: [{ path: ["embedding"] }, null],
+          },
+          {
+            equal: [{ path: ["version"] }, { parameter: "latest" }],
+          },
+        ],
+      },
+    });
+
+export const updateAllPropertyTypeEmbeddings =
+  async (): Promise<CreateEmbeddingResponse.Usage> =>
+    await updatePropertyTypeEmbeddings({
+      authentication: {
+        actorId: "00000000-0000-0000-0000-000000000000" as AccountId,
+      },
+      filter: {
+        all: [
+          {
+            // @ts-expect-error -- Support null in Path parameter in structural queries in Node
+            //                     see https://linear.app/hash/issue/H-1207
+            equal: [{ path: ["embedding"] }, null],
+          },
+          {
+            equal: [{ path: ["version"] }, { parameter: "latest" }],
+          },
+        ],
+      },
+    });
+
+export const updateAllEntityTypeEmbeddings =
+  async (): Promise<CreateEmbeddingResponse.Usage> =>
+    await updateEntityTypeEmbeddings({
+      authentication: {
+        actorId: "00000000-0000-0000-0000-000000000000" as AccountId,
+      },
+      filter: {
+        all: [
+          {
+            // @ts-expect-error -- Support null in Path parameter in structural queries in Node
+            //                     see https://linear.app/hash/issue/H-1207
+            equal: [{ path: ["embedding"] }, null],
+          },
+          {
+            equal: [{ path: ["version"] }, { parameter: "latest" }],
+          },
+        ],
+      },
+    });
+
 export const updateAllEntityEmbeddings =
   async (): Promise<CreateEmbeddingResponse.Usage> => {
     const accountIds = await graphActivities.getUserAccountIds();


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To generate all type embeddings similar as how all entity embeddings are generated it's useful to have a dedicated workflow for that. The workflow assumes that only the most recent version of a type needs an embedding and only generates embeddings if no embedding was already added for that specific type.

## 🔍 What does this change?

Add workflows for create all embeddings for all three ontology types

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

We don't have pagination, yet, so the workflow may fail if too many types needs a new embedding. For our production environment this is not the case, yet.