### PR TITLE
H-2224, H-2239, H-2373: Bug fixes in entities table, redirect after signin

### DIFF
--- a/apps/hash-frontend/src/components/grid/utils/sorting.ts
+++ b/apps/hash-frontend/src/components/grid/utils/sorting.ts
@@ -21,21 +21,21 @@ export const defaultSortRows = <T extends Row>(
   const clone = [...rows] as T[];
   return clone.sort((row1, row2) => {
     // we sort only by alphabetical order for now
-    const key1 = String(row1[sort.columnKey]);
-    const key2 = String(row2[sort.columnKey]);
+    const value1 = String(row1[sort.columnKey]);
+    const value2 = String(row2[sort.columnKey]);
 
-    const previousKey1 = previousSort?.columnKey
+    const previousValue1 = previousSort?.columnKey
       ? String(row1[previousSort.columnKey])
       : undefined;
-    const previousKey2 = previousSort?.columnKey
+    const previousValue2 = previousSort?.columnKey
       ? String(row2[previousSort.columnKey])
       : undefined;
 
-    let comparison = key1.localeCompare(key2);
+    let comparison = value1.localeCompare(value2);
 
-    if (comparison === 0 && previousKey1 && previousKey2) {
+    if (comparison === 0 && previousValue1 && previousValue2) {
       // if the two keys are equal, we sort by the previous sort
-      comparison = previousKey1.localeCompare(previousKey2);
+      comparison = previousValue1.localeCompare(previousValue2);
     }
 
     if (sort.direction === "desc") {

--- a/apps/hash-frontend/src/pages/_app.page.tsx
+++ b/apps/hash-frontend/src/pages/_app.page.tsx
@@ -222,7 +222,7 @@ const publiclyAccessiblePagePathnames = [
 
 AppWithTypeSystemContextProvider.getInitialProps = async (appContext) => {
   const {
-    ctx: { req, pathname },
+    ctx: { req, pathname, asPath },
   } = appContext;
 
   const { cookie } = req?.headers ?? {};
@@ -255,7 +255,7 @@ AppWithTypeSystemContextProvider.getInitialProps = async (appContext) => {
       // ...redirect them to the login page
       redirectInGetInitialProps({
         appContext,
-        location: `/signin${["", "/", "/404"].includes(pathname) ? "" : `?return_to=${pathname}`}`,
+        location: `/signin${["", "/", "/404"].includes(pathname) ? "" : `?return_to=${asPath}`}`,
       });
     }
 

--- a/apps/hash-frontend/src/pages/shared/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table.tsx
@@ -163,6 +163,8 @@ export const EntitiesTable: FunctionComponent<{
   useEffect(() => {
     if (isDisplayingFilesOnly) {
       setView("Grid");
+    } else {
+      setView("Table");
     }
   }, [isDisplayingFilesOnly]);
 

--- a/apps/hash-frontend/src/pages/shared/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table.tsx
@@ -358,8 +358,7 @@ export const EntitiesTable: FunctionComponent<{
             };
           }
 
-          const propertyCellValue =
-            columnId && row.properties && row.properties[columnId];
+          const propertyCellValue = columnId && row[columnId];
 
           if (propertyCellValue) {
             return {

--- a/apps/hash-frontend/src/pages/shared/entities-table/use-entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table/use-entities-table.tsx
@@ -200,7 +200,7 @@ export const useEntitiesTable = (params: {
               lastEditedBy,
               /** @todo: uncomment this when we have additional types for entities */
               // additionalTypes: "",
-              properties: propertyColumns.reduce((fields, column) => {
+              ...propertyColumns.reduce((fields, column) => {
                 if (column.id) {
                   const propertyValue = entity.properties[column.id as BaseUrl];
 

--- a/apps/hash-graph/package.json
+++ b/apps/hash-graph/package.json
@@ -22,6 +22,7 @@
     "exe": "tsx",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
+    "migrate": "cargo run --bin hash-graph --all-features -- migrate --user postgres --password postgres",
     "reset-database": "httpyac send --all tests/reset-database.http",
     "test:integration": "just test-integration",
     "test:unit": "just test-unit"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "lint:prettier": "prettier --check --ignore-unknown .",
     "lint:tsc": "turbo --continue lint:tsc --",
     "lint:yarn-deduplicate": "yarn-deduplicate --fail --list --strategy=fewer",
+    "migrate:graph": "yarn workspace @apps/hash-graph migrate",
     "postinstall": "turbo run postinstall; patch-package --error-on-warn && husky install .config/husky",
     "seed-data:opensearch": "yarn workspace @apps/hash-search-loader clear-opensearch",
     "seed-data:redis": "yarn workspace @apps/hash-realtime clear-redis",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A few small bug fixes:
1. The entities table didn't switch back to non-file view when switching to a non-file type from a file type (via the sidebar)
2. The table wasn't sorting on properties, because the sort function tries to do `row[value]` but the properties were under `row.properties[value]`
3. The `return_to` if a user visited a page they needed to log in for wasn't taking account of dynamic paths (e.g. `/@[shortname]`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->