### PR TITLE
H-2298: Encode `graph` database permissions in Terraform

### DIFF
--- a/infra/terraform/hash/postgres_roles/postgres_roles.tf
+++ b/infra/terraform/hash/postgres_roles/postgres_roles.tf
@@ -116,6 +116,16 @@ resource "postgresql_database" "kratos" {
   allow_connections = true
 }
 
+resource "postgresql_default_privileges" "kratos_readwrite_tables" {
+  owner    = var.pg_superuser_username
+  role     = postgresql_role.kratos_user.name
+  database = postgresql_database.kratos.name
+  schema   = "public"
+
+  object_type = "table"
+  privileges  = ["SELECT", "INSERT", "UPDATE", "DELETE"]
+}
+
 # Hydra
 resource "postgresql_role" "hydra_user" {
   name           = "hydra"
@@ -133,6 +143,16 @@ resource "postgresql_database" "hydra" {
   lc_collate        = "C"
   connection_limit  = -1
   allow_connections = true
+}
+
+resource "postgresql_default_privileges" "hydra_readwrite_tables" {
+  owner    = var.pg_superuser_username
+  role     = postgresql_role.hydra_user.name
+  database = postgresql_database.hydra.name
+  schema   = "public"
+
+  object_type = "table"
+  privileges  = ["SELECT", "INSERT", "UPDATE", "DELETE"]
 }
 
 # Graph

--- a/infra/terraform/hash/postgres_roles/postgres_roles.tf
+++ b/infra/terraform/hash/postgres_roles/postgres_roles.tf
@@ -154,6 +154,16 @@ resource "postgresql_database" "graph" {
   allow_connections = true
 }
 
+resource "postgresql_default_privileges" "graph_readwrite_tables" {
+  owner    = var.pg_superuser_username
+  role     = postgresql_role.graph_user.name
+  database = postgresql_database.graph.name
+  schema   = "public"
+
+  object_type = "table"
+  privileges  = ["SELECT", "INSERT", "UPDATE", "DELETE"]
+}
+
 # Temporal
 resource "postgresql_role" "temporal_user" {
   name           = "temporal"
@@ -173,10 +183,10 @@ resource "postgresql_database" "temporal" {
 }
 
 resource "postgresql_default_privileges" "temporal_readwrite_tables" {
-  owner       = var.pg_superuser_username
-  role        = postgresql_role.temporal_user.name
-  database    = postgresql_database.temporal.name
-  schema      = "public"
+  owner    = var.pg_superuser_username
+  role     = postgresql_role.temporal_user.name
+  database = postgresql_database.temporal.name
+  schema   = "public"
 
   object_type = "table"
   privileges  = ["SELECT", "INSERT", "UPDATE", "DELETE"]
@@ -192,10 +202,10 @@ resource "postgresql_database" "temporal_visibility" {
 }
 
 resource "postgresql_default_privileges" "temporal_visibility_readwrite_tables" {
-  owner       = var.pg_superuser_username
-  role        = postgresql_role.temporal_user.name
-  database    = postgresql_database.temporal_visibility.name
-  schema      = "public"
+  owner    = var.pg_superuser_username
+  role     = postgresql_role.temporal_user.name
+  database = postgresql_database.temporal_visibility.name
+  schema   = "public"
 
   object_type = "table"
   privileges  = ["SELECT", "INSERT", "UPDATE", "DELETE"]
@@ -220,10 +230,10 @@ resource "postgresql_database" "spicedb" {
 }
 
 resource "postgresql_default_privileges" "spicedb_readwrite_tables" {
-  owner       = var.pg_superuser_username
-  role        = postgresql_role.spicedb_user.name
-  database    = postgresql_database.spicedb.name
-  schema      = "public"
+  owner    = var.pg_superuser_username
+  role     = postgresql_role.spicedb_user.name
+  database = postgresql_database.spicedb.name
+  schema   = "public"
 
   object_type = "table"
   privileges  = ["SELECT", "INSERT", "UPDATE", "DELETE"]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `entity_drafts` table wasn't accessible from the graph user in production. A `GRANT` call was able to solve this issue:

```sql
GRANT SELECT, UPDATE, INSERT ON ALL TABLES IN SCHEMA public TO graph;
```

We currently don't manage permissions for the graph database in terraform and this could be the issue as no default privileges are set.