### PR TITLE
H-2513: Allow validating an entity without checking linkData

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.79"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/persist-entities/create-entities.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/persist-entities/create-entities.ts
@@ -310,7 +310,9 @@ export const createEntities = async ({
           try {
             await graphApiClient.validateEntity(actorId, {
               entityTypes: [entityTypeId],
-              profile: createAsDraft ? "draft" : "full",
+              components: createAsDraft
+                ? { numItems: false, requiredProperties: false }
+                : {},
               properties,
             });
 
@@ -508,7 +510,9 @@ export const createEntities = async ({
           try {
             await graphApiClient.validateEntity(actorId, {
               entityTypes: [entityTypeId],
-              profile: createAsDraft ? "draft" : "full",
+              components: createAsDraft
+                ? { numItems: false, requiredProperties: false }
+                : {},
               properties,
               linkData,
             });

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/persist-entities/update-entities.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/persist-entities/update-entities.ts
@@ -114,7 +114,9 @@ export const updateEntities = async ({
 
             await graphApiClient.validateEntity(actorId, {
               entityTypes: [entityTypeId],
-              profile: createAsDraft ? "draft" : "full",
+              components: createAsDraft
+                ? { numItems: false, requiredProperties: false }
+                : {},
               properties,
               linkData: existingEntity.linkData,
             });

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/propose-entities.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/propose-entities.ts
@@ -371,7 +371,10 @@ export const proposeEntities = async (params: {
                       try {
                         await graphApiClient.validateEntity(validationActorId, {
                           entityTypes: [entityTypeId],
-                          profile: "draft",
+                          components: {
+                            numItems: false,
+                            requiredProperties: false,
+                          },
                           properties: proposedEntityOfType.properties ?? {},
                         });
 

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/propose-entities.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/propose-entities.ts
@@ -372,6 +372,7 @@ export const proposeEntities = async (params: {
                         await graphApiClient.validateEntity(validationActorId, {
                           entityTypes: [entityTypeId],
                           components: {
+                            linkData: false,
                             numItems: false,
                             requiredProperties: false,
                           },

--- a/apps/hash-graph/libs/api/src/rest/entity.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity.rs
@@ -55,7 +55,7 @@ use json_patch::{
 use serde::{Deserialize, Serialize};
 use temporal_client::TemporalClient;
 use utoipa::{OpenApi, ToSchema};
-use validation::ValidationProfile;
+use validation::ValidateEntityComponents;
 
 use crate::rest::{
     api_resource::RoutedResource, json::Json, status::report_to_response,
@@ -85,7 +85,7 @@ use crate::rest::{
             CreateEntityRequest,
             ValidateEntityParams,
             EntityValidationType,
-            ValidationProfile,
+            ValidateEntityComponents,
             Embedding,
             UpdateEntityEmbeddingsParams,
             EntityEmbedding,

--- a/apps/hash-graph/libs/graph/src/snapshot/entity/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/entity/batch.rs
@@ -11,7 +11,7 @@ use futures::TryStreamExt;
 use graph_types::knowledge::entity::{Entity, EntityUuid};
 use tokio_postgres::GenericClient;
 use type_system::ClosedEntityType;
-use validation::{Validate, ValidationProfile};
+use validation::{Validate, ValidateEntityComponents};
 
 use crate::{
     snapshot::{
@@ -336,9 +336,9 @@ impl<C: AsClient> WriteBatch<C> for EntityRowBatch {
                     .validate(
                         &schema,
                         if entity.metadata.record_id.entity_id.draft_id.is_some() {
-                            ValidationProfile::Draft
+                            ValidateEntityComponents::draft()
                         } else {
-                            ValidationProfile::Full
+                            ValidateEntityComponents::full()
                         },
                         &validator_provider,
                     )

--- a/apps/hash-graph/libs/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/libs/graph/src/store/knowledge.rs
@@ -21,7 +21,7 @@ use utoipa::{
     openapi::{schema, Ref, RefOr, Schema},
     ToSchema,
 };
-use validation::ValidationProfile;
+use validation::ValidateEntityComponents;
 
 use crate::{
     knowledge::EntityQueryPath,
@@ -199,7 +199,9 @@ pub struct ValidateEntityParams<'a> {
     #[serde(borrow, default)]
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     pub link_data: Option<Cow<'a, LinkData>>,
-    pub profile: ValidationProfile,
+    #[serde(default)]
+    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
+    pub components: ValidateEntityComponents,
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -6456,14 +6456,35 @@
         },
         "additionalProperties": false
       },
+      "ValidateEntityComponents": {
+        "type": "object",
+        "properties": {
+          "linkData": {
+            "type": "boolean"
+          },
+          "numItems": {
+            "type": "boolean"
+          },
+          "requiredProperties": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
       "ValidateEntityParams": {
         "type": "object",
         "required": [
           "entityTypes",
-          "properties",
-          "profile"
+          "properties"
         ],
         "properties": {
+          "components": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ValidateEntityComponents"
+              }
+            ]
+          },
           "entityTypes": {
             "$ref": "#/components/schemas/EntityValidationType"
           },
@@ -6474,21 +6495,11 @@
               }
             ]
           },
-          "profile": {
-            "$ref": "#/components/schemas/ValidationProfile"
-          },
           "properties": {
             "$ref": "#/components/schemas/EntityProperties"
           }
         },
         "additionalProperties": false
-      },
-      "ValidationProfile": {
-        "type": "string",
-        "enum": [
-          "full",
-          "draft"
-        ]
       },
       "VersionedUrl": {
         "type": "string",

--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -1606,8 +1606,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "entityTypes": ["http://localhost:3000/@alice/types/entity-type/person/v/1"],
   "properties": {
     "http://localhost:3000/@alice/types/property-type/name/": "Alice"
-  },
-  "profile": "full"
+  }
 }
 
 > {%
@@ -1757,8 +1756,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "entityTypes": ["http://localhost:3000/@alice/types/entity-type/person/v/2"],
   "properties": {
     "http://localhost:3000/@alice/types/property-type/name/": "Alice Allison"
-  },
-  "profile": "draft"
+  }
 }
 
 > {%
@@ -2023,8 +2021,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "linkData": {
     "leftEntityId": "{{person_a_entity_id}}",
     "rightEntityId": "{{person_b_entity_id}}"
-  },
-  "profile": "draft"
+  }
 }
 
 > {%

--- a/libs/@local/hash-validation/src/data_type.rs
+++ b/libs/@local/hash-validation/src/data_type.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 
 use crate::{
     error::{Actual, Expected},
-    OntologyTypeProvider, Schema, Validate, ValidationProfile,
+    OntologyTypeProvider, Schema, Validate, ValidateEntityComponents,
 };
 
 #[derive(Debug, Error)]
@@ -425,7 +425,7 @@ impl<P: Sync> Schema<Property, P> for DataType {
     async fn validate_value<'a>(
         &'a self,
         property: &'a Property,
-        _: ValidationProfile,
+        _: ValidateEntityComponents,
         _: &'a P,
     ) -> Result<(), Report<DataValidationError>> {
         match (self.json_type(), property) {
@@ -515,10 +515,10 @@ impl Validate<DataType, ()> for Property {
     async fn validate(
         &self,
         schema: &DataType,
-        profile: ValidationProfile,
+        components: ValidateEntityComponents,
         (): &(),
     ) -> Result<(), Report<Self::Error>> {
-        schema.validate_value(self, profile, &()).await
+        schema.validate_value(self, components, &()).await
     }
 }
 
@@ -531,7 +531,7 @@ where
     async fn validate_value<'a>(
         &'a self,
         value: &'a Property,
-        profile: ValidationProfile,
+        components: ValidateEntityComponents,
         provider: &'a P,
     ) -> Result<(), Report<Self::Error>> {
         let data_type = provider
@@ -542,7 +542,7 @@ where
             })?;
         data_type
             .borrow()
-            .validate_value(value, profile, provider)
+            .validate_value(value, components, provider)
             .await
             .attach_lazy(|| Expected::DataType(data_type.borrow().clone()))
             .attach_lazy(|| Actual::Property(value.clone()))
@@ -558,10 +558,10 @@ where
     async fn validate(
         &self,
         schema: &DataTypeReference,
-        profile: ValidationProfile,
+        components: ValidateEntityComponents,
         context: &P,
     ) -> Result<(), Report<Self::Error>> {
-        schema.validate_value(self, profile, context).await
+        schema.validate_value(self, components, context).await
     }
 }
 
@@ -570,14 +570,14 @@ mod tests {
     use serde_json::json;
     use uuid::Uuid;
 
-    use crate::{tests::validate_data, ValidationProfile};
+    use crate::{tests::validate_data, ValidateEntityComponents};
 
     #[tokio::test]
     async fn null() {
         validate_data(
             json!(null),
             graph_test_data::data_type::NULL_V1,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -588,7 +588,7 @@ mod tests {
         validate_data(
             json!(true),
             graph_test_data::data_type::BOOLEAN_V1,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -599,7 +599,7 @@ mod tests {
         validate_data(
             json!(42),
             graph_test_data::data_type::NUMBER_V1,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -616,29 +616,33 @@ mod tests {
         }))
         .expect("failed to serialize temperature unit type");
 
-        validate_data(json!(10), &integer_type, ValidationProfile::Full)
+        validate_data(json!(10), &integer_type, ValidateEntityComponents::full())
             .await
             .expect("validation failed");
 
-        validate_data(json!(-10), &integer_type, ValidationProfile::Full)
+        validate_data(json!(-10), &integer_type, ValidateEntityComponents::full())
             .await
             .expect("validation failed");
 
-        _ = validate_data(json!(1.0), &integer_type, ValidationProfile::Full)
+        _ = validate_data(json!(1.0), &integer_type, ValidateEntityComponents::full())
             .await
             .expect_err("validation succeeded");
 
         _ = validate_data(
             json!(std::f64::consts::PI),
             &integer_type,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect_err("validation succeeded");
 
-        _ = validate_data(json!("foo"), &integer_type, ValidationProfile::Full)
-            .await
-            .expect_err("validation succeeded");
+        _ = validate_data(
+            json!("foo"),
+            &integer_type,
+            ValidateEntityComponents::full(),
+        )
+        .await
+        .expect_err("validation succeeded");
     }
 
     #[tokio::test]
@@ -646,7 +650,7 @@ mod tests {
         validate_data(
             json!("foo"),
             graph_test_data::data_type::TEXT_V1,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -657,7 +661,7 @@ mod tests {
         validate_data(
             json!([]),
             graph_test_data::data_type::EMPTY_LIST_V1,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -665,7 +669,7 @@ mod tests {
         _ = validate_data(
             json!(["foo", "bar"]),
             graph_test_data::data_type::EMPTY_LIST_V1,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect_err("validation succeeded");
@@ -679,7 +683,7 @@ mod tests {
                 "baz": "qux"
             }),
             graph_test_data::data_type::OBJECT_V1,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -697,15 +701,23 @@ mod tests {
         }))
         .expect("failed to serialize temperature unit type");
 
-        validate_data(json!("Celsius"), &meter_type, ValidationProfile::Full)
-            .await
-            .expect("validation failed");
+        validate_data(
+            json!("Celsius"),
+            &meter_type,
+            ValidateEntityComponents::full(),
+        )
+        .await
+        .expect("validation failed");
 
-        validate_data(json!("Fahrenheit"), &meter_type, ValidationProfile::Full)
-            .await
-            .expect("validation failed");
+        validate_data(
+            json!("Fahrenheit"),
+            &meter_type,
+            ValidateEntityComponents::full(),
+        )
+        .await
+        .expect("validation failed");
 
-        _ = validate_data(json!("foo"), &meter_type, ValidationProfile::Full)
+        _ = validate_data(json!("foo"), &meter_type, ValidateEntityComponents::full())
             .await
             .expect_err("validation succeeded");
     }
@@ -722,15 +734,15 @@ mod tests {
         }))
         .expect("failed to serialize meter type");
 
-        validate_data(json!(10), &meter_type, ValidationProfile::Full)
+        validate_data(json!(10), &meter_type, ValidateEntityComponents::full())
             .await
             .expect("validation failed");
 
-        validate_data(json!(0.0), &meter_type, ValidationProfile::Full)
+        validate_data(json!(0.0), &meter_type, ValidateEntityComponents::full())
             .await
             .expect("validation failed");
 
-        _ = validate_data(json!(-1.0), &meter_type, ValidationProfile::Full)
+        _ = validate_data(json!(-1.0), &meter_type, ValidateEntityComponents::full())
             .await
             .expect_err("validation succeeded");
     }
@@ -747,19 +759,23 @@ mod tests {
         }))
         .expect("failed to serialize uri type");
 
-        validate_data(json!("localhost:3000"), &url_type, ValidationProfile::Full)
-            .await
-            .expect("validation failed");
-
         validate_data(
-            json!("https://blockprotocol.org/types/modules/graph/0.3/schema/data-type"),
+            json!("localhost:3000"),
             &url_type,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
 
-        _ = validate_data(json!("10"), &url_type, ValidationProfile::Full)
+        validate_data(
+            json!("https://blockprotocol.org/types/modules/graph/0.3/schema/data-type"),
+            &url_type,
+            ValidateEntityComponents::full(),
+        )
+        .await
+        .expect("validation failed");
+
+        _ = validate_data(json!("10"), &url_type, ValidateEntityComponents::full())
             .await
             .expect_err("validation succeeded");
     }
@@ -776,14 +792,18 @@ mod tests {
         }))
         .expect("failed to serialize uuid type");
 
-        validate_data(json!(Uuid::nil()), &uuid_type, ValidationProfile::Full)
-            .await
-            .expect("validation failed");
+        validate_data(
+            json!(Uuid::nil()),
+            &uuid_type,
+            ValidateEntityComponents::full(),
+        )
+        .await
+        .expect("validation failed");
 
         validate_data(
             json!("00000000-0000-0000-0000-000000000000"),
             &uuid_type,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -791,7 +811,7 @@ mod tests {
         validate_data(
             json!("AC8E0011-84C3-4A7E-872D-1B9F86DB0479"),
             &uuid_type,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -799,7 +819,7 @@ mod tests {
         validate_data(
             json!("urn:uuid:cc2c0477-2fe7-4eb4-af7b-45bfe7d7bb26"),
             &uuid_type,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -807,12 +827,12 @@ mod tests {
         validate_data(
             json!("9544f491598e4c238f6bbb8c1f7d05c9"),
             &uuid_type,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
 
-        _ = validate_data(json!("10"), &uuid_type, ValidationProfile::Full)
+        _ = validate_data(json!("10"), &uuid_type, ValidateEntityComponents::full())
             .await
             .expect_err("validation succeeded");
     }
@@ -832,7 +852,7 @@ mod tests {
         validate_data(
             json!("bob@example.com"),
             &mail_type,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -840,14 +860,18 @@ mod tests {
         validate_data(
             json!("user.name+tag+sorting@example.com"),
             &mail_type,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
 
-        _ = validate_data(json!("job!done"), &mail_type, ValidationProfile::Full)
-            .await
-            .expect_err("validation succeeded");
+        _ = validate_data(
+            json!("job!done"),
+            &mail_type,
+            ValidateEntityComponents::full(),
+        )
+        .await
+        .expect_err("validation succeeded");
     }
 
     #[tokio::test]
@@ -862,15 +886,19 @@ mod tests {
         }))
         .expect("failed to serialize zip code type");
 
-        validate_data(json!("12345"), &zip_code, ValidationProfile::Full)
+        validate_data(json!("12345"), &zip_code, ValidateEntityComponents::full())
             .await
             .expect("validation failed");
 
-        validate_data(json!("12345-6789"), &zip_code, ValidationProfile::Full)
-            .await
-            .expect("validation failed");
+        validate_data(
+            json!("12345-6789"),
+            &zip_code,
+            ValidateEntityComponents::full(),
+        )
+        .await
+        .expect("validation failed");
 
-        _ = validate_data(json!("1234"), &zip_code, ValidationProfile::Full)
+        _ = validate_data(json!("1234"), &zip_code, ValidateEntityComponents::full())
             .await
             .expect_err("validation succeeded");
     }
@@ -887,18 +915,26 @@ mod tests {
         }))
         .expect("failed to serialize ipv4 type");
 
-        validate_data(json!("127.0.0.1"), &ipv4_type, ValidationProfile::Full)
-            .await
-            .expect("validation failed");
+        validate_data(
+            json!("127.0.0.1"),
+            &ipv4_type,
+            ValidateEntityComponents::full(),
+        )
+        .await
+        .expect("validation failed");
 
-        validate_data(json!("0.0.0.0"), &ipv4_type, ValidationProfile::Full)
-            .await
-            .expect("validation failed");
+        validate_data(
+            json!("0.0.0.0"),
+            &ipv4_type,
+            ValidateEntityComponents::full(),
+        )
+        .await
+        .expect("validation failed");
 
         validate_data(
             json!("255.255.255.255"),
             &ipv4_type,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -906,14 +942,18 @@ mod tests {
         _ = validate_data(
             json!("255.255.255.256"),
             &ipv4_type,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect_err("validation succeeded");
 
-        _ = validate_data(json!("localhost"), &ipv4_type, ValidationProfile::Full)
-            .await
-            .expect_err("validation succeeded");
+        _ = validate_data(
+            json!("localhost"),
+            &ipv4_type,
+            ValidateEntityComponents::full(),
+        )
+        .await
+        .expect_err("validation succeeded");
     }
 
     #[tokio::test]
@@ -928,18 +968,18 @@ mod tests {
         }))
         .expect("failed to serialize ipv6 type");
 
-        validate_data(json!("::1"), &ipv6_type, ValidationProfile::Full)
+        validate_data(json!("::1"), &ipv6_type, ValidateEntityComponents::full())
             .await
             .expect("validation failed");
 
-        validate_data(json!("::"), &ipv6_type, ValidationProfile::Full)
+        validate_data(json!("::"), &ipv6_type, ValidateEntityComponents::full())
             .await
             .expect("validation failed");
 
         validate_data(
             json!("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"),
             &ipv6_type,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -947,14 +987,18 @@ mod tests {
         _ = validate_data(
             json!("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"),
             &ipv6_type,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect_err("validation succeeded");
 
-        _ = validate_data(json!("localhost"), &ipv6_type, ValidationProfile::Full)
-            .await
-            .expect_err("validation succeeded");
+        _ = validate_data(
+            json!("localhost"),
+            &ipv6_type,
+            ValidateEntityComponents::full(),
+        )
+        .await
+        .expect_err("validation succeeded");
     }
 
     #[tokio::test]
@@ -969,22 +1013,34 @@ mod tests {
         }))
         .expect("failed to serialize hostname type");
 
-        validate_data(json!("localhost"), &hostname_type, ValidationProfile::Full)
-            .await
-            .expect("validation failed");
+        validate_data(
+            json!("localhost"),
+            &hostname_type,
+            ValidateEntityComponents::full(),
+        )
+        .await
+        .expect("validation failed");
 
-        validate_data(json!("[::1]"), &hostname_type, ValidationProfile::Full)
-            .await
-            .expect("validation failed");
+        validate_data(
+            json!("[::1]"),
+            &hostname_type,
+            ValidateEntityComponents::full(),
+        )
+        .await
+        .expect("validation failed");
 
-        validate_data(json!("127.0.0.1"), &hostname_type, ValidationProfile::Full)
-            .await
-            .expect("validation failed");
+        validate_data(
+            json!("127.0.0.1"),
+            &hostname_type,
+            ValidateEntityComponents::full(),
+        )
+        .await
+        .expect("validation failed");
 
         validate_data(
             json!("example.com"),
             &hostname_type,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -992,7 +1048,7 @@ mod tests {
         validate_data(
             json!("subdomain.example.com"),
             &hostname_type,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -1000,7 +1056,7 @@ mod tests {
         validate_data(
             json!("subdomain.example.com."),
             &hostname_type,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -1008,14 +1064,18 @@ mod tests {
         _ = validate_data(
             json!("localhost:3000"),
             &hostname_type,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect_err("validation succeeded");
 
-        _ = validate_data(json!("::1"), &hostname_type, ValidationProfile::Full)
-            .await
-            .expect_err("validation succeeded");
+        _ = validate_data(
+            json!("::1"),
+            &hostname_type,
+            ValidateEntityComponents::full(),
+        )
+        .await
+        .expect_err("validation succeeded");
     }
 
     #[tokio::test]
@@ -1030,15 +1090,15 @@ mod tests {
         }))
         .expect("failed to serialize regex type");
 
-        validate_data(json!("^a*$"), &regex_type, ValidationProfile::Full)
+        validate_data(json!("^a*$"), &regex_type, ValidateEntityComponents::full())
             .await
             .expect("validation failed");
 
-        validate_data(json!("^a+$"), &regex_type, ValidationProfile::Full)
+        validate_data(json!("^a+$"), &regex_type, ValidateEntityComponents::full())
             .await
             .expect("validation failed");
 
-        _ = validate_data(json!("("), &regex_type, ValidationProfile::Full)
+        _ = validate_data(json!("("), &regex_type, ValidateEntityComponents::full())
             .await
             .expect_err("validation succeeded");
     }
@@ -1056,17 +1116,21 @@ mod tests {
         }))
         .expect("failed to serialize short string type");
 
-        validate_data(json!("foo"), &url_type, ValidationProfile::Full)
+        validate_data(json!("foo"), &url_type, ValidateEntityComponents::full())
             .await
             .expect("validation failed");
 
-        _ = validate_data(json!(""), &url_type, ValidationProfile::Full)
+        _ = validate_data(json!(""), &url_type, ValidateEntityComponents::full())
             .await
             .expect_err("validation succeeded");
 
-        _ = validate_data(json!("foo bar baz"), &url_type, ValidationProfile::Full)
-            .await
-            .expect_err("validation succeeded");
+        _ = validate_data(
+            json!("foo bar baz"),
+            &url_type,
+            ValidateEntityComponents::full(),
+        )
+        .await
+        .expect_err("validation succeeded");
     }
 
     #[tokio::test]
@@ -1455,7 +1519,7 @@ mod tests {
 
         let mut failed_formats = Vec::new();
         for format in VALID_FORMATS {
-            if validate_data(json!(format), &url_type, ValidationProfile::Full)
+            if validate_data(json!(format), &url_type, ValidateEntityComponents::full())
                 .await
                 .is_err()
             {
@@ -1467,13 +1531,13 @@ mod tests {
             "failed to validate formats: {failed_formats:#?}"
         );
 
-        _ = validate_data(json!(""), &url_type, ValidationProfile::Full)
+        _ = validate_data(json!(""), &url_type, ValidateEntityComponents::full())
             .await
             .expect_err("validation succeeded");
 
         let mut passed_formats = Vec::new();
         for format in INVALID_FORMATS {
-            if validate_data(json!(format), &url_type, ValidationProfile::Full)
+            if validate_data(json!(format), &url_type, ValidateEntityComponents::full())
                 .await
                 .is_ok()
             {
@@ -1520,7 +1584,7 @@ mod tests {
 
         let mut failed_formats = Vec::new();
         for format in VALID_FORMATS {
-            if validate_data(json!(format), &url_type, ValidationProfile::Full)
+            if validate_data(json!(format), &url_type, ValidateEntityComponents::full())
                 .await
                 .is_err()
             {
@@ -1532,13 +1596,13 @@ mod tests {
             "failed to validate formats: {failed_formats:#?}"
         );
 
-        _ = validate_data(json!(""), &url_type, ValidationProfile::Full)
+        _ = validate_data(json!(""), &url_type, ValidateEntityComponents::full())
             .await
             .expect_err("validation succeeded");
 
         let mut passed_formats = Vec::new();
         for format in INVALID_FORMATS {
-            if validate_data(json!(format), &url_type, ValidationProfile::Full)
+            if validate_data(json!(format), &url_type, ValidateEntityComponents::full())
                 .await
                 .is_ok()
             {
@@ -1770,7 +1834,7 @@ mod tests {
 
         let mut failed_formats = Vec::new();
         for format in VALID_FORMATS {
-            if validate_data(json!(format), &url_type, ValidationProfile::Full)
+            if validate_data(json!(format), &url_type, ValidateEntityComponents::full())
                 .await
                 .is_err()
             {
@@ -1782,13 +1846,13 @@ mod tests {
             "failed to validate formats: {failed_formats:#?}"
         );
 
-        _ = validate_data(json!(""), &url_type, ValidationProfile::Full)
+        _ = validate_data(json!(""), &url_type, ValidateEntityComponents::full())
             .await
             .expect_err("validation succeeded");
 
         let mut passed_formats = Vec::new();
         for format in INVALID_FORMATS {
-            if validate_data(json!(format), &url_type, ValidationProfile::Full)
+            if validate_data(json!(format), &url_type, ValidateEntityComponents::full())
                 .await
                 .is_ok()
             {
@@ -1854,7 +1918,7 @@ mod tests {
 
         let mut failed_formats = Vec::new();
         for format in VALID_FORMATS {
-            if validate_data(json!(format), &url_type, ValidationProfile::Full)
+            if validate_data(json!(format), &url_type, ValidateEntityComponents::full())
                 .await
                 .is_err()
             {
@@ -1866,13 +1930,13 @@ mod tests {
             "failed to validate formats: {failed_formats:#?}"
         );
 
-        _ = validate_data(json!(""), &url_type, ValidationProfile::Full)
+        _ = validate_data(json!(""), &url_type, ValidateEntityComponents::full())
             .await
             .expect_err("validation succeeded");
 
         let mut passed_formats = Vec::new();
         for format in INVALID_FORMATS {
-            if validate_data(json!(format), &url_type, ValidationProfile::Full)
+            if validate_data(json!(format), &url_type, ValidateEntityComponents::full())
                 .await
                 .is_ok()
             {

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -33,7 +33,7 @@ trait Schema<V: ?Sized, P: Sync> {
     fn validate_value<'a>(
         &'a self,
         value: &'a V,
-        profile: ValidationProfile,
+        components: ValidateEntityComponents,
         provider: &'a P,
     ) -> impl Future<Output = Result<(), Report<Self::Error>>> + Send + 'a;
 }
@@ -48,7 +48,7 @@ impl<T> Valid<T> {
     pub async fn new<S, C>(
         value: T,
         schema: S,
-        profile: ValidationProfile,
+        components: ValidateEntityComponents,
         context: C,
     ) -> Result<Self, Report<T::Error>>
     where
@@ -56,7 +56,7 @@ impl<T> Valid<T> {
         S: Send,
         C: Send,
     {
-        value.validate(&schema, profile, &context).await?;
+        value.validate(&schema, components, &context).await?;
         Ok(Self { value })
     }
 
@@ -65,12 +65,49 @@ impl<T> Valid<T> {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
+const fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Copy, Clone, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[serde(rename_all = "camelCase")]
-pub enum ValidationProfile {
-    Full,
-    Draft,
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ValidateEntityComponents {
+    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
+    #[serde(default = "default_true")]
+    pub link_data: bool,
+    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
+    #[serde(default = "default_true")]
+    pub required_properties: bool,
+    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
+    #[serde(default = "default_true")]
+    pub num_items: bool,
+}
+
+impl ValidateEntityComponents {
+    #[must_use]
+    pub const fn full() -> Self {
+        Self {
+            link_data: true,
+            required_properties: true,
+            num_items: true,
+        }
+    }
+
+    #[must_use]
+    pub const fn draft() -> Self {
+        Self {
+            num_items: false,
+            required_properties: false,
+            ..Self::full()
+        }
+    }
+}
+
+impl Default for ValidateEntityComponents {
+    fn default() -> Self {
+        Self::full()
+    }
 }
 
 impl<T> AsRef<T> for Valid<T> {
@@ -91,7 +128,7 @@ pub trait Validate<S, C> {
     fn validate(
         &self,
         schema: &S,
-        profile: ValidationProfile,
+        components: ValidateEntityComponents,
         context: &C,
     ) -> impl Future<Output = Result<(), Report<Self::Error>>> + Send;
 }
@@ -264,7 +301,7 @@ mod tests {
         entity_types: impl IntoIterator<Item = &'static str> + Send,
         property_types: impl IntoIterator<Item = &'static str> + Send,
         data_types: impl IntoIterator<Item = &'static str> + Send,
-        profile: ValidationProfile,
+        components: ValidateEntityComponents,
     ) -> Result<(), Report<EntityValidationError>> {
         install_error_stack_hooks();
 
@@ -288,7 +325,7 @@ mod tests {
         let entity =
             serde_json::from_str::<EntityProperties>(entity).expect("failed to read entity string");
 
-        entity.validate(&entity_type, profile, &provider).await
+        entity.validate(&entity_type, components, &provider).await
     }
 
     pub(crate) async fn validate_property(
@@ -296,7 +333,7 @@ mod tests {
         property_type: &'static str,
         property_types: impl IntoIterator<Item = &'static str> + Send,
         data_types: impl IntoIterator<Item = &'static str> + Send,
-        profile: ValidationProfile,
+        components: ValidateEntityComponents,
     ) -> Result<(), Report<PropertyValidationError>> {
         install_error_stack_hooks();
         let property = Property::deserialize(property).expect("failed to deserialize property");
@@ -315,13 +352,15 @@ mod tests {
         let property_type: PropertyType =
             serde_json::from_str(property_type).expect("failed to parse property type");
 
-        property.validate(&property_type, profile, &provider).await
+        property
+            .validate(&property_type, components, &provider)
+            .await
     }
 
     pub(crate) async fn validate_data(
         data: JsonValue,
         data_type: &str,
-        profile: ValidationProfile,
+        components: ValidateEntityComponents,
     ) -> Result<(), Report<DataValidationError>> {
         install_error_stack_hooks();
 
@@ -330,6 +369,6 @@ mod tests {
         let data_type: DataType =
             serde_json::from_str(data_type).expect("failed to parse data type");
 
-        property.validate(&data_type, profile, &()).await
+        property.validate(&data_type, components, &()).await
     }
 }

--- a/libs/@local/hash-validation/src/property_type.rs
+++ b/libs/@local/hash-validation/src/property_type.rs
@@ -12,7 +12,7 @@ use type_system::{
 
 use crate::{
     error::{Actual, Expected},
-    OntologyTypeProvider, Schema, Validate, ValidationProfile,
+    OntologyTypeProvider, Schema, Validate, ValidateEntityComponents,
 };
 
 macro_rules! extend_report {
@@ -67,7 +67,7 @@ where
     async fn validate_value<'a>(
         &'a self,
         value: &'a Property,
-        profile: ValidationProfile,
+        components: ValidateEntityComponents,
         provider: &'a P,
     ) -> Result<(), Report<PropertyValidationError>> {
         // TODO: Distinguish between format validation and content validation so it's possible
@@ -75,7 +75,7 @@ where
         //   see https://linear.app/hash/issue/BP-33
         OneOf::new(self.one_of().to_vec())
             .expect("was validated before")
-            .validate_value(value, profile, provider)
+            .validate_value(value, components, provider)
             .await
             .attach_lazy(|| Expected::PropertyType(self.clone()))
             .attach_lazy(|| Actual::Property(value.clone()))
@@ -91,10 +91,10 @@ where
     async fn validate(
         &self,
         schema: &PropertyType,
-        profile: ValidationProfile,
+        components: ValidateEntityComponents,
         provider: &P,
     ) -> Result<(), Report<Self::Error>> {
-        schema.validate_value(self, profile, provider).await
+        schema.validate_value(self, components, provider).await
     }
 }
 
@@ -107,7 +107,7 @@ where
     async fn validate_value<'a>(
         &'a self,
         value: &'a Property,
-        profile: ValidationProfile,
+        components: ValidateEntityComponents,
         provider: &'a P,
     ) -> Result<(), Report<Self::Error>> {
         let property_type =
@@ -118,7 +118,7 @@ where
                 })?;
         property_type
             .borrow()
-            .validate_value(value, profile, provider)
+            .validate_value(value, components, provider)
             .await
             .attach_lazy(|| Expected::PropertyType(property_type.borrow().clone()))
             .attach_lazy(|| Actual::Property(value.clone()))
@@ -134,10 +134,10 @@ where
     async fn validate(
         &self,
         schema: &PropertyTypeReference,
-        profile: ValidationProfile,
+        components: ValidateEntityComponents,
         context: &P,
     ) -> Result<(), Report<Self::Error>> {
-        schema.validate_value(self, profile, context).await
+        schema.validate_value(self, components, context).await
     }
 }
 
@@ -152,12 +152,12 @@ where
     async fn validate_value<'a>(
         &'a self,
         values: &'a [V],
-        profile: ValidationProfile,
+        components: ValidateEntityComponents,
         provider: &'a P,
     ) -> Result<(), Report<Self::Error>> {
         let mut status: Result<(), Report<PropertyValidationError>> = Ok(());
 
-        if profile == ValidationProfile::Full {
+        if components.num_items {
             if let Some(min) = self.min_items() {
                 if values.len() < min {
                     extend_report!(
@@ -184,7 +184,11 @@ where
         }
 
         for value in values {
-            if let Err(report) = self.items().validate_value(value, profile, provider).await {
+            if let Err(report) = self
+                .items()
+                .validate_value(value, components, provider)
+                .await
+            {
                 extend_report!(status, report);
             }
         }
@@ -204,13 +208,13 @@ where
     async fn validate_value<'a>(
         &'a self,
         value: &'a V,
-        profile: ValidationProfile,
+        components: ValidateEntityComponents,
         provider: &'a P,
     ) -> Result<(), Report<Self::Error>> {
         let mut status: Result<(), Report<S::Error>> = Ok(());
 
         for schema in self.one_of() {
-            if let Err(error) = schema.validate_value(value, profile, provider).await {
+            if let Err(error) = schema.validate_value(value, components, provider).await {
                 extend_report!(status, error);
             } else {
                 // Only one schema must match
@@ -232,13 +236,15 @@ where
     async fn validate_value<'a>(
         &'a self,
         value: &'a Property,
-        profile: ValidationProfile,
+        components: ValidateEntityComponents,
         provider: &'a P,
     ) -> Result<(), Report<Self::Error>> {
         match (value, self) {
-            (value, Self::Value(schema)) => schema.validate_value(value, profile, provider).await,
+            (value, Self::Value(schema)) => {
+                schema.validate_value(value, components, provider).await
+            }
             (Property::Array(array), Self::Array(schema)) => {
-                schema.validate_value(array, profile, provider).await
+                schema.validate_value(array, components, provider).await
             }
             (_, Self::Array(_)) => {
                 bail!(PropertyValidationError::InvalidType {
@@ -260,7 +266,7 @@ where
     async fn validate_value<'a>(
         &'a self,
         value: &'a HashMap<BaseUrl, Property>,
-        profile: ValidationProfile,
+        components: ValidateEntityComponents,
         provider: &'a P,
     ) -> Result<(), Report<Self::Error>> {
         let mut status: Result<(), Report<Self::Error>> = Ok(());
@@ -268,7 +274,7 @@ where
         for (key, property) in value {
             if let Some(object_schema) = self.properties().get(key) {
                 if let Err(report) = object_schema
-                    .validate_value(property, profile, provider)
+                    .validate_value(property, components, provider)
                     .await
                 {
                     extend_report!(
@@ -286,7 +292,7 @@ where
             }
         }
 
-        if profile == ValidationProfile::Full {
+        if components.required_properties {
             for required_property in self.required() {
                 if !value.contains_key(required_property) {
                     extend_report!(
@@ -312,19 +318,19 @@ where
     fn validate_value<'a>(
         &'a self,
         value: &'a Property,
-        profile: ValidationProfile,
+        components: ValidateEntityComponents,
         provider: &'a P,
     ) -> impl Future<Output = Result<(), Report<Self::Error>>> + Send + '_ {
         Box::pin(async move {
             match (value, self) {
                 (value, Self::DataTypeReference(reference)) => reference
-                    .validate_value(value, profile, provider)
+                    .validate_value(value, components, provider)
                     .await
                     .change_context(PropertyValidationError::DataTypeValidation {
                         id: reference.url().clone(),
                     }),
                 (Property::Array(values), Self::ArrayOfPropertyValues(schema)) => {
-                    schema.validate_value(values, profile, provider).await
+                    schema.validate_value(values, components, provider).await
                 }
                 (Property::Array(_), Self::PropertyTypeObject(_)) => {
                     Err(Report::new(PropertyValidationError::InvalidType {
@@ -333,7 +339,7 @@ where
                     }))
                 }
                 (Property::Object(object), Self::PropertyTypeObject(schema)) => {
-                    schema.validate_value(object, profile, provider).await
+                    schema.validate_value(object, components, provider).await
                 }
                 (Property::Object(_), Self::ArrayOfPropertyValues(_)) => {
                     Err(Report::new(PropertyValidationError::InvalidType {
@@ -363,7 +369,7 @@ mod tests {
 
     use serde_json::json;
 
-    use crate::{tests::validate_property, ValidationProfile};
+    use crate::{tests::validate_property, ValidateEntityComponents};
 
     #[tokio::test]
     async fn address_line_1() {
@@ -375,7 +381,7 @@ mod tests {
             graph_test_data::property_type::ADDRESS_LINE_1_V1,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -391,7 +397,7 @@ mod tests {
             graph_test_data::property_type::AGE_V1,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -407,7 +413,7 @@ mod tests {
             graph_test_data::property_type::BLURB_V1,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -423,7 +429,7 @@ mod tests {
             graph_test_data::property_type::CITY_V1,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -445,7 +451,7 @@ mod tests {
             graph_test_data::property_type::CONTACT_INFORMATION_V1,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -461,7 +467,7 @@ mod tests {
             graph_test_data::property_type::CONTRIVED_PROPERTY_V1,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -471,7 +477,7 @@ mod tests {
             graph_test_data::property_type::CONTRIVED_PROPERTY_V1,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -481,7 +487,7 @@ mod tests {
             graph_test_data::property_type::CONTRIVED_PROPERTY_V1,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect_err("validation succeeded");
@@ -497,7 +503,7 @@ mod tests {
             graph_test_data::property_type::EMAIL_V1,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -513,7 +519,7 @@ mod tests {
             graph_test_data::property_type::FAVORITE_FILM_V1,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -529,7 +535,7 @@ mod tests {
             graph_test_data::property_type::FAVORITE_QUOTE_V1,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -545,7 +551,7 @@ mod tests {
             graph_test_data::property_type::FAVORITE_SONG_V1,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -561,7 +567,7 @@ mod tests {
             graph_test_data::property_type::HOBBY_V1,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -577,7 +583,7 @@ mod tests {
             graph_test_data::property_type::NUMBERS_V1,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -593,7 +599,7 @@ mod tests {
             graph_test_data::property_type::PHONE_NUMBER_V1,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -609,7 +615,7 @@ mod tests {
             graph_test_data::property_type::POSTCODE_NUMBER_V1,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -625,7 +631,7 @@ mod tests {
             graph_test_data::property_type::PUBLISHED_ON_V1,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -641,7 +647,7 @@ mod tests {
             graph_test_data::property_type::TEXT_V1,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -660,7 +666,7 @@ mod tests {
             graph_test_data::property_type::USER_ID_V1,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -670,7 +676,7 @@ mod tests {
             graph_test_data::property_type::USER_ID_V1,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect_err("validation succeeded");
@@ -680,7 +686,7 @@ mod tests {
             graph_test_data::property_type::USER_ID_V2,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");
@@ -690,7 +696,7 @@ mod tests {
             graph_test_data::property_type::USER_ID_V2,
             property_types,
             data_types,
-            ValidationProfile::Full,
+            ValidateEntityComponents::full(),
         )
         .await
         .expect("validation failed");


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In some circumstances it's desired to only check the entity part, not the link part. This adds the support for this.

## 🔍 What does this change?

- Remove the `ValidationProfile`
- Adds a `ValidateEntityComponents` object which determines what components of an entity has to be validated. Currently, three components can be tweaked:
	- `required_properties`: Check if all required properties are present
	- `num_items`: Check if the number in arrays are correct
	- `link_data`: Check links
By default (or when omitting the parameter) everything will be checked.

The previous `ValidateProfile::Draft` corresponds to `{ required_properties: false, num_items: false }`.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph