### PR TITLE
H-2210: Store provenance data for first non-draft entity date

### DIFF
--- a/apps/hash-graph/libs/graph/src/knowledge/query.rs
+++ b/apps/hash-graph/libs/graph/src/knowledge/query.rs
@@ -160,8 +160,8 @@ pub enum EntityQueryPath<'p> {
     /// # use serde::Deserialize;
     /// # use serde_json::json;
     /// # use graph::knowledge::EntityQueryPath;
-    /// let path = EntityQueryPath::deserialize(json!(["firstNonDraftCreatedAtTransactionTime"]))?;
-    /// assert_eq!(path, EntityQueryPath::FirstNonDraftCreatedAtTransactionTime);
+    /// let path = EntityQueryPath::deserialize(json!(["firstNonDraftCreatedAtDecisionTime"]))?;
+    /// assert_eq!(path, EntityQueryPath::FirstNonDraftCreatedAtDecisionTime);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     ///

--- a/apps/hash-graph/libs/graph/src/knowledge/query.rs
+++ b/apps/hash-graph/libs/graph/src/knowledge/query.rs
@@ -134,6 +134,41 @@ pub enum EntityQueryPath<'p> {
     /// [`EntityMetadata`]: graph_types::knowledge::entity::EntityMetadata
     /// [`EntityTemporalMetadata`]: graph_types::knowledge::entity::EntityTemporalMetadata
     CreatedAtDecisionTime,
+    /// The timestamp of the transaction time when the [`Entity`] was _first undrafted_ in the
+    /// database.
+    ///
+    /// ```rust
+    /// # use serde::Deserialize;
+    /// # use serde_json::json;
+    /// # use graph::knowledge::EntityQueryPath;
+    /// let path = EntityQueryPath::deserialize(json!(["firstNonDraftCreatedAtTransactionTime"]))?;
+    /// assert_eq!(path, EntityQueryPath::FirstNonDraftCreatedAtTransactionTime);
+    /// # Ok::<(), serde_json::Error>(())
+    /// ```
+    ///
+    /// [`StructuralQuery`]: crate::subgraph::query::StructuralQuery
+    /// [`EntityMetadata`]: graph_types::knowledge::entity::EntityMetadata
+    /// [`EntityTemporalMetadata`]: graph_types::knowledge::entity::EntityTemporalMetadata
+    FirstNonDraftCreatedAtTransactionTime,
+    /// The timestamp of the decision time when the [`Entity`] was _first undrafted_ in the
+    /// database.
+    ///
+    /// This does not take into account if the [`Entity`] was updated with an earlier decision
+    /// time.
+    ///
+    /// ```rust
+    /// # use serde::Deserialize;
+    /// # use serde_json::json;
+    /// # use graph::knowledge::EntityQueryPath;
+    /// let path = EntityQueryPath::deserialize(json!(["firstNonDraftCreatedAtTransactionTime"]))?;
+    /// assert_eq!(path, EntityQueryPath::FirstNonDraftCreatedAtTransactionTime);
+    /// # Ok::<(), serde_json::Error>(())
+    /// ```
+    ///
+    /// [`StructuralQuery`]: crate::subgraph::query::StructuralQuery
+    /// [`EntityMetadata`]: graph_types::knowledge::entity::EntityMetadata
+    /// [`EntityTemporalMetadata`]: graph_types::knowledge::entity::EntityTemporalMetadata
+    FirstNonDraftCreatedAtDecisionTime,
     /// Whether or not the [`Entity`] is in a draft state.
     ///
     /// ```rust
@@ -409,6 +444,12 @@ impl fmt::Display for EntityQueryPath<'_> {
             Self::TransactionTime => fmt.write_str("transactionTime"),
             Self::CreatedAtDecisionTime => fmt.write_str("createdAtDecisionTime"),
             Self::CreatedAtTransactionTime => fmt.write_str("createdAtTransactionTime"),
+            Self::FirstNonDraftCreatedAtDecisionTime => {
+                fmt.write_str("firstNonDraftCreatedAtDecisionTime")
+            }
+            Self::FirstNonDraftCreatedAtTransactionTime => {
+                fmt.write_str("firstNonDraftCreatedAtTransactionTime")
+            }
             Self::Archived => fmt.write_str("archived"),
             Self::Properties(Some(property)) => write!(fmt, "properties.{property}"),
             Self::Properties(None) => fmt.write_str("properties"),
@@ -459,9 +500,10 @@ impl QueryPath for EntityQueryPath<'_> {
             | Self::EditionCreatedById
             | Self::CreatedById => ParameterType::Uuid,
             Self::DecisionTime | Self::TransactionTime => ParameterType::TimeInterval,
-            Self::CreatedAtDecisionTime | Self::CreatedAtTransactionTime => {
-                ParameterType::Timestamp
-            }
+            Self::CreatedAtDecisionTime
+            | Self::CreatedAtTransactionTime
+            | Self::FirstNonDraftCreatedAtDecisionTime
+            | Self::FirstNonDraftCreatedAtTransactionTime => ParameterType::Timestamp,
             Self::Properties(_) => ParameterType::Any,
             Self::Embedding => ParameterType::Vector,
             Self::LeftToRightOrder | Self::RightToLeftOrder => ParameterType::I32,
@@ -487,6 +529,8 @@ pub enum EntityQueryToken {
     CreatedById,
     CreatedAtTransactionTime,
     CreatedAtDecisionTime,
+    FirstNonDraftCreatedAtTransactionTime,
+    FirstNonDraftCreatedAtDecisionTime,
     Type,
     Properties,
     Embedding,
@@ -507,7 +551,8 @@ pub struct EntityQueryPathVisitor {
 impl EntityQueryPathVisitor {
     pub const EXPECTING: &'static str =
         "one of `uuid`, `editionId`, `draftId`, `archived`, `ownedById`, `editionCreatedById`, \
-         `createdById`, `createdAtTransactionTime`, `createdAtDecisionTime`, `type`, \
+         `createdById`, `createdAtTransactionTime`, `createdAtDecisionTime`, \
+         `firstNonDraftCreatedAtTransactionTime`, `firstNonDraftCreatedAtDecisionTime`, `type`, \
          `properties`, `embedding`, `incomingLinks`, `outgoingLinks`, `leftEntity`, \
          `rightEntity`, `leftToRightOrder`, `rightToLeftOrder`";
 
@@ -543,6 +588,12 @@ impl<'de> Visitor<'de> for EntityQueryPathVisitor {
             EntityQueryToken::CreatedById => EntityQueryPath::CreatedById,
             EntityQueryToken::CreatedAtTransactionTime => EntityQueryPath::CreatedAtTransactionTime,
             EntityQueryToken::CreatedAtDecisionTime => EntityQueryPath::CreatedAtDecisionTime,
+            EntityQueryToken::FirstNonDraftCreatedAtTransactionTime => {
+                EntityQueryPath::FirstNonDraftCreatedAtTransactionTime
+            }
+            EntityQueryToken::FirstNonDraftCreatedAtDecisionTime => {
+                EntityQueryPath::FirstNonDraftCreatedAtDecisionTime
+            }
             EntityQueryToken::Archived => EntityQueryPath::Archived,
             EntityQueryToken::Embedding => EntityQueryPath::Embedding,
             EntityQueryToken::Type => EntityQueryPath::EntityTypeEdge {
@@ -709,6 +760,12 @@ impl<'de: 'p, 'p> EntityQueryPath<'p> {
             EntityQueryPath::TransactionTime => EntityQueryPath::TransactionTime,
             EntityQueryPath::CreatedAtTransactionTime => EntityQueryPath::CreatedAtTransactionTime,
             EntityQueryPath::CreatedAtDecisionTime => EntityQueryPath::CreatedAtDecisionTime,
+            EntityQueryPath::FirstNonDraftCreatedAtTransactionTime => {
+                EntityQueryPath::FirstNonDraftCreatedAtTransactionTime
+            }
+            EntityQueryPath::FirstNonDraftCreatedAtDecisionTime => {
+                EntityQueryPath::FirstNonDraftCreatedAtDecisionTime
+            }
             EntityQueryPath::Archived => EntityQueryPath::Archived,
             EntityQueryPath::EditionCreatedById => EntityQueryPath::EditionCreatedById,
             EntityQueryPath::CreatedById => EntityQueryPath::CreatedById,

--- a/apps/hash-graph/libs/graph/src/knowledge/query.rs
+++ b/apps/hash-graph/libs/graph/src/knowledge/query.rs
@@ -134,8 +134,8 @@ pub enum EntityQueryPath<'p> {
     /// [`EntityMetadata`]: graph_types::knowledge::entity::EntityMetadata
     /// [`EntityTemporalMetadata`]: graph_types::knowledge::entity::EntityTemporalMetadata
     CreatedAtDecisionTime,
-    /// The timestamp of the transaction time when the [`Entity`] was _first undrafted_ in the
-    /// database.
+    /// The timestamp of the transaction time when the first non-draft edition of the [`Entity`] 
+    /// was inserted into the database. This may be the first edition, if created as non-draft.
     ///
     /// ```rust
     /// # use serde::Deserialize;

--- a/apps/hash-graph/libs/graph/src/knowledge/query.rs
+++ b/apps/hash-graph/libs/graph/src/knowledge/query.rs
@@ -125,8 +125,8 @@ pub enum EntityQueryPath<'p> {
     /// # use serde::Deserialize;
     /// # use serde_json::json;
     /// # use graph::knowledge::EntityQueryPath;
-    /// let path = EntityQueryPath::deserialize(json!(["createdAtTransactionTime"]))?;
-    /// assert_eq!(path, EntityQueryPath::CreatedAtTransactionTime);
+    /// let path = EntityQueryPath::deserialize(json!(["createdAtDecisionTime"]))?;
+    /// assert_eq!(path, EntityQueryPath::CreatedAtDecisionTime);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     ///

--- a/apps/hash-graph/libs/graph/src/knowledge/query.rs
+++ b/apps/hash-graph/libs/graph/src/knowledge/query.rs
@@ -134,7 +134,7 @@ pub enum EntityQueryPath<'p> {
     /// [`EntityMetadata`]: graph_types::knowledge::entity::EntityMetadata
     /// [`EntityTemporalMetadata`]: graph_types::knowledge::entity::EntityTemporalMetadata
     CreatedAtDecisionTime,
-    /// The timestamp of the transaction time when the first non-draft edition of the [`Entity`] 
+    /// The timestamp of the transaction time when the first non-draft edition of the [`Entity`]
     /// was inserted into the database. This may be the first edition, if created as non-draft.
     ///
     /// ```rust

--- a/apps/hash-graph/libs/graph/src/snapshot/entity/channel.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/entity/channel.rs
@@ -69,6 +69,14 @@ impl Sink<EntitySnapshotRecord> for EntitySender {
                 created_by_id: entity.metadata.provenance.created_by_id,
                 created_at_transaction_time: entity.metadata.provenance.created_at_transaction_time,
                 created_at_decision_time: entity.metadata.provenance.created_at_decision_time,
+                first_non_draft_created_at_transaction_time: entity
+                    .metadata
+                    .provenance
+                    .first_non_draft_created_at_transaction_time,
+                first_non_draft_created_at_decision_time: entity
+                    .metadata
+                    .provenance
+                    .first_non_draft_created_at_decision_time,
                 web_id: entity.metadata.record_id.entity_id.owned_by_id,
                 entity_uuid: entity.metadata.record_id.entity_id.entity_uuid,
             })

--- a/apps/hash-graph/libs/graph/src/snapshot/entity/table.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/entity/table.rs
@@ -17,6 +17,8 @@ pub struct EntityIdRow {
     pub created_by_id: CreatedById,
     pub created_at_transaction_time: Timestamp<TransactionTime>,
     pub created_at_decision_time: Timestamp<DecisionTime>,
+    pub first_non_draft_created_at_transaction_time: Option<Timestamp<TransactionTime>>,
+    pub first_non_draft_created_at_decision_time: Option<Timestamp<DecisionTime>>,
     pub web_id: OwnedById,
     pub entity_uuid: EntityUuid,
 }
@@ -69,6 +71,7 @@ pub struct EntityLinkEdgeRow {
 pub struct EntityEmbeddingRow {
     pub web_id: OwnedById,
     pub entity_uuid: EntityUuid,
+    pub draft_id: Option<DraftId>,
     pub property: Option<String>,
     pub embedding: Embedding<'static>,
     pub updated_at_transaction_time: Timestamp<TransactionTime>,

--- a/apps/hash-graph/libs/graph/src/snapshot/restore/channel.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/restore/channel.rs
@@ -160,6 +160,7 @@ impl Sink<SnapshotEntry> for SnapshotRecordSender {
                 .start_send_unpin(EntityEmbeddingRow {
                     web_id: embedding.entity_id.owned_by_id,
                     entity_uuid: embedding.entity_id.entity_uuid,
+                    draft_id: embedding.entity_id.draft_id,
                     property: embedding.property.as_ref().map(ToString::to_string),
                     embedding: embedding.embedding,
                     updated_at_transaction_time: embedding.updated_at_transaction_time,

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/query.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/query.rs
@@ -190,6 +190,8 @@ pub struct EntityRecordRowIndices {
     pub created_by_id: usize,
     pub created_at_transaction_time: usize,
     pub created_at_decision_time: usize,
+    pub first_non_draft_created_at_transaction_time: usize,
+    pub first_non_draft_created_at_decision_time: usize,
     pub edition_created_by_id: usize,
 
     pub archived: usize,
@@ -304,6 +306,10 @@ impl QueryRecordDecode for Entity {
                     created_by_id: row.get(indices.created_by_id),
                     created_at_transaction_time: row.get(indices.created_at_transaction_time),
                     created_at_decision_time: row.get(indices.created_at_decision_time),
+                    first_non_draft_created_at_transaction_time: row
+                        .get(indices.first_non_draft_created_at_transaction_time),
+                    first_non_draft_created_at_decision_time: row
+                        .get(indices.first_non_draft_created_at_decision_time),
                     edition: EntityEditionProvenanceMetadata {
                         created_by_id: row.get(indices.edition_created_by_id),
                     },
@@ -377,6 +383,10 @@ impl PostgresRecord for Entity {
                 .add_selection_path(&EntityQueryPath::CreatedAtTransactionTime),
             created_at_decision_time: compiler
                 .add_selection_path(&EntityQueryPath::CreatedAtDecisionTime),
+            first_non_draft_created_at_transaction_time: compiler
+                .add_selection_path(&EntityQueryPath::FirstNonDraftCreatedAtTransactionTime),
+            first_non_draft_created_at_decision_time: compiler
+                .add_selection_path(&EntityQueryPath::FirstNonDraftCreatedAtDecisionTime),
             edition_created_by_id: compiler
                 .add_selection_path(&EntityQueryPath::EditionCreatedById),
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/entity.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/entity.rs
@@ -21,7 +21,11 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
             | Self::DecisionTime
             | Self::TransactionTime
             | Self::DraftId => vec![],
-            Self::CreatedById | Self::CreatedAtTransactionTime | Self::CreatedAtDecisionTime => {
+            Self::CreatedById
+            | Self::CreatedAtTransactionTime
+            | Self::CreatedAtDecisionTime
+            | Self::FirstNonDraftCreatedAtTransactionTime
+            | Self::FirstNonDraftCreatedAtDecisionTime => {
                 vec![Relation::EntityIds]
             }
             Self::Embedding => vec![Relation::EntityEmbeddings],
@@ -98,6 +102,12 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
             Self::CreatedAtDecisionTime => Column::EntityIds(EntityIds::CreatedAtDecisionTime),
             Self::CreatedAtTransactionTime => {
                 Column::EntityIds(EntityIds::CreatedAtTransactionTime)
+            }
+            Self::FirstNonDraftCreatedAtDecisionTime => {
+                Column::EntityIds(EntityIds::FirstNonDraftCreatedAtDecisionTime)
+            }
+            Self::FirstNonDraftCreatedAtTransactionTime => {
+                Column::EntityIds(EntityIds::FirstNonDraftCreatedAtTransactionTime)
             }
             Self::EntityTypeEdge { path, .. } => path.terminating_column(),
             Self::EntityEdge {

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/table.rs
@@ -649,6 +649,8 @@ pub enum EntityIds {
     CreatedById,
     CreatedAtDecisionTime,
     CreatedAtTransactionTime,
+    FirstNonDraftCreatedAtDecisionTime,
+    FirstNonDraftCreatedAtTransactionTime,
 }
 
 impl EntityIds {
@@ -659,6 +661,10 @@ impl EntityIds {
             Self::CreatedById => "created_by_id",
             Self::CreatedAtDecisionTime => "created_at_decision_time",
             Self::CreatedAtTransactionTime => "created_at_transaction_time",
+            Self::FirstNonDraftCreatedAtDecisionTime => "first_non_draft_created_at_decision_time",
+            Self::FirstNonDraftCreatedAtTransactionTime => {
+                "first_non_draft_created_at_transaction_time"
+            }
         };
         table.transpile(fmt)?;
         write!(fmt, r#"."{column}""#)
@@ -666,17 +672,23 @@ impl EntityIds {
 
     pub const fn nullable(self) -> bool {
         match self {
-            Self::WebId | Self::EntityUuid | Self::CreatedById => false,
-            Self::CreatedAtDecisionTime | Self::CreatedAtTransactionTime => true,
+            Self::WebId
+            | Self::EntityUuid
+            | Self::CreatedById
+            | Self::CreatedAtDecisionTime
+            | Self::CreatedAtTransactionTime => false,
+            Self::FirstNonDraftCreatedAtDecisionTime
+            | Self::FirstNonDraftCreatedAtTransactionTime => true,
         }
     }
 
     pub const fn parameter_type(self) -> ParameterType {
         match self {
             Self::WebId | Self::EntityUuid | Self::CreatedById => ParameterType::Uuid,
-            Self::CreatedAtDecisionTime | Self::CreatedAtTransactionTime => {
-                ParameterType::Timestamp
-            }
+            Self::CreatedAtDecisionTime
+            | Self::CreatedAtTransactionTime
+            | Self::FirstNonDraftCreatedAtDecisionTime
+            | Self::FirstNonDraftCreatedAtTransactionTime => ParameterType::Timestamp,
         }
     }
 }

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -3384,6 +3384,20 @@
           },
           "edition": {
             "$ref": "#/components/schemas/EntityEditionProvenanceMetadata"
+          },
+          "firstNonDraftCreatedAtDecisionTime": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Timestamp"
+              }
+            ]
+          },
+          "firstNonDraftCreatedAtTransactionTime": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Timestamp"
+              }
+            ]
           }
         },
         "additionalProperties": false
@@ -3453,6 +3467,8 @@
           "createdById",
           "createdAtTransactionTime",
           "createdAtDecisionTime",
+          "firstNonDraftCreatedAtTransactionTime",
+          "firstNonDraftCreatedAtDecisionTime",
           "type",
           "properties",
           "embedding",

--- a/apps/hash-graph/postgres_migrations/V18__undrafted_at.sql
+++ b/apps/hash-graph/postgres_migrations/V18__undrafted_at.sql
@@ -1,0 +1,64 @@
+ALTER TABLE "entity_ids"
+    ADD COLUMN "first_non_draft_created_at_transaction_time" TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN "first_non_draft_created_at_decision_time"    TIMESTAMP WITH TIME ZONE;
+
+-- Some created-at times were not calculated correctly. This will fix them.
+UPDATE "entity_ids"
+SET created_at_transaction_time = transaction_time,
+    created_at_decision_time    = decision_time
+FROM (
+    WITH transaction_times AS (
+        SELECT web_id,
+               entity_uuid,
+               min(lower(transaction_time)) AS "transaction_time"
+        FROM entity_temporal_metadata
+        GROUP BY web_id, entity_uuid
+    ), decision_times AS (
+        SELECT web_id,
+               entity_uuid,
+               min(lower(decision_time)) AS "decision_time"
+        FROM entity_temporal_metadata
+        GROUP BY web_id, entity_uuid
+    )
+    SELECT DISTINCT ON (web_id, entity_uuid)
+          web_id,
+          entity_uuid,
+          transaction_times.transaction_time,
+          decision_times.decision_time
+     FROM entity_temporal_metadata
+     JOIN decision_times USING (web_id, entity_uuid)
+     JOIN transaction_times USING (web_id, entity_uuid)
+) AS subquery
+WHERE "entity_ids".web_id = subquery.web_id
+  AND "entity_ids".entity_uuid = subquery.entity_uuid;
+
+UPDATE "entity_ids"
+SET first_non_draft_created_at_transaction_time = transaction_time,
+    first_non_draft_created_at_decision_time    = decision_time
+FROM (
+    WITH transaction_times AS (
+        SELECT web_id,
+               entity_uuid,
+               min(lower(transaction_time)) AS "transaction_time"
+        FROM entity_temporal_metadata
+        WHERE draft_id IS NULL
+        GROUP BY web_id, entity_uuid
+    ), decision_times AS (
+        SELECT web_id,
+               entity_uuid,
+               min(lower(decision_time)) AS "decision_time"
+        FROM entity_temporal_metadata
+        WHERE draft_id IS NULL
+        GROUP BY web_id, entity_uuid
+    )
+    SELECT DISTINCT ON (web_id, entity_uuid)
+          web_id,
+          entity_uuid,
+          transaction_times.transaction_time,
+          decision_times.decision_time
+     FROM entity_temporal_metadata
+     JOIN decision_times USING (web_id, entity_uuid)
+     JOIN transaction_times USING (web_id, entity_uuid)
+) AS subquery
+WHERE "entity_ids".web_id = subquery.web_id
+  AND "entity_ids".entity_uuid = subquery.entity_uuid;

--- a/libs/@local/hash-graph-types/rust/src/knowledge/entity.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/entity.rs
@@ -142,6 +142,12 @@ pub struct EntityProvenanceMetadata {
     pub created_by_id: CreatedById,
     pub created_at_transaction_time: Timestamp<TransactionTime>,
     pub created_at_decision_time: Timestamp<DecisionTime>,
+    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_non_draft_created_at_transaction_time: Option<Timestamp<TransactionTime>>,
+    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_non_draft_created_at_decision_time: Option<Timestamp<DecisionTime>>,
     pub edition: EntityEditionProvenanceMetadata,
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

It's interesting to know if for a given draft a non-draft entity exists and if so at which time that one was created. This adds two new provenance fields (decision time + transaction time) for the time when an entity of a given ID was first created in a non-draft state.

## 🔍 What does this change?

- Add provenance fields and do required changes to the Graph API
- Drive-by: Fix `created-at-*` not calculated correctly in database
- Drive-by: Fix snapshots not being able to be restored when embeddings are part of the snapshot

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- A bunch of assertions were added to the `draft` tests