### PR TITLE
H-2302: Add step to install missing required `yarn global dependencies`

### DIFF
--- a/apps/hash/README.md
+++ b/apps/hash/README.md
@@ -87,6 +87,11 @@ To run HASH locally, please follow these steps:
    ```sh
    yarn install
    ```
+   
+1. Install yarn global dependencies
+   ```sh
+   yarn global add typescript wasm-pack
+   ```
 
 1. Ensure Docker is running.
    If you are on Windows or macOS, you should see app icon in the system tray or the menu bar.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

update documentation for running hash locally

While trying to follow instructions yarn install fails first on missing typescript and then on missing wasm-pack
