### PR TITLE
H-2385: Convert Graph API entity type to Node API type in AI worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2476,9 +2476,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.25"
+version = "0.11.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eea5a9eb898d3783f17c6407670e3592fd174cb81a10e51d4c37f49450b9946"
+checksum = "78bf93c4af7a8bb7d879d51cebe797356ff10ae8516ace542b5182d9dcac10b2"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -3039,20 +3039,20 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "system-configuration"
-version = "0.6.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bc6ee10a9b4fcf576e9b0819d95ec16f4d2c02d39fd83ac1c8789785c4a42"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 1.3.2",
  "core-foundation",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.6.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/apps/hash-ai-worker-ts/src/workflows.ts
+++ b/apps/hash-ai-worker-ts/src/workflows.ts
@@ -1,4 +1,5 @@
 import type { EntityQueryCursor, Filter } from "@local/hash-graph-client";
+import type { Entity as GraphApiEntity } from "@local/hash-graph-client/api";
 import type {
   CreateEmbeddingsParams,
   CreateEmbeddingsReturn,
@@ -14,6 +15,7 @@ import type {
   EntityTypeWithMetadata,
   PropertyTypeWithMetadata,
 } from "@local/hash-subgraph";
+import { mapGraphApiEntityToEntity } from "@local/hash-subgraph/src/stdlib/subgraph/roots";
 import { CancelledFailure } from "@temporalio/common";
 import {
   ActivityCancellationType,
@@ -343,7 +345,7 @@ type UpdateEntityEmbeddingsParams = {
   };
 } & (
   | {
-      entities: Entity[];
+      entities: GraphApiEntity[];
     }
   | {
       filter: Filter;
@@ -378,7 +380,7 @@ export const updateEntityEmbeddings = async (
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   while (true) {
     if ("entities" in params) {
-      entities = params.entities;
+      entities = params.entities.map(mapGraphApiEntityToEntity);
     } else {
       const queryResponse = await graphActivities.getEntitiesByQuery({
         authentication: params.authentication,
@@ -418,7 +420,7 @@ export const updateEntityEmbeddings = async (
         authentication: params.authentication,
         query: {
           filter: {
-            equal: [
+            containsSegment: [
               { path: ["versionedUrl"] },
               { parameter: entity.metadata.entityTypeId },
             ],

--- a/apps/hash-ai-worker-ts/src/workflows.ts
+++ b/apps/hash-ai-worker-ts/src/workflows.ts
@@ -15,7 +15,7 @@ import type {
   EntityTypeWithMetadata,
   PropertyTypeWithMetadata,
 } from "@local/hash-subgraph";
-import { mapGraphApiEntityToEntity } from "@local/hash-subgraph/src/stdlib/subgraph/roots";
+import { mapGraphApiEntityToEntity } from "@local/hash-subgraph/stdlib";
 import { CancelledFailure } from "@temporalio/common";
 import {
   ActivityCancellationType,

--- a/apps/hash-ai-worker-ts/src/workflows.ts
+++ b/apps/hash-ai-worker-ts/src/workflows.ts
@@ -420,7 +420,7 @@ export const updateEntityEmbeddings = async (
         authentication: params.authentication,
         query: {
           filter: {
-            containsSegment: [
+            equal: [
               { path: ["versionedUrl"] },
               { parameter: entity.metadata.entityTypeId },
             ],

--- a/apps/hash-ai-worker-ts/src/workflows.ts
+++ b/apps/hash-ai-worker-ts/src/workflows.ts
@@ -12,10 +12,10 @@ import type {
   AccountId,
   DataTypeWithMetadata,
   Entity,
+  EntityMetadata,
   EntityTypeWithMetadata,
   PropertyTypeWithMetadata,
 } from "@local/hash-subgraph";
-import { mapGraphApiEntityToEntity } from "@local/hash-subgraph/stdlib";
 import { CancelledFailure } from "@temporalio/common";
 import {
   ActivityCancellationType,
@@ -380,7 +380,24 @@ export const updateEntityEmbeddings = async (
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   while (true) {
     if ("entities" in params) {
-      entities = params.entities.map(mapGraphApiEntityToEntity);
+      entities = params.entities.map((entity) => {
+        // We should use `mapGraphApiEntityToEntity` but due to Temporal this function is not available in workflows
+        if (entity.metadata.entityTypeIds.length !== 1) {
+          throw new Error(
+            `Expected entity metadata to have exactly one entity type id, but got ${entity.metadata.entityTypeIds.length}`,
+          );
+        }
+        return {
+          ...entity,
+          metadata: {
+            recordId: entity.metadata.recordId,
+            entityTypeId: entity.metadata.entityTypeIds[0],
+            temporalVersioning: entity.metadata.temporalVersioning,
+            provenance: entity.metadata.provenance,
+            archived: entity.metadata.archived,
+          } as EntityMetadata,
+        } as Entity;
+      });
     } else {
       const queryResponse = await graphActivities.getEntitiesByQuery({
         authentication: params.authentication,

--- a/libs/@local/hash-subgraph/src/stdlib/subgraph/roots.ts
+++ b/libs/@local/hash-subgraph/src/stdlib/subgraph/roots.ts
@@ -8,6 +8,7 @@ import {
 } from "@blockprotocol/graph/temporal/stdlib";
 import { typedEntries } from "@local/advanced-types/typed-entries";
 import type {
+  Entity as GraphApiEntity,
   EntityMetadata as GraphApiEntityMetadata,
   KnowledgeGraphVertex as KnowledgeGraphVertexGraphApi,
   Subgraph as GraphApiSubgraph,
@@ -16,6 +17,7 @@ import type {
 
 import type {
   DataTypeRootType,
+  Entity,
   EntityMetadata,
   EntityRootType,
   EntityTypeRootType,
@@ -167,14 +169,17 @@ export const mapGraphApiEntityMetadataToMetadata = (
   } as EntityMetadata;
 };
 
+export const mapGraphApiEntityToEntity = (entity: GraphApiEntity) => {
+  return {
+    ...entity,
+    metadata: mapGraphApiEntityMetadataToMetadata(entity.metadata),
+  } as Entity;
+};
+
 const mapKnowledgeGraphVertex = (vertex: KnowledgeGraphVertexGraphApi) => {
   return {
     kind: vertex.kind,
-    inner: {
-      properties: vertex.inner.properties,
-      linkData: vertex.inner.linkData,
-      metadata: mapGraphApiEntityMetadataToMetadata(vertex.inner.metadata),
-    },
+    inner: mapGraphApiEntityToEntity(vertex.inner),
   } as KnowledgeGraphVertex;
 };
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `updateEntityEmbeddings` workflow may take a filter or a list of entities. Entities passed from the Graph may contain more than a single type id, so the entities has to be mapped, first.