### PR TITLE
H-2331: Introduce a `ClosedEntityType` struct

### DIFF
--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/entity_type/channel.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/entity_type/channel.rs
@@ -12,6 +12,7 @@ use futures::{
 };
 use graph_types::ontology::OntologyTypeVersion;
 use postgres_types::Json;
+use type_system::ClosedEntityType;
 use uuid::Uuid;
 
 use crate::snapshot::{
@@ -177,7 +178,7 @@ impl Sink<EntityTypeSnapshotRecord> for EntityTypeSender {
                 schema: Json(entity_type.schema.clone()),
                 // The unclosed schema is inserted initially. This will be replaced later by the
                 // closed schema.
-                closed_schema: Json(entity_type.schema),
+                closed_schema: Json(ClosedEntityType::from(entity_type.schema)),
                 label_property: entity_type
                     .metadata
                     .label_property

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/table.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/table.rs
@@ -7,7 +7,7 @@ use graph_types::{
 use postgres_types::{Json, ToSql};
 use temporal_versioning::{LeftClosedTemporalInterval, Timestamp, TransactionTime};
 use time::OffsetDateTime;
-use type_system::{DataType, EntityType, PropertyType};
+use type_system::{ClosedEntityType, DataType, EntityType, PropertyType};
 use uuid::Uuid;
 
 #[derive(Debug, ToSql)]
@@ -92,7 +92,7 @@ pub struct PropertyTypeConstrainsPropertiesOnRow {
 pub struct EntityTypeRow {
     pub ontology_id: Uuid,
     pub schema: Json<EntityType>,
-    pub closed_schema: Json<EntityType>,
+    pub closed_schema: Json<ClosedEntityType>,
     pub label_property: Option<String>,
     pub icon: Option<String>,
 }

--- a/apps/hash-graph/libs/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/libs/graph/src/store/knowledge.rs
@@ -13,7 +13,7 @@ use graph_types::{
 use serde::{Deserialize, Serialize};
 use temporal_client::TemporalClient;
 use temporal_versioning::{DecisionTime, Timestamp, TransactionTime};
-use type_system::{url::VersionedUrl, EntityType};
+use type_system::{url::VersionedUrl, ClosedEntityType, EntityType};
 #[cfg(feature = "utoipa")]
 use utoipa::{
     openapi,
@@ -33,9 +33,12 @@ use crate::{
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
+#[expect(clippy::large_enum_variant)]
 pub enum EntityValidationType<'a> {
-    Schema(Cow<'a, EntityType>),
+    Schema(EntityType),
     Id(Cow<'a, VersionedUrl>),
+    #[serde(skip)]
+    ClosedSchema(Cow<'a, ClosedEntityType>),
 }
 
 #[cfg(feature = "utoipa")]

--- a/apps/hash-graph/libs/graph/src/store/postgres/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/mod.rs
@@ -41,7 +41,8 @@ use tokio_postgres::{
 };
 use type_system::{
     url::{BaseUrl, VersionedUrl},
-    DataTypeReference, EntityType, EntityTypeReference, PropertyType, PropertyTypeReference,
+    ClosedEntityType, DataTypeReference, EntityType, EntityTypeReference, PropertyType,
+    PropertyTypeReference,
 };
 
 pub use self::{
@@ -432,7 +433,7 @@ where
         &self,
         ontology_id: OntologyId,
         entity_type: &EntityType,
-        closed_entity_type: &EntityType,
+        closed_entity_type: &ClosedEntityType,
         label_property: Option<&BaseUrl>,
         icon: Option<&str>,
     ) -> Result<Option<OntologyId>, InsertionError> {

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/read.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/read.rs
@@ -9,7 +9,7 @@ use temporal_versioning::RightBoundedTemporalInterval;
 use tokio_postgres::GenericClient;
 use type_system::{
     url::{BaseUrl, VersionedUrl},
-    EntityType,
+    ClosedEntityType,
 };
 
 use crate::{
@@ -65,7 +65,7 @@ impl<C: AsClient> PostgresStore<C> {
         &self,
         filter: &Filter<'f, EntityTypeWithMetadata>,
         temporal_axes: Option<&'f QueryTemporalAxes>,
-    ) -> Result<impl Stream<Item = Result<(EntityTypeId, EntityType), QueryError>>, QueryError>
+    ) -> Result<impl Stream<Item = Result<(EntityTypeId, ClosedEntityType), QueryError>>, QueryError>
     {
         let mut compiler = SelectCompiler::new(temporal_axes, false);
 

--- a/apps/hash-graph/libs/graph/src/store/validation.rs
+++ b/apps/hash-graph/libs/graph/src/store/validation.rs
@@ -20,7 +20,7 @@ use tokio::sync::RwLock;
 use tokio_postgres::GenericClient;
 use type_system::{
     url::{BaseUrl, VersionedUrl},
-    DataType, EntityType, PropertyType,
+    ClosedEntityType, DataType, PropertyType,
 };
 use validation::{EntityProvider, EntityTypeProvider, OntologyTypeProvider};
 
@@ -118,7 +118,7 @@ where
 pub struct StoreCache {
     data_types: CacheHashMap<DataTypeId, DataType>,
     property_types: CacheHashMap<PropertyTypeId, PropertyType>,
-    entity_types: CacheHashMap<EntityTypeId, EntityType>,
+    entity_types: CacheHashMap<EntityTypeId, ClosedEntityType>,
 }
 
 #[derive(Debug)]
@@ -295,7 +295,7 @@ where
     async fn fetch_entity_type(
         &self,
         type_id: &VersionedUrl,
-    ) -> Result<EntityType, Report<QueryError>> {
+    ) -> Result<ClosedEntityType, Report<QueryError>> {
         let mut schemas = self
             .store
             .read_closed_schemas(
@@ -333,7 +333,7 @@ where
     }
 }
 
-impl<C, A> OntologyTypeProvider<EntityType> for StoreProvider<'_, PostgresStore<C>, A>
+impl<C, A> OntologyTypeProvider<ClosedEntityType> for StoreProvider<'_, PostgresStore<C>, A>
 where
     C: AsClient,
     A: AuthorizationApi + Sync,
@@ -342,7 +342,7 @@ where
     async fn provide_type(
         &self,
         type_id: &VersionedUrl,
-    ) -> Result<Arc<EntityType>, Report<QueryError>> {
+    ) -> Result<Arc<ClosedEntityType>, Report<QueryError>> {
         let entity_type_id = EntityTypeId::from_url(type_id);
 
         if let Some(cached) = self.cache.entity_types.get(&entity_type_id).await {

--- a/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/closed.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/closed.rs
@@ -1,0 +1,98 @@
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    url::{BaseUrl, VersionedUrl},
+    EntityType, EntityTypeReference, Links, PropertyTypeReference, ValueOrArray,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ClosedEntityTypeSchemaData {
+    pub title: String,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ClosedEntityType {
+    pub schemas: HashMap<VersionedUrl, ClosedEntityTypeSchemaData>,
+    pub properties: HashMap<BaseUrl, ValueOrArray<PropertyTypeReference>>,
+    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    pub required: HashSet<BaseUrl>,
+    #[serde(flatten)]
+    pub links: Links,
+    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    pub inherits_from: HashSet<EntityTypeReference>,
+}
+
+impl From<EntityType> for ClosedEntityType {
+    fn from(entity_type: EntityType) -> Self {
+        Self {
+            schemas: HashMap::from([(
+                entity_type.id,
+                ClosedEntityTypeSchemaData {
+                    title: entity_type.title,
+                    description: entity_type.description,
+                },
+            )]),
+            properties: entity_type.property_object.properties,
+            required: entity_type.property_object.required,
+            links: entity_type.links,
+            inherits_from: entity_type.inherits_from.elements.into_iter().collect(),
+        }
+    }
+}
+
+impl FromIterator<EntityType> for ClosedEntityType {
+    fn from_iter<T: IntoIterator<Item = EntityType>>(iter: T) -> Self {
+        let iter = iter.into_iter();
+
+        let mut entity_type = Self {
+            schemas: HashMap::with_capacity(iter.size_hint().0),
+            properties: HashMap::new(),
+            required: HashSet::new(),
+            links: Links(HashMap::new()),
+            inherits_from: HashSet::new(),
+        };
+        entity_type.extend(iter);
+        entity_type
+    }
+}
+
+impl Extend<Self> for ClosedEntityType {
+    fn extend<T: IntoIterator<Item = Self>>(&mut self, iter: T) {
+        for other in iter {
+            self.inherits_from.extend(other.inherits_from);
+            self.schemas.extend(other.schemas);
+            self.properties.extend(other.properties);
+            self.required.extend(other.required);
+            self.links.extend_one(other.links);
+        }
+
+        self.inherits_from
+            .retain(|x| !self.schemas.contains_key(x.url()));
+    }
+}
+
+impl Extend<EntityType> for ClosedEntityType {
+    fn extend<T: IntoIterator<Item = EntityType>>(&mut self, iter: T) {
+        for other in iter {
+            self.inherits_from.extend(other.inherits_from.elements);
+            self.schemas.insert(
+                other.id,
+                ClosedEntityTypeSchemaData {
+                    title: other.title,
+                    description: other.description,
+                },
+            );
+            self.properties.extend(other.property_object.properties);
+            self.required.extend(other.property_object.required);
+            self.links.extend_one(other.links);
+        }
+
+        self.inherits_from
+            .retain(|x| !self.schemas.contains_key(x.url()));
+    }
+}

--- a/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/links/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/links/mod.rs
@@ -9,13 +9,15 @@ use std::{
 };
 
 pub use error::ParseLinksError;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     url::{BaseUrl, VersionedUrl},
     Array, EntityTypeReference, OneOf, ValidateUrl, ValidationError,
 };
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "raw::Links", into = "raw::Links")]
 pub struct Links(
     pub(crate) HashMap<VersionedUrl, MaybeOrderedArray<Option<OneOf<EntityTypeReference>>>>,
 );

--- a/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/raw.rs
@@ -164,7 +164,9 @@ impl From<super::EntityTypeReference> for EntityTypeReference {
 
 #[cfg(test)]
 mod tests {
-    use crate::{raw, url::BaseUrl, utils::tests::check_serialization_from_str, EntityType};
+    use crate::{
+        raw, url::BaseUrl, utils::tests::check_serialization_from_str, ClosedEntityType, EntityType,
+    };
 
     #[test]
     fn merge_entity_type() {
@@ -172,15 +174,15 @@ mod tests {
             graph_test_data::entity_type::BUILDING_V1,
             None,
         );
-        let mut church: EntityType = check_serialization_from_str::<EntityType, raw::EntityType>(
+        let church: EntityType = check_serialization_from_str::<EntityType, raw::EntityType>(
             graph_test_data::entity_type::CHURCH_V1,
             None,
         );
 
-        church.extend_one(building);
+        let closed_church: ClosedEntityType = [building, church].into_iter().collect();
 
         assert!(
-            church.properties().contains_key(
+            closed_church.properties.contains_key(
                 &BaseUrl::new(
                     "https://blockprotocol.org/@alice/types/property-type/built-at/".to_owned()
                 )
@@ -188,13 +190,13 @@ mod tests {
             )
         );
         assert!(
-            church.properties().contains_key(
+            closed_church.properties.contains_key(
                 &BaseUrl::new(
                     "https://blockprotocol.org/@alice/types/property-type/number-bells/".to_owned()
                 )
                 .expect("invalid url")
             )
         );
-        assert!(church.inherits_from().all_of().is_empty());
+        assert!(closed_church.inherits_from.is_empty());
     }
 }

--- a/libs/@blockprotocol/type-system/rust/src/ontology/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/mod.rs
@@ -15,7 +15,8 @@ mod shared;
 pub use data_type::{DataType, DataTypeReference, ParseDataTypeError};
 pub use entity_type::{
     links::{Links, MaybeOrderedArray, ParseLinksError},
-    EntityType, EntityTypeReference, MergeEntityTypeError, ParseEntityTypeError,
+    ClosedEntityType, ClosedEntityTypeSchemaData, EntityType, EntityTypeReference,
+    MergeEntityTypeError, ParseEntityTypeError,
 };
 pub use property_type::{
     ParsePropertyTypeError, PropertyType, PropertyTypeReference, PropertyValues,

--- a/libs/@blockprotocol/type-system/rust/src/ontology/property_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/property_type/mod.rs
@@ -78,7 +78,11 @@ impl PropertyType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(
+    try_from = "raw::PropertyTypeReference",
+    into = "raw::PropertyTypeReference"
+)]
 #[repr(transparent)]
 pub struct PropertyTypeReference {
     url: VersionedUrl,

--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -9,7 +9,7 @@ use serde_json::Value as JsonValue;
 use thiserror::Error;
 use type_system::{
     url::{BaseUrl, VersionedUrl},
-    DataType, EntityType, Object, PropertyType,
+    ClosedEntityType, DataType, Object, PropertyType,
 };
 
 use crate::{
@@ -39,13 +39,13 @@ pub enum EntityValidationError {
     EntityTypeRetrieval { id: VersionedUrl },
     #[error("the validator was unable to read the entity `{id}`")]
     EntityRetrieval { id: EntityId },
-    #[error("The link type `{link_type}` is not allowed")]
-    InvalidLinkTypeId { link_type: VersionedUrl },
-    #[error("The link target `{target_type}` is not allowed")]
-    InvalidLinkTargetId { target_type: VersionedUrl },
+    #[error("The link type `{link_types:?}` is not allowed")]
+    InvalidLinkTypeId { link_types: Vec<VersionedUrl> },
+    #[error("The link target `{target_types:?}` is not allowed")]
+    InvalidLinkTargetId { target_types: Vec<VersionedUrl> },
 }
 
-impl<P> Schema<HashMap<BaseUrl, JsonValue>, P> for EntityType
+impl<P> Schema<HashMap<BaseUrl, JsonValue>, P> for ClosedEntityType
 where
     P: OntologyTypeProvider<PropertyType> + OntologyTypeProvider<DataType> + Sync,
 {
@@ -60,7 +60,7 @@ where
         // TODO: Distinguish between format validation and content validation so it's possible
         //       to directly use the correct type.
         //   see https://linear.app/hash/issue/BP-33
-        Object::<_, 0>::new(self.properties().clone(), self.required().clone())
+        Object::<_, 0>::new(self.properties.clone(), self.required.clone())
             .expect("`Object` was already validated")
             .validate_value(value, profile, provider)
             .await
@@ -70,7 +70,7 @@ where
     }
 }
 
-impl<P> Validate<EntityType, P> for EntityProperties
+impl<P> Validate<ClosedEntityType, P> for EntityProperties
 where
     P: OntologyTypeProvider<PropertyType> + OntologyTypeProvider<DataType> + Sync,
 {
@@ -78,7 +78,7 @@ where
 
     async fn validate(
         &self,
-        schema: &EntityType,
+        schema: &ClosedEntityType,
         profile: ValidationProfile,
         provider: &P,
     ) -> Result<(), Report<Self::Error>> {
@@ -88,7 +88,7 @@ where
     }
 }
 
-impl<P> Validate<EntityType, P> for Option<&LinkData>
+impl<P> Validate<ClosedEntityType, P> for Option<&LinkData>
 where
     P: EntityProvider
         + EntityTypeProvider
@@ -100,34 +100,24 @@ where
 
     async fn validate(
         &self,
-        schema: &EntityType,
+        schema: &ClosedEntityType,
         profile: ValidationProfile,
         provider: &P,
     ) -> Result<(), Report<Self::Error>> {
         let mut status: Result<(), Report<EntityValidationError>> = Ok(());
 
-        let is_link = provider
-            .is_parent_of(
-                schema.id(),
-                // TODO: The link type should be a const but the type system crate does not allow
-                //       to make this a `const` variable.
-                //   see https://linear.app/hash/issue/BP-57
-                &BaseUrl::new(
-                    "https://blockprotocol.org/@blockprotocol/types/entity-type/link/".to_owned(),
-                )
-                .expect("Not a valid URL"),
+        // TODO: The link type should be a const but the type system crate does not allow
+        //       to make this a `const` variable.
+        //   see https://linear.app/hash/issue/BP-57
+        let link_type_id = VersionedUrl {
+            base_url: BaseUrl::new(
+                "https://blockprotocol.org/@blockprotocol/types/entity-type/link/".to_owned(),
             )
-            .await
-            .change_context_lazy(|| EntityValidationError::EntityTypeRetrieval {
-                id: schema.id().clone(),
-            })
-            .map_err(|error| extend_report!(status, error))
-            .unwrap_or(
-                // We were not able to check if the entity type is a link, so we assume it is. The
-                // validation already failed anyway. This way we don't pollute the error report
-                // with additional errors wich might be a false positive.
-                true,
-            );
+            .expect("Not a valid URL"),
+            version: 1,
+        };
+        let is_link = schema.schemas.contains_key(&link_type_id);
+
         if let Some(link_data) = self {
             if !is_link {
                 extend_report!(status, EntityValidationError::UnexpectedLinkData);
@@ -144,7 +134,7 @@ where
     }
 }
 
-impl<P> Validate<EntityType, P> for Entity
+impl<P> Validate<ClosedEntityType, P> for Entity
 where
     P: EntityProvider
         + EntityTypeProvider
@@ -156,7 +146,7 @@ where
 
     async fn validate(
         &self,
-        schema: &EntityType,
+        schema: &ClosedEntityType,
         profile: ValidationProfile,
         provider: &P,
     ) -> Result<(), Report<Self::Error>> {
@@ -178,7 +168,7 @@ where
     }
 }
 
-impl<P> Schema<LinkData, P> for EntityType
+impl<P> Schema<LinkData, P> for ClosedEntityType
 where
     P: EntityProvider + EntityTypeProvider + Sync,
 {
@@ -186,7 +176,6 @@ where
 
     // TODO: validate link data
     //   see https://linear.app/hash/issue/H-972
-    #[expect(clippy::too_many_lines)]
     async fn validate_value<'a>(
         &'a self,
         link_data: &'a LinkData,
@@ -200,109 +189,77 @@ where
             .await
             .change_context_lazy(|| EntityValidationError::EntityRetrieval {
                 id: link_data.left_entity_id,
-            })
-            .map_err(|error| extend_report!(status, error))
-            .ok();
+            })?;
+
+        let left_entity_type = provider
+            .provide_type(&left_entity.borrow().metadata.entity_type_id)
+            .await
+            .change_context_lazy(|| EntityValidationError::EntityTypeRetrieval {
+                id: left_entity.borrow().metadata.entity_type_id.clone(),
+            })?;
 
         let right_entity = provider
             .provide_entity(link_data.right_entity_id, true)
             .await
             .change_context_lazy(|| EntityValidationError::EntityRetrieval {
                 id: link_data.right_entity_id,
-            })
-            .map_err(|error| extend_report!(status, error))
-            .ok();
+            })?;
 
-        let right_entity_type_id = right_entity
-            .as_ref()
-            .map(|entity| &entity.borrow().metadata.entity_type_id);
+        let right_entity_type = provider
+            .provide_type(&right_entity.borrow().metadata.entity_type_id)
+            .await
+            .change_context_lazy(|| EntityValidationError::EntityTypeRetrieval {
+                id: right_entity.borrow().metadata.entity_type_id.clone(),
+            })?;
 
-        if let Some(left_entity) = left_entity {
-            let left_entity_type = provider
-                .provide_type(&left_entity.borrow().metadata.entity_type_id)
-                .await
-                .change_context_lazy(|| EntityValidationError::EntityTypeRetrieval {
-                    id: left_entity.borrow().metadata.entity_type_id.clone(),
-                })
-                .map_err(|error| extend_report!(status, error))
-                .ok();
+        // We track that at least one link type was found to avoid reporting an error if no
+        // link type was found.
+        let mut found_link_target = false;
+        for link_type_id in self.schemas.keys() {
+            let Some(maybe_allowed_targets) =
+                left_entity_type.borrow().links.links().get(link_type_id)
+            else {
+                continue;
+            };
 
-            if let Some(left_entity_type) = left_entity_type {
-                let mut maybe_allowed_targets = left_entity_type.borrow().links().get(self.id());
-                if maybe_allowed_targets.is_none() {
-                    // No exact match found, so we look up parent types
-                    for (link_type, allowed_targets) in left_entity_type.borrow().links() {
-                        if self.id().base_url == link_type.base_url
-                            || provider
-                                .is_parent_of(self.id(), &link_type.base_url)
-                                .await
-                                .change_context_lazy(|| {
-                                    EntityValidationError::EntityTypeRetrieval {
-                                        id: self.id().clone(),
-                                    }
-                                })
-                                .map_err(|error| extend_report!(status, error))
-                                .unwrap_or(false)
-                        {
-                            maybe_allowed_targets = Some(allowed_targets);
-                            break;
-                        }
-                    }
-                }
+            // At least one link type was found
+            found_link_target = true;
 
-                if let Some(maybe_allowed_targets) = maybe_allowed_targets {
-                    if let (Some(allowed_targets), Some(right_entity_type_id)) =
-                        (maybe_allowed_targets.array().items(), right_entity_type_id)
-                    {
-                        let mut found_match = false;
-                        for allowed_target in allowed_targets.one_of() {
-                            // We test exact matches first to avoid looking up parent types
-                            if allowed_target.url().base_url == right_entity_type_id.base_url {
-                                found_match = true;
-                                break;
-                            }
-                        }
-                        if !found_match {
-                            // No exact match found, so we look up parent types
-                            for allowed_target in allowed_targets.one_of() {
-                                if provider
-                                    .is_parent_of(
-                                        right_entity_type_id,
-                                        &allowed_target.url().base_url,
-                                    )
-                                    .await
-                                    .change_context_lazy(|| {
-                                        EntityValidationError::EntityTypeRetrieval {
-                                            id: right_entity_type_id.clone(),
-                                        }
-                                    })
-                                    .map_err(|error| extend_report!(status, error))
-                                    .unwrap_or(false)
-                                {
-                                    found_match = true;
-                                    break;
-                                }
-                            }
-                        }
+            let Some(allowed_targets) = maybe_allowed_targets.array().items() else {
+                continue;
+            };
 
-                        if !found_match {
-                            extend_report!(
-                                status,
-                                EntityValidationError::InvalidLinkTargetId {
-                                    target_type: right_entity_type_id.clone(),
-                                }
-                            );
-                        }
-                    }
-                } else {
-                    extend_report!(
-                        status,
-                        EntityValidationError::InvalidLinkTypeId {
-                            link_type: self.id().clone(),
-                        }
-                    );
+            // Link destinations are constrained, search for the right entity's type
+            let mut found_match = false;
+            for allowed_target in allowed_targets.one_of() {
+                if right_entity_type
+                    .borrow()
+                    .schemas
+                    .keys()
+                    .any(|right_type| right_type.base_url == allowed_target.url().base_url)
+                {
+                    found_match = true;
+                    break;
                 }
             }
+
+            if !found_match {
+                extend_report!(
+                    status,
+                    EntityValidationError::InvalidLinkTargetId {
+                        target_types: right_entity_type.borrow().schemas.keys().cloned().collect(),
+                    }
+                );
+            }
+        }
+
+        if !found_link_target {
+            extend_report!(
+                status,
+                EntityValidationError::InvalidLinkTypeId {
+                    link_types: self.schemas.keys().cloned().collect(),
+                }
+            );
         }
 
         status

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -23,7 +23,7 @@ use graph_types::knowledge::entity::{Entity, EntityId};
 use serde::Deserialize;
 use type_system::{
     url::{BaseUrl, VersionedUrl},
-    EntityType,
+    ClosedEntityType,
 };
 
 trait Schema<V: ?Sized, P: Sync> {
@@ -102,7 +102,7 @@ pub trait OntologyTypeProvider<O> {
     ) -> impl Future<Output = Result<impl Borrow<O> + Send, Report<impl Context>>> + Send;
 }
 
-pub trait EntityTypeProvider: OntologyTypeProvider<EntityType> {
+pub trait EntityTypeProvider: OntologyTypeProvider<ClosedEntityType> {
     fn is_parent_of(
         &self,
         child: &VersionedUrl,
@@ -124,21 +124,21 @@ mod tests {
     use graph_types::knowledge::entity::EntityProperties;
     use serde_json::Value as JsonValue;
     use thiserror::Error;
-    use type_system::{DataType, PropertyType};
+    use type_system::{DataType, EntityType, PropertyType};
 
     use super::*;
     use crate::error::install_error_stack_hooks;
 
     struct Provider {
         entities: HashMap<EntityId, Entity>,
-        entity_types: HashMap<VersionedUrl, EntityType>,
+        entity_types: HashMap<VersionedUrl, ClosedEntityType>,
         property_types: HashMap<VersionedUrl, PropertyType>,
         data_types: HashMap<VersionedUrl, DataType>,
     }
     impl Provider {
         fn new(
             entities: impl IntoIterator<Item = Entity>,
-            entity_types: impl IntoIterator<Item = EntityType>,
+            entity_types: impl IntoIterator<Item = (VersionedUrl, ClosedEntityType)>,
             property_types: impl IntoIterator<Item = PropertyType>,
             data_types: impl IntoIterator<Item = DataType>,
         ) -> Self {
@@ -147,10 +147,7 @@ mod tests {
                     .into_iter()
                     .map(|entity| (entity.metadata.record_id.entity_id, entity))
                     .collect(),
-                entity_types: entity_types
-                    .into_iter()
-                    .map(|schema| (schema.id().clone(), schema))
-                    .collect(),
+                entity_types: entity_types.into_iter().collect(),
                 property_types: property_types
                     .into_iter()
                     .map(|schema| (schema.id().clone(), schema))
@@ -205,21 +202,20 @@ mod tests {
             parent: &BaseUrl,
         ) -> Result<bool, Report<InvalidEntityType>> {
             Ok(
-                OntologyTypeProvider::<EntityType>::provide_type(self, child)
+                OntologyTypeProvider::<ClosedEntityType>::provide_type(self, child)
                     .await?
-                    .inherits_from()
-                    .all_of()
+                    .inherits_from
                     .iter()
                     .any(|id| id.url().base_url == *parent),
             )
         }
     }
 
-    impl OntologyTypeProvider<EntityType> for Provider {
+    impl OntologyTypeProvider<ClosedEntityType> for Provider {
         async fn provide_type(
             &self,
             type_id: &VersionedUrl,
-        ) -> Result<&EntityType, Report<InvalidEntityType>> {
+        ) -> Result<&ClosedEntityType, Report<InvalidEntityType>> {
             self.entity_types.get(type_id).ok_or_else(|| {
                 Report::new(InvalidEntityType {
                     id: type_id.clone(),
@@ -278,8 +274,9 @@ mod tests {
             }),
         );
 
-        let entity_type: EntityType =
-            serde_json::from_str(entity_type).expect("failed to parse entity type");
+        let entity_type = ClosedEntityType::from(
+            serde_json::from_str::<EntityType>(entity_type).expect("failed to parse entity type"),
+        );
 
         let entity =
             serde_json::from_str::<EntityProperties>(entity).expect("failed to read entity string");


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `EntityType` struct does not keep track over the IDs of the types when merging them together to create a closed schema. That tracking, however, is very useful when validating entities and more. This introduces a type which keeps track over the IDs when merging but don't expose it to the Node API, yet. This will be especially useful when multi-type entities will be introduced.

## 🚫 Blocked by

- #4113 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change
### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph