### PR TITLE
H-2264: Add index for temporal metadata

### DIFF
--- a/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
@@ -229,7 +229,7 @@ fn bench_scaling_read_entity_zero_depths(c: &mut Criterion) {
         Uuid::from_str("bf5a9ef5-dc3b-43cf-a291-6210c0321eba").expect("invalid uuid"),
     );
 
-    for size in [1, 5, 10, 25] {
+    for size in [1, 5, 10, 25, 50] {
         // TODO: reuse the database if it already exists like we do for representative_read
         let (runtime, mut store_wrapper) = setup(DB_NAME, true, true, account_id);
 
@@ -281,7 +281,7 @@ fn bench_scaling_read_entity_one_depth(c: &mut Criterion) {
         Uuid::from_str("bf5a9ef5-dc3b-43cf-a291-6210c0321eba").expect("invalid uuid"),
     );
 
-    for size in [1, 5, 10, 25] {
+    for size in [1, 5, 10, 25, 50] {
         // TODO: reuse the database if it already exists like we do for representative_read
         let (runtime, mut store_wrapper) = setup(DB_NAME, true, true, account_id);
 

--- a/apps/hash-graph/postgres_migrations/V19__temporal_indices.sql
+++ b/apps/hash-graph/postgres_migrations/V19__temporal_indices.sql
@@ -1,0 +1,3 @@
+CREATE INDEX entity_temporal_metadata_temporal_idx
+    ON entity_temporal_metadata
+        USING gist (web_id, entity_uuid, transaction_time, decision_time);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We noticed a significant performance regression when traversing entities. The query, which is responsible to find edges from one entities to other entities, is the reason for this (e.g. finding the left entities of a link). To find these edges, these steps are done in the query:
- Get the temporal data of the source entities (“source entities”) for:
    - the source’s pinned axis lies inside the queried pinned axis
    - the source’s variable axis starts with the entity version being queried
    - the source’s entity id (web id + uuid) matches the requested entity’s id
- read all edges from the “source entities” (identified by the entity ID), this results in a set of potential target entity IDs
- Get the temporal data of target entities, where:
    - the target’s pinned axis lies inside the queried pinned axis
    - the target’s variable axis overlaps with the queried variable axis
    - the source’s and target’s variable axes overlap

The impact on performance is due to the overlapping check of the source's and target's variable axes because:
- Previously, we had a constraint, which restricts overlapping decision times and transaction times based on the web_id and entity_uuid
- With draft IDs being stored in the temporal metadata as well, this is no longer enough as drafts may overlap with their undrafted entity
- The constraint was split into two:
    1. Overlapping check as before “Where draft_id is null”
    1. Overlapping check including draft id “Where draft_id is not null”
- Looking up by temporal data without specifying if the draft id is null or not (cannot tell at this point), Postgres cannot use the index (probably it could look up both and do some smart things here but it doesn’t), so because of this, the query get’s so incredible slow

## 🔍 What does this change?

- Add a new index only based on the web id, the entity uuid, the decision time, and the transaction time
- Re-enable slow benchmarks

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

The benchmarks are covering this case, however, we currently don't run the Benchmarks in CI. See H-2286