### PR TITLE
H-2195: Change port for type fetcher to `4455`

### DIFF
--- a/.env
+++ b/.env
@@ -52,7 +52,7 @@ HASH_GRAPH_PG_DATABASE=graph
 HASH_GRAPH_LOG_LEVEL=trace,h2=info,tokio_util=debug,tower=info,tonic=debug,hyper=info,tokio_postgres=info,rustls=info,tarpc=warn
 
 HASH_GRAPH_TYPE_FETCHER_HOST=localhost
-HASH_GRAPH_TYPE_FETCHER_PORT=4444
+HASH_GRAPH_TYPE_FETCHER_PORT=4455
 
 HASH_GRAPH_REALTIME_PG_USER=realtime
 HASH_GRAPH_REALTIME_PG_PASSWORD=realtime

--- a/apps/hash-external-services/docker-compose.type-fetcher.yml
+++ b/apps/hash-external-services/docker-compose.type-fetcher.yml
@@ -11,7 +11,7 @@ services:
       - logs:/logs
     command: type-fetcher
     ports:
-      - "${HASH_GRAPH_TYPE_FETCHER_PORT}:4444"
+      - "${HASH_GRAPH_TYPE_FETCHER_PORT}:4455"
     environment:
       HASH_GRAPH_LOG_FORMAT: "${HASH_GRAPH_LOG_FORMAT:-full}"
       HASH_GRAPH_LOG_FOLDER: "/logs/graph-type-fetcher"

--- a/apps/hash-graph/bins/cli/src/subcommand/type_fetcher.rs
+++ b/apps/hash-graph/bins/cli/src/subcommand/type_fetcher.rs
@@ -27,7 +27,7 @@ pub struct TypeFetcherAddress {
     pub type_fetcher_host: String,
 
     /// The port the type fetcher RPC server is listening at.
-    #[clap(long, default_value_t = 4444, env = "HASH_GRAPH_TYPE_FETCHER_PORT")]
+    #[clap(long, default_value_t = 4455, env = "HASH_GRAPH_TYPE_FETCHER_PORT")]
     pub type_fetcher_port: u16,
 }
 

--- a/infra/terraform/hash/hash_application/graph.tf
+++ b/infra/terraform/hash/hash_application/graph.tf
@@ -58,8 +58,8 @@ resource "aws_security_group" "graph" {
     cidr_blocks = [var.vpc.cidr_block]
   }
   egress {
-    from_port   = 4444
-    to_port     = 4444
+    from_port   = 4455
+    to_port     = 4455
     protocol    = "tcp"
     description = "Allow connections with the type fetcher"
     cidr_blocks = [var.vpc.cidr_block]

--- a/infra/terraform/hash/hash_application/main.tf
+++ b/infra/terraform/hash/hash_application/main.tf
@@ -122,8 +122,8 @@ resource "aws_security_group" "alb_sg" {
   }
 
   ingress {
-    from_port   = 4444
-    to_port     = 4444
+    from_port   = 4455
+    to_port     = 4455
     protocol    = "tcp"
     description = "Allow connections with the type fetcher"
     cidr_blocks = [var.vpc.cidr_block]

--- a/infra/terraform/hash/hash_application/type_fetcher.tf
+++ b/infra/terraform/hash/hash_application/type_fetcher.tf
@@ -2,7 +2,7 @@ locals {
   type_fetcher_service_name        = "typefetcher"
   type_fetcher_prefix              = "${var.prefix}-${local.type_fetcher_service_name}"
   type_fetcher_param_prefix        = "${local.param_prefix}/${local.type_fetcher_service_name}"
-  type_fetcher_container_port      = 4444
+  type_fetcher_container_port      = 4455
   type_fetcher_container_port_name = local.type_fetcher_service_name
   type_fetcher_container_port_dns  = "localhost"
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The port `4444` is currently used by the type fetcher and conflicts with Ory Hydra. As we are in full control over the default port of the type fetcher and it would be annoying to change the default port to another port for Ory Hydra, we change the port for the type fetcher.


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph