### PR TITLE
H-2190: Pin Postgres to the major version only

### DIFF
--- a/infra/terraform/hash/postgres/postgres.tf
+++ b/infra/terraform/hash/postgres/postgres.tf
@@ -67,7 +67,7 @@ resource "aws_db_instance" "postgres" {
   parameter_group_name            = aws_db_parameter_group.postgres.name
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
   engine                          = "postgres"
-  engine_version                  = "15.5"
+  engine_version                  = "15"
   allow_major_version_upgrade     = true
   instance_class                  = var.instance_class
   db_name                         = "postgres" # Initial database name

--- a/infra/terraform/hash/postgres/postgres.tf
+++ b/infra/terraform/hash/postgres/postgres.tf
@@ -67,7 +67,7 @@ resource "aws_db_instance" "postgres" {
   parameter_group_name            = aws_db_parameter_group.postgres.name
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
   engine                          = "postgres"
-  engine_version                  = "15.3"
+  engine_version                  = "15.5"
   allow_major_version_upgrade     = true
   instance_class                  = var.instance_class
   db_name                         = "postgres" # Initial database name


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

AWS updated Postgres from 15.3 to 15.5 which breaks our `terraform apply` step.