### PR TITLE
H-2497: Update `HASH-O` license page redirect from HDEV

### DIFF
--- a/apps/hashdotai/guide/10_flows/00_index.mdx
+++ b/apps/hashdotai/guide/10_flows/00_index.mdx
@@ -21,9 +21,9 @@ sidebarIcon: https://app.hash.ai/icons/docs/flows-overview.svg
 
 Flows consist of different kinds of steps:
 
-- [Triggers](/guide/flows/triggers) which
-- [Actions](/guide/flows/actions) which
-- [Filters](/guide/flows/filters) which
+- [Triggers](/guide/flows/triggers) result in a flow's execution
+- [Actions](/guide/flows/actions) do things as part of a flow
+- [Filters](/guide/flows/filters) allow for conditional execution of different actions
 - [Waits](/guide/flows/waits) allow you to pause flows until a trigger is satisfied
 
 # Runs

--- a/apps/hashdotdev/next.config.js
+++ b/apps/hashdotdev/next.config.js
@@ -184,12 +184,12 @@ const nextConfig = {
        */
       {
         source: "/license",
-        destination: "https://hash.ai/legal/developers/license",
+        destination: "https://hash.ai/legal/developers/license-open",
         permanent: true,
       },
       {
         source: "/licence",
-        destination: "https://hash.ai/legal/developers/license",
+        destination: "https://hash.ai/legal/developers/license-open",
         permanent: true,
       },
       /**


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Points to new open license home. Merge after [this PR](https://github.com/hashintel/internal-gitstart/pull/84).