### PR TITLE
H-2381: Enable backtraces in production

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,4 +71,4 @@ uuid = { version = "1.7.0", default-features = false }
 [profile.production]
 inherits = "release"
 lto = "fat"
-strip = "symbols"
+strip = "none"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently cannot use the backtraces generated in production as symbols are stripped. See the [official documentation](https://doc.rust-lang.org/cargo/reference/profiles.html#strip).