### PR TITLE
H-2355: Install Rust in Vercel install step

### DIFF
--- a/apps/hash-frontend/vercel-install.sh
+++ b/apps/hash-frontend/vercel-install.sh
@@ -45,6 +45,7 @@ yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"
 
 echo "Installing Rust"
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none --profile minimal
+for _ in {1..5}; do rustup show && break || sleep 5; done
 source "$HOME/.cargo/env"
 
 echo "Installing yarn dependencies"

--- a/apps/hash-frontend/vercel-install.sh
+++ b/apps/hash-frontend/vercel-install.sh
@@ -43,9 +43,9 @@ yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"
 
 echo "Installing Rust"
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none --profile minimal
+source "$HOME/.cargo/env"
 # `rustup show` uses `rust-toolchain.toml` to install the correct toolchain.
 for _ in {1..5}; do rustup show && break || sleep 5; done
-source "$HOME/.cargo/env"
 
 # Install the pruned dependencies
 

--- a/apps/hash-frontend/vercel-install.sh
+++ b/apps/hash-frontend/vercel-install.sh
@@ -41,12 +41,13 @@ yarn global add "turbo@$(jq -r '.devDependencies.turbo' < package.json)"
 #mv out/* .
 #rm out -r
 
-# Install the pruned dependencies
-
 echo "Installing Rust"
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none --profile minimal
+# `rustup show` uses `rust-toolchain.toml` to install the correct toolchain.
 for _ in {1..5}; do rustup show && break || sleep 5; done
 source "$HOME/.cargo/env"
+
+# Install the pruned dependencies
 
 echo "Installing yarn dependencies"
 HUSKY=0 yarn install --frozen-lockfile --prefer-offline --force --build-from-source

--- a/apps/hashdotdesign/vercel-install.sh
+++ b/apps/hashdotdesign/vercel-install.sh
@@ -5,6 +5,7 @@ cd ../..
 
 echo "Installing Rust"
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none --profile minimal
+# `rustup show` uses `rust-toolchain.toml` to install the correct toolchain.
 for _ in {1..5}; do rustup show && break || sleep 5; done
 source "$HOME/.cargo/env"
 

--- a/apps/hashdotdesign/vercel-install.sh
+++ b/apps/hashdotdesign/vercel-install.sh
@@ -5,9 +5,9 @@ cd ../..
 
 echo "Installing Rust"
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none --profile minimal
+source "$HOME/.cargo/env"
 # `rustup show` uses `rust-toolchain.toml` to install the correct toolchain.
 for _ in {1..5}; do rustup show && break || sleep 5; done
-source "$HOME/.cargo/env"
 
 echo "Installing yarn dependencies"
 HUSKY=0 yarn install --frozen-lockfile --prefer-offline --force --build-from-source

--- a/apps/hashdotdesign/vercel-install.sh
+++ b/apps/hashdotdesign/vercel-install.sh
@@ -5,6 +5,7 @@ cd ../..
 
 echo "Installing Rust"
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none --profile minimal
+for _ in {1..5}; do rustup show && break || sleep 5; done
 source "$HOME/.cargo/env"
 
 echo "Installing yarn dependencies"

--- a/apps/hashdotdev/vercel-install.sh
+++ b/apps/hashdotdev/vercel-install.sh
@@ -5,6 +5,7 @@ cd ../..
 
 echo "Installing Rust"
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none --profile minimal
+# `rustup show` uses `rust-toolchain.toml` to install the correct toolchain.
 for _ in {1..5}; do rustup show && break || sleep 5; done
 source "$HOME/.cargo/env"
 

--- a/apps/hashdotdev/vercel-install.sh
+++ b/apps/hashdotdev/vercel-install.sh
@@ -5,9 +5,9 @@ cd ../..
 
 echo "Installing Rust"
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none --profile minimal
+source "$HOME/.cargo/env"
 # `rustup show` uses `rust-toolchain.toml` to install the correct toolchain.
 for _ in {1..5}; do rustup show && break || sleep 5; done
-source "$HOME/.cargo/env"
 
 echo "Installing yarn dependencies"
 HUSKY=0 yarn install --frozen-lockfile --prefer-offline --force --build-from-source

--- a/apps/hashdotdev/vercel-install.sh
+++ b/apps/hashdotdev/vercel-install.sh
@@ -5,6 +5,7 @@ cd ../..
 
 echo "Installing Rust"
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none --profile minimal
+for _ in {1..5}; do rustup show && break || sleep 5; done
 source "$HOME/.cargo/env"
 
 echo "Installing yarn dependencies"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We encounter frequent failures in the Vercel build step when installing Rust. This moves the toolchain installation to the install step and adds a retry logic.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing
### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph