### PR TITLE
H-2034: Restore basic search bar to frontend

### DIFF
--- a/apps/hash-ai-worker-ts/src/workflows.ts
+++ b/apps/hash-ai-worker-ts/src/workflows.ts
@@ -1,5 +1,7 @@
 import type { EntityQueryCursor, Filter } from "@local/hash-graph-client";
 import type {
+  CreateEmbeddingsParams,
+  CreateEmbeddingsReturn,
   InferEntitiesCallerParams,
   InferEntitiesReturn,
 } from "@local/hash-isomorphic-utils/ai-inference-types";
@@ -72,6 +74,12 @@ export const inferEntities = async (params: InferEntitiesCallerParams) => {
     }
     throw err;
   }
+};
+
+export const createEmbeddings = async (
+  params: CreateEmbeddingsParams,
+): Promise<CreateEmbeddingsReturn> => {
+  return await aiActivities.createEmbeddingsActivity(params);
 };
 
 type UpdateDataTypeEmbeddingsParams = {

--- a/apps/hash-api/src/graph/knowledge/primitive/entity.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity.ts
@@ -196,8 +196,6 @@ export const getEntities: ImpureGraphFunction<
     }
   }
 
-  console.log(JSON.stringify(query, undefined, 2));
-
   return await graphApi
     .getEntitiesByQuery(actorId, { query })
     .then(({ data }) => {

--- a/apps/hash-api/src/graph/knowledge/primitive/entity.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity.ts
@@ -196,6 +196,8 @@ export const getEntities: ImpureGraphFunction<
     }
   }
 
+  console.log(JSON.stringify(query, undefined, 2));
+
   return await graphApi
     .getEntitiesByQuery(actorId, { query })
     .then(({ data }) => {

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/use-rows/generate-property-rows-from-entity/get-expected-types-of-property-type.ts
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/use-rows/generate-property-rows-from-entity/get-expected-types-of-property-type.ts
@@ -47,7 +47,11 @@ export const getExpectedTypesOfPropertyType = (
   let isArray = false;
   let expectedTypes: DataTypeWithMetadata["schema"][] = [];
 
-  // @todo handle property types with multiple expected values
+  /**
+   * @todo handle property types with multiple expected values -- H-2257
+   * e.g. the Paragraph block expects either 'string' or 'object[]'
+   * The entity editor input currently can only handle either different single values, or a mixed array – not single value or array
+   */
   const firstType = propertyType.oneOf[0];
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- improve logic or types to remove this comment

--- a/apps/hash-frontend/src/shared/layout/layout-with-header/page-header.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-header/page-header.tsx
@@ -25,7 +25,7 @@ const Nav: FunctionComponent<{ children?: ReactNode }> = ({ children }) => (
   </Box>
 );
 
-export const HEADER_HEIGHT = 54;
+export const HEADER_HEIGHT = 60;
 
 export const PageHeader: FunctionComponent = () => {
   const theme = useTheme();

--- a/apps/hash-frontend/src/shared/layout/layout-with-header/search-bar.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-header/search-bar.tsx
@@ -11,7 +11,7 @@ import {
   extractOwnedByIdFromEntityId,
   Subgraph,
 } from "@local/hash-subgraph";
-import { getRoots } from "@local/hash-subgraph/stdlib";
+import { getRoots, isEntityRootedSubgraph } from "@local/hash-subgraph/stdlib";
 import { Box, SxProps, Theme, useMediaQuery, useTheme } from "@mui/material";
 import {
   FunctionComponent,
@@ -53,7 +53,7 @@ const ResultList: FunctionComponent<{
     sx={(theme) => ({
       position: !isMobile ? "absolute" : "unset",
       top: !isMobile ? "calc(100% + 1px)" : "unset",
-      zIndex: 10,
+      zIndex: 10_000,
       width: "100%",
       maxHeight: "15rem",
       overflow: "auto",
@@ -204,14 +204,17 @@ export const SearchBar: FunctionComponent = () => {
         includeDrafts: true,
       },
       includePermissions: false,
+      skip: !submittedQuery,
     },
   });
 
-  const results = resultData?.structuralQueryEntities
-    ? getRoots(
-        resultData.structuralQueryEntities.subgraph as Subgraph<EntityRootType>,
-      )
-    : [];
+  const subgraph =
+    resultData &&
+    isEntityRootedSubgraph(resultData.structuralQueryEntities.subgraph)
+      ? resultData.structuralQueryEntities.subgraph
+      : undefined;
+
+  const results = subgraph ? getRoots(subgraph) : [];
 
   useKey(["Escape"], () => setResultListVisible(false));
 
@@ -286,9 +289,7 @@ export const SearchBar: FunctionComponent = () => {
                 <EntityResult
                   key={entity.metadata.recordId.entityId}
                   entity={entity}
-                  subgraph={
-                    resultData?.structuralQueryEntities.subgraph as Subgraph
-                  }
+                  subgraph={subgraph!}
                 />
               );
             })

--- a/apps/hash-frontend/src/shared/layout/layout-with-header/search-bar/search-input.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-header/search-bar/search-input.tsx
@@ -4,12 +4,17 @@ import {
   Box,
   InputAdornment,
   OutlinedInput,
+  outlinedInputClasses,
   Tooltip,
   Typography,
 } from "@mui/material";
 import { FunctionComponent, useCallback, useEffect, useRef } from "react";
 
 import { SearchIcon } from "../../../icons";
+import {
+  useSetKeyboardShortcuts,
+  useUnsetKeyboardShortcuts,
+} from "../../../keyboard-shortcuts-context";
 
 const ClearSearchIcon: FunctionComponent<{
   clearSearch: () => void;
@@ -69,7 +74,7 @@ const ShortcutIcon = () => {
             fontWeight: 500,
           })}
         >
-          {isMac ? "Cmd" : "Ctrl"} + P
+          {isMac ? "Cmd" : "Ctrl"} + /
         </Typography>
       </Box>
     </Box>
@@ -86,33 +91,30 @@ export const SearchInput: FunctionComponent<{
 
   const inputRef = useRef<HTMLInputElement>(null);
 
-  /**
-   * @todo reinstate this when search functionality is restored
-   */
-  // const setKeyboardShortcuts = useSetKeyboardShortcuts();
-  // const unsetKeyboardShortcuts = useUnsetKeyboardShortcuts();
-  //
-  // useEffect(() => {
-  //   const shortcut = {
-  //     keys: ["Control", "p"],
-  //     callback: (evt: KeyboardEvent) => {
-  //      event.preventDefault();
-  //      if (!isMac) {
-  //        inputRef.current?.focus();
-  //      }
-  //     },
-  //   };
-  //
-  //   setKeyboardShortcuts([shortcut]);
-  //
-  //   return () => {
-  //     unsetKeyboardShortcuts([shortcut]);
-  //   };
-  // }, [setKeyboardShortcuts, unsetKeyboardShortcuts]);
+  const setKeyboardShortcuts = useSetKeyboardShortcuts();
+  const unsetKeyboardShortcuts = useUnsetKeyboardShortcuts();
+
+  useEffect(() => {
+    const shortcut = {
+      keys: ["Meta", "/"],
+      callback: (event: KeyboardEvent) => {
+        event.preventDefault();
+        if (!isMac) {
+          inputRef.current?.focus();
+        }
+      },
+    };
+
+    setKeyboardShortcuts([shortcut]);
+
+    return () => {
+      unsetKeyboardShortcuts([shortcut]);
+    };
+  }, [isMac, setKeyboardShortcuts, unsetKeyboardShortcuts]);
 
   useEffect(() => {
     function checkSearchKey(event: KeyboardEvent) {
-      if (isMac && event.key === "p" && event.metaKey) {
+      if (isMac && event.key === "/" && event.metaKey) {
         event.preventDefault();
         inputRef.current?.focus();
       }
@@ -141,13 +143,23 @@ export const SearchInput: FunctionComponent<{
         setQueryText(event.target.value);
       }}
       sx={{
+        boxShadow: "none",
         width: isMobile ? "100%" : "385px",
         "& .MuiInputBase-input": {
           paddingLeft: "unset",
           paddingRight: isMobile ? 1 : "unset",
         },
+        [`& .${outlinedInputClasses.notchedOutline}`]: {
+          border: ({ palette }) => `1px solid ${palette.gray[30]}`,
+        },
       }}
-      inputProps={{ "aria-label": "search" }}
+      inputProps={{
+        "aria-label": "search",
+        sx: {
+          fontSize: 15,
+          py: 1.2,
+        },
+      }}
       startAdornment={
         <InputAdornment position="start">
           <Box

--- a/libs/@local/hash-backend-utils/src/create-graph-client.ts
+++ b/libs/@local/hash-backend-utils/src/create-graph-client.ts
@@ -100,7 +100,7 @@ export const createGraphClient = (
         /* @todo - Do we have any useful information we can extract from `response.request`? */
         return Promise.reject(
           new Error(
-            "Encountered an error while calling the Graph API, which wasn't identified as coming from the Graph API.",
+            `Encountered an error while calling the Graph API, which wasn't identified as coming from the Graph API: ${(secondaryError as Error).message},`,
           ),
         );
       }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR restores the search bar in HASH. It searches for entities based on their semantic distance, and links results to the entity editor.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues / next steps

- Because search involves calling a Temporal workflow to create the embedding of the search text, there might be unacceptable delay introduced that could be mitigated by calling OpenAI's embedding model directly from the API. To see how this works in practice and potentially change.
- Results are not paginated, which means they might be slow to load with lots of results. H-2258
- Ideally for entities which are contained in a page (e.g. paragraphs), we would link to the containing Page rather than the entity editor. H-2258. 
- The entity editor crashes if you try and load a paragraph block into it, because the entity editor does not handle properties with an expected value of either a single value or an array of values. H-2257

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- Manual.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. You must have rebuilt the Graph since https://github.com/hashintel/hash/commit/244f242b84842d5cce111a59fbb5a8021ff00bda (any entities unmodified prior to rebuilding will not have embeddings and won't appear in results – you can update them after rebuilding to generate an embedding for them), or run it outside of Docker
2. You must rebuild the AI Temporal worker or run it ouside of Docker, because it was missing a workflow the search query depends on
3. Try searching for something

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

https://github.com/hashintel/hash/assets/37743469/e27dbd4d-c80f-42f6-a1ed-98473713363e

