### PR TITLE
H-2500: Add initial currency data types, script for Flow test types

### DIFF
--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/003-create-linear-system-types.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/003-create-linear-system-types.migration.ts
@@ -1,7 +1,4 @@
-import { systemPropertyTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
-import type { BaseUrl } from "@local/hash-subgraph";
 import { linkEntityTypeUrl } from "@local/hash-subgraph";
-import { versionedUrlFromComponents } from "@local/hash-subgraph/type-system-patch";
 
 import { enabledIntegrations } from "../../../../integrations/enabled-integrations";
 import type { MigrationFunction } from "../types";
@@ -9,6 +6,7 @@ import {
   anyUserInstantiator,
   createSystemEntityTypeIfNotExists,
   createSystemPropertyTypeIfNotExists,
+  getCurrentHashPropertyTypeId,
 } from "../util";
 
 const migrate: MigrationFunction = async ({
@@ -505,19 +503,10 @@ const migrate: MigrationFunction = async ({
     },
   );
 
-  const emailPropertyTypeBaseUrl = systemPropertyTypes.email
-    .propertyTypeBaseUrl as BaseUrl;
-
-  const emailPropertyTypeVersion =
-    migrationState.propertyTypeVersions[emailPropertyTypeBaseUrl];
-
-  if (typeof emailPropertyTypeVersion === "undefined") {
-    throw new Error("Expected HASH email property type to have been seeded");
-  }
-  const emailPropertyTypeId = versionedUrlFromComponents(
-    emailPropertyTypeBaseUrl,
-    emailPropertyTypeVersion,
-  );
+  const emailPropertyTypeId = getCurrentHashPropertyTypeId({
+    propertyTypeKey: "email",
+    migrationState,
+  });
 
   const guestPropertyType = await createSystemPropertyTypeIfNotExists(
     context,

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/007-create-api-usage-tracking.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/007-create-api-usage-tracking.migration.ts
@@ -1,6 +1,5 @@
 import type { OwnedById } from "@local/hash-subgraph";
 import { linkEntityTypeUrl } from "@local/hash-subgraph";
-import { versionedUrlFromComponents } from "@local/hash-subgraph/type-system-patch";
 
 import { logger } from "../../../../logger";
 import { createEntity } from "../../../knowledge/primitive/entity";
@@ -10,7 +9,7 @@ import {
   anyUserInstantiator,
   createSystemEntityTypeIfNotExists,
   createSystemPropertyTypeIfNotExists,
-  generateSystemTypeBaseUrl,
+  getCurrentHashDataTypeId,
   getEntitiesByType,
 } from "../util";
 
@@ -76,16 +75,10 @@ const migrate: MigrationFunction = async ({
     },
   );
 
-  const dateDataTypeBaseUrl = generateSystemTypeBaseUrl({
-    kind: "data-type",
-    title: "DateTime",
-    shortname: "hash",
+  const datetimeDataTypeVersionedUrl = getCurrentHashDataTypeId({
+    dataTypeKey: "datetime",
+    migrationState,
   });
-  const dataTypeVersion = migrationState.dataTypeVersions[dateDataTypeBaseUrl]!;
-  const dataTypeVersionUrl = versionedUrlFromComponents(
-    dateDataTypeBaseUrl,
-    dataTypeVersion,
-  );
 
   const appliesFromPropertyType = await createSystemPropertyTypeIfNotExists(
     context,
@@ -94,7 +87,7 @@ const migrate: MigrationFunction = async ({
       propertyTypeDefinition: {
         title: "Applies From",
         description: "The point in time at which something begins to apply",
-        possibleValues: [{ dataTypeId: dataTypeVersionUrl }],
+        possibleValues: [{ dataTypeId: datetimeDataTypeVersionedUrl }],
       },
       webShortname: "hash",
       migrationState,
@@ -108,7 +101,7 @@ const migrate: MigrationFunction = async ({
       propertyTypeDefinition: {
         title: "Applies Until",
         description: "The point at which something ceases to apply",
-        possibleValues: [{ dataTypeId: dataTypeVersionUrl }],
+        possibleValues: [{ dataTypeId: datetimeDataTypeVersionedUrl }],
       },
       webShortname: "hash",
       migrationState,

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/009-add-upload-completed-at-property-type.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/009-add-upload-completed-at-property-type.migration.ts
@@ -1,18 +1,13 @@
 import type { EntityType } from "@blockprotocol/type-system";
-import {
-  systemDataTypes,
-  systemEntityTypes,
-} from "@local/hash-isomorphic-utils/ontology-type-ids";
+import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import type { BaseUrl } from "@local/hash-subgraph";
-import {
-  extractBaseUrl,
-  versionedUrlFromComponents,
-} from "@local/hash-subgraph/type-system-patch";
+import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 
 import { getEntityTypeById } from "../../../ontology/primitive/entity-type";
 import type { MigrationFunction } from "../types";
 import {
   createSystemPropertyTypeIfNotExists,
+  getCurrentHashDataTypeId,
   getCurrentHashSystemEntityTypeId,
   updateSystemEntityType,
   upgradeDependenciesInHashEntityType,
@@ -25,22 +20,11 @@ const migrate: MigrationFunction = async ({
   migrationState,
 }) => {
   /** Step 1: Create the upload completed at */
-  const dateTimeDataTypeBaseUrl = systemDataTypes.datetime
-    .dataTypeBaseUrl as BaseUrl;
 
-  const dateTimeDataTypeVersion =
-    migrationState.dataTypeVersions[dateTimeDataTypeBaseUrl];
-
-  if (typeof dateTimeDataTypeVersion === "undefined") {
-    throw new Error(
-      `Expected data type version for ${dateTimeDataTypeBaseUrl} to be defined`,
-    );
-  }
-
-  const dateTimeDataTypeId = versionedUrlFromComponents(
-    dateTimeDataTypeBaseUrl,
-    dateTimeDataTypeVersion,
-  );
+  const dateTimeDataTypeId = getCurrentHashDataTypeId({
+    dataTypeKey: "datetime",
+    migrationState,
+  });
 
   const uploadCompletedAtPropertyType =
     await createSystemPropertyTypeIfNotExists(context, authentication, {

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/016-add-initial-currency-data-types.dev.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/016-add-initial-currency-data-types.dev.migration.ts
@@ -1,0 +1,32 @@
+import type { MigrationFunction } from "../types";
+import { createSystemDataTypeIfNotExists } from "../util";
+
+const migrate: MigrationFunction = async ({
+  context,
+  authentication,
+  migrationState,
+}) => {
+  await createSystemDataTypeIfNotExists(context, authentication, {
+    dataTypeDefinition: {
+      title: "USD",
+      description: "An amount denominated in US Dollars",
+      type: "number",
+    },
+    webShortname: "hash",
+    migrationState,
+  });
+
+  await createSystemDataTypeIfNotExists(context, authentication, {
+    dataTypeDefinition: {
+      title: "GBP",
+      description: "An amount denominated in British pounds sterling",
+      type: "number",
+    },
+    webShortname: "hash",
+    migrationState,
+  });
+
+  return migrationState;
+};
+
+export default migrate;

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
@@ -35,6 +35,7 @@ import {
 import {
   blockProtocolDataTypes,
   googleEntityTypes,
+  systemDataTypes,
   systemEntityTypes,
   systemLinkEntityTypes,
   systemPropertyTypes,
@@ -321,7 +322,7 @@ export const loadExternalEntityTypeIfNotExists: ImpureGraphFunction<
   return await getEntityTypeById(context, authentication, { entityTypeId });
 };
 
-type PropertyTypeDefinition = {
+export type PropertyTypeDefinition = {
   propertyTypeId: VersionedUrl;
   title: string;
   description?: string;
@@ -898,6 +899,25 @@ export const getCurrentHashPropertyTypeId = ({
   }
 
   return versionedUrlFromComponents(propertyTypeBaseUrl, propertyTypeVersion);
+};
+
+export const getCurrentHashDataTypeId = ({
+  dataTypeKey,
+  migrationState,
+}: {
+  dataTypeKey: keyof typeof systemDataTypes;
+  migrationState: MigrationState;
+}) => {
+  const dataTypeBaseUrl = systemDataTypes[dataTypeKey]
+    .dataTypeBaseUrl as BaseUrl;
+
+  const dataTypeVersion = migrationState.dataTypeVersions[dataTypeBaseUrl];
+
+  if (typeof dataTypeVersion === "undefined") {
+    throw new Error(`Expected '${dataTypeKey}' data type to have been seeded`);
+  }
+
+  return versionedUrlFromComponents(dataTypeBaseUrl, dataTypeVersion);
 };
 
 type BaseUpdateTypeParameters = {

--- a/apps/hash-api/src/graphql/resolvers/ontology/entity-type.ts
+++ b/apps/hash-api/src/graphql/resolvers/ontology/entity-type.ts
@@ -1,6 +1,7 @@
 import type { OntologyTemporalMetadata } from "@local/hash-graph-client";
 import {
   currentTimeInstantTemporalAxes,
+  defaultEntityTypeAuthorizationRelationships,
   fullTransactionTimeAxis,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
@@ -51,27 +52,7 @@ export const createEntityTypeResolver: ResolverFn<
     schema: entityType,
     icon: params.icon ?? undefined,
     labelProperty: (params.labelProperty as BaseUrl | undefined) ?? undefined,
-    relationships: [
-      {
-        relation: "setting",
-        subject: {
-          kind: "setting",
-          subjectId: "updateFromWeb",
-        },
-      },
-      {
-        relation: "viewer",
-        subject: {
-          kind: "public",
-        },
-      },
-      {
-        relation: "instantiator",
-        subject: {
-          kind: "public",
-        },
-      },
-    ],
+    relationships: defaultEntityTypeAuthorizationRelationships,
   });
 
   return createdEntityType;

--- a/apps/hash-api/src/graphql/resolvers/ontology/property-type.ts
+++ b/apps/hash-api/src/graphql/resolvers/ontology/property-type.ts
@@ -1,6 +1,7 @@
 import type { OntologyTemporalMetadata } from "@local/hash-graph-client";
 import {
   currentTimeInstantTemporalAxes,
+  defaultPropertyTypeAuthorizationRelationships,
   fullTransactionTimeAxis,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
@@ -49,21 +50,7 @@ export const createPropertyTypeResolver: ResolverFn<
     {
       ownedById: (ownedById ?? user.accountId) as OwnedById,
       schema: propertyType,
-      relationships: [
-        {
-          relation: "setting",
-          subject: {
-            kind: "setting",
-            subjectId: "updateFromWeb",
-          },
-        },
-        {
-          relation: "viewer",
-          subject: {
-            kind: "public",
-          },
-        },
-      ],
+      relationships: defaultPropertyTypeAuthorizationRelationships,
     },
   );
 

--- a/apps/hash-api/src/seed-data/seed-flow-test-types.ts
+++ b/apps/hash-api/src/seed-data/seed-flow-test-types.ts
@@ -1,0 +1,364 @@
+import { createGraphClient } from "@local/hash-backend-utils/create-graph-client";
+import { getRequiredEnv } from "@local/hash-backend-utils/environment";
+import { NotFoundError } from "@local/hash-backend-utils/error";
+import { getMachineActorId } from "@local/hash-backend-utils/machine-actors";
+import {
+  defaultEntityTypeAuthorizationRelationships,
+  defaultPropertyTypeAuthorizationRelationships,
+} from "@local/hash-isomorphic-utils/graph-queries";
+import {
+  blockProtocolPropertyTypes,
+  systemDataTypes,
+  systemPropertyTypes,
+} from "@local/hash-isomorphic-utils/ontology-type-ids";
+import type {
+  EntityTypeRelationAndSubject,
+  EntityTypeWithMetadata,
+  OwnedById,
+  PropertyTypeWithMetadata,
+} from "@local/hash-subgraph";
+import { linkEntityTypeUrl } from "@local/hash-subgraph";
+import { versionedUrlFromComponents } from "@local/hash-subgraph/type-system-patch";
+
+import { publicUserAccountId } from "../auth/public-user-account-id";
+import type { ImpureGraphFunction } from "../graph/context-types";
+import type {
+  EntityTypeDefinition,
+  PropertyTypeDefinition,
+} from "../graph/ensure-system-graph-is-initialized/migrate-ontology-types/util";
+import {
+  generateSystemEntityTypeSchema,
+  generateSystemPropertyTypeSchema,
+  generateSystemTypeBaseUrl,
+} from "../graph/ensure-system-graph-is-initialized/migrate-ontology-types/util";
+import {
+  createOrg,
+  getOrgByShortname,
+} from "../graph/knowledge/system-types/org";
+import {
+  createEntityType,
+  getEntityTypeById,
+} from "../graph/ontology/primitive/entity-type";
+import {
+  createPropertyType,
+  getPropertyTypeById,
+} from "../graph/ontology/primitive/property-type";
+import { logger } from "../logger";
+
+const webShortname = "ftse";
+const createSystemPropertyTypeIfNotExists: ImpureGraphFunction<
+  {
+    propertyTypeDefinition: Omit<PropertyTypeDefinition, "propertyTypeId">;
+    ownedById: OwnedById;
+  },
+  Promise<PropertyTypeWithMetadata>
+> = async (context, authentication, { propertyTypeDefinition, ownedById }) => {
+  const { title } = propertyTypeDefinition;
+
+  const baseUrl = generateSystemTypeBaseUrl({
+    kind: "property-type",
+    title,
+    // @ts-expect-error -- temporary seeding script
+    shortname: webShortname,
+  });
+
+  const versionNumber = 1;
+
+  const propertyTypeId = versionedUrlFromComponents(baseUrl, versionNumber);
+
+  const existingPropertyType = await getPropertyTypeById(
+    context,
+    authentication,
+    { propertyTypeId },
+  ).catch((error: Error) => {
+    if (error instanceof NotFoundError) {
+      return null;
+    }
+    throw error;
+  });
+
+  if (existingPropertyType) {
+    return existingPropertyType;
+  }
+
+  const propertyTypeSchema = generateSystemPropertyTypeSchema({
+    ...propertyTypeDefinition,
+    propertyTypeId,
+  });
+
+  const createdPropertyType = await createPropertyType(
+    context,
+    authentication,
+    {
+      ownedById,
+      schema: propertyTypeSchema,
+      webShortname,
+      relationships: defaultPropertyTypeAuthorizationRelationships,
+    },
+  ).catch((createError) => {
+    throw createError;
+  });
+
+  return createdPropertyType;
+};
+
+const createSystemEntityTypeIfNotExists: ImpureGraphFunction<
+  {
+    entityTypeDefinition: Omit<EntityTypeDefinition, "entityTypeId">;
+    ownedById: OwnedById;
+  },
+  Promise<EntityTypeWithMetadata>
+> = async (context, authentication, { entityTypeDefinition, ownedById }) => {
+  const { title } = entityTypeDefinition;
+  const baseUrl = generateSystemTypeBaseUrl({
+    kind: "entity-type",
+    title,
+    // @ts-expect-error -- temporary seeding script
+    shortname: webShortname,
+  });
+
+  const versionNumber = 1;
+
+  const entityTypeId = versionedUrlFromComponents(baseUrl, versionNumber);
+
+  const existingEntityType = await getEntityTypeById(context, authentication, {
+    entityTypeId,
+  }).catch((error: Error) => {
+    if (error instanceof NotFoundError) {
+      return null;
+    }
+    throw error;
+  });
+
+  if (existingEntityType) {
+    return existingEntityType;
+  }
+
+  const entityTypeSchema = generateSystemEntityTypeSchema({
+    ...entityTypeDefinition,
+    entityTypeId,
+  });
+
+  const relationships: EntityTypeRelationAndSubject[] =
+    defaultEntityTypeAuthorizationRelationships;
+
+  const createdEntityType = await createEntityType(context, authentication, {
+    ownedById,
+    schema: entityTypeSchema,
+    webShortname,
+    relationships,
+  }).catch((createError) => {
+    throw createError;
+  });
+
+  return createdEntityType;
+};
+
+/**
+ * When this script is deleted, also remove 'ftse' from getEntityTypeBaseUrl in the frontend
+ */
+const seedFlowTestTypes = async () => {
+  const graphApi = createGraphClient(logger, {
+    host: getRequiredEnv("HASH_GRAPH_API_HOST"),
+    port: parseInt(getRequiredEnv("HASH_GRAPH_API_PORT"), 10),
+  });
+
+  const context = { graphApi };
+
+  const hashBotActorId = await getMachineActorId(
+    context,
+    { actorId: publicUserAccountId },
+    { identifier: "hash" },
+  );
+
+  const authentication = { actorId: hashBotActorId };
+
+  let org = await getOrgByShortname(context, authentication, {
+    shortname: webShortname,
+  });
+
+  if (!org) {
+    org = await createOrg(context, authentication, {
+      shortname: webShortname,
+      name: "FTSE",
+    });
+  }
+
+  const ownedById = org.accountGroupId as OwnedById;
+
+  const valuePropertyType = await createSystemPropertyTypeIfNotExists(
+    context,
+    authentication,
+    {
+      propertyTypeDefinition: {
+        title: "Value",
+        description: "The value of something",
+        possibleValues: [{ dataTypeId: systemDataTypes.usd.dataTypeId }],
+      },
+      ownedById,
+    },
+  );
+
+  const measuredOnPropertyType = await createSystemPropertyTypeIfNotExists(
+    context,
+    authentication,
+    {
+      propertyTypeDefinition: {
+        title: "Measured On",
+        description: "The date and time at which something was measured.",
+        possibleValues: [{ dataTypeId: systemDataTypes.datetime.dataTypeId }],
+      },
+      ownedById,
+    },
+  );
+
+  const marketCapitalizationPropertyType =
+    await createSystemPropertyTypeIfNotExists(context, authentication, {
+      propertyTypeDefinition: {
+        title: "Market Capitalization",
+        description: "The market capitalization of a company.",
+        possibleValues: [
+          {
+            propertyTypeObjectProperties: {
+              [measuredOnPropertyType.metadata.recordId.baseUrl]: {
+                $ref: measuredOnPropertyType.schema.$id,
+              },
+              [valuePropertyType.metadata.recordId.baseUrl]: {
+                $ref: valuePropertyType.schema.$id,
+              },
+            },
+            propertyTypeObjectRequiredProperties: [
+              measuredOnPropertyType.metadata.recordId.baseUrl,
+              valuePropertyType.metadata.recordId.baseUrl,
+            ],
+          },
+        ],
+      },
+      ownedById,
+    });
+
+  const investedInLinkEntityType = await createSystemEntityTypeIfNotExists(
+    context,
+    authentication,
+    {
+      entityTypeDefinition: {
+        allOf: [linkEntityTypeUrl],
+        title: "Invested In",
+        description: "Something that something is invested in",
+        properties: [
+          {
+            propertyType: valuePropertyType.schema.$id,
+            required: true,
+          },
+          { propertyType: measuredOnPropertyType.schema.$id },
+        ],
+      },
+      ownedById,
+    },
+  );
+
+  const appearsInIndexLinkEntityType = await createSystemEntityTypeIfNotExists(
+    context,
+    authentication,
+    {
+      entityTypeDefinition: {
+        allOf: [linkEntityTypeUrl],
+        title: "Appears In Index",
+        description: "The index that something appears in.",
+        properties: [
+          {
+            propertyType: systemPropertyTypes.appliesFrom.propertyTypeId,
+            required: true,
+          },
+          { propertyType: systemPropertyTypes.appliesUntil.propertyTypeId },
+        ],
+      },
+      ownedById,
+    },
+  );
+
+  const stockMarketIndexEntityType = await createSystemEntityTypeIfNotExists(
+    context,
+    authentication,
+    {
+      entityTypeDefinition: {
+        title: "Stock Market Index",
+        description: "A stock market index.",
+        properties: [
+          {
+            propertyType: blockProtocolPropertyTypes.name.propertyTypeId,
+            required: true,
+          },
+          {
+            propertyType: blockProtocolPropertyTypes.description.propertyTypeId,
+            required: true,
+          },
+        ],
+      },
+      ownedById,
+    },
+  );
+
+  const stockMarketConstituentEntityType =
+    await createSystemEntityTypeIfNotExists(context, authentication, {
+      entityTypeDefinition: {
+        title: "Stock Market Constituent",
+        description: "A stock market constituent.",
+        properties: [
+          {
+            propertyType: blockProtocolPropertyTypes.name.propertyTypeId,
+            required: true,
+          },
+          {
+            propertyType: blockProtocolPropertyTypes.description.propertyTypeId,
+            required: true,
+          },
+          {
+            propertyType: marketCapitalizationPropertyType.schema.$id,
+            array: true,
+          },
+        ],
+        outgoingLinks: [
+          {
+            linkEntityType: appearsInIndexLinkEntityType,
+            destinationEntityTypes: [stockMarketIndexEntityType],
+          },
+          {
+            linkEntityType: investedInLinkEntityType,
+            destinationEntityTypes: ["SELF_REFERENCE"],
+          },
+        ],
+      },
+      ownedById,
+    });
+
+  const _investmentFundEntityType = await createSystemEntityTypeIfNotExists(
+    context,
+    authentication,
+    {
+      entityTypeDefinition: {
+        title: "Investment Fund",
+        description: "An investment fund.",
+        properties: [
+          {
+            propertyType: blockProtocolPropertyTypes.name.propertyTypeId,
+            required: true,
+          },
+          {
+            propertyType: blockProtocolPropertyTypes.description.propertyTypeId,
+            required: true,
+          },
+        ],
+        outgoingLinks: [
+          {
+            linkEntityType: investedInLinkEntityType,
+            destinationEntityTypes: [stockMarketConstituentEntityType],
+          },
+        ],
+      },
+      ownedById,
+    },
+  );
+};
+
+await seedFlowTestTypes();

--- a/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/get-entity-type-base-url.ts
+++ b/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/get-entity-type-base-url.ts
@@ -10,7 +10,7 @@ export const getEntityTypeBaseUrl = (
   `${
     // To be removed in H-1172: Temporary provision until https://app.hash.ai migrated to https://hash.ai
     // To be replaced with simply 'frontendUrl'
-    (systemTypeWebShortnames.includes(
+    ([...systemTypeWebShortnames, "ftse"].includes(
       namespaceWithAt.slice(1) as SystemTypeWebShortname,
     ) &&
       frontendUrl === "http://localhost:3000") ||

--- a/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
@@ -11,6 +11,8 @@ import type {
 import type {
   AccountId,
   EntityRelationAndSubject,
+  EntityTypeRelationAndSubject,
+  PropertyTypeRelationAndSubject,
   QueryTemporalAxesUnresolved,
   Subgraph,
   SubgraphRootType,
@@ -256,3 +258,43 @@ export const createOrgMembershipAuthorizationRelationships = ({
     },
   },
 ];
+
+export const defaultPropertyTypeAuthorizationRelationships: PropertyTypeRelationAndSubject[] =
+  [
+    {
+      relation: "setting",
+      subject: {
+        kind: "setting",
+        subjectId: "updateFromWeb",
+      },
+    },
+    {
+      relation: "viewer",
+      subject: {
+        kind: "public",
+      },
+    },
+  ];
+
+export const defaultEntityTypeAuthorizationRelationships: EntityTypeRelationAndSubject[] =
+  [
+    {
+      relation: "setting",
+      subject: {
+        kind: "setting",
+        subjectId: "updateFromWeb",
+      },
+    },
+    {
+      relation: "viewer",
+      subject: {
+        kind: "public",
+      },
+    },
+    {
+      relation: "instantiator",
+      subject: {
+        kind: "public",
+      },
+    },
+  ];

--- a/libs/@local/hash-isomorphic-utils/src/ontology-type-ids.ts
+++ b/libs/@local/hash-isomorphic-utils/src/ontology-type-ids.ts
@@ -736,6 +736,12 @@ export const systemDataTypes = {
     description:
       "An identifier for an email box to which messages are delivered.",
   },
+  gbp: {
+    dataTypeId: "https://hash.ai/@hash/types/data-type/gbp/v/1",
+    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/gbp/",
+    title: "GBP",
+    description: "An amount denominated in British pounds sterling",
+  },
   kilometers: {
     dataTypeId: "https://hash.ai/@hash/types/data-type/kilometers/v/1",
     dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/kilometers/",
@@ -776,6 +782,12 @@ export const systemDataTypes = {
     dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/uri/",
     title: "URI",
     description: "A unique identifier for a resource (e.g. a URL, or URN).",
+  },
+  usd: {
+    dataTypeId: "https://hash.ai/@hash/types/data-type/usd/v/1",
+    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/usd/",
+    title: "USD",
+    description: "An amount denominated in US Dollars",
   },
 } as const;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

1. Adds some initial currency data types (GBP and USD)
2. Adds a script to seed minimal types for testing an example Flow
3. Cleans up migration scripts to consistently use `getCurrentXTypeId` instead of a few scripts implementing it themselves

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. From the repo root, run

```
npx tsx apps/hash-api/src/seed-data/seed-flow-test-types.ts
```

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

https://github.com/hashintel/hash/assets/37743469/39c00393-cde5-47e9-be76-e94a29e29c83


