### PR TITLE
H-2187: Allow setting email on signup page from query params

### DIFF
--- a/apps/hash-frontend/src/pages/signin.page.tsx
+++ b/apps/hash-frontend/src/pages/signin.page.tsx
@@ -254,6 +254,7 @@ const SigninPage: NextPageWithLayout = () => {
               label="Email address"
               type="email"
               autoComplete="email"
+              autoFocus
               placeholder="Enter your email address"
               value={email}
               onChange={({ target }) => setEmail(target.value)}

--- a/apps/hash-frontend/src/pages/signup.page/signup-registration-form.tsx
+++ b/apps/hash-frontend/src/pages/signup.page/signup-registration-form.tsx
@@ -46,7 +46,19 @@ export const SignupRegistrationForm: FunctionComponent = () => {
   // information about the form we need to render (e.g. username + password)
   const [flow, setFlow] = useState<RegistrationFlow>();
 
-  const [email, setEmail] = useState<string>("");
+  const { email: emailFromQuery, ...restOfQuery } = router.query;
+
+  const initialEmail = typeof emailFromQuery === "string" ? emailFromQuery : "";
+
+  useEffect(() => {
+    if (emailFromQuery) {
+      void router.push({ query: restOfQuery }, undefined, {
+        shallow: true,
+      });
+    }
+  }, [emailFromQuery, restOfQuery, router]);
+
+  const [email, setEmail] = useState<string>(initialEmail);
   const [password, setPassword] = useState<string>("");
   const [errorMessage, setErrorMessage] = useState<string | undefined>();
 
@@ -172,6 +184,7 @@ export const SignupRegistrationForm: FunctionComponent = () => {
             label="Your personal email"
             type="email"
             autoComplete="email"
+            autoFocus={!initialEmail}
             placeholder="Enter your email address"
             value={email}
             onChange={({ target }) => setEmail(target.value)}
@@ -188,6 +201,7 @@ export const SignupRegistrationForm: FunctionComponent = () => {
             label="Password"
             type="password"
             autoComplete="new-password"
+            autoFocus={!!initialEmail}
             value={password}
             placeholder="Enter a password"
             onChange={({ target }) => setPassword(target.value)}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR allows the email value on `/signup` to be set from a query parameter, so that we can send people here to complete registration having entered their email elsewhere.

It also adds autofocus to inputs on login and signup routes.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Visit `https://localhost:3000/signup?email=something@example.com`

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
