### PR TITLE
H-2362: Support converting `BaseUrl` to/from Postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,12 +1365,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http 1.0.0",
  "http-body 1.0.0",
  "pin-project-lite",
@@ -3223,18 +3223,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3745,6 +3745,7 @@ version = "0.0.0"
 dependencies = [
  "console_error_panic_hook",
  "graph-test-data",
+ "postgres-types",
  "serde",
  "serde_json",
  "thiserror",

--- a/apps/hash-graph/bench/representative_read/seed.rs
+++ b/apps/hash-graph/bench/representative_read/seed.rs
@@ -291,10 +291,7 @@ async fn get_samples(account_id: AccountId, store_wrapper: &StoreWrapper) -> Sam
                 ORDER BY RANDOM()
                 LIMIT 50
                 ",
-                &[
-                    &entity_type_id.base_url.as_str(),
-                    &i64::from(entity_type_id.version),
-                ],
+                &[&entity_type_id.base_url, &entity_type_id.version],
             )
             .await
             .unwrap_or_else(|err| {

--- a/apps/hash-graph/libs/api/src/rest/data_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/data_type.rs
@@ -51,7 +51,10 @@ use hash_status::Status;
 use serde::{Deserialize, Serialize};
 use temporal_client::TemporalClient;
 use time::OffsetDateTime;
-use type_system::{url::VersionedUrl, DataType};
+use type_system::{
+    url::{OntologyTypeVersion, VersionedUrl},
+    DataType,
+};
 use utoipa::{OpenApi, ToSchema};
 
 use super::api_resource::RoutedResource;
@@ -468,7 +471,7 @@ where
         relationships,
     }) = body;
 
-    type_to_update.version += 1;
+    type_to_update.version = OntologyTypeVersion::new(type_to_update.version.inner() + 1);
 
     let data_type = patch_id_and_parse(&type_to_update, schema).map_err(|report| {
         tracing::error!(error=?report, "Couldn't patch schema and convert to Data Type");

--- a/apps/hash-graph/libs/api/src/rest/entity_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity_type.rs
@@ -52,7 +52,7 @@ use serde::{Deserialize, Serialize};
 use temporal_client::TemporalClient;
 use time::OffsetDateTime;
 use type_system::{
-    url::{BaseUrl, VersionedUrl},
+    url::{BaseUrl, OntologyTypeVersion, VersionedUrl},
     EntityType,
 };
 use utoipa::{OpenApi, ToSchema};
@@ -781,7 +781,7 @@ where
         relationships,
     }) = body;
 
-    type_to_update.version += 1;
+    type_to_update.version = OntologyTypeVersion::new(type_to_update.version.inner() + 1);
 
     let entity_type = patch_id_and_parse(&type_to_update, schema).map_err(|report| {
         tracing::error!(error=?report, "Couldn't convert schema to Entity Type");

--- a/apps/hash-graph/libs/api/src/rest/mod.rs
+++ b/apps/hash-graph/libs/api/src/rest/mod.rs
@@ -54,7 +54,7 @@ use graph_types::{
     ontology::{
         DataTypeMetadata, EntityTypeMetadata, OntologyEditionProvenanceMetadata,
         OntologyProvenanceMetadata, OntologyTemporalMetadata, OntologyTypeMetadata,
-        OntologyTypeRecordId, OntologyTypeReference, OntologyTypeVersion, PropertyTypeMetadata,
+        OntologyTypeRecordId, OntologyTypeReference, PropertyTypeMetadata,
     },
     owned_by_id::OwnedById,
 };
@@ -68,7 +68,7 @@ use temporal_versioning::{
     ClosedTemporalBound, DecisionTime, LeftClosedTemporalInterval, LimitedTemporalBound,
     OpenTemporalBound, RightBoundedTemporalInterval, TemporalBound, Timestamp, TransactionTime,
 };
-use type_system::url::{BaseUrl, VersionedUrl};
+use type_system::url::{BaseUrl, OntologyTypeVersion, VersionedUrl};
 use utoipa::{
     openapi::{
         self, schema, ArrayBuilder, KnownFormat, Object, ObjectBuilder, OneOfBuilder, Ref, RefOr,

--- a/apps/hash-graph/libs/api/src/rest/property_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/property_type.rs
@@ -54,7 +54,10 @@ use hash_status::Status;
 use serde::{Deserialize, Serialize};
 use temporal_client::TemporalClient;
 use time::OffsetDateTime;
-use type_system::{url::VersionedUrl, PropertyType};
+use type_system::{
+    url::{OntologyTypeVersion, VersionedUrl},
+    PropertyType,
+};
 use utoipa::{OpenApi, ToSchema};
 
 use super::api_resource::RoutedResource;
@@ -474,7 +477,7 @@ where
         relationships,
     }) = body;
 
-    type_to_update.version += 1;
+    type_to_update.version = OntologyTypeVersion::new(type_to_update.version.inner() + 1);
 
     let property_type = patch_id_and_parse(&type_to_update, schema).map_err(|report| {
         tracing::error!(error=?report, "Couldn't patch schema and convert to Property Type");

--- a/apps/hash-graph/libs/api/src/rest/utoipa_typedef/subgraph/edges.rs
+++ b/apps/hash-graph/libs/api/src/rest/utoipa_typedef/subgraph/edges.rs
@@ -10,10 +10,10 @@ use graph::subgraph::{
     },
     temporal_axes::VariableAxis,
 };
-use graph_types::{knowledge::entity::EntityId, ontology::OntologyTypeVersion};
+use graph_types::knowledge::entity::EntityId;
 use serde::Serialize;
 use temporal_versioning::Timestamp;
-use type_system::url::BaseUrl;
+use type_system::url::{BaseUrl, OntologyTypeVersion};
 use utoipa::{
     openapi::{schema::AdditionalProperties, ObjectBuilder, OneOfBuilder, Ref, RefOr, Schema},
     ToSchema,
@@ -245,13 +245,12 @@ mod tests {
     };
     use graph_types::{
         knowledge::entity::{EntityId, EntityUuid},
-        ontology::OntologyTypeVersion,
         owned_by_id::OwnedById,
     };
     use temporal_versioning::{
         ClosedTemporalBound, LeftClosedTemporalInterval, OpenTemporalBound, Timestamp,
     };
-    use type_system::url::BaseUrl;
+    use type_system::url::{BaseUrl, OntologyTypeVersion};
     use uuid::Uuid;
 
     use crate::rest::utoipa_typedef::subgraph::Edges;

--- a/apps/hash-graph/libs/api/src/rest/utoipa_typedef/subgraph/vertices/mod.rs
+++ b/apps/hash-graph/libs/api/src/rest/utoipa_typedef/subgraph/vertices/mod.rs
@@ -1,10 +1,10 @@
 use std::collections::{hash_map::Entry, BTreeMap, HashMap};
 
 use graph::subgraph::temporal_axes::VariableAxis;
-use graph_types::{knowledge::entity::EntityId, ontology::OntologyTypeVersion};
+use graph_types::knowledge::entity::EntityId;
 use serde::Serialize;
 use temporal_versioning::Timestamp;
-use type_system::url::BaseUrl;
+use type_system::url::{BaseUrl, OntologyTypeVersion};
 use utoipa::{
     openapi::{schema::AdditionalProperties, ObjectBuilder, OneOfBuilder, Ref, RefOr, Schema},
     ToSchema,

--- a/apps/hash-graph/libs/api/src/rest/utoipa_typedef/subgraph/vertices/vertex.rs
+++ b/apps/hash-graph/libs/api/src/rest/utoipa_typedef/subgraph/vertices/vertex.rs
@@ -1,12 +1,10 @@
 use graph::subgraph::identifier::{DataTypeVertexId, EntityTypeVertexId, PropertyTypeVertexId};
 use graph_types::{
     knowledge::entity::Entity,
-    ontology::{
-        DataTypeWithMetadata, EntityTypeWithMetadata, OntologyTypeVersion, PropertyTypeWithMetadata,
-    },
+    ontology::{DataTypeWithMetadata, EntityTypeWithMetadata, PropertyTypeWithMetadata},
 };
 use serde::Serialize;
-use type_system::url::BaseUrl;
+use type_system::url::{BaseUrl, OntologyTypeVersion};
 use utoipa::ToSchema;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, ToSchema)]

--- a/apps/hash-graph/libs/graph/Cargo.toml
+++ b/apps/hash-graph/libs/graph/Cargo.toml
@@ -18,7 +18,7 @@ codec = { workspace = true }
 
 error-stack = { workspace = true, features = ["std", "serde"] }
 hash-status = { workspace = true }
-type-system = { workspace = true }
+type-system = { workspace = true, features = ["postgres"] }
 
 postgres-types = { workspace = true, features = ["derive", "with-serde_json-1"] }
 serde = { workspace = true, features = ["derive"] }

--- a/apps/hash-graph/libs/graph/src/snapshot/mod.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/mod.rs
@@ -40,9 +40,7 @@ use futures::{
 use graph_types::{
     account::{AccountGroupId, AccountId},
     knowledge::entity::{Entity, EntityId, EntityUuid},
-    ontology::{
-        DataTypeWithMetadata, EntityTypeWithMetadata, OntologyTypeVersion, PropertyTypeWithMetadata,
-    },
+    ontology::{DataTypeWithMetadata, EntityTypeWithMetadata, PropertyTypeWithMetadata},
     owned_by_id::OwnedById,
 };
 use hash_status::StatusCode;
@@ -404,7 +402,7 @@ where
                     data_type_id: VersionedUrl {
                         base_url: BaseUrl::new(row.get(0))
                             .expect("Invalid base URL returned from Postgres"),
-                        version: row.get::<_, OntologyTypeVersion>(1).inner(),
+                        version: row.get(1),
                     },
                     embedding: row.get(2),
                     updated_at_transaction_time: row.get(3),
@@ -437,7 +435,7 @@ where
                     property_type_id: VersionedUrl {
                         base_url: BaseUrl::new(row.get(0))
                             .expect("Invalid base URL returned from Postgres"),
-                        version: row.get::<_, OntologyTypeVersion>(1).inner(),
+                        version: row.get(1),
                     },
                     embedding: row.get(2),
                     updated_at_transaction_time: row.get(3),
@@ -470,7 +468,7 @@ where
                     entity_type_id: VersionedUrl {
                         base_url: BaseUrl::new(row.get(0))
                             .expect("Invalid base URL returned from Postgres"),
-                        version: row.get::<_, OntologyTypeVersion>(1).inner(),
+                        version: row.get(1),
                     },
                     embedding: row.get(2),
                     updated_at_transaction_time: row.get(3),
@@ -507,13 +505,11 @@ where
             .map_ok(|row| {
                 SnapshotEntry::EntityEmbedding(EntityEmbeddingRecord {
                     entity_id: EntityId {
-                        owned_by_id: OwnedById::new(row.get(0)),
+                        owned_by_id: row.get(0),
                         entity_uuid: row.get(1),
                         draft_id: row.get(2),
                     },
-                    property: row.get::<_, Option<String>>(3).map(|property| {
-                        BaseUrl::new(property).expect("Invalid property URL returned from Postgres")
-                    }),
+                    property: row.get(3),
                     embedding: row.get(4),
                     updated_at_decision_time: row.get(5),
                     updated_at_transaction_time: row.get(6),

--- a/apps/hash-graph/libs/graph/src/snapshot/mod.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/mod.rs
@@ -51,7 +51,7 @@ use tokio_postgres::{
     tls::{MakeTlsConnect, TlsConnect},
     Socket,
 };
-use type_system::url::{BaseUrl, VersionedUrl};
+use type_system::url::VersionedUrl;
 
 use crate::{
     snapshot::{
@@ -400,8 +400,7 @@ where
             .map_ok(|row| {
                 SnapshotEntry::DataTypeEmbedding(DataTypeEmbeddingRecord {
                     data_type_id: VersionedUrl {
-                        base_url: BaseUrl::new(row.get(0))
-                            .expect("Invalid base URL returned from Postgres"),
+                        base_url: row.get(0),
                         version: row.get(1),
                     },
                     embedding: row.get(2),
@@ -433,8 +432,7 @@ where
             .map_ok(|row| {
                 SnapshotEntry::PropertyTypeEmbedding(PropertyTypeEmbeddingRecord {
                     property_type_id: VersionedUrl {
-                        base_url: BaseUrl::new(row.get(0))
-                            .expect("Invalid base URL returned from Postgres"),
+                        base_url: row.get(0),
                         version: row.get(1),
                     },
                     embedding: row.get(2),
@@ -466,8 +464,7 @@ where
             .map_ok(|row| {
                 SnapshotEntry::EntityTypeEmbedding(EntityTypeEmbeddingRecord {
                     entity_type_id: VersionedUrl {
-                        base_url: BaseUrl::new(row.get(0))
-                            .expect("Invalid base URL returned from Postgres"),
+                        base_url: row.get(0),
                         version: row.get(1),
                     },
                     embedding: row.get(2),

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/entity_type/channel.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/entity_type/channel.rs
@@ -10,7 +10,6 @@ use futures::{
     stream::{select_all, BoxStream, SelectAll},
     Sink, SinkExt, Stream, StreamExt,
 };
-use graph_types::ontology::OntologyTypeVersion;
 use postgres_types::Json;
 use type_system::ClosedEntityType;
 use uuid::Uuid;
@@ -100,8 +99,8 @@ impl Sink<EntityTypeSnapshotRecord> for EntityTypeSender {
                 let url = entity_type_ref.url();
                 EntityTypeInheritsFromRow {
                     source_entity_type_ontology_id: ontology_id,
-                    target_entity_type_base_url: url.base_url.as_str().to_owned(),
-                    target_entity_type_version: OntologyTypeVersion::new(url.version),
+                    target_entity_type_base_url: url.base_url.clone(),
+                    target_entity_type_version: url.version,
                 }
             })
             .collect();
@@ -120,8 +119,8 @@ impl Sink<EntityTypeSnapshotRecord> for EntityTypeSender {
                 let url = entity_type_ref.url();
                 EntityTypeConstrainsPropertiesOnRow {
                     source_entity_type_ontology_id: ontology_id,
-                    target_property_type_base_url: url.base_url.as_str().to_owned(),
-                    target_property_type_version: OntologyTypeVersion::new(url.version),
+                    target_property_type_base_url: url.base_url.clone(),
+                    target_property_type_version: url.version,
                 }
             })
             .collect();
@@ -141,8 +140,8 @@ impl Sink<EntityTypeSnapshotRecord> for EntityTypeSender {
                 let url = entity_type_ref.url();
                 EntityTypeConstrainsLinksOnRow {
                     source_entity_type_ontology_id: ontology_id,
-                    target_entity_type_base_url: url.base_url.as_str().to_owned(),
-                    target_entity_type_version: OntologyTypeVersion::new(url.version),
+                    target_entity_type_base_url: url.base_url.clone(),
+                    target_entity_type_version: url.version,
                 }
             })
             .collect();
@@ -160,8 +159,8 @@ impl Sink<EntityTypeSnapshotRecord> for EntityTypeSender {
                 let url = entity_type_ref.url();
                 EntityTypeConstrainsLinkDestinationsOnRow {
                     source_entity_type_ontology_id: ontology_id,
-                    target_entity_type_base_url: url.base_url.as_str().to_owned(),
-                    target_entity_type_version: OntologyTypeVersion::new(url.version),
+                    target_entity_type_base_url: url.base_url.clone(),
+                    target_entity_type_version: url.version,
                 }
             })
             .collect();

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/metadata/channel.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/metadata/channel.rs
@@ -93,7 +93,7 @@ impl
         self.id
             .start_send(OntologyIdRow {
                 ontology_id,
-                base_url: record_id.base_url.as_str().to_owned(),
+                base_url: record_id.base_url,
                 version: record_id.version,
             })
             .change_context(SnapshotRestoreError::Read)

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/property_type/channel.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/property_type/channel.rs
@@ -10,7 +10,6 @@ use futures::{
     stream::{select_all, BoxStream, SelectAll},
     Sink, SinkExt, Stream, StreamExt,
 };
-use graph_types::ontology::OntologyTypeVersion;
 use postgres_types::Json;
 use uuid::Uuid;
 
@@ -89,8 +88,8 @@ impl Sink<PropertyTypeSnapshotRecord> for PropertyTypeSender {
                 let url = data_type_ref.url();
                 PropertyTypeConstrainsValuesOnRow {
                     source_property_type_ontology_id: ontology_id,
-                    target_data_type_base_url: url.base_url.as_str().to_owned(),
-                    target_data_type_version: OntologyTypeVersion::new(url.version),
+                    target_data_type_base_url: url.base_url.clone(),
+                    target_data_type_version: url.version,
                 }
             })
             .collect();
@@ -109,8 +108,8 @@ impl Sink<PropertyTypeSnapshotRecord> for PropertyTypeSender {
                 let url = property_type_ref.url();
                 PropertyTypeConstrainsPropertiesOnRow {
                     source_property_type_ontology_id: ontology_id,
-                    target_property_type_base_url: url.base_url.as_str().to_owned(),
-                    target_property_type_version: OntologyTypeVersion::new(url.version),
+                    target_property_type_base_url: url.base_url.clone(),
+                    target_property_type_version: url.version,
                 }
             })
             .collect();

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/table.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/table.rs
@@ -1,20 +1,22 @@
 use graph_types::{
     account::{EditionArchivedById, EditionCreatedById},
-    ontology::OntologyTypeVersion,
     owned_by_id::OwnedById,
     Embedding,
 };
 use postgres_types::{Json, ToSql};
 use temporal_versioning::{LeftClosedTemporalInterval, Timestamp, TransactionTime};
 use time::OffsetDateTime;
-use type_system::{ClosedEntityType, DataType, EntityType, PropertyType};
+use type_system::{
+    url::{BaseUrl, OntologyTypeVersion},
+    ClosedEntityType, DataType, EntityType, PropertyType,
+};
 use uuid::Uuid;
 
 #[derive(Debug, ToSql)]
 #[postgres(name = "ontology_ids")]
 pub struct OntologyIdRow {
     pub ontology_id: Uuid,
-    pub base_url: String,
+    pub base_url: BaseUrl,
     pub version: OntologyTypeVersion,
 }
 
@@ -67,7 +69,7 @@ pub struct PropertyTypeRow {
 #[postgres(name = "property_type_constrains_values_on_tmp")]
 pub struct PropertyTypeConstrainsValuesOnRow {
     pub source_property_type_ontology_id: Uuid,
-    pub target_data_type_base_url: String,
+    pub target_data_type_base_url: BaseUrl,
     pub target_data_type_version: OntologyTypeVersion,
 }
 
@@ -83,7 +85,7 @@ pub struct PropertyTypeEmbeddingRow {
 #[postgres(name = "property_type_constrains_properties_on_tmp")]
 pub struct PropertyTypeConstrainsPropertiesOnRow {
     pub source_property_type_ontology_id: Uuid,
-    pub target_property_type_base_url: String,
+    pub target_property_type_base_url: BaseUrl,
     pub target_property_type_version: OntologyTypeVersion,
 }
 
@@ -109,7 +111,7 @@ pub struct EntityTypeEmbeddingRow {
 #[postgres(name = "entity_type_constrains_properties_on_tmp")]
 pub struct EntityTypeConstrainsPropertiesOnRow {
     pub source_entity_type_ontology_id: Uuid,
-    pub target_property_type_base_url: String,
+    pub target_property_type_base_url: BaseUrl,
     pub target_property_type_version: OntologyTypeVersion,
 }
 
@@ -117,7 +119,7 @@ pub struct EntityTypeConstrainsPropertiesOnRow {
 #[postgres(name = "entity_type_inherits_from_tmp")]
 pub struct EntityTypeInheritsFromRow {
     pub source_entity_type_ontology_id: Uuid,
-    pub target_entity_type_base_url: String,
+    pub target_entity_type_base_url: BaseUrl,
     pub target_entity_type_version: OntologyTypeVersion,
 }
 
@@ -125,7 +127,7 @@ pub struct EntityTypeInheritsFromRow {
 #[postgres(name = "entity_type_constrains_links_on_tmp")]
 pub struct EntityTypeConstrainsLinksOnRow {
     pub source_entity_type_ontology_id: Uuid,
-    pub target_entity_type_base_url: String,
+    pub target_entity_type_base_url: BaseUrl,
     pub target_entity_type_version: OntologyTypeVersion,
 }
 
@@ -133,6 +135,6 @@ pub struct EntityTypeConstrainsLinksOnRow {
 #[postgres(name = "entity_type_constrains_link_destinations_on_tmp")]
 pub struct EntityTypeConstrainsLinkDestinationsOnRow {
     pub source_entity_type_ontology_id: Uuid,
-    pub target_entity_type_base_url: String,
+    pub target_entity_type_base_url: BaseUrl,
     pub target_entity_type_version: OntologyTypeVersion,
 }

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -20,8 +20,8 @@ use graph_types::{
     ontology::{
         DataTypeMetadata, EntityTypeMetadata, OntologyTemporalMetadata, OntologyType,
         OntologyTypeClassificationMetadata, OntologyTypeMetadata, OntologyTypeReference,
-        OntologyTypeVersion, PartialDataTypeMetadata, PartialEntityTypeMetadata,
-        PartialPropertyTypeMetadata, PropertyTypeMetadata,
+        PartialDataTypeMetadata, PartialEntityTypeMetadata, PartialPropertyTypeMetadata,
+        PropertyTypeMetadata,
     },
     owned_by_id::OwnedById,
 };
@@ -32,7 +32,7 @@ use tokio::net::ToSocketAddrs;
 use tokio_serde::formats::Json;
 use type_fetcher::fetcher::{FetchedOntologyType, FetcherClient};
 use type_system::{
-    url::{BaseUrl, VersionedUrl},
+    url::{BaseUrl, OntologyTypeVersion, VersionedUrl},
     DataType, EntityType, EntityTypeReference, PropertyType,
 };
 
@@ -740,8 +740,7 @@ where
         .find(|metadata| {
             let record_id = metadata.record_id();
             let reference = reference.url();
-            record_id.base_url == reference.base_url
-                && record_id.version.inner() == reference.version
+            record_id.base_url == reference.base_url && record_id.version == reference.version
         })
         .ok_or_else(|| {
             Report::new(InsertionError).attach_printable(format!(

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/read.rs
@@ -6,7 +6,7 @@ use graph_types::{
     owned_by_id::OwnedById,
 };
 use temporal_versioning::{
-    LeftClosedTemporalInterval, RightBoundedTemporalInterval, TemporalTagged, TimeAxis, Timestamp,
+    LeftClosedTemporalInterval, RightBoundedTemporalInterval, TimeAxis, Timestamp,
 };
 use tokio_postgres::GenericClient;
 use type_system::url::BaseUrl;
@@ -273,7 +273,7 @@ impl<C: AsClient> PostgresStore<C> {
                         },
                         right_endpoint: EntityVertexId {
                             base_id: right_endpoint_base_id,
-                            revision_id: row.get::<_, Timestamp<()>>(3).cast(),
+                            revision_id: row.get(3),
                         },
                         right_endpoint_edition_id: row.get(4),
                         edge_interval: row.get(5),

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
@@ -24,7 +24,7 @@ use temporal_client::TemporalClient;
 use temporal_versioning::{RightBoundedTemporalInterval, Timestamp, TransactionTime};
 use tokio_postgres::{GenericClient, Row};
 use type_system::{
-    url::{BaseUrl, VersionedUrl},
+    url::{OntologyTypeVersion, VersionedUrl},
     DataType,
 };
 
@@ -412,7 +412,18 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
     {
         let old_ontology_id = DataTypeId::from_url(&VersionedUrl {
             base_url: params.schema.id().base_url.clone(),
-            version: params.schema.id().version - 1,
+            version: OntologyTypeVersion::new(
+                params
+                    .schema
+                    .id()
+                    .version
+                    .inner()
+                    .checked_sub(1)
+                    .ok_or(UpdateError)
+                    .attach_printable(
+                        "The version of the data type is already at the lowest possible value",
+                    )?,
+            ),
         });
         authorization_api
             .check_data_type_permission(
@@ -614,8 +625,7 @@ impl QueryRecordDecode for DataTypeWithMetadata {
 
     fn decode(row: &Row, indices: &Self::CompilationArtifacts) -> Self {
         let record_id = OntologyTypeRecordId {
-            base_url: BaseUrl::new(row.get(indices.base_url))
-                .expect("invalid base URL returned from Postgres"),
+            base_url: row.get(indices.base_url),
             version: row.get(indices.version),
         };
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/read.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/read.rs
@@ -3,14 +3,11 @@ use std::borrow::Cow;
 use authorization::schema::EntityTypeId;
 use error_stack::{Result, ResultExt};
 use futures::{Stream, StreamExt};
-use graph_types::ontology::{EntityTypeWithMetadata, OntologyTypeVersion};
+use graph_types::ontology::EntityTypeWithMetadata;
 use postgres_types::Json;
 use temporal_versioning::RightBoundedTemporalInterval;
 use tokio_postgres::GenericClient;
-use type_system::{
-    url::{BaseUrl, VersionedUrl},
-    ClosedEntityType,
-};
+use type_system::{url::VersionedUrl, ClosedEntityType};
 
 use crate::{
     ontology::EntityTypeQueryPath,
@@ -171,19 +168,12 @@ impl<C: AsClient> PostgresStore<C> {
                     right_endpoint_ontology_id,
                     OntologyEdgeTraversal {
                         left_endpoint: L::from(VersionedUrl {
-                            base_url: BaseUrl::new(row.get(1)).unwrap_or_else(|error| {
-                                // The `BaseUrl` was just inserted as a parameter to the query
-                                unreachable!("invalid URL: {error}")
-                            }),
-                            version: row.get::<_, OntologyTypeVersion>(2).inner(),
+                            base_url: row.get(1),
+                            version: row.get(2),
                         }),
                         right_endpoint: R::from(VersionedUrl {
-                            base_url: BaseUrl::new(row.get(3)).unwrap_or_else(|error| {
-                                // The `BaseUrl` was already validated when it was inserted into
-                                // the database, so this should never happen.
-                                unreachable!("invalid URL: {error}")
-                            }),
-                            version: row.get::<_, OntologyTypeVersion>(4).inner(),
+                            base_url: row.get(3),
+                            version: row.get(4),
                         }),
                         right_endpoint_ontology_id,
                         resolve_depths: record_ids.resolve_depths[index],

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/statement/select.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/statement/select.rs
@@ -1052,10 +1052,9 @@ mod tests {
     mod predefined {
         use graph_types::{
             knowledge::entity::{EntityId, EntityUuid},
-            ontology::OntologyTypeVersion,
             owned_by_id::OwnedById,
         };
-        use type_system::url::{BaseUrl, VersionedUrl};
+        use type_system::url::{BaseUrl, OntologyTypeVersion, VersionedUrl};
 
         use super::*;
 
@@ -1066,7 +1065,7 @@ mod tests {
                     "https://blockprotocol.org/@blockprotocol/types/data-type/text/".to_owned(),
                 )
                 .expect("invalid base url"),
-                version: 1,
+                version: OntologyTypeVersion::new(1),
             };
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
@@ -1087,11 +1086,7 @@ mod tests {
                 WHERE "ontology_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
                   AND ("ontology_ids_0_1_0"."base_url" = $2) AND ("ontology_ids_0_1_0"."version" = $3)
                 "#,
-                &[
-                    &pinned_timestamp,
-                    &url.base_url.as_str(),
-                    &OntologyTypeVersion::new(url.version),
-                ],
+                &[&pinned_timestamp, &url.base_url, &url.version],
             );
         }
 

--- a/apps/hash-graph/libs/graph/src/store/query/filter.rs
+++ b/apps/hash-graph/libs/graph/src/store/query/filter.rs
@@ -4,13 +4,12 @@ use derivative::Derivative;
 use error_stack::{bail, Context, Report, ResultExt};
 use graph_types::{
     knowledge::entity::{Entity, EntityId},
-    ontology::OntologyTypeVersion,
     Embedding,
 };
 use serde::Deserialize;
 use serde_json::{Number, Value};
 use temporal_versioning::Timestamp;
-use type_system::url::{BaseUrl, VersionedUrl};
+use type_system::url::{BaseUrl, OntologyTypeVersion, VersionedUrl};
 use uuid::Uuid;
 
 use crate::{
@@ -75,7 +74,7 @@ where
             Self::Equal(
                 Some(FilterExpression::Path(<R::QueryPath<'p>>::version())),
                 Some(FilterExpression::Parameter(Parameter::OntologyTypeVersion(
-                    OntologyTypeVersion::new(versioned_url.version),
+                    versioned_url.version,
                 ))),
             ),
         ])
@@ -479,7 +478,7 @@ mod tests {
                 "https://blockprotocol.org/@blockprotocol/types/data-type/text/".to_owned(),
             )
             .expect("invalid base url"),
-            version: 1,
+            version: OntologyTypeVersion::new(1),
         };
 
         let expected = json!({

--- a/apps/hash-graph/libs/graph/src/store/query/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/query/mod.rs
@@ -94,6 +94,6 @@ pub trait OntologyQueryPath {
 
     /// Returns the path identifying the [`OntologyTypeVersion`].
     ///
-    /// [`OntologyTypeVersion`]: graph_types::ontology::OntologyTypeVersion
+    /// [`OntologyTypeVersion`]: type_system::url::OntologyTypeVersion
     fn version() -> Self;
 }

--- a/apps/hash-graph/libs/graph/src/subgraph/identifier/vertex.rs
+++ b/apps/hash-graph/libs/graph/src/subgraph/identifier/vertex.rs
@@ -2,13 +2,11 @@ use std::collections::hash_map::{RandomState, RawEntryMut};
 
 use graph_types::{
     knowledge::entity::{Entity, EntityId},
-    ontology::{
-        DataTypeWithMetadata, EntityTypeWithMetadata, OntologyTypeVersion, PropertyTypeWithMetadata,
-    },
+    ontology::{DataTypeWithMetadata, EntityTypeWithMetadata, PropertyTypeWithMetadata},
 };
 use serde::{Deserialize, Serialize};
 use temporal_versioning::Timestamp;
-use type_system::url::{BaseUrl, VersionedUrl};
+use type_system::url::{BaseUrl, OntologyTypeVersion, VersionedUrl};
 #[cfg(feature = "utoipa")]
 use utoipa::ToSchema;
 
@@ -88,7 +86,7 @@ macro_rules! define_ontology_type_vertex_id {
             fn from(url: VersionedUrl) -> Self {
                 Self {
                     base_id: url.base_url,
-                    revision_id: OntologyTypeVersion::new(url.version),
+                    revision_id: url.version,
                 }
             }
         }

--- a/libs/@blockprotocol/type-system/rust/Cargo.toml
+++ b/libs/@blockprotocol/type-system/rust/Cargo.toml
@@ -1,7 +1,9 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "type-system"
 version = "0.0.0"
-edition = "2021"
+edition.workspace = true
 authors = ["HASH"]
 publish = false
 description = "Definitions of types within the Block Protocol Type System"
@@ -11,6 +13,7 @@ name = "type_system"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+postgres-types = { workspace = true, optional = true }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
 thiserror = "1.0.58"
@@ -20,6 +23,10 @@ utoipa = { version = "4.2.0", features = ["url"], optional = true }
 
 [dev-dependencies]
 graph-test-data = { workspace = true }
+
+[features]
+postgres = ["dep:postgres-types"]
+utoipa = ["dep:utoipa"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2.92", features = ["serde-serialize"] }

--- a/libs/@blockprotocol/type-system/rust/Cargo.toml
+++ b/libs/@blockprotocol/type-system/rust/Cargo.toml
@@ -13,7 +13,7 @@ name = "type_system"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-postgres-types = { workspace = true, optional = true }
+postgres-types = { workspace = true, features = ["derive"], optional = true }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
 thiserror = "1.0.58"

--- a/libs/@blockprotocol/type-system/rust/src/ontology/url/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/url/mod.rs
@@ -1,6 +1,7 @@
-use std::{fmt, num::IntErrorKind, str::FromStr};
+use std::{error::Error, fmt, num::IntErrorKind, str::FromStr};
 
 pub use error::{ParseBaseUrlError, ParseVersionedUrlError};
+use postgres_types::{private::BytesMut, FromSql, IsNull, ToSql, Type};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(target_arch = "wasm32")]
 use tsify::Tsify;
@@ -13,6 +14,7 @@ mod error;
 mod wasm;
 
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
+#[cfg_attr(feature = "postgres", derive(ToSql), postgres(transparent))]
 #[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub struct BaseUrl(String);
 
@@ -105,12 +107,68 @@ impl ToSchema<'_> for BaseUrl {
     }
 }
 
+#[cfg(feature = "postgres")]
+impl<'a> FromSql<'a> for BaseUrl {
+    fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        Ok(Self::new(String::from_sql(ty, raw)?)?)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <String as FromSql>::accepts(ty)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[repr(transparent)]
+pub struct OntologyTypeVersion(u32);
+
+impl OntologyTypeVersion {
+    #[must_use]
+    pub const fn new(inner: u32) -> Self {
+        Self(inner)
+    }
+
+    #[must_use]
+    pub const fn inner(self) -> u32 {
+        self.0
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl ToSql for OntologyTypeVersion {
+    postgres_types::accepts!(INT8);
+
+    postgres_types::to_sql_checked!();
+
+    fn to_sql(&self, ty: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>>
+    where
+        Self: Sized,
+    {
+        i64::from(self.0).to_sql(ty, out)
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> FromSql<'a> for OntologyTypeVersion {
+    postgres_types::accepts!(INT8);
+
+    fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        Ok(Self::new(i64::from_sql(ty, raw)?.try_into()?))
+    }
+}
+
 // TODO: can we impl Tsify to turn this into a type: template string
 //  if we can then we should delete wasm::VersionedUrlPatch
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(
+    feature = "postgres",
+    derive(FromSql, ToSql),
+    postgres(name = "VersionedUrl")
+)]
 pub struct VersionedUrl {
     pub base_url: BaseUrl,
-    pub version: u32,
+    pub version: OntologyTypeVersion,
 }
 
 impl VersionedUrl {
@@ -123,7 +181,7 @@ impl VersionedUrl {
         let mut url = self.base_url.to_url();
         url.path_segments_mut()
             .expect("invalid Base URL, we should have caught an invalid base already")
-            .extend(["v", &self.version.to_string()]);
+            .extend(["v", &self.version.0.to_string()]);
 
         url
     }
@@ -131,7 +189,7 @@ impl VersionedUrl {
 
 impl fmt::Display for VersionedUrl {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}v/{}", self.base_url.as_str(), self.version)
+        write!(fmt, "{}v/{}", self.base_url.as_str(), self.version.0)
     }
 }
 
@@ -149,33 +207,35 @@ impl FromStr for VersionedUrl {
                 Ok(Self {
                     base_url: BaseUrl::new(base_url.to_owned())
                         .map_err(ParseVersionedUrlError::InvalidBaseUrl)?,
-                    version: version.parse::<u32>().map_err(|error| match error.kind() {
-                        IntErrorKind::Empty => ParseVersionedUrlError::MissingVersion,
-                        IntErrorKind::InvalidDigit => {
-                            let invalid_digit_index =
-                                version.find(|c: char| !c.is_numeric()).unwrap_or(0);
+                    version: version.parse().map(OntologyTypeVersion).map_err(
+                        |error| match error.kind() {
+                            IntErrorKind::Empty => ParseVersionedUrlError::MissingVersion,
+                            IntErrorKind::InvalidDigit => {
+                                let invalid_digit_index =
+                                    version.find(|c: char| !c.is_numeric()).unwrap_or(0);
 
-                            if invalid_digit_index == 0 {
-                                ParseVersionedUrlError::InvalidVersion(
-                                    version.to_owned(),
-                                    error.to_string(),
-                                )
-                            } else {
-                                #[expect(
-                                    clippy::string_slice,
-                                    reason = "we just found the index of the first non-numeric \
-                                              character"
-                                )]
-                                ParseVersionedUrlError::AdditionalEndContent(
-                                    version[invalid_digit_index..].to_owned(),
-                                )
+                                if invalid_digit_index == 0 {
+                                    ParseVersionedUrlError::InvalidVersion(
+                                        version.to_owned(),
+                                        error.to_string(),
+                                    )
+                                } else {
+                                    #[expect(
+                                        clippy::string_slice,
+                                        reason = "we just found the index of the first \
+                                                  non-numeric character"
+                                    )]
+                                    ParseVersionedUrlError::AdditionalEndContent(
+                                        version[invalid_digit_index..].to_owned(),
+                                    )
+                                }
                             }
-                        }
-                        _ => ParseVersionedUrlError::InvalidVersion(
-                            version.to_owned(),
-                            error.to_string(),
-                        ),
-                    })?,
+                            _ => ParseVersionedUrlError::InvalidVersion(
+                                version.to_owned(),
+                                error.to_string(),
+                            ),
+                        },
+                    )?,
                 })
             },
         )

--- a/libs/@blockprotocol/type-system/rust/src/ontology/url/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/url/mod.rs
@@ -164,11 +164,7 @@ impl<'a> FromSql<'a> for OntologyTypeVersion {
 // TODO: can we impl Tsify to turn this into a type: template string
 //  if we can then we should delete wasm::VersionedUrlPatch
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
-#[cfg_attr(
-    feature = "postgres",
-    derive(FromSql, ToSql),
-    postgres(name = "VersionedUrl")
-)]
+#[cfg_attr(feature = "postgres", derive(FromSql, ToSql))]
 pub struct VersionedUrl {
     pub base_url: BaseUrl,
     pub version: OntologyTypeVersion,

--- a/libs/@blockprotocol/type-system/rust/src/ontology/url/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/url/mod.rs
@@ -164,7 +164,6 @@ impl<'a> FromSql<'a> for OntologyTypeVersion {
 // TODO: can we impl Tsify to turn this into a type: template string
 //  if we can then we should delete wasm::VersionedUrlPatch
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
-#[cfg_attr(feature = "postgres", derive(FromSql, ToSql))]
 pub struct VersionedUrl {
     pub base_url: BaseUrl,
     pub version: OntologyTypeVersion,

--- a/libs/@blockprotocol/type-system/rust/src/ontology/url/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/url/mod.rs
@@ -1,6 +1,9 @@
-use std::{error::Error, fmt, num::IntErrorKind, str::FromStr};
+#[cfg(feature = "postgres")]
+use std::error::Error;
+use std::{fmt, num::IntErrorKind, str::FromStr};
 
 pub use error::{ParseBaseUrlError, ParseVersionedUrlError};
+#[cfg(feature = "postgres")]
 use postgres_types::{private::BytesMut, FromSql, IsNull, ToSql, Type};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(target_arch = "wasm32")]

--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -9,7 +9,7 @@ use graph_types::knowledge::{
 use serde_json::Value as JsonValue;
 use thiserror::Error;
 use type_system::{
-    url::{BaseUrl, VersionedUrl},
+    url::{BaseUrl, OntologyTypeVersion, VersionedUrl},
     ClosedEntityType, DataType, Object, PropertyType,
 };
 
@@ -115,7 +115,7 @@ where
                 "https://blockprotocol.org/@blockprotocol/types/entity-type/link/".to_owned(),
             )
             .expect("Not a valid URL"),
-            version: 1,
+            version: OntologyTypeVersion::new(1),
         };
         let is_link = schema.schemas.contains_key(&link_type_id);
 

--- a/tests/hash-graph-integration/postgres/drafts.rs
+++ b/tests/hash-graph-integration/postgres/drafts.rs
@@ -5,7 +5,7 @@ use graph_types::knowledge::{
 };
 use pretty_assertions::assert_eq;
 use temporal_versioning::ClosedTemporalBound;
-use type_system::url::{BaseUrl, VersionedUrl};
+use type_system::url::{BaseUrl, OntologyTypeVersion, VersionedUrl};
 
 use crate::{DatabaseApi, DatabaseTestWrapper};
 
@@ -36,7 +36,7 @@ fn person_entity_type_id() -> VersionedUrl {
             "https://blockprotocol.org/@alice/types/entity-type/person/".to_owned(),
         )
         .expect("couldn't construct Base URL"),
-        version: 1,
+        version: OntologyTypeVersion::new(1),
     }
 }
 

--- a/tests/hash-graph-integration/postgres/entity.rs
+++ b/tests/hash-graph-integration/postgres/entity.rs
@@ -1,7 +1,7 @@
 use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::knowledge::{entity::EntityProperties, link::EntityLinkOrder};
 use temporal_versioning::ClosedTemporalBound;
-use type_system::url::{BaseUrl, VersionedUrl};
+use type_system::url::{BaseUrl, OntologyTypeVersion, VersionedUrl};
 
 use crate::DatabaseTestWrapper;
 
@@ -33,7 +33,7 @@ async fn insert() {
                     "https://blockprotocol.org/@alice/types/entity-type/person/".to_owned(),
                 )
                 .expect("couldn't construct Base URL"),
-                version: 1,
+                version: OntologyTypeVersion::new(1),
             }],
             None,
             false,
@@ -73,7 +73,7 @@ async fn query() {
                     "https://blockprotocol.org/@alice/types/entity-type/organization/".to_owned(),
                 )
                 .expect("couldn't construct Base URL"),
-                version: 1,
+                version: OntologyTypeVersion::new(1),
             }],
             None,
             false,
@@ -115,7 +115,7 @@ async fn update() {
                     "https://blockprotocol.org/@alice/types/entity-type/page/".to_owned(),
                 )
                 .expect("couldn't construct Base URL"),
-                version: 1,
+                version: OntologyTypeVersion::new(1),
             }],
             None,
             false,
@@ -132,7 +132,7 @@ async fn update() {
                     "https://blockprotocol.org/@alice/types/entity-type/page/".to_owned(),
                 )
                 .expect("couldn't construct Base URL"),
-                version: 1,
+                version: OntologyTypeVersion::new(1),
             }],
             EntityLinkOrder {
                 left_to_right: None,

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -63,8 +63,7 @@ use graph_types::{
     },
     ontology::{
         DataTypeMetadata, DataTypeWithMetadata, EntityTypeMetadata, EntityTypeWithMetadata,
-        OntologyTypeClassificationMetadata, OntologyTypeVersion, PropertyTypeMetadata,
-        PropertyTypeWithMetadata,
+        OntologyTypeClassificationMetadata, PropertyTypeMetadata, PropertyTypeWithMetadata,
     },
     owned_by_id::OwnedById,
 };
@@ -800,7 +799,7 @@ impl DatabaseApi<'_> {
                     inheritance_depth: Some(0),
                 })),
                 Some(FilterExpression::Parameter(Parameter::OntologyTypeVersion(
-                    OntologyTypeVersion::new(link_type_id.version),
+                    link_type_id.version,
                 ))),
             ),
         ]);

--- a/tests/hash-graph-integration/postgres/links.rs
+++ b/tests/hash-graph-integration/postgres/links.rs
@@ -1,6 +1,6 @@
 use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::knowledge::{entity::EntityProperties, link::EntityLinkOrder};
-use type_system::url::{BaseUrl, VersionedUrl};
+use type_system::url::{BaseUrl, OntologyTypeVersion, VersionedUrl};
 
 use crate::DatabaseTestWrapper;
 
@@ -30,7 +30,7 @@ async fn insert() {
             "https://blockprotocol.org/@alice/types/entity-type/person/".to_owned(),
         )
         .expect("couldn't construct Base URL"),
-        version: 1,
+        version: OntologyTypeVersion::new(1),
     };
 
     let alice_metadata = api
@@ -48,7 +48,7 @@ async fn insert() {
             "https://blockprotocol.org/@alice/types/entity-type/friend-of/".to_owned(),
         )
         .expect("couldn't construct Base URL"),
-        version: 1,
+        version: OntologyTypeVersion::new(1),
     };
 
     api.create_link_entity(
@@ -98,7 +98,7 @@ async fn get_entity_links() {
             "https://blockprotocol.org/@alice/types/entity-type/person/".to_owned(),
         )
         .expect("couldn't construct Base URL"),
-        version: 1,
+        version: OntologyTypeVersion::new(1),
     };
 
     let friend_link_type_id = VersionedUrl {
@@ -106,7 +106,7 @@ async fn get_entity_links() {
             "https://blockprotocol.org/@alice/types/entity-type/friend-of/".to_owned(),
         )
         .expect("couldn't construct Base URL"),
-        version: 1,
+        version: OntologyTypeVersion::new(1),
     };
 
     let acquaintance_entity_link_type_id = VersionedUrl {
@@ -114,7 +114,7 @@ async fn get_entity_links() {
             "https://blockprotocol.org/@alice/types/entity-type/acquaintance-of/".to_owned(),
         )
         .expect("couldn't construct Base URL"),
-        version: 1,
+        version: OntologyTypeVersion::new(1),
     };
 
     let alice_metadata = api
@@ -215,7 +215,7 @@ async fn remove_link() {
             "https://blockprotocol.org/@alice/types/entity-type/person/".to_owned(),
         )
         .expect("couldn't construct Base URL"),
-        version: 1,
+        version: OntologyTypeVersion::new(1),
     };
 
     let friend_link_type_id = VersionedUrl {
@@ -223,7 +223,7 @@ async fn remove_link() {
             "https://blockprotocol.org/@alice/types/entity-type/friend-of/".to_owned(),
         )
         .expect("couldn't construct Base URL"),
-        version: 1,
+        version: OntologyTypeVersion::new(1),
     };
 
     let alice_metadata = api

--- a/tests/hash-graph-integration/postgres/sorting.rs
+++ b/tests/hash-graph-integration/postgres/sorting.rs
@@ -10,7 +10,7 @@ use graph::{
 use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::knowledge::entity::{EntityProperties, EntityUuid};
 use pretty_assertions::assert_eq;
-use type_system::url::{BaseUrl, VersionedUrl};
+use type_system::url::{BaseUrl, OntologyTypeVersion, VersionedUrl};
 use uuid::Uuid;
 
 use crate::{DatabaseApi, DatabaseTestWrapper};
@@ -106,14 +106,14 @@ async fn insert(database: &mut DatabaseTestWrapper) -> DatabaseApi<'_> {
             "https://blockprotocol.org/@alice/types/entity-type/person/".to_owned(),
         )
         .expect("couldn't construct Base URL"),
-        version: 1,
+        version: OntologyTypeVersion::new(1),
     };
     let page_entity_type = VersionedUrl {
         base_url: BaseUrl::new(
             "https://blockprotocol.org/@alice/types/entity-type/page/".to_owned(),
         )
         .expect("couldn't construct Base URL"),
-        version: 1,
+        version: OntologyTypeVersion::new(1),
     };
     let entities_properties = [
         (entity::PERSON_ALICE_V1, &person_entity_type),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To allow converting a full `VersionedUrl` to/from Postgres the underlying `BaseUrl` has to be convertible. This allows a lot of simplification in queries as the types don't need to be converted to an intermediate string.

## 🚫 Blocked by

- #4140 
## 🔍 What does this change?

- Move `OntologyTypeVersion` to type system crate
- Implement postgres traits for `BaseUrl` and `VersionedUrl`
- Use `BaseUrl` directly to convert from/to Postgres

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph