### PR TITLE
BP-94 (PR2): Make `Model Licensing` glossary page more general in nature

### DIFF
--- a/apps/hashdotai/glossary/licensing.mdx
+++ b/apps/hashdotai/glossary/licensing.mdx
@@ -1,27 +1,31 @@
 ---
 objectId: 1ecc72a6-5511-46c3-9819-9ea9766dea07
-title: Model Licensing
-description: There are lots of ways to license simulation models. Here we outline some key considerations and things to be aware of.
-slug: model-licensing
+title: "Licensing"
+description: "There are lots of ways to license intellectual property, including your datasets, simulation models, and other code. Here we outline some key considerations and things to be aware of."
+slug: licensing
 tags: ["Simulation Modeling"]
 ---
 
-There are lots of ways to license simulation models.
+"Licensing" refers to the terms under which intellectual property such as datasets, code, or pieces of writing are made available.
 
-Whilst simulation models can be published transparently and publicly on [hIndex](https://hash.ai/platform/index) with all rights regarding their usage reserved under traditional copyright law, this is fairly uncommon. More often, one of two alternatives takes place:
+## Code Licenses
 
-1.  If a simulation author doesn’t want other people using their code, they don’t publish it transparently at all. Projects can be kept private on hIndex so there is no need to make available copyrighted code if you do not wish to.
+There are lots of ways to license code, including HASH [simulation models](https://hash.ai/glossary/simulation).
+
+Whilst simulation models can be published transparently and publicly on [HASH](https://hash.ai/platform/index) with all rights regarding their usage reserved under traditional copyright law, this is fairly uncommon. More often, one of two alternatives takes place:
+
+1.  If a simulation author doesn’t want other people using their code, they don’t publish it transparently at all. Projects can be kept private on HASH so there is no need to make available copyrighted code if you do not wish to.
 1.  Oftentimes, code that is published publicly on the internet is released under the terms of a software license.
 
-## What is a software license?
+### What is a software license?
 
 Software licenses, including open-source licenses, and end-user license agreements (EULAs) specify what others can do with your raw code, and its compiled outputs (in this case the simulation itself).
 
-## What software licenses does HASH support?
+### What software licenses does HASH support?
 
 HASH allows you to specify absolutely any terms you like. You’re responsible for making sure that these are statutorily enforceable, and what counts as such may differ from place to place. You should remember that when you publish things on the internet, they are accessible globally.
 
-To make things easy, when you publish projects to hIndex we allow you to select from a long list of well-established, battle-tested licenses for software. These include:
+To make things easy, when you publish projects to HASH we allow you to select from a long list of well-established, battle-tested licenses for software. These include:
 
 - Apache License 2.0
 - Attribution (CC BY)
@@ -40,12 +44,14 @@ To make things easy, when you publish projects to hIndex we allow you to select 
 - Mozilla Public License 2.0
 - The Unlicense
 
+## Data Licenses
+
 We also make additional licenses available when publishing certain types of data publicly, including:
 
 - Open Data Commons Attribution License
 - Open Data Commons Open Database License (ODbL)
 - Open Data Commons Public Domain Dedication and License (PDDL)
 
-As previously mentioned, there is however no limit to the license terms under which you may publish content to hIndex and you are always free to choose an alternative license or specify custom terms yourself.
+As previously mentioned, there is however no limit to the license terms under which you may publish content to HASH and you are always free to choose an alternative license or specify custom terms yourself.
 
 We recommend selecting from one of the pre-supported above licenses which are widely used and understood already in the software world today. This ensures that prospective users of your simulation model can quickly determine the rights they have (and limitations placed upon them) when interacting with your work, without needing to consult with legal counsel.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Turns `Model Licensing` glossary page into a `Licensing` one. Sister of [hashintel/internal-site#75](https://github.com/hashintel/internal-gitstart/pull/75).