### PR TITLE
H-2465: Support confidence values for entities, links, and properties

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,7 +1014,6 @@ dependencies = [
  "graph-test-data",
  "graph-types",
  "hash-status",
- "json-patch",
  "mime",
  "postgres-types",
  "refinery",
@@ -1058,7 +1057,6 @@ dependencies = [
  "http-body-util",
  "hyper 1.2.0",
  "include_dir",
- "json-patch",
  "mime",
  "opentelemetry 0.21.0",
  "opentelemetry_sdk 0.21.2",
@@ -1112,7 +1110,6 @@ dependencies = [
  "graph",
  "graph-test-data",
  "graph-types",
- "json-patch",
  "pretty_assertions",
  "rand",
  "serde",
@@ -1134,12 +1131,15 @@ name = "graph-types"
 version = "0.0.0"
 dependencies = [
  "bytes",
+ "error-stack",
  "graph-test-data",
+ "json-patch",
  "postgres-types",
  "pretty_assertions",
  "serde",
  "serde_json",
  "temporal-versioning",
+ "thiserror",
  "time",
  "type-system",
  "utoipa",
@@ -1611,7 +1611,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "utoipa",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -85,7 +85,7 @@ checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -411,7 +411,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -644,7 +644,7 @@ checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -757,7 +757,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -905,7 +905,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2055,7 +2055,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2107,7 +2107,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2313,7 +2313,7 @@ dependencies = [
 name = "query-builder-derive"
 version = "0.1.0"
 dependencies = [
- "syn 2.0.57",
+ "syn 2.0.58",
  "trybuild",
  "virtue",
 ]
@@ -2427,7 +2427,7 @@ dependencies = [
  "quote",
  "refinery-core",
  "regex",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2900,7 +2900,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2911,7 +2911,7 @@ checksum = "e578a843d40b4189a4d66bba51d7684f57da5bd7c304c64e14bd63efbef49509"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -3085,9 +3085,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.57"
+version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a6ae1e52eb25aab8f3fb9fca13be982a373b8f1157ca14b897a825ba4a2d35"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3306,7 +3306,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -3411,7 +3411,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -3662,7 +3662,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -3801,7 +3801,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -3862,7 +3862,7 @@ checksum = "ac73887f47b9312552aa90ef477927ff014d63d1920ca8037c6c1951eab64bb1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -3956,7 +3956,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
  "url",
  "uuid",
 ]
@@ -4066,7 +4066,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
  "wasm-bindgen-shared",
 ]
 
@@ -4100,7 +4100,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4133,7 +4133,7 @@ checksum = "b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]

--- a/apps/hash-api/src/graph/knowledge/primitive/entity.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity.ts
@@ -127,6 +127,7 @@ export const createEntity: ImpureGraphFunction<
     entityUuid: overrideEntityUuid,
     draft,
     relationships: params.relationships,
+    propertyConfidence,
   });
 
   const entity = {

--- a/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
@@ -22,10 +22,7 @@ use graph::{
 use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::{
     account::AccountId,
-    knowledge::{
-        entity::{EntityMetadata, PropertyObject},
-        link::LinkData,
-    },
+    knowledge::{entity::EntityMetadata, link::LinkData, PropertyObject},
     owned_by_id::OwnedById,
 };
 use rand::{prelude::IteratorRandom, thread_rng};

--- a/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
@@ -23,7 +23,7 @@ use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::{
     account::AccountId,
     knowledge::{
-        entity::{EntityMetadata, EntityProperties},
+        entity::{EntityMetadata, PropertyObject},
         link::LinkData,
     },
     owned_by_id::OwnedById,
@@ -106,7 +106,7 @@ async fn seed_db(
     )
     .await;
 
-    let properties: EntityProperties =
+    let properties: PropertyObject =
         serde_json::from_str(entity::BOOK_V1).expect("could not parse entity");
     let entity_type: EntityType =
         serde_json::from_str(entity_type::BOOK_V1).expect("could not parse entity type");

--- a/apps/hash-graph/bench/read_scaling/knowledge/linkless/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/linkless/entity.rs
@@ -22,7 +22,7 @@ use graph::{
 use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::{
     account::AccountId,
-    knowledge::entity::{EntityMetadata, PropertyObject},
+    knowledge::{entity::EntityMetadata, PropertyObject},
     owned_by_id::OwnedById,
 };
 use rand::{prelude::IteratorRandom, thread_rng};

--- a/apps/hash-graph/bench/read_scaling/knowledge/linkless/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/linkless/entity.rs
@@ -22,7 +22,7 @@ use graph::{
 use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::{
     account::AccountId,
-    knowledge::entity::{EntityMetadata, EntityProperties},
+    knowledge::entity::{EntityMetadata, PropertyObject},
     owned_by_id::OwnedById,
 };
 use rand::{prelude::IteratorRandom, thread_rng};
@@ -94,7 +94,7 @@ async fn seed_db(
     )
     .await;
 
-    let properties: EntityProperties =
+    let properties: PropertyObject =
         serde_json::from_str(entity::BOOK_V1).expect("could not parse entity");
     let entity_type: EntityType =
         serde_json::from_str(entity_type::BOOK_V1).expect("could not parse entity type");

--- a/apps/hash-graph/bench/representative_read/seed.rs
+++ b/apps/hash-graph/bench/representative_read/seed.rs
@@ -12,10 +12,7 @@ use graph::store::{
 use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::{
     account::AccountId,
-    knowledge::{
-        entity::{EntityUuid, PropertyObject},
-        link::LinkData,
-    },
+    knowledge::{entity::EntityUuid, link::LinkData, PropertyObject},
     owned_by_id::OwnedById,
 };
 use type_system::{url::VersionedUrl, EntityType};

--- a/apps/hash-graph/bench/representative_read/seed.rs
+++ b/apps/hash-graph/bench/representative_read/seed.rs
@@ -13,7 +13,7 @@ use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::{
     account::AccountId,
     knowledge::{
-        entity::{EntityProperties, EntityUuid},
+        entity::{EntityUuid, PropertyObject},
         link::LinkData,
     },
     owned_by_id::OwnedById,
@@ -164,7 +164,7 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
     let mut total_link_entities = 0;
     let mut entity_uuids = Vec::new();
     for (entity_type_str, entity_str, quantity) in SEED_ENTITIES {
-        let properties: EntityProperties =
+        let properties: PropertyObject =
             serde_json::from_str(entity_str).expect("could not parse entity");
         let entity_type: EntityType =
             serde_json::from_str(entity_type_str).expect("could not parse entity type");
@@ -207,7 +207,7 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
                         (
                             OwnedById::new(account_id.into_uuid()),
                             None,
-                            EntityProperties::empty(),
+                            PropertyObject::empty(),
                             Some(LinkData {
                                 left_entity_id: left_entity_metadata.record_id.entity_id,
                                 right_entity_id: right_entity_metadata.record_id.entity_id,

--- a/apps/hash-graph/libs/api/Cargo.toml
+++ b/apps/hash-graph/libs/api/Cargo.toml
@@ -29,7 +29,6 @@ futures = { workspace = true }
 http-body-util = "0.1.1"
 hyper = "1.2.0"
 include_dir = "0.7.3"
-json-patch = { version = "1.2.0", default-features = false, features = ["utoipa"] }
 mime = "0.3.17"
 opentelemetry = "0.21.0"
 opentelemetry_sdk = { version = "0.21.2", features = ["rt-tokio"] }

--- a/apps/hash-graph/libs/api/src/rest/entity.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity.rs
@@ -39,11 +39,11 @@ use graph_types::{
     knowledge::{
         entity::{
             Entity, EntityEditionId, EntityEditionProvenanceMetadata, EntityEmbedding, EntityId,
-            EntityMetadata, EntityProperties, EntityProvenanceMetadata, EntityRecordId,
-            EntityTemporalMetadata, EntityUuid, PropertyPath,
+            EntityMetadata, EntityProvenanceMetadata, EntityRecordId, EntityTemporalMetadata,
+            EntityUuid, PropertyObject,
         },
         link::LinkData,
-        Confidence,
+        Confidence, PropertyPath,
     },
     owned_by_id::OwnedById,
     Embedding,
@@ -127,7 +127,7 @@ use crate::rest::{
             EntityMetadata,
             EntityProvenanceMetadata,
             EntityEditionProvenanceMetadata,
-            EntityProperties,
+            PropertyObject,
             EntityRecordId,
             EntityTemporalMetadata,
             EntityQueryToken,

--- a/apps/hash-graph/libs/api/src/rest/entity.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity.rs
@@ -40,17 +40,14 @@ use graph_types::{
         entity::{
             Entity, EntityEditionId, EntityEditionProvenanceMetadata, EntityEmbedding, EntityId,
             EntityMetadata, EntityProvenanceMetadata, EntityRecordId, EntityTemporalMetadata,
-            EntityUuid, PropertyObject,
+            EntityUuid,
         },
         link::LinkData,
-        Confidence, PropertyPath,
+        Confidence, Property, PropertyConfidence, PropertyObject, PropertyPatchOperation,
+        PropertyPath,
     },
     owned_by_id::OwnedById,
     Embedding,
-};
-use json_patch::{
-    AddOperation, CopyOperation, MoveOperation, PatchOperation, RemoveOperation, ReplaceOperation,
-    TestOperation,
 };
 use serde::{Deserialize, Serialize};
 use temporal_client::TemporalClient;
@@ -93,13 +90,7 @@ use crate::rest::{
             EntityStructuralQuery,
 
             PatchEntityParams,
-            PatchOperation,
-            AddOperation,
-            ReplaceOperation,
-            RemoveOperation,
-            CopyOperation,
-            MoveOperation,
-            TestOperation,
+            PropertyPatchOperation,
 
             EntityRelationAndSubject,
             EntityPermission,
@@ -121,13 +112,15 @@ use crate::rest::{
             GetEntityByQueryResponse,
 
             Entity,
+            Property,
+            PropertyObject,
+            PropertyConfidence,
             EntityUuid,
             EntityId,
             EntityEditionId,
             EntityMetadata,
             EntityProvenanceMetadata,
             EntityEditionProvenanceMetadata,
-            PropertyObject,
             EntityRecordId,
             EntityTemporalMetadata,
             EntityQueryToken,

--- a/apps/hash-graph/libs/graph/Cargo.toml
+++ b/apps/hash-graph/libs/graph/Cargo.toml
@@ -32,7 +32,6 @@ bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"], optional = true }
 derivative = "2.2.0"
 dotenv-flow = "0.16.2"
-json-patch = { version = "1.2.0", default-features = false }
 futures = { workspace = true }
 mime = "0.3.17"
 refinery = { version = "0.8", features = ["tokio-postgres"] }
@@ -56,4 +55,4 @@ tokio = { workspace = true, features = ["macros"] }
 
 [features]
 clap = ["dep:clap"]
-utoipa = ["dep:utoipa", "graph-types/utoipa", "temporal-versioning/utoipa", "authorization/utoipa", "json-patch/utoipa"]
+utoipa = ["dep:utoipa", "graph-types/utoipa", "temporal-versioning/utoipa", "authorization/utoipa"]

--- a/apps/hash-graph/libs/graph/src/snapshot/entity/channel.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/entity/channel.rs
@@ -102,17 +102,6 @@ impl Sink<EntitySnapshotRecord> for EntitySender {
                 .attach_printable("could not send entity draft id")?;
         }
 
-        self.edition
-            .start_send_unpin(EntityEditionRow {
-                entity_edition_id: entity.metadata.record_id.edition_id,
-                properties: entity.properties,
-                edition_created_by_id: entity.metadata.provenance.edition.created_by_id,
-                archived: entity.metadata.archived,
-                confidence: entity.metadata.confidence,
-            })
-            .change_context(SnapshotRestoreError::Read)
-            .attach_printable("could not send entity edition")?;
-
         for (path, confidence) in entity.metadata.property_confidence {
             self.property
                 .start_send_unpin(EntityPropertyRow {
@@ -123,6 +112,17 @@ impl Sink<EntitySnapshotRecord> for EntitySender {
                 .change_context(SnapshotRestoreError::Read)
                 .attach_printable("could not send entity property")?;
         }
+
+        self.edition
+            .start_send_unpin(EntityEditionRow {
+                entity_edition_id: entity.metadata.record_id.edition_id,
+                properties: entity.properties,
+                edition_created_by_id: entity.metadata.provenance.edition.created_by_id,
+                archived: entity.metadata.archived,
+                confidence: entity.metadata.confidence,
+            })
+            .change_context(SnapshotRestoreError::Read)
+            .attach_printable("could not send entity edition")?;
 
         for is_of_type in &entity.metadata.entity_type_ids {
             self.is_of_type

--- a/apps/hash-graph/libs/graph/src/snapshot/entity/record.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/entity/record.rs
@@ -1,7 +1,7 @@
 use authorization::schema::EntityRelationAndSubject;
 use graph_types::{
     knowledge::{
-        entity::{EntityId, EntityMetadata, EntityProperties, EntityUuid},
+        entity::{EntityId, EntityMetadata, EntityUuid, PropertyObject},
         link::LinkData,
     },
     Embedding,
@@ -13,7 +13,7 @@ use type_system::url::BaseUrl;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EntitySnapshotRecord {
-    pub properties: EntityProperties,
+    pub properties: PropertyObject,
     pub metadata: EntityMetadata,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub link_data: Option<LinkData>,

--- a/apps/hash-graph/libs/graph/src/snapshot/entity/record.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/entity/record.rs
@@ -1,8 +1,9 @@
 use authorization::schema::EntityRelationAndSubject;
 use graph_types::{
     knowledge::{
-        entity::{EntityId, EntityMetadata, EntityUuid, PropertyObject},
+        entity::{EntityId, EntityMetadata, EntityUuid},
         link::LinkData,
+        PropertyObject,
     },
     Embedding,
 };

--- a/apps/hash-graph/libs/graph/src/snapshot/entity/table.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/entity/table.rs
@@ -1,8 +1,8 @@
 use graph_types::{
     account::{CreatedById, EditionCreatedById},
     knowledge::{
-        entity::{DraftId, EntityEditionId, EntityProperties, EntityUuid, PropertyPath},
-        Confidence,
+        entity::{DraftId, EntityEditionId, EntityUuid, PropertyObject},
+        Confidence, PropertyPath,
     },
     owned_by_id::OwnedById,
     Embedding,
@@ -35,7 +35,7 @@ pub struct EntityDraftRow {
 #[postgres(name = "entity_editions")]
 pub struct EntityEditionRow {
     pub entity_edition_id: EntityEditionId,
-    pub properties: EntityProperties,
+    pub properties: PropertyObject,
     pub edition_created_by_id: EditionCreatedById,
     pub archived: bool,
     pub confidence: Option<Confidence>,

--- a/apps/hash-graph/libs/graph/src/snapshot/entity/table.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/entity/table.rs
@@ -1,8 +1,8 @@
 use graph_types::{
     account::{CreatedById, EditionCreatedById},
     knowledge::{
-        entity::{DraftId, EntityEditionId, EntityUuid, PropertyObject},
-        Confidence, PropertyPath,
+        entity::{DraftId, EntityEditionId, EntityUuid},
+        Confidence, PropertyObject, PropertyPath,
     },
     owned_by_id::OwnedById,
     Embedding,

--- a/apps/hash-graph/libs/graph/src/snapshot/mod.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/mod.rs
@@ -97,7 +97,6 @@ pub enum AuthorizationRelation {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "type", deny_unknown_fields)]
-#[expect(clippy::large_enum_variant)]
 pub enum SnapshotEntry {
     Snapshot(SnapshotMetadata),
     Account(Account),

--- a/apps/hash-graph/libs/graph/src/snapshot/mod.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/mod.rs
@@ -108,7 +108,7 @@ pub enum SnapshotEntry {
     PropertyTypeEmbedding(PropertyTypeEmbeddingRecord),
     EntityType(EntityTypeSnapshotRecord),
     EntityTypeEmbedding(EntityTypeEmbeddingRecord),
-    Entity(EntitySnapshotRecord),
+    Entity(Box<EntitySnapshotRecord>),
     EntityEmbedding(EntityEmbeddingRecord),
     Relation(AuthorizationRelation),
 }
@@ -649,11 +649,11 @@ where
                 self.create_dump_stream::<Entity>()
                     .try_flatten_stream()
                     .and_then(move |entity| async move {
-                        Ok(SnapshotEntry::Entity(EntitySnapshotRecord {
+                        Ok(SnapshotEntry::Entity(Box::new(EntitySnapshotRecord {
                             properties: entity.properties,
                             link_data: entity.link_data,
                             metadata: entity.metadata,
-                        }))
+                        })))
                     })
                     .forward(snapshot_record_tx.clone()),
             );

--- a/apps/hash-graph/libs/graph/src/snapshot/restore/channel.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/restore/channel.rs
@@ -145,7 +145,7 @@ impl Sink<SnapshotEntry> for SnapshotRecordSender {
                 .attach_printable("could not send entity type embedding"),
             SnapshotEntry::Entity(entity) => self
                 .entity
-                .start_send_unpin(entity)
+                .start_send_unpin(*entity)
                 .attach_printable("could not send entity"),
             SnapshotEntry::Relation(AuthorizationRelation::Entity {
                 object: entity_uuid,

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -14,8 +14,9 @@ use error_stack::{Report, Result, ResultExt};
 use graph_types::{
     account::AccountId,
     knowledge::{
-        entity::{EntityMetadata, EntityUuid, PropertyObject},
+        entity::{EntityMetadata, EntityUuid},
         link::LinkData,
+        PropertyObject,
     },
     ontology::{
         DataTypeMetadata, EntityTypeMetadata, OntologyTemporalMetadata, OntologyType,

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -14,7 +14,7 @@ use error_stack::{Report, Result, ResultExt};
 use graph_types::{
     account::AccountId,
     knowledge::{
-        entity::{EntityMetadata, EntityProperties, EntityUuid},
+        entity::{EntityMetadata, EntityUuid, PropertyObject},
         link::LinkData,
     },
     ontology::{
@@ -1275,7 +1275,7 @@ where
             Item = (
                 OwnedById,
                 Option<EntityUuid>,
-                EntityProperties,
+                PropertyObject,
                 Option<LinkData>,
                 Option<Timestamp<DecisionTime>>,
             ),

--- a/apps/hash-graph/libs/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/libs/graph/src/store/knowledge.rs
@@ -7,7 +7,7 @@ use graph_types::{
     knowledge::{
         entity::{Entity, EntityEmbedding, EntityId, EntityMetadata, EntityUuid},
         link::LinkData,
-        PropertyConfidence, PropertyObject, PropertyPatchOperation,
+        Confidence, PropertyConfidence, PropertyObject, PropertyPatchOperation,
     },
     owned_by_id::OwnedById,
 };
@@ -182,6 +182,9 @@ pub struct CreateEntityParams<R> {
     pub entity_type_ids: Vec<VersionedUrl>,
     pub properties: PropertyObject,
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<Confidence>,
+    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     #[serde(default, skip_serializing_if = "PropertyConfidence::is_empty")]
     pub property_confidence: PropertyConfidence<'static>,
     #[serde(default)]
@@ -239,6 +242,9 @@ pub struct PatchEntityParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     pub archived: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
+    pub confidence: Option<Confidence>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -23,10 +23,11 @@ use graph_types::{
     knowledge::{
         entity::{
             DraftId, Entity, EntityEditionId, EntityEditionProvenanceMetadata, EntityEmbedding,
-            EntityId, EntityMetadata, EntityProperties, EntityProvenanceMetadata, EntityRecordId,
-            EntityTemporalMetadata, EntityUuid, PropertyPath,
+            EntityId, EntityMetadata, EntityProvenanceMetadata, EntityRecordId,
+            EntityTemporalMetadata, EntityUuid, PropertyObject,
         },
         link::LinkData,
+        PropertyPath,
     },
     owned_by_id::OwnedById,
     Embedding,
@@ -769,7 +770,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             Item = (
                 OwnedById,
                 Option<EntityUuid>,
-                EntityProperties,
+                PropertyObject,
                 Option<LinkData>,
                 Option<Timestamp<DecisionTime>>,
             ),
@@ -1506,7 +1507,7 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
         edition_created_by_id: EditionCreatedById,
         archived: bool,
         entity_type_ids: &[VersionedUrl],
-        properties: &EntityProperties,
+        properties: &PropertyObject,
     ) -> Result<(EntityEditionId, ClosedEntityType), InsertionError> {
         let edition_id: EntityEditionId = self
             .as_client()

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/query.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/query.rs
@@ -4,10 +4,10 @@ use graph_types::{
     knowledge::{
         entity::{
             Entity, EntityEditionProvenanceMetadata, EntityId, EntityMetadata,
-            EntityProvenanceMetadata, EntityRecordId, EntityUuid, PropertyPath,
+            EntityProvenanceMetadata, EntityRecordId, EntityUuid,
         },
         link::LinkData,
-        Confidence,
+        Confidence, PropertyPath,
     },
     owned_by_id::OwnedById,
 };

--- a/apps/hash-graph/libs/graph/src/store/postgres/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/mod.rs
@@ -22,7 +22,10 @@ use authorization::{
 use error_stack::{Report, Result, ResultExt};
 use graph_types::{
     account::{AccountGroupId, AccountId, CreatedById, EditionArchivedById, EditionCreatedById},
-    knowledge::entity::{EntityEditionId, EntityId, EntityTemporalMetadata, PropertyObject},
+    knowledge::{
+        entity::{EntityEditionId, EntityId, EntityTemporalMetadata},
+        PropertyObject,
+    },
     ontology::{
         OntologyTemporalMetadata, OntologyTypeClassificationMetadata, OntologyTypeRecordId,
     },

--- a/apps/hash-graph/libs/graph/src/store/postgres/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/mod.rs
@@ -22,7 +22,7 @@ use authorization::{
 use error_stack::{Report, Result, ResultExt};
 use graph_types::{
     account::{AccountGroupId, AccountId, CreatedById, EditionArchivedById, EditionCreatedById},
-    knowledge::entity::{EntityEditionId, EntityId, EntityProperties, EntityTemporalMetadata},
+    knowledge::entity::{EntityEditionId, EntityId, EntityTemporalMetadata, PropertyObject},
     ontology::{
         OntologyTemporalMetadata, OntologyTypeClassificationMetadata, OntologyTypeRecordId,
     },
@@ -1121,7 +1121,7 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
 
     async fn insert_entity_records(
         &self,
-        entities: impl IntoIterator<Item = EntityProperties, IntoIter: Send> + Send,
+        entities: impl IntoIterator<Item = PropertyObject, IntoIter: Send> + Send,
         actor_id: EditionCreatedById,
     ) -> Result<Vec<EntityEditionId>, InsertionError> {
         self.client

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -2622,23 +2622,6 @@
         "type": "string",
         "format": "uuid"
       },
-      "AddOperation": {
-        "type": "object",
-        "description": "JSON Patch 'add' operation representation",
-        "required": [
-          "path",
-          "value"
-        ],
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location\nwithin the target document where the operation is performed."
-          },
-          "value": {
-            "description": "Value to add to the target location."
-          }
-        }
-      },
       "ArchiveDataTypeParams": {
         "type": "object",
         "required": [
@@ -2710,24 +2693,6 @@
         "format": "double",
         "maximum": 1,
         "minimum": 0
-      },
-      "CopyOperation": {
-        "type": "object",
-        "description": "JSON Patch 'copy' operation representation",
-        "required": [
-          "from",
-          "path"
-        ],
-        "properties": {
-          "from": {
-            "type": "string",
-            "description": "JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location\nto copy value from."
-          },
-          "path": {
-            "type": "string",
-            "description": "JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location\nwithin the target document where the operation is performed."
-          }
-        }
       },
       "CreateDataTypeRequest": {
         "type": "object",
@@ -2806,7 +2771,14 @@
             "$ref": "#/components/schemas/OwnedById"
           },
           "properties": {
-            "$ref": "#/components/schemas/EntityProperties"
+            "$ref": "#/components/schemas/PropertyObject"
+          },
+          "propertyConfidence": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PropertyConfidence"
+              }
+            ]
           },
           "relationships": {
             "type": "array",
@@ -3193,7 +3165,7 @@
             "$ref": "#/components/schemas/EntityMetadata"
           },
           "properties": {
-            "$ref": "#/components/schemas/EntityProperties"
+            "$ref": "#/components/schemas/PropertyObject"
           }
         }
       },
@@ -3364,10 +3336,11 @@
             }
           },
           "propertyConfidence": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/Confidence"
-            }
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PropertyConfidence"
+              }
+            ]
           },
           "provenance": {
             "$ref": "#/components/schemas/EntityProvenanceMetadata"
@@ -3413,10 +3386,6 @@
           "update",
           "view"
         ]
-      },
-      "EntityProperties": {
-        "type": "object",
-        "description": "The properties of an entity.\n\nWhen expressed as JSON, this should validate against its respective entity type(s)."
       },
       "EntityProvenanceMetadata": {
         "type": "object",
@@ -5014,24 +4983,6 @@
           }
         }
       },
-      "MoveOperation": {
-        "type": "object",
-        "description": "JSON Patch 'move' operation representation",
-        "required": [
-          "from",
-          "path"
-        ],
-        "properties": {
-          "from": {
-            "type": "string",
-            "description": "JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location\nto move value from."
-          },
-          "path": {
-            "type": "string",
-            "description": "JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location\nwithin the target document where the operation is performed."
-          }
-        }
-      },
       "NullOrdering": {
         "type": "string",
         "enum": [
@@ -5347,145 +5298,11 @@
           "properties": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/PatchOperation"
+              "$ref": "#/components/schemas/PropertyPatchOperation"
             }
           }
         },
         "additionalProperties": false
-      },
-      "PatchOperation": {
-        "oneOf": [
-          {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AddOperation"
-              },
-              {
-                "type": "object",
-                "required": [
-                  "op"
-                ],
-                "properties": {
-                  "op": {
-                    "type": "string",
-                    "enum": [
-                      "add"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/RemoveOperation"
-              },
-              {
-                "type": "object",
-                "required": [
-                  "op"
-                ],
-                "properties": {
-                  "op": {
-                    "type": "string",
-                    "enum": [
-                      "remove"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ReplaceOperation"
-              },
-              {
-                "type": "object",
-                "required": [
-                  "op"
-                ],
-                "properties": {
-                  "op": {
-                    "type": "string",
-                    "enum": [
-                      "replace"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/MoveOperation"
-              },
-              {
-                "type": "object",
-                "required": [
-                  "op"
-                ],
-                "properties": {
-                  "op": {
-                    "type": "string",
-                    "enum": [
-                      "move"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/CopyOperation"
-              },
-              {
-                "type": "object",
-                "required": [
-                  "op"
-                ],
-                "properties": {
-                  "op": {
-                    "type": "string",
-                    "enum": [
-                      "copy"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TestOperation"
-              },
-              {
-                "type": "object",
-                "required": [
-                  "op"
-                ],
-                "properties": {
-                  "op": {
-                    "type": "string",
-                    "enum": [
-                      "test"
-                    ]
-                  }
-                }
-              }
-            ]
-          }
-        ],
-        "description": "JSON Patch single patch operation",
-        "discriminator": {
-          "propertyName": "op"
-        }
       },
       "PermissionResponse": {
         "type": "object",
@@ -5496,6 +5313,195 @@
           "has_permission": {
             "type": "boolean"
           }
+        }
+      },
+      "Property": {
+        "oneOf": [
+          {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Property"
+            }
+          },
+          {
+            "$ref": "#/components/schemas/PropertyObject"
+          },
+          {}
+        ]
+      },
+      "PropertyConfidence": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/Confidence"
+        }
+      },
+      "PropertyObject": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/Property"
+        }
+      },
+      "PropertyPatchOperation": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "path",
+              "value",
+              "op"
+            ],
+            "properties": {
+              "confidence": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Confidence"
+                  }
+                ]
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "add"
+                ]
+              },
+              "path": {
+                "$ref": "#/components/schemas/PropertyPath"
+              },
+              "value": {
+                "$ref": "#/components/schemas/Property"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "path",
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "type": "string",
+                "enum": [
+                  "remove"
+                ]
+              },
+              "path": {
+                "$ref": "#/components/schemas/PropertyPath"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "path",
+              "value",
+              "op"
+            ],
+            "properties": {
+              "confidence": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Confidence"
+                  }
+                ]
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "replace"
+                ]
+              },
+              "path": {
+                "$ref": "#/components/schemas/PropertyPath"
+              },
+              "value": {
+                "$ref": "#/components/schemas/Property"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "from",
+              "path",
+              "op"
+            ],
+            "properties": {
+              "confidence": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Confidence"
+                  }
+                ]
+              },
+              "from": {
+                "$ref": "#/components/schemas/PropertyPath"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "move"
+                ]
+              },
+              "path": {
+                "$ref": "#/components/schemas/PropertyPath"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "from",
+              "path",
+              "op"
+            ],
+            "properties": {
+              "confidence": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Confidence"
+                  }
+                ]
+              },
+              "from": {
+                "$ref": "#/components/schemas/PropertyPath"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "copy"
+                ]
+              },
+              "path": {
+                "$ref": "#/components/schemas/PropertyPath"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "path",
+              "value",
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "type": "string",
+                "enum": [
+                  "test"
+                ]
+              },
+              "path": {
+                "$ref": "#/components/schemas/PropertyPath"
+              },
+              "value": {
+                "$ref": "#/components/schemas/Property"
+              }
+            }
+          }
+        ],
+        "discriminator": {
+          "propertyName": "op"
         }
       },
       "PropertyPath": {
@@ -6021,36 +6027,6 @@
         ],
         "description": "Defines the two possible combinations of pinned/variable temporal axes that are used in queries\nthat return [`Subgraph`]s.\n\nThe [`VariableTemporalAxisUnresolved`] is optionally bounded, in the absence of provided\nbounds an inclusive bound at the timestamp at point of resolving is assumed.\n\n[`Subgraph`]: crate::subgraph::Subgraph"
       },
-      "RemoveOperation": {
-        "type": "object",
-        "description": "JSON Patch 'remove' operation representation",
-        "required": [
-          "path"
-        ],
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location\nwithin the target document where the operation is performed."
-          }
-        }
-      },
-      "ReplaceOperation": {
-        "type": "object",
-        "description": "JSON Patch 'replace' operation representation",
-        "required": [
-          "path",
-          "value"
-        ],
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location\nwithin the target document where the operation is performed."
-          },
-          "value": {
-            "description": "Value to replace with."
-          }
-        }
-      },
       "RightBoundedTemporalInterval": {
         "type": "object",
         "required": [
@@ -6181,23 +6157,6 @@
         ],
         "discriminator": {
           "propertyName": "kind"
-        }
-      },
-      "TestOperation": {
-        "type": "object",
-        "description": "JSON Patch 'test' operation representation",
-        "required": [
-          "path",
-          "value"
-        ],
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location\nwithin the target document where the operation is performed."
-          },
-          "value": {
-            "description": "Value to test against."
-          }
         }
       },
       "Timestamp": {
@@ -6478,7 +6437,14 @@
             "$ref": "#/components/schemas/ValidationProfile"
           },
           "properties": {
-            "$ref": "#/components/schemas/EntityProperties"
+            "$ref": "#/components/schemas/PropertyObject"
+          },
+          "propertyConfidence": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PropertyConfidence"
+              }
+            ]
           }
         },
         "additionalProperties": false

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -2737,6 +2737,13 @@
           "relationships"
         ],
         "properties": {
+          "confidence": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Confidence"
+              }
+            ]
+          },
           "decisionTime": {
             "allOf": [
               {
@@ -5275,6 +5282,13 @@
         "properties": {
           "archived": {
             "type": "boolean"
+          },
+          "confidence": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Confidence"
+              }
+            ]
           },
           "decisionTime": {
             "allOf": [

--- a/libs/@local/hash-graph-types/rust/Cargo.toml
+++ b/libs/@local/hash-graph-types/rust/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 temporal-versioning.workspace = true
-
+error-stack = { workspace = true }
 type-system.workspace = true
 
 serde = { workspace = true, features = ["derive"] }
@@ -20,6 +20,9 @@ utoipa = { version = "4.2.0", optional = true }
 postgres-types = { version = "0.2.6", default-features = false, features = ["derive", "with-uuid-1", "with-serde_json-1"], optional = true }
 time = { version = "0.3.34", default-features = false, features = ["serde", "parsing", "formatting", "macros"] }
 uuid = { version = "1.8.0", default-features = false, features = ["serde"] }
+json-patch = { version = "1.2.0", default-features = false }
+thiserror = "1.0.58"
+
 
 [dev-dependencies]
 graph-test-data = { workspace = true }

--- a/libs/@local/hash-graph-types/rust/src/knowledge/confidence.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/confidence.rs
@@ -7,10 +7,25 @@ use utoipa::{
     ToSchema,
 };
 
-#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Serialize)]
 #[cfg_attr(feature = "postgres", derive(FromSql, ToSql), postgres(transparent))]
 #[repr(transparent)]
 pub struct Confidence(f64);
+
+impl<'de> Deserialize<'de> for Confidence {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = f64::deserialize(deserializer)?;
+        if !(0.0..=1.0).contains(&value) {
+            return Err(serde::de::Error::custom(
+                "Confidence must be between 0 and 1",
+            ));
+        }
+        Ok(Self(value))
+    }
+}
 
 #[cfg(feature = "utoipa")]
 impl ToSchema<'_> for Confidence {

--- a/libs/@local/hash-graph-types/rust/src/knowledge/entity.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/entity.rs
@@ -134,6 +134,11 @@ pub struct Entity {
 }
 
 impl Entity {
+    /// Modify the properties and confidence values of the entity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the patch operation failed
     pub fn patch(
         &mut self,
         operations: &[PropertyPatchOperation],

--- a/libs/@local/hash-graph-types/rust/src/knowledge/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/mod.rs
@@ -1,10 +1,13 @@
 pub mod entity;
 pub mod link;
 
-mod confidence;
-mod property;
-
 pub use self::{
     confidence::Confidence,
-    property::{PropertyPath, PropertyPathElement},
+    property::{
+        Property, PropertyConfidence, PropertyDiff, PropertyObject, PropertyPatchOperation,
+        PropertyPath, PropertyPathElement,
+    },
 };
+
+mod confidence;
+mod property;

--- a/libs/@local/hash-graph-types/rust/src/knowledge/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/mod.rs
@@ -2,5 +2,9 @@ pub mod entity;
 pub mod link;
 
 mod confidence;
+mod property;
 
-pub use self::confidence::Confidence;
+pub use self::{
+    confidence::Confidence,
+    property::{PropertyPath, PropertyPathElement},
+};

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/confidence.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/confidence.rs
@@ -1,0 +1,101 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::knowledge::{Confidence, PropertyPatchOperation, PropertyPath};
+
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+pub struct PropertyConfidence<'a> {
+    #[serde(flatten)]
+    map: HashMap<PropertyPath<'a>, Confidence>,
+}
+
+impl<'a> PropertyConfidence<'a> {
+    #[must_use]
+    pub const fn new(confidences: HashMap<PropertyPath<'a>, Confidence>) -> Self {
+        Self { map: confidences }
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&PropertyPath<'a>, &Confidence)> {
+        self.map.iter()
+    }
+
+    pub fn patch(&mut self, operations: &[PropertyPatchOperation]) {
+        for operation in operations {
+            match operation {
+                PropertyPatchOperation::Remove { path } => {
+                    self.map.retain(|key, _| !key.starts_with(path));
+                }
+                PropertyPatchOperation::Add {
+                    path,
+                    value: _,
+                    confidence,
+                }
+                | PropertyPatchOperation::Copy {
+                    from: _,
+                    path,
+                    confidence,
+                }
+                | PropertyPatchOperation::Replace {
+                    path,
+                    value: _,
+                    confidence,
+                } => {
+                    self.map.retain(|key, _| !key.starts_with(path));
+                    if let Some(confidence) = confidence {
+                        self.map.insert(path.clone(), *confidence);
+                    }
+                }
+                PropertyPatchOperation::Move {
+                    from,
+                    path,
+                    confidence,
+                } => {
+                    self.map
+                        .retain(|key, _| !key.starts_with(from) && !key.starts_with(path));
+                    if let Some(confidence) = confidence {
+                        self.map.insert(path.clone(), *confidence);
+                    }
+                }
+                PropertyPatchOperation::Test { path: _, value: _ } => {}
+            }
+        }
+    }
+}
+
+impl<'a> IntoIterator for PropertyConfidence<'a> {
+    type IntoIter = std::collections::hash_map::IntoIter<PropertyPath<'a>, Confidence>;
+    type Item = (PropertyPath<'a>, Confidence);
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.map.into_iter()
+    }
+}
+
+impl<'a, 'p> IntoIterator for &'p PropertyConfidence<'a> {
+    type IntoIter = std::collections::hash_map::Iter<'p, PropertyPath<'a>, Confidence>;
+    type Item = (&'p PropertyPath<'a>, &'p Confidence);
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.map.iter()
+    }
+}
+
+impl<'a> FromIterator<(PropertyPath<'a>, Confidence)> for PropertyConfidence<'a> {
+    fn from_iter<T: IntoIterator<Item = (PropertyPath<'a>, Confidence)>>(iter: T) -> Self {
+        Self {
+            map: iter.into_iter().collect(),
+        }
+    }
+}

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/diff.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/diff.rs
@@ -1,0 +1,18 @@
+use crate::knowledge::{Property, PropertyPath};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PropertyDiff<'e> {
+    Added {
+        path: PropertyPath<'e>,
+        added: &'e Property,
+    },
+    Removed {
+        path: PropertyPath<'e>,
+        removed: &'e Property,
+    },
+    Changed {
+        path: PropertyPath<'e>,
+        old: &'e Property,
+        new: &'e Property,
+    },
+}

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/mod.rs
@@ -1,0 +1,3 @@
+mod path;
+
+pub use self::path::{PropertyPath, PropertyPathElement};

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/mod.rs
@@ -68,7 +68,10 @@ impl Property {
     }
 
     #[must_use]
-    pub fn get(&self, path: &PropertyPath<'_>) -> Option<&Self> {
+    pub fn get<'a>(
+        &self,
+        path: impl IntoIterator<Item = &'a PropertyPathElement<'a>>,
+    ) -> Option<&Self> {
         let mut value = self;
         for element in path {
             match element {

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/mod.rs
@@ -1,3 +1,246 @@
+mod confidence;
+mod diff;
+mod object;
+mod patch;
 mod path;
 
-pub use self::path::{PropertyPath, PropertyPathElement};
+use std::{cmp::Ordering, collections::HashMap, fmt, io};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use thiserror::Error;
+use type_system::{url::BaseUrl, JsonSchemaValueType};
+
+pub use self::{
+    confidence::PropertyConfidence,
+    diff::PropertyDiff,
+    object::PropertyObject,
+    patch::PropertyPatchOperation,
+    path::{PropertyPath, PropertyPathElement},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(untagged)]
+pub enum Property {
+    Array(Vec<Self>),
+    Object(PropertyObject),
+    Value(serde_json::Value),
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Error)]
+#[error("Failed to apply patch")]
+pub struct PatchError;
+
+impl Property {
+    #[must_use]
+    pub fn json_type(&self) -> JsonSchemaValueType {
+        match self {
+            Self::Array(_) => JsonSchemaValueType::Array,
+            Self::Object(_) => JsonSchemaValueType::Object,
+            Self::Value(property) => JsonSchemaValueType::from(property),
+        }
+    }
+
+    pub gen fn properties(&self) -> (PropertyPath<'_>, &JsonValue) {
+        let mut elements = PropertyPath::default();
+        match self {
+            Self::Array(array) => {
+                for (index, property) in array.iter().enumerate() {
+                    elements.push(index);
+                    for yielded in Box::new(property.properties()) {
+                        yield yielded;
+                    }
+                    elements.pop();
+                }
+            }
+            Self::Object(object) => {
+                for (key, property) in object.properties() {
+                    elements.push(key);
+                    for yielded in Box::new(property.properties()) {
+                        yield yielded;
+                    }
+                    elements.pop();
+                }
+            }
+            Self::Value(property) => yield (elements.clone(), property),
+        }
+    }
+
+    #[must_use]
+    pub fn get(&self, path: &PropertyPath<'_>) -> Option<&Self> {
+        let mut value = self;
+        for element in path {
+            match element {
+                PropertyPathElement::Property(key) => {
+                    value = match value {
+                        Self::Object(object) => object.properties().get(key)?,
+                        _ => return None,
+                    };
+                }
+                PropertyPathElement::Index(index) => {
+                    value = match value {
+                        Self::Array(array) => array.get(*index)?,
+                        _ => return None,
+                    };
+                }
+            }
+        }
+        Some(value)
+    }
+
+    gen fn diff_array<'a>(
+        lhs: &'a [Self],
+        rhs: &'a [Self],
+        path: &mut PropertyPath<'a>,
+    ) -> PropertyDiff<'a> {
+        for (index, (lhs, rhs)) in lhs.iter().zip(rhs).enumerate() {
+            path.push(index);
+            for yielded in Box::new(lhs.diff(rhs, path)) {
+                yield yielded;
+            }
+            path.pop();
+        }
+
+        match lhs.len().cmp(&rhs.len()) {
+            Ordering::Less => {
+                for (index, property) in rhs.iter().enumerate().skip(lhs.len()) {
+                    path.push(index);
+                    yield PropertyDiff::Added {
+                        path: path.clone(),
+                        added: property,
+                    };
+                    path.pop();
+                }
+            }
+            Ordering::Equal => {}
+            Ordering::Greater => {
+                for (index, property) in lhs.iter().enumerate().skip(rhs.len()) {
+                    path.push(index);
+                    yield PropertyDiff::Removed {
+                        path: path.clone(),
+                        removed: property,
+                    };
+                    path.pop();
+                }
+            }
+        }
+    }
+
+    pub(super) gen fn diff_object<'a>(
+        lhs: &'a HashMap<BaseUrl, Self>,
+        rhs: &'a HashMap<BaseUrl, Self>,
+        path: &mut PropertyPath<'a>,
+    ) -> PropertyDiff<'a> {
+        for (key, property) in lhs {
+            path.push(key);
+            let other_property = rhs.get(key);
+            if let Some(other_property) = other_property {
+                for yielded in Box::new(property.diff(other_property, path)) {
+                    yield yielded;
+                }
+            } else {
+                yield PropertyDiff::Removed {
+                    path: path.clone(),
+                    removed: property,
+                };
+            }
+            path.pop();
+        }
+        for (key, property) in rhs {
+            if !lhs.contains_key(key) {
+                path.push(key);
+                yield PropertyDiff::Added {
+                    path: path.clone(),
+                    added: property,
+                };
+                path.pop();
+            }
+        }
+    }
+
+    pub gen fn diff<'a>(
+        &'a self,
+        other: &'a Self,
+        path: &mut PropertyPath<'a>,
+    ) -> PropertyDiff<'_> {
+        let mut changed = false;
+        match (self, other) {
+            (Self::Array(lhs), Self::Array(rhs)) => {
+                for yielded in Self::diff_array(lhs, rhs, path) {
+                    changed = true;
+                    yield yielded;
+                }
+            }
+            (Self::Object(lhs), Self::Object(rhs)) => {
+                for yielded in Self::diff_object(lhs.properties(), rhs.properties(), path) {
+                    changed = true;
+                    yield yielded;
+                }
+            }
+            (lhs, rhs) => {
+                changed = lhs != rhs;
+            }
+        }
+
+        if changed {
+            yield PropertyDiff::Changed {
+                path: path.clone(),
+                old: self,
+                new: other,
+            };
+        }
+    }
+}
+
+impl fmt::Display for Property {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Inspired by `serde_json`
+        struct WriterFormatter<'a, 'b: 'a>(&'a mut fmt::Formatter<'b>);
+
+        impl io::Write for WriterFormatter<'_, '_> {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.0
+                    .write_str(&String::from_utf8_lossy(buf))
+                    .map_err(|error| io::Error::new(io::ErrorKind::Other, error))?;
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        if fmt.alternate() {
+            serde_json::to_writer_pretty(WriterFormatter(fmt), &self).map_err(|_ignored| fmt::Error)
+        } else {
+            serde_json::to_writer(WriterFormatter(fmt), &self).map_err(|_ignored| fmt::Error)
+        }
+    }
+}
+
+impl PartialEq<JsonValue> for Property {
+    fn eq(&self, rhs: &JsonValue) -> bool {
+        match self {
+            Self::Array(lhs) => {
+                let JsonValue::Array(rhs) = rhs else {
+                    return false;
+                };
+
+                lhs == rhs
+            }
+            Self::Object(lhs) => {
+                let JsonValue::Object(rhs) = rhs else {
+                    return false;
+                };
+
+                lhs.properties().len() == rhs.len()
+                    && lhs.properties().iter().all(|(key, value)| {
+                        rhs.get(key.as_str())
+                            .map_or(false, |other_value| value == other_value)
+                    })
+            }
+            Self::Value(lhs) => lhs == rhs,
+        }
+    }
+}

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/object.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/object.rs
@@ -1,0 +1,174 @@
+use std::{collections::HashMap, error::Error};
+
+use bytes::BytesMut;
+use error_stack::{Report, ResultExt};
+use json_patch::{
+    AddOperation, CopyOperation, MoveOperation, PatchOperation, RemoveOperation, ReplaceOperation,
+    TestOperation,
+};
+#[cfg(feature = "postgres")]
+use postgres_types::{FromSql, IsNull, ToSql, Type};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use type_system::url::BaseUrl;
+#[cfg(feature = "utoipa")]
+use utoipa::ToSchema;
+
+use crate::knowledge::{
+    property::{PatchError, Property},
+    PropertyDiff, PropertyPatchOperation, PropertyPath,
+};
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(ToSchema))]
+pub struct PropertyObject(HashMap<BaseUrl, Property>);
+
+impl PropertyObject {
+    #[must_use]
+    pub const fn new(properties: HashMap<BaseUrl, Property>) -> Self {
+        Self(properties)
+    }
+
+    #[must_use]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub const fn properties(&self) -> &HashMap<BaseUrl, Property> {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&BaseUrl, &Property)> {
+        self.0.iter()
+    }
+
+    pub fn diff<'a>(
+        &'a self,
+        other: &'a Self,
+        path: &mut PropertyPath<'a>,
+    ) -> impl Iterator<Item = PropertyDiff<'_>> {
+        Property::diff_object(self.properties(), other.properties(), path)
+    }
+
+    pub fn patch(
+        &mut self,
+        operations: &[PropertyPatchOperation],
+    ) -> Result<(), Report<PatchError>> {
+        let patches = operations
+            .iter()
+            .map(|operation| {
+                Ok(match operation {
+                    PropertyPatchOperation::Add {
+                        path,
+                        value,
+                        confidence: _,
+                    } => PatchOperation::Add(AddOperation {
+                        path: path.to_json_pointer(),
+                        value: serde_json::to_value(value).change_context(PatchError)?,
+                    }),
+                    PropertyPatchOperation::Remove { path } => {
+                        PatchOperation::Remove(RemoveOperation {
+                            path: path.to_json_pointer(),
+                        })
+                    }
+                    PropertyPatchOperation::Replace {
+                        path,
+                        value,
+                        confidence: _,
+                    } => PatchOperation::Replace(ReplaceOperation {
+                        path: path.to_json_pointer(),
+                        value: serde_json::to_value(value).change_context(PatchError)?,
+                    }),
+                    PropertyPatchOperation::Move {
+                        from,
+                        path,
+                        confidence: _,
+                    } => PatchOperation::Move(MoveOperation {
+                        from: from.to_json_pointer(),
+                        path: path.to_json_pointer(),
+                    }),
+                    PropertyPatchOperation::Copy {
+                        from,
+                        path,
+                        confidence: _,
+                    } => PatchOperation::Copy(CopyOperation {
+                        from: from.to_json_pointer(),
+                        path: path.to_json_pointer(),
+                    }),
+                    PropertyPatchOperation::Test { path, value } => {
+                        PatchOperation::Test(TestOperation {
+                            path: path.to_json_pointer(),
+                            value: serde_json::to_value(value).change_context(PatchError)?,
+                        })
+                    }
+                })
+            })
+            .collect::<Result<Vec<_>, Report<PatchError>>>()?;
+
+        // TODO: Implement more efficient patching without serialization
+        let mut this = serde_json::to_value(&self).change_context(PatchError)?;
+        json_patch::patch(&mut this, &patches).change_context(PatchError)?;
+        *self = serde_json::from_value(this).change_context(PatchError)?;
+        Ok(())
+    }
+}
+
+impl PartialEq<JsonValue> for PropertyObject {
+    fn eq(&self, other: &JsonValue) -> bool {
+        let JsonValue::Object(other_object) = other else {
+            return false;
+        };
+
+        self.0.len() == other_object.len()
+            && self.0.iter().all(|(key, value)| {
+                other_object
+                    .get(key.as_str())
+                    .map_or(false, |other_value| value == other_value)
+            })
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl ToSql for PropertyObject {
+    postgres_types::to_sql_checked!();
+
+    fn to_sql(&self, ty: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>>
+    where
+        Self: Sized,
+    {
+        postgres_types::Json(&self).to_sql(ty, out)
+    }
+
+    fn accepts(ty: &Type) -> bool
+    where
+        Self: Sized,
+    {
+        <postgres_types::Json<Self> as ToSql>::accepts(ty)
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> FromSql<'a> for PropertyObject {
+    fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        let json = postgres_types::Json::from_sql(ty, raw)?;
+        Ok(json.0)
+    }
+
+    fn accepts(ty: &Type) -> bool
+    where
+        Self: Sized,
+    {
+        <postgres_types::Json<Self> as ToSql>::accepts(ty)
+    }
+}

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/patch.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/patch.rs
@@ -1,0 +1,44 @@
+use serde::Deserialize;
+
+use crate::knowledge::{Confidence, Property, PropertyPath};
+
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", tag = "op")]
+pub enum PropertyPatchOperation {
+    Add {
+        path: PropertyPath<'static>,
+        value: Property,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "utoipa", schema(nullable = false))]
+        confidence: Option<Confidence>,
+    },
+    Remove {
+        path: PropertyPath<'static>,
+    },
+    Replace {
+        path: PropertyPath<'static>,
+        value: Property,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "utoipa", schema(nullable = false))]
+        confidence: Option<Confidence>,
+    },
+    Move {
+        from: PropertyPath<'static>,
+        path: PropertyPath<'static>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "utoipa", schema(nullable = false))]
+        confidence: Option<Confidence>,
+    },
+    Copy {
+        from: PropertyPath<'static>,
+        path: PropertyPath<'static>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "utoipa", schema(nullable = false))]
+        confidence: Option<Confidence>,
+    },
+    Test {
+        path: PropertyPath<'static>,
+        value: Property,
+    },
+}

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/path.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/path.rs
@@ -1,0 +1,204 @@
+use std::{borrow::Cow, error::Error};
+
+use bytes::BytesMut;
+use postgres_types::{FromSql, IsNull, ToSql, Type};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use type_system::url::{BaseUrl, ParseBaseUrlError};
+use utoipa::{openapi, ToSchema};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum PropertyPathElement<'k> {
+    Property(Cow<'k, BaseUrl>),
+    Index(usize),
+}
+
+impl From<usize> for PropertyPathElement<'_> {
+    fn from(index: usize) -> Self {
+        PropertyPathElement::Index(index)
+    }
+}
+
+impl From<BaseUrl> for PropertyPathElement<'_> {
+    fn from(key: BaseUrl) -> Self {
+        PropertyPathElement::Property(Cow::Owned(key))
+    }
+}
+
+impl<'k> From<&'k BaseUrl> for PropertyPathElement<'k> {
+    fn from(key: &'k BaseUrl) -> Self {
+        PropertyPathElement::Property(Cow::Borrowed(key))
+    }
+}
+
+impl PropertyPathElement<'_> {
+    #[must_use]
+    pub fn into_owned(self) -> PropertyPathElement<'static> {
+        match self {
+            PropertyPathElement::Property(key) => {
+                PropertyPathElement::Property(Cow::Owned(key.into_owned()))
+            }
+            PropertyPathElement::Index(index) => PropertyPathElement::Index(index),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+pub struct PropertyPath<'k> {
+    elements: Vec<PropertyPathElement<'k>>,
+}
+
+impl<'k> PropertyPath<'k> {
+    pub fn push(&mut self, element: impl Into<PropertyPathElement<'k>>) {
+        self.elements.push(element.into());
+    }
+
+    pub fn pop(&mut self) -> Option<PropertyPathElement<'k>> {
+        self.elements.pop()
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.elements.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.elements.is_empty()
+    }
+
+    pub fn iter(&'k self) -> impl Iterator<Item = &'k PropertyPathElement<'k>> {
+        <&Self as IntoIterator>::into_iter(self)
+    }
+
+    /// Creates a new `PropertyPath` from a JSON Pointer.
+    ///
+    /// # Errors
+    ///
+    /// - `ParseBaseUrlError` if the JSON Pointer contains an invalid [`BaseUrl`].
+    pub fn from_json_pointer(json_patch: &str) -> Result<Self, ParseBaseUrlError> {
+        Ok(Self {
+            elements: json_patch
+                .split('/')
+                .map(|element| {
+                    if let Ok(index) = element.parse() {
+                        Ok(PropertyPathElement::Index(index))
+                    } else {
+                        Ok(PropertyPathElement::Property(Cow::Owned(BaseUrl::new(
+                            element.replace("~1", "/").replace("~0", "~"),
+                        )?)))
+                    }
+                })
+                .collect::<Result<Vec<_>, ParseBaseUrlError>>()?,
+        })
+    }
+
+    #[must_use]
+    pub fn to_json_pointer(&self) -> String {
+        self.elements
+            .iter()
+            .map(|element| match element {
+                PropertyPathElement::Property(key) => key.to_string(),
+                PropertyPathElement::Index(index) => index.to_string(),
+            })
+            .collect::<Vec<_>>()
+            .join("/")
+    }
+
+    pub fn into_owned(self) -> PropertyPath<'static> {
+        PropertyPath {
+            elements: self
+                .elements
+                .into_iter()
+                .map(PropertyPathElement::into_owned)
+                .collect(),
+        }
+    }
+}
+
+impl<'k> FromIterator<PropertyPathElement<'k>> for PropertyPath<'k> {
+    fn from_iter<T: IntoIterator<Item = PropertyPathElement<'k>>>(iter: T) -> Self {
+        Self {
+            elements: iter.into_iter().collect(),
+        }
+    }
+}
+
+impl<'k> IntoIterator for PropertyPath<'k> {
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+    type Item = PropertyPathElement<'k>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.elements.into_iter()
+    }
+}
+
+impl<'k> IntoIterator for &'k PropertyPath<'k> {
+    type IntoIter = std::slice::Iter<'k, PropertyPathElement<'k>>;
+    type Item = &'k PropertyPathElement<'k>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.elements.iter()
+    }
+}
+
+impl Serialize for PropertyPath<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.to_json_pointer().serialize(serializer)
+    }
+}
+
+impl<'de, 'a: 'de> Deserialize<'de> for PropertyPath<'a> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::from_json_pointer(&String::deserialize(deserializer)?).map_err(de::Error::custom)
+    }
+}
+
+#[cfg(feature = "utoipa")]
+impl ToSchema<'_> for PropertyPath<'_> {
+    fn schema() -> (&'static str, openapi::RefOr<openapi::Schema>) {
+        (
+            "PropertyPath",
+            openapi::Schema::Object(openapi::schema::Object::with_type(
+                openapi::SchemaType::String,
+            ))
+            .into(),
+        )
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl ToSql for PropertyPath<'_> {
+    postgres_types::to_sql_checked!();
+
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        self.to_json_pointer().to_sql(ty, out)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <&str as FromSql>::accepts(ty)
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl<'k> FromSql<'k> for PropertyPath<'k> {
+    fn from_sql(ty: &Type, raw: &'k [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        Ok(Self::from_json_pointer(<&str as FromSql>::from_sql(
+            ty, raw,
+        )?)?)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <&str as FromSql>::accepts(ty)
+    }
+}

--- a/libs/@local/hash-validation/src/data_type.rs
+++ b/libs/@local/hash-validation/src/data_type.rs
@@ -7,7 +7,7 @@ use std::{
 
 use email_address::EmailAddress;
 use error_stack::{bail, ensure, Report, ResultExt};
-use graph_types::knowledge::entity::Property;
+use graph_types::knowledge::Property;
 use iso8601_duration::Duration;
 use regex::Regex;
 use serde_json::Value as JsonValue;

--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -3,7 +3,7 @@ use std::borrow::Borrow;
 use error_stack::{Report, ResultExt};
 use futures::{stream, StreamExt, TryStreamExt};
 use graph_types::knowledge::{
-    entity::{Entity, EntityId, EntityProperties},
+    entity::{Entity, EntityId, PropertyObject},
     link::LinkData,
 };
 use thiserror::Error;
@@ -47,7 +47,7 @@ pub enum EntityValidationError {
     InvalidLinkTargetId { target_types: Vec<VersionedUrl> },
 }
 
-impl<P> Schema<EntityProperties, P> for ClosedEntityType
+impl<P> Schema<PropertyObject, P> for ClosedEntityType
 where
     P: OntologyTypeProvider<PropertyType> + OntologyTypeProvider<DataType> + Sync,
 {
@@ -55,7 +55,7 @@ where
 
     async fn validate_value<'a>(
         &'a self,
-        value: &'a EntityProperties,
+        value: &'a PropertyObject,
         profile: ValidationProfile,
         provider: &'a P,
     ) -> Result<(), Report<EntityValidationError>> {
@@ -72,7 +72,7 @@ where
     }
 }
 
-impl<P> Validate<ClosedEntityType, P> for EntityProperties
+impl<P> Validate<ClosedEntityType, P> for PropertyObject
 where
     P: OntologyTypeProvider<PropertyType> + OntologyTypeProvider<DataType> + Sync,
 {

--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -3,8 +3,9 @@ use std::borrow::Borrow;
 use error_stack::{Report, ResultExt};
 use futures::{stream, StreamExt, TryStreamExt};
 use graph_types::knowledge::{
-    entity::{Entity, EntityId, PropertyObject},
+    entity::{Entity, EntityId},
     link::LinkData,
+    PropertyObject,
 };
 use thiserror::Error;
 use type_system::{

--- a/libs/@local/hash-validation/src/error.rs
+++ b/libs/@local/hash-validation/src/error.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use error_stack::Report;
-use graph_types::knowledge::entity::{Property, PropertyObject};
+use graph_types::knowledge::{Property, PropertyObject};
 use serde_json::Value as JsonValue;
 use type_system::{url::VersionedUrl, ClosedEntityType, DataType, PropertyType};
 

--- a/libs/@local/hash-validation/src/error.rs
+++ b/libs/@local/hash-validation/src/error.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use error_stack::Report;
-use graph_types::knowledge::entity::{EntityProperties, Property};
+use graph_types::knowledge::entity::{Property, PropertyObject};
 use serde_json::Value as JsonValue;
 use type_system::{url::VersionedUrl, ClosedEntityType, DataType, PropertyType};
 
@@ -61,7 +61,7 @@ pub fn install_error_stack_hooks() {
 pub enum Actual {
     Json(JsonValue),
     Property(Property),
-    Properties(EntityProperties),
+    Properties(PropertyObject),
 }
 
 #[derive(Debug)]

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -123,7 +123,7 @@ pub trait EntityProvider {
 mod tests {
     use std::collections::HashMap;
 
-    use graph_types::knowledge::entity::{EntityProperties, Property};
+    use graph_types::knowledge::entity::{Property, PropertyObject};
     use serde_json::Value as JsonValue;
     use thiserror::Error;
     use type_system::{DataType, EntityType, PropertyType};
@@ -286,7 +286,7 @@ mod tests {
         );
 
         let entity =
-            serde_json::from_str::<EntityProperties>(entity).expect("failed to read entity string");
+            serde_json::from_str::<PropertyObject>(entity).expect("failed to read entity string");
 
         entity.validate(&entity_type, profile, &provider).await
     }

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -123,7 +123,7 @@ pub trait EntityProvider {
 mod tests {
     use std::collections::HashMap;
 
-    use graph_types::knowledge::entity::{Property, PropertyObject};
+    use graph_types::knowledge::{Property, PropertyObject};
     use serde_json::Value as JsonValue;
     use thiserror::Error;
     use type_system::{DataType, EntityType, PropertyType};
@@ -285,10 +285,10 @@ mod tests {
             serde_json::from_str::<EntityType>(entity_type).expect("failed to parse entity type"),
         );
 
-        let entity =
+        let properties =
             serde_json::from_str::<PropertyObject>(entity).expect("failed to read entity string");
 
-        entity.validate(&entity_type, profile, &provider).await
+        properties.validate(&entity_type, profile, &provider).await
     }
 
     pub(crate) async fn validate_property(

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -15,6 +15,7 @@ pub use self::{
 
 mod data_type;
 mod entity_type;
+mod property;
 mod property_type;
 
 use std::borrow::Borrow;

--- a/libs/@local/hash-validation/src/property.rs
+++ b/libs/@local/hash-validation/src/property.rs
@@ -1,0 +1,43 @@
+use error_stack::Report;
+use graph_types::knowledge::{PropertyConfidence, PropertyObject};
+
+use crate::{EntityValidationError, Validate, ValidationProfile};
+
+macro_rules! extend_report {
+    ($status:ident, $error:expr $(,)?) => {
+        if let Err(ref mut report) = $status {
+            report.extend_one(error_stack::report!($error))
+        } else {
+            $status = Err(error_stack::report!($error))
+        }
+    };
+}
+
+impl<P> Validate<PropertyObject, P> for PropertyConfidence<'_>
+where
+    P: Sync,
+{
+    type Error = EntityValidationError;
+
+    async fn validate(
+        &self,
+        object: &PropertyObject,
+        _profile: ValidationProfile,
+        _provider: &P,
+    ) -> Result<(), Report<Self::Error>> {
+        let mut status: Result<(), Report<EntityValidationError>> = Ok(());
+
+        for (path, _confidence) in self {
+            if !object.path_exists(path) {
+                extend_report!(
+                    status,
+                    EntityValidationError::InvalidPropertyPath {
+                        path: path.clone().into_owned()
+                    }
+                );
+            }
+        }
+
+        status
+    }
+}

--- a/libs/@local/hash-validation/src/property_type.rs
+++ b/libs/@local/hash-validation/src/property_type.rs
@@ -2,7 +2,7 @@ use core::borrow::Borrow;
 use std::{collections::HashMap, num::NonZeroUsize};
 
 use error_stack::{bail, Report, ResultExt};
-use graph_types::knowledge::entity::Property;
+use graph_types::knowledge::Property;
 use thiserror::Error;
 use type_system::{
     url::{BaseUrl, VersionedUrl},
@@ -333,7 +333,9 @@ where
                     }))
                 }
                 (Property::Object(object), Self::PropertyTypeObject(schema)) => {
-                    schema.validate_value(object, profile, provider).await
+                    schema
+                        .validate_value(object.properties(), profile, provider)
+                        .await
                 }
                 (Property::Object(_), Self::ArrayOfPropertyValues(_)) => {
                     Err(Report::new(PropertyValidationError::InvalidType {

--- a/tests/hash-graph-integration/Cargo.toml
+++ b/tests/hash-graph-integration/Cargo.toml
@@ -22,7 +22,6 @@ serde_json = "1.0.115"
 time = "0.3.34"
 tokio = { version = "1.37.0", default-features = false, features = ["macros"] }
 tokio-postgres = { version = "0.7.10", default-features = false }
-json-patch = { version = "1.2.0", default-features = false }
 uuid = { version = "1.8.0", features = ["v4", "serde"] }
 
 [[test]]

--- a/tests/hash-graph-integration/postgres/confidence.rs
+++ b/tests/hash-graph-integration/postgres/confidence.rs
@@ -1,0 +1,351 @@
+use std::{borrow::Cow, collections::HashMap, iter::once, str::FromStr};
+
+use graph::store::knowledge::PatchEntityParams;
+use graph_test_data::{data_type, entity, entity_type, property_type};
+use graph_types::knowledge::{
+    Confidence, Property, PropertyConfidence, PropertyObject, PropertyPatchOperation, PropertyPath,
+    PropertyPathElement,
+};
+use pretty_assertions::assert_eq;
+use serde_json::json;
+use type_system::url::{BaseUrl, VersionedUrl};
+
+use crate::{DatabaseApi, DatabaseTestWrapper};
+
+async fn seed(database: &mut DatabaseTestWrapper) -> DatabaseApi<'_> {
+    database
+        .seed(
+            [data_type::TEXT_V1, data_type::NUMBER_V1],
+            [
+                property_type::NAME_V1,
+                property_type::AGE_V1,
+                property_type::FAVORITE_SONG_V1,
+                property_type::FAVORITE_FILM_V1,
+                property_type::HOBBY_V1,
+                property_type::INTERESTS_V1,
+            ],
+            [
+                entity_type::PERSON_V1,
+                entity_type::ORGANIZATION_V1,
+                entity_type::LINK_V1,
+                entity_type::link::FRIEND_OF_V1,
+                entity_type::link::ACQUAINTANCE_OF_V1,
+            ],
+        )
+        .await
+        .expect("could not seed database")
+}
+
+fn person_entity_type_id() -> VersionedUrl {
+    VersionedUrl::from_str("https://blockprotocol.org/@alice/types/entity-type/person/v/1")
+        .expect("couldn't construct entity type id")
+}
+
+fn name_property_type_id() -> BaseUrl {
+    BaseUrl::new("https://blockprotocol.org/@alice/types/property-type/name/".to_owned())
+        .expect("couldn't construct Base URL")
+}
+fn age_property_type_id() -> BaseUrl {
+    BaseUrl::new("https://blockprotocol.org/@alice/types/property-type/age/".to_owned())
+        .expect("couldn't construct Base URL")
+}
+fn interests_property_type_id() -> BaseUrl {
+    BaseUrl::new("https://blockprotocol.org/@alice/types/property-type/interests/".to_owned())
+        .expect("couldn't construct Base URL")
+}
+fn film_property_type_id() -> BaseUrl {
+    BaseUrl::new("https://blockprotocol.org/@alice/types/property-type/favorite-film/".to_owned())
+        .expect("couldn't construct Base URL")
+}
+
+fn alice() -> PropertyObject {
+    serde_json::from_str(entity::PERSON_ALICE_V1).expect("could not parse entity")
+}
+
+fn confidence(value: f64) -> Confidence {
+    serde_json::from_str(&value.to_string()).expect("could not parse confidence")
+}
+
+fn property_confidence<'a>(value: &'a [(&'a str, f64)]) -> PropertyConfidence<'a> {
+    let mut map = HashMap::new();
+    for (key, value) in value {
+        map.insert(
+            PropertyPath::from_json_pointer(key).expect("could not parse path"),
+            confidence(*value),
+        );
+    }
+    PropertyConfidence::new(map)
+}
+
+#[tokio::test]
+async fn initial_confidence() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+
+    let entity_property_confidence = property_confidence(&[("", 0.5)]);
+    let entity = api
+        .create_entity(
+            alice(),
+            vec![person_entity_type_id()],
+            None,
+            true,
+            Some(confidence(0.5)),
+            entity_property_confidence.clone(),
+        )
+        .await
+        .expect("could not create entity");
+
+    assert_eq!(entity.confidence, Some(confidence(0.5)));
+    assert_eq!(entity.property_confidence, entity_property_confidence);
+
+    let updated_entity = api
+        .patch_entity(PatchEntityParams {
+            entity_id: entity.record_id.entity_id,
+            properties: Vec::new(),
+            entity_type_ids: vec![],
+            archived: None,
+            draft: None,
+            decision_time: None,
+            confidence: Some(confidence(0.5)),
+        })
+        .await
+        .expect("could not update entity");
+
+    assert_eq!(updated_entity, entity);
+
+    let updated_entity = api
+        .patch_entity(PatchEntityParams {
+            entity_id: entity.record_id.entity_id,
+            properties: Vec::new(),
+            entity_type_ids: vec![],
+            archived: None,
+            draft: None,
+            decision_time: None,
+            confidence: None,
+        })
+        .await
+        .expect("could not update entity");
+
+    assert!(updated_entity.confidence.is_none());
+    assert_eq!(
+        updated_entity.property_confidence,
+        entity_property_confidence
+    );
+}
+
+#[tokio::test]
+async fn no_initial_draft() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+
+    let entity = api
+        .create_entity(
+            alice(),
+            vec![person_entity_type_id()],
+            None,
+            false,
+            None,
+            PropertyConfidence::default(),
+        )
+        .await
+        .expect("could not create entity");
+
+    assert!(entity.confidence.is_none());
+    assert!(entity.property_confidence.is_empty());
+
+    let updated_entity = api
+        .patch_entity(PatchEntityParams {
+            entity_id: entity.record_id.entity_id,
+            properties: Vec::new(),
+            entity_type_ids: vec![],
+            archived: None,
+            draft: None,
+            decision_time: None,
+            confidence: None,
+        })
+        .await
+        .expect("could not update entity");
+
+    assert_eq!(entity, updated_entity);
+
+    let updated_entity = api
+        .patch_entity(PatchEntityParams {
+            entity_id: entity.record_id.entity_id,
+            properties: Vec::new(),
+            entity_type_ids: vec![],
+            archived: None,
+            draft: None,
+            decision_time: None,
+            confidence: Some(confidence(0.5)),
+        })
+        .await
+        .expect("could not update entity");
+
+    assert_eq!(updated_entity.confidence, Some(confidence(0.5)));
+    assert!(updated_entity.property_confidence.is_empty());
+
+    let path: PropertyPath = once(PropertyPathElement::from(name_property_type_id())).collect();
+    let path_pointer = path.to_json_pointer();
+    let updated_entity = api
+        .patch_entity(PatchEntityParams {
+            entity_id: entity.record_id.entity_id,
+            properties: vec![PropertyPatchOperation::Replace {
+                path: once(PropertyPathElement::from(name_property_type_id())).collect(),
+                value: Property::Value(json!("Alice")),
+                confidence: Some(confidence(0.5)),
+            }],
+            entity_type_ids: vec![],
+            archived: None,
+            draft: None,
+            decision_time: None,
+            confidence: None,
+        })
+        .await
+        .expect("could not update entity");
+
+    assert!(updated_entity.confidence.is_none());
+    assert_eq!(
+        updated_entity.property_confidence,
+        property_confidence(&[(path_pointer.as_str(), 0.5)])
+    );
+
+    let updated_entity = api
+        .patch_entity(PatchEntityParams {
+            entity_id: entity.record_id.entity_id,
+            properties: Vec::new(),
+            entity_type_ids: vec![],
+            archived: None,
+            draft: None,
+            decision_time: None,
+            confidence: Some(confidence(0.5)),
+        })
+        .await
+        .expect("could not update entity");
+
+    assert_eq!(updated_entity.confidence, Some(confidence(0.5)));
+    assert_eq!(
+        updated_entity.property_confidence,
+        property_confidence(&[(path_pointer.as_str(), 0.5)])
+    );
+}
+
+#[tokio::test]
+async fn properties_add() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+
+    let entity = api
+        .create_entity(
+            alice(),
+            vec![person_entity_type_id()],
+            None,
+            false,
+            None,
+            PropertyConfidence::default(),
+        )
+        .await
+        .expect("could not create entity");
+    let entity_id = entity.record_id.entity_id;
+
+    let path: PropertyPath = once(PropertyPathElement::from(age_property_type_id())).collect();
+    let updated_entity = api
+        .patch_entity(PatchEntityParams {
+            entity_id,
+            decision_time: None,
+            entity_type_ids: vec![],
+            properties: vec![PropertyPatchOperation::Add {
+                path: path.clone(),
+                value: Property::Value(json!(30)),
+                confidence: Some(confidence(0.5)),
+            }],
+            draft: None,
+            archived: None,
+            confidence: None,
+        })
+        .await
+        .expect("could not patch entity");
+
+    assert_eq!(
+        updated_entity.property_confidence,
+        once((path, confidence(0.5))).collect()
+    );
+}
+
+#[tokio::test]
+async fn properties_remove() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+
+    let entity = api
+        .create_entity(
+            alice(),
+            vec![person_entity_type_id()],
+            None,
+            false,
+            None,
+            PropertyConfidence::default(),
+        )
+        .await
+        .expect("could not create entity");
+    let entity_id = entity.record_id.entity_id;
+
+    let interests_path: PropertyPath =
+        once(PropertyPathElement::from(interests_property_type_id())).collect();
+    let film_path = [
+        PropertyPathElement::Property(Cow::Owned(interests_property_type_id())),
+        PropertyPathElement::Property(Cow::Owned(film_property_type_id())),
+    ]
+    .into_iter()
+    .collect::<PropertyPath>();
+
+    let updated_entity = api
+        .patch_entity(PatchEntityParams {
+            entity_id,
+            decision_time: None,
+            entity_type_ids: vec![],
+            properties: vec![
+                PropertyPatchOperation::Add {
+                    path: once(PropertyPathElement::from(interests_property_type_id())).collect(),
+                    value: Property::Value(json!({})),
+                    confidence: Some(confidence(0.5)),
+                },
+                PropertyPatchOperation::Add {
+                    path: film_path.clone(),
+                    value: Property::Value(json!("Fight Club")),
+                    confidence: Some(confidence(0.5)),
+                },
+            ],
+            draft: None,
+            archived: None,
+            confidence: None,
+        })
+        .await
+        .expect("could not patch entity");
+
+    let film_path_pointer = film_path.to_json_pointer();
+    let interests_path_pointer = interests_path.to_json_pointer();
+    assert_eq!(
+        updated_entity.property_confidence,
+        property_confidence(&[
+            (interests_path_pointer.as_str(), 0.5),
+            (film_path_pointer.as_str(), 0.5)
+        ])
+    );
+
+    let updated_entity = api
+        .patch_entity(PatchEntityParams {
+            entity_id,
+            decision_time: None,
+            entity_type_ids: vec![],
+            properties: vec![PropertyPatchOperation::Remove {
+                path: interests_path,
+            }],
+            draft: None,
+            archived: None,
+            confidence: None,
+        })
+        .await
+        .expect("could not patch entity");
+
+    assert!(updated_entity.property_confidence.is_empty());
+}

--- a/tests/hash-graph-integration/postgres/drafts.rs
+++ b/tests/hash-graph-integration/postgres/drafts.rs
@@ -62,6 +62,7 @@ async fn check_entity_exists(api: &DatabaseApi<'_>, id: EntityId) -> bool {
 }
 
 #[tokio::test]
+#[expect(clippy::too_many_lines)]
 async fn initial_draft() {
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = seed(&mut database).await;
@@ -284,6 +285,7 @@ async fn no_initial_draft() {
 }
 
 #[tokio::test]
+#[expect(clippy::too_many_lines)]
 async fn multiple_drafts() {
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = seed(&mut database).await;

--- a/tests/hash-graph-integration/postgres/drafts.rs
+++ b/tests/hash-graph-integration/postgres/drafts.rs
@@ -1,6 +1,6 @@
 use graph::store::knowledge::PatchEntityParams;
 use graph_test_data::{data_type, entity, entity_type, property_type};
-use graph_types::knowledge::entity::{EntityId, EntityProperties};
+use graph_types::knowledge::entity::{EntityId, PropertyObject};
 use json_patch::{PatchOperation, ReplaceOperation};
 use pretty_assertions::assert_eq;
 use temporal_versioning::ClosedTemporalBound;
@@ -43,15 +43,15 @@ fn person_entity_type_id() -> VersionedUrl {
     }
 }
 
-fn alice() -> EntityProperties {
+fn alice() -> PropertyObject {
     serde_json::from_str(entity::PERSON_ALICE_V1).expect("could not parse entity")
 }
 
-fn bob() -> EntityProperties {
+fn bob() -> PropertyObject {
     serde_json::from_str(entity::PERSON_BOB_V1).expect("could not parse entity")
 }
 
-fn charles() -> EntityProperties {
+fn charles() -> PropertyObject {
     serde_json::from_str(entity::PERSON_CHARLES_V1).expect("could not parse entity")
 }
 

--- a/tests/hash-graph-integration/postgres/drafts.rs
+++ b/tests/hash-graph-integration/postgres/drafts.rs
@@ -98,6 +98,7 @@ async fn initial_draft() {
             archived: None,
             draft: Some(true),
             decision_time: None,
+            confidence: None,
         })
         .await
         .expect("could not update entity");
@@ -133,6 +134,7 @@ async fn initial_draft() {
             archived: None,
             draft: Some(false),
             decision_time: None,
+            confidence: None,
         })
         .await
         .expect("could not update entity");
@@ -213,6 +215,7 @@ async fn no_initial_draft() {
                 archived: None,
                 draft: Some(true),
                 decision_time: None,
+                confidence: None,
             })
             .await
             .expect("could not update entity");
@@ -253,6 +256,7 @@ async fn no_initial_draft() {
                 archived: None,
                 draft: Some(false),
                 decision_time: None,
+                confidence: None,
             })
             .await
             .expect("could not update entity");
@@ -319,6 +323,7 @@ async fn multiple_drafts() {
                 archived: None,
                 draft: Some(true),
                 decision_time: None,
+                confidence: None,
             })
             .await
             .expect("could not update entity");
@@ -362,6 +367,7 @@ async fn multiple_drafts() {
                 archived: None,
                 draft: Some(false),
                 decision_time: None,
+                confidence: None,
             })
             .await
             .expect("could not update entity");

--- a/tests/hash-graph-integration/postgres/drafts.rs
+++ b/tests/hash-graph-integration/postgres/drafts.rs
@@ -1,7 +1,8 @@
 use graph::store::knowledge::PatchEntityParams;
 use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::knowledge::{
-    entity::EntityId, Property, PropertyObject, PropertyPatchOperation, PropertyPath,
+    entity::EntityId, Property, PropertyConfidence, PropertyObject, PropertyPatchOperation,
+    PropertyPath,
 };
 use pretty_assertions::assert_eq;
 use temporal_versioning::ClosedTemporalBound;
@@ -68,7 +69,14 @@ async fn initial_draft() {
     let mut api = seed(&mut database).await;
 
     let entity = api
-        .create_entity(alice(), vec![person_entity_type_id()], None, true)
+        .create_entity(
+            alice(),
+            vec![person_entity_type_id()],
+            None,
+            true,
+            None,
+            PropertyConfidence::default(),
+        )
         .await
         .expect("could not create entity");
     assert!(entity.record_id.entity_id.draft_id.is_some());
@@ -177,12 +185,20 @@ async fn initial_draft() {
 }
 
 #[tokio::test]
+#[expect(clippy::too_many_lines)]
 async fn no_initial_draft() {
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = seed(&mut database).await;
 
     let entity = api
-        .create_entity(alice(), vec![person_entity_type_id()], None, false)
+        .create_entity(
+            alice(),
+            vec![person_entity_type_id()],
+            None,
+            false,
+            None,
+            PropertyConfidence::default(),
+        )
         .await
         .expect("could not create entity");
     assert!(entity.record_id.entity_id.draft_id.is_none());
@@ -291,7 +307,14 @@ async fn multiple_drafts() {
     let mut api = seed(&mut database).await;
 
     let entity = api
-        .create_entity(alice(), vec![person_entity_type_id()], None, false)
+        .create_entity(
+            alice(),
+            vec![person_entity_type_id()],
+            None,
+            false,
+            None,
+            PropertyConfidence::default(),
+        )
         .await
         .expect("could not create entity");
     assert!(entity.record_id.entity_id.draft_id.is_none());

--- a/tests/hash-graph-integration/postgres/drafts.rs
+++ b/tests/hash-graph-integration/postgres/drafts.rs
@@ -1,7 +1,8 @@
 use graph::store::knowledge::PatchEntityParams;
 use graph_test_data::{data_type, entity, entity_type, property_type};
-use graph_types::knowledge::entity::{EntityId, PropertyObject};
-use json_patch::{PatchOperation, ReplaceOperation};
+use graph_types::knowledge::{
+    entity::EntityId, Property, PropertyObject, PropertyPatchOperation, PropertyPath,
+};
 use pretty_assertions::assert_eq;
 use temporal_versioning::ClosedTemporalBound;
 use type_system::url::{BaseUrl, OntologyTypeVersion, VersionedUrl};
@@ -88,10 +89,11 @@ async fn initial_draft() {
     let updated_entity = api
         .patch_entity(PatchEntityParams {
             entity_id: entity.record_id.entity_id,
-            properties: vec![PatchOperation::Replace(ReplaceOperation {
-                path: String::new(),
-                value: serde_json::to_value(bob()).expect("could not serialize entity"),
-            })],
+            properties: vec![PropertyPatchOperation::Replace {
+                path: PropertyPath::default(),
+                value: Property::Object(bob()),
+                confidence: None,
+            }],
             entity_type_ids: vec![],
             archived: None,
             draft: Some(true),
@@ -122,10 +124,11 @@ async fn initial_draft() {
     let updated_live_entity = api
         .patch_entity(PatchEntityParams {
             entity_id: updated_entity.record_id.entity_id,
-            properties: vec![PatchOperation::Replace(ReplaceOperation {
-                path: String::new(),
-                value: serde_json::to_value(charles()).expect("could not serialize entity"),
-            })],
+            properties: vec![PropertyPatchOperation::Replace {
+                path: PropertyPath::default(),
+                value: Property::Object(charles()),
+                confidence: None,
+            }],
             entity_type_ids: vec![],
             archived: None,
             draft: Some(false),
@@ -201,10 +204,11 @@ async fn no_initial_draft() {
         let updated_entity = api
             .patch_entity(PatchEntityParams {
                 entity_id: entity.record_id.entity_id,
-                properties: vec![PatchOperation::Replace(ReplaceOperation {
-                    path: String::new(),
-                    value: serde_json::to_value(bob()).expect("could not serialize entity"),
-                })],
+                properties: vec![PropertyPatchOperation::Replace {
+                    path: PropertyPath::default(),
+                    value: Property::Object(bob()),
+                    confidence: None,
+                }],
                 entity_type_ids: vec![],
                 archived: None,
                 draft: Some(true),
@@ -240,10 +244,11 @@ async fn no_initial_draft() {
         let updated_live_entity = api
             .patch_entity(PatchEntityParams {
                 entity_id: updated_entity.record_id.entity_id,
-                properties: vec![PatchOperation::Replace(ReplaceOperation {
-                    path: String::new(),
-                    value: serde_json::to_value(charles()).expect("could not serialize entity"),
-                })],
+                properties: vec![PropertyPatchOperation::Replace {
+                    path: PropertyPath::default(),
+                    value: Property::Object(charles()),
+                    confidence: None,
+                }],
                 entity_type_ids: vec![],
                 archived: None,
                 draft: Some(false),
@@ -305,10 +310,11 @@ async fn multiple_drafts() {
         let updated_entity = api
             .patch_entity(PatchEntityParams {
                 entity_id: entity.record_id.entity_id,
-                properties: vec![PatchOperation::Replace(ReplaceOperation {
-                    path: String::new(),
-                    value: serde_json::to_value(bob()).expect("could not serialize entity"),
-                })],
+                properties: vec![PropertyPatchOperation::Replace {
+                    path: PropertyPath::default(),
+                    value: Property::Object(bob()),
+                    confidence: None,
+                }],
                 entity_type_ids: vec![],
                 archived: None,
                 draft: Some(true),
@@ -347,10 +353,11 @@ async fn multiple_drafts() {
         let updated_live_entity = api
             .patch_entity(PatchEntityParams {
                 entity_id: draft,
-                properties: vec![PatchOperation::Replace(ReplaceOperation {
-                    path: String::new(),
-                    value: serde_json::to_value(charles()).expect("could not serialize entity"),
-                })],
+                properties: vec![PropertyPatchOperation::Replace {
+                    path: PropertyPath::default(),
+                    value: Property::Object(charles()),
+                    confidence: None,
+                }],
                 entity_type_ids: vec![],
                 archived: None,
                 draft: Some(false),

--- a/tests/hash-graph-integration/postgres/entity.rs
+++ b/tests/hash-graph-integration/postgres/entity.rs
@@ -143,6 +143,7 @@ async fn update() {
             archived: None,
             draft: None,
             decision_time: None,
+            confidence: None,
         })
         .await
         .expect("could not update entity");

--- a/tests/hash-graph-integration/postgres/entity.rs
+++ b/tests/hash-graph-integration/postgres/entity.rs
@@ -1,6 +1,6 @@
 use graph::store::knowledge::PatchEntityParams;
 use graph_test_data::{data_type, entity, entity_type, property_type};
-use graph_types::knowledge::entity::EntityProperties;
+use graph_types::knowledge::entity::PropertyObject;
 use json_patch::{PatchOperation, ReplaceOperation};
 use temporal_versioning::ClosedTemporalBound;
 use type_system::url::{BaseUrl, OntologyTypeVersion, VersionedUrl};
@@ -9,7 +9,7 @@ use crate::DatabaseTestWrapper;
 
 #[tokio::test]
 async fn insert() {
-    let person: EntityProperties =
+    let person: PropertyObject =
         serde_json::from_str(entity::PERSON_ALICE_V1).expect("could not parse entity");
 
     let mut database = DatabaseTestWrapper::new().await;
@@ -61,7 +61,7 @@ async fn insert() {
 
 #[tokio::test]
 async fn query() {
-    let organization: EntityProperties =
+    let organization: PropertyObject =
         serde_json::from_str(entity::ORGANIZATION_V1).expect("could not parse entity");
 
     let mut database = DatabaseTestWrapper::new().await;
@@ -101,9 +101,9 @@ async fn query() {
 
 #[tokio::test]
 async fn update() {
-    let page_v1: EntityProperties =
+    let page_v1: PropertyObject =
         serde_json::from_str(entity::PAGE_V1).expect("could not parse entity");
-    let page_v2: EntityProperties =
+    let page_v2: PropertyObject =
         serde_json::from_str(entity::PAGE_V2).expect("could not parse entity");
 
     let mut database = DatabaseTestWrapper::new().await;

--- a/tests/hash-graph-integration/postgres/entity.rs
+++ b/tests/hash-graph-integration/postgres/entity.rs
@@ -1,6 +1,8 @@
 use graph::store::knowledge::PatchEntityParams;
 use graph_test_data::{data_type, entity, entity_type, property_type};
-use graph_types::knowledge::{Property, PropertyObject, PropertyPatchOperation, PropertyPath};
+use graph_types::knowledge::{
+    Property, PropertyConfidence, PropertyObject, PropertyPatchOperation, PropertyPath,
+};
 use temporal_versioning::ClosedTemporalBound;
 use type_system::url::{BaseUrl, OntologyTypeVersion, VersionedUrl};
 
@@ -45,6 +47,8 @@ async fn insert() {
             }],
             None,
             false,
+            None,
+            PropertyConfidence::default(),
         )
         .await
         .expect("could not create entity");
@@ -85,6 +89,8 @@ async fn query() {
             }],
             None,
             false,
+            None,
+            PropertyConfidence::default(),
         )
         .await
         .expect("could not create entity");
@@ -127,6 +133,8 @@ async fn update() {
             }],
             None,
             false,
+            None,
+            PropertyConfidence::default(),
         )
         .await
         .expect("could not create entity");

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -5,6 +5,7 @@
     clippy::unwrap_used
 )]
 
+mod confidence;
 mod data_type;
 mod drafts;
 mod entity;

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -62,7 +62,7 @@ use graph_types::{
     knowledge::{
         entity::{Entity, EntityId, EntityMetadata, EntityUuid},
         link::LinkData,
-        PropertyConfidence, PropertyObject,
+        Confidence, PropertyConfidence, PropertyObject,
     },
     ontology::{
         DataTypeMetadata, DataTypeWithMetadata, EntityTypeMetadata, EntityTypeWithMetadata,
@@ -528,6 +528,8 @@ impl DatabaseApi<'_> {
         entity_type_ids: Vec<VersionedUrl>,
         entity_uuid: Option<EntityUuid>,
         draft: bool,
+        confidence: Option<Confidence>,
+        property_confidence: PropertyConfidence<'static>,
     ) -> Result<EntityMetadata, InsertionError> {
         self.store
             .create_entity(
@@ -540,11 +542,11 @@ impl DatabaseApi<'_> {
                     decision_time: Some(generate_decision_time()),
                     entity_type_ids,
                     properties,
-                    property_confidence: PropertyConfidence::default(),
+                    property_confidence,
                     link_data: None,
                     draft,
                     relationships: [],
-                    confidence: None,
+                    confidence,
                 },
             )
             .await

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -60,8 +60,9 @@ use graph::{
 use graph_types::{
     account::AccountId,
     knowledge::{
-        entity::{Entity, EntityId, EntityMetadata, EntityUuid, PropertyObject},
+        entity::{Entity, EntityId, EntityMetadata, EntityUuid},
         link::LinkData,
+        PropertyConfidence, PropertyObject,
     },
     ontology::{
         DataTypeMetadata, DataTypeWithMetadata, EntityTypeMetadata, EntityTypeWithMetadata,
@@ -539,6 +540,7 @@ impl DatabaseApi<'_> {
                     decision_time: Some(generate_decision_time()),
                     entity_type_ids,
                     properties,
+                    property_confidence: PropertyConfidence::default(),
                     link_data: None,
                     draft,
                     relationships: [],
@@ -789,6 +791,7 @@ impl DatabaseApi<'_> {
                     decision_time: Some(generate_decision_time()),
                     entity_type_ids,
                     properties,
+                    property_confidence: PropertyConfidence::default(),
                     link_data: Some(LinkData {
                         left_entity_id,
                         right_entity_id,

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -60,7 +60,7 @@ use graph::{
 use graph_types::{
     account::AccountId,
     knowledge::{
-        entity::{Entity, EntityId, EntityMetadata, EntityProperties, EntityUuid},
+        entity::{Entity, EntityId, EntityMetadata, EntityUuid, PropertyObject},
         link::LinkData,
     },
     ontology::{
@@ -523,7 +523,7 @@ impl DatabaseApi<'_> {
 
     pub async fn create_entity(
         &mut self,
-        properties: EntityProperties,
+        properties: PropertyObject,
         entity_type_ids: Vec<VersionedUrl>,
         entity_uuid: Option<EntityUuid>,
         draft: bool,
@@ -772,7 +772,7 @@ impl DatabaseApi<'_> {
 
     async fn create_link_entity(
         &mut self,
-        properties: EntityProperties,
+        properties: PropertyObject,
         entity_type_ids: Vec<VersionedUrl>,
         entity_uuid: Option<EntityUuid>,
         left_entity_id: EntityId,

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -544,6 +544,7 @@ impl DatabaseApi<'_> {
                     link_data: None,
                     draft,
                     relationships: [],
+                    confidence: None,
                 },
             )
             .await
@@ -800,6 +801,7 @@ impl DatabaseApi<'_> {
                     }),
                     draft: false,
                     relationships: [],
+                    confidence: None,
                 },
             )
             .await
@@ -979,6 +981,7 @@ impl DatabaseApi<'_> {
                     draft: None,
                     entity_type_ids: vec![],
                     properties: vec![],
+                    confidence: None,
                 },
             )
             .await

--- a/tests/hash-graph-integration/postgres/links.rs
+++ b/tests/hash-graph-integration/postgres/links.rs
@@ -1,5 +1,5 @@
 use graph_test_data::{data_type, entity, entity_type, property_type};
-use graph_types::knowledge::PropertyObject;
+use graph_types::knowledge::{PropertyConfidence, PropertyObject};
 use type_system::url::{BaseUrl, OntologyTypeVersion, VersionedUrl};
 
 use crate::DatabaseTestWrapper;
@@ -41,12 +41,26 @@ async fn insert() {
     };
 
     let alice_metadata = api
-        .create_entity(alice, vec![person_type_id.clone()], None, false)
+        .create_entity(
+            alice,
+            vec![person_type_id.clone()],
+            None,
+            false,
+            None,
+            PropertyConfidence::default(),
+        )
         .await
         .expect("could not create entity");
 
     let bob_metadata = api
-        .create_entity(bob, vec![person_type_id.clone()], None, false)
+        .create_entity(
+            bob,
+            vec![person_type_id.clone()],
+            None,
+            false,
+            None,
+            PropertyConfidence::default(),
+        )
         .await
         .expect("could not create entity");
 
@@ -132,17 +146,38 @@ async fn get_entity_links() {
     };
 
     let alice_metadata = api
-        .create_entity(alice, vec![person_type_id.clone()], None, false)
+        .create_entity(
+            alice,
+            vec![person_type_id.clone()],
+            None,
+            false,
+            None,
+            PropertyConfidence::default(),
+        )
         .await
         .expect("could not create entity");
 
     let bob_metadata = api
-        .create_entity(bob, vec![person_type_id.clone()], None, false)
+        .create_entity(
+            bob,
+            vec![person_type_id.clone()],
+            None,
+            false,
+            None,
+            PropertyConfidence::default(),
+        )
         .await
         .expect("could not create entity");
 
     let charles_metadata = api
-        .create_entity(charles, vec![person_type_id.clone()], None, false)
+        .create_entity(
+            charles,
+            vec![person_type_id.clone()],
+            None,
+            false,
+            None,
+            PropertyConfidence::default(),
+        )
         .await
         .expect("could not create entity");
 
@@ -248,12 +283,26 @@ async fn remove_link() {
     };
 
     let alice_metadata = api
-        .create_entity(alice, vec![person_type_id.clone()], None, false)
+        .create_entity(
+            alice,
+            vec![person_type_id.clone()],
+            None,
+            false,
+            None,
+            PropertyConfidence::default(),
+        )
         .await
         .expect("could not create entity");
 
     let bob_metadata = api
-        .create_entity(bob, vec![person_type_id.clone()], None, false)
+        .create_entity(
+            bob,
+            vec![person_type_id.clone()],
+            None,
+            false,
+            None,
+            PropertyConfidence::default(),
+        )
         .await
         .expect("could not create entity");
 

--- a/tests/hash-graph-integration/postgres/links.rs
+++ b/tests/hash-graph-integration/postgres/links.rs
@@ -1,5 +1,5 @@
 use graph_test_data::{data_type, entity, entity_type, property_type};
-use graph_types::knowledge::entity::PropertyObject;
+use graph_types::knowledge::PropertyObject;
 use type_system::url::{BaseUrl, OntologyTypeVersion, VersionedUrl};
 
 use crate::DatabaseTestWrapper;

--- a/tests/hash-graph-integration/postgres/links.rs
+++ b/tests/hash-graph-integration/postgres/links.rs
@@ -1,5 +1,5 @@
 use graph_test_data::{data_type, entity, entity_type, property_type};
-use graph_types::knowledge::entity::EntityProperties;
+use graph_types::knowledge::entity::PropertyObject;
 use type_system::url::{BaseUrl, OntologyTypeVersion, VersionedUrl};
 
 use crate::DatabaseTestWrapper;
@@ -8,7 +8,7 @@ use crate::DatabaseTestWrapper;
 async fn insert() {
     let alice = serde_json::from_str(entity::PERSON_ALICE_V1).expect("could not parse entity");
     let bob = serde_json::from_str(entity::PERSON_BOB_V1).expect("could not parse entity");
-    let friend_of = EntityProperties::empty();
+    let friend_of = PropertyObject::empty();
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database
@@ -147,7 +147,7 @@ async fn get_entity_links() {
         .expect("could not create entity");
 
     api.create_link_entity(
-        EntityProperties::empty(),
+        PropertyObject::empty(),
         vec![friend_link_type_id.clone()],
         None,
         alice_metadata.record_id.entity_id,
@@ -157,7 +157,7 @@ async fn get_entity_links() {
     .expect("could not create link");
 
     api.create_link_entity(
-        EntityProperties::empty(),
+        PropertyObject::empty(),
         vec![acquaintance_entity_link_type_id.clone()],
         None,
         alice_metadata.record_id.entity_id,
@@ -259,7 +259,7 @@ async fn remove_link() {
 
     let link_entity_metadata = api
         .create_link_entity(
-            EntityProperties::empty(),
+            PropertyObject::empty(),
             vec![friend_link_type_id.clone()],
             None,
             alice_metadata.record_id.entity_id,

--- a/tests/hash-graph-integration/postgres/multi_type.rs
+++ b/tests/hash-graph-integration/postgres/multi_type.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use graph::store::knowledge::PatchEntityParams;
 use graph_test_data::{data_type, entity, entity_type, property_type};
-use graph_types::knowledge::entity::{Entity, PropertyObject};
+use graph_types::knowledge::{entity::Entity, PropertyObject};
 use pretty_assertions::assert_eq;
 use type_system::url::VersionedUrl;
 

--- a/tests/hash-graph-integration/postgres/multi_type.rs
+++ b/tests/hash-graph-integration/postgres/multi_type.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use graph::store::knowledge::PatchEntityParams;
 use graph_test_data::{data_type, entity, entity_type, property_type};
-use graph_types::knowledge::entity::{Entity, EntityProperties};
+use graph_types::knowledge::entity::{Entity, PropertyObject};
 use pretty_assertions::assert_eq;
 use type_system::url::VersionedUrl;
 
@@ -44,7 +44,7 @@ fn org_entity_type_id() -> VersionedUrl {
         .expect("couldn't construct entity type id")
 }
 
-fn alice() -> EntityProperties {
+fn alice() -> PropertyObject {
     serde_json::from_str(entity::PERSON_ALICE_V1).expect("could not parse entity")
 }
 
@@ -54,7 +54,7 @@ async fn empty_entity() {
     let mut api = seed(&mut database).await;
 
     let _ = api
-        .create_entity(EntityProperties::empty(), vec![], None, false)
+        .create_entity(PropertyObject::empty(), vec![], None, false)
         .await
         .expect_err("created entity with no types");
 }

--- a/tests/hash-graph-integration/postgres/multi_type.rs
+++ b/tests/hash-graph-integration/postgres/multi_type.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use graph::store::knowledge::PatchEntityParams;
 use graph_test_data::{data_type, entity, entity_type, property_type};
-use graph_types::knowledge::{entity::Entity, PropertyObject};
+use graph_types::knowledge::{entity::Entity, PropertyConfidence, PropertyObject};
 use pretty_assertions::assert_eq;
 use type_system::url::VersionedUrl;
 
@@ -54,7 +54,14 @@ async fn empty_entity() {
     let mut api = seed(&mut database).await;
 
     let _ = api
-        .create_entity(PropertyObject::empty(), vec![], None, false)
+        .create_entity(
+            PropertyObject::empty(),
+            vec![],
+            None,
+            false,
+            None,
+            PropertyConfidence::default(),
+        )
         .await
         .expect_err("created entity with no types");
 }
@@ -65,7 +72,14 @@ async fn initial_person() {
     let mut api = seed(&mut database).await;
 
     let entity_metadata = api
-        .create_entity(alice(), vec![person_entity_type_id()], None, false)
+        .create_entity(
+            alice(),
+            vec![person_entity_type_id()],
+            None,
+            false,
+            None,
+            PropertyConfidence::default(),
+        )
         .await
         .expect("could not create entity");
 
@@ -130,6 +144,8 @@ async fn create_multi() {
             vec![person_entity_type_id(), org_entity_type_id()],
             None,
             false,
+            None,
+            PropertyConfidence::default(),
         )
         .await
         .expect("could not create entity");

--- a/tests/hash-graph-integration/postgres/multi_type.rs
+++ b/tests/hash-graph-integration/postgres/multi_type.rs
@@ -91,6 +91,7 @@ async fn initial_person() {
             properties: vec![],
             draft: None,
             archived: None,
+            confidence: None,
         })
         .await
         .expect("could not create entity");
@@ -163,6 +164,7 @@ async fn create_multi() {
             properties: vec![],
             draft: None,
             archived: None,
+            confidence: None,
         })
         .await
         .expect("could not create entity");

--- a/tests/hash-graph-integration/postgres/partial_updates.rs
+++ b/tests/hash-graph-integration/postgres/partial_updates.rs
@@ -88,6 +88,7 @@ async fn properties_add() {
         }],
         draft: None,
         archived: None,
+        confidence: None,
     })
     .await
     .expect("could not patch entity");
@@ -122,6 +123,7 @@ async fn properties_remove() {
         }],
         draft: None,
         archived: None,
+        confidence: None,
     })
     .await
     .expect("could not patch entity");
@@ -156,6 +158,7 @@ async fn properties_replace() {
         }],
         draft: None,
         archived: None,
+        confidence: None,
     })
     .await
     .expect("could not patch entity");
@@ -197,6 +200,7 @@ async fn properties_move() {
             }],
             draft: None,
             archived: None,
+            confidence: None,
         })
         .await
         .expect_err("Could patch entity with invalid move operation");
@@ -224,6 +228,7 @@ async fn properties_move() {
         ],
         draft: None,
         archived: None,
+        confidence: None,
     })
     .await
     .expect("could not patch entity");
@@ -278,6 +283,7 @@ async fn properties_copy() {
         ],
         draft: None,
         archived: None,
+        confidence: None,
     })
     .await
     .expect("could not patch entity");
@@ -318,6 +324,7 @@ async fn type_ids() {
         properties: vec![],
         draft: None,
         archived: None,
+        confidence: None,
     })
     .await
     .expect("could not patch entity");
@@ -339,6 +346,7 @@ async fn type_ids() {
         properties: vec![],
         draft: None,
         archived: None,
+        confidence: None,
     })
     .await
     .expect("could not patch entity");
@@ -364,6 +372,7 @@ async fn type_ids() {
         properties: vec![],
         draft: None,
         archived: None,
+        confidence: None,
     })
     .await
     .expect("could not patch entity");

--- a/tests/hash-graph-integration/postgres/partial_updates.rs
+++ b/tests/hash-graph-integration/postgres/partial_updates.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, iter::once, str::FromStr};
 use graph::store::knowledge::PatchEntityParams;
 use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::knowledge::{
-    Property, PropertyObject, PropertyPatchOperation, PropertyPathElement,
+    Property, PropertyConfidence, PropertyObject, PropertyPatchOperation, PropertyPathElement,
 };
 use pretty_assertions::assert_eq;
 use serde_json::json;
@@ -72,7 +72,14 @@ async fn properties_add() {
     let mut api = seed(&mut database).await;
 
     let entity = api
-        .create_entity(alice(), vec![person_entity_type_id()], None, false)
+        .create_entity(
+            alice(),
+            vec![person_entity_type_id()],
+            None,
+            false,
+            None,
+            PropertyConfidence::default(),
+        )
         .await
         .expect("could not create entity");
     let entity_id = entity.record_id.entity_id;
@@ -109,7 +116,14 @@ async fn properties_remove() {
     let mut api = seed(&mut database).await;
 
     let entity = api
-        .create_entity(alice(), vec![person_entity_type_id()], None, false)
+        .create_entity(
+            alice(),
+            vec![person_entity_type_id()],
+            None,
+            false,
+            None,
+            PropertyConfidence::default(),
+        )
         .await
         .expect("could not create entity");
     let entity_id = entity.record_id.entity_id;
@@ -142,7 +156,14 @@ async fn properties_replace() {
     let mut api = seed(&mut database).await;
 
     let entity = api
-        .create_entity(alice(), vec![person_entity_type_id()], None, false)
+        .create_entity(
+            alice(),
+            vec![person_entity_type_id()],
+            None,
+            false,
+            None,
+            PropertyConfidence::default(),
+        )
         .await
         .expect("could not create entity");
     let entity_id = entity.record_id.entity_id;
@@ -178,7 +199,14 @@ async fn properties_move() {
     let mut api = seed(&mut database).await;
 
     let entity = api
-        .create_entity(alice(), vec![person_entity_type_id()], None, false)
+        .create_entity(
+            alice(),
+            vec![person_entity_type_id()],
+            None,
+            false,
+            None,
+            PropertyConfidence::default(),
+        )
         .await
         .expect("could not create entity");
     let entity_id = entity.record_id.entity_id;
@@ -251,7 +279,14 @@ async fn properties_copy() {
     let mut api = seed(&mut database).await;
 
     let entity = api
-        .create_entity(alice(), vec![person_entity_type_id()], None, false)
+        .create_entity(
+            alice(),
+            vec![person_entity_type_id()],
+            None,
+            false,
+            None,
+            PropertyConfidence::default(),
+        )
         .await
         .expect("could not create entity");
     let entity_id = entity.record_id.entity_id;
@@ -312,6 +347,8 @@ async fn type_ids() {
             vec![person_entity_type_id()],
             None,
             false,
+            None,
+            PropertyConfidence::default(),
         )
         .await
         .expect("could not create entity");

--- a/tests/hash-graph-integration/postgres/partial_updates.rs
+++ b/tests/hash-graph-integration/postgres/partial_updates.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, str::FromStr};
 
 use graph::store::knowledge::PatchEntityParams;
 use graph_test_data::{data_type, entity, entity_type, property_type};
-use graph_types::knowledge::entity::EntityProperties;
+use graph_types::knowledge::entity::PropertyObject;
 use json_patch::{
     AddOperation, CopyOperation, MoveOperation, PatchOperation, RemoveOperation, ReplaceOperation,
     TestOperation,
@@ -64,7 +64,7 @@ fn film_property_type_id() -> BaseUrl {
         .expect("couldn't construct Base URL")
 }
 
-fn alice() -> EntityProperties {
+fn alice() -> PropertyObject {
     serde_json::from_str(entity::PERSON_ALICE_V1).expect("could not parse entity")
 }
 
@@ -303,7 +303,7 @@ async fn type_ids() {
 
     let entity = api
         .create_entity(
-            EntityProperties::empty(),
+            PropertyObject::empty(),
             vec![person_entity_type_id()],
             None,
             false,

--- a/tests/hash-graph-integration/postgres/sorting.rs
+++ b/tests/hash-graph-integration/postgres/sorting.rs
@@ -8,7 +8,7 @@ use graph::{
     },
 };
 use graph_test_data::{data_type, entity, entity_type, property_type};
-use graph_types::knowledge::{entity::EntityUuid, PropertyObject};
+use graph_types::knowledge::{entity::EntityUuid, PropertyConfidence, PropertyObject};
 use pretty_assertions::assert_eq;
 use type_system::url::{BaseUrl, OntologyTypeVersion, VersionedUrl};
 use uuid::Uuid;
@@ -135,6 +135,8 @@ async fn insert(database: &mut DatabaseTestWrapper) -> DatabaseApi<'_> {
             vec![type_id.clone()],
             Some(EntityUuid::new(Uuid::from_u128(idx as u128))),
             false,
+            None,
+            PropertyConfidence::default(),
         )
         .await
         .expect("could not create entity");

--- a/tests/hash-graph-integration/postgres/sorting.rs
+++ b/tests/hash-graph-integration/postgres/sorting.rs
@@ -8,7 +8,7 @@ use graph::{
     },
 };
 use graph_test_data::{data_type, entity, entity_type, property_type};
-use graph_types::knowledge::entity::{EntityUuid, PropertyObject};
+use graph_types::knowledge::{entity::EntityUuid, PropertyObject};
 use pretty_assertions::assert_eq;
 use type_system::url::{BaseUrl, OntologyTypeVersion, VersionedUrl};
 use uuid::Uuid;

--- a/tests/hash-graph-integration/postgres/sorting.rs
+++ b/tests/hash-graph-integration/postgres/sorting.rs
@@ -8,7 +8,7 @@ use graph::{
     },
 };
 use graph_test_data::{data_type, entity, entity_type, property_type};
-use graph_types::knowledge::entity::{EntityProperties, EntityUuid};
+use graph_types::knowledge::entity::{EntityUuid, PropertyObject};
 use pretty_assertions::assert_eq;
 use type_system::url::{BaseUrl, OntologyTypeVersion, VersionedUrl};
 use uuid::Uuid;
@@ -18,7 +18,7 @@ use crate::{DatabaseApi, DatabaseTestWrapper};
 async fn test_root_sorting_chunked<const N: usize, const M: usize>(
     api: &DatabaseApi<'_>,
     sort: [(EntityQueryPath<'static>, Ordering, NullOrdering); N],
-    expected_order: [EntityProperties; M],
+    expected_order: [PropertyObject; M],
 ) {
     for chunk_size in 0..expected_order.len() {
         test_root_sorting(api, chunk_size + 1, sort.clone(), &expected_order).await;
@@ -29,7 +29,7 @@ async fn test_root_sorting(
     api: &DatabaseApi<'_>,
     chunk_size: usize,
     sort: impl IntoIterator<Item = (EntityQueryPath<'static>, Ordering, NullOrdering)> + Send,
-    expected_order: impl IntoIterator<Item = &EntityProperties> + Send,
+    expected_order: impl IntoIterator<Item = &PropertyObject> + Send,
 ) {
     let sorting_paths = sort
         .into_iter()
@@ -128,7 +128,7 @@ async fn insert(database: &mut DatabaseTestWrapper) -> DatabaseApi<'_> {
     ];
 
     for (idx, (entity, type_id)) in entities_properties.into_iter().enumerate() {
-        let properties: EntityProperties =
+        let properties: PropertyObject =
             serde_json::from_str(entity).expect("could not parse entity");
         api.create_entity(
             properties.clone(),
@@ -154,23 +154,23 @@ fn name_property_path() -> EntityQueryPath<'static> {
     )])))
 }
 
-fn alice() -> EntityProperties {
+fn alice() -> PropertyObject {
     serde_json::from_str(entity::PERSON_ALICE_V1).expect("could not parse entity")
 }
 
-fn bob() -> EntityProperties {
+fn bob() -> PropertyObject {
     serde_json::from_str(entity::PERSON_BOB_V1).expect("could not parse entity")
 }
 
-fn charles() -> EntityProperties {
+fn charles() -> PropertyObject {
     serde_json::from_str(entity::PERSON_CHARLES_V1).expect("could not parse entity")
 }
 
-fn page_v1() -> EntityProperties {
+fn page_v1() -> PropertyObject {
     serde_json::from_str(entity::PAGE_V1).expect("could not parse entity")
 }
 
-fn page_v2() -> EntityProperties {
+fn page_v2() -> PropertyObject {
     serde_json::from_str(entity::PAGE_V2).expect("could not parse entity")
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR adds the possibility to specify a confidence value for:
- The whole entity ("How confident is the user this entity is a thing?")
- Each property ("How confident is the user a specific property exists/is correct?")
- (for links): The left and right entity ("How confident is the user the left/right entity is correct?")


## 🔍 What does this change?

- Allow specifying the confidence values for the above when creating and updating an entity
- Property confidence values are encoded as property path (which currently is a JSON Pointer but this will change with H-2503)
- Confidence values can be set for each property and each property nested inside of another property (object or array)
- If a confidence value is updated, each nested property confidence is reset
- Each property confidence needs to correspond to an actual property (They are validated against the entity's properties, not against the schema)
- When patching an entity, the confidence value has to be specified (Patching an entity will not retain the edition confidence value)
- Link confidences has to be specified on construction. This can be lifted in the future when links can be updated. If required, we can allow updating link confidences inside of `PATCH`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- A bunch of test cases were added to test this functionality