### PR TITLE
H-2290: Implement `utoipa` schema for type system URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3744,6 +3744,7 @@ dependencies = [
  "thiserror",
  "tsify",
  "url",
+ "utoipa",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]
@@ -3869,6 +3870,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.52",
+ "url",
  "uuid",
 ]
 

--- a/apps/hash-graph/libs/api/Cargo.toml
+++ b/apps/hash-graph/libs/api/Cargo.toml
@@ -14,7 +14,7 @@ hash-tracing = { workspace = true }
 temporal-client = { workspace = true }
 temporal-versioning = { workspace = true }
 authorization = { workspace = true }
-type-system = { workspace = true }
+type-system = { workspace = true, features = ["utoipa"] }
 validation = { workspace = true, features = ["utoipa"] }
 codec = { workspace = true, optional = true }
 

--- a/apps/hash-graph/libs/api/src/rest/data_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/data_type.rs
@@ -252,10 +252,7 @@ where
 #[serde(untagged)]
 enum LoadExternalDataTypeRequest {
     #[serde(rename_all = "camelCase")]
-    Fetch {
-        #[schema(value_type = SHARED_VersionedUrl)]
-        data_type_id: VersionedUrl,
-    },
+    Fetch { data_type_id: VersionedUrl },
     Create {
         #[schema(value_type = VAR_DATA_TYPE)]
         schema: DataType,
@@ -431,7 +428,6 @@ where
 struct UpdateDataTypeRequest {
     #[schema(value_type = VAR_UPDATE_DATA_TYPE)]
     schema: serde_json::Value,
-    #[schema(value_type = SHARED_VersionedUrl)]
     type_to_update: VersionedUrl,
     relationships: Vec<DataTypeRelationAndSubject>,
 }
@@ -676,7 +672,6 @@ where
 #[serde(rename_all = "camelCase")]
 struct ModifyDataTypeAuthorizationRelationship {
     operation: ModifyRelationshipOperation,
-    #[schema(value_type = SHARED_VersionedUrl)]
     resource: VersionedUrl,
     relation_and_subject: DataTypeRelationAndSubject,
 }

--- a/apps/hash-graph/libs/api/src/rest/entity.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity.rs
@@ -462,7 +462,6 @@ where
 struct UpdateEntityRequest {
     properties: EntityProperties,
     entity_id: EntityId,
-    #[schema(value_type = SHARED_VersionedUrl)]
     entity_type_id: VersionedUrl,
     #[serde(flatten)]
     order: EntityLinkOrder,

--- a/apps/hash-graph/libs/api/src/rest/entity_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity_type.rs
@@ -162,7 +162,6 @@ struct CreateEntityTypeRequest {
     schema: MaybeListOfEntityType,
     owned_by_id: OwnedById,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = SHARED_BaseUrl)]
     label_property: Option<BaseUrl>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     icon: Option<String>,
@@ -173,7 +172,6 @@ struct CreateEntityTypeRequest {
 #[serde(rename_all = "camelCase")]
 struct ModifyEntityTypeAuthorizationRelationship {
     operation: ModifyRelationshipOperation,
-    #[schema(value_type = SHARED_VersionedUrl)]
     resource: VersionedUrl,
     relation_and_subject: EntityTypeRelationAndSubject,
 }
@@ -523,15 +521,11 @@ where
 #[serde(untagged)]
 enum LoadExternalEntityTypeRequest {
     #[serde(rename_all = "camelCase")]
-    Fetch {
-        #[schema(value_type = SHARED_VersionedUrl)]
-        entity_type_id: VersionedUrl,
-    },
+    Fetch { entity_type_id: VersionedUrl },
     Create {
         #[schema(value_type = VAR_ENTITY_TYPE)]
         schema: EntityType,
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        #[schema(value_type = SHARED_BaseUrl)]
         label_property: Option<BaseUrl>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         icon: Option<String>,
@@ -741,10 +735,8 @@ where
 struct UpdateEntityTypeRequest {
     #[schema(value_type = VAR_UPDATE_ENTITY_TYPE)]
     schema: serde_json::Value,
-    #[schema(value_type = SHARED_VersionedUrl)]
     type_to_update: VersionedUrl,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = SHARED_BaseUrl)]
     label_property: Option<BaseUrl>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     icon: Option<String>,

--- a/apps/hash-graph/libs/api/src/rest/mod.rs
+++ b/apps/hash-graph/libs/api/src/rest/mod.rs
@@ -68,6 +68,7 @@ use temporal_versioning::{
     ClosedTemporalBound, DecisionTime, LeftClosedTemporalInterval, LimitedTemporalBound,
     OpenTemporalBound, RightBoundedTemporalInterval, TemporalBound, Timestamp, TransactionTime,
 };
+use type_system::url::{BaseUrl, VersionedUrl};
 use utoipa::{
     openapi::{
         self, schema, ArrayBuilder, KnownFormat, Object, ObjectBuilder, OneOfBuilder, Ref, RefOr,
@@ -343,6 +344,8 @@ async fn serve_static_schema(Path(path): Path<String>) -> Result<Response, Statu
         schemas(
             PermissionResponse,
 
+            BaseUrl,
+            VersionedUrl,
             OwnedById,
             CreatedById,
             EditionCreatedById,
@@ -549,7 +552,6 @@ fn modify_schema_references(schema_component: &mut RefOr<openapi::Schema>) {
 
 fn modify_reference(reference: &mut openapi::Ref) {
     static REF_PREFIX_MODELS: &str = "#/components/schemas/VAR_";
-    static REF_PREFIX_SHARED: &str = "#/components/schemas/SHARED_";
 
     if reference.ref_location.starts_with(REF_PREFIX_MODELS) {
         reference
@@ -557,13 +559,6 @@ fn modify_reference(reference: &mut openapi::Ref) {
             .replace_range(0..REF_PREFIX_MODELS.len(), "./models/");
         reference.ref_location.make_ascii_lowercase();
         reference.ref_location.push_str(".json");
-    };
-
-    if reference.ref_location.starts_with(REF_PREFIX_SHARED) {
-        reference.ref_location.replace_range(
-            0..REF_PREFIX_SHARED.len(),
-            "./models/shared.json#/definitions/",
-        );
     };
 }
 

--- a/apps/hash-graph/libs/api/src/rest/property_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/property_type.rs
@@ -259,10 +259,7 @@ where
 #[serde(untagged)]
 enum LoadExternalPropertyTypeRequest {
     #[serde(rename_all = "camelCase")]
-    Fetch {
-        #[schema(value_type = SHARED_VersionedUrl)]
-        property_type_id: VersionedUrl,
-    },
+    Fetch { property_type_id: VersionedUrl },
     Create {
         #[schema(value_type = VAR_PROPERTY_TYPE)]
         schema: PropertyType,
@@ -437,7 +434,6 @@ where
 struct UpdatePropertyTypeRequest {
     #[schema(value_type = VAR_UPDATE_PROPERTY_TYPE)]
     schema: serde_json::Value,
-    #[schema(value_type = SHARED_VersionedUrl)]
     type_to_update: VersionedUrl,
     relationships: Vec<PropertyTypeRelationAndSubject>,
 }
@@ -682,7 +678,6 @@ where
 #[serde(rename_all = "camelCase")]
 struct ModifyPropertyTypeAuthorizationRelationship {
     operation: ModifyRelationshipOperation,
-    #[schema(value_type = SHARED_VersionedUrl)]
     resource: VersionedUrl,
     relation_and_subject: PropertyTypeRelationAndSubject,
 }

--- a/apps/hash-graph/libs/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/libs/graph/src/store/knowledge.rs
@@ -46,7 +46,7 @@ impl ToSchema<'_> for EntityValidationType<'_> {
             Schema::OneOf(
                 schema::OneOfBuilder::new()
                     .item(Ref::from_schema_name("VAR_ENTITY_TYPE"))
-                    .item(Ref::from_schema_name("SHARED_VersionedUrl"))
+                    .item(Ref::from_schema_name("VersionedUrl"))
                     .build(),
             )
             .into(),
@@ -175,7 +175,6 @@ pub struct CreateEntityParams<R> {
     #[serde(default)]
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     pub decision_time: Option<Timestamp<DecisionTime>>,
-    #[cfg_attr(feature = "utoipa", schema(value_type = SHARED_VersionedUrl))]
     pub entity_type_id: VersionedUrl,
     pub properties: EntityProperties,
     #[serde(default)]
@@ -218,7 +217,6 @@ pub struct UpdateEntityParams {
     #[serde(default)]
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     pub decision_time: Option<Timestamp<DecisionTime>>,
-    #[cfg_attr(feature = "utoipa", schema(value_type = SHARED_VersionedUrl))]
     pub entity_type_id: VersionedUrl,
     pub properties: EntityProperties,
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]

--- a/apps/hash-graph/libs/graph/src/store/ontology.rs
+++ b/apps/hash-graph/libs/graph/src/store/ontology.rs
@@ -70,7 +70,6 @@ pub struct UpdateDataTypesParams<R> {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ArchiveDataTypeParams<'a> {
     #[serde(borrow)]
-    #[cfg_attr(feature = "utoipa", schema(value_type = SHARED_VersionedUrl))]
     pub data_type_id: Cow<'a, VersionedUrl>,
 }
 
@@ -78,7 +77,6 @@ pub struct ArchiveDataTypeParams<'a> {
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct UnarchiveDataTypeParams {
-    #[cfg_attr(feature = "utoipa", schema(value_type = SHARED_VersionedUrl))]
     pub data_type_id: VersionedUrl,
 }
 
@@ -87,7 +85,6 @@ pub struct UnarchiveDataTypeParams {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct UpdateDataTypeEmbeddingParams<'a> {
     #[serde(borrow)]
-    #[cfg_attr(feature = "utoipa", schema(value_type = SHARED_VersionedUrl))]
     pub data_type_id: Cow<'a, VersionedUrl>,
     #[serde(borrow)]
     pub embedding: Embedding<'a>,
@@ -245,7 +242,6 @@ pub struct UpdatePropertyTypesParams<R> {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ArchivePropertyTypeParams<'a> {
     #[serde(borrow)]
-    #[cfg_attr(feature = "utoipa", schema(value_type = SHARED_VersionedUrl))]
     pub property_type_id: Cow<'a, VersionedUrl>,
 }
 
@@ -253,7 +249,6 @@ pub struct ArchivePropertyTypeParams<'a> {
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct UnarchivePropertyTypeParams<'a> {
-    #[cfg_attr(feature = "utoipa", schema(value_type = SHARED_VersionedUrl))]
     pub property_type_id: Cow<'a, VersionedUrl>,
 }
 
@@ -262,7 +257,6 @@ pub struct UnarchivePropertyTypeParams<'a> {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct UpdatePropertyTypeEmbeddingParams<'a> {
     #[serde(borrow)]
-    #[cfg_attr(feature = "utoipa", schema(value_type = SHARED_VersionedUrl))]
     pub property_type_id: Cow<'a, VersionedUrl>,
     #[serde(borrow)]
     pub embedding: Embedding<'a>,
@@ -424,7 +418,6 @@ pub struct UpdateEntityTypesParams<R> {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ArchiveEntityTypeParams<'a> {
     #[serde(borrow)]
-    #[cfg_attr(feature = "utoipa", schema(value_type = SHARED_VersionedUrl))]
     pub entity_type_id: Cow<'a, VersionedUrl>,
 }
 
@@ -432,7 +425,6 @@ pub struct ArchiveEntityTypeParams<'a> {
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct UnarchiveEntityTypeParams<'a> {
-    #[cfg_attr(feature = "utoipa", schema(value_type = SHARED_VersionedUrl))]
     pub entity_type_id: Cow<'a, VersionedUrl>,
 }
 
@@ -441,7 +433,6 @@ pub struct UnarchiveEntityTypeParams<'a> {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct UpdateEntityTypeEmbeddingParams<'a> {
     #[serde(borrow)]
-    #[cfg_attr(feature = "utoipa", schema(value_type = SHARED_VersionedUrl))]
     pub entity_type_id: Cow<'a, VersionedUrl>,
     #[serde(borrow)]
     pub embedding: Embedding<'a>,

--- a/apps/hash-graph/libs/graph/src/subgraph/identifier/vertex.rs
+++ b/apps/hash-graph/libs/graph/src/subgraph/identifier/vertex.rs
@@ -42,7 +42,6 @@ macro_rules! define_ontology_type_vertex_id {
         #[cfg_attr(feature = "utoipa", derive(ToSchema))]
         #[serde(rename_all = "camelCase")]
         pub struct $name {
-            #[cfg_attr(feature = "utoipa", schema(value_type = SHARED_BaseUrl))]
             pub base_id: BaseUrl,
             pub revision_id: OntologyTypeVersion,
         }

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -2629,7 +2629,7 @@
         ],
         "properties": {
           "dataTypeId": {
-            "$ref": "./models/shared.json#/definitions/VersionedUrl"
+            "$ref": "#/components/schemas/VersionedUrl"
           }
         },
         "additionalProperties": false
@@ -2641,7 +2641,7 @@
         ],
         "properties": {
           "entityTypeId": {
-            "$ref": "./models/shared.json#/definitions/VersionedUrl"
+            "$ref": "#/components/schemas/VersionedUrl"
           }
         },
         "additionalProperties": false
@@ -2653,10 +2653,14 @@
         ],
         "properties": {
           "propertyTypeId": {
-            "$ref": "./models/shared.json#/definitions/VersionedUrl"
+            "$ref": "#/components/schemas/VersionedUrl"
           }
         },
         "additionalProperties": false
+      },
+      "BaseUrl": {
+        "type": "string",
+        "format": "uri"
       },
       "ClosedTemporalBound": {
         "oneOf": [
@@ -2738,7 +2742,7 @@
             "type": "boolean"
           },
           "entityTypeId": {
-            "$ref": "./models/shared.json#/definitions/VersionedUrl"
+            "$ref": "#/components/schemas/VersionedUrl"
           },
           "entityUuid": {
             "allOf": [
@@ -2782,7 +2786,12 @@
             "nullable": true
           },
           "labelProperty": {
-            "$ref": "./models/shared.json#/definitions/BaseUrl"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BaseUrl"
+              }
+            ],
+            "nullable": true
           },
           "ownedById": {
             "$ref": "#/components/schemas/OwnedById"
@@ -3020,7 +3029,7 @@
         ],
         "properties": {
           "baseId": {
-            "$ref": "./models/shared.json#/definitions/BaseUrl"
+            "$ref": "#/components/schemas/BaseUrl"
           },
           "revisionId": {
             "$ref": "#/components/schemas/OntologyTypeVersion"
@@ -3256,7 +3265,12 @@
             "$ref": "#/components/schemas/Embedding"
           },
           "property": {
-            "$ref": "./models/shared.json#/definitions/BaseUrl"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BaseUrl"
+              }
+            ],
+            "nullable": true
           }
         }
       },
@@ -3313,7 +3327,7 @@
             "type": "boolean"
           },
           "entityTypeId": {
-            "$ref": "./models/shared.json#/definitions/VersionedUrl"
+            "$ref": "#/components/schemas/VersionedUrl"
           },
           "provenance": {
             "$ref": "#/components/schemas/EntityProvenanceMetadata"
@@ -4058,7 +4072,7 @@
         ],
         "properties": {
           "baseId": {
-            "$ref": "./models/shared.json#/definitions/BaseUrl"
+            "$ref": "#/components/schemas/BaseUrl"
           },
           "revisionId": {
             "$ref": "#/components/schemas/OntologyTypeVersion"
@@ -4108,7 +4122,7 @@
             "$ref": "./models/entity_type.json"
           },
           {
-            "$ref": "./models/shared.json#/definitions/VersionedUrl"
+            "$ref": "#/components/schemas/VersionedUrl"
           }
         ]
       },
@@ -4707,7 +4721,7 @@
             ],
             "properties": {
               "dataTypeId": {
-                "$ref": "./models/shared.json#/definitions/VersionedUrl"
+                "$ref": "#/components/schemas/VersionedUrl"
               }
             }
           },
@@ -4740,7 +4754,7 @@
             ],
             "properties": {
               "entityTypeId": {
-                "$ref": "./models/shared.json#/definitions/VersionedUrl"
+                "$ref": "#/components/schemas/VersionedUrl"
               }
             }
           },
@@ -4756,7 +4770,12 @@
                 "nullable": true
               },
               "label_property": {
-                "$ref": "./models/shared.json#/definitions/BaseUrl"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BaseUrl"
+                  }
+                ],
+                "nullable": true
               },
               "relationships": {
                 "type": "array",
@@ -4780,7 +4799,7 @@
             ],
             "properties": {
               "propertyTypeId": {
-                "$ref": "./models/shared.json#/definitions/VersionedUrl"
+                "$ref": "#/components/schemas/VersionedUrl"
               }
             }
           },
@@ -4858,7 +4877,7 @@
             "$ref": "#/components/schemas/DataTypeRelationAndSubject"
           },
           "resource": {
-            "$ref": "./models/shared.json#/definitions/VersionedUrl"
+            "$ref": "#/components/schemas/VersionedUrl"
           }
         }
       },
@@ -4896,7 +4915,7 @@
             "$ref": "#/components/schemas/EntityTypeRelationAndSubject"
           },
           "resource": {
-            "$ref": "./models/shared.json#/definitions/VersionedUrl"
+            "$ref": "#/components/schemas/VersionedUrl"
           }
         }
       },
@@ -4915,7 +4934,7 @@
             "$ref": "#/components/schemas/PropertyTypeRelationAndSubject"
           },
           "resource": {
-            "$ref": "./models/shared.json#/definitions/VersionedUrl"
+            "$ref": "#/components/schemas/VersionedUrl"
           }
         }
       },
@@ -5542,7 +5561,7 @@
         ],
         "properties": {
           "baseId": {
-            "$ref": "./models/shared.json#/definitions/BaseUrl"
+            "$ref": "#/components/schemas/BaseUrl"
           },
           "revisionId": {
             "$ref": "#/components/schemas/OntologyTypeVersion"
@@ -5912,7 +5931,7 @@
         ],
         "properties": {
           "dataTypeId": {
-            "$ref": "./models/shared.json#/definitions/VersionedUrl"
+            "$ref": "#/components/schemas/VersionedUrl"
           }
         },
         "additionalProperties": false
@@ -5924,7 +5943,7 @@
         ],
         "properties": {
           "entityTypeId": {
-            "$ref": "./models/shared.json#/definitions/VersionedUrl"
+            "$ref": "#/components/schemas/VersionedUrl"
           }
         },
         "additionalProperties": false
@@ -5936,7 +5955,7 @@
         ],
         "properties": {
           "propertyTypeId": {
-            "$ref": "./models/shared.json#/definitions/VersionedUrl"
+            "$ref": "#/components/schemas/VersionedUrl"
           }
         },
         "additionalProperties": false
@@ -5976,7 +5995,7 @@
         ],
         "properties": {
           "dataTypeId": {
-            "$ref": "./models/shared.json#/definitions/VersionedUrl"
+            "$ref": "#/components/schemas/VersionedUrl"
           },
           "embedding": {
             "$ref": "#/components/schemas/Embedding"
@@ -6008,7 +6027,7 @@
             "$ref": "./models/update_data_type.json"
           },
           "typeToUpdate": {
-            "$ref": "./models/shared.json#/definitions/VersionedUrl"
+            "$ref": "#/components/schemas/VersionedUrl"
           }
         },
         "additionalProperties": false
@@ -6076,7 +6095,7 @@
                 "$ref": "#/components/schemas/EntityId"
               },
               "entityTypeId": {
-                "$ref": "./models/shared.json#/definitions/VersionedUrl"
+                "$ref": "#/components/schemas/VersionedUrl"
               },
               "properties": {
                 "$ref": "#/components/schemas/EntityProperties"
@@ -6098,7 +6117,7 @@
             "$ref": "#/components/schemas/Embedding"
           },
           "entityTypeId": {
-            "$ref": "./models/shared.json#/definitions/VersionedUrl"
+            "$ref": "#/components/schemas/VersionedUrl"
           },
           "reset": {
             "type": "boolean"
@@ -6122,7 +6141,12 @@
             "nullable": true
           },
           "labelProperty": {
-            "$ref": "./models/shared.json#/definitions/BaseUrl"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BaseUrl"
+              }
+            ],
+            "nullable": true
           },
           "relationships": {
             "type": "array",
@@ -6134,7 +6158,7 @@
             "$ref": "./models/update_entity_type.json"
           },
           "typeToUpdate": {
-            "$ref": "./models/shared.json#/definitions/VersionedUrl"
+            "$ref": "#/components/schemas/VersionedUrl"
           }
         },
         "additionalProperties": false
@@ -6152,7 +6176,7 @@
             "$ref": "#/components/schemas/Embedding"
           },
           "propertyTypeId": {
-            "$ref": "./models/shared.json#/definitions/VersionedUrl"
+            "$ref": "#/components/schemas/VersionedUrl"
           },
           "reset": {
             "type": "boolean"
@@ -6181,7 +6205,7 @@
             "$ref": "./models/update_property_type.json"
           },
           "typeToUpdate": {
-            "$ref": "./models/shared.json#/definitions/VersionedUrl"
+            "$ref": "#/components/schemas/VersionedUrl"
           }
         },
         "additionalProperties": false
@@ -6219,6 +6243,10 @@
           "full",
           "draft"
         ]
+      },
+      "VersionedUrl": {
+        "type": "string",
+        "format": "uri"
       },
       "Vertex": {
         "oneOf": [

--- a/libs/@blockprotocol/type-system/rust/Cargo.toml
+++ b/libs/@blockprotocol/type-system/rust/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1.0.114"
 thiserror = "1.0.57"
 tsify = "0.4.5"
 url = "2.5.0"
+utoipa = { version = "4.2.0", features = ["url"], optional = true }
 
 [dev-dependencies]
 graph-test-data = { workspace = true }

--- a/libs/@blockprotocol/type-system/rust/src/ontology/url/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/url/mod.rs
@@ -5,6 +5,8 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(target_arch = "wasm32")]
 use tsify::Tsify;
 use url::Url;
+#[cfg(feature = "utoipa")]
+use utoipa::{openapi, ToSchema};
 
 mod error;
 #[cfg(target_arch = "wasm32")]
@@ -85,6 +87,21 @@ impl<'de> Deserialize<'de> for BaseUrl {
         D: Deserializer<'de>,
     {
         Self::new(String::deserialize(deserializer)?).map_err(de::Error::custom)
+    }
+}
+
+#[cfg(feature = "utoipa")]
+impl ToSchema<'_> for BaseUrl {
+    fn schema() -> (&'static str, openapi::RefOr<openapi::Schema>) {
+        (
+            "BaseUrl",
+            openapi::schema::ObjectBuilder::new()
+                .schema_type(openapi::SchemaType::String)
+                .format(Some(openapi::SchemaFormat::KnownFormat(
+                    openapi::KnownFormat::Uri,
+                )))
+                .into(),
+        )
     }
 }
 
@@ -182,6 +199,21 @@ impl<'de> Deserialize<'de> for VersionedUrl {
         String::deserialize(deserializer)?
             .parse()
             .map_err(de::Error::custom)
+    }
+}
+
+#[cfg(feature = "utoipa")]
+impl ToSchema<'_> for VersionedUrl {
+    fn schema() -> (&'static str, openapi::RefOr<openapi::Schema>) {
+        (
+            "VersionedUrl",
+            openapi::schema::ObjectBuilder::new()
+                .schema_type(openapi::SchemaType::String)
+                .format(Some(openapi::SchemaFormat::KnownFormat(
+                    openapi::KnownFormat::Uri,
+                )))
+                .into(),
+        )
     }
 }
 

--- a/libs/@local/hash-graph-types/rust/src/knowledge/entity.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/entity.rs
@@ -158,7 +158,6 @@ pub struct EntityProvenanceMetadata {
 pub struct EntityMetadata {
     pub record_id: EntityRecordId,
     pub temporal_versioning: EntityTemporalMetadata,
-    #[cfg_attr(feature = "utoipa", schema(value_type = SHARED_VersionedUrl))]
     pub entity_type_id: VersionedUrl,
     pub provenance: EntityProvenanceMetadata,
     pub archived: bool,
@@ -307,7 +306,6 @@ pub struct EntityEmbedding<'e> {
     // TODO: Stop allocating everywhere in type-system package
     //   see https://linear.app/hash/issue/BP-57
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "utoipa", schema(value_type = SHARED_BaseUrl))]
     pub property: Option<BaseUrl>,
     pub embedding: Embedding<'e>,
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`ToSchema` is not implemented for `BaseUrl` and `VersionedUrl`. For simple types this can be avoided by explicitly specifying the value type, however, when nested this is an issue (as required for multi type entities).

## 🔍 What does this change?

- Implement `ToSchema` for URL types
- Use that definition everywhere (removing workaround code)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph