### PR TITLE
H-2189: Add hash.ai to Node API CORS list

### DIFF
--- a/apps/hash-api/src/lib/config.ts
+++ b/apps/hash-api/src/lib/config.ts
@@ -22,5 +22,10 @@ export const LOCAL_FILE_UPLOAD_PATH =
 
 export const CORS_CONFIG: corsMiddleware.CorsOptions = {
   credentials: true,
-  origin: [/-hashintel\.vercel\.app$/, /\.stage\.hash\.ai$/, frontendUrl],
+  origin: [
+    /-hashintel\.vercel\.app$/,
+    /\.stage\.hash\.ai$/,
+    "https://hash.ai",
+    frontendUrl,
+  ],
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

It adds `https://hash.ai` to the Node API CORS list, so that we can call the API from https://hash.ai (to check if a user is logged in to the app).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
