### PR TITLE
H-2233: Add more missing Hydra environment variables, fix consent form

### DIFF
--- a/apps/hash-api/views/consent.hbs
+++ b/apps/hash-api/views/consent.hbs
@@ -29,13 +29,21 @@
             xhr.send(JSON.stringify(data));
         }
 
-        window.addEventListener("DOMContentLoaded", function() {
+        if (document.readyState !== 'loading') {
             var form = document.querySelector('form');
             form.addEventListener('submit', function(event) {
                 event.preventDefault();
                 submit();
             });
-        })
+        } else {
+            document.addEventListener('DOMContentLoaded', function() {
+                var form = document.querySelector('form');
+                form.addEventListener('submit', function(event) {
+                    event.preventDefault();
+                    submit();
+                });
+            });
+        }
     </script>
     <div class="auth-box">
         <h1>Grant access to HASH</h1>

--- a/infra/terraform/hash/prod-usea1.tfvars
+++ b/infra/terraform/hash/prod-usea1.tfvars
@@ -39,11 +39,14 @@ hydra_env_vars = [
   { name = "COOKIES_PATH", secret = false, value = "/" },
   { name = "COOKIES_DOMAIN", secret = false, value = "hash.ai" },
   { name = "COOKIES_SAME_SITE", secret = false, value = "Lax" },
+  { name = "URLS_CONSENT", value = "https://app-api.hash.ai/oauth2/consent"},
   { name = "URLS_LOGIN", secret = false, value = "https://app.hash.ai/signin" },
   { name = "URLS_REGISTRATION", secret = false, value = "https://app.hash.ai/signup" },
   { name = "URLS_POST_LOGOUT_REDIRECT", secret = false, value = "https://app.hash.ai" },
   { name = "URLS_IDENTITY_PROVIDER_PUBLICURL", secret = false, value = "http://localhost:4433" }, # Kratos public endpoint
   { name = "URLS_IDENTITY_PROVIDER_URL", secret = false, value = "http://localhost:4434" }, # Kratos admin endpoint
+  { name = "URLS_SELF_ISSUER", secret = false, value = "https://app-api.hash.ai" },
+  { name = "URLS_SELF_PUBLIC", secret = false, value = "https://app-api.hash.ai" }
 ]
 
 hash_graph_env_vars = [

--- a/infra/terraform/hash/prod-usea1.tfvars
+++ b/infra/terraform/hash/prod-usea1.tfvars
@@ -39,7 +39,7 @@ hydra_env_vars = [
   { name = "COOKIES_PATH", secret = false, value = "/" },
   { name = "COOKIES_DOMAIN", secret = false, value = "hash.ai" },
   { name = "COOKIES_SAME_SITE", secret = false, value = "Lax" },
-  { name = "URLS_CONSENT", value = "https://app-api.hash.ai/oauth2/consent"},
+  { name = "URLS_CONSENT", secret = false, value = "https://app-api.hash.ai/oauth2/consent"},
   { name = "URLS_LOGIN", secret = false, value = "https://app.hash.ai/signin" },
   { name = "URLS_REGISTRATION", secret = false, value = "https://app.hash.ai/signup" },
   { name = "URLS_POST_LOGOUT_REDIRECT", secret = false, value = "https://app.hash.ai" },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This should be the last PR fixing up the production flow for OAuth2 consent – I've tested with these changes in production and the flow completes successfully.

This PR adds some more environment variables to the Terraform config that I missed, and also fixes an issue with the consent form where the submission handler might not be added to the form if the page loaded before the JS that's supposed to add the handler is executed.
<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change
- [x] are in a state where docs changes are not _yet_ required but will be
  - this is tracked in: [Insert Link Here](link)
- [x] require changes to docs which **are made** as part of this PR
- [x] require changes to docs which are **not** made in this PR
  - _Provide more detail here_
- [x] I am unsure / need advice

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
