### PR TITLE
H-2303: Overhaul merge logic for entity types

### DIFF
--- a/apps/hash-graph/libs/graph/src/lib.rs
+++ b/apps/hash-graph/libs/graph/src/lib.rs
@@ -11,6 +11,7 @@
 #![feature(hash_raw_entry)]
 #![feature(let_chains)]
 #![feature(never_type)]
+#![feature(extend_one)]
 #![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
 #![cfg_attr(not(miri), doc(test(attr(deny(warnings, clippy::all)))))]
 #![expect(

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
@@ -309,7 +309,6 @@ impl<C: AsClient> PostgresStore<C> {
         let mut visited_ids = HashSet::from([entity_type_id]);
 
         loop {
-            let mut parents = Vec::with_capacity(current_type.inherits_from.elements.len());
             for parent in current_type.inherits_from.elements.clone() {
                 let parent_id = EntityTypeId::from_url(parent.url());
 
@@ -328,7 +327,7 @@ impl<C: AsClient> PostgresStore<C> {
                     break;
                 }
 
-                parents.push(
+                current_type.extend_one(
                     available_types
                         .get(&parent_id)
                         .ok_or_else(|| Report::new(QueryError))
@@ -339,10 +338,6 @@ impl<C: AsClient> PostgresStore<C> {
 
                 visited_ids.insert(parent_id);
             }
-            current_type
-                .merge_parents(parents)
-                .change_context(QueryError)
-                .attach_printable("could not merge parent")?;
 
             if current_type.inherits_from.elements.is_empty() {
                 break;

--- a/libs/@blockprotocol/type-system/rust/src/lib.rs
+++ b/libs/@blockprotocol/type-system/rust/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(lint_reasons)]
+#![feature(generic_nonzero)]
 #![allow(unsafe_code)]
 #![cfg_attr(
     target_arch = "wasm32",

--- a/libs/@blockprotocol/type-system/rust/src/lib.rs
+++ b/libs/@blockprotocol/type-system/rust/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(lint_reasons)]
 #![feature(generic_nonzero)]
+#![feature(extend_one)]
 #![allow(unsafe_code)]
 #![cfg_attr(
     target_arch = "wasm32",

--- a/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/error.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/error.rs
@@ -5,7 +5,7 @@ use tsify::Tsify;
 
 use crate::{
     url::{ParseBaseUrlError, ParseVersionedUrlError, VersionedUrl},
-    ParseAllOfError, ParseLinksError, ParsePropertyTypeObjectError,
+    EntityTypeReference, ParseAllOfError, ParseLinksError, ParsePropertyTypeObjectError,
 };
 
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
@@ -37,4 +37,8 @@ pub enum MergeEntityTypeError {
         child: VersionedUrl,
         parent: VersionedUrl,
     },
+    #[error("Not all parents are properly merged: {unmerged:?}")]
+    IncompleteMerge { unmerged: Vec<EntityTypeReference> },
+    #[error("Parent missing: {missing:?}")]
+    ParentMissing { missing: Vec<EntityTypeReference> },
 }

--- a/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/links/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/links/mod.rs
@@ -3,7 +3,10 @@ pub(in crate::ontology) mod raw;
 #[cfg(target_arch = "wasm32")]
 mod wasm;
 
-use std::collections::HashMap;
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    num::NonZero,
+};
 
 pub use error::ParseLinksError;
 
@@ -12,7 +15,7 @@ use crate::{
     Array, EntityTypeReference, OneOf, ValidateUrl, ValidationError,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Links(
     pub(crate) HashMap<VersionedUrl, MaybeOrderedArray<Option<OneOf<EntityTypeReference>>>>,
 );
@@ -34,10 +37,68 @@ impl Links {
     }
 }
 
+impl FromIterator<Self> for Links {
+    fn from_iter<I: IntoIterator<Item = Self>>(iter: I) -> Self {
+        let mut links = HashMap::<_, MaybeOrderedArray<Option<OneOf<EntityTypeReference>>>>::new();
+        for (id, new_destinations) in iter.into_iter().flat_map(|links| links.0) {
+            match links.entry(id) {
+                Entry::Vacant(entry) => {
+                    entry.insert(new_destinations);
+                }
+                Entry::Occupied(mut entry) => {
+                    let entry = entry.get_mut();
+                    let existing_destination_items = &mut entry.array.items;
+                    let new_destination_items = new_destinations.array.items;
+
+                    match (
+                        new_destination_items.as_ref(),
+                        existing_destination_items.as_mut(),
+                    ) {
+                        (Some(destinations), Some(existing_destinations)) => {
+                            existing_destinations
+                                .possibilities
+                                .retain(|existing_destination| {
+                                    destinations.possibilities.contains(existing_destination)
+                                });
+                        }
+                        (Some(_), None) => {
+                            *existing_destination_items = new_destination_items;
+                        }
+                        (None, _) => {}
+                    }
+
+                    if new_destinations.ordered {
+                        entry.ordered = true;
+                    }
+                    match (new_destinations.array.min_items, entry.array.min_items) {
+                        (Some(min_items), Some(existing_min_items)) => {
+                            entry.array.min_items = Some(existing_min_items.max(min_items));
+                        }
+                        (Some(_), None) => {
+                            entry.array.min_items = new_destinations.array.min_items;
+                        }
+                        (None, _) => {}
+                    }
+                    match (new_destinations.array.max_items, entry.array.max_items) {
+                        (Some(max_items), Some(existing_max_items)) => {
+                            entry.array.max_items = Some(existing_max_items.min(max_items));
+                        }
+                        (Some(_), None) => {
+                            entry.array.max_items = new_destinations.array.max_items;
+                        }
+                        (None, _) => {}
+                    }
+                }
+            }
+        }
+        Self(links)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MaybeOrderedArray<T> {
-    array: Array<T>,
-    ordered: bool,
+    pub array: Array<T>,
+    pub ordered: bool,
 }
 
 impl<T> MaybeOrderedArray<T> {
@@ -46,7 +107,7 @@ impl<T> MaybeOrderedArray<T> {
         ordered: bool,
         items: T,
         min_items: Option<usize>,
-        max_items: Option<usize>,
+        max_items: Option<NonZero<usize>>,
     ) -> Self {
         Self {
             array: Array::new(items, min_items, max_items),
@@ -70,120 +131,3 @@ impl<T: ValidateUrl> ValidateUrl for MaybeOrderedArray<T> {
         self.array().items().validate_url(base_url)
     }
 }
-
-// TODO - write some tests for validation of Link schemas, although most testing
-//   happens on entity types
-
-// #[cfg(test)]
-// mod tests {
-//     use serde_json::json;
-//
-//     use super::*;
-//     use crate::ontology::tests::{
-//         check, check_deserialization, check_invalid_json, StringTypeStruct,
-//     };
-//
-//
-//     mod maybe_ordered_array {
-//
-//         use super::*;
-//
-//         #[test]
-//         fn unordered() -> Result<(), serde_json::Error> {
-//             check(
-//                 &MaybeOrderedArray::new(false, StringTypeStruct::default(), None, None),
-//                 json!({
-//                     "type": "array",
-//                     "items": {
-//                         "type": "string"
-//                     },
-//                     "ordered": false,
-//                 }),
-//             )?;
-//
-//             check_deserialization(
-//                 &MaybeOrderedArray::new(false, StringTypeStruct::default(), None, None),
-//                 json!({
-//                     "type": "array",
-//                     "items": {
-//                         "type": "string"
-//                     },
-//                 }),
-//             )?;
-//
-//             Ok(())
-//         }
-//
-//         #[test]
-//         fn ordered() -> Result<(), serde_json::Error> {
-//             check(
-//                 &MaybeOrderedArray::new(true, StringTypeStruct::default(), None, None),
-//                 json!({
-//                     "type": "array",
-//                     "items": {
-//                         "type": "string"
-//                     },
-//                     "ordered": true
-//                 }),
-//             )
-//         }
-//
-//         #[test]
-//         fn constrained() -> Result<(), serde_json::Error> {
-//             check(
-//                 &MaybeOrderedArray::new(false, StringTypeStruct::default(), Some(10), Some(20)),
-//                 json!({
-//                     "type": "array",
-//                     "items": {
-//                         "type": "string"
-//                     },
-//                     "ordered": false,
-//                     "minItems": 10,
-//                     "maxItems": 20,
-//                 }),
-//             )
-//         }
-//
-//         #[test]
-//         fn additional_properties() {
-//             check_invalid_json::<MaybeOrderedArray<StringTypeStruct>>(json!({
-//                 "type": "array",
-//                 "items": {
-//                     "type": "string"
-//                 },
-//                 "ordered": false,
-//                 "minItems": 10,
-//                 "maxItems": 20,
-//                 "additional": 30,
-//             }));
-//         }
-//     }
-//
-//     mod value_or_maybe_ordered_array {
-//         use serde_json::json;
-//
-//         use super::*;
-//
-//         #[test]
-//         fn value() -> Result<(), serde_json::Error> {
-//             check(
-//                 &ValueOrMaybeOrderedArray::Value("value".to_owned()),
-//                 json!("value"),
-//             )
-//         }
-//
-//         #[test]
-//         fn array() -> Result<(), serde_json::Error> {
-//             check(
-//                 &MaybeOrderedArray::new(false, StringTypeStruct::default(), None, None),
-//                 json!({
-//                     "type": "array",
-//                     "items": {
-//                         "type": "string"
-//                     },
-//                     "ordered": false
-//                 }),
-//             )
-//         }
-//     }
-// }

--- a/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/links/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/links/mod.rs
@@ -37,11 +37,10 @@ impl Links {
     }
 }
 
-impl FromIterator<Self> for Links {
-    fn from_iter<I: IntoIterator<Item = Self>>(iter: I) -> Self {
-        let mut links = HashMap::<_, MaybeOrderedArray<Option<OneOf<EntityTypeReference>>>>::new();
+impl Extend<Self> for Links {
+    fn extend<T: IntoIterator<Item = Self>>(&mut self, iter: T) {
         for (id, new_destinations) in iter.into_iter().flat_map(|links| links.0) {
-            match links.entry(id) {
+            match self.0.entry(id) {
                 Entry::Vacant(entry) => {
                     entry.insert(new_destinations);
                 }
@@ -91,7 +90,14 @@ impl FromIterator<Self> for Links {
                 }
             }
         }
-        Self(links)
+    }
+}
+
+impl FromIterator<Self> for Links {
+    fn from_iter<I: IntoIterator<Item = Self>>(iter: I) -> Self {
+        let mut default = Self::default();
+        default.extend(iter);
+        default
     }
 }
 

--- a/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/links/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/links/raw.rs
@@ -62,7 +62,7 @@ pub struct MaybeOrderedArray<T> {
     #[serde(flatten)]
     array: raw::Array<T>,
     #[cfg_attr(target_arch = "wasm32", tsify(optional))]
-    #[serde(default, skip_serializing_if = "core::ops::Not::not")]
+    #[serde(default)]
     ordered: bool,
 }
 
@@ -166,7 +166,8 @@ mod tests {
                 "type": "array",
                 "items": {
                     "type": "string"
-                }
+                },
+                "ordered": false,
             });
 
             let inner_array: raw::Array<StringTypeStruct> = serde_json::from_value(expected_inner)
@@ -221,7 +222,7 @@ mod tests {
                         "type": "string"
                     },
                     "minItems": 10,
-                    "maxItems": 20
+                    "maxItems": 20,
                 }
             );
 
@@ -232,6 +233,7 @@ mod tests {
                 },
                 "minItems": 10,
                 "maxItems": 20,
+                "ordered": false,
             });
 
             let inner_array: raw::Array<StringTypeStruct> = serde_json::from_value(expected_inner)
@@ -264,6 +266,7 @@ mod tests {
                             "type": "array",
                             "items": {},
                             "maxItems": 10,
+                            "ordered": false,
                         }
                     }
                 }),
@@ -324,6 +327,7 @@ mod tests {
                             "items": {},
                             "minItems": 2,
                             "maxItems": 10,
+                            "ordered": false,
                         },
                         link_type_b.to_string(): {
                             "type": "array",
@@ -334,6 +338,7 @@ mod tests {
                             },
                             "minItems": 15,
                             "maxItems": 10,
+                            "ordered": false,
                         },
                         link_type_c.to_string(): {
                             "type": "array",
@@ -344,6 +349,7 @@ mod tests {
                             },
                             "minItems": 1,
                             "maxItems": 2,
+                            "ordered": false,
                         },
                     }
                 }),
@@ -355,6 +361,7 @@ mod tests {
                                     "type": "array",
                                     "items": {},
                                     "maxItems": 10,
+                                    "ordered": false,
                                 },
                                 link_type_b.to_string(): {
                                     "type": "array",
@@ -366,6 +373,7 @@ mod tests {
                                     },
                                     "minItems": 2,
                                     "maxItems": 10,
+                                    "ordered": false,
                                 },
                                 link_type_c.to_string(): {
                                     "type": "array",
@@ -383,6 +391,7 @@ mod tests {
                                     "type": "array",
                                     "items": {},
                                     "minItems": 2,
+                                    "ordered": false,
                                 },
                                 link_type_b.to_string(): {
                                     "type": "array",
@@ -392,12 +401,14 @@ mod tests {
                                         ]
                                     },
                                     "minItems": 15,
+                                    "ordered": false,
                                 },
                                 link_type_c.to_string(): {
                                     "type": "array",
                                     "items": {},
                                     "minItems": 1,
                                     "maxItems": 2,
+                                    "ordered": false,
                                 },
                             }
                         }),

--- a/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/links/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/links/raw.rs
@@ -61,6 +61,8 @@ impl From<super::Links> for Links {
 pub struct MaybeOrderedArray<T> {
     #[serde(flatten)]
     array: raw::Array<T>,
+    #[cfg_attr(target_arch = "wasm32", tsify(optional))]
+    #[serde(default, skip_serializing_if = "core::ops::Not::not")]
     ordered: bool,
 }
 
@@ -144,7 +146,10 @@ mod tests {
     //  entity types
 
     mod maybe_ordered_array {
+        use std::num::NonZero;
+
         use super::*;
+        use crate::ontology::raw::Array;
 
         #[test]
         fn unordered() {
@@ -161,8 +166,7 @@ mod tests {
                 "type": "array",
                 "items": {
                     "type": "string"
-                },
-                "ordered": false
+                }
             });
 
             let inner_array: raw::Array<StringTypeStruct> = serde_json::from_value(expected_inner)
@@ -226,7 +230,6 @@ mod tests {
                 "items": {
                     "type": "string"
                 },
-                "ordered": false,
                 "minItems": 10,
                 "maxItems": 20,
             });
@@ -240,6 +243,175 @@ mod tests {
                     array: inner_array,
                     ordered: false,
                 }),
+            );
+        }
+
+        #[test]
+        fn unconstrained() {
+            check_repr_serialization_from_value(
+                json!({}),
+                Some(Links {
+                    links: HashMap::new(),
+                }),
+            );
+
+            let link_type = "https://example.com/@example-org/types/entity-type/friend-of/v/1";
+
+            check_repr_serialization_from_value(
+                json!({
+                    "links": {
+                        link_type: {
+                            "type": "array",
+                            "items": {},
+                            "maxItems": 10,
+                        }
+                    }
+                }),
+                Some(Links {
+                    links: HashMap::from([(
+                        link_type.to_owned(),
+                        MaybeOrderedArray {
+                            array: Array::new(
+                                MaybeOneOfEntityTypeReference { inner: None },
+                                None,
+                                NonZero::new(10),
+                            ),
+                            ordered: false,
+                        },
+                    )]),
+                }),
+            );
+        }
+
+        #[test]
+        #[expect(
+            clippy::too_many_lines,
+            reason = "Test is long because it's merging multiple link constraints"
+        )]
+        fn merged() {
+            let link_type_a = VersionedUrl::from_str(
+                "https://example.com/@example-org/types/entity-type/friend-of/v/1",
+            )
+            .expect("failed to parse VersionedUrl");
+
+            let link_type_b = VersionedUrl::from_str(
+                "https://example.com/@example-org/types/entity-type/created-at/v/1",
+            )
+            .expect("failed to parse VersionedUrl");
+            let link_type_b_1_dest = VersionedUrl::from_str(
+                "https://example.com/@example-org/types/entity-type/location/v/1",
+            )
+            .expect("failed to parse VersionedUrl");
+            let link_type_b_2_dest = VersionedUrl::from_str(
+                "https://example.com/@example-org/types/entity-type/city/v/1",
+            )
+            .expect("failed to parse VersionedUrl");
+
+            let link_type_c = VersionedUrl::from_str(
+                "https://example.com/@example-org/types/entity-type/born-in/v/1",
+            )
+            .expect("failed to parse VersionedUrl");
+            let link_type_c_dest = VersionedUrl::from_str(
+                "https://example.com/@example-org/types/entity-type/country/v/1",
+            )
+            .expect("failed to parse VersionedUrl");
+
+            check_repr_serialization_from_value(
+                json!({
+                    "links": {
+                        link_type_a.to_string(): {
+                            "type": "array",
+                            "items": {},
+                            "minItems": 2,
+                            "maxItems": 10,
+                        },
+                        link_type_b.to_string(): {
+                            "type": "array",
+                            "items": {
+                                "oneOf": [
+                                    { "$ref": link_type_b_1_dest.to_string() },
+                                ]
+                            },
+                            "minItems": 15,
+                            "maxItems": 10,
+                        },
+                        link_type_c.to_string(): {
+                            "type": "array",
+                            "items": {
+                                "oneOf": [
+                                    { "$ref": link_type_c_dest.to_string() },
+                                ]
+                            },
+                            "minItems": 1,
+                            "maxItems": 2,
+                        },
+                    }
+                }),
+                Some(Links::from(
+                    [
+                        json!({
+                            "links": {
+                                link_type_a.to_string(): {
+                                    "type": "array",
+                                    "items": {},
+                                    "maxItems": 10,
+                                },
+                                link_type_b.to_string(): {
+                                    "type": "array",
+                                    "items": {
+                                        "oneOf": [
+                                            { "$ref": link_type_b_1_dest.to_string() },
+                                            { "$ref": link_type_b_2_dest.to_string() },
+                                        ]
+                                    },
+                                    "minItems": 2,
+                                    "maxItems": 10,
+                                },
+                                link_type_c.to_string(): {
+                                    "type": "array",
+                                    "items": {
+                                        "oneOf": [
+                                            { "$ref": link_type_c_dest.to_string() },
+                                        ]
+                                    },
+                                },
+                            }
+                        }),
+                        json!({
+                            "links": {
+                                link_type_a.to_string(): {
+                                    "type": "array",
+                                    "items": {},
+                                    "minItems": 2,
+                                },
+                                link_type_b.to_string(): {
+                                    "type": "array",
+                                    "items": {
+                                        "oneOf": [
+                                            { "$ref": link_type_b_1_dest.to_string() },
+                                        ]
+                                    },
+                                    "minItems": 15,
+                                },
+                                link_type_c.to_string(): {
+                                    "type": "array",
+                                    "items": {},
+                                    "minItems": 1,
+                                    "maxItems": 2,
+                                },
+                            }
+                        }),
+                    ]
+                    .into_iter()
+                    .map(|json| {
+                        crate::Links::try_from(
+                            serde_json::from_value::<Links>(json)
+                                .expect("failed to deserialize links"),
+                        )
+                        .expect("failed to convert links")
+                    })
+                    .collect::<crate::Links>(),
+                )),
             );
         }
 

--- a/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/raw.rs
@@ -178,7 +178,7 @@ mod tests {
         );
 
         church
-            .merge_parent(building)
+            .merge_parents([building])
             .expect("merging entity types failed");
 
         assert!(

--- a/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/raw.rs
@@ -177,9 +177,7 @@ mod tests {
             None,
         );
 
-        church
-            .merge_parents([building])
-            .expect("merging entity types failed");
+        church.extend_one(building);
 
         assert!(
             church.properties().contains_key(

--- a/libs/@blockprotocol/type-system/rust/src/ontology/shared/array/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/shared/array/mod.rs
@@ -1,18 +1,24 @@
 pub(crate) mod error;
 pub(in crate::ontology) mod raw;
 
+use std::num::NonZero;
+
 use crate::{url::BaseUrl, ValidateUrl, ValidationError};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Array<T> {
-    items: T,
-    min_items: Option<usize>,
-    max_items: Option<usize>,
+    pub items: T,
+    pub min_items: Option<usize>,
+    pub max_items: Option<NonZero<usize>>,
 }
 
 impl<T> Array<T> {
     #[must_use]
-    pub const fn new(items: T, min_items: Option<usize>, max_items: Option<usize>) -> Self {
+    pub const fn new(
+        items: T,
+        min_items: Option<usize>,
+        max_items: Option<NonZero<usize>>,
+    ) -> Self {
         Self {
             items,
             min_items,
@@ -31,7 +37,7 @@ impl<T> Array<T> {
     }
 
     #[must_use]
-    pub const fn max_items(&self) -> Option<usize> {
+    pub const fn max_items(&self) -> Option<NonZero<usize>> {
         self.max_items
     }
 }

--- a/libs/@blockprotocol/type-system/rust/src/ontology/shared/array/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/shared/array/raw.rs
@@ -1,3 +1,5 @@
+use std::num::NonZero;
+
 use serde::{Deserialize, Serialize};
 #[cfg(target_arch = "wasm32")]
 use tsify::Tsify;
@@ -22,13 +24,28 @@ enum ArrayTypeTag {
 pub struct Array<T> {
     #[cfg_attr(target_arch = "wasm32", tsify(type = "'array'"))]
     r#type: ArrayTypeTag,
-    items: T,
+    pub items: T,
     #[cfg_attr(target_arch = "wasm32", tsify(optional))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    min_items: Option<usize>,
+    pub min_items: Option<usize>,
     #[cfg_attr(target_arch = "wasm32", tsify(optional))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    max_items: Option<usize>,
+    pub max_items: Option<NonZero<usize>>,
+}
+
+impl<T> Array<T> {
+    pub const fn new(
+        items: T,
+        min_items: Option<usize>,
+        max_items: Option<NonZero<usize>>,
+    ) -> Self {
+        Self {
+            r#type: ArrayTypeTag::Array,
+            items,
+            min_items,
+            max_items,
+        }
+    }
 }
 
 impl TryFrom<Array<raw::OneOf<raw::PropertyValues>>> for super::Array<OneOf<PropertyValues>> {
@@ -185,7 +202,7 @@ mod tests {
                 r#type: ArrayTypeTag::Array,
                 items: StringTypeStruct::default(),
                 min_items: Some(10),
-                max_items: Some(20),
+                max_items: NonZero::new(20),
             }),
         );
     }

--- a/libs/@blockprotocol/type-system/rust/src/ontology/shared/object/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/shared/object/mod.rs
@@ -76,11 +76,8 @@ impl<T, const MIN: usize> Object<T, MIN> {
     }
 }
 
-impl<T, const MIN: usize> FromIterator<Self> for Object<T, MIN> {
-    fn from_iter<I: IntoIterator<Item = Self>>(iter: I) -> Self {
-        let mut properties = HashMap::new();
-        let mut required = HashSet::new();
-
+impl<T, const MIN: usize> Extend<Self> for Object<T, MIN> {
+    fn extend<I: IntoIterator<Item = Self>>(&mut self, iter: I) {
         for property_object in iter {
             // TODO: We want to merge properties and bail on conflicting properties, however, we
             //       want to allow properties where the origin is the same entity type. For that it
@@ -88,14 +85,17 @@ impl<T, const MIN: usize> FromIterator<Self> for Object<T, MIN> {
             //       Note, that this requires the full property type to be available and this
             //       function is only aware of the ID of the property type.
             //   see https://linear.app/hash/issue/H-860/improve-type-parent-validation
-            properties.extend(property_object.properties);
-            required.extend(property_object.required);
+            self.properties.extend(property_object.properties);
+            self.required.extend(property_object.required);
         }
+    }
+}
 
-        Self {
-            properties,
-            required,
-        }
+impl<T, const MIN: usize> FromIterator<Self> for Object<T, MIN> {
+    fn from_iter<I: IntoIterator<Item = Self>>(iter: I) -> Self {
+        let mut default = Self::default();
+        default.extend(iter);
+        default
     }
 }
 

--- a/libs/@blockprotocol/type-system/rust/src/ontology/shared/object/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/shared/object/raw.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, fmt::Debug};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Debug,
+};
 
 use serde::{Deserialize, Serialize};
 #[cfg(target_arch = "wasm32")]
@@ -22,8 +25,8 @@ pub struct Object<T> {
     #[cfg_attr(target_arch = "wasm32", tsify(type = "Record<BaseUrl, T>"))]
     pub properties: HashMap<String, T>,
     #[cfg_attr(target_arch = "wasm32", tsify(optional, type = "BaseUrl[]"))]
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub required: Vec<String>,
+    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    pub required: HashSet<String>,
 }
 
 impl<const MIN: usize> TryFrom<Object<raw::ValueOrArray<raw::PropertyTypeReference>>>
@@ -52,7 +55,7 @@ impl<const MIN: usize> TryFrom<Object<raw::ValueOrArray<raw::PropertyTypeReferen
             .map(|base_url| {
                 BaseUrl::new(base_url).map_err(ParsePropertyTypeObjectError::InvalidRequiredKey)
             })
-            .collect::<Result<Vec<_>, Self::Error>>()?;
+            .collect::<Result<_, Self::Error>>()?;
 
         Self::new(properties, required).map_err(ParsePropertyTypeObjectError::ValidationError)
     }
@@ -109,7 +112,7 @@ mod tests {
                 Some(Object {
                     r#type: ObjectTypeTag::Object,
                     properties: HashMap::new(),
-                    required: vec![],
+                    required: HashSet::new(),
                 }),
             );
         }
@@ -132,7 +135,7 @@ mod tests {
                         url.base_url.to_string(),
                         PropertyTypeReference::new(url.to_string()),
                     )]),
-                    required: vec![],
+                    required: HashSet::new(),
                 }),
             );
         }
@@ -164,7 +167,7 @@ mod tests {
                             PropertyTypeReference::new(url_b.to_string()),
                         ),
                     ]),
-                    required: vec![],
+                    required: HashSet::new(),
                 }),
             );
         }
@@ -193,7 +196,7 @@ mod tests {
                         url.base_url.to_string(),
                         PropertyTypeReference::new(url.to_string()),
                     )]),
-                    required: vec![],
+                    required: HashSet::new(),
                 }),
             );
         }
@@ -225,7 +228,7 @@ mod tests {
                             PropertyTypeReference::new(url_b.to_string()),
                         ),
                     ]),
-                    required: vec![],
+                    required: HashSet::new(),
                 }),
             );
         }
@@ -261,7 +264,7 @@ mod tests {
                         PropertyTypeReference::new(url_b.to_string()),
                     ),
                 ]),
-                required: vec![url_a.base_url.to_string()],
+                required: HashSet::from([url_a.base_url.to_string()]),
             }),
         );
     }

--- a/libs/@blockprotocol/type-system/rust/src/ontology/shared/one_of/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/shared/one_of/mod.rs
@@ -5,7 +5,7 @@ use crate::ValidationError;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OneOf<T> {
-    possibilities: Vec<T>,
+    pub(crate) possibilities: Vec<T>,
 }
 
 impl<T> OneOf<T> {

--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -60,7 +60,7 @@ where
         // TODO: Distinguish between format validation and content validation so it's possible
         //       to directly use the correct type.
         //   see https://linear.app/hash/issue/BP-33
-        Object::<_, 0>::new(self.properties().clone(), self.required().to_vec())
+        Object::<_, 0>::new(self.properties().clone(), self.required().clone())
             .expect("`Object` was already validated")
             .validate_value(value, profile, provider)
             .await

--- a/libs/@local/hash-validation/src/property_type.rs
+++ b/libs/@local/hash-validation/src/property_type.rs
@@ -1,5 +1,5 @@
 use core::{borrow::Borrow, future::Future, pin::Pin};
-use std::collections::HashMap;
+use std::{collections::HashMap, num::NonZeroUsize};
 
 use error_stack::{bail, Report, ResultExt};
 use serde_json::Value as JsonValue;
@@ -171,7 +171,7 @@ where
                 }
             }
 
-            if let Some(max) = self.max_items() {
+            if let Some(max) = self.max_items().map(NonZeroUsize::get) {
                 if values.len() > max {
                     extend_report!(
                         status,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Quite a few issues were detected in the type system package. This fixes a few of them.

## 🔍 What does this change?

- Properly implement merging entity types (`properties`, `required`, `links`)
- Fix a deserializing issue for `links`
- Don't allow `0` in `maxItems`
- Make `ordered` in `links` optional (it's deprecated)
- Tests for merging links were added

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph