### PR TITLE
H-2417: Mark packages that shouldn't be published as private

### DIFF
--- a/apps/hashdotdesign/package.json
+++ b/apps/hashdotdesign/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@apps/hashdotdesign",
   "version": "0.0.0",
+  "private": true,
   "description": "HASH design system storybook",
   "sideEffects": false,
   "scripts": {

--- a/blocks/kanban-board/package.json
+++ b/blocks/kanban-board/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocks/kanban-board",
   "version": "0.0.2",
+  "private": true,
   "description": "Capture information in cards, and drag cards flexibly between customizable columns",
   "keywords": [
     "blockprotocol",

--- a/libs/@blockprotocol/graph/package.json
+++ b/libs/@blockprotocol/graph/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blockprotocol/graph",
   "version": "0.3.4-canary.0",
+  "private": true,
   "description": "Implementation of the Block Protocol Graph service specification for blocks and embedding applications",
   "keywords": [
     "blockprotocol",

--- a/libs/@blockprotocol/type-system/typescript/package.json
+++ b/libs/@blockprotocol/type-system/typescript/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blockprotocol/type-system",
   "version": "0.1.2-canary.0",
+  "private": true,
   "description": "Definitions of types within the Block Protocol Type System",
   "homepage": "https://blockprotocol.org",
   "repository": {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We haven't merged the Version Packages PR for a while, and [we just did and it](https://github.com/hashintel/hash/actions/runs/8300661559/job/22719071158) (a) attempted to publish some apps that aren't on the registry, and (b) successfully published the copy of `@blockprotocol/graph` package we have in this repo as `latest`, that it shouldn't have.

This PR marks those packages as private to stop them being published again, and I am merging the [release PR](https://github.com/blockprotocol/blockprotocol/pull/1376#pullrequestreview-1939993506) in the `blockprotocol` PR so that we get another `latest` version of `@blockprotocol/graph` to override the one just published from here.
