### PR TITLE
H-2406: Add environment variables for connecting to vault to Terraform

### DIFF
--- a/infra/terraform/hash/hash_application/main.tf
+++ b/infra/terraform/hash/hash_application/main.tf
@@ -67,7 +67,7 @@ locals {
   worker_task_defs = [
     {
       task_def = local.temporal_worker_integration_service_container_def
-      env_vars = []
+      env_vars = aws_ssm_parameter.temporal_worker_integration_env_vars
       ecr_arn  = var.temporal_worker_integration_image.ecr_arn
     }
   ]

--- a/infra/terraform/hash/hash_application/temporal_worker_integration.tf
+++ b/infra/terraform/hash/hash_application/temporal_worker_integration.tf
@@ -4,6 +4,18 @@ locals {
   temporal_worker_integration_param_prefix = "${local.param_prefix}/worker/integration"
 }
 
+resource "aws_ssm_parameter" "temporal_worker_integration_env_vars" {
+  # Only put secrets into SSM
+  for_each = {for env_var in var.temporal_worker_integration_env_vars : env_var.name => env_var if env_var.secret}
+
+  name      = "${local.temporal_worker_integration_param_prefix}/${each.value.name}"
+  # Still supports non-secret values
+  type      = each.value.secret ? "SecureString" : "String"
+  value     = each.value.secret ? sensitive(each.value.value) : each.value.value
+  overwrite = true
+  tags      = {}
+}
+
 locals {
   temporal_worker_integration_service_container_def = {
     essential   = true
@@ -28,6 +40,10 @@ locals {
       }
     }
     Environment = concat(
+      [
+        for env_var in var.temporal_worker_integration_env_vars : { name = env_var.name, value = env_var.value }
+        if !env_var.secret
+      ],
       [
         { name = "HASH_TEMPORAL_SERVER_HOST", value = var.temporal_host },
         { name = "HASH_TEMPORAL_SERVER_PORT", value = var.temporal_port },

--- a/infra/terraform/hash/hash_application/variables.tf
+++ b/infra/terraform/hash/hash_application/variables.tf
@@ -167,6 +167,15 @@ variable "temporal_worker_integration_image" {
   description = "URL of the docker image for the Temporal integration worker"
 }
 
+variable "temporal_worker_integration_env_vars" {
+  type = list(object({
+    name   = string,
+    secret = bool,
+    value  = string
+  }))
+  description = "A list of environment variables to save as system parameters and inject into the Temporal integration worker"
+}
+
 variable "ses_verified_domain_identity" {
   type        = string
   description = "A verified AWS SES identity to use for email sending in the application."

--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -347,6 +347,9 @@ module "application" {
     { name = "HASH_REDIS_PORT", secret = false, value = module.redis.node.port },
     { name = "HASH_REDIS_ENCRYPTED_TRANSIT", secret = false, value = "true" },
     { name = "HASH_INTEGRATION_QUEUE_NAME", secret = false, value = "integration" },
+    { name = "HASH_VAULT_HOST", secret = true, value =  sensitive(data.vault_kv_secret_v2.secrets.data["hash_vault_host"]) },
+    { name = "HASH_VAULT_PORT", secret = true, value =  sensitive(data.vault_kv_secret_v2.secrets.data["hash_vault_port"]) },
+    { name = "HASH_VAULT_ROOT_TOKEN", secret = true, value =  sensitive(data.vault_kv_secret_v2.secrets.data["hash_vault_root_token"]) },
     #    { name = "LINEAR_CLIENT_ID", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["linear_client_id"]) },
     #    { name = "LINEAR_CLIENT_SECRET", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["linear_client_secret"]) },
     {
@@ -366,6 +369,11 @@ module "application" {
     },
   ]
   temporal_worker_integration_image = module.temporal_worker_integration_ecr
+  temporal_worker_integration_env_vars = [
+    { name = "HASH_VAULT_HOST", secret = true, value =  sensitive(data.vault_kv_secret_v2.secrets.data["hash_vault_host"]) },
+    { name = "HASH_VAULT_PORT", secret = true, value =  sensitive(data.vault_kv_secret_v2.secrets.data["hash_vault_port"]) },
+    { name = "HASH_VAULT_ROOT_TOKEN", secret = true, value =  sensitive(data.vault_kv_secret_v2.secrets.data["hash_vault_root_token"]) },
+  ]
   temporal_host                     = module.temporal.host
   temporal_port                     = module.temporal.port
   spicedb_image                     = {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds variables needed to connect to Vault to Terraform. Stops the integration worker crashing in AWS, because it expects them.

Worth flagging that the 'provide a token' approach is unlikely to be the desired authentication solution, instead relying on an IAM policy as outlined in #2837.


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
