### PR TITLE
H-2460: Support storing confidence values in Graph database

### DIFF
--- a/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
@@ -137,6 +137,8 @@ async fn seed_db(
                         Some(LinkData {
                             left_entity_id: entity_a_metadata.record_id.entity_id,
                             right_entity_id: entity_b_metadata.record_id.entity_id,
+                            left_entity_confidence: None,
+                            right_entity_confidence: None,
                         }),
                         None,
                     )

--- a/apps/hash-graph/bench/representative_read/seed.rs
+++ b/apps/hash-graph/bench/representative_read/seed.rs
@@ -211,6 +211,8 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
                             Some(LinkData {
                                 left_entity_id: left_entity_metadata.record_id.entity_id,
                                 right_entity_id: right_entity_metadata.record_id.entity_id,
+                                left_entity_confidence: None,
+                                right_entity_confidence: None,
                             }),
                             None,
                         )

--- a/apps/hash-graph/libs/api/src/rest/entity.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity.rs
@@ -40,9 +40,10 @@ use graph_types::{
         entity::{
             Entity, EntityEditionId, EntityEditionProvenanceMetadata, EntityEmbedding, EntityId,
             EntityMetadata, EntityProperties, EntityProvenanceMetadata, EntityRecordId,
-            EntityTemporalMetadata, EntityUuid,
+            EntityTemporalMetadata, EntityUuid, PropertyPath,
         },
         link::LinkData,
+        Confidence,
     },
     owned_by_id::OwnedById,
     Embedding,
@@ -131,6 +132,9 @@ use crate::rest::{
             EntityTemporalMetadata,
             EntityQueryToken,
             LinkData,
+
+            PropertyPath,
+            Confidence,
         )
     ),
     tags(

--- a/apps/hash-graph/libs/api/src/rest/utoipa_typedef/subgraph/vertices/vertex.rs
+++ b/apps/hash-graph/libs/api/src/rest/utoipa_typedef/subgraph/vertices/vertex.rs
@@ -67,7 +67,7 @@ impl From<EntityTypeWithMetadata> for OntologyVertex {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, ToSchema)]
+#[derive(Debug, PartialEq, Serialize, ToSchema)]
 #[serde(tag = "kind", content = "inner")]
 #[serde(rename_all = "camelCase")]
 pub(crate) enum KnowledgeGraphVertex {
@@ -75,7 +75,7 @@ pub(crate) enum KnowledgeGraphVertex {
     Entity(Entity),
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, ToSchema)]
+#[derive(Debug, PartialEq, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
 #[expect(dead_code, reason = "This is used in the generated OpenAPI spec")]

--- a/apps/hash-graph/libs/graph/src/snapshot/entity/record.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/entity/record.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use temporal_versioning::{DecisionTime, Timestamp, TransactionTime};
 use type_system::url::BaseUrl;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EntitySnapshotRecord {
     pub properties: EntityProperties,

--- a/apps/hash-graph/libs/graph/src/snapshot/entity/table.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/entity/table.rs
@@ -1,6 +1,9 @@
 use graph_types::{
     account::{CreatedById, EditionCreatedById},
-    knowledge::entity::{DraftId, EntityEditionId, EntityProperties, EntityUuid},
+    knowledge::{
+        entity::{DraftId, EntityEditionId, EntityProperties, EntityUuid, PropertyPath},
+        Confidence,
+    },
     owned_by_id::OwnedById,
     Embedding,
 };
@@ -35,6 +38,15 @@ pub struct EntityEditionRow {
     pub properties: EntityProperties,
     pub edition_created_by_id: EditionCreatedById,
     pub archived: bool,
+    pub confidence: Option<Confidence>,
+}
+
+#[derive(Debug, ToSql)]
+#[postgres(name = "entity_editions")]
+pub struct EntityPropertyRow {
+    pub entity_edition_id: EntityEditionId,
+    pub property_path: PropertyPath<'static>,
+    pub confidence: Option<Confidence>,
 }
 
 #[derive(Debug, ToSql)]
@@ -62,8 +74,10 @@ pub struct EntityLinkEdgeRow {
     pub entity_uuid: EntityUuid,
     pub left_web_id: OwnedById,
     pub left_entity_uuid: EntityUuid,
+    pub left_entity_confidence: Option<Confidence>,
     pub right_web_id: OwnedById,
     pub right_entity_uuid: EntityUuid,
+    pub right_entity_confidence: Option<Confidence>,
 }
 
 #[derive(Debug, ToSql)]

--- a/apps/hash-graph/libs/graph/src/snapshot/mod.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/mod.rs
@@ -97,6 +97,7 @@ pub enum AuthorizationRelation {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "type", deny_unknown_fields)]
+#[expect(clippy::large_enum_variant)]
 pub enum SnapshotEntry {
     Snapshot(SnapshotMetadata),
     Account(Account),

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -286,6 +286,7 @@ impl<C: AsClient> PostgresStore<C> {
                 "
                     DELETE FROM entity_has_left_entity;
                     DELETE FROM entity_has_right_entity;
+                    DELETE FROM entity_property;
                     DELETE FROM entity_is_of_type;
                     DELETE FROM entity_temporal_metadata;
                     DELETE FROM entity_editions;
@@ -615,6 +616,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 },
                 temporal_versioning,
                 archived: false,
+                confidence: None,
+                property_confidence: HashMap::new(),
             };
             if let Some(temporal_client) = temporal_client {
                 temporal_client
@@ -901,6 +904,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                     },
                     temporal_versioning,
                     archived: false,
+                    confidence: None,
+                    property_confidence: HashMap::new(),
                 },
             )
             .collect())
@@ -1203,6 +1208,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 entity_type_ids,
                 provenance: previous_entity.metadata.provenance,
                 archived,
+                confidence: previous_entity.metadata.confidence,
+                property_confidence: previous_entity.metadata.property_confidence,
             });
         }
 
@@ -1339,6 +1346,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                     created_by_id: EditionCreatedById::new(actor_id),
                 },
             },
+            confidence: None,
+            property_confidence: HashMap::new(),
             archived,
         };
         if let Some(temporal_client) = temporal_client {

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/entity.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/entity.rs
@@ -5,8 +5,8 @@ use crate::{
     store::postgres::query::{
         table::{
             Column, EntityEditions, EntityEmbeddings, EntityHasLeftEntity, EntityHasRightEntity,
-            EntityIds, EntityIsOfTypeIds, EntityTemporalMetadata, JsonField, ReferenceTable,
-            Relation,
+            EntityIds, EntityIsOfTypeIds, EntityProperties, EntityTemporalMetadata, JsonField,
+            ReferenceTable, Relation,
         },
         PostgresQueryPath,
     },
@@ -30,7 +30,13 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
                 vec![Relation::EntityIds]
             }
             Self::Embedding => vec![Relation::EntityEmbeddings],
-            Self::Properties(_) | Self::EditionCreatedById | Self::Archived => {
+            Self::LeftEntityConfidence => vec![Relation::LeftEntity],
+            Self::RightEntityConfidence => vec![Relation::RightEntity],
+            Self::PropertyPaths | Self::PropertyConfidences => vec![Relation::EntityProperties],
+            Self::Properties(_)
+            | Self::EditionCreatedById
+            | Self::Archived
+            | Self::EntityConfidence => {
                 vec![Relation::EntityEditions]
             }
             Self::TypeBaseUrls | Self::TypeVersions => vec![Relation::EntityIsOfTypes],
@@ -149,6 +155,15 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
                     ))))
                 },
             ),
+            Self::EntityConfidence => Column::EntityEditions(EntityEditions::Confidence),
+            Self::LeftEntityConfidence => {
+                Column::EntityHasLeftEntity(EntityHasLeftEntity::Confidence)
+            }
+            Self::RightEntityConfidence => {
+                Column::EntityHasRightEntity(EntityHasRightEntity::Confidence)
+            }
+            Self::PropertyPaths => Column::EntityProperties(EntityProperties::PropertyPaths),
+            Self::PropertyConfidences => Column::EntityProperties(EntityProperties::Confidences),
         }
     }
 }

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -2705,6 +2705,12 @@
           "propertyName": "kind"
         }
       },
+      "Confidence": {
+        "type": "number",
+        "format": "double",
+        "maximum": 1,
+        "minimum": 0
+      },
       "CopyOperation": {
         "type": "object",
         "description": "JSON Patch 'copy' operation representation",
@@ -3344,10 +3350,23 @@
           "archived": {
             "type": "boolean"
           },
+          "confidence": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Confidence"
+              }
+            ]
+          },
           "entityTypeIds": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/VersionedUrl"
+            }
+          },
+          "propertyConfidence": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Confidence"
             }
           },
           "provenance": {
@@ -4718,8 +4737,22 @@
           "rightEntityId"
         ],
         "properties": {
+          "leftEntityConfidence": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Confidence"
+              }
+            ]
+          },
           "leftEntityId": {
             "$ref": "#/components/schemas/EntityId"
+          },
+          "rightEntityConfidence": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Confidence"
+              }
+            ]
           },
           "rightEntityId": {
             "$ref": "#/components/schemas/EntityId"
@@ -5464,6 +5497,9 @@
             "type": "boolean"
           }
         }
+      },
+      "PropertyPath": {
+        "type": "string"
       },
       "PropertyTypeEditorSubject": {
         "oneOf": [

--- a/apps/hash-graph/postgres_migrations/V22__entity_properties.sql
+++ b/apps/hash-graph/postgres_migrations/V22__entity_properties.sql
@@ -1,0 +1,19 @@
+CREATE TABLE entity_property (
+    entity_edition_id UUID NOT NULL REFERENCES entity_editions,
+    property_path TEXT NOT NULL,
+    confidence DOUBLE PRECISION
+);
+
+CREATE VIEW entity_properties AS
+SELECT entity_edition_id, array_agg(property_path) AS property_paths, array_agg(confidence) AS confidences
+FROM entity_property
+GROUP BY entity_edition_id;
+
+ALTER TABLE entity_editions
+ADD COLUMN confidence DOUBLE PRECISION;
+
+ALTER TABLE entity_has_left_entity
+ADD COLUMN confidence DOUBLE PRECISION;
+
+ALTER TABLE entity_has_right_entity
+ADD COLUMN confidence DOUBLE PRECISION;

--- a/libs/@local/hash-graph-types/rust/src/knowledge/confidence.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/confidence.rs
@@ -1,0 +1,31 @@
+#[cfg(feature = "postgres")]
+use postgres_types::{FromSql, ToSql};
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "utoipa")]
+use utoipa::{
+    openapi::{self, KnownFormat, SchemaFormat},
+    ToSchema,
+};
+
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[cfg_attr(feature = "postgres", derive(FromSql, ToSql), postgres(transparent))]
+#[repr(transparent)]
+pub struct Confidence(f64);
+
+#[cfg(feature = "utoipa")]
+impl ToSchema<'_> for Confidence {
+    fn schema() -> (&'static str, openapi::RefOr<openapi::Schema>) {
+        (
+            "Confidence",
+            openapi::Schema::Object(
+                openapi::schema::ObjectBuilder::new()
+                    .schema_type(openapi::SchemaType::Number)
+                    .format(Some(SchemaFormat::KnownFormat(KnownFormat::Double)))
+                    .minimum(Some(0.0))
+                    .maximum(Some(1.0))
+                    .build(),
+            )
+            .into(),
+        )
+    }
+}

--- a/libs/@local/hash-graph-types/rust/src/knowledge/entity.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/entity.rs
@@ -433,6 +433,7 @@ impl PropertyPath<'_> {
     }
 }
 
+#[cfg(feature = "postgres")]
 impl<'k> FromSql<'k> for PropertyPath<'k> {
     fn from_sql(ty: &Type, raw: &'k [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
         Ok(Self {
@@ -456,6 +457,7 @@ impl<'k> FromSql<'k> for PropertyPath<'k> {
     }
 }
 
+#[cfg(feature = "postgres")]
 impl ToSql for PropertyPath<'_> {
     postgres_types::to_sql_checked!();
 

--- a/libs/@local/hash-graph-types/rust/src/knowledge/entity.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/entity.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "postgres")]
 use std::error::Error;
-use std::{cmp::Ordering, collections::HashMap, fmt, io, str::FromStr};
+use std::{borrow::Cow, cmp::Ordering, collections::HashMap, fmt, io, str::FromStr};
 
 #[cfg(feature = "postgres")]
 use bytes::BytesMut;
@@ -10,7 +10,7 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value as JsonValue;
 use temporal_versioning::{DecisionTime, LeftClosedTemporalInterval, Timestamp, TransactionTime};
 use type_system::{
-    url::{BaseUrl, VersionedUrl},
+    url::{BaseUrl, ParseBaseUrlError, VersionedUrl},
     JsonSchemaValueType,
 };
 #[cfg(feature = "utoipa")]
@@ -19,7 +19,7 @@ use uuid::Uuid;
 
 use crate::{
     account::{CreatedById, EditionCreatedById},
-    knowledge::link::LinkData,
+    knowledge::{link::LinkData, Confidence},
     owned_by_id::OwnedById,
     Embedding,
 };
@@ -127,7 +127,7 @@ impl Property {
             }
             Self::Object(object) => {
                 for (key, property) in object {
-                    elements.push(PropertyPathElement::Property(key));
+                    elements.push(PropertyPathElement::Property(Cow::Borrowed(key)));
                     for yielded in Box::new(property.properties()) {
                         yield yielded;
                     }
@@ -204,7 +204,8 @@ impl Property {
         path: &mut PropertyPath<'a>,
     ) -> PropertyDiff<'a> {
         for (key, property) in lhs {
-            path.elements.push(PropertyPathElement::Property(key));
+            path.elements
+                .push(PropertyPathElement::Property(Cow::Borrowed(key)));
             let other_property = rhs.get(key);
             if let Some(other_property) = other_property {
                 for yielded in Box::new(property.diff(other_property, path)) {
@@ -220,7 +221,8 @@ impl Property {
         }
         for (key, property) in rhs {
             if !lhs.contains_key(key) {
-                path.elements.push(PropertyPathElement::Property(key));
+                path.elements
+                    .push(PropertyPathElement::Property(Cow::Borrowed(key)));
                 yield PropertyDiff::Added {
                     path: path.clone(),
                     added: property,
@@ -382,15 +384,145 @@ impl EntityProperties {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(untagged)]
 pub enum PropertyPathElement<'k> {
-    Property(&'k BaseUrl),
+    Property(Cow<'k, BaseUrl>),
     Index(usize),
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+impl PropertyPathElement<'_> {
+    #[must_use]
+    pub fn into_owned(self) -> PropertyPathElement<'static> {
+        match self {
+            PropertyPathElement::Property(key) => {
+                PropertyPathElement::Property(Cow::Owned(key.into_owned()))
+            }
+            PropertyPathElement::Index(index) => PropertyPathElement::Index(index),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 pub struct PropertyPath<'k> {
     elements: Vec<PropertyPathElement<'k>>,
+}
+
+#[cfg(feature = "utoipa")]
+impl ToSchema<'_> for PropertyPath<'_> {
+    fn schema() -> (&'static str, openapi::RefOr<openapi::Schema>) {
+        (
+            "PropertyPath",
+            openapi::Schema::Object(openapi::schema::Object::with_type(
+                openapi::SchemaType::String,
+            ))
+            .into(),
+        )
+    }
+}
+
+impl PropertyPath<'_> {
+    pub fn into_owned(self) -> PropertyPath<'static> {
+        PropertyPath {
+            elements: self
+                .elements
+                .into_iter()
+                .map(PropertyPathElement::into_owned)
+                .collect(),
+        }
+    }
+}
+
+impl<'k> FromSql<'k> for PropertyPath<'k> {
+    fn from_sql(ty: &Type, raw: &'k [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        Ok(Self {
+            elements: <&str as FromSql>::from_sql(ty, raw)?
+                .split('/')
+                .map(|element| {
+                    if let Ok(index) = element.parse() {
+                        Ok(PropertyPathElement::Index(index))
+                    } else {
+                        Ok(PropertyPathElement::Property(Cow::Owned(BaseUrl::new(
+                            element.replace("~1", "/").replace("~0", "~"),
+                        )?)))
+                    }
+                })
+                .collect::<Result<Vec<_>, ParseBaseUrlError>>()?,
+        })
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <&str as FromSql>::accepts(ty)
+    }
+}
+
+impl ToSql for PropertyPath<'_> {
+    postgres_types::to_sql_checked!();
+
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        self.elements
+            .iter()
+            .map(|element| match element {
+                PropertyPathElement::Property(key) => {
+                    key.as_str().replace('~', "~0").replace('/', "~1")
+                }
+                PropertyPathElement::Index(index) => index.to_string(),
+            })
+            .collect::<Vec<_>>()
+            .join("/")
+            .to_sql(ty, out)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <&str as ToSql>::accepts(ty)
+    }
+}
+
+impl Serialize for PropertyPath<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.elements
+            .iter()
+            .map(|element| match element {
+                PropertyPathElement::Property(key) => {
+                    key.as_str().replace('~', "~0").replace('/', "~1")
+                }
+                PropertyPathElement::Index(index) => index.to_string(),
+            })
+            .collect::<Vec<_>>()
+            .join("/")
+            .serialize(serializer)
+    }
+}
+
+impl<'de, 'a: 'de> Deserialize<'de> for PropertyPath<'a> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let path = String::deserialize(deserializer)?;
+        Ok(Self {
+            elements: path
+                .split('/')
+                .map(|element| {
+                    if let Ok(index) = element.parse() {
+                        Ok(PropertyPathElement::Index(index))
+                    } else {
+                        Ok(PropertyPathElement::Property(Cow::Owned(BaseUrl::new(
+                            element.replace("~1", "/").replace("~0", "~"),
+                        )?)))
+                    }
+                })
+                .collect::<Result<Vec<_>, ParseBaseUrlError>>()
+                .map_err(de::Error::custom)?,
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -441,7 +573,7 @@ pub struct EntityProvenanceMetadata {
 }
 
 /// The metadata of an [`Entity`] record.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct EntityMetadata {
@@ -450,11 +582,17 @@ pub struct EntityMetadata {
     pub entity_type_ids: Vec<VersionedUrl>,
     pub provenance: EntityProvenanceMetadata,
     pub archived: bool,
+    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<Confidence>,
+    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub property_confidence: HashMap<PropertyPath<'static>, Confidence>,
 }
 
 /// A record of an [`Entity`] that has been persisted in the datastore, with its associated
 /// metadata.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[cfg_attr(feature = "utoipa", derive(ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct Entity {
@@ -657,6 +795,8 @@ mod tests {
     }
 
     mod diff {
+        use std::borrow::Cow;
+
         use type_system::url::BaseUrl;
 
         use crate::knowledge::entity::{Property, PropertyDiff, PropertyPath, PropertyPathElement};
@@ -859,7 +999,7 @@ mod tests {
                         path: PropertyPath {
                             elements: vec![
                                 PropertyPathElement::Index(0),
-                                PropertyPathElement::Property(&create_base_url(0)),
+                                PropertyPathElement::Property(Cow::Borrowed(&create_base_url(0))),
                             ],
                         },
                         old: &property!("bar"),
@@ -893,7 +1033,7 @@ mod tests {
                         path: PropertyPath {
                             elements: vec![
                                 PropertyPathElement::Index(0),
-                                PropertyPathElement::Property(&create_base_url(0)),
+                                PropertyPathElement::Property(Cow::Borrowed(&create_base_url(0))),
                             ],
                         },
                         removed: &property!("bar"),
@@ -902,7 +1042,7 @@ mod tests {
                         path: PropertyPath {
                             elements: vec![
                                 PropertyPathElement::Index(0),
-                                PropertyPathElement::Property(&create_base_url(1)),
+                                PropertyPathElement::Property(Cow::Borrowed(&create_base_url(1))),
                             ],
                         },
                         added: &property!("baz"),
@@ -942,7 +1082,9 @@ mod tests {
                 [
                     PropertyDiff::Added {
                         path: PropertyPath {
-                            elements: vec![PropertyPathElement::Property(&create_base_url(1))],
+                            elements: vec![PropertyPathElement::Property(Cow::Borrowed(
+                                &create_base_url(1),
+                            ))],
                         },
                         added: &property!("foo"),
                     },
@@ -966,8 +1108,8 @@ mod tests {
                     PropertyDiff::Changed {
                         path: PropertyPath {
                             elements: vec![
-                                PropertyPathElement::Property(&create_base_url(1)),
-                                PropertyPathElement::Property(&create_base_url(2)),
+                                PropertyPathElement::Property(Cow::Borrowed(&create_base_url(1))),
+                                PropertyPathElement::Property(Cow::Borrowed(&create_base_url(2))),
                             ],
                         },
                         old: &property!("foo"),
@@ -975,7 +1117,9 @@ mod tests {
                     },
                     PropertyDiff::Changed {
                         path: PropertyPath {
-                            elements: vec![PropertyPathElement::Property(&create_base_url(1))],
+                            elements: vec![PropertyPathElement::Property(Cow::Borrowed(
+                                &create_base_url(1),
+                            ))],
                         },
                         old: &property!({ create_base_url(2): "foo" }),
                         new: &property!({ create_base_url(2): "bar" }),
@@ -999,13 +1143,17 @@ mod tests {
                 [
                     PropertyDiff::Removed {
                         path: PropertyPath {
-                            elements: vec![PropertyPathElement::Property(&create_base_url(1))],
+                            elements: vec![PropertyPathElement::Property(Cow::Borrowed(
+                                &create_base_url(1),
+                            ))],
                         },
                         removed: &property!({ create_base_url(3): "foo" }),
                     },
                     PropertyDiff::Added {
                         path: PropertyPath {
-                            elements: vec![PropertyPathElement::Property(&create_base_url(2))],
+                            elements: vec![PropertyPathElement::Property(Cow::Borrowed(
+                                &create_base_url(2),
+                            ))],
                         },
                         added: &property!({ create_base_url(3): "foo" }),
                     },
@@ -1029,8 +1177,8 @@ mod tests {
                     PropertyDiff::Added {
                         path: PropertyPath {
                             elements: vec![
-                                PropertyPathElement::Property(&create_base_url(2)),
-                                PropertyPathElement::Property(&create_base_url(3)),
+                                PropertyPathElement::Property(Cow::Borrowed(&create_base_url(2))),
+                                PropertyPathElement::Property(Cow::Borrowed(&create_base_url(3))),
                             ],
                         },
                         added: &property!("foo"),
@@ -1038,22 +1186,26 @@ mod tests {
                     PropertyDiff::Removed {
                         path: PropertyPath {
                             elements: vec![
-                                PropertyPathElement::Property(&create_base_url(1)),
-                                PropertyPathElement::Property(&create_base_url(3)),
+                                PropertyPathElement::Property(Cow::Borrowed(&create_base_url(1))),
+                                PropertyPathElement::Property(Cow::Borrowed(&create_base_url(3))),
                             ],
                         },
                         removed: &property!("foo"),
                     },
                     PropertyDiff::Changed {
                         path: PropertyPath {
-                            elements: vec![PropertyPathElement::Property(&create_base_url(1))],
+                            elements: vec![PropertyPathElement::Property(Cow::Borrowed(
+                                &create_base_url(1),
+                            ))],
                         },
                         old: &property!({ create_base_url(3): "foo" }),
                         new: &property!({}),
                     },
                     PropertyDiff::Changed {
                         path: PropertyPath {
-                            elements: vec![PropertyPathElement::Property(&create_base_url(2))],
+                            elements: vec![PropertyPathElement::Property(Cow::Borrowed(
+                                &create_base_url(2),
+                            ))],
                         },
                         old: &property!({}),
                         new: &property!({ create_base_url(3): "foo" }),
@@ -1077,7 +1229,9 @@ mod tests {
                 [
                     PropertyDiff::Changed {
                         path: PropertyPath {
-                            elements: vec![PropertyPathElement::Property(&create_base_url(1))],
+                            elements: vec![PropertyPathElement::Property(Cow::Borrowed(
+                                &create_base_url(1),
+                            ))],
                         },
                         old: &property!("foo"),
                         new: &property!("bar"),
@@ -1101,7 +1255,9 @@ mod tests {
                 [
                     PropertyDiff::Removed {
                         path: PropertyPath {
-                            elements: vec![PropertyPathElement::Property(&create_base_url(1))],
+                            elements: vec![PropertyPathElement::Property(Cow::Borrowed(
+                                &create_base_url(1),
+                            ))],
                         },
                         removed: &property!("foo"),
                     },

--- a/libs/@local/hash-graph-types/rust/src/knowledge/link.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/link.rs
@@ -1,12 +1,18 @@
 use serde::{Deserialize, Serialize};
 
-use crate::knowledge::entity::EntityId;
+use crate::knowledge::{entity::EntityId, Confidence};
 
 /// The associated information for 'Link' entities
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct LinkData {
     pub left_entity_id: EntityId,
     pub right_entity_id: EntityId,
+    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub left_entity_confidence: Option<Confidence>,
+    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub right_entity_confidence: Option<Confidence>,
 }

--- a/libs/@local/hash-graph-types/rust/src/knowledge/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/mod.rs
@@ -1,2 +1,6 @@
 pub mod entity;
 pub mod link;
+
+mod confidence;
+
+pub use self::confidence::Confidence;

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -792,6 +792,8 @@ impl DatabaseApi<'_> {
                     link_data: Some(LinkData {
                         left_entity_id,
                         right_entity_id,
+                        left_entity_confidence: None,
+                        right_entity_confidence: None,
                     }),
                     draft: false,
                     relationships: [],


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We want to support storing a confidence value for:
- the whole entity
- the every entity's properties
- the entity's link source and target (if the entity is a link)

This implements the datastore implementation to store all three kinds in the database and exposes the values to the REST API. This does not add support to specify the values (which will be addressed in a follow-up PR).

## 🚫 Blocked by

- #4202 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change
### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

- Allow specifying the confidence values when creating/updating an entity