### PR TITLE
Redirect app `/login` to `/signin`

### DIFF
--- a/apps/hash-frontend/next.config.js
+++ b/apps/hash-frontend/next.config.js
@@ -77,6 +77,11 @@ module.exports = withSentryConfig(
             destination: "/settings/organizations/:shortname/general",
             permanent: true,
           },
+          {
+            source: "/login",
+            destination: "/signin",
+            permanent: true,
+          },
         ];
       },
       async headers() {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

- **Redirects the HASH app `/login` route to `/signin`.** Originally intended upon implementation of the new signin/signup flow, but seemingly missed at the time ([see Slack](https://hashintel.slack.com/archives/C022217GAHF/p1707385980550749?thread_ts=1707383098.345499&cid=C022217GAHF) - _internal link_).
