### PR TITLE
H-2532: Use the same interface for graph integration tests as for the API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,6 +1106,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "temporal-client 0.0.0",
  "temporal-versioning",
  "time",
  "tokio",

--- a/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
@@ -1,6 +1,6 @@
 use std::{iter::repeat, str::FromStr};
 
-use authorization::{schema::WebOwnerSubject, NoAuthorization};
+use authorization::{schema::WebOwnerSubject, AuthorizationApi, NoAuthorization};
 use criterion::{BatchSize::SmallInput, Bencher, BenchmarkId, Criterion, SamplingMode};
 use criterion_macro::criterion;
 use graph::{
@@ -44,9 +44,13 @@ struct DatastoreEntitiesMetadata {
 }
 
 #[expect(clippy::too_many_lines)]
-async fn seed_db(
+#[expect(
+    clippy::significant_drop_tightening,
+    reason = "transaction is committed which consumes the object"
+)]
+async fn seed_db<A: AuthorizationApi>(
     account_id: AccountId,
-    store_wrapper: &mut StoreWrapper,
+    store_wrapper: &mut StoreWrapper<A>,
     total: usize,
 ) -> DatastoreEntitiesMetadata {
     let mut transaction = store_wrapper
@@ -59,17 +63,12 @@ async fn seed_db(
     eprintln!("Seeding database: {}", store_wrapper.bench_db_name);
 
     transaction
-        .insert_account_id(
-            account_id,
-            &mut NoAuthorization,
-            InsertAccountIdParams { account_id },
-        )
+        .insert_account_id(account_id, InsertAccountIdParams { account_id })
         .await
         .expect("could not insert account id");
     transaction
         .insert_web_id(
             account_id,
-            &mut NoAuthorization,
             InsertWebIdParams {
                 owned_by_id: OwnedById::new(account_id.into_uuid()),
                 owner: WebOwnerSubject::Account { id: account_id },
@@ -114,7 +113,6 @@ async fn seed_db(
     let entity_metadata_list = transaction
         .insert_entities_batched_by_type(
             account_id,
-            &mut NoAuthorization,
             repeat((owned_by_id, None, properties.clone(), None, None)).take(total),
             &entity_type_id,
         )
@@ -124,7 +122,6 @@ async fn seed_db(
     let link_entity_metadata_list = transaction
         .insert_entities_batched_by_type(
             account_id,
-            &mut NoAuthorization,
             entity_metadata_list.iter().flat_map(|entity_a_metadata| {
                 entity_metadata_list.iter().map(|entity_b_metadata| {
                     (
@@ -167,10 +164,10 @@ async fn seed_db(
     }
 }
 
-pub fn bench_get_entity_by_id(
+pub fn bench_get_entity_by_id<A: AuthorizationApi>(
     b: &mut Bencher,
     runtime: &Runtime,
-    store: &Store,
+    store: &Store<A>,
     actor_id: AccountId,
     entity_metadata_list: &[EntityMetadata],
     graph_resolve_depths: GraphResolveDepths,
@@ -189,7 +186,6 @@ pub fn bench_get_entity_by_id(
             store
                 .get_entity(
                     actor_id,
-                    &NoAuthorization,
                     GetEntityParams {
                         query: StructuralQuery {
                             filter: Filter::for_entity_by_entity_id(entity_record_id.entity_id),
@@ -233,7 +229,7 @@ fn bench_scaling_read_entity_zero_depths(c: &mut Criterion) {
 
     for size in [1, 5, 10, 25, 50] {
         // TODO: reuse the database if it already exists like we do for representative_read
-        let (runtime, mut store_wrapper) = setup(DB_NAME, true, true, account_id);
+        let (runtime, mut store_wrapper) = setup(DB_NAME, true, true, account_id, NoAuthorization);
 
         let DatastoreEntitiesMetadata {
             entity_metadata_list,
@@ -285,7 +281,7 @@ fn bench_scaling_read_entity_one_depth(c: &mut Criterion) {
 
     for size in [1, 5, 10, 25, 50] {
         // TODO: reuse the database if it already exists like we do for representative_read
-        let (runtime, mut store_wrapper) = setup(DB_NAME, true, true, account_id);
+        let (runtime, mut store_wrapper) = setup(DB_NAME, true, true, account_id, NoAuthorization);
 
         let DatastoreEntitiesMetadata {
             entity_metadata_list,

--- a/apps/hash-graph/bench/read_scaling/lib.rs
+++ b/apps/hash-graph/bench/read_scaling/lib.rs
@@ -10,6 +10,10 @@
     reason = "This is a benchmark but as we want to document this crate as well this should be a \
               warning instead"
 )]
+#![expect(
+    clippy::significant_drop_in_scrutinee,
+    reason = "This should be enabled but it's currently too noisy"
+)]
 
 //! TODO: Introduce benchmarks testing the differing performance of operations as the graph's scale
 //!  changes

--- a/apps/hash-graph/bench/representative_read/knowledge/entity.rs
+++ b/apps/hash-graph/bench/representative_read/knowledge/entity.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use authorization::NoAuthorization;
+use authorization::AuthorizationApi;
 use criterion::{BatchSize::SmallInput, Bencher};
 use graph::{
     knowledge::EntityQueryPath,
@@ -25,10 +25,10 @@ use tokio::runtime::Runtime;
 
 use crate::util::Store;
 
-pub fn bench_get_entity_by_id(
+pub fn bench_get_entity_by_id<A: AuthorizationApi>(
     b: &mut Bencher,
     runtime: &Runtime,
-    store: &Store,
+    store: &Store<A>,
     actor_id: AccountId,
     entity_uuids: &[EntityUuid],
 ) {
@@ -44,7 +44,6 @@ pub fn bench_get_entity_by_id(
             let response = store
                 .get_entity(
                     actor_id,
-                    &NoAuthorization,
                     GetEntityParams {
                         query: StructuralQuery {
                             filter: Filter::Equal(
@@ -76,10 +75,10 @@ pub fn bench_get_entity_by_id(
     );
 }
 
-pub fn bench_get_entities_by_property(
+pub fn bench_get_entities_by_property<A: AuthorizationApi>(
     b: &mut Bencher,
     runtime: &Runtime,
-    store: &Store,
+    store: &Store<A>,
     actor_id: AccountId,
     graph_resolve_depths: GraphResolveDepths,
 ) {
@@ -100,7 +99,6 @@ pub fn bench_get_entities_by_property(
         let response = store
             .get_entity(
                 actor_id,
-                &NoAuthorization,
                 GetEntityParams {
                     query: StructuralQuery {
                         filter,
@@ -128,10 +126,10 @@ pub fn bench_get_entities_by_property(
     });
 }
 
-pub fn bench_get_link_by_target_by_property(
+pub fn bench_get_link_by_target_by_property<A: AuthorizationApi>(
     b: &mut Bencher,
     runtime: &Runtime,
-    store: &Store,
+    store: &Store<A>,
     actor_id: AccountId,
     graph_resolve_depths: GraphResolveDepths,
 ) {
@@ -156,7 +154,6 @@ pub fn bench_get_link_by_target_by_property(
         let response = store
             .get_entity(
                 actor_id,
-                &NoAuthorization,
                 GetEntityParams {
                     query: StructuralQuery {
                         filter,

--- a/apps/hash-graph/bench/representative_read/lib.rs
+++ b/apps/hash-graph/bench/representative_read/lib.rs
@@ -10,6 +10,10 @@
     reason = "This is a benchmark but as we want to document this crate as well this should be a \
               warning instead"
 )]
+#![expect(
+    clippy::significant_drop_in_scrutinee,
+    reason = "This should be enabled but it's currently too noisy"
+)]
 
 //! Benchmarks to check the performance of operations across a "representative" graph.
 //!
@@ -40,6 +44,7 @@ mod seed;
 
 use std::str::FromStr;
 
+use authorization::NoAuthorization;
 use criterion::{BenchmarkId, Criterion, SamplingMode};
 use criterion_macro::criterion;
 use graph::subgraph::edges::{EdgeResolveDepths, GraphResolveDepths, OutgoingEdgeResolveDepth};
@@ -60,7 +65,7 @@ fn bench_representative_read_entity(c: &mut Criterion) {
     );
 
     let mut group = c.benchmark_group("representative_read_entity");
-    let (runtime, mut store_wrapper) = setup(DB_NAME, false, false, account_id);
+    let (runtime, mut store_wrapper) = setup(DB_NAME, false, false, account_id, NoAuthorization);
 
     let samples = runtime.block_on(setup_and_extract_samples(&mut store_wrapper));
     let store = &store_wrapper.store;
@@ -97,7 +102,7 @@ fn bench_representative_read_multiple_entities(c: &mut Criterion) {
     );
 
     let mut group = c.benchmark_group("representative_read_multiple_entities");
-    let (runtime, store_wrapper) = setup(DB_NAME, false, false, account_id);
+    let (runtime, store_wrapper) = setup(DB_NAME, false, false, account_id, NoAuthorization);
     group.sample_size(10);
     group.sampling_mode(SamplingMode::Flat);
 
@@ -391,7 +396,7 @@ fn bench_representative_read_entity_type(c: &mut Criterion) {
     );
 
     let mut group = c.benchmark_group("representative_read_entity_type");
-    let (runtime, mut store_wrapper) = setup(DB_NAME, false, false, account_id);
+    let (runtime, mut store_wrapper) = setup(DB_NAME, false, false, account_id, NoAuthorization);
 
     let samples = runtime.block_on(setup_and_extract_samples(&mut store_wrapper));
     let store = &store_wrapper.store;

--- a/apps/hash-graph/bench/representative_read/ontology/entity_type.rs
+++ b/apps/hash-graph/bench/representative_read/ontology/entity_type.rs
@@ -1,4 +1,4 @@
-use authorization::NoAuthorization;
+use authorization::AuthorizationApi;
 use criterion::{BatchSize::SmallInput, Bencher};
 use graph::{
     store::{ontology::GetEntityTypesParams, query::Filter, EntityTypeStore},
@@ -19,10 +19,10 @@ use type_system::url::VersionedUrl;
 
 use crate::util::Store;
 
-pub fn bench_get_entity_type_by_id(
+pub fn bench_get_entity_type_by_id<A: AuthorizationApi>(
     b: &mut Bencher,
     runtime: &Runtime,
-    store: &Store,
+    store: &Store<A>,
     actor_id: AccountId,
     entity_type_ids: &[VersionedUrl],
 ) {
@@ -38,7 +38,6 @@ pub fn bench_get_entity_type_by_id(
             store
                 .get_entity_type(
                     actor_id,
-                    &NoAuthorization,
                     GetEntityTypesParams {
                         query: StructuralQuery {
                             filter: Filter::for_versioned_url(entity_type_id),

--- a/apps/hash-graph/bins/cli/src/subcommand/migrate.rs
+++ b/apps/hash-graph/bins/cli/src/subcommand/migrate.rs
@@ -1,3 +1,4 @@
+use authorization::NoAuthorization;
 use clap::Parser;
 use error_stack::{Result, ResultExt};
 use graph::store::{DatabaseConnectionInfo, PostgresStorePool, StoreMigration, StorePool};
@@ -21,16 +22,13 @@ pub async fn migrate(args: MigrateArgs) -> Result<(), GraphError> {
             report
         })?;
 
-    let mut connection = pool
-        .acquire()
+    pool.acquire(NoAuthorization, None)
         .await
         .change_context(GraphError)
         .map_err(|report| {
             tracing::error!(error = ?report, "Failed to acquire database connection");
             report
-        })?;
-
-    connection
+        })?
         .run_migrations()
         .await
         .change_context(GraphError)

--- a/apps/hash-graph/bins/cli/src/subcommand/server.rs
+++ b/apps/hash-graph/bins/cli/src/subcommand/server.rs
@@ -9,7 +9,7 @@ use std::{
 use authorization::{
     backend::{SpiceDbOpenApi, ZanzibarBackend},
     zanzibar::ZanzibarClient,
-    AuthorizationApi,
+    AuthorizationApi, NoAuthorization,
 };
 use clap::Parser;
 use error_stack::{Report, Result, ResultExt};
@@ -166,7 +166,7 @@ pub async fn server(args: ServerArgs) -> Result<(), GraphError> {
             report
         })?;
     _ = pool
-        .acquire()
+        .acquire(NoAuthorization, None)
         .await
         .change_context(GraphError)
         .attach_printable("Connection to database failed")?;

--- a/apps/hash-graph/bins/cli/src/subcommand/test_server.rs
+++ b/apps/hash-graph/bins/cli/src/subcommand/test_server.rs
@@ -78,9 +78,8 @@ pub async fn test_server(args: TestServerArgs) -> Result<(), GraphError> {
 
     let mut zanzibar_client = ZanzibarClient::new(spicedb_client);
     zanzibar_client.seed().await.change_context(GraphError)?;
-    let authorization_api = zanzibar_client.into_backend();
 
-    let router = graph_api::rest::test_server::routes(pool, authorization_api);
+    let router = graph_api::rest::test_server::routes(pool, zanzibar_client);
 
     tracing::info!("Listening on {}", args.api_address);
     axum::serve(

--- a/apps/hash-graph/libs/api/src/rest/api_resource.rs
+++ b/apps/hash-graph/libs/api/src/rest/api_resource.rs
@@ -15,7 +15,7 @@ pub(crate) trait RoutedResource: utoipa::OpenApi {
     where
         S: StorePool + Send + Sync + 'static,
         A: AuthorizationApiPool + Send + Sync + 'static,
-        for<'pool> S::Store<'pool>: RestApiStore;
+        for<'pool> S::Store<'pool, A::Api<'pool>>: RestApiStore;
 
     fn documentation() -> utoipa::openapi::OpenApi {
         Self::openapi()

--- a/apps/hash-graph/libs/graph/src/lib.rs
+++ b/apps/hash-graph/libs/graph/src/lib.rs
@@ -16,6 +16,8 @@
 #![cfg_attr(not(miri), doc(test(attr(deny(warnings, clippy::all)))))]
 #![expect(
     unreachable_pub,
+    clippy::significant_drop_tightening,
+    clippy::significant_drop_in_scrutinee,
     reason = "This should be enabled but it's currently too noisy"
 )]
 

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/property_type/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/property_type/batch.rs
@@ -31,8 +31,12 @@ pub enum PropertyTypeRowBatch {
 }
 
 #[async_trait]
-impl<C: AsClient> WriteBatch<C> for PropertyTypeRowBatch {
-    async fn begin(postgres_client: &PostgresStore<C>) -> Result<(), InsertionError> {
+impl<C, A> WriteBatch<C, A> for PropertyTypeRowBatch
+where
+    C: AsClient,
+    A: ZanzibarBackend + Send + Sync,
+{
+    async fn begin(postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError> {
         postgres_client
             .as_client()
             .client()
@@ -65,11 +69,7 @@ impl<C: AsClient> WriteBatch<C> for PropertyTypeRowBatch {
         Ok(())
     }
 
-    async fn write(
-        self,
-        postgres_client: &PostgresStore<C>,
-        authorization_api: &mut (impl ZanzibarBackend + Send),
-    ) -> Result<(), InsertionError> {
+    async fn write(self, postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError> {
         let client = postgres_client.as_client().client();
         match self {
             Self::Schema(property_types) => {
@@ -127,7 +127,8 @@ impl<C: AsClient> WriteBatch<C> for PropertyTypeRowBatch {
                 reason = "Lifetime error, probably the signatures are wrong"
             )]
             Self::Relations(relations) => {
-                authorization_api
+                postgres_client
+                    .authorization_api
                     .touch_relationships(
                         relations
                             .into_iter()
@@ -160,7 +161,7 @@ impl<C: AsClient> WriteBatch<C> for PropertyTypeRowBatch {
     }
 
     async fn commit(
-        postgres_client: &PostgresStore<C>,
+        postgres_client: &mut PostgresStore<C, A>,
         _validation: bool,
     ) -> Result<(), InsertionError> {
         postgres_client

--- a/apps/hash-graph/libs/graph/src/snapshot/owner/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/owner/batch.rs
@@ -19,8 +19,12 @@ pub enum AccountRowBatch {
 }
 
 #[async_trait]
-impl<C: AsClient> WriteBatch<C> for AccountRowBatch {
-    async fn begin(postgres_client: &PostgresStore<C>) -> Result<(), InsertionError> {
+impl<C, A> WriteBatch<C, A> for AccountRowBatch
+where
+    C: AsClient,
+    A: ZanzibarBackend + Send + Sync,
+{
+    async fn begin(postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError> {
         postgres_client
             .as_client()
             .client()
@@ -40,11 +44,7 @@ impl<C: AsClient> WriteBatch<C> for AccountRowBatch {
         Ok(())
     }
 
-    async fn write(
-        self,
-        postgres_client: &PostgresStore<C>,
-        authorization_api: &mut (impl ZanzibarBackend + Send),
-    ) -> Result<(), InsertionError> {
+    async fn write(self, postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError> {
         let client = postgres_client.as_client().client();
         match self {
             Self::Accounts(accounts) => {
@@ -82,7 +82,8 @@ impl<C: AsClient> WriteBatch<C> for AccountRowBatch {
                 }
             }
             Self::AccountGroupAccountRelations(relations) => {
-                authorization_api
+                postgres_client
+                    .authorization_api
                     .touch_relationships(relations)
                     .await
                     .change_context(InsertionError)?;
@@ -92,7 +93,7 @@ impl<C: AsClient> WriteBatch<C> for AccountRowBatch {
     }
 
     async fn commit(
-        postgres_client: &PostgresStore<C>,
+        postgres_client: &mut PostgresStore<C, A>,
         _validation: bool,
     ) -> Result<(), InsertionError> {
         postgres_client

--- a/apps/hash-graph/libs/graph/src/snapshot/web/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/web/batch.rs
@@ -15,8 +15,12 @@ pub enum WebBatch {
 }
 
 #[async_trait]
-impl<C: AsClient> WriteBatch<C> for WebBatch {
-    async fn begin(postgres_client: &PostgresStore<C>) -> Result<(), InsertionError> {
+impl<C, A> WriteBatch<C, A> for WebBatch
+where
+    C: AsClient,
+    A: ZanzibarBackend + Send + Sync,
+{
+    async fn begin(postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError> {
         postgres_client
             .as_client()
             .client()
@@ -33,11 +37,7 @@ impl<C: AsClient> WriteBatch<C> for WebBatch {
         Ok(())
     }
 
-    async fn write(
-        self,
-        postgres_client: &PostgresStore<C>,
-        authorization_api: &mut (impl ZanzibarBackend + Send),
-    ) -> Result<(), InsertionError> {
+    async fn write(self, postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError> {
         let client = postgres_client.as_client().client();
         match self {
             Self::Webs(webs) => {
@@ -58,7 +58,8 @@ impl<C: AsClient> WriteBatch<C> for WebBatch {
                 }
             }
             Self::Relations(relations) => {
-                authorization_api
+                postgres_client
+                    .authorization_api
                     .touch_relationships(relations)
                     .await
                     .change_context(InsertionError)?;
@@ -68,7 +69,7 @@ impl<C: AsClient> WriteBatch<C> for WebBatch {
     }
 
     async fn commit(
-        postgres_client: &PostgresStore<C>,
+        postgres_client: &mut PostgresStore<C, A>,
         _validation: bool,
     ) -> Result<(), InsertionError> {
         postgres_client

--- a/apps/hash-graph/libs/graph/src/store/account.rs
+++ b/apps/hash-graph/libs/graph/src/store/account.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use authorization::{schema::WebOwnerSubject, AuthorizationApi};
+use authorization::schema::WebOwnerSubject;
 use error_stack::Result;
 use graph_types::{
     account::{AccountGroupId, AccountId},
@@ -49,10 +49,9 @@ pub trait AccountStore {
     /// # Errors
     ///
     /// - if insertion failed, e.g. because the [`AccountId`] already exists.
-    async fn insert_account_id<A: AuthorizationApi + Send + Sync>(
+    async fn insert_account_id(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
         params: InsertAccountIdParams,
     ) -> Result<(), InsertionError>;
 
@@ -61,10 +60,9 @@ pub trait AccountStore {
     /// # Errors
     ///
     /// - if insertion failed, e.g. because the [`AccountGroupId`] already exists.
-    async fn insert_account_group_id<A: AuthorizationApi + Send + Sync>(
+    async fn insert_account_group_id(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
         params: InsertAccountGroupIdParams,
     ) -> Result<(), InsertionError>;
 
@@ -73,10 +71,9 @@ pub trait AccountStore {
     /// # Errors
     ///
     /// - if insertion failed, e.g. because the [`OwnedById`] already exists.
-    async fn insert_web_id<A: AuthorizationApi + Send + Sync>(
+    async fn insert_web_id(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
         params: InsertWebIdParams,
     ) -> Result<(), InsertionError>;
 

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -1183,22 +1183,15 @@ where
         self.store.get_entity(actor_id, params).await
     }
 
-    async fn get_entity_by_id<Au: AuthorizationApi + Sync>(
+    async fn get_entity_by_id(
         &self,
         actor_id: AccountId,
-        authorization_api: &Au,
         entity_id: EntityId,
         transaction_time: Option<Timestamp<TransactionTime>>,
         decision_time: Option<Timestamp<DecisionTime>>,
     ) -> Result<Entity, QueryError> {
         self.store
-            .get_entity_by_id(
-                actor_id,
-                authorization_api,
-                entity_id,
-                transaction_time,
-                decision_time,
-            )
+            .get_entity_by_id(actor_id, entity_id, transaction_time, decision_time)
             .await
     }
 

--- a/apps/hash-graph/libs/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/libs/graph/src/store/knowledge.rs
@@ -6,8 +6,7 @@ use graph_types::{
     account::AccountId,
     knowledge::{
         entity::{
-            Entity, EntityEmbedding, EntityId, EntityMetadata, EntityUuid,
-            ProvidedEntityEditionProvenance,
+            EntityEmbedding, EntityId, EntityMetadata, EntityUuid, ProvidedEntityEditionProvenance,
         },
         link::LinkData,
         Confidence, PropertyDiff, PropertyMetadataMap, PropertyObject, PropertyPatchOperation,
@@ -29,8 +28,8 @@ use validation::ValidateEntityComponents;
 use crate::{
     knowledge::EntityQueryPath,
     store::{
-        crud, crud::Sorting, postgres::CursorField, InsertionError, NullOrdering, Ordering,
-        QueryError, UpdateError,
+        crud::Sorting, postgres::CursorField, InsertionError, NullOrdering, Ordering, QueryError,
+        UpdateError,
     },
     subgraph::{query::EntityStructuralQuery, Subgraph},
 };
@@ -306,7 +305,7 @@ pub struct DiffEntityResult<'e> {
 /// Describes the API of a store implementation for [Entities].
 ///
 /// [Entities]: Entity
-pub trait EntityStore: crud::ReadPaginated<Entity> {
+pub trait EntityStore {
     /// Creates a new [`Entity`].
     ///
     /// # Errors:

--- a/apps/hash-graph/libs/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/libs/graph/src/store/knowledge.rs
@@ -304,7 +304,7 @@ pub struct DiffEntityResult<'e> {
 
 /// Describes the API of a store implementation for [Entities].
 ///
-/// [Entities]: Entity
+/// [Entities]: graph_types::knowledge::entity::Entity
 pub trait EntityStore {
     /// Creates a new [`Entity`].
     ///
@@ -316,6 +316,7 @@ pub trait EntityStore {
     /// - if an [`EntityUuid`] was supplied and already exists in the store
     ///
     /// [`EntityType`]: type_system::EntityType
+    /// [`Entity`]: graph_types::knowledge::entity::Entity
     fn create_entity<R>(
         &mut self,
         actor_id: AccountId,
@@ -329,6 +330,8 @@ pub trait EntityStore {
     /// # Errors:
     ///
     /// - if the validation failed
+    ///
+    /// [`Entity`]: graph_types::knowledge::entity::Entity
     fn validate_entity(
         &self,
         actor_id: AccountId,
@@ -352,6 +355,7 @@ pub trait EntityStore {
     /// - if the account referred to by `owned_by_id` does not exist
     /// - if an [`EntityUuid`] was supplied and already exists in the store
     ///
+    /// [`Entity`]: graph_types::knowledge::entity::Entity
     /// [`EntityType`]: type_system::EntityType
     fn insert_entities_batched_by_type(
         &mut self,
@@ -375,6 +379,7 @@ pub trait EntityStore {
     ///
     /// - if the requested [`Entity`] doesn't exist
     ///
+    /// [`Entity`]: graph_types::knowledge::entity::Entity
     /// [`StructuralQuery`]: crate::subgraph::query::StructuralQuery
     fn get_entity(
         &self,

--- a/apps/hash-graph/libs/graph/src/store/ontology.rs
+++ b/apps/hash-graph/libs/graph/src/store/ontology.rs
@@ -1,10 +1,7 @@
 use std::{borrow::Cow, iter};
 
-use authorization::{
-    schema::{
-        DataTypeRelationAndSubject, EntityTypeRelationAndSubject, PropertyTypeRelationAndSubject,
-    },
-    AuthorizationApi,
+use authorization::schema::{
+    DataTypeRelationAndSubject, EntityTypeRelationAndSubject, PropertyTypeRelationAndSubject,
 };
 use error_stack::Result;
 use graph_types::{
@@ -17,7 +14,6 @@ use graph_types::{
     Embedding,
 };
 use serde::Deserialize;
-use temporal_client::TemporalClient;
 use temporal_versioning::{Timestamp, TransactionTime};
 use type_system::{
     url::{BaseUrl, VersionedUrl},
@@ -108,11 +104,9 @@ pub trait DataTypeStore {
     /// - if the [`BaseUrl`] of the `data_type` already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    fn create_data_type<A: AuthorizationApi + Send + Sync, R>(
+    fn create_data_type<R>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
-        temporal_client: Option<&TemporalClient>,
         params: CreateDataTypeParams<R>,
     ) -> impl Future<Output = Result<DataTypeMetadata, InsertionError>> + Send
     where
@@ -121,12 +115,7 @@ pub trait DataTypeStore {
     {
         async move {
             Ok(self
-                .create_data_types(
-                    actor_id,
-                    authorization_api,
-                    temporal_client,
-                    iter::once(params),
-                )
+                .create_data_types(actor_id, iter::once(params))
                 .await?
                 .pop()
                 .expect("created exactly one data type"))
@@ -141,11 +130,9 @@ pub trait DataTypeStore {
     /// - if any [`BaseUrl`] of the data type already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    fn create_data_types<A: AuthorizationApi + Send + Sync, P, R>(
+    fn create_data_types<P, R>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
-        temporal_client: Option<&TemporalClient>,
         params: P,
     ) -> impl Future<Output = Result<Vec<DataTypeMetadata>, InsertionError>> + Send
     where
@@ -157,10 +144,9 @@ pub trait DataTypeStore {
     /// # Errors
     ///
     /// - if the requested [`DataType`] doesn't exist.
-    fn get_data_type<A: AuthorizationApi + Sync>(
+    fn get_data_type(
         &self,
         actor_id: AccountId,
-        authorization_api: &A,
         params: GetDataTypesParams<'_>,
     ) -> impl Future<Output = Result<Subgraph, QueryError>> + Send;
 
@@ -169,11 +155,9 @@ pub trait DataTypeStore {
     /// # Errors
     ///
     /// - if the [`DataType`] doesn't exist.
-    fn update_data_type<A: AuthorizationApi + Send + Sync, R>(
+    fn update_data_type<R>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
-        temporal_client: Option<&TemporalClient>,
         params: UpdateDataTypesParams<R>,
     ) -> impl Future<Output = Result<DataTypeMetadata, UpdateError>> + Send
     where
@@ -184,10 +168,9 @@ pub trait DataTypeStore {
     /// # Errors
     ///
     /// - if the [`DataType`] doesn't exist.
-    fn archive_data_type<A: AuthorizationApi + Send + Sync>(
+    fn archive_data_type(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
         params: ArchiveDataTypeParams,
     ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
 
@@ -196,17 +179,17 @@ pub trait DataTypeStore {
     /// # Errors
     ///
     /// - if the [`DataType`] doesn't exist.
-    fn unarchive_data_type<A: AuthorizationApi + Send + Sync>(
+    fn unarchive_data_type(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
+
         params: UnarchiveDataTypeParams,
     ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
 
-    fn update_data_type_embeddings<A: AuthorizationApi + Send + Sync>(
+    fn update_data_type_embeddings(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
+
         params: UpdateDataTypeEmbeddingParams<'_>,
     ) -> impl Future<Output = Result<(), UpdateError>> + Send;
 }
@@ -286,11 +269,9 @@ pub trait PropertyTypeStore {
     /// - if the [`BaseUrl`] of the `property_type` already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    fn create_property_type<A: AuthorizationApi + Send + Sync, R>(
+    fn create_property_type<R>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
-        temporal_client: Option<&TemporalClient>,
         params: CreatePropertyTypeParams<R>,
     ) -> impl Future<Output = Result<PropertyTypeMetadata, InsertionError>> + Send
     where
@@ -299,12 +280,7 @@ pub trait PropertyTypeStore {
     {
         async move {
             Ok(self
-                .create_property_types(
-                    actor_id,
-                    authorization_api,
-                    temporal_client,
-                    iter::once(params),
-                )
+                .create_property_types(actor_id, iter::once(params))
                 .await?
                 .pop()
                 .expect("created exactly one property type"))
@@ -319,11 +295,9 @@ pub trait PropertyTypeStore {
     /// - if any [`BaseUrl`] of the property type already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    fn create_property_types<A: AuthorizationApi + Send + Sync, P, R>(
+    fn create_property_types<P, R>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
-        temporal_client: Option<&TemporalClient>,
         params: P,
     ) -> impl Future<Output = Result<Vec<PropertyTypeMetadata>, InsertionError>> + Send
     where
@@ -335,10 +309,9 @@ pub trait PropertyTypeStore {
     /// # Errors
     ///
     /// - if the requested [`PropertyType`] doesn't exist.
-    fn get_property_type<A: AuthorizationApi + Sync>(
+    fn get_property_type(
         &self,
         actor_id: AccountId,
-        authorization_api: &A,
         params: GetPropertyTypesParams<'_>,
     ) -> impl Future<Output = Result<Subgraph, QueryError>> + Send;
 
@@ -347,11 +320,9 @@ pub trait PropertyTypeStore {
     /// # Errors
     ///
     /// - if the [`PropertyType`] doesn't exist.
-    fn update_property_type<A: AuthorizationApi + Send + Sync, R>(
+    fn update_property_type<R>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
-        temporal_client: Option<&TemporalClient>,
         params: UpdatePropertyTypesParams<R>,
     ) -> impl Future<Output = Result<PropertyTypeMetadata, UpdateError>> + Send
     where
@@ -362,10 +333,10 @@ pub trait PropertyTypeStore {
     /// # Errors
     ///
     /// - if the [`PropertyType`] doesn't exist.
-    fn archive_property_type<A: AuthorizationApi + Send + Sync>(
+    fn archive_property_type(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
+
         params: ArchivePropertyTypeParams<'_>,
     ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
 
@@ -374,17 +345,17 @@ pub trait PropertyTypeStore {
     /// # Errors
     ///
     /// - if the [`PropertyType`] doesn't exist.
-    fn unarchive_property_type<A: AuthorizationApi + Send + Sync>(
+    fn unarchive_property_type(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
+
         params: UnarchivePropertyTypeParams<'_>,
     ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
 
-    fn update_property_type_embeddings<A: AuthorizationApi + Send + Sync>(
+    fn update_property_type_embeddings(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
+
         params: UpdatePropertyTypeEmbeddingParams<'_>,
     ) -> impl Future<Output = Result<(), UpdateError>> + Send;
 }
@@ -468,11 +439,9 @@ pub trait EntityTypeStore {
     /// - if the [`BaseUrl`] of the `entity_type` already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    fn create_entity_type<A: AuthorizationApi + Send + Sync, R>(
+    fn create_entity_type<R>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
-        temporal_client: Option<&TemporalClient>,
         params: CreateEntityTypeParams<R>,
     ) -> impl Future<Output = Result<EntityTypeMetadata, InsertionError>> + Send
     where
@@ -481,12 +450,7 @@ pub trait EntityTypeStore {
     {
         async move {
             Ok(self
-                .create_entity_types(
-                    actor_id,
-                    authorization_api,
-                    temporal_client,
-                    iter::once(params),
-                )
+                .create_entity_types(actor_id, iter::once(params))
                 .await?
                 .pop()
                 .expect("created exactly one entity type"))
@@ -501,11 +465,9 @@ pub trait EntityTypeStore {
     /// - if any [`BaseUrl`] of the entity type already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    fn create_entity_types<A: AuthorizationApi + Send + Sync, P, R>(
+    fn create_entity_types<P, R>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
-        temporal_client: Option<&TemporalClient>,
         params: P,
     ) -> impl Future<Output = Result<Vec<EntityTypeMetadata>, InsertionError>> + Send
     where
@@ -517,10 +479,9 @@ pub trait EntityTypeStore {
     /// # Errors
     ///
     /// - if the requested [`EntityType`] doesn't exist.
-    fn get_entity_type<A: AuthorizationApi + Sync>(
+    fn get_entity_type(
         &self,
         actor_id: AccountId,
-        authorization_api: &A,
         params: GetEntityTypesParams<'_>,
     ) -> impl Future<Output = Result<Subgraph, QueryError>> + Send;
 
@@ -529,11 +490,9 @@ pub trait EntityTypeStore {
     /// # Errors
     ///
     /// - if the [`EntityType`] doesn't exist.
-    fn update_entity_type<A: AuthorizationApi + Send + Sync, R>(
+    fn update_entity_type<R>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
-        temporal_client: Option<&TemporalClient>,
         params: UpdateEntityTypesParams<R>,
     ) -> impl Future<Output = Result<EntityTypeMetadata, UpdateError>> + Send
     where
@@ -544,10 +503,10 @@ pub trait EntityTypeStore {
     /// # Errors
     ///
     /// - if the [`EntityType`] doesn't exist.
-    fn archive_entity_type<A: AuthorizationApi + Send + Sync>(
+    fn archive_entity_type(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
+
         params: ArchiveEntityTypeParams,
     ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
 
@@ -556,17 +515,17 @@ pub trait EntityTypeStore {
     /// # Errors
     ///
     /// - if the [`EntityType`] doesn't exist.
-    fn unarchive_entity_type<A: AuthorizationApi + Send + Sync>(
+    fn unarchive_entity_type(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
+
         params: UnarchiveEntityTypeParams,
     ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
 
-    fn update_entity_type_embeddings<A: AuthorizationApi + Send + Sync>(
+    fn update_entity_type_embeddings(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
+
         params: UpdateEntityTypeEmbeddingParams<'_>,
     ) -> impl Future<Output = Result<(), UpdateError>> + Send;
 }

--- a/apps/hash-graph/libs/graph/src/store/postgres/crud.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/crud.rs
@@ -41,11 +41,12 @@ where
     }
 }
 
-impl<Cl, R, S> ReadPaginated<R, S> for PostgresStore<Cl>
+impl<Cl, A, R, S> ReadPaginated<R, S> for PostgresStore<Cl, A>
 where
     Cl: AsClient,
     for<'c> R: PostgresRecord<QueryPath<'c>: PostgresQueryPath>,
     for<'s> S: PostgresSorting<'s, R> + Sync,
+    A: Send + Sync,
 {
     type QueryResult = Row;
 
@@ -101,10 +102,11 @@ where
 }
 
 #[async_trait]
-impl<Cl, R> Read<R> for PostgresStore<Cl>
+impl<Cl, A, R> Read<R> for PostgresStore<Cl, A>
 where
     Cl: AsClient,
     for<'c> R: PostgresRecord<QueryPath<'c>: PostgresQueryPath>,
+    A: Send + Sync,
 {
     type ReadStream = impl Stream<Item = Result<R, Report<QueryError>>> + Send + Sync;
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -1213,15 +1213,14 @@ where
             .count())
     }
 
-    async fn get_entity_by_id<A: AuthorizationApi + Sync>(
+    async fn get_entity_by_id(
         &self,
         actor_id: AccountId,
-        authorization_api: &A,
         entity_id: EntityId,
         transaction_time: Option<Timestamp<TransactionTime>>,
         decision_time: Option<Timestamp<DecisionTime>>,
     ) -> Result<Entity, QueryError> {
-        authorization_api
+        self.authorization_api
             .check_entity_permission(
                 actor_id,
                 EntityPermission::View,

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -34,7 +34,6 @@ use graph_types::{
 };
 use hash_status::StatusCode;
 use postgres_types::{Json, ToSql};
-use temporal_client::TemporalClient;
 use temporal_versioning::{
     ClosedTemporalBound, DecisionTime, LeftClosedTemporalInterval, LimitedTemporalBound,
     RightBoundedTemporalInterval, TemporalBound, Timestamp, TransactionTime,
@@ -77,15 +76,16 @@ use crate::{
     },
 };
 
-impl<C: AsClient> PostgresStore<C> {
+impl<C, A> PostgresStore<C, A>
+where
+    C: AsClient,
+    A: AuthorizationApi,
+{
     /// Internal method to read an [`Entity`] into a [`TraversalContext`].
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
-    #[tracing::instrument(
-        level = "info",
-        skip(self, traversal_context, subgraph, authorization_api, zookie)
-    )]
-    pub(crate) async fn traverse_entities<A>(
+    #[tracing::instrument(level = "info", skip(self, traversal_context, subgraph, zookie))]
+    pub(crate) async fn traverse_entities(
         &self,
         mut entity_queue: Vec<(
             EntityVertexId,
@@ -94,13 +94,9 @@ impl<C: AsClient> PostgresStore<C> {
         )>,
         traversal_context: &mut TraversalContext,
         actor_id: AccountId,
-        authorization_api: &A,
         zookie: &Zookie<'static>,
         subgraph: &mut Subgraph,
-    ) -> Result<(), QueryError>
-    where
-        A: AuthorizationApi + Sync,
-    {
+    ) -> Result<(), QueryError> {
         let variable_axis = subgraph.temporal_axes.resolved.variable_time_axis();
 
         let mut entity_type_queue = Vec::new();
@@ -180,7 +176,7 @@ impl<C: AsClient> PostgresStore<C> {
                     Self::filter_entity_types_by_permission(
                         self.read_shared_edges(&traversal_data, Some(0)).await?,
                         actor_id,
-                        authorization_api,
+                        &self.authorization_api,
                         zookie,
                     )
                     .await?
@@ -214,7 +210,8 @@ impl<C: AsClient> PostgresStore<C> {
                         continue;
                     }
 
-                    let permissions = authorization_api
+                    let permissions = self
+                        .authorization_api
                         .check_entities_permission(
                             actor_id,
                             EntityPermission::View,
@@ -270,7 +267,6 @@ impl<C: AsClient> PostgresStore<C> {
             entity_type_queue,
             traversal_context,
             actor_id,
-            authorization_api,
             zookie,
             subgraph,
         )
@@ -303,13 +299,15 @@ impl<C: AsClient> PostgresStore<C> {
     }
 }
 
-impl<C: AsClient> EntityStore for PostgresStore<C> {
-    #[tracing::instrument(level = "info", skip(self, authorization_api, temporal_client, params))]
-    async fn create_entity<A: AuthorizationApi + Send + Sync, R>(
+impl<C, A> EntityStore for PostgresStore<C, A>
+where
+    C: AsClient,
+    A: AuthorizationApi,
+{
+    #[tracing::instrument(level = "info", skip(self, params))]
+    async fn create_entity<R>(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
-        temporal_client: Option<&TemporalClient>,
         params: CreateEntityParams<R>,
     ) -> Result<EntityMetadata, InsertionError>
     where
@@ -332,7 +330,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
 
         for entity_type_id in &params.entity_type_ids {
             let entity_type_id = EntityTypeId::from_url(entity_type_id);
-            authorization_api
+            self.authorization_api
                 .check_entity_type_permission(
                     actor_id,
                     EntityTypePermission::Instantiate,
@@ -347,7 +345,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         }
 
         if Some(params.owned_by_id.into_uuid()) != params.entity_uuid.map(EntityUuid::into_uuid) {
-            authorization_api
+            self.authorization_api
                 .check_web_permission(
                     actor_id,
                     WebPermission::CreateEntity,
@@ -572,7 +570,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             .insert_temporal_metadata(entity_id, edition_id, params.decision_time)
             .await?;
 
-        authorization_api
+        transaction
+            .authorization_api
             .modify_entity_relations(relationships.clone().into_iter().map(
                 |relation_and_subject| {
                     (
@@ -588,7 +587,6 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         transaction
             .validate_entity(
                 actor_id,
-                authorization_api,
                 Consistency::FullyConsistent,
                 ValidateEntityParams {
                     entity_types: EntityValidationType::ClosedSchema(Cow::Owned(closed_schema)),
@@ -616,7 +614,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             transaction.commit().await.change_context(InsertionError)
         };
         if let Err(mut error) = commit_result {
-            if let Err(auth_error) = authorization_api
+            if let Err(auth_error) = self
+                .authorization_api
                 .modify_entity_relations(relationships.into_iter().map(|relation_and_subject| {
                     (
                         ModifyRelationshipOperation::Delete,
@@ -662,7 +661,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 confidence: params.confidence,
                 properties: params.property_metadata,
             };
-            if let Some(temporal_client) = temporal_client {
+            if let Some(temporal_client) = &self.temporal_client {
                 temporal_client
                     .start_update_entity_embeddings_workflow(
                         actor_id,
@@ -683,11 +682,10 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
     //   see https://linear.app/hash/issue/H-1449
     // TODO: Restrict non-draft links to non-draft entities
     //   see https://linear.app/hash/issue/H-1450
-    #[tracing::instrument(level = "info", skip(self, authorization_api))]
-    async fn validate_entity<A: AuthorizationApi + Sync>(
+    #[tracing::instrument(level = "info", skip(self))]
+    async fn validate_entity(
         &self,
         actor_id: AccountId,
-        authorization_api: &A,
         consistency: Consistency<'_>,
         params: ValidateEntityParams<'_>,
     ) -> Result<(), ValidateEntityError> {
@@ -704,7 +702,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                     })
                     .unzip();
 
-                if !authorization_api
+                if !self
+                    .authorization_api
                     .check_entity_types_permission(
                         actor_id,
                         EntityTypePermission::View,
@@ -770,7 +769,11 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         let validator_provider = StoreProvider {
             store: self,
             cache: StoreCache::default(),
-            authorization: Some((authorization_api, actor_id, Consistency::FullyConsistent)),
+            authorization: Some((
+                &self.authorization_api,
+                actor_id,
+                Consistency::FullyConsistent,
+            )),
         };
 
         if let Err(error) = params
@@ -819,11 +822,14 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             .attach(StatusCode::InvalidArgument)
     }
 
-    #[tracing::instrument(level = "info", skip(self, authorization_api, entities))]
-    async fn insert_entities_batched_by_type<A: AuthorizationApi + Send + Sync>(
+    #[expect(
+        clippy::significant_drop_tightening,
+        reason = "The connection is required to borrow the client"
+    )]
+    #[tracing::instrument(level = "info", skip(self, entities))]
+    async fn insert_entities_batched_by_type(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
         entities: impl IntoIterator<
             Item = (
                 OwnedById,
@@ -837,7 +843,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         entity_type_url: &VersionedUrl,
     ) -> Result<Vec<EntityMetadata>, InsertionError> {
         let entity_type_id = EntityTypeId::from_url(entity_type_url);
-        authorization_api
+        self.authorization_api
             .check_entity_type_permission(
                 actor_id,
                 EntityTypePermission::Instantiate,
@@ -974,11 +980,10 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             .collect())
     }
 
-    #[tracing::instrument(level = "info", skip(self, authorization_api, params))]
-    async fn get_entity<A: AuthorizationApi + Sync>(
+    #[tracing::instrument(level = "info", skip(self, params))]
+    async fn get_entity(
         &self,
         actor_id: AccountId,
-        authorization_api: &A,
         mut params: GetEntityParams<'_>,
     ) -> Result<GetEntityResponse<'static>, QueryError> {
         let query = &mut params.query;
@@ -1001,7 +1006,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             .try_collect::<Vec<_>>()
             .await?;
 
-            let (permissions, zookie) = authorization_api
+            let (permissions, zookie) = self
+                .authorization_api
                 .check_entities_permission(
                     actor_id,
                     EntityPermission::View,
@@ -1063,7 +1069,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                     .map(|(entity, _)| entity.metadata.record_id.entity_id)
                     .collect::<HashSet<_>>();
 
-                let (permissions, zookie) = authorization_api
+                let (permissions, zookie) = self
+                    .authorization_api
                     .check_entities_permission(
                         actor_id,
                         EntityPermission::View,
@@ -1151,7 +1158,6 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 .collect(),
             &mut traversal_context,
             actor_id,
-            authorization_api,
             &latest_zookie,
             &mut subgraph,
         )
@@ -1168,10 +1174,9 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         })
     }
 
-    async fn count_entities<Au: AuthorizationApi + Sync>(
+    async fn count_entities(
         &self,
         actor_id: AccountId,
-        authorization_api: &Au,
         query: EntityStructuralQuery<'_>,
     ) -> Result<usize, QueryError> {
         let temporal_axes = query.temporal_axes.resolve();
@@ -1187,7 +1192,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         .try_collect::<Vec<_>>()
         .await?;
 
-        let permitted_ids = authorization_api
+        let permitted_ids = self
+            .authorization_api
             .check_entities_permission(
                 actor_id,
                 EntityPermission::View,
@@ -1245,12 +1251,14 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         .await
     }
 
-    #[tracing::instrument(level = "info", skip(self, authorization_api, temporal_client, params))]
-    async fn patch_entity<A: AuthorizationApi + Send + Sync>(
+    #[expect(
+        clippy::significant_drop_tightening,
+        reason = "The connection is required to borrow the client"
+    )]
+    #[tracing::instrument(level = "info", skip(self, params))]
+    async fn patch_entity(
         &mut self,
         actor_id: AccountId,
-        authorization_api: &mut A,
-        temporal_client: Option<&TemporalClient>,
         mut params: PatchEntityParams,
     ) -> Result<EntityMetadata, UpdateError> {
         let entity_type_ids = params
@@ -1259,7 +1267,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             .map(EntityTypeId::from_url)
             .collect::<Vec<_>>();
 
-        if !authorization_api
+        if !self
+            .authorization_api
             .check_entity_types_permission(
                 actor_id,
                 EntityTypePermission::Instantiate,
@@ -1275,7 +1284,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             bail!(Report::new(UpdateError).attach(StatusCode::PermissionDenied));
         }
 
-        authorization_api
+        self.authorization_api
             .check_entity_permission(
                 actor_id,
                 EntityPermission::Update,
@@ -1522,7 +1531,6 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         transaction
             .validate_entity(
                 actor_id,
-                authorization_api,
                 Consistency::FullyConsistent,
                 ValidateEntityParams {
                     entity_types: EntityValidationType::ClosedSchema(Cow::Borrowed(&closed_schema)),
@@ -1557,7 +1565,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             properties: property_metadata,
             archived,
         };
-        if let Some(temporal_client) = temporal_client {
+        if let Some(temporal_client) = &self.temporal_client {
             temporal_client
                 .start_update_entity_embeddings_workflow(
                     actor_id,
@@ -1574,10 +1582,9 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
     }
 
     #[tracing::instrument(level = "info", skip(self, params))]
-    async fn update_entity_embeddings<A: AuthorizationApi + Send + Sync>(
+    async fn update_entity_embeddings(
         &mut self,
         _: AccountId,
-        _: &mut A,
         params: UpdateEntityEmbeddingsParams<'_>,
     ) -> Result<(), UpdateError> {
         #[derive(Debug, ToSql)]
@@ -1706,7 +1713,10 @@ struct LockedEntityEdition {
     updated_at_decision_time: Timestamp<DecisionTime>,
 }
 
-impl PostgresStore<tokio_postgres::Transaction<'_>> {
+impl<A> PostgresStore<tokio_postgres::Transaction<'_>, A>
+where
+    A: Send + Sync,
+{
     #[tracing::instrument(level = "trace", skip(self))]
     async fn insert_entity_edition(
         &self,

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/read.rs
@@ -82,7 +82,11 @@ pub struct KnowledgeEdgeTraversal {
     pub traversal_interval: RightBoundedTemporalInterval<VariableAxis>,
 }
 
-impl<C: AsClient> PostgresStore<C> {
+impl<C, A> PostgresStore<C, A>
+where
+    C: AsClient,
+    A: Send + Sync,
+{
     #[tracing::instrument(level = "trace", skip(self))]
     pub(crate) async fn read_shared_edges<'t>(
         &self,

--- a/apps/hash-graph/libs/graph/src/store/postgres/migration.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/migration.rs
@@ -15,7 +15,11 @@ mod embedded {
 }
 
 #[async_trait]
-impl<C: AsClient<Client = Client>> StoreMigration for PostgresStore<C> {
+impl<C, A> StoreMigration for PostgresStore<C, A>
+where
+    C: AsClient<Client = Client>,
+    A: Send + Sync,
+{
     async fn run_migrations(&mut self) -> Result<Vec<Migration>, MigrationError> {
         Ok(embedded::migrations::runner()
             .run_async(self.as_mut_client())

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/mod.rs
@@ -61,7 +61,10 @@ impl OntologyDatabaseType for EntityType {
     }
 }
 
-impl PostgresStore<Transaction<'_>> {
+impl<A> PostgresStore<Transaction<'_>, A>
+where
+    A: Send + Sync,
+{
     #[tracing::instrument(level = "trace", skip(self))]
     pub async fn delete_ontology_ids(
         &self,

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/read.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/read.rs
@@ -56,7 +56,7 @@ pub struct OntologyEdgeTraversal<L, R> {
     pub traversal_interval: RightBoundedTemporalInterval<VariableAxis>,
 }
 
-impl<C: AsClient> PostgresStore<C> {
+impl<C: AsClient, A: Send + Sync> PostgresStore<C, A> {
     #[tracing::instrument(level = "trace", skip(self, filter))]
     pub(crate) async fn read_closed_schemas<'f>(
         &self,

--- a/apps/hash-graph/libs/graph/src/store/postgres/traversal_context.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/traversal_context.rs
@@ -19,7 +19,11 @@ use crate::{
     subgraph::{edges::GraphResolveDepths, temporal_axes::VariableAxis, Subgraph},
 };
 
-impl<C: AsClient> PostgresStore<C> {
+impl<C, A> PostgresStore<C, A>
+where
+    C: AsClient,
+    A: Send + Sync,
+{
     async fn read_data_types_by_ids(
         &self,
         vertex_ids: impl IntoIterator<Item = OntologyId, IntoIter: Send> + Send,
@@ -226,9 +230,9 @@ pub struct TraversalContext {
 }
 
 impl TraversalContext {
-    pub async fn read_traversed_vertices<C: AsClient>(
+    pub async fn read_traversed_vertices<C: AsClient, A: Send + Sync>(
         &self,
-        store: &PostgresStore<C>,
+        store: &PostgresStore<C, A>,
         subgraph: &mut Subgraph,
         include_drafts: bool,
     ) -> Result<(), QueryError> {

--- a/apps/hash-graph/libs/graph/src/store/validation.rs
+++ b/apps/hash-graph/libs/graph/src/store/validation.rs
@@ -131,7 +131,7 @@ pub struct StoreProvider<'a, S, A> {
 impl<S, A> StoreProvider<'_, S, A>
 where
     S: Read<DataTypeWithMetadata>,
-    A: AuthorizationApi + Sync,
+    A: AuthorizationApi,
 {
     async fn authorize_data_type(&self, type_id: DataTypeId) -> Result<(), Report<QueryError>> {
         if let Some((authorization_api, actor_id, consistency)) = self.authorization {
@@ -155,7 +155,7 @@ where
 impl<S, A> OntologyTypeProvider<DataType> for StoreProvider<'_, S, A>
 where
     S: Read<DataTypeWithMetadata>,
-    A: AuthorizationApi + Sync,
+    A: AuthorizationApi,
 {
     #[expect(refining_impl_trait)]
     async fn provide_type(
@@ -198,7 +198,7 @@ where
 impl<S, A> StoreProvider<'_, S, A>
 where
     S: Read<PropertyTypeWithMetadata>,
-    A: AuthorizationApi + Sync,
+    A: AuthorizationApi,
 {
     async fn authorize_property_type(
         &self,
@@ -225,7 +225,7 @@ where
 impl<S, A> OntologyTypeProvider<PropertyType> for StoreProvider<'_, S, A>
 where
     S: Read<PropertyTypeWithMetadata>,
-    A: AuthorizationApi + Sync,
+    A: AuthorizationApi,
 {
     #[expect(refining_impl_trait)]
     async fn provide_type(
@@ -269,10 +269,10 @@ where
     }
 }
 
-impl<C, A> StoreProvider<'_, PostgresStore<C>, A>
+impl<C, A> StoreProvider<'_, PostgresStore<C, A>, A>
 where
     C: AsClient,
-    A: AuthorizationApi + Sync,
+    A: AuthorizationApi,
 {
     async fn authorize_entity_type(&self, type_id: EntityTypeId) -> Result<(), Report<QueryError>> {
         if let Some((authorization_api, actor_id, consistency)) = self.authorization {
@@ -333,10 +333,10 @@ where
     }
 }
 
-impl<C, A> OntologyTypeProvider<ClosedEntityType> for StoreProvider<'_, PostgresStore<C>, A>
+impl<C, A> OntologyTypeProvider<ClosedEntityType> for StoreProvider<'_, PostgresStore<C, A>, A>
 where
     C: AsClient,
-    A: AuthorizationApi + Sync,
+    A: AuthorizationApi,
 {
     #[expect(refining_impl_trait)]
     async fn provide_type(
@@ -367,10 +367,10 @@ where
     }
 }
 
-impl<C, A> EntityTypeProvider for StoreProvider<'_, PostgresStore<C>, A>
+impl<C, A> EntityTypeProvider for StoreProvider<'_, PostgresStore<C, A>, A>
 where
     C: AsClient,
-    A: AuthorizationApi + Sync,
+    A: AuthorizationApi,
 {
     #[expect(refining_impl_trait)]
     async fn is_parent_of(
@@ -403,7 +403,7 @@ where
 impl<S, A> EntityProvider for StoreProvider<'_, S, A>
 where
     S: Read<Entity>,
-    A: AuthorizationApi + Sync,
+    A: AuthorizationApi,
 {
     #[expect(refining_impl_trait)]
     async fn provide_entity(

--- a/libs/@local/hash-authorization/src/api.rs
+++ b/libs/@local/hash-authorization/src/api.rs
@@ -20,7 +20,7 @@ use crate::{
     zanzibar::{Consistency, Zookie},
 };
 
-pub trait AuthorizationApi {
+pub trait AuthorizationApi: Send + Sync {
     fn seed(&mut self)
     -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
 
@@ -65,8 +65,6 @@ pub trait AuthorizationApi {
         entities: impl IntoIterator<Item = OwnedById, IntoIter: Send> + Send,
         consistency: Consistency<'_>,
     ) -> impl Future<Output = Result<(HashMap<OwnedById, bool>, Zookie<'static>), CheckError>> + Send
-    where
-        Self: Sync,
     {
         async move {
             let mut zookie = Zookie::empty();
@@ -252,13 +250,269 @@ pub trait AuthorizationApi {
     ) -> impl Future<Output = Result<Vec<DataTypeRelationAndSubject>, ReadError>> + Send;
 }
 
+impl<A: AuthorizationApi> AuthorizationApi for &mut A {
+    async fn seed(&mut self) -> Result<Zookie<'static>, ModifyRelationError> {
+        (**self).seed().await
+    }
+
+    async fn check_account_group_permission(
+        &self,
+        actor: AccountId,
+        permission: AccountGroupPermission,
+        account_group: AccountGroupId,
+        consistency: Consistency<'_>,
+    ) -> Result<CheckResponse, CheckError> {
+        (**self)
+            .check_account_group_permission(actor, permission, account_group, consistency)
+            .await
+    }
+
+    async fn modify_account_group_relations(
+        &mut self,
+        relationships: impl IntoIterator<
+            Item = (
+                ModifyRelationshipOperation,
+                AccountGroupId,
+                AccountGroupRelationAndSubject,
+            ),
+            IntoIter: Send,
+        > + Send,
+    ) -> Result<Zookie<'static>, ModifyRelationError> {
+        (**self).modify_account_group_relations(relationships).await
+    }
+
+    async fn check_web_permission(
+        &self,
+        actor: AccountId,
+        permission: WebPermission,
+        web: OwnedById,
+        consistency: Consistency<'_>,
+    ) -> Result<CheckResponse, CheckError> {
+        (**self)
+            .check_web_permission(actor, permission, web, consistency)
+            .await
+    }
+
+    async fn modify_web_relations(
+        &mut self,
+        relationships: impl IntoIterator<
+            Item = (
+                ModifyRelationshipOperation,
+                OwnedById,
+                WebRelationAndSubject,
+            ),
+            IntoIter: Send,
+        > + Send,
+    ) -> Result<Zookie<'static>, ModifyRelationError> {
+        (**self).modify_web_relations(relationships).await
+    }
+
+    async fn get_web_relations(
+        &self,
+        web: OwnedById,
+        consistency: Consistency<'static>,
+    ) -> Result<Vec<WebRelationAndSubject>, ReadError> {
+        (**self).get_web_relations(web, consistency).await
+    }
+
+    async fn check_entity_permission(
+        &self,
+        actor: AccountId,
+        permission: EntityPermission,
+        entity: EntityId,
+        consistency: Consistency<'_>,
+    ) -> Result<CheckResponse, CheckError> {
+        (**self)
+            .check_entity_permission(actor, permission, entity, consistency)
+            .await
+    }
+
+    async fn modify_entity_relations(
+        &mut self,
+        relationships: impl IntoIterator<
+            Item = (
+                ModifyRelationshipOperation,
+                EntityId,
+                EntityRelationAndSubject,
+            ),
+            IntoIter: Send,
+        > + Send,
+    ) -> Result<Zookie<'static>, ModifyRelationError> {
+        (**self).modify_entity_relations(relationships).await
+    }
+
+    async fn check_entities_permission(
+        &self,
+        actor: AccountId,
+        permission: EntityPermission,
+        entities: impl IntoIterator<Item = EntityId, IntoIter: Send> + Send,
+        consistency: Consistency<'_>,
+    ) -> Result<(HashMap<EntityUuid, bool>, Zookie<'static>), CheckError> {
+        (**self)
+            .check_entities_permission(actor, permission, entities, consistency)
+            .await
+    }
+
+    async fn get_entity_relations(
+        &self,
+        entity: EntityId,
+        consistency: Consistency<'static>,
+    ) -> Result<Vec<EntityRelationAndSubject>, ReadError> {
+        (**self).get_entity_relations(entity, consistency).await
+    }
+
+    async fn check_entity_type_permission(
+        &self,
+        actor: AccountId,
+        permission: EntityTypePermission,
+        entity_type: EntityTypeId,
+        consistency: Consistency<'_>,
+    ) -> Result<CheckResponse, CheckError> {
+        (**self)
+            .check_entity_type_permission(actor, permission, entity_type, consistency)
+            .await
+    }
+
+    async fn modify_entity_type_relations(
+        &mut self,
+        relationships: impl IntoIterator<
+            Item = (
+                ModifyRelationshipOperation,
+                EntityTypeId,
+                EntityTypeRelationAndSubject,
+            ),
+            IntoIter: Send,
+        > + Send,
+    ) -> Result<Zookie<'static>, ModifyRelationError> {
+        (**self).modify_entity_type_relations(relationships).await
+    }
+
+    async fn check_entity_types_permission(
+        &self,
+        actor: AccountId,
+        permission: EntityTypePermission,
+        entity_types: impl IntoIterator<Item = EntityTypeId, IntoIter: Send> + Send,
+        consistency: Consistency<'_>,
+    ) -> Result<(HashMap<EntityTypeId, bool>, Zookie<'static>), CheckError> {
+        (**self)
+            .check_entity_types_permission(actor, permission, entity_types, consistency)
+            .await
+    }
+
+    async fn get_entity_type_relations(
+        &self,
+        entity_type: EntityTypeId,
+        consistency: Consistency<'static>,
+    ) -> Result<Vec<EntityTypeRelationAndSubject>, ReadError> {
+        (**self)
+            .get_entity_type_relations(entity_type, consistency)
+            .await
+    }
+
+    async fn check_property_type_permission(
+        &self,
+        actor: AccountId,
+        permission: PropertyTypePermission,
+        property_type: PropertyTypeId,
+        consistency: Consistency<'_>,
+    ) -> Result<CheckResponse, CheckError> {
+        (**self)
+            .check_property_type_permission(actor, permission, property_type, consistency)
+            .await
+    }
+
+    async fn modify_property_type_relations(
+        &mut self,
+        relationships: impl IntoIterator<
+            Item = (
+                ModifyRelationshipOperation,
+                PropertyTypeId,
+                PropertyTypeRelationAndSubject,
+            ),
+            IntoIter: Send,
+        > + Send,
+    ) -> Result<Zookie<'static>, ModifyRelationError> {
+        (**self).modify_property_type_relations(relationships).await
+    }
+
+    async fn check_property_types_permission(
+        &self,
+        actor: AccountId,
+        permission: PropertyTypePermission,
+        property_types: impl IntoIterator<Item = PropertyTypeId, IntoIter: Send> + Send,
+        consistency: Consistency<'_>,
+    ) -> Result<(HashMap<PropertyTypeId, bool>, Zookie<'static>), CheckError> {
+        (**self)
+            .check_property_types_permission(actor, permission, property_types, consistency)
+            .await
+    }
+
+    async fn get_property_type_relations(
+        &self,
+        property_type: PropertyTypeId,
+        consistency: Consistency<'static>,
+    ) -> Result<Vec<PropertyTypeRelationAndSubject>, ReadError> {
+        (**self)
+            .get_property_type_relations(property_type, consistency)
+            .await
+    }
+
+    async fn check_data_type_permission(
+        &self,
+        actor: AccountId,
+        permission: DataTypePermission,
+        data_type: DataTypeId,
+        consistency: Consistency<'_>,
+    ) -> Result<CheckResponse, CheckError> {
+        (**self)
+            .check_data_type_permission(actor, permission, data_type, consistency)
+            .await
+    }
+
+    async fn modify_data_type_relations(
+        &mut self,
+        relationships: impl IntoIterator<
+            Item = (
+                ModifyRelationshipOperation,
+                DataTypeId,
+                DataTypeRelationAndSubject,
+            ),
+            IntoIter: Send,
+        > + Send,
+    ) -> Result<Zookie<'static>, ModifyRelationError> {
+        (**self).modify_data_type_relations(relationships).await
+    }
+
+    async fn check_data_types_permission(
+        &self,
+        actor: AccountId,
+        permission: DataTypePermission,
+        data_types: impl IntoIterator<Item = DataTypeId, IntoIter: Send> + Send,
+        consistency: Consistency<'_>,
+    ) -> Result<(HashMap<DataTypeId, bool>, Zookie<'static>), CheckError> {
+        (**self)
+            .check_data_types_permission(actor, permission, data_types, consistency)
+            .await
+    }
+
+    async fn get_data_type_relations(
+        &self,
+        data_type: DataTypeId,
+        consistency: Consistency<'static>,
+    ) -> Result<Vec<DataTypeRelationAndSubject>, ReadError> {
+        (**self)
+            .get_data_type_relations(data_type, consistency)
+            .await
+    }
+}
+
 /// Managed pool to keep track about [`AuthorizationApi`]s.
 pub trait AuthorizationApiPool {
     /// The error returned when acquiring an [`AuthorizationApi`].
     type Error: Context;
 
     /// The [`AuthorizationApi`] returned when acquiring.
-    type Api<'pool>: AuthorizationApi + Send + Sync;
+    type Api<'pool>: AuthorizationApi;
 
     /// Retrieves an [`AuthorizationApi`] from the pool.
     fn acquire(&self) -> impl Future<Output = Result<Self::Api<'_>, Self::Error>> + Send;

--- a/tests/hash-graph-integration/Cargo.toml
+++ b/tests/hash-graph-integration/Cargo.toml
@@ -1,7 +1,9 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "graph-integration"
 version = "0.0.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dev-dependencies]
@@ -10,6 +12,7 @@ graph-test-data = { workspace = true }
 graph-types = { workspace = true }
 temporal-versioning = { workspace = true }
 authorization = { workspace = true }
+temporal-client = { workspace = true }
 
 error-stack = { workspace = true, features = ["spantrace"] }
 type-system = { workspace = true }

--- a/tests/hash-graph-integration/postgres/drafts.rs
+++ b/tests/hash-graph-integration/postgres/drafts.rs
@@ -1,10 +1,27 @@
 use authorization::AuthorizationApi;
-use graph::store::knowledge::PatchEntityParams;
+use graph::{
+    store::{
+        knowledge::{CreateEntityParams, PatchEntityParams},
+        query::Filter,
+        EntityStore,
+    },
+    subgraph::{
+        edges::GraphResolveDepths,
+        query::StructuralQuery,
+        temporal_axes::{
+            PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
+            VariableTemporalAxisUnresolved,
+        },
+    },
+};
 use graph_test_data::{data_type, entity, entity_type, property_type};
-use graph_types::knowledge::{
-    entity::{EntityId, ProvidedEntityEditionProvenance},
-    Property, PropertyMetadataMap, PropertyObject, PropertyPatchOperation, PropertyPath,
-    PropertyProvenance,
+use graph_types::{
+    knowledge::{
+        entity::{EntityId, ProvidedEntityEditionProvenance},
+        Property, PropertyMetadataMap, PropertyObject, PropertyPatchOperation, PropertyPath,
+        PropertyProvenance,
+    },
+    owned_by_id::OwnedById,
 };
 use pretty_assertions::assert_eq;
 use temporal_versioning::ClosedTemporalBound;
@@ -63,7 +80,21 @@ fn charles() -> PropertyObject {
 
 #[must_use]
 async fn check_entity_exists<A: AuthorizationApi>(api: &DatabaseApi<'_, A>, id: EntityId) -> bool {
-    api.get_latest_entity(id).await.is_ok()
+    api.count_entities(
+        api.account_id,
+        StructuralQuery {
+            filter: Filter::for_entity_by_entity_id(id),
+            graph_resolve_depths: GraphResolveDepths::default(),
+            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                pinned: PinnedTemporalAxisUnresolved::new(None),
+                variable: VariableTemporalAxisUnresolved::new(None, None),
+            },
+            include_drafts: id.draft_id.is_some(),
+        },
+    )
+    .await
+    .expect("could not count entities")
+        == 1
 }
 
 #[tokio::test]
@@ -74,12 +105,20 @@ async fn initial_draft() {
 
     let entity = api
         .create_entity(
-            alice(),
-            vec![person_entity_type_id()],
-            None,
-            true,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_entity_type_id()],
+                properties: alice(),
+                confidence: None,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: true,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
@@ -102,21 +141,24 @@ async fn initial_draft() {
     );
 
     let updated_entity = api
-        .patch_entity(PatchEntityParams {
-            entity_id: entity.record_id.entity_id,
-            properties: vec![PropertyPatchOperation::Replace {
-                path: PropertyPath::default(),
-                value: Property::Object(bob()),
+        .patch_entity(
+            api.account_id,
+            PatchEntityParams {
+                entity_id: entity.record_id.entity_id,
+                properties: vec![PropertyPatchOperation::Replace {
+                    path: PropertyPath::default(),
+                    value: Property::Object(bob()),
+                    confidence: None,
+                    provenance: PropertyProvenance::default(),
+                }],
+                entity_type_ids: vec![],
+                archived: None,
+                draft: Some(true),
+                decision_time: None,
                 confidence: None,
-                provenance: PropertyProvenance::default(),
-            }],
-            entity_type_ids: vec![],
-            archived: None,
-            draft: Some(true),
-            decision_time: None,
-            confidence: None,
-            provenance: ProvidedEntityEditionProvenance::default(),
-        })
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
+        )
         .await
         .expect("could not update entity");
 
@@ -142,21 +184,24 @@ async fn initial_draft() {
     );
 
     let updated_live_entity = api
-        .patch_entity(PatchEntityParams {
-            entity_id: updated_entity.record_id.entity_id,
-            properties: vec![PropertyPatchOperation::Replace {
-                path: PropertyPath::default(),
-                value: Property::Object(charles()),
+        .patch_entity(
+            api.account_id,
+            PatchEntityParams {
+                entity_id: updated_entity.record_id.entity_id,
+                properties: vec![PropertyPatchOperation::Replace {
+                    path: PropertyPath::default(),
+                    value: Property::Object(charles()),
+                    confidence: None,
+                    provenance: PropertyProvenance::default(),
+                }],
+                entity_type_ids: vec![],
+                archived: None,
+                draft: Some(false),
+                decision_time: None,
                 confidence: None,
-                provenance: PropertyProvenance::default(),
-            }],
-            entity_type_ids: vec![],
-            archived: None,
-            draft: Some(false),
-            decision_time: None,
-            confidence: None,
-            provenance: ProvidedEntityEditionProvenance::default(),
-        })
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
+        )
         .await
         .expect("could not update entity");
 
@@ -206,12 +251,20 @@ async fn no_initial_draft() {
 
     let entity = api
         .create_entity(
-            alice(),
-            vec![person_entity_type_id()],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_entity_type_id()],
+                properties: alice(),
+                confidence: None,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
@@ -239,21 +292,24 @@ async fn no_initial_draft() {
 
     for _ in 0..5 {
         let updated_entity = api
-            .patch_entity(PatchEntityParams {
-                entity_id: entity.record_id.entity_id,
-                properties: vec![PropertyPatchOperation::Replace {
-                    path: PropertyPath::default(),
-                    value: Property::Object(bob()),
+            .patch_entity(
+                api.account_id,
+                PatchEntityParams {
+                    entity_id: entity.record_id.entity_id,
+                    properties: vec![PropertyPatchOperation::Replace {
+                        path: PropertyPath::default(),
+                        value: Property::Object(bob()),
+                        confidence: None,
+                        provenance: PropertyProvenance::default(),
+                    }],
+                    entity_type_ids: vec![],
+                    archived: None,
+                    draft: Some(true),
+                    decision_time: None,
                     confidence: None,
-                    provenance: PropertyProvenance::default(),
-                }],
-                entity_type_ids: vec![],
-                archived: None,
-                draft: Some(true),
-                decision_time: None,
-                confidence: None,
-                provenance: ProvidedEntityEditionProvenance::default(),
-            })
+                    provenance: ProvidedEntityEditionProvenance::default(),
+                },
+            )
             .await
             .expect("could not update entity");
 
@@ -284,21 +340,24 @@ async fn no_initial_draft() {
         );
 
         let updated_live_entity = api
-            .patch_entity(PatchEntityParams {
-                entity_id: updated_entity.record_id.entity_id,
-                properties: vec![PropertyPatchOperation::Replace {
-                    path: PropertyPath::default(),
-                    value: Property::Object(charles()),
+            .patch_entity(
+                api.account_id,
+                PatchEntityParams {
+                    entity_id: updated_entity.record_id.entity_id,
+                    properties: vec![PropertyPatchOperation::Replace {
+                        path: PropertyPath::default(),
+                        value: Property::Object(charles()),
+                        confidence: None,
+                        provenance: PropertyProvenance::default(),
+                    }],
+                    entity_type_ids: vec![],
+                    archived: None,
+                    draft: Some(false),
+                    decision_time: None,
                     confidence: None,
-                    provenance: PropertyProvenance::default(),
-                }],
-                entity_type_ids: vec![],
-                archived: None,
-                draft: Some(false),
-                decision_time: None,
-                confidence: None,
-                provenance: ProvidedEntityEditionProvenance::default(),
-            })
+                    provenance: ProvidedEntityEditionProvenance::default(),
+                },
+            )
             .await
             .expect("could not update entity");
 
@@ -334,12 +393,20 @@ async fn multiple_drafts() {
 
     let entity = api
         .create_entity(
-            alice(),
-            vec![person_entity_type_id()],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_entity_type_id()],
+                properties: alice(),
+                confidence: None,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
@@ -367,21 +434,24 @@ async fn multiple_drafts() {
     let mut drafts = Vec::new();
     for _ in 0..5 {
         let updated_entity = api
-            .patch_entity(PatchEntityParams {
-                entity_id: entity.record_id.entity_id,
-                properties: vec![PropertyPatchOperation::Replace {
-                    path: PropertyPath::default(),
-                    value: Property::Object(bob()),
+            .patch_entity(
+                api.account_id,
+                PatchEntityParams {
+                    entity_id: entity.record_id.entity_id,
+                    properties: vec![PropertyPatchOperation::Replace {
+                        path: PropertyPath::default(),
+                        value: Property::Object(bob()),
+                        confidence: None,
+                        provenance: PropertyProvenance::default(),
+                    }],
+                    entity_type_ids: vec![],
+                    archived: None,
+                    draft: Some(true),
+                    decision_time: None,
                     confidence: None,
-                    provenance: PropertyProvenance::default(),
-                }],
-                entity_type_ids: vec![],
-                archived: None,
-                draft: Some(true),
-                decision_time: None,
-                confidence: None,
-                provenance: ProvidedEntityEditionProvenance::default(),
-            })
+                    provenance: ProvidedEntityEditionProvenance::default(),
+                },
+            )
             .await
             .expect("could not update entity");
 
@@ -415,21 +485,24 @@ async fn multiple_drafts() {
 
     for draft in drafts {
         let updated_live_entity = api
-            .patch_entity(PatchEntityParams {
-                entity_id: draft,
-                properties: vec![PropertyPatchOperation::Replace {
-                    path: PropertyPath::default(),
-                    value: Property::Object(charles()),
+            .patch_entity(
+                api.account_id,
+                PatchEntityParams {
+                    entity_id: draft,
+                    properties: vec![PropertyPatchOperation::Replace {
+                        path: PropertyPath::default(),
+                        value: Property::Object(charles()),
+                        confidence: None,
+                        provenance: PropertyProvenance::default(),
+                    }],
+                    entity_type_ids: vec![],
+                    archived: None,
+                    draft: Some(false),
+                    decision_time: None,
                     confidence: None,
-                    provenance: PropertyProvenance::default(),
-                }],
-                entity_type_ids: vec![],
-                archived: None,
-                draft: Some(false),
-                decision_time: None,
-                confidence: None,
-                provenance: ProvidedEntityEditionProvenance::default(),
-            })
+                    provenance: ProvidedEntityEditionProvenance::default(),
+                },
+            )
             .await
             .expect("could not update entity");
 

--- a/tests/hash-graph-integration/postgres/entity.rs
+++ b/tests/hash-graph-integration/postgres/entity.rs
@@ -1,10 +1,27 @@
-use graph::store::knowledge::PatchEntityParams;
-use graph_test_data::{data_type, entity, entity_type, property_type};
-use graph_types::knowledge::{
-    entity::ProvidedEntityEditionProvenance, Property, PropertyMetadataMap, PropertyObject,
-    PropertyPatchOperation, PropertyPath, PropertyProvenance,
+use graph::{
+    store::{
+        knowledge::{CreateEntityParams, GetEntityParams, PatchEntityParams},
+        query::Filter,
+        EntityQuerySorting, EntityStore,
+    },
+    subgraph::{
+        edges::GraphResolveDepths,
+        query::StructuralQuery,
+        temporal_axes::{
+            PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
+            VariableTemporalAxisUnresolved,
+        },
+    },
 };
-use temporal_versioning::ClosedTemporalBound;
+use graph_test_data::{data_type, entity, entity_type, property_type};
+use graph_types::{
+    knowledge::{
+        entity::ProvidedEntityEditionProvenance, Property, PropertyMetadataMap, PropertyObject,
+        PropertyPatchOperation, PropertyPath, PropertyProvenance,
+    },
+    owned_by_id::OwnedById,
+};
+use temporal_versioning::{ClosedTemporalBound, LimitedTemporalBound, TemporalBound};
 use type_system::url::{BaseUrl, OntologyTypeVersion, VersionedUrl};
 
 use crate::DatabaseTestWrapper;
@@ -38,28 +55,63 @@ async fn insert() {
 
     let metadata = api
         .create_entity(
-            person.clone(),
-            vec![VersionedUrl {
-                base_url: BaseUrl::new(
-                    "https://blockprotocol.org/@alice/types/entity-type/person/".to_owned(),
-                )
-                .expect("couldn't construct Base URL"),
-                version: OntologyTypeVersion::new(1),
-            }],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![VersionedUrl {
+                    base_url: BaseUrl::new(
+                        "https://blockprotocol.org/@alice/types/entity-type/person/".to_owned(),
+                    )
+                    .expect("couldn't construct Base URL"),
+                    version: OntologyTypeVersion::new(1),
+                }],
+                properties: person.clone(),
+                confidence: None,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
 
     let entities = api
-        .get_entities(metadata.record_id.entity_id)
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::for_entity_by_entity_id(metadata.record_id.entity_id),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(
+                            Some(TemporalBound::Unbounded),
+                            None,
+                        ),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: true,
+            },
+        )
         .await
-        .expect("could not get entity");
-    assert_eq!(entities.len(), 1);
+        .expect("could not get entity")
+        .subgraph
+        .vertices
+        .entities
+        .into_values()
+        .collect::<Vec<_>>();
 
+    assert_eq!(entities.len(), 1);
     assert_eq!(entities[0].properties, person);
 }
 
@@ -80,32 +132,69 @@ async fn query() {
 
     let metadata = api
         .create_entity(
-            organization.clone(),
-            vec![VersionedUrl {
-                base_url: BaseUrl::new(
-                    "https://blockprotocol.org/@alice/types/entity-type/organization/".to_owned(),
-                )
-                .expect("couldn't construct Base URL"),
-                version: OntologyTypeVersion::new(1),
-            }],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![VersionedUrl {
+                    base_url: BaseUrl::new(
+                        "https://blockprotocol.org/@alice/types/entity-type/organization/"
+                            .to_owned(),
+                    )
+                    .expect("couldn't construct Base URL"),
+                    version: OntologyTypeVersion::new(1),
+                }],
+                properties: organization.clone(),
+                confidence: None,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
 
     let queried_organizations = api
-        .get_entities(metadata.record_id.entity_id)
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::for_entity_by_entity_id(metadata.record_id.entity_id),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(
+                            Some(TemporalBound::Unbounded),
+                            None,
+                        ),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: true,
+            },
+        )
         .await
-        .expect("could not get entity");
-    assert_eq!(queried_organizations.len(), 1);
+        .expect("could not get entity")
+        .subgraph
+        .vertices
+        .entities
+        .into_values()
+        .collect::<Vec<_>>();
 
+    assert_eq!(queried_organizations.len(), 1);
     assert_eq!(queried_organizations[0].properties, organization);
 }
 
 #[tokio::test]
+#[expect(clippy::too_many_lines)]
 async fn update() {
     let page_v1: PropertyObject =
         serde_json::from_str(entity::PAGE_V1).expect("could not parse entity");
@@ -124,69 +213,179 @@ async fn update() {
 
     let v1_metadata = api
         .create_entity(
-            page_v1.clone(),
-            vec![VersionedUrl {
-                base_url: BaseUrl::new(
-                    "https://blockprotocol.org/@alice/types/entity-type/page/".to_owned(),
-                )
-                .expect("couldn't construct Base URL"),
-                version: OntologyTypeVersion::new(1),
-            }],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![VersionedUrl {
+                    base_url: BaseUrl::new(
+                        "https://blockprotocol.org/@alice/types/entity-type/page/".to_owned(),
+                    )
+                    .expect("couldn't construct Base URL"),
+                    version: OntologyTypeVersion::new(1),
+                }],
+                properties: page_v1.clone(),
+                confidence: None,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
 
     let v2_metadata = api
-        .patch_entity(PatchEntityParams {
-            entity_id: v1_metadata.record_id.entity_id,
-            properties: vec![PropertyPatchOperation::Replace {
-                path: PropertyPath::default(),
-                value: Property::Object(page_v2.clone()),
+        .patch_entity(
+            api.account_id,
+            PatchEntityParams {
+                entity_id: v1_metadata.record_id.entity_id,
+                properties: vec![PropertyPatchOperation::Replace {
+                    path: PropertyPath::default(),
+                    value: Property::Object(page_v2.clone()),
+                    confidence: None,
+                    provenance: PropertyProvenance::default(),
+                }],
+                entity_type_ids: vec![],
+                archived: None,
+                draft: None,
+                decision_time: None,
                 confidence: None,
-                provenance: PropertyProvenance::default(),
-            }],
-            entity_type_ids: vec![],
-            archived: None,
-            draft: None,
-            decision_time: None,
-            confidence: None,
-            provenance: ProvidedEntityEditionProvenance::default(),
-        })
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
+        )
         .await
         .expect("could not update entity");
 
+    let num_entities = api
+        .count_entities(
+            api.account_id,
+            StructuralQuery {
+                filter: Filter::for_entity_by_entity_id(v2_metadata.record_id.entity_id),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(
+                        Some(TemporalBound::Unbounded),
+                        None,
+                    ),
+                },
+                include_drafts: false,
+            },
+        )
+        .await
+        .expect("could not count entities");
+    assert_eq!(num_entities, 2);
+
     let entities = api
-        .get_entities(v2_metadata.record_id.entity_id)
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::for_entity_by_entity_id(v2_metadata.record_id.entity_id),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: false,
+            },
+        )
         .await
-        .expect("could not get entity");
-
-    assert_eq!(entities.len(), 2);
-
-    let entity_v2 = api
-        .get_latest_entity(v2_metadata.record_id.entity_id)
-        .await
-        .expect("could not get entity");
+        .expect("could not get entity")
+        .subgraph
+        .vertices
+        .entities
+        .into_values()
+        .collect::<Vec<_>>();
+    assert_eq!(entities.len(), 1, "unexpected number of entities found");
+    let entity_v2 = entities.into_iter().next().unwrap();
 
     assert_eq!(entity_v2.properties.properties(), page_v2.properties());
 
     let ClosedTemporalBound::Inclusive(entity_v1_timestamp) =
         *v1_metadata.temporal_versioning.decision_time.start();
-    let entity_v1 = api
-        .get_entity_by_timestamp(v1_metadata.record_id.entity_id, entity_v1_timestamp)
+
+    let response_v1 = api
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::for_entity_by_entity_id(v1_metadata.record_id.entity_id),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(
+                            Some(TemporalBound::Inclusive(entity_v1_timestamp)),
+                            Some(LimitedTemporalBound::Inclusive(entity_v1_timestamp)),
+                        ),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: true,
+            },
+        )
         .await
-        .expect("could not get entity v1");
+        .expect("could not get entity");
+    assert_eq!(response_v1.count, Some(1));
+    let entity_v1 = response_v1
+        .subgraph
+        .vertices
+        .entities
+        .into_values()
+        .next()
+        .expect("no entity found");
     assert_eq!(entity_v1.properties.properties(), page_v1.properties());
 
     let ClosedTemporalBound::Inclusive(entity_v2_timestamp) =
         *v2_metadata.temporal_versioning.decision_time.start();
-    let entity_v2 = api
-        .get_entity_by_timestamp(v2_metadata.record_id.entity_id, entity_v2_timestamp)
+    let response_v2 = api
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::for_entity_by_entity_id(v2_metadata.record_id.entity_id),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(
+                            Some(TemporalBound::Inclusive(entity_v2_timestamp)),
+                            Some(LimitedTemporalBound::Inclusive(entity_v2_timestamp)),
+                        ),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: true,
+            },
+        )
         .await
-        .expect("could not get entity v2");
-
+        .expect("could not get entity");
+    assert_eq!(response_v2.count, Some(1));
+    let entity_v2 = response_v2
+        .subgraph
+        .vertices
+        .entities
+        .into_values()
+        .next()
+        .expect("no entity found");
     assert_eq!(entity_v2.properties.properties(), page_v2.properties());
 }

--- a/tests/hash-graph-integration/postgres/entity_type.rs
+++ b/tests/hash-graph-integration/postgres/entity_type.rs
@@ -1,15 +1,36 @@
+use graph::{
+    store::{
+        ontology::{CreateEntityTypeParams, GetEntityTypesParams, UpdateEntityTypesParams},
+        query::Filter,
+        ConflictBehavior, EntityTypeStore,
+    },
+    subgraph::{
+        edges::GraphResolveDepths,
+        identifier::EntityTypeVertexId,
+        query::StructuralQuery,
+        temporal_axes::{
+            PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
+            VariableTemporalAxisUnresolved,
+        },
+    },
+};
 use graph_test_data::{data_type, entity_type, property_type};
+use graph_types::{
+    ontology::{OntologyTypeClassificationMetadata, ProvidedOntologyEditionProvenance},
+    owned_by_id::OwnedById,
+};
+use temporal_versioning::TemporalBound;
 use type_system::EntityType;
 
-use crate::DatabaseTestWrapper;
+use crate::{entity_type_relationships, DatabaseTestWrapper};
 
 #[tokio::test]
 async fn insert() {
     let person_et: EntityType = serde_json::from_str(entity_type::PERSON_V1)
         .expect("could not parse entity type representation");
 
-    DatabaseTestWrapper::new()
-        .await
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = database
         .seed(
             [data_type::TEXT_V1, data_type::NUMBER_V1],
             [
@@ -27,10 +48,24 @@ async fn insert() {
             ],
         )
         .await
-        .expect("could not seed database")
-        .create_entity_type(person_et)
-        .await
-        .expect("could not create entity type");
+        .expect("could not seed database");
+
+    api.create_entity_type(
+        api.account_id,
+        CreateEntityTypeParams {
+            schema: person_et,
+            classification: OntologyTypeClassificationMetadata::Owned {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+            },
+            label_property: None,
+            icon: None,
+            relationships: entity_type_relationships(),
+            conflict_behavior: ConflictBehavior::Fail,
+            provenance: ProvidedOntologyEditionProvenance::default(),
+        },
+    )
+    .await
+    .expect("could not create entity type");
 }
 
 #[tokio::test]
@@ -44,19 +79,55 @@ async fn query() {
         .await
         .expect("could not seed database");
 
-    api.create_entity_type(organization_et.clone())
-        .await
-        .expect("could not create entity type");
+    api.create_entity_type(
+        api.account_id,
+        CreateEntityTypeParams {
+            schema: organization_et.clone(),
+            classification: OntologyTypeClassificationMetadata::Owned {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+            },
+            label_property: None,
+            icon: None,
+            relationships: entity_type_relationships(),
+            conflict_behavior: ConflictBehavior::Fail,
+            provenance: ProvidedOntologyEditionProvenance::default(),
+        },
+    )
+    .await
+    .expect("could not create entity type");
 
     let entity_type = api
-        .get_entity_type(organization_et.id())
+        .get_entity_type(
+            api.account_id,
+            GetEntityTypesParams {
+                query: StructuralQuery {
+                    filter: Filter::for_versioned_url(organization_et.id()),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(
+                            Some(TemporalBound::Unbounded),
+                            None,
+                        ),
+                    },
+                    include_drafts: false,
+                },
+                after: None,
+                limit: None,
+            },
+        )
         .await
-        .expect("could not get entity type");
+        .expect("could not get entity type")
+        .vertices
+        .entity_types
+        .remove(&EntityTypeVertexId::from(organization_et.id().clone()))
+        .expect("no entity type found");
 
     assert_eq!(entity_type.schema, organization_et);
 }
 
 #[tokio::test]
+#[expect(clippy::too_many_lines)]
 async fn update() {
     let page_et_v1: EntityType = serde_json::from_str(entity_type::PAGE_V1)
         .expect("could not parse entity type representation");
@@ -90,26 +161,89 @@ async fn update() {
         .await
         .expect("could not seed database:");
 
-    api.create_entity_type(page_et_v1.clone())
-        .await
-        .expect("could not create entity type");
+    api.create_entity_type(
+        api.account_id,
+        CreateEntityTypeParams {
+            schema: page_et_v1.clone(),
+            classification: OntologyTypeClassificationMetadata::Owned {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+            },
+            label_property: None,
+            icon: None,
+            relationships: entity_type_relationships(),
+            conflict_behavior: ConflictBehavior::Fail,
+            provenance: ProvidedOntologyEditionProvenance::default(),
+        },
+    )
+    .await
+    .expect("could not create entity type");
 
-    api.update_entity_type(page_et_v2.clone())
-        .await
-        .expect("could not update entity type");
+    api.update_entity_type(
+        api.account_id,
+        UpdateEntityTypesParams {
+            schema: page_et_v2.clone(),
+            label_property: None,
+            icon: None,
+            relationships: entity_type_relationships(),
+            provenance: ProvidedOntologyEditionProvenance::default(),
+        },
+    )
+    .await
+    .expect("could not update entity type");
 
     let returned_page_et_v1 = api
-        .get_entity_type(page_et_v1.id())
+        .get_entity_type(
+            api.account_id,
+            GetEntityTypesParams {
+                query: StructuralQuery {
+                    filter: Filter::for_versioned_url(page_et_v1.id()),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(
+                            Some(TemporalBound::Unbounded),
+                            None,
+                        ),
+                    },
+                    include_drafts: false,
+                },
+                after: None,
+                limit: None,
+            },
+        )
         .await
-        .expect("could not get entity type");
+        .expect("could not get entity type")
+        .vertices
+        .entity_types
+        .remove(&EntityTypeVertexId::from(page_et_v1.id().clone()))
+        .expect("no entity type found");
 
-    // TODO: we probably want to be testing more interesting queries, checking an update should
-    //  probably use getLatestVersion
-    //  https://app.asana.com/0/0/1202884883200974/f
     let returned_page_et_v2 = api
-        .get_entity_type(page_et_v2.id())
+        .get_entity_type(
+            api.account_id,
+            GetEntityTypesParams {
+                query: StructuralQuery {
+                    filter: Filter::for_versioned_url(page_et_v2.id()),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(
+                            Some(TemporalBound::Unbounded),
+                            None,
+                        ),
+                    },
+                    include_drafts: false,
+                },
+                after: None,
+                limit: None,
+            },
+        )
         .await
-        .expect("could not get entity type");
+        .expect("could not get entity type")
+        .vertices
+        .entity_types
+        .remove(&EntityTypeVertexId::from(page_et_v2.id().clone()))
+        .expect("no entity type found");
 
     assert_eq!(page_et_v1, returned_page_et_v1.schema);
     assert_eq!(page_et_v2, returned_page_et_v2.schema);

--- a/tests/hash-graph-integration/postgres/entity_type.rs
+++ b/tests/hash-graph-integration/postgres/entity_type.rs
@@ -8,8 +8,8 @@ async fn insert() {
     let person_et: EntityType = serde_json::from_str(entity_type::PERSON_V1)
         .expect("could not parse entity type representation");
 
-    let mut database = DatabaseTestWrapper::new().await;
-    let mut api = database
+    DatabaseTestWrapper::new()
+        .await
         .seed(
             [data_type::TEXT_V1, data_type::NUMBER_V1],
             [
@@ -27,9 +27,8 @@ async fn insert() {
             ],
         )
         .await
-        .expect("could not seed database");
-
-    api.create_entity_type(person_et)
+        .expect("could not seed database")
+        .create_entity_type(person_et)
         .await
         .expect("could not create entity type");
 }

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -5,7 +5,6 @@
     clippy::unwrap_used
 )]
 #![expect(
-    clippy::same_name_method,
     clippy::significant_drop_tightening,
     reason = "This should be enabled but it's currently too noisy"
 )]
@@ -53,9 +52,7 @@ use graph::{
     },
     subgraph::{
         edges::{EdgeDirection, GraphResolveDepths, KnowledgeGraphEdgeKind, SharedEdgeKind},
-        identifier::{
-            DataTypeVertexId, EntityTypeVertexId, GraphElementVertexId, PropertyTypeVertexId,
-        },
+        identifier::{EntityTypeVertexId, GraphElementVertexId, PropertyTypeVertexId},
         query::StructuralQuery,
         temporal_axes::{
             PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
@@ -73,9 +70,9 @@ use graph_types::{
         Confidence, PropertyMetadataMap, PropertyObject, PropertyProvenance,
     },
     ontology::{
-        DataTypeMetadata, DataTypeWithMetadata, EntityTypeMetadata, EntityTypeWithMetadata,
-        OntologyTemporalMetadata, OntologyTypeClassificationMetadata, PropertyTypeMetadata,
-        PropertyTypeWithMetadata, ProvidedOntologyEditionProvenance,
+        DataTypeMetadata, EntityTypeMetadata, EntityTypeWithMetadata, OntologyTemporalMetadata,
+        OntologyTypeClassificationMetadata, PropertyTypeMetadata, PropertyTypeWithMetadata,
+        ProvidedOntologyEditionProvenance,
     },
     owned_by_id::OwnedById,
 };
@@ -344,96 +341,7 @@ impl<A: AuthorizationApi> DataTypeStore for DatabaseApi<'_, A> {
     }
 }
 
-// TODO: Add get_all_* methods
 impl<A: AuthorizationApi> DatabaseApi<'_, A> {
-    pub async fn create_owned_data_type(
-        &mut self,
-        data_type: DataType,
-    ) -> Result<DataTypeMetadata, InsertionError> {
-        self.store
-            .create_data_type(
-                self.account_id,
-                CreateDataTypeParams {
-                    schema: data_type,
-                    classification: OntologyTypeClassificationMetadata::Owned {
-                        owned_by_id: OwnedById::new(self.account_id.into_uuid()),
-                    },
-                    relationships: data_type_relationships(),
-                    conflict_behavior: ConflictBehavior::Fail,
-                    provenance: ProvidedOntologyEditionProvenance::default(),
-                },
-            )
-            .await
-    }
-
-    pub async fn create_external_data_type(
-        &mut self,
-        data_type: DataType,
-    ) -> Result<DataTypeMetadata, InsertionError> {
-        self.store
-            .create_data_type(
-                self.account_id,
-                CreateDataTypeParams {
-                    schema: data_type,
-                    classification: OntologyTypeClassificationMetadata::External {
-                        fetched_at: OffsetDateTime::now_utc(),
-                    },
-                    relationships: data_type_relationships(),
-                    conflict_behavior: ConflictBehavior::Fail,
-                    provenance: ProvidedOntologyEditionProvenance::default(),
-                },
-            )
-            .await
-    }
-
-    pub async fn get_data_type(
-        &mut self,
-        url: &VersionedUrl,
-    ) -> Result<DataTypeWithMetadata, QueryError> {
-        Ok(self
-            .store
-            .get_data_type(
-                self.account_id,
-                GetDataTypesParams {
-                    query: StructuralQuery {
-                        filter: Filter::for_versioned_url(url),
-                        graph_resolve_depths: GraphResolveDepths::default(),
-                        temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                            pinned: PinnedTemporalAxisUnresolved::new(None),
-                            variable: VariableTemporalAxisUnresolved::new(
-                                Some(TemporalBound::Unbounded),
-                                None,
-                            ),
-                        },
-                        include_drafts: false,
-                    },
-                    limit: None,
-                    after: None,
-                },
-            )
-            .await?
-            .vertices
-            .data_types
-            .remove(&DataTypeVertexId::from(url.clone()))
-            .expect("no data type found"))
-    }
-
-    pub async fn update_data_type(
-        &mut self,
-        schema: DataType,
-    ) -> Result<DataTypeMetadata, UpdateError> {
-        self.store
-            .update_data_type(
-                self.account_id,
-                UpdateDataTypesParams {
-                    schema,
-                    relationships: data_type_relationships(),
-                    provenance: ProvidedOntologyEditionProvenance::default(),
-                },
-            )
-            .await
-    }
-
     pub async fn create_property_type(
         &mut self,
         property_type: PropertyType,

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -60,7 +60,7 @@ use graph::{
 use graph_types::{
     account::AccountId,
     knowledge::{
-        entity::{EntityMetadata, EntityUuid},
+        entity::{Entity, EntityId, EntityMetadata, EntityUuid},
         link::LinkData,
         PropertyObject,
     },
@@ -71,7 +71,7 @@ use graph_types::{
     },
     owned_by_id::OwnedById,
 };
-use temporal_versioning::{DecisionTime, Timestamp};
+use temporal_versioning::{DecisionTime, Timestamp, TransactionTime};
 use time::{format_description::well_known::Iso8601, Duration, OffsetDateTime};
 use tokio_postgres::{NoTls, Transaction};
 use type_system::{url::VersionedUrl, DataType, EntityType, PropertyType};
@@ -535,6 +535,18 @@ where
         query: EntityStructuralQuery<'_>,
     ) -> Result<usize, QueryError> {
         self.store.count_entities(actor_id, query).await
+    }
+
+    async fn get_entity_by_id(
+        &self,
+        actor_id: AccountId,
+        entity_id: EntityId,
+        transaction_time: Option<Timestamp<TransactionTime>>,
+        decision_time: Option<Timestamp<DecisionTime>>,
+    ) -> Result<Entity, QueryError> {
+        self.store
+            .get_entity_by_id(actor_id, entity_id, transaction_time, decision_time)
+            .await
     }
 
     async fn patch_entity(

--- a/tests/hash-graph-integration/postgres/links.rs
+++ b/tests/hash-graph-integration/postgres/links.rs
@@ -86,6 +86,7 @@ async fn insert() {
         .get_link_entity_target(alice_metadata.record_id.entity_id, friend_of_type_id)
         .await
         .expect("could not fetch entity");
+
     let link_data = link_entity.link_data.expect("entity is not a link");
 
     assert_eq!(link_data.left_entity_id, alice_metadata.record_id.entity_id);

--- a/tests/hash-graph-integration/postgres/links.rs
+++ b/tests/hash-graph-integration/postgres/links.rs
@@ -1,10 +1,38 @@
+use std::borrow::Cow;
+
+use graph::{
+    knowledge::EntityQueryPath,
+    ontology::EntityTypeQueryPath,
+    store::{
+        knowledge::{CreateEntityParams, GetEntityParams, PatchEntityParams},
+        query::{Filter, FilterExpression, Parameter},
+        EntityQuerySorting, EntityStore,
+    },
+    subgraph::{
+        edges::{EdgeDirection, GraphResolveDepths, KnowledgeGraphEdgeKind, SharedEdgeKind},
+        identifier::GraphElementVertexId,
+        query::StructuralQuery,
+        temporal_axes::{
+            PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
+            VariableTemporalAxisUnresolved,
+        },
+    },
+};
 use graph_test_data::{data_type, entity, entity_type, property_type};
-use graph_types::knowledge::{PropertyMetadataMap, PropertyObject};
+use graph_types::{
+    knowledge::{
+        entity::ProvidedEntityEditionProvenance, link::LinkData, PropertyMetadataMap,
+        PropertyObject, PropertyProvenance,
+    },
+    owned_by_id::OwnedById,
+};
+use temporal_versioning::TemporalBound;
 use type_system::url::{BaseUrl, OntologyTypeVersion, VersionedUrl};
 
 use crate::DatabaseTestWrapper;
 
 #[tokio::test]
+#[expect(clippy::too_many_lines)]
 async fn insert() {
     let alice = serde_json::from_str(entity::PERSON_ALICE_V1).expect("could not parse entity");
     let bob = serde_json::from_str(entity::PERSON_BOB_V1).expect("could not parse entity");
@@ -42,24 +70,40 @@ async fn insert() {
 
     let alice_metadata = api
         .create_entity(
-            alice,
-            vec![person_type_id.clone()],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_type_id.clone()],
+                properties: alice,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                confidence: None,
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
 
     let bob_metadata = api
         .create_entity(
-            bob,
-            vec![person_type_id.clone()],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_type_id.clone()],
+                properties: bob,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                confidence: None,
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
@@ -72,20 +116,116 @@ async fn insert() {
         version: OntologyTypeVersion::new(1),
     };
 
-    api.create_link_entity(
-        friend_of,
-        vec![friend_of_type_id.clone()],
-        None,
-        alice_metadata.record_id.entity_id,
-        bob_metadata.record_id.entity_id,
+    api.create_entity(
+        api.account_id,
+        CreateEntityParams {
+            owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+            entity_uuid: None,
+            decision_time: None,
+            entity_type_ids: vec![friend_of_type_id.clone()],
+            properties: friend_of,
+            property_metadata: PropertyMetadataMap::default(),
+            link_data: Some(LinkData {
+                left_entity_id: alice_metadata.record_id.entity_id,
+                right_entity_id: bob_metadata.record_id.entity_id,
+                left_entity_confidence: None,
+                left_entity_provenance: PropertyProvenance::default(),
+                right_entity_confidence: None,
+                right_entity_provenance: PropertyProvenance::default(),
+            }),
+            draft: false,
+            relationships: [],
+            confidence: None,
+            provenance: ProvidedEntityEditionProvenance::default(),
+        },
     )
     .await
     .expect("could not create link");
 
-    let link_entity = api
-        .get_link_entity_target(alice_metadata.record_id.entity_id, friend_of_type_id)
+    let mut response = api
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::All(vec![
+                        Filter::Equal(
+                            Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
+                                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                                path: Box::new(EntityQueryPath::Uuid),
+                                direction: EdgeDirection::Outgoing,
+                            })),
+                            Some(FilterExpression::Parameter(Parameter::Uuid(
+                                alice_metadata.record_id.entity_id.entity_uuid.into_uuid(),
+                            ))),
+                        ),
+                        Filter::Equal(
+                            Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
+                                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                                path: Box::new(EntityQueryPath::OwnedById),
+                                direction: EdgeDirection::Outgoing,
+                            })),
+                            Some(FilterExpression::Parameter(Parameter::Uuid(
+                                alice_metadata.record_id.entity_id.owned_by_id.into_uuid(),
+                            ))),
+                        ),
+                        Filter::Equal(
+                            Some(FilterExpression::Path(EntityQueryPath::EntityTypeEdge {
+                                edge_kind: SharedEdgeKind::IsOfType,
+                                path: EntityTypeQueryPath::BaseUrl,
+                                inheritance_depth: Some(0),
+                            })),
+                            Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
+                                friend_of_type_id.base_url.as_str(),
+                            )))),
+                        ),
+                        Filter::Equal(
+                            Some(FilterExpression::Path(EntityQueryPath::EntityTypeEdge {
+                                edge_kind: SharedEdgeKind::IsOfType,
+                                path: EntityTypeQueryPath::Version,
+                                inheritance_depth: Some(0),
+                            })),
+                            Some(FilterExpression::Parameter(Parameter::OntologyTypeVersion(
+                                friend_of_type_id.version,
+                            ))),
+                        ),
+                    ]),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(
+                            Some(TemporalBound::Unbounded),
+                            None,
+                        ),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: false,
+            },
+        )
         .await
-        .expect("could not fetch entity");
+        .expect("could not get entity");
+
+    let roots = response
+        .subgraph
+        .roots
+        .into_iter()
+        .filter_map(|vertex_id| match vertex_id {
+            GraphElementVertexId::KnowledgeGraph(vertex_id) => {
+                response.subgraph.vertices.entities.remove(&vertex_id)
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    let link_entity = match roots.len() {
+        1 => roots.into_iter().next().unwrap(),
+        len => panic!("unexpected number of entities found, expected 1 but received {len}"),
+    };
 
     let link_data = link_entity.link_data.expect("entity is not a link");
 
@@ -148,64 +288,160 @@ async fn get_entity_links() {
 
     let alice_metadata = api
         .create_entity(
-            alice,
-            vec![person_type_id.clone()],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_type_id.clone()],
+                properties: alice,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                confidence: None,
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
 
     let bob_metadata = api
         .create_entity(
-            bob,
-            vec![person_type_id.clone()],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_type_id.clone()],
+                properties: bob,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                confidence: None,
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
 
     let charles_metadata = api
         .create_entity(
-            charles,
-            vec![person_type_id.clone()],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_type_id.clone()],
+                properties: charles,
+                confidence: None,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
 
-    api.create_link_entity(
-        PropertyObject::empty(),
-        vec![friend_link_type_id.clone()],
-        None,
-        alice_metadata.record_id.entity_id,
-        bob_metadata.record_id.entity_id,
+    api.create_entity(
+        api.account_id,
+        CreateEntityParams {
+            owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+            entity_uuid: None,
+            decision_time: None,
+            entity_type_ids: vec![friend_link_type_id.clone()],
+            properties: PropertyObject::empty(),
+            property_metadata: PropertyMetadataMap::default(),
+            link_data: Some(LinkData {
+                left_entity_id: alice_metadata.record_id.entity_id,
+                right_entity_id: bob_metadata.record_id.entity_id,
+                left_entity_confidence: None,
+                left_entity_provenance: PropertyProvenance::default(),
+                right_entity_confidence: None,
+                right_entity_provenance: PropertyProvenance::default(),
+            }),
+            draft: false,
+            relationships: [],
+            confidence: None,
+            provenance: ProvidedEntityEditionProvenance::default(),
+        },
     )
     .await
     .expect("could not create link");
 
-    api.create_link_entity(
-        PropertyObject::empty(),
-        vec![acquaintance_entity_link_type_id.clone()],
-        None,
-        alice_metadata.record_id.entity_id,
-        charles_metadata.record_id.entity_id,
+    api.create_entity(
+        api.account_id,
+        CreateEntityParams {
+            owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+            entity_uuid: None,
+            decision_time: None,
+            entity_type_ids: vec![acquaintance_entity_link_type_id.clone()],
+            properties: PropertyObject::empty(),
+            property_metadata: PropertyMetadataMap::default(),
+            link_data: Some(LinkData {
+                left_entity_id: alice_metadata.record_id.entity_id,
+                right_entity_id: charles_metadata.record_id.entity_id,
+                left_entity_confidence: None,
+                left_entity_provenance: PropertyProvenance::default(),
+                right_entity_confidence: None,
+                right_entity_provenance: PropertyProvenance::default(),
+            }),
+            draft: false,
+            relationships: [],
+            confidence: None,
+            provenance: ProvidedEntityEditionProvenance::default(),
+        },
     )
     .await
     .expect("could not create link");
 
-    let links_from_source = api
-        .get_latest_entity_links(alice_metadata.record_id.entity_id)
+    let mut response = api
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::Equal(
+                        Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
+                            edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                            path: Box::new(EntityQueryPath::Uuid),
+                            direction: EdgeDirection::Outgoing,
+                        })),
+                        Some(FilterExpression::Parameter(Parameter::Uuid(
+                            alice_metadata.record_id.entity_id.entity_uuid.into_uuid(),
+                        ))),
+                    ),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: false,
+            },
+        )
         .await
-        .expect("could not fetch link");
+        .expect("could not get entity");
+
+    let links_from_source = response
+        .subgraph
+        .roots
+        .into_iter()
+        .filter_map(|vertex_id| match vertex_id {
+            GraphElementVertexId::KnowledgeGraph(edition_id) => {
+                response.subgraph.vertices.entities.remove(&edition_id)
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
 
     assert!(
         links_from_source
@@ -241,6 +477,7 @@ async fn get_entity_links() {
 }
 
 #[tokio::test]
+#[expect(clippy::too_many_lines)]
 async fn remove_link() {
     let alice = serde_json::from_str(entity::PERSON_ALICE_V1).expect("could not parse entity");
     let bob = serde_json::from_str(entity::PERSON_BOB_V1).expect("could not parse entity");
@@ -285,54 +522,190 @@ async fn remove_link() {
 
     let alice_metadata = api
         .create_entity(
-            alice,
-            vec![person_type_id.clone()],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_type_id.clone()],
+                properties: alice,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                confidence: None,
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
 
     let bob_metadata = api
         .create_entity(
-            bob,
-            vec![person_type_id.clone()],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_type_id.clone()],
+                properties: bob,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                confidence: None,
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
 
     let link_entity_metadata = api
-        .create_link_entity(
-            PropertyObject::empty(),
-            vec![friend_link_type_id.clone()],
-            None,
-            alice_metadata.record_id.entity_id,
-            bob_metadata.record_id.entity_id,
+        .create_entity(
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![friend_link_type_id.clone()],
+                properties: PropertyObject::empty(),
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: Some(LinkData {
+                    left_entity_id: alice_metadata.record_id.entity_id,
+                    right_entity_id: bob_metadata.record_id.entity_id,
+                    left_entity_confidence: None,
+                    left_entity_provenance: PropertyProvenance::default(),
+                    right_entity_confidence: None,
+                    right_entity_provenance: PropertyProvenance::default(),
+                }),
+                draft: false,
+                relationships: [],
+                confidence: None,
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create link");
 
-    assert!(
-        !api.get_latest_entity_links(alice_metadata.record_id.entity_id)
-            .await
-            .expect("could not fetch links")
-            .is_empty()
-    );
-
-    api.archive_entity(link_entity_metadata.record_id.entity_id)
+    let response = api
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::All(vec![
+                        Filter::Equal(
+                            Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
+                                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                                path: Box::new(EntityQueryPath::Uuid),
+                                direction: EdgeDirection::Outgoing,
+                            })),
+                            Some(FilterExpression::Parameter(Parameter::Uuid(
+                                alice_metadata.record_id.entity_id.entity_uuid.into_uuid(),
+                            ))),
+                        ),
+                        Filter::Equal(
+                            Some(FilterExpression::Path(EntityQueryPath::Archived)),
+                            Some(FilterExpression::Parameter(Parameter::Boolean(false))),
+                        ),
+                    ]),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: false,
+            },
+        )
         .await
-        .expect("could not remove link");
+        .expect("could not get entity");
 
-    assert!(
-        api.get_latest_entity_links(alice_metadata.record_id.entity_id)
-            .await
-            .expect("could not fetch links")
-            .is_empty()
-    );
+    let has_link = response
+        .subgraph
+        .roots
+        .into_iter()
+        .any(|vertex_id| match vertex_id {
+            GraphElementVertexId::KnowledgeGraph(edition_id) => response
+                .subgraph
+                .vertices
+                .entities
+                .contains_key(&edition_id),
+            _ => false,
+        });
+    assert!(has_link);
+
+    api.patch_entity(
+        api.account_id,
+        PatchEntityParams {
+            entity_id: link_entity_metadata.record_id.entity_id,
+            decision_time: None,
+            archived: Some(true),
+            draft: None,
+            entity_type_ids: vec![],
+            properties: vec![],
+            confidence: None,
+            provenance: ProvidedEntityEditionProvenance::default(),
+        },
+    )
+    .await
+    .expect("could not remove link");
+
+    let response = api
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::All(vec![
+                        Filter::Equal(
+                            Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
+                                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                                path: Box::new(EntityQueryPath::Uuid),
+                                direction: EdgeDirection::Outgoing,
+                            })),
+                            Some(FilterExpression::Parameter(Parameter::Uuid(
+                                alice_metadata.record_id.entity_id.entity_uuid.into_uuid(),
+                            ))),
+                        ),
+                        Filter::Equal(
+                            Some(FilterExpression::Path(EntityQueryPath::Archived)),
+                            Some(FilterExpression::Parameter(Parameter::Boolean(false))),
+                        ),
+                    ]),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: false,
+            },
+        )
+        .await
+        .expect("could not get entity");
+
+    let has_link = response
+        .subgraph
+        .roots
+        .into_iter()
+        .any(|vertex_id| match vertex_id {
+            GraphElementVertexId::KnowledgeGraph(edition_id) => response
+                .subgraph
+                .vertices
+                .entities
+                .contains_key(&edition_id),
+            _ => false,
+        });
+    assert!(!has_link);
 }

--- a/tests/hash-graph-integration/postgres/multi_type.rs
+++ b/tests/hash-graph-integration/postgres/multi_type.rs
@@ -1,11 +1,29 @@
 use std::str::FromStr;
 
 use authorization::AuthorizationApi;
-use graph::store::knowledge::PatchEntityParams;
+use graph::{
+    store::{
+        knowledge::{CreateEntityParams, GetEntityParams, PatchEntityParams},
+        query::Filter,
+        EntityQuerySorting, EntityStore,
+    },
+    subgraph::{
+        edges::GraphResolveDepths,
+        identifier::GraphElementVertexId,
+        query::StructuralQuery,
+        temporal_axes::{
+            PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
+            VariableTemporalAxisUnresolved,
+        },
+    },
+};
 use graph_test_data::{data_type, entity, entity_type, property_type};
-use graph_types::knowledge::{
-    entity::{Entity, ProvidedEntityEditionProvenance},
-    PropertyMetadataMap, PropertyObject,
+use graph_types::{
+    knowledge::{
+        entity::{Entity, ProvidedEntityEditionProvenance},
+        PropertyMetadataMap, PropertyObject,
+    },
+    owned_by_id::OwnedById,
 };
 use pretty_assertions::assert_eq;
 use type_system::url::VersionedUrl;
@@ -57,42 +75,92 @@ fn alice() -> PropertyObject {
 #[tokio::test]
 async fn empty_entity() {
     let mut database = DatabaseTestWrapper::new().await;
-    _ = seed(&mut database)
-        .await
+    let mut api = seed(&mut database).await;
+
+    let _ = api
         .create_entity(
-            PropertyObject::empty(),
-            vec![],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![],
+                properties: PropertyObject::empty(),
+                confidence: None,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect_err("created entity with no types");
 }
 
 #[tokio::test]
+#[expect(clippy::too_many_lines)]
 async fn initial_person() {
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = seed(&mut database).await;
 
     let entity_metadata = api
         .create_entity(
-            alice(),
-            vec![person_entity_type_id()],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_entity_type_id()],
+                properties: alice(),
+                confidence: None,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
 
     assert_eq!(entity_metadata.entity_type_ids, [person_entity_type_id()]);
-    let entities = api
-        .get_entities_by_type(&person_entity_type_id())
+
+    let mut response = api
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: true,
+            },
+        )
         .await
         .expect("could not get entities");
+    let entities = response
+        .subgraph
+        .roots
+        .into_iter()
+        .filter_map(|vertex_id| {
+            let GraphElementVertexId::KnowledgeGraph(vertex_id) = vertex_id else {
+                panic!("unexpected vertex id found: {vertex_id:?}");
+            };
+            response.subgraph.vertices.entities.remove(&vertex_id)
+        })
+        .collect::<Vec<_>>();
+
     assert_eq!(
         entities,
         [Entity {
@@ -103,16 +171,19 @@ async fn initial_person() {
     );
 
     let updated_entity_metadata = api
-        .patch_entity(PatchEntityParams {
-            entity_id: entity_metadata.record_id.entity_id,
-            decision_time: None,
-            entity_type_ids: vec![person_entity_type_id(), org_entity_type_id()],
-            properties: vec![],
-            draft: None,
-            archived: None,
-            confidence: None,
-            provenance: ProvidedEntityEditionProvenance::default(),
-        })
+        .patch_entity(
+            api.account_id,
+            PatchEntityParams {
+                entity_id: entity_metadata.record_id.entity_id,
+                decision_time: None,
+                entity_type_ids: vec![person_entity_type_id(), org_entity_type_id()],
+                properties: vec![],
+                draft: None,
+                archived: None,
+                confidence: None,
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
+        )
         .await
         .expect("could not create entity");
 
@@ -120,14 +191,80 @@ async fn initial_person() {
         updated_entity_metadata.entity_type_ids,
         [person_entity_type_id(), org_entity_type_id()]
     );
-    let updated_person_entities = api
-        .get_entities_by_type(&person_entity_type_id())
+
+    let mut person_response = api
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: true,
+            },
+        )
         .await
         .expect("could not get entities");
-    let updated_org_entities = api
-        .get_entities_by_type(&org_entity_type_id())
+    let updated_person_entities = person_response
+        .subgraph
+        .roots
+        .into_iter()
+        .filter_map(|vertex_id| {
+            let GraphElementVertexId::KnowledgeGraph(vertex_id) = vertex_id else {
+                panic!("unexpected vertex id found: {vertex_id:?}");
+            };
+            person_response
+                .subgraph
+                .vertices
+                .entities
+                .remove(&vertex_id)
+        })
+        .collect::<Vec<_>>();
+
+    let mut org_response = api
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: true,
+            },
+        )
         .await
         .expect("could not get entities");
+    let updated_org_entities = org_response
+        .subgraph
+        .roots
+        .into_iter()
+        .filter_map(|vertex_id| {
+            let GraphElementVertexId::KnowledgeGraph(vertex_id) = vertex_id else {
+                panic!("unexpected vertex id found: {vertex_id:?}");
+            };
+            org_response.subgraph.vertices.entities.remove(&vertex_id)
+        })
+        .collect::<Vec<_>>();
 
     assert_eq!(updated_person_entities, updated_org_entities);
     assert_eq!(
@@ -141,18 +278,27 @@ async fn initial_person() {
 }
 
 #[tokio::test]
+#[expect(clippy::too_many_lines)]
 async fn create_multi() {
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = seed(&mut database).await;
 
     let entity_metadata = api
         .create_entity(
-            alice(),
-            vec![person_entity_type_id(), org_entity_type_id()],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_entity_type_id(), org_entity_type_id()],
+                properties: alice(),
+                confidence: None,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
@@ -161,14 +307,81 @@ async fn create_multi() {
         entity_metadata.entity_type_ids,
         [person_entity_type_id(), org_entity_type_id()]
     );
-    let person_entities = api
-        .get_entities_by_type(&person_entity_type_id())
+
+    let mut person_response = api
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: true,
+            },
+        )
         .await
         .expect("could not get entities");
-    let org_entities = api
-        .get_entities_by_type(&org_entity_type_id())
+    let person_entities = person_response
+        .subgraph
+        .roots
+        .into_iter()
+        .filter_map(|vertex_id| {
+            let GraphElementVertexId::KnowledgeGraph(vertex_id) = vertex_id else {
+                panic!("unexpected vertex id found: {vertex_id:?}");
+            };
+            person_response
+                .subgraph
+                .vertices
+                .entities
+                .remove(&vertex_id)
+        })
+        .collect::<Vec<_>>();
+
+    let mut org_response = api
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: true,
+            },
+        )
         .await
         .expect("could not get entities");
+    let org_entities = org_response
+        .subgraph
+        .roots
+        .into_iter()
+        .filter_map(|vertex_id| {
+            let GraphElementVertexId::KnowledgeGraph(vertex_id) = vertex_id else {
+                panic!("unexpected vertex id found: {vertex_id:?}");
+            };
+            org_response.subgraph.vertices.entities.remove(&vertex_id)
+        })
+        .collect::<Vec<_>>();
+
     assert_eq!(person_entities, org_entities);
     assert_eq!(
         person_entities,
@@ -180,16 +393,19 @@ async fn create_multi() {
     );
 
     let updated_entity_metadata = api
-        .patch_entity(PatchEntityParams {
-            entity_id: entity_metadata.record_id.entity_id,
-            decision_time: None,
-            entity_type_ids: vec![person_entity_type_id()],
-            properties: vec![],
-            draft: None,
-            archived: None,
-            confidence: None,
-            provenance: ProvidedEntityEditionProvenance::default(),
-        })
+        .patch_entity(
+            api.account_id,
+            PatchEntityParams {
+                entity_id: entity_metadata.record_id.entity_id,
+                decision_time: None,
+                entity_type_ids: vec![person_entity_type_id()],
+                properties: vec![],
+                draft: None,
+                archived: None,
+                confidence: None,
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
+        )
         .await
         .expect("could not create entity");
 
@@ -197,10 +413,41 @@ async fn create_multi() {
         updated_entity_metadata.entity_type_ids,
         [person_entity_type_id()]
     );
-    let updated_person_entities = api
-        .get_entities_by_type(&person_entity_type_id())
+
+    let mut response = api
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: true,
+            },
+        )
         .await
         .expect("could not get entities");
+    let updated_person_entities = response
+        .subgraph
+        .roots
+        .into_iter()
+        .filter_map(|vertex_id| {
+            let GraphElementVertexId::KnowledgeGraph(vertex_id) = vertex_id else {
+                panic!("unexpected vertex id found: {vertex_id:?}");
+            };
+            response.subgraph.vertices.entities.remove(&vertex_id)
+        })
+        .collect::<Vec<_>>();
 
     assert_eq!(
         updated_person_entities,

--- a/tests/hash-graph-integration/postgres/partial_updates.rs
+++ b/tests/hash-graph-integration/postgres/partial_updates.rs
@@ -1,11 +1,28 @@
 use std::{collections::HashSet, iter::once, str::FromStr};
 
 use authorization::AuthorizationApi;
-use graph::store::knowledge::PatchEntityParams;
+use graph::{
+    store::{
+        knowledge::{CreateEntityParams, GetEntityParams, PatchEntityParams},
+        query::Filter,
+        EntityQuerySorting, EntityStore,
+    },
+    subgraph::{
+        edges::GraphResolveDepths,
+        query::StructuralQuery,
+        temporal_axes::{
+            PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
+            VariableTemporalAxisUnresolved,
+        },
+    },
+};
 use graph_test_data::{data_type, entity, entity_type, property_type};
-use graph_types::knowledge::{
-    entity::ProvidedEntityEditionProvenance, Property, PropertyMetadataMap, PropertyObject,
-    PropertyPatchOperation, PropertyPathElement, PropertyProvenance,
+use graph_types::{
+    knowledge::{
+        entity::ProvidedEntityEditionProvenance, Property, PropertyMetadataMap, PropertyObject,
+        PropertyPatchOperation, PropertyPathElement, PropertyProvenance,
+    },
+    owned_by_id::OwnedById,
 };
 use pretty_assertions::assert_eq;
 use serde_json::json;
@@ -77,39 +94,76 @@ async fn properties_add() {
 
     let entity = api
         .create_entity(
-            alice(),
-            vec![person_entity_type_id()],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_entity_type_id()],
+                properties: alice(),
+                confidence: None,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
     let entity_id = entity.record_id.entity_id;
 
-    api.patch_entity(PatchEntityParams {
-        entity_id,
-        decision_time: None,
-        entity_type_ids: vec![],
-        properties: vec![PropertyPatchOperation::Add {
-            path: once(PropertyPathElement::from(age_property_type_id())).collect(),
-            value: Property::Value(json!(30)),
+    api.patch_entity(
+        api.account_id,
+        PatchEntityParams {
+            entity_id,
+            decision_time: None,
+            entity_type_ids: vec![],
+            properties: vec![PropertyPatchOperation::Add {
+                path: once(PropertyPathElement::from(age_property_type_id())).collect(),
+                value: Property::Value(json!(30)),
+                confidence: None,
+                provenance: PropertyProvenance::default(),
+            }],
+            draft: None,
+            archived: None,
             confidence: None,
-            provenance: PropertyProvenance::default(),
-        }],
-        draft: None,
-        archived: None,
-        confidence: None,
-        provenance: ProvidedEntityEditionProvenance::default(),
-    })
+            provenance: ProvidedEntityEditionProvenance::default(),
+        },
+    )
     .await
     .expect("could not patch entity");
 
-    let entity = api
-        .get_latest_entity(entity_id)
+    let entities = api
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::for_entity_by_entity_id(entity_id),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: false,
+            },
+        )
         .await
-        .expect("could not get entity");
+        .expect("could not get entity")
+        .subgraph
+        .vertices
+        .entities
+        .into_values()
+        .collect::<Vec<_>>();
+    assert_eq!(entities.len(), 1, "unexpected number of entities found");
+    let entity = entities.into_iter().next().unwrap();
 
     let properties = entity.properties.properties();
     assert_eq!(properties.len(), 2);
@@ -124,36 +178,73 @@ async fn properties_remove() {
 
     let entity = api
         .create_entity(
-            alice(),
-            vec![person_entity_type_id()],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_entity_type_id()],
+                properties: alice(),
+                confidence: None,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
     let entity_id = entity.record_id.entity_id;
 
-    api.patch_entity(PatchEntityParams {
-        entity_id,
-        decision_time: None,
-        entity_type_ids: vec![],
-        properties: vec![PropertyPatchOperation::Remove {
-            path: once(PropertyPathElement::from(name_property_type_id())).collect(),
-        }],
-        draft: None,
-        archived: None,
-        confidence: None,
-        provenance: ProvidedEntityEditionProvenance::default(),
-    })
+    api.patch_entity(
+        api.account_id,
+        PatchEntityParams {
+            entity_id,
+            decision_time: None,
+            entity_type_ids: vec![],
+            properties: vec![PropertyPatchOperation::Remove {
+                path: once(PropertyPathElement::from(name_property_type_id())).collect(),
+            }],
+            draft: None,
+            archived: None,
+            confidence: None,
+            provenance: ProvidedEntityEditionProvenance::default(),
+        },
+    )
     .await
     .expect("could not patch entity");
 
-    let entity = api
-        .get_latest_entity(entity_id)
+    let entities = api
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::for_entity_by_entity_id(entity_id),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: false,
+            },
+        )
         .await
-        .expect("could not get entity");
+        .expect("could not get entity")
+        .subgraph
+        .vertices
+        .entities
+        .into_values()
+        .collect::<Vec<_>>();
+    assert_eq!(entities.len(), 1, "unexpected number of entities found");
+    let entity = entities.into_iter().next().unwrap();
 
     let properties = entity.properties.properties();
     assert_eq!(properties.len(), 0);
@@ -166,76 +257,34 @@ async fn properties_replace() {
 
     let entity = api
         .create_entity(
-            alice(),
-            vec![person_entity_type_id()],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_entity_type_id()],
+                properties: alice(),
+                confidence: None,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
     let entity_id = entity.record_id.entity_id;
 
-    api.patch_entity(PatchEntityParams {
-        entity_id,
-        decision_time: None,
-        entity_type_ids: vec![],
-        properties: vec![PropertyPatchOperation::Replace {
-            path: once(PropertyPathElement::from(name_property_type_id())).collect(),
-            value: Property::Value(json!("Bob")),
-            confidence: None,
-            provenance: PropertyProvenance::default(),
-        }],
-        draft: None,
-        archived: None,
-        confidence: None,
-        provenance: ProvidedEntityEditionProvenance::default(),
-    })
-    .await
-    .expect("could not patch entity");
-
-    let entity = api
-        .get_latest_entity(entity_id)
-        .await
-        .expect("could not get entity");
-
-    let properties = entity.properties.properties();
-    assert_eq!(properties.len(), 1);
-    assert_eq!(properties[&name_property_type_id()], json!("Bob"));
-}
-
-#[tokio::test]
-async fn properties_move() {
-    let mut database = DatabaseTestWrapper::new().await;
-    let mut api = seed(&mut database).await;
-
-    let entity = api
-        .create_entity(
-            alice(),
-            vec![person_entity_type_id()],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
-        )
-        .await
-        .expect("could not create entity");
-    let entity_id = entity.record_id.entity_id;
-
-    let _ = api
-        .patch_entity(PatchEntityParams {
+    api.patch_entity(
+        api.account_id,
+        PatchEntityParams {
             entity_id,
             decision_time: None,
             entity_type_ids: vec![],
-            properties: vec![PropertyPatchOperation::Move {
-                from: once(PropertyPathElement::from(name_property_type_id())).collect(),
-                path: [
-                    PropertyPathElement::from(interests_property_type_id()),
-                    PropertyPathElement::from(film_property_type_id()),
-                ]
-                .into_iter()
-                .collect(),
+            properties: vec![PropertyPatchOperation::Replace {
+                path: once(PropertyPathElement::from(name_property_type_id())).collect(),
+                value: Property::Value(json!("Bob")),
                 confidence: None,
                 provenance: PropertyProvenance::default(),
             }],
@@ -243,45 +292,165 @@ async fn properties_move() {
             archived: None,
             confidence: None,
             provenance: ProvidedEntityEditionProvenance::default(),
-        })
-        .await
-        .expect_err("Could patch entity with invalid move operation");
-
-    api.patch_entity(PatchEntityParams {
-        entity_id,
-        decision_time: None,
-        entity_type_ids: vec![],
-        properties: vec![
-            PropertyPatchOperation::Add {
-                path: once(PropertyPathElement::from(interests_property_type_id())).collect(),
-                value: Property::Value(json!({})),
-                confidence: None,
-                provenance: PropertyProvenance::default(),
-            },
-            PropertyPatchOperation::Move {
-                from: once(PropertyPathElement::from(name_property_type_id())).collect(),
-                path: [
-                    PropertyPathElement::from(interests_property_type_id()),
-                    PropertyPathElement::from(film_property_type_id()),
-                ]
-                .into_iter()
-                .collect(),
-                confidence: None,
-                provenance: PropertyProvenance::default(),
-            },
-        ],
-        draft: None,
-        archived: None,
-        confidence: None,
-        provenance: ProvidedEntityEditionProvenance::default(),
-    })
+        },
+    )
     .await
     .expect("could not patch entity");
 
-    let entity = api
-        .get_latest_entity(entity_id)
+    let entities = api
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::for_entity_by_entity_id(entity_id),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: false,
+            },
+        )
         .await
-        .expect("could not get entity");
+        .expect("could not get entity")
+        .subgraph
+        .vertices
+        .entities
+        .into_values()
+        .collect::<Vec<_>>();
+    assert_eq!(entities.len(), 1, "unexpected number of entities found");
+    let entity = entities.into_iter().next().unwrap();
+
+    let properties = entity.properties.properties();
+    assert_eq!(properties.len(), 1);
+    assert_eq!(properties[&name_property_type_id()], json!("Bob"));
+}
+
+#[tokio::test]
+#[expect(clippy::too_many_lines)]
+async fn properties_move() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+
+    let entity = api
+        .create_entity(
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_entity_type_id()],
+                properties: alice(),
+                confidence: None,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
+        )
+        .await
+        .expect("could not create entity");
+    let entity_id = entity.record_id.entity_id;
+
+    let _ = api
+        .patch_entity(
+            api.account_id,
+            PatchEntityParams {
+                entity_id,
+                decision_time: None,
+                entity_type_ids: vec![],
+                properties: vec![PropertyPatchOperation::Move {
+                    from: once(PropertyPathElement::from(name_property_type_id())).collect(),
+                    path: [
+                        PropertyPathElement::from(interests_property_type_id()),
+                        PropertyPathElement::from(film_property_type_id()),
+                    ]
+                    .into_iter()
+                    .collect(),
+                    confidence: None,
+                    provenance: PropertyProvenance::default(),
+                }],
+                draft: None,
+                archived: None,
+                confidence: None,
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
+        )
+        .await
+        .expect_err("Could patch entity with invalid move operation");
+
+    api.patch_entity(
+        api.account_id,
+        PatchEntityParams {
+            entity_id,
+            decision_time: None,
+            entity_type_ids: vec![],
+            properties: vec![
+                PropertyPatchOperation::Add {
+                    path: once(PropertyPathElement::from(interests_property_type_id())).collect(),
+                    value: Property::Value(json!({})),
+                    confidence: None,
+                    provenance: PropertyProvenance::default(),
+                },
+                PropertyPatchOperation::Move {
+                    from: once(PropertyPathElement::from(name_property_type_id())).collect(),
+                    path: [
+                        PropertyPathElement::from(interests_property_type_id()),
+                        PropertyPathElement::from(film_property_type_id()),
+                    ]
+                    .into_iter()
+                    .collect(),
+                    confidence: None,
+                    provenance: PropertyProvenance::default(),
+                },
+            ],
+            draft: None,
+            archived: None,
+            confidence: None,
+            provenance: ProvidedEntityEditionProvenance::default(),
+        },
+    )
+    .await
+    .expect("could not patch entity");
+
+    let entities = api
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::for_entity_by_entity_id(entity_id),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: false,
+            },
+        )
+        .await
+        .expect("could not get entity")
+        .subgraph
+        .vertices
+        .entities
+        .into_values()
+        .collect::<Vec<_>>();
+    assert_eq!(entities.len(), 1, "unexpected number of entities found");
+    let entity = entities.into_iter().next().unwrap();
 
     let properties = entity.properties.properties();
     assert_eq!(properties.len(), 1);
@@ -298,56 +467,93 @@ async fn properties_copy() {
 
     let entity = api
         .create_entity(
-            alice(),
-            vec![person_entity_type_id()],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_entity_type_id()],
+                properties: alice(),
+                confidence: None,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
     let entity_id = entity.record_id.entity_id;
 
-    api.patch_entity(PatchEntityParams {
-        entity_id,
-        decision_time: None,
-        entity_type_ids: vec![],
-        properties: vec![
-            PropertyPatchOperation::Add {
-                path: once(PropertyPathElement::from(interests_property_type_id())).collect(),
-                value: Property::Value(json!({})),
-                confidence: None,
-                provenance: PropertyProvenance::default(),
-            },
-            PropertyPatchOperation::Test {
-                path: once(PropertyPathElement::from(interests_property_type_id())).collect(),
-                value: Property::Value(json!({})),
-            },
-            PropertyPatchOperation::Copy {
-                from: once(PropertyPathElement::from(name_property_type_id())).collect(),
-                path: [
-                    PropertyPathElement::from(interests_property_type_id()),
-                    PropertyPathElement::from(film_property_type_id()),
-                ]
-                .into_iter()
-                .collect(),
-                confidence: None,
-                provenance: PropertyProvenance::default(),
-            },
-        ],
-        draft: None,
-        archived: None,
-        confidence: None,
-        provenance: ProvidedEntityEditionProvenance::default(),
-    })
+    api.patch_entity(
+        api.account_id,
+        PatchEntityParams {
+            entity_id,
+            decision_time: None,
+            entity_type_ids: vec![],
+            properties: vec![
+                PropertyPatchOperation::Add {
+                    path: once(PropertyPathElement::from(interests_property_type_id())).collect(),
+                    value: Property::Value(json!({})),
+                    confidence: None,
+                    provenance: PropertyProvenance::default(),
+                },
+                PropertyPatchOperation::Test {
+                    path: once(PropertyPathElement::from(interests_property_type_id())).collect(),
+                    value: Property::Value(json!({})),
+                },
+                PropertyPatchOperation::Copy {
+                    from: once(PropertyPathElement::from(name_property_type_id())).collect(),
+                    path: [
+                        PropertyPathElement::from(interests_property_type_id()),
+                        PropertyPathElement::from(film_property_type_id()),
+                    ]
+                    .into_iter()
+                    .collect(),
+                    confidence: None,
+                    provenance: PropertyProvenance::default(),
+                },
+            ],
+            draft: None,
+            archived: None,
+            confidence: None,
+            provenance: ProvidedEntityEditionProvenance::default(),
+        },
+    )
     .await
     .expect("could not patch entity");
 
-    let entity = api
-        .get_latest_entity(entity_id)
+    let entities = api
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::for_entity_by_entity_id(entity_id),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: false,
+            },
+        )
         .await
-        .expect("could not get entity");
+        .expect("could not get entity")
+        .subgraph
+        .vertices
+        .entities
+        .into_values()
+        .collect::<Vec<_>>();
+    assert_eq!(entities.len(), 1, "unexpected number of entities found");
+    let entity = entities.into_iter().next().unwrap();
 
     let properties = entity.properties.properties();
     assert_eq!(properties.len(), 2);
@@ -359,63 +565,130 @@ async fn properties_copy() {
 }
 
 #[tokio::test]
+#[expect(clippy::too_many_lines)]
 async fn type_ids() {
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = seed(&mut database).await;
 
     let entity = api
         .create_entity(
-            PropertyObject::empty(),
-            vec![person_entity_type_id()],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_entity_type_id()],
+                properties: PropertyObject::empty(),
+                confidence: None,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
     let entity_id = entity.record_id.entity_id;
 
-    api.patch_entity(PatchEntityParams {
-        entity_id,
-        decision_time: None,
-        entity_type_ids: vec![],
-        properties: vec![],
-        draft: None,
-        archived: None,
-        confidence: None,
-        provenance: ProvidedEntityEditionProvenance::default(),
-    })
+    api.patch_entity(
+        api.account_id,
+        PatchEntityParams {
+            entity_id,
+            decision_time: None,
+            entity_type_ids: vec![],
+            properties: vec![],
+            draft: None,
+            archived: None,
+            confidence: None,
+            provenance: ProvidedEntityEditionProvenance::default(),
+        },
+    )
     .await
     .expect("could not patch entity");
 
-    let entity = api
-        .get_latest_entity(entity_id)
+    let entities = api
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::for_entity_by_entity_id(entity_id),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: false,
+            },
+        )
         .await
-        .expect("could not get entity");
+        .expect("could not get entity")
+        .subgraph
+        .vertices
+        .entities
+        .into_values()
+        .collect::<Vec<_>>();
+    assert_eq!(entities.len(), 1, "unexpected number of entities found");
+    let entity = entities.into_iter().next().unwrap();
     assert_eq!(
         entity.metadata.entity_type_ids,
         [person_entity_type_id()],
         "Entity type ids changed even though none were provided in the patch operation"
     );
 
-    api.patch_entity(PatchEntityParams {
-        entity_id,
-        decision_time: None,
-        entity_type_ids: vec![person_entity_type_id(), org_entity_type_id()],
-        properties: vec![],
-        draft: None,
-        archived: None,
-        confidence: None,
-        provenance: ProvidedEntityEditionProvenance::default(),
-    })
+    api.patch_entity(
+        api.account_id,
+        PatchEntityParams {
+            entity_id,
+            decision_time: None,
+            entity_type_ids: vec![person_entity_type_id(), org_entity_type_id()],
+            properties: vec![],
+            draft: None,
+            archived: None,
+            confidence: None,
+            provenance: ProvidedEntityEditionProvenance::default(),
+        },
+    )
     .await
     .expect("could not patch entity");
 
-    let entity = api
-        .get_latest_entity(entity_id)
+    let entities = api
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::for_entity_by_entity_id(entity_id),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: false,
+            },
+        )
         .await
-        .expect("could not get entity");
+        .expect("could not get entity")
+        .subgraph
+        .vertices
+        .entities
+        .into_values()
+        .collect::<Vec<_>>();
+    assert_eq!(entities.len(), 1, "unexpected number of entities found");
+    let entity = entities.into_iter().next().unwrap();
     assert_eq!(
         entity
             .metadata
@@ -426,23 +699,52 @@ async fn type_ids() {
         HashSet::from([person_entity_type_id(), org_entity_type_id()]),
     );
 
-    api.patch_entity(PatchEntityParams {
-        entity_id,
-        decision_time: None,
-        entity_type_ids: vec![person_entity_type_id()],
-        properties: vec![],
-        draft: None,
-        archived: None,
-        confidence: None,
-        provenance: ProvidedEntityEditionProvenance::default(),
-    })
+    api.patch_entity(
+        api.account_id,
+        PatchEntityParams {
+            entity_id,
+            decision_time: None,
+            entity_type_ids: vec![person_entity_type_id()],
+            properties: vec![],
+            draft: None,
+            archived: None,
+            confidence: None,
+            provenance: ProvidedEntityEditionProvenance::default(),
+        },
+    )
     .await
     .expect("could not patch entity");
 
-    let entity = api
-        .get_latest_entity(entity_id)
+    let entities = api
+        .get_entity(
+            api.account_id,
+            GetEntityParams {
+                query: StructuralQuery {
+                    filter: Filter::for_entity_by_entity_id(entity_id),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
+                    include_drafts: false,
+                },
+                sorting: EntityQuerySorting {
+                    paths: Vec::new(),
+                    cursor: None,
+                },
+                limit: None,
+                include_count: false,
+            },
+        )
         .await
-        .expect("could not get entity");
+        .expect("could not get entity")
+        .subgraph
+        .vertices
+        .entities
+        .into_values()
+        .collect::<Vec<_>>();
+    assert_eq!(entities.len(), 1, "unexpected number of entities found");
+    let entity = entities.into_iter().next().unwrap();
 
     assert_eq!(entity.metadata.entity_type_ids, [person_entity_type_id()],);
 }

--- a/tests/hash-graph-integration/postgres/partial_updates.rs
+++ b/tests/hash-graph-integration/postgres/partial_updates.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashSet, iter::once, str::FromStr};
 
+use authorization::AuthorizationApi;
 use graph::store::knowledge::PatchEntityParams;
 use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::knowledge::{
@@ -12,7 +13,9 @@ use type_system::url::{BaseUrl, VersionedUrl};
 
 use crate::{DatabaseApi, DatabaseTestWrapper};
 
-async fn seed(database: &mut DatabaseTestWrapper) -> DatabaseApi<'_> {
+async fn seed<A: AuthorizationApi>(
+    database: &mut DatabaseTestWrapper<A>,
+) -> DatabaseApi<'_, &mut A> {
     database
         .seed(
             [data_type::TEXT_V1, data_type::NUMBER_V1],
@@ -107,6 +110,7 @@ async fn properties_add() {
         .get_latest_entity(entity_id)
         .await
         .expect("could not get entity");
+
     let properties = entity.properties.properties();
     assert_eq!(properties.len(), 2);
     assert_eq!(properties[&name_property_type_id()], json!("Alice"));
@@ -150,6 +154,7 @@ async fn properties_remove() {
         .get_latest_entity(entity_id)
         .await
         .expect("could not get entity");
+
     let properties = entity.properties.properties();
     assert_eq!(properties.len(), 0);
 }
@@ -194,6 +199,7 @@ async fn properties_replace() {
         .get_latest_entity(entity_id)
         .await
         .expect("could not get entity");
+
     let properties = entity.properties.properties();
     assert_eq!(properties.len(), 1);
     assert_eq!(properties[&name_property_type_id()], json!("Bob"));
@@ -276,6 +282,7 @@ async fn properties_move() {
         .get_latest_entity(entity_id)
         .await
         .expect("could not get entity");
+
     let properties = entity.properties.properties();
     assert_eq!(properties.len(), 1);
     assert_eq!(
@@ -341,6 +348,7 @@ async fn properties_copy() {
         .get_latest_entity(entity_id)
         .await
         .expect("could not get entity");
+
     let properties = entity.properties.properties();
     assert_eq!(properties.len(), 2);
     assert_eq!(properties[&name_property_type_id()], json!("Alice"));
@@ -435,5 +443,6 @@ async fn type_ids() {
         .get_latest_entity(entity_id)
         .await
         .expect("could not get entity");
+
     assert_eq!(entity.metadata.entity_type_ids, [person_entity_type_id()],);
 }

--- a/tests/hash-graph-integration/postgres/property_metadata.rs
+++ b/tests/hash-graph-integration/postgres/property_metadata.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, collections::HashMap, iter::once, str::FromStr};
 
+use authorization::AuthorizationApi;
 use graph::store::knowledge::PatchEntityParams;
 use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::knowledge::{
@@ -13,7 +14,9 @@ use type_system::url::{BaseUrl, VersionedUrl};
 
 use crate::{DatabaseApi, DatabaseTestWrapper};
 
-async fn seed(database: &mut DatabaseTestWrapper) -> DatabaseApi<'_> {
+async fn seed<A: AuthorizationApi>(
+    database: &mut DatabaseTestWrapper<A>,
+) -> DatabaseApi<'_, &mut A> {
     database
         .seed(
             [data_type::TEXT_V1, data_type::NUMBER_V1],

--- a/tests/hash-graph-integration/postgres/property_metadata.rs
+++ b/tests/hash-graph-integration/postgres/property_metadata.rs
@@ -1,12 +1,18 @@
 use std::{borrow::Cow, collections::HashMap, iter::once, str::FromStr};
 
 use authorization::AuthorizationApi;
-use graph::store::knowledge::PatchEntityParams;
+use graph::store::{
+    knowledge::{CreateEntityParams, PatchEntityParams},
+    EntityStore,
+};
 use graph_test_data::{data_type, entity, entity_type, property_type};
-use graph_types::knowledge::{
-    entity::{Location, ProvidedEntityEditionProvenance, SourceProvenance, SourceType},
-    Confidence, Property, PropertyMetadata, PropertyMetadataMap, PropertyObject,
-    PropertyPatchOperation, PropertyPath, PropertyPathElement, PropertyProvenance,
+use graph_types::{
+    knowledge::{
+        entity::{Location, ProvidedEntityEditionProvenance, SourceProvenance, SourceType},
+        Confidence, Property, PropertyMetadata, PropertyMetadataMap, PropertyObject,
+        PropertyPatchOperation, PropertyPath, PropertyPathElement, PropertyProvenance,
+    },
+    owned_by_id::OwnedById,
 };
 use pretty_assertions::assert_eq;
 use serde_json::json;
@@ -147,54 +153,68 @@ async fn initial_metadata() {
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = seed(&mut database).await;
 
-    let entity_property_confidence = property_metadata([("", 0.5, property_provenance_a())]);
+    let entity_property_metadata = property_metadata([("", 0.5, property_provenance_a())]);
     let entity = api
         .create_entity(
-            alice(),
-            vec![person_entity_type_id()],
-            None,
-            true,
-            Some(confidence(0.5)),
-            entity_property_confidence.clone(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_entity_type_id()],
+                properties: alice(),
+                confidence: Some(confidence(0.5)),
+                property_metadata: entity_property_metadata.clone(),
+                link_data: None,
+                draft: true,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
 
     assert_eq!(entity.confidence, Some(confidence(0.5)));
-    assert_eq!(entity.properties, entity_property_confidence);
+    assert_eq!(entity.properties, entity_property_metadata);
 
     let updated_entity = api
-        .patch_entity(PatchEntityParams {
-            entity_id: entity.record_id.entity_id,
-            properties: Vec::new(),
-            entity_type_ids: vec![],
-            archived: None,
-            draft: None,
-            decision_time: None,
-            confidence: Some(confidence(0.5)),
-            provenance: edition_provenance(),
-        })
+        .patch_entity(
+            api.account_id,
+            PatchEntityParams {
+                entity_id: entity.record_id.entity_id,
+                properties: Vec::new(),
+                entity_type_ids: vec![],
+                archived: None,
+                draft: None,
+                decision_time: None,
+                confidence: Some(confidence(0.5)),
+                provenance: edition_provenance(),
+            },
+        )
         .await
         .expect("could not update entity");
 
     assert_eq!(updated_entity, entity);
 
     let updated_entity = api
-        .patch_entity(PatchEntityParams {
-            entity_id: entity.record_id.entity_id,
-            properties: Vec::new(),
-            entity_type_ids: vec![],
-            archived: None,
-            draft: None,
-            decision_time: None,
-            confidence: None,
-            provenance: edition_provenance(),
-        })
+        .patch_entity(
+            api.account_id,
+            PatchEntityParams {
+                entity_id: entity.record_id.entity_id,
+                properties: Vec::new(),
+                entity_type_ids: vec![],
+                archived: None,
+                draft: None,
+                decision_time: None,
+                confidence: None,
+                provenance: edition_provenance(),
+            },
+        )
         .await
         .expect("could not update entity");
 
     assert!(updated_entity.confidence.is_none());
-    assert_eq!(updated_entity.properties, entity_property_confidence);
+    assert_eq!(updated_entity.properties, entity_property_metadata);
     assert_eq!(
         updated_entity.provenance.edition.provided,
         edition_provenance()
@@ -202,18 +222,27 @@ async fn initial_metadata() {
 }
 
 #[tokio::test]
+#[expect(clippy::too_many_lines)]
 async fn no_initial_metadata() {
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = seed(&mut database).await;
 
     let entity = api
         .create_entity(
-            alice(),
-            vec![person_entity_type_id()],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_entity_type_id()],
+                properties: alice(),
+                confidence: None,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
@@ -222,32 +251,38 @@ async fn no_initial_metadata() {
     assert!(entity.properties.is_empty());
 
     let updated_entity = api
-        .patch_entity(PatchEntityParams {
-            entity_id: entity.record_id.entity_id,
-            properties: Vec::new(),
-            entity_type_ids: vec![],
-            archived: None,
-            draft: None,
-            decision_time: None,
-            confidence: None,
-            provenance: ProvidedEntityEditionProvenance::default(),
-        })
+        .patch_entity(
+            api.account_id,
+            PatchEntityParams {
+                entity_id: entity.record_id.entity_id,
+                properties: Vec::new(),
+                entity_type_ids: vec![],
+                archived: None,
+                draft: None,
+                decision_time: None,
+                confidence: None,
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
+        )
         .await
         .expect("could not update entity");
 
     assert_eq!(entity, updated_entity);
 
     let updated_entity = api
-        .patch_entity(PatchEntityParams {
-            entity_id: entity.record_id.entity_id,
-            properties: Vec::new(),
-            entity_type_ids: vec![],
-            archived: None,
-            draft: None,
-            decision_time: None,
-            confidence: Some(confidence(0.5)),
-            provenance: ProvidedEntityEditionProvenance::default(),
-        })
+        .patch_entity(
+            api.account_id,
+            PatchEntityParams {
+                entity_id: entity.record_id.entity_id,
+                properties: Vec::new(),
+                entity_type_ids: vec![],
+                archived: None,
+                draft: None,
+                decision_time: None,
+                confidence: Some(confidence(0.5)),
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
+        )
         .await
         .expect("could not update entity");
 
@@ -257,21 +292,24 @@ async fn no_initial_metadata() {
     let path: PropertyPath = once(PropertyPathElement::from(name_property_type_id())).collect();
     let path_pointer = path.to_json_pointer();
     let updated_entity = api
-        .patch_entity(PatchEntityParams {
-            entity_id: entity.record_id.entity_id,
-            properties: vec![PropertyPatchOperation::Replace {
-                path: once(PropertyPathElement::from(name_property_type_id())).collect(),
-                value: Property::Value(json!("Alice")),
-                confidence: Some(confidence(0.5)),
-                provenance: property_provenance_a(),
-            }],
-            entity_type_ids: vec![],
-            archived: None,
-            draft: None,
-            decision_time: None,
-            confidence: None,
-            provenance: ProvidedEntityEditionProvenance::default(),
-        })
+        .patch_entity(
+            api.account_id,
+            PatchEntityParams {
+                entity_id: entity.record_id.entity_id,
+                properties: vec![PropertyPatchOperation::Replace {
+                    path: once(PropertyPathElement::from(name_property_type_id())).collect(),
+                    value: Property::Value(json!("Alice")),
+                    confidence: Some(confidence(0.5)),
+                    provenance: property_provenance_a(),
+                }],
+                entity_type_ids: vec![],
+                archived: None,
+                draft: None,
+                decision_time: None,
+                confidence: None,
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
+        )
         .await
         .expect("could not update entity");
 
@@ -282,16 +320,19 @@ async fn no_initial_metadata() {
     );
 
     let updated_entity = api
-        .patch_entity(PatchEntityParams {
-            entity_id: entity.record_id.entity_id,
-            properties: Vec::new(),
-            entity_type_ids: vec![],
-            archived: None,
-            draft: None,
-            decision_time: None,
-            confidence: Some(confidence(0.5)),
-            provenance: edition_provenance(),
-        })
+        .patch_entity(
+            api.account_id,
+            PatchEntityParams {
+                entity_id: entity.record_id.entity_id,
+                properties: Vec::new(),
+                entity_type_ids: vec![],
+                archived: None,
+                draft: None,
+                decision_time: None,
+                confidence: Some(confidence(0.5)),
+                provenance: edition_provenance(),
+            },
+        )
         .await
         .expect("could not update entity");
 
@@ -313,12 +354,20 @@ async fn properties_add() {
 
     let entity = api
         .create_entity(
-            alice(),
-            vec![person_entity_type_id()],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_entity_type_id()],
+                properties: alice(),
+                confidence: None,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
@@ -326,21 +375,24 @@ async fn properties_add() {
 
     let path: PropertyPath = once(PropertyPathElement::from(age_property_type_id())).collect();
     let updated_entity = api
-        .patch_entity(PatchEntityParams {
-            entity_id,
-            decision_time: None,
-            entity_type_ids: vec![],
-            properties: vec![PropertyPatchOperation::Add {
-                path: path.clone(),
-                value: Property::Value(json!(30)),
-                confidence: Some(confidence(0.5)),
-                provenance: property_provenance_a(),
-            }],
-            draft: None,
-            archived: None,
-            confidence: None,
-            provenance: ProvidedEntityEditionProvenance::default(),
-        })
+        .patch_entity(
+            api.account_id,
+            PatchEntityParams {
+                entity_id,
+                decision_time: None,
+                entity_type_ids: vec![],
+                properties: vec![PropertyPatchOperation::Add {
+                    path: path.clone(),
+                    value: Property::Value(json!(30)),
+                    confidence: Some(confidence(0.5)),
+                    provenance: property_provenance_a(),
+                }],
+                draft: None,
+                archived: None,
+                confidence: None,
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
+        )
         .await
         .expect("could not patch entity");
 
@@ -358,12 +410,20 @@ async fn properties_remove() {
 
     let entity = api
         .create_entity(
-            alice(),
-            vec![person_entity_type_id()],
-            None,
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: vec![person_entity_type_id()],
+                properties: alice(),
+                confidence: None,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");
@@ -379,29 +439,33 @@ async fn properties_remove() {
     .collect::<PropertyPath>();
 
     let updated_entity = api
-        .patch_entity(PatchEntityParams {
-            entity_id,
-            decision_time: None,
-            entity_type_ids: vec![],
-            properties: vec![
-                PropertyPatchOperation::Add {
-                    path: once(PropertyPathElement::from(interests_property_type_id())).collect(),
-                    value: Property::Value(json!({})),
-                    confidence: Some(confidence(0.5)),
-                    provenance: property_provenance_a(),
-                },
-                PropertyPatchOperation::Add {
-                    path: film_path.clone(),
-                    value: Property::Value(json!("Fight Club")),
-                    confidence: Some(confidence(0.5)),
-                    provenance: property_provenance_b(),
-                },
-            ],
-            draft: None,
-            archived: None,
-            confidence: None,
-            provenance: ProvidedEntityEditionProvenance::default(),
-        })
+        .patch_entity(
+            api.account_id,
+            PatchEntityParams {
+                entity_id,
+                decision_time: None,
+                entity_type_ids: vec![],
+                properties: vec![
+                    PropertyPatchOperation::Add {
+                        path: once(PropertyPathElement::from(interests_property_type_id()))
+                            .collect(),
+                        value: Property::Value(json!({})),
+                        confidence: Some(confidence(0.5)),
+                        provenance: property_provenance_a(),
+                    },
+                    PropertyPatchOperation::Add {
+                        path: film_path.clone(),
+                        value: Property::Value(json!("Fight Club")),
+                        confidence: Some(confidence(0.5)),
+                        provenance: property_provenance_b(),
+                    },
+                ],
+                draft: None,
+                archived: None,
+                confidence: None,
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
+        )
         .await
         .expect("could not patch entity");
 
@@ -420,18 +484,21 @@ async fn properties_remove() {
     );
 
     let updated_entity = api
-        .patch_entity(PatchEntityParams {
-            entity_id,
-            decision_time: None,
-            entity_type_ids: vec![],
-            properties: vec![PropertyPatchOperation::Remove {
-                path: interests_path,
-            }],
-            draft: None,
-            archived: None,
-            confidence: None,
-            provenance: ProvidedEntityEditionProvenance::default(),
-        })
+        .patch_entity(
+            api.account_id,
+            PatchEntityParams {
+                entity_id,
+                decision_time: None,
+                entity_type_ids: vec![],
+                properties: vec![PropertyPatchOperation::Remove {
+                    path: interests_path,
+                }],
+                draft: None,
+                archived: None,
+                confidence: None,
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
+        )
         .await
         .expect("could not patch entity");
 

--- a/tests/hash-graph-integration/postgres/property_type.rs
+++ b/tests/hash-graph-integration/postgres/property_type.rs
@@ -8,13 +8,12 @@ async fn insert() {
     let age_pt: PropertyType =
         serde_json::from_str(property_type::AGE_V1).expect("could not parse property type");
 
-    let mut database = DatabaseTestWrapper::new().await;
-    let mut api = database
+    DatabaseTestWrapper::new()
+        .await
         .seed([data_type::NUMBER_V1], [], [])
         .await
-        .expect("could not seed database");
-
-    api.create_property_type(age_pt)
+        .expect("could not seed database")
+        .create_property_type(age_pt)
         .await
         .expect("could not create property type");
 }

--- a/tests/hash-graph-integration/postgres/sorting.rs
+++ b/tests/hash-graph-integration/postgres/sorting.rs
@@ -4,12 +4,28 @@ use authorization::AuthorizationApi;
 use graph::{
     knowledge::EntityQueryPath,
     store::{
-        query::{JsonPath, PathToken},
-        EntityQuerySorting, EntityQuerySortingRecord, NullOrdering, Ordering,
+        knowledge::{CreateEntityParams, GetEntityParams},
+        query::{Filter, JsonPath, PathToken},
+        EntityQuerySorting, EntityQuerySortingRecord, EntityStore, NullOrdering, Ordering,
+    },
+    subgraph::{
+        edges::GraphResolveDepths,
+        identifier::GraphElementVertexId,
+        query::StructuralQuery,
+        temporal_axes::{
+            PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
+            VariableTemporalAxisUnresolved,
+        },
     },
 };
 use graph_test_data::{data_type, entity, entity_type, property_type};
-use graph_types::knowledge::{entity::EntityUuid, PropertyMetadataMap, PropertyObject};
+use graph_types::{
+    knowledge::{
+        entity::{EntityUuid, ProvidedEntityEditionProvenance},
+        PropertyMetadataMap, PropertyObject,
+    },
+    owned_by_id::OwnedById,
+};
 use pretty_assertions::assert_eq;
 use type_system::url::{BaseUrl, OntologyTypeVersion, VersionedUrl};
 use uuid::Uuid;
@@ -46,16 +62,41 @@ async fn test_root_sorting<A: AuthorizationApi>(
     let mut entities = Vec::new();
 
     loop {
-        let (new_entities, new_cursor) = api
-            .get_all_entities(
-                chunk_size,
-                EntityQuerySorting {
-                    paths: sorting_paths.clone(),
-                    cursor: cursor.take(),
+        let mut response = api
+            .get_entity(
+                api.account_id,
+                GetEntityParams {
+                    query: StructuralQuery {
+                        filter: Filter::All(Vec::new()),
+                        graph_resolve_depths: GraphResolveDepths::default(),
+                        temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                            pinned: PinnedTemporalAxisUnresolved::new(None),
+                            variable: VariableTemporalAxisUnresolved::new(None, None),
+                        },
+                        include_drafts: false,
+                    },
+                    sorting: EntityQuerySorting {
+                        paths: sorting_paths.clone(),
+                        cursor: cursor.take(),
+                    },
+                    limit: Some(chunk_size),
+                    include_count: false,
                 },
             )
             .await
-            .expect("could not get entities");
+            .expect("could not get entity");
+
+        let new_entities = response
+            .subgraph
+            .roots
+            .into_iter()
+            .filter_map(|vertex_id| {
+                let GraphElementVertexId::KnowledgeGraph(vertex_id) = vertex_id else {
+                    panic!("unexpected vertex id found: {vertex_id:?}");
+                };
+                response.subgraph.vertices.entities.remove(&vertex_id)
+            })
+            .collect::<Vec<_>>();
         let num_entities = new_entities.len();
         for entity in new_entities {
             assert!(
@@ -68,7 +109,7 @@ async fn test_root_sorting<A: AuthorizationApi>(
         if num_entities < chunk_size {
             break;
         }
-        if let Some(new_cursor) = new_cursor {
+        if let Some(new_cursor) = response.cursor {
             cursor.replace(new_cursor);
         }
     }
@@ -134,12 +175,20 @@ async fn insert<A: AuthorizationApi>(
         let properties: PropertyObject =
             serde_json::from_str(entity).expect("could not parse entity");
         api.create_entity(
-            properties.clone(),
-            vec![type_id.clone()],
-            Some(EntityUuid::new(Uuid::from_u128(idx as u128))),
-            false,
-            None,
-            PropertyMetadataMap::default(),
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: Some(EntityUuid::new(Uuid::from_u128(idx as u128))),
+                decision_time: None,
+                entity_type_ids: vec![type_id.clone()],
+                properties: properties.clone(),
+                confidence: None,
+                property_metadata: PropertyMetadataMap::default(),
+                link_data: None,
+                draft: false,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
         )
         .await
         .expect("could not create entity");

--- a/tests/hash-graph-integration/postgres/sorting.rs
+++ b/tests/hash-graph-integration/postgres/sorting.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, collections::HashSet};
 
+use authorization::AuthorizationApi;
 use graph::{
     knowledge::EntityQueryPath,
     store::{
@@ -15,8 +16,8 @@ use uuid::Uuid;
 
 use crate::{DatabaseApi, DatabaseTestWrapper};
 
-async fn test_root_sorting_chunked<const N: usize, const M: usize>(
-    api: &DatabaseApi<'_>,
+async fn test_root_sorting_chunked<const N: usize, const M: usize, A: AuthorizationApi>(
+    api: &DatabaseApi<'_, A>,
     sort: [(EntityQueryPath<'static>, Ordering, NullOrdering); N],
     expected_order: [PropertyObject; M],
 ) {
@@ -25,8 +26,8 @@ async fn test_root_sorting_chunked<const N: usize, const M: usize>(
     }
 }
 
-async fn test_root_sorting(
-    api: &DatabaseApi<'_>,
+async fn test_root_sorting<A: AuthorizationApi>(
+    api: &DatabaseApi<'_, A>,
     chunk_size: usize,
     sort: impl IntoIterator<Item = (EntityQueryPath<'static>, Ordering, NullOrdering)> + Send,
     expected_order: impl IntoIterator<Item = &PropertyObject> + Send,
@@ -81,7 +82,9 @@ async fn test_root_sorting(
     );
 }
 
-async fn insert(database: &mut DatabaseTestWrapper) -> DatabaseApi<'_> {
+async fn insert<A: AuthorizationApi>(
+    database: &mut DatabaseTestWrapper<A>,
+) -> DatabaseApi<'_, &mut A> {
     let mut api = database
         .seed(
             [data_type::TEXT_V1, data_type::NUMBER_V1],


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The current integration test interface is quite limited which makes more in-depth testing in the integration test suit hard.

## 🔍 What does this change?

- Don't pass around `AuthorizationApi` and `TemporalClient` everywhere but pass them when acquiring the `Store`. This implies that it now is in theory possible to gain access to both APIs in Graph integration tests and benchmarks which will be required in the future.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph