### PR TITLE
Pin `packageManager` to `yarn@1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,5 +105,6 @@
     "turbo": "1.13.0",
     "wait-on": "6.0.1",
     "yarn-deduplicate": "6.0.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha256.c17d3797fb9a9115bf375e31bfd30058cac6bc9c3b8807a3d8cb2094794b51ca"
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This pins the package manager to `yarn@1` (done through `corepack use yarn@1`). This enables the use of `yarn 1` even on systems where an alternative yarn is installed, as long as `corepack` is active. `corepack` is a new package manager for package managers (the JS ecosystem sure is wild), and each package manager and node nowadays recommends managing the package manager of a repo.

> This is mostly done because I was frustrated w/ `yarn 4` (which I use in every other repo) and `yarn 1` (which is used in `hashintel/hash`) The `packageManager` field is ignored if `corepack` isn't used, although you really should!

## 🔗 Related links

- https://github.com/nodejs/corepack

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
