### PR TITLE
H-2503: Use arrays instead of JSON pointer for property paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,9 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56dea16b0a29e94408b9aa5e2940a4eedbd128a1ba20e8f7ae60fd3d465af0e"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/get-file-from-url-action.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/get-file-from-url-action.ts
@@ -232,7 +232,7 @@ export const getFileFromUrlAction: FlowActionActivity<{
         properties: [
           {
             op: "replace",
-            path: "",
+            path: [],
             value: properties,
           },
         ],

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/persist-entity-action.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/persist-entity-action.ts
@@ -101,12 +101,10 @@ export const persistEntityAction: FlowActionActivity<{
   if (existingEntity) {
     for (const [key, value] of typedEntries(properties)) {
       // @todo better handle property objects, will currently overwrite the entire object if there are any differences
-      const jsonPointerKey = `/${key.replace(/\//g, "~1")}`;
-
       if (!isEqual(existingEntity.properties[key], value)) {
         patchOperations.push({
           op: existingEntity.properties[key] ? "replace" : "add",
-          path: jsonPointerKey,
+          path: [key],
           value,
         });
       }

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/persist-flow-activity.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/persist-flow-activity.ts
@@ -82,7 +82,7 @@ export const createPersistFlowActivity =
         properties: [
           {
             op: "replace",
-            path: "",
+            path: [],
             value: flowProperties,
           },
         ],

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/persist-entities/update-entities.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/persist-entities/update-entities.ts
@@ -129,7 +129,7 @@ export const updateEntities = async ({
                 properties: [
                   {
                     op: "replace",
-                    path: "",
+                    path: [],
                     value: newProperties,
                   },
                 ],

--- a/apps/hash-ai-worker-ts/src/activities/parse-text-from-file.ts
+++ b/apps/hash-ai-worker-ts/src/activities/parse-text-from-file.ts
@@ -58,7 +58,7 @@ export const parseTextFromFile = async (
       properties: [
         {
           op: "replace",
-          path: "",
+          path: [],
           value: updatedProperties,
         },
       ],

--- a/apps/hash-api/src/graph/knowledge/primitive/entity.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity.ts
@@ -559,7 +559,7 @@ export const updateEntity: ImpureGraphFunction<
     properties: [
       {
         op: "replace",
-        path: "",
+        path: [],
         value: params.properties,
       },
     ],

--- a/apps/hash-api/src/graph/knowledge/primitive/link-entity.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/link-entity.ts
@@ -157,7 +157,7 @@ export const updateLinkEntity: ImpureGraphFunction<
     properties: [
       {
         op: "replace",
-        path: "",
+        path: [],
         value: properties,
       },
     ],

--- a/apps/hash-graph/libs/api/src/rest/entity.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity.rs
@@ -45,7 +45,7 @@ use graph_types::{
         },
         link::LinkData,
         Confidence, Property, PropertyDiff, PropertyMetadata, PropertyMetadataMap, PropertyObject,
-        PropertyPatchOperation, PropertyPath, PropertyProvenance,
+        PropertyPatchOperation, PropertyPath, PropertyPathElement, PropertyProvenance,
     },
     owned_by_id::OwnedById,
     Embedding,
@@ -141,6 +141,7 @@ use crate::rest::{
             DiffEntityResult,
             PropertyDiff,
             PropertyPath,
+            PropertyPathElement,
             Confidence,
         )
     ),

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -5859,9 +5859,21 @@
         }
       },
       "PropertyMetadataMap": {
-        "type": "object",
-        "additionalProperties": {
-          "$ref": "#/components/schemas/PropertyMetadata"
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": [
+            "path",
+            "metadata"
+          ],
+          "properties": {
+            "metadata": {
+              "$ref": "#/components/schemas/PropertyMetadata"
+            },
+            "path": {
+              "$ref": "#/components/schemas/PropertyPath"
+            }
+          }
         }
       },
       "PropertyObject": {
@@ -6062,7 +6074,21 @@
         }
       },
       "PropertyPath": {
-        "type": "string"
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/PropertyPathElement"
+        }
+      },
+      "PropertyPathElement": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BaseUrl"
+          },
+          {
+            "type": "integer",
+            "minimum": 0
+          }
+        ]
       },
       "PropertyProvenance": {
         "type": "object",

--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -1771,7 +1771,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "properties": [
     {
       "op": "replace",
-      "path": "/http:~1~1localhost:3000~1@alice~1types~1property-type~1name~1",
+      "path": ["http://localhost:3000/@alice/types/property-type/name/"],
       "value": "Alice Allison 3"
     }
   ]
@@ -2067,7 +2067,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "properties": [
     {
       "op": "replace",
-      "path": "/http:~1~1localhost:3000~1@alice~1types~1property-type~1name~1",
+      "path": ["http://localhost:3000/@alice/types/property-type/name/"],
       "value": "Bob"
     }
   ]
@@ -2868,7 +2868,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "properties": [
     {
       "op": "replace",
-      "path": "/http:~1~1localhost:3000~1@alice~1types~1property-type~1name~1",
+      "path": ["http://localhost:3000/@alice/types/property-type/name/"],
       "value": "Charles 2 draft"
     }
   ]
@@ -2893,7 +2893,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "properties": [
     {
       "op": "replace",
-      "path": "/http:~1~1localhost:3000~1@alice~1types~1property-type~1name~1",
+      "path": ["http://localhost:3000/@alice/types/property-type/name/"],
       "value": "Charles 2"
     }
   ],

--- a/apps/hash-integration-worker/src/linear-activities.ts
+++ b/apps/hash-integration-worker/src/linear-activities.ts
@@ -229,7 +229,7 @@ const createOrUpdateHashEntity = async (params: {
       properties: [
         {
           op: "replace",
-          path: "",
+          path: [],
           value: mergedProperties,
         },
       ],


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In structural queries, we use an array syntax of path elements into an object. To make it consistent and to avoid encoding/decoding JSON pointers, this syntax should be used for all property paths (e.g. property confidences, or PATCH operations)

## 🚫 Blocked by

- #4306 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph