### PR TITLE
H-2306: Enable `consistent-type-imports` ESLint

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities.ts
+++ b/apps/hash-ai-worker-ts/src/activities.ts
@@ -9,7 +9,7 @@ import type {
   InferEntitiesCallerParams,
   InferEntitiesReturn,
 } from "@local/hash-isomorphic-utils/ai-inference-types";
-import { ParseTextFromFileParams } from "@local/hash-isomorphic-utils/parse-text-from-file-types";
+import type { ParseTextFromFileParams } from "@local/hash-isomorphic-utils/parse-text-from-file-types";
 import type {
   DataTypeWithMetadata,
   EntityPropertiesObject,
@@ -18,7 +18,7 @@ import type {
 } from "@local/hash-subgraph";
 import { StatusCode } from "@local/status";
 import { ApplicationFailure } from "@temporalio/activity";
-import { CreateEmbeddingResponse } from "openai/resources";
+import type { CreateEmbeddingResponse } from "openai/resources";
 
 import { inferEntitiesActivity } from "./activities/infer-entities";
 import { parseTextFromFile } from "./activities/parse-text-from-file";

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities.ts
@@ -24,16 +24,14 @@ import type { AccountId, Subgraph, Timestamp } from "@local/hash-subgraph";
 import { StatusCode } from "@local/status";
 import { CancelledFailure, Context } from "@temporalio/activity";
 import dedent from "dedent";
-import OpenAI from "openai";
+import type OpenAI from "openai";
 
 import { createInferenceUsageRecord } from "./infer-entities/create-inference-usage-record";
-import {
-  DereferencedEntityType,
-  dereferenceEntityType,
-} from "./infer-entities/dereference-entity-type";
+import type { DereferencedEntityType } from "./infer-entities/dereference-entity-type";
+import { dereferenceEntityType } from "./infer-entities/dereference-entity-type";
 import { getResultsFromInferenceState } from "./infer-entities/get-results-from-inference-state";
 import { inferEntitySummaries } from "./infer-entities/infer-entity-summaries";
-import {
+import type {
   InferenceState,
   PermittedOpenAiModel,
 } from "./infer-entities/inference-types";

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/dereference-entity-type.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/dereference-entity-type.ts
@@ -1,9 +1,7 @@
-import {
+import type {
   Array,
   DataType,
   EntityType,
-  extractBaseUrl,
-  extractVersion,
   Object as BpObject,
   OneOf,
   PropertyType,
@@ -11,13 +9,14 @@ import {
   ValueOrArray,
   VersionedUrl,
 } from "@blockprotocol/type-system";
+import { extractBaseUrl, extractVersion } from "@blockprotocol/type-system";
 import { typedEntries } from "@local/advanced-types/typed-entries";
-import {
+import type {
   BaseUrl,
   EntityTypeMetadata,
-  linkEntityTypeUrl,
   Subgraph,
 } from "@local/hash-subgraph";
+import { linkEntityTypeUrl } from "@local/hash-subgraph";
 import {
   getDataTypeById,
   getEntityTypeAndParentsById,

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/get-results-from-inference-state.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/get-results-from-inference-state.ts
@@ -1,6 +1,6 @@
-import { InferredEntityChangeResult } from "@local/hash-isomorphic-utils/ai-inference-types";
+import type { InferredEntityChangeResult } from "@local/hash-isomorphic-utils/ai-inference-types";
 
-import { InferenceState } from "./inference-types";
+import type { InferenceState } from "./inference-types";
 
 export const getResultsFromInferenceState = (inferenceState: InferenceState) =>
   Object.values(inferenceState.resultsByTemporaryId).filter(

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/infer-entity-summaries.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/infer-entity-summaries.ts
@@ -1,16 +1,19 @@
-import { VersionedUrl } from "@blockprotocol/type-system/slim";
+import type { VersionedUrl } from "@blockprotocol/type-system/slim";
 import { typedKeys } from "@local/advanced-types/typed-entries";
-import { Status, StatusCode } from "@local/status";
+import type { Status } from "@local/status";
+import { StatusCode } from "@local/status";
 import dedent from "dedent";
-import OpenAI from "openai";
+import type OpenAI from "openai";
 
-import {
+import type {
   CouldNotInferEntitiesReturn,
-  generateSummaryTools,
   ProposedEntitySummariesByType,
-  validateEntitySummariesByType,
 } from "./infer-entity-summaries/generate-summary-tools";
 import {
+  generateSummaryTools,
+  validateEntitySummariesByType,
+} from "./infer-entity-summaries/generate-summary-tools";
+import type {
   CompletionPayload,
   DereferencedEntityTypesByTypeId,
   InferenceState,

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/infer-entity-summaries/generate-summary-tools.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/infer-entity-summaries/generate-summary-tools.ts
@@ -1,12 +1,13 @@
 import type { JsonObject } from "@blockprotocol/core";
-import { validateVersionedUrl, VersionedUrl } from "@blockprotocol/type-system";
+import type { VersionedUrl } from "@blockprotocol/type-system";
+import { validateVersionedUrl } from "@blockprotocol/type-system";
 import type { Subtype } from "@local/advanced-types/subtype";
 import { typedEntries } from "@local/advanced-types/typed-entries";
-import OpenAI from "openai";
+import type OpenAI from "openai";
 import type { JSONSchema } from "openai/lib/jsonschema";
 
-import { DereferencedEntityType } from "../dereference-entity-type";
-import {
+import type { DereferencedEntityType } from "../dereference-entity-type";
+import type {
   DereferencedEntityTypesByTypeId,
   ProposedEntitySummary,
 } from "../inference-types";

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/inference-types.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/inference-types.ts
@@ -1,13 +1,13 @@
-import { VersionedUrl } from "@blockprotocol/type-system/slim";
+import type { VersionedUrl } from "@blockprotocol/type-system/slim";
 import type { Entity } from "@local/hash-graph-client";
-import {
+import type {
   InferenceTokenUsage,
   InferredEntityChangeResult,
   ProposedEntity,
 } from "@local/hash-isomorphic-utils/ai-inference-types";
-import OpenAI from "openai";
+import type OpenAI from "openai";
 
-import { DereferencedEntityType } from "./dereference-entity-type";
+import type { DereferencedEntityType } from "./dereference-entity-type";
 
 export type PermittedOpenAiModel =
   | "gpt-3.5-turbo-1106"

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/persist-entities.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/persist-entities.ts
@@ -5,20 +5,22 @@ import type { InferEntitiesReturn } from "@local/hash-isomorphic-utils/ai-infere
 import type { AccountId, Entity, OwnedById } from "@local/hash-subgraph";
 import { StatusCode } from "@local/status";
 import dedent from "dedent";
-import OpenAI from "openai";
+import type OpenAI from "openai";
 
 import { getResultsFromInferenceState } from "./get-results-from-inference-state";
-import {
+import type {
   CompletionPayload,
   DereferencedEntityTypesByTypeId,
   InferenceState,
 } from "./inference-types";
 import { log } from "./log";
 import { createEntities } from "./persist-entities/create-entities";
-import {
-  generatePersistEntitiesTools,
+import type {
   ProposedEntityCreationsByType,
   ProposedEntityUpdatesByType,
+} from "./persist-entities/generate-persist-entities-tools";
+import {
+  generatePersistEntitiesTools,
   validateProposedEntitiesByType,
 } from "./persist-entities/generate-persist-entities-tools";
 import { updateEntities } from "./persist-entities/update-entities";

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/persist-entities/create-entities.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/persist-entities/create-entities.ts
@@ -29,7 +29,7 @@ import isMatch from "lodash.ismatch";
 
 import { createEntityEmbeddings } from "../../shared/embeddings";
 import type { DereferencedEntityType } from "../dereference-entity-type";
-import { InferenceState, UpdateCandidate } from "../inference-types";
+import type { InferenceState, UpdateCandidate } from "../inference-types";
 import { extractErrorMessage } from "../shared/extract-validation-failure-details";
 import { getEntityByFilter } from "../shared/get-entity-by-filter";
 import { stringify } from "../stringify";

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/persist-entities/ensure-trailing-slash.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/persist-entities/ensure-trailing-slash.ts
@@ -1,4 +1,4 @@
-import { BaseUrl, EntityPropertiesObject } from "@local/hash-subgraph";
+import type { BaseUrl, EntityPropertiesObject } from "@local/hash-subgraph";
 
 /**
  * Property keys must end with a trailing slash, but the AI Model sometimes omits them.

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/persist-entities/generate-persist-entities-tools.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/persist-entities/generate-persist-entities-tools.ts
@@ -1,15 +1,16 @@
 import type { JsonObject } from "@blockprotocol/core";
-import { validateVersionedUrl, VersionedUrl } from "@blockprotocol/type-system";
-import {
+import type { VersionedUrl } from "@blockprotocol/type-system";
+import { validateVersionedUrl } from "@blockprotocol/type-system";
+import type {
   ProposedEntity,
   ProposedEntitySchemaOrData,
 } from "@local/hash-isomorphic-utils/ai-inference-types";
-import { Entity } from "@local/hash-subgraph";
+import type { Entity } from "@local/hash-subgraph";
 import dedent from "dedent";
-import OpenAI from "openai";
+import type OpenAI from "openai";
 import type { JSONSchema } from "openai/lib/jsonschema";
 
-import { DereferencedEntityType } from "../dereference-entity-type";
+import type { DereferencedEntityType } from "../dereference-entity-type";
 
 export type FunctionName =
   | "abandon_entities"

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/persist-entities/update-entities.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/persist-entities/update-entities.ts
@@ -22,7 +22,7 @@ import { extractErrorMessage } from "../shared/extract-validation-failure-detail
 import { getEntityByFilter } from "../shared/get-entity-by-filter";
 import { stringify } from "../stringify";
 import { ensureTrailingSlash } from "./ensure-trailing-slash";
-import { ProposedEntityUpdatesByType } from "./generate-persist-entities-tools";
+import type { ProposedEntityUpdatesByType } from "./generate-persist-entities-tools";
 
 type StatusByTemporaryId<T> = Record<string, T>;
 

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/shared/get-open-ai-response.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/shared/get-open-ai-response.ts
@@ -1,9 +1,10 @@
-import { Status, StatusCode } from "@local/status";
+import type { Status } from "@local/status";
+import { StatusCode } from "@local/status";
 import { Context } from "@temporalio/activity";
-import OpenAI from "openai";
+import type OpenAI from "openai";
 import { promptTokensEstimate } from "openai-chat-tokens";
 
-import { PermittedOpenAiModel } from "../inference-types";
+import type { PermittedOpenAiModel } from "../inference-types";
 import { log } from "../log";
 import { stringify } from "../stringify";
 import { firstUserMessageIndex } from "./first-user-message-index";

--- a/apps/hash-ai-worker-ts/src/activities/parse-text-from-file.ts
+++ b/apps/hash-ai-worker-ts/src/activities/parse-text-from-file.ts
@@ -1,8 +1,8 @@
-import { VersionedUrl } from "@blockprotocol/type-system";
+import type { VersionedUrl } from "@blockprotocol/type-system";
 import type { GraphApi } from "@local/hash-graph-client";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
-import { ParseTextFromFileParams } from "@local/hash-isomorphic-utils/parse-text-from-file-types";
-import { DOCXDocumentProperties } from "@local/hash-isomorphic-utils/system-types/docxdocument";
+import type { ParseTextFromFileParams } from "@local/hash-isomorphic-utils/parse-text-from-file-types";
+import type { DOCXDocumentProperties } from "@local/hash-isomorphic-utils/system-types/docxdocument";
 import { extractDraftIdFromEntityId } from "@local/hash-subgraph";
 import isDocker from "is-docker";
 import officeParser from "officeparser";

--- a/apps/hash-ai-worker-ts/src/workflows.ts
+++ b/apps/hash-ai-worker-ts/src/workflows.ts
@@ -2,10 +2,10 @@ import type { EntityQueryCursor, Filter } from "@local/hash-graph-client";
 import type {
   CreateEmbeddingsParams,
   CreateEmbeddingsReturn,
+  GetResultsFromCancelledInferenceRequestQuery,
   InferEntitiesCallerParams,
   InferEntitiesReturn,
 } from "@local/hash-isomorphic-utils/ai-inference-types";
-import { GetResultsFromCancelledInferenceRequestQuery } from "@local/hash-isomorphic-utils/ai-inference-types";
 import type { ParseTextFromFileParams } from "@local/hash-isomorphic-utils/parse-text-from-file-types";
 import type {
   AccountId,
@@ -23,9 +23,9 @@ import {
   proxyActivities,
   setHandler,
 } from "@temporalio/workflow";
-import { CreateEmbeddingResponse } from "openai/resources";
+import type { CreateEmbeddingResponse } from "openai/resources";
 
-import { createAiActivities, createGraphActivities } from "./activities";
+import type { createAiActivities, createGraphActivities } from "./activities";
 
 const aiActivities = proxyActivities<ReturnType<typeof createAiActivities>>({
   cancellationType: ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,

--- a/apps/hash-integration-worker/src/activities.ts
+++ b/apps/hash-integration-worker/src/activities.ts
@@ -1,20 +1,21 @@
-import { Connection, LinearClient, LinearDocument, Team } from "@linear/sdk";
+import type { Connection, LinearDocument, Team } from "@linear/sdk";
+import { LinearClient } from "@linear/sdk";
 import { getLinearMappingByHashEntityTypeId } from "@local/hash-backend-utils/linear-type-mappings";
-import {
+import type {
   CreateHashEntityFromLinearData,
   PartialEntity,
   UpdateHashEntityFromLinearData,
   UpdateLinearDataWorkflow,
 } from "@local/hash-backend-utils/temporal-workflow-types";
-import { GraphApi } from "@local/hash-graph-client";
+import type { GraphApi } from "@local/hash-graph-client";
 import { linearPropertyTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
-import {
+import type {
   AccountId,
   BaseUrl,
   EntityId,
-  extractDraftIdFromEntityId,
   OwnedById,
 } from "@local/hash-subgraph";
+import { extractDraftIdFromEntityId } from "@local/hash-subgraph";
 
 import {
   archiveEntity,

--- a/apps/hash-integration-worker/src/activities/graph-requests.ts
+++ b/apps/hash-integration-worker/src/activities/graph-requests.ts
@@ -1,26 +1,28 @@
-import { VersionedUrl } from "@blockprotocol/type-system";
-import { GraphApi } from "@local/hash-graph-client";
+import type { VersionedUrl } from "@blockprotocol/type-system";
+import type { GraphApi } from "@local/hash-graph-client";
 import {
   currentTimeInstantTemporalAxes,
   generateVersionedUrlMatchingFilter,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { linearPropertyTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
-import {
+import type {
   AccountId,
   Entity,
   EntityId,
   EntityRootType,
+  OwnedById,
+} from "@local/hash-subgraph";
+import {
   extractEntityUuidFromEntityId,
   extractOwnedByIdFromEntityId,
-  OwnedById,
   splitEntityId,
 } from "@local/hash-subgraph";
 import {
   getRoots,
   mapGraphApiSubgraphToSubgraph,
 } from "@local/hash-subgraph/stdlib";
-import { LinkEntity } from "@local/hash-subgraph/type-system-patch";
+import type { LinkEntity } from "@local/hash-subgraph/type-system-patch";
 
 export const getEntitiesByLinearId = async (params: {
   graphApiClient: GraphApi;

--- a/apps/hash-integration-worker/src/activities/mappings.ts
+++ b/apps/hash-integration-worker/src/activities/mappings.ts
@@ -1,13 +1,13 @@
-import { VersionedUrl } from "@blockprotocol/type-system";
-import {
-  getLinearMappingByLinearType,
+import type { VersionedUrl } from "@blockprotocol/type-system";
+import type {
   SupportedLinearTypeNames,
   SupportedLinearTypes,
   SupportedLinearUpdateInput,
 } from "@local/hash-backend-utils/linear-type-mappings";
-import { PartialEntity } from "@local/hash-backend-utils/temporal-workflow-types";
-import { GraphApi } from "@local/hash-graph-client";
-import {
+import { getLinearMappingByLinearType } from "@local/hash-backend-utils/linear-type-mappings";
+import type { PartialEntity } from "@local/hash-backend-utils/temporal-workflow-types";
+import type { GraphApi } from "@local/hash-graph-client";
+import type {
   AccountId,
   Entity,
   EntityId,

--- a/apps/hash-integration-worker/src/main.ts
+++ b/apps/hash-integration-worker/src/main.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import { createGraphClient } from "@local/hash-backend-utils/create-graph-client";
 import { getRequiredEnv } from "@local/hash-backend-utils/environment";
 import { Logger } from "@local/hash-backend-utils/logger";
-import { WorkflowTypeMap } from "@local/hash-backend-utils/temporal-workflow-types";
+import type { WorkflowTypeMap } from "@local/hash-backend-utils/temporal-workflow-types";
 import { NativeConnection, Worker } from "@temporalio/worker";
 import { config } from "dotenv-flow";
 

--- a/apps/hash-integration-worker/src/workflows.ts
+++ b/apps/hash-integration-worker/src/workflows.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   CreateHashEntityFromLinearData,
   ReadLinearTeamsWorkflow,
   SyncWorkspaceWorkflow,
@@ -7,7 +7,7 @@ import {
 } from "@local/hash-backend-utils/temporal-workflow-types";
 import { proxyActivities } from "@temporalio/workflow";
 
-import { createLinearIntegrationActivities } from "./activities";
+import type { createLinearIntegrationActivities } from "./activities";
 
 const linear = proxyActivities<
   ReturnType<typeof createLinearIntegrationActivities>

--- a/apps/hash-realtime/src/config.ts
+++ b/apps/hash-realtime/src/config.ts
@@ -1,6 +1,6 @@
 import { getRequiredEnv } from "@local/hash-backend-utils/environment";
-import { Logger } from "@local/hash-backend-utils/logger";
-import { QueueProducer } from "@local/hash-backend-utils/queue/adapter";
+import type { Logger } from "@local/hash-backend-utils/logger";
+import type { QueueProducer } from "@local/hash-backend-utils/queue/adapter";
 import { RedisQueueProducer } from "@local/hash-backend-utils/queue/redis";
 import { supportedRealtimeTables } from "@local/hash-backend-utils/realtime";
 import { AsyncRedisClient } from "@local/hash-backend-utils/redis";

--- a/apps/hash-realtime/src/index.ts
+++ b/apps/hash-realtime/src/index.ts
@@ -9,10 +9,8 @@ import {
   waitOnResource,
 } from "@local/hash-backend-utils/environment";
 import { Logger } from "@local/hash-backend-utils/logger";
-import {
-  createPostgresConnPool,
-  PgPool,
-} from "@local/hash-backend-utils/postgres";
+import type { PgPool } from "@local/hash-backend-utils/postgres";
+import { createPostgresConnPool } from "@local/hash-backend-utils/postgres";
 import { GracefulShutdown } from "@local/hash-backend-utils/shutdown";
 import {
   clearIntervalAsync,

--- a/libs/@blockprotocol/type-system/typescript/src/native/data-type.ts
+++ b/libs/@blockprotocol/type-system/typescript/src/native/data-type.ts
@@ -1,4 +1,4 @@
-import { DataType } from "@blockprotocol/type-system-rs";
+import type { DataType } from "@blockprotocol/type-system-rs";
 
 export const DATA_TYPE_META_SCHEMA: DataType["$schema"] =
   "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type";

--- a/libs/@blockprotocol/type-system/typescript/src/native/entity-type.ts
+++ b/libs/@blockprotocol/type-system/typescript/src/native/entity-type.ts
@@ -1,4 +1,4 @@
-import { EntityType, VersionedUrl } from "@blockprotocol/type-system-rs";
+import type { EntityType, VersionedUrl } from "@blockprotocol/type-system-rs";
 
 export const ENTITY_TYPE_META_SCHEMA: EntityType["$schema"] =
   "https://blockprotocol.org/types/modules/graph/0.3/schema/entity-type";

--- a/libs/@blockprotocol/type-system/typescript/src/native/property-type.ts
+++ b/libs/@blockprotocol/type-system/typescript/src/native/property-type.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Array as TypeSystemArray,
   OneOf,
   PropertyType,

--- a/libs/@blockprotocol/type-system/typescript/src/native/url.ts
+++ b/libs/@blockprotocol/type-system/typescript/src/native/url.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   BaseUrl,
   ParseBaseUrlError,
   ParseVersionedUrlError,

--- a/libs/@blockprotocol/type-system/typescript/test/data-type.test.ts
+++ b/libs/@blockprotocol/type-system/typescript/test/data-type.test.ts
@@ -1,9 +1,5 @@
-import {
-  DataType,
-  ParseDataTypeError,
-  TypeSystemInitializer,
-  validateDataType,
-} from "../src/main";
+import type { DataType, ParseDataTypeError } from "../src/main";
+import { TypeSystemInitializer, validateDataType } from "../src/main";
 
 const primitiveDataTypes: DataType[] = [
   {

--- a/libs/@blockprotocol/type-system/typescript/test/entity-type.test.ts
+++ b/libs/@blockprotocol/type-system/typescript/test/entity-type.test.ts
@@ -1,9 +1,5 @@
-import {
-  EntityType,
-  ParseEntityTypeError,
-  TypeSystemInitializer,
-  validateEntityType,
-} from "../src/main";
+import type { EntityType, ParseEntityTypeError } from "../src/main";
+import { TypeSystemInitializer, validateEntityType } from "../src/main";
 
 const entityTypes: EntityType[] = [
   {

--- a/libs/@blockprotocol/type-system/typescript/test/property-type.test.ts
+++ b/libs/@blockprotocol/type-system/typescript/test/property-type.test.ts
@@ -1,9 +1,5 @@
-import {
-  ParsePropertyTypeError,
-  PropertyType,
-  TypeSystemInitializer,
-  validatePropertyType,
-} from "../src/main";
+import type { ParsePropertyTypeError, PropertyType } from "../src/main";
+import { TypeSystemInitializer, validatePropertyType } from "../src/main";
 
 const propertyTypes: PropertyType[] = [
   {

--- a/libs/@blockprotocol/type-system/typescript/test/url.test.ts
+++ b/libs/@blockprotocol/type-system/typescript/test/url.test.ts
@@ -1,13 +1,15 @@
-import {
+import type {
   BaseUrl,
-  extractBaseUrl,
-  extractVersion,
   ParseBaseUrlError,
   ParseVersionedUrlError,
+  VersionedUrl,
+} from "../src/main";
+import {
+  extractBaseUrl,
+  extractVersion,
   TypeSystemInitializer,
   validateBaseUrl,
   validateVersionedUrl,
-  VersionedUrl,
 } from "../src/main";
 
 const invalidBaseUrlCases: [string, ParseBaseUrlError][] = [

--- a/libs/@local/eslint-config/generate-workspace-config.cjs
+++ b/libs/@local/eslint-config/generate-workspace-config.cjs
@@ -18,4 +18,7 @@ module.exports = (workspaceDirPath) => ({
       },
     },
   },
+  rules: {
+    "@typescript-eslint/consistent-type-imports": "error",
+  },
 });

--- a/libs/@local/hash-subgraph/src/main.ts
+++ b/libs/@local/hash-subgraph/src/main.ts
@@ -1,4 +1,4 @@
-import { VersionedUrl } from "@blockprotocol/type-system/slim";
+import type { VersionedUrl } from "@blockprotocol/type-system/slim";
 
 export * from "./types";
 

--- a/libs/@local/hash-subgraph/src/shared/type-system-patch.ts
+++ b/libs/@local/hash-subgraph/src/shared/type-system-patch.ts
@@ -1,12 +1,14 @@
+import type {
+  ParseVersionedUrlError,
+  VersionedUrl,
+} from "@blockprotocol/type-system/slim";
 import {
   extractBaseUrl as extractBaseUrlBp,
   extractVersion,
-  ParseVersionedUrlError,
   validateVersionedUrl,
-  VersionedUrl,
 } from "@blockprotocol/type-system/slim";
 
-import { BaseUrl, Entity, EntityPropertiesObject } from "../types";
+import type { BaseUrl, Entity, EntityPropertiesObject } from "../types";
 
 export const extractBaseUrl = (versionedUrl: VersionedUrl): BaseUrl =>
   extractBaseUrlBp(versionedUrl) as BaseUrl;

--- a/libs/@local/hash-subgraph/src/stdlib/bound.ts
+++ b/libs/@local/hash-subgraph/src/stdlib/bound.ts
@@ -1,6 +1,6 @@
 import { compareBounds as compareBoundsBp } from "@blockprotocol/graph/temporal/stdlib";
 
-import { TemporalBound, TimeInterval } from "../main";
+import type { TemporalBound, TimeInterval } from "../main";
 
 export const compareBounds = (
   left: TemporalBound,

--- a/libs/@local/hash-subgraph/src/stdlib/interval.ts
+++ b/libs/@local/hash-subgraph/src/stdlib/interval.ts
@@ -14,7 +14,7 @@ import {
   unionOfIntervals as unionOfIntervalsBp,
 } from "@blockprotocol/graph/temporal/stdlib";
 
-import {
+import type {
   BoundedTimeInterval,
   LimitedTemporalBound,
   TemporalBound,

--- a/libs/@local/hash-subgraph/src/stdlib/subgraph/edge/entity-type.ts
+++ b/libs/@local/hash-subgraph/src/stdlib/subgraph/edge/entity-type.ts
@@ -1,8 +1,8 @@
-import { Subgraph as SubgraphBp } from "@blockprotocol/graph/temporal";
+import type { Subgraph as SubgraphBp } from "@blockprotocol/graph/temporal";
 import { getPropertyTypesReferencedByEntityType as getPropertyTypesReferencedByEntityTypeBp } from "@blockprotocol/graph/temporal/stdlib";
-import { VersionedUrl } from "@blockprotocol/type-system/slim";
+import type { VersionedUrl } from "@blockprotocol/type-system/slim";
 
-import { OntologyTypeVertexId, Subgraph } from "../../../main";
+import type { OntologyTypeVertexId, Subgraph } from "../../../main";
 
 /**
  * Gets identifiers for all `PropertyType`s referenced within a given `EntityType` schema by searching for

--- a/libs/@local/hash-subgraph/src/stdlib/subgraph/edge/link-entity.ts
+++ b/libs/@local/hash-subgraph/src/stdlib/subgraph/edge/link-entity.ts
@@ -1,4 +1,4 @@
-import { Subgraph as SubgraphBp } from "@blockprotocol/graph/temporal";
+import type { Subgraph as SubgraphBp } from "@blockprotocol/graph/temporal";
 import {
   getIncomingLinksForEntity as getIncomingLinksForEntityBp,
   getLeftEntityForLinkEntity as getLeftEntityForLinkEntityBp,
@@ -7,7 +7,7 @@ import {
   getRightEntityForLinkEntity as getRightEntityForLinkEntityBp,
 } from "@blockprotocol/graph/temporal/stdlib";
 
-import {
+import type {
   Entity,
   EntityId,
   LinkEntityAndRightEntity,

--- a/libs/@local/hash-subgraph/src/stdlib/subgraph/element/data-type.ts
+++ b/libs/@local/hash-subgraph/src/stdlib/subgraph/element/data-type.ts
@@ -5,10 +5,10 @@ import {
   getDataTypes as getDataTypesBp,
   getDataTypesByBaseUrl as getDataTypesByBaseUrlBp,
 } from "@blockprotocol/graph/temporal/stdlib";
-import { VersionedUrl } from "@blockprotocol/type-system/slim";
-import { DataType } from "@local/hash-graph-client";
+import type { VersionedUrl } from "@blockprotocol/type-system/slim";
+import type { DataType } from "@local/hash-graph-client";
 
-import {
+import type {
   BaseUrl,
   DataTypeWithMetadata,
   OntologyTypeVertexId,

--- a/libs/@local/hash-subgraph/src/stdlib/subgraph/element/entity-type.ts
+++ b/libs/@local/hash-subgraph/src/stdlib/subgraph/element/entity-type.ts
@@ -5,9 +5,9 @@ import {
   getEntityTypes as getEntityTypesBp,
   getEntityTypesByBaseUrl as getEntityTypesByBaseUrlBp,
 } from "@blockprotocol/graph/temporal/stdlib";
-import { VersionedUrl } from "@blockprotocol/type-system/slim";
+import type { VersionedUrl } from "@blockprotocol/type-system/slim";
 
-import {
+import type {
   BaseUrl,
   EntityTypeWithMetadata,
   OntologyTypeVertexId,

--- a/libs/@local/hash-subgraph/src/stdlib/subgraph/element/entity.ts
+++ b/libs/@local/hash-subgraph/src/stdlib/subgraph/element/entity.ts
@@ -1,12 +1,12 @@
-import { Timestamp } from "@blockprotocol/graph";
-import { Subgraph as SubgraphBp } from "@blockprotocol/graph/temporal";
+import type { Timestamp } from "@blockprotocol/graph";
+import type { Subgraph as SubgraphBp } from "@blockprotocol/graph/temporal";
 import {
   getEntities as getEntitiesBp,
   getEntityRevision as getEntityRevisionBp,
   getEntityRevisionsByEntityId as getEntityRevisionsByEntityIdBp,
 } from "@blockprotocol/graph/temporal/stdlib";
 
-import {
+import type {
   Entity,
   EntityId,
   EntityRevisionId,

--- a/libs/@local/hash-subgraph/src/stdlib/subgraph/element/map-revisions.ts
+++ b/libs/@local/hash-subgraph/src/stdlib/subgraph/element/map-revisions.ts
@@ -1,6 +1,6 @@
 import { mapElementsIntoRevisions as mapElementsIntoRevisionsBp } from "@blockprotocol/graph/temporal/stdlib";
 
-import { Vertex } from "../../../main";
+import type { Vertex } from "../../../main";
 
 type BaseIdToRevisions<GraphElementType extends Vertex["inner"]> = Record<
   /*

--- a/libs/@local/hash-subgraph/src/stdlib/subgraph/element/property-type.ts
+++ b/libs/@local/hash-subgraph/src/stdlib/subgraph/element/property-type.ts
@@ -1,18 +1,18 @@
-import { DataTypeReference, JsonValue } from "@blockprotocol/graph";
-import { Subgraph as SubgraphBp } from "@blockprotocol/graph/temporal";
+import type { DataTypeReference, JsonValue } from "@blockprotocol/graph";
+import type { Subgraph as SubgraphBp } from "@blockprotocol/graph/temporal";
 import {
   getPropertyTypeById as getPropertyTypeByIdBp,
   getPropertyTypeByVertexId as getPropertyTypeByVertexIdBp,
   getPropertyTypes as getPropertyTypesBp,
   getPropertyTypesByBaseUrl as getPropertyTypesByBaseUrlBp,
 } from "@blockprotocol/graph/temporal/stdlib";
-import {
+import type {
   EntityType,
   PropertyType,
   VersionedUrl,
 } from "@blockprotocol/type-system/slim";
 
-import {
+import type {
   BaseUrl,
   DataTypeWithMetadata,
   OntologyTypeVertexId,

--- a/libs/@local/hash-subgraph/src/stdlib/subgraph/roots.ts
+++ b/libs/@local/hash-subgraph/src/stdlib/subgraph/roots.ts
@@ -1,4 +1,4 @@
-import { Subgraph as SubgraphBp } from "@blockprotocol/graph/temporal";
+import type { Subgraph as SubgraphBp } from "@blockprotocol/graph/temporal";
 import {
   getRoots as getRootsBp,
   isDataTypeRootedSubgraph as isDataTypeRootedSubgraphBp,
@@ -6,12 +6,12 @@ import {
   isEntityTypeRootedSubgraph as isEntityTypeRootedSubgraphBp,
   isPropertyTypeRootedSubgraph as isPropertyTypeRootedSubgraphBp,
 } from "@blockprotocol/graph/temporal/stdlib";
-import {
+import type {
   EntityMetadata as GraphApiEntityMetadata,
   Subgraph as GraphApiSubgraph,
 } from "@local/hash-graph-client";
 
-import {
+import type {
   DataTypeRootType,
   EntityMetadata,
   EntityRootType,

--- a/libs/@local/hash-subgraph/src/stdlib/subgraph/temporal-axes.ts
+++ b/libs/@local/hash-subgraph/src/stdlib/subgraph/temporal-axes.ts
@@ -1,7 +1,7 @@
-import { Subgraph as SubgraphBp } from "@blockprotocol/graph/temporal";
+import type { Subgraph as SubgraphBp } from "@blockprotocol/graph/temporal";
 import { getLatestInstantIntervalForSubgraph as getLatestInstantIntervalForSubgraphBp } from "@blockprotocol/graph/temporal/stdlib";
 
-import { BoundedTimeInterval, Subgraph } from "../../main";
+import type { BoundedTimeInterval, Subgraph } from "../../main";
 
 /**
  * For a given {@link Subgraph} that supports temporal versioning, this returns a {@link TimeInterval} that spans

--- a/libs/@local/hash-subgraph/src/types/element.ts
+++ b/libs/@local/hash-subgraph/src/types/element.ts
@@ -1,5 +1,5 @@
-import { Entity } from "./element/knowledge";
-import {
+import type { Entity } from "./element/knowledge";
+import type {
   DataTypeWithMetadata,
   EntityTypeWithMetadata,
   PropertyTypeWithMetadata,

--- a/libs/@local/hash-subgraph/src/types/element/knowledge.ts
+++ b/libs/@local/hash-subgraph/src/types/element/knowledge.ts
@@ -1,14 +1,14 @@
 import type {
-  type Entity as EntityBp,
-  type EntityMetadata as EntityMetadataBp,
-  type EntityPropertiesObject as EntityPropertiesObjectBp,
-  type EntityPropertyValue as EntityPropertyValueBp,
-  type EntityRecordId as EntityRecordIdBp,
-  type EntityRevisionId as EntityRevisionIdBp,
-  type EntityTemporalVersioningMetadata as EntityTemporalVersioningMetadataBp,
+  Entity as EntityBp,
+  EntityMetadata as EntityMetadataBp,
+  EntityPropertiesObject as EntityPropertiesObjectBp,
+  EntityPropertyValue as EntityPropertyValueBp,
+  EntityRecordId as EntityRecordIdBp,
+  EntityRevisionId as EntityRevisionIdBp,
+  EntityTemporalVersioningMetadata as EntityTemporalVersioningMetadataBp,
   isEntityRecordId as isEntityRecordIdBp,
-  type LinkData as LinkDataBp,
-  type LinkEntityAndRightEntity as LinkEntityAndRightEntityBp,
+  LinkData as LinkDataBp,
+  LinkEntityAndRightEntity as LinkEntityAndRightEntityBp,
 } from "@blockprotocol/graph/temporal";
 import type { VersionedUrl } from "@blockprotocol/type-system/slim";
 import type { Brand } from "@local/advanced-types/brand";

--- a/libs/@local/hash-subgraph/src/types/element/knowledge.ts
+++ b/libs/@local/hash-subgraph/src/types/element/knowledge.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   type Entity as EntityBp,
   type EntityMetadata as EntityMetadataBp,
   type EntityPropertiesObject as EntityPropertiesObjectBp,
@@ -10,22 +10,22 @@ import {
   type LinkData as LinkDataBp,
   type LinkEntityAndRightEntity as LinkEntityAndRightEntityBp,
 } from "@blockprotocol/graph/temporal";
-import { VersionedUrl } from "@blockprotocol/type-system/slim";
-import { Brand } from "@local/advanced-types/brand";
-import { Subtype } from "@local/advanced-types/subtype";
+import type { VersionedUrl } from "@blockprotocol/type-system/slim";
+import type { Brand } from "@local/advanced-types/brand";
+import type { Subtype } from "@local/advanced-types/subtype";
 
-import {
+import type {
   BaseUrl,
   EntityId,
   EntityProvenanceMetadata,
   ExclusiveLimitedTemporalBound,
   InclusiveLimitedTemporalBound,
-  isEntityId,
   TemporalAxis,
   TimeInterval,
   Timestamp,
   Unbounded,
 } from "../shared";
+import { isEntityId } from "../shared";
 
 // This isn't necessary, it just _could_ provide greater clarity that this corresponds to an exact vertex and can be
 // used in a direct lookup and not a search in the vertices

--- a/libs/@local/hash-subgraph/src/types/element/ontology.ts
+++ b/libs/@local/hash-subgraph/src/types/element/ontology.ts
@@ -1,7 +1,7 @@
 import type {
   DataTypeWithMetadata as DataTypeWithMetadataBp,
   EntityTypeWithMetadata as EntityTypeWithMetadataBp,
-  type OntologyElementMetadata as OntologyElementMetadataBp,
+  OntologyElementMetadata as OntologyElementMetadataBp,
   PropertyTypeWithMetadata as PropertyTypeWithMetadataBp,
 } from "@blockprotocol/graph/temporal";
 import type {

--- a/libs/@local/hash-subgraph/src/types/element/ontology.ts
+++ b/libs/@local/hash-subgraph/src/types/element/ontology.ts
@@ -1,21 +1,21 @@
-import {
+import type {
   DataTypeWithMetadata as DataTypeWithMetadataBp,
   EntityTypeWithMetadata as EntityTypeWithMetadataBp,
   type OntologyElementMetadata as OntologyElementMetadataBp,
   PropertyTypeWithMetadata as PropertyTypeWithMetadataBp,
 } from "@blockprotocol/graph/temporal";
-import {
+import type {
   EntityType,
   PropertyType,
-  validateBaseUrl,
   VersionedUrl,
 } from "@blockprotocol/type-system/slim";
-import { Brand } from "@local/advanced-types/brand";
-import { DistributiveOmit } from "@local/advanced-types/distribute";
-import { Subtype } from "@local/advanced-types/subtype";
-import { DataType } from "@local/hash-graph-client";
+import { validateBaseUrl } from "@blockprotocol/type-system/slim";
+import type { Brand } from "@local/advanced-types/brand";
+import type { DistributiveOmit } from "@local/advanced-types/distribute";
+import type { Subtype } from "@local/advanced-types/subtype";
+import type { DataType } from "@local/hash-graph-client";
 
-import {
+import type {
   BaseUrl,
   ExclusiveLimitedTemporalBound,
   InclusiveLimitedTemporalBound,

--- a/libs/@local/hash-subgraph/src/types/shared.ts
+++ b/libs/@local/hash-subgraph/src/types/shared.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   CreatedAtDecisionTime,
   CreatedAtTransactionTime,
   CreatedById,

--- a/libs/@local/hash-subgraph/src/types/shared/branded.ts
+++ b/libs/@local/hash-subgraph/src/types/shared/branded.ts
@@ -1,10 +1,10 @@
-import {
+import type {
   BaseUrl as BaseUrlBp,
-  validateBaseUrl,
   VersionedUrl,
 } from "@blockprotocol/type-system/slim";
-import { Brand } from "@local/advanced-types/brand";
-import {
+import { validateBaseUrl } from "@blockprotocol/type-system/slim";
+import type { Brand } from "@local/advanced-types/brand";
+import type {
   DataTypeRelationAndSubject as DataTypeRelationAndSubjectGraph,
   EntityRelationAndSubject as EntityRelationAndSubjectGraph,
   EntityTypeInstantiatorSubject as EntityTypeInstantiatorSubjectGraph,
@@ -14,7 +14,7 @@ import {
 } from "@local/hash-graph-client";
 import { validate as validateUuid } from "uuid";
 
-import { Timestamp } from "./temporal-versioning";
+import type { Timestamp } from "./temporal-versioning";
 
 export type BaseUrl = Brand<BaseUrlBp, "BaseUrl">;
 

--- a/libs/@local/hash-subgraph/src/types/shared/temporal-versioning.ts
+++ b/libs/@local/hash-subgraph/src/types/shared/temporal-versioning.ts
@@ -17,8 +17,8 @@ import {
   type VariableTemporalAxis as VariableTemporalAxisBp,
   type VariableTemporalAxisUnresolved as VariableTemporalAxisUnresolvedBp,
 } from "@blockprotocol/graph/temporal";
-import { Brand } from "@local/advanced-types/brand";
-import { Subtype } from "@local/advanced-types/subtype";
+import type { Brand } from "@local/advanced-types/brand";
+import type { Subtype } from "@local/advanced-types/subtype";
 
 /**
  * An ISO 8601 formatted timestamp string

--- a/libs/@local/hash-subgraph/src/types/subgraph.ts
+++ b/libs/@local/hash-subgraph/src/types/subgraph.ts
@@ -5,18 +5,18 @@ import {
   type PropertyTypeRootType as PropertyTypeRootTypeBp,
   type SubgraphRootType as SubgraphRootTypeBp,
 } from "@blockprotocol/graph/temporal";
-import { Subtype } from "@local/advanced-types/subtype";
+import type { Subtype } from "@local/advanced-types/subtype";
 
-import {
+import type {
   DataTypeWithMetadata,
   Entity,
   EntityTypeWithMetadata,
   PropertyTypeWithMetadata,
 } from "./element";
-import { Edges } from "./subgraph/edges";
-import { GraphResolveDepths } from "./subgraph/graph-resolve-depths";
-import { SubgraphTemporalAxes } from "./subgraph/temporal-axes";
-import {
+import type { Edges } from "./subgraph/edges";
+import type { GraphResolveDepths } from "./subgraph/graph-resolve-depths";
+import type { SubgraphTemporalAxes } from "./subgraph/temporal-axes";
+import type {
   EntityVertexId,
   OntologyTypeVertexId,
   Vertices,

--- a/libs/@local/hash-subgraph/src/types/subgraph/edges.ts
+++ b/libs/@local/hash-subgraph/src/types/subgraph/edges.ts
@@ -3,11 +3,11 @@ import {
   type KnowledgeGraphRootedEdges as KnowledgeGraphRootedEdgesBp,
   type OntologyRootedEdges as OntologyRootedEdgesBp,
 } from "@blockprotocol/graph/temporal";
-import { Subtype } from "@local/advanced-types/subtype";
+import type { Subtype } from "@local/advanced-types/subtype";
 
-import { OntologyTypeRevisionId } from "../element";
-import { BaseUrl, EntityId, Timestamp } from "../shared";
-import {
+import type { OntologyTypeRevisionId } from "../element";
+import type { BaseUrl, EntityId, Timestamp } from "../shared";
+import type {
   KnowledgeGraphOutwardEdge,
   OntologyOutwardEdge,
 } from "./edges/variants";

--- a/libs/@local/hash-subgraph/src/types/subgraph/edges/generic-outward-edge.ts
+++ b/libs/@local/hash-subgraph/src/types/subgraph/edges/generic-outward-edge.ts
@@ -1,5 +1,5 @@
-import { GraphElementIdentifiers } from "../element-mappings";
-import {
+import type { GraphElementIdentifiers } from "../element-mappings";
+import type {
   KnowledgeGraphEdgeKind,
   OntologyEdgeKind,
   SharedEdgeKind,

--- a/libs/@local/hash-subgraph/src/types/subgraph/edges/outward-edge.ts
+++ b/libs/@local/hash-subgraph/src/types/subgraph/edges/outward-edge.ts
@@ -5,16 +5,19 @@ import {
   isOntologyOutwardEdge as isOntologyOutwardEdgeBp,
   type OutwardEdge as OutwardEdgeBp,
 } from "@blockprotocol/graph/temporal";
-import { Subtype } from "@local/advanced-types/subtype";
+import type { Subtype } from "@local/advanced-types/subtype";
 
-import {
+import type {
   EntityId,
   LimitedTemporalBound,
   TemporalBound,
   TimeInterval,
   Timestamp,
 } from "../../shared";
-import { KnowledgeGraphOutwardEdge, OntologyOutwardEdge } from "./variants";
+import type {
+  KnowledgeGraphOutwardEdge,
+  OntologyOutwardEdge,
+} from "./variants";
 
 /**
  * A simple tuple type which identifies an {@link Entity} by its {@link EntityId}, at a given {@link Timestamp}.

--- a/libs/@local/hash-subgraph/src/types/subgraph/edges/variants/knowledge.ts
+++ b/libs/@local/hash-subgraph/src/types/subgraph/edges/variants/knowledge.ts
@@ -11,12 +11,12 @@ import {
   type KnowledgeGraphOutwardEdge as KnowledgeGraphOutwardEdgeBp,
   type OutgoingLinkEdge as OutgoingLinkEdgeBp,
 } from "@blockprotocol/graph/temporal";
-import { Subtype } from "@local/advanced-types/subtype";
+import type { Subtype } from "@local/advanced-types/subtype";
 
-import { OntologyTypeVertexId } from "../../vertices";
-import { GenericOutwardEdge } from "../generic-outward-edge";
-import { KnowledgeGraphEdgeKind, SharedEdgeKind } from "../kind";
-import { EntityIdWithInterval, OutwardEdge } from "../outward-edge";
+import type { OntologyTypeVertexId } from "../../vertices";
+import type { GenericOutwardEdge } from "../generic-outward-edge";
+import type { KnowledgeGraphEdgeKind, SharedEdgeKind } from "../kind";
+import type { EntityIdWithInterval, OutwardEdge } from "../outward-edge";
 
 export type OutgoingLinkEdge = Subtype<
   OutgoingLinkEdgeBp,

--- a/libs/@local/hash-subgraph/src/types/subgraph/edges/variants/ontology.ts
+++ b/libs/@local/hash-subgraph/src/types/subgraph/edges/variants/ontology.ts
@@ -23,12 +23,12 @@ import {
   type PropertiesConstrainedByEdge as PropertiesConstrainedByEdgeBp,
   type ValuesConstrainedByEdge as ValuesConstrainedByEdgeBp,
 } from "@blockprotocol/graph/temporal";
-import { Subtype } from "@local/advanced-types/subtype";
+import type { Subtype } from "@local/advanced-types/subtype";
 
-import { OntologyTypeVertexId } from "../../vertices";
-import { GenericOutwardEdge } from "../generic-outward-edge";
-import { OntologyEdgeKind, SharedEdgeKind } from "../kind";
-import { EntityIdWithInterval, OutwardEdge } from "../outward-edge";
+import type { OntologyTypeVertexId } from "../../vertices";
+import type { GenericOutwardEdge } from "../generic-outward-edge";
+import type { OntologyEdgeKind, SharedEdgeKind } from "../kind";
+import type { EntityIdWithInterval, OutwardEdge } from "../outward-edge";
 
 export type InheritsFromEdge = Subtype<
   InheritsFromEdgeBp,

--- a/libs/@local/hash-subgraph/src/types/subgraph/element-mappings.ts
+++ b/libs/@local/hash-subgraph/src/types/subgraph/element-mappings.ts
@@ -1,8 +1,8 @@
 import { type GraphElementIdentifiers as GraphElementIdentifiersBp } from "@blockprotocol/graph/temporal";
-import { VersionedUrl } from "@blockprotocol/type-system/slim";
-import { Subtype } from "@local/advanced-types/subtype";
+import type { VersionedUrl } from "@blockprotocol/type-system/slim";
+import type { Subtype } from "@local/advanced-types/subtype";
 
-import {
+import type {
   DataTypeWithMetadata,
   Entity,
   EntityRecordId,
@@ -10,9 +10,9 @@ import {
   OntologyTypeRecordId,
   PropertyTypeWithMetadata,
 } from "../element";
-import { BaseUrl, EntityId } from "../shared";
-import { EntityIdWithInterval, EntityIdWithTimestamp } from "./edges";
-import {
+import type { BaseUrl, EntityId } from "../shared";
+import type { EntityIdWithInterval, EntityIdWithTimestamp } from "./edges";
+import type {
   DataTypeVertex,
   EntityTypeVertex,
   EntityVertex,

--- a/libs/@local/hash-subgraph/src/types/subgraph/graph-resolve-depths.ts
+++ b/libs/@local/hash-subgraph/src/types/subgraph/graph-resolve-depths.ts
@@ -2,7 +2,7 @@ import {
   type EdgeResolveDepths as EdgeResolveDepthsBp,
   type GraphResolveDepths as GraphResolveDepthsBp,
 } from "@blockprotocol/graph/temporal";
-import { Subtype } from "@local/advanced-types/subtype";
+import type { Subtype } from "@local/advanced-types/subtype";
 
 export type OutgoingEdgeResolveDepth = {
   outgoing: number;

--- a/libs/@local/hash-subgraph/src/types/subgraph/temporal-axes.ts
+++ b/libs/@local/hash-subgraph/src/types/subgraph/temporal-axes.ts
@@ -3,9 +3,9 @@ import {
   type QueryTemporalAxesUnresolved as QueryTemporalAxesUnresolvedBp,
   type SubgraphTemporalAxes as SubgraphTemporalAxesBp,
 } from "@blockprotocol/graph/temporal";
-import { Subtype } from "@local/advanced-types/subtype";
+import type { Subtype } from "@local/advanced-types/subtype";
 
-import {
+import type {
   PinnedTemporalAxis,
   PinnedTemporalAxisUnresolved,
   VariableTemporalAxis,

--- a/libs/@local/hash-subgraph/src/types/subgraph/vertices.ts
+++ b/libs/@local/hash-subgraph/src/types/subgraph/vertices.ts
@@ -20,9 +20,9 @@ import {
   type VertexId as VertexIdBp,
   type Vertices as VerticesBp,
 } from "@blockprotocol/graph/temporal";
-import { Subtype } from "@local/advanced-types/subtype";
+import type { Subtype } from "@local/advanced-types/subtype";
 
-import {
+import type {
   DataTypeWithMetadata,
   Entity,
   EntityPropertiesObject,
@@ -32,7 +32,7 @@ import {
   OntologyTypeRevisionId,
   PropertyTypeWithMetadata,
 } from "../element";
-import { BaseUrl, EntityId } from "../shared";
+import type { BaseUrl, EntityId } from "../shared";
 
 export type DataTypeVertex = Subtype<
   DataTypeVertexBp,

--- a/libs/@local/hash-subgraph/tests/compatibility.test.ts
+++ b/libs/@local/hash-subgraph/tests/compatibility.test.ts
@@ -8,9 +8,9 @@
  * be used everywhere.
  */
 
-import { Subgraph as SubgraphGraphApi } from "@local/hash-graph-client";
+import type { Subgraph as SubgraphGraphApi } from "@local/hash-graph-client";
 
-import { Subgraph } from "../src/main";
+import type { Subgraph } from "../src/main";
 import {
   mapQueryTemporalAxes,
   mapQueryTemporalAxesUnresolved,

--- a/libs/@local/hash-subgraph/tests/compatibility.test/map-axes.ts
+++ b/libs/@local/hash-subgraph/tests/compatibility.test/map-axes.ts
@@ -1,8 +1,8 @@
-import {
+import type {
   QueryTemporalAxes as QueryTemporalAxesGraphApi,
   QueryTemporalAxesUnresolved as QueryTemporalAxesUnresolvedGraphApi,
 } from "@local/hash-graph-client";
-import {
+import type {
   QueryTemporalAxes,
   QueryTemporalAxesUnresolved,
   Timestamp,

--- a/libs/@local/hash-subgraph/tests/compatibility.test/map-edges.ts
+++ b/libs/@local/hash-subgraph/tests/compatibility.test/map-edges.ts
@@ -1,5 +1,5 @@
 import { validateBaseUrl } from "@blockprotocol/type-system";
-import {
+import type {
   Edges as EdgesGraphApi,
   EntityIdWithInterval as EntityIdWithIntervalGraphApi,
   ExclusiveBound as ExclusiveBoundGraphApi,
@@ -7,16 +7,18 @@ import {
   OntologyOutwardEdge as OntologyOutwardEdgeGraphApi,
   OntologyTypeVertexId as OntologyTypeVertexIdGraphApi,
 } from "@local/hash-graph-client";
-import {
+import type {
   BaseUrl,
   Edges,
   EntityId,
-  isEntityId,
-  isKnowledgeGraphOutwardEdge,
-  isOntologyOutwardEdge,
   OntologyTypeRevisionId,
   OutwardEdge,
   Timestamp,
+} from "@local/hash-subgraph";
+import {
+  isEntityId,
+  isKnowledgeGraphOutwardEdge,
+  isOntologyOutwardEdge,
 } from "@local/hash-subgraph";
 
 export const mapOutwardEdge = (

--- a/libs/@local/hash-subgraph/tests/compatibility.test/map-roots.ts
+++ b/libs/@local/hash-subgraph/tests/compatibility.test/map-roots.ts
@@ -1,5 +1,5 @@
-import { Subgraph as SubgraphGraphApi } from "@local/hash-graph-client";
-import {
+import type { Subgraph as SubgraphGraphApi } from "@local/hash-graph-client";
+import type {
   EntityRevisionId,
   OntologyTypeRevisionId,
   Subgraph,

--- a/libs/@local/hash-subgraph/tests/compatibility.test/map-vertices.ts
+++ b/libs/@local/hash-subgraph/tests/compatibility.test/map-vertices.ts
@@ -1,13 +1,15 @@
-import {
+import type {
   EntityType,
   OneOf,
   PropertyType,
   PropertyValues,
-  validateBaseUrl,
-  validateVersionedUrl,
   VersionedUrl,
 } from "@blockprotocol/type-system";
 import {
+  validateBaseUrl,
+  validateVersionedUrl,
+} from "@blockprotocol/type-system";
+import type {
   DataType as DataTypeGraphApi,
   DataTypeMetadata as DataTypeMetadataGraphApi,
   EntityMetadata as EntityMetadataGraphApi,
@@ -25,7 +27,7 @@ import {
   PropertyTypeMetadata as PropertyTypeMetadataGraphApi,
   Vertices as VerticesGraphApi,
 } from "@local/hash-graph-client";
-import {
+import type {
   BaseUrl,
   CreatedAtDecisionTime,
   CreatedAtTransactionTime,
@@ -41,7 +43,6 @@ import {
   EntityRecordId,
   EntityTemporalVersioningMetadata,
   EntityTypeMetadata,
-  isEntityId,
   KnowledgeGraphVertex,
   LinkData,
   OntologyProvenanceMetadata,
@@ -50,6 +51,7 @@ import {
   Timestamp,
   Vertices,
 } from "@local/hash-subgraph";
+import { isEntityId } from "@local/hash-subgraph";
 
 const mapDataType = (dataType: DataTypeGraphApi): CustomDataType => {
   const idResult = validateVersionedUrl(dataType.$id);

--- a/tests/hash-playwright/playwright.config.ts
+++ b/tests/hash-playwright/playwright.config.ts
@@ -1,4 +1,5 @@
-import { devices, PlaywrightTestConfig } from "@playwright/test";
+import type { PlaywrightTestConfig } from "@playwright/test";
+import { devices } from "@playwright/test";
 
 const ci = process.env.CI === "true";
 

--- a/tests/hash-playwright/tests/browser-plugin.spec.ts
+++ b/tests/hash-playwright/tests/browser-plugin.spec.ts
@@ -1,6 +1,6 @@
 import { sleep } from "@local/hash-isomorphic-utils/sleep";
 // eslint-disable-next-line no-restricted-imports
-import { Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 
 import { expect, test } from "./browser-plugin/fixtures";
 import { loginUsingTempForm } from "./shared/login-using-temp-form";

--- a/tests/hash-playwright/tests/entity-creation.spec.ts
+++ b/tests/hash-playwright/tests/entity-creation.spec.ts
@@ -2,7 +2,8 @@ import { sleep } from "@local/hash-isomorphic-utils/sleep";
 
 import { loginUsingTempForm } from "./shared/login-using-temp-form";
 import { resetDb } from "./shared/reset-db";
-import { expect, Locator, Page, test } from "./shared/runtime";
+import type { Locator, Page } from "./shared/runtime";
+import { expect, test } from "./shared/runtime";
 
 const getCellText = async (
   canvas: Locator,

--- a/tests/hash-playwright/tests/shared/login-using-temp-form.ts
+++ b/tests/hash-playwright/tests/shared/login-using-temp-form.ts
@@ -1,4 +1,5 @@
-import { expect, Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
 
 /**
  * @todo Remove this function in favor of `loginUsingUi`once we have a proper login flow

--- a/tests/hash-playwright/tests/shared/login-using-ui.ts
+++ b/tests/hash-playwright/tests/shared/login-using-ui.ts
@@ -1,4 +1,5 @@
-import { expect, Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
 
 import { getDerivedPayloadFromMostRecentEmail } from "./get-derived-payload-from-most-recent-email";
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This enables the `consistent-type-imports` lint rule, which is automatically fixable, and restricts type imports to be prefixed with `type.` This is an official recommendation by Typescript because these imports are stripped during execution.

This step also makes the next step of moving from CommonJS to ES-Modules easier.


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

