### PR TITLE
H-2376: Fix `Organizations` user guide page icon

### DIFF
--- a/apps/hashdotai/guide/02_webs/02_orgs.mdx
+++ b/apps/hashdotai/guide/02_webs/02_orgs.mdx
@@ -4,7 +4,7 @@ description: "Collaborating as a team on HASH"
 metaTitle: "Organizations - HASH"
 metaDescription: "Discover everything you need to know about collaborating as a team or in a group using HASH"
 sidebarTitle: "Organizations"
-sidebarIcon: https://app.hash.ai/icons/docs/webs-orgs.svg
+sidebarIcon: https://app.hash.ai/icons/docs/webs-organizations.svg
 ---
 
 # Overview


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Corrects a misspecified icon URL.
