### PR TITLE
H-1409: Add interface to return records from the Graph without creating a subgraph

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/persist-flow-activity.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/persist-flow-activity.ts
@@ -31,23 +31,21 @@ const getExistingFlowEntity = async (params: {
   const { flowId, userAuthentication, graphApiClient } = params;
 
   const [existingFlowEntity] = await graphApiClient
-    .getEntitiesByQuery(userAuthentication.actorId, {
-      query: {
-        filter: {
-          all: [
-            {
-              equal: [{ path: ["uuid"] }, { parameter: flowId }],
-            },
-            generateVersionedUrlMatchingFilter(
-              systemEntityTypes.flow.entityTypeId,
-              { ignoreParents: true },
-            ),
-          ],
-        },
-        graphResolveDepths: zeroedGraphResolveDepths,
-        temporalAxes: currentTimeInstantTemporalAxes,
-        includeDrafts: false,
+    .getEntitySubgraph(userAuthentication.actorId, {
+      filter: {
+        all: [
+          {
+            equal: [{ path: ["uuid"] }, { parameter: flowId }],
+          },
+          generateVersionedUrlMatchingFilter(
+            systemEntityTypes.flow.entityTypeId,
+            { ignoreParents: true },
+          ),
+        ],
       },
+      graphResolveDepths: zeroedGraphResolveDepths,
+      temporalAxes: currentTimeInstantTemporalAxes,
+      includeDrafts: false,
     })
     .then(({ data }) => {
       const subgraph = mapGraphApiSubgraphToSubgraph<EntityRootType>(

--- a/apps/hash-ai-worker-ts/src/activities/get-dereferenced-entity-types-activity.ts
+++ b/apps/hash-ai-worker-ts/src/activities/get-dereferenced-entity-types-activity.ts
@@ -23,8 +23,9 @@ export const getDereferencedEntityTypesActivity = async (params: {
   /** Fetch the full schemas for the requested entity types */
   const entityTypes: DereferencedEntityTypesByTypeId = {};
 
-  const { data: entityTypesSubgraph } =
-    await graphApiClient.getEntityTypesByQuery(actorId, {
+  const { data: response } = await graphApiClient.getEntityTypeSubgraph(
+    actorId,
+    {
       filter: {
         any: entityTypeIds.map((entityTypeId) => ({
           equal: [{ path: ["versionedUrl"] }, { parameter: entityTypeId }],
@@ -38,12 +39,13 @@ export const getDereferencedEntityTypesActivity = async (params: {
       },
       temporalAxes: currentTimeInstantTemporalAxes,
       includeDrafts: false,
-    });
+    },
+  );
 
   for (const entityTypeId of entityTypeIds) {
     entityTypes[entityTypeId] = dereferenceEntityType({
       entityTypeId,
-      subgraph: mapGraphApiSubgraphToSubgraph(entityTypesSubgraph, actorId),
+      subgraph: mapGraphApiSubgraphToSubgraph(response.subgraph, actorId),
       simplifyPropertyKeys,
     });
   }

--- a/apps/hash-ai-worker-ts/src/activities/graph.ts
+++ b/apps/hash-ai-worker-ts/src/activities/graph.ts
@@ -1,11 +1,11 @@
 import { getHashInstanceAdminAccountGroupId } from "@local/hash-backend-utils/hash-instance";
 import type {
-  DataTypeStructuralQuery,
   EntityQueryCursor,
-  EntityStructuralQuery,
-  EntityTypeStructuralQuery,
+  GetDataTypeSubgraphRequest,
+  GetEntitySubgraphRequest,
+  GetEntityTypeSubgraphRequest,
+  GetPropertyTypeSubgraphRequest,
   GraphApi,
-  PropertyTypeStructuralQuery,
   UpdateDataTypeEmbeddingParams,
   UpdateEntityEmbeddingsParams,
   UpdateEntityTypeEmbeddingParams,
@@ -50,22 +50,20 @@ export const createGraphActivities = ({
 }) => ({
   async getUserAccountIds(): Promise<AccountId[]> {
     return graphApiClient
-      .getEntitiesByQuery("00000000-0000-0000-0000-000000000000", {
-        query: {
-          filter: {
-            all: [
-              {
-                equal: [
-                  { path: ["type", "baseUrl"] },
-                  { parameter: systemEntityTypes.user.entityTypeBaseUrl },
-                ],
-              },
-            ],
-          },
-          graphResolveDepths: zeroedGraphResolveDepths,
-          includeDrafts: false,
-          temporalAxes: currentTimeInstantTemporalAxes,
+      .getEntitySubgraph("00000000-0000-0000-0000-000000000000", {
+        filter: {
+          all: [
+            {
+              equal: [
+                { path: ["type", "baseUrl"] },
+                { parameter: systemEntityTypes.user.entityTypeBaseUrl },
+              ],
+            },
+          ],
         },
+        graphResolveDepths: zeroedGraphResolveDepths,
+        includeDrafts: false,
+        temporalAxes: currentTimeInstantTemporalAxes,
       })
       .then((response) => {
         const subgraph: Subgraph<EntityRootType> =
@@ -77,74 +75,68 @@ export const createGraphActivities = ({
       });
   },
 
-  async getDataTypesByQuery(params: {
+  async getDataTypesSubgraph(params: {
     authentication: {
       actorId: AccountId;
     };
-    query: DataTypeStructuralQuery;
+    request: GetDataTypeSubgraphRequest;
   }): Promise<Subgraph<DataTypeRootType>> {
     return graphApiClient
-      .getDataTypesByQuery(params.authentication.actorId, params.query)
-      .then((response) =>
+      .getDataTypeSubgraph(params.authentication.actorId, params.request)
+      .then(({ data: response }) =>
         mapGraphApiSubgraphToSubgraph(
-          response.data,
+          response.subgraph,
           params.authentication.actorId,
         ),
       );
   },
 
-  async getPropertyTypesByQuery(params: {
+  async getPropertyTypesSubgraph(params: {
     authentication: {
       actorId: AccountId;
     };
-    query: PropertyTypeStructuralQuery;
+    request: GetPropertyTypeSubgraphRequest;
   }): Promise<Subgraph<PropertyTypeRootType>> {
     return graphApiClient
-      .getPropertyTypesByQuery(params.authentication.actorId, params.query)
-      .then((response) =>
+      .getPropertyTypeSubgraph(params.authentication.actorId, params.request)
+      .then(({ data: response }) =>
         mapGraphApiSubgraphToSubgraph(
-          response.data,
+          response.subgraph,
           params.authentication.actorId,
         ),
       );
   },
 
-  async getEntityTypesByQuery(params: {
+  async getEntityTypesSubgraph(params: {
     authentication: {
       actorId: AccountId;
     };
-    query: EntityTypeStructuralQuery;
+    request: GetEntityTypeSubgraphRequest;
   }): Promise<Subgraph<EntityTypeRootType>> {
     return graphApiClient
-      .getEntityTypesByQuery(params.authentication.actorId, params.query)
-      .then((response) =>
+      .getEntityTypeSubgraph(params.authentication.actorId, params.request)
+      .then(({ data: response }) =>
         mapGraphApiSubgraphToSubgraph(
-          response.data,
+          response.subgraph,
           params.authentication.actorId,
         ),
       );
   },
 
-  async getEntitiesByQuery(params: {
+  async getEntitySubgraph(params: {
     authentication: {
       actorId: AccountId;
     };
-    query: EntityStructuralQuery;
-    limit?: number;
-    cursor?: EntityQueryCursor;
+    request: GetEntitySubgraphRequest;
   }): Promise<EntityQueryResponse> {
     return graphApiClient
-      .getEntitiesByQuery(params.authentication.actorId, {
-        query: params.query,
-        limit: params.limit,
-        cursor: params.cursor,
-      })
-      .then((response) => ({
+      .getEntitySubgraph(params.authentication.actorId, params.request)
+      .then(({ data: response }) => ({
         subgraph: mapGraphApiSubgraphToSubgraph(
-          response.data.subgraph,
+          response.subgraph,
           params.authentication.actorId,
         ),
-        cursor: response.data.cursor,
+        cursor: response.cursor,
       }));
   },
 

--- a/apps/hash-ai-worker-ts/src/activities/shared/find-existing-entity.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/find-existing-entity.ts
@@ -51,7 +51,7 @@ export const findExistingEntity = async ({
   const entityType: DereferencedEntityType | undefined =
     dereferencedEntityType ??
     (await graphApiClient
-      .getEntityTypesByQuery(actorId, {
+      .getEntityTypeSubgraph(actorId, {
         includeDrafts: false,
 
         filter: {
@@ -65,7 +65,7 @@ export const findExistingEntity = async ({
       })
       .then(({ data }) => {
         const subgraph = mapGraphApiSubgraphToSubgraph<EntityTypeRootType>(
-          data,
+          data.subgraph,
           actorId,
         );
 

--- a/apps/hash-ai-worker-ts/src/activities/shared/get-entity-by-filter.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/get-entity-by-filter.ts
@@ -19,13 +19,11 @@ export const getEntityByFilter = async ({
   includeDrafts: boolean;
 }): Promise<Entity | undefined> => {
   const matchedEntities = await graphApiClient
-    .getEntitiesByQuery(actorId, {
-      query: {
-        filter,
-        graphResolveDepths: zeroedGraphResolveDepths,
-        temporalAxes: currentTimeInstantTemporalAxes,
-        includeDrafts,
-      },
+    .getEntitySubgraph(actorId, {
+      filter,
+      graphResolveDepths: zeroedGraphResolveDepths,
+      temporalAxes: currentTimeInstantTemporalAxes,
+      includeDrafts,
     })
     .then(({ data }) => {
       const subgraph = mapGraphApiSubgraphToSubgraph<EntityRootType>(

--- a/apps/hash-ai-worker-ts/src/workflows.ts
+++ b/apps/hash-ai-worker-ts/src/workflows.ts
@@ -126,9 +126,9 @@ export const updateDataTypeEmbeddings = async (
   if ("dataTypes" in params) {
     dataTypes = params.dataTypes;
   } else {
-    const subgraph = await graphActivities.getDataTypesByQuery({
+    const response = await graphActivities.getEntitySubgraph({
       authentication: params.authentication,
-      query: {
+      request: {
         filter: params.filter,
         graphResolveDepths: {
           inheritsFrom: { outgoing: 0 },
@@ -145,7 +145,7 @@ export const updateDataTypeEmbeddings = async (
       },
     });
     dataTypes = await graphActivities.getSubgraphDataTypes({
-      subgraph,
+      subgraph: response.subgraph,
     });
   }
 
@@ -211,9 +211,9 @@ export const updatePropertyTypeEmbeddings = async (
   if ("propertyTypes" in params) {
     propertyTypes = params.propertyTypes;
   } else {
-    const subgraph = await graphActivities.getPropertyTypesByQuery({
+    const response = await graphActivities.getEntitySubgraph({
       authentication: params.authentication,
-      query: {
+      request: {
         filter: params.filter,
         graphResolveDepths: {
           inheritsFrom: { outgoing: 0 },
@@ -230,7 +230,7 @@ export const updatePropertyTypeEmbeddings = async (
       },
     });
     propertyTypes = await graphActivities.getSubgraphPropertyTypes({
-      subgraph,
+      subgraph: response.subgraph,
     });
   }
 
@@ -296,9 +296,9 @@ export const updateEntityTypeEmbeddings = async (
   if ("entityTypes" in params) {
     entityTypes = params.entityTypes;
   } else {
-    const subgraph = await graphActivities.getEntityTypesByQuery({
+    const response = await graphActivities.getEntitySubgraph({
       authentication: params.authentication,
-      query: {
+      request: {
         filter: params.filter,
         graphResolveDepths: {
           inheritsFrom: { outgoing: 0 },
@@ -315,7 +315,7 @@ export const updateEntityTypeEmbeddings = async (
       },
     });
     entityTypes = await graphActivities.getSubgraphEntityTypes({
-      subgraph,
+      subgraph: response.subgraph,
     });
   }
 
@@ -401,9 +401,9 @@ export const updateEntityEmbeddings = async (
         } as Entity;
       });
     } else {
-      const queryResponse = await graphActivities.getEntitiesByQuery({
+      const queryResponse = await graphActivities.getEntitySubgraph({
         authentication: params.authentication,
-        query: {
+        request: {
           filter: params.filter,
           graphResolveDepths: {
             inheritsFrom: { outgoing: 0 },
@@ -417,9 +417,9 @@ export const updateEntityEmbeddings = async (
           },
           temporalAxes,
           includeDrafts: true,
+          cursor,
+          limit: 100,
         },
-        cursor,
-        limit: 100,
       });
       cursor = queryResponse.cursor;
       entities = await graphActivities.getSubgraphEntities({
@@ -448,9 +448,9 @@ export const updateEntityEmbeddings = async (
       // TODO: The subgraph library does not have the required methods to do this client side so for simplicity we're
       //       just making another request here. We should add the required methods to the library and do this client
       //       side.
-      const subgraph = await graphActivities.getEntityTypesByQuery({
+      const response = await graphActivities.getEntitySubgraph({
         authentication: params.authentication,
-        query: {
+        request: {
           filter: {
             equal: [
               { path: ["versionedUrl"] },
@@ -473,7 +473,7 @@ export const updateEntityEmbeddings = async (
       });
 
       const propertyTypes = await graphActivities.getSubgraphPropertyTypes({
-        subgraph,
+        subgraph: response.subgraph,
       });
 
       const generatedEmbeddings =

--- a/apps/hash-api/src/ai/gpt/gpt-query-types.ts
+++ b/apps/hash-api/src/ai/gpt/gpt-query-types.ts
@@ -73,7 +73,7 @@ export const gptQueryTypes: RequestHandler<
     : null;
 
   const queryResponse: GptQueryTypesResponseBody = await req.context.graphApi
-    .getEntityTypesByQuery(user.accountId, {
+    .getEntityTypeSubgraph(user.accountId, {
       filter: {
         all: [
           ...(webUuids?.length
@@ -111,11 +111,11 @@ export const gptQueryTypes: RequestHandler<
         hasRightEntity: { incoming: 0, outgoing: 0 },
       },
     })
-    .then(async (response) => {
+    .then(async ({ data: response }) => {
       const entityTypes: SimpleEntityType[] = [];
 
       const subgraph = mapGraphApiSubgraphToSubgraph(
-        response.data,
+        response.subgraph,
         user.accountId,
       );
 

--- a/apps/hash-api/src/generate-ontology-type-ids.ts
+++ b/apps/hash-api/src/generate-ontology-type-ids.ts
@@ -237,39 +237,59 @@ const generateOntologyIds = async () => {
     blockProtocolDataTypes,
   ] = await Promise.all([
     // HASH types
-    getEntityTypes(graphContext, authentication, {
-      query: getLatestTypesInOrganizationQuery({ organization: hashOrg }),
-    }).then((subgraph) => getRoots(subgraph)),
-    getPropertyTypes(graphContext, authentication, {
-      query: getLatestTypesInOrganizationQuery({ organization: hashOrg }),
-    }).then((subgraph) => getRoots(subgraph)),
-    getDataTypes(graphContext, authentication, {
-      query: getLatestTypesInOrganizationQuery({ organization: hashOrg }),
-    }).then((subgraph) => getRoots(subgraph)),
+    getEntityTypes(
+      graphContext,
+      authentication,
+      getLatestTypesInOrganizationQuery({ organization: hashOrg }),
+    ).then((subgraph) => getRoots(subgraph)),
+    getPropertyTypes(
+      graphContext,
+      authentication,
+      getLatestTypesInOrganizationQuery({ organization: hashOrg }),
+    ).then((subgraph) => getRoots(subgraph)),
+    getDataTypes(
+      graphContext,
+      authentication,
+      getLatestTypesInOrganizationQuery({ organization: hashOrg }),
+    ).then((subgraph) => getRoots(subgraph)),
     // Google types
-    getEntityTypes(graphContext, authentication, {
-      query: getLatestTypesInOrganizationQuery({ organization: googleOrg }),
-    }).then((subgraph) => getRoots(subgraph)),
-    getPropertyTypes(graphContext, authentication, {
-      query: getLatestTypesInOrganizationQuery({ organization: googleOrg }),
-    }).then((subgraph) => getRoots(subgraph)),
+    getEntityTypes(
+      graphContext,
+      authentication,
+      getLatestTypesInOrganizationQuery({ organization: googleOrg }),
+    ).then((subgraph) => getRoots(subgraph)),
+    getPropertyTypes(
+      graphContext,
+      authentication,
+      getLatestTypesInOrganizationQuery({ organization: googleOrg }),
+    ).then((subgraph) => getRoots(subgraph)),
     // Linear types
-    getEntityTypes(graphContext, authentication, {
-      query: getLatestTypesInOrganizationQuery({ organization: linearOrg }),
-    }).then((subgraph) => getRoots(subgraph)),
-    getPropertyTypes(graphContext, authentication, {
-      query: getLatestTypesInOrganizationQuery({ organization: linearOrg }),
-    }).then((subgraph) => getRoots(subgraph)),
+    getEntityTypes(
+      graphContext,
+      authentication,
+      getLatestTypesInOrganizationQuery({ organization: linearOrg }),
+    ).then((subgraph) => getRoots(subgraph)),
+    getPropertyTypes(
+      graphContext,
+      authentication,
+      getLatestTypesInOrganizationQuery({ organization: linearOrg }),
+    ).then((subgraph) => getRoots(subgraph)),
     // BlockProtocol types
-    getEntityTypes(graphContext, authentication, {
-      query: getLatestBlockprotocolTypesQuery,
-    }).then((subgraph) => getRoots(subgraph)),
-    getPropertyTypes(graphContext, authentication, {
-      query: getLatestBlockprotocolTypesQuery,
-    }).then((subgraph) => getRoots(subgraph)),
-    getDataTypes(graphContext, authentication, {
-      query: getLatestBlockprotocolTypesQuery,
-    }).then((subgraph) => getRoots(subgraph)),
+    getEntityTypes(
+      graphContext,
+      authentication,
+      getLatestBlockprotocolTypesQuery,
+    ).then((subgraph) => getRoots(subgraph)),
+    getPropertyTypes(
+      graphContext,
+      authentication,
+      getLatestBlockprotocolTypesQuery,
+    ).then((subgraph) => getRoots(subgraph)),
+    getDataTypes(
+      graphContext,
+      authentication,
+      getLatestBlockprotocolTypesQuery,
+    ).then((subgraph) => getRoots(subgraph)),
   ]);
 
   const outputPath = path.join(

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/014-add-instance-admin-permission.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/014-add-instance-admin-permission.migration.ts
@@ -7,7 +7,7 @@ import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-id
 import { getRoots } from "@local/hash-subgraph/stdlib";
 
 import {
-  getEntities,
+  getEntitySubgraph,
   modifyEntityAuthorizationRelationships,
 } from "../../../knowledge/primitive/entity";
 import type { MigrationFunction } from "../types";
@@ -24,22 +24,20 @@ const migrate: MigrationFunction = async ({
   const hashInstanceAdminsAccountGroupId =
     await getHashInstanceAdminAccountGroupId(context, authentication);
 
-  const userEntities = await getEntities(context, authentication, {
-    query: {
-      filter: {
-        all: [
-          {
-            equal: [
-              { path: ["type(inheritanceDepth = 0)", "baseUrl"] },
-              { parameter: systemEntityTypes.user.entityTypeBaseUrl },
-            ],
-          },
-        ],
-      },
-      graphResolveDepths: zeroedGraphResolveDepths,
-      includeDrafts: true,
-      temporalAxes: currentTimeInstantTemporalAxes,
+  const userEntities = await getEntitySubgraph(context, authentication, {
+    filter: {
+      all: [
+        {
+          equal: [
+            { path: ["type(inheritanceDepth = 0)", "baseUrl"] },
+            { parameter: systemEntityTypes.user.entityTypeBaseUrl },
+          ],
+        },
+      ],
     },
+    graphResolveDepths: zeroedGraphResolveDepths,
+    includeDrafts: true,
+    temporalAxes: currentTimeInstantTemporalAxes,
   }).then((subgraph) => getRoots(subgraph));
 
   for (const userEntity of userEntities) {

--- a/apps/hash-api/src/graph/knowledge/system-types/block.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/block.ts
@@ -27,9 +27,9 @@ import type { CreateEntityParams } from "../primitive/entity";
 import {
   archiveEntity,
   createEntity,
-  getEntities,
   getEntityIncomingLinks,
   getEntityOutgoingLinks,
+  getEntitySubgraph,
   getLatestEntityById,
 } from "../primitive/entity";
 import {
@@ -257,8 +257,10 @@ export const getBlockCollectionByBlock: ImpureGraphFunction<
     block.entity.metadata.recordId.entityId,
   );
 
-  const matchingContainsLinks = await getEntities(context, authentication, {
-    query: {
+  const matchingContainsLinks = await getEntitySubgraph(
+    context,
+    authentication,
+    {
       filter: {
         all: [
           contentLinkTypeFilter,
@@ -278,7 +280,7 @@ export const getBlockCollectionByBlock: ImpureGraphFunction<
       temporalAxes: currentTimeInstantTemporalAxes,
       includeDrafts,
     },
-  }).then((subgraph) => getRoots(subgraph).filter(isEntityLinkEntity));
+  ).then((subgraph) => getRoots(subgraph).filter(isEntityLinkEntity));
 
   /** @todo: account for blocks that are in multiple pages */
 

--- a/apps/hash-api/src/graph/knowledge/system-types/linear-integration-entity.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/linear-integration-entity.ts
@@ -77,33 +77,31 @@ export const getAllLinearIntegrationsWithLinearOrgId: ImpureGraphFunction<
   const { linearOrgId, includeDrafts = false } = params;
 
   const entities = await graphApi
-    .getEntitiesByQuery(actorId, {
-      query: {
-        filter: {
-          all: [
-            generateVersionedUrlMatchingFilter(
-              systemEntityTypes.linearIntegration.entityTypeId,
-              { ignoreParents: true },
-            ),
-            {
-              equal: [
-                {
-                  path: [
-                    "properties",
-                    extractBaseUrl(
-                      systemPropertyTypes.linearOrgId.propertyTypeId,
-                    ),
-                  ],
-                },
-                { parameter: linearOrgId },
-              ],
-            },
-          ],
-        },
-        graphResolveDepths: zeroedGraphResolveDepths,
-        temporalAxes: currentTimeInstantTemporalAxes,
-        includeDrafts,
+    .getEntitySubgraph(actorId, {
+      filter: {
+        all: [
+          generateVersionedUrlMatchingFilter(
+            systemEntityTypes.linearIntegration.entityTypeId,
+            { ignoreParents: true },
+          ),
+          {
+            equal: [
+              {
+                path: [
+                  "properties",
+                  extractBaseUrl(
+                    systemPropertyTypes.linearOrgId.propertyTypeId,
+                  ),
+                ],
+              },
+              { parameter: linearOrgId },
+            ],
+          },
+        ],
       },
+      graphResolveDepths: zeroedGraphResolveDepths,
+      temporalAxes: currentTimeInstantTemporalAxes,
+      includeDrafts,
     })
     .then(({ data }) => {
       const subgraph = mapGraphApiSubgraphToSubgraph<EntityRootType>(
@@ -126,36 +124,34 @@ export const getLinearIntegrationByLinearOrgId: ImpureGraphFunction<
 > = async ({ graphApi }, { actorId }, params) => {
   const { userAccountId, linearOrgId, includeDrafts = false } = params;
   const entities = await graphApi
-    .getEntitiesByQuery(actorId, {
-      query: {
-        filter: {
-          all: [
-            {
-              equal: [{ path: ["ownedById"] }, { parameter: userAccountId }],
-            },
-            generateVersionedUrlMatchingFilter(
-              systemEntityTypes.linearIntegration.entityTypeId,
-              { ignoreParents: true },
-            ),
-            {
-              equal: [
-                {
-                  path: [
-                    "properties",
-                    extractBaseUrl(
-                      systemPropertyTypes.linearOrgId.propertyTypeId,
-                    ),
-                  ],
-                },
-                { parameter: linearOrgId },
-              ],
-            },
-          ],
-        },
-        graphResolveDepths: zeroedGraphResolveDepths,
-        temporalAxes: currentTimeInstantTemporalAxes,
-        includeDrafts,
+    .getEntitySubgraph(actorId, {
+      filter: {
+        all: [
+          {
+            equal: [{ path: ["ownedById"] }, { parameter: userAccountId }],
+          },
+          generateVersionedUrlMatchingFilter(
+            systemEntityTypes.linearIntegration.entityTypeId,
+            { ignoreParents: true },
+          ),
+          {
+            equal: [
+              {
+                path: [
+                  "properties",
+                  extractBaseUrl(
+                    systemPropertyTypes.linearOrgId.propertyTypeId,
+                  ),
+                ],
+              },
+              { parameter: linearOrgId },
+            ],
+          },
+        ],
       },
+      graphResolveDepths: zeroedGraphResolveDepths,
+      temporalAxes: currentTimeInstantTemporalAxes,
+      includeDrafts,
     })
     .then(({ data }) => {
       const subgraph = mapGraphApiSubgraphToSubgraph<EntityRootType>(
@@ -202,36 +198,34 @@ export const getSyncedWorkspacesForLinearIntegration: ImpureGraphFunction<
   { linearIntegrationEntityId, includeDrafts = false },
 ) =>
   graphApi
-    .getEntitiesByQuery(actorId, {
-      query: {
-        filter: {
-          all: [
-            {
-              equal: [{ path: ["archived"] }, { parameter: false }],
-            },
-            generateVersionedUrlMatchingFilter(
-              systemLinkEntityTypes.syncLinearDataWith.linkEntityTypeId,
-              { ignoreParents: true },
-            ),
-            {
-              equal: [
-                { path: ["leftEntity", "uuid"] },
-                {
-                  parameter: extractEntityUuidFromEntityId(
-                    linearIntegrationEntityId,
-                  ),
-                },
-              ],
-            },
-          ],
-        },
-        graphResolveDepths: {
-          ...zeroedGraphResolveDepths,
-          hasRightEntity: { incoming: 0, outgoing: 1 },
-        },
-        temporalAxes: currentTimeInstantTemporalAxes,
-        includeDrafts,
+    .getEntitySubgraph(actorId, {
+      filter: {
+        all: [
+          {
+            equal: [{ path: ["archived"] }, { parameter: false }],
+          },
+          generateVersionedUrlMatchingFilter(
+            systemLinkEntityTypes.syncLinearDataWith.linkEntityTypeId,
+            { ignoreParents: true },
+          ),
+          {
+            equal: [
+              { path: ["leftEntity", "uuid"] },
+              {
+                parameter: extractEntityUuidFromEntityId(
+                  linearIntegrationEntityId,
+                ),
+              },
+            ],
+          },
+        ],
       },
+      graphResolveDepths: {
+        ...zeroedGraphResolveDepths,
+        hasRightEntity: { incoming: 0, outgoing: 1 },
+      },
+      temporalAxes: currentTimeInstantTemporalAxes,
+      includeDrafts,
     })
     .then(({ data }) => {
       const subgraph = mapGraphApiSubgraphToSubgraph<EntityRootType>(
@@ -273,41 +267,39 @@ export const linkIntegrationToWorkspace: ImpureGraphFunction<
   } = params;
 
   const existingLinkEntities = await context.graphApi
-    .getEntitiesByQuery(authentication.actorId, {
-      query: {
-        filter: {
-          all: [
-            {
-              equal: [{ path: ["archived"] }, { parameter: false }],
-            },
-            generateVersionedUrlMatchingFilter(
-              systemLinkEntityTypes.syncLinearDataWith.linkEntityTypeId,
-              { ignoreParents: true },
-            ),
-            {
-              equal: [
-                { path: ["leftEntity", "uuid"] },
-                {
-                  parameter: extractEntityUuidFromEntityId(
-                    linearIntegrationEntityId,
-                  ),
-                },
-              ],
-            },
-            {
-              equal: [
-                { path: ["rightEntity", "uuid"] },
-                {
-                  parameter: extractEntityUuidFromEntityId(workspaceEntityId),
-                },
-              ],
-            },
-          ],
-        },
-        graphResolveDepths: zeroedGraphResolveDepths,
-        temporalAxes: currentTimeInstantTemporalAxes,
-        includeDrafts,
+    .getEntitySubgraph(authentication.actorId, {
+      filter: {
+        all: [
+          {
+            equal: [{ path: ["archived"] }, { parameter: false }],
+          },
+          generateVersionedUrlMatchingFilter(
+            systemLinkEntityTypes.syncLinearDataWith.linkEntityTypeId,
+            { ignoreParents: true },
+          ),
+          {
+            equal: [
+              { path: ["leftEntity", "uuid"] },
+              {
+                parameter: extractEntityUuidFromEntityId(
+                  linearIntegrationEntityId,
+                ),
+              },
+            ],
+          },
+          {
+            equal: [
+              { path: ["rightEntity", "uuid"] },
+              {
+                parameter: extractEntityUuidFromEntityId(workspaceEntityId),
+              },
+            ],
+          },
+        ],
       },
+      graphResolveDepths: zeroedGraphResolveDepths,
+      temporalAxes: currentTimeInstantTemporalAxes,
+      includeDrafts,
     })
     .then(({ data }) => {
       const subgraph = mapGraphApiSubgraphToSubgraph<EntityRootType>(

--- a/apps/hash-api/src/graph/knowledge/system-types/notification.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/notification.ts
@@ -32,7 +32,7 @@ import type {
 import type { CreateEntityParams } from "../primitive/entity";
 import {
   createEntity,
-  getEntities,
+  getEntitySubgraph,
   updateEntityProperties,
 } from "../primitive/entity";
 import { createLinkEntity } from "../primitive/link-entity";
@@ -209,31 +209,26 @@ export const getMentionNotification: ImpureGraphFunction<
     includeDrafts = false,
   } = params;
 
-  const entitiesSubgraph = await getEntities(context, authentication, {
-    query: {
-      filter: {
-        all: [
-          generateVersionedUrlMatchingFilter(
-            systemEntityTypes.mentionNotification.entityTypeId,
-            { ignoreParents: true },
-          ),
-          {
-            equal: [
-              { path: ["ownedById"] },
-              { parameter: recipient.accountId },
-            ],
-          },
-          notArchivedFilter,
-        ],
-      },
-      graphResolveDepths: {
-        ...zeroedGraphResolveDepths,
-        // Get the outgoing links of the entities
-        hasLeftEntity: { outgoing: 0, incoming: 1 },
-      },
-      temporalAxes: currentTimeInstantTemporalAxes,
-      includeDrafts,
+  const entitiesSubgraph = await getEntitySubgraph(context, authentication, {
+    filter: {
+      all: [
+        generateVersionedUrlMatchingFilter(
+          systemEntityTypes.mentionNotification.entityTypeId,
+          { ignoreParents: true },
+        ),
+        {
+          equal: [{ path: ["ownedById"] }, { parameter: recipient.accountId }],
+        },
+        notArchivedFilter,
+      ],
     },
+    graphResolveDepths: {
+      ...zeroedGraphResolveDepths,
+      // Get the outgoing links of the entities
+      hasLeftEntity: { outgoing: 0, incoming: 1 },
+    },
+    temporalAxes: currentTimeInstantTemporalAxes,
+    includeDrafts,
   });
 
   /**
@@ -457,63 +452,54 @@ export const getCommentNotification: ImpureGraphFunction<
     includeDrafts = false,
   } = params;
 
-  const entitiesSubgraph = await getEntities(context, authentication, {
-    query: {
-      filter: {
-        all: [
-          generateVersionedUrlMatchingFilter(
-            systemEntityTypes.commentNotification.entityTypeId,
-            { ignoreParents: true },
-          ),
-          {
-            equal: [
-              { path: ["ownedById"] },
-              { parameter: recipient.accountId },
-            ],
-          },
-          /** @todo: enforce the type of these links somehow */
-          {
-            any: [
-              {
-                equal: [
-                  {
-                    path: [
-                      "properties",
-                      extractBaseUrl(
-                        systemPropertyTypes.archived.propertyTypeId,
-                      ),
-                    ],
-                  },
-                  // @ts-expect-error -- We need to update the type definition of `EntityStructuralQuery` to allow for this
-                  //   @see https://linear.app/hash/issue/H-1207
-                  null,
-                ],
-              },
-              {
-                equal: [
-                  {
-                    path: [
-                      "properties",
-                      extractBaseUrl(
-                        systemPropertyTypes.archived.propertyTypeId,
-                      ),
-                    ],
-                  },
-                  { parameter: false },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      graphResolveDepths: {
-        ...zeroedGraphResolveDepths,
-        // Get the outgoing links of the entities
-        hasLeftEntity: { outgoing: 0, incoming: 1 },
-      },
-      temporalAxes: currentTimeInstantTemporalAxes,
-      includeDrafts,
+  const entitiesSubgraph = await getEntitySubgraph(context, authentication, {
+    filter: {
+      all: [
+        generateVersionedUrlMatchingFilter(
+          systemEntityTypes.commentNotification.entityTypeId,
+          { ignoreParents: true },
+        ),
+        {
+          equal: [{ path: ["ownedById"] }, { parameter: recipient.accountId }],
+        },
+        /** @todo: enforce the type of these links somehow */
+        {
+          any: [
+            {
+              equal: [
+                {
+                  path: [
+                    "properties",
+                    extractBaseUrl(systemPropertyTypes.archived.propertyTypeId),
+                  ],
+                },
+                // @ts-expect-error -- We need to update the type definition of `EntityStructuralQuery` to allow for this
+                //   @see https://linear.app/hash/issue/H-1207
+                null,
+              ],
+            },
+            {
+              equal: [
+                {
+                  path: [
+                    "properties",
+                    extractBaseUrl(systemPropertyTypes.archived.propertyTypeId),
+                  ],
+                },
+                { parameter: false },
+              ],
+            },
+          ],
+        },
+      ],
     },
+    graphResolveDepths: {
+      ...zeroedGraphResolveDepths,
+      // Get the outgoing links of the entities
+      hasLeftEntity: { outgoing: 0, incoming: 1 },
+    },
+    temporalAxes: currentTimeInstantTemporalAxes,
+    includeDrafts,
   });
 
   /**

--- a/apps/hash-api/src/graph/knowledge/system-types/org.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/org.ts
@@ -197,39 +197,35 @@ export const getOrgByShortname: ImpureGraphFunction<
   Promise<Org | null>
 > = async ({ graphApi }, { actorId }, params) => {
   const [orgEntity, ...unexpectedEntities] = await graphApi
-    .getEntitiesByQuery(actorId, {
-      query: {
-        filter: {
-          all: [
-            {
-              equal: [
-                { path: ["type(inheritanceDepth = 0)", "baseUrl"] },
-                { parameter: systemEntityTypes.organization.entityTypeBaseUrl },
-              ],
-            },
-            {
-              equal: [
-                {
-                  path: [
-                    "properties",
-                    extractBaseUrl(
-                      systemPropertyTypes.shortname.propertyTypeId,
-                    ),
-                  ],
-                },
-                { parameter: params.shortname },
-              ],
-            },
-          ],
-        },
-        graphResolveDepths: zeroedGraphResolveDepths,
-        // TODO: Should this be an all-time query? What happens if the org is
-        //       archived/deleted, do we want to allow orgs to replace their
-        //       shortname?
-        //   see https://linear.app/hash/issue/H-757
-        temporalAxes: currentTimeInstantTemporalAxes,
-        includeDrafts: false,
+    .getEntitySubgraph(actorId, {
+      filter: {
+        all: [
+          {
+            equal: [
+              { path: ["type(inheritanceDepth = 0)", "baseUrl"] },
+              { parameter: systemEntityTypes.organization.entityTypeBaseUrl },
+            ],
+          },
+          {
+            equal: [
+              {
+                path: [
+                  "properties",
+                  extractBaseUrl(systemPropertyTypes.shortname.propertyTypeId),
+                ],
+              },
+              { parameter: params.shortname },
+            ],
+          },
+        ],
       },
+      graphResolveDepths: zeroedGraphResolveDepths,
+      // TODO: Should this be an all-time query? What happens if the org is
+      //       archived/deleted, do we want to allow orgs to replace their
+      //       shortname?
+      //   see https://linear.app/hash/issue/H-757
+      temporalAxes: currentTimeInstantTemporalAxes,
+      includeDrafts: false,
     })
     .then(({ data }) => {
       const userEntitiesSubgraph =

--- a/apps/hash-api/src/graph/knowledge/system-types/page.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/page.ts
@@ -256,20 +256,18 @@ export const getAllPagesInWorkspace: ImpureGraphFunction<
   const { graphApi } = ctx;
   const { ownedById, includeArchived = false, includeDrafts = false } = params;
   const pageEntities = await graphApi
-    .getEntitiesByQuery(authentication.actorId, {
-      query: {
-        filter: {
-          all: [
-            pageEntityTypeFilter,
-            {
-              equal: [{ path: ["ownedById"] }, { parameter: ownedById }],
-            },
-          ],
-        },
-        graphResolveDepths: zeroedGraphResolveDepths,
-        temporalAxes: currentTimeInstantTemporalAxes,
-        includeDrafts,
+    .getEntitySubgraph(authentication.actorId, {
+      filter: {
+        all: [
+          pageEntityTypeFilter,
+          {
+            equal: [{ path: ["ownedById"] }, { parameter: ownedById }],
+          },
+        ],
       },
+      graphResolveDepths: zeroedGraphResolveDepths,
+      temporalAxes: currentTimeInstantTemporalAxes,
+      includeDrafts,
     })
     .then(({ data }) => {
       const subgraph = mapGraphApiSubgraphToSubgraph<EntityRootType>(

--- a/apps/hash-api/src/graph/knowledge/system-types/user.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user.ts
@@ -127,37 +127,33 @@ export const getUserByShortname: ImpureGraphFunction<
   Promise<User | null>
 > = async ({ graphApi }, { actorId }, params) => {
   const [userEntity, ...unexpectedEntities] = await graphApi
-    .getEntitiesByQuery(actorId, {
-      query: {
-        filter: {
-          all: [
-            generateVersionedUrlMatchingFilter(
-              systemEntityTypes.user.entityTypeId,
-              { ignoreParents: true },
-            ),
-            {
-              equal: [
-                {
-                  path: [
-                    "properties",
-                    extractBaseUrl(
-                      systemPropertyTypes.shortname.propertyTypeId,
-                    ),
-                  ],
-                },
-                { parameter: params.shortname },
-              ],
-            },
-          ],
-        },
-        graphResolveDepths: zeroedGraphResolveDepths,
-        // TODO: Should this be an all-time query? What happens if the user is
-        //       archived/deleted, do we want to allow users to replace their
-        //       shortname?
-        //   see https://linear.app/hash/issue/H-757
-        temporalAxes: currentTimeInstantTemporalAxes,
-        includeDrafts: params.includeDrafts ?? false,
+    .getEntitySubgraph(actorId, {
+      filter: {
+        all: [
+          generateVersionedUrlMatchingFilter(
+            systemEntityTypes.user.entityTypeId,
+            { ignoreParents: true },
+          ),
+          {
+            equal: [
+              {
+                path: [
+                  "properties",
+                  extractBaseUrl(systemPropertyTypes.shortname.propertyTypeId),
+                ],
+              },
+              { parameter: params.shortname },
+            ],
+          },
+        ],
       },
+      graphResolveDepths: zeroedGraphResolveDepths,
+      // TODO: Should this be an all-time query? What happens if the user is
+      //       archived/deleted, do we want to allow users to replace their
+      //       shortname?
+      //   see https://linear.app/hash/issue/H-757
+      temporalAxes: currentTimeInstantTemporalAxes,
+      includeDrafts: params.includeDrafts ?? false,
     })
     .then(({ data }) => {
       const subgraph = mapGraphApiSubgraphToSubgraph<EntityRootType>(
@@ -187,33 +183,31 @@ export const getUserByKratosIdentityId: ImpureGraphFunction<
   Promise<User | null>
 > = async ({ graphApi }, { actorId }, params) => {
   const [userEntity, ...unexpectedEntities] = await graphApi
-    .getEntitiesByQuery(actorId, {
-      query: {
-        filter: {
-          all: [
-            generateVersionedUrlMatchingFilter(
-              systemEntityTypes.user.entityTypeId,
-              { ignoreParents: true },
-            ),
-            {
-              equal: [
-                {
-                  path: [
-                    "properties",
-                    extractBaseUrl(
-                      systemPropertyTypes.kratosIdentityId.propertyTypeId,
-                    ),
-                  ],
-                },
-                { parameter: params.kratosIdentityId },
-              ],
-            },
-          ],
-        },
-        graphResolveDepths: zeroedGraphResolveDepths,
-        temporalAxes: currentTimeInstantTemporalAxes,
-        includeDrafts: params.includeDrafts ?? false,
+    .getEntitySubgraph(actorId, {
+      filter: {
+        all: [
+          generateVersionedUrlMatchingFilter(
+            systemEntityTypes.user.entityTypeId,
+            { ignoreParents: true },
+          ),
+          {
+            equal: [
+              {
+                path: [
+                  "properties",
+                  extractBaseUrl(
+                    systemPropertyTypes.kratosIdentityId.propertyTypeId,
+                  ),
+                ],
+              },
+              { parameter: params.kratosIdentityId },
+            ],
+          },
+        ],
       },
+      graphResolveDepths: zeroedGraphResolveDepths,
+      temporalAxes: currentTimeInstantTemporalAxes,
+      includeDrafts: params.includeDrafts ?? false,
     })
     .then(({ data }) => {
       const subgraph = mapGraphApiSubgraphToSubgraph<EntityRootType>(

--- a/apps/hash-api/src/graphql/resolvers/index.ts
+++ b/apps/hash-api/src/graphql/resolvers/index.ts
@@ -38,12 +38,12 @@ import {
   createEntityResolver,
   getEntityAuthorizationRelationshipsResolver,
   getEntityResolver,
+  getEntitySubgraphResolver,
   isEntityPublicResolver,
   queryEntitiesResolver,
   removeEntityEditorResolver,
   removeEntityOwnerResolver,
   removeEntityViewerResolver,
-  structuralQueryEntitiesResolver,
   updateEntitiesResolver,
   updateEntityResolver,
 } from "./knowledge/entity/entity";
@@ -118,7 +118,7 @@ export const resolvers: Omit<Resolvers, "Query" | "Mutation"> & {
     getEntityAuthorizationRelationships: loggedInAndSignedUpMiddleware(
       getEntityAuthorizationRelationshipsResolver,
     ),
-    structuralQueryEntities: structuralQueryEntitiesResolver,
+    getEntitySubgraph: getEntitySubgraphResolver,
     hashInstanceEntity: hashInstanceEntityResolver,
     // Integration
     getLinearOrganization: loggedInAndSignedUpMiddleware(

--- a/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -32,8 +32,8 @@ import {
   canUserReadEntity,
   checkEntityPermission,
   createEntityWithLinks,
-  getEntities,
   getEntityAuthorizationRelationships,
+  getEntitySubgraph,
   getLatestEntityById,
   modifyEntityAuthorizationRelationships,
   removeEntityAdministrator,
@@ -61,9 +61,9 @@ import type {
   MutationUpdateEntityArgs,
   Query,
   QueryGetEntityArgs,
+  QueryGetEntitySubgraphArgs,
   QueryIsEntityPublicArgs,
   QueryResolvers,
-  QueryStructuralQueryEntitiesArgs,
   ResolverFn,
 } from "../../../api-types.gen";
 import {
@@ -183,23 +183,21 @@ export const queryEntitiesResolver: NonNullable<
     );
   }
 
-  const entitySubgraph = await getEntities(context, authentication, {
-    query: {
-      filter,
-      graphResolveDepths: {
-        ...zeroedGraphResolveDepths,
-        constrainsValuesOn,
-        constrainsPropertiesOn,
-        constrainsLinksOn,
-        constrainsLinkDestinationsOn,
-        inheritsFrom,
-        isOfType,
-        hasLeftEntity,
-        hasRightEntity,
-      },
-      temporalAxes: currentTimeInstantTemporalAxes,
-      includeDrafts: includeDrafts ?? false,
+  const entitySubgraph = await getEntitySubgraph(context, authentication, {
+    filter,
+    graphResolveDepths: {
+      ...zeroedGraphResolveDepths,
+      constrainsValuesOn,
+      constrainsPropertiesOn,
+      constrainsLinksOn,
+      constrainsLinkDestinationsOn,
+      inheritsFrom,
+      isOfType,
+      hasLeftEntity,
+      hasRightEntity,
     },
+    temporalAxes: currentTimeInstantTemporalAxes,
+    includeDrafts: includeDrafts ?? false,
   });
 
   return createSubgraphAndPermissionsReturn(
@@ -209,20 +207,20 @@ export const queryEntitiesResolver: NonNullable<
   );
 };
 
-export const structuralQueryEntitiesResolver: ResolverFn<
-  Query["structuralQueryEntities"],
+export const getEntitySubgraphResolver: ResolverFn<
+  Query["getEntitySubgraph"],
   Record<string, never>,
   GraphQLContext,
-  QueryStructuralQueryEntitiesArgs
-> = async (_, { query }, graphQLContext, info) => {
+  QueryGetEntitySubgraphArgs
+> = async (_, { request }, graphQLContext, info) => {
   const context = graphQLContextToImpureGraphContext(graphQLContext);
 
-  const subgraph = await getEntities(
+  const subgraph = await getEntitySubgraph(
     graphQLContextToImpureGraphContext(graphQLContext),
     graphQLContext.authentication,
     {
       temporalClient: context.temporalClient,
-      query,
+      ...request,
     },
   );
 
@@ -288,26 +286,24 @@ export const getEntityResolver: ResolverFn<
       }
     : currentTimeInstantTemporalAxes;
 
-  const entitySubgraph = await getEntities(
+  const entitySubgraph = await getEntitySubgraph(
     graphQLContextToImpureGraphContext(graphQLContext),
     graphQLContext.authentication,
     {
-      query: {
-        filter,
-        graphResolveDepths: {
-          ...zeroedGraphResolveDepths,
-          constrainsValuesOn,
-          constrainsPropertiesOn,
-          constrainsLinksOn,
-          constrainsLinkDestinationsOn,
-          inheritsFrom,
-          isOfType,
-          hasLeftEntity,
-          hasRightEntity,
-        },
-        temporalAxes,
-        includeDrafts: includeDrafts ?? false,
+      filter,
+      graphResolveDepths: {
+        ...zeroedGraphResolveDepths,
+        constrainsValuesOn,
+        constrainsPropertiesOn,
+        constrainsLinksOn,
+        constrainsLinkDestinationsOn,
+        inheritsFrom,
+        isOfType,
+        hasLeftEntity,
+        hasRightEntity,
       },
+      temporalAxes,
+      includeDrafts: includeDrafts ?? false,
     },
   );
 

--- a/apps/hash-api/src/graphql/resolvers/knowledge/user/get-usage-records.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/user/get-usage-records.ts
@@ -13,7 +13,7 @@ import { extractAccountId } from "@local/hash-subgraph";
 import { getRoots } from "@local/hash-subgraph/stdlib";
 import { ForbiddenError } from "apollo-server-express";
 
-import { getEntities } from "../../../../graph/knowledge/primitive/entity";
+import { getEntitySubgraph } from "../../../../graph/knowledge/primitive/entity";
 import type {
   Query,
   ResolverFn,
@@ -39,23 +39,21 @@ export const getUsageRecordsResolver: ResolverFn<
     throw new ForbiddenError("User is not a HASH instance admin");
   }
 
-  const users = await getEntities(
+  const users = await getEntitySubgraph(
     graphQLContextToImpureGraphContext(graphQLContext),
     authentication,
     {
-      query: {
-        filter: {
-          all: [
-            generateVersionedUrlMatchingFilter(
-              systemEntityTypes.user.entityTypeId,
-              { ignoreParents: true },
-            ),
-          ],
-        },
-        graphResolveDepths: zeroedGraphResolveDepths,
-        temporalAxes: currentTimeInstantTemporalAxes,
-        includeDrafts: false,
+      filter: {
+        all: [
+          generateVersionedUrlMatchingFilter(
+            systemEntityTypes.user.entityTypeId,
+            { ignoreParents: true },
+          ),
+        ],
       },
+      graphResolveDepths: zeroedGraphResolveDepths,
+      temporalAxes: currentTimeInstantTemporalAxes,
+      includeDrafts: false,
     },
   ).then((subgraph) => getRoots(subgraph));
 

--- a/apps/hash-api/src/graphql/resolvers/ontology/data-type.ts
+++ b/apps/hash-api/src/graphql/resolvers/ontology/data-type.ts
@@ -27,22 +27,25 @@ export const queryDataTypes: ResolverFn<
 ) => {
   const { graphApi } = dataSources;
 
-  const { data } = await graphApi.getDataTypesByQuery(authentication.actorId, {
-    filter: {
-      equal: [{ path: ["version"] }, { parameter: "latest" }],
+  const { data: response } = await graphApi.getDataTypeSubgraph(
+    authentication.actorId,
+    {
+      filter: {
+        equal: [{ path: ["version"] }, { parameter: "latest" }],
+      },
+      graphResolveDepths: {
+        ...zeroedGraphResolveDepths,
+        constrainsValuesOn,
+      },
+      temporalAxes: includeArchived
+        ? fullTransactionTimeAxis
+        : currentTimeInstantTemporalAxes,
+      includeDrafts: false,
     },
-    graphResolveDepths: {
-      ...zeroedGraphResolveDepths,
-      constrainsValuesOn,
-    },
-    temporalAxes: includeArchived
-      ? fullTransactionTimeAxis
-      : currentTimeInstantTemporalAxes,
-    includeDrafts: false,
-  });
+  );
 
   const subgraph = mapGraphApiSubgraphToSubgraph<DataTypeRootType>(
-    data,
+    response.subgraph,
     authentication.actorId,
   );
 

--- a/apps/hash-api/src/graphql/resolvers/ontology/entity-type.ts
+++ b/apps/hash-api/src/graphql/resolvers/ontology/entity-type.ts
@@ -84,24 +84,22 @@ export const queryEntityTypesResolver: ResolverFn<
   };
 
   const subgraph = await getEntityTypes({ graphApi }, authentication, {
-    query: {
-      filter: latestOnly
-        ? filter
-          ? { all: [filter, latestOnlyFilter] }
-          : latestOnlyFilter
-        : { all: [] },
-      graphResolveDepths: {
-        ...zeroedGraphResolveDepths,
-        constrainsValuesOn,
-        constrainsPropertiesOn,
-        constrainsLinksOn,
-        constrainsLinkDestinationsOn,
-        inheritsFrom,
-      },
-      temporalAxes: includeArchived
-        ? fullTransactionTimeAxis
-        : currentTimeInstantTemporalAxes,
+    filter: latestOnly
+      ? filter
+        ? { all: [filter, latestOnlyFilter] }
+        : latestOnlyFilter
+      : { all: [] },
+    graphResolveDepths: {
+      ...zeroedGraphResolveDepths,
+      constrainsValuesOn,
+      constrainsPropertiesOn,
+      constrainsLinksOn,
+      constrainsLinkDestinationsOn,
+      inheritsFrom,
     },
+    temporalAxes: includeArchived
+      ? fullTransactionTimeAxis
+      : currentTimeInstantTemporalAxes,
     temporalClient: temporal,
   });
 

--- a/apps/hash-api/src/graphql/resolvers/ontology/property-type.ts
+++ b/apps/hash-api/src/graphql/resolvers/ontology/property-type.ts
@@ -81,7 +81,7 @@ export const queryPropertyTypesResolver: ResolverFn<
    *   authorized to see.
    *   https://app.asana.com/0/1202805690238892/1202890446280569/f
    */
-  const { data } = await graphApi.getPropertyTypesByQuery(
+  const { data: response } = await graphApi.getPropertyTypeSubgraph(
     authentication.actorId,
     {
       filter: latestOnly
@@ -102,7 +102,7 @@ export const queryPropertyTypesResolver: ResolverFn<
   );
 
   const subgraph = mapGraphApiSubgraphToSubgraph<PropertyTypeRootType>(
-    data,
+    response.subgraph,
     authentication.actorId,
   );
 

--- a/apps/hash-api/src/integrations/google/shared/get-google-account.ts
+++ b/apps/hash-api/src/integrations/google/shared/get-google-account.ts
@@ -9,7 +9,7 @@ import type { AccountId, Entity } from "@local/hash-subgraph";
 import { getRoots } from "@local/hash-subgraph/stdlib";
 
 import type { ImpureGraphFunction } from "../../../graph/context-types";
-import { getEntities } from "../../../graph/knowledge/primitive/entity";
+import { getEntitySubgraph } from "../../../graph/knowledge/primitive/entity";
 
 /**
  * Get a Google Account entity by the account id in Google
@@ -19,35 +19,33 @@ export const getGoogleAccountById: ImpureGraphFunction<
   Promise<Entity<GoogleAccountProperties> | undefined>
 > = async (context, authentication, params) => {
   const { userAccountId, googleAccountId } = params;
-  const entities = await getEntities(context, authentication, {
-    query: {
-      filter: {
-        all: [
-          {
-            equal: [{ path: ["ownedById"] }, { parameter: userAccountId }],
-          },
-          { equal: [{ path: ["archived"] }, { parameter: false }] },
-          generateVersionedUrlMatchingFilter(
-            googleEntityTypes.account.entityTypeId,
-            { ignoreParents: true },
-          ),
-          {
-            equal: [
-              {
-                path: [
-                  "properties",
-                  "https://hash.ai/@google/types/property-type/account-id/",
-                ],
-              },
-              { parameter: googleAccountId },
-            ],
-          },
-        ],
-      },
-      graphResolveDepths: zeroedGraphResolveDepths,
-      temporalAxes: currentTimeInstantTemporalAxes,
-      includeDrafts: false,
+  const entities = await getEntitySubgraph(context, authentication, {
+    filter: {
+      all: [
+        {
+          equal: [{ path: ["ownedById"] }, { parameter: userAccountId }],
+        },
+        { equal: [{ path: ["archived"] }, { parameter: false }] },
+        generateVersionedUrlMatchingFilter(
+          googleEntityTypes.account.entityTypeId,
+          { ignoreParents: true },
+        ),
+        {
+          equal: [
+            {
+              path: [
+                "properties",
+                "https://hash.ai/@google/types/property-type/account-id/",
+              ],
+            },
+            { parameter: googleAccountId },
+          ],
+        },
+      ],
     },
+    graphResolveDepths: zeroedGraphResolveDepths,
+    temporalAxes: currentTimeInstantTemporalAxes,
+    includeDrafts: false,
   }).then((subgraph) => {
     return getRoots(subgraph);
   });

--- a/apps/hash-api/src/integrations/sync-back-watcher.ts
+++ b/apps/hash-api/src/integrations/sync-back-watcher.ts
@@ -57,18 +57,16 @@ export const createIntegrationSyncBackWatcher = async (
 
         const entity = (
           await graphApiClient
-            .getEntitiesByQuery(linearBotAccountId, {
-              query: {
-                filter: {
-                  equal: [
-                    { path: ["editionId"] },
-                    { parameter: entityEdition.entityEditionId },
-                  ],
-                },
-                graphResolveDepths: zeroedGraphResolveDepths,
-                temporalAxes: fullDecisionTimeAxis,
-                includeDrafts: false,
+            .getEntitySubgraph(linearBotAccountId, {
+              filter: {
+                equal: [
+                  { path: ["editionId"] },
+                  { parameter: entityEdition.entityEditionId },
+                ],
               },
+              graphResolveDepths: zeroedGraphResolveDepths,
+              temporalAxes: fullDecisionTimeAxis,
+              includeDrafts: false,
             })
             .then(({ data }) => {
               const subgraph = mapGraphApiSubgraphToSubgraph<EntityRootType>(

--- a/apps/hash-api/src/storage/index.ts
+++ b/apps/hash-api/src/storage/index.ts
@@ -105,35 +105,33 @@ const getFileEntity = async (
   const [ownedById, entityUuid] = splitEntityId(entityId);
 
   const fileEntityRevisions = await graphApi
-    .getEntitiesByQuery(actorId, {
-      query: {
-        filter: {
-          all: [
-            {
-              equal: [{ path: ["uuid"] }, { parameter: entityUuid }],
-            },
-            {
-              equal: [{ path: ["ownedById"] }, { parameter: ownedById }],
-            },
-            {
-              equal: [
-                {
-                  path: [
-                    "properties",
-                    extractBaseUrl(
-                      systemPropertyTypes.fileStorageKey.propertyTypeId,
-                    ),
-                  ],
-                },
-                { parameter: key },
-              ],
-            },
-          ],
-        },
-        graphResolveDepths: zeroedGraphResolveDepths,
-        temporalAxes: fullDecisionTimeAxis,
-        includeDrafts,
+    .getEntitySubgraph(actorId, {
+      filter: {
+        all: [
+          {
+            equal: [{ path: ["uuid"] }, { parameter: entityUuid }],
+          },
+          {
+            equal: [{ path: ["ownedById"] }, { parameter: ownedById }],
+          },
+          {
+            equal: [
+              {
+                path: [
+                  "properties",
+                  extractBaseUrl(
+                    systemPropertyTypes.fileStorageKey.propertyTypeId,
+                  ),
+                ],
+              },
+              { parameter: key },
+            ],
+          },
+        ],
       },
+      graphResolveDepths: zeroedGraphResolveDepths,
+      temporalAxes: fullDecisionTimeAxis,
+      includeDrafts,
     })
     .then(({ data }) => {
       const subgraph = mapGraphApiSubgraphToSubgraph<EntityRootType>(

--- a/apps/hash-frontend/src/components/hooks/shared/get-page-refetch-queries.ts
+++ b/apps/hash-frontend/src/components/hooks/shared/get-page-refetch-queries.ts
@@ -5,7 +5,7 @@ import {
 } from "@local/hash-subgraph";
 import { useCallback } from "react";
 
-import { structuralQueryEntitiesQuery } from "../../../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../../../graphql/queries/knowledge/entity.queries";
 import { getBlockCollectionContentsStructuralQueryVariables } from "../../../pages/shared/block-collection-contents";
 import { getAccountPagesVariables } from "../../../shared/account-pages-variables";
 
@@ -21,7 +21,7 @@ export const useGetPageRefetchQueries = () =>
   useCallback(
     (pageEntityId: EntityId) => [
       {
-        query: structuralQueryEntitiesQuery,
+        query: getEntitySubgraphQuery,
         variables: getAccountPagesVariables({
           ownedById: extractOwnedByIdFromEntityId(pageEntityId),
           // Breadcrumbs use the archived query (since they may be archived)
@@ -29,14 +29,14 @@ export const useGetPageRefetchQueries = () =>
         }),
       },
       {
-        query: structuralQueryEntitiesQuery,
+        query: getEntitySubgraphQuery,
         variables: getAccountPagesVariables({
           // The page sidebar does not include archived pages
           ownedById: extractOwnedByIdFromEntityId(pageEntityId),
         }),
       },
       {
-        query: structuralQueryEntitiesQuery,
+        query: getEntitySubgraphQuery,
         variables: getBlockCollectionContentsStructuralQueryVariables(
           extractEntityUuidFromEntityId(pageEntityId),
         ),

--- a/apps/hash-frontend/src/components/hooks/use-account-pages.ts
+++ b/apps/hash-frontend/src/components/hooks/use-account-pages.ts
@@ -20,10 +20,10 @@ import {
 import { useMemo } from "react";
 
 import type {
-  StructuralQueryEntitiesQuery,
-  StructuralQueryEntitiesQueryVariables,
+  GetEntitySubgraphQuery,
+  GetEntitySubgraphQueryVariables,
 } from "../../graphql/api-types.gen";
-import { structuralQueryEntitiesQuery } from "../../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../../graphql/queries/knowledge/entity.queries";
 import { getAccountPagesVariables } from "../../shared/account-pages-variables";
 import { useHashInstance } from "./use-hash-instance";
 
@@ -37,7 +37,7 @@ export type AccountPagesInfo = {
   data: SimplePage[];
   lastRootPageIndex: string | null;
   loading: boolean;
-  refetch: () => Promise<ApolloQueryResult<StructuralQueryEntitiesQuery>>;
+  refetch: () => Promise<ApolloQueryResult<GetEntitySubgraphQuery>>;
 };
 
 export const useAccountPages = (
@@ -47,9 +47,9 @@ export const useAccountPages = (
   const { hashInstance } = useHashInstance();
 
   const { data, loading, refetch } = useQuery<
-    StructuralQueryEntitiesQuery,
-    StructuralQueryEntitiesQueryVariables
-  >(structuralQueryEntitiesQuery, {
+    GetEntitySubgraphQuery,
+    GetEntitySubgraphQueryVariables
+  >(getEntitySubgraphQuery, {
     variables: getAccountPagesVariables({
       ownedById,
       includeArchived,
@@ -58,7 +58,7 @@ export const useAccountPages = (
   });
 
   const pages = useMemo<SimplePage[]>(() => {
-    const subgraph = data?.structuralQueryEntities.subgraph;
+    const subgraph = data?.getEntitySubgraph.subgraph;
 
     if (!subgraph) {
       return [];

--- a/apps/hash-frontend/src/components/hooks/use-archive-page.ts
+++ b/apps/hash-frontend/src/components/hooks/use-archive-page.ts
@@ -10,7 +10,7 @@ import type {
   UpdatePageMutation,
   UpdatePageMutationVariables,
 } from "../../graphql/api-types.gen";
-import { structuralQueryEntitiesQuery } from "../../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../../graphql/queries/knowledge/entity.queries";
 import { updatePage } from "../../graphql/queries/page.queries";
 import { getBlockCollectionContentsStructuralQueryVariables } from "../../pages/shared/block-collection-contents";
 import { getAccountPagesVariables } from "../../shared/account-pages-variables";
@@ -35,12 +35,12 @@ export const useArchivePage = () => {
     const ownedById = extractOwnedByIdFromEntityId(pageEntityId);
     return [
       {
-        query: structuralQueryEntitiesQuery,
+        query: getEntitySubgraphQuery,
         variables: getAccountPagesVariables({ ownedById }),
       },
 
       {
-        query: structuralQueryEntitiesQuery,
+        query: getEntitySubgraphQuery,
         variables: getBlockCollectionContentsStructuralQueryVariables(
           extractEntityUuidFromEntityId(pageEntityId),
         ),

--- a/apps/hash-frontend/src/components/hooks/use-create-page.ts
+++ b/apps/hash-frontend/src/components/hooks/use-create-page.ts
@@ -12,7 +12,7 @@ import type {
   CreatePageMutationVariables,
 } from "../../graphql/api-types.gen";
 import { PageType } from "../../graphql/api-types.gen";
-import { structuralQueryEntitiesQuery } from "../../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../../graphql/queries/knowledge/entity.queries";
 import { createPage } from "../../graphql/queries/page.queries";
 import { constructPageRelativeUrl } from "../../lib/routes";
 import { getAccountPagesVariables } from "../../shared/account-pages-variables";
@@ -35,7 +35,7 @@ export const useCreatePage = ({
       data
         ? [
             {
-              query: structuralQueryEntitiesQuery,
+              query: getEntitySubgraphQuery,
               variables: getAccountPagesVariables({
                 ownedById: extractOwnedByIdFromEntityId(
                   data.createPage.metadata.recordId.entityId,

--- a/apps/hash-frontend/src/components/hooks/use-create-sub-page.ts
+++ b/apps/hash-frontend/src/components/hooks/use-create-sub-page.ts
@@ -11,7 +11,7 @@ import type {
   SetParentPageMutationVariables,
 } from "../../graphql/api-types.gen";
 import { PageType } from "../../graphql/api-types.gen";
-import { structuralQueryEntitiesQuery } from "../../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../../graphql/queries/knowledge/entity.queries";
 import { createPage, setParentPage } from "../../graphql/queries/page.queries";
 import { constructPageRelativeUrl } from "../../lib/routes";
 import { getAccountPagesVariables } from "../../shared/account-pages-variables";
@@ -37,7 +37,7 @@ export const useCreateSubPage = ({
     awaitRefetchQueries: false,
     refetchQueries: [
       {
-        query: structuralQueryEntitiesQuery,
+        query: getEntitySubgraphQuery,
         variables: getAccountPagesVariables({ ownedById }),
       },
     ],

--- a/apps/hash-frontend/src/components/hooks/use-orgs-with-links.ts
+++ b/apps/hash-frontend/src/components/hooks/use-orgs-with-links.ts
@@ -11,10 +11,10 @@ import { getRoots } from "@local/hash-subgraph/stdlib";
 import { useMemo } from "react";
 
 import type {
-  StructuralQueryEntitiesQuery,
-  StructuralQueryEntitiesQueryVariables,
+  GetEntitySubgraphQuery,
+  GetEntitySubgraphQueryVariables,
 } from "../../graphql/api-types.gen";
-import { structuralQueryEntitiesQuery } from "../../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../../graphql/queries/knowledge/entity.queries";
 import type { Org } from "../../lib/user-and-org";
 import { constructOrg, isEntityOrgEntity } from "../../lib/user-and-org";
 
@@ -28,15 +28,15 @@ export const useOrgsWithLinks = ({
 }): {
   loading: boolean;
   orgs?: Org[];
-  refetch: () => Promise<ApolloQueryResult<StructuralQueryEntitiesQuery>>;
+  refetch: () => Promise<ApolloQueryResult<GetEntitySubgraphQuery>>;
 } => {
   const { data, loading, refetch } = useQuery<
-    StructuralQueryEntitiesQuery,
-    StructuralQueryEntitiesQueryVariables
-  >(structuralQueryEntitiesQuery, {
+    GetEntitySubgraphQuery,
+    GetEntitySubgraphQueryVariables
+  >(getEntitySubgraphQuery, {
     variables: {
       includePermissions: false,
-      query: {
+      request: {
         filter: {
           all: [
             ...(orgAccountGroupIds
@@ -80,7 +80,7 @@ export const useOrgsWithLinks = ({
     skip: !orgAccountGroupIds || !orgAccountGroupIds.length,
   });
 
-  const { structuralQueryEntities: subgraphAndPermissions } = data ?? {};
+  const { getEntitySubgraph: subgraphAndPermissions } = data ?? {};
 
   const orgs = useMemo(() => {
     if (!subgraphAndPermissions) {

--- a/apps/hash-frontend/src/components/hooks/use-reorder-page.ts
+++ b/apps/hash-frontend/src/components/hooks/use-reorder-page.ts
@@ -7,7 +7,7 @@ import type {
   SetParentPageMutation,
   SetParentPageMutationVariables,
 } from "../../graphql/api-types.gen";
-import { structuralQueryEntitiesQuery } from "../../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../../graphql/queries/knowledge/entity.queries";
 import { setParentPage } from "../../graphql/queries/page.queries";
 import { getAccountPagesVariables } from "../../shared/account-pages-variables";
 
@@ -21,7 +21,7 @@ export const useReorderPage = () => {
       data
         ? [
             {
-              query: structuralQueryEntitiesQuery,
+              query: getEntitySubgraphQuery,
               variables: getAccountPagesVariables({
                 ownedById: extractOwnedByIdFromEntityId(
                   data.setParentPage.metadata.recordId.entityId,

--- a/apps/hash-frontend/src/components/hooks/use-users-with-links.ts
+++ b/apps/hash-frontend/src/components/hooks/use-users-with-links.ts
@@ -11,10 +11,10 @@ import { getRoots } from "@local/hash-subgraph/stdlib";
 import { useMemo } from "react";
 
 import type {
-  StructuralQueryEntitiesQuery,
-  StructuralQueryEntitiesQueryVariables,
+  GetEntitySubgraphQuery,
+  GetEntitySubgraphQueryVariables,
 } from "../../graphql/api-types.gen";
-import { structuralQueryEntitiesQuery } from "../../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../../graphql/queries/knowledge/entity.queries";
 import type { User } from "../../lib/user-and-org";
 import { constructUser, isEntityUserEntity } from "../../lib/user-and-org";
 
@@ -28,15 +28,15 @@ export const useUsersWithLinks = ({
 }): {
   loading: boolean;
   users?: User[];
-  refetch: () => Promise<ApolloQueryResult<StructuralQueryEntitiesQuery>>;
+  refetch: () => Promise<ApolloQueryResult<GetEntitySubgraphQuery>>;
 } => {
   const { data, loading, refetch } = useQuery<
-    StructuralQueryEntitiesQuery,
-    StructuralQueryEntitiesQueryVariables
-  >(structuralQueryEntitiesQuery, {
+    GetEntitySubgraphQuery,
+    GetEntitySubgraphQueryVariables
+  >(getEntitySubgraphQuery, {
     variables: {
       includePermissions: false,
-      query: {
+      request: {
         filter: {
           all: [
             ...(userAccountIds
@@ -81,7 +81,7 @@ export const useUsersWithLinks = ({
 
   const subgraph = data
     ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
-        data.structuralQueryEntities.subgraph,
+        data.getEntitySubgraph.subgraph,
       )
     : undefined;
 

--- a/apps/hash-frontend/src/graphql/queries/knowledge/entity.queries.ts
+++ b/apps/hash-frontend/src/graphql/queries/knowledge/entity.queries.ts
@@ -55,12 +55,12 @@ export const queryEntitiesQuery = gql`
   ${subgraphFieldsFragment}
 `;
 
-export const structuralQueryEntitiesQuery = gql`
-  query structuralQueryEntities(
-    $query: EntityStructuralQuery!
+export const getEntitySubgraphQuery = gql`
+  query getEntitySubgraph(
+    $request: GetEntitySubgraphRequest!
     $includePermissions: Boolean!
   ) {
-    structuralQueryEntities(query: $query) {
+    getEntitySubgraph(request: $request) {
       userPermissionsOnEntities @include(if: $includePermissions)
       subgraph {
         ...SubgraphFields

--- a/apps/hash-frontend/src/pages/[shortname].page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname].page.tsx
@@ -18,10 +18,10 @@ import { useRouter } from "next/router";
 import { useCallback, useMemo, useState } from "react";
 
 import type {
-  StructuralQueryEntitiesQuery,
-  StructuralQueryEntitiesQueryVariables,
+  GetEntitySubgraphQuery,
+  GetEntitySubgraphQueryVariables,
 } from "../graphql/api-types.gen";
-import { structuralQueryEntitiesQuery } from "../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../graphql/queries/knowledge/entity.queries";
 import {
   constructOrg,
   constructUser,
@@ -123,12 +123,12 @@ const ProfilePage: NextPageWithLayout = () => {
   );
 
   const { data: pinnedEntityTypesData } = useQuery<
-    StructuralQueryEntitiesQuery,
-    StructuralQueryEntitiesQueryVariables
-  >(structuralQueryEntitiesQuery, {
+    GetEntitySubgraphQuery,
+    GetEntitySubgraphQueryVariables
+  >(getEntitySubgraphQuery, {
     variables: {
       includePermissions: false,
-      query: {
+      request: {
         filter: {
           all: [
             {
@@ -171,7 +171,7 @@ const ProfilePage: NextPageWithLayout = () => {
 
   const entitiesSubgraph = pinnedEntityTypesData
     ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
-        pinnedEntityTypesData.structuralQueryEntities.subgraph,
+        pinnedEntityTypesData.getEntitySubgraph.subgraph,
       )
     : undefined;
 

--- a/apps/hash-frontend/src/pages/[shortname]/[page-slug].page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/[page-slug].page.tsx
@@ -28,10 +28,10 @@ import { PageIcon } from "../../components/page-icon";
 import { PageLoadingState } from "../../components/page-loading-state";
 import { CollabPositionProvider } from "../../contexts/collab-position-context";
 import type {
-  StructuralQueryEntitiesQuery,
-  StructuralQueryEntitiesQueryVariables,
+  GetEntitySubgraphQuery,
+  GetEntitySubgraphQueryVariables,
 } from "../../graphql/api-types.gen";
-import { structuralQueryEntitiesQuery } from "../../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../../graphql/queries/knowledge/entity.queries";
 import { constructPageRelativeUrl } from "../../lib/routes";
 import type { MinimalOrg, MinimalUser } from "../../lib/user-and-org";
 import { iconVariantSizes } from "../../shared/edit-emoji-icon-button";
@@ -195,9 +195,9 @@ const Page: NextPageWithLayout<PageProps> = () => {
   const { workspaceShortname, pageEntityUuid } = parsePageUrlQueryParams(query);
 
   const { data, error, loading } = useQuery<
-    StructuralQueryEntitiesQuery,
-    StructuralQueryEntitiesQueryVariables
-  >(structuralQueryEntitiesQuery, {
+    GetEntitySubgraphQuery,
+    GetEntitySubgraphQueryVariables
+  >(getEntitySubgraphQuery, {
     variables:
       getBlockCollectionContentsStructuralQueryVariables(pageEntityUuid),
     fetchPolicy: "cache-and-network",
@@ -231,8 +231,7 @@ const Page: NextPageWithLayout<PageProps> = () => {
     pageHeaderRef.current.scrollIntoView({ behavior: "smooth" });
   };
 
-  const { subgraph, userPermissionsOnEntities } =
-    data?.structuralQueryEntities ?? {};
+  const { subgraph, userPermissionsOnEntities } = data?.getEntitySubgraph ?? {};
 
   const pageSubgraph = subgraph
     ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(subgraph)

--- a/apps/hash-frontend/src/pages/[shortname]/[page-slug].page/canvas-page/block-creation-dialog.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/[page-slug].page/canvas-page/block-creation-dialog.tsx
@@ -12,7 +12,7 @@ import type {
   UpdateBlockCollectionContentsMutation,
   UpdateBlockCollectionContentsMutationVariables,
 } from "../../../../graphql/api-types.gen";
-import { structuralQueryEntitiesQuery } from "../../../../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../../../../graphql/queries/knowledge/entity.queries";
 import { BlockSuggester } from "../../../shared/block-collection/create-suggester/block-suggester";
 import { usePageContext } from "../../../shared/block-collection/page-context";
 import { getBlockCollectionContentsStructuralQueryVariables } from "../../../shared/block-collection-contents";
@@ -84,7 +84,7 @@ export const BlockCreationDialog = ({ onClose }: DialogProps) => {
         // temporary hack to keep page data consistent, in the absence of proper data subscriptions
         refetchQueries: [
           {
-            query: structuralQueryEntitiesQuery,
+            query: getEntitySubgraphQuery,
             variables: getBlockCollectionContentsStructuralQueryVariables(
               extractEntityUuidFromEntityId(pageEntityId),
             ),

--- a/apps/hash-frontend/src/pages/[shortname]/[page-slug].page/canvas-page/block-shape.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/[page-slug].page/canvas-page/block-shape.tsx
@@ -16,7 +16,7 @@ import {
 } from "@tldraw/tldraw";
 
 import { BlockLoader } from "../../../../components/block-loader/block-loader";
-import { structuralQueryEntitiesQuery } from "../../../../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../../../../graphql/queries/knowledge/entity.queries";
 import { apolloClient } from "../../../../lib/apollo-client";
 import { BlockContextProvider } from "../../../shared/block-collection/block-context";
 import { getBlockCollectionContentsStructuralQueryVariables } from "../../../shared/block-collection-contents";
@@ -64,7 +64,7 @@ const persistBlockPosition = ({
     refetchQueries: [
       // Refetch the page
       {
-        query: structuralQueryEntitiesQuery,
+        query: getEntitySubgraphQuery,
         variables: getBlockCollectionContentsStructuralQueryVariables(
           extractEntityUuidFromEntityId(pageEntityId),
         ),

--- a/apps/hash-frontend/src/pages/actions.page.tsx
+++ b/apps/hash-frontend/src/pages/actions.page.tsx
@@ -19,10 +19,10 @@ import { NextSeo } from "next-seo";
 import { useMemo, useState } from "react";
 
 import type {
-  StructuralQueryEntitiesQuery,
-  StructuralQueryEntitiesQueryVariables,
+  GetEntitySubgraphQuery,
+  GetEntitySubgraphQueryVariables,
 } from "../graphql/api-types.gen";
-import { structuralQueryEntitiesQuery } from "../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../graphql/queries/knowledge/entity.queries";
 import { useDraftEntities } from "../shared/draft-entities-context";
 import { BarsSortRegularIcon } from "../shared/icons/bars-sort-regular-icon";
 import type { NextPageWithLayout } from "../shared/layout";
@@ -69,14 +69,14 @@ const ActionsPage: NextPageWithLayout = () => {
   const [
     previouslyFetchedDraftEntitiesWithLinkedDataResponse,
     setPreviouslyFetchedDraftEntitiesWithLinkedDataResponse,
-  ] = useState<StructuralQueryEntitiesQuery>();
+  ] = useState<GetEntitySubgraphQuery>();
 
   const { data: draftEntitiesWithLinkedDataResponse } = useQuery<
-    StructuralQueryEntitiesQuery,
-    StructuralQueryEntitiesQueryVariables
-  >(structuralQueryEntitiesQuery, {
+    GetEntitySubgraphQuery,
+    GetEntitySubgraphQueryVariables
+  >(getEntitySubgraphQuery, {
     variables: {
-      query: {
+      request: {
         filter: getDraftEntitiesFilter,
         includeDrafts: true,
         temporalAxes: currentTimeInstantTemporalAxes,
@@ -106,7 +106,7 @@ const ActionsPage: NextPageWithLayout = () => {
         ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
             (draftEntitiesWithLinkedDataResponse ??
               previouslyFetchedDraftEntitiesWithLinkedDataResponse)!
-              .structuralQueryEntities.subgraph,
+              .getEntitySubgraph.subgraph,
           )
         : undefined,
     [

--- a/apps/hash-frontend/src/pages/admin/users/[user-entity-uuid].page.tsx
+++ b/apps/hash-frontend/src/pages/admin/users/[user-entity-uuid].page.tsx
@@ -38,7 +38,7 @@ const AdminUserPage: NextPageWithLayout = () => {
   const refetchUser = useCallback(async () => {
     const {
       data: {
-        structuralQueryEntities: { subgraph: refetchedSubgraph },
+        getEntitySubgraph: { subgraph: refetchedSubgraph },
       },
     } = await refetch();
 

--- a/apps/hash-frontend/src/pages/notes.page.tsx
+++ b/apps/hash-frontend/src/pages/notes.page.tsx
@@ -19,10 +19,10 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import { BlockLoadedProvider } from "../blocks/on-block-loaded";
 import { UserBlocksProvider } from "../blocks/user-blocks";
 import type {
-  StructuralQueryEntitiesQuery,
-  StructuralQueryEntitiesQueryVariables,
+  GetEntitySubgraphQuery,
+  GetEntitySubgraphQueryVariables,
 } from "../graphql/api-types.gen";
-import { structuralQueryEntitiesQuery } from "../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../graphql/queries/knowledge/entity.queries";
 import { NoteIcon } from "../shared/icons/note-icon";
 import type { NextPageWithLayout } from "../shared/layout";
 import { getLayoutWithSidebar } from "../shared/layout";
@@ -39,15 +39,15 @@ const NotesPage: NextPageWithLayout = () => {
   const sectionRefs = useRef<Array<HTMLDivElement>>([]);
 
   const [previouslyFetchedQuickNotesData, setPreviouslyFetchedQuickNotesData] =
-    useState<StructuralQueryEntitiesQuery>();
+    useState<GetEntitySubgraphQuery>();
 
   const { data: quickNotesData, refetch } = useQuery<
-    StructuralQueryEntitiesQuery,
-    StructuralQueryEntitiesQueryVariables
-  >(structuralQueryEntitiesQuery, {
+    GetEntitySubgraphQuery,
+    GetEntitySubgraphQueryVariables
+  >(getEntitySubgraphQuery, {
     variables: {
       includePermissions: true,
-      query: {
+      request: {
         filter: {
           all: [
             generateVersionedUrlMatchingFilter(
@@ -72,7 +72,7 @@ const NotesPage: NextPageWithLayout = () => {
   });
 
   const quickNotesSubgraph = (quickNotesData ?? previouslyFetchedQuickNotesData)
-    ?.structuralQueryEntities.subgraph as Subgraph<EntityRootType> | undefined;
+    ?.getEntitySubgraph.subgraph as Subgraph<EntityRootType> | undefined;
 
   const latestQuickNoteEntities = useMemo<Entity[] | undefined>(() => {
     if (!quickNotesSubgraph) {
@@ -204,8 +204,7 @@ const NotesPage: NextPageWithLayout = () => {
             <BlockCollectionContextProvider
               blockCollectionSubgraph={quickNotesSubgraph}
               userPermissionsOnEntities={
-                quickNotesData?.structuralQueryEntities
-                  .userPermissionsOnEntities
+                quickNotesData?.getEntitySubgraph.userPermissionsOnEntities
               }
             >
               <TodaySection

--- a/apps/hash-frontend/src/pages/settings/integrations/google-sheets/google-auth-context/use-google-accounts.ts
+++ b/apps/hash-frontend/src/pages/settings/integrations/google-sheets/google-auth-context/use-google-accounts.ts
@@ -12,10 +12,10 @@ import { getRoots } from "@local/hash-subgraph/stdlib";
 import { useMemo } from "react";
 
 import type {
-  StructuralQueryEntitiesQuery,
-  StructuralQueryEntitiesQueryVariables,
+  GetEntitySubgraphQuery,
+  GetEntitySubgraphQueryVariables,
 } from "../../../../../graphql/api-types.gen";
-import { structuralQueryEntitiesQuery } from "../../../../../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../../../../../graphql/queries/knowledge/entity.queries";
 import { useAuthenticatedUser } from "../../../../shared/auth-info-context";
 
 type UseGoogleAccountsResult = {
@@ -28,12 +28,12 @@ export const useGoogleAccounts = (): UseGoogleAccountsResult => {
   const { authenticatedUser } = useAuthenticatedUser();
 
   const { data, loading, refetch } = useQuery<
-    StructuralQueryEntitiesQuery,
-    StructuralQueryEntitiesQueryVariables
-  >(structuralQueryEntitiesQuery, {
+    GetEntitySubgraphQuery,
+    GetEntitySubgraphQueryVariables
+  >(getEntitySubgraphQuery, {
     variables: {
       includePermissions: false,
-      query: {
+      request: {
         filter: {
           all: [
             generateVersionedUrlMatchingFilter(
@@ -61,7 +61,7 @@ export const useGoogleAccounts = (): UseGoogleAccountsResult => {
   return useMemo(() => {
     const subgraph = data
       ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
-          data.structuralQueryEntities.subgraph,
+          data.getEntitySubgraph.subgraph,
         )
       : undefined;
 

--- a/apps/hash-frontend/src/pages/settings/integrations/google-sheets/use-sheet-integrations.ts
+++ b/apps/hash-frontend/src/pages/settings/integrations/google-sheets/use-sheet-integrations.ts
@@ -23,10 +23,10 @@ import {
 import { useMemo } from "react";
 
 import type {
-  StructuralQueryEntitiesQuery,
-  StructuralQueryEntitiesQueryVariables,
+  GetEntitySubgraphQuery,
+  GetEntitySubgraphQueryVariables,
 } from "../../../../graphql/api-types.gen";
-import { structuralQueryEntitiesQuery } from "../../../../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../../../../graphql/queries/knowledge/entity.queries";
 import { useAuthenticatedUser } from "../../../shared/auth-info-context";
 
 export type UseSheetsIntegrationsData = {
@@ -42,12 +42,12 @@ export const useSheetsIntegrations = (): UseSheetsIntegrationsData => {
   const { authenticatedUser } = useAuthenticatedUser();
 
   const { data, loading, refetch } = useQuery<
-    StructuralQueryEntitiesQuery,
-    StructuralQueryEntitiesQueryVariables
-  >(structuralQueryEntitiesQuery, {
+    GetEntitySubgraphQuery,
+    GetEntitySubgraphQueryVariables
+  >(getEntitySubgraphQuery, {
     variables: {
       includePermissions: false,
-      query: {
+      request: {
         filter: {
           all: [
             generateVersionedUrlMatchingFilter(
@@ -79,7 +79,7 @@ export const useSheetsIntegrations = (): UseSheetsIntegrationsData => {
   return useMemo(() => {
     const subgraph = data
       ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
-          data.structuralQueryEntities.subgraph,
+          data.getEntitySubgraph.subgraph,
         )
       : undefined;
 

--- a/apps/hash-frontend/src/pages/shared/block-collection-contents.ts
+++ b/apps/hash-frontend/src/pages/shared/block-collection-contents.ts
@@ -31,7 +31,7 @@ import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 
 import type {
   BlockCollectionContentItem,
-  StructuralQueryEntitiesQueryVariables,
+  GetEntitySubgraphQueryVariables,
 } from "../../graphql/api-types.gen";
 
 /**
@@ -65,9 +65,9 @@ export const blockCollectionContentsGetEntityVariables = {
 
 export const getBlockCollectionContentsStructuralQueryVariables = (
   pageEntityUuid: EntityUuid,
-): StructuralQueryEntitiesQueryVariables => ({
+): GetEntitySubgraphQueryVariables => ({
   includePermissions: true,
-  query: {
+  request: {
     filter: {
       all: [
         {

--- a/apps/hash-frontend/src/pages/shared/block-collection/shared/mention-suggester.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/shared/mention-suggester.tsx
@@ -44,10 +44,10 @@ import {
 import { useKey } from "rooks";
 
 import type {
-  StructuralQueryEntitiesQuery,
-  StructuralQueryEntitiesQueryVariables,
+  GetEntitySubgraphQuery,
+  GetEntitySubgraphQueryVariables,
 } from "../../../../graphql/api-types.gen";
-import { structuralQueryEntitiesQuery } from "../../../../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../../../../graphql/queries/knowledge/entity.queries";
 import { isPageArchived } from "../../../../shared/is-archived";
 import { isEntityPageEntity } from "../../../../shared/is-of-type";
 import { usePropertyTypes } from "../../../../shared/property-types-context";
@@ -138,12 +138,12 @@ export const MentionSuggester: FunctionComponent<MentionSuggesterProps> = ({
   );
 
   const { data, loading: loadingEntities } = useQuery<
-    StructuralQueryEntitiesQuery,
-    StructuralQueryEntitiesQueryVariables
-  >(structuralQueryEntitiesQuery, {
+    GetEntitySubgraphQuery,
+    GetEntitySubgraphQueryVariables
+  >(getEntitySubgraphQuery, {
     variables: {
       includePermissions: false,
-      query: {
+      request: {
         filter: {
           all: [
             {
@@ -193,7 +193,7 @@ export const MentionSuggester: FunctionComponent<MentionSuggesterProps> = ({
 
   const entitiesSubgraph = data
     ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
-        data.structuralQueryEntities.subgraph,
+        data.getEntitySubgraph.subgraph,
       )
     : undefined;
 

--- a/apps/hash-frontend/src/pages/shared/entities-table/use-get-entities-table-additional-csv-data.ts
+++ b/apps/hash-frontend/src/pages/shared/entities-table/use-get-entities-table-additional-csv-data.ts
@@ -19,10 +19,10 @@ import type { MutableRefObject } from "react";
 import { useCallback } from "react";
 
 import type {
-  StructuralQueryEntitiesQuery,
-  StructuralQueryEntitiesQueryVariables,
+  GetEntitySubgraphQuery,
+  GetEntitySubgraphQueryVariables,
 } from "../../../graphql/api-types.gen";
-import { structuralQueryEntitiesQuery } from "../../../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../../../graphql/queries/knowledge/entity.queries";
 import type { GetAdditionalCsvDataFunction } from "../../../shared/table-header";
 import type { TypeEntitiesRow } from "./use-entities-table";
 
@@ -34,10 +34,10 @@ export const useGetEntitiesTableAdditionalCsvData = (props: {
   const { currentlyDisplayedRowsRef, propertyTypes, addPropertiesColumns } =
     props;
 
-  const [structuralQueryEntities] = useLazyQuery<
-    StructuralQueryEntitiesQuery,
-    StructuralQueryEntitiesQueryVariables
-  >(structuralQueryEntitiesQuery);
+  const [getEntitySubgraph] = useLazyQuery<
+    GetEntitySubgraphQuery,
+    GetEntitySubgraphQueryVariables
+  >(getEntitySubgraphQuery);
 
   const fetchOutgoingLinksOfEntities = useCallback(
     async (params: {
@@ -50,9 +50,9 @@ export const useGetEntitiesTableAdditionalCsvData = (props: {
     > => {
       const { leftEntities } = params;
 
-      const { data } = await structuralQueryEntities({
+      const { data } = await getEntitySubgraph({
         variables: {
-          query: {
+          request: {
             filter: {
               any: leftEntities.map((entity) => ({
                 equal: [
@@ -78,7 +78,7 @@ export const useGetEntitiesTableAdditionalCsvData = (props: {
 
       const outgoingLinksSubgraph = data
         ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
-            data.structuralQueryEntities.subgraph,
+            data.getEntitySubgraph.subgraph,
           )
         : undefined;
 
@@ -104,7 +104,7 @@ export const useGetEntitiesTableAdditionalCsvData = (props: {
         })
         .flat();
     },
-    [structuralQueryEntities],
+    [getEntitySubgraph],
   );
 
   const getEntitiesTableAdditionalCsvData =

--- a/apps/hash-frontend/src/pages/shared/entity-selector.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-selector.tsx
@@ -27,10 +27,10 @@ import { getRoots } from "@local/hash-subgraph/stdlib";
 import { useMemo, useState } from "react";
 
 import type {
-  StructuralQueryEntitiesQuery,
-  StructuralQueryEntitiesQueryVariables,
+  GetEntitySubgraphQuery,
+  GetEntitySubgraphQueryVariables,
 } from "../../graphql/api-types.gen";
-import { structuralQueryEntitiesQuery } from "../../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../../graphql/queries/knowledge/entity.queries";
 
 type EntitySelectorProps<Multiple extends boolean = false> = Omit<
   SelectorAutocompleteProps<Entity, Multiple>,
@@ -64,11 +64,11 @@ export const EntitySelector = <Multiple extends boolean>({
   const [query, setQuery] = useState("");
 
   const { data: entitiesData, loading } = useQuery<
-    StructuralQueryEntitiesQuery,
-    StructuralQueryEntitiesQueryVariables
-  >(structuralQueryEntitiesQuery, {
+    GetEntitySubgraphQuery,
+    GetEntitySubgraphQueryVariables
+  >(getEntitySubgraphQuery, {
     variables: {
-      query: {
+      request: {
         filter:
           !expectedEntityTypes || expectedEntityTypes.length === 0
             ? { all: [] }
@@ -93,7 +93,7 @@ export const EntitySelector = <Multiple extends boolean>({
 
   const entitiesSubgraph = entitiesData
     ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
-        entitiesData.structuralQueryEntities.subgraph,
+        entitiesData.getEntitySubgraph.subgraph,
       )
     : undefined;
 

--- a/apps/hash-frontend/src/pages/shared/notifications-with-links-context.tsx
+++ b/apps/hash-frontend/src/pages/shared/notifications-with-links-context.tsx
@@ -38,10 +38,10 @@ import type { FunctionComponent, PropsWithChildren } from "react";
 import { createContext, useContext, useMemo, useRef } from "react";
 
 import type {
-  StructuralQueryEntitiesQuery,
-  StructuralQueryEntitiesQueryVariables,
+  GetEntitySubgraphQuery,
+  GetEntitySubgraphQueryVariables,
 } from "../../graphql/api-types.gen";
-import { structuralQueryEntitiesQuery } from "../../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../../graphql/queries/knowledge/entity.queries";
 import type { MinimalUser } from "../../lib/user-and-org";
 import { constructMinimalUser } from "../../lib/user-and-org";
 import { useNotificationEntities } from "../../shared/notification-entities-context";
@@ -137,12 +137,12 @@ export const useNotificationsWithLinksContextValue =
     );
 
     const { data: notificationsWithOutgoingLinksData } = useQuery<
-      StructuralQueryEntitiesQuery,
-      StructuralQueryEntitiesQueryVariables
-    >(structuralQueryEntitiesQuery, {
+      GetEntitySubgraphQuery,
+      GetEntitySubgraphQueryVariables
+    >(getEntitySubgraphQuery, {
       variables: {
         includePermissions: false,
-        query: {
+        request: {
           filter: getNotificationEntitiesFilter,
           graphResolveDepths: {
             ...zeroedGraphResolveDepths,
@@ -164,8 +164,7 @@ export const useNotificationsWithLinksContextValue =
       () =>
         notificationsWithOutgoingLinksData
           ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
-              notificationsWithOutgoingLinksData.structuralQueryEntities
-                .subgraph,
+              notificationsWithOutgoingLinksData.getEntitySubgraph.subgraph,
             )
           : undefined,
       [notificationsWithOutgoingLinksData],

--- a/apps/hash-frontend/src/shared/account-pages-variables.ts
+++ b/apps/hash-frontend/src/shared/account-pages-variables.ts
@@ -13,7 +13,7 @@ export const getAccountPagesVariables = ({
   ownedById?: OwnedById;
   includeArchived?: boolean;
 }) => ({
-  query: {
+  request: {
     filter: {
       all: [
         pageEntityTypeFilter,

--- a/apps/hash-frontend/src/shared/entity-type-entities-context.ts
+++ b/apps/hash-frontend/src/shared/entity-type-entities-context.ts
@@ -12,7 +12,7 @@ import type {
 } from "@local/hash-subgraph";
 import { createContext, useContext } from "react";
 
-import type { StructuralQueryEntitiesQuery } from "../graphql/api-types.gen";
+import type { GetEntitySubgraphQuery } from "../graphql/api-types.gen";
 
 export type EntityTypeEntitiesContextValue = {
   entityTypeId?: VersionedUrl;
@@ -27,7 +27,7 @@ export type EntityTypeEntitiesContextValue = {
    * The cached content will be replaced automatically and the value updated when the network request completes.
    */
   loading: boolean;
-  refetch: () => Promise<ApolloQueryResult<StructuralQueryEntitiesQuery>>;
+  refetch: () => Promise<ApolloQueryResult<GetEntitySubgraphQuery>>;
   propertyTypes?: PropertyType[];
   subgraph?: Subgraph<EntityRootType>;
 };

--- a/apps/hash-frontend/src/shared/layout/layout-with-header/search-bar.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-header/search-bar.tsx
@@ -30,12 +30,12 @@ import { useDebounce, useKey, useOutsideClickRef } from "rooks";
 
 import { useUserOrOrgShortnameByOwnedById } from "../../../components/hooks/use-user-or-org-shortname-by-owned-by-id";
 import type {
+  GetEntitySubgraphQuery,
+  GetEntitySubgraphQueryVariables,
   QueryEntityTypesQuery,
   QueryEntityTypesQueryVariables,
-  StructuralQueryEntitiesQuery,
-  StructuralQueryEntitiesQueryVariables,
 } from "../../../graphql/api-types.gen";
-import { structuralQueryEntitiesQuery } from "../../../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../../../graphql/queries/knowledge/entity.queries";
 import { queryEntityTypesQuery } from "../../../graphql/queries/ontology/entity-type.queries";
 import { generateLinkParameters } from "../../generate-link-parameters";
 import { SearchIcon } from "../../icons";
@@ -237,11 +237,11 @@ export const SearchBar: FunctionComponent = () => {
   );
 
   const { data: entityResultData, loading: entitiesLoading } = useQuery<
-    StructuralQueryEntitiesQuery,
-    StructuralQueryEntitiesQueryVariables
-  >(structuralQueryEntitiesQuery, {
+    GetEntitySubgraphQuery,
+    GetEntitySubgraphQueryVariables
+  >(getEntitySubgraphQuery, {
     variables: {
-      query: {
+      request: {
         filter: queryFilter,
         temporalAxes: currentTimeInstantTemporalAxes,
         graphResolveDepths: {
@@ -270,8 +270,8 @@ export const SearchBar: FunctionComponent = () => {
 
   const entitySubgraph =
     entityResultData &&
-    isEntityRootedSubgraph(entityResultData.structuralQueryEntities.subgraph)
-      ? entityResultData.structuralQueryEntities.subgraph
+    isEntityRootedSubgraph(entityResultData.getEntitySubgraph.subgraph)
+      ? entityResultData.getEntitySubgraph.subgraph
       : undefined;
 
   const entityResults = entitySubgraph ? getRoots(entitySubgraph) : [];

--- a/apps/hash-frontend/src/shared/notification-entities-context.tsx
+++ b/apps/hash-frontend/src/shared/notification-entities-context.tsx
@@ -16,13 +16,13 @@ import { createContext, useCallback, useContext, useMemo } from "react";
 
 import { useBlockProtocolUpdateEntity } from "../components/hooks/block-protocol-functions/knowledge/use-block-protocol-update-entity";
 import type {
-  StructuralQueryEntitiesQuery,
-  StructuralQueryEntitiesQueryVariables,
+  GetEntitySubgraphQuery,
+  GetEntitySubgraphQueryVariables,
   UpdateEntitiesMutation,
   UpdateEntitiesMutationVariables,
 } from "../graphql/api-types.gen";
 import {
-  structuralQueryEntitiesQuery,
+  getEntitySubgraphQuery,
   updateEntitiesMutation,
 } from "../graphql/queries/knowledge/entity.queries";
 import { useAuthInfo } from "../pages/shared/auth-info-context";
@@ -69,43 +69,43 @@ export const NotificationEntitiesContextProvider: FunctionComponent<
     data: notificationEntitiesData,
     loading: loadingNotificationEntities,
     refetch: refetchNotificationEntities,
-  } = useQuery<
-    StructuralQueryEntitiesQuery,
-    StructuralQueryEntitiesQueryVariables
-  >(structuralQueryEntitiesQuery, {
-    pollInterval,
-    variables: {
-      includePermissions: false,
-      query: {
-        filter: {
-          all: [
-            {
-              equal: [
-                { path: ["ownedById"] },
-                { parameter: authenticatedUser?.accountId },
-              ],
-            },
-            generateVersionedUrlMatchingFilter(
-              systemEntityTypes.notification.entityTypeId,
-              { ignoreParents: false },
-            ),
-            notArchivedFilter,
-          ],
+  } = useQuery<GetEntitySubgraphQuery, GetEntitySubgraphQueryVariables>(
+    getEntitySubgraphQuery,
+    {
+      pollInterval,
+      variables: {
+        includePermissions: false,
+        request: {
+          filter: {
+            all: [
+              {
+                equal: [
+                  { path: ["ownedById"] },
+                  { parameter: authenticatedUser?.accountId },
+                ],
+              },
+              generateVersionedUrlMatchingFilter(
+                systemEntityTypes.notification.entityTypeId,
+                { ignoreParents: false },
+              ),
+              notArchivedFilter,
+            ],
+          },
+          graphResolveDepths: zeroedGraphResolveDepths,
+          temporalAxes: currentTimeInstantTemporalAxes,
+          includeDrafts: false,
         },
-        graphResolveDepths: zeroedGraphResolveDepths,
-        temporalAxes: currentTimeInstantTemporalAxes,
-        includeDrafts: false,
       },
+      skip: !authenticatedUser,
+      fetchPolicy: "network-only",
     },
-    skip: !authenticatedUser,
-    fetchPolicy: "network-only",
-  });
+  );
 
   const notificationEntitiesSubgraph = useMemo(
     () =>
       notificationEntitiesData
         ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
-            notificationEntitiesData.structuralQueryEntities.subgraph,
+            notificationEntitiesData.getEntitySubgraph.subgraph,
           )
         : undefined,
     [notificationEntitiesData],

--- a/apps/hash-frontend/src/shared/use-actors.ts
+++ b/apps/hash-frontend/src/shared/use-actors.ts
@@ -13,10 +13,10 @@ import { useMemo } from "react";
 
 import { useUsers } from "../components/hooks/use-users";
 import type {
-  StructuralQueryEntitiesQuery,
-  StructuralQueryEntitiesQueryVariables,
+  GetEntitySubgraphQuery,
+  GetEntitySubgraphQueryVariables,
 } from "../graphql/api-types.gen";
-import { structuralQueryEntitiesQuery } from "../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../graphql/queries/knowledge/entity.queries";
 import type { MinimalUser } from "../lib/user-and-org";
 
 type MachineActor = {
@@ -43,12 +43,12 @@ export const useActors = (params: {
   );
 
   const { data: machineActorsData, loading: machinesLoading } = useQuery<
-    StructuralQueryEntitiesQuery,
-    StructuralQueryEntitiesQueryVariables
-  >(structuralQueryEntitiesQuery, {
+    GetEntitySubgraphQuery,
+    GetEntitySubgraphQueryVariables
+  >(getEntitySubgraphQuery, {
     variables: {
       includePermissions: false,
-      query: {
+      request: {
         filter: {
           any: (params.accountIds ?? []).map((accountId) => ({
             all: [
@@ -83,7 +83,7 @@ export const useActors = (params: {
     }
 
     const subgraph = mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
-      machineActorsData.structuralQueryEntities.subgraph,
+      machineActorsData.getEntitySubgraph.subgraph,
     );
 
     const machineActors = getRoots(subgraph).map((entity) => {

--- a/apps/hash-frontend/src/shared/use-entity-type-entities.tsx
+++ b/apps/hash-frontend/src/shared/use-entity-type-entities.tsx
@@ -15,13 +15,13 @@ import { getRoots } from "@local/hash-subgraph/stdlib";
 import { useMemo } from "react";
 
 import type {
+  GetEntitySubgraphQuery,
+  GetEntitySubgraphQueryVariables,
   QueryEntitiesQueryVariables,
-  StructuralQueryEntitiesQuery,
-  StructuralQueryEntitiesQueryVariables,
 } from "../graphql/api-types.gen";
 import {
+  getEntitySubgraphQuery,
   queryEntitiesQuery,
-  structuralQueryEntitiesQuery,
 } from "../graphql/queries/knowledge/entity.queries";
 import { apolloClient } from "../lib/apollo-client";
 import type { EntityTypeEntitiesContextValue } from "./entity-type-entities-context";
@@ -79,9 +79,9 @@ export const useEntityTypeEntities = (params: {
   const { entityTypeBaseUrl, entityTypeId, ownedById, graphResolveDepths } =
     params;
 
-  const variables = useMemo<StructuralQueryEntitiesQueryVariables>(
+  const variables = useMemo<GetEntitySubgraphQueryVariables>(
     () => ({
-      query: {
+      request: {
         filter: {
           all: [
             ...(ownedById
@@ -125,9 +125,9 @@ export const useEntityTypeEntities = (params: {
   );
 
   const { data, loading, refetch } = useQuery<
-    StructuralQueryEntitiesQuery,
-    StructuralQueryEntitiesQueryVariables
-  >(structuralQueryEntitiesQuery, {
+    GetEntitySubgraphQuery,
+    GetEntitySubgraphQueryVariables
+  >(getEntitySubgraphQuery, {
     fetchPolicy: "cache-and-network",
     variables,
   });
@@ -137,9 +137,9 @@ export const useEntityTypeEntities = (params: {
     [variables],
   );
 
-  const subgraph = data?.structuralQueryEntities.subgraph
+  const subgraph = data?.getEntitySubgraph.subgraph
     ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
-        data.structuralQueryEntities.subgraph,
+        data.getEntitySubgraph.subgraph,
       )
     : undefined;
 

--- a/apps/hash-frontend/src/shared/use-user-or-org.ts
+++ b/apps/hash-frontend/src/shared/use-user-or-org.ts
@@ -23,10 +23,10 @@ import { getRoots } from "@local/hash-subgraph/stdlib";
 import { useMemo } from "react";
 
 import type {
-  StructuralQueryEntitiesQuery,
-  StructuralQueryEntitiesQueryVariables,
+  GetEntitySubgraphQuery,
+  GetEntitySubgraphQueryVariables,
 } from "../graphql/api-types.gen";
-import { structuralQueryEntitiesQuery } from "../graphql/queries/knowledge/entity.queries";
+import { getEntitySubgraphQuery } from "../graphql/queries/knowledge/entity.queries";
 import { isEntityOrgEntity, isEntityUserEntity } from "../lib/user-and-org";
 
 export const useUserOrOrg = (
@@ -40,12 +40,12 @@ export const useUserOrOrg = (
   ),
 ) => {
   const { data, loading, refetch } = useQuery<
-    StructuralQueryEntitiesQuery,
-    StructuralQueryEntitiesQueryVariables
-  >(structuralQueryEntitiesQuery, {
+    GetEntitySubgraphQuery,
+    GetEntitySubgraphQueryVariables
+  >(getEntitySubgraphQuery, {
     variables: {
       includePermissions: params.includePermissions ?? false,
-      query: {
+      request: {
         filter: {
           all: [
             ...("shortname" in params
@@ -103,7 +103,7 @@ export const useUserOrOrg = (
   return useMemo(() => {
     const subgraph = data
       ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
-          data.structuralQueryEntities.subgraph,
+          data.getEntitySubgraph.subgraph,
         )
       : undefined;
 
@@ -136,14 +136,14 @@ export const useUserOrOrg = (
 
     const userOrOrgSubgraph = data
       ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
-          data.structuralQueryEntities.subgraph,
+          data.getEntitySubgraph.subgraph,
         )
       : undefined;
 
     return {
       canUserEdit: !!(
         rootEntity &&
-        data?.structuralQueryEntities.userPermissionsOnEntities?.[
+        data?.getEntitySubgraph.userPermissionsOnEntities?.[
           rootEntity.metadata.recordId.entityId
         ]?.edit
       ),

--- a/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
@@ -6,13 +6,12 @@ use criterion_macro::criterion;
 use graph::{
     store::{
         account::{InsertAccountIdParams, InsertWebIdParams},
-        knowledge::GetEntityParams,
+        knowledge::GetEntitySubgraphParams,
         query::Filter,
         AccountStore, EntityQuerySorting, EntityStore,
     },
     subgraph::{
         edges::{EdgeResolveDepths, GraphResolveDepths, OutgoingEdgeResolveDepth},
-        query::StructuralQuery,
         temporal_axes::{
             PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
             VariableTemporalAxisUnresolved,
@@ -184,20 +183,17 @@ pub fn bench_get_entity_by_id<A: AuthorizationApi>(
         },
         |entity_record_id| async move {
             store
-                .get_entity(
+                .get_entity_subgraph(
                     actor_id,
-                    GetEntityParams {
-                        query: StructuralQuery {
-                            filter: Filter::for_entity_by_entity_id(entity_record_id.entity_id),
-                            graph_resolve_depths,
-                            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                                pinned: PinnedTemporalAxisUnresolved::new(None),
-                                variable: VariableTemporalAxisUnresolved::new(
-                                    Some(TemporalBound::Unbounded),
-                                    None,
-                                ),
-                            },
-                            include_drafts: false,
+                    GetEntitySubgraphParams {
+                        filter: Filter::for_entity_by_entity_id(entity_record_id.entity_id),
+                        graph_resolve_depths,
+                        temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                            pinned: PinnedTemporalAxisUnresolved::new(None),
+                            variable: VariableTemporalAxisUnresolved::new(
+                                Some(TemporalBound::Unbounded),
+                                None,
+                            ),
                         },
                         sorting: EntityQuerySorting {
                             paths: Vec::new(),
@@ -205,6 +201,7 @@ pub fn bench_get_entity_by_id<A: AuthorizationApi>(
                         },
                         limit: None,
                         include_count: false,
+                        include_drafts: false,
                     },
                 )
                 .await

--- a/apps/hash-graph/bench/read_scaling/knowledge/linkless/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/linkless/entity.rs
@@ -6,16 +6,12 @@ use criterion_macro::criterion;
 use graph::{
     store::{
         account::{InsertAccountIdParams, InsertWebIdParams},
-        knowledge::GetEntitySubgraphParams,
+        knowledge::GetEntitiesParams,
         query::Filter,
         AccountStore, EntityQuerySorting, EntityStore,
     },
-    subgraph::{
-        edges::GraphResolveDepths,
-        temporal_axes::{
-            PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
-            VariableTemporalAxisUnresolved,
-        },
+    subgraph::temporal_axes::{
+        PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved, VariableTemporalAxisUnresolved,
     },
 };
 use graph_test_data::{data_type, entity, entity_type, property_type};
@@ -148,11 +144,10 @@ pub fn bench_get_entity_by_id<A: AuthorizationApi>(
         },
         |entity_record_id| async move {
             store
-                .get_entity_subgraph(
+                .get_entities(
                     actor_id,
-                    GetEntitySubgraphParams {
+                    GetEntitiesParams {
                         filter: Filter::for_entity_by_entity_id(entity_record_id.entity_id),
-                        graph_resolve_depths: GraphResolveDepths::default(),
                         temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                             pinned: PinnedTemporalAxisUnresolved::new(None),
                             variable: VariableTemporalAxisUnresolved::new(

--- a/apps/hash-graph/bench/read_scaling/knowledge/linkless/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/linkless/entity.rs
@@ -6,13 +6,12 @@ use criterion_macro::criterion;
 use graph::{
     store::{
         account::{InsertAccountIdParams, InsertWebIdParams},
-        knowledge::GetEntityParams,
+        knowledge::GetEntitySubgraphParams,
         query::Filter,
         AccountStore, EntityQuerySorting, EntityStore,
     },
     subgraph::{
         edges::GraphResolveDepths,
-        query::StructuralQuery,
         temporal_axes::{
             PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
             VariableTemporalAxisUnresolved,
@@ -149,20 +148,17 @@ pub fn bench_get_entity_by_id<A: AuthorizationApi>(
         },
         |entity_record_id| async move {
             store
-                .get_entity(
+                .get_entity_subgraph(
                     actor_id,
-                    GetEntityParams {
-                        query: StructuralQuery {
-                            filter: Filter::for_entity_by_entity_id(entity_record_id.entity_id),
-                            graph_resolve_depths: GraphResolveDepths::default(),
-                            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                                pinned: PinnedTemporalAxisUnresolved::new(None),
-                                variable: VariableTemporalAxisUnresolved::new(
-                                    Some(TemporalBound::Unbounded),
-                                    None,
-                                ),
-                            },
-                            include_drafts: false,
+                    GetEntitySubgraphParams {
+                        filter: Filter::for_entity_by_entity_id(entity_record_id.entity_id),
+                        graph_resolve_depths: GraphResolveDepths::default(),
+                        temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                            pinned: PinnedTemporalAxisUnresolved::new(None),
+                            variable: VariableTemporalAxisUnresolved::new(
+                                Some(TemporalBound::Unbounded),
+                                None,
+                            ),
                         },
                         sorting: EntityQuerySorting {
                             paths: Vec::new(),
@@ -170,6 +166,7 @@ pub fn bench_get_entity_by_id<A: AuthorizationApi>(
                         },
                         limit: None,
                         include_count: false,
+                        include_drafts: false,
                     },
                 )
                 .await

--- a/apps/hash-graph/bench/representative_read/knowledge/entity.rs
+++ b/apps/hash-graph/bench/representative_read/knowledge/entity.rs
@@ -5,13 +5,12 @@ use criterion::{BatchSize::SmallInput, Bencher};
 use graph::{
     knowledge::EntityQueryPath,
     store::{
-        knowledge::GetEntityParams,
+        knowledge::GetEntitySubgraphParams,
         query::{Filter, FilterExpression, JsonPath, Parameter, PathToken},
         EntityQuerySorting, EntityStore,
     },
     subgraph::{
         edges::{EdgeDirection, GraphResolveDepths, KnowledgeGraphEdgeKind},
-        query::StructuralQuery,
         temporal_axes::{
             PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
             VariableTemporalAxisUnresolved,
@@ -42,22 +41,19 @@ pub fn bench_get_entity_by_id<A: AuthorizationApi>(
         },
         |entity_uuid| async move {
             let response = store
-                .get_entity(
+                .get_entity_subgraph(
                     actor_id,
-                    GetEntityParams {
-                        query: StructuralQuery {
-                            filter: Filter::Equal(
-                                Some(FilterExpression::Path(EntityQueryPath::Uuid)),
-                                Some(FilterExpression::Parameter(Parameter::Uuid(
-                                    entity_uuid.into_uuid(),
-                                ))),
-                            ),
-                            graph_resolve_depths: GraphResolveDepths::default(),
-                            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                                pinned: PinnedTemporalAxisUnresolved::new(None),
-                                variable: VariableTemporalAxisUnresolved::new(None, None),
-                            },
-                            include_drafts: false,
+                    GetEntitySubgraphParams {
+                        filter: Filter::Equal(
+                            Some(FilterExpression::Path(EntityQueryPath::Uuid)),
+                            Some(FilterExpression::Parameter(Parameter::Uuid(
+                                entity_uuid.into_uuid(),
+                            ))),
+                        ),
+                        graph_resolve_depths: GraphResolveDepths::default(),
+                        temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                            pinned: PinnedTemporalAxisUnresolved::new(None),
+                            variable: VariableTemporalAxisUnresolved::new(None, None),
                         },
                         sorting: EntityQuerySorting {
                             paths: Vec::new(),
@@ -65,6 +61,7 @@ pub fn bench_get_entity_by_id<A: AuthorizationApi>(
                         },
                         limit: None,
                         include_count: false,
+                        include_drafts: false,
                     },
                 )
                 .await
@@ -97,20 +94,17 @@ pub fn bench_get_entities_by_property<A: AuthorizationApi>(
             .convert_parameters()
             .expect("failed to convert parameters");
         let response = store
-            .get_entity(
+            .get_entity_subgraph(
                 actor_id,
-                GetEntityParams {
-                    query: StructuralQuery {
-                        filter,
-                        graph_resolve_depths,
-                        temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                            pinned: PinnedTemporalAxisUnresolved::new(None),
-                            variable: VariableTemporalAxisUnresolved::new(
-                                Some(TemporalBound::Unbounded),
-                                None,
-                            ),
-                        },
-                        include_drafts: false,
+                GetEntitySubgraphParams {
+                    filter,
+                    graph_resolve_depths,
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(
+                            Some(TemporalBound::Unbounded),
+                            None,
+                        ),
                     },
                     sorting: EntityQuerySorting {
                         paths: Vec::new(),
@@ -118,6 +112,7 @@ pub fn bench_get_entities_by_property<A: AuthorizationApi>(
                     },
                     limit: None,
                     include_count: false,
+                    include_drafts: false,
                 },
             )
             .await
@@ -152,20 +147,17 @@ pub fn bench_get_link_by_target_by_property<A: AuthorizationApi>(
             .convert_parameters()
             .expect("failed to convert parameters");
         let response = store
-            .get_entity(
+            .get_entity_subgraph(
                 actor_id,
-                GetEntityParams {
-                    query: StructuralQuery {
-                        filter,
-                        graph_resolve_depths,
-                        temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                            pinned: PinnedTemporalAxisUnresolved::new(None),
-                            variable: VariableTemporalAxisUnresolved::new(
-                                Some(TemporalBound::Unbounded),
-                                None,
-                            ),
-                        },
-                        include_drafts: false,
+                GetEntitySubgraphParams {
+                    filter,
+                    graph_resolve_depths,
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(
+                            Some(TemporalBound::Unbounded),
+                            None,
+                        ),
                     },
                     sorting: EntityQuerySorting {
                         paths: Vec::new(),
@@ -173,6 +165,7 @@ pub fn bench_get_link_by_target_by_property<A: AuthorizationApi>(
                     },
                     limit: None,
                     include_count: false,
+                    include_drafts: false,
                 },
             )
             .await

--- a/apps/hash-graph/bench/representative_read/knowledge/entity.rs
+++ b/apps/hash-graph/bench/representative_read/knowledge/entity.rs
@@ -5,7 +5,7 @@ use criterion::{BatchSize::SmallInput, Bencher};
 use graph::{
     knowledge::EntityQueryPath,
     store::{
-        knowledge::GetEntitySubgraphParams,
+        knowledge::{GetEntitiesParams, GetEntitySubgraphParams},
         query::{Filter, FilterExpression, JsonPath, Parameter, PathToken},
         EntityQuerySorting, EntityStore,
     },
@@ -41,16 +41,15 @@ pub fn bench_get_entity_by_id<A: AuthorizationApi>(
         },
         |entity_uuid| async move {
             let response = store
-                .get_entity_subgraph(
+                .get_entities(
                     actor_id,
-                    GetEntitySubgraphParams {
+                    GetEntitiesParams {
                         filter: Filter::Equal(
                             Some(FilterExpression::Path(EntityQueryPath::Uuid)),
                             Some(FilterExpression::Parameter(Parameter::Uuid(
                                 entity_uuid.into_uuid(),
                             ))),
                         ),
-                        graph_resolve_depths: GraphResolveDepths::default(),
                         temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                             pinned: PinnedTemporalAxisUnresolved::new(None),
                             variable: VariableTemporalAxisUnresolved::new(None, None),
@@ -66,7 +65,7 @@ pub fn bench_get_entity_by_id<A: AuthorizationApi>(
                 )
                 .await
                 .expect("failed to read entity from store");
-            assert_eq!(response.subgraph.roots.len(), 1);
+            assert_eq!(response.entities.len(), 1);
         },
         SmallInput,
     );

--- a/apps/hash-graph/bench/representative_read/ontology/entity_type.rs
+++ b/apps/hash-graph/bench/representative_read/ontology/entity_type.rs
@@ -1,13 +1,9 @@
 use authorization::AuthorizationApi;
 use criterion::{BatchSize::SmallInput, Bencher};
 use graph::{
-    store::{ontology::GetEntityTypeSubgraphParams, query::Filter, EntityTypeStore},
-    subgraph::{
-        edges::GraphResolveDepths,
-        temporal_axes::{
-            PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
-            VariableTemporalAxisUnresolved,
-        },
+    store::{ontology::GetEntityTypesParams, query::Filter, EntityTypeStore},
+    subgraph::temporal_axes::{
+        PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved, VariableTemporalAxisUnresolved,
     },
 };
 use graph_types::account::AccountId;
@@ -35,11 +31,10 @@ pub fn bench_get_entity_type_by_id<A: AuthorizationApi>(
         },
         |entity_type_id| async move {
             store
-                .get_entity_type_subgraph(
+                .get_entity_types(
                     actor_id,
-                    GetEntityTypeSubgraphParams {
+                    GetEntityTypesParams {
                         filter: Filter::for_versioned_url(entity_type_id),
-                        graph_resolve_depths: GraphResolveDepths::default(),
                         temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                             pinned: PinnedTemporalAxisUnresolved::new(None),
                             variable: VariableTemporalAxisUnresolved::new(

--- a/apps/hash-graph/bench/representative_read/ontology/entity_type.rs
+++ b/apps/hash-graph/bench/representative_read/ontology/entity_type.rs
@@ -1,10 +1,9 @@
 use authorization::AuthorizationApi;
 use criterion::{BatchSize::SmallInput, Bencher};
 use graph::{
-    store::{ontology::GetEntityTypesParams, query::Filter, EntityTypeStore},
+    store::{ontology::GetEntityTypeSubgraphParams, query::Filter, EntityTypeStore},
     subgraph::{
         edges::GraphResolveDepths,
-        query::StructuralQuery,
         temporal_axes::{
             PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
             VariableTemporalAxisUnresolved,
@@ -36,23 +35,21 @@ pub fn bench_get_entity_type_by_id<A: AuthorizationApi>(
         },
         |entity_type_id| async move {
             store
-                .get_entity_type(
+                .get_entity_type_subgraph(
                     actor_id,
-                    GetEntityTypesParams {
-                        query: StructuralQuery {
-                            filter: Filter::for_versioned_url(entity_type_id),
-                            graph_resolve_depths: GraphResolveDepths::default(),
-                            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                                pinned: PinnedTemporalAxisUnresolved::new(None),
-                                variable: VariableTemporalAxisUnresolved::new(
-                                    Some(TemporalBound::Unbounded),
-                                    None,
-                                ),
-                            },
-                            include_drafts: false,
+                    GetEntityTypeSubgraphParams {
+                        filter: Filter::for_versioned_url(entity_type_id),
+                        graph_resolve_depths: GraphResolveDepths::default(),
+                        temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                            pinned: PinnedTemporalAxisUnresolved::new(None),
+                            variable: VariableTemporalAxisUnresolved::new(
+                                Some(TemporalBound::Unbounded),
+                                None,
+                            ),
                         },
                         after: None,
                         limit: None,
+                        include_drafts: false,
                     },
                 )
                 .await

--- a/apps/hash-graph/libs/api/src/rest/data_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/data_type.rs
@@ -29,15 +29,16 @@ use graph::{
     store::{
         error::VersionedUrlAlreadyExists,
         ontology::{
-            ArchiveDataTypeParams, CreateDataTypeParams, GetDataTypesParams,
+            ArchiveDataTypeParams, CreateDataTypeParams, GetDataTypeSubgraphParams,
             UnarchiveDataTypeParams, UpdateDataTypeEmbeddingParams, UpdateDataTypesParams,
         },
+        query::Filter,
         BaseUrlAlreadyExists, ConflictBehavior, DataTypeStore, OntologyVersionDoesNotExist,
         StorePool,
     },
     subgraph::{
-        identifier::DataTypeVertexId,
-        query::{DataTypeStructuralQuery, StructuralQuery},
+        edges::GraphResolveDepths, identifier::DataTypeVertexId,
+        temporal_axes::QueryTemporalAxesUnresolved,
     },
 };
 use graph_types::{
@@ -75,7 +76,7 @@ use crate::rest::{
 
         create_data_type,
         load_external_data_type,
-        get_data_types_by_query,
+        get_data_type_subgraph,
         update_data_type,
         update_data_type_embeddings,
         archive_data_type,
@@ -96,7 +97,8 @@ use crate::rest::{
             UpdateDataTypeRequest,
             UpdateDataTypeEmbeddingParams,
             DataTypeQueryToken,
-            DataTypeStructuralQuery,
+            GetDataTypeSubgraphRequest,
+            GetDataTypeSubgraphResponse,
             ArchiveDataTypeParams,
             UnarchiveDataTypeParams,
         )
@@ -139,7 +141,7 @@ impl RoutedResource for DataTypeResource {
                             get(check_data_type_permission::<A>),
                         ),
                 )
-                .route("/query", post(get_data_types_by_query::<S, A>))
+                .route("/query", post(get_data_type_subgraph::<S, A>))
                 .route("/load", post(load_external_data_type::<S, A>))
                 .route("/archive", put(archive_data_type::<S, A>))
                 .route("/unarchive", put(unarchive_data_type::<S, A>))
@@ -371,10 +373,26 @@ where
     }
 }
 
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct GetDataTypeSubgraphRequest<'q> {
+    #[serde(borrow)]
+    filter: Filter<'q, DataTypeWithMetadata>,
+    graph_resolve_depths: GraphResolveDepths,
+    temporal_axes: QueryTemporalAxesUnresolved,
+    include_drafts: bool,
+}
+
+#[derive(Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct GetDataTypeSubgraphResponse {
+    subgraph: Subgraph,
+}
+
 #[utoipa::path(
     post,
     path = "/data-types/query",
-    request_body = DataTypeStructuralQuery,
+    request_body = GetDataTypeSubgraphRequest,
     tag = "DataType",
     params(
         ("X-Authenticated-User-Actor-Id" = AccountId, Header, description = "The ID of the actor which is used to authorize the request"),
@@ -383,7 +401,7 @@ where
         (
             status = 200,
             content_type = "application/json",
-            body = Subgraph,
+            body = GetDataTypeSubgraphResponse,
             description = "Gets a subgraph rooted at all data types that satisfy the given query, each resolved to the requested depth.",
             headers(
                 ("Link" = String, description = "The link to be used to query the next page of data types"),
@@ -394,16 +412,16 @@ where
         (status = 500, description = "Store error occurred"),
     )
 )]
-#[tracing::instrument(level = "info", skip(store_pool, authorization_api_pool, query))]
-async fn get_data_types_by_query<S, A>(
+#[tracing::instrument(level = "info", skip(store_pool, authorization_api_pool, request))]
+async fn get_data_type_subgraph<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
     authorization_api_pool: Extension<Arc<A>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Query(pagination): Query<Pagination<DataTypeVertexId>>,
     OriginalUri(uri): OriginalUri,
-    Json(query): Json<serde_json::Value>,
-) -> Result<(HeaderMap, Json<Subgraph>), Response>
+    Json(request): Json<serde_json::Value>,
+) -> Result<(HeaderMap, Json<GetDataTypeSubgraphResponse>), Response>
 where
     S: StorePool + Send + Sync,
     A: AuthorizationApiPool + Send + Sync,
@@ -420,29 +438,38 @@ where
 
     // Manually deserialize the query from a JSON value to allow borrowed deserialization and better
     // error reporting.
-    let mut query = StructuralQuery::deserialize(&query).map_err(report_to_response)?;
-    query
+    let mut request =
+        GetDataTypeSubgraphRequest::deserialize(&request).map_err(report_to_response)?;
+    request
         .filter
         .convert_parameters()
         .map_err(report_to_response)?;
-    let subgraph = store
-        .get_data_type(
+    let response = store
+        .get_data_type_subgraph(
             actor_id,
-            GetDataTypesParams {
-                query,
+            GetDataTypeSubgraphParams {
+                filter: request.filter,
+                graph_resolve_depths: request.graph_resolve_depths,
                 after: pagination.after.map(|cursor| cursor.0),
                 limit: pagination.limit,
+                temporal_axes: request.temporal_axes,
+                include_drafts: request.include_drafts,
             },
         )
         .await
         .map_err(report_to_response)?;
 
-    let cursor = subgraph.roots.iter().last().map(Cursor);
+    let cursor = response.subgraph.roots.iter().last().map(Cursor);
     let mut headers = HeaderMap::new();
     if let (Some(cursor), Some(limit)) = (cursor, pagination.limit) {
         headers.insert(LINK, cursor.link_header("next", uri, limit)?);
     }
-    Ok((headers, Json(Subgraph::from(subgraph))))
+    Ok((
+        headers,
+        Json(GetDataTypeSubgraphResponse {
+            subgraph: Subgraph::from(response.subgraph),
+        }),
+    ))
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]

--- a/apps/hash-graph/libs/api/src/rest/entity_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity_type.rs
@@ -30,14 +30,15 @@ use graph::{
     store::{
         error::{BaseUrlAlreadyExists, OntologyVersionDoesNotExist, VersionedUrlAlreadyExists},
         ontology::{
-            ArchiveEntityTypeParams, CreateEntityTypeParams, GetEntityTypesParams,
+            ArchiveEntityTypeParams, CreateEntityTypeParams, GetEntityTypeSubgraphParams,
             UnarchiveEntityTypeParams, UpdateEntityTypeEmbeddingParams, UpdateEntityTypesParams,
         },
+        query::Filter,
         ConflictBehavior, EntityTypeStore, StorePool,
     },
     subgraph::{
-        identifier::EntityTypeVertexId,
-        query::{EntityTypeStructuralQuery, StructuralQuery},
+        edges::GraphResolveDepths, identifier::EntityTypeVertexId,
+        temporal_axes::QueryTemporalAxesUnresolved,
     },
 };
 use graph_types::{
@@ -78,7 +79,7 @@ use crate::{
 
         create_entity_type,
         load_external_entity_type,
-        get_entity_types_by_query,
+        get_entity_type_subgraph,
         update_entity_type,
         update_entity_type_embeddings,
         archive_entity_type,
@@ -104,7 +105,8 @@ use crate::{
             UpdateEntityTypeRequest,
             UpdateEntityTypeEmbeddingParams,
             EntityTypeQueryToken,
-            EntityTypeStructuralQuery,
+            GetEntityTypeSubgraphRequest,
+            GetEntityTypeSubgraphResponse,
             ArchiveEntityTypeParams,
             UnarchiveEntityTypeParams,
         )
@@ -147,7 +149,7 @@ impl RoutedResource for EntityTypeResource {
                             get(check_entity_type_permission::<A>),
                         ),
                 )
-                .route("/query", post(get_entity_types_by_query::<S, A>))
+                .route("/query", post(get_entity_type_subgraph::<S, A>))
                 .route("/load", post(load_external_entity_type::<S, A>))
                 .route("/archive", put(archive_entity_type::<S, A>))
                 .route("/unarchive", put(unarchive_entity_type::<S, A>))
@@ -676,10 +678,26 @@ where
     }
 }
 
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct GetEntityTypeSubgraphRequest<'q> {
+    #[serde(borrow)]
+    filter: Filter<'q, EntityTypeWithMetadata>,
+    graph_resolve_depths: GraphResolveDepths,
+    temporal_axes: QueryTemporalAxesUnresolved,
+    include_drafts: bool,
+}
+
+#[derive(Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct GetEntityTypeSubgraphResponse {
+    subgraph: Subgraph,
+}
+
 #[utoipa::path(
     post,
     path = "/entity-types/query",
-    request_body = EntityTypeStructuralQuery,
+    request_body = GetEntityTypeSubgraphRequest,
     tag = "EntityType",
     params(
         ("X-Authenticated-User-Actor-Id" = AccountId, Header, description = "The ID of the actor which is used to authorize the request"),
@@ -688,7 +706,7 @@ where
         (
             status = 200,
             content_type = "application/json",
-            body = Subgraph,
+            body = GetEntityTypeSubgraphResponse,
             description = "A subgraph rooted at entity types that satisfy the given query, each resolved to the requested depth.",
             headers(
                 ("Link" = String, description = "The link to be used to query the next page of entity types"),
@@ -698,16 +716,16 @@ where
         (status = 500, description = "Store error occurred"),
     )
 )]
-#[tracing::instrument(level = "info", skip(store_pool, authorization_api_pool, query))]
-async fn get_entity_types_by_query<S, A>(
+#[tracing::instrument(level = "info", skip(store_pool, authorization_api_pool, request))]
+async fn get_entity_type_subgraph<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
     authorization_api_pool: Extension<Arc<A>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Query(pagination): Query<Pagination<EntityTypeVertexId>>,
     OriginalUri(uri): OriginalUri,
-    Json(query): Json<serde_json::Value>,
-) -> Result<(HeaderMap, Json<Subgraph>), Response>
+    Json(request): Json<serde_json::Value>,
+) -> Result<(HeaderMap, Json<GetEntityTypeSubgraphResponse>), Response>
 where
     S: StorePool + Send + Sync,
     A: AuthorizationApiPool + Send + Sync,
@@ -722,30 +740,39 @@ where
         .await
         .map_err(report_to_response)?;
 
-    let mut query = StructuralQuery::deserialize(&query).map_err(report_to_response)?;
-    query
+    let mut request =
+        GetEntityTypeSubgraphRequest::deserialize(&request).map_err(report_to_response)?;
+    request
         .filter
         .convert_parameters()
         .map_err(report_to_response)?;
 
-    let subgraph = store
-        .get_entity_type(
+    let response = store
+        .get_entity_type_subgraph(
             actor_id,
-            GetEntityTypesParams {
-                query,
+            GetEntityTypeSubgraphParams {
+                filter: request.filter,
+                graph_resolve_depths: request.graph_resolve_depths,
                 after: pagination.after.map(|cursor| cursor.0),
                 limit: pagination.limit,
+                temporal_axes: request.temporal_axes,
+                include_drafts: request.include_drafts,
             },
         )
         .await
         .map_err(report_to_response)?;
 
-    let cursor = subgraph.roots.iter().last().map(Cursor);
+    let cursor = response.subgraph.roots.iter().last().map(Cursor);
     let mut headers = HeaderMap::new();
     if let (Some(cursor), Some(limit)) = (cursor, pagination.limit) {
         headers.insert(LINK, cursor.link_header("next", uri, limit)?);
     }
-    Ok((headers, Json(Subgraph::from(subgraph))))
+    Ok((
+        headers,
+        Json(GetEntityTypeSubgraphResponse {
+            subgraph: Subgraph::from(response.subgraph),
+        }),
+    ))
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]

--- a/apps/hash-graph/libs/graph/src/knowledge/query.rs
+++ b/apps/hash-graph/libs/graph/src/knowledge/query.rs
@@ -82,20 +82,18 @@ pub enum EntityQueryPath<'p> {
     /// The decision time axis of the [`EntityTemporalMetadata`] belonging to the [`Entity`].
     ///
     /// It's not possible to query for the temporal axis directly, this has to be done via the
-    /// `temporalAxes` parameter on [`StructuralQuery`]. The decision time is returned as part of
+    /// `temporalAxes` parameter on the request. The decision time is returned as part of
     /// [`EntityTemporalMetadata`] of the [`EntityMetadata`].
     ///
-    /// [`StructuralQuery`]: crate::subgraph::query::StructuralQuery
     /// [`EntityMetadata`]: graph_types::knowledge::entity::EntityMetadata
     /// [`EntityTemporalMetadata`]: graph_types::knowledge::entity::EntityTemporalMetadata
     DecisionTime,
     /// The transaction time axis of the [`EntityTemporalMetadata`] belonging to the [`Entity`].
     ///
     /// It's not possible to query for the temporal axis directly, this has to be done via the
-    /// `temporalAxes` parameter on [`StructuralQuery`]. The transaction time is returned as part
+    /// `temporalAxes` parameter on the request. The transaction time is returned as part
     /// of [`EntityTemporalMetadata`] of the [`EntityMetadata`].
     ///
-    /// [`StructuralQuery`]: crate::subgraph::query::StructuralQuery
     /// [`EntityMetadata`]: graph_types::knowledge::entity::EntityMetadata
     /// [`EntityTemporalMetadata`]: graph_types::knowledge::entity::EntityTemporalMetadata
     TransactionTime,

--- a/apps/hash-graph/libs/graph/src/ontology/data_type.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/data_type.rs
@@ -88,10 +88,9 @@ pub enum DataTypeQueryPath<'p> {
     /// The transaction time of the [`DataType`].
     ///
     /// It's not possible to query for the temporal axis directly, this has to be done via the
-    /// `temporalAxes` parameter on [`StructuralQuery`].
+    /// `temporalAxes` parameter on the request.
     ///
     /// [`DataType`]: type_system::DataType
-    /// [`StructuralQuery`]: crate::subgraph::query::StructuralQuery
     TransactionTime,
     /// The [`OwnedById`] of the [`DataTypeMetadata`] belonging to the [`DataType`].
     ///

--- a/apps/hash-graph/libs/graph/src/ontology/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/entity_type.rs
@@ -88,10 +88,9 @@ pub enum EntityTypeQueryPath<'p> {
     /// The transaction time of the [`EntityType`].
     ///
     /// It's not possible to query for the temporal axis directly, this has to be done via the
-    /// `temporalAxes` parameter on [`StructuralQuery`].
+    /// `temporalAxes` parameter on the request.
     ///
     /// [`EntityType`]: type_system::EntityType
-    /// [`StructuralQuery`]: crate::subgraph::query::StructuralQuery
     TransactionTime,
     /// The [`OwnedById`] of the [`EntityTypeMetadata`] belonging to the [`EntityType`].
     ///

--- a/apps/hash-graph/libs/graph/src/ontology/property_type.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/property_type.rs
@@ -68,10 +68,9 @@ pub enum PropertyTypeQueryPath<'p> {
     /// The transaction time of the [`PropertyType`].
     ///
     /// It's not possible to query for the temporal axis directly, this has to be done via the
-    /// `temporalAxes` parameter on [`StructuralQuery`].
+    /// `temporalAxes` parameter on the request.
     ///
     /// [`PropertyType`]: type_system::PropertyType
-    /// [`StructuralQuery`]: crate::subgraph::query::StructuralQuery
     TransactionTime,
     /// The [`OwnedById`] of the [`PropertyTypeMetadata`] belonging to the [`PropertyType`].
     ///

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -47,24 +47,22 @@ use crate::{
         ontology::{
             ArchiveDataTypeParams, ArchiveEntityTypeParams, ArchivePropertyTypeParams,
             CreateDataTypeParams, CreateEntityTypeParams, CreatePropertyTypeParams,
-            GetDataTypeSubgraphParams, GetDataTypeSubgraphResponse, GetEntityTypeSubgraphParams,
-            GetEntityTypeSubgraphResponse, GetPropertyTypeSubgraphParams,
-            GetPropertyTypeSubgraphResponse, UnarchiveDataTypeParams, UnarchiveEntityTypeParams,
-            UnarchivePropertyTypeParams, UpdateDataTypeEmbeddingParams, UpdateDataTypesParams,
-            UpdateEntityTypeEmbeddingParams, UpdateEntityTypesParams,
-            UpdatePropertyTypeEmbeddingParams, UpdatePropertyTypesParams,
+            GetDataTypeSubgraphParams, GetDataTypeSubgraphResponse, GetDataTypesParams,
+            GetDataTypesResponse, GetEntityTypeSubgraphParams, GetEntityTypeSubgraphResponse,
+            GetEntityTypesParams, GetEntityTypesResponse, GetPropertyTypeSubgraphParams,
+            GetPropertyTypeSubgraphResponse, GetPropertyTypesParams, GetPropertyTypesResponse,
+            UnarchiveDataTypeParams, UnarchiveEntityTypeParams, UnarchivePropertyTypeParams,
+            UpdateDataTypeEmbeddingParams, UpdateDataTypesParams, UpdateEntityTypeEmbeddingParams,
+            UpdateEntityTypesParams, UpdatePropertyTypeEmbeddingParams, UpdatePropertyTypesParams,
         },
         query::Filter,
         AccountStore, ConflictBehavior, DataTypeStore, EntityStore, EntityTypeStore,
         InsertionError, PropertyTypeStore, QueryError, QueryRecord, StoreError, StorePool,
         UpdateError,
     },
-    subgraph::{
-        edges::GraphResolveDepths,
-        temporal_axes::{
-            PinnedTemporalAxisUnresolved, QueryTemporalAxes, QueryTemporalAxesUnresolved,
-            VariableTemporalAxisUnresolved,
-        },
+    subgraph::temporal_axes::{
+        PinnedTemporalAxisUnresolved, QueryTemporalAxes, QueryTemporalAxesUnresolved,
+        VariableTemporalAxisUnresolved,
     },
 };
 
@@ -259,11 +257,10 @@ where
         match ontology_type_reference {
             OntologyTypeReference::DataTypeReference(_) => self
                 .store
-                .get_data_type_subgraph(
+                .get_data_types(
                     actor_id,
-                    GetDataTypeSubgraphParams {
+                    GetDataTypesParams {
                         filter: Filter::for_versioned_url(url),
-                        graph_resolve_depths: GraphResolveDepths::default(),
                         temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                             pinned: PinnedTemporalAxisUnresolved::new(None),
                             variable: VariableTemporalAxisUnresolved::new(None, None),
@@ -274,14 +271,13 @@ where
                     },
                 )
                 .await
-                .map(|response| !response.subgraph.roots.is_empty()),
+                .map(|response| !response.data_types.is_empty()),
             OntologyTypeReference::PropertyTypeReference(_) => self
                 .store
-                .get_property_type_subgraph(
+                .get_property_types(
                     actor_id,
-                    GetPropertyTypeSubgraphParams {
+                    GetPropertyTypesParams {
                         filter: Filter::for_versioned_url(url),
-                        graph_resolve_depths: GraphResolveDepths::default(),
                         temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                             pinned: PinnedTemporalAxisUnresolved::new(None),
                             variable: VariableTemporalAxisUnresolved::new(None, None),
@@ -292,14 +288,13 @@ where
                     },
                 )
                 .await
-                .map(|response| !response.subgraph.roots.is_empty()),
+                .map(|response| !response.property_types.is_empty()),
             OntologyTypeReference::EntityTypeReference(_) => self
                 .store
-                .get_entity_type_subgraph(
+                .get_entity_types(
                     actor_id,
-                    GetEntityTypeSubgraphParams {
+                    GetEntityTypesParams {
                         filter: Filter::for_versioned_url(url),
-                        graph_resolve_depths: GraphResolveDepths::default(),
                         temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                             pinned: PinnedTemporalAxisUnresolved::new(None),
                             variable: VariableTemporalAxisUnresolved::new(None, None),
@@ -310,7 +305,7 @@ where
                     },
                 )
                 .await
-                .map(|response| !response.subgraph.roots.is_empty()),
+                .map(|response| !response.entity_types.is_empty()),
         }
         .change_context(StoreError)
         .attach_printable("Could not check if ontology type exists")
@@ -848,6 +843,14 @@ where
             .await
     }
 
+    async fn get_data_types(
+        &self,
+        actor_id: AccountId,
+        params: GetDataTypesParams<'_>,
+    ) -> Result<GetDataTypesResponse, QueryError> {
+        self.store.get_data_types(actor_id, params).await
+    }
+
     async fn get_data_type_subgraph(
         &self,
         actor_id: AccountId,
@@ -945,6 +948,14 @@ where
         self.store
             .create_property_types(actor_id, creation_parameters)
             .await
+    }
+
+    async fn get_property_types(
+        &self,
+        actor_id: AccountId,
+        params: GetPropertyTypesParams<'_>,
+    ) -> Result<GetPropertyTypesResponse, QueryError> {
+        self.store.get_property_types(actor_id, params).await
     }
 
     async fn get_property_type_subgraph(
@@ -1046,6 +1057,14 @@ where
         self.store
             .create_entity_types(actor_id, creation_parameters)
             .await
+    }
+
+    async fn get_entity_types(
+        &self,
+        actor_id: AccountId,
+        params: GetEntityTypesParams<'_>,
+    ) -> Result<GetEntityTypesResponse, QueryError> {
+        self.store.get_entity_types(actor_id, params).await
     }
 
     async fn get_entity_type_subgraph(

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -32,10 +32,7 @@ use temporal_versioning::{DecisionTime, Timestamp, TransactionTime};
 use tokio::net::ToSocketAddrs;
 use tokio_serde::formats::Json;
 use type_fetcher::fetcher::{FetchedOntologyType, FetcherClient};
-use type_system::{
-    url::{BaseUrl, OntologyTypeVersion, VersionedUrl},
-    DataType, EntityType, EntityTypeReference, PropertyType,
-};
+use type_system::{url::VersionedUrl, DataType, EntityType, EntityTypeReference, PropertyType};
 
 use crate::{
     ontology::domain_validator::DomainValidator,
@@ -43,31 +40,31 @@ use crate::{
         account::{InsertAccountGroupIdParams, InsertAccountIdParams, InsertWebIdParams},
         crud::{QueryResult, Read, ReadPaginated, Sorting},
         knowledge::{
-            CreateEntityParams, GetEntityParams, GetEntityResponse, PatchEntityParams,
-            UpdateEntityEmbeddingsParams, ValidateEntityError, ValidateEntityParams,
+            CountEntitiesParams, CreateEntityParams, GetEntitySubgraphParams,
+            GetEntitySubgraphResponse, PatchEntityParams, UpdateEntityEmbeddingsParams,
+            ValidateEntityError, ValidateEntityParams,
         },
         ontology::{
             ArchiveDataTypeParams, ArchiveEntityTypeParams, ArchivePropertyTypeParams,
             CreateDataTypeParams, CreateEntityTypeParams, CreatePropertyTypeParams,
-            GetDataTypesParams, GetEntityTypesParams, GetPropertyTypesParams,
-            UnarchiveDataTypeParams, UnarchiveEntityTypeParams, UnarchivePropertyTypeParams,
-            UpdateDataTypeEmbeddingParams, UpdateDataTypesParams, UpdateEntityTypeEmbeddingParams,
-            UpdateEntityTypesParams, UpdatePropertyTypeEmbeddingParams, UpdatePropertyTypesParams,
+            GetDataTypeSubgraphParams, GetDataTypeSubgraphResponse, GetEntityTypeSubgraphParams,
+            GetEntityTypeSubgraphResponse, GetPropertyTypeSubgraphParams,
+            GetPropertyTypeSubgraphResponse, UnarchiveDataTypeParams, UnarchiveEntityTypeParams,
+            UnarchivePropertyTypeParams, UpdateDataTypeEmbeddingParams, UpdateDataTypesParams,
+            UpdateEntityTypeEmbeddingParams, UpdateEntityTypesParams,
+            UpdatePropertyTypeEmbeddingParams, UpdatePropertyTypesParams,
         },
-        query::{Filter, OntologyQueryPath},
+        query::Filter,
         AccountStore, ConflictBehavior, DataTypeStore, EntityStore, EntityTypeStore,
         InsertionError, PropertyTypeStore, QueryError, QueryRecord, StoreError, StorePool,
-        SubgraphRecord, UpdateError,
+        UpdateError,
     },
     subgraph::{
         edges::GraphResolveDepths,
-        identifier::VertexId,
-        query::{EntityStructuralQuery, StructuralQuery},
         temporal_axes::{
             PinnedTemporalAxisUnresolved, QueryTemporalAxes, QueryTemporalAxesUnresolved,
             VariableTemporalAxisUnresolved,
         },
-        Subgraph,
     },
 };
 
@@ -242,22 +239,6 @@ where
         actor_id: AccountId,
         ontology_type_reference: OntologyTypeReference<'_>,
     ) -> Result<bool, StoreError> {
-        fn create_query<'u, T>(versioned_url: &'u VersionedUrl) -> StructuralQuery<'u, T>
-        where
-            T: SubgraphRecord<QueryPath<'u>: OntologyQueryPath>,
-            T::VertexId: VertexId<BaseId = BaseUrl, RevisionId = OntologyTypeVersion>,
-        {
-            StructuralQuery {
-                filter: Filter::for_versioned_url(versioned_url),
-                graph_resolve_depths: GraphResolveDepths::default(),
-                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                    pinned: PinnedTemporalAxisUnresolved::new(None),
-                    variable: VariableTemporalAxisUnresolved::new(None, None),
-                },
-                include_drafts: true,
-            }
-        }
-
         let url = match ontology_type_reference {
             OntologyTypeReference::DataTypeReference(reference) => reference.url(),
             OntologyTypeReference::PropertyTypeReference(reference) => reference.url(),
@@ -276,46 +257,63 @@ where
         }
 
         match ontology_type_reference {
-            OntologyTypeReference::DataTypeReference(_) => {
-                self.store
-                    .get_data_type(
-                        actor_id,
-                        GetDataTypesParams {
-                            query: create_query(url),
-                            after: None,
-                            limit: None,
+            OntologyTypeReference::DataTypeReference(_) => self
+                .store
+                .get_data_type_subgraph(
+                    actor_id,
+                    GetDataTypeSubgraphParams {
+                        filter: Filter::for_versioned_url(url),
+                        graph_resolve_depths: GraphResolveDepths::default(),
+                        temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                            pinned: PinnedTemporalAxisUnresolved::new(None),
+                            variable: VariableTemporalAxisUnresolved::new(None, None),
                         },
-                    )
-                    .await
-            }
-            OntologyTypeReference::PropertyTypeReference(_) => {
-                self.store
-                    .get_property_type(
-                        actor_id,
-                        GetPropertyTypesParams {
-                            query: create_query(url),
-                            after: None,
-                            limit: None,
+                        after: None,
+                        limit: None,
+                        include_drafts: true,
+                    },
+                )
+                .await
+                .map(|response| !response.subgraph.roots.is_empty()),
+            OntologyTypeReference::PropertyTypeReference(_) => self
+                .store
+                .get_property_type_subgraph(
+                    actor_id,
+                    GetPropertyTypeSubgraphParams {
+                        filter: Filter::for_versioned_url(url),
+                        graph_resolve_depths: GraphResolveDepths::default(),
+                        temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                            pinned: PinnedTemporalAxisUnresolved::new(None),
+                            variable: VariableTemporalAxisUnresolved::new(None, None),
                         },
-                    )
-                    .await
-            }
-            OntologyTypeReference::EntityTypeReference(_) => {
-                self.store
-                    .get_entity_type(
-                        actor_id,
-                        GetEntityTypesParams {
-                            query: create_query(url),
-                            after: None,
-                            limit: None,
+                        after: None,
+                        limit: None,
+                        include_drafts: true,
+                    },
+                )
+                .await
+                .map(|response| !response.subgraph.roots.is_empty()),
+            OntologyTypeReference::EntityTypeReference(_) => self
+                .store
+                .get_entity_type_subgraph(
+                    actor_id,
+                    GetEntityTypeSubgraphParams {
+                        filter: Filter::for_versioned_url(url),
+                        graph_resolve_depths: GraphResolveDepths::default(),
+                        temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                            pinned: PinnedTemporalAxisUnresolved::new(None),
+                            variable: VariableTemporalAxisUnresolved::new(None, None),
                         },
-                    )
-                    .await
-            }
+                        after: None,
+                        limit: None,
+                        include_drafts: true,
+                    },
+                )
+                .await
+                .map(|response| !response.subgraph.roots.is_empty()),
         }
         .change_context(StoreError)
         .attach_printable("Could not check if ontology type exists")
-        .map(|subgraph| !subgraph.roots.is_empty())
     }
 
     #[tracing::instrument(level = "trace", skip(self, ontology_type))]
@@ -850,12 +848,12 @@ where
             .await
     }
 
-    async fn get_data_type(
+    async fn get_data_type_subgraph(
         &self,
         actor_id: AccountId,
-        params: GetDataTypesParams<'_>,
-    ) -> Result<Subgraph, QueryError> {
-        self.store.get_data_type(actor_id, params).await
+        params: GetDataTypeSubgraphParams<'_>,
+    ) -> Result<GetDataTypeSubgraphResponse, QueryError> {
+        self.store.get_data_type_subgraph(actor_id, params).await
     }
 
     async fn update_data_type<R>(
@@ -949,12 +947,14 @@ where
             .await
     }
 
-    async fn get_property_type(
+    async fn get_property_type_subgraph(
         &self,
         actor_id: AccountId,
-        params: GetPropertyTypesParams<'_>,
-    ) -> Result<Subgraph, QueryError> {
-        self.store.get_property_type(actor_id, params).await
+        params: GetPropertyTypeSubgraphParams<'_>,
+    ) -> Result<GetPropertyTypeSubgraphResponse, QueryError> {
+        self.store
+            .get_property_type_subgraph(actor_id, params)
+            .await
     }
 
     async fn update_property_type<R>(
@@ -1048,12 +1048,12 @@ where
             .await
     }
 
-    async fn get_entity_type(
+    async fn get_entity_type_subgraph(
         &self,
         actor_id: AccountId,
-        params: GetEntityTypesParams<'_>,
-    ) -> Result<Subgraph, QueryError> {
-        self.store.get_entity_type(actor_id, params).await
+        params: GetEntityTypeSubgraphParams<'_>,
+    ) -> Result<GetEntityTypeSubgraphResponse, QueryError> {
+        self.store.get_entity_type_subgraph(actor_id, params).await
     }
 
     async fn update_entity_type<R>(
@@ -1175,12 +1175,12 @@ where
             .await
     }
 
-    async fn get_entity(
+    async fn get_entity_subgraph(
         &self,
         actor_id: AccountId,
-        params: GetEntityParams<'_>,
-    ) -> Result<GetEntityResponse<'static>, QueryError> {
-        self.store.get_entity(actor_id, params).await
+        params: GetEntitySubgraphParams<'_>,
+    ) -> Result<GetEntitySubgraphResponse<'static>, QueryError> {
+        self.store.get_entity_subgraph(actor_id, params).await
     }
 
     async fn get_entity_by_id(
@@ -1198,9 +1198,9 @@ where
     async fn count_entities(
         &self,
         actor_id: AccountId,
-        query: EntityStructuralQuery<'_>,
+        params: CountEntitiesParams<'_>,
     ) -> Result<usize, QueryError> {
-        self.store.count_entities(actor_id, query).await
+        self.store.count_entities(actor_id, params).await
     }
 
     async fn patch_entity(

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -40,9 +40,9 @@ use crate::{
         account::{InsertAccountGroupIdParams, InsertAccountIdParams, InsertWebIdParams},
         crud::{QueryResult, Read, ReadPaginated, Sorting},
         knowledge::{
-            CountEntitiesParams, CreateEntityParams, GetEntitySubgraphParams,
-            GetEntitySubgraphResponse, PatchEntityParams, UpdateEntityEmbeddingsParams,
-            ValidateEntityError, ValidateEntityParams,
+            CountEntitiesParams, CreateEntityParams, GetEntitiesParams, GetEntitiesResponse,
+            GetEntitySubgraphParams, GetEntitySubgraphResponse, PatchEntityParams,
+            UpdateEntityEmbeddingsParams, ValidateEntityError, ValidateEntityParams,
         },
         ontology::{
             ArchiveDataTypeParams, ArchiveEntityTypeParams, ArchivePropertyTypeParams,
@@ -1173,6 +1173,14 @@ where
         self.store
             .insert_entities_batched_by_type(actor_id, entities, entity_type_id)
             .await
+    }
+
+    async fn get_entities(
+        &self,
+        actor_id: AccountId,
+        params: GetEntitiesParams<'_>,
+    ) -> Result<GetEntitiesResponse<'static>, QueryError> {
+        self.store.get_entities(actor_id, params).await
     }
 
     async fn get_entity_subgraph(

--- a/apps/hash-graph/libs/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/libs/graph/src/store/knowledge.rs
@@ -29,10 +29,10 @@ use validation::ValidateEntityComponents;
 use crate::{
     knowledge::EntityQueryPath,
     store::{
-        crud::Sorting, postgres::CursorField, InsertionError, NullOrdering, Ordering, QueryError,
-        UpdateError,
+        crud::Sorting, postgres::CursorField, query::Filter, InsertionError, NullOrdering,
+        Ordering, QueryError, UpdateError,
     },
-    subgraph::{query::EntityStructuralQuery, Subgraph},
+    subgraph::{edges::GraphResolveDepths, temporal_axes::QueryTemporalAxesUnresolved, Subgraph},
 };
 
 #[derive(Debug, Clone, Deserialize)]
@@ -221,21 +221,34 @@ pub struct ValidateEntityParams<'a> {
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct GetEntityParams<'a> {
+pub struct GetEntitySubgraphParams<'a> {
     #[serde(borrow)]
-    pub query: EntityStructuralQuery<'a>,
+    pub filter: Filter<'a, Entity>,
+    pub temporal_axes: QueryTemporalAxesUnresolved,
+    pub graph_resolve_depths: GraphResolveDepths,
     #[serde(borrow)]
     pub sorting: EntityQuerySorting<'static>,
     pub limit: Option<usize>,
+    pub include_drafts: bool,
     #[serde(default)]
     pub include_count: bool,
 }
 
 #[derive(Debug)]
-pub struct GetEntityResponse<'r> {
+pub struct GetEntitySubgraphResponse<'r> {
     pub subgraph: Subgraph,
     pub cursor: Option<EntityQueryCursor<'r>>,
     pub count: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CountEntitiesParams<'a> {
+    #[serde(borrow)]
+    pub filter: Filter<'a, Entity>,
+    pub temporal_axes: QueryTemporalAxesUnresolved,
+    pub include_drafts: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -366,18 +379,16 @@ pub trait EntityStore {
         entity_type_id: &VersionedUrl,
     ) -> impl Future<Output = Result<Vec<EntityMetadata>, Report<InsertionError>>> + Send;
 
-    /// Get the [`Subgraph`]s specified by the [`StructuralQuery`].
+    /// Get the [`Subgraph`]s specified by the [`GetEntitySubgraphParams`].
     ///
     /// # Errors
     ///
     /// - if the requested [`Entity`] doesn't exist
-    ///
-    /// [`StructuralQuery`]: crate::subgraph::query::StructuralQuery
-    fn get_entity(
+    fn get_entity_subgraph(
         &self,
         actor_id: AccountId,
-        params: GetEntityParams<'_>,
-    ) -> impl Future<Output = Result<GetEntityResponse<'static>, Report<QueryError>>> + Send;
+        params: GetEntitySubgraphParams<'_>,
+    ) -> impl Future<Output = Result<GetEntitySubgraphResponse<'static>, Report<QueryError>>> + Send;
 
     /// Count the number of entities that would be returned in [`get_entity`].
     ///
@@ -385,11 +396,11 @@ pub trait EntityStore {
     ///
     /// - if the request to the database fails
     ///
-    /// [`get_entity`]: Self::get_entity
+    /// [`get_entity`]: Self::get_entity_subgraph
     fn count_entities(
         &self,
         actor_id: AccountId,
-        query: EntityStructuralQuery<'_>,
+        params: CountEntitiesParams<'_>,
     ) -> impl Future<Output = Result<usize, Report<QueryError>>> + Send;
 
     fn get_entity_by_id(

--- a/apps/hash-graph/libs/graph/src/store/ontology.rs
+++ b/apps/hash-graph/libs/graph/src/store/ontology.rs
@@ -21,10 +21,11 @@ use type_system::{
 };
 
 use crate::{
-    store::{ConflictBehavior, InsertionError, QueryError, UpdateError},
+    store::{query::Filter, ConflictBehavior, InsertionError, QueryError, UpdateError},
     subgraph::{
+        edges::GraphResolveDepths,
         identifier::{DataTypeVertexId, EntityTypeVertexId, PropertyTypeVertexId},
-        query::StructuralQuery,
+        temporal_axes::QueryTemporalAxesUnresolved,
         Subgraph,
     },
 };
@@ -48,11 +49,19 @@ pub struct CreateDataTypeParams<R> {
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct GetDataTypesParams<'p> {
+pub struct GetDataTypeSubgraphParams<'p> {
     #[serde(borrow)]
-    pub query: StructuralQuery<'p, DataTypeWithMetadata>,
+    pub filter: Filter<'p, DataTypeWithMetadata>,
+    pub graph_resolve_depths: GraphResolveDepths,
+    pub temporal_axes: QueryTemporalAxesUnresolved,
     pub after: Option<DataTypeVertexId>,
     pub limit: Option<usize>,
+    pub include_drafts: bool,
+}
+
+#[derive(Debug)]
+pub struct GetDataTypeSubgraphResponse {
+    pub subgraph: Subgraph,
 }
 
 #[derive(Debug, Deserialize)]
@@ -139,16 +148,16 @@ pub trait DataTypeStore {
         P: IntoIterator<Item = CreateDataTypeParams<R>, IntoIter: Send> + Send,
         R: IntoIterator<Item = DataTypeRelationAndSubject> + Send + Sync;
 
-    /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
+    /// Get the [`Subgraph`] specified by the [`GetDataTypeSubgraphParams`].
     ///
     /// # Errors
     ///
     /// - if the requested [`DataType`] doesn't exist.
-    fn get_data_type(
+    fn get_data_type_subgraph(
         &self,
         actor_id: AccountId,
-        params: GetDataTypesParams<'_>,
-    ) -> impl Future<Output = Result<Subgraph, QueryError>> + Send;
+        params: GetDataTypeSubgraphParams<'_>,
+    ) -> impl Future<Output = Result<GetDataTypeSubgraphResponse, QueryError>> + Send;
 
     /// Update the definition of an existing [`DataType`].
     ///
@@ -213,11 +222,19 @@ pub struct CreatePropertyTypeParams<R> {
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct GetPropertyTypesParams<'p> {
+pub struct GetPropertyTypeSubgraphParams<'p> {
     #[serde(borrow)]
-    pub query: StructuralQuery<'p, PropertyTypeWithMetadata>,
+    pub filter: Filter<'p, PropertyTypeWithMetadata>,
+    pub graph_resolve_depths: GraphResolveDepths,
+    pub temporal_axes: QueryTemporalAxesUnresolved,
     pub after: Option<PropertyTypeVertexId>,
     pub limit: Option<usize>,
+    pub include_drafts: bool,
+}
+
+#[derive(Debug)]
+pub struct GetPropertyTypeSubgraphResponse {
+    pub subgraph: Subgraph,
 }
 
 #[derive(Debug, Deserialize)]
@@ -304,16 +321,16 @@ pub trait PropertyTypeStore {
         P: IntoIterator<Item = CreatePropertyTypeParams<R>, IntoIter: Send> + Send,
         R: IntoIterator<Item = PropertyTypeRelationAndSubject> + Send + Sync;
 
-    /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
+    /// Get the [`Subgraph`] specified by the [`GetPropertyTypeSubgraphParams`].
     ///
     /// # Errors
     ///
     /// - if the requested [`PropertyType`] doesn't exist.
-    fn get_property_type(
+    fn get_property_type_subgraph(
         &self,
         actor_id: AccountId,
-        params: GetPropertyTypesParams<'_>,
-    ) -> impl Future<Output = Result<Subgraph, QueryError>> + Send;
+        params: GetPropertyTypeSubgraphParams<'_>,
+    ) -> impl Future<Output = Result<GetPropertyTypeSubgraphResponse, QueryError>> + Send;
 
     /// Update the definition of an existing [`PropertyType`].
     ///
@@ -381,11 +398,19 @@ pub struct CreateEntityTypeParams<R> {
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct GetEntityTypesParams<'p> {
+pub struct GetEntityTypeSubgraphParams<'p> {
     #[serde(borrow)]
-    pub query: StructuralQuery<'p, EntityTypeWithMetadata>,
+    pub filter: Filter<'p, EntityTypeWithMetadata>,
+    pub graph_resolve_depths: GraphResolveDepths,
+    pub temporal_axes: QueryTemporalAxesUnresolved,
     pub after: Option<EntityTypeVertexId>,
     pub limit: Option<usize>,
+    pub include_drafts: bool,
+}
+
+#[derive(Debug)]
+pub struct GetEntityTypeSubgraphResponse {
+    pub subgraph: Subgraph,
 }
 
 #[derive(Debug, Deserialize)]
@@ -474,16 +499,16 @@ pub trait EntityTypeStore {
         P: IntoIterator<Item = CreateEntityTypeParams<R>, IntoIter: Send> + Send,
         R: IntoIterator<Item = EntityTypeRelationAndSubject> + Send + Sync;
 
-    /// Get the [`Subgraph`]s specified by the [`StructuralQuery`].
+    /// Get the [`Subgraph`]s specified by the [`GetEntityTypeSubgraphParams`].
     ///
     /// # Errors
     ///
     /// - if the requested [`EntityType`] doesn't exist.
-    fn get_entity_type(
+    fn get_entity_type_subgraph(
         &self,
         actor_id: AccountId,
-        params: GetEntityTypesParams<'_>,
-    ) -> impl Future<Output = Result<Subgraph, QueryError>> + Send;
+        params: GetEntityTypeSubgraphParams<'_>,
+    ) -> impl Future<Output = Result<GetEntityTypeSubgraphResponse, QueryError>> + Send;
 
     /// Update the definition of an existing [`EntityType`].
     ///

--- a/apps/hash-graph/libs/graph/src/store/ontology.rs
+++ b/apps/hash-graph/libs/graph/src/store/ontology.rs
@@ -67,6 +67,25 @@ pub struct GetDataTypeSubgraphResponse {
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GetDataTypesParams<'p> {
+    #[serde(borrow)]
+    pub filter: Filter<'p, DataTypeWithMetadata>,
+    pub temporal_axes: QueryTemporalAxesUnresolved,
+    pub after: Option<DataTypeVertexId>,
+    pub limit: Option<usize>,
+    pub include_drafts: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GetDataTypesResponse {
+    pub data_types: Vec<DataTypeWithMetadata>,
+}
+
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct UpdateDataTypesParams<R> {
     pub schema: DataType,
     pub relationships: R,
@@ -147,6 +166,19 @@ pub trait DataTypeStore {
     where
         P: IntoIterator<Item = CreateDataTypeParams<R>, IntoIter: Send> + Send,
         R: IntoIterator<Item = DataTypeRelationAndSubject> + Send + Sync;
+
+    /// Get the [`DataTypes`] specified by the [`GetDataTypesParams`].
+    ///
+    /// # Errors
+    ///
+    /// - if the requested [`DataType`] doesn't exist.
+    ///
+    /// [`DataTypes`]: DataType
+    fn get_data_types(
+        &self,
+        actor_id: AccountId,
+        params: GetDataTypesParams<'_>,
+    ) -> impl Future<Output = Result<GetDataTypesResponse, QueryError>> + Send;
 
     /// Get the [`Subgraph`] specified by the [`GetDataTypeSubgraphParams`].
     ///
@@ -235,6 +267,25 @@ pub struct GetPropertyTypeSubgraphParams<'p> {
 #[derive(Debug)]
 pub struct GetPropertyTypeSubgraphResponse {
     pub subgraph: Subgraph,
+}
+
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GetPropertyTypesParams<'p> {
+    #[serde(borrow)]
+    pub filter: Filter<'p, PropertyTypeWithMetadata>,
+    pub temporal_axes: QueryTemporalAxesUnresolved,
+    pub after: Option<PropertyTypeVertexId>,
+    pub limit: Option<usize>,
+    pub include_drafts: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GetPropertyTypesResponse {
+    pub property_types: Vec<PropertyTypeWithMetadata>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -332,6 +383,19 @@ pub trait PropertyTypeStore {
         params: GetPropertyTypeSubgraphParams<'_>,
     ) -> impl Future<Output = Result<GetPropertyTypeSubgraphResponse, QueryError>> + Send;
 
+    /// Get the [`PropertyTypes`] specified by the [`GetPropertyTypesParams`].
+    ///
+    /// # Errors
+    ///
+    /// - if the requested [`PropertyType`] doesn't exist.
+    ///
+    /// [`PropertyTypes`]: PropertyType
+    fn get_property_types(
+        &self,
+        actor_id: AccountId,
+        params: GetPropertyTypesParams<'_>,
+    ) -> impl Future<Output = Result<GetPropertyTypesResponse, QueryError>> + Send;
+
     /// Update the definition of an existing [`PropertyType`].
     ///
     /// # Errors
@@ -411,6 +475,25 @@ pub struct GetEntityTypeSubgraphParams<'p> {
 #[derive(Debug)]
 pub struct GetEntityTypeSubgraphResponse {
     pub subgraph: Subgraph,
+}
+
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GetEntityTypesParams<'p> {
+    #[serde(borrow)]
+    pub filter: Filter<'p, EntityTypeWithMetadata>,
+    pub temporal_axes: QueryTemporalAxesUnresolved,
+    pub after: Option<EntityTypeVertexId>,
+    pub limit: Option<usize>,
+    pub include_drafts: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GetEntityTypesResponse {
+    pub entity_types: Vec<EntityTypeWithMetadata>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -509,6 +592,19 @@ pub trait EntityTypeStore {
         actor_id: AccountId,
         params: GetEntityTypeSubgraphParams<'_>,
     ) -> impl Future<Output = Result<GetEntityTypeSubgraphResponse, QueryError>> + Send;
+
+    /// Get the [`EntityTypes`] specified by the [`GetEntityTypesParams`].
+    ///
+    /// # Errors
+    ///
+    /// - if the requested [`EntityType`] doesn't exist.
+    ///
+    /// [`EntityTypes`]: EntityType
+    fn get_entity_types(
+        &self,
+        actor_id: AccountId,
+        params: GetEntityTypesParams<'_>,
+    ) -> impl Future<Output = Result<GetEntityTypesResponse, QueryError>> + Send;
 
     /// Update the definition of an existing [`EntityType`].
     ///

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
@@ -32,8 +32,9 @@ use crate::{
         crud::{QueryResult, ReadPaginated, VertexIdSorting},
         error::DeletionError,
         ontology::{
-            ArchiveDataTypeParams, CreateDataTypeParams, GetDataTypesParams,
-            UnarchiveDataTypeParams, UpdateDataTypeEmbeddingParams, UpdateDataTypesParams,
+            ArchiveDataTypeParams, CreateDataTypeParams, GetDataTypeSubgraphParams,
+            GetDataTypeSubgraphResponse, UnarchiveDataTypeParams, UpdateDataTypeEmbeddingParams,
+            UpdateDataTypesParams,
         },
         postgres::{
             crud::QueryRecordDecode,
@@ -44,9 +45,7 @@ use crate::{
         AsClient, DataTypeStore, InsertionError, PostgresStore, QueryError, SubgraphRecord,
         UpdateError,
     },
-    subgraph::{
-        edges::GraphResolveDepths, query::StructuralQuery, temporal_axes::VariableAxis, Subgraph,
-    },
+    subgraph::{edges::GraphResolveDepths, temporal_axes::VariableAxis, Subgraph},
 };
 
 impl<C, A> PostgresStore<C, A>
@@ -298,19 +297,12 @@ where
     }
 
     #[tracing::instrument(level = "info", skip(self))]
-    async fn get_data_type(
+    async fn get_data_type_subgraph(
         &self,
         actor_id: AccountId,
-        params: GetDataTypesParams<'_>,
-    ) -> Result<Subgraph, QueryError> {
-        let StructuralQuery {
-            ref filter,
-            graph_resolve_depths,
-            temporal_axes: ref unresolved_temporal_axes,
-            include_drafts,
-        } = params.query;
-
-        let temporal_axes = unresolved_temporal_axes.clone().resolve();
+        params: GetDataTypeSubgraphParams<'_>,
+    ) -> Result<GetDataTypeSubgraphResponse, QueryError> {
+        let temporal_axes = params.temporal_axes.clone().resolve();
         let time_axis = temporal_axes.variable_time_axis();
 
         // TODO: Remove again when subgraph logic was revisited
@@ -319,13 +311,13 @@ where
 
         let (data, artifacts) = ReadPaginated::<DataTypeWithMetadata>::read_paginated_vec(
             self,
-            filter,
+            &params.filter,
             Some(&temporal_axes),
             &VertexIdSorting {
                 cursor: params.after,
             },
             params.limit,
-            include_drafts,
+            params.include_drafts,
         )
         .await?;
         let data_types = data
@@ -358,8 +350,8 @@ where
             .change_context(QueryError)?;
 
         let mut subgraph = Subgraph::new(
-            graph_resolve_depths,
-            unresolved_temporal_axes.clone(),
+            params.graph_resolve_depths,
+            params.temporal_axes,
             temporal_axes.clone(),
         );
 
@@ -398,10 +390,10 @@ where
         .await?;
 
         traversal_context
-            .read_traversed_vertices(self, &mut subgraph, include_drafts)
+            .read_traversed_vertices(self, &mut subgraph, params.include_drafts)
             .await?;
 
-        Ok(subgraph)
+        Ok(GetDataTypeSubgraphResponse { subgraph })
     }
 
     #[tracing::instrument(level = "info", skip(self, params))]

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/property_type.rs
@@ -37,8 +37,9 @@ use crate::{
         error::DeletionError,
         ontology::{
             ArchivePropertyTypeParams, CreatePropertyTypeParams, GetPropertyTypeSubgraphParams,
-            GetPropertyTypeSubgraphResponse, UnarchivePropertyTypeParams,
-            UpdatePropertyTypeEmbeddingParams, UpdatePropertyTypesParams,
+            GetPropertyTypeSubgraphResponse, GetPropertyTypesParams, GetPropertyTypesResponse,
+            UnarchivePropertyTypeParams, UpdatePropertyTypeEmbeddingParams,
+            UpdatePropertyTypesParams,
         },
         postgres::{
             crud::QueryRecordDecode,
@@ -54,8 +55,8 @@ use crate::{
     },
     subgraph::{
         edges::{EdgeDirection, GraphResolveDepths, OntologyEdgeKind},
-        identifier::{DataTypeVertexId, PropertyTypeVertexId},
-        temporal_axes::VariableAxis,
+        identifier::{DataTypeVertexId, GraphElementVertexId, PropertyTypeVertexId},
+        temporal_axes::{QueryTemporalAxes, VariableAxis},
         Subgraph,
     },
 };
@@ -102,6 +103,69 @@ where
                     .unwrap_or(false)
                     .then_some(property_type)
             }))
+    }
+
+    async fn get_property_types_impl(
+        &self,
+        actor_id: AccountId,
+        params: GetPropertyTypesParams<'_>,
+        temporal_axes: &QueryTemporalAxes,
+    ) -> Result<(GetPropertyTypesResponse, Zookie<'static>), QueryError> {
+        // TODO: Remove again when subgraph logic was revisited
+        //   see https://linear.app/hash/issue/H-297
+        let mut visited_ontology_ids = HashSet::new();
+
+        let (data, artifacts) = ReadPaginated::<PropertyTypeWithMetadata>::read_paginated_vec(
+            self,
+            &params.filter,
+            Some(temporal_axes),
+            &VertexIdSorting {
+                cursor: params.after,
+            },
+            params.limit,
+            params.include_drafts,
+        )
+        .await?;
+        let property_types = data
+            .into_iter()
+            .filter_map(|row| {
+                let property_type = row.decode_record(&artifacts);
+                let id = PropertyTypeId::from_url(property_type.schema.id());
+                // The records are already sorted by time, so we can just take the first one
+                visited_ontology_ids
+                    .insert(id)
+                    .then_some((id, property_type))
+            })
+            .collect::<Vec<_>>();
+
+        let filtered_ids = property_types
+            .iter()
+            .map(|(property_type_id, _)| *property_type_id)
+            .collect::<Vec<_>>();
+
+        let (permissions, zookie) = self
+            .authorization_api
+            .check_property_types_permission(
+                actor_id,
+                PropertyTypePermission::View,
+                filtered_ids,
+                Consistency::FullyConsistent,
+            )
+            .await
+            .change_context(QueryError)?;
+
+        let property_types = property_types
+            .into_iter()
+            .filter_map(|(id, property_type)| {
+                permissions
+                    .get(&id)
+                    .copied()
+                    .unwrap_or(false)
+                    .then_some(property_type)
+            })
+            .collect();
+
+        Ok((GetPropertyTypesResponse { property_types }, zookie))
     }
 
     /// Internal method to read a [`PropertyTypeWithMetadata`] into two [`TraversalContext`]s.
@@ -423,6 +487,17 @@ where
         }
     }
 
+    async fn get_property_types(
+        &self,
+        actor_id: AccountId,
+        params: GetPropertyTypesParams<'_>,
+    ) -> Result<GetPropertyTypesResponse, QueryError> {
+        let temporal_axes = params.temporal_axes.clone().resolve();
+        self.get_property_types_impl(actor_id, params, &temporal_axes)
+            .await
+            .map(|(response, _)| response)
+    }
+
     #[tracing::instrument(level = "info", skip(self))]
     async fn get_property_type_subgraph(
         &self,
@@ -432,49 +507,19 @@ where
         let temporal_axes = params.temporal_axes.clone().resolve();
         let time_axis = temporal_axes.variable_time_axis();
 
-        // TODO: Remove again when subgraph logic was revisited
-        //   see https://linear.app/hash/issue/H-297
-        let mut visited_ontology_ids = HashSet::new();
-
-        let (data, artifacts) = ReadPaginated::<PropertyTypeWithMetadata>::read_paginated_vec(
-            self,
-            &params.filter,
-            Some(&temporal_axes),
-            &VertexIdSorting {
-                cursor: params.after,
-            },
-            params.limit,
-            params.include_drafts,
-        )
-        .await?;
-        let property_types = data
-            .into_iter()
-            .filter_map(|row| {
-                let property_type = row.decode_record(&artifacts);
-                let id = PropertyTypeId::from_url(property_type.schema.id());
-                let vertex_id = property_type.vertex_id(time_axis);
-                // The records are already sorted by time, so we can just take the first one
-                visited_ontology_ids
-                    .insert(id)
-                    .then_some((id, (vertex_id, property_type)))
-            })
-            .collect::<Vec<_>>();
-
-        let filtered_ids = property_types
-            .iter()
-            .map(|(property_type_id, _)| *property_type_id)
-            .collect::<Vec<_>>();
-
-        let (permissions, zookie) = self
-            .authorization_api
-            .check_property_types_permission(
+        let (GetPropertyTypesResponse { property_types }, zookie) = self
+            .get_property_types_impl(
                 actor_id,
-                PropertyTypePermission::View,
-                filtered_ids,
-                Consistency::FullyConsistent,
+                GetPropertyTypesParams {
+                    filter: params.filter,
+                    temporal_axes: params.temporal_axes.clone(),
+                    after: params.after,
+                    limit: params.limit,
+                    include_drafts: params.include_drafts,
+                },
+                &temporal_axes,
             )
-            .await
-            .change_context(QueryError)?;
+            .await?;
 
         let mut subgraph = Subgraph::new(
             params.graph_resolve_depths,
@@ -482,17 +527,20 @@ where
             temporal_axes.clone(),
         );
 
-        let (property_type_ids, property_type_vertices): (Vec<_>, Vec<_>) = property_types
-            .into_iter()
-            .filter(|(id, _)| permissions.get(id).copied().unwrap_or(false))
+        let (property_type_ids, property_type_vertex_ids): (Vec<_>, Vec<_>) = property_types
+            .iter()
+            .map(|property_type| {
+                (
+                    PropertyTypeId::from_url(property_type.schema.id()),
+                    GraphElementVertexId::from(property_type.vertex_id(time_axis)),
+                )
+            })
             .unzip();
-
-        subgraph.roots.extend(
-            property_type_vertices
-                .iter()
-                .map(|(vertex_id, _)| vertex_id.clone().into()),
-        );
-        subgraph.vertices.property_types = property_type_vertices.into_iter().collect();
+        subgraph.roots.extend(property_type_vertex_ids);
+        subgraph.vertices.property_types = property_types
+            .into_iter()
+            .map(|property_type| (property_type.vertex_id(time_axis), property_type))
+            .collect();
 
         let mut traversal_context = TraversalContext::default();
 

--- a/apps/hash-graph/libs/graph/src/subgraph/mod.rs
+++ b/apps/hash-graph/libs/graph/src/subgraph/mod.rs
@@ -1,6 +1,5 @@
 pub mod edges;
 pub mod identifier;
-pub mod query;
 pub mod temporal_axes;
 pub mod vertices;
 

--- a/apps/hash-graph/libs/graph/src/subgraph/query.rs
+++ b/apps/hash-graph/libs/graph/src/subgraph/query.rs
@@ -207,7 +207,6 @@ where
 pub type DataTypeStructuralQuery = StructuralQuery<'static, DataTypeWithMetadata>;
 pub type PropertyTypeStructuralQuery = StructuralQuery<'static, PropertyTypeWithMetadata>;
 pub type EntityTypeStructuralQuery = StructuralQuery<'static, EntityTypeWithMetadata>;
-pub type EntityStructuralQuery<'q> = StructuralQuery<'q, Entity>;
 
 #[cfg(feature = "utoipa")]
 impl<'p> ToSchema<'_> for StructuralQuery<'p, DataTypeWithMetadata> {

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -524,7 +524,7 @@
           "Graph",
           "DataType"
         ],
-        "operationId": "get_data_types_by_query",
+        "operationId": "get_data_type_subgraph",
         "parameters": [
           {
             "name": "X-Authenticated-User-Actor-Id",
@@ -540,7 +540,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/DataTypeStructuralQuery"
+                "$ref": "#/components/schemas/GetDataTypeSubgraphRequest"
               }
             }
           },
@@ -560,7 +560,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Subgraph"
+                  "$ref": "#/components/schemas/GetDataTypeSubgraphResponse"
                 }
               }
             }
@@ -970,7 +970,7 @@
           "Graph",
           "Entity"
         ],
-        "operationId": "get_entities_by_query",
+        "operationId": "get_entity_subgraph",
         "parameters": [
           {
             "name": "X-Authenticated-User-Actor-Id",
@@ -1007,7 +1007,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GetEntityByQueryRequest"
+                "$ref": "#/components/schemas/GetEntitySubgraphRequest"
               }
             }
           },
@@ -1019,7 +1019,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GetEntityByQueryResponse"
+                  "$ref": "#/components/schemas/GetEntitySubgraphResponse"
                 }
               }
             }
@@ -1055,7 +1055,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/EntityStructuralQuery"
+                "$ref": "#/components/schemas/CountEntitiesParams"
               }
             }
           },
@@ -1762,7 +1762,7 @@
           "Graph",
           "EntityType"
         ],
-        "operationId": "get_entity_types_by_query",
+        "operationId": "get_entity_type_subgraph",
         "parameters": [
           {
             "name": "X-Authenticated-User-Actor-Id",
@@ -1778,7 +1778,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/EntityTypeStructuralQuery"
+                "$ref": "#/components/schemas/GetEntityTypeSubgraphRequest"
               }
             }
           },
@@ -1798,7 +1798,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Subgraph"
+                  "$ref": "#/components/schemas/GetEntityTypeSubgraphResponse"
                 }
               }
             }
@@ -2280,7 +2280,7 @@
           "Graph",
           "PropertyType"
         ],
-        "operationId": "get_property_types_by_query",
+        "operationId": "get_property_type_subgraph",
         "parameters": [
           {
             "name": "X-Authenticated-User-Actor-Id",
@@ -2296,7 +2296,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PropertyTypeStructuralQuery"
+                "$ref": "#/components/schemas/GetPropertyTypeSubgraphRequest"
               }
             }
           },
@@ -2316,7 +2316,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Subgraph"
+                  "$ref": "#/components/schemas/GetPropertyTypeSubgraphResponse"
                 }
               }
             }
@@ -2801,6 +2801,26 @@
         "maximum": 1,
         "minimum": 0
       },
+      "CountEntitiesParams": {
+        "type": "object",
+        "required": [
+          "filter",
+          "temporalAxes",
+          "includeDrafts"
+        ],
+        "properties": {
+          "filter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "includeDrafts": {
+            "type": "boolean"
+          },
+          "temporalAxes": {
+            "$ref": "#/components/schemas/QueryTemporalAxesUnresolved"
+          }
+        },
+        "additionalProperties": false
+      },
       "CreateDataTypeRequest": {
         "type": "object",
         "required": [
@@ -3137,29 +3157,6 @@
         ],
         "discriminator": {
           "propertyName": "relation"
-        }
-      },
-      "DataTypeStructuralQuery": {
-        "type": "object",
-        "required": [
-          "filter",
-          "graphResolveDepths",
-          "temporalAxes",
-          "includeDrafts"
-        ],
-        "properties": {
-          "filter": {
-            "$ref": "#/components/schemas/Filter"
-          },
-          "graphResolveDepths": {
-            "$ref": "#/components/schemas/GraphResolveDepths"
-          },
-          "includeDrafts": {
-            "type": "boolean"
-          },
-          "temporalAxes": {
-            "$ref": "#/components/schemas/QueryTemporalAxesUnresolved"
-          }
         }
       },
       "DataTypeVertexId": {
@@ -3823,29 +3820,6 @@
           "propertyName": "kind"
         }
       },
-      "EntityStructuralQuery": {
-        "type": "object",
-        "required": [
-          "filter",
-          "graphResolveDepths",
-          "temporalAxes",
-          "includeDrafts"
-        ],
-        "properties": {
-          "filter": {
-            "$ref": "#/components/schemas/Filter"
-          },
-          "graphResolveDepths": {
-            "$ref": "#/components/schemas/GraphResolveDepths"
-          },
-          "includeDrafts": {
-            "type": "boolean"
-          },
-          "temporalAxes": {
-            "$ref": "#/components/schemas/QueryTemporalAxesUnresolved"
-          }
-        }
-      },
       "EntityTemporalMetadata": {
         "type": "object",
         "required": [
@@ -4224,29 +4198,6 @@
           "propertyName": "kind"
         }
       },
-      "EntityTypeStructuralQuery": {
-        "type": "object",
-        "required": [
-          "filter",
-          "graphResolveDepths",
-          "temporalAxes",
-          "includeDrafts"
-        ],
-        "properties": {
-          "filter": {
-            "$ref": "#/components/schemas/Filter"
-          },
-          "graphResolveDepths": {
-            "$ref": "#/components/schemas/GraphResolveDepths"
-          },
-          "includeDrafts": {
-            "type": "boolean"
-          },
-          "temporalAxes": {
-            "$ref": "#/components/schemas/QueryTemporalAxesUnresolved"
-          }
-        }
-      },
       "EntityTypeVertexId": {
         "type": "object",
         "required": [
@@ -4586,10 +4537,48 @@
           }
         ]
       },
-      "GetEntityByQueryRequest": {
+      "GetDataTypeSubgraphRequest": {
         "type": "object",
         "required": [
-          "query"
+          "filter",
+          "graphResolveDepths",
+          "temporalAxes",
+          "includeDrafts"
+        ],
+        "properties": {
+          "filter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "graphResolveDepths": {
+            "$ref": "#/components/schemas/GraphResolveDepths"
+          },
+          "includeDrafts": {
+            "type": "boolean"
+          },
+          "temporalAxes": {
+            "$ref": "#/components/schemas/QueryTemporalAxesUnresolved"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetDataTypeSubgraphResponse": {
+        "type": "object",
+        "required": [
+          "subgraph"
+        ],
+        "properties": {
+          "subgraph": {
+            "$ref": "#/components/schemas/Subgraph"
+          }
+        }
+      },
+      "GetEntitySubgraphRequest": {
+        "type": "object",
+        "required": [
+          "filter",
+          "graphResolveDepths",
+          "temporalAxes",
+          "includeDrafts"
         ],
         "properties": {
           "cursor": {
@@ -4600,7 +4589,16 @@
             ],
             "nullable": true
           },
+          "filter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "graphResolveDepths": {
+            "$ref": "#/components/schemas/GraphResolveDepths"
+          },
           "includeCount": {
+            "type": "boolean"
+          },
+          "includeDrafts": {
             "type": "boolean"
           },
           "limit": {
@@ -4608,20 +4606,20 @@
             "nullable": true,
             "minimum": 0
           },
-          "query": {
-            "$ref": "#/components/schemas/EntityStructuralQuery"
-          },
           "sortingPaths": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/EntityQuerySortingRecord"
             },
             "nullable": true
+          },
+          "temporalAxes": {
+            "$ref": "#/components/schemas/QueryTemporalAxesUnresolved"
           }
         },
         "additionalProperties": false
       },
-      "GetEntityByQueryResponse": {
+      "GetEntitySubgraphResponse": {
         "type": "object",
         "required": [
           "subgraph"
@@ -4640,6 +4638,76 @@
             ],
             "nullable": true
           },
+          "subgraph": {
+            "$ref": "#/components/schemas/Subgraph"
+          }
+        }
+      },
+      "GetEntityTypeSubgraphRequest": {
+        "type": "object",
+        "required": [
+          "filter",
+          "graphResolveDepths",
+          "temporalAxes",
+          "includeDrafts"
+        ],
+        "properties": {
+          "filter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "graphResolveDepths": {
+            "$ref": "#/components/schemas/GraphResolveDepths"
+          },
+          "includeDrafts": {
+            "type": "boolean"
+          },
+          "temporalAxes": {
+            "$ref": "#/components/schemas/QueryTemporalAxesUnresolved"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetEntityTypeSubgraphResponse": {
+        "type": "object",
+        "required": [
+          "subgraph"
+        ],
+        "properties": {
+          "subgraph": {
+            "$ref": "#/components/schemas/Subgraph"
+          }
+        }
+      },
+      "GetPropertyTypeSubgraphRequest": {
+        "type": "object",
+        "required": [
+          "filter",
+          "graphResolveDepths",
+          "temporalAxes",
+          "includeDrafts"
+        ],
+        "properties": {
+          "filter": {
+            "$ref": "#/components/schemas/Filter"
+          },
+          "graphResolveDepths": {
+            "$ref": "#/components/schemas/GraphResolveDepths"
+          },
+          "includeDrafts": {
+            "type": "boolean"
+          },
+          "temporalAxes": {
+            "$ref": "#/components/schemas/QueryTemporalAxesUnresolved"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetPropertyTypeSubgraphResponse": {
+        "type": "object",
+        "required": [
+          "subgraph"
+        ],
+        "properties": {
           "subgraph": {
             "$ref": "#/components/schemas/Subgraph"
           }
@@ -6424,29 +6492,6 @@
         ],
         "discriminator": {
           "propertyName": "kind"
-        }
-      },
-      "PropertyTypeStructuralQuery": {
-        "type": "object",
-        "required": [
-          "filter",
-          "graphResolveDepths",
-          "temporalAxes",
-          "includeDrafts"
-        ],
-        "properties": {
-          "filter": {
-            "$ref": "#/components/schemas/Filter"
-          },
-          "graphResolveDepths": {
-            "$ref": "#/components/schemas/GraphResolveDepths"
-          },
-          "includeDrafts": {
-            "type": "boolean"
-          },
-          "temporalAxes": {
-            "$ref": "#/components/schemas/QueryTemporalAxesUnresolved"
-          }
         }
       },
       "PropertyTypeVertexId": {

--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -135,7 +135,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
-        client.assert(response.body.roots.length === 0, "Unexpected number of data types"); // The number of primitive data types
+        client.assert(response.body.subgraph.roots.length === 0, "Unexpected number of data types"); // The number of primitive data types
     });
 %}
 
@@ -310,7 +310,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
-        client.assert(response.body.roots.length === 1, "Unexpected number of data types");
+        client.assert(response.body.subgraph.roots.length === 1, "Unexpected number of data types");
     });
 %}
 
@@ -538,7 +538,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
-        client.assert(response.body.roots.length === 1, "Unexpected number of property types");
+        client.assert(response.body.subgraph.roots.length === 1, "Unexpected number of property types");
     });
 %}
 
@@ -664,7 +664,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
-        client.assert(response.body.roots.length === 2, "Unexpected number of property types");
+        client.assert(response.body.subgraph.roots.length === 2, "Unexpected number of property types");
     });
 %}
 
@@ -863,7 +863,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
-        client.assert(response.body.roots.length === 1, "Unexpected number of entities");
+        client.assert(response.body.subgraph.roots.length === 1, "Unexpected number of entities");
     });
 %}
 
@@ -1005,7 +1005,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
-        client.assert(response.body.roots.length === 1, "Unexpected number of entity types");
+        client.assert(response.body.subgraph.roots.length === 1, "Unexpected number of entity types");
     });
 %}
 
@@ -1169,7 +1169,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 > {%
   client.test("status", function() {
     client.assert(response.status === 200, "Response status is not 200");
-    client.assert(response.body.roots.length === 3, "Unexpected number of entity types");
+    client.assert(response.body.subgraph.roots.length === 3, "Unexpected number of entity types");
   });
 %}
 
@@ -1240,7 +1240,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 > {%
   client.test("status", function() {
     client.assert(response.status === 200, "Response status is not 200");
-    client.assert(response.body.roots.length === 1, "Unexpected number of entity types");
+    client.assert(response.body.subgraph.roots.length === 1, "Unexpected number of entity types");
   });
 %}
 
@@ -1313,7 +1313,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
-        client.assert(response.body.roots.length === 1, "Unexpected number of entity types");
+        client.assert(response.body.subgraph.roots.length === 1, "Unexpected number of entity types");
     });
 %}
 
@@ -1384,8 +1384,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 > {%
   client.test("status", function() {
     client.assert(response.status === 200, "Response status is not 200");
-    client.assert(response.body.roots.length === 1, "Unexpected number of entity types");
-    client.assert(response.body.roots[0].baseId === "https://blockprotocol.org/@blockprotocol/types/entity-type/link/", "Unexpected parent type");
+    client.assert(response.body.subgraph.roots.length === 1, "Unexpected number of entity types");
+    client.assert(response.body.subgraph.roots[0].baseId === "https://blockprotocol.org/@blockprotocol/types/entity-type/link/", "Unexpected parent type");
   });
 %}
 
@@ -1462,7 +1462,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
-        client.assert(response.body.roots.length === 0, "Unexpected number of entity types");
+        client.assert(response.body.subgraph.roots.length === 0, "Unexpected number of entity types");
     });
 %}
 
@@ -1527,7 +1527,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
-        client.assert(response.body.roots.length === 3, "Unexpected number of entity types");
+        client.assert(response.body.subgraph.roots.length === 3, "Unexpected number of entity types");
     });
 %}
 
@@ -1592,8 +1592,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
-        client.assert(response.body.roots.length === 1, "Unexpected number of entity types");
-        client.assert(response.body.roots[0].baseId === "http://localhost:3000/@alice/types/entity-type/friendship/", "Unexpected number of entity types");
+        client.assert(response.body.subgraph.roots.length === 1, "Unexpected number of entity types");
+        client.assert(response.body.subgraph.roots[0].baseId === "http://localhost:3000/@alice/types/entity-type/friendship/", "Unexpected number of entity types");
     });
 %}
 
@@ -1677,60 +1677,58 @@ X-Authenticated-User-Actor-Id: {{account_id}}
       "ordering": "descending"
     }
   ],
-  "query": {
-    "filter": {
-      "all": [
-        {
-          "equal": [
-            { "path": ["provenance", "createdById"] },
-            { "parameter": "{{account_id}}" }
-          ]
-        }
-      ]
-    },
-    "graphResolveDepths": {
-      "inheritsFrom": {
-        "outgoing": 0
-      },
-      "constrainsValuesOn": {
-        "outgoing": 0
-      },
-      "constrainsPropertiesOn": {
-        "outgoing": 0
-      },
-      "constrainsLinksOn": {
-        "outgoing": 0
-      },
-      "constrainsLinkDestinationsOn": {
-        "outgoing": 0
-      },
-      "isOfType": {
-        "outgoing": 0
-      },
-      "hasLeftEntity": {
-        "incoming": 0,
-        "outgoing": 0
-      },
-      "hasRightEntity": {
-        "incoming": 0,
-        "outgoing": 0
+  "filter": {
+    "all": [
+      {
+        "equal": [
+          { "path": ["provenance", "createdById"] },
+          { "parameter": "{{account_id}}" }
+        ]
       }
+    ]
+  },
+  "graphResolveDepths": {
+    "inheritsFrom": {
+      "outgoing": 0
     },
-    "temporalAxes": {
-      "pinned": {
-        "axis": "transactionTime",
-        "timestamp": null
-      },
-      "variable": {
-        "axis": "decisionTime",
-        "interval": {
-          "start": null,
-          "end": null
-        }
+    "constrainsValuesOn": {
+      "outgoing": 0
+    },
+    "constrainsPropertiesOn": {
+      "outgoing": 0
+    },
+    "constrainsLinksOn": {
+      "outgoing": 0
+    },
+    "constrainsLinkDestinationsOn": {
+      "outgoing": 0
+    },
+    "isOfType": {
+      "outgoing": 0
+    },
+    "hasLeftEntity": {
+      "incoming": 0,
+      "outgoing": 0
+    },
+    "hasRightEntity": {
+      "incoming": 0,
+      "outgoing": 0
+    }
+  },
+  "temporalAxes": {
+    "pinned": {
+      "axis": "transactionTime",
+      "timestamp": null
+    },
+    "variable": {
+      "axis": "decisionTime",
+      "interval": {
+        "start": null,
+        "end": null
       }
-    },
-    "includeDrafts": false
-  }
+    }
+  },
+  "includeDrafts": false
 }
 
 > {%
@@ -1886,53 +1884,51 @@ Content-Type: application/json
 X-Authenticated-User-Actor-Id: {{account_id}}
 
 {
-  "query": {
-    "filter": {
-      "all": []
+  "filter": {
+    "all": []
+  },
+  "graphResolveDepths": {
+    "inheritsFrom": {
+      "outgoing": 0
     },
-    "graphResolveDepths": {
-      "inheritsFrom": {
-        "outgoing": 0
-      },
-      "constrainsValuesOn": {
-        "outgoing": 0
-      },
-      "constrainsPropertiesOn": {
-        "outgoing": 0
-      },
-      "constrainsLinksOn": {
-        "outgoing": 0
-      },
-      "constrainsLinkDestinationsOn": {
-        "outgoing": 0
-      },
-      "isOfType": {
-        "outgoing": 0
-      },
-      "hasLeftEntity": {
-        "incoming": 2,
-        "outgoing": 2
-      },
-      "hasRightEntity": {
-        "incoming": 2,
-        "outgoing": 2
+    "constrainsValuesOn": {
+      "outgoing": 0
+    },
+    "constrainsPropertiesOn": {
+      "outgoing": 0
+    },
+    "constrainsLinksOn": {
+      "outgoing": 0
+    },
+    "constrainsLinkDestinationsOn": {
+      "outgoing": 0
+    },
+    "isOfType": {
+      "outgoing": 0
+    },
+    "hasLeftEntity": {
+      "incoming": 2,
+      "outgoing": 2
+    },
+    "hasRightEntity": {
+      "incoming": 2,
+      "outgoing": 2
+    }
+  },
+  "temporalAxes": {
+    "pinned": {
+      "axis": "transactionTime",
+      "timestamp": null
+    },
+    "variable": {
+      "axis": "decisionTime",
+      "interval": {
+        "start": null,
+        "end": null
       }
-    },
-    "temporalAxes": {
-      "pinned": {
-        "axis": "transactionTime",
-        "timestamp": null
-      },
-      "variable": {
-        "axis": "decisionTime",
-        "interval": {
-          "start": null,
-          "end": null
-        }
-      }
-    },
-    "includeDrafts": true
-  }
+    }
+  },
+  "includeDrafts": true
 }
 
 > {%
@@ -1948,53 +1944,51 @@ Content-Type: application/json
 X-Authenticated-User-Actor-Id: {{account_id}}
 
 {
-  "query": {
     "filter": {
-      "all": []
+    "all": []
+  },
+  "graphResolveDepths": {
+    "inheritsFrom": {
+      "outgoing": 0
     },
-    "graphResolveDepths": {
-      "inheritsFrom": {
-        "outgoing": 0
-      },
-      "constrainsValuesOn": {
-        "outgoing": 0
-      },
-      "constrainsPropertiesOn": {
-        "outgoing": 0
-      },
-      "constrainsLinksOn": {
-        "outgoing": 0
-      },
-      "constrainsLinkDestinationsOn": {
-        "outgoing": 0
-      },
-      "isOfType": {
-        "outgoing": 0
-      },
-      "hasLeftEntity": {
-        "incoming": 2,
-        "outgoing": 2
-      },
-      "hasRightEntity": {
-        "incoming": 2,
-        "outgoing": 2
+    "constrainsValuesOn": {
+      "outgoing": 0
+    },
+    "constrainsPropertiesOn": {
+      "outgoing": 0
+    },
+    "constrainsLinksOn": {
+      "outgoing": 0
+    },
+    "constrainsLinkDestinationsOn": {
+      "outgoing": 0
+    },
+    "isOfType": {
+      "outgoing": 0
+    },
+    "hasLeftEntity": {
+      "incoming": 2,
+      "outgoing": 2
+    },
+    "hasRightEntity": {
+      "incoming": 2,
+      "outgoing": 2
+    }
+  },
+  "temporalAxes": {
+    "pinned": {
+      "axis": "transactionTime",
+      "timestamp": null
+    },
+    "variable": {
+      "axis": "decisionTime",
+      "interval": {
+        "start": null,
+        "end": null
       }
-    },
-    "temporalAxes": {
-      "pinned": {
-        "axis": "transactionTime",
-        "timestamp": null
-      },
-      "variable": {
-        "axis": "decisionTime",
-        "interval": {
-          "start": null,
-          "end": null
-        }
-      }
-    },
-    "includeDrafts": false
-  }
+    }
+  },
+  "includeDrafts": false
 }
 
 > {%
@@ -2098,63 +2092,61 @@ Content-Type: application/json
 X-Authenticated-User-Actor-Id: {{account_id}}
 
 {
-  "query": {
-    "filter": {
-      "equal": [
-        {
-          "path": [
-            "type",
-            "versionedUrl"
-          ]
-        },
-        {
-          "parameter": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1"
-        }
-      ]
-    },
-    "graphResolveDepths": {
-      "inheritsFrom": {
-        "outgoing": 0
+  "filter": {
+    "equal": [
+      {
+        "path": [
+          "type",
+          "versionedUrl"
+        ]
       },
-      "constrainsValuesOn": {
-        "outgoing": 0
-      },
-      "constrainsPropertiesOn": {
-        "outgoing": 0
-      },
-      "constrainsLinksOn": {
-        "outgoing": 0
-      },
-      "constrainsLinkDestinationsOn": {
-        "outgoing": 0
-      },
-      "isOfType": {
-        "outgoing": 0
-      },
-      "hasLeftEntity": {
-        "incoming": 0,
-        "outgoing": 0
-      },
-      "hasRightEntity": {
-        "incoming": 0,
-        "outgoing": 0
+      {
+        "parameter": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1"
       }
+    ]
+  },
+  "graphResolveDepths": {
+    "inheritsFrom": {
+      "outgoing": 0
     },
-    "temporalAxes": {
-      "pinned": {
-        "axis": "transactionTime",
-        "timestamp": null
-      },
-      "variable": {
-        "axis": "decisionTime",
-        "interval": {
-          "start": null,
-          "end": null
-        }
+    "constrainsValuesOn": {
+      "outgoing": 0
+    },
+    "constrainsPropertiesOn": {
+      "outgoing": 0
+    },
+    "constrainsLinksOn": {
+      "outgoing": 0
+    },
+    "constrainsLinkDestinationsOn": {
+      "outgoing": 0
+    },
+    "isOfType": {
+      "outgoing": 0
+    },
+    "hasLeftEntity": {
+      "incoming": 0,
+      "outgoing": 0
+    },
+    "hasRightEntity": {
+      "incoming": 0,
+      "outgoing": 0
+    }
+  },
+  "temporalAxes": {
+    "pinned": {
+      "axis": "transactionTime",
+      "timestamp": null
+    },
+    "variable": {
+      "axis": "decisionTime",
+      "interval": {
+        "start": null,
+        "end": null
       }
-    },
-    "includeDrafts": false
-  }
+    }
+  },
+  "includeDrafts": false
 }
 
 > {%
@@ -2172,80 +2164,78 @@ Content-Type: application/json
 X-Authenticated-User-Actor-Id: {{account_id}}
 
 {
-  "query": {
-    "filter": {
-      "all": [
-        {
-          "equal": [
-            {
-              "path": [
-                "leftEntity",
-                "uuid"
-              ]
-            },
-            {
-              "parameter": "{{person_a_entity_uuid}}"
-            }
-          ]
-        },
-        {
-          "equal": [
-            {
-              "path": [
-                "rightEntity",
-                "uuid"
-              ]
-            },
-            {
-              "parameter": "{{person_b_entity_uuid}}"
-            }
-          ]
-        }
-      ]
-    },
-    "graphResolveDepths": {
-      "inheritsFrom": {
-        "outgoing": 0
+  "filter": {
+    "all": [
+      {
+        "equal": [
+          {
+            "path": [
+              "leftEntity",
+              "uuid"
+            ]
+          },
+          {
+            "parameter": "{{person_a_entity_uuid}}"
+          }
+        ]
       },
-      "constrainsValuesOn": {
-        "outgoing": 0
-      },
-      "constrainsPropertiesOn": {
-        "outgoing": 0
-      },
-      "constrainsLinksOn": {
-        "outgoing": 0
-      },
-      "constrainsLinkDestinationsOn": {
-        "outgoing": 0
-      },
-      "isOfType": {
-        "outgoing": 0
-      },
-      "hasLeftEntity": {
-        "incoming": 2,
-        "outgoing": 2
-      },
-      "hasRightEntity": {
-        "incoming": 2,
-        "outgoing": 2
+      {
+        "equal": [
+          {
+            "path": [
+              "rightEntity",
+              "uuid"
+            ]
+          },
+          {
+            "parameter": "{{person_b_entity_uuid}}"
+          }
+        ]
       }
+    ]
+  },
+  "graphResolveDepths": {
+    "inheritsFrom": {
+      "outgoing": 0
     },
-    "temporalAxes": {
-      "pinned": {
-        "axis": "transactionTime",
-        "timestamp": null
-      },
-      "variable": {
-        "axis": "decisionTime",
-        "interval": {
-          "start": null,
-          "end": null
-        }
+    "constrainsValuesOn": {
+      "outgoing": 0
+    },
+    "constrainsPropertiesOn": {
+      "outgoing": 0
+    },
+    "constrainsLinksOn": {
+      "outgoing": 0
+    },
+    "constrainsLinkDestinationsOn": {
+      "outgoing": 0
+    },
+    "isOfType": {
+      "outgoing": 0
+    },
+    "hasLeftEntity": {
+      "incoming": 2,
+      "outgoing": 2
+    },
+    "hasRightEntity": {
+      "incoming": 2,
+      "outgoing": 2
+    }
+  },
+  "temporalAxes": {
+    "pinned": {
+      "axis": "transactionTime",
+      "timestamp": null
+    },
+    "variable": {
+      "axis": "decisionTime",
+      "interval": {
+        "start": null,
+        "end": null
       }
-    },
-    "includeDrafts": false
-  }
+    }
+  },
+  "includeDrafts": false
 }
 
 > {%
@@ -2279,62 +2269,60 @@ Content-Type: application/json
 X-Authenticated-User-Actor-Id: {{account_id}}
 
 {
-  "query": {
-    "filter": {
-      "equal": [
-        {
-          "path": [
-            "archived"
-          ]
-        },
-        {
-          "parameter": false
-        }
-      ]
-    },
-    "graphResolveDepths": {
-      "inheritsFrom": {
-        "outgoing": 0
+  "filter": {
+    "equal": [
+      {
+        "path": [
+          "archived"
+        ]
       },
-      "constrainsValuesOn": {
-        "outgoing": 0
-      },
-      "constrainsPropertiesOn": {
-        "outgoing": 0
-      },
-      "constrainsLinksOn": {
-        "outgoing": 0
-      },
-      "constrainsLinkDestinationsOn": {
-        "outgoing": 0
-      },
-      "isOfType": {
-        "outgoing": 0
-      },
-      "hasLeftEntity": {
-        "incoming": 2,
-        "outgoing": 2
-      },
-      "hasRightEntity": {
-        "incoming": 2,
-        "outgoing": 2
+      {
+        "parameter": false
       }
+    ]
+  },
+  "graphResolveDepths": {
+    "inheritsFrom": {
+      "outgoing": 0
     },
-    "temporalAxes": {
-      "pinned": {
-        "axis": "transactionTime",
-        "timestamp": null
-      },
-      "variable": {
-        "axis": "decisionTime",
-        "interval": {
-          "start": null,
-          "end": null
-        }
+    "constrainsValuesOn": {
+      "outgoing": 0
+    },
+    "constrainsPropertiesOn": {
+      "outgoing": 0
+    },
+    "constrainsLinksOn": {
+      "outgoing": 0
+    },
+    "constrainsLinkDestinationsOn": {
+      "outgoing": 0
+    },
+    "isOfType": {
+      "outgoing": 0
+    },
+    "hasLeftEntity": {
+      "incoming": 2,
+      "outgoing": 2
+    },
+    "hasRightEntity": {
+      "incoming": 2,
+      "outgoing": 2
+    }
+  },
+  "temporalAxes": {
+    "pinned": {
+      "axis": "transactionTime",
+      "timestamp": null
+    },
+    "variable": {
+      "axis": "decisionTime",
+      "interval": {
+        "start": null,
+        "end": null
       }
-    },
-    "includeDrafts": false
-  }
+    }
+  },
+  "includeDrafts": false
 }
 
 > {%
@@ -2351,63 +2339,62 @@ Content-Type: application/json
 X-Authenticated-User-Actor-Id: {{account_id}}
 
 {
-  "query": {
-    "filter": {
-      "equal": [
-        {
-          "path": [
-            "archived"
-          ]
-        },
-        {
-          "parameter": true
-        }
-      ]
-    },
-    "graphResolveDepths": {
-      "inheritsFrom": {
-        "outgoing": 0
+  "filter": {
+    "equal": [
+      {
+        "path": [
+          "archived"
+        ]
       },
-      "constrainsValuesOn": {
-        "outgoing": 0
-      },
-      "constrainsPropertiesOn": {
-        "outgoing": 0
-      },
-      "constrainsLinksOn": {
-        "outgoing": 0
-      },
-      "constrainsLinkDestinationsOn": {
-        "outgoing": 0
-      },
-      "isOfType": {
-        "outgoing": 0
-      },
-      "hasLeftEntity": {
-        "incoming": 2,
-        "outgoing": 2
-      },
-      "hasRightEntity": {
-        "incoming": 2,
-        "outgoing": 2
+      {
+        "parameter": true
       }
+    ]
+  },
+  "graphResolveDepths": {
+    "inheritsFrom": {
+      "outgoing": 0
     },
-    "temporalAxes": {
-      "pinned": {
-        "axis": "transactionTime",
-        "timestamp": null
-      },
-      "variable": {
-        "axis": "decisionTime",
-        "interval": {
-          "start": { "kind": "unbounded" },
-          "end": null
-        }
+    "constrainsValuesOn": {
+      "outgoing": 0
+    },
+    "constrainsPropertiesOn": {
+      "outgoing": 0
+    },
+    "constrainsLinksOn": {
+      "outgoing": 0
+    },
+    "constrainsLinkDestinationsOn": {
+      "outgoing": 0
+    },
+    "isOfType": {
+      "outgoing": 0
+    },
+    "hasLeftEntity": {
+      "incoming": 2,
+      "outgoing": 2
+    },
+    "hasRightEntity": {
+      "incoming": 2,
+      "outgoing": 2
+    }
+  },
+  "temporalAxes": {
+    "pinned": {
+      "axis": "transactionTime",
+      "timestamp": null
+    },
+    "variable": {
+      "axis": "decisionTime",
+      "interval": {
+        "start": { "kind": "unbounded" },
+        "end": null
       }
-    },
-    "includeDrafts": true
-  }
+    }
+  },
+  "includeDrafts": true
 }
+
 
 > {%
     client.test("status", function() {
@@ -2423,58 +2410,56 @@ Content-Type: application/json
 X-Authenticated-User-Actor-Id: {{account_id}}
 
 {
-  "query": {
-    "filter": {
-      "containsSegment": [
-        { "path": ["properties", "http://localhost:3000/@alice/types/property-type/name/"] },
-        { "parameter": "Alice" }
-      ]
+  "filter": {
+    "containsSegment": [
+      { "path": ["properties", "http://localhost:3000/@alice/types/property-type/name/"] },
+      { "parameter": "Alice" }
+    ]
+  },
+  "graphResolveDepths": {
+    "inheritsFrom": {
+      "outgoing": 0
     },
-    "graphResolveDepths": {
-      "inheritsFrom": {
-        "outgoing": 0
-      },
-      "constrainsValuesOn": {
-        "outgoing": 0
-      },
-      "constrainsPropertiesOn": {
-        "outgoing": 0
-      },
-      "constrainsLinksOn": {
-        "outgoing": 0
-      },
-      "constrainsLinkDestinationsOn": {
-        "outgoing": 0
-      },
-      "isOfType": {
-        "outgoing": 0
-      },
-      "hasLeftEntity": {
-        "incoming": 0,
-        "outgoing": 0
-      },
-      "hasRightEntity": {
-        "incoming": 0,
-        "outgoing": 0
+    "constrainsValuesOn": {
+      "outgoing": 0
+    },
+    "constrainsPropertiesOn": {
+      "outgoing": 0
+    },
+    "constrainsLinksOn": {
+      "outgoing": 0
+    },
+    "constrainsLinkDestinationsOn": {
+      "outgoing": 0
+    },
+    "isOfType": {
+      "outgoing": 0
+    },
+    "hasLeftEntity": {
+      "incoming": 0,
+      "outgoing": 0
+    },
+    "hasRightEntity": {
+      "incoming": 0,
+      "outgoing": 0
+    }
+  },
+  "temporalAxes": {
+    "pinned": {
+      "axis": "transactionTime",
+      "timestamp": null
+    },
+    "variable": {
+      "axis": "decisionTime",
+      "interval": {
+        "start": {
+          "kind": "unbounded"
+        },
+        "end": null
       }
-    },
-    "temporalAxes": {
-      "pinned": {
-        "axis": "transactionTime",
-        "timestamp": null
-      },
-      "variable": {
-        "axis": "decisionTime",
-        "interval": {
-          "start": {
-            "kind": "unbounded"
-          },
-          "end": null
-        }
-      }
-    },
-    "includeDrafts": false
-  }
+    }
+  },
+  "includeDrafts": false
 }
 
 > {%
@@ -2544,8 +2529,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
-        client.assert(response.body.roots.length === 2, "Unexpected number of data types");
-        client.assert(response.body.roots[0].baseId === "https://blockprotocol.org/@blockprotocol/types/data-type/text/", `Invalid order, expected text data type but got ${response.body.roots[0].baseId}`);
+        client.assert(response.body.subgraph.roots.length === 2, "Unexpected number of data types");
+        client.assert(response.body.subgraph.roots[0].baseId === "https://blockprotocol.org/@blockprotocol/types/data-type/text/", `Invalid order, expected text data type but got ${response.body.subgraph.roots[0].baseId}`);
     });
 %}
 
@@ -2609,8 +2594,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
-        client.assert(response.body.roots.length === 2, "Unexpected number of property types");
-        client.assert(response.body.roots[0].baseId === "http://localhost:3000/@alice/types/property-type/name/", `Invalid order, expected name property type but got ${response.body.roots[0].baseId}`);
+        client.assert(response.body.subgraph.roots.length === 2, "Unexpected number of property types");
+        client.assert(response.body.subgraph.roots[0].baseId === "http://localhost:3000/@alice/types/property-type/name/", `Invalid order, expected name property type but got ${response.body.subgraph.roots[0].baseId}`);
     });
 %}
 
@@ -2674,8 +2659,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
-        client.assert(response.body.roots.length === 3, "Unexpected number of entity types");
-        client.assert(response.body.roots[0].baseId === "http://localhost:3000/@alice/types/entity-type/person/", `Invalid order, expected name entity type but got ${response.body.roots[0].baseId}`);
+        client.assert(response.body.subgraph.roots.length === 3, "Unexpected number of entity types");
+        client.assert(response.body.subgraph.roots[0].baseId === "http://localhost:3000/@alice/types/entity-type/person/", `Invalid order, expected name entity type but got ${response.body.subgraph.roots[0].baseId}`);
     });
 %}
 
@@ -2687,57 +2672,55 @@ Content-Type: application/json
 X-Authenticated-User-Actor-Id: {{account_id}}
 
 {
-  "query": {
-    "filter": {
-      "cosineDistance": [
-        { "path": ["embedding"] },
-        { "parameter": [-0.025600875,0.018428829,-0.008834439,-0.014676568,-0.0045517944,0.008573205,-0.022735223,-0.0017573884,-0.0005610581,0.030841375,-0.017589716,0.002804301,-0.037965924,0.037364293,-0.013061671,-0.00043118355,-0.008628619,0.019077955,-0.0092539955,-0.017431393,-0.0041639023,0.012444209,-0.0045042974,0.004820944,-0.0064991703,0.007809296,0.005691722,-0.004975309,-0.021737786,-0.0019572715,-0.013789957,0.02224442,0.047971953,0.028719842,0.015206951,-0.031727985,0.014747813,0.011367612,-0.011510102,0.06636912,0.014462831,0.05544481,-0.036414355,0.015523598,-0.0021670498,-0.016639777,-0.0012141416,0.030113088,-0.022687726,0.0033010403,-0.014375754,-0.002317457,0.010655156,0.022846049,-0.014518244,-0.004690327,0.0069780983,0.028102381,-0.01768471,-0.02862485,-0.003712681,-0.018492159,0.023716828,-0.0061231526,0.0044211773,0.008858187,-0.023985976,0.039390832,0.014431166,0.043380577,0.016877262,-0.01428076,-0.014375754,0.030841375,0.00559277,0.022893546,0.016069813,0.015325693,-0.039232507,-0.047718637,0.028577352,-0.030350571,0.020107057,0.0008341658,-0.011090546,-0.027025783,-0.026028346,-0.12032569,0.012681695,-0.021991104,-0.007963661,0.0042866026,0.005074261,-0.010932222,-0.03128468,-0.024951749,0.04939686,0.010932222,-0.016576447,0.011359695,0.0036097707,0.013093335,-0.013687047,-0.048953556,-0.009420235,0.016782267,-0.005280081,-0.029400632,0.000350785,0.020455368,0.014169933,0.042019,-0.02856152,-0.026218334,0.016433956,0.018143848,-0.03815591,-0.029353136,-0.008406966,0.009744798,-0.013663298,-0.05170838,-0.0125787845,-0.035464413,0.00020693347,0.03999246,-0.012080066,0.03666767,0.003629561,0.0029289806,0.014296592,0.016956422,-0.018682146,0.009562726,0.026012514,0.020772014,-0.01295876,-0.00072630803,0.03400784,0.042019,-0.0409424,-0.010164354,-0.024429282,0.006162734,-0.023827653,-0.026677473,-0.0084861275,-0.053418275,-0.0094123185,-0.0051019676,-0.039010856,-0.032804582,-0.0150090465,0.01735223,0.0054384046,0.016623944,0.0134099815,-0.017336398,0.014494496,-0.019267943,0.009341073,0.04024578,-0.0012972613,-0.010211851,0.003629561,-0.030287243,0.03856755,-0.01714641,-0.014731981,0.015998567,0.0054819435,-0.009911037,0.0149773825,-0.008937349,-0.02346351,0.049080215,0.04110072,-0.016671441,-0.02005956,-0.020914504,0.008430715,0.03210796,-0.006000452,-0.015974818,-0.010006031,-0.022846049,-0.01017227,-0.05136007,0.035876054,-0.032867912,0.025015078,0.0017237447,0.025901688,-0.0013180412,0.04284228,0.051043425,0.015365274,0.00070503337,0.04420386,-0.0134099815,0.05189837,-0.06231604,0.019647919,-0.009238163,-0.06218938,0.02680413,0.02631333,0.002424325,0.01213548,-0.0047932374,0.010892642,-0.010987636,-0.005311746,-0.014969466,0.0065070866,-0.0031961512,-0.032551266,-0.036699336,-0.016046064,-0.03441948,0.0099268695,0.015056544,-0.0061191944,0.0003223363,-0.065862484,-0.0012537225,0.0132516585,0.038884196,0.014106604,-0.007092883,-0.013322904,-0.0078845,0.032804582,0.02455594,0.010283097,0.010006031,0.006613955,0.030841375,0.03631936,0.0041797347,0.020455368,0.037427623,0.012665862,-0.029875603,0.016528951,-0.027453257,0.02237108,-0.019774577,0.022830216,0.033152893,0.04319059,0.0058144224,0.018982962,0.013956197,-0.0043697227,0.0073659904,-6.419514e-05,-0.032551266,0.011684258,-0.01599065,-0.028308202,-0.0036612258,0.0021017415,0.01795386,0.0036473726,-0.0525,0.02352684,-0.02890983,-0.0084227985,-0.0031565703,-0.011795084,-0.016038148,-0.0071799606,0.029368969,-0.0038630879,-0.0010004052,-0.025664203,0.021595296,-0.0019058165,-0.0148823885,0.03536942,0.00066396827,0.025125904,0.02769074,-0.01238088,-0.03638269,0.015381106,-0.021373643,0.0029210644,0.014581574,-0.015127789,0.016307298,0.0048605246,0.00039605558,-0.010797648,0.010283097,0.0010281118,-0.030366404,-0.010298929,0.020661188,-0.013045838,-0.05164505,-0.044457175,-0.019220445,0.012800437,0.04651538,0.016291466,0.00323969,-0.020882841,0.019932901,-0.051518396,-0.011510102,-0.012436293,-0.028118214,-0.068269,-0.0030239746,-0.0018919632,0.0035088395,-0.0025252562,0.00054473104,0.025695868,-0.012119647,-0.0041243215,0.02061369,-0.004654704,0.014573658,0.0067406134,-0.012198809,0.01591149,-0.012840018,-0.019362938,0.012372964,-0.03422949,0.00897693,0.01557901,0.0012418482,0.04053076,0.024049306,0.016813932,-0.018602986,-0.009515229,-0.04645205,0.0027389927,0.02210193,-0.012990425,0.002410472,0.065419175,-0.022766888,0.016172722,0.009641888,0.0008801785,-0.0043261833,0.006186482,-0.0041164053,0.023590168,-0.009198583,0.037237633,-0.022956876,0.008153649,0.0193946,0.005588812,0.017985525,-0.02802322,-0.0019018584,0.034799457,-0.064500906,0.0019740933,0.04249397,0.038820866,-0.026202502,-0.045058805,-0.01190591,-0.006922685,-0.0404041,0.0012418482,-0.034514476,-0.0056679733,-0.026487485,0.006609997,0.016275633,0.019030457,0.010298929,-0.010670989,-0.0151673695,0.031522166,-0.0068870625,0.04243064,-0.00086929376,-0.0003619171,-0.004785321,-0.010718486,-0.015111957,0.0042905607,-0.004749698,0.05379825,0.028988993,0.0007693522,-0.019362938,0.009792294,-0.018761309,0.010995552,-0.029812273,0.012942928,0.017336398,0.039200842,-0.06972557,-0.01619647,-0.012800437,0.022181092,0.015214867,-0.008240727,0.0038472556,0.0010904516,-0.031727985,-0.009689384,0.0059173326,-0.005109884,0.032804582,-0.025157569,-0.011454689,-0.009990199,-0.015974818,0.0024460945,0.024191797,-0.028482357,0.00037280185,-0.026740802,0.020629523,-0.03407117,-0.006040033,-0.04699035,-0.005371117,-0.021658624,0.01768471,-0.02849819,-0.03815591,0.0029270016,-0.060701143,0.0018207177,-0.009032343,-0.023558503,0.009515229,-0.0015317777,0.015183202,-0.020977834,0.0378076,0.004654704,0.0034197827,0.048953556,0.010164354,0.024983414,0.011589264,0.0031625074,-0.036889322,-0.01673477,-0.03654101,0.024065139,0.04537545,0.013307071,0.02265606,-0.007524314,0.009436067,0.018444661,0.012032569,-0.010575995,-0.03394451,0.0063052247,0.007734092,-0.0013625697,0.04116405,-0.008185313,-0.020803679,0.029242309,-0.020708684,0.0017089018,-0.0064437576,-0.007769715,-0.00513759,-0.032012966,0.03555941,-0.029337304,-0.0039501656,-0.047781967,0.01741556,-0.013647467,-0.017225573,0.02536339,-0.025727533,-0.004258896,-0.0025707742,-0.007714302,-0.00090541126,0.0035899803,-0.029068153,-0.03714264,-0.029210644,0.017130578,-0.030113088,0.030778045,0.04122738,0.023716828,0.0299231,-0.0019770619,0.01896713,0.025806693,-0.0041797347,-0.0066377036,-0.025616705,-0.017653046,0.025205066,0.00030873038,0.048256934,-0.009372738,-0.02224442,-0.0024361995,-0.007096841,0.0378076,0.006162734,-0.00042920452,-0.020107057,-0.03006559,0.01952126,0.026376657,0.002845861,0.008446547,0.015998567,0.011399276,-0.05297497,-0.0514234,-0.04100573,0.028529854,-0.021943606,0.014993214,-0.010987636,-0.0045082555,0.045882087,0.012428377,0.015816495,0.015127789,-0.021975271,-0.0028359657,0.0026459778,0.0005239511,-0.013797874,0.0023431845,0.007761799,0.05585645,0.008881936,-0.015935238,-0.004306393,-0.023178527,-0.013758292,0.016750602,0.02005956,0.036731,0.026835795,0.009333157,-0.012895431,0.0038630879,0.0054265303,-0.016988087,0.0030318908,-0.012847934,0.03654101,0.009064008,0.027912393,-0.0008509876,0.020692853,-0.0019345125,0.024904251,0.023700995,-0.03584439,-0.0016881219,0.003623624,-0.01033851,0.039359167,0.011795084,-0.023273522,0.013077503,-0.042019,-0.016513119,-0.0006783163,0.006182524,-0.022339415,-0.039960794,-0.012618365,-0.027279101,-0.0038037167,-0.00030205114,-0.034039505,0.025331724,-0.012499623,0.050980095,0.02251357,0.008636535,0.009380654,0.014431166,0.02020205,-0.007967619,0.0062696016,-0.0008010168,0.016014399,0.0039778724,-0.0063923025,-0.01380579,-0.019537093,0.021231152,0.00092124357,-0.031379674,0.030841375,-0.059814535,0.0072670383,-0.019220445,0.0012576806,0.020107057,-0.0054740272,0.004737824,0.021246985,0.0042430637,0.006186482,-0.013386233,-0.033564534,0.0040451596,-0.023574336,-0.022830216,0.01659228,-0.02631333,0.022402743,0.014652819,-0.013489143,0.011573432,-0.010940138,-0.005707554,-0.027880728,0.0048051113,0.029495627,-0.009633971,-0.04923854,0.023716828,-0.021753618,0.017114745,-0.0066416613,0.00074609846,0.060574487,-0.013465395,0.044932146,0.02523673,0.0039561028,0.012127563,0.03372286,0.011882162,0.010599744,0.010425588,0.009618139,-0.012879599,0.007999283,0.013037922,-0.008581121,-0.0029111693,0.016141059,-0.009238163,0.0019899257,-0.009333157,-0.006906853,0.023099367,-0.0039343336,-0.0044568004,-0.0335962,-0.011050965,-0.007492649,0.018887967,-0.06294934,-0.054114897,-0.0033228097,-0.027247436,-0.00025603842,-0.020027895,-0.0050544706,-0.015531514,-0.030698884,-0.041575693,-0.046198733,-0.008209062,-0.014597407,0.023368515,-0.0026974329,-0.01910962,0.045882087,0.03182298,-0.0043776385,-0.063487634,-0.004896147,-0.01207215,0.014312425,-0.009998115,-0.022434408,-0.022640228,0.0020384123,-0.03584439,-0.048858564,-0.00013482217,0.023653498,0.02156363,-0.022561068,-0.003237711,0.024777593,0.0054859016,-0.002410472,0.017843034,-0.0069424757,0.008335721,0.0061943983,0.0073224516,0.030208081,0.02856152,-0.026297497,0.006020243,-0.00041188792,0.0013299155,-0.009040259,-0.01747889,0.017225573,0.025347557,-0.010164354,-0.033374548,-0.021816948,0.01568192,0.033817854,0.05538148,0.0030239746,-0.029606452,0.0204712,0.021658624,-0.008921517,0.0020918462,0.019917069,0.017922195,-0.048446923,0.00018145332,6.147396e-05,0.017193908,-0.0069187274,0.006427925,-0.021531966,0.00019134852,0.01159718,-0.028134046,-0.0041639023,-0.01735223,0.0225769,0.0023926606,-0.009546894,0.023178527,-0.008660283,0.0055848537,0.017463058,0.023241857,0.032709587,-0.0013823601,0.0064833383,-0.009950618,0.0012824185,-0.0288465,0.02829237,0.017304733,-0.0035682109,0.0070612184,-0.026439987,-0.028102381,-0.028260704,0.0048169857,-0.011296365,-0.01720974,0.009998115,0.028941495,-0.017573884,0.012531287,-0.036161035,-0.0016732791,0.00907984,0.0042430637,0.017431393,-0.0025292144,-0.019220445,0.0142728435,-0.0014902179,-0.022086097,-0.062474366,-0.03543275,-0.004923854,-0.009356906,0.018191345,0.00016846586,0.0066495775,-0.019141285,-0.018919632,0.011035132,-0.028134046,0.007686595,0.019758744,0.00027929214,0.0143361725,0.0051257163,-0.009151085,0.0078845,-0.019552926,9.6601936e-05,-0.007381823,-0.036889322,0.021991104,-0.026819963,0.019283775,-0.002804301,0.024128467,0.033342883,-0.02564837,0.0019839886,-0.002172987,-0.008446547,-0.011486353,0.0125154555,-0.008161565,-0.025141736,-0.021183655,0.011581347,0.0001293798,-0.0019216487,-0.0150723765,0.016014399,-0.0081694815,-0.0063131405,-0.027199939,-0.018761309,-0.018872134,-0.030239746,0.005711512,-0.01896713,0.01537319,0.038472556,0.024397617,-0.013101251,-0.019774577,-0.018460494,0.01353664,-0.0030497022,-0.0053869495,0.0067762365,0.01564234,0.013884951,-0.013164581,0.0015218825,-0.00080695393,0.03107886,0.012729191,0.03147467,-0.017114745,0.0017326503,-0.0020364332,0.021025332,-0.0018414976,0.0009860572,0.00303387,0.010876809,-0.020993667,0.0022006936,0.010528498,0.017098915,-0.014470748,-0.0053354944,0.0043340996,0.003869025,-0.013291239,-0.0018523823,-0.0030793878,-0.02366933,0.0009929838,0.013837455,-0.015871909,0.012190892,0.011953408,-0.038060915,-0.0061469013,-0.009823959,-0.018650481,-0.016924758,-0.009586475,7.684245e-06,0.023985976,0.016576447,-0.022640228,0.041417368,0.03483112,0.03182298,0.0035167558,0.04616707,0.012935012,0.021436973,-0.016544782,0.015389022,0.037427623,0.003283229,-0.032709587,-0.019822074,0.02482509,0.009174834,0.02965395,0.029812273,-0.03182298,0.008042823,-0.0042232736,-0.01394828,0.021674456,-0.011383444,-0.042557295,0.014352005,0.00012585464,-0.047971953,0.043887213,0.028719842,-0.010552246,-0.0076549305,0.024365952,0.0070335115,0.017637214,-0.0041164053,-0.013821622,-0.011367612,-0.016623944,0.01910962,-0.018982962,0.002519319,0.0043855547,-0.00056204764,0.012673778,0.027057448,0.0015100082,0.0016475517,0.03590772,-0.047180336,0.0060044103,-0.0014882388,-0.0036453935,-0.0046190815,-0.009792294,0.011636761,-0.038820866,0.007939912,0.0023253732,0.025901688,0.0016782267,-0.028260704,-0.0041441116,-0.0011953408,0.0065585417,0.03318456,0.037649274,-0.0043815966,-0.020977834,-0.007959703,0.0027172233,0.0049990574,0.0083594695,-0.03378619,-0.0028379448,-0.011359695,0.011913827,0.008826523,0.009602306,0.0070849666,-0.0035108186,-0.008636535,0.028134046,0.007500565,0.011897994,-0.009744798,-0.008201146,0.00406495,0.00013618276,0.016972255,0.011272618,0.039264172,-0.013853286,0.008145733,0.010401839,-0.025110072,-0.020597858,0.00425098,0.02428679,0.0036731001,0.010568079,-0.00022486853,0.03080971,-0.0073620323,-0.009206499,-0.027849065,0.015444436,-0.047180336,-0.0050940514,0.014636987,0.02618667,-0.0108530605,0.0023827653,0.013663298,0.012562952,-0.022133594,0.052753314,0.009388571,-0.028514022,0.0059212907,-0.020360373,-0.0064160507,0.012151311,0.01747889,-0.01632313,0.019822074,0.035749394,0.010488917,-0.019489596,0.0023115198,0.089231,0.005216752,-0.023162695,-0.012008821,-0.029273974,0.0013586116,0.027136609,0.030287243,-0.0016524992,-0.012737107,-0.025490047,0.0074174455,0.00057936425,0.01285585,0.0067841522,-0.02259273,0.023352683,0.006431883,-0.018951297,-0.004583459,0.024112634,0.008098235,0.022941044,-0.0010736297,0.024745928,-0.006716865,0.0109163895,-0.0065427097,0.04284228,-0.0071799606,0.01917295,0.00406495,-0.022877714,0.0062458534,-0.0049594766,-0.018428829,-0.022070264,0.004543878,0.0014268885,0.008232811,0.0048644827,0.008098235,-0.00042029883,0.0019839886,0.01207215,-0.016671441,0.009610223,-0.0100535285,0.003679037,0.00540674,-0.028339867,-0.016671441,-0.0050584287,0.033057902,-0.015286112,0.02427096,0.011787168,-0.0018484243,-0.009016511,-0.0054898597,-0.007579727,-0.021405308,-0.029226476,-0.010006031,0.026091676,-0.021864444,-0.022418575,-0.017985525,0.023780156,-0.004009537,0.027706573,-0.04610374,-0.0045082555,0.017700542,0.00056749,-0.005806506,-0.01659228,0.03562274,0.026614143,0.02216526,0.0067049908,-0.008185313,-0.0072274576,-0.016228136,0.0010894621,0.015468184,-0.01207215,0.002843882,-0.0017920216,-0.020186218,0.03720597,-0.009333157,0.013599969,0.026550815,0.036889322,0.012895431,-0.024793426,0.016125226,0.010797648,0.009000679,-0.016291466,0.01884047,-0.011795084,-0.0019444077,0.020170385,-0.00084604,-0.043665558,-0.011541767,0.009641888,0.026677473,0.018112183,-0.021436973,0.030619722,0.026503317,-0.0011310219,0.024096804,0.008414882,-0.015895657,-0.0023332892,0.033849515,-0.0404041,-0.016354794,0.0029270016,0.012309635,0.027231604,0.017193908,-0.007761799,-0.012499623,0.039707478,-0.02849819,0.013164581,-0.004824902,-0.010101025,0.0051930035,0.003574148,0.004532004,0.00064516737,-0.014969466,-0.006764362,-0.02354267,-0.0029665823,0.004203483,0.027453257,-0.00019369864,0.020376205,-0.014692401,0.003138759,-0.0016465621,-0.029273974,0.0010953991,0.018697979,-0.01809635,-0.013916616,-0.018682146,-0.0021512175,0.02340018,-0.02108866,-0.017763872,-0.021975271,-0.0038373605,-0.010393923,0.0058737937,0.005747135,-0.015832327,0.021785283,-0.005596728,-0.008668199,0.0056679733,-0.021816948,0.015175286,-0.014359921,-0.0040768245,0.018476326,0.0016287507,-0.008763193,0.021975271,-0.0064872964,-0.0029566872,0.0031051154,-0.007148296,0.005751093,0.012491707,-0.0034336362,-2.7923032e-05,0.008030948,0.014043274,0.0013477269,0.030239746,0.024951749,-0.024160132,0.0074886912,0.013687047,-0.030033926,0.0028696095,-0.005545273,-0.021706121,0.015151538,-0.021816948,0.0109163895,0.0075124395,-0.0030556393,0.0010726402,-0.014043274,-0.00011886615,-0.002649936,-0.017431393,0.01795386,-0.016109394,0.002709307,-0.006958308,0.018143848,0.017700542,-0.009230247,0.016077729,0.009823959,-0.017510554,0.0041322378,-0.0038017377,-0.0053394525,-0.038187575,0.0010963887,0.0036394564,0.0051969616,-0.00503468,-0.032899577,0.012254221,0.02271939,0.01122512,0.022070264,0.00013086408,0.0067049908,0.005759009,-0.007892415,-0.019267943,-0.017542219,-0.013497059,-0.032266285,0.037110977,0.016750602,-0.010908474,0.0021630917,-0.018602986,-0.005794632,0.032313783,0.02577503,0.025885856,0.0021452804,0.018602986,-0.015769,-0.0067247814,-0.007864709,-0.02115199,-0.013196245,-0.010591827,-0.012024653,-0.018001357,-0.0025410885,-0.007947829,-0.005636309,0.009436067,-0.0023075617,0.019632086,0.02271939,-0.033279553,-0.012285886,0.0116525935,0.00839905,0.020772014,0.011058881,-0.000943013,0.018587153,-0.0068197753,0.004630956,0.0183655,-0.008446547,-0.011668426,0.0077736727,-0.023131032,-0.001640625,-0.019410433,-0.0026697263,-0.002649936,0.025474215,-0.0014338152,0.0065466673,-0.012254221,0.0024065138,0.0051969616,-0.0007144338,-0.040150784,0.028830668,0.0037581988,-0.017621381,0.002841903,-0.008216978,0.02530006,0.0053948658,0.022846049,0.0151040405,0.027785735,0.0068356073,0.0116525935,-0.0072512063,0.003989747,0.007714302,0.02769074,-0.031680487,-0.011145959,-0.0024361995,-0.015294028,-0.019774577,0.0029052321,-0.014668652,0.011193456,0.0069147693,0.026962453,0.03407117,-0.012016737,-0.019378768,-0.002802322,-0.033057902,0.02420763,-0.013560389,-0.0003334684,-0.0042905607,0.018729644,-0.027769903,-0.016718939,-0.008161565,-0.015697753,0.026344994,-0.006040033,0.001450637,0.009602306,0.0065822904,-0.0027627412,0.02591752,-0.008185313,0.0031308427,-0.013821622,0.020645356,-0.0061548175,-0.008280307,0.011423024,-0.0141778495,-0.0039323545,0.03761761,0.015863992,-0.019157117,-0.006859356,0.0009979315,-0.012095898,0.018682146,0.021167822,0.019806242,-0.017763872,-0.028514022,0.015096124,0.026408322,-0.020249547,-0.007579727,0.041132387,0.0018454557,0.032677926,-0.001062745,0.0064041764,0.026139174,0.00091035885,-0.007354116,-0.0073224516,0.023115199,-0.0020027894,0.003989747,0.02556921,-0.027991556,0.027184106,-0.01370288,0.019901237,0.022117762,0.0022006936,0.013172497,-0.015024879,0.02121532,0.0049792673,-0.013655382,-0.0068831043,0.006570416,-0.010536415,0.027864898,-0.021041164,0.026060011,0.0054344465,0.00025653318,0.018207178,-0.014454915,-0.0014516265,-0.010797648,0.021658624,0.020297045,-0.028419029,-0.022291917,-0.01027518,-0.005952955,-0.0062221047,0.022323582,-0.0009034322,-0.015191118,-0.013093335,-0.008193229,0.0028240914,-0.0048090694,0.0042786864,-0.009649804,0.028387364,-0.02354267,0.0038907945,-0.0010914411,0.0012655967,-0.0065625,-0.0065031284,0.009230247,0.0073145353,-0.018729644,0.005948997,-0.014629071,0.0056758896,-0.0032080254,0.024318455,-0.036731,0.009491481,-0.017225573,0.013164581,-0.020154553,-0.028086549,0.0109480545,-0.0028735674,0.036920987,-0.018777141,0.0014348048,0.02115199,0.008438631,-0.032551266,-0.017336398,0.01632313,0.011842581,-0.011407192,-0.008763193,-0.017383896,0.011335947,-0.034514476,0.022814384,0.019632086,-0.007619308,-0.044235524,-0.0011755503,-0.0023352683,-0.008454463,-0.022766888,-0.027944058,-0.014328256,-0.016307298,-0.019030457,-0.0067801946,0.0060637817,0.011153875,0.03495778,-0.010425588,0.011454689,0.00029413495,-0.004987183,0.015515681,-0.011478438,0.007852835,0.009847708,-0.011343863,-0.02040787,-0.02026538,0.02775407,0.031268846,0.012974593,-0.019663751,0.005755051,-0.008335721,0.010457252,-0.0045715845,-0.034039505,-0.0035068607,-0.008818607,-0.0018988898,0.0059094164,0.026614143,-0.0071285055,0.0101801865,0.012539203,0.022386912,-0.025157569,0.002901274,-0.009428151,0.0031605284,0.023368515,0.015175286,0.014193682,0.0189038,-0.0053790333,0.032123793,0.013053754,0.012974593,0.019742914,-0.015412771,-0.011676341,0.023416013,0.0142095145,-0.02142114,-0.014629071,-0.009823959,-0.0002773131,-0.0020700768,-0.0108530605,0.00037651256,-0.024397617,-0.0036374773,-0.017336398,0.0038749622,-0.01795386,0.015650256,-0.0065427097,-0.016030231,0.005022806,0.013956197,-0.009341073,-0.020423703,-0.011027216,0.009151085,-0.001087483,0.009728965,-0.01054433,0.0025034868,-0.000627356,0.026835795,-0.009364822,0.02237108,0.00976063,0.00763514,0.013916616,-0.015547345,-0.015689837,0.017938027,-0.0015802642,0.023922646,0.0035444624,0.0071799606,-0.032931242,0.009151085,0.010528498,-0.0039343336,-0.0071205893,0.017874697,-0.018666314,-0.015230699,0.0021828823,0.018428829,-0.011003468,0.029558957,0.021389475,0.0109480545,0.00069761195,-0.0010211852,0.0069820564,-0.0059015,-0.009626055,-0.035306092,-0.014557825,-0.0030160584,-0.0151040405,0.007813253,-0.011177624,-0.002796385,0.033311218,-0.0012893452,-0.000736698,0.020455368,0.039454162,0.01720974,0.0048051113,-0.0064002187,0.0026281665,-0.010560162,-0.0015980756,0.031110523,0.017336398,0.013045838,0.025157569,0.018618817,0.023970144,-0.0020997624,0.02666164,-0.022561068,-0.026772466,-0.00887402,0.024540108,0.007575769,0.012341299,-0.010219768,0.017716374,0.007259122,0.010124774,-0.005082177,-0.0015466205,0.007354116,-0.0023036036,-0.007627224,0.012372964,0.01700392,0.011153875,-0.01265003,0.012539203,0.0019681563,0.00763514,-0.007207667,-0.02427096,-0.019980397,-0.007338284,0.001516935,0.0032753127,-0.015111957,0.004797195,0.013560389,0.028893998,0.019948732,-0.0030299118,-0.0049040634,-0.026962453,0.014217431,-0.0010350384,0.012349215,-0.014304508,0.014106604,-0.024587605,-0.014352005,-0.00081585965,-0.013528724,-0.0054304884,-0.009032343,-0.007476817,0.017763872,-0.0005585843,-0.018887967,-0.0063645956,-0.003823507,-0.0016633839,-0.012570868,0.0059569133,-0.008478211,-0.021959439,0.0013823601,0.0007648993,0.018191345,0.0075995172,0.0026756634,-0.011391359,-0.020376205,-0.007041428,-0.02020205,-0.005703596,-0.008304056,-0.037554283,0.0065427097,-0.0070097633,0.014304508,0.0034197827,0.0031822978,-0.013861203,0.028102381,0.0016336984,-0.007647014,0.0017514513,0.0058856676,0.0215003,-0.019679584,0.018349668,-2.926816e-05,-0.023922646,-0.025347557,0.0069306013,-0.012270054,0.008652367,0.003532588,-0.021484468,0.0025589,-0.008185313,0.008850271,-0.0043143095,0.012816269,0.0052840393,-0.01619647,-0.005280081,0.006000452,-0.017542219,0.0035029026,-0.020012062,0.0028141963,-0.000943013,0.012919179,0.010227684,0.010773899,-0.011486353,-0.003582064,0.002172987,-0.007069134,-0.014557825,0.01190591,0.008644451,-0.018982962,-0.0036632048,-0.008209062,-0.0012438273,-0.018001357,-0.008494044,-0.018729644,0.029543124,-0.0064595896,-0.013631634,0.020154553,0.020217882,0.0029784567,-0.011248869,0.007116631,0.0063012666,-0.0014536056,0.00559277,0.025616705,-0.0016713002,0.006043991,0.017447226,0.009420235,0.0067999847,-0.009174834,0.0074214037,-0.011826749,-0.025284227,-0.017288903,-0.002756804,0.0047576143,-0.0043855547,0.0067326976,-0.0025331725,-0.013837455,-0.004876357,0.007286829,-0.01370288,-0.027215771,-0.003991726,-0.006712907,-0.008786942,0.0013200203,-0.0035959175,0.01060766,0.008478211,-0.0022937085,-0.015444436,-0.0062181465,-0.00017118704,0.023115199,0.008209062,-0.00676832,4.217831e-05,-0.0006110289,-0.0025133821,0.0034672797,-0.009475648,0.0052207103,0.0055531887,-0.0067762365,-0.0094123185,0.009626055,-0.010797648,0.011027216,-0.011035132,0.027421592,-0.010393923,-0.0067049908,0.024223462,0.010773899,0.025030911,0.016893094,0.0007599517,-0.03101553,0.0063052247,0.027722405,-0.001952324,-0.0058262968,-0.011058881,0.0049555185,-0.021516133,-0.009325241,-0.0101801865,0.008121984,0.012080066,0.009641888,-0.018128015,0.00044751063,-0.011161791,-0.0151040405,-0.004591375,0.0033524954,0.01735223,-0.0011854456,0.01006936,0.014312425,-0.009887288,-0.011446773,0.0064160507,-2.8340484e-05,0.007935954,-0.011438857,-0.02129448,-0.00965772,-0.01432034,-0.007920122,-0.012000904,0.011771335,0.0074134874,0.004876357,-0.02251357,0.0011696132,0.029685615,-0.014257011,0.026899125,-0.0058381706,-0.012349215,0.018523823,-0.018666314,0.018697979,-0.021326145,-0.0060281586,0.01500113,-0.0072274576,-0.003677058,0.014636987,-0.0016960381,0.0060321167,0.0046942853,0.033849515,-0.0063685537,-0.0010078266,-0.022481905,-0.0061191944,0.017668879,0.02055036,0.001838529,0.022497738,0.01537319,0.0014229305,0.0007396666,-0.017083082,0.009135253,0.01394828,-0.0042113992,-0.021864444,-0.01789053,0.005228626,0.012610449,0.00724329,0.028355699,0.01918878,-0.024999246,-0.008094277,0.0022501696,-0.0050980095,0.00031046206,-0.005707554,0.0023471427,-0.019869572,-0.021721954,-0.026978286,-0.0079122055,-0.009198583,0.00022981613,-0.0027152442,-0.03080971,-0.0041757766,-0.008612786,0.0012339321,-0.015531514,0.0027290974,0.004943644,-0.007920122,-0.02387515,0.0046151234,0.0029250225,-0.0069306013,-0.0036434145,0.011066797,-0.02094617,0.024745928,0.0073699486,0.03422949,0.0061508594,-0.014541993,-0.008525709,-0.019331273,-0.0011112315,0.0021571547,-0.02115199,-0.0059806616,-0.00047249603,0.014478664,-0.01190591,0.039169177,0.009087756,0.024587605,-0.0032931243,-0.0016485411,-0.0035048816,-0.019695416,0.012151311,0.0037008065,-8.577906e-05,0.0020542445,0.036351025,-0.011423024,0.013212077,-0.0054740272,-0.027199939,-0.008533625,-0.0044686743,-0.0008485138,0.009681469,-0.00015696269,0.0017573884,0.0037047646,-0.0033109356,0.0024282832,-0.0036810162,0.011969239,-0.0015634424,-0.028308202,-0.018998792,-0.0020215902,0.0060756556,-0.0027746155,-0.0065981224,-0.0054779854,-0.0011300324,0.03435615,-0.015602759,-0.033912845,0.008589038,0.0066456194,-0.028925663,0.016560614,0.025458382,-0.012903347,0.009246079,-0.002707328,0.014446999,-0.0149457175,0.0068197753,0.01353664,-0.005541315,0.0049476023,0.0061706495,0.030793877,0.007639098,-0.00012022674,0.0031229267,0.012198809,-0.0037027856,-0.019299608,-0.018207178,0.008929433,0.00028448715,-0.0025133821,0.01217506,-0.0033643697,-0.0024856755,0.010496833,-0.0051969616,-0.018112183,-0.012586701,0.0070335115,0.018887967,-0.021706121,0.015571094,0.00036414355,-0.004892189,-0.0027884687,0.01931544,0.0074411943,-0.007761799,0.013647467,-0.0036354982,0.012064233,-0.0056006857,-0.007769715,0.0150090465,0.0032238578,0.0026261874,0.022861881,0.0053948658,-0.022434408,0.003991726,0.0043697227,-0.018428829,-0.0065387515,0.0042905607,0.023906816,-0.02911565,0.03115802,0.0035998756,0.008430715,0.0204712,0.0015119873,0.00744911,-0.0031070942,0.017874697,0.029400632,-0.007389739,0.032487936,0.0081299,-0.00047224865,-0.023368515,-0.018634649,-0.008509876,0.0071205893,-0.0047615725,0.010322678,0.0017821264,-0.026091676,-0.0039303754,-0.01884047,-0.0030378278,-0.013053754,-0.005846087,0.020091224,0.0050069736,-0.0055333986,0.0077103437,0.0030536603,-0.02550588,-0.011953408,-0.022386912,-0.005462153,-0.0067010326,-0.011961323,-0.012103815,-0.0032555223,-0.015389022,-0.013607886,-0.01809635,0.00089798984,-0.005066345,-0.022022767,-0.011937575,0.0043578483,-0.0001442226,-0.005418614,0.0071839187,0.0067960266,-0.010362258,0.007207667,-0.014217431,0.015389022,-0.020867009,-0.015222783,-0.0020878883,0.008248643,-0.010623492,0.0021353853,0.001743535,0.01500113,-0.0031486542,-0.0065387515,-0.0033287469,0.012840018,0.0026816004,0.005830255,-0.008818607,0.0015159454,0.0026222293,0.017494721,0.012832101,-0.018587153,0.005945039,0.0035523786,-0.01428076,-0.0025410885,0.0031704237,0.0054265303,0.026123341,-0.01917295,-0.013750376,-0.00763514,-0.022861881,0.0134099815,0.024381785,-0.0006916748,-0.01801719,-0.003235732,0.01781137,0.0125154555,0.0071799606,-0.00396204,-0.025632538,0.0032001093,-0.0028893999,0.021769451,-0.03489445,-0.01489822,-0.0019097745,-0.016687274,0.0162598,0.017431393,-0.008446547,-0.009626055,-0.023606,-0.014431166,0.0005026764,0.020803679,-0.01213548,-0.013014173,0.013639551,0.003621645,0.012697527,-0.009087756,-0.015191118,-0.009792294,0.02040787,-0.010101025,0.0335962,-0.00484865,0.0025826485,-0.01896713,0.014557825,0.016061896,0.007496607,0.013679131,-0.0030358487,0.0050544706,0.00040718768,-0.009309408,-0.009404402,-0.010742234,0.024096804,0.008660283,0.018856302,-0.031506334,-0.01054433,0.003235732,0.014716148,-0.002891379,0.005157381,-0.0044290936,0.028957328,-0.01884047,0.008446547,-0.009665636,-0.005185087,-0.008121984,0.020154553,0.0026281665,-0.004785321,0.00054819434,0.00928566,-0.009633971,0.005347369,0.028656512,0.0309522,-0.015507765,0.011478438,-0.0016950486,0.020772014,-0.0162598,-0.004654704,0.016433956,-0.00044751063,0.02346351,-0.0034118667,-0.010409756,-0.014067023,0.01496155,0.009911037,-0.017288903,-0.01979041,0.0025945227,0.0069345594,0.014811142,0.009174834,-0.041259047,-0.003865067,0.029432297,-0.011090546,-0.009578559,0.017922195,0.009792294,0.004927812,0.0031585493,-0.010940138,-0.0062735598,-5.1455067e-05,0.00022474484,0.0017227551,-0.0009939733,0.025094239,0.013750376,-0.0054304884,0.010409756,0.018887967,0.004868441,-0.010987636,-0.023922646,0.015586927,0.023495175,-0.013694963,0.0060994043,-0.01489822,0.0024876546,-0.008185313,-0.010821396,0.018143848,0.031949636,-0.019204613,0.015444436,0.0012062255,0.0126421135,0.0052919555,-0.0071245474,0.014296592,-0.013758292,-0.0010667031,-0.0060044103,0.0028260704,-0.006024201,-0.008462379,0.016243968,0.00049006,0.022117762,-0.007199751,-0.002509424,0.015460268,-0.0024817174,0.0019176907,0.019299608,-0.043665558,0.026819963,-0.001933523,-0.0016366668,-1.118622e-05,0.0125471195,-0.002461927,0.011050965,0.02959062,0.008636535,0.010148522,-0.0032931243,-0.008794858,-0.003967977,-0.0046467884,0.012080066,-0.006993931,-0.0064833383,0.010188103,-0.0133149875,-0.013164581,0.0020107056,-0.02259273,-0.032345444,-0.0065862485,0.011383444,0.012935012,0.0022897504,0.00763514,0.00606774,0.013924533,-0.01060766,-0.01064724,0.01599065,-0.0010221746,-0.014557825,-0.0054581948,0.026107509,0.014660736,0.012190892,0.016291466,0.0133149875,0.010987636,-0.015935238,-0.020233715,0.04087907,-0.02672497,0.012000904,-0.007350158,0.014621154,0.02428679,-0.0021551757,-0.007983452,0.00773805,-0.010283097,0.014541993,-0.0039956835,0.01720974,0.012293803,0.016370626,0.008030948,-0.025790863,-0.0017791578,-0.010623492,-0.0040016207,-0.0044528423,0.02026538,-0.011399276,0.008224894,0.0050069736,0.0033247888,-0.010631408,0.019347105,0.031189686,-0.0013358527,0.013354569,0.0096973,0.0024084928,-0.01673477,-0.018444661,-0.006423967,-0.009966451,0.0079122055,-0.008114068,-0.009151085,-0.00453992,0.0047932374,-0.021896109,0.037332628,0.0053434107,-0.006135027,-0.0054779854,0.0022877713,0.022466073,0.013520808,-0.0065427097,-0.028197376,-0.0015970861,0.0055373567,0.014201598,-0.009839792,-0.020455368,0.01979041,-0.022466073,-0.004306393,-0.013243742,0.010148522,-0.0062458534,-0.0007916164,-0.023795988,0.00619044,-0.0042747287,0.013180413,0.007342242,0.0065506254,-0.010156439,-0.0039402707,-0.02707328,-0.016014399,-0.009681469,-0.0037403875,0.001743535,-0.018555488,-0.007983452,-0.01789053,0.010378091,-0.005062387,0.002604418,0.0013853287,0.018792974,0.016085645,0.009151085,-0.019568756,0.011573432,-0.0058262968,-0.016402291,0.0032654176,-0.0038037167,-0.032867912,0.011296365,0.0059687877,-0.004872399,0.0012665862,0.0065110447,-0.014162017,-0.013837455,-0.01945793,-0.023241857,0.00033396317,4.304414e-05,-0.009990199,-0.0025232772,-0.01122512,-0.017542219,-0.004868441,-0.0006382407,0.0059806616,-0.010536415,0.014257011,0.0072749546,-0.0049357284,0.0042747287,-0.00030873038,-0.012602533,0.008494044,-0.019473763,0.0057273447,-0.017383896,0.0059094164,-0.0039006898,-0.0012487748,-0.0013259575,0.017257238,-0.012555036,-0.013560389,-0.0077934633,-0.009531061,0.0049950993,-0.01735223,-0.011058881,-0.016402291,-0.016307298,-0.008406966,0.0059094164,0.0064160507,0.011264701,0.0043736803,-0.004492423,-0.021943606,0.0013526744,-0.015863992,0.008335721,-0.009626055,0.017193908,-0.0016891115,-0.01686143,0.004389513,-0.004634914,0.016275633,-0.0065031284,0.007290787,0.017383896,-0.01432034,0.005367159,-0.018777141,0.030192249,-0.014122437,-0.0033445791,0.012111731,0.0028201335,-0.004302435,-0.005363201,-0.0025747323,-0.0042272317,0.00094350777,-0.010765983,-0.017779704,-0.00887402,0.015689837,-0.033564534,0.0050069736,0.016212303,0.0032693758,-0.012151311,-0.0020918462,0.0033049984,0.029907268,0.0073739067,-0.009048175,-0.0061112787,-0.01557901,-0.0034692588,0.014534077,-0.0004680432,0.010663073,0.015586927,-0.03809258,-0.0062023145,-0.028830668,0.025616705,0.009016511,0.0063527217,0.010140606,0.0071562123,0.013694963,-0.010678905,0.007714302,0.008351553,-0.0204712,-0.011826749,0.02672497,-0.010298929,-0.02026538,0.018064685,0.016433956,-0.020724516,-0.0029744986,-0.013797874,0.009562726,0.009396487,0.0018276443,0.021468636,-0.0059054582,0.006946434,0.023637665,0.011977156,-0.0019800304,-0.017542219,0.020233715,-0.010061445,0.002802322,0.006950392,-0.034577806,0.028419029,-0.0048169857,0.0014684484,0.013354569,-0.024856754,0.013014173,-0.014826975,0.017051417,0.022925211,0.0022838132,-0.009602306,0.03346954,-0.0011280534,-0.0014971445,0.00532362,0.0016208346,0.005232584,-0.003526651,-0.010465168,0.0034435312,0.008517792,-0.008351553,0.0034613425,0.025790863,-7.5512784e-05,-0.005755051,-0.021832779,-0.013607886,0.023859318,-0.0070374697,0.0059371227,-0.0057154703,-0.0090956725,0.013180413,0.0060519073,-0.009388571,0.008905685,0.0070889248,-0.017019752,0.0116525935,0.032962907,-0.00058084854,0.010393923,0.0044053453,0.0012764814,0.008209062,0.0096973,-0.021911941,0.009887288,0.028688177,-0.008224894,0.0074689006,0.0052009197,0.027849065,0.0025034868,-0.010259348,-0.018745476,-0.003047723,-0.009681469,-0.00012183471,-0.021373643,0.002032475,0.0056323507,-0.004039223,0.017637214,-0.020851176,-0.028957328,0.004393471,0.019204613,-0.012721275,0.009071924,0.0047576143,-0.016924758,-0.010520582,0.0051059257,0.0019572715,-0.010932222,-0.00051207683,-0.011272618,-0.015396939,0.014676568,0.027089113,0.013212077,0.0013665278,-0.020645356,0.0062933504,0.028339867,0.004393471,0.003045744,0.0050505125,0.014225346,0.013694963,-0.011929659,0.0067208232,0.019378768,0.012673778,-0.018112183,-0.02162696,-0.0018286338,0.0019760723,0.009816043,-0.0024084928,0.010314762,-0.009586475,0.0062023145,-0.00503468,-0.006182524,0.003332705,0.0126421135,0.011929659,-0.012404629,0.004876357,-0.029036488,-0.00021682867,-0.009087756,-0.014185766,-0.0189038,0.0047061592,-0.020027895,5.5846063e-05,-0.015824411,-0.019837907,-0.0004999552,0.01112221,0.014621154,0.008304056,0.0005971756,-0.023970144,0.003334684,-0.025585042,0.009087756,-0.023416013,-0.0035880012,0.009626055,0.0012002883,-0.019410433,0.021658624,-0.020914504,-0.027928226,0.006135027,-0.001229974,0.018112183,-0.008470295,-0.0043103513,0.01931544,-0.023004372,-0.032804582,0.008961097,0.01190591,0.009507312,0.027849065,0.0021927773,-0.016133143,-0.026629975,-0.009911037,-0.00063032453,0.0032990612,-0.008858187,0.0050900932,0.025901688,0.0125471195,0.017019752,-0.01553943,-0.00019357495,0.022687726,-0.011367612,-0.011549683,0.010575995,-0.007761799,0.008628619,0.0016772372,0.0034059295,-0.012539203,0.0065585417,0.012095898,0.007892415,0.012190892,-0.0063012666,-0.004306393,0.024460947,0.02020205,0.00064566213,0.026075844,0.0068356073,0.018539656,-0.006756446,-0.018808804,0.04537545,0.010441421,0.022877714,0.0014743855,0.01122512,0.0027409717,-0.015856076,0.013069587,-0.032709587,-0.020993667,0.0066456194,0.0018899841,0.013394149,0.011050965,-0.008153649,-0.02040787,-0.011423024,-0.0062458534,-0.027057448,-0.008343637,-0.00014917021,-0.039200842,0.0062498115,-0.00068029534,-0.016687274,-0.01774804,-0.037427623,0.0014625113,0.012887515,0.02319436,0.011644677,0.014391586,-0.016924758,-0.018460494,-0.023083534,0.016972255,0.0023847444,0.018270506,-0.013109167,0.002171008,0.0078488765,0.0015060502,-0.020692853,0.0020918462,-0.0100218635,-0.026788298,0.02012289,-0.021943606,0.006859356,-0.0070889248,-0.008945265,0.005161339,-0.0116209285,0.036952652,0.0010033738,-0.012325468,0.02094617,0.033817854,0.0005214773,0.010409756,-0.00021200476,0.016101478,-0.005062387,-0.006043991,-0.0034831122,0.0051455065,0.016433956,-0.0019364916,0.02523673,0.013378317,-0.018143848,-0.015626507,-0.01700392,0.015966903,0.0010300908,0.016418124,-0.024096804,0.0015307881,0.00054671004,0.0038967317,0.0023570377,0.0019740933,0.022355247,-0.013544557,-0.0061587756,-0.011858414,-0.008011158,-0.0021630917,-0.018555488,-0.0003846761,-0.012198809,-0.01632313,0.021959439,0.0075638946,-0.009214414,0.019378768,0.007235374,0.0076113916,-0.0031625074,0.020803679,-0.0035286301,0.018397165,0.017637214,0.001304188,-0.00025195666,0.013774125,0.0050267642,-0.009855624,0.012840018,0.016156891,0.020692853,-0.006898937,-0.022434408,0.0032713548,-0.006570416,0.022703558,-0.0014704275,-0.028593184,0.008937349,0.024904251,0.009768547,-0.009341073,-0.002845861,-0.040024124,-0.009538977,-0.003522693,-0.011486353,0.003623624,-0.0027805525,0.010433504,-0.022608563,0.0036335192,0.014819059,0.0024025557,0.0151357055,-0.024793426,0.008905685,0.00685144,0.003908606,-0.0066377036,0.024223462,0.023764323,-0.0031466752,0.0029665823,0.009570642,0.0020542445,0.04252563,0.0204712,-0.0014991235,-0.0064912545,0.014811142,-5.4145323e-05,-0.0021967355,-0.008905685,-0.0075836848,-0.024745928,-0.0027429508,0.004678453,0.01884047,0.008121984,-0.008691948,-0.001838529,0.00328125,0.009103589,-0.021579463,-0.010386007,0.012879599,0.0016643734,-0.025347557,-0.008383217,-0.007959703,0.010283097,0.002171008,-0.0012942927,0.025078407,-0.033152893,-0.013639551,-0.0017712417,0.016156891,-0.000447758,0.011454689,0.015309861,-0.0015179244,-0.022402743,0.025458382,-0.013465395,0.009776463,-0.02271939,0.025268395,-0.008074488,-0.008699864,-0.009903121,0.0006793058,0.00054473104,-0.0068910206,-0.017130578,0.0033999924,-0.010702654,-0.00065506255,-0.037269298,0.0036335192,0.013101251,-0.009143169,-0.001133001,0.04116405,-0.005351327,-0.0037008065,0.0022838132,-0.0037918424,-0.004824902,-0.047655307,0.0046032495,-0.016354794,-0.00031169894,-0.007789505,-0.0028696095,-0.0074689006,-0.005897542,-0.01727307,0.010227684,0.01918878,-0.009341073,0.008644451,-0.025220899,-0.0038789203,0.014708232,-0.00022610543,0.03365953,-0.021595296,-0.020217882,-0.0012972613,0.020803679,-0.0010548289,-0.002756804,-0.009823959,-0.023780156,0.019584589,0.017193908,0.03612937,-0.014581574,-0.012151311,-0.00907984,0.005109884,-0.0038353815,-0.003716639,-0.007781589,-0.004991141,0.03793426,-0.0027251395,0.0083911335,-0.0133466525,-0.0010607659,-0.0011557599,-0.0043340996,0.015080292,-0.011755504,0.025141736,-0.004037244,0.005711512,0.005897542,0.0044053453,-0.011921743,0.05123341,0.019331273,-0.034609467,-0.009024427,-0.0079122055,0.021832779,-0.010449336,0.0071680862,0.010322678,0.012008821,0.007647014,-0.0023075617,0.004342016,-0.0010043633,-0.005355285,0.0011913826,-0.0070374697,-0.00647938,0.0041322378,-0.014510328,0.01050475,0.0069899727,0.008517792,-0.002616292,-0.020107057,0.029036488,0.020233715,-0.018951297,-0.0028854418,-0.005699638,0.013053754,-0.020439535,-0.005177171,-0.005640267,-0.0023095408,0.019869572,-0.00087127276,-0.0013487164,-0.017795537,0.01570567,-0.017653046,0.008256559,0.00010315751,-0.010291013,-0.018697979,0.008636535,0.010805564,-0.027453257,0.027025783,0.018919632,-0.014993214,0.017463058,-0.0014921969,0.009333157,-0.006475422,0.010670989,-0.018935464,-0.0030239746,0.016908927,0.008224894,-0.0006590206,-0.030223913,-0.02265606,-0.0026004598,-0.02482509,0.026265832,-0.01700392,-0.008201146,0.025838358,0.018286338,0.02034454,-0.014739897,0.0042905607,-0.0027251395,-0.022529403,0.007900331,-0.005996494,-0.0063685537,-0.0070335115,0.004345974,0.009887288,-0.008739445,0.00976063,0.014787395,0.0014417314,-0.023067702,0.009135253,-0.022766888] },
-        { "parameter": 1.0 }
-      ]
+  "filter": {
+    "cosineDistance": [
+      { "path": ["embedding"] },
+      { "parameter": [-0.025600875,0.018428829,-0.008834439,-0.014676568,-0.0045517944,0.008573205,-0.022735223,-0.0017573884,-0.0005610581,0.030841375,-0.017589716,0.002804301,-0.037965924,0.037364293,-0.013061671,-0.00043118355,-0.008628619,0.019077955,-0.0092539955,-0.017431393,-0.0041639023,0.012444209,-0.0045042974,0.004820944,-0.0064991703,0.007809296,0.005691722,-0.004975309,-0.021737786,-0.0019572715,-0.013789957,0.02224442,0.047971953,0.028719842,0.015206951,-0.031727985,0.014747813,0.011367612,-0.011510102,0.06636912,0.014462831,0.05544481,-0.036414355,0.015523598,-0.0021670498,-0.016639777,-0.0012141416,0.030113088,-0.022687726,0.0033010403,-0.014375754,-0.002317457,0.010655156,0.022846049,-0.014518244,-0.004690327,0.0069780983,0.028102381,-0.01768471,-0.02862485,-0.003712681,-0.018492159,0.023716828,-0.0061231526,0.0044211773,0.008858187,-0.023985976,0.039390832,0.014431166,0.043380577,0.016877262,-0.01428076,-0.014375754,0.030841375,0.00559277,0.022893546,0.016069813,0.015325693,-0.039232507,-0.047718637,0.028577352,-0.030350571,0.020107057,0.0008341658,-0.011090546,-0.027025783,-0.026028346,-0.12032569,0.012681695,-0.021991104,-0.007963661,0.0042866026,0.005074261,-0.010932222,-0.03128468,-0.024951749,0.04939686,0.010932222,-0.016576447,0.011359695,0.0036097707,0.013093335,-0.013687047,-0.048953556,-0.009420235,0.016782267,-0.005280081,-0.029400632,0.000350785,0.020455368,0.014169933,0.042019,-0.02856152,-0.026218334,0.016433956,0.018143848,-0.03815591,-0.029353136,-0.008406966,0.009744798,-0.013663298,-0.05170838,-0.0125787845,-0.035464413,0.00020693347,0.03999246,-0.012080066,0.03666767,0.003629561,0.0029289806,0.014296592,0.016956422,-0.018682146,0.009562726,0.026012514,0.020772014,-0.01295876,-0.00072630803,0.03400784,0.042019,-0.0409424,-0.010164354,-0.024429282,0.006162734,-0.023827653,-0.026677473,-0.0084861275,-0.053418275,-0.0094123185,-0.0051019676,-0.039010856,-0.032804582,-0.0150090465,0.01735223,0.0054384046,0.016623944,0.0134099815,-0.017336398,0.014494496,-0.019267943,0.009341073,0.04024578,-0.0012972613,-0.010211851,0.003629561,-0.030287243,0.03856755,-0.01714641,-0.014731981,0.015998567,0.0054819435,-0.009911037,0.0149773825,-0.008937349,-0.02346351,0.049080215,0.04110072,-0.016671441,-0.02005956,-0.020914504,0.008430715,0.03210796,-0.006000452,-0.015974818,-0.010006031,-0.022846049,-0.01017227,-0.05136007,0.035876054,-0.032867912,0.025015078,0.0017237447,0.025901688,-0.0013180412,0.04284228,0.051043425,0.015365274,0.00070503337,0.04420386,-0.0134099815,0.05189837,-0.06231604,0.019647919,-0.009238163,-0.06218938,0.02680413,0.02631333,0.002424325,0.01213548,-0.0047932374,0.010892642,-0.010987636,-0.005311746,-0.014969466,0.0065070866,-0.0031961512,-0.032551266,-0.036699336,-0.016046064,-0.03441948,0.0099268695,0.015056544,-0.0061191944,0.0003223363,-0.065862484,-0.0012537225,0.0132516585,0.038884196,0.014106604,-0.007092883,-0.013322904,-0.0078845,0.032804582,0.02455594,0.010283097,0.010006031,0.006613955,0.030841375,0.03631936,0.0041797347,0.020455368,0.037427623,0.012665862,-0.029875603,0.016528951,-0.027453257,0.02237108,-0.019774577,0.022830216,0.033152893,0.04319059,0.0058144224,0.018982962,0.013956197,-0.0043697227,0.0073659904,-6.419514e-05,-0.032551266,0.011684258,-0.01599065,-0.028308202,-0.0036612258,0.0021017415,0.01795386,0.0036473726,-0.0525,0.02352684,-0.02890983,-0.0084227985,-0.0031565703,-0.011795084,-0.016038148,-0.0071799606,0.029368969,-0.0038630879,-0.0010004052,-0.025664203,0.021595296,-0.0019058165,-0.0148823885,0.03536942,0.00066396827,0.025125904,0.02769074,-0.01238088,-0.03638269,0.015381106,-0.021373643,0.0029210644,0.014581574,-0.015127789,0.016307298,0.0048605246,0.00039605558,-0.010797648,0.010283097,0.0010281118,-0.030366404,-0.010298929,0.020661188,-0.013045838,-0.05164505,-0.044457175,-0.019220445,0.012800437,0.04651538,0.016291466,0.00323969,-0.020882841,0.019932901,-0.051518396,-0.011510102,-0.012436293,-0.028118214,-0.068269,-0.0030239746,-0.0018919632,0.0035088395,-0.0025252562,0.00054473104,0.025695868,-0.012119647,-0.0041243215,0.02061369,-0.004654704,0.014573658,0.0067406134,-0.012198809,0.01591149,-0.012840018,-0.019362938,0.012372964,-0.03422949,0.00897693,0.01557901,0.0012418482,0.04053076,0.024049306,0.016813932,-0.018602986,-0.009515229,-0.04645205,0.0027389927,0.02210193,-0.012990425,0.002410472,0.065419175,-0.022766888,0.016172722,0.009641888,0.0008801785,-0.0043261833,0.006186482,-0.0041164053,0.023590168,-0.009198583,0.037237633,-0.022956876,0.008153649,0.0193946,0.005588812,0.017985525,-0.02802322,-0.0019018584,0.034799457,-0.064500906,0.0019740933,0.04249397,0.038820866,-0.026202502,-0.045058805,-0.01190591,-0.006922685,-0.0404041,0.0012418482,-0.034514476,-0.0056679733,-0.026487485,0.006609997,0.016275633,0.019030457,0.010298929,-0.010670989,-0.0151673695,0.031522166,-0.0068870625,0.04243064,-0.00086929376,-0.0003619171,-0.004785321,-0.010718486,-0.015111957,0.0042905607,-0.004749698,0.05379825,0.028988993,0.0007693522,-0.019362938,0.009792294,-0.018761309,0.010995552,-0.029812273,0.012942928,0.017336398,0.039200842,-0.06972557,-0.01619647,-0.012800437,0.022181092,0.015214867,-0.008240727,0.0038472556,0.0010904516,-0.031727985,-0.009689384,0.0059173326,-0.005109884,0.032804582,-0.025157569,-0.011454689,-0.009990199,-0.015974818,0.0024460945,0.024191797,-0.028482357,0.00037280185,-0.026740802,0.020629523,-0.03407117,-0.006040033,-0.04699035,-0.005371117,-0.021658624,0.01768471,-0.02849819,-0.03815591,0.0029270016,-0.060701143,0.0018207177,-0.009032343,-0.023558503,0.009515229,-0.0015317777,0.015183202,-0.020977834,0.0378076,0.004654704,0.0034197827,0.048953556,0.010164354,0.024983414,0.011589264,0.0031625074,-0.036889322,-0.01673477,-0.03654101,0.024065139,0.04537545,0.013307071,0.02265606,-0.007524314,0.009436067,0.018444661,0.012032569,-0.010575995,-0.03394451,0.0063052247,0.007734092,-0.0013625697,0.04116405,-0.008185313,-0.020803679,0.029242309,-0.020708684,0.0017089018,-0.0064437576,-0.007769715,-0.00513759,-0.032012966,0.03555941,-0.029337304,-0.0039501656,-0.047781967,0.01741556,-0.013647467,-0.017225573,0.02536339,-0.025727533,-0.004258896,-0.0025707742,-0.007714302,-0.00090541126,0.0035899803,-0.029068153,-0.03714264,-0.029210644,0.017130578,-0.030113088,0.030778045,0.04122738,0.023716828,0.0299231,-0.0019770619,0.01896713,0.025806693,-0.0041797347,-0.0066377036,-0.025616705,-0.017653046,0.025205066,0.00030873038,0.048256934,-0.009372738,-0.02224442,-0.0024361995,-0.007096841,0.0378076,0.006162734,-0.00042920452,-0.020107057,-0.03006559,0.01952126,0.026376657,0.002845861,0.008446547,0.015998567,0.011399276,-0.05297497,-0.0514234,-0.04100573,0.028529854,-0.021943606,0.014993214,-0.010987636,-0.0045082555,0.045882087,0.012428377,0.015816495,0.015127789,-0.021975271,-0.0028359657,0.0026459778,0.0005239511,-0.013797874,0.0023431845,0.007761799,0.05585645,0.008881936,-0.015935238,-0.004306393,-0.023178527,-0.013758292,0.016750602,0.02005956,0.036731,0.026835795,0.009333157,-0.012895431,0.0038630879,0.0054265303,-0.016988087,0.0030318908,-0.012847934,0.03654101,0.009064008,0.027912393,-0.0008509876,0.020692853,-0.0019345125,0.024904251,0.023700995,-0.03584439,-0.0016881219,0.003623624,-0.01033851,0.039359167,0.011795084,-0.023273522,0.013077503,-0.042019,-0.016513119,-0.0006783163,0.006182524,-0.022339415,-0.039960794,-0.012618365,-0.027279101,-0.0038037167,-0.00030205114,-0.034039505,0.025331724,-0.012499623,0.050980095,0.02251357,0.008636535,0.009380654,0.014431166,0.02020205,-0.007967619,0.0062696016,-0.0008010168,0.016014399,0.0039778724,-0.0063923025,-0.01380579,-0.019537093,0.021231152,0.00092124357,-0.031379674,0.030841375,-0.059814535,0.0072670383,-0.019220445,0.0012576806,0.020107057,-0.0054740272,0.004737824,0.021246985,0.0042430637,0.006186482,-0.013386233,-0.033564534,0.0040451596,-0.023574336,-0.022830216,0.01659228,-0.02631333,0.022402743,0.014652819,-0.013489143,0.011573432,-0.010940138,-0.005707554,-0.027880728,0.0048051113,0.029495627,-0.009633971,-0.04923854,0.023716828,-0.021753618,0.017114745,-0.0066416613,0.00074609846,0.060574487,-0.013465395,0.044932146,0.02523673,0.0039561028,0.012127563,0.03372286,0.011882162,0.010599744,0.010425588,0.009618139,-0.012879599,0.007999283,0.013037922,-0.008581121,-0.0029111693,0.016141059,-0.009238163,0.0019899257,-0.009333157,-0.006906853,0.023099367,-0.0039343336,-0.0044568004,-0.0335962,-0.011050965,-0.007492649,0.018887967,-0.06294934,-0.054114897,-0.0033228097,-0.027247436,-0.00025603842,-0.020027895,-0.0050544706,-0.015531514,-0.030698884,-0.041575693,-0.046198733,-0.008209062,-0.014597407,0.023368515,-0.0026974329,-0.01910962,0.045882087,0.03182298,-0.0043776385,-0.063487634,-0.004896147,-0.01207215,0.014312425,-0.009998115,-0.022434408,-0.022640228,0.0020384123,-0.03584439,-0.048858564,-0.00013482217,0.023653498,0.02156363,-0.022561068,-0.003237711,0.024777593,0.0054859016,-0.002410472,0.017843034,-0.0069424757,0.008335721,0.0061943983,0.0073224516,0.030208081,0.02856152,-0.026297497,0.006020243,-0.00041188792,0.0013299155,-0.009040259,-0.01747889,0.017225573,0.025347557,-0.010164354,-0.033374548,-0.021816948,0.01568192,0.033817854,0.05538148,0.0030239746,-0.029606452,0.0204712,0.021658624,-0.008921517,0.0020918462,0.019917069,0.017922195,-0.048446923,0.00018145332,6.147396e-05,0.017193908,-0.0069187274,0.006427925,-0.021531966,0.00019134852,0.01159718,-0.028134046,-0.0041639023,-0.01735223,0.0225769,0.0023926606,-0.009546894,0.023178527,-0.008660283,0.0055848537,0.017463058,0.023241857,0.032709587,-0.0013823601,0.0064833383,-0.009950618,0.0012824185,-0.0288465,0.02829237,0.017304733,-0.0035682109,0.0070612184,-0.026439987,-0.028102381,-0.028260704,0.0048169857,-0.011296365,-0.01720974,0.009998115,0.028941495,-0.017573884,0.012531287,-0.036161035,-0.0016732791,0.00907984,0.0042430637,0.017431393,-0.0025292144,-0.019220445,0.0142728435,-0.0014902179,-0.022086097,-0.062474366,-0.03543275,-0.004923854,-0.009356906,0.018191345,0.00016846586,0.0066495775,-0.019141285,-0.018919632,0.011035132,-0.028134046,0.007686595,0.019758744,0.00027929214,0.0143361725,0.0051257163,-0.009151085,0.0078845,-0.019552926,9.6601936e-05,-0.007381823,-0.036889322,0.021991104,-0.026819963,0.019283775,-0.002804301,0.024128467,0.033342883,-0.02564837,0.0019839886,-0.002172987,-0.008446547,-0.011486353,0.0125154555,-0.008161565,-0.025141736,-0.021183655,0.011581347,0.0001293798,-0.0019216487,-0.0150723765,0.016014399,-0.0081694815,-0.0063131405,-0.027199939,-0.018761309,-0.018872134,-0.030239746,0.005711512,-0.01896713,0.01537319,0.038472556,0.024397617,-0.013101251,-0.019774577,-0.018460494,0.01353664,-0.0030497022,-0.0053869495,0.0067762365,0.01564234,0.013884951,-0.013164581,0.0015218825,-0.00080695393,0.03107886,0.012729191,0.03147467,-0.017114745,0.0017326503,-0.0020364332,0.021025332,-0.0018414976,0.0009860572,0.00303387,0.010876809,-0.020993667,0.0022006936,0.010528498,0.017098915,-0.014470748,-0.0053354944,0.0043340996,0.003869025,-0.013291239,-0.0018523823,-0.0030793878,-0.02366933,0.0009929838,0.013837455,-0.015871909,0.012190892,0.011953408,-0.038060915,-0.0061469013,-0.009823959,-0.018650481,-0.016924758,-0.009586475,7.684245e-06,0.023985976,0.016576447,-0.022640228,0.041417368,0.03483112,0.03182298,0.0035167558,0.04616707,0.012935012,0.021436973,-0.016544782,0.015389022,0.037427623,0.003283229,-0.032709587,-0.019822074,0.02482509,0.009174834,0.02965395,0.029812273,-0.03182298,0.008042823,-0.0042232736,-0.01394828,0.021674456,-0.011383444,-0.042557295,0.014352005,0.00012585464,-0.047971953,0.043887213,0.028719842,-0.010552246,-0.0076549305,0.024365952,0.0070335115,0.017637214,-0.0041164053,-0.013821622,-0.011367612,-0.016623944,0.01910962,-0.018982962,0.002519319,0.0043855547,-0.00056204764,0.012673778,0.027057448,0.0015100082,0.0016475517,0.03590772,-0.047180336,0.0060044103,-0.0014882388,-0.0036453935,-0.0046190815,-0.009792294,0.011636761,-0.038820866,0.007939912,0.0023253732,0.025901688,0.0016782267,-0.028260704,-0.0041441116,-0.0011953408,0.0065585417,0.03318456,0.037649274,-0.0043815966,-0.020977834,-0.007959703,0.0027172233,0.0049990574,0.0083594695,-0.03378619,-0.0028379448,-0.011359695,0.011913827,0.008826523,0.009602306,0.0070849666,-0.0035108186,-0.008636535,0.028134046,0.007500565,0.011897994,-0.009744798,-0.008201146,0.00406495,0.00013618276,0.016972255,0.011272618,0.039264172,-0.013853286,0.008145733,0.010401839,-0.025110072,-0.020597858,0.00425098,0.02428679,0.0036731001,0.010568079,-0.00022486853,0.03080971,-0.0073620323,-0.009206499,-0.027849065,0.015444436,-0.047180336,-0.0050940514,0.014636987,0.02618667,-0.0108530605,0.0023827653,0.013663298,0.012562952,-0.022133594,0.052753314,0.009388571,-0.028514022,0.0059212907,-0.020360373,-0.0064160507,0.012151311,0.01747889,-0.01632313,0.019822074,0.035749394,0.010488917,-0.019489596,0.0023115198,0.089231,0.005216752,-0.023162695,-0.012008821,-0.029273974,0.0013586116,0.027136609,0.030287243,-0.0016524992,-0.012737107,-0.025490047,0.0074174455,0.00057936425,0.01285585,0.0067841522,-0.02259273,0.023352683,0.006431883,-0.018951297,-0.004583459,0.024112634,0.008098235,0.022941044,-0.0010736297,0.024745928,-0.006716865,0.0109163895,-0.0065427097,0.04284228,-0.0071799606,0.01917295,0.00406495,-0.022877714,0.0062458534,-0.0049594766,-0.018428829,-0.022070264,0.004543878,0.0014268885,0.008232811,0.0048644827,0.008098235,-0.00042029883,0.0019839886,0.01207215,-0.016671441,0.009610223,-0.0100535285,0.003679037,0.00540674,-0.028339867,-0.016671441,-0.0050584287,0.033057902,-0.015286112,0.02427096,0.011787168,-0.0018484243,-0.009016511,-0.0054898597,-0.007579727,-0.021405308,-0.029226476,-0.010006031,0.026091676,-0.021864444,-0.022418575,-0.017985525,0.023780156,-0.004009537,0.027706573,-0.04610374,-0.0045082555,0.017700542,0.00056749,-0.005806506,-0.01659228,0.03562274,0.026614143,0.02216526,0.0067049908,-0.008185313,-0.0072274576,-0.016228136,0.0010894621,0.015468184,-0.01207215,0.002843882,-0.0017920216,-0.020186218,0.03720597,-0.009333157,0.013599969,0.026550815,0.036889322,0.012895431,-0.024793426,0.016125226,0.010797648,0.009000679,-0.016291466,0.01884047,-0.011795084,-0.0019444077,0.020170385,-0.00084604,-0.043665558,-0.011541767,0.009641888,0.026677473,0.018112183,-0.021436973,0.030619722,0.026503317,-0.0011310219,0.024096804,0.008414882,-0.015895657,-0.0023332892,0.033849515,-0.0404041,-0.016354794,0.0029270016,0.012309635,0.027231604,0.017193908,-0.007761799,-0.012499623,0.039707478,-0.02849819,0.013164581,-0.004824902,-0.010101025,0.0051930035,0.003574148,0.004532004,0.00064516737,-0.014969466,-0.006764362,-0.02354267,-0.0029665823,0.004203483,0.027453257,-0.00019369864,0.020376205,-0.014692401,0.003138759,-0.0016465621,-0.029273974,0.0010953991,0.018697979,-0.01809635,-0.013916616,-0.018682146,-0.0021512175,0.02340018,-0.02108866,-0.017763872,-0.021975271,-0.0038373605,-0.010393923,0.0058737937,0.005747135,-0.015832327,0.021785283,-0.005596728,-0.008668199,0.0056679733,-0.021816948,0.015175286,-0.014359921,-0.0040768245,0.018476326,0.0016287507,-0.008763193,0.021975271,-0.0064872964,-0.0029566872,0.0031051154,-0.007148296,0.005751093,0.012491707,-0.0034336362,-2.7923032e-05,0.008030948,0.014043274,0.0013477269,0.030239746,0.024951749,-0.024160132,0.0074886912,0.013687047,-0.030033926,0.0028696095,-0.005545273,-0.021706121,0.015151538,-0.021816948,0.0109163895,0.0075124395,-0.0030556393,0.0010726402,-0.014043274,-0.00011886615,-0.002649936,-0.017431393,0.01795386,-0.016109394,0.002709307,-0.006958308,0.018143848,0.017700542,-0.009230247,0.016077729,0.009823959,-0.017510554,0.0041322378,-0.0038017377,-0.0053394525,-0.038187575,0.0010963887,0.0036394564,0.0051969616,-0.00503468,-0.032899577,0.012254221,0.02271939,0.01122512,0.022070264,0.00013086408,0.0067049908,0.005759009,-0.007892415,-0.019267943,-0.017542219,-0.013497059,-0.032266285,0.037110977,0.016750602,-0.010908474,0.0021630917,-0.018602986,-0.005794632,0.032313783,0.02577503,0.025885856,0.0021452804,0.018602986,-0.015769,-0.0067247814,-0.007864709,-0.02115199,-0.013196245,-0.010591827,-0.012024653,-0.018001357,-0.0025410885,-0.007947829,-0.005636309,0.009436067,-0.0023075617,0.019632086,0.02271939,-0.033279553,-0.012285886,0.0116525935,0.00839905,0.020772014,0.011058881,-0.000943013,0.018587153,-0.0068197753,0.004630956,0.0183655,-0.008446547,-0.011668426,0.0077736727,-0.023131032,-0.001640625,-0.019410433,-0.0026697263,-0.002649936,0.025474215,-0.0014338152,0.0065466673,-0.012254221,0.0024065138,0.0051969616,-0.0007144338,-0.040150784,0.028830668,0.0037581988,-0.017621381,0.002841903,-0.008216978,0.02530006,0.0053948658,0.022846049,0.0151040405,0.027785735,0.0068356073,0.0116525935,-0.0072512063,0.003989747,0.007714302,0.02769074,-0.031680487,-0.011145959,-0.0024361995,-0.015294028,-0.019774577,0.0029052321,-0.014668652,0.011193456,0.0069147693,0.026962453,0.03407117,-0.012016737,-0.019378768,-0.002802322,-0.033057902,0.02420763,-0.013560389,-0.0003334684,-0.0042905607,0.018729644,-0.027769903,-0.016718939,-0.008161565,-0.015697753,0.026344994,-0.006040033,0.001450637,0.009602306,0.0065822904,-0.0027627412,0.02591752,-0.008185313,0.0031308427,-0.013821622,0.020645356,-0.0061548175,-0.008280307,0.011423024,-0.0141778495,-0.0039323545,0.03761761,0.015863992,-0.019157117,-0.006859356,0.0009979315,-0.012095898,0.018682146,0.021167822,0.019806242,-0.017763872,-0.028514022,0.015096124,0.026408322,-0.020249547,-0.007579727,0.041132387,0.0018454557,0.032677926,-0.001062745,0.0064041764,0.026139174,0.00091035885,-0.007354116,-0.0073224516,0.023115199,-0.0020027894,0.003989747,0.02556921,-0.027991556,0.027184106,-0.01370288,0.019901237,0.022117762,0.0022006936,0.013172497,-0.015024879,0.02121532,0.0049792673,-0.013655382,-0.0068831043,0.006570416,-0.010536415,0.027864898,-0.021041164,0.026060011,0.0054344465,0.00025653318,0.018207178,-0.014454915,-0.0014516265,-0.010797648,0.021658624,0.020297045,-0.028419029,-0.022291917,-0.01027518,-0.005952955,-0.0062221047,0.022323582,-0.0009034322,-0.015191118,-0.013093335,-0.008193229,0.0028240914,-0.0048090694,0.0042786864,-0.009649804,0.028387364,-0.02354267,0.0038907945,-0.0010914411,0.0012655967,-0.0065625,-0.0065031284,0.009230247,0.0073145353,-0.018729644,0.005948997,-0.014629071,0.0056758896,-0.0032080254,0.024318455,-0.036731,0.009491481,-0.017225573,0.013164581,-0.020154553,-0.028086549,0.0109480545,-0.0028735674,0.036920987,-0.018777141,0.0014348048,0.02115199,0.008438631,-0.032551266,-0.017336398,0.01632313,0.011842581,-0.011407192,-0.008763193,-0.017383896,0.011335947,-0.034514476,0.022814384,0.019632086,-0.007619308,-0.044235524,-0.0011755503,-0.0023352683,-0.008454463,-0.022766888,-0.027944058,-0.014328256,-0.016307298,-0.019030457,-0.0067801946,0.0060637817,0.011153875,0.03495778,-0.010425588,0.011454689,0.00029413495,-0.004987183,0.015515681,-0.011478438,0.007852835,0.009847708,-0.011343863,-0.02040787,-0.02026538,0.02775407,0.031268846,0.012974593,-0.019663751,0.005755051,-0.008335721,0.010457252,-0.0045715845,-0.034039505,-0.0035068607,-0.008818607,-0.0018988898,0.0059094164,0.026614143,-0.0071285055,0.0101801865,0.012539203,0.022386912,-0.025157569,0.002901274,-0.009428151,0.0031605284,0.023368515,0.015175286,0.014193682,0.0189038,-0.0053790333,0.032123793,0.013053754,0.012974593,0.019742914,-0.015412771,-0.011676341,0.023416013,0.0142095145,-0.02142114,-0.014629071,-0.009823959,-0.0002773131,-0.0020700768,-0.0108530605,0.00037651256,-0.024397617,-0.0036374773,-0.017336398,0.0038749622,-0.01795386,0.015650256,-0.0065427097,-0.016030231,0.005022806,0.013956197,-0.009341073,-0.020423703,-0.011027216,0.009151085,-0.001087483,0.009728965,-0.01054433,0.0025034868,-0.000627356,0.026835795,-0.009364822,0.02237108,0.00976063,0.00763514,0.013916616,-0.015547345,-0.015689837,0.017938027,-0.0015802642,0.023922646,0.0035444624,0.0071799606,-0.032931242,0.009151085,0.010528498,-0.0039343336,-0.0071205893,0.017874697,-0.018666314,-0.015230699,0.0021828823,0.018428829,-0.011003468,0.029558957,0.021389475,0.0109480545,0.00069761195,-0.0010211852,0.0069820564,-0.0059015,-0.009626055,-0.035306092,-0.014557825,-0.0030160584,-0.0151040405,0.007813253,-0.011177624,-0.002796385,0.033311218,-0.0012893452,-0.000736698,0.020455368,0.039454162,0.01720974,0.0048051113,-0.0064002187,0.0026281665,-0.010560162,-0.0015980756,0.031110523,0.017336398,0.013045838,0.025157569,0.018618817,0.023970144,-0.0020997624,0.02666164,-0.022561068,-0.026772466,-0.00887402,0.024540108,0.007575769,0.012341299,-0.010219768,0.017716374,0.007259122,0.010124774,-0.005082177,-0.0015466205,0.007354116,-0.0023036036,-0.007627224,0.012372964,0.01700392,0.011153875,-0.01265003,0.012539203,0.0019681563,0.00763514,-0.007207667,-0.02427096,-0.019980397,-0.007338284,0.001516935,0.0032753127,-0.015111957,0.004797195,0.013560389,0.028893998,0.019948732,-0.0030299118,-0.0049040634,-0.026962453,0.014217431,-0.0010350384,0.012349215,-0.014304508,0.014106604,-0.024587605,-0.014352005,-0.00081585965,-0.013528724,-0.0054304884,-0.009032343,-0.007476817,0.017763872,-0.0005585843,-0.018887967,-0.0063645956,-0.003823507,-0.0016633839,-0.012570868,0.0059569133,-0.008478211,-0.021959439,0.0013823601,0.0007648993,0.018191345,0.0075995172,0.0026756634,-0.011391359,-0.020376205,-0.007041428,-0.02020205,-0.005703596,-0.008304056,-0.037554283,0.0065427097,-0.0070097633,0.014304508,0.0034197827,0.0031822978,-0.013861203,0.028102381,0.0016336984,-0.007647014,0.0017514513,0.0058856676,0.0215003,-0.019679584,0.018349668,-2.926816e-05,-0.023922646,-0.025347557,0.0069306013,-0.012270054,0.008652367,0.003532588,-0.021484468,0.0025589,-0.008185313,0.008850271,-0.0043143095,0.012816269,0.0052840393,-0.01619647,-0.005280081,0.006000452,-0.017542219,0.0035029026,-0.020012062,0.0028141963,-0.000943013,0.012919179,0.010227684,0.010773899,-0.011486353,-0.003582064,0.002172987,-0.007069134,-0.014557825,0.01190591,0.008644451,-0.018982962,-0.0036632048,-0.008209062,-0.0012438273,-0.018001357,-0.008494044,-0.018729644,0.029543124,-0.0064595896,-0.013631634,0.020154553,0.020217882,0.0029784567,-0.011248869,0.007116631,0.0063012666,-0.0014536056,0.00559277,0.025616705,-0.0016713002,0.006043991,0.017447226,0.009420235,0.0067999847,-0.009174834,0.0074214037,-0.011826749,-0.025284227,-0.017288903,-0.002756804,0.0047576143,-0.0043855547,0.0067326976,-0.0025331725,-0.013837455,-0.004876357,0.007286829,-0.01370288,-0.027215771,-0.003991726,-0.006712907,-0.008786942,0.0013200203,-0.0035959175,0.01060766,0.008478211,-0.0022937085,-0.015444436,-0.0062181465,-0.00017118704,0.023115199,0.008209062,-0.00676832,4.217831e-05,-0.0006110289,-0.0025133821,0.0034672797,-0.009475648,0.0052207103,0.0055531887,-0.0067762365,-0.0094123185,0.009626055,-0.010797648,0.011027216,-0.011035132,0.027421592,-0.010393923,-0.0067049908,0.024223462,0.010773899,0.025030911,0.016893094,0.0007599517,-0.03101553,0.0063052247,0.027722405,-0.001952324,-0.0058262968,-0.011058881,0.0049555185,-0.021516133,-0.009325241,-0.0101801865,0.008121984,0.012080066,0.009641888,-0.018128015,0.00044751063,-0.011161791,-0.0151040405,-0.004591375,0.0033524954,0.01735223,-0.0011854456,0.01006936,0.014312425,-0.009887288,-0.011446773,0.0064160507,-2.8340484e-05,0.007935954,-0.011438857,-0.02129448,-0.00965772,-0.01432034,-0.007920122,-0.012000904,0.011771335,0.0074134874,0.004876357,-0.02251357,0.0011696132,0.029685615,-0.014257011,0.026899125,-0.0058381706,-0.012349215,0.018523823,-0.018666314,0.018697979,-0.021326145,-0.0060281586,0.01500113,-0.0072274576,-0.003677058,0.014636987,-0.0016960381,0.0060321167,0.0046942853,0.033849515,-0.0063685537,-0.0010078266,-0.022481905,-0.0061191944,0.017668879,0.02055036,0.001838529,0.022497738,0.01537319,0.0014229305,0.0007396666,-0.017083082,0.009135253,0.01394828,-0.0042113992,-0.021864444,-0.01789053,0.005228626,0.012610449,0.00724329,0.028355699,0.01918878,-0.024999246,-0.008094277,0.0022501696,-0.0050980095,0.00031046206,-0.005707554,0.0023471427,-0.019869572,-0.021721954,-0.026978286,-0.0079122055,-0.009198583,0.00022981613,-0.0027152442,-0.03080971,-0.0041757766,-0.008612786,0.0012339321,-0.015531514,0.0027290974,0.004943644,-0.007920122,-0.02387515,0.0046151234,0.0029250225,-0.0069306013,-0.0036434145,0.011066797,-0.02094617,0.024745928,0.0073699486,0.03422949,0.0061508594,-0.014541993,-0.008525709,-0.019331273,-0.0011112315,0.0021571547,-0.02115199,-0.0059806616,-0.00047249603,0.014478664,-0.01190591,0.039169177,0.009087756,0.024587605,-0.0032931243,-0.0016485411,-0.0035048816,-0.019695416,0.012151311,0.0037008065,-8.577906e-05,0.0020542445,0.036351025,-0.011423024,0.013212077,-0.0054740272,-0.027199939,-0.008533625,-0.0044686743,-0.0008485138,0.009681469,-0.00015696269,0.0017573884,0.0037047646,-0.0033109356,0.0024282832,-0.0036810162,0.011969239,-0.0015634424,-0.028308202,-0.018998792,-0.0020215902,0.0060756556,-0.0027746155,-0.0065981224,-0.0054779854,-0.0011300324,0.03435615,-0.015602759,-0.033912845,0.008589038,0.0066456194,-0.028925663,0.016560614,0.025458382,-0.012903347,0.009246079,-0.002707328,0.014446999,-0.0149457175,0.0068197753,0.01353664,-0.005541315,0.0049476023,0.0061706495,0.030793877,0.007639098,-0.00012022674,0.0031229267,0.012198809,-0.0037027856,-0.019299608,-0.018207178,0.008929433,0.00028448715,-0.0025133821,0.01217506,-0.0033643697,-0.0024856755,0.010496833,-0.0051969616,-0.018112183,-0.012586701,0.0070335115,0.018887967,-0.021706121,0.015571094,0.00036414355,-0.004892189,-0.0027884687,0.01931544,0.0074411943,-0.007761799,0.013647467,-0.0036354982,0.012064233,-0.0056006857,-0.007769715,0.0150090465,0.0032238578,0.0026261874,0.022861881,0.0053948658,-0.022434408,0.003991726,0.0043697227,-0.018428829,-0.0065387515,0.0042905607,0.023906816,-0.02911565,0.03115802,0.0035998756,0.008430715,0.0204712,0.0015119873,0.00744911,-0.0031070942,0.017874697,0.029400632,-0.007389739,0.032487936,0.0081299,-0.00047224865,-0.023368515,-0.018634649,-0.008509876,0.0071205893,-0.0047615725,0.010322678,0.0017821264,-0.026091676,-0.0039303754,-0.01884047,-0.0030378278,-0.013053754,-0.005846087,0.020091224,0.0050069736,-0.0055333986,0.0077103437,0.0030536603,-0.02550588,-0.011953408,-0.022386912,-0.005462153,-0.0067010326,-0.011961323,-0.012103815,-0.0032555223,-0.015389022,-0.013607886,-0.01809635,0.00089798984,-0.005066345,-0.022022767,-0.011937575,0.0043578483,-0.0001442226,-0.005418614,0.0071839187,0.0067960266,-0.010362258,0.007207667,-0.014217431,0.015389022,-0.020867009,-0.015222783,-0.0020878883,0.008248643,-0.010623492,0.0021353853,0.001743535,0.01500113,-0.0031486542,-0.0065387515,-0.0033287469,0.012840018,0.0026816004,0.005830255,-0.008818607,0.0015159454,0.0026222293,0.017494721,0.012832101,-0.018587153,0.005945039,0.0035523786,-0.01428076,-0.0025410885,0.0031704237,0.0054265303,0.026123341,-0.01917295,-0.013750376,-0.00763514,-0.022861881,0.0134099815,0.024381785,-0.0006916748,-0.01801719,-0.003235732,0.01781137,0.0125154555,0.0071799606,-0.00396204,-0.025632538,0.0032001093,-0.0028893999,0.021769451,-0.03489445,-0.01489822,-0.0019097745,-0.016687274,0.0162598,0.017431393,-0.008446547,-0.009626055,-0.023606,-0.014431166,0.0005026764,0.020803679,-0.01213548,-0.013014173,0.013639551,0.003621645,0.012697527,-0.009087756,-0.015191118,-0.009792294,0.02040787,-0.010101025,0.0335962,-0.00484865,0.0025826485,-0.01896713,0.014557825,0.016061896,0.007496607,0.013679131,-0.0030358487,0.0050544706,0.00040718768,-0.009309408,-0.009404402,-0.010742234,0.024096804,0.008660283,0.018856302,-0.031506334,-0.01054433,0.003235732,0.014716148,-0.002891379,0.005157381,-0.0044290936,0.028957328,-0.01884047,0.008446547,-0.009665636,-0.005185087,-0.008121984,0.020154553,0.0026281665,-0.004785321,0.00054819434,0.00928566,-0.009633971,0.005347369,0.028656512,0.0309522,-0.015507765,0.011478438,-0.0016950486,0.020772014,-0.0162598,-0.004654704,0.016433956,-0.00044751063,0.02346351,-0.0034118667,-0.010409756,-0.014067023,0.01496155,0.009911037,-0.017288903,-0.01979041,0.0025945227,0.0069345594,0.014811142,0.009174834,-0.041259047,-0.003865067,0.029432297,-0.011090546,-0.009578559,0.017922195,0.009792294,0.004927812,0.0031585493,-0.010940138,-0.0062735598,-5.1455067e-05,0.00022474484,0.0017227551,-0.0009939733,0.025094239,0.013750376,-0.0054304884,0.010409756,0.018887967,0.004868441,-0.010987636,-0.023922646,0.015586927,0.023495175,-0.013694963,0.0060994043,-0.01489822,0.0024876546,-0.008185313,-0.010821396,0.018143848,0.031949636,-0.019204613,0.015444436,0.0012062255,0.0126421135,0.0052919555,-0.0071245474,0.014296592,-0.013758292,-0.0010667031,-0.0060044103,0.0028260704,-0.006024201,-0.008462379,0.016243968,0.00049006,0.022117762,-0.007199751,-0.002509424,0.015460268,-0.0024817174,0.0019176907,0.019299608,-0.043665558,0.026819963,-0.001933523,-0.0016366668,-1.118622e-05,0.0125471195,-0.002461927,0.011050965,0.02959062,0.008636535,0.010148522,-0.0032931243,-0.008794858,-0.003967977,-0.0046467884,0.012080066,-0.006993931,-0.0064833383,0.010188103,-0.0133149875,-0.013164581,0.0020107056,-0.02259273,-0.032345444,-0.0065862485,0.011383444,0.012935012,0.0022897504,0.00763514,0.00606774,0.013924533,-0.01060766,-0.01064724,0.01599065,-0.0010221746,-0.014557825,-0.0054581948,0.026107509,0.014660736,0.012190892,0.016291466,0.0133149875,0.010987636,-0.015935238,-0.020233715,0.04087907,-0.02672497,0.012000904,-0.007350158,0.014621154,0.02428679,-0.0021551757,-0.007983452,0.00773805,-0.010283097,0.014541993,-0.0039956835,0.01720974,0.012293803,0.016370626,0.008030948,-0.025790863,-0.0017791578,-0.010623492,-0.0040016207,-0.0044528423,0.02026538,-0.011399276,0.008224894,0.0050069736,0.0033247888,-0.010631408,0.019347105,0.031189686,-0.0013358527,0.013354569,0.0096973,0.0024084928,-0.01673477,-0.018444661,-0.006423967,-0.009966451,0.0079122055,-0.008114068,-0.009151085,-0.00453992,0.0047932374,-0.021896109,0.037332628,0.0053434107,-0.006135027,-0.0054779854,0.0022877713,0.022466073,0.013520808,-0.0065427097,-0.028197376,-0.0015970861,0.0055373567,0.014201598,-0.009839792,-0.020455368,0.01979041,-0.022466073,-0.004306393,-0.013243742,0.010148522,-0.0062458534,-0.0007916164,-0.023795988,0.00619044,-0.0042747287,0.013180413,0.007342242,0.0065506254,-0.010156439,-0.0039402707,-0.02707328,-0.016014399,-0.009681469,-0.0037403875,0.001743535,-0.018555488,-0.007983452,-0.01789053,0.010378091,-0.005062387,0.002604418,0.0013853287,0.018792974,0.016085645,0.009151085,-0.019568756,0.011573432,-0.0058262968,-0.016402291,0.0032654176,-0.0038037167,-0.032867912,0.011296365,0.0059687877,-0.004872399,0.0012665862,0.0065110447,-0.014162017,-0.013837455,-0.01945793,-0.023241857,0.00033396317,4.304414e-05,-0.009990199,-0.0025232772,-0.01122512,-0.017542219,-0.004868441,-0.0006382407,0.0059806616,-0.010536415,0.014257011,0.0072749546,-0.0049357284,0.0042747287,-0.00030873038,-0.012602533,0.008494044,-0.019473763,0.0057273447,-0.017383896,0.0059094164,-0.0039006898,-0.0012487748,-0.0013259575,0.017257238,-0.012555036,-0.013560389,-0.0077934633,-0.009531061,0.0049950993,-0.01735223,-0.011058881,-0.016402291,-0.016307298,-0.008406966,0.0059094164,0.0064160507,0.011264701,0.0043736803,-0.004492423,-0.021943606,0.0013526744,-0.015863992,0.008335721,-0.009626055,0.017193908,-0.0016891115,-0.01686143,0.004389513,-0.004634914,0.016275633,-0.0065031284,0.007290787,0.017383896,-0.01432034,0.005367159,-0.018777141,0.030192249,-0.014122437,-0.0033445791,0.012111731,0.0028201335,-0.004302435,-0.005363201,-0.0025747323,-0.0042272317,0.00094350777,-0.010765983,-0.017779704,-0.00887402,0.015689837,-0.033564534,0.0050069736,0.016212303,0.0032693758,-0.012151311,-0.0020918462,0.0033049984,0.029907268,0.0073739067,-0.009048175,-0.0061112787,-0.01557901,-0.0034692588,0.014534077,-0.0004680432,0.010663073,0.015586927,-0.03809258,-0.0062023145,-0.028830668,0.025616705,0.009016511,0.0063527217,0.010140606,0.0071562123,0.013694963,-0.010678905,0.007714302,0.008351553,-0.0204712,-0.011826749,0.02672497,-0.010298929,-0.02026538,0.018064685,0.016433956,-0.020724516,-0.0029744986,-0.013797874,0.009562726,0.009396487,0.0018276443,0.021468636,-0.0059054582,0.006946434,0.023637665,0.011977156,-0.0019800304,-0.017542219,0.020233715,-0.010061445,0.002802322,0.006950392,-0.034577806,0.028419029,-0.0048169857,0.0014684484,0.013354569,-0.024856754,0.013014173,-0.014826975,0.017051417,0.022925211,0.0022838132,-0.009602306,0.03346954,-0.0011280534,-0.0014971445,0.00532362,0.0016208346,0.005232584,-0.003526651,-0.010465168,0.0034435312,0.008517792,-0.008351553,0.0034613425,0.025790863,-7.5512784e-05,-0.005755051,-0.021832779,-0.013607886,0.023859318,-0.0070374697,0.0059371227,-0.0057154703,-0.0090956725,0.013180413,0.0060519073,-0.009388571,0.008905685,0.0070889248,-0.017019752,0.0116525935,0.032962907,-0.00058084854,0.010393923,0.0044053453,0.0012764814,0.008209062,0.0096973,-0.021911941,0.009887288,0.028688177,-0.008224894,0.0074689006,0.0052009197,0.027849065,0.0025034868,-0.010259348,-0.018745476,-0.003047723,-0.009681469,-0.00012183471,-0.021373643,0.002032475,0.0056323507,-0.004039223,0.017637214,-0.020851176,-0.028957328,0.004393471,0.019204613,-0.012721275,0.009071924,0.0047576143,-0.016924758,-0.010520582,0.0051059257,0.0019572715,-0.010932222,-0.00051207683,-0.011272618,-0.015396939,0.014676568,0.027089113,0.013212077,0.0013665278,-0.020645356,0.0062933504,0.028339867,0.004393471,0.003045744,0.0050505125,0.014225346,0.013694963,-0.011929659,0.0067208232,0.019378768,0.012673778,-0.018112183,-0.02162696,-0.0018286338,0.0019760723,0.009816043,-0.0024084928,0.010314762,-0.009586475,0.0062023145,-0.00503468,-0.006182524,0.003332705,0.0126421135,0.011929659,-0.012404629,0.004876357,-0.029036488,-0.00021682867,-0.009087756,-0.014185766,-0.0189038,0.0047061592,-0.020027895,5.5846063e-05,-0.015824411,-0.019837907,-0.0004999552,0.01112221,0.014621154,0.008304056,0.0005971756,-0.023970144,0.003334684,-0.025585042,0.009087756,-0.023416013,-0.0035880012,0.009626055,0.0012002883,-0.019410433,0.021658624,-0.020914504,-0.027928226,0.006135027,-0.001229974,0.018112183,-0.008470295,-0.0043103513,0.01931544,-0.023004372,-0.032804582,0.008961097,0.01190591,0.009507312,0.027849065,0.0021927773,-0.016133143,-0.026629975,-0.009911037,-0.00063032453,0.0032990612,-0.008858187,0.0050900932,0.025901688,0.0125471195,0.017019752,-0.01553943,-0.00019357495,0.022687726,-0.011367612,-0.011549683,0.010575995,-0.007761799,0.008628619,0.0016772372,0.0034059295,-0.012539203,0.0065585417,0.012095898,0.007892415,0.012190892,-0.0063012666,-0.004306393,0.024460947,0.02020205,0.00064566213,0.026075844,0.0068356073,0.018539656,-0.006756446,-0.018808804,0.04537545,0.010441421,0.022877714,0.0014743855,0.01122512,0.0027409717,-0.015856076,0.013069587,-0.032709587,-0.020993667,0.0066456194,0.0018899841,0.013394149,0.011050965,-0.008153649,-0.02040787,-0.011423024,-0.0062458534,-0.027057448,-0.008343637,-0.00014917021,-0.039200842,0.0062498115,-0.00068029534,-0.016687274,-0.01774804,-0.037427623,0.0014625113,0.012887515,0.02319436,0.011644677,0.014391586,-0.016924758,-0.018460494,-0.023083534,0.016972255,0.0023847444,0.018270506,-0.013109167,0.002171008,0.0078488765,0.0015060502,-0.020692853,0.0020918462,-0.0100218635,-0.026788298,0.02012289,-0.021943606,0.006859356,-0.0070889248,-0.008945265,0.005161339,-0.0116209285,0.036952652,0.0010033738,-0.012325468,0.02094617,0.033817854,0.0005214773,0.010409756,-0.00021200476,0.016101478,-0.005062387,-0.006043991,-0.0034831122,0.0051455065,0.016433956,-0.0019364916,0.02523673,0.013378317,-0.018143848,-0.015626507,-0.01700392,0.015966903,0.0010300908,0.016418124,-0.024096804,0.0015307881,0.00054671004,0.0038967317,0.0023570377,0.0019740933,0.022355247,-0.013544557,-0.0061587756,-0.011858414,-0.008011158,-0.0021630917,-0.018555488,-0.0003846761,-0.012198809,-0.01632313,0.021959439,0.0075638946,-0.009214414,0.019378768,0.007235374,0.0076113916,-0.0031625074,0.020803679,-0.0035286301,0.018397165,0.017637214,0.001304188,-0.00025195666,0.013774125,0.0050267642,-0.009855624,0.012840018,0.016156891,0.020692853,-0.006898937,-0.022434408,0.0032713548,-0.006570416,0.022703558,-0.0014704275,-0.028593184,0.008937349,0.024904251,0.009768547,-0.009341073,-0.002845861,-0.040024124,-0.009538977,-0.003522693,-0.011486353,0.003623624,-0.0027805525,0.010433504,-0.022608563,0.0036335192,0.014819059,0.0024025557,0.0151357055,-0.024793426,0.008905685,0.00685144,0.003908606,-0.0066377036,0.024223462,0.023764323,-0.0031466752,0.0029665823,0.009570642,0.0020542445,0.04252563,0.0204712,-0.0014991235,-0.0064912545,0.014811142,-5.4145323e-05,-0.0021967355,-0.008905685,-0.0075836848,-0.024745928,-0.0027429508,0.004678453,0.01884047,0.008121984,-0.008691948,-0.001838529,0.00328125,0.009103589,-0.021579463,-0.010386007,0.012879599,0.0016643734,-0.025347557,-0.008383217,-0.007959703,0.010283097,0.002171008,-0.0012942927,0.025078407,-0.033152893,-0.013639551,-0.0017712417,0.016156891,-0.000447758,0.011454689,0.015309861,-0.0015179244,-0.022402743,0.025458382,-0.013465395,0.009776463,-0.02271939,0.025268395,-0.008074488,-0.008699864,-0.009903121,0.0006793058,0.00054473104,-0.0068910206,-0.017130578,0.0033999924,-0.010702654,-0.00065506255,-0.037269298,0.0036335192,0.013101251,-0.009143169,-0.001133001,0.04116405,-0.005351327,-0.0037008065,0.0022838132,-0.0037918424,-0.004824902,-0.047655307,0.0046032495,-0.016354794,-0.00031169894,-0.007789505,-0.0028696095,-0.0074689006,-0.005897542,-0.01727307,0.010227684,0.01918878,-0.009341073,0.008644451,-0.025220899,-0.0038789203,0.014708232,-0.00022610543,0.03365953,-0.021595296,-0.020217882,-0.0012972613,0.020803679,-0.0010548289,-0.002756804,-0.009823959,-0.023780156,0.019584589,0.017193908,0.03612937,-0.014581574,-0.012151311,-0.00907984,0.005109884,-0.0038353815,-0.003716639,-0.007781589,-0.004991141,0.03793426,-0.0027251395,0.0083911335,-0.0133466525,-0.0010607659,-0.0011557599,-0.0043340996,0.015080292,-0.011755504,0.025141736,-0.004037244,0.005711512,0.005897542,0.0044053453,-0.011921743,0.05123341,0.019331273,-0.034609467,-0.009024427,-0.0079122055,0.021832779,-0.010449336,0.0071680862,0.010322678,0.012008821,0.007647014,-0.0023075617,0.004342016,-0.0010043633,-0.005355285,0.0011913826,-0.0070374697,-0.00647938,0.0041322378,-0.014510328,0.01050475,0.0069899727,0.008517792,-0.002616292,-0.020107057,0.029036488,0.020233715,-0.018951297,-0.0028854418,-0.005699638,0.013053754,-0.020439535,-0.005177171,-0.005640267,-0.0023095408,0.019869572,-0.00087127276,-0.0013487164,-0.017795537,0.01570567,-0.017653046,0.008256559,0.00010315751,-0.010291013,-0.018697979,0.008636535,0.010805564,-0.027453257,0.027025783,0.018919632,-0.014993214,0.017463058,-0.0014921969,0.009333157,-0.006475422,0.010670989,-0.018935464,-0.0030239746,0.016908927,0.008224894,-0.0006590206,-0.030223913,-0.02265606,-0.0026004598,-0.02482509,0.026265832,-0.01700392,-0.008201146,0.025838358,0.018286338,0.02034454,-0.014739897,0.0042905607,-0.0027251395,-0.022529403,0.007900331,-0.005996494,-0.0063685537,-0.0070335115,0.004345974,0.009887288,-0.008739445,0.00976063,0.014787395,0.0014417314,-0.023067702,0.009135253,-0.022766888] },
+      { "parameter": 1.0 }
+    ]
+  },
+  "graphResolveDepths": {
+    "inheritsFrom": {
+      "outgoing": 0
     },
-    "graphResolveDepths": {
-      "inheritsFrom": {
-        "outgoing": 0
-      },
-      "constrainsValuesOn": {
-        "outgoing": 0
-      },
-      "constrainsPropertiesOn": {
-        "outgoing": 0
-      },
-      "constrainsLinksOn": {
-        "outgoing": 0
-      },
-      "constrainsLinkDestinationsOn": {
-        "outgoing": 0
-      },
-      "isOfType": {
-        "outgoing": 0
-      },
-      "hasLeftEntity": {
-        "incoming": 0,
-        "outgoing": 0
-      },
-      "hasRightEntity": {
-        "incoming": 0,
-        "outgoing": 0
+    "constrainsValuesOn": {
+      "outgoing": 0
+    },
+    "constrainsPropertiesOn": {
+      "outgoing": 0
+    },
+    "constrainsLinksOn": {
+      "outgoing": 0
+    },
+    "constrainsLinkDestinationsOn": {
+      "outgoing": 0
+    },
+    "isOfType": {
+      "outgoing": 0
+    },
+    "hasLeftEntity": {
+      "incoming": 0,
+      "outgoing": 0
+    },
+    "hasRightEntity": {
+      "incoming": 0,
+      "outgoing": 0
+    }
+  },
+  "temporalAxes": {
+    "pinned": {
+      "axis": "transactionTime",
+      "timestamp": null
+    },
+    "variable": {
+      "axis": "decisionTime",
+      "interval": {
+        "start": null,
+        "end": null
       }
-    },
-    "temporalAxes": {
-      "pinned": {
-        "axis": "transactionTime",
-        "timestamp": null
-      },
-      "variable": {
-        "axis": "decisionTime",
-        "interval": {
-          "start": null,
-          "end": null
-        }
-      }
-    },
-    "includeDrafts": true
-  }
+    }
+  },
+  "includeDrafts": true
 }
 
 > {%
@@ -2755,57 +2738,55 @@ Content-Type: application/json
 X-Authenticated-User-Actor-Id: {{account_id}}
 
 {
-  "query": {
-    "filter": {
-      "cosineDistance": [
-        { "path": ["embedding"] },
-        { "parameter": [-0.008173416,-0.011068422,-0.013374682,-0.0013307687,0.024556793,0.012895565,-0.018839868,0.01630623,0.0023590438,0.017475601,-0.010053343,0.0012668187,-0.019018522,0.03836187,0.00020403089,0.069772474,-0.02402083,0.035243545,-0.027057948,-0.0018149613,0.013975608,0.0021357264,-0.020967472,0.0377447,-0.008396734,0.0065168077,-0.011588142,-0.010987216,-0.014202986,-0.0076902388,-0.007767385,0.034886237,0.047814284,0.0099721365,0.053985965,-0.024686722,0.012993012,0.0011267378,-0.011523178,0.053498726,0.02221805,0.04635257,-0.03147557,0.002645296,0.009176315,0.003518264,-0.03426907,0.015274909,-0.016712261,0.023338698,-0.012627584,-0.009005781,-0.007483163,0.04287694,-0.014397881,-0.0011998235,0.013626422,0.023679765,-0.008713439,-0.026668157,0.0054895477,0.0023549835,0.039758615,-0.046807326,0.022900183,0.02400459,-0.018531283,0.023858419,0.0028280104,0.024719205,-0.0034025451,-0.03288856,-0.0050347922,0.059865303,0.023712248,0.01591644,0.05093261,-0.019944273,-0.028519662,-0.04739201,0.018904833,-0.027999941,0.022510393,-0.008526664,-0.0065289885,-0.029088106,-0.019310864,-0.113299064,0.014617139,-0.012635704,0.007048709,0.020496476,0.00037532547,-0.0053108935,-0.026148437,-0.023890901,0.03313218,-0.006261008,0.005684443,0.013667025,-0.015502287,0.0068578743,-0.014909482,-0.027285324,-0.01991179,0.012952409,0.020870026,0.009890931,-0.010995337,0.033294592,0.010475616,0.017767943,-0.03696512,0.024573034,-0.0026026627,0.016501125,-0.019034762,-0.047976695,-0.01206726,-0.008892093,-0.007795807,-0.053823553,-0.029055623,-0.05174467,-0.0011815521,0.029802721,-0.02363104,0.0225916,0.009825965,-0.00950114,-0.0017642074,0.014292313,-0.011961692,-0.0069918646,-0.011872365,0.0068253917,-0.015477926,-0.007795807,0.031264435,0.038491797,-0.068408206,-0.009842207,-0.0016809709,0.037842147,-0.021373505,-0.02041527,-0.008429216,-0.020626407,-0.011271438,0.012180949,-0.029234277,-0.019635689,0.0035020227,0.0079176165,0.035211064,-0.022916425,0.0047059064,-0.021552159,0.00898954,-0.023972107,0.009346848,0.031264435,-0.003879632,0.009452417,-0.023809694,-0.037322428,0.042324737,-0.030549819,0.0073613534,-0.001655594,0.015055653,-0.02606723,0.032044016,0.0073288707,-0.02772384,0.045150716,0.013301596,0.0055260905,-0.005932122,-0.04966579,0.0156647,0.009907172,-0.033684384,-0.009330607,0.009744759,0.0019276352,-0.0051972046,-0.0218445,0.037582286,-0.07237108,0.023679765,-0.016338713,0.021925708,-0.017881632,0.07951723,0.03469134,0.010751718,0.022721529,0.016403677,-0.01693964,0.028519662,-0.026976742,0.044663478,-0.011677469,-0.01771922,0.028032424,0.028730799,0.020821301,0.02864959,0.009200676,0.036023125,-0.0351461,-0.050737713,-0.0036887974,0.0114094885,-0.023533594,-0.017930357,-0.01771922,-0.017069569,-0.010231997,0.020870026,0.01347213,-0.009964016,0.014341037,-0.04070061,0.0045922175,0.020122927,0.012432688,0.011466333,0.026148437,0.0033944244,0.0030980213,0.051517293,0.02774008,-0.02595354,0.013066098,0.005128179,-0.0043201763,-0.0056722616,0.021503435,0.049763236,0.033976726,-0.016379315,-0.03017627,0.028292283,-0.014917602,-0.027139153,-0.010045222,0.006342214,0.018157734,0.0025904817,-0.003966929,0.03891407,0.030452373,0.0056194775,-0.0024585214,-0.010970974,-0.009598588,0.027447738,-0.0097853625,-0.053336315,0.016208783,-0.011563781,0.012863082,-0.004086708,-0.057851385,0.022412946,-0.018141493,-0.025579993,-0.010564943,0.011441971,-0.015542891,0.02439438,0.054538168,0.0013490401,-0.026489504,-0.015770268,0.0023590438,-0.0047180876,0.0030858403,0.056454636,0.0011622655,0.022055637,-0.011758676,0.0059524234,0.0077470834,0.033976726,-0.02324125,0.0021824199,-0.014706465,-0.005993027,0.02787001,0.03171919,0.03400921,-0.028795762,0.033197146,0.024248209,-0.019083487,-0.0058955792,0.021129886,-0.008071909,-0.023712248,-0.057461597,-0.04752194,-0.023501111,0.024930341,0.01680971,0.02244543,-0.028665833,0.014406002,-0.045345612,-0.021535918,-0.032547496,0.0009775212,-0.037127532,0.013999971,-0.019798102,0.016062612,-0.02426445,0.013910644,-0.007933858,-0.015648458,-0.031995293,0.015892077,0.039238896,0.013553335,-0.0139918495,0.013325958,0.0032015594,-0.0032056198,-0.036315467,-0.012229673,-0.031881604,-0.0008582494,0.0028929752,-0.041252814,0.01297677,0.026684398,-0.008502303,-0.010564943,-0.011701832,-0.02182826,-0.028682074,0.010719235,-0.012733152,0.003183288,0.04414376,-0.015088135,0.018774902,-0.006874115,0.0008572343,-0.011848003,0.025498787,-0.012505774,0.019879308,-0.010110187,0.00706089,0.00071816845,0.015218065,0.013301596,0.014194866,0.011953571,-0.008092211,-0.008754042,0.035633337,-0.04303935,0.015810871,0.012254034,0.022656566,-0.00988281,-0.03210898,-0.008080029,0.02283522,-0.025352614,-0.006768547,-0.019619448,-0.0118398825,-0.0070202868,-0.008100331,0.019424552,-0.018303907,0.0023407724,0.018125251,-0.047197115,0.006573652,-0.015721545,0.022786494,-0.01232712,-0.019213416,0.0096879145,0.0075318865,-0.0070202868,0.015218065,-0.021194851,0.019700654,0.00016761493,-0.020593924,0.006626436,0.049275998,0.013715749,0.022640323,-0.0028726738,-0.0033457007,-0.012530136,0.023793453,-0.02785377,-0.053043973,-0.01168559,0.0073897755,0.01835263,0.002300169,0.0025173961,-0.0012404266,-0.0010424862,0.018157734,0.010045222,0.018563766,0.042422183,-0.012854962,-0.015185582,0.023403663,-0.029088106,-0.025238926,0.038979035,-0.02298139,0.005067275,-0.029364208,0.0012495624,0.012473292,-0.005339316,-0.02244543,0.012765634,-0.006780728,0.019051004,-0.028211078,-0.030793438,0.010435013,-0.027788805,0.005534211,0.011060301,0.002298139,-0.00044790364,0.038199455,0.004567856,-0.012513895,0.02567744,0.028454697,0.00088362634,0.047456976,0.0063868775,0.040473234,-2.2839278e-05,-0.029818963,-0.00551797,-0.032433808,-0.058858346,0.005688503,0.025011549,0.009095108,-0.00410904,-0.008754042,-0.017150776,0.008745921,0.005960544,-0.005574814,-0.032823596,-0.021324782,-0.034334034,0.0017347701,0.02415076,-0.022672806,-0.027236601,0.032563735,0.016614813,-0.010970974,-0.011701832,-0.014446605,0.0032462229,-0.0034208165,0.004823656,-0.0066304966,-0.01283872,-0.030890886,-0.00019755977,0.018969797,-0.02671688,0.014503449,-0.009176315,0.004129342,0.004803354,-0.012765634,0.019798102,-0.019522,0.0034329975,-0.0065168077,-0.030517338,0.0033964545,0.023696005,0.030371165,0.019359589,0.01693964,-0.0017895844,-0.00094300846,0.025206443,0.0017022876,-0.025385097,0.017751703,-0.007048709,-0.00859163,0.016070731,0.0075156456,0.024231967,-0.006902538,-0.037582286,-0.0071989405,-0.023127561,0.017865391,-0.02104868,0.029250517,0.004685605,-2.1586291e-05,0.017800426,0.040927988,0.030224994,0.015177462,-0.007613093,0.019976756,-0.049958132,-0.04632009,-0.054278307,-0.00056083116,-0.024800412,0.032271393,-0.03465886,0.003646164,0.021194851,0.015851475,0.020561442,0.0008176462,-0.0017956749,0.0008272894,0.0068862964,-0.0007100478,-0.031020816,0.007970401,0.0032117101,0.036640294,0.017459359,-0.017475601,0.0010861346,-0.0036624053,0.0071177343,0.024231967,-0.0024483707,0.029510379,0.033034734,-0.0065005664,-0.023436146,-0.014259831,0.0045272526,-0.018596249,0.016216904,-0.04492334,0.024053313,0.03183288,0.018515043,-0.022965148,0.039985996,-0.01965193,0.001733755,0.014389761,-0.016452402,0.014665863,-0.0087784035,0.009996499,0.030484855,0.010361927,-0.018433835,-0.018027805,-0.02143847,-0.028990658,-0.021324782,-0.03121571,-0.011182111,-0.0033457007,-0.0017154836,-0.019749379,0.006882236,0.0014109599,-0.0029863627,0.02967279,0.006484325,0.024459345,0.04040827,0.006707642,-0.0027325929,0.005428643,0.024800412,0.0010648179,0.007255785,0.0106461495,0.01568094,0.0017865391,0.008851489,-0.010841045,-0.02260784,0.032531254,-0.004299875,-0.019570725,0.047716837,-0.07048709,-0.002734623,0.0030635085,-0.008108452,0.029429173,-0.016972123,-0.015827112,0.01682595,-0.007207061,0.019749379,-0.009298124,-0.026245885,-0.005761589,0.016988363,-0.047197115,0.013033615,-0.00012606013,0.013423406,-0.0047221477,-0.009460537,0.016070731,0.044468585,0.012513895,-0.021081163,-0.0118074,0.022185568,0.015599735,-0.06506251,-0.011718073,0.017313188,0.027366532,-0.0030736595,0.0029762117,0.06623188,-0.02671688,0.026424538,0.02208812,0.027025465,-0.0024300993,0.005928062,-0.02887697,-0.034496445,0.0039831703,0.0047789924,0.00025072452,0.02632709,0.006216344,-0.0042024273,-0.014690224,0.0035913498,-0.016030129,-0.00029995586,0.0024707024,-0.0081815375,-0.020220375,0.007523766,-0.021974431,-0.028438454,0.01014267,0.025206443,0.019180935,-0.03839435,-0.028470937,-0.020626407,-0.036607813,-0.004328297,-0.028389731,0.015965164,0.007905436,-0.010207635,-0.022364222,-0.03673774,-0.0062813093,-0.003016815,0.014690224,-0.011864244,-0.02606723,-0.002643266,0.038459316,0.014154263,-0.040635645,-0.0202691,-0.0031995291,0.0055260905,0.0059483633,-0.012351482,-0.022640323,-0.026814329,-0.028665833,-0.028552145,-0.008100331,0.0023793452,0.008173416,-0.013951247,-0.007215182,0.012773755,0.00019882861,0.011888606,0.011019698,-0.027269084,0.008786525,0.006874115,-0.030078823,0.03579575,0.027610151,-0.017085811,0.019294623,0.013455888,-0.014958205,0.01169371,-0.020139169,0.013537094,0.016216904,0.008997661,-0.016095094,-0.00449477,0.015274909,0.006480265,0.019781861,0.008372372,-0.008802766,-0.013520853,0.024865376,-0.007824229,0.02260784,-0.01965193,0.018222699,-0.0546681,0.021617124,0.0118398825,0.019992998,-0.008632232,0.020821301,-0.031670466,-0.010589304,0.0063259727,-0.012944289,3.94612e-05,-0.007921677,0.02426445,0.006496506,0.014844516,-0.006707642,0.009557985,-0.020236617,0.010386289,0.018644972,-0.0019205296,0.011255196,0.02631085,0.01604637,-0.0107842,-0.027204119,0.015997646,-0.0067766677,0.005684443,0.02338742,-0.033684384,-0.013926885,-0.032774873,0.0016129606,0.003863391,0.00058976095,0.00083185727,0.022867702,-0.020382788,-0.020740096,-0.020707613,-0.0106461495,-0.018531283,-0.0019276352,0.014056815,0.0031020816,-0.013699507,0.012879323,-0.02143847,-0.025271408,-0.024280692,-0.01861249,0.0052175066,-0.0035933799,0.01911597,0.012538256,0.021795778,0.010743597,-0.034139138,-0.0018819566,0.005237808,-0.027675116,0.018190216,-0.010800441,0.0007846561,0.0051038177,-0.008770283,-0.013837558,-0.009078867,-0.0057778303,-0.02067513,-0.01629811,-0.009233159,-0.018417595,-0.011644987,-0.00038649136,0.002476793,0.026002266,-0.012018536,0.0088271275,-0.002657477,0.006175741,-0.024426863,-0.0024463406,-0.024589276,-0.011515057,-0.010435013,0.034204103,0.026034748,-0.01976562,-0.0073613534,0.023907142,0.017832909,0.009103229,-0.0015419051,-0.034431484,-0.013805076,-0.03478879,0.010329445,-0.026099714,0.0064477823,0.018190216,0.006488385,-0.010897889,-0.017865391,-0.05203701,0.004774932,-1.29105365e-05,0.0010922251,0.009704156,0.013074218,-0.013642662,-0.026635675,0.0006841633,-0.008120633,-0.0022169326,0.024167003,-0.0024361897,-0.015185582,-0.009265642,-0.008372372,-0.008246502,0.004429805,-0.020041721,-0.0029599706,0.0001896929,0.0030472674,0.01373199,0.0037050387,0.019879308,-0.030452373,-0.0053961603,-0.006252887,-0.010629908,-0.0020017358,0.015453564,-0.00423897,-0.022965148,0.015705302,0.0056682015,-0.017621772,0.01181552,0.011831761,-0.012984891,-0.004839897,-0.020041721,-0.036380433,0.0066304966,-0.010215756,0.00744662,0.02052896,0.019879308,-0.011052181,0.022559118,0.0336519,0.035665818,-0.010085826,0.038751658,0.009931534,-0.01568094,-0.03517858,0.010231997,0.04118785,-0.0020565502,0.0042836335,-0.00061818317,0.029201794,0.008656594,0.049860682,0.021584641,-0.01872618,0.018969797,0.007345112,-0.0050916364,-0.002271747,-0.011109025,-0.018807385,0.012984891,0.0031406546,-0.018157734,-0.003108172,0.033229627,-0.011125267,0.012140346,0.025271408,-0.023842176,0.034853756,0.0009419934,-0.015754027,-0.003325399,-0.016858432,0.005534211,-0.004096859,0.03219019,-0.015218065,-0.027447738,0.022380464,0.017540567,0.01218907,0.017378153,0.017621772,-0.023793453,-0.020122927,0.008226201,0.0431368,0.0024199486,-0.028990658,0.03171919,-0.032644942,-0.004632821,-0.016346833,-0.00047480324,-0.0042430307,0.01797908,0.010556823,-0.0073532327,0.009436175,0.024475586,0.033814315,0.010832923,-0.0066710995,-0.030322442,0.004571916,-0.017832909,-6.769309e-05,-0.037907112,0.013041736,-0.006650798,0.015218065,0.024881618,0.011336403,-0.030874645,-0.0013591909,-0.0047018463,0.021876983,0.002170239,-0.003962869,-0.026034748,-0.006654858,-0.0021133947,-0.008965178,0.015347996,-0.008721559,0.029981375,-0.00654523,0.006987804,0.020090444,0.0024097976,-0.013585818,-0.013618301,0.04161012,0.0067766677,-0.020171652,-0.006508687,-0.010800441,-0.025238926,-0.03556837,0.014828275,0.00295388,-0.03595816,-0.0016393526,0.005351497,-0.010767959,-0.006711703,-0.0061026555,-0.012660066,-0.018661214,-0.0029701213,0.01476331,0.03144309,-0.01695588,-0.014365399,0.0029112468,-0.0026818388,0.01989555,-0.0008800735,-0.009476778,0.017167017,0.046969738,-0.014966326,-0.019522,0.028600868,0.10680256,-0.003916175,-0.014438485,-0.028844487,-0.02618092,-0.0031914085,0.04508575,0.0040075323,0.009192556,0.0056560207,-0.0076699373,0.016988363,-0.011848003,-0.006520868,-0.007406017,0.00038953658,0.030338682,-0.0018129312,-0.018044045,-0.0027955277,0.034106657,0.020382788,-0.007548128,0.0025255168,0.016696021,-0.0106461495,-0.00199057,0.0054245824,0.033457007,-0.008315528,0.016249385,-0.024719205,-0.013196028,-0.0016393526,-0.0030858403,-0.011669349,-0.006646738,-0.0038613607,-0.00988281,0.023809694,-0.0075521884,0.017670495,-0.016281867,0.017410636,0.028990658,-0.0019093637,0.0022108422,-0.0071177343,0.0071299155,0.00038725266,-0.016216904,-0.013675145,-0.00042785582,0.036120575,-0.01643616,0.02387466,-0.0070040454,-0.0006166605,-0.013147304,-0.027756322,-0.026765605,-0.011904847,-0.02387466,-0.01642804,0.013967488,-0.011368886,-0.007101493,-0.00036974254,0.029234277,-0.004957646,0.012570739,-0.045508023,-0.014267951,0.0149013605,-0.011198352,0.01950576,-0.0052702907,0.03080968,0.034399,0.008185597,-0.020480236,-0.014990687,-0.021162368,-0.011823641,0.0123677235,0.013163545,0.00068111805,0.015551011,0.005107878,-0.018580006,0.0064518424,-0.006200103,-0.0079663405,0.0024970945,0.034821272,0.020772578,-0.021958191,-0.004072497,-0.013634542,-0.004271453,-0.021243574,0.017280705,-0.017508084,0.003607591,0.0071705184,0.013504612,-0.0022676867,0.009127591,0.01911597,0.032450046,0.019359589,-0.025044031,0.025969783,0.03901152,0.011515057,-0.0006354395,0.011961692,0.0030492975,-0.0045516146,0.024053313,-0.034171622,-0.011214593,-0.0026371754,0.010702994,0.016728504,0.0012901655,-0.0028848548,-0.014414122,0.029624067,-0.019554483,-0.0069431406,-0.006918779,-0.026879294,0.02283522,0.017849151,-0.001156175,0.010629908,-0.0040318943,-0.023696005,-0.024085796,0.0072436044,-0.021324782,0.025044031,-0.013699507,-0.00526623,0.008043487,0.014974446,0.0060823536,-0.026473261,0.012570739,0.0022900184,-0.010824803,-0.0058103125,-0.03248253,-0.007783626,0.032401323,0.018320147,0.0009333652,-0.042162325,0.006959382,-0.043981347,0.005432703,-0.013886281,0.00654929,-0.0037090988,-0.015047532,-0.011774917,-0.008412975,-0.009095108,0.010280721,-0.009931534,-0.011742434,0.0029416992,-0.0037375211,-0.011238955,0.0028706435,0.0025133358,-0.0026229643,0.007227363,-0.023988348,0.014470967,0.012773755,0.023663523,0.021779537,-0.0023732549,0.015469805,-0.00068873115,0.017102052,-0.005850916,-0.012676307,0.0051647224,0.00693096,-0.020480236,0.010167032,-0.023793453,0.0056316587,-0.0021783598,-0.011238955,-0.0031000515,0.0102726,0.0076902388,0.0074994043,0.008039426,-0.016460523,0.017849151,-0.039206415,-0.009151953,-0.014113659,-0.021958191,-0.01809277,0.010321324,-0.007292328,-0.012822479,0.033050973,0.008258684,-0.015559132,0.015973285,-0.0072192424,-0.018547524,-0.017296948,0.009484898,0.03209274,0.01604637,0.012651945,-0.032953527,0.0053961603,0.022916425,0.013537094,0.015754027,-0.0008582494,0.0056479,-0.0021824199,-0.0089245755,-0.019619448,-0.022429187,-0.006403119,-0.043948863,0.024459345,0.03547092,-0.0019022581,-0.008104391,0.010613667,-0.0070284074,0.033424523,0.019213416,0.049081102,-0.0036928577,0.0269605,0.0019834645,-0.007040588,0.00846982,-0.0336519,-0.0054124016,-0.012879323,0.0069756233,-0.0048683193,0.011393247,-0.017167017,-0.019343346,0.015770268,0.0023976169,0.020788819,-0.0005623538,-0.020756336,0.007434439,-6.883505e-05,0.0023265611,0.026749363,0.009078867,0.006236646,0.020723853,0.014300434,0.00859975,-0.0097853625,0.020642648,-0.007511585,0.029753998,-0.014738948,0.028162353,-0.006252887,0.009769121,0.0068091503,-0.00078770134,0.011109025,0.020756336,-0.0088271275,-0.0049373447,0.010727355,-0.0056113573,-0.036380433,0.028146112,-0.00898954,-0.0051119383,0.01734567,0.004596278,0.017475601,0.009493019,0.02093499,0.014503449,0.005676322,0.01630623,-0.007239544,-0.0072354837,0.030533578,-0.0148526365,0.0015246487,-0.0076861787,-0.013723869,0.0202691,-0.030192511,-0.010491857,-0.0022372343,-0.010183273,-0.0070324675,-0.0025701802,0.022055637,0.014170504,-0.005928062,-0.002978242,-0.0092575215,-0.015542891,-0.01026448,-0.023095079,-0.0003347223,0.004953586,0.0054530045,-0.0205452,-0.021194851,-0.038816623,-0.017946597,-0.019392071,0.0055382713,-0.0038735417,0.004515072,-0.009939654,-0.0042795734,0.023566075,0.004267392,0.0056154174,-0.01502317,0.0057534683,-0.0010577124,-0.013423406,-0.01773546,-0.018856108,-0.0061432584,0.015989525,0.0013662964,-0.0018139463,0.018937316,0.026245885,-0.0023285914,0.016127577,0.0055504525,0.00205249,-0.037257463,-0.016509246,0.00091509375,0.0140405735,-0.009484898,-0.0148526365,0.016078852,-0.011880485,0.02208812,-0.016525486,0.0025904817,0.018336387,0.010816682,0.018076528,-0.012002295,0.028357249,0.011563781,-0.0026655977,0.042357218,-0.025044031,-0.012156587,-0.01580275,0.016346833,0.0077470834,0.0035669878,0.010540581,0.0060011474,-0.0055869953,0.03131316,-0.004340478,-0.0004557705,0.0080150645,-0.0056316587,-0.01065427,-0.016354954,0.03914145,-0.014828275,-0.015810871,0.0071096136,0.015494167,0.0069918646,-0.01476331,-0.00026848842,0.028048664,-0.040213373,-0.027788805,0.00027001102,-0.014519691,-0.01592456,-0.0007684149,-0.002992453,-0.015989525,-0.026619432,-0.0071623977,0.0030350864,-0.014738948,0.02556375,-0.0047789924,-0.007125855,-0.004324237,-0.015128738,-0.007950099,0.0060052075,0.010167032,-0.0019113938,0.017832909,0.015201824,-0.01874242,0.019018522,0.010305082,0.008461699,0.016679779,0.016647296,-0.044078793,0.022656566,-0.009663553,0.02168209,-0.031166987,-0.026846811,0.01757305,0.0055139093,0.012660066,0.0044379258,0.0054530045,0.031004574,0.0010506068,-0.027821288,-0.017004605,-0.011109025,-0.0050347922,-0.0043445383,0.0006384847,-0.031637985,0.015429202,-0.027707597,0.019197175,-0.004608459,-0.015307392,-0.01629811,0.013723869,0.00087905844,0.00628943,0.012083502,-0.05609733,-0.011539419,-0.018791143,0.0048439573,0.001771313,0.005635719,0.011653108,0.005355557,-0.027220361,0.011328283,-0.013122942,0.021779537,0.021422228,0.004965767,0.0114582125,0.0035913498,-0.019245898,-0.02811363,-0.009233159,0.018287664,0.007755204,0.018580006,-0.013504612,0.006370636,0.010004619,0.017946597,-0.0062975506,-0.020463994,0.0011074513,-0.0316055,0.0038573004,0.00023143803,0.034853756,0.0091113495,0.0123189995,0.00937933,0.012237793,-0.033457007,0.0114094885,0.0016890916,-0.006520868,0.025579993,-0.0018088709,0.015697183,0.0074994043,0.0030614785,0.011190232,0.0023428025,-0.0057453476,0.021470953,-0.019619448,-0.0047952337,0.030890886,0.014332917,-0.016590452,-0.0105487015,-0.006236646,-0.02322501,-0.031410605,0.021633364,-0.006508687,-0.013033615,0.010954733,-0.011831761,-0.0020849723,-0.035373475,0.020691372,-0.029250517,-0.0109303715,0.001566267,0.019700654,-0.00937933,-0.0010308127,-0.0104999775,0.0011318132,0.0013571607,-0.011141508,-0.0088271275,0.0028807945,-0.002927488,0.019180935,-0.032141462,0.0052824714,0.020041721,0.00094554614,-0.0042552114,-0.022347981,-0.010719235,0.0062325853,-0.0046409415,0.02143847,0.01643616,0.0012729091,-0.017426878,0.017865391,0.0010719235,-0.007783626,-0.00017751195,-0.0051038177,-0.00244025,-0.01680971,-0.00085571164,0.008640353,-0.008940816,0.02592106,-0.0025275468,-0.005294652,0.028795762,-0.0028198897,0.010061463,-0.013926885,-0.005928062,-0.0062975506,0.012359602,0.004161824,-0.02824356,-0.011336403,0.0068862964,-0.011165869,0.021097403,0.006853814,-0.0031771974,0.011385127,0.0026128136,0.038037043,0.016070731,-0.015396719,-0.009606708,0.001079029,0.012002295,0.006732004,0.0036136815,-0.00038420744,0.024296932,0.009517381,0.035665818,0.0030005737,0.016574211,-0.009151953,-0.038654212,-0.0013683266,0.022266774,0.005826554,0.006269128,0.006455903,0.016533608,-0.016614813,0.029234277,-0.007844531,0.0020037661,0.0008871791,0.0008049577,-0.00047277307,0.027707597,0.007138036,-0.008356131,0.01141761,0.011263317,-0.0041537033,-0.014560294,0.012083502,-0.0020829423,-0.027626392,0.006894417,0.022754012,-0.0059483633,-0.007458801,0.0023915262,0.02710667,0.02030158,0.026343333,0.009817844,-0.02169833,-0.01206726,0.011385127,-0.005794071,0.03251501,-0.006179801,0.014430364,-0.028048664,-0.010435013,-0.013796954,-0.00018169916,0.009298124,0.013959367,-0.020382788,0.004454167,0.0080840895,-0.027269084,-0.008120633,0.012692548,0.019846825,0.0041009192,0.009078867,0.012660066,-0.035633337,-0.0038938434,-0.0050347922,0.0058346745,-0.0021722692,-0.006654858,-0.026846811,-0.023988348,-0.014284193,-0.02787001,-0.02283522,0.00091204856,-0.024556793,0.016078852,-0.023452386,0.010256358,-0.01168559,0.0011145568,-0.012919926,0.015510408,-0.012302758,-0.021990674,-0.00616356,-0.019051004,0.0044866493,-0.0069756233,-0.007540007,0.007994763,-0.022055637,-0.037095048,0.011474454,-0.020236617,0.008412975,0.0028442515,-0.014430364,-0.0039872304,-0.011588142,0.008518543,0.0012404266,0.032027774,0.0038471497,0.00385121,0.014032453,0.012245914,-0.030988334,0.0018088709,-0.017085811,-0.00410701,-0.004316116,0.01425171,0.01347213,0.0009333652,-0.005014491,-0.017556807,0.0048845606,-0.0018037955,-0.016208783,0.006780728,0.006622376,-0.01065427,0.013707628,-0.006829452,-0.01053246,-0.012481412,-0.017849151,-0.005201265,0.032433808,-0.013317837,-0.0019936152,0.026781846,0.021129886,0.012164707,-0.0076577566,0.0076333946,0.013569577,-0.0037334608,0.018303907,-0.0034878117,-0.0068050902,-0.002145877,0.008173416,0.024670482,0.020187892,-0.018661214,-0.012554497,-0.009907172,-0.01836887,-0.009947775,-0.015518528,0.017849151,0.012229673,0.01654985,-0.0022818977,0.011628746,0.0003080765,0.0075684297,-0.025596233,-0.017816668,0.013650783,-0.0029863627,-0.0029315483,-0.0029985434,-0.009281883,0.03787463,-0.003134564,0.0023976169,-0.01797908,0.019440794,-0.0021641485,0.008071909,0.01309046,-0.0011338433,0.02502779,0.026050989,4.7074293e-05,0.0027041705,-0.0102726,-0.018596249,-0.003928356,-0.008421096,-0.017102052,-0.0020139168,0.0026777785,-0.0041455827,-0.012424568,0.033327077,-0.010102067,-0.002773196,0.017702978,-0.0029416992,0.035016168,0.018531283,-0.0067604263,-0.0074100774,0.008205899,0.02657071,-0.0074669216,0.012993012,-0.014316675,0.011279559,0.012083502,-0.012262155,0.0076983594,0.022380464,0.020772578,-0.011190232,-0.015835233,-0.011238955,0.0073613534,0.00731669,0.010467495,-0.0029863627,0.0015317543,-0.0100695845,-0.00094554614,-0.002657477,-0.0072963885,-0.0013256932,0.006086414,-3.1530893e-05,-0.0047302684,-0.018044045,-0.02002548,-0.011214593,-0.014235469,-0.017394396,-0.0068578743,-0.010735476,0.003948658,-0.005107878,-0.023647282,-0.0074709817,0.030972091,-0.008323648,0.013464008,0.0064234203,0.0058346745,-0.006853814,-0.036607813,0.013577698,0.0017317248,-0.0018768812,0.0058224937,-0.0106461495,0.0030878705,0.0059727253,0.0026107833,0.009566105,-0.00256612,0.029120589,-0.004466348,-0.0139918495,-0.01015079,-0.016858432,0.0072354837,0.025255168,-0.009955895,0.014771431,0.026457021,0.019440794,0.020382788,-0.024443103,0.013577698,0.02363104,0.018271424,-0.0051444205,-0.038329385,0.008404855,0.028584626,0.016281867,0.014154263,0.01950576,-0.010378168,9.23722e-05,-0.019310864,0.00924128,-0.019635689,-0.017849151,-0.0056032366,-0.01257886,-0.02400459,-0.0069675026,-0.024849135,-0.0037923353,0.0022940787,0.0027671056,-0.033457007,-0.011904847,-0.0067847883,-0.013074218,0.0015043472,0.012627584,0.009468658,-0.01014267,-0.028064907,0.021373505,-0.015258669,-0.0043079956,-0.010556823,0.011588142,-0.0042592715,0.013520853,0.023955867,0.024605516,0.004848018,-0.02247791,-0.007454741,-0.016744744,0.0041780653,-0.0056925635,-0.012359602,0.0014028393,0.01875866,0.011921088,-0.021860743,0.0019672231,0.019310864,0.0038755718,0.00023283376,0.0014393821,0.004019713,-0.01386192,0.019327106,0.010418772,0.011109025,0.0008333799,0.027528943,-0.0040258034,0.0124164475,-0.0045028906,-0.01297677,-0.010313204,-0.01926214,-0.022867702,0.008421096,0.0075278264,-0.010638028,-0.00052936375,-0.0003233027,0.009525502,-0.0017784185,0.013780713,0.0016241265,-0.014056815,-0.027447738,-0.0060661123,-0.0023773152,0.012627584,-0.0032665245,-0.017832909,0.030062582,0.019668171,-0.01887235,-0.030890886,-0.004214608,0.018320147,-0.033050973,0.008165296,0.022883942,0.008697198,0.010776079,-0.0069918646,-0.0032320118,-0.026424538,-0.016281867,0.014552173,0.002578301,0.011165869,0.012335241,0.017459359,0.0053636776,-0.012684428,-0.0039831703,-0.0022778374,0.0012373814,-0.002620934,-0.008534784,0.011149628,0.019781861,-0.00096635526,0.0059158807,-0.0066061346,0.007730842,0.02363104,-0.0045922175,-0.017037086,-0.011149628,-0.009346848,0.029347965,-0.022624083,0.021146128,0.02850342,-0.03478879,0.0076374547,0.014552173,-0.0080840895,-0.01386192,-0.0028097387,-0.033521973,0.0031406546,-0.007089312,-0.002541758,0.0076333946,-0.016233144,-0.0043445383,0.030647267,0.02169833,-0.024491828,-0.0011328282,0.021487193,-0.0040603164,0.00040780802,0.006569592,0.012042898,-0.01810901,0.02244543,0.015323633,-0.0073775947,0.018986039,0.0124164475,0.0043445383,-0.00089022436,0.030387407,0.01682595,-0.00061158516,0.017491842,0.015080014,-0.012124104,-0.034204103,-0.02374473,-0.005993027,0.0055504525,-0.0021641485,-0.0038146672,-0.008542906,-0.036640294,-0.019603208,-0.015047532,-0.0059158807,-0.0005146451,0.002091063,0.016663538,0.010004619,-0.021860743,0.024053313,-0.0063503347,-0.009330607,-0.014803913,-0.02065889,-0.00039841855,0.01104406,-0.022786494,-0.021178609,0.005818433,0.006727944,-0.014146142,-0.01773546,0.009354969,-0.014868878,-0.00784047,-0.020009238,-0.008656594,-0.006200103,0.0083480105,0.007950099,0.013577698,-0.005623538,-0.00013843141,-0.01991179,0.025206443,-0.01682595,-0.011563781,-0.008656594,0.011523178,-0.010995337,-0.0063381535,-0.00064406765,0.002787407,0.0002224292,0.010702994,-0.0008724604,0.03246629,0.002618904,0.00026544317,-0.02322501,0.0036238323,-0.031995293,0.028682074,0.012773755,-0.022250533,-0.0010181243,0.015071894,0.0074100774,0.01296865,0.007215182,0.01771922,0.026115954,-0.011669349,-0.019213416,-0.01810901,-0.025888577,0.012042898,0.015940802,0.002143847,-0.01425171,-0.009119471,0.004852078,0.0071339756,-0.0067482456,-0.0017357852,-0.023679765,0.0016149908,0.0012982861,0.009679794,-0.016484885,-0.01245705,0.0019073336,-0.02749646,-9.427547e-05,0.017459359,-0.0019012431,-0.00937121,0.009038264,-0.0011104965,-0.007239544,0.002758985,-0.008421096,-0.004161824,0.0008272894,0.0036258623,-0.013658904,-0.016842192,-0.016403677,-0.011726193,0.019375829,-0.0021682088,0.01888859,0.009225039,-0.007893255,-0.0075806105,0.023679765,-0.0037801545,0.01540484,-1.4750368e-05,-0.011636866,0.007893255,0.037809666,-0.009947775,-0.025385097,-0.008721559,0.025856094,-0.000108676904,0.00552203,-0.023013873,0.00693096,-0.017248223,0.0097366385,-0.026781846,0.007820169,-0.0014952115,0.029201794,0.0053880396,0.0029843324,-0.010540581,-0.0014566384,-0.013805076,0.015542891,-0.004210548,0.010288841,-0.01258698,-0.0064112395,-0.006204163,0.012302758,0.022315498,0.038459316,-0.018222699,-0.015356116,-0.03043613,0.0005968665,-0.030598544,-0.00924128,0.011969812,0.009509261,0.004681545,-0.027122913,-0.011125267,-0.0070811915,0.015250548,0.019635689,-0.023501111,-0.006764487,-0.0023631041,0.0045110113,0.02812987,0.0033720927,-0.038686693,-0.008721559,-0.0010506068,-0.012562619,-0.022364222,-0.002208812,0.006780728,-0.0052581094,0.012213431,-0.016363075,-0.00846982,0.0097853625,0.0059402427,0.01091413,-0.003696918,0.031767916,-0.0005189592,0.008461699,-0.003325399,0.005984906,0.016696021,-0.01590832,-0.004965767,0.011604384,0.0043079956,-0.0036421036,0.016744744,-0.00782829,-0.0039121145,-0.011117146,-0.013805076,0.010987216,0.0023346818,-0.014154263,0.009996499,0.0037537625,-0.0060255094,-0.0001028402,-0.0053921,-0.007267966,-0.002604693,0.009533622,0.0072963885,-0.0012120045,0.00094300846,-0.008615991,0.017508084,-0.0058630966,0.01206726,0.003120353,0.020870026,0.00090849574,0.00030655388,-0.016289989,0.018807385,-0.031280678,0.02746398,0.01168559,0.004929224,-8.152354e-06,-0.0059118206,-0.019554483,0.016728504,-0.0005039868,0.0037192497,0.0039608385,-0.009054505,-0.016387437,0.0056682015,0.009549864,0.0052784113,0.002466642,-0.0038471497,0.0038187273,-0.023403663,-0.00071816845,-0.004738389,-0.014454726,-0.03404169,-0.030744715,0.02465424,0.012294638,0.008311467,0.0017814637,-0.0105487015,0.006127017,-5.563109e-06,-0.013139184,0.015697183,0.018547524,-0.01965193,-0.0054002204,0.026733123,0.001193733,0.0030756895,0.024637999,0.008754042,0.011872365,-0.0013967488,-0.009964016,0.013780713,-0.027821288,0.012383965,-0.028081147,0.009387451,0.025450062,0.00014376057,0.011661229,-0.006370636,-0.0114582125,-0.0020088414,-0.015331754,0.0032198308,0.02774008,0.016647296,0.014909482,-0.0171995,0.0011622655,0.017784186,0.006070173,-0.01514498,0.03106954,0.0022697167,-0.0035588671,-0.005993027,-0.005046973,-0.0046287607,0.01580275,0.03813449,-0.02298139,0.014032453,-0.005956484,-0.014519691,-0.017037086,-0.024800412,-0.019992998,-0.010564943,-0.005493608,0.010670511,0.00011933523,0.00036035306,0.018580006,-0.023939624,0.03144309,0.013074218,-0.0071826996,-0.011904847,0.0037639132,-0.002117455,-0.0032056198,-0.002375285,-0.015551011,-0.001835263,-0.017946597,0.003761883,-0.02374473,-0.010028982,0.017215742,-0.020561442,-0.0015165281,-0.020074204,0.019440794,0.0044095037,0.013634542,-0.01309046,0.005509849,0.012733152,0.015323633,-0.0072476645,-0.0047221477,-0.026521986,-0.008957057,-0.024329415,-0.007978521,-0.015778389,-0.011076543,0.010946613,-0.022006914,-0.009151953,-0.014154263,0.008721559,0.007215182,0.0033071276,0.007714601,-0.0035608974,-0.00010017562,-0.0061188964,-0.040213373,0.0071623977,0.012879323,-0.021211091,-0.014227348,-0.0010039132,-0.029624067,0.01142573,-0.00036289077,-0.019976756,0.023598557,-0.017767943,-0.013301596,-0.0046937256,0.0018281573,-0.013041736,0.0029741817,-0.006870055,0.012505774,0.007422258,-0.025044031,-0.011287679,-0.009923412,0.0013500551,0.004056256,-0.016363075,0.02065889,0.0020139168,0.004742449,0.02091875,-0.0079663405,0.0011876425,0.014812034,-0.018823626,0.0032421625,-0.007743023,0.012887443,-0.0016068702,0.011677469,0.007215182,0.014332917,0.0025498786,-0.011563781,0.0018718058,-0.011994174,0.02337118,-0.019684413,-0.0053474363,-0.003311188,-0.009306245,-0.0013774623,-0.010061463,-0.0035142037,-7.9620266e-05,0.003824818,-0.011173991,-0.015469805,0.0014028393,-0.015810871,-0.00018601323,-0.008607871,0.020902509,0.0008359176,-0.00796228,0.00053190143,0.011165869,0.010256358,0.011092784,0.011109025,0.014211107,0.00028396837,0.021974431,0.019814344,0.013593939,-0.014974446,-0.00924128,0.011498815,0.0066345567,-0.0019854947,-0.005071335,-0.009923412,-0.027074188,0.016070731,-0.031589262,-0.015339875,-0.007836411,-0.018807385,-0.01913221,-0.0066589187,0.0070690108,0.014186745,-0.01014267,0.013001133,0.0015094226,0.01887235,-0.010305082,-0.01641992,-0.0032888562,-0.033359557,0.0016292019,0.00847794,-0.013325958,0.0025823612,0.010223877,-0.024605516,0.008197779,-0.030371165,0.0205452,-0.0058062524,0.005176903,0.0019814344,-0.0070446488,0.017361913,-0.013764472,0.003451269,-0.0044460464,-0.01463338,-0.002913277,0.043234248,-0.008429216,-0.012635704,0.017491842,-0.00092372193,-0.0184988,-0.0009988378,-0.0035629275,0.015745906,0.020707613,0.007986642,0.022331739,-0.014568415,0.011718073,-0.009955895,0.003171107,-0.007673998,-0.026521986,0.020431511,-0.013196028,0.00565196,0.026538227,-0.027269084,0.00410904,-0.0046450016,-0.0011480544,0.0057453476,-0.0035994702,-0.003877602,-0.034171622,0.012294638,0.019619448,0.008940816,0.0300301,0.016712261,0.013293476,0.0009978227,-0.00061209267,-0.022932665,0.014381641,-0.0029173372,0.0017286796,-0.011336403,0.019034762,-0.0015885987,-0.0068619344,0.011596263,0.0037557925,-0.019489517,-0.002771166,0.012854962,0.005737227,0.00053849944,0.0010932401,0.003296977,-0.00028472967,0.015689062,0.024410622,-0.02387466,0.01718326,0.003696918,-0.0018281573,0.0056479,0.03634795,0.0045597353,0.010613667,-0.0045637954,0.02145471,0.0037253401,0.009712276,-0.006593954,-0.007925738,0.019749379,0.0053921,0.015372357,-0.0029173372,0.032450046,0.026083471,-0.015006929,-0.014414122,0.011109025,-0.012928047,-0.006403119,-0.008412975,0.01693964,0.011742434,0.0055910554,0.0028361308,-0.029705273,-0.020870026,-0.015559132,0.0036400736,0.011328283,-0.0055626333,-0.0033193086,-0.012254034,0.018466318,0.0073329313,0.017215742,-0.002411828,0.008973299,-0.00083287235,-0.007877014,0.020220375,0.03621802,0.0022676867,0.0060295695,-0.015632218,0.02437814,0.006764487,-0.0050591542,0.010418772,0.0156647,0.01989555,0.039596204,-0.010873527,-0.01309858,0.029283,0.01425171,-0.011352644,-0.017849151,0.0035933799,0.0010318279,0.018937316,0.011084664,0.004649062,0.0033213387,0.0018088709,-0.011003457,-0.004275513,0.0018850018,0.002606723,-0.021665847,-0.007824229,0.0041699447,0.00051566015,0.0047546304,-0.0063340934,-0.026392056,-0.009671673,-0.00063493196,0.0073248106,-0.006602074,-0.02671688,0.0031386244,0.014454726,0.0076699373,0.010223877,0.01861249,0.0053921,-0.024361897,0.009980258,-0.011368886,-0.008120633,-0.004649062,0.002478823,0.030972091,-0.012124104,0.007714601,0.0048358366,-0.015607855,-0.036900155,-0.004458227,-0.006017389,0.017556807,-0.0024300993,-0.008551026,0.03209274,-0.033359557,-0.008494182,0.0040318943,0.033554453,0.016151939,-0.0030411768,-0.010629908,-0.008019124,-0.020837544,-0.003353821,-0.0023346818,0.005814373,-0.0021215153,-0.007791747,0.02733405,0.0073085693,0.025076512,-0.004567856,-0.007905436,0.0043567196,0.0039648986,-0.025450062,0.014990687,0.004904862,0.006874115,-0.00050982344,0.011125267,-0.0056479,0.006870055,-0.002990423,-0.001245502,0.014673983,0.0030736595,-0.0097366385,-0.0012140345,0.01296053,0.014657741,-0.00085469655,0.0055057886,-0.0020890327,-0.019034762,-0.03157302,0.029624067,0.008737801,0.02298139,-0.0035263847,-0.00045526295,-0.0023062597,-0.013634542,0.021097403,-0.018141493,0.0026534167,0.003991291,0.021081163,0.029835204,0.017605532,-0.015453564,-0.022705289,-0.027041705,-0.01296865,-0.014909482,-0.005209386,-0.0011500845,-0.029299242,0.011734314,0.01001274,-0.021227334,-0.006261008,-0.011027819,-0.0016657447,0.014519691,0.020821301,0.00023181867,0.0024037072,-0.026798088,0.0025113055,-0.02220181,0.020610165,0.008632232,0.013139184,-0.0033050973,0.0007577565,-0.019863067,-0.006459963,-0.015437323,-0.014828275,0.0016484885,-0.031556778,0.005534211,-0.035698302,-0.0056560207,-0.02091875,-0.01732943,0.007905436,-0.007852651,0.025823612,0.011019698,-0.028081147,0.025709923,0.029071864,0.0014140052,0.017134534,0.01181552,0.013196028,0.0082018385,0.014747068,0.0053717983,-0.014097418,0.018953556,0.02402083,0.00049205957,0.021763295,-0.012286517,-0.005319014,-0.021763295,0.022315498,0.005765649,0.010564943,0.0011318132,0.017605532,-0.008092211,0.010451254,-0.0003045237,0.0072517246,0.006573652,-0.009825965,-0.013845678,-0.0013470099,-0.012952409,0.00526623,-0.017849151,0.0037090988,-0.015169341,0.006407179,0.026018506,-0.0046937256,-0.006780728,0.017313188,0.0003918205,0.02338742,-0.0058833985,0.019034762,-0.0050266716,0.0074141375,0.014032453,-0.0059767854,-0.012172828,-0.0020575654,-0.0012901655,-0.0008587569,-0.0049454654,0.022494152,0.021730812,-0.0028950055,-0.007779566,0.004815535,-0.03296977,0.012595101,0.0073532327,-0.017231982,0.004738389,0.015932681,0.0077755055,-0.013033615,-0.017069569,-0.041382745,-0.026928017,-0.02298139,-0.021373505,0.020106686,0.00308178,0.029997617,-0.009460537,0.007970401,0.016395558,0.023306215,0.009444295,-0.03168671,0.01629811,0.0052540493,0.009622949,-0.013805076,-0.015875837,0.019392071,-0.01810901,0.000552203,0.010946613,0.01245705,0.046190158,0.030371165,-0.0014972417,-0.003786245,0.006317852,0.0045516146,-0.012091622,-0.023890901,-0.008153115,-0.00087652076,0.0014667893,-0.032141462,0.009777241,0.01950576,-0.010361927,0.0090626255,0.010223877,0.008027245,-0.011344523,-0.009484898,0.009354969,0.0018768812,-0.032206427,-0.020642648,0.02298139,-0.0039973813,0.0054733064,0.0033842735,0.030777197,-0.03982358,0.009874689,-0.009493019,0.003991291,0.0025965723,0.022234293,0.030354924,-0.0008059728,-0.010378168,0.012026656,-0.023598557,-0.027967459,-0.03145933,0.02811363,-0.031004574,-0.017020846,0.003930386,0.01502317,-0.008551026,-0.012789996,-0.002990423,0.018791143,-0.0072517246,-0.008075969,0.0039872304,0.007548128,0.001977374,0.0016921367,-0.008615991,0.0052784113,0.004405443,0.0028726738,-0.007239544,0.004685605,0.0016190511,-0.04804166,0.02785377,-0.024410622,-0.011027819,0.014600897,0.0074263182,-0.005176903,0.00021418168,0.0058224937,0.015770268,0.022526635,-0.011441971,-0.000648128,-0.017524324,-0.009582346,0.005469246,-0.006427481,0.0018169915,-0.025222685,-0.013975608,0.0048358366,0.016842192,0.0062325853,-0.0115556605,0.0022920484,-0.013057977,0.03751732,0.012392085,0.030452373,-0.010962854,-0.010418772,0.0045272526,-0.002105274,-0.014365399,-0.0014454726,-0.01540484,0.030533578,0.025709923,-0.01695588,0.015445443,-0.015031291,-0.020236617,0.023013873,-0.014933843,0.010386289,-0.010605546,0.0073775947,-0.009769121,-0.0021032437,0.007897316,0.010280721,-0.015607855,0.051289916,0.0064721443,-0.030582301,-0.00411107,0.00019781353,0.007048709,-0.00095062156,-0.0057981317,0.0043201763,0.005457065,0.0112958,-0.0017063479,0.0063746967,0.005213446,-0.015932681,0.008380493,-0.010199514,-0.009541743,-0.0080150645,-0.013821317,0.005343376,0.005213446,0.0082505625,0.016273748,-0.020691372,0.04135026,-0.0021742994,-0.009468658,0.0069268993,-0.0082992865,-0.0114582125,-0.0032340419,0.005319014,-0.004774932,-0.009647312,0.030208753,0.013618301,0.0025153658,-0.021552159,0.003810607,-0.004982008,0.001245502,0.0009907172,0.00628943,-0.027821288,-0.008632232,0.021617124,-0.006898477,0.018060287,-0.0016099154,-0.011563781,0.019424552,0.016363075,-0.0036522544,0.007089312,0.004094829,-0.0071339756,0.0010160941,-0.0057209856,0.003889783,0.0069918646,-0.03735491,-0.010719235,0.007430379,-0.0124164475,0.007458801,-0.011986054,0.005623538,0.009395571,0.008445458,0.012107863,-0.018937316,0.0063625155,-0.0215684,-0.0006537109,-8.406124e-06,0.0045637954,0.009955895,0.0014931813,-0.0066142553,-0.004082648,-0.014738948,0.0061188964,-0.009679794,0.00898142,-0.017832909,0.014576536,0.0045231925] },
-        { "parameter": 1.0 }
-      ]
+  "filter": {
+    "cosineDistance": [
+      { "path": ["embedding"] },
+      { "parameter": [-0.008173416,-0.011068422,-0.013374682,-0.0013307687,0.024556793,0.012895565,-0.018839868,0.01630623,0.0023590438,0.017475601,-0.010053343,0.0012668187,-0.019018522,0.03836187,0.00020403089,0.069772474,-0.02402083,0.035243545,-0.027057948,-0.0018149613,0.013975608,0.0021357264,-0.020967472,0.0377447,-0.008396734,0.0065168077,-0.011588142,-0.010987216,-0.014202986,-0.0076902388,-0.007767385,0.034886237,0.047814284,0.0099721365,0.053985965,-0.024686722,0.012993012,0.0011267378,-0.011523178,0.053498726,0.02221805,0.04635257,-0.03147557,0.002645296,0.009176315,0.003518264,-0.03426907,0.015274909,-0.016712261,0.023338698,-0.012627584,-0.009005781,-0.007483163,0.04287694,-0.014397881,-0.0011998235,0.013626422,0.023679765,-0.008713439,-0.026668157,0.0054895477,0.0023549835,0.039758615,-0.046807326,0.022900183,0.02400459,-0.018531283,0.023858419,0.0028280104,0.024719205,-0.0034025451,-0.03288856,-0.0050347922,0.059865303,0.023712248,0.01591644,0.05093261,-0.019944273,-0.028519662,-0.04739201,0.018904833,-0.027999941,0.022510393,-0.008526664,-0.0065289885,-0.029088106,-0.019310864,-0.113299064,0.014617139,-0.012635704,0.007048709,0.020496476,0.00037532547,-0.0053108935,-0.026148437,-0.023890901,0.03313218,-0.006261008,0.005684443,0.013667025,-0.015502287,0.0068578743,-0.014909482,-0.027285324,-0.01991179,0.012952409,0.020870026,0.009890931,-0.010995337,0.033294592,0.010475616,0.017767943,-0.03696512,0.024573034,-0.0026026627,0.016501125,-0.019034762,-0.047976695,-0.01206726,-0.008892093,-0.007795807,-0.053823553,-0.029055623,-0.05174467,-0.0011815521,0.029802721,-0.02363104,0.0225916,0.009825965,-0.00950114,-0.0017642074,0.014292313,-0.011961692,-0.0069918646,-0.011872365,0.0068253917,-0.015477926,-0.007795807,0.031264435,0.038491797,-0.068408206,-0.009842207,-0.0016809709,0.037842147,-0.021373505,-0.02041527,-0.008429216,-0.020626407,-0.011271438,0.012180949,-0.029234277,-0.019635689,0.0035020227,0.0079176165,0.035211064,-0.022916425,0.0047059064,-0.021552159,0.00898954,-0.023972107,0.009346848,0.031264435,-0.003879632,0.009452417,-0.023809694,-0.037322428,0.042324737,-0.030549819,0.0073613534,-0.001655594,0.015055653,-0.02606723,0.032044016,0.0073288707,-0.02772384,0.045150716,0.013301596,0.0055260905,-0.005932122,-0.04966579,0.0156647,0.009907172,-0.033684384,-0.009330607,0.009744759,0.0019276352,-0.0051972046,-0.0218445,0.037582286,-0.07237108,0.023679765,-0.016338713,0.021925708,-0.017881632,0.07951723,0.03469134,0.010751718,0.022721529,0.016403677,-0.01693964,0.028519662,-0.026976742,0.044663478,-0.011677469,-0.01771922,0.028032424,0.028730799,0.020821301,0.02864959,0.009200676,0.036023125,-0.0351461,-0.050737713,-0.0036887974,0.0114094885,-0.023533594,-0.017930357,-0.01771922,-0.017069569,-0.010231997,0.020870026,0.01347213,-0.009964016,0.014341037,-0.04070061,0.0045922175,0.020122927,0.012432688,0.011466333,0.026148437,0.0033944244,0.0030980213,0.051517293,0.02774008,-0.02595354,0.013066098,0.005128179,-0.0043201763,-0.0056722616,0.021503435,0.049763236,0.033976726,-0.016379315,-0.03017627,0.028292283,-0.014917602,-0.027139153,-0.010045222,0.006342214,0.018157734,0.0025904817,-0.003966929,0.03891407,0.030452373,0.0056194775,-0.0024585214,-0.010970974,-0.009598588,0.027447738,-0.0097853625,-0.053336315,0.016208783,-0.011563781,0.012863082,-0.004086708,-0.057851385,0.022412946,-0.018141493,-0.025579993,-0.010564943,0.011441971,-0.015542891,0.02439438,0.054538168,0.0013490401,-0.026489504,-0.015770268,0.0023590438,-0.0047180876,0.0030858403,0.056454636,0.0011622655,0.022055637,-0.011758676,0.0059524234,0.0077470834,0.033976726,-0.02324125,0.0021824199,-0.014706465,-0.005993027,0.02787001,0.03171919,0.03400921,-0.028795762,0.033197146,0.024248209,-0.019083487,-0.0058955792,0.021129886,-0.008071909,-0.023712248,-0.057461597,-0.04752194,-0.023501111,0.024930341,0.01680971,0.02244543,-0.028665833,0.014406002,-0.045345612,-0.021535918,-0.032547496,0.0009775212,-0.037127532,0.013999971,-0.019798102,0.016062612,-0.02426445,0.013910644,-0.007933858,-0.015648458,-0.031995293,0.015892077,0.039238896,0.013553335,-0.0139918495,0.013325958,0.0032015594,-0.0032056198,-0.036315467,-0.012229673,-0.031881604,-0.0008582494,0.0028929752,-0.041252814,0.01297677,0.026684398,-0.008502303,-0.010564943,-0.011701832,-0.02182826,-0.028682074,0.010719235,-0.012733152,0.003183288,0.04414376,-0.015088135,0.018774902,-0.006874115,0.0008572343,-0.011848003,0.025498787,-0.012505774,0.019879308,-0.010110187,0.00706089,0.00071816845,0.015218065,0.013301596,0.014194866,0.011953571,-0.008092211,-0.008754042,0.035633337,-0.04303935,0.015810871,0.012254034,0.022656566,-0.00988281,-0.03210898,-0.008080029,0.02283522,-0.025352614,-0.006768547,-0.019619448,-0.0118398825,-0.0070202868,-0.008100331,0.019424552,-0.018303907,0.0023407724,0.018125251,-0.047197115,0.006573652,-0.015721545,0.022786494,-0.01232712,-0.019213416,0.0096879145,0.0075318865,-0.0070202868,0.015218065,-0.021194851,0.019700654,0.00016761493,-0.020593924,0.006626436,0.049275998,0.013715749,0.022640323,-0.0028726738,-0.0033457007,-0.012530136,0.023793453,-0.02785377,-0.053043973,-0.01168559,0.0073897755,0.01835263,0.002300169,0.0025173961,-0.0012404266,-0.0010424862,0.018157734,0.010045222,0.018563766,0.042422183,-0.012854962,-0.015185582,0.023403663,-0.029088106,-0.025238926,0.038979035,-0.02298139,0.005067275,-0.029364208,0.0012495624,0.012473292,-0.005339316,-0.02244543,0.012765634,-0.006780728,0.019051004,-0.028211078,-0.030793438,0.010435013,-0.027788805,0.005534211,0.011060301,0.002298139,-0.00044790364,0.038199455,0.004567856,-0.012513895,0.02567744,0.028454697,0.00088362634,0.047456976,0.0063868775,0.040473234,-2.2839278e-05,-0.029818963,-0.00551797,-0.032433808,-0.058858346,0.005688503,0.025011549,0.009095108,-0.00410904,-0.008754042,-0.017150776,0.008745921,0.005960544,-0.005574814,-0.032823596,-0.021324782,-0.034334034,0.0017347701,0.02415076,-0.022672806,-0.027236601,0.032563735,0.016614813,-0.010970974,-0.011701832,-0.014446605,0.0032462229,-0.0034208165,0.004823656,-0.0066304966,-0.01283872,-0.030890886,-0.00019755977,0.018969797,-0.02671688,0.014503449,-0.009176315,0.004129342,0.004803354,-0.012765634,0.019798102,-0.019522,0.0034329975,-0.0065168077,-0.030517338,0.0033964545,0.023696005,0.030371165,0.019359589,0.01693964,-0.0017895844,-0.00094300846,0.025206443,0.0017022876,-0.025385097,0.017751703,-0.007048709,-0.00859163,0.016070731,0.0075156456,0.024231967,-0.006902538,-0.037582286,-0.0071989405,-0.023127561,0.017865391,-0.02104868,0.029250517,0.004685605,-2.1586291e-05,0.017800426,0.040927988,0.030224994,0.015177462,-0.007613093,0.019976756,-0.049958132,-0.04632009,-0.054278307,-0.00056083116,-0.024800412,0.032271393,-0.03465886,0.003646164,0.021194851,0.015851475,0.020561442,0.0008176462,-0.0017956749,0.0008272894,0.0068862964,-0.0007100478,-0.031020816,0.007970401,0.0032117101,0.036640294,0.017459359,-0.017475601,0.0010861346,-0.0036624053,0.0071177343,0.024231967,-0.0024483707,0.029510379,0.033034734,-0.0065005664,-0.023436146,-0.014259831,0.0045272526,-0.018596249,0.016216904,-0.04492334,0.024053313,0.03183288,0.018515043,-0.022965148,0.039985996,-0.01965193,0.001733755,0.014389761,-0.016452402,0.014665863,-0.0087784035,0.009996499,0.030484855,0.010361927,-0.018433835,-0.018027805,-0.02143847,-0.028990658,-0.021324782,-0.03121571,-0.011182111,-0.0033457007,-0.0017154836,-0.019749379,0.006882236,0.0014109599,-0.0029863627,0.02967279,0.006484325,0.024459345,0.04040827,0.006707642,-0.0027325929,0.005428643,0.024800412,0.0010648179,0.007255785,0.0106461495,0.01568094,0.0017865391,0.008851489,-0.010841045,-0.02260784,0.032531254,-0.004299875,-0.019570725,0.047716837,-0.07048709,-0.002734623,0.0030635085,-0.008108452,0.029429173,-0.016972123,-0.015827112,0.01682595,-0.007207061,0.019749379,-0.009298124,-0.026245885,-0.005761589,0.016988363,-0.047197115,0.013033615,-0.00012606013,0.013423406,-0.0047221477,-0.009460537,0.016070731,0.044468585,0.012513895,-0.021081163,-0.0118074,0.022185568,0.015599735,-0.06506251,-0.011718073,0.017313188,0.027366532,-0.0030736595,0.0029762117,0.06623188,-0.02671688,0.026424538,0.02208812,0.027025465,-0.0024300993,0.005928062,-0.02887697,-0.034496445,0.0039831703,0.0047789924,0.00025072452,0.02632709,0.006216344,-0.0042024273,-0.014690224,0.0035913498,-0.016030129,-0.00029995586,0.0024707024,-0.0081815375,-0.020220375,0.007523766,-0.021974431,-0.028438454,0.01014267,0.025206443,0.019180935,-0.03839435,-0.028470937,-0.020626407,-0.036607813,-0.004328297,-0.028389731,0.015965164,0.007905436,-0.010207635,-0.022364222,-0.03673774,-0.0062813093,-0.003016815,0.014690224,-0.011864244,-0.02606723,-0.002643266,0.038459316,0.014154263,-0.040635645,-0.0202691,-0.0031995291,0.0055260905,0.0059483633,-0.012351482,-0.022640323,-0.026814329,-0.028665833,-0.028552145,-0.008100331,0.0023793452,0.008173416,-0.013951247,-0.007215182,0.012773755,0.00019882861,0.011888606,0.011019698,-0.027269084,0.008786525,0.006874115,-0.030078823,0.03579575,0.027610151,-0.017085811,0.019294623,0.013455888,-0.014958205,0.01169371,-0.020139169,0.013537094,0.016216904,0.008997661,-0.016095094,-0.00449477,0.015274909,0.006480265,0.019781861,0.008372372,-0.008802766,-0.013520853,0.024865376,-0.007824229,0.02260784,-0.01965193,0.018222699,-0.0546681,0.021617124,0.0118398825,0.019992998,-0.008632232,0.020821301,-0.031670466,-0.010589304,0.0063259727,-0.012944289,3.94612e-05,-0.007921677,0.02426445,0.006496506,0.014844516,-0.006707642,0.009557985,-0.020236617,0.010386289,0.018644972,-0.0019205296,0.011255196,0.02631085,0.01604637,-0.0107842,-0.027204119,0.015997646,-0.0067766677,0.005684443,0.02338742,-0.033684384,-0.013926885,-0.032774873,0.0016129606,0.003863391,0.00058976095,0.00083185727,0.022867702,-0.020382788,-0.020740096,-0.020707613,-0.0106461495,-0.018531283,-0.0019276352,0.014056815,0.0031020816,-0.013699507,0.012879323,-0.02143847,-0.025271408,-0.024280692,-0.01861249,0.0052175066,-0.0035933799,0.01911597,0.012538256,0.021795778,0.010743597,-0.034139138,-0.0018819566,0.005237808,-0.027675116,0.018190216,-0.010800441,0.0007846561,0.0051038177,-0.008770283,-0.013837558,-0.009078867,-0.0057778303,-0.02067513,-0.01629811,-0.009233159,-0.018417595,-0.011644987,-0.00038649136,0.002476793,0.026002266,-0.012018536,0.0088271275,-0.002657477,0.006175741,-0.024426863,-0.0024463406,-0.024589276,-0.011515057,-0.010435013,0.034204103,0.026034748,-0.01976562,-0.0073613534,0.023907142,0.017832909,0.009103229,-0.0015419051,-0.034431484,-0.013805076,-0.03478879,0.010329445,-0.026099714,0.0064477823,0.018190216,0.006488385,-0.010897889,-0.017865391,-0.05203701,0.004774932,-1.29105365e-05,0.0010922251,0.009704156,0.013074218,-0.013642662,-0.026635675,0.0006841633,-0.008120633,-0.0022169326,0.024167003,-0.0024361897,-0.015185582,-0.009265642,-0.008372372,-0.008246502,0.004429805,-0.020041721,-0.0029599706,0.0001896929,0.0030472674,0.01373199,0.0037050387,0.019879308,-0.030452373,-0.0053961603,-0.006252887,-0.010629908,-0.0020017358,0.015453564,-0.00423897,-0.022965148,0.015705302,0.0056682015,-0.017621772,0.01181552,0.011831761,-0.012984891,-0.004839897,-0.020041721,-0.036380433,0.0066304966,-0.010215756,0.00744662,0.02052896,0.019879308,-0.011052181,0.022559118,0.0336519,0.035665818,-0.010085826,0.038751658,0.009931534,-0.01568094,-0.03517858,0.010231997,0.04118785,-0.0020565502,0.0042836335,-0.00061818317,0.029201794,0.008656594,0.049860682,0.021584641,-0.01872618,0.018969797,0.007345112,-0.0050916364,-0.002271747,-0.011109025,-0.018807385,0.012984891,0.0031406546,-0.018157734,-0.003108172,0.033229627,-0.011125267,0.012140346,0.025271408,-0.023842176,0.034853756,0.0009419934,-0.015754027,-0.003325399,-0.016858432,0.005534211,-0.004096859,0.03219019,-0.015218065,-0.027447738,0.022380464,0.017540567,0.01218907,0.017378153,0.017621772,-0.023793453,-0.020122927,0.008226201,0.0431368,0.0024199486,-0.028990658,0.03171919,-0.032644942,-0.004632821,-0.016346833,-0.00047480324,-0.0042430307,0.01797908,0.010556823,-0.0073532327,0.009436175,0.024475586,0.033814315,0.010832923,-0.0066710995,-0.030322442,0.004571916,-0.017832909,-6.769309e-05,-0.037907112,0.013041736,-0.006650798,0.015218065,0.024881618,0.011336403,-0.030874645,-0.0013591909,-0.0047018463,0.021876983,0.002170239,-0.003962869,-0.026034748,-0.006654858,-0.0021133947,-0.008965178,0.015347996,-0.008721559,0.029981375,-0.00654523,0.006987804,0.020090444,0.0024097976,-0.013585818,-0.013618301,0.04161012,0.0067766677,-0.020171652,-0.006508687,-0.010800441,-0.025238926,-0.03556837,0.014828275,0.00295388,-0.03595816,-0.0016393526,0.005351497,-0.010767959,-0.006711703,-0.0061026555,-0.012660066,-0.018661214,-0.0029701213,0.01476331,0.03144309,-0.01695588,-0.014365399,0.0029112468,-0.0026818388,0.01989555,-0.0008800735,-0.009476778,0.017167017,0.046969738,-0.014966326,-0.019522,0.028600868,0.10680256,-0.003916175,-0.014438485,-0.028844487,-0.02618092,-0.0031914085,0.04508575,0.0040075323,0.009192556,0.0056560207,-0.0076699373,0.016988363,-0.011848003,-0.006520868,-0.007406017,0.00038953658,0.030338682,-0.0018129312,-0.018044045,-0.0027955277,0.034106657,0.020382788,-0.007548128,0.0025255168,0.016696021,-0.0106461495,-0.00199057,0.0054245824,0.033457007,-0.008315528,0.016249385,-0.024719205,-0.013196028,-0.0016393526,-0.0030858403,-0.011669349,-0.006646738,-0.0038613607,-0.00988281,0.023809694,-0.0075521884,0.017670495,-0.016281867,0.017410636,0.028990658,-0.0019093637,0.0022108422,-0.0071177343,0.0071299155,0.00038725266,-0.016216904,-0.013675145,-0.00042785582,0.036120575,-0.01643616,0.02387466,-0.0070040454,-0.0006166605,-0.013147304,-0.027756322,-0.026765605,-0.011904847,-0.02387466,-0.01642804,0.013967488,-0.011368886,-0.007101493,-0.00036974254,0.029234277,-0.004957646,0.012570739,-0.045508023,-0.014267951,0.0149013605,-0.011198352,0.01950576,-0.0052702907,0.03080968,0.034399,0.008185597,-0.020480236,-0.014990687,-0.021162368,-0.011823641,0.0123677235,0.013163545,0.00068111805,0.015551011,0.005107878,-0.018580006,0.0064518424,-0.006200103,-0.0079663405,0.0024970945,0.034821272,0.020772578,-0.021958191,-0.004072497,-0.013634542,-0.004271453,-0.021243574,0.017280705,-0.017508084,0.003607591,0.0071705184,0.013504612,-0.0022676867,0.009127591,0.01911597,0.032450046,0.019359589,-0.025044031,0.025969783,0.03901152,0.011515057,-0.0006354395,0.011961692,0.0030492975,-0.0045516146,0.024053313,-0.034171622,-0.011214593,-0.0026371754,0.010702994,0.016728504,0.0012901655,-0.0028848548,-0.014414122,0.029624067,-0.019554483,-0.0069431406,-0.006918779,-0.026879294,0.02283522,0.017849151,-0.001156175,0.010629908,-0.0040318943,-0.023696005,-0.024085796,0.0072436044,-0.021324782,0.025044031,-0.013699507,-0.00526623,0.008043487,0.014974446,0.0060823536,-0.026473261,0.012570739,0.0022900184,-0.010824803,-0.0058103125,-0.03248253,-0.007783626,0.032401323,0.018320147,0.0009333652,-0.042162325,0.006959382,-0.043981347,0.005432703,-0.013886281,0.00654929,-0.0037090988,-0.015047532,-0.011774917,-0.008412975,-0.009095108,0.010280721,-0.009931534,-0.011742434,0.0029416992,-0.0037375211,-0.011238955,0.0028706435,0.0025133358,-0.0026229643,0.007227363,-0.023988348,0.014470967,0.012773755,0.023663523,0.021779537,-0.0023732549,0.015469805,-0.00068873115,0.017102052,-0.005850916,-0.012676307,0.0051647224,0.00693096,-0.020480236,0.010167032,-0.023793453,0.0056316587,-0.0021783598,-0.011238955,-0.0031000515,0.0102726,0.0076902388,0.0074994043,0.008039426,-0.016460523,0.017849151,-0.039206415,-0.009151953,-0.014113659,-0.021958191,-0.01809277,0.010321324,-0.007292328,-0.012822479,0.033050973,0.008258684,-0.015559132,0.015973285,-0.0072192424,-0.018547524,-0.017296948,0.009484898,0.03209274,0.01604637,0.012651945,-0.032953527,0.0053961603,0.022916425,0.013537094,0.015754027,-0.0008582494,0.0056479,-0.0021824199,-0.0089245755,-0.019619448,-0.022429187,-0.006403119,-0.043948863,0.024459345,0.03547092,-0.0019022581,-0.008104391,0.010613667,-0.0070284074,0.033424523,0.019213416,0.049081102,-0.0036928577,0.0269605,0.0019834645,-0.007040588,0.00846982,-0.0336519,-0.0054124016,-0.012879323,0.0069756233,-0.0048683193,0.011393247,-0.017167017,-0.019343346,0.015770268,0.0023976169,0.020788819,-0.0005623538,-0.020756336,0.007434439,-6.883505e-05,0.0023265611,0.026749363,0.009078867,0.006236646,0.020723853,0.014300434,0.00859975,-0.0097853625,0.020642648,-0.007511585,0.029753998,-0.014738948,0.028162353,-0.006252887,0.009769121,0.0068091503,-0.00078770134,0.011109025,0.020756336,-0.0088271275,-0.0049373447,0.010727355,-0.0056113573,-0.036380433,0.028146112,-0.00898954,-0.0051119383,0.01734567,0.004596278,0.017475601,0.009493019,0.02093499,0.014503449,0.005676322,0.01630623,-0.007239544,-0.0072354837,0.030533578,-0.0148526365,0.0015246487,-0.0076861787,-0.013723869,0.0202691,-0.030192511,-0.010491857,-0.0022372343,-0.010183273,-0.0070324675,-0.0025701802,0.022055637,0.014170504,-0.005928062,-0.002978242,-0.0092575215,-0.015542891,-0.01026448,-0.023095079,-0.0003347223,0.004953586,0.0054530045,-0.0205452,-0.021194851,-0.038816623,-0.017946597,-0.019392071,0.0055382713,-0.0038735417,0.004515072,-0.009939654,-0.0042795734,0.023566075,0.004267392,0.0056154174,-0.01502317,0.0057534683,-0.0010577124,-0.013423406,-0.01773546,-0.018856108,-0.0061432584,0.015989525,0.0013662964,-0.0018139463,0.018937316,0.026245885,-0.0023285914,0.016127577,0.0055504525,0.00205249,-0.037257463,-0.016509246,0.00091509375,0.0140405735,-0.009484898,-0.0148526365,0.016078852,-0.011880485,0.02208812,-0.016525486,0.0025904817,0.018336387,0.010816682,0.018076528,-0.012002295,0.028357249,0.011563781,-0.0026655977,0.042357218,-0.025044031,-0.012156587,-0.01580275,0.016346833,0.0077470834,0.0035669878,0.010540581,0.0060011474,-0.0055869953,0.03131316,-0.004340478,-0.0004557705,0.0080150645,-0.0056316587,-0.01065427,-0.016354954,0.03914145,-0.014828275,-0.015810871,0.0071096136,0.015494167,0.0069918646,-0.01476331,-0.00026848842,0.028048664,-0.040213373,-0.027788805,0.00027001102,-0.014519691,-0.01592456,-0.0007684149,-0.002992453,-0.015989525,-0.026619432,-0.0071623977,0.0030350864,-0.014738948,0.02556375,-0.0047789924,-0.007125855,-0.004324237,-0.015128738,-0.007950099,0.0060052075,0.010167032,-0.0019113938,0.017832909,0.015201824,-0.01874242,0.019018522,0.010305082,0.008461699,0.016679779,0.016647296,-0.044078793,0.022656566,-0.009663553,0.02168209,-0.031166987,-0.026846811,0.01757305,0.0055139093,0.012660066,0.0044379258,0.0054530045,0.031004574,0.0010506068,-0.027821288,-0.017004605,-0.011109025,-0.0050347922,-0.0043445383,0.0006384847,-0.031637985,0.015429202,-0.027707597,0.019197175,-0.004608459,-0.015307392,-0.01629811,0.013723869,0.00087905844,0.00628943,0.012083502,-0.05609733,-0.011539419,-0.018791143,0.0048439573,0.001771313,0.005635719,0.011653108,0.005355557,-0.027220361,0.011328283,-0.013122942,0.021779537,0.021422228,0.004965767,0.0114582125,0.0035913498,-0.019245898,-0.02811363,-0.009233159,0.018287664,0.007755204,0.018580006,-0.013504612,0.006370636,0.010004619,0.017946597,-0.0062975506,-0.020463994,0.0011074513,-0.0316055,0.0038573004,0.00023143803,0.034853756,0.0091113495,0.0123189995,0.00937933,0.012237793,-0.033457007,0.0114094885,0.0016890916,-0.006520868,0.025579993,-0.0018088709,0.015697183,0.0074994043,0.0030614785,0.011190232,0.0023428025,-0.0057453476,0.021470953,-0.019619448,-0.0047952337,0.030890886,0.014332917,-0.016590452,-0.0105487015,-0.006236646,-0.02322501,-0.031410605,0.021633364,-0.006508687,-0.013033615,0.010954733,-0.011831761,-0.0020849723,-0.035373475,0.020691372,-0.029250517,-0.0109303715,0.001566267,0.019700654,-0.00937933,-0.0010308127,-0.0104999775,0.0011318132,0.0013571607,-0.011141508,-0.0088271275,0.0028807945,-0.002927488,0.019180935,-0.032141462,0.0052824714,0.020041721,0.00094554614,-0.0042552114,-0.022347981,-0.010719235,0.0062325853,-0.0046409415,0.02143847,0.01643616,0.0012729091,-0.017426878,0.017865391,0.0010719235,-0.007783626,-0.00017751195,-0.0051038177,-0.00244025,-0.01680971,-0.00085571164,0.008640353,-0.008940816,0.02592106,-0.0025275468,-0.005294652,0.028795762,-0.0028198897,0.010061463,-0.013926885,-0.005928062,-0.0062975506,0.012359602,0.004161824,-0.02824356,-0.011336403,0.0068862964,-0.011165869,0.021097403,0.006853814,-0.0031771974,0.011385127,0.0026128136,0.038037043,0.016070731,-0.015396719,-0.009606708,0.001079029,0.012002295,0.006732004,0.0036136815,-0.00038420744,0.024296932,0.009517381,0.035665818,0.0030005737,0.016574211,-0.009151953,-0.038654212,-0.0013683266,0.022266774,0.005826554,0.006269128,0.006455903,0.016533608,-0.016614813,0.029234277,-0.007844531,0.0020037661,0.0008871791,0.0008049577,-0.00047277307,0.027707597,0.007138036,-0.008356131,0.01141761,0.011263317,-0.0041537033,-0.014560294,0.012083502,-0.0020829423,-0.027626392,0.006894417,0.022754012,-0.0059483633,-0.007458801,0.0023915262,0.02710667,0.02030158,0.026343333,0.009817844,-0.02169833,-0.01206726,0.011385127,-0.005794071,0.03251501,-0.006179801,0.014430364,-0.028048664,-0.010435013,-0.013796954,-0.00018169916,0.009298124,0.013959367,-0.020382788,0.004454167,0.0080840895,-0.027269084,-0.008120633,0.012692548,0.019846825,0.0041009192,0.009078867,0.012660066,-0.035633337,-0.0038938434,-0.0050347922,0.0058346745,-0.0021722692,-0.006654858,-0.026846811,-0.023988348,-0.014284193,-0.02787001,-0.02283522,0.00091204856,-0.024556793,0.016078852,-0.023452386,0.010256358,-0.01168559,0.0011145568,-0.012919926,0.015510408,-0.012302758,-0.021990674,-0.00616356,-0.019051004,0.0044866493,-0.0069756233,-0.007540007,0.007994763,-0.022055637,-0.037095048,0.011474454,-0.020236617,0.008412975,0.0028442515,-0.014430364,-0.0039872304,-0.011588142,0.008518543,0.0012404266,0.032027774,0.0038471497,0.00385121,0.014032453,0.012245914,-0.030988334,0.0018088709,-0.017085811,-0.00410701,-0.004316116,0.01425171,0.01347213,0.0009333652,-0.005014491,-0.017556807,0.0048845606,-0.0018037955,-0.016208783,0.006780728,0.006622376,-0.01065427,0.013707628,-0.006829452,-0.01053246,-0.012481412,-0.017849151,-0.005201265,0.032433808,-0.013317837,-0.0019936152,0.026781846,0.021129886,0.012164707,-0.0076577566,0.0076333946,0.013569577,-0.0037334608,0.018303907,-0.0034878117,-0.0068050902,-0.002145877,0.008173416,0.024670482,0.020187892,-0.018661214,-0.012554497,-0.009907172,-0.01836887,-0.009947775,-0.015518528,0.017849151,0.012229673,0.01654985,-0.0022818977,0.011628746,0.0003080765,0.0075684297,-0.025596233,-0.017816668,0.013650783,-0.0029863627,-0.0029315483,-0.0029985434,-0.009281883,0.03787463,-0.003134564,0.0023976169,-0.01797908,0.019440794,-0.0021641485,0.008071909,0.01309046,-0.0011338433,0.02502779,0.026050989,4.7074293e-05,0.0027041705,-0.0102726,-0.018596249,-0.003928356,-0.008421096,-0.017102052,-0.0020139168,0.0026777785,-0.0041455827,-0.012424568,0.033327077,-0.010102067,-0.002773196,0.017702978,-0.0029416992,0.035016168,0.018531283,-0.0067604263,-0.0074100774,0.008205899,0.02657071,-0.0074669216,0.012993012,-0.014316675,0.011279559,0.012083502,-0.012262155,0.0076983594,0.022380464,0.020772578,-0.011190232,-0.015835233,-0.011238955,0.0073613534,0.00731669,0.010467495,-0.0029863627,0.0015317543,-0.0100695845,-0.00094554614,-0.002657477,-0.0072963885,-0.0013256932,0.006086414,-3.1530893e-05,-0.0047302684,-0.018044045,-0.02002548,-0.011214593,-0.014235469,-0.017394396,-0.0068578743,-0.010735476,0.003948658,-0.005107878,-0.023647282,-0.0074709817,0.030972091,-0.008323648,0.013464008,0.0064234203,0.0058346745,-0.006853814,-0.036607813,0.013577698,0.0017317248,-0.0018768812,0.0058224937,-0.0106461495,0.0030878705,0.0059727253,0.0026107833,0.009566105,-0.00256612,0.029120589,-0.004466348,-0.0139918495,-0.01015079,-0.016858432,0.0072354837,0.025255168,-0.009955895,0.014771431,0.026457021,0.019440794,0.020382788,-0.024443103,0.013577698,0.02363104,0.018271424,-0.0051444205,-0.038329385,0.008404855,0.028584626,0.016281867,0.014154263,0.01950576,-0.010378168,9.23722e-05,-0.019310864,0.00924128,-0.019635689,-0.017849151,-0.0056032366,-0.01257886,-0.02400459,-0.0069675026,-0.024849135,-0.0037923353,0.0022940787,0.0027671056,-0.033457007,-0.011904847,-0.0067847883,-0.013074218,0.0015043472,0.012627584,0.009468658,-0.01014267,-0.028064907,0.021373505,-0.015258669,-0.0043079956,-0.010556823,0.011588142,-0.0042592715,0.013520853,0.023955867,0.024605516,0.004848018,-0.02247791,-0.007454741,-0.016744744,0.0041780653,-0.0056925635,-0.012359602,0.0014028393,0.01875866,0.011921088,-0.021860743,0.0019672231,0.019310864,0.0038755718,0.00023283376,0.0014393821,0.004019713,-0.01386192,0.019327106,0.010418772,0.011109025,0.0008333799,0.027528943,-0.0040258034,0.0124164475,-0.0045028906,-0.01297677,-0.010313204,-0.01926214,-0.022867702,0.008421096,0.0075278264,-0.010638028,-0.00052936375,-0.0003233027,0.009525502,-0.0017784185,0.013780713,0.0016241265,-0.014056815,-0.027447738,-0.0060661123,-0.0023773152,0.012627584,-0.0032665245,-0.017832909,0.030062582,0.019668171,-0.01887235,-0.030890886,-0.004214608,0.018320147,-0.033050973,0.008165296,0.022883942,0.008697198,0.010776079,-0.0069918646,-0.0032320118,-0.026424538,-0.016281867,0.014552173,0.002578301,0.011165869,0.012335241,0.017459359,0.0053636776,-0.012684428,-0.0039831703,-0.0022778374,0.0012373814,-0.002620934,-0.008534784,0.011149628,0.019781861,-0.00096635526,0.0059158807,-0.0066061346,0.007730842,0.02363104,-0.0045922175,-0.017037086,-0.011149628,-0.009346848,0.029347965,-0.022624083,0.021146128,0.02850342,-0.03478879,0.0076374547,0.014552173,-0.0080840895,-0.01386192,-0.0028097387,-0.033521973,0.0031406546,-0.007089312,-0.002541758,0.0076333946,-0.016233144,-0.0043445383,0.030647267,0.02169833,-0.024491828,-0.0011328282,0.021487193,-0.0040603164,0.00040780802,0.006569592,0.012042898,-0.01810901,0.02244543,0.015323633,-0.0073775947,0.018986039,0.0124164475,0.0043445383,-0.00089022436,0.030387407,0.01682595,-0.00061158516,0.017491842,0.015080014,-0.012124104,-0.034204103,-0.02374473,-0.005993027,0.0055504525,-0.0021641485,-0.0038146672,-0.008542906,-0.036640294,-0.019603208,-0.015047532,-0.0059158807,-0.0005146451,0.002091063,0.016663538,0.010004619,-0.021860743,0.024053313,-0.0063503347,-0.009330607,-0.014803913,-0.02065889,-0.00039841855,0.01104406,-0.022786494,-0.021178609,0.005818433,0.006727944,-0.014146142,-0.01773546,0.009354969,-0.014868878,-0.00784047,-0.020009238,-0.008656594,-0.006200103,0.0083480105,0.007950099,0.013577698,-0.005623538,-0.00013843141,-0.01991179,0.025206443,-0.01682595,-0.011563781,-0.008656594,0.011523178,-0.010995337,-0.0063381535,-0.00064406765,0.002787407,0.0002224292,0.010702994,-0.0008724604,0.03246629,0.002618904,0.00026544317,-0.02322501,0.0036238323,-0.031995293,0.028682074,0.012773755,-0.022250533,-0.0010181243,0.015071894,0.0074100774,0.01296865,0.007215182,0.01771922,0.026115954,-0.011669349,-0.019213416,-0.01810901,-0.025888577,0.012042898,0.015940802,0.002143847,-0.01425171,-0.009119471,0.004852078,0.0071339756,-0.0067482456,-0.0017357852,-0.023679765,0.0016149908,0.0012982861,0.009679794,-0.016484885,-0.01245705,0.0019073336,-0.02749646,-9.427547e-05,0.017459359,-0.0019012431,-0.00937121,0.009038264,-0.0011104965,-0.007239544,0.002758985,-0.008421096,-0.004161824,0.0008272894,0.0036258623,-0.013658904,-0.016842192,-0.016403677,-0.011726193,0.019375829,-0.0021682088,0.01888859,0.009225039,-0.007893255,-0.0075806105,0.023679765,-0.0037801545,0.01540484,-1.4750368e-05,-0.011636866,0.007893255,0.037809666,-0.009947775,-0.025385097,-0.008721559,0.025856094,-0.000108676904,0.00552203,-0.023013873,0.00693096,-0.017248223,0.0097366385,-0.026781846,0.007820169,-0.0014952115,0.029201794,0.0053880396,0.0029843324,-0.010540581,-0.0014566384,-0.013805076,0.015542891,-0.004210548,0.010288841,-0.01258698,-0.0064112395,-0.006204163,0.012302758,0.022315498,0.038459316,-0.018222699,-0.015356116,-0.03043613,0.0005968665,-0.030598544,-0.00924128,0.011969812,0.009509261,0.004681545,-0.027122913,-0.011125267,-0.0070811915,0.015250548,0.019635689,-0.023501111,-0.006764487,-0.0023631041,0.0045110113,0.02812987,0.0033720927,-0.038686693,-0.008721559,-0.0010506068,-0.012562619,-0.022364222,-0.002208812,0.006780728,-0.0052581094,0.012213431,-0.016363075,-0.00846982,0.0097853625,0.0059402427,0.01091413,-0.003696918,0.031767916,-0.0005189592,0.008461699,-0.003325399,0.005984906,0.016696021,-0.01590832,-0.004965767,0.011604384,0.0043079956,-0.0036421036,0.016744744,-0.00782829,-0.0039121145,-0.011117146,-0.013805076,0.010987216,0.0023346818,-0.014154263,0.009996499,0.0037537625,-0.0060255094,-0.0001028402,-0.0053921,-0.007267966,-0.002604693,0.009533622,0.0072963885,-0.0012120045,0.00094300846,-0.008615991,0.017508084,-0.0058630966,0.01206726,0.003120353,0.020870026,0.00090849574,0.00030655388,-0.016289989,0.018807385,-0.031280678,0.02746398,0.01168559,0.004929224,-8.152354e-06,-0.0059118206,-0.019554483,0.016728504,-0.0005039868,0.0037192497,0.0039608385,-0.009054505,-0.016387437,0.0056682015,0.009549864,0.0052784113,0.002466642,-0.0038471497,0.0038187273,-0.023403663,-0.00071816845,-0.004738389,-0.014454726,-0.03404169,-0.030744715,0.02465424,0.012294638,0.008311467,0.0017814637,-0.0105487015,0.006127017,-5.563109e-06,-0.013139184,0.015697183,0.018547524,-0.01965193,-0.0054002204,0.026733123,0.001193733,0.0030756895,0.024637999,0.008754042,0.011872365,-0.0013967488,-0.009964016,0.013780713,-0.027821288,0.012383965,-0.028081147,0.009387451,0.025450062,0.00014376057,0.011661229,-0.006370636,-0.0114582125,-0.0020088414,-0.015331754,0.0032198308,0.02774008,0.016647296,0.014909482,-0.0171995,0.0011622655,0.017784186,0.006070173,-0.01514498,0.03106954,0.0022697167,-0.0035588671,-0.005993027,-0.005046973,-0.0046287607,0.01580275,0.03813449,-0.02298139,0.014032453,-0.005956484,-0.014519691,-0.017037086,-0.024800412,-0.019992998,-0.010564943,-0.005493608,0.010670511,0.00011933523,0.00036035306,0.018580006,-0.023939624,0.03144309,0.013074218,-0.0071826996,-0.011904847,0.0037639132,-0.002117455,-0.0032056198,-0.002375285,-0.015551011,-0.001835263,-0.017946597,0.003761883,-0.02374473,-0.010028982,0.017215742,-0.020561442,-0.0015165281,-0.020074204,0.019440794,0.0044095037,0.013634542,-0.01309046,0.005509849,0.012733152,0.015323633,-0.0072476645,-0.0047221477,-0.026521986,-0.008957057,-0.024329415,-0.007978521,-0.015778389,-0.011076543,0.010946613,-0.022006914,-0.009151953,-0.014154263,0.008721559,0.007215182,0.0033071276,0.007714601,-0.0035608974,-0.00010017562,-0.0061188964,-0.040213373,0.0071623977,0.012879323,-0.021211091,-0.014227348,-0.0010039132,-0.029624067,0.01142573,-0.00036289077,-0.019976756,0.023598557,-0.017767943,-0.013301596,-0.0046937256,0.0018281573,-0.013041736,0.0029741817,-0.006870055,0.012505774,0.007422258,-0.025044031,-0.011287679,-0.009923412,0.0013500551,0.004056256,-0.016363075,0.02065889,0.0020139168,0.004742449,0.02091875,-0.0079663405,0.0011876425,0.014812034,-0.018823626,0.0032421625,-0.007743023,0.012887443,-0.0016068702,0.011677469,0.007215182,0.014332917,0.0025498786,-0.011563781,0.0018718058,-0.011994174,0.02337118,-0.019684413,-0.0053474363,-0.003311188,-0.009306245,-0.0013774623,-0.010061463,-0.0035142037,-7.9620266e-05,0.003824818,-0.011173991,-0.015469805,0.0014028393,-0.015810871,-0.00018601323,-0.008607871,0.020902509,0.0008359176,-0.00796228,0.00053190143,0.011165869,0.010256358,0.011092784,0.011109025,0.014211107,0.00028396837,0.021974431,0.019814344,0.013593939,-0.014974446,-0.00924128,0.011498815,0.0066345567,-0.0019854947,-0.005071335,-0.009923412,-0.027074188,0.016070731,-0.031589262,-0.015339875,-0.007836411,-0.018807385,-0.01913221,-0.0066589187,0.0070690108,0.014186745,-0.01014267,0.013001133,0.0015094226,0.01887235,-0.010305082,-0.01641992,-0.0032888562,-0.033359557,0.0016292019,0.00847794,-0.013325958,0.0025823612,0.010223877,-0.024605516,0.008197779,-0.030371165,0.0205452,-0.0058062524,0.005176903,0.0019814344,-0.0070446488,0.017361913,-0.013764472,0.003451269,-0.0044460464,-0.01463338,-0.002913277,0.043234248,-0.008429216,-0.012635704,0.017491842,-0.00092372193,-0.0184988,-0.0009988378,-0.0035629275,0.015745906,0.020707613,0.007986642,0.022331739,-0.014568415,0.011718073,-0.009955895,0.003171107,-0.007673998,-0.026521986,0.020431511,-0.013196028,0.00565196,0.026538227,-0.027269084,0.00410904,-0.0046450016,-0.0011480544,0.0057453476,-0.0035994702,-0.003877602,-0.034171622,0.012294638,0.019619448,0.008940816,0.0300301,0.016712261,0.013293476,0.0009978227,-0.00061209267,-0.022932665,0.014381641,-0.0029173372,0.0017286796,-0.011336403,0.019034762,-0.0015885987,-0.0068619344,0.011596263,0.0037557925,-0.019489517,-0.002771166,0.012854962,0.005737227,0.00053849944,0.0010932401,0.003296977,-0.00028472967,0.015689062,0.024410622,-0.02387466,0.01718326,0.003696918,-0.0018281573,0.0056479,0.03634795,0.0045597353,0.010613667,-0.0045637954,0.02145471,0.0037253401,0.009712276,-0.006593954,-0.007925738,0.019749379,0.0053921,0.015372357,-0.0029173372,0.032450046,0.026083471,-0.015006929,-0.014414122,0.011109025,-0.012928047,-0.006403119,-0.008412975,0.01693964,0.011742434,0.0055910554,0.0028361308,-0.029705273,-0.020870026,-0.015559132,0.0036400736,0.011328283,-0.0055626333,-0.0033193086,-0.012254034,0.018466318,0.0073329313,0.017215742,-0.002411828,0.008973299,-0.00083287235,-0.007877014,0.020220375,0.03621802,0.0022676867,0.0060295695,-0.015632218,0.02437814,0.006764487,-0.0050591542,0.010418772,0.0156647,0.01989555,0.039596204,-0.010873527,-0.01309858,0.029283,0.01425171,-0.011352644,-0.017849151,0.0035933799,0.0010318279,0.018937316,0.011084664,0.004649062,0.0033213387,0.0018088709,-0.011003457,-0.004275513,0.0018850018,0.002606723,-0.021665847,-0.007824229,0.0041699447,0.00051566015,0.0047546304,-0.0063340934,-0.026392056,-0.009671673,-0.00063493196,0.0073248106,-0.006602074,-0.02671688,0.0031386244,0.014454726,0.0076699373,0.010223877,0.01861249,0.0053921,-0.024361897,0.009980258,-0.011368886,-0.008120633,-0.004649062,0.002478823,0.030972091,-0.012124104,0.007714601,0.0048358366,-0.015607855,-0.036900155,-0.004458227,-0.006017389,0.017556807,-0.0024300993,-0.008551026,0.03209274,-0.033359557,-0.008494182,0.0040318943,0.033554453,0.016151939,-0.0030411768,-0.010629908,-0.008019124,-0.020837544,-0.003353821,-0.0023346818,0.005814373,-0.0021215153,-0.007791747,0.02733405,0.0073085693,0.025076512,-0.004567856,-0.007905436,0.0043567196,0.0039648986,-0.025450062,0.014990687,0.004904862,0.006874115,-0.00050982344,0.011125267,-0.0056479,0.006870055,-0.002990423,-0.001245502,0.014673983,0.0030736595,-0.0097366385,-0.0012140345,0.01296053,0.014657741,-0.00085469655,0.0055057886,-0.0020890327,-0.019034762,-0.03157302,0.029624067,0.008737801,0.02298139,-0.0035263847,-0.00045526295,-0.0023062597,-0.013634542,0.021097403,-0.018141493,0.0026534167,0.003991291,0.021081163,0.029835204,0.017605532,-0.015453564,-0.022705289,-0.027041705,-0.01296865,-0.014909482,-0.005209386,-0.0011500845,-0.029299242,0.011734314,0.01001274,-0.021227334,-0.006261008,-0.011027819,-0.0016657447,0.014519691,0.020821301,0.00023181867,0.0024037072,-0.026798088,0.0025113055,-0.02220181,0.020610165,0.008632232,0.013139184,-0.0033050973,0.0007577565,-0.019863067,-0.006459963,-0.015437323,-0.014828275,0.0016484885,-0.031556778,0.005534211,-0.035698302,-0.0056560207,-0.02091875,-0.01732943,0.007905436,-0.007852651,0.025823612,0.011019698,-0.028081147,0.025709923,0.029071864,0.0014140052,0.017134534,0.01181552,0.013196028,0.0082018385,0.014747068,0.0053717983,-0.014097418,0.018953556,0.02402083,0.00049205957,0.021763295,-0.012286517,-0.005319014,-0.021763295,0.022315498,0.005765649,0.010564943,0.0011318132,0.017605532,-0.008092211,0.010451254,-0.0003045237,0.0072517246,0.006573652,-0.009825965,-0.013845678,-0.0013470099,-0.012952409,0.00526623,-0.017849151,0.0037090988,-0.015169341,0.006407179,0.026018506,-0.0046937256,-0.006780728,0.017313188,0.0003918205,0.02338742,-0.0058833985,0.019034762,-0.0050266716,0.0074141375,0.014032453,-0.0059767854,-0.012172828,-0.0020575654,-0.0012901655,-0.0008587569,-0.0049454654,0.022494152,0.021730812,-0.0028950055,-0.007779566,0.004815535,-0.03296977,0.012595101,0.0073532327,-0.017231982,0.004738389,0.015932681,0.0077755055,-0.013033615,-0.017069569,-0.041382745,-0.026928017,-0.02298139,-0.021373505,0.020106686,0.00308178,0.029997617,-0.009460537,0.007970401,0.016395558,0.023306215,0.009444295,-0.03168671,0.01629811,0.0052540493,0.009622949,-0.013805076,-0.015875837,0.019392071,-0.01810901,0.000552203,0.010946613,0.01245705,0.046190158,0.030371165,-0.0014972417,-0.003786245,0.006317852,0.0045516146,-0.012091622,-0.023890901,-0.008153115,-0.00087652076,0.0014667893,-0.032141462,0.009777241,0.01950576,-0.010361927,0.0090626255,0.010223877,0.008027245,-0.011344523,-0.009484898,0.009354969,0.0018768812,-0.032206427,-0.020642648,0.02298139,-0.0039973813,0.0054733064,0.0033842735,0.030777197,-0.03982358,0.009874689,-0.009493019,0.003991291,0.0025965723,0.022234293,0.030354924,-0.0008059728,-0.010378168,0.012026656,-0.023598557,-0.027967459,-0.03145933,0.02811363,-0.031004574,-0.017020846,0.003930386,0.01502317,-0.008551026,-0.012789996,-0.002990423,0.018791143,-0.0072517246,-0.008075969,0.0039872304,0.007548128,0.001977374,0.0016921367,-0.008615991,0.0052784113,0.004405443,0.0028726738,-0.007239544,0.004685605,0.0016190511,-0.04804166,0.02785377,-0.024410622,-0.011027819,0.014600897,0.0074263182,-0.005176903,0.00021418168,0.0058224937,0.015770268,0.022526635,-0.011441971,-0.000648128,-0.017524324,-0.009582346,0.005469246,-0.006427481,0.0018169915,-0.025222685,-0.013975608,0.0048358366,0.016842192,0.0062325853,-0.0115556605,0.0022920484,-0.013057977,0.03751732,0.012392085,0.030452373,-0.010962854,-0.010418772,0.0045272526,-0.002105274,-0.014365399,-0.0014454726,-0.01540484,0.030533578,0.025709923,-0.01695588,0.015445443,-0.015031291,-0.020236617,0.023013873,-0.014933843,0.010386289,-0.010605546,0.0073775947,-0.009769121,-0.0021032437,0.007897316,0.010280721,-0.015607855,0.051289916,0.0064721443,-0.030582301,-0.00411107,0.00019781353,0.007048709,-0.00095062156,-0.0057981317,0.0043201763,0.005457065,0.0112958,-0.0017063479,0.0063746967,0.005213446,-0.015932681,0.008380493,-0.010199514,-0.009541743,-0.0080150645,-0.013821317,0.005343376,0.005213446,0.0082505625,0.016273748,-0.020691372,0.04135026,-0.0021742994,-0.009468658,0.0069268993,-0.0082992865,-0.0114582125,-0.0032340419,0.005319014,-0.004774932,-0.009647312,0.030208753,0.013618301,0.0025153658,-0.021552159,0.003810607,-0.004982008,0.001245502,0.0009907172,0.00628943,-0.027821288,-0.008632232,0.021617124,-0.006898477,0.018060287,-0.0016099154,-0.011563781,0.019424552,0.016363075,-0.0036522544,0.007089312,0.004094829,-0.0071339756,0.0010160941,-0.0057209856,0.003889783,0.0069918646,-0.03735491,-0.010719235,0.007430379,-0.0124164475,0.007458801,-0.011986054,0.005623538,0.009395571,0.008445458,0.012107863,-0.018937316,0.0063625155,-0.0215684,-0.0006537109,-8.406124e-06,0.0045637954,0.009955895,0.0014931813,-0.0066142553,-0.004082648,-0.014738948,0.0061188964,-0.009679794,0.00898142,-0.017832909,0.014576536,0.0045231925] },
+      { "parameter": 1.0 }
+    ]
+  },
+  "graphResolveDepths": {
+    "inheritsFrom": {
+      "outgoing": 0
     },
-    "graphResolveDepths": {
-      "inheritsFrom": {
-        "outgoing": 0
-      },
-      "constrainsValuesOn": {
-        "outgoing": 0
-      },
-      "constrainsPropertiesOn": {
-        "outgoing": 0
-      },
-      "constrainsLinksOn": {
-        "outgoing": 0
-      },
-      "constrainsLinkDestinationsOn": {
-        "outgoing": 0
-      },
-      "isOfType": {
-        "outgoing": 0
-      },
-      "hasLeftEntity": {
-        "incoming": 0,
-        "outgoing": 0
-      },
-      "hasRightEntity": {
-        "incoming": 0,
-        "outgoing": 0
+    "constrainsValuesOn": {
+      "outgoing": 0
+    },
+    "constrainsPropertiesOn": {
+      "outgoing": 0
+    },
+    "constrainsLinksOn": {
+      "outgoing": 0
+    },
+    "constrainsLinkDestinationsOn": {
+      "outgoing": 0
+    },
+    "isOfType": {
+      "outgoing": 0
+    },
+    "hasLeftEntity": {
+      "incoming": 0,
+      "outgoing": 0
+    },
+    "hasRightEntity": {
+      "incoming": 0,
+      "outgoing": 0
+    }
+  },
+  "temporalAxes": {
+    "pinned": {
+      "axis": "transactionTime",
+      "timestamp": null
+    },
+    "variable": {
+      "axis": "decisionTime",
+      "interval": {
+        "start": null,
+        "end": null
       }
-    },
-    "temporalAxes": {
-      "pinned": {
-        "axis": "transactionTime",
-        "timestamp": null
-      },
-      "variable": {
-        "axis": "decisionTime",
-        "interval": {
-          "start": null,
-          "end": null
-        }
-      }
-    },
-    "includeDrafts": true
-  }
+    }
+  },
+  "includeDrafts": true
 }
 
 > {%

--- a/apps/hash-integration-worker/src/graph-activities.ts
+++ b/apps/hash-integration-worker/src/graph-activities.ts
@@ -46,31 +46,29 @@ export const getSubgraphFromBlockProtocolQueryEntity = async ({
 
   const filter = convertBpFilterToGraphFilter(multiFilter as MultiFilter);
 
-  const response = await graphApiClient.getEntitiesByQuery(
+  const { data: response } = await graphApiClient.getEntitySubgraph(
     authentication.actorId,
     {
-      query: {
-        filter,
-        graphResolveDepths: {
-          ...zeroedGraphResolveDepths,
-          isOfType: { outgoing: 255 },
-          inheritsFrom: { outgoing: 255 },
-          constrainsPropertiesOn: { outgoing: 255 },
-          constrainsLinksOn: { outgoing: 255 },
-          hasRightEntity: {
-            outgoing: traversalDepth,
-            incoming: traversalDepth,
-          },
-          hasLeftEntity: { incoming: traversalDepth, outgoing: traversalDepth },
+      filter,
+      graphResolveDepths: {
+        ...zeroedGraphResolveDepths,
+        isOfType: { outgoing: 255 },
+        inheritsFrom: { outgoing: 255 },
+        constrainsPropertiesOn: { outgoing: 255 },
+        constrainsLinksOn: { outgoing: 255 },
+        hasRightEntity: {
+          outgoing: traversalDepth,
+          incoming: traversalDepth,
         },
-        temporalAxes: currentTimeInstantTemporalAxes,
-        includeDrafts: false,
+        hasLeftEntity: { incoming: traversalDepth, outgoing: traversalDepth },
       },
+      temporalAxes: currentTimeInstantTemporalAxes,
+      includeDrafts: false,
     },
   );
 
   return mapGraphApiSubgraphToSubgraph<EntityRootType>(
-    response.data.subgraph,
+    response.subgraph,
     authentication.actorId,
   );
 };

--- a/libs/@local/hash-backend-utils/src/google.ts
+++ b/libs/@local/hash-backend-utils/src/google.ts
@@ -125,40 +125,38 @@ export const getGoogleSheetsIntegrationEntities = async ({
 }): Promise<GoogleSheetsIntegrationEntities> => {
   const [ownedById, uuid] = splitEntityId(integrationEntityId);
   const existingIntegrationEntitySubgraph = await graphApi
-    .getEntitiesByQuery(authentication.actorId, {
-      query: {
-        filter: {
-          all: [
-            {
-              equal: [
-                {
-                  path: ["uuid"],
-                },
-                {
-                  parameter: uuid,
-                },
-              ],
-            },
-            {
-              equal: [
-                {
-                  path: ["ownedById"],
-                },
-                {
-                  parameter: ownedById,
-                },
-              ],
-            },
-          ],
-        },
-        graphResolveDepths: {
-          ...zeroedGraphResolveDepths,
-          hasLeftEntity: { incoming: 1, outgoing: 0 },
-          hasRightEntity: { outgoing: 1, incoming: 0 },
-        },
-        includeDrafts: false,
-        temporalAxes: currentTimeInstantTemporalAxes,
+    .getEntitySubgraph(authentication.actorId, {
+      filter: {
+        all: [
+          {
+            equal: [
+              {
+                path: ["uuid"],
+              },
+              {
+                parameter: uuid,
+              },
+            ],
+          },
+          {
+            equal: [
+              {
+                path: ["ownedById"],
+              },
+              {
+                parameter: ownedById,
+              },
+            ],
+          },
+        ],
       },
+      graphResolveDepths: {
+        ...zeroedGraphResolveDepths,
+        hasLeftEntity: { incoming: 1, outgoing: 0 },
+        hasRightEntity: { outgoing: 1, incoming: 0 },
+      },
+      includeDrafts: false,
+      temporalAxes: currentTimeInstantTemporalAxes,
     })
     .then(({ data }) =>
       mapGraphApiSubgraphToSubgraph<EntityRootType>(

--- a/libs/@local/hash-backend-utils/src/hash-instance.ts
+++ b/libs/@local/hash-backend-utils/src/hash-instance.ts
@@ -55,16 +55,14 @@ export const getHashInstance = async (
   { actorId }: { actorId: AccountId },
 ): Promise<HashInstance> => {
   const entities = await graphApi
-    .getEntitiesByQuery(actorId, {
-      query: {
-        filter: generateVersionedUrlMatchingFilter(
-          systemEntityTypes.hashInstance.entityTypeId,
-          { ignoreParents: true },
-        ),
-        graphResolveDepths: zeroedGraphResolveDepths,
-        temporalAxes: currentTimeInstantTemporalAxes,
-        includeDrafts: false,
-      },
+    .getEntitySubgraph(actorId, {
+      filter: generateVersionedUrlMatchingFilter(
+        systemEntityTypes.hashInstance.entityTypeId,
+        { ignoreParents: true },
+      ),
+      graphResolveDepths: zeroedGraphResolveDepths,
+      temporalAxes: currentTimeInstantTemporalAxes,
+      includeDrafts: false,
     })
     .then(({ data }) => {
       const subgraph = mapGraphApiSubgraphToSubgraph<EntityRootType>(

--- a/libs/@local/hash-backend-utils/src/machine-actors.ts
+++ b/libs/@local/hash-backend-utils/src/machine-actors.ts
@@ -47,39 +47,37 @@ export const getMachineActorId = async (
   { identifier }: { identifier: MachineActorIdentifier },
 ): Promise<AccountId> => {
   const [machineEntity, ...unexpectedEntities] = await context.graphApi
-    .getEntitiesByQuery(authentication.actorId, {
-      query: {
-        filter: {
-          all: [
-            {
-              equal: [
-                {
-                  path: ["type(inheritanceDepth = 0)", "baseUrl"],
-                },
-                {
-                  parameter: systemEntityTypes.machine.entityTypeBaseUrl,
-                },
-              ],
-            },
-            {
-              equal: [
-                {
-                  path: [
-                    "properties",
-                    extractBaseUrl(
-                      systemPropertyTypes.machineIdentifier.propertyTypeId,
-                    ),
-                  ],
-                },
-                { parameter: identifier },
-              ],
-            },
-          ],
-        },
-        graphResolveDepths: zeroedGraphResolveDepths,
-        temporalAxes: currentTimeInstantTemporalAxes,
-        includeDrafts: false,
+    .getEntitySubgraph(authentication.actorId, {
+      filter: {
+        all: [
+          {
+            equal: [
+              {
+                path: ["type(inheritanceDepth = 0)", "baseUrl"],
+              },
+              {
+                parameter: systemEntityTypes.machine.entityTypeBaseUrl,
+              },
+            ],
+          },
+          {
+            equal: [
+              {
+                path: [
+                  "properties",
+                  extractBaseUrl(
+                    systemPropertyTypes.machineIdentifier.propertyTypeId,
+                  ),
+                ],
+              },
+              { parameter: identifier },
+            ],
+          },
+        ],
       },
+      graphResolveDepths: zeroedGraphResolveDepths,
+      temporalAxes: currentTimeInstantTemporalAxes,
+      includeDrafts: false,
     })
     .then(({ data }) => {
       const subgraph = mapGraphApiSubgraphToSubgraph<EntityRootType>(

--- a/libs/@local/hash-backend-utils/src/service-usage.ts
+++ b/libs/@local/hash-backend-utils/src/service-usage.ts
@@ -47,44 +47,42 @@ export const getUserServiceUsage = async (
   }: { userAccountId: AccountId; decisionTimeInterval?: BoundedTimeInterval },
 ): Promise<AggregatedUsageRecord[]> => {
   const serviceUsageRecordSubgraph = await context.graphApi
-    .getEntitiesByQuery(authentication.actorId, {
-      query: {
-        filter: {
-          all: [
-            generateVersionedUrlMatchingFilter(
-              systemEntityTypes.usageRecord.entityTypeId,
-              { ignoreParents: true },
-            ),
-            {
-              equal: [
-                {
-                  path: ["ownedById"],
-                },
-                { parameter: userAccountId },
-              ],
-            },
-          ],
-        },
-        graphResolveDepths: {
-          ...zeroedGraphResolveDepths,
-          // Depths required to retrieve the service the usage record relates to
-          hasLeftEntity: { incoming: 1, outgoing: 0 },
-          hasRightEntity: { incoming: 0, outgoing: 1 },
-        },
-        temporalAxes: decisionTimeInterval
-          ? {
-              pinned: {
-                axis: "transactionTime",
-                timestamp: null,
+    .getEntitySubgraph(authentication.actorId, {
+      filter: {
+        all: [
+          generateVersionedUrlMatchingFilter(
+            systemEntityTypes.usageRecord.entityTypeId,
+            { ignoreParents: true },
+          ),
+          {
+            equal: [
+              {
+                path: ["ownedById"],
               },
-              variable: {
-                axis: "decisionTime",
-                interval: decisionTimeInterval,
-              },
-            }
-          : currentTimeInstantTemporalAxes,
-        includeDrafts: false,
+              { parameter: userAccountId },
+            ],
+          },
+        ],
       },
+      graphResolveDepths: {
+        ...zeroedGraphResolveDepths,
+        // Depths required to retrieve the service the usage record relates to
+        hasLeftEntity: { incoming: 1, outgoing: 0 },
+        hasRightEntity: { incoming: 0, outgoing: 1 },
+      },
+      temporalAxes: decisionTimeInterval
+        ? {
+            pinned: {
+              axis: "transactionTime",
+              timestamp: null,
+            },
+            variable: {
+              axis: "decisionTime",
+              interval: decisionTimeInterval,
+            },
+          }
+        : currentTimeInstantTemporalAxes,
+      includeDrafts: false,
     })
     .then(({ data }) => {
       return mapGraphApiSubgraphToSubgraph<EntityRootType>(
@@ -224,42 +222,40 @@ export const createUsageRecord = async (
   );
 
   const serviceFeatureEntities = await context.graphApi
-    .getEntitiesByQuery(authentication.actorId, {
-      query: {
-        filter: {
-          all: [
-            generateVersionedUrlMatchingFilter(
-              systemEntityTypes.serviceFeature.entityTypeId,
-              { ignoreParents: true },
-            ),
-            {
-              equal: [
-                {
-                  path: [
-                    "properties",
-                    systemPropertyTypes.serviceName.propertyTypeBaseUrl,
-                  ],
-                },
-                { parameter: serviceName },
-              ],
-            },
-            {
-              equal: [
-                {
-                  path: [
-                    "properties",
-                    systemPropertyTypes.featureName.propertyTypeBaseUrl,
-                  ],
-                },
-                { parameter: featureName },
-              ],
-            },
-          ],
-        },
-        graphResolveDepths: zeroedGraphResolveDepths,
-        temporalAxes: currentTimeInstantTemporalAxes,
-        includeDrafts: false,
+    .getEntitySubgraph(authentication.actorId, {
+      filter: {
+        all: [
+          generateVersionedUrlMatchingFilter(
+            systemEntityTypes.serviceFeature.entityTypeId,
+            { ignoreParents: true },
+          ),
+          {
+            equal: [
+              {
+                path: [
+                  "properties",
+                  systemPropertyTypes.serviceName.propertyTypeBaseUrl,
+                ],
+              },
+              { parameter: serviceName },
+            ],
+          },
+          {
+            equal: [
+              {
+                path: [
+                  "properties",
+                  systemPropertyTypes.featureName.propertyTypeBaseUrl,
+                ],
+              },
+              { parameter: featureName },
+            ],
+          },
+        ],
       },
+      graphResolveDepths: zeroedGraphResolveDepths,
+      temporalAxes: currentTimeInstantTemporalAxes,
+      includeDrafts: false,
     })
     .then((data) => {
       const subgraph = mapGraphApiSubgraphToSubgraph<EntityRootType>(

--- a/libs/@local/hash-backend-utils/src/user-secret.ts
+++ b/libs/@local/hash-backend-utils/src/user-secret.ts
@@ -39,42 +39,40 @@ export const getSecretEntitiesForIntegration = async ({
   }[]
 > => {
   return await graphApi
-    .getEntitiesByQuery(authentication.actorId, {
-      query: {
-        filter: {
-          all: [
-            generateVersionedUrlMatchingFilter(
-              systemLinkEntityTypes.usesUserSecret.linkEntityTypeId,
+    .getEntitySubgraph(authentication.actorId, {
+      filter: {
+        all: [
+          generateVersionedUrlMatchingFilter(
+            systemLinkEntityTypes.usesUserSecret.linkEntityTypeId,
+            {
+              ignoreParents: true,
+            },
+          ),
+          {
+            equal: [
+              { path: ["leftEntity", "uuid"] },
               {
-                ignoreParents: true,
+                parameter: extractEntityUuidFromEntityId(integrationEntityId),
               },
-            ),
-            {
-              equal: [
-                { path: ["leftEntity", "uuid"] },
-                {
-                  parameter: extractEntityUuidFromEntityId(integrationEntityId),
-                },
-              ],
-            },
-            {
-              equal: [
-                { path: ["rightEntity", "type", "versionedUrl"] },
-                {
-                  parameter: systemEntityTypes.userSecret.entityTypeId,
-                },
-              ],
-            },
-            { equal: [{ path: ["archived"] }, { parameter: false }] },
-          ],
-        },
-        graphResolveDepths: {
-          ...zeroedGraphResolveDepths,
-          hasRightEntity: { incoming: 0, outgoing: 1 },
-        },
-        temporalAxes: currentTimeInstantTemporalAxes,
-        includeDrafts: false,
+            ],
+          },
+          {
+            equal: [
+              { path: ["rightEntity", "type", "versionedUrl"] },
+              {
+                parameter: systemEntityTypes.userSecret.entityTypeId,
+              },
+            ],
+          },
+          { equal: [{ path: ["archived"] }, { parameter: false }] },
+        ],
       },
+      graphResolveDepths: {
+        ...zeroedGraphResolveDepths,
+        hasRightEntity: { incoming: 0, outgoing: 1 },
+      },
+      temporalAxes: currentTimeInstantTemporalAxes,
+      includeDrafts: false,
     })
     .then(({ data }) => {
       const subgraph = mapGraphApiSubgraphToSubgraph<EntityRootType>(

--- a/libs/@local/hash-isomorphic-utils/src/graphql/scalar-mapping.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graphql/scalar-mapping.ts
@@ -30,7 +30,7 @@ export const scalars = {
   EntityRecordId: "@local/hash-subgraph#EntityRecordId",
   EntityMetadata: "@local/hash-subgraph#EntityMetadata",
   EntityRelationAndSubject: "@local/hash-subgraph#EntityRelationAndSubject",
-  EntityStructuralQuery: "@local/hash-graph-client#EntityStructuralQuery",
+  GetEntitySubgraphRequest: "@local/hash-graph-client#GetEntitySubgraphRequest",
   EntityTemporalVersioningMetadata:
     "@local/hash-subgraph#EntityTemporalVersioningMetadata",
   EntityPropertiesObject: "@local/hash-subgraph#EntityPropertiesObject",

--- a/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/knowledge/entity.typedef.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/knowledge/entity.typedef.ts
@@ -7,7 +7,7 @@ export const entityTypedef = gql`
   scalar EntityPropertiesObject
   scalar EntityMetadata
   scalar EntityRelationAndSubject
-  scalar EntityStructuralQuery
+  scalar GetEntitySubgraphRequest
   scalar LinkData
   scalar QueryOperationInput
   scalar UserPermissions
@@ -102,8 +102,8 @@ export const entityTypedef = gql`
       includeDrafts: Boolean
     ): SubgraphAndPermissions!
 
-    structuralQueryEntities(
-      query: EntityStructuralQuery!
+    getEntitySubgraph(
+      request: GetEntitySubgraphRequest!
     ): SubgraphAndPermissions!
 
     """

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/primitive/entity.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/primitive/entity.test.ts
@@ -263,30 +263,28 @@ describe("Entity CRU", () => {
 
   it("can read all latest person entities", async () => {
     const allEntities = await graphApi
-      .getEntitiesByQuery(testUser.accountId, {
-        query: {
-          filter: {
-            all: [
-              {
-                equal: [
-                  { path: ["ownedById"] },
-                  { parameter: testOrg.accountGroupId },
-                ],
-              },
-              {
-                endsWith: [
-                  { path: ["type(inheritanceDepth=0)", "baseUrl"] },
-                  {
-                    parameter: `/types/entity-type/person/`,
-                  },
-                ],
-              },
-            ],
-          },
-          graphResolveDepths: zeroedGraphResolveDepths,
-          temporalAxes: currentTimeInstantTemporalAxes,
-          includeDrafts: false,
+      .getEntitySubgraph(testUser.accountId, {
+        filter: {
+          all: [
+            {
+              equal: [
+                { path: ["ownedById"] },
+                { parameter: testOrg.accountGroupId },
+              ],
+            },
+            {
+              endsWith: [
+                { path: ["type(inheritanceDepth=0)", "baseUrl"] },
+                {
+                  parameter: `/types/entity-type/person/`,
+                },
+              ],
+            },
+          ],
         },
+        graphResolveDepths: zeroedGraphResolveDepths,
+        temporalAxes: currentTimeInstantTemporalAxes,
+        includeDrafts: false,
       })
       .then(({ data }) =>
         getRoots(

--- a/tests/hash-backend-integration/src/tests/subgraph/circular.test.ts
+++ b/tests/hash-backend-integration/src/tests/subgraph/circular.test.ts
@@ -1,8 +1,8 @@
 import path from "node:path";
 
 import type { ImpureGraphContext } from "@apps/hash-api/src/graph/context-types";
-import { getEntities } from "@apps/hash-api/src/graph/knowledge/primitive/entity";
-import type { EntityStructuralQuery } from "@local/hash-graph-client";
+import { getEntitySubgraph } from "@apps/hash-api/src/graph/knowledge/primitive/entity";
+import type { GetEntitySubgraphRequest } from "@local/hash-graph-client";
 import {
   currentTimeInstantTemporalAxes,
   zeroedGraphResolveDepths,
@@ -25,10 +25,10 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { resetGraph, restoreSnapshot } from "../test-server";
 import { createTestImpureGraphContext } from "../util";
 
-const createQuery = (
+const createRequest = (
   resolveDepths: Partial<GraphResolveDepths> = zeroedGraphResolveDepths,
   timestamp: string = "2010-01-01T00:00:00.000Z",
-): EntityStructuralQuery => {
+): GetEntitySubgraphRequest => {
   return {
     filter: {
       equal: [
@@ -90,15 +90,13 @@ beforeAll(async () => {
 
   graphContext = createTestImpureGraphContext();
 
-  const entities = await getEntities(graphContext, authentication, {
-    query: {
-      filter: {
-        all: [],
-      },
-      graphResolveDepths: zeroedGraphResolveDepths,
-      temporalAxes: currentTimeInstantTemporalAxes,
-      includeDrafts: false,
+  const entities = await getEntitySubgraph(graphContext, authentication, {
+    filter: {
+      all: [],
     },
+    graphResolveDepths: zeroedGraphResolveDepths,
+    temporalAxes: currentTimeInstantTemporalAxes,
+    includeDrafts: false,
   }).then(getRoots);
 
   expect(entities.length).toBe(12);
@@ -202,8 +200,10 @@ describe("Single linked list", () => {
   // │ Entity D │◄────┤ Link CD │◄──┤ Entity C │
   // └──────────┘     └─────────┘   └──────────┘
   it("finds AB", async () => {
-    const subgraph = await getEntities(graphContext, authentication, {
-      query: createQuery(
+    const subgraph = await getEntitySubgraph(
+      graphContext,
+      authentication,
+      createRequest(
         {
           hasLeftEntity: {
             incoming: 1,
@@ -212,7 +212,7 @@ describe("Single linked list", () => {
         },
         "2002-05-01T00:00:00.000Z",
       ),
-    });
+    );
 
     expect(getRoots(subgraph)).toStrictEqual([entity_a]);
     expect(verticesEquals(subgraph, [entity_a, link_ab])).toBe(true);
@@ -229,8 +229,10 @@ describe("Single linked list", () => {
   });
 
   it("finds AB and travels back", async () => {
-    const subgraph = await getEntities(graphContext, authentication, {
-      query: createQuery(
+    const subgraph = await getEntitySubgraph(
+      graphContext,
+      authentication,
+      createRequest(
         {
           hasLeftEntity: {
             incoming: 1,
@@ -239,7 +241,7 @@ describe("Single linked list", () => {
         },
         "2002-05-01T00:00:00.000Z",
       ),
-    });
+    );
 
     expect(getRoots(subgraph)).toStrictEqual([entity_a]);
     expect(verticesEquals(subgraph, [entity_a, link_ab])).toBe(true);
@@ -266,8 +268,10 @@ describe("Single linked list", () => {
   });
 
   it("finds B", async () => {
-    const subgraph = await getEntities(graphContext, authentication, {
-      query: createQuery(
+    const subgraph = await getEntitySubgraph(
+      graphContext,
+      authentication,
+      createRequest(
         {
           hasLeftEntity: {
             incoming: 1,
@@ -280,7 +284,7 @@ describe("Single linked list", () => {
         },
         "2002-05-01T00:00:00.000Z",
       ),
-    });
+    );
 
     expect(getRoots(subgraph)).toStrictEqual([entity_a]);
     expect(verticesEquals(subgraph, [entity_a, link_ab, entity_b])).toBe(true);
@@ -307,8 +311,10 @@ describe("Single linked list", () => {
   });
 
   it("finds B and travels back", async () => {
-    const subgraph = await getEntities(graphContext, authentication, {
-      query: createQuery(
+    const subgraph = await getEntitySubgraph(
+      graphContext,
+      authentication,
+      createRequest(
         {
           hasLeftEntity: {
             incoming: 1,
@@ -321,7 +327,7 @@ describe("Single linked list", () => {
         },
         "2002-05-01T00:00:00.000Z",
       ),
-    });
+    );
 
     expect(getRoots(subgraph)).toStrictEqual([entity_a]);
     expect(
@@ -405,8 +411,10 @@ describe("Single linked list", () => {
   });
 
   it("finds D", async () => {
-    const subgraph = await getEntities(graphContext, authentication, {
-      query: createQuery(
+    const subgraph = await getEntitySubgraph(
+      graphContext,
+      authentication,
+      createRequest(
         {
           hasLeftEntity: {
             incoming: 3,
@@ -419,7 +427,7 @@ describe("Single linked list", () => {
         },
         "2002-05-01T00:00:00.000Z",
       ),
-    });
+    );
 
     expect(getRoots(subgraph)).toStrictEqual([entity_a]);
     expect(
@@ -523,14 +531,16 @@ describe("Double linked list", () => {
   //                └────►│ Link DC ├────┘
   //                      └─────────┘
   it("finds AB/AD", async () => {
-    const subgraph = await getEntities(graphContext, authentication, {
-      query: createQuery({
+    const subgraph = await getEntitySubgraph(
+      graphContext,
+      authentication,
+      createRequest({
         hasLeftEntity: {
           incoming: 1,
           outgoing: 0,
         },
       }),
-    });
+    );
 
     expect(getRoots(subgraph)).toStrictEqual([entity_a]);
     expect(verticesEquals(subgraph, [entity_a, link_ab, link_ad])).toBe(true);
@@ -548,14 +558,16 @@ describe("Double linked list", () => {
   });
 
   it("finds AD/DA and travels back", async () => {
-    const subgraph = await getEntities(graphContext, authentication, {
-      query: createQuery({
+    const subgraph = await getEntitySubgraph(
+      graphContext,
+      authentication,
+      createRequest({
         hasLeftEntity: {
           incoming: 1,
           outgoing: 1,
         },
       }),
-    });
+    );
 
     expect(getRoots(subgraph)).toStrictEqual([entity_a]);
     expect(verticesEquals(subgraph, [entity_a, link_ab, link_ad])).toBe(true);
@@ -593,8 +605,10 @@ describe("Double linked list", () => {
   });
 
   it("finds B/D", async () => {
-    const subgraph = await getEntities(graphContext, authentication, {
-      query: createQuery({
+    const subgraph = await getEntitySubgraph(
+      graphContext,
+      authentication,
+      createRequest({
         hasLeftEntity: {
           incoming: 1,
           outgoing: 0,
@@ -604,7 +618,7 @@ describe("Double linked list", () => {
           outgoing: 1,
         },
       }),
-    });
+    );
 
     expect(getRoots(subgraph)).toStrictEqual([entity_a]);
     expect(
@@ -650,8 +664,10 @@ describe("Double linked list", () => {
   });
 
   it("finds B/D and travels back", async () => {
-    const subgraph = await getEntities(graphContext, authentication, {
-      query: createQuery({
+    const subgraph = await getEntitySubgraph(
+      graphContext,
+      authentication,
+      createRequest({
         hasLeftEntity: {
           incoming: 1,
           outgoing: 1,
@@ -661,7 +677,7 @@ describe("Double linked list", () => {
           outgoing: 1,
         },
       }),
-    });
+    );
 
     expect(getRoots(subgraph)).toStrictEqual([entity_a]);
     expect(
@@ -863,8 +879,10 @@ describe("Double linked list", () => {
   });
 
   it("finds D/A", async () => {
-    const subgraph = await getEntities(graphContext, authentication, {
-      query: createQuery({
+    const subgraph = await getEntitySubgraph(
+      graphContext,
+      authentication,
+      createRequest({
         hasLeftEntity: {
           incoming: 3,
           outgoing: 0,
@@ -874,7 +892,7 @@ describe("Double linked list", () => {
           outgoing: 3,
         },
       }),
-    });
+    );
 
     expect(getRoots(subgraph)).toStrictEqual([entity_a]);
     expect(

--- a/tests/hash-graph-integration/postgres/data_type.rs
+++ b/tests/hash-graph-integration/postgres/data_type.rs
@@ -1,14 +1,13 @@
 use graph::{
     store::{
         error::{OntologyTypeIsNotOwned, OntologyVersionDoesNotExist, VersionedUrlAlreadyExists},
-        ontology::{CreateDataTypeParams, GetDataTypesParams, UpdateDataTypesParams},
+        ontology::{CreateDataTypeParams, GetDataTypeSubgraphParams, UpdateDataTypesParams},
         query::Filter,
         BaseUrlAlreadyExists, ConflictBehavior, DataTypeStore,
     },
     subgraph::{
         edges::GraphResolveDepths,
         identifier::DataTypeVertexId,
-        query::StructuralQuery,
         temporal_axes::{
             PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
             VariableTemporalAxisUnresolved,
@@ -79,27 +78,26 @@ async fn query() {
     .expect("could not create data type");
 
     let data_type = api
-        .get_data_type(
+        .get_data_type_subgraph(
             api.account_id,
-            GetDataTypesParams {
-                query: StructuralQuery {
-                    filter: Filter::for_versioned_url(empty_list_dt.id()),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(
-                            Some(TemporalBound::Unbounded),
-                            None,
-                        ),
-                    },
-                    include_drafts: false,
+            GetDataTypeSubgraphParams {
+                filter: Filter::for_versioned_url(empty_list_dt.id()),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(
+                        Some(TemporalBound::Unbounded),
+                        None,
+                    ),
                 },
                 after: None,
                 limit: None,
+                include_drafts: false,
             },
         )
         .await
         .expect("could not get data type")
+        .subgraph
         .vertices
         .data_types
         .remove(&DataTypeVertexId::from(empty_list_dt.id().clone()))
@@ -149,54 +147,52 @@ async fn update() {
     .expect("could not update data type");
 
     let returned_object_dt_v1 = api
-        .get_data_type(
+        .get_data_type_subgraph(
             api.account_id,
-            GetDataTypesParams {
-                query: StructuralQuery {
-                    filter: Filter::for_versioned_url(object_dt_v1.id()),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(
-                            Some(TemporalBound::Unbounded),
-                            None,
-                        ),
-                    },
-                    include_drafts: false,
+            GetDataTypeSubgraphParams {
+                filter: Filter::for_versioned_url(object_dt_v1.id()),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(
+                        Some(TemporalBound::Unbounded),
+                        None,
+                    ),
                 },
                 after: None,
                 limit: None,
+                include_drafts: false,
             },
         )
         .await
         .expect("could not get data type")
+        .subgraph
         .vertices
         .data_types
         .remove(&DataTypeVertexId::from(object_dt_v1.id().clone()))
         .expect("no data type found");
 
     let returned_object_dt_v2 = api
-        .get_data_type(
+        .get_data_type_subgraph(
             api.account_id,
-            GetDataTypesParams {
-                query: StructuralQuery {
-                    filter: Filter::for_versioned_url(object_dt_v2.id()),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(
-                            Some(TemporalBound::Unbounded),
-                            None,
-                        ),
-                    },
-                    include_drafts: false,
+            GetDataTypeSubgraphParams {
+                filter: Filter::for_versioned_url(object_dt_v2.id()),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(
+                        Some(TemporalBound::Unbounded),
+                        None,
+                    ),
                 },
                 after: None,
                 limit: None,
+                include_drafts: false,
             },
         )
         .await
         .expect("could not get data type")
+        .subgraph
         .vertices
         .data_types
         .remove(&DataTypeVertexId::from(object_dt_v2.id().clone()))

--- a/tests/hash-graph-integration/postgres/drafts.rs
+++ b/tests/hash-graph-integration/postgres/drafts.rs
@@ -1,17 +1,12 @@
 use authorization::AuthorizationApi;
 use graph::{
     store::{
-        knowledge::{CreateEntityParams, PatchEntityParams},
+        knowledge::{CountEntitiesParams, CreateEntityParams, PatchEntityParams},
         query::Filter,
         EntityStore,
     },
-    subgraph::{
-        edges::GraphResolveDepths,
-        query::StructuralQuery,
-        temporal_axes::{
-            PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
-            VariableTemporalAxisUnresolved,
-        },
+    subgraph::temporal_axes::{
+        PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved, VariableTemporalAxisUnresolved,
     },
 };
 use graph_test_data::{data_type, entity, entity_type, property_type};
@@ -82,9 +77,8 @@ fn charles() -> PropertyObject {
 async fn check_entity_exists<A: AuthorizationApi>(api: &DatabaseApi<'_, A>, id: EntityId) -> bool {
     api.count_entities(
         api.account_id,
-        StructuralQuery {
+        CountEntitiesParams {
             filter: Filter::for_entity_by_entity_id(id),
-            graph_resolve_depths: GraphResolveDepths::default(),
             temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                 pinned: PinnedTemporalAxisUnresolved::new(None),
                 variable: VariableTemporalAxisUnresolved::new(None, None),

--- a/tests/hash-graph-integration/postgres/entity.rs
+++ b/tests/hash-graph-integration/postgres/entity.rs
@@ -1,12 +1,13 @@
 use graph::{
     store::{
-        knowledge::{CreateEntityParams, GetEntityParams, PatchEntityParams},
+        knowledge::{
+            CountEntitiesParams, CreateEntityParams, GetEntitySubgraphParams, PatchEntityParams,
+        },
         query::Filter,
         EntityQuerySorting, EntityStore,
     },
     subgraph::{
         edges::GraphResolveDepths,
-        query::StructuralQuery,
         temporal_axes::{
             PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
             VariableTemporalAxisUnresolved,
@@ -80,20 +81,17 @@ async fn insert() {
         .expect("could not create entity");
 
     let entities = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::for_entity_by_entity_id(metadata.record_id.entity_id),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(
-                            Some(TemporalBound::Unbounded),
-                            None,
-                        ),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::for_entity_by_entity_id(metadata.record_id.entity_id),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(
+                        Some(TemporalBound::Unbounded),
+                        None,
+                    ),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -101,6 +99,7 @@ async fn insert() {
                 },
                 limit: None,
                 include_count: true,
+                include_drafts: false,
             },
         )
         .await
@@ -158,20 +157,17 @@ async fn query() {
         .expect("could not create entity");
 
     let queried_organizations = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::for_entity_by_entity_id(metadata.record_id.entity_id),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(
-                            Some(TemporalBound::Unbounded),
-                            None,
-                        ),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::for_entity_by_entity_id(metadata.record_id.entity_id),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(
+                        Some(TemporalBound::Unbounded),
+                        None,
+                    ),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -179,6 +175,7 @@ async fn query() {
                 },
                 limit: None,
                 include_count: true,
+                include_drafts: false,
             },
         )
         .await
@@ -262,9 +259,8 @@ async fn update() {
     let num_entities = api
         .count_entities(
             api.account_id,
-            StructuralQuery {
+            CountEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(v2_metadata.record_id.entity_id),
-                graph_resolve_depths: GraphResolveDepths::default(),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(
@@ -280,17 +276,14 @@ async fn update() {
     assert_eq!(num_entities, 2);
 
     let entities = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::for_entity_by_entity_id(v2_metadata.record_id.entity_id),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::for_entity_by_entity_id(v2_metadata.record_id.entity_id),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(None, None),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -298,6 +291,7 @@ async fn update() {
                 },
                 limit: None,
                 include_count: false,
+                include_drafts: false,
             },
         )
         .await
@@ -316,20 +310,17 @@ async fn update() {
         *v1_metadata.temporal_versioning.decision_time.start();
 
     let response_v1 = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::for_entity_by_entity_id(v1_metadata.record_id.entity_id),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(
-                            Some(TemporalBound::Inclusive(entity_v1_timestamp)),
-                            Some(LimitedTemporalBound::Inclusive(entity_v1_timestamp)),
-                        ),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::for_entity_by_entity_id(v1_metadata.record_id.entity_id),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(
+                        Some(TemporalBound::Inclusive(entity_v1_timestamp)),
+                        Some(LimitedTemporalBound::Inclusive(entity_v1_timestamp)),
+                    ),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -337,6 +328,7 @@ async fn update() {
                 },
                 limit: None,
                 include_count: true,
+                include_drafts: false,
             },
         )
         .await
@@ -354,20 +346,17 @@ async fn update() {
     let ClosedTemporalBound::Inclusive(entity_v2_timestamp) =
         *v2_metadata.temporal_versioning.decision_time.start();
     let response_v2 = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::for_entity_by_entity_id(v2_metadata.record_id.entity_id),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(
-                            Some(TemporalBound::Inclusive(entity_v2_timestamp)),
-                            Some(LimitedTemporalBound::Inclusive(entity_v2_timestamp)),
-                        ),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::for_entity_by_entity_id(v2_metadata.record_id.entity_id),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(
+                        Some(TemporalBound::Inclusive(entity_v2_timestamp)),
+                        Some(LimitedTemporalBound::Inclusive(entity_v2_timestamp)),
+                    ),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -375,6 +364,7 @@ async fn update() {
                 },
                 limit: None,
                 include_count: true,
+                include_drafts: false,
             },
         )
         .await

--- a/tests/hash-graph-integration/postgres/entity_type.rs
+++ b/tests/hash-graph-integration/postgres/entity_type.rs
@@ -1,13 +1,12 @@
 use graph::{
     store::{
-        ontology::{CreateEntityTypeParams, GetEntityTypesParams, UpdateEntityTypesParams},
+        ontology::{CreateEntityTypeParams, GetEntityTypeSubgraphParams, UpdateEntityTypesParams},
         query::Filter,
         ConflictBehavior, EntityTypeStore,
     },
     subgraph::{
         edges::GraphResolveDepths,
         identifier::EntityTypeVertexId,
-        query::StructuralQuery,
         temporal_axes::{
             PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
             VariableTemporalAxisUnresolved,
@@ -97,27 +96,26 @@ async fn query() {
     .expect("could not create entity type");
 
     let entity_type = api
-        .get_entity_type(
+        .get_entity_type_subgraph(
             api.account_id,
-            GetEntityTypesParams {
-                query: StructuralQuery {
-                    filter: Filter::for_versioned_url(organization_et.id()),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(
-                            Some(TemporalBound::Unbounded),
-                            None,
-                        ),
-                    },
-                    include_drafts: false,
+            GetEntityTypeSubgraphParams {
+                filter: Filter::for_versioned_url(organization_et.id()),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(
+                        Some(TemporalBound::Unbounded),
+                        None,
+                    ),
                 },
                 after: None,
                 limit: None,
+                include_drafts: false,
             },
         )
         .await
         .expect("could not get entity type")
+        .subgraph
         .vertices
         .entity_types
         .remove(&EntityTypeVertexId::from(organization_et.id().clone()))
@@ -192,54 +190,52 @@ async fn update() {
     .expect("could not update entity type");
 
     let returned_page_et_v1 = api
-        .get_entity_type(
+        .get_entity_type_subgraph(
             api.account_id,
-            GetEntityTypesParams {
-                query: StructuralQuery {
-                    filter: Filter::for_versioned_url(page_et_v1.id()),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(
-                            Some(TemporalBound::Unbounded),
-                            None,
-                        ),
-                    },
-                    include_drafts: false,
+            GetEntityTypeSubgraphParams {
+                filter: Filter::for_versioned_url(page_et_v1.id()),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(
+                        Some(TemporalBound::Unbounded),
+                        None,
+                    ),
                 },
                 after: None,
                 limit: None,
+                include_drafts: false,
             },
         )
         .await
         .expect("could not get entity type")
+        .subgraph
         .vertices
         .entity_types
         .remove(&EntityTypeVertexId::from(page_et_v1.id().clone()))
         .expect("no entity type found");
 
     let returned_page_et_v2 = api
-        .get_entity_type(
+        .get_entity_type_subgraph(
             api.account_id,
-            GetEntityTypesParams {
-                query: StructuralQuery {
-                    filter: Filter::for_versioned_url(page_et_v2.id()),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(
-                            Some(TemporalBound::Unbounded),
-                            None,
-                        ),
-                    },
-                    include_drafts: false,
+            GetEntityTypeSubgraphParams {
+                filter: Filter::for_versioned_url(page_et_v2.id()),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(
+                        Some(TemporalBound::Unbounded),
+                        None,
+                    ),
                 },
                 after: None,
                 limit: None,
+                include_drafts: false,
             },
         )
         .await
         .expect("could not get entity type")
+        .subgraph
         .vertices
         .entity_types
         .remove(&EntityTypeVertexId::from(page_et_v2.id().clone()))

--- a/tests/hash-graph-integration/postgres/entity_type.rs
+++ b/tests/hash-graph-integration/postgres/entity_type.rs
@@ -1,16 +1,11 @@
 use graph::{
     store::{
-        ontology::{CreateEntityTypeParams, GetEntityTypeSubgraphParams, UpdateEntityTypesParams},
+        ontology::{CreateEntityTypeParams, GetEntityTypesParams, UpdateEntityTypesParams},
         query::Filter,
         ConflictBehavior, EntityTypeStore,
     },
-    subgraph::{
-        edges::GraphResolveDepths,
-        identifier::EntityTypeVertexId,
-        temporal_axes::{
-            PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
-            VariableTemporalAxisUnresolved,
-        },
+    subgraph::temporal_axes::{
+        PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved, VariableTemporalAxisUnresolved,
     },
 };
 use graph_test_data::{data_type, entity_type, property_type};
@@ -96,11 +91,10 @@ async fn query() {
     .expect("could not create entity type");
 
     let entity_type = api
-        .get_entity_type_subgraph(
+        .get_entity_types(
             api.account_id,
-            GetEntityTypeSubgraphParams {
+            GetEntityTypesParams {
                 filter: Filter::for_versioned_url(organization_et.id()),
-                graph_resolve_depths: GraphResolveDepths::default(),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(
@@ -115,10 +109,8 @@ async fn query() {
         )
         .await
         .expect("could not get entity type")
-        .subgraph
-        .vertices
         .entity_types
-        .remove(&EntityTypeVertexId::from(organization_et.id().clone()))
+        .pop()
         .expect("no entity type found");
 
     assert_eq!(entity_type.schema, organization_et);
@@ -190,11 +182,10 @@ async fn update() {
     .expect("could not update entity type");
 
     let returned_page_et_v1 = api
-        .get_entity_type_subgraph(
+        .get_entity_types(
             api.account_id,
-            GetEntityTypeSubgraphParams {
+            GetEntityTypesParams {
                 filter: Filter::for_versioned_url(page_et_v1.id()),
-                graph_resolve_depths: GraphResolveDepths::default(),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(
@@ -209,18 +200,15 @@ async fn update() {
         )
         .await
         .expect("could not get entity type")
-        .subgraph
-        .vertices
         .entity_types
-        .remove(&EntityTypeVertexId::from(page_et_v1.id().clone()))
+        .pop()
         .expect("no entity type found");
 
     let returned_page_et_v2 = api
-        .get_entity_type_subgraph(
+        .get_entity_types(
             api.account_id,
-            GetEntityTypeSubgraphParams {
+            GetEntityTypesParams {
                 filter: Filter::for_versioned_url(page_et_v2.id()),
-                graph_resolve_depths: GraphResolveDepths::default(),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(
@@ -235,10 +223,8 @@ async fn update() {
         )
         .await
         .expect("could not get entity type")
-        .subgraph
-        .vertices
         .entity_types
-        .remove(&EntityTypeVertexId::from(page_et_v2.id().clone()))
+        .pop()
         .expect("no entity type found");
 
     assert_eq!(page_et_v1, returned_page_et_v1.schema);

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -46,12 +46,13 @@ use graph::{
         ontology::{
             ArchiveDataTypeParams, ArchiveEntityTypeParams, ArchivePropertyTypeParams,
             CreateDataTypeParams, CreateEntityTypeParams, CreatePropertyTypeParams,
-            GetDataTypeSubgraphParams, GetDataTypeSubgraphResponse, GetEntityTypeSubgraphParams,
-            GetEntityTypeSubgraphResponse, GetPropertyTypeSubgraphParams,
-            GetPropertyTypeSubgraphResponse, UnarchiveDataTypeParams, UnarchiveEntityTypeParams,
-            UnarchivePropertyTypeParams, UpdateDataTypeEmbeddingParams, UpdateDataTypesParams,
-            UpdateEntityTypeEmbeddingParams, UpdateEntityTypesParams,
-            UpdatePropertyTypeEmbeddingParams, UpdatePropertyTypesParams,
+            GetDataTypeSubgraphParams, GetDataTypeSubgraphResponse, GetDataTypesParams,
+            GetDataTypesResponse, GetEntityTypeSubgraphParams, GetEntityTypeSubgraphResponse,
+            GetEntityTypesParams, GetEntityTypesResponse, GetPropertyTypeSubgraphParams,
+            GetPropertyTypeSubgraphResponse, GetPropertyTypesParams, GetPropertyTypesResponse,
+            UnarchiveDataTypeParams, UnarchiveEntityTypeParams, UnarchivePropertyTypeParams,
+            UpdateDataTypeEmbeddingParams, UpdateDataTypesParams, UpdateEntityTypeEmbeddingParams,
+            UpdateEntityTypesParams, UpdatePropertyTypeEmbeddingParams, UpdatePropertyTypesParams,
         },
         AccountStore, ConflictBehavior, DataTypeStore, DatabaseConnectionInfo, DatabaseType,
         EntityStore, EntityTypeStore, InsertionError, PostgresStore, PostgresStorePool,
@@ -304,6 +305,14 @@ impl<A: AuthorizationApi> DataTypeStore for DatabaseApi<'_, A> {
         self.store.create_data_types(actor_id, params).await
     }
 
+    async fn get_data_types(
+        &self,
+        actor_id: AccountId,
+        params: GetDataTypesParams<'_>,
+    ) -> Result<GetDataTypesResponse, QueryError> {
+        self.store.get_data_types(actor_id, params).await
+    }
+
     async fn get_data_type_subgraph(
         &self,
         actor_id: AccountId,
@@ -361,6 +370,14 @@ impl<A: AuthorizationApi> PropertyTypeStore for DatabaseApi<'_, A> {
         R: IntoIterator<Item = PropertyTypeRelationAndSubject> + Send + Sync,
     {
         self.store.create_property_types(actor_id, params).await
+    }
+
+    async fn get_property_types(
+        &self,
+        actor_id: AccountId,
+        params: GetPropertyTypesParams<'_>,
+    ) -> Result<GetPropertyTypesResponse, QueryError> {
+        self.store.get_property_types(actor_id, params).await
     }
 
     async fn get_property_type_subgraph(
@@ -422,6 +439,14 @@ impl<A: AuthorizationApi> EntityTypeStore for DatabaseApi<'_, A> {
         R: IntoIterator<Item = EntityTypeRelationAndSubject> + Send + Sync,
     {
         self.store.create_entity_types(actor_id, params).await
+    }
+
+    async fn get_entity_types(
+        &self,
+        actor_id: AccountId,
+        params: GetEntityTypesParams<'_>,
+    ) -> Result<GetEntityTypesResponse, QueryError> {
+        self.store.get_entity_types(actor_id, params).await
     }
 
     async fn get_entity_type_subgraph(

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -39,22 +39,24 @@ use graph::{
     store::{
         account::{InsertAccountIdParams, InsertWebIdParams},
         knowledge::{
-            CreateEntityParams, GetEntityParams, GetEntityResponse, PatchEntityParams,
-            UpdateEntityEmbeddingsParams, ValidateEntityError, ValidateEntityParams,
+            CountEntitiesParams, CreateEntityParams, GetEntitySubgraphParams,
+            GetEntitySubgraphResponse, PatchEntityParams, UpdateEntityEmbeddingsParams,
+            ValidateEntityError, ValidateEntityParams,
         },
         ontology::{
             ArchiveDataTypeParams, ArchiveEntityTypeParams, ArchivePropertyTypeParams,
             CreateDataTypeParams, CreateEntityTypeParams, CreatePropertyTypeParams,
-            GetDataTypesParams, GetEntityTypesParams, GetPropertyTypesParams,
-            UnarchiveDataTypeParams, UnarchiveEntityTypeParams, UnarchivePropertyTypeParams,
-            UpdateDataTypeEmbeddingParams, UpdateDataTypesParams, UpdateEntityTypeEmbeddingParams,
-            UpdateEntityTypesParams, UpdatePropertyTypeEmbeddingParams, UpdatePropertyTypesParams,
+            GetDataTypeSubgraphParams, GetDataTypeSubgraphResponse, GetEntityTypeSubgraphParams,
+            GetEntityTypeSubgraphResponse, GetPropertyTypeSubgraphParams,
+            GetPropertyTypeSubgraphResponse, UnarchiveDataTypeParams, UnarchiveEntityTypeParams,
+            UnarchivePropertyTypeParams, UpdateDataTypeEmbeddingParams, UpdateDataTypesParams,
+            UpdateEntityTypeEmbeddingParams, UpdateEntityTypesParams,
+            UpdatePropertyTypeEmbeddingParams, UpdatePropertyTypesParams,
         },
         AccountStore, ConflictBehavior, DataTypeStore, DatabaseConnectionInfo, DatabaseType,
         EntityStore, EntityTypeStore, InsertionError, PostgresStore, PostgresStorePool,
         PropertyTypeStore, QueryError, StorePool, UpdateError,
     },
-    subgraph::{query::EntityStructuralQuery, Subgraph},
     Environment,
 };
 use graph_types::{
@@ -302,12 +304,12 @@ impl<A: AuthorizationApi> DataTypeStore for DatabaseApi<'_, A> {
         self.store.create_data_types(actor_id, params).await
     }
 
-    async fn get_data_type(
+    async fn get_data_type_subgraph(
         &self,
         actor_id: AccountId,
-        params: GetDataTypesParams<'_>,
-    ) -> Result<Subgraph, QueryError> {
-        self.store.get_data_type(actor_id, params).await
+        params: GetDataTypeSubgraphParams<'_>,
+    ) -> Result<GetDataTypeSubgraphResponse, QueryError> {
+        self.store.get_data_type_subgraph(actor_id, params).await
     }
 
     async fn update_data_type<R>(
@@ -361,12 +363,14 @@ impl<A: AuthorizationApi> PropertyTypeStore for DatabaseApi<'_, A> {
         self.store.create_property_types(actor_id, params).await
     }
 
-    async fn get_property_type(
+    async fn get_property_type_subgraph(
         &self,
         actor_id: AccountId,
-        params: GetPropertyTypesParams<'_>,
-    ) -> Result<Subgraph, QueryError> {
-        self.store.get_property_type(actor_id, params).await
+        params: GetPropertyTypeSubgraphParams<'_>,
+    ) -> Result<GetPropertyTypeSubgraphResponse, QueryError> {
+        self.store
+            .get_property_type_subgraph(actor_id, params)
+            .await
     }
 
     async fn update_property_type<R>(
@@ -420,12 +424,12 @@ impl<A: AuthorizationApi> EntityTypeStore for DatabaseApi<'_, A> {
         self.store.create_entity_types(actor_id, params).await
     }
 
-    async fn get_entity_type(
+    async fn get_entity_type_subgraph(
         &self,
         actor_id: AccountId,
-        params: GetEntityTypesParams<'_>,
-    ) -> Result<Subgraph, QueryError> {
-        self.store.get_entity_type(actor_id, params).await
+        params: GetEntityTypeSubgraphParams<'_>,
+    ) -> Result<GetEntityTypeSubgraphResponse, QueryError> {
+        self.store.get_entity_type_subgraph(actor_id, params).await
     }
 
     async fn update_entity_type<R>(
@@ -516,17 +520,26 @@ where
             .await
     }
 
-    async fn get_entity(
+    async fn get_entity_subgraph(
         &self,
         actor_id: AccountId,
-        mut params: GetEntityParams<'_>,
-    ) -> Result<GetEntityResponse<'static>, QueryError> {
+        mut params: GetEntitySubgraphParams<'_>,
+    ) -> Result<GetEntitySubgraphResponse<'static>, QueryError> {
         let include_count = params.include_count;
         let has_limit = params.limit.is_some();
         params.include_count = true;
 
-        let count = self.count_entities(actor_id, params.query.clone()).await?;
-        let mut response = self.store.get_entity(actor_id, params).await?;
+        let count = self
+            .count_entities(
+                actor_id,
+                CountEntitiesParams {
+                    filter: params.filter.clone(),
+                    temporal_axes: params.temporal_axes.clone(),
+                    include_drafts: params.include_drafts,
+                },
+            )
+            .await?;
+        let mut response = self.store.get_entity_subgraph(actor_id, params).await?;
 
         // We can ensure that `count_entities` and `get_entity` return the same count;
         assert_eq!(response.count, Some(count));
@@ -544,9 +557,9 @@ where
     async fn count_entities(
         &self,
         actor_id: AccountId,
-        query: EntityStructuralQuery<'_>,
+        params: CountEntitiesParams<'_>,
     ) -> Result<usize, QueryError> {
-        self.store.count_entities(actor_id, query).await
+        self.store.count_entities(actor_id, params).await
     }
 
     async fn get_entity_by_id(

--- a/tests/hash-graph-integration/postgres/links.rs
+++ b/tests/hash-graph-integration/postgres/links.rs
@@ -4,14 +4,13 @@ use graph::{
     knowledge::EntityQueryPath,
     ontology::EntityTypeQueryPath,
     store::{
-        knowledge::{CreateEntityParams, GetEntityParams, PatchEntityParams},
+        knowledge::{CreateEntityParams, GetEntitySubgraphParams, PatchEntityParams},
         query::{Filter, FilterExpression, Parameter},
         EntityQuerySorting, EntityStore,
     },
     subgraph::{
         edges::{EdgeDirection, GraphResolveDepths, KnowledgeGraphEdgeKind, SharedEdgeKind},
         identifier::GraphElementVertexId,
-        query::StructuralQuery,
         temporal_axes::{
             PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
             VariableTemporalAxisUnresolved,
@@ -143,61 +142,58 @@ async fn insert() {
     .expect("could not create link");
 
     let mut response = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::All(vec![
-                        Filter::Equal(
-                            Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
-                                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
-                                path: Box::new(EntityQueryPath::Uuid),
-                                direction: EdgeDirection::Outgoing,
-                            })),
-                            Some(FilterExpression::Parameter(Parameter::Uuid(
-                                alice_metadata.record_id.entity_id.entity_uuid.into_uuid(),
-                            ))),
-                        ),
-                        Filter::Equal(
-                            Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
-                                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
-                                path: Box::new(EntityQueryPath::OwnedById),
-                                direction: EdgeDirection::Outgoing,
-                            })),
-                            Some(FilterExpression::Parameter(Parameter::Uuid(
-                                alice_metadata.record_id.entity_id.owned_by_id.into_uuid(),
-                            ))),
-                        ),
-                        Filter::Equal(
-                            Some(FilterExpression::Path(EntityQueryPath::EntityTypeEdge {
-                                edge_kind: SharedEdgeKind::IsOfType,
-                                path: EntityTypeQueryPath::BaseUrl,
-                                inheritance_depth: Some(0),
-                            })),
-                            Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                                friend_of_type_id.base_url.as_str(),
-                            )))),
-                        ),
-                        Filter::Equal(
-                            Some(FilterExpression::Path(EntityQueryPath::EntityTypeEdge {
-                                edge_kind: SharedEdgeKind::IsOfType,
-                                path: EntityTypeQueryPath::Version,
-                                inheritance_depth: Some(0),
-                            })),
-                            Some(FilterExpression::Parameter(Parameter::OntologyTypeVersion(
-                                friend_of_type_id.version,
-                            ))),
-                        ),
-                    ]),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(
-                            Some(TemporalBound::Unbounded),
-                            None,
-                        ),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::All(vec![
+                    Filter::Equal(
+                        Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
+                            edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                            path: Box::new(EntityQueryPath::Uuid),
+                            direction: EdgeDirection::Outgoing,
+                        })),
+                        Some(FilterExpression::Parameter(Parameter::Uuid(
+                            alice_metadata.record_id.entity_id.entity_uuid.into_uuid(),
+                        ))),
+                    ),
+                    Filter::Equal(
+                        Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
+                            edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                            path: Box::new(EntityQueryPath::OwnedById),
+                            direction: EdgeDirection::Outgoing,
+                        })),
+                        Some(FilterExpression::Parameter(Parameter::Uuid(
+                            alice_metadata.record_id.entity_id.owned_by_id.into_uuid(),
+                        ))),
+                    ),
+                    Filter::Equal(
+                        Some(FilterExpression::Path(EntityQueryPath::EntityTypeEdge {
+                            edge_kind: SharedEdgeKind::IsOfType,
+                            path: EntityTypeQueryPath::BaseUrl,
+                            inheritance_depth: Some(0),
+                        })),
+                        Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
+                            friend_of_type_id.base_url.as_str(),
+                        )))),
+                    ),
+                    Filter::Equal(
+                        Some(FilterExpression::Path(EntityQueryPath::EntityTypeEdge {
+                            edge_kind: SharedEdgeKind::IsOfType,
+                            path: EntityTypeQueryPath::Version,
+                            inheritance_depth: Some(0),
+                        })),
+                        Some(FilterExpression::Parameter(Parameter::OntologyTypeVersion(
+                            friend_of_type_id.version,
+                        ))),
+                    ),
+                ]),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(
+                        Some(TemporalBound::Unbounded),
+                        None,
+                    ),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -205,6 +201,7 @@ async fn insert() {
                 },
                 limit: None,
                 include_count: false,
+                include_drafts: false,
             },
         )
         .await
@@ -399,26 +396,23 @@ async fn get_entity_links() {
     .expect("could not create link");
 
     let mut response = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::Equal(
-                        Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
-                            edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
-                            path: Box::new(EntityQueryPath::Uuid),
-                            direction: EdgeDirection::Outgoing,
-                        })),
-                        Some(FilterExpression::Parameter(Parameter::Uuid(
-                            alice_metadata.record_id.entity_id.entity_uuid.into_uuid(),
-                        ))),
-                    ),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::Equal(
+                    Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
+                        edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                        path: Box::new(EntityQueryPath::Uuid),
+                        direction: EdgeDirection::Outgoing,
+                    })),
+                    Some(FilterExpression::Parameter(Parameter::Uuid(
+                        alice_metadata.record_id.entity_id.entity_uuid.into_uuid(),
+                    ))),
+                ),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(None, None),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -426,6 +420,7 @@ async fn get_entity_links() {
                 },
                 limit: None,
                 include_count: false,
+                include_drafts: false,
             },
         )
         .await
@@ -588,32 +583,29 @@ async fn remove_link() {
         .expect("could not create link");
 
     let response = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::All(vec![
-                        Filter::Equal(
-                            Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
-                                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
-                                path: Box::new(EntityQueryPath::Uuid),
-                                direction: EdgeDirection::Outgoing,
-                            })),
-                            Some(FilterExpression::Parameter(Parameter::Uuid(
-                                alice_metadata.record_id.entity_id.entity_uuid.into_uuid(),
-                            ))),
-                        ),
-                        Filter::Equal(
-                            Some(FilterExpression::Path(EntityQueryPath::Archived)),
-                            Some(FilterExpression::Parameter(Parameter::Boolean(false))),
-                        ),
-                    ]),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::All(vec![
+                    Filter::Equal(
+                        Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
+                            edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                            path: Box::new(EntityQueryPath::Uuid),
+                            direction: EdgeDirection::Outgoing,
+                        })),
+                        Some(FilterExpression::Parameter(Parameter::Uuid(
+                            alice_metadata.record_id.entity_id.entity_uuid.into_uuid(),
+                        ))),
+                    ),
+                    Filter::Equal(
+                        Some(FilterExpression::Path(EntityQueryPath::Archived)),
+                        Some(FilterExpression::Parameter(Parameter::Boolean(false))),
+                    ),
+                ]),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(None, None),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -621,6 +613,7 @@ async fn remove_link() {
                 },
                 limit: None,
                 include_count: false,
+                include_drafts: false,
             },
         )
         .await
@@ -657,32 +650,29 @@ async fn remove_link() {
     .expect("could not remove link");
 
     let response = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::All(vec![
-                        Filter::Equal(
-                            Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
-                                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
-                                path: Box::new(EntityQueryPath::Uuid),
-                                direction: EdgeDirection::Outgoing,
-                            })),
-                            Some(FilterExpression::Parameter(Parameter::Uuid(
-                                alice_metadata.record_id.entity_id.entity_uuid.into_uuid(),
-                            ))),
-                        ),
-                        Filter::Equal(
-                            Some(FilterExpression::Path(EntityQueryPath::Archived)),
-                            Some(FilterExpression::Parameter(Parameter::Boolean(false))),
-                        ),
-                    ]),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::All(vec![
+                    Filter::Equal(
+                        Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
+                            edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                            path: Box::new(EntityQueryPath::Uuid),
+                            direction: EdgeDirection::Outgoing,
+                        })),
+                        Some(FilterExpression::Parameter(Parameter::Uuid(
+                            alice_metadata.record_id.entity_id.entity_uuid.into_uuid(),
+                        ))),
+                    ),
+                    Filter::Equal(
+                        Some(FilterExpression::Path(EntityQueryPath::Archived)),
+                        Some(FilterExpression::Parameter(Parameter::Boolean(false))),
+                    ),
+                ]),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(None, None),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -690,6 +680,7 @@ async fn remove_link() {
                 },
                 limit: None,
                 include_count: false,
+                include_drafts: false,
             },
         )
         .await

--- a/tests/hash-graph-integration/postgres/multi_type.rs
+++ b/tests/hash-graph-integration/postgres/multi_type.rs
@@ -3,17 +3,12 @@ use std::str::FromStr;
 use authorization::AuthorizationApi;
 use graph::{
     store::{
-        knowledge::{CreateEntityParams, GetEntitySubgraphParams, PatchEntityParams},
+        knowledge::{CreateEntityParams, GetEntitiesParams, PatchEntityParams},
         query::Filter,
         EntityQuerySorting, EntityStore,
     },
-    subgraph::{
-        edges::GraphResolveDepths,
-        identifier::GraphElementVertexId,
-        temporal_axes::{
-            PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
-            VariableTemporalAxisUnresolved,
-        },
+    subgraph::temporal_axes::{
+        PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved, VariableTemporalAxisUnresolved,
     },
 };
 use graph_test_data::{data_type, entity, entity_type, property_type};
@@ -125,12 +120,11 @@ async fn initial_person() {
 
     assert_eq!(entity_metadata.entity_type_ids, [person_entity_type_id()]);
 
-    let mut response = api
-        .get_entity_subgraph(
+    let entities = api
+        .get_entities(
             api.account_id,
-            GetEntitySubgraphParams {
+            GetEntitiesParams {
                 filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
-                graph_resolve_depths: GraphResolveDepths::default(),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(None, None),
@@ -145,18 +139,8 @@ async fn initial_person() {
             },
         )
         .await
-        .expect("could not get entities");
-    let entities = response
-        .subgraph
-        .roots
-        .into_iter()
-        .filter_map(|vertex_id| {
-            let GraphElementVertexId::KnowledgeGraph(vertex_id) = vertex_id else {
-                panic!("unexpected vertex id found: {vertex_id:?}");
-            };
-            response.subgraph.vertices.entities.remove(&vertex_id)
-        })
-        .collect::<Vec<_>>();
+        .expect("could not get entities")
+        .entities;
 
     assert_eq!(
         entities,
@@ -189,12 +173,11 @@ async fn initial_person() {
         [person_entity_type_id(), org_entity_type_id()]
     );
 
-    let mut person_response = api
-        .get_entity_subgraph(
+    let updated_person_entities = api
+        .get_entities(
             api.account_id,
-            GetEntitySubgraphParams {
+            GetEntitiesParams {
                 filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
-                graph_resolve_depths: GraphResolveDepths::default(),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(None, None),
@@ -209,29 +192,14 @@ async fn initial_person() {
             },
         )
         .await
-        .expect("could not get entities");
-    let updated_person_entities = person_response
-        .subgraph
-        .roots
-        .into_iter()
-        .filter_map(|vertex_id| {
-            let GraphElementVertexId::KnowledgeGraph(vertex_id) = vertex_id else {
-                panic!("unexpected vertex id found: {vertex_id:?}");
-            };
-            person_response
-                .subgraph
-                .vertices
-                .entities
-                .remove(&vertex_id)
-        })
-        .collect::<Vec<_>>();
+        .expect("could not get entities")
+        .entities;
 
-    let mut org_response = api
-        .get_entity_subgraph(
+    let updated_org_entities = api
+        .get_entities(
             api.account_id,
-            GetEntitySubgraphParams {
+            GetEntitiesParams {
                 filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
-                graph_resolve_depths: GraphResolveDepths::default(),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(None, None),
@@ -246,18 +214,8 @@ async fn initial_person() {
             },
         )
         .await
-        .expect("could not get entities");
-    let updated_org_entities = org_response
-        .subgraph
-        .roots
-        .into_iter()
-        .filter_map(|vertex_id| {
-            let GraphElementVertexId::KnowledgeGraph(vertex_id) = vertex_id else {
-                panic!("unexpected vertex id found: {vertex_id:?}");
-            };
-            org_response.subgraph.vertices.entities.remove(&vertex_id)
-        })
-        .collect::<Vec<_>>();
+        .expect("could not get entities")
+        .entities;
 
     assert_eq!(updated_person_entities, updated_org_entities);
     assert_eq!(
@@ -301,12 +259,11 @@ async fn create_multi() {
         [person_entity_type_id(), org_entity_type_id()]
     );
 
-    let mut person_response = api
-        .get_entity_subgraph(
+    let person_entities = api
+        .get_entities(
             api.account_id,
-            GetEntitySubgraphParams {
+            GetEntitiesParams {
                 filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
-                graph_resolve_depths: GraphResolveDepths::default(),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(None, None),
@@ -321,29 +278,14 @@ async fn create_multi() {
             },
         )
         .await
-        .expect("could not get entities");
-    let person_entities = person_response
-        .subgraph
-        .roots
-        .into_iter()
-        .filter_map(|vertex_id| {
-            let GraphElementVertexId::KnowledgeGraph(vertex_id) = vertex_id else {
-                panic!("unexpected vertex id found: {vertex_id:?}");
-            };
-            person_response
-                .subgraph
-                .vertices
-                .entities
-                .remove(&vertex_id)
-        })
-        .collect::<Vec<_>>();
+        .expect("could not get entities")
+        .entities;
 
-    let mut org_response = api
-        .get_entity_subgraph(
+    let org_entities = api
+        .get_entities(
             api.account_id,
-            GetEntitySubgraphParams {
+            GetEntitiesParams {
                 filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
-                graph_resolve_depths: GraphResolveDepths::default(),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(None, None),
@@ -358,18 +300,8 @@ async fn create_multi() {
             },
         )
         .await
-        .expect("could not get entities");
-    let org_entities = org_response
-        .subgraph
-        .roots
-        .into_iter()
-        .filter_map(|vertex_id| {
-            let GraphElementVertexId::KnowledgeGraph(vertex_id) = vertex_id else {
-                panic!("unexpected vertex id found: {vertex_id:?}");
-            };
-            org_response.subgraph.vertices.entities.remove(&vertex_id)
-        })
-        .collect::<Vec<_>>();
+        .expect("could not get entities")
+        .entities;
 
     assert_eq!(person_entities, org_entities);
     assert_eq!(
@@ -403,12 +335,11 @@ async fn create_multi() {
         [person_entity_type_id()]
     );
 
-    let mut response = api
-        .get_entity_subgraph(
+    let updated_person_entities = api
+        .get_entities(
             api.account_id,
-            GetEntitySubgraphParams {
+            GetEntitiesParams {
                 filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
-                graph_resolve_depths: GraphResolveDepths::default(),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(None, None),
@@ -423,18 +354,8 @@ async fn create_multi() {
             },
         )
         .await
-        .expect("could not get entities");
-    let updated_person_entities = response
-        .subgraph
-        .roots
-        .into_iter()
-        .filter_map(|vertex_id| {
-            let GraphElementVertexId::KnowledgeGraph(vertex_id) = vertex_id else {
-                panic!("unexpected vertex id found: {vertex_id:?}");
-            };
-            response.subgraph.vertices.entities.remove(&vertex_id)
-        })
-        .collect::<Vec<_>>();
+        .expect("could not get entities")
+        .entities;
 
     assert_eq!(
         updated_person_entities,

--- a/tests/hash-graph-integration/postgres/multi_type.rs
+++ b/tests/hash-graph-integration/postgres/multi_type.rs
@@ -3,14 +3,13 @@ use std::str::FromStr;
 use authorization::AuthorizationApi;
 use graph::{
     store::{
-        knowledge::{CreateEntityParams, GetEntityParams, PatchEntityParams},
+        knowledge::{CreateEntityParams, GetEntitySubgraphParams, PatchEntityParams},
         query::Filter,
         EntityQuerySorting, EntityStore,
     },
     subgraph::{
         edges::GraphResolveDepths,
         identifier::GraphElementVertexId,
-        query::StructuralQuery,
         temporal_axes::{
             PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
             VariableTemporalAxisUnresolved,
@@ -127,17 +126,14 @@ async fn initial_person() {
     assert_eq!(entity_metadata.entity_type_ids, [person_entity_type_id()]);
 
     let mut response = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(None, None),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -145,6 +141,7 @@ async fn initial_person() {
                 },
                 limit: None,
                 include_count: true,
+                include_drafts: false,
             },
         )
         .await
@@ -193,17 +190,14 @@ async fn initial_person() {
     );
 
     let mut person_response = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(None, None),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -211,6 +205,7 @@ async fn initial_person() {
                 },
                 limit: None,
                 include_count: true,
+                include_drafts: false,
             },
         )
         .await
@@ -232,17 +227,14 @@ async fn initial_person() {
         .collect::<Vec<_>>();
 
     let mut org_response = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(None, None),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -250,6 +242,7 @@ async fn initial_person() {
                 },
                 limit: None,
                 include_count: true,
+                include_drafts: false,
             },
         )
         .await
@@ -309,17 +302,14 @@ async fn create_multi() {
     );
 
     let mut person_response = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(None, None),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -327,6 +317,7 @@ async fn create_multi() {
                 },
                 limit: None,
                 include_count: true,
+                include_drafts: false,
             },
         )
         .await
@@ -348,17 +339,14 @@ async fn create_multi() {
         .collect::<Vec<_>>();
 
     let mut org_response = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(None, None),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -366,6 +354,7 @@ async fn create_multi() {
                 },
                 limit: None,
                 include_count: true,
+                include_drafts: false,
             },
         )
         .await
@@ -415,17 +404,14 @@ async fn create_multi() {
     );
 
     let mut response = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(None, None),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -433,6 +419,7 @@ async fn create_multi() {
                 },
                 limit: None,
                 include_count: true,
+                include_drafts: false,
             },
         )
         .await

--- a/tests/hash-graph-integration/postgres/partial_updates.rs
+++ b/tests/hash-graph-integration/postgres/partial_updates.rs
@@ -3,13 +3,12 @@ use std::{collections::HashSet, iter::once, str::FromStr};
 use authorization::AuthorizationApi;
 use graph::{
     store::{
-        knowledge::{CreateEntityParams, GetEntityParams, PatchEntityParams},
+        knowledge::{CreateEntityParams, GetEntitySubgraphParams, PatchEntityParams},
         query::Filter,
         EntityQuerySorting, EntityStore,
     },
     subgraph::{
         edges::GraphResolveDepths,
-        query::StructuralQuery,
         temporal_axes::{
             PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
             VariableTemporalAxisUnresolved,
@@ -135,17 +134,14 @@ async fn properties_add() {
     .expect("could not patch entity");
 
     let entities = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::for_entity_by_entity_id(entity_id),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::for_entity_by_entity_id(entity_id),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(None, None),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -153,6 +149,7 @@ async fn properties_add() {
                 },
                 limit: None,
                 include_count: false,
+                include_drafts: false,
             },
         )
         .await
@@ -216,17 +213,14 @@ async fn properties_remove() {
     .expect("could not patch entity");
 
     let entities = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::for_entity_by_entity_id(entity_id),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::for_entity_by_entity_id(entity_id),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(None, None),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -234,6 +228,7 @@ async fn properties_remove() {
                 },
                 limit: None,
                 include_count: false,
+                include_drafts: false,
             },
         )
         .await
@@ -298,17 +293,14 @@ async fn properties_replace() {
     .expect("could not patch entity");
 
     let entities = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::for_entity_by_entity_id(entity_id),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::for_entity_by_entity_id(entity_id),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(None, None),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -316,6 +308,7 @@ async fn properties_replace() {
                 },
                 limit: None,
                 include_count: false,
+                include_drafts: false,
             },
         )
         .await
@@ -422,17 +415,14 @@ async fn properties_move() {
     .expect("could not patch entity");
 
     let entities = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::for_entity_by_entity_id(entity_id),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::for_entity_by_entity_id(entity_id),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(None, None),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -440,6 +430,7 @@ async fn properties_move() {
                 },
                 limit: None,
                 include_count: false,
+                include_drafts: false,
             },
         )
         .await
@@ -525,17 +516,14 @@ async fn properties_copy() {
     .expect("could not patch entity");
 
     let entities = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::for_entity_by_entity_id(entity_id),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::for_entity_by_entity_id(entity_id),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(None, None),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -543,6 +531,7 @@ async fn properties_copy() {
                 },
                 limit: None,
                 include_count: false,
+                include_drafts: false,
             },
         )
         .await
@@ -608,17 +597,14 @@ async fn type_ids() {
     .expect("could not patch entity");
 
     let entities = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::for_entity_by_entity_id(entity_id),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::for_entity_by_entity_id(entity_id),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(None, None),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -626,6 +612,7 @@ async fn type_ids() {
                 },
                 limit: None,
                 include_count: false,
+                include_drafts: false,
             },
         )
         .await
@@ -660,17 +647,14 @@ async fn type_ids() {
     .expect("could not patch entity");
 
     let entities = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::for_entity_by_entity_id(entity_id),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::for_entity_by_entity_id(entity_id),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(None, None),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -678,6 +662,7 @@ async fn type_ids() {
                 },
                 limit: None,
                 include_count: false,
+                include_drafts: false,
             },
         )
         .await
@@ -716,17 +701,14 @@ async fn type_ids() {
     .expect("could not patch entity");
 
     let entities = api
-        .get_entity(
+        .get_entity_subgraph(
             api.account_id,
-            GetEntityParams {
-                query: StructuralQuery {
-                    filter: Filter::for_entity_by_entity_id(entity_id),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    },
-                    include_drafts: false,
+            GetEntitySubgraphParams {
+                filter: Filter::for_entity_by_entity_id(entity_id),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(None, None),
                 },
                 sorting: EntityQuerySorting {
                     paths: Vec::new(),
@@ -734,6 +716,7 @@ async fn type_ids() {
                 },
                 limit: None,
                 include_count: false,
+                include_drafts: false,
             },
         )
         .await

--- a/tests/hash-graph-integration/postgres/partial_updates.rs
+++ b/tests/hash-graph-integration/postgres/partial_updates.rs
@@ -3,16 +3,12 @@ use std::{collections::HashSet, iter::once, str::FromStr};
 use authorization::AuthorizationApi;
 use graph::{
     store::{
-        knowledge::{CreateEntityParams, GetEntitySubgraphParams, PatchEntityParams},
+        knowledge::{CreateEntityParams, GetEntitiesParams, PatchEntityParams},
         query::Filter,
         EntityQuerySorting, EntityStore,
     },
-    subgraph::{
-        edges::GraphResolveDepths,
-        temporal_axes::{
-            PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
-            VariableTemporalAxisUnresolved,
-        },
+    subgraph::temporal_axes::{
+        PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved, VariableTemporalAxisUnresolved,
     },
 };
 use graph_test_data::{data_type, entity, entity_type, property_type};
@@ -134,11 +130,10 @@ async fn properties_add() {
     .expect("could not patch entity");
 
     let entities = api
-        .get_entity_subgraph(
+        .get_entities(
             api.account_id,
-            GetEntitySubgraphParams {
+            GetEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
-                graph_resolve_depths: GraphResolveDepths::default(),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(None, None),
@@ -154,11 +149,7 @@ async fn properties_add() {
         )
         .await
         .expect("could not get entity")
-        .subgraph
-        .vertices
-        .entities
-        .into_values()
-        .collect::<Vec<_>>();
+        .entities;
     assert_eq!(entities.len(), 1, "unexpected number of entities found");
     let entity = entities.into_iter().next().unwrap();
 
@@ -213,11 +204,10 @@ async fn properties_remove() {
     .expect("could not patch entity");
 
     let entities = api
-        .get_entity_subgraph(
+        .get_entities(
             api.account_id,
-            GetEntitySubgraphParams {
+            GetEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
-                graph_resolve_depths: GraphResolveDepths::default(),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(None, None),
@@ -233,11 +223,7 @@ async fn properties_remove() {
         )
         .await
         .expect("could not get entity")
-        .subgraph
-        .vertices
-        .entities
-        .into_values()
-        .collect::<Vec<_>>();
+        .entities;
     assert_eq!(entities.len(), 1, "unexpected number of entities found");
     let entity = entities.into_iter().next().unwrap();
 
@@ -293,11 +279,10 @@ async fn properties_replace() {
     .expect("could not patch entity");
 
     let entities = api
-        .get_entity_subgraph(
+        .get_entities(
             api.account_id,
-            GetEntitySubgraphParams {
+            GetEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
-                graph_resolve_depths: GraphResolveDepths::default(),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(None, None),
@@ -313,11 +298,7 @@ async fn properties_replace() {
         )
         .await
         .expect("could not get entity")
-        .subgraph
-        .vertices
-        .entities
-        .into_values()
-        .collect::<Vec<_>>();
+        .entities;
     assert_eq!(entities.len(), 1, "unexpected number of entities found");
     let entity = entities.into_iter().next().unwrap();
 
@@ -415,11 +396,10 @@ async fn properties_move() {
     .expect("could not patch entity");
 
     let entities = api
-        .get_entity_subgraph(
+        .get_entities(
             api.account_id,
-            GetEntitySubgraphParams {
+            GetEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
-                graph_resolve_depths: GraphResolveDepths::default(),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(None, None),
@@ -435,11 +415,7 @@ async fn properties_move() {
         )
         .await
         .expect("could not get entity")
-        .subgraph
-        .vertices
-        .entities
-        .into_values()
-        .collect::<Vec<_>>();
+        .entities;
     assert_eq!(entities.len(), 1, "unexpected number of entities found");
     let entity = entities.into_iter().next().unwrap();
 
@@ -516,11 +492,10 @@ async fn properties_copy() {
     .expect("could not patch entity");
 
     let entities = api
-        .get_entity_subgraph(
+        .get_entities(
             api.account_id,
-            GetEntitySubgraphParams {
+            GetEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
-                graph_resolve_depths: GraphResolveDepths::default(),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(None, None),
@@ -536,11 +511,7 @@ async fn properties_copy() {
         )
         .await
         .expect("could not get entity")
-        .subgraph
-        .vertices
-        .entities
-        .into_values()
-        .collect::<Vec<_>>();
+        .entities;
     assert_eq!(entities.len(), 1, "unexpected number of entities found");
     let entity = entities.into_iter().next().unwrap();
 
@@ -597,11 +568,10 @@ async fn type_ids() {
     .expect("could not patch entity");
 
     let entities = api
-        .get_entity_subgraph(
+        .get_entities(
             api.account_id,
-            GetEntitySubgraphParams {
+            GetEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
-                graph_resolve_depths: GraphResolveDepths::default(),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(None, None),
@@ -617,11 +587,7 @@ async fn type_ids() {
         )
         .await
         .expect("could not get entity")
-        .subgraph
-        .vertices
-        .entities
-        .into_values()
-        .collect::<Vec<_>>();
+        .entities;
     assert_eq!(entities.len(), 1, "unexpected number of entities found");
     let entity = entities.into_iter().next().unwrap();
     assert_eq!(
@@ -647,11 +613,10 @@ async fn type_ids() {
     .expect("could not patch entity");
 
     let entities = api
-        .get_entity_subgraph(
+        .get_entities(
             api.account_id,
-            GetEntitySubgraphParams {
+            GetEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
-                graph_resolve_depths: GraphResolveDepths::default(),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(None, None),
@@ -667,11 +632,7 @@ async fn type_ids() {
         )
         .await
         .expect("could not get entity")
-        .subgraph
-        .vertices
-        .entities
-        .into_values()
-        .collect::<Vec<_>>();
+        .entities;
     assert_eq!(entities.len(), 1, "unexpected number of entities found");
     let entity = entities.into_iter().next().unwrap();
     assert_eq!(
@@ -701,11 +662,10 @@ async fn type_ids() {
     .expect("could not patch entity");
 
     let entities = api
-        .get_entity_subgraph(
+        .get_entities(
             api.account_id,
-            GetEntitySubgraphParams {
+            GetEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
-                graph_resolve_depths: GraphResolveDepths::default(),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(None, None),
@@ -721,11 +681,7 @@ async fn type_ids() {
         )
         .await
         .expect("could not get entity")
-        .subgraph
-        .vertices
-        .entities
-        .into_values()
-        .collect::<Vec<_>>();
+        .entities;
     assert_eq!(entities.len(), 1, "unexpected number of entities found");
     let entity = entities.into_iter().next().unwrap();
 

--- a/tests/hash-graph-integration/postgres/property_type.rs
+++ b/tests/hash-graph-integration/postgres/property_type.rs
@@ -1,13 +1,14 @@
 use graph::{
     store::{
-        ontology::{CreatePropertyTypeParams, GetPropertyTypesParams, UpdatePropertyTypesParams},
+        ontology::{
+            CreatePropertyTypeParams, GetPropertyTypeSubgraphParams, UpdatePropertyTypesParams,
+        },
         query::Filter,
         ConflictBehavior, PropertyTypeStore,
     },
     subgraph::{
         edges::GraphResolveDepths,
         identifier::PropertyTypeVertexId,
-        query::StructuralQuery,
         temporal_axes::{
             PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
             VariableTemporalAxisUnresolved,
@@ -78,27 +79,26 @@ async fn query() {
     .expect("could not create property type");
 
     let property_type = api
-        .get_property_type(
+        .get_property_type_subgraph(
             api.account_id,
-            GetPropertyTypesParams {
-                query: StructuralQuery {
-                    filter: Filter::for_versioned_url(favorite_quote_pt.id()),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(
-                            Some(TemporalBound::Unbounded),
-                            None,
-                        ),
-                    },
-                    include_drafts: false,
+            GetPropertyTypeSubgraphParams {
+                filter: Filter::for_versioned_url(favorite_quote_pt.id()),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(
+                        Some(TemporalBound::Unbounded),
+                        None,
+                    ),
                 },
                 after: None,
                 limit: None,
+                include_drafts: false,
             },
         )
         .await
         .expect("could not get property type")
+        .subgraph
         .vertices
         .property_types
         .remove(&PropertyTypeVertexId::from(favorite_quote_pt.id().clone()))
@@ -148,54 +148,52 @@ async fn update() {
     .expect("could not update property type");
 
     let returned_user_id_pt_v1 = api
-        .get_property_type(
+        .get_property_type_subgraph(
             api.account_id,
-            GetPropertyTypesParams {
-                query: StructuralQuery {
-                    filter: Filter::for_versioned_url(user_id_pt_v1.id()),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(
-                            Some(TemporalBound::Unbounded),
-                            None,
-                        ),
-                    },
-                    include_drafts: false,
+            GetPropertyTypeSubgraphParams {
+                filter: Filter::for_versioned_url(user_id_pt_v1.id()),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(
+                        Some(TemporalBound::Unbounded),
+                        None,
+                    ),
                 },
                 after: None,
                 limit: None,
+                include_drafts: false,
             },
         )
         .await
         .expect("could not get property type")
+        .subgraph
         .vertices
         .property_types
         .remove(&PropertyTypeVertexId::from(user_id_pt_v1.id().clone()))
         .expect("no property type found");
 
     let returned_user_id_pt_v2 = api
-        .get_property_type(
+        .get_property_type_subgraph(
             api.account_id,
-            GetPropertyTypesParams {
-                query: StructuralQuery {
-                    filter: Filter::for_versioned_url(user_id_pt_v2.id()),
-                    graph_resolve_depths: GraphResolveDepths::default(),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(
-                            Some(TemporalBound::Unbounded),
-                            None,
-                        ),
-                    },
-                    include_drafts: false,
+            GetPropertyTypeSubgraphParams {
+                filter: Filter::for_versioned_url(user_id_pt_v2.id()),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                    pinned: PinnedTemporalAxisUnresolved::new(None),
+                    variable: VariableTemporalAxisUnresolved::new(
+                        Some(TemporalBound::Unbounded),
+                        None,
+                    ),
                 },
                 after: None,
                 limit: None,
+                include_drafts: false,
             },
         )
         .await
         .expect("could not get property type")
+        .subgraph
         .vertices
         .property_types
         .remove(&PropertyTypeVertexId::from(user_id_pt_v2.id().clone()))

--- a/tests/hash-graph-integration/postgres/property_type.rs
+++ b/tests/hash-graph-integration/postgres/property_type.rs
@@ -1,18 +1,11 @@
 use graph::{
     store::{
-        ontology::{
-            CreatePropertyTypeParams, GetPropertyTypeSubgraphParams, UpdatePropertyTypesParams,
-        },
+        ontology::{CreatePropertyTypeParams, GetPropertyTypesParams, UpdatePropertyTypesParams},
         query::Filter,
         ConflictBehavior, PropertyTypeStore,
     },
-    subgraph::{
-        edges::GraphResolveDepths,
-        identifier::PropertyTypeVertexId,
-        temporal_axes::{
-            PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
-            VariableTemporalAxisUnresolved,
-        },
+    subgraph::temporal_axes::{
+        PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved, VariableTemporalAxisUnresolved,
     },
 };
 use graph_test_data::{data_type, property_type};
@@ -79,11 +72,10 @@ async fn query() {
     .expect("could not create property type");
 
     let property_type = api
-        .get_property_type_subgraph(
+        .get_property_types(
             api.account_id,
-            GetPropertyTypeSubgraphParams {
+            GetPropertyTypesParams {
                 filter: Filter::for_versioned_url(favorite_quote_pt.id()),
-                graph_resolve_depths: GraphResolveDepths::default(),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(
@@ -98,10 +90,8 @@ async fn query() {
         )
         .await
         .expect("could not get property type")
-        .subgraph
-        .vertices
         .property_types
-        .remove(&PropertyTypeVertexId::from(favorite_quote_pt.id().clone()))
+        .pop()
         .expect("no property type found");
 
     assert_eq!(property_type.schema, favorite_quote_pt);
@@ -148,11 +138,10 @@ async fn update() {
     .expect("could not update property type");
 
     let returned_user_id_pt_v1 = api
-        .get_property_type_subgraph(
+        .get_property_types(
             api.account_id,
-            GetPropertyTypeSubgraphParams {
+            GetPropertyTypesParams {
                 filter: Filter::for_versioned_url(user_id_pt_v1.id()),
-                graph_resolve_depths: GraphResolveDepths::default(),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(
@@ -167,18 +156,15 @@ async fn update() {
         )
         .await
         .expect("could not get property type")
-        .subgraph
-        .vertices
         .property_types
-        .remove(&PropertyTypeVertexId::from(user_id_pt_v1.id().clone()))
+        .pop()
         .expect("no property type found");
 
     let returned_user_id_pt_v2 = api
-        .get_property_type_subgraph(
+        .get_property_types(
             api.account_id,
-            GetPropertyTypeSubgraphParams {
+            GetPropertyTypesParams {
                 filter: Filter::for_versioned_url(user_id_pt_v2.id()),
-                graph_resolve_depths: GraphResolveDepths::default(),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(
@@ -193,10 +179,8 @@ async fn update() {
         )
         .await
         .expect("could not get property type")
-        .subgraph
-        .vertices
         .property_types
-        .remove(&PropertyTypeVertexId::from(user_id_pt_v2.id().clone()))
+        .pop()
         .expect("no property type found");
 
     assert_eq!(user_id_pt_v1, returned_user_id_pt_v1.schema);

--- a/tests/hash-graph-integration/postgres/sorting.rs
+++ b/tests/hash-graph-integration/postgres/sorting.rs
@@ -4,14 +4,13 @@ use authorization::AuthorizationApi;
 use graph::{
     knowledge::EntityQueryPath,
     store::{
-        knowledge::{CreateEntityParams, GetEntityParams},
+        knowledge::{CreateEntityParams, GetEntitySubgraphParams},
         query::{Filter, JsonPath, PathToken},
         EntityQuerySorting, EntityQuerySortingRecord, EntityStore, NullOrdering, Ordering,
     },
     subgraph::{
         edges::GraphResolveDepths,
         identifier::GraphElementVertexId,
-        query::StructuralQuery,
         temporal_axes::{
             PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
             VariableTemporalAxisUnresolved,
@@ -63,17 +62,14 @@ async fn test_root_sorting<A: AuthorizationApi>(
 
     loop {
         let mut response = api
-            .get_entity(
+            .get_entity_subgraph(
                 api.account_id,
-                GetEntityParams {
-                    query: StructuralQuery {
-                        filter: Filter::All(Vec::new()),
-                        graph_resolve_depths: GraphResolveDepths::default(),
-                        temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                            pinned: PinnedTemporalAxisUnresolved::new(None),
-                            variable: VariableTemporalAxisUnresolved::new(None, None),
-                        },
-                        include_drafts: false,
+                GetEntitySubgraphParams {
+                    filter: Filter::All(Vec::new()),
+                    graph_resolve_depths: GraphResolveDepths::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(None),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
                     },
                     sorting: EntityQuerySorting {
                         paths: sorting_paths.clone(),
@@ -81,6 +77,7 @@ async fn test_root_sorting<A: AuthorizationApi>(
                     },
                     limit: Some(chunk_size),
                     include_count: false,
+                    include_drafts: false,
                 },
             )
             .await

--- a/tests/hash-graph-integration/postgres/sorting.rs
+++ b/tests/hash-graph-integration/postgres/sorting.rs
@@ -51,6 +51,7 @@ async fn test_root_sorting<A: AuthorizationApi>(
         })
         .collect::<Vec<_>>();
     let mut cursor = None;
+    let expected_order = expected_order.into_iter().collect::<Vec<_>>();
 
     let mut found_entities = HashSet::new();
     let mut entities = Vec::new();
@@ -80,6 +81,8 @@ async fn test_root_sorting<A: AuthorizationApi>(
             )
             .await
             .expect("could not get entity");
+        assert_eq!(count, Some(expected_order.len()));
+        let num_entities = new_entities.len();
 
         for entity in new_entities {
             assert!(
@@ -89,7 +92,7 @@ async fn test_root_sorting<A: AuthorizationApi>(
             );
             entities.push(entity);
         }
-        if count.expect("Count was not returned from query") < chunk_size {
+        if num_entities < chunk_size {
             break;
         }
         if let Some(new_cursor) = new_cursor {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In many cases, a subgraph is not required. This adds interfaces to return values without creating a subgraph from it.


## 🔍 What does this change?

- Use a similar interface for all endpoints returning a subgraph:
    - Pass a `Get*SubgraphRequest { filter, graphResolveDepth, ... }`
    - Get back a `Get*SubgraphResponse { subgraph, ... }`
    - Rename functions to `get*Subgraph`
    - Remove the struct `*StructuralQuery` as they are now part of the `Request` object. Previously, a `StructuralQuery` was the only endpoint to read data, as this has changed also the parameters has changed (e.g. a resolve depth does not make sense if only a flat list is returned)
- Add functions `get_entities`, `get_entity_types`, `get_property_types`, and `get_data_types` and use them in integration tests

## 🚫 Blocked by

- #4331 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph