### PR TITLE
H-2168: Add type embeddings to Snapshots

### DIFF
--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/mod.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/mod.rs
@@ -13,8 +13,12 @@ pub use self::{
     },
     property_type::{property_type_channel, PropertyTypeRowBatch, PropertyTypeSender},
     record::{
-        DataTypeSnapshotRecord, EntityTypeSnapshotRecord, OntologyTypeSnapshotRecord,
+        DataTypeEmbeddingRecord, DataTypeSnapshotRecord, EntityTypeEmbeddingRecord,
+        EntityTypeSnapshotRecord, OntologyTypeSnapshotRecord, PropertyTypeEmbeddingRecord,
         PropertyTypeSnapshotRecord,
     },
-    table::{OntologyExternalMetadataRow, OntologyIdRow, OntologyOwnedMetadataRow},
+    table::{
+        DataTypeEmbeddingRow, EntityTypeEmbeddingRow, OntologyExternalMetadataRow, OntologyIdRow,
+        OntologyOwnedMetadataRow, PropertyTypeEmbeddingRow,
+    },
 };

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/record.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/record.rs
@@ -1,9 +1,10 @@
 use authorization::schema::{
     DataTypeRelationAndSubject, EntityTypeRelationAndSubject, PropertyTypeRelationAndSubject,
 };
-use graph_types::ontology::OntologyType;
+use graph_types::{ontology::OntologyType, Embedding};
 use serde::{Deserialize, Serialize};
-use type_system::{DataType, EntityType, PropertyType};
+use temporal_versioning::{Timestamp, TransactionTime};
+use type_system::{url::VersionedUrl, DataType, EntityType, PropertyType};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(
@@ -25,3 +26,27 @@ pub type PropertyTypeSnapshotRecord =
     OntologyTypeSnapshotRecord<PropertyType, PropertyTypeRelationAndSubject>;
 pub type EntityTypeSnapshotRecord =
     OntologyTypeSnapshotRecord<EntityType, EntityTypeRelationAndSubject>;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DataTypeEmbeddingRecord {
+    pub data_type_id: VersionedUrl,
+    pub embedding: Embedding<'static>,
+    pub updated_at_transaction_time: Timestamp<TransactionTime>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PropertyTypeEmbeddingRecord {
+    pub property_type_id: VersionedUrl,
+    pub embedding: Embedding<'static>,
+    pub updated_at_transaction_time: Timestamp<TransactionTime>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityTypeEmbeddingRecord {
+    pub entity_type_id: VersionedUrl,
+    pub embedding: Embedding<'static>,
+    pub updated_at_transaction_time: Timestamp<TransactionTime>,
+}

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/table.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/table.rs
@@ -2,9 +2,10 @@ use graph_types::{
     account::{EditionArchivedById, EditionCreatedById},
     ontology::OntologyTypeVersion,
     owned_by_id::OwnedById,
+    Embedding,
 };
 use postgres_types::{Json, ToSql};
-use temporal_versioning::{LeftClosedTemporalInterval, TransactionTime};
+use temporal_versioning::{LeftClosedTemporalInterval, Timestamp, TransactionTime};
 use time::OffsetDateTime;
 use type_system::{DataType, EntityType, PropertyType};
 use uuid::Uuid;
@@ -48,6 +49,14 @@ pub struct DataTypeRow {
 }
 
 #[derive(Debug, ToSql)]
+#[postgres(name = "data_type_embeddings_tmp")]
+pub struct DataTypeEmbeddingRow {
+    pub ontology_id: Uuid,
+    pub embedding: Embedding<'static>,
+    pub updated_at_transaction_time: Timestamp<TransactionTime>,
+}
+
+#[derive(Debug, ToSql)]
 #[postgres(name = "property_types")]
 pub struct PropertyTypeRow {
     pub ontology_id: Uuid,
@@ -60,6 +69,14 @@ pub struct PropertyTypeConstrainsValuesOnRow {
     pub source_property_type_ontology_id: Uuid,
     pub target_data_type_base_url: String,
     pub target_data_type_version: OntologyTypeVersion,
+}
+
+#[derive(Debug, ToSql)]
+#[postgres(name = "property_type_embeddings_tmp")]
+pub struct PropertyTypeEmbeddingRow {
+    pub ontology_id: Uuid,
+    pub embedding: Embedding<'static>,
+    pub updated_at_transaction_time: Timestamp<TransactionTime>,
 }
 
 #[derive(Debug, ToSql)]
@@ -78,6 +95,14 @@ pub struct EntityTypeRow {
     pub closed_schema: Json<EntityType>,
     pub label_property: Option<String>,
     pub icon: Option<String>,
+}
+
+#[derive(Debug, ToSql)]
+#[postgres(name = "entity_type_embeddings_tmp")]
+pub struct EntityTypeEmbeddingRow {
+    pub ontology_id: Uuid,
+    pub embedding: Embedding<'static>,
+    pub updated_at_transaction_time: Timestamp<TransactionTime>,
 }
 
 #[derive(Debug, ToSql)]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To make snapshot migrations possible, the embeddings should be stored in the snapshots as well.
