### PR TITLE
H-2455: Make `@hashintel/block-design-system` private

### DIFF
--- a/libs/@hashintel/block-design-system/package.json
+++ b/libs/@hashintel/block-design-system/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@hashintel/block-design-system",
   "version": "0.0.2",
+  "private": true,
   "description": "Block Design System",
   "bugs": {
     "url": "https://github.com/hashintel/hash/issues"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
`@hashintel/block-design-system` has a private local dependency which means publishing it to `npm` fails. We don't need it there for now.