### PR TITLE
H-2451: Partially fix entity editor behavior when clicking between cells

### DIFF
--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/single-value-editor.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/single-value-editor.tsx
@@ -153,22 +153,41 @@ export const SingleValueEditor: ValueCellEditorComponent = (props) => {
     );
   }
 
+  /**
+   * Force validation on the text input form.
+   * If the form is valid or if the form has been unmounted, allow <Grid /> to handle clicks events again.
+   */
   const validationHandler = () => {
-    if (!textInputFormRef.current) {
-      return;
+    if (textInputFormRef.current) {
+      textInputFormRef.current.requestSubmit();
+
+      if (!textInputFormRef.current.checkValidity()) {
+        return;
+      }
     }
-    textInputFormRef.current.requestSubmit();
-    if (textInputFormRef.current.checkValidity()) {
-      document.body.classList.remove(GRID_CLICK_IGNORE_CLASS);
-      onFinishedEditing(latestValueCellRef.current);
-      document.removeEventListener("click", validationHandler);
-    }
+
+    /**
+     * Update the value and clean up the validation handler in either of these scenarios:
+     * 1. The form is valid
+     * 2. The form has been unmounted and we can't check its validity – this happens if another grid cell is clicked
+     *
+     * If another grid cell is clicked, we cannot validate using the input and we may have an invalid value in the table.
+     * The alternative is that clicking another cell wipes the value, which is slightly worse UX.
+     * Ideally we would prevent the form being closed when another cell is clicked, to allow validation to run,
+     * and in any case have an indicator that an invalid value is in the form – tracked in H-1834
+     */
+    onFinishedEditing(latestValueCellRef.current);
+    document.removeEventListener("click", validationHandler);
+    document.body.classList.remove(GRID_CLICK_IGNORE_CLASS);
+
+    return true;
   };
 
   /**
    * Glide Grid will close the editing interface when it is clicked outside.
    * We need to prevent that behavior by adding the GRID_CLICK_IGNORE_CLASS to the body,
    * and only permitting it when the form is valid.
+   * This does not catch clicks on other cells, because the form is unmounted before validation can run.
    */
   const ensureFormValidation = () => {
     if (document.body.classList.contains(GRID_CLICK_IGNORE_CLASS)) {
@@ -193,16 +212,27 @@ export const SingleValueEditor: ValueCellEditorComponent = (props) => {
           value={(value as number | string | undefined) ?? ""}
           onChange={(newValue) => {
             if (
-              !(
-                "format" in expectedType &&
+              ("format" in expectedType &&
                 expectedType.format &&
-                ["date", "date-time", "time"].includes(expectedType.format)
-              )
+                /**
+                 * We use the native browser date/time inputs which handle validation for us,
+                 * and the validation click handler assumes there will be a click outside after a change
+                 * - which there won't for those inputs, because clicking to select a value closes the input.
+                 */
+                !["date", "date-time", "time"].includes(expectedType.format)) ||
+              "minLength" in expectedType ||
+              "maxLength" in expectedType ||
+              "minimum" in expectedType ||
+              "maximum" in expectedType ||
+              "step" in expectedType
             ) {
               /**
-               * We use the native browser date/time inputs which handle validation for us,
-               * and the validation click handler assumes there will be a click outside after a change
-               * - which there won't for those inputs, because clicking to select a value closes the input.
+               * Add the validation enforcer if there are any validation rules.
+               * We don't add this if we know the user cannot input an invalid value (e.g. unconstrained string or number).
+               * Adding the validation enforcer means clicking into another cell requires a second click to activate it,
+               * so we don't want to add it unnecessarily.
+               * Ideally we wouldn't need the click handler hacks to enforce validation, or have a different validation strategy –
+               * especially given that the validation enforcement can be bypassed by clicking another cell – see H-1834.
                */
               ensureFormValidation();
             }

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/single-value-editor.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/single-value-editor.tsx
@@ -155,7 +155,7 @@ export const SingleValueEditor: ValueCellEditorComponent = (props) => {
 
   /**
    * Force validation on the text input form.
-   * If the form is valid or if the form has been unmounted, allow <Grid /> to handle clicks events again.
+   * If the form is valid or if the form has been unmounted, allow <Grid /> to handle click events again.
    */
   const validationHandler = () => {
     if (textInputFormRef.current) {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This fixes some issues with editing entity properties when clicking from a cell being edited into another cell.

We're currently relying on native HTML input validation attributes (e.g. `type: "url"`, `minLength: 4`), triggering validation of the form when clicked outside of it, and preventing closing the form if it's invalid.

However, the click handler is not triggered when another grid cell is clicked. The form is unmounted immediately without validation being run. In order to force validation we need to somehow change `glide-data-grid`'s behavior to stop an open editor being closed when another cell is clicked based on some conditions. H-1834 tracks that.

In the meantime, this is an interim fix for existing issues (see demos):
1. Persists the value if the form has been unmounted. Previously, switching to another cell would lose the value in the first cell (since the validation handler didn't persist the value if the form wasn't present)
2. Cleans up the handler if the form has been unmounted
3. Doesn't add the validation handler if no constraints are present on the value. We can rely on the relevant HTML input forcing the user to input a number or a string at least, so we don't need additional validation unless there are additional constraints.

This does mean that it's possible to have an invalid value in a cell, e.g. input a non-URL and then click to another cell. But we need form-level validation for other things anyway (e.g. missing required properties), which should flag this up – also H-1834.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- There is a test for editing an entity property

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. See demos

## 📹 Demo

### Buggy behavior

1. Clicking into another cell loses existing value
2. Once another cell is clicked into, clicking outside the grid does not close the editor, because the click handler was not cleaned up from the previous cell. You must hit enter to save


https://github.com/hashintel/hash/assets/37743469/9e980680-390e-47e5-adfb-40e1b41e1f07



### New behavior
<!-- Add a screenshot or video showcasing your work -->


https://github.com/hashintel/hash/assets/37743469/b4c3bde9-71df-4ae6-8018-58cfc3cbfe71

