### PR TITLE
H-2351: Allow querying multiple entity types for a single entity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2476,9 +2476,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.25"
+version = "0.11.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eea5a9eb898d3783f17c6407670e3592fd174cb81a10e51d4c37f49450b9946"
+checksum = "78bf93c4af7a8bb7d879d51cebe797356ff10ae8516ace542b5182d9dcac10b2"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -3039,20 +3039,20 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "system-configuration"
-version = "0.6.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bc6ee10a9b4fcf576e9b0819d95ec16f4d2c02d39fd83ac1c8789785c4a42"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 1.3.2",
  "core-foundation",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.6.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/apps/hash-graph/libs/graph/src/knowledge/query.rs
+++ b/apps/hash-graph/libs/graph/src/knowledge/query.rs
@@ -104,6 +104,8 @@ pub enum EntityQueryPath<'p> {
     /// It's currently not possible to query for the list of types directly. Use [`EntityTypeEdge`]
     /// instead.
     ///
+    /// [`BaseUrl`]: type_system::url::BaseUrl
+    /// [`EntityType`]: type_system::EntityType
     /// [`EntityTypeEdge`]: Self::EntityTypeEdge
     TypeBaseUrls,
     /// The list of [`EntityType`]s' versions belonging to the [`Entity`].
@@ -111,6 +113,7 @@ pub enum EntityQueryPath<'p> {
     /// It's currently not possible to query for the list of types directly. Use [`EntityTypeEdge`]
     /// instead.
     ///
+    /// [`EntityType`]: type_system::EntityType
     /// [`EntityTypeEdge`]: Self::EntityTypeEdge
     TypeVersions,
     /// The timestamp of the transaction time when the [`Entity`] was _first inserted_ into the

--- a/apps/hash-graph/libs/graph/src/knowledge/query.rs
+++ b/apps/hash-graph/libs/graph/src/knowledge/query.rs
@@ -99,6 +99,20 @@ pub enum EntityQueryPath<'p> {
     /// [`EntityMetadata`]: graph_types::knowledge::entity::EntityMetadata
     /// [`EntityTemporalMetadata`]: graph_types::knowledge::entity::EntityTemporalMetadata
     TransactionTime,
+    /// The list of [`EntityType`]s' [`BaseUrl`]s belonging to the [`Entity`].
+    ///
+    /// It's currently not possible to query for the list of types directly. Use [`EntityTypeEdge`]
+    /// instead.
+    ///
+    /// [`EntityTypeEdge`]: Self::EntityTypeEdge
+    TypeBaseUrls,
+    /// The list of [`EntityType`]s' versions belonging to the [`Entity`].
+    ///
+    /// It's currently not possible to query for the list of types directly. Use [`EntityTypeEdge`]
+    /// instead.
+    ///
+    /// [`EntityTypeEdge`]: Self::EntityTypeEdge
+    TypeVersions,
     /// The timestamp of the transaction time when the [`Entity`] was _first inserted_ into the
     /// database.
     ///
@@ -442,6 +456,8 @@ impl fmt::Display for EntityQueryPath<'_> {
             Self::EditionId => fmt.write_str("editionId"),
             Self::DecisionTime => fmt.write_str("decisionTime"),
             Self::TransactionTime => fmt.write_str("transactionTime"),
+            Self::TypeBaseUrls => fmt.write_str("typeBaseUrls"),
+            Self::TypeVersions => fmt.write_str("typeVersions"),
             Self::CreatedAtDecisionTime => fmt.write_str("createdAtDecisionTime"),
             Self::CreatedAtTransactionTime => fmt.write_str("createdAtTransactionTime"),
             Self::FirstNonDraftCreatedAtDecisionTime => {
@@ -500,12 +516,16 @@ impl QueryPath for EntityQueryPath<'_> {
             | Self::EditionCreatedById
             | Self::CreatedById => ParameterType::Uuid,
             Self::DecisionTime | Self::TransactionTime => ParameterType::TimeInterval,
+            Self::TypeBaseUrls => ParameterType::Vector(Box::new(ParameterType::VersionedUrl)),
+            Self::TypeVersions => {
+                ParameterType::Vector(Box::new(ParameterType::OntologyTypeVersion))
+            }
             Self::CreatedAtDecisionTime
             | Self::CreatedAtTransactionTime
             | Self::FirstNonDraftCreatedAtDecisionTime
             | Self::FirstNonDraftCreatedAtTransactionTime => ParameterType::Timestamp,
             Self::Properties(_) => ParameterType::Any,
-            Self::Embedding => ParameterType::Vector,
+            Self::Embedding => ParameterType::Vector(Box::new(ParameterType::F64)),
             Self::LeftToRightOrder | Self::RightToLeftOrder => ParameterType::I32,
             Self::Archived => ParameterType::Boolean,
             Self::EntityTypeEdge { path, .. } => path.expected_type(),
@@ -758,6 +778,8 @@ impl<'de: 'p, 'p> EntityQueryPath<'p> {
             EntityQueryPath::EditionId => EntityQueryPath::EditionId,
             EntityQueryPath::DecisionTime => EntityQueryPath::DecisionTime,
             EntityQueryPath::TransactionTime => EntityQueryPath::TransactionTime,
+            EntityQueryPath::TypeBaseUrls => EntityQueryPath::TypeBaseUrls,
+            EntityQueryPath::TypeVersions => EntityQueryPath::TypeVersions,
             EntityQueryPath::CreatedAtTransactionTime => EntityQueryPath::CreatedAtTransactionTime,
             EntityQueryPath::CreatedAtDecisionTime => EntityQueryPath::CreatedAtDecisionTime,
             EntityQueryPath::FirstNonDraftCreatedAtTransactionTime => {

--- a/apps/hash-graph/libs/graph/src/ontology/data_type.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/data_type.rs
@@ -237,7 +237,7 @@ impl QueryPath for DataTypeQueryPath<'_> {
             Self::TransactionTime => ParameterType::TimeInterval,
             Self::Version => ParameterType::OntologyTypeVersion,
             Self::Description | Self::Title | Self::Type => ParameterType::Text,
-            Self::Embedding => ParameterType::Vector,
+            Self::Embedding => ParameterType::Vector(Box::new(ParameterType::F64)),
             Self::PropertyTypeEdge { path, .. } => path.expected_type(),
         }
     }

--- a/apps/hash-graph/libs/graph/src/ontology/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/entity_type.rs
@@ -517,7 +517,7 @@ impl QueryPath for EntityTypeQueryPath<'_> {
             Self::Version => ParameterType::OntologyTypeVersion,
             Self::TransactionTime => ParameterType::TimeInterval,
             Self::Title | Self::Description | Self::Icon => ParameterType::Text,
-            Self::Embedding => ParameterType::Vector,
+            Self::Embedding => ParameterType::Vector(Box::new(ParameterType::F64)),
             Self::PropertyTypeEdge { path, .. } => path.expected_type(),
             Self::EntityTypeEdge { path, .. } => path.expected_type(),
             Self::EntityEdge { path, .. } => path.expected_type(),

--- a/apps/hash-graph/libs/graph/src/ontology/property_type.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/property_type.rs
@@ -283,7 +283,7 @@ impl QueryPath for PropertyTypeQueryPath<'_> {
             Self::Version => ParameterType::OntologyTypeVersion,
             Self::TransactionTime => ParameterType::TimeInterval,
             Self::Title | Self::Description => ParameterType::Text,
-            Self::Embedding => ParameterType::Vector,
+            Self::Embedding => ParameterType::Vector(Box::new(ParameterType::F64)),
             Self::DataTypeEdge { path, .. } => path.expected_type(),
             Self::PropertyTypeEdge { path, .. } => path.expected_type(),
             Self::EntityTypeEdge { path, .. } => path.expected_type(),

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/compile.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/compile.rs
@@ -768,7 +768,7 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
             }
             Parameter::Vector(vector) => {
                 self.artifacts.parameters.push(vector);
-                ParameterType::Vector
+                ParameterType::Vector(Box::new(ParameterType::F64))
             }
             Parameter::Any(json) => {
                 self.artifacts.parameters.push(json);

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/entity.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/entity.rs
@@ -5,7 +5,8 @@ use crate::{
     store::postgres::query::{
         table::{
             Column, EntityEditions, EntityEmbeddings, EntityHasLeftEntity, EntityHasRightEntity,
-            EntityIds, EntityTemporalMetadata, JsonField, ReferenceTable, Relation,
+            EntityIds, EntityIsOfTypeIds, EntityTemporalMetadata, JsonField, ReferenceTable,
+            Relation,
         },
         PostgresQueryPath,
     },
@@ -34,6 +35,7 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
             | Self::RightToLeftOrder
             | Self::EditionCreatedById
             | Self::Archived => vec![Relation::EntityEditions],
+            Self::TypeBaseUrls | Self::TypeVersions => vec![Relation::EntityIsOfTypes],
             Self::EntityTypeEdge {
                 edge_kind: SharedEdgeKind::IsOfType,
                 path,
@@ -99,6 +101,8 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
             Self::EditionCreatedById => Column::EntityEditions(EntityEditions::EditionCreatedById),
             Self::Embedding => Column::EntityEmbeddings(EntityEmbeddings::Embedding),
             Self::CreatedById => Column::EntityIds(EntityIds::CreatedById),
+            Self::TypeBaseUrls => Column::EntityIsOfTypeIds(EntityIsOfTypeIds::BaseUrls),
+            Self::TypeVersions => Column::EntityIsOfTypeIds(EntityIsOfTypeIds::Versions),
             Self::CreatedAtDecisionTime => Column::EntityIds(EntityIds::CreatedAtDecisionTime),
             Self::CreatedAtTransactionTime => {
                 Column::EntityIds(EntityIds::CreatedAtTransactionTime)

--- a/apps/hash-graph/libs/graph/src/store/query/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/query/mod.rs
@@ -49,14 +49,14 @@ pub fn parse_query_token<'de, T: Deserialize<'de>, E: de::Error>(
     T::deserialize(token.into_deserializer()).map(|token| (token, parameters))
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ParameterType {
     Boolean,
     I32,
     F64,
     OntologyTypeVersion,
     Text,
-    Vector,
+    Vector(Box<Self>),
     Uuid,
     BaseUrl,
     VersionedUrl,
@@ -74,7 +74,7 @@ impl fmt::Display for ParameterType {
             Self::F64 => fmt.write_str("64 bit floating point number"),
             Self::OntologyTypeVersion => fmt.write_str("ontology type version"),
             Self::Text => fmt.write_str("text"),
-            Self::Vector => fmt.write_str("vector"),
+            Self::Vector(inner) => write!(fmt, "{inner}[]"),
             Self::Uuid => fmt.write_str("UUID"),
             Self::BaseUrl => fmt.write_str("base URL"),
             Self::VersionedUrl => fmt.write_str("versioned URL"),

--- a/apps/hash-graph/postgres_migrations/V20__multi_type_entities.sql
+++ b/apps/hash-graph/postgres_migrations/V20__multi_type_entities.sql
@@ -1,0 +1,5 @@
+CREATE VIEW entity_is_of_type_ids AS
+    SELECT entity_edition_id, array_agg(base_url) AS base_urls, array_agg(version) AS versions
+    FROM entity_is_of_type
+    JOIN ontology_ids ON entity_type_ontology_id = ontology_id
+    GROUP BY entity_edition_id


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The logic to read multiple entity types for a single entity is different. This creates a view to aggregate the types and make them available.

## 🚫 Blocked by

- #4148 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

Write tests for multi type pentities

## 🛡 What tests cover this?

None, yet