### PR TITLE
H-2454: Allow viewing and triggering Flows

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/shared/find-existing-entity.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/find-existing-entity.ts
@@ -118,7 +118,7 @@ export const findExistingEntity = async ({
   ] satisfies AllFilter["all"];
 
   // starting point for a threshold that will get only values which are a semantic match
-  const maximumSemanticDistance = 0.5;
+  const maximumSemanticDistance = 0.3;
 
   /**
    * First find suitable specific properties to match on

--- a/apps/hash-ai-worker-ts/src/activities/shared/find-existing-entity.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/find-existing-entity.ts
@@ -46,6 +46,8 @@ export const findExistingEntity = async ({
 }): Promise<Entity | undefined> => {
   const entityTypeId = proposedEntity.entityTypeId;
 
+  return undefined;
+
   const entityType: DereferencedEntityType | undefined =
     dereferencedEntityType ??
     (await graphApiClient

--- a/apps/hash-ai-worker-ts/src/activities/shared/find-existing-entity.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/find-existing-entity.ts
@@ -46,8 +46,6 @@ export const findExistingEntity = async ({
 }): Promise<Entity | undefined> => {
   const entityTypeId = proposedEntity.entityTypeId;
 
-  return undefined;
-
   const entityType: DereferencedEntityType | undefined =
     dereferencedEntityType ??
     (await graphApiClient

--- a/apps/hash-ai-worker-ts/src/shared/signals.ts
+++ b/apps/hash-ai-worker-ts/src/shared/signals.ts
@@ -1,10 +1,5 @@
-import type { StepProgressLog } from "@local/hash-isomorphic-utils/flows/types";
+import type { ProgressLogSignalData } from "@local/hash-isomorphic-utils/flows/types";
 import { defineSignal } from "@temporalio/workflow";
-
-export type ProgressLogSignalData = {
-  attempt: number;
-  logs: StepProgressLog[];
-};
 
 export const logProgressSignal =
   defineSignal<[ProgressLogSignalData]>("logProgress");

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/015-add-flow-types.dev.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/015-add-flow-types.dev.migration.ts
@@ -100,6 +100,10 @@ const migrate: MigrationFunction = async ({
             required: true,
           },
           {
+            propertyType: blockProtocolPropertyTypes.description.propertyTypeId,
+            required: true,
+          },
+          {
             propertyType: triggerDefinitionPropertyType,
             required: true,
           },

--- a/apps/hash-api/src/graphql/resolvers/flows/runs.ts
+++ b/apps/hash-api/src/graphql/resolvers/flows/runs.ts
@@ -202,6 +202,10 @@ const mapTemporalWorkflowToFlowStatus = async (
         ? getActivityScheduledDetails(event)
         : getActivityStartedDetails(events, nonScheduledAttributes!);
 
+      if (activityType === "persistFlowActivity") {
+        continue;
+      }
+
       if (stepMap[activityId]) {
         // We've already encountered and therefore populated all the details for this step
         continue;
@@ -322,7 +326,7 @@ const mapTemporalWorkflowToFlowStatus = async (
     executedAt: executionTime?.toISOString(),
     closedAt: closeTime?.toISOString(),
     inputs: workflowInputs,
-    outputs: workflowOutputs,
+    flowOutputs: workflowOutputs,
     steps: Object.values(stepMap),
   };
 };

--- a/apps/hash-api/src/graphql/resolvers/flows/runs.ts
+++ b/apps/hash-api/src/graphql/resolvers/flows/runs.ts
@@ -1,3 +1,4 @@
+import type { ProgressLogSignalData } from "@local/hash-isomorphic-utils/flows/types";
 import type {
   Client as TemporalClient,
   WorkflowExecutionInfo,
@@ -165,6 +166,13 @@ const mapTemporalWorkflowToFlowStatus = async (
 
   const stepMap: { [activityId: string]: StepRun } = {};
 
+  /**
+   * Collect all progress signal events when building the step map,
+   * and assign them to the appropriate step afterwards.
+   */
+  const progressSignalEvents: proto.temporal.api.history.v1.IHistoryEvent[] =
+    [];
+
   if (events?.length) {
     /*
      * Walk backwards from the most recent event until we have populated the latest state data for each step
@@ -173,6 +181,14 @@ const mapTemporalWorkflowToFlowStatus = async (
       const event = events[i];
       if (!event) {
         throw new Error("Somehow out of bounds for events array");
+      }
+
+      if (
+        event.workflowExecutionSignaledEventAttributes?.signalName ===
+        "logProgress"
+      ) {
+        progressSignalEvents.push(event);
+        continue;
       }
 
       const nonScheduledAttributes =
@@ -187,7 +203,7 @@ const mapTemporalWorkflowToFlowStatus = async (
         !nonScheduledAttributes &&
         !event.activityTaskScheduledEventAttributes
       ) {
-        // This is not an activity-related event
+        // This is not an activity-related event. It may be a signal, which we handle in bulk below
         continue;
       }
 
@@ -217,31 +233,7 @@ const mapTemporalWorkflowToFlowStatus = async (
         startedAt,
         scheduledAt,
         inputs,
-        logs: events
-          .flatMap((historyEvent) => {
-            const { workflowExecutionSignaledEventAttributes } = historyEvent;
-            if (
-              workflowExecutionSignaledEventAttributes?.signalName !==
-              "logProgress"
-            ) {
-              return null;
-            }
-            /**
-             * @todo handle cases where the activity has been retried, where there may be logs from earlier attempts
-             *    –– new start events are not written to the history until the activity has been closed,
-             *    so we need to count the previous close events to determine the attempt number.
-             */
-
-            const logs = parseHistoryItemPayload(
-              workflowExecutionSignaledEventAttributes.input,
-            )?.[0]?.logs;
-
-            return logs;
-          })
-          .filter(
-            (historyEvent): historyEvent is NonNullable<typeof historyEvent> =>
-              !!historyEvent,
-          ),
+        logs: [],
         status: FlowStepStatus.Scheduled,
         attempt,
       };
@@ -315,6 +307,56 @@ const mapTemporalWorkflowToFlowStatus = async (
     }
   }
 
+  /**
+   * Assign logs to the appropriate step. The earliest logs will be at the end of the array,
+   * as we walked the events from latest to earliest. We want the logs in ascending order, so go backwards again.
+   */
+  for (let i = progressSignalEvents.length - 1; i >= 0; i--) {
+    const progressSignalEvent = progressSignalEvents[i];
+    if (!progressSignalEvent) {
+      throw new Error("Somehow out of bounds for progressSignalEvents array");
+    }
+
+    if (!progressSignalEvent.workflowExecutionSignaledEventAttributes) {
+      throw new Error(
+        `No signal attributes on progress signal event with id ${progressSignalEvent.eventId}`,
+      );
+    }
+
+    const signalData = parseHistoryItemPayload(
+      progressSignalEvent.workflowExecutionSignaledEventAttributes.input,
+    )?.[0] as ProgressLogSignalData | undefined;
+
+    if (!signalData) {
+      throw new Error(
+        `No signal data on progress signal event with id ${progressSignalEvent.eventId}`,
+      );
+    }
+
+    const { attempt, logs } = signalData;
+    for (const log of logs) {
+      const { stepId } = log;
+
+      const activityRecord = stepMap[stepId];
+      if (!activityRecord) {
+        throw new Error(`No activity record found for step with id ${stepId}`);
+      }
+
+      if (log.type === "ProposedEntity" && attempt < activityRecord.attempt) {
+        /**
+         * If we have a proposed entity logged from a retried attempt, don't record it as nothing will happen with it.
+         * By contrast, a PersistedEntity has already been committed to the database and is therefore relevant.
+         *
+         * @todo H-2545: heartbeat details of persisted entities from an activity so that if it's retried, the activity
+         *    can pick up where it left off.
+         */
+        continue;
+      }
+
+      activityRecord.logs.push(log);
+    }
+  }
+
   const { runId, status, startTime, executionTime, closeTime, memo } = workflow;
 
   return {
@@ -326,7 +368,7 @@ const mapTemporalWorkflowToFlowStatus = async (
     executedAt: executionTime?.toISOString(),
     closedAt: closeTime?.toISOString(),
     inputs: workflowInputs,
-    flowOutputs: workflowOutputs,
+    outputs: workflowOutputs,
     steps: Object.values(stepMap),
   };
 };

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/linked-with-cell/linked-entity-list-editor.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/linked-with-cell/linked-entity-list-editor.tsx
@@ -25,9 +25,9 @@ import { AddAnotherButton } from "../../../../properties-section/property-table/
 import { GridEditorWrapper } from "../../../../shared/grid-editor-wrapper";
 import type { LinkedWithCell } from "../linked-with-cell";
 import { sortLinkAndTargetEntities } from "../sort-link-and-target-entities";
-import { EntitySelector } from "./entity-selector";
 import { LinkedEntityListRow } from "./linked-entity-list-editor/linked-entity-list-row";
 import { MaxItemsReached } from "./linked-entity-list-editor/max-items-reached";
+import { LinkedEntitySelector } from "./linked-entity-selector";
 
 /**
  * @todo - This is unsafe, and should be refactored to return a new type `DraftEntity`, so that we aren't
@@ -194,7 +194,7 @@ export const LinkedEntityListEditor: ProvideEditorComponent<LinkedWithCell> = (
       {!canAddMore && <MaxItemsReached limit={maxItems} />}
       {canAddMore &&
         (addingLink ? (
-          <EntitySelector
+          <LinkedEntitySelector
             includeDrafts={
               !!extractDraftIdFromEntityId(entity.metadata.recordId.entityId)
             }

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/linked-with-cell/linked-with-cell-editor.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/linked-with-cell/linked-with-cell-editor.tsx
@@ -7,11 +7,11 @@ import { useMemo } from "react";
 import { useMarkLinkEntityToArchive } from "../../../../../shared/use-mark-link-entity-to-archive";
 import { useEntityEditor } from "../../../../entity-editor-context";
 import type { LinkedWithCell } from "../linked-with-cell";
-import { EntitySelector } from "./entity-selector";
 import {
   createDraftLinkEntity,
   LinkedEntityListEditor,
 } from "./linked-entity-list-editor";
+import { LinkedEntitySelector } from "./linked-entity-selector";
 
 export const LinkedWithCellEditor: ProvideEditorComponent<LinkedWithCell> = (
   props,
@@ -78,7 +78,7 @@ export const LinkedWithCellEditor: ProvideEditorComponent<LinkedWithCell> = (
       linkAndTargetEntities[0]?.rightEntity.metadata.recordId.entityId;
 
     return (
-      <EntitySelector
+      <LinkedEntitySelector
         includeDrafts={
           !!extractDraftIdFromEntityId(entity.metadata.recordId.entityId)
         }

--- a/apps/hash-frontend/src/pages/ai.page/research-task-flow.tsx
+++ b/apps/hash-frontend/src/pages/ai.page/research-task-flow.tsx
@@ -38,6 +38,7 @@ const constructFlowDefinition = (params: {
   return {
     name: "Research Task",
     flowDefinitionId: "research-task" as EntityUuid,
+    description: "Research task",
     trigger: {
       triggerDefinitionId: "userTrigger",
       description: "User provides research prompt and entity types of interest",
@@ -136,28 +137,25 @@ const constructFlowDefinition = (params: {
         : []),
     ],
     outputs: [
-      {
-        stepId: "2",
-        stepOutputName:
-          "persistedEntities" satisfies OutputNameForAction<"persistEntities">,
-        name: "persistedEntities" as const,
-        payloadKind: "PersistedEntities",
-        array: false,
-        required: true,
-      },
-      ...(includeQuestionAnswerAction
-        ? [
-            {
-              stepId: "3",
-              stepOutputName:
-                "answer" satisfies OutputNameForAction<"answerQuestion">,
-              payloadKind: "Text",
-              name: "answer" as const,
-              array: false,
-              required: true,
-            } as const,
-          ]
-        : []),
+      includeQuestionAnswerAction
+        ? ({
+            stepId: "3",
+            stepOutputName:
+              "answer" satisfies OutputNameForAction<"answerQuestion">,
+            payloadKind: "Text",
+            name: "answer" as const,
+            array: false,
+            required: true,
+          } as const)
+        : {
+            stepId: "2",
+            stepOutputName:
+              "persistedEntities" satisfies OutputNameForAction<"persistEntities">,
+            name: "persistedEntities" as const,
+            payloadKind: "PersistedEntities",
+            array: false,
+            required: true,
+          },
     ],
   };
 };

--- a/apps/hash-frontend/src/pages/ai.page/research-task-flow.tsx
+++ b/apps/hash-frontend/src/pages/ai.page/research-task-flow.tsx
@@ -269,10 +269,9 @@ export const ResearchTaskFlow: FunctionComponent = () => {
           const status = data.startFlow as RunFlowWorkflowResponse;
 
           if (status.code === StatusCode.Ok) {
-            const persistedEntitiesOutput =
-              status.contents[0]?.flowOutputs?.find(
-                (output) => output.outputName === "persistedEntities",
-              );
+            const persistedEntitiesOutput = status.contents[0]?.outputs?.find(
+              (output) => output.outputName === "persistedEntities",
+            );
 
             if (!persistedEntitiesOutput) {
               throw new Error(
@@ -285,7 +284,7 @@ export const ResearchTaskFlow: FunctionComponent = () => {
             );
 
             if (includeQuestionAnswerAction) {
-              const answerOutput = status.contents[0]?.flowOutputs?.find(
+              const answerOutput = status.contents[0]?.outputs?.find(
                 (output) => output.outputName === "answer",
               );
 

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition.tsx
@@ -1,5 +1,6 @@
 import "reactflow/dist/style.css";
 
+import { useMutation } from "@apollo/client";
 import { customColors } from "@hashintel/design-system/theme";
 import { actionDefinitions } from "@local/hash-isomorphic-utils/flows/action-definitions";
 import type {
@@ -14,28 +15,27 @@ import { useMemo, useState } from "react";
 import type { Edge } from "reactflow";
 import { MarkerType, ReactFlowProvider } from "reactflow";
 
+import type {
+  StartFlowMutation,
+  StartFlowMutationVariables,
+} from "../../graphql/api-types.gen";
+import { startFlowMutation } from "../../graphql/queries/knowledge/entity.queries";
 import { isNonNullable } from "../../lib/typeguards";
+import { Button } from "../../shared/ui/button";
 import { Deliverable } from "./flow-definition/deliverable";
 import { EntityResultTable } from "./flow-definition/entity-result-table";
 import { PersistedEntityGraph } from "./flow-definition/persisted-entity-graph";
+import { RunFlowModal } from "./flow-definition/run-flow-modal";
 import { nodeDimensions } from "./flow-definition/shared/dimensions";
 import { useFlowDefinitionsContext } from "./flow-definition/shared/flow-definitions-context";
 import { useFlowRunsContext } from "./flow-definition/shared/flow-runs-context";
+import { transitionOptions } from "./flow-definition/shared/styles";
 import type { CustomNodeType } from "./flow-definition/shared/types";
 import {
   getFlattenedSteps,
   groupStepsByDependencyLayer,
 } from "./flow-definition/sort-graph";
 import { Swimlane } from "./flow-definition/swimlane";
-import { transitionOptions } from "./flow-definition/shared/styles";
-import { Button } from "../../shared/ui/button";
-import { useMutation } from "@apollo/client";
-import {
-  StartFlowMutation,
-  StartFlowMutationVariables,
-} from "../../graphql/api-types.gen";
-import { startFlowMutation } from "../../graphql/queries/knowledge/entity.queries";
-import { RunFlowModal } from "./flow-definition/run-flow-modal";
 
 const getGraphFromFlowDefinition = (
   flowDefinition: FlowDefinitionType,
@@ -368,7 +368,12 @@ export const FlowDefinition = () => {
         }}
       />
       <Box p={3}>
-        <Stack direction="row" justifyContent="space-between" mb={1}>
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          mb={1}
+          sx={{ height: 40 }}
+        >
           <select
             value={selectedFlow.name}
             onChange={(event) => {
@@ -425,7 +430,7 @@ export const FlowDefinition = () => {
             background: palette.common.white,
             border: `1px solid ${palette.gray[selectedFlowRun ? 20 : 30]}`,
             borderRadius: 2.5,
-            "& > :first-child": {
+            "& > :first-of-type": {
               borderTopRightRadius: "10px",
               borderTopLeftRadius: "10px",
             },
@@ -433,27 +438,32 @@ export const FlowDefinition = () => {
               borderBottomRightRadius: "10px",
               borderBottomLeftRadius: "10px",
             },
-            "& > :last-child > :first-child": {
+            "& > :last-child > :first-of-type": {
               borderBottomLeftRadius: "10px",
             },
             transition: transitions.create("border", transitionOptions),
           })}
         >
-          <Box
+          <Stack
+            direction="row"
             sx={{
               borderBottom: ({ palette }) => `1px solid ${palette.gray[20]}`,
               p: 3,
             }}
           >
-            <Typography sx={{ fontSize: 14, fontWeight: 400 }}>
+            <Typography
+              component="span"
+              sx={{ fontSize: 14, fontWeight: 600, mr: 2 }}
+            >
+              {selectedFlow.name}
+            </Typography>
+            <Typography component="span" sx={{ fontSize: 14, fontWeight: 400 }}>
               {selectedFlow.description}
             </Typography>
-          </Box>
+          </Stack>
           {Object.entries(nodesAndEdgesByGroup).map(
             ([groupId, { group, nodes, edges }]) => (
-              <ReactFlowProvider
-                key={`${selectedFlow.name}-${groupId}-${selectedFlowRun?.runId ?? "definition"}`}
-              >
+              <ReactFlowProvider key={`${selectedFlow.name}-${groupId}`}>
                 <Swimlane group={group} nodes={nodes} edges={edges} />
               </ReactFlowProvider>
             ),
@@ -492,7 +502,7 @@ export const FlowDefinition = () => {
         <Box sx={{ width: "40%", pl: 3, pt: 2.5 }}>
           <SectionLabel text="Deliverable" />
 
-          <Deliverable outputs={selectedFlowRun?.flowOutputs ?? []} />
+          <Deliverable outputs={selectedFlowRun?.outputs ?? []} />
         </Box>
       </Stack>
     </Box>

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition.tsx
@@ -1,6 +1,7 @@
 import "reactflow/dist/style.css";
 
 import { useMutation } from "@apollo/client";
+import { PlayIconSolid } from "@hashintel/design-system";
 import { customColors } from "@hashintel/design-system/theme";
 import { actionDefinitions } from "@local/hash-isomorphic-utils/flows/action-definitions";
 import type {
@@ -392,6 +393,13 @@ export const FlowDefinition = () => {
           </select>
           {!selectedFlowRun && (
             <Button onClick={handleRunFlowClicked} size="xs">
+              <PlayIconSolid
+                sx={{
+                  fill: ({ palette }) => palette.blue[40],
+                  fontSize: 14,
+                  mr: 1,
+                }}
+              />
               Run
             </Button>
           )}

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition.tsx
@@ -338,6 +338,9 @@ export const FlowDefinition = () => {
     }
   };
 
+  const flowDefinitionStateKey = `${selectedFlow.name}`;
+  const flowRunStateKey = `${flowDefinitionStateKey}-${selectedFlowRun?.runId ?? "definition"}`;
+
   return (
     <Box
       sx={{
@@ -471,7 +474,7 @@ export const FlowDefinition = () => {
           </Stack>
           {Object.entries(nodesAndEdgesByGroup).map(
             ([groupId, { group, nodes, edges }]) => (
-              <ReactFlowProvider key={`${selectedFlow.name}-${groupId}`}>
+              <ReactFlowProvider key={`${flowDefinitionStateKey}-${groupId}`}>
                 <Swimlane group={group} nodes={nodes} edges={edges} />
               </ReactFlowProvider>
             ),
@@ -501,16 +504,23 @@ export const FlowDefinition = () => {
           <SectionLabel text="Raw output" />
           <Stack direction="row" gap={1} sx={{ height: "100%", width: "100%" }}>
             <EntityResultTable
+              key={`${flowRunStateKey}-entity-result-table`}
               persistedEntities={persistedEntities}
               proposedEntities={proposedEntities}
             />
-            <PersistedEntityGraph persistedEntities={persistedEntities} />
+            <PersistedEntityGraph
+              key={`${flowRunStateKey}-persisted-entity-graph`}
+              persistedEntities={persistedEntities}
+            />
           </Stack>
         </Box>
         <Box sx={{ width: "40%", pl: 3, pt: 2.5 }}>
           <SectionLabel text="Deliverable" />
 
-          <Deliverable outputs={selectedFlowRun?.outputs ?? []} />
+          <Deliverable
+            key={`${flowRunStateKey}-deliverable`}
+            outputs={selectedFlowRun?.outputs ?? []}
+          />
         </Box>
       </Stack>
     </Box>

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition.tsx
@@ -4,6 +4,7 @@ import { customColors } from "@hashintel/design-system/theme";
 import { actionDefinitions } from "@local/hash-isomorphic-utils/flows/action-definitions";
 import type {
   FlowDefinition as FlowDefinitionType,
+  FlowTrigger,
   ProposedEntity,
   StepGroup,
 } from "@local/hash-isomorphic-utils/flows/types";
@@ -34,6 +35,7 @@ import {
   StartFlowMutationVariables,
 } from "../../graphql/api-types.gen";
 import { startFlowMutation } from "../../graphql/queries/knowledge/entity.queries";
+import { RunFlowModal } from "./flow-definition/run-flow-modal";
 
 const getGraphFromFlowDefinition = (
   flowDefinition: FlowDefinitionType,
@@ -347,6 +349,24 @@ export const FlowDefinition = () => {
           transitions.create("background", transitionOptions),
       }}
     >
+      <RunFlowModal
+        key={selectedFlow.name}
+        flowDefinition={selectedFlow}
+        open={showRunModal}
+        onClose={() => setShowRunModal(false)}
+        runFlow={(outputs: FlowTrigger["outputs"]) => {
+          void startFlow({
+            variables: {
+              flowDefinition: selectedFlow,
+              flowTrigger: {
+                outputs,
+                triggerDefinitionId: "userTrigger",
+              },
+            },
+          });
+          setShowRunModal(false);
+        }}
+      />
       <Box p={3}>
         <Stack direction="row" justifyContent="space-between" mb={1}>
           <select
@@ -431,7 +451,9 @@ export const FlowDefinition = () => {
           </Box>
           {Object.entries(nodesAndEdgesByGroup).map(
             ([groupId, { group, nodes, edges }]) => (
-              <ReactFlowProvider key={groupId}>
+              <ReactFlowProvider
+                key={`${selectedFlow.name}-${groupId}-${selectedFlowRun?.runId ?? "definition"}`}
+              >
                 <Swimlane group={group} nodes={nodes} edges={edges} />
               </ReactFlowProvider>
             ),

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/deliverable.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/deliverable.tsx
@@ -17,10 +17,10 @@ import { FlowRun } from "../../../graphql/api-types.gen";
 export const Deliverable = ({
   outputs,
 }: {
-  outputs?: FlowRun["flowOutputs"][];
+  outputs?: FlowRun["flowOutputs"];
 }) => {
   const flowOutputs = useMemo(
-    () => outputs?.[0]?.contents?.[0]?.flowOutputs ?? [],
+    () => outputs?.[0]?.contents?.[0]?.outputs ?? [],
     [outputs],
   );
 

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/deliverable.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/deliverable.tsx
@@ -12,12 +12,19 @@ import { useMemo } from "react";
 
 import { Cell } from "../../settings/organizations/shared/cell";
 import { OrgTable } from "../../settings/organizations/shared/org-table";
+import { FlowRun } from "../../../graphql/api-types.gen";
 
-export const Deliverable = ({ outputs }: { outputs?: StepRunOutput[] }) => {
+export const Deliverable = ({
+  outputs,
+}: {
+  outputs?: FlowRun["flowOutputs"][];
+}) => {
   const flowOutputs = useMemo(
-    () => outputs?.[0]?.contents?.[0]?.outputs ?? [],
+    () => outputs?.[0]?.contents?.[0]?.flowOutputs ?? [],
     [outputs],
   );
+
+  console.log({ outputs });
 
   const parsedCsv = useMemo(() => {
     const answer = flowOutputs.find((output) => output.outputName === "answer")
@@ -34,6 +41,8 @@ export const Deliverable = ({ outputs }: { outputs?: StepRunOutput[] }) => {
     }
   }, [flowOutputs]);
 
+  console.log({ flowOutputs, parsedCsv });
+
   return (
     <Box
       sx={{
@@ -45,7 +54,14 @@ export const Deliverable = ({ outputs }: { outputs?: StepRunOutput[] }) => {
       }}
     >
       {parsedCsv ? (
-        <OrgTable sx={{ maxWidth: "100%", overflow: "hidden" }}>
+        <OrgTable
+          sx={{
+            maxWidth: "100%",
+            overflow: "auto",
+            maxHeight: "100%",
+            display: "block",
+          }}
+        >
           <TableHead>
             <TableRow>
               {parsedCsv.data[0]?.map((column) => (

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/deliverable/csv.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/deliverable/csv.tsx
@@ -1,0 +1,44 @@
+import { TableBody, TableCell, TableHead, TableRow } from "@mui/material";
+import type { ParseResult } from "papaparse";
+
+import { Cell } from "../../../settings/organizations/shared/cell";
+import { OrgTable } from "../../../settings/organizations/shared/org-table";
+
+type CsvProps = {
+  parsedCsv: ParseResult<(string | number | boolean)[]>;
+};
+
+export const Csv = ({ parsedCsv }: CsvProps) => {
+  return (
+    <OrgTable
+      sx={{
+        maxWidth: "100%",
+        overflow: "auto",
+        maxHeight: "100%",
+        display: "block",
+      }}
+    >
+      <TableHead>
+        <TableRow>
+          {parsedCsv.data[0]?.map((column) => (
+            <Cell key={column.toString()}>{column}</Cell>
+          ))}
+        </TableRow>
+      </TableHead>
+
+      <TableBody>
+        {parsedCsv.data.slice(1).map((row, index) => {
+          return (
+            // eslint-disable-next-line react/no-array-index-key -- no better alternative, arbitrary CSV data
+            <TableRow key={index} sx={{ fontSize: 13 }}>
+              {row.map((content, idx) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <TableCell key={idx}>{content}</TableCell>
+              ))}
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </OrgTable>
+  );
+};

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/entity-result-table.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/entity-result-table.tsx
@@ -134,7 +134,14 @@ export const EntityResultTable = ({
       }}
     >
       {hasData ? (
-        <OrgTable sx={{ maxWidth: "100%", overflow: "hidden" }}>
+        <OrgTable
+          sx={{
+            maxWidth: "100%",
+            maxHeight: "100%",
+            display: "block",
+            overflow: "auto",
+          }}
+        >
           <TableHead>
             <TableRow>
               {columns.map((column) => (

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/persisted-entity-graph.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/persisted-entity-graph.tsx
@@ -6,9 +6,10 @@ import {
   generateVersionedUrlMatchingFilter,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
-import type { Entity } from "@local/hash-subgraph";
+import type { Entity, EntityId } from "@local/hash-subgraph";
 import type { SxProps, Theme } from "@mui/material";
 import { Box } from "@mui/material";
+import { useMemo } from "react";
 
 import type {
   QueryEntityTypesQuery,
@@ -56,15 +57,32 @@ export const PersistedEntityGraph = ({
 
   const entityTypeSubgraph = entityTypeResultData?.queryEntityTypes;
 
+  const deduplicatedPersistedEntities = useMemo(() => {
+    const deduplicatedLatestEntitiesByEntityId: Record<EntityId, Entity> = {};
+    for (const entity of persistedEntities) {
+      const entityId = entity.metadata.recordId.entityId;
+
+      const existing = deduplicatedLatestEntitiesByEntityId[entityId];
+
+      if (
+        !existing ||
+        existing.metadata.temporalVersioning.decisionTime.start.limit <
+          entity.metadata.temporalVersioning.decisionTime.start.limit
+      ) {
+        deduplicatedLatestEntitiesByEntityId[entityId] = entity;
+      }
+    }
+
+    return Object.values(deduplicatedLatestEntitiesByEntityId);
+  }, [persistedEntities]);
+
   if (!entityTypeSubgraph && !persistedEntities.length) {
     return <Box sx={containerSx} />;
   }
 
-  console.log({ persistedEntities });
-
   return (
     <EntitiesGraphChart
-      entities={persistedEntities}
+      entities={deduplicatedPersistedEntities}
       sx={containerSx}
       subgraph={entityTypeSubgraph as unknown as Subgraph<EntityRootType>} // @todo sort out this param to EntitiesGraphChart
     />

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/persisted-entity-graph.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/persisted-entity-graph.tsx
@@ -60,6 +60,8 @@ export const PersistedEntityGraph = ({
     return <Box sx={containerSx} />;
   }
 
+  console.log({ persistedEntities });
+
   return (
     <EntitiesGraphChart
       entities={persistedEntities}

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/persisted-entity-graph.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/persisted-entity-graph.tsx
@@ -57,6 +57,12 @@ export const PersistedEntityGraph = ({
 
   const entityTypeSubgraph = entityTypeResultData?.queryEntityTypes;
 
+  /**
+   * If a Flow updates the same entity as non-draft multiple times, it will have a record of persisting
+   * an entity with the same id multiple times. Duplicates crash the chart.
+   * We could also deduplicate in the entities table, but having duplicates be visible there
+   * will help to detect where update / deduplication logic can be improved in the inference process.
+   */
   const deduplicatedPersistedEntities = useMemo(() => {
     const deduplicatedLatestEntitiesByEntityId: Record<EntityId, Entity> = {};
     for (const entity of persistedEntities) {

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/run-flow-modal.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/run-flow-modal.tsx
@@ -1,0 +1,40 @@
+import { Box, Typography } from "@mui/material";
+import { Modal } from "../../../shared/ui/modal";
+import { FlowDefinition } from "@local/hash-isomorphic-utils/flows/types";
+import { useState } from "react";
+import { OwnedById } from "@local/hash-subgraph";
+import { VersionedUrl } from "@blockprotocol/type-system";
+
+type RunFlowModalProps = {
+  flowDefinition: FlowDefinition;
+  open: boolean;
+  onClose: () => void;
+};
+
+type TriggerInputValue = VersionedUrl | string | number | OwnedById;
+
+export const RunFlowModal = ({
+  flowDefinition,
+  open,
+  onClose,
+}: RunFlowModalProps) => {
+  const { outputs } = flowDefinition.trigger;
+
+  const [formState, setFormState] = useState<
+    Record<string, TriggerInputValue | TriggerInputValue[]>
+  >({});
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <>
+        <Box>
+          <Typography sx={{ fontWeight: 600 }}>Run flow</Typography>
+        </Box>
+        <Box>
+          In order to run the <strong>{flowDefinition.name}</strong> flow,
+          you'll need to provide a bit more information first.
+        </Box>
+      </>
+    </Modal>
+  );
+};

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/run-flow-modal.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/run-flow-modal.tsx
@@ -1,38 +1,253 @@
-import { Box, Typography } from "@mui/material";
+import { IconButton, TextField } from "@hashintel/design-system";
+import {
+  FlowDefinition,
+  FlowTrigger,
+  OutputDefinition,
+  PayloadKind,
+} from "@local/hash-isomorphic-utils/flows/types";
+import { EntityTypeWithMetadata, OwnedById } from "@local/hash-subgraph";
+import { Box, Stack, Switch, Typography } from "@mui/material";
+import { PropsWithChildren, useState } from "react";
+
+import { XMarkRegularIcon } from "../../../shared/icons/x-mark-regular-icon";
+import { Button } from "../../../shared/ui/button";
 import { Modal } from "../../../shared/ui/modal";
-import { FlowDefinition } from "@local/hash-isomorphic-utils/flows/types";
-import { useState } from "react";
-import { OwnedById } from "@local/hash-subgraph";
-import { VersionedUrl } from "@blockprotocol/type-system";
+import { EntityTypeSelector } from "../../shared/entity-type-selector";
+import { WebSelector } from "./run-flow-modal/web-selector";
+import { typedValues } from "@local/advanced-types/typed-entries";
 
 type RunFlowModalProps = {
   flowDefinition: FlowDefinition;
   open: boolean;
   onClose: () => void;
+  runFlow: (outputs: FlowTrigger["outputs"]) => void;
 };
 
-type TriggerInputValue = VersionedUrl | string | number | OwnedById;
+type LocalInputValues = {
+  Text: string;
+  Number: number;
+  Boolean: boolean;
+  VersionedUrl: EntityTypeWithMetadata;
+  WebId: OwnedById;
+};
+
+type LocalPayloadKind = keyof LocalInputValues;
+
+type LocalPayload<K extends LocalPayloadKind = LocalPayloadKind> = {
+  kind: K;
+  value: LocalInputValues[K] | LocalInputValues[K][];
+};
+
+type FormState = {
+  [outputName: string]: {
+    outputName: string;
+    payload: LocalPayload;
+  };
+};
+
+const ManualTriggerInput = <
+  Array extends boolean,
+  Kind extends keyof LocalInputValues,
+>({
+  outputDefinition,
+  value,
+  setValue,
+}: {
+  outputDefinition: OutputDefinition<Array, Kind>;
+  value?: Array extends true
+    ? LocalInputValues[Kind][]
+    : LocalInputValues[Kind];
+  setValue: (
+    value: Array extends true
+      ? LocalInputValues[Kind][]
+      : LocalInputValues[Kind],
+  ) => void;
+}) => {
+  console.log({ outputDefinition });
+  switch (outputDefinition.payloadKind) {
+    case "Text":
+      if (outputDefinition.array) {
+        throw new Error("Selecting multiple texts is not supported");
+      }
+      return (
+        <TextField
+          onChange={(event) => setValue(event.target.value)}
+          value={value}
+        />
+      );
+    case "Number":
+      return (
+        <TextField
+          onChange={(event) => setValue(event.target.value)}
+          type="number"
+          value={value}
+        />
+      );
+    case "Boolean":
+      return (
+        <Switch
+          size="small"
+          checked={!!value}
+          onChange={(event) => setValue(event.target.checked)}
+        />
+      );
+    case "VersionedUrl": {
+      return (
+        <EntityTypeSelector<Array>
+          autoFocus={false}
+          disableCreate
+          multiple={outputDefinition.array}
+          onSelect={(newValue) =>
+            setValue(Array.isArray(newValue) ? newValue : newValue)
+          }
+        />
+      );
+    }
+    case "WebId": {
+      if (outputDefinition.array) {
+        throw new Error("Selecting multiple webs is not supported");
+      }
+      return (
+        <WebSelector
+          selectedWebOwnedById={value}
+          setSelectedWebOwnedById={(newValue) => setValue(newValue)}
+        />
+      );
+    }
+  }
+
+  throw new Error(
+    `Unhandled trigger input type: ${outputDefinition.array ? "array of " : ""}${outputDefinition.payloadKind}`,
+  );
+};
+
+const Label = ({
+  children,
+  required,
+  text,
+}: PropsWithChildren<{ required: boolean; text: string }>) => (
+  <Typography
+    component="label"
+    variant="smallTextLabels"
+    sx={{
+      color: ({ palette }) => palette.gray[70],
+      fontWeight: 500,
+      lineHeight: 1.5,
+    }}
+  >
+    {text}
+    {children}
+  </Typography>
+);
 
 export const RunFlowModal = ({
   flowDefinition,
   open,
   onClose,
+  runFlow,
 }: RunFlowModalProps) => {
   const { outputs } = flowDefinition.trigger;
 
-  const [formState, setFormState] = useState<
-    Record<string, TriggerInputValue | TriggerInputValue[]>
-  >({});
+  const [formState, setFormState] = useState<FormState>({});
+
+  const submitValues = () => {
+    if (!allRequiredValuesPresent) {
+      return;
+    }
+
+    const outputValues: FlowTrigger["outputs"] = typedValues(formState).map(
+      ({ outputName, payload }) => ({
+        outputName,
+        payload:
+          payload.kind === "VersionedUrl"
+            ? {
+                kind: payload.kind,
+                value: Array.isArray(payload.value)
+                  ? payload.value.map(
+                      (entityType) =>
+                        (entityType as EntityTypeWithMetadata).schema.$id,
+                    )
+                  : (payload.value as EntityTypeWithMetadata).schema.$id,
+              }
+            : payload,
+      }),
+    );
+
+    runFlow(outputValues);
+  };
+
+  const allRequiredValuesPresent = (outputs ?? []).every(
+    (output) => !output.required || formState[output.name].payload.value,
+  );
 
   return (
-    <Modal open={open} onClose={onClose}>
+    <Modal contentStyle={{ p: { xs: 0, md: 0 } }} open={open} onClose={onClose}>
       <>
-        <Box>
-          <Typography sx={{ fontWeight: 600 }}>Run flow</Typography>
-        </Box>
-        <Box>
-          In order to run the <strong>{flowDefinition.name}</strong> flow,
-          you'll need to provide a bit more information first.
+        <Stack
+          alignItems="center"
+          direction="row"
+          justifyContent="space-between"
+          sx={{
+            borderBottom: ({ palette }) => `1px solid ${palette.gray[20]}`,
+            py: 1,
+            pl: 2.5,
+            pr: 1.5,
+          }}
+        >
+          <Typography
+            sx={{ fontWeight: 500, color: ({ palette }) => palette.gray[80] }}
+          >
+            Run flow
+          </Typography>
+          <IconButton onClick={onClose} sx={{ "& svg": { fontSize: 20 } }}>
+            <XMarkRegularIcon />
+          </IconButton>
+        </Stack>
+        <Box sx={{ px: 4.5, py: 2.5 }}>
+          <Typography
+            component="p"
+            variant="smallTextLabels"
+            sx={{
+              color: ({ palette }) => palette.gray[70],
+              fontWeight: 500,
+              lineHeight: 1.5,
+            }}
+          >
+            In order to run the <strong>{flowDefinition.name}</strong> flow,
+            you'll need to provide a bit more information first.
+          </Typography>
+          {(outputs ?? []).map((outputDef) => {
+            switch (outputDef.payloadKind) {
+              case "PersistedEntities":
+              case "PersistedEntity":
+              case "ProposedEntity":
+              case "ProposedEntityWithResolvedLinks": {
+                throw new Error("Unsupported input kind");
+              }
+            }
+
+            return (
+              <ManualTriggerInput
+                key={outputDef.name}
+                outputDefinition={outputDef}
+                value={formState[outputDef.name]}
+                setValue={(newValue) =>
+                  setFormState((currentValue) => ({
+                    ...currentValue,
+                    [outputDef.name]: newValue,
+                  }))
+                }
+              />
+            );
+          })}
+          <Button
+            disabled={allRequiredValuesPresent}
+            size="small"
+            onClick={submitValues}
+            sx={{ mt: 2 }}
+          >
+            Run flow
+          </Button>
         </Box>
       </>
     </Modal>

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/run-flow-modal/manual-trigger-input.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/run-flow-modal/manual-trigger-input.tsx
@@ -1,0 +1,98 @@
+import { TextField } from "@hashintel/design-system";
+import type { SxProps, Theme } from "@mui/material";
+import { Switch } from "@mui/material";
+
+import { EntityTypeSelector } from "../../../shared/entity-type-selector";
+import { WebSelector } from "./manual-trigger-input/web-selector";
+import { inputHeight } from "./shared/dimensions";
+import type { LocalPayload } from "./types";
+
+const textFieldSx: SxProps<Theme> = {
+  width: "100%",
+  /**
+   * Aligns with the Autocomplete used for EntityTypeSelector and WebSelector.
+   * Changing these
+   */
+  height: inputHeight,
+};
+
+export const ManualTriggerInput = <Payload extends LocalPayload>({
+  array,
+  payload,
+  required,
+  setValue,
+}: {
+  array: boolean;
+  payload: Payload;
+  required: boolean;
+  setValue: (value: Payload["value"]) => void;
+}) => {
+  switch (payload.kind) {
+    case "Text":
+      if (array || Array.isArray(payload.value)) {
+        throw new Error("Selecting multiple texts is not supported");
+      }
+      return (
+        <TextField
+          onChange={(event) => setValue(event.target.value)}
+          placeholder={`${required ? "Required" : "Optional"} to start the flow`}
+          sx={textFieldSx}
+          value={payload.value}
+        />
+      );
+    case "Number":
+      if (array || Array.isArray(payload.value)) {
+        throw new Error("Selecting multiple numbers is not supported");
+      }
+      return (
+        <TextField
+          onChange={(event) =>
+            setValue(
+              event.target.value !== "" ? Number(event.target.value) : "",
+            )
+          }
+          placeholder={`${required ? "Required" : "Optional"} to start the flow`}
+          sx={textFieldSx}
+          type="number"
+          value={payload.value}
+        />
+      );
+    case "Boolean":
+      if (array || Array.isArray(payload.value)) {
+        throw new Error("Selecting multiple booleans is not supported");
+      }
+      return (
+        <Switch
+          size="medium"
+          checked={payload.value}
+          onChange={(event) => setValue(event.target.checked)}
+        />
+      );
+    case "VersionedUrl": {
+      return (
+        <EntityTypeSelector
+          autoFocus={false}
+          disableCreate
+          inputHeight={inputHeight}
+          multiple={array}
+          onSelect={(newValue) =>
+            setValue(Array.isArray(newValue) ? newValue : newValue)
+          }
+          sx={{ height: inputHeight, maxWidth: "100%" }}
+          value={payload.value}
+        />
+      );
+    }
+    case "WebId": {
+      if (array || Array.isArray(payload.value)) {
+        throw new Error("Selecting multiple webs is not supported");
+      }
+      return (
+        <WebSelector
+          selectedWebOwnedById={payload.value}
+          setSelectedWebOwnedById={(newValue) => setValue(newValue)}
+        />
+      );
+    }
+  }
+};

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/run-flow-modal/manual-trigger-input.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/run-flow-modal/manual-trigger-input.tsx
@@ -2,6 +2,7 @@ import { TextField } from "@hashintel/design-system";
 import type { SxProps, Theme } from "@mui/material";
 import { Switch } from "@mui/material";
 
+import { EntitySelector } from "../../../shared/entity-selector";
 import { EntityTypeSelector } from "../../../shared/entity-type-selector";
 import { WebSelector } from "./manual-trigger-input/web-selector";
 import { inputHeight } from "./shared/dimensions";
@@ -91,6 +92,18 @@ export const ManualTriggerInput = <Payload extends LocalPayload>({
         <WebSelector
           selectedWebOwnedById={payload.value}
           setSelectedWebOwnedById={(newValue) => setValue(newValue)}
+        />
+      );
+    }
+    case "Entity": {
+      return (
+        <EntitySelector
+          autoFocus={false}
+          includeDrafts={false}
+          inputHeight={inputHeight}
+          multiple={array}
+          onSelect={setValue}
+          value={payload.value}
         />
       );
     }

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/run-flow-modal/manual-trigger-input/web-selector.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/run-flow-modal/manual-trigger-input/web-selector.tsx
@@ -1,31 +1,38 @@
 import { Autocomplete, Avatar } from "@hashintel/design-system";
 import type { OwnedById } from "@local/hash-subgraph";
-import { Stack, Typography } from "@mui/material";
+import {
+  autocompleteClasses,
+  Box,
+  outlinedInputClasses,
+  Stack,
+  Typography,
+} from "@mui/material";
 import type { ReactElement } from "react";
 import { useMemo } from "react";
 
-import { useAuthenticatedUser } from "../../../shared/auth-info-context";
-import { getImageUrlFromEntityProperties } from "../../../shared/get-image-url-from-properties";
-import { MenuItem } from "../../../../shared/ui/menu-item";
+import { MenuItem } from "../../../../../shared/ui/menu-item";
+import { useAuthenticatedUser } from "../../../../shared/auth-info-context";
+import { getImageUrlFromEntityProperties } from "../../../../shared/get-image-url-from-properties";
+import { inputHeight } from "../shared/dimensions";
 
 const RenderOptionContent = ({
   avatarComponent,
-  title,
+  label,
 }: {
   avatarComponent: ReactElement;
-  title: string;
+  label: string;
 }) => {
   return (
-    <Stack direction="row" alignItems="center">
+    <Stack direction="row" alignItems="center" py={0.5} px={0}>
       {avatarComponent}
       <Typography
         sx={{
           fontSize: 14,
           fontWeight: 500,
-          ml: 1,
+          ml: 1.2,
         }}
       >
-        {title}
+        {label}
       </Typography>
     </Stack>
   );
@@ -35,6 +42,8 @@ type WebSelectorProps = {
   selectedWebOwnedById?: OwnedById;
   setSelectedWebOwnedById: (ownedById: OwnedById) => void;
 };
+
+const optionPx = 2;
 
 export const WebSelector = ({
   selectedWebOwnedById,
@@ -47,7 +56,7 @@ export const WebSelector = ({
       {
         avatarComponent: (
           <Avatar
-            size={22}
+            size={26}
             src={
               authenticatedUser.hasAvatar
                 ? getImageUrlFromEntityProperties(
@@ -58,14 +67,14 @@ export const WebSelector = ({
             title={authenticatedUser.displayName ?? "?"}
           />
         ),
-        ownedById: authenticatedUser.accountId as OwnedById,
-        title: "My web",
+        label: "My web",
+        value: authenticatedUser.accountId as OwnedById,
       },
       ...authenticatedUser.memberOf.map(
         ({ org: { accountGroupId, name, hasAvatar } }) => ({
           avatarComponent: (
             <Avatar
-              size={22}
+              size={26}
               src={
                 hasAvatar
                   ? getImageUrlFromEntityProperties(
@@ -76,15 +85,15 @@ export const WebSelector = ({
               title={name}
             />
           ),
-          ownedById: accountGroupId as OwnedById,
-          title: name,
+          label: name,
+          value: accountGroupId as OwnedById,
         }),
       ),
     ];
   }, [authenticatedUser]);
 
   const selectedWeb = options.find(
-    (option) => option.ownedById === selectedWebOwnedById,
+    (option) => option.value === selectedWebOwnedById,
   );
 
   return (
@@ -99,22 +108,41 @@ export const WebSelector = ({
         popper: { placement: "top" },
       }}
       disableClearable
+      inputHeight={inputHeight}
       inputProps={{
         endAdornment: <div />,
-        startAdornment: selectedWeb ? selectedWeb.avatarComponent : undefined,
+        startAdornment: selectedWeb ? (
+          <Box mr={0.5}>{selectedWeb.avatarComponent}</Box>
+        ) : undefined,
+        sx: {
+          [`&.${outlinedInputClasses.root}`]: {
+            px: optionPx,
+            py: 0,
+          },
+          height: inputHeight,
+        },
       }}
       multiple={false}
       onChange={(_event, option) => {
-        setSelectedWebOwnedById(option.ownedById);
+        setSelectedWebOwnedById(option.value);
       }}
       options={options}
       renderOption={(props, option) => (
-        <MenuItem {...props} key={option.ownedById} value={option.ownedById}>
+        <MenuItem
+          {...props}
+          key={option.value}
+          value={option.value}
+          sx={{
+            [`&.${autocompleteClasses.option}`]: {
+              px: optionPx - 0.5,
+            },
+          }}
+        >
           <RenderOptionContent {...option} />
         </MenuItem>
       )}
       sx={{
-        width: 150,
+        width: 250,
       }}
       value={selectedWeb}
     />

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/run-flow-modal/shared/dimensions.ts
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/run-flow-modal/shared/dimensions.ts
@@ -1,0 +1,1 @@
+export const inputHeight = 50;

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/run-flow-modal/types.ts
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/run-flow-modal/types.ts
@@ -1,6 +1,11 @@
-import type { EntityTypeWithMetadata, OwnedById } from "@local/hash-subgraph";
+import type {
+  Entity,
+  EntityTypeWithMetadata,
+  OwnedById,
+} from "@local/hash-subgraph";
 
 export type LocalInputValues = {
+  Entity: Entity;
   Text: string;
   Number: number;
   Boolean: boolean;
@@ -13,6 +18,6 @@ export type LocalPayloadKind = keyof LocalInputValues;
 export type LocalPayload = {
   [K in LocalPayloadKind]: {
     kind: K;
-    value: LocalInputValues[K] | LocalInputValues[K][];
+    value?: LocalInputValues[K] | LocalInputValues[K][];
   };
 }[LocalPayloadKind];

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/run-flow-modal/types.ts
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/run-flow-modal/types.ts
@@ -1,0 +1,18 @@
+import type { EntityTypeWithMetadata, OwnedById } from "@local/hash-subgraph";
+
+export type LocalInputValues = {
+  Text: string;
+  Number: number;
+  Boolean: boolean;
+  VersionedUrl: EntityTypeWithMetadata;
+  WebId: OwnedById;
+};
+
+export type LocalPayloadKind = keyof LocalInputValues;
+
+export type LocalPayload = {
+  [K in LocalPayloadKind]: {
+    kind: K;
+    value: LocalInputValues[K] | LocalInputValues[K][];
+  };
+}[LocalPayloadKind];

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/run-flow-modal/web-selector.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/run-flow-modal/web-selector.tsx
@@ -1,0 +1,122 @@
+import { Autocomplete, Avatar } from "@hashintel/design-system";
+import type { OwnedById } from "@local/hash-subgraph";
+import { Stack, Typography } from "@mui/material";
+import type { ReactElement } from "react";
+import { useMemo } from "react";
+
+import { useAuthenticatedUser } from "../../../shared/auth-info-context";
+import { getImageUrlFromEntityProperties } from "../../../shared/get-image-url-from-properties";
+import { MenuItem } from "../../../../shared/ui/menu-item";
+
+const RenderOptionContent = ({
+  avatarComponent,
+  title,
+}: {
+  avatarComponent: ReactElement;
+  title: string;
+}) => {
+  return (
+    <Stack direction="row" alignItems="center">
+      {avatarComponent}
+      <Typography
+        sx={{
+          fontSize: 14,
+          fontWeight: 500,
+          ml: 1,
+        }}
+      >
+        {title}
+      </Typography>
+    </Stack>
+  );
+};
+
+type WebSelectorProps = {
+  selectedWebOwnedById?: OwnedById;
+  setSelectedWebOwnedById: (ownedById: OwnedById) => void;
+};
+
+export const WebSelector = ({
+  selectedWebOwnedById,
+  setSelectedWebOwnedById,
+}: WebSelectorProps) => {
+  const { authenticatedUser } = useAuthenticatedUser();
+
+  const options = useMemo(() => {
+    return [
+      {
+        avatarComponent: (
+          <Avatar
+            size={22}
+            src={
+              authenticatedUser.hasAvatar
+                ? getImageUrlFromEntityProperties(
+                    authenticatedUser.hasAvatar.imageEntity.properties,
+                  )
+                : undefined
+            }
+            title={authenticatedUser.displayName ?? "?"}
+          />
+        ),
+        ownedById: authenticatedUser.accountId as OwnedById,
+        title: "My web",
+      },
+      ...authenticatedUser.memberOf.map(
+        ({ org: { accountGroupId, name, hasAvatar } }) => ({
+          avatarComponent: (
+            <Avatar
+              size={22}
+              src={
+                hasAvatar
+                  ? getImageUrlFromEntityProperties(
+                      hasAvatar.imageEntity.properties,
+                    )
+                  : undefined
+              }
+              title={name}
+            />
+          ),
+          ownedById: accountGroupId as OwnedById,
+          title: name,
+        }),
+      ),
+    ];
+  }, [authenticatedUser]);
+
+  const selectedWeb = options.find(
+    (option) => option.ownedById === selectedWebOwnedById,
+  );
+
+  return (
+    <Autocomplete
+      autoFocus={false}
+      componentsProps={{
+        paper: {
+          sx: {
+            p: 0.2,
+          },
+        },
+        popper: { placement: "top" },
+      }}
+      disableClearable
+      inputProps={{
+        endAdornment: <div />,
+        startAdornment: selectedWeb ? selectedWeb.avatarComponent : undefined,
+      }}
+      multiple={false}
+      onChange={(_event, option) => {
+        setSelectedWebOwnedById(option.ownedById);
+      }}
+      options={options}
+      renderOption={(props, option) => (
+        <MenuItem {...props} key={option.ownedById} value={option.ownedById}>
+          <RenderOptionContent {...option} />
+        </MenuItem>
+      )}
+      sx={{
+        width: 150,
+      }}
+      value={selectedWeb}
+    />
+  );
+};

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/shared/dimensions.ts
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/shared/dimensions.ts
@@ -3,11 +3,16 @@ export const nodeDimensions = {
   height: 245,
 };
 
-export const nodeTabHeight = 40;
+const tabHeight = 40;
+const offset = 12;
+
+export const nodeTabHeight = {
+  gross: tabHeight,
+  offset,
+  net: tabHeight - offset,
+};
 
 export const parentGroupPadding = {
   base: 30,
   top: 85,
 };
-
-export const baseNodeZIndex = 0;

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/shared/dimensions.ts
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/shared/dimensions.ts
@@ -1,6 +1,6 @@
 export const nodeDimensions = {
   width: 350,
-  height: 245,
+  height: 225,
 };
 
 const tabHeight = 40;

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/shared/flow-runs-context.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/shared/flow-runs-context.tsx
@@ -133,19 +133,23 @@ export const statusToSimpleStatus = (
 
 export const useStatusForSteps = (
   steps: { stepId: string }[],
-): SimpleStatus => {
+): SimpleStatus | null => {
   const { selectedFlowRun } = useFlowRunsContext();
 
   return useMemo(() => {
-    const stepRuns = selectedFlowRun?.steps.filter((stepRun) =>
+    if (!selectedFlowRun) {
+      return null;
+    }
+
+    const stepRuns = selectedFlowRun.steps.filter((stepRun) =>
       steps.find((step) => step.stepId === stepRun.stepId),
     );
 
-    const statuses = stepRuns?.map((stepRun) =>
+    const statuses = stepRuns.map((stepRun) =>
       statusToSimpleStatus(stepRun.status),
     );
 
-    if (!statuses || statuses.length === 0) {
+    if (statuses.length === 0) {
       return "Waiting";
     }
 

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/shared/flow-runs-context.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/shared/flow-runs-context.tsx
@@ -166,5 +166,5 @@ export const useStatusForSteps = (
     }
 
     return "Complete";
-  }, [selectedFlowRun?.steps, steps]);
+  }, [selectedFlowRun, steps]);
 };

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/shared/styles.ts
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/shared/styles.ts
@@ -1,0 +1,1 @@
+export const transitionOptions = { duration: 300 };

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/swimlane.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/swimlane.tsx
@@ -1,5 +1,6 @@
 import "reactflow/dist/style.css";
 
+import { customColors } from "@hashintel/design-system/theme";
 import type { StepGroup } from "@local/hash-isomorphic-utils/flows/types";
 import { Box, Fade, Stack, Typography } from "@mui/material";
 import type { ElkNode } from "elkjs/lib/elk.bundled.js";
@@ -20,11 +21,10 @@ import {
   useFlowRunsContext,
   useStatusForSteps,
 } from "./shared/flow-runs-context";
+import { transitionOptions } from "./shared/styles";
 import type { CustomNodeType } from "./shared/types";
 import { CustomEdge } from "./swimlane/custom-edge";
 import { CustomNode } from "./swimlane/custom-node";
-import { customColors } from "@hashintel/design-system/theme";
-import { transitionOptions } from "./shared/styles";
 
 const nodeTypes = {
   action: CustomNode,

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/swimlane.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/swimlane.tsx
@@ -208,6 +208,8 @@ export const Swimlane = ({
           edges={edges}
           edgeTypes={edgeTypes}
           proOptions={{ hideAttribution: true }}
+          preventScrolling={false}
+          zoomOnScroll={false}
           // fitView
           // onNodesChange={onNodesChange}
           // onEdgesChange={onEdgesChange}

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/swimlane/custom-node.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/swimlane/custom-node.tsx
@@ -1,5 +1,6 @@
 import { Box, Stack, Typography } from "@mui/material";
 import { formatDistance } from "date-fns";
+import { useEffect, useState } from "react";
 import type { NodeProps } from "reactflow";
 
 import {
@@ -10,7 +11,6 @@ import type { NodeData } from "../shared/types";
 import { Handles } from "./custom-node/handles";
 import { NodeContainer } from "./custom-node/node-container";
 import { statusSx } from "./custom-node/node-styles";
-import { useEffect, useState } from "react";
 
 const getTimeAgo = (isoString: string) =>
   formatDistance(new Date(isoString), new Date(), {
@@ -47,9 +47,13 @@ export const CustomNode = ({ data, selected }: NodeProps<NodeData>) => {
     let timeUpdateInterval: NodeJS.Timeout | undefined;
 
     if (isoString) {
+      setTimeAgo(getTimeAgo(isoString));
+
       timeUpdateInterval = setInterval(() => {
         setTimeAgo(getTimeAgo(isoString));
       }, 5_000);
+    } else {
+      setTimeAgo("");
     }
 
     return () => {
@@ -57,7 +61,7 @@ export const CustomNode = ({ data, selected }: NodeProps<NodeData>) => {
         clearInterval(timeUpdateInterval);
       }
     };
-  }, [isoString, timeAgo]);
+  }, [isoString]);
 
   return (
     <NodeContainer
@@ -85,7 +89,7 @@ export const CustomNode = ({ data, selected }: NodeProps<NodeData>) => {
           </Typography>
         </Stack>
 
-        {!isParallelizedGroup && (
+        {!isParallelizedGroup && statusData && (
           <Box
             sx={{
               background: styles.lightestBackground,

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/swimlane/custom-node/handles.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/swimlane/custom-node/handles.tsx
@@ -80,7 +80,7 @@ const CustomHandle = ({
   );
 };
 
-const halfContentHeight = (nodeDimensions.height - nodeTabHeight) / 2;
+const halfContentHeight = (nodeDimensions.height - nodeTabHeight.gross) / 2;
 
 export const Handles = ({
   kind,

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/swimlane/custom-node/node-container.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/swimlane/custom-node/node-container.tsx
@@ -6,6 +6,8 @@ import { useNodeId, useStore } from "reactflow";
 import { nodeTabHeight } from "../../shared/dimensions";
 import type { SimpleStatus } from "../../shared/flow-runs-context";
 import { statusSx } from "./node-styles";
+import { useFlowRunsContext } from "../../shared/flow-runs-context";
+import { transitionOptions } from "../../shared/styles";
 
 const Tab = ({
   label,
@@ -24,23 +26,26 @@ const Tab = ({
         background:
           position === "left" ? styles.lightBackground : styles.darkBackground,
         borderColor: styles.borderColor,
-        transition: transitions.create(["background", "borderColor"]),
         borderWidth: 1,
         borderStyle: "solid",
         borderBottomWidth: 0,
         borderTopLeftRadius: "7px",
         borderTopRightRadius: "7px",
-        height: nodeTabHeight,
+        height: nodeTabHeight.gross,
         px: 1,
         pt: 0.5,
         pb: 2,
         position: "relative",
-        top: 12,
+        top: nodeTabHeight.offset,
+        transition: transitions.create(
+          ["background", "borderColor"],
+          transitionOptions,
+        ),
         zIndex: -1,
       })}
     >
       <Typography
-        sx={({ palette }) => ({
+        sx={({ palette, transitions }) => ({
           color:
             position === "left"
               ? styles.text
@@ -49,6 +54,7 @@ const Tab = ({
                 : palette.common.white,
           fontSize: 12,
           fontWeight: 500,
+          transition: transitions.create("color", transitionOptions),
         })}
       >
         {label}
@@ -68,6 +74,8 @@ export const NodeContainer = ({
   stepStatusName: SimpleStatus;
 }>) => {
   const nodeId = useNodeId();
+
+  const { selectedFlowRun } = useFlowRunsContext();
 
   const size = useStore((state) => {
     if (nodeId) {
@@ -95,7 +103,7 @@ export const NodeContainer = ({
           label={nodeId === "trigger" ? "Trigger" : `Action ${nodeId ?? "?"}`}
           position="left"
         />
-        {kind !== "parallel-group" && (
+        {selectedFlowRun && kind !== "parallel-group" && (
           <Tab
             status={stepStatusName}
             label={stepStatusName}

--- a/apps/hash-frontend/src/pages/flows.page/flow-definition/swimlane/custom-node/node-container.tsx
+++ b/apps/hash-frontend/src/pages/flows.page/flow-definition/swimlane/custom-node/node-container.tsx
@@ -5,9 +5,9 @@ import { useNodeId, useStore } from "reactflow";
 
 import { nodeTabHeight } from "../../shared/dimensions";
 import type { SimpleStatus } from "../../shared/flow-runs-context";
-import { statusSx } from "./node-styles";
 import { useFlowRunsContext } from "../../shared/flow-runs-context";
 import { transitionOptions } from "../../shared/styles";
+import { statusSx } from "./node-styles";
 
 const Tab = ({
   label,

--- a/apps/hash-frontend/src/pages/shared/block-collection/block-context-menu/block-select-data-modal.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/block-context-menu/block-select-data-modal.tsx
@@ -186,9 +186,8 @@ export const BlockSelectDataModal: FunctionComponent<
       {...modalProps}
       contentStyle={{
         overflow: "hidden",
-        /** @todo: figure out why !important is required here */
-        padding: "0px !important",
-        width: "fit-content !important",
+        p: { xs: 0, md: 0 },
+        width: { xs: "fit-content", sm: "fit-content" },
         maxWidth: "90vw",
       }}
       onClose={onClose}

--- a/apps/hash-frontend/src/pages/shared/entity-selector.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-selector.tsx
@@ -1,0 +1,213 @@
+import { useQuery } from "@apollo/client";
+import type {
+  SelectorAutocompleteProps,
+  TypeListSelectorDropdownProps,
+} from "@hashintel/design-system";
+import { Chip, SelectorAutocomplete } from "@hashintel/design-system";
+import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
+import {
+  currentTimeInstantTemporalAxes,
+  generateVersionedUrlMatchingFilter,
+  mapGqlSubgraphFieldsFragmentToSubgraph,
+  zeroedGraphResolveDepths,
+} from "@local/hash-isomorphic-utils/graph-queries";
+import type {
+  Entity,
+  EntityId,
+  EntityRootType,
+  EntityTypeWithMetadata,
+  Subgraph,
+} from "@local/hash-subgraph";
+import {
+  entityIdFromComponents,
+  extractDraftIdFromEntityId,
+  splitEntityId,
+} from "@local/hash-subgraph";
+import { getRoots } from "@local/hash-subgraph/stdlib";
+import { useMemo, useState } from "react";
+
+import type {
+  StructuralQueryEntitiesQuery,
+  StructuralQueryEntitiesQueryVariables,
+} from "../../graphql/api-types.gen";
+import { structuralQueryEntitiesQuery } from "../../graphql/queries/knowledge/entity.queries";
+
+type EntitySelectorProps<Multiple extends boolean = false> = Omit<
+  SelectorAutocompleteProps<Entity, Multiple>,
+  | "inputValue"
+  | "loading"
+  | "options"
+  | "onSelect"
+  | "onInputChange"
+  | "optionToRenderData"
+  | "dropdownProps"
+> & {
+  dropdownProps?: Omit<TypeListSelectorDropdownProps, "query">;
+  expectedEntityTypes?: EntityTypeWithMetadata[];
+  entityIdsToFilterOut?: EntityId[];
+  includeDrafts: boolean;
+  multiple?: Multiple;
+  onSelect: (
+    event: Multiple extends true ? Entity[] : Entity,
+    sourceSubgraph: Subgraph<EntityRootType> | null,
+  ) => void;
+  value?: Multiple extends true ? Entity : Entity[];
+};
+
+export const EntitySelector = <Multiple extends boolean>({
+  expectedEntityTypes,
+  entityIdsToFilterOut,
+  includeDrafts,
+  onSelect,
+  ...autocompleteProps
+}: EntitySelectorProps<Multiple>) => {
+  const [query, setQuery] = useState("");
+
+  const { data: entitiesData, loading } = useQuery<
+    StructuralQueryEntitiesQuery,
+    StructuralQueryEntitiesQueryVariables
+  >(structuralQueryEntitiesQuery, {
+    variables: {
+      query: {
+        filter:
+          !expectedEntityTypes || expectedEntityTypes.length === 0
+            ? { all: [] }
+            : {
+                any: expectedEntityTypes.map(({ schema }) =>
+                  generateVersionedUrlMatchingFilter(schema.$id, {
+                    ignoreParents: true,
+                  }),
+                ),
+              },
+        temporalAxes: currentTimeInstantTemporalAxes,
+        graphResolveDepths: {
+          ...zeroedGraphResolveDepths,
+          inheritsFrom: { outgoing: 255 },
+          isOfType: { outgoing: 1 },
+        },
+        includeDrafts,
+      },
+      includePermissions: false,
+    },
+  });
+
+  const entitiesSubgraph = entitiesData
+    ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
+        entitiesData.structuralQueryEntities.subgraph,
+      )
+    : undefined;
+
+  const sortedAndFilteredEntities = useMemo(() => {
+    if (!entitiesSubgraph) {
+      return [];
+    }
+    const subgraphRoots = getRoots(entitiesSubgraph);
+
+    const hasLiveVersion: Record<EntityId, boolean> = {};
+
+    return subgraphRoots
+      .filter((entity) => {
+        const rootEntityId = entity.metadata.recordId.entityId;
+
+        if (entity.metadata.archived) {
+          return false;
+        }
+
+        if (entityIdsToFilterOut?.includes(rootEntityId)) {
+          return false;
+        }
+
+        if (includeDrafts) {
+          /**
+           * If we have included drafts in the query, we may have multiple roots for a single entity for the current
+           * time, in the case where it has a 'live' (non-draft) version and one or more unarchived draft updates.
+           *
+           * We only want one result, which should be the live version if it exists, or the single draft if there's no
+           * live. Entities without a live version can't have multiple drafts at a point in time because there's
+           * nothing to fork multiple from.
+           */
+          const [ownedById, entityUuid, draftId] = splitEntityId(rootEntityId);
+          if (!draftId) {
+            /** If there is no draftId, this is the live version, which is always preferred in the selector */
+            hasLiveVersion[rootEntityId] = true;
+            return true;
+          }
+
+          /** This has a draftId, and therefore is only permitted if there is no live version */
+          const liveEntityId = entityIdFromComponents(ownedById, entityUuid);
+          if (hasLiveVersion[liveEntityId]) {
+            /**
+             * We already checked for this entityId and there is a live version
+             */
+            return false;
+          }
+          if (
+            subgraphRoots.some(
+              (possiblyLiveEntity) =>
+                possiblyLiveEntity.metadata.recordId.entityId === liveEntityId,
+            )
+          ) {
+            hasLiveVersion[liveEntityId] = true;
+            return false;
+          }
+          /**
+           * We don't bother to memoize a false result because there will only one draft version if there isn't a live,
+           * and therefore we're not going to see this liveEntityId again in the loop.
+           */
+        }
+
+        return true;
+      })
+      .sort((a, b) =>
+        a.metadata.temporalVersioning.decisionTime.start.limit.localeCompare(
+          b.metadata.temporalVersioning.decisionTime.start.limit,
+        ),
+      );
+  }, [entitiesSubgraph, entityIdsToFilterOut, includeDrafts]);
+
+  return (
+    <SelectorAutocomplete<Entity, Multiple>
+      loading={loading}
+      onChange={(_, option) => {
+        onSelect(option, entitiesSubgraph ?? null);
+      }}
+      inputValue={query}
+      isOptionEqualToValue={(option, value) =>
+        option.metadata.recordId.entityId === value.metadata.recordId.entityId
+      }
+      onInputChange={(_, value) => setQuery(value)}
+      options={sortedAndFilteredEntities}
+      optionToRenderData={(entity) => {
+        return {
+          entityProperties: entity.properties,
+          uniqueId: entity.metadata.recordId.entityId,
+          icon: null,
+          /**
+           * @todo update SelectorAutocomplete to show an entity's namespace as well as / instead of its entityTypeId
+           * */
+          typeId: entity.metadata.entityTypeId,
+          title: generateEntityLabel(entitiesSubgraph!, entity),
+          draft: !!extractDraftIdFromEntityId(
+            entity.metadata.recordId.entityId,
+          ),
+        };
+      }}
+      placeholder="Search for an entity"
+      renderTags={(tagValue, getTagProps) =>
+        tagValue.map((option, index) => (
+          <Chip
+            {...getTagProps({ index })}
+            key={option.metadata.recordId.entityId}
+            variant="outlined"
+            label={generateEntityLabel(entitiesSubgraph!, option)}
+          />
+        ))
+      }
+      {...autocompleteProps}
+      dropdownProps={{
+        query,
+        ...autocompleteProps.dropdownProps,
+      }}
+    />
+  );
+};

--- a/apps/hash-frontend/src/pages/shared/entity-type-page/shared/entity-type-header.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-page/shared/entity-type-header.tsx
@@ -125,10 +125,7 @@ export const EntityTypeHeader = ({
           <EntityTypeDescription readonly={isReadonly} />
         </Box>
       </Box>
-      <Modal
-        open={showExtendTypeModal}
-        contentStyle={{ padding: "0px !important" }}
-      >
+      <Modal open={showExtendTypeModal} contentStyle={{ p: { xs: 0, md: 0 } }}>
         <>
           <Typography
             sx={({ palette }) => ({

--- a/apps/hash-frontend/src/pages/shared/entity-type-selector.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-selector.tsx
@@ -16,6 +16,7 @@ export const EntityTypeSelector = <Multiple extends boolean = false>({
   disableCreate,
   disableCreateNewEmpty,
   excludeEntityTypeIds,
+  inputHeight,
   autoFocus,
   multiple,
   onCancel,
@@ -25,6 +26,7 @@ export const EntityTypeSelector = <Multiple extends boolean = false>({
   value,
 }: {
   excludeEntityTypeIds?: VersionedUrl[];
+  inputHeight?: number;
   multiple?: Multiple;
   onSelect: (
     value: Multiple extends true
@@ -74,6 +76,7 @@ export const EntityTypeSelector = <Multiple extends boolean = false>({
         variant: "entity type",
       }}
       autoFocus={autoFocus}
+      inputHeight={inputHeight}
       options={filteredEntityTypes ?? []}
       multiple={multiple}
       filterOptions={(options, { inputValue }) => {

--- a/apps/hash-frontend/src/pages/shared/entity-type-selector.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-selector.tsx
@@ -63,17 +63,19 @@ export const EntityTypeSelector = <Multiple extends boolean = false>({
     <SelectorAutocomplete<EntityTypeWithMetadata, Multiple>
       dropdownProps={{
         query: search,
-        createButtonProps: disableCreate
-          ? null
-          : {
-              onMouseDown: (evt) => {
-                evt.preventDefault();
-                evt.stopPropagation();
-                onCreateNew?.(search);
+        creationProps: {
+          createButtonProps: disableCreate
+            ? null
+            : {
+                onMouseDown: (evt) => {
+                  evt.preventDefault();
+                  evt.stopPropagation();
+                  onCreateNew?.(search);
+                },
+                disabled: disableCreateNewEmpty && search === "",
               },
-              disabled: disableCreateNewEmpty && search === "",
-            },
-        variant: "entity type",
+          variant: "entity type",
+        },
       }}
       autoFocus={autoFocus}
       inputHeight={inputHeight}

--- a/apps/hash-frontend/src/pages/signin.page.tsx
+++ b/apps/hash-frontend/src/pages/signin.page.tsx
@@ -103,8 +103,6 @@ const SigninPage: NextPageWithLayout = () => {
     return redirectPath;
   }, [router]);
 
-  console.log({ returnTo });
-
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
   const [errorMessage, setErrorMessage] = useState<string>();

--- a/apps/hash-frontend/src/pages/signin.page.tsx
+++ b/apps/hash-frontend/src/pages/signin.page.tsx
@@ -103,6 +103,8 @@ const SigninPage: NextPageWithLayout = () => {
     return redirectPath;
   }, [router]);
 
+  console.log({ returnTo });
+
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
   const [errorMessage, setErrorMessage] = useState<string>();

--- a/apps/plugin-browser/src/pages/shared/use-storage-sync.ts
+++ b/apps/plugin-browser/src/pages/shared/use-storage-sync.ts
@@ -1,10 +1,9 @@
+import type { NonUndefined } from "@local/advanced-types/non-undefined";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import browser from "webextension-polyfill";
 
 import type { LocalStorage } from "../../shared/storage";
 import { getFromLocalStorage, setInLocalStorage } from "../../shared/storage";
-
-type NonUndefined<T> = T extends undefined ? never : T;
 
 /**
  * A hook to keep React state synced with local storage shared across the extension.

--- a/libs/@hashintel/block-design-system/src/entities-graph-chart.tsx
+++ b/libs/@hashintel/block-design-system/src/entities-graph-chart.tsx
@@ -39,8 +39,6 @@ export const EntitiesGraphChart: FunctionComponent<{
 }) => {
   const [chart, setChart] = useState<Chart>();
 
-  /** @todo filter out duplicate entities, which crash the chart */
-
   const nonLinkEntities = useMemo(
     () =>
       entities?.filter(

--- a/libs/@hashintel/block-design-system/src/entities-graph-chart.tsx
+++ b/libs/@hashintel/block-design-system/src/entities-graph-chart.tsx
@@ -39,6 +39,8 @@ export const EntitiesGraphChart: FunctionComponent<{
 }) => {
   const [chart, setChart] = useState<Chart>();
 
+  /** @todo filter out duplicate entities, which crash the chart */
+
   const nonLinkEntities = useMemo(
     () =>
       entities?.filter(
@@ -122,7 +124,7 @@ export const EntitiesGraphChart: FunctionComponent<{
               ({ metadata }) => metadata.recordId.entityId === id,
             );
 
-            if (linkEntity) {
+            if (linkEntity && subgraph) {
               const leftEntity = entities?.find(
                 ({ metadata }) =>
                   metadata.recordId.entityId ===
@@ -136,18 +138,18 @@ export const EntitiesGraphChart: FunctionComponent<{
               );
 
               const linkEntityTypeTitle = getEntityTypeById(
-                subgraph!,
+                subgraph,
                 linkEntity.metadata.entityTypeId,
               )?.schema.title;
 
               return [
                 `<strong>${generateEntityLabel(
-                  subgraph!,
+                  subgraph,
                   leftEntity!,
                 )}</strong>`,
                 linkEntityTypeTitle?.toLowerCase(),
                 `<strong>${generateEntityLabel(
-                  subgraph!,
+                  subgraph,
                   rightEntity!,
                 )}</strong>`,
               ].join(" ");
@@ -157,9 +159,9 @@ export const EntitiesGraphChart: FunctionComponent<{
               ({ metadata }) => metadata.recordId.entityId === id,
             );
 
-            if (entity) {
+            if (entity && subgraph) {
               const entityType = getEntityTypeById(
-                subgraph!,
+                subgraph,
                 entity.metadata.entityTypeId,
               );
 

--- a/libs/@hashintel/design-system/src/autocomplete-dropdown.tsx
+++ b/libs/@hashintel/design-system/src/autocomplete-dropdown.tsx
@@ -19,7 +19,8 @@ export const AutocompleteDropdown = ({
           left: 0,
           right: 0,
           width: "100%",
-          height: `calc(100% + ${inputHeight}px)`,
+          /** If we have a fixed height, we can stretch the box shadow over the input. If not, don't stretch it */
+          height: `calc(100% + ${inputHeight === "auto" ? 0 : inputHeight}px)`,
           boxShadow: theme.boxShadows.md,
           pointerEvents: "none",
           borderRadius: `${textFieldBorderRadius}px`,

--- a/libs/@hashintel/design-system/src/components.ts
+++ b/libs/@hashintel/design-system/src/components.ts
@@ -41,6 +41,7 @@ export * from "./icon-list-regular";
 export * from "./icon-magnifying-glass-regular";
 export * from "./icon-pen-to-square-solid";
 export * from "./icon-person-running-regular";
+export * from "./icon-play-solid";
 export * from "./icon-plus";
 export * from "./icon-rainbow-hash";
 export * from "./icon-rotate-regular";

--- a/libs/@hashintel/design-system/src/icon-play-solid.tsx
+++ b/libs/@hashintel/design-system/src/icon-play-solid.tsx
@@ -1,0 +1,17 @@
+import type { SvgIconProps } from "@mui/material";
+import { SvgIcon } from "@mui/material";
+import type { FunctionComponent } from "react";
+
+export const PlayIconSolid: FunctionComponent<SvgIconProps> = (props) => {
+  return (
+    <SvgIcon
+      width="384"
+      height="512"
+      viewBox="0 0 384 512"
+      fill="none"
+      {...props}
+    >
+      <path d="M73 39c-14.8-9.1-33.4-9.4-48.5-.9S0 62.6 0 80V432c0 17.4 9.4 33.4 24.5 41.9s33.7 8.1 48.5-.9L361 297c14.3-8.7 23-24.2 23-41s-8.7-32.2-23-41L73 39z" />
+    </SvgIcon>
+  );
+};

--- a/libs/@hashintel/design-system/src/selector-autocomplete.tsx
+++ b/libs/@hashintel/design-system/src/selector-autocomplete.tsx
@@ -30,14 +30,23 @@ import { TextField } from "./text-field";
 export const TYPE_SELECTOR_HEIGHT = 57;
 
 export type TypeListSelectorDropdownProps = {
+  creationProps?: {
+    createButtonProps: Omit<
+      ButtonProps,
+      "children" | "variant" | "size"
+    > | null;
+    variant: "entity type" | "property type" | "entity" | "file" | "link type";
+  };
   query: string;
-  createButtonProps: Omit<ButtonProps, "children" | "variant" | "size"> | null;
-  inputHeight?: number;
-  variant: "entity type" | "property type" | "entity" | "file" | "link type";
 };
 
-const DropdownPropsContext =
-  createContext<TypeListSelectorDropdownProps | null>(null);
+const DropdownPropsContext = createContext<
+  | (TypeListSelectorDropdownProps & {
+      inputHeight: number | string;
+      multiple?: boolean;
+    })
+  | null
+>(null);
 
 const useDropdownProps = () => {
   const value = useContext(DropdownPropsContext);
@@ -52,16 +61,16 @@ const useDropdownProps = () => {
 const TypeListSelectorDropdown = ({
   children,
   ...props
-}: PaperProps & { inputHeight?: number }) => {
-  const { query, createButtonProps, inputHeight, variant } = useDropdownProps();
+}: PaperProps & { inputHeight?: number; multiple?: boolean }) => {
+  const { query, creationProps, inputHeight, multiple } = useDropdownProps();
 
   return (
     <AutocompleteDropdown
       {...props}
-      inputHeight={inputHeight ?? TYPE_SELECTOR_HEIGHT}
+      inputHeight={multiple ? "auto" : inputHeight}
     >
       {children}
-      {createButtonProps ? (
+      {creationProps ? (
         <Button
           variant="tertiary"
           startIcon={<StyledPlusCircleIcon />}
@@ -71,7 +80,7 @@ const TypeListSelectorDropdown = ({
             alignItems: "center",
             mt: 1,
           }}
-          {...createButtonProps}
+          {...creationProps.createButtonProps}
         >
           <Typography
             variant="smallTextLabels"
@@ -96,16 +105,28 @@ const TypeListSelectorDropdown = ({
               </Typography>
             </>
           ) : null}
-          {variant === "entity type" ? (
-            <Chip color="teal" label={variant.toUpperCase()} sx={{ ml: 1.5 }} />
-          ) : variant === "entity" ? (
-            <Chip color="teal" label={variant.toUpperCase()} sx={{ ml: 1.5 }} />
-          ) : variant === "link type" ? (
-            <Chip color="aqua" label={variant.toUpperCase()} sx={{ ml: 1.5 }} />
+          {creationProps.variant === "entity type" ? (
+            <Chip
+              color="teal"
+              label={creationProps.variant.toUpperCase()}
+              sx={{ ml: 1.5 }}
+            />
+          ) : creationProps.variant === "entity" ? (
+            <Chip
+              color="teal"
+              label={creationProps.variant.toUpperCase()}
+              sx={{ ml: 1.5 }}
+            />
+          ) : creationProps.variant === "link type" ? (
+            <Chip
+              color="aqua"
+              label={creationProps.variant.toUpperCase()}
+              sx={{ ml: 1.5 }}
+            />
           ) : (
             <Chip
               color="purple"
-              label={variant.toUpperCase()}
+              label={creationProps.variant.toUpperCase()}
               sx={{ ml: 1.5 }}
             />
           )}
@@ -120,14 +141,14 @@ type OptionRenderData = Omit<SelectorAutocompleteOptionProps, "liProps"> & {
   uniqueId: string;
 };
 
-type SelectorAutocompleteProps<
+export type SelectorAutocompleteProps<
   T,
   Multiple extends boolean | undefined = undefined,
 > = Omit<
   AutocompleteProps<T, Multiple, true, false>,
   "renderInput" | "renderOption" | "getOptionLabel" | "componentsProps"
 > & {
-  inputHeight?: number;
+  inputHeight?: number | string;
   inputRef?: Ref<Element>;
   inputPlaceholder?: string;
   /** Determines if a given option matches a selected value (defaults to strict equality) */
@@ -162,6 +183,7 @@ export const SelectorAutocomplete = <
   joined,
   onClickAway,
   PaperComponent,
+  multiple,
   ...rest
 }: SelectorAutocompleteProps<
   Multiple extends true ? (T extends unknown[] ? T[number] : T) : T,
@@ -179,10 +201,22 @@ export const SelectorAutocomplete = <
 
   const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
 
+  const height = inputHeight ?? TYPE_SELECTOR_HEIGHT;
+
+  const dropdownContextValue = useMemo(
+    () => ({
+      inputHeight: height,
+      multiple,
+      ...dropdownProps,
+    }),
+    [dropdownProps, height, multiple],
+  );
+
   return (
-    <DropdownPropsContext.Provider value={dropdownProps}>
+    <DropdownPropsContext.Provider value={dropdownContextValue}>
       <ClickAwayListener onClickAway={() => onClickAway?.()}>
         <Autocomplete
+          multiple={multiple}
           open={open}
           sx={[{ width: "100%" }, ...(Array.isArray(sx) ? sx : [sx])]}
           /**
@@ -227,7 +261,8 @@ export const SelectorAutocomplete = <
                   (theme) => ({
                     // The popover needs to know how tall this is to draw
                     // a shadow around it
-                    height: inputHeight ?? TYPE_SELECTOR_HEIGHT,
+                    height: multiple ? "auto" : height,
+                    minHeight: height,
                     py: "0 !important",
 
                     // Focus is handled by the options popover

--- a/libs/@hashintel/design-system/src/selector-autocomplete.tsx
+++ b/libs/@hashintel/design-system/src/selector-autocomplete.tsx
@@ -32,6 +32,7 @@ export const TYPE_SELECTOR_HEIGHT = 57;
 export type TypeListSelectorDropdownProps = {
   query: string;
   createButtonProps: Omit<ButtonProps, "children" | "variant" | "size"> | null;
+  inputHeight?: number;
   variant: "entity type" | "property type" | "entity" | "file" | "link type";
 };
 
@@ -48,11 +49,17 @@ const useDropdownProps = () => {
   return value;
 };
 
-const TypeListSelectorDropdown = ({ children, ...props }: PaperProps) => {
-  const { query, createButtonProps, variant } = useDropdownProps();
+const TypeListSelectorDropdown = ({
+  children,
+  ...props
+}: PaperProps & { inputHeight?: number }) => {
+  const { query, createButtonProps, inputHeight, variant } = useDropdownProps();
 
   return (
-    <AutocompleteDropdown {...props} inputHeight={TYPE_SELECTOR_HEIGHT}>
+    <AutocompleteDropdown
+      {...props}
+      inputHeight={inputHeight ?? TYPE_SELECTOR_HEIGHT}
+    >
       {children}
       {createButtonProps ? (
         <Button
@@ -120,6 +127,7 @@ type SelectorAutocompleteProps<
   AutocompleteProps<T, Multiple, true, false>,
   "renderInput" | "renderOption" | "getOptionLabel" | "componentsProps"
 > & {
+  inputHeight?: number;
   inputRef?: Ref<Element>;
   inputPlaceholder?: string;
   /** Determines if a given option matches a selected value (defaults to strict equality) */
@@ -145,6 +153,7 @@ export const SelectorAutocomplete = <
   isOptionEqualToValue,
   optionToRenderData,
   sx,
+  inputHeight,
   inputRef,
   inputPlaceholder,
   dropdownProps,
@@ -218,7 +227,8 @@ export const SelectorAutocomplete = <
                   (theme) => ({
                     // The popover needs to know how tall this is to draw
                     // a shadow around it
-                    height: TYPE_SELECTOR_HEIGHT,
+                    height: inputHeight ?? TYPE_SELECTOR_HEIGHT,
+                    py: "0 !important",
 
                     // Focus is handled by the options popover
                     "&.Mui-focused": {

--- a/libs/@hashintel/type-editor/src/entity-type-editor/property-list-card/property-type-form/expected-value-selector/shared/delete-expected-value-modal.tsx
+++ b/libs/@hashintel/type-editor/src/entity-type-editor/property-list-card/property-type-form/expected-value-selector/shared/delete-expected-value-modal.tsx
@@ -64,7 +64,7 @@ export const DeleteExpectedValueModal = ({
     <Modal
       {...bindDialog(popupState)}
       contentStyle={(theme) => ({
-        p: "0px !important",
+        p: { xs: 0, md: 0 },
         border: 1,
         borderColor: theme.palette.gray[20],
       })}

--- a/libs/@hashintel/type-editor/src/entity-type-editor/shared/insert-type-field.tsx
+++ b/libs/@hashintel/type-editor/src/entity-type-editor/shared/insert-type-field.tsx
@@ -108,18 +108,20 @@ export const InsertTypeField = <T extends TypeSelectorType>({
             options={options}
             dropdownProps={{
               query: searchText,
-              createButtonProps: createModalPopupState
-                ? {
-                    ...withHandler(bindTrigger(createModalPopupState), () => {
-                      ourInputRef.current?.focus();
-                    }),
-                    onMouseDown: (evt) => {
-                      evt.preventDefault();
-                      evt.stopPropagation();
-                    },
-                  }
-                : null,
-              variant,
+              creationProps: {
+                createButtonProps: createModalPopupState
+                  ? {
+                      ...withHandler(bindTrigger(createModalPopupState), () => {
+                        ourInputRef.current?.focus();
+                      }),
+                      onMouseDown: (evt) => {
+                        evt.preventDefault();
+                        evt.stopPropagation();
+                      },
+                    }
+                  : null,
+                variant,
+              },
             }}
             variant={variant}
           />

--- a/libs/@hashintel/type-editor/src/entity-type-editor/shared/type-form.tsx
+++ b/libs/@hashintel/type-editor/src/entity-type-editor/shared/type-form.tsx
@@ -214,7 +214,7 @@ export const TypeFormModal: PolymorphicComponent = forwardRef(
         {...bindDialog(popupState)}
         disableEscapeKeyDown
         contentStyle={(theme) => ({
-          p: "0px !important",
+          p: { xs: 0, md: 0 },
           border: 1,
           borderColor: theme.palette.gray[20],
         })}

--- a/libs/@local/advanced-types/src/distribute.ts
+++ b/libs/@local/advanced-types/src/distribute.ts
@@ -1,7 +1,8 @@
 /**
- * 'Omit' for use on a union, to 'distribute' the omit across the union, rather than applying it to an interaction of the union
- * – 'Omit' applys to an interaction because of its use of keyof, which returns the common keys of the union,
- *    which results in also losing keys which are not present on all members of the union.
+ * 'Omit' for use on a union, to 'distribute' the omit across the union, rather than applying it to an intersection of the union
+ * – 'Omit' applies to an intersection because it applies keyof to T, which gives an interaction of the keys of union T.
+ * We must use a conditional mapped type to apply the Omit to each member of the union instead.
+ * @see https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types
  */
 export type DistributiveOmit<T, K extends keyof T> = T extends unknown
   ? Omit<T, K>

--- a/libs/@local/advanced-types/src/non-undefined.ts
+++ b/libs/@local/advanced-types/src/non-undefined.ts
@@ -1,0 +1,1 @@
+export type NonUndefined<T> = T extends undefined ? never : T;

--- a/libs/@local/hash-isomorphic-utils/src/flows/example-flow-definitions.ts
+++ b/libs/@local/hash-isomorphic-utils/src/flows/example-flow-definitions.ts
@@ -19,19 +19,31 @@ export const researchTaskFlowDefinition: FlowDefinition = {
     outputs: [
       {
         payloadKind: "Text",
-        name: "prompt" as const,
+        name: "Research guidance" as const,
         array: false,
         required: true,
       },
       {
         payloadKind: "VersionedUrl",
-        name: "entityTypeIds",
+        name: "Entity Types",
         array: true,
         required: true,
       },
       {
         payloadKind: "Text",
-        name: "question",
+        name: "Research question",
+        array: false,
+        required: true,
+      },
+      {
+        payloadKind: "WebId",
+        name: "Create in",
+        array: false,
+        required: true,
+      },
+      {
+        payloadKind: "Boolean",
+        name: "Create as draft",
         array: false,
         required: true,
       },
@@ -49,14 +61,14 @@ export const researchTaskFlowDefinition: FlowDefinition = {
           inputName: "prompt" satisfies InputNameForAction<"researchEntities">,
           kind: "step-output",
           sourceStepId: "trigger",
-          sourceStepOutputName: "prompt",
+          sourceStepOutputName: "Research guidance",
         },
         {
           inputName:
             "entityTypeIds" satisfies InputNameForAction<"researchEntities">,
           kind: "step-output",
           sourceStepId: "trigger",
-          sourceStepOutputName: "entityTypeIds",
+          sourceStepOutputName: "Entity Types",
         },
       ],
     },
@@ -74,6 +86,19 @@ export const researchTaskFlowDefinition: FlowDefinition = {
           sourceStepOutputName:
             "proposedEntities" satisfies OutputNameForAction<"researchEntities">,
         },
+        {
+          inputName: "webId" satisfies InputNameForAction<"persistEntities">,
+          kind: "step-output",
+          sourceStepId: "trigger",
+          sourceStepOutputName: "Create in",
+        },
+        {
+          inputName:
+            "proposedEntities" satisfies InputNameForAction<"persistEntities">,
+          kind: "step-output",
+          sourceStepId: "trigger",
+          sourceStepOutputName: "Create as draft",
+        },
       ],
     },
     {
@@ -86,7 +111,7 @@ export const researchTaskFlowDefinition: FlowDefinition = {
           inputName: "question" satisfies InputNameForAction<"answerQuestion">,
           kind: "step-output",
           sourceStepId: "trigger",
-          sourceStepOutputName: "question",
+          sourceStepOutputName: "Research question",
         },
         {
           inputName: "entities" satisfies InputNameForAction<"answerQuestion">,

--- a/libs/@local/hash-isomorphic-utils/src/flows/example-flow-definitions.ts
+++ b/libs/@local/hash-isomorphic-utils/src/flows/example-flow-definitions.ts
@@ -9,6 +9,8 @@ import type { FlowDefinition } from "./types";
 export const researchTaskFlowDefinition: FlowDefinition = {
   name: "Research Task",
   flowDefinitionId: "research-task" as EntityUuid,
+  description:
+    "Conduct research on a given topic, and provide expert analysis on the discovered data",
   trigger: {
     triggerDefinitionId: "userTrigger",
     description:
@@ -120,6 +122,8 @@ export const researchTaskFlowDefinition: FlowDefinition = {
 export const ftseInvestorsFlowDefinition: FlowDefinition = {
   name: "FTSE350 Investors",
   flowDefinitionId: "ftse-350-investors" as EntityUuid,
+  description:
+    "Research the FTSE350 index, its constituents, and the top investors in the index",
   trigger: {
     triggerDefinitionId: "userTrigger",
     description:
@@ -355,6 +359,8 @@ export const ftseInvestorsFlowDefinition: FlowDefinition = {
 export const inferUserEntitiesFromWebPageFlowDefinition: FlowDefinition = {
   name: "Infer User Entities from Web Page",
   flowDefinitionId: "infer-user-entities-from-web-page" as EntityUuid,
+  description:
+    "Infer entities from a web page, based on the user's provided entity types",
   trigger: {
     kind: "trigger",
     description: "Triggered when user visits a web page",
@@ -468,6 +474,7 @@ export const inferUserEntitiesFromWebPageFlowDefinition: FlowDefinition = {
 export const answerQuestionFlow: FlowDefinition = {
   name: "Answer Question Flow",
   flowDefinitionId: "answer-question-flow" as EntityUuid,
+  description: "Answer a question based on the provided context",
   trigger: {
     kind: "trigger",
     description: "Triggered when user asks a question and provides context",
@@ -548,6 +555,7 @@ export const answerQuestionFlow: FlowDefinition = {
 export const saveFileFromUrl: FlowDefinition = {
   name: "Save File From Url",
   flowDefinitionId: "saveFileFromUrl" as EntityUuid,
+  description: "Save file from URL to HASH",
   trigger: {
     triggerDefinitionId: "userTrigger",
     description: "Triggered when user provides a URL to a file",

--- a/libs/@local/hash-isomorphic-utils/src/flows/example-flow-definitions.ts
+++ b/libs/@local/hash-isomorphic-utils/src/flows/example-flow-definitions.ts
@@ -93,8 +93,7 @@ export const researchTaskFlowDefinition: FlowDefinition = {
           sourceStepOutputName: "Create in",
         },
         {
-          inputName:
-            "proposedEntities" satisfies InputNameForAction<"persistEntities">,
+          inputName: "draft" satisfies InputNameForAction<"persistEntities">,
           kind: "step-output",
           sourceStepId: "trigger",
           sourceStepOutputName: "Create as draft",

--- a/libs/@local/hash-isomorphic-utils/src/flows/mappings.ts
+++ b/libs/@local/hash-isomorphic-utils/src/flows/mappings.ts
@@ -12,6 +12,8 @@ export const mapFlowDefinitionToEntityProperties = (
 ): FlowDefinitionProperties => ({
   "https://blockprotocol.org/@blockprotocol/types/property-type/name/":
     flowDefinition.name,
+  "https://blockprotocol.org/@blockprotocol/types/property-type/description/":
+    flowDefinition.description,
   "https://hash.ai/@hash/types/property-type/output-definitions/":
     flowDefinition.outputs,
   "https://hash.ai/@hash/types/property-type/step-definitions/":
@@ -27,11 +29,17 @@ export const mapFlowDefinitionToEntityProperties = (
 export const mapFlowDefinitionEntityToFlowDefinition = (
   entity: Entity<FlowDefinitionProperties>,
 ): FlowDefinition => {
-  const { name, outputDefinitions, stepDefinitions, triggerDefinition } =
-    simplifyProperties(entity.properties);
+  const {
+    name,
+    description,
+    outputDefinitions,
+    stepDefinitions,
+    triggerDefinition,
+  } = simplifyProperties(entity.properties);
 
   return {
     name,
+    description,
     flowDefinitionId: extractEntityUuidFromEntityId(
       entity.metadata.recordId.entityId,
     ),

--- a/libs/@local/hash-isomorphic-utils/src/flows/temporal-types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/flows/temporal-types.ts
@@ -10,7 +10,7 @@ export type RunFlowWorkflowParams = {
 };
 
 export type RunFlowWorkflowResponse = Status<{
-  flowOutputs?: Flow["outputs"];
   flow?: Flow;
+  outputs?: Flow["outputs"];
   stepErrors?: Status<{ stepId: string }>[];
 }>;

--- a/libs/@local/hash-isomorphic-utils/src/flows/types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/flows/types.ts
@@ -113,10 +113,13 @@ export type InputDefinition = {
   default?: Payload;
 };
 
-export type OutputDefinition<A extends boolean = boolean> = {
+export type OutputDefinition<
+  A extends boolean = boolean,
+  K extends PayloadKind = PayloadKind,
+> = {
   name: string;
   description?: string;
-  payloadKind: PayloadKind;
+  payloadKind: K;
   array: A;
   required: boolean;
 };

--- a/libs/@local/hash-isomorphic-utils/src/flows/types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/flows/types.ts
@@ -249,6 +249,7 @@ export type StepGroup = {
 
 export type FlowDefinition = {
   name: string;
+  description: string;
   flowDefinitionId: EntityUuid;
   trigger: FlowDefinitionTrigger;
   groups?: StepGroup[];

--- a/libs/@local/hash-isomorphic-utils/src/flows/types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/flows/types.ts
@@ -337,3 +337,8 @@ export type PersistedEntityLog = {
 };
 
 export type StepProgressLog = PersistedEntityLog | ProposedEntityLog;
+
+export type ProgressLogSignalData = {
+  attempt: number;
+  logs: StepProgressLog[];
+};

--- a/libs/@local/hash-isomorphic-utils/src/graphql/queries/flow.queries.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graphql/queries/flow.queries.ts
@@ -10,7 +10,7 @@ export const getFlowRunsQuery = gql`
       executedAt
       closedAt
       inputs
-      outputs
+      flowOutputs
       steps {
         stepId
         stepType

--- a/libs/@local/hash-isomorphic-utils/src/graphql/queries/flow.queries.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graphql/queries/flow.queries.ts
@@ -10,7 +10,7 @@ export const getFlowRunsQuery = gql`
       executedAt
       closedAt
       inputs
-      flowOutputs
+      outputs
       steps {
         stepId
         stepType

--- a/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/knowledge/flow.typedef.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/knowledge/flow.typedef.ts
@@ -142,7 +142,7 @@ export const flowTypedef = gql`
     """
     Outputs of the flow run
     """
-    flowOutputs: [StepRunOutput!]
+    outputs: [StepRunOutput!]
     """
     The steps in the flow
     """

--- a/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/knowledge/flow.typedef.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/knowledge/flow.typedef.ts
@@ -142,7 +142,7 @@ export const flowTypedef = gql`
     """
     Outputs of the flow run
     """
-    outputs: [StepRunOutput!]
+    flowOutputs: [StepRunOutput!]
     """
     The steps in the flow
     """

--- a/libs/@local/hash-isomorphic-utils/src/system-types/flowdefinition.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/flowdefinition.ts
@@ -23,6 +23,7 @@ export type FlowDefinitionOutgoingLinksByLinkEntityTypeId = {};
  */
 export type FlowDefinitionProperties = {
   "https://blockprotocol.org/@blockprotocol/types/property-type/name/": NamePropertyValue;
+  "https://blockprotocol.org/@blockprotocol/types/property-type/description/": TextDataType;
   "https://hash.ai/@hash/types/property-type/output-definitions/": OutputDefinitionsPropertyValue;
   "https://hash.ai/@hash/types/property-type/step-definitions/": StepDefinitionsPropertyValue;
   "https://hash.ai/@hash/types/property-type/trigger-definition/": TriggerDefinitionPropertyValue;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The PR introduces a UI for viewing a Flow definition, which is a variant of the existing UI for viewing an in-progress Flow run, as well as a form for manually triggering a Flow run and providing its inputs, if any.

Recap of terms:
- Flow definition: defines a sequence of actions 
- Flow run: an instance of a Flow definition, i.e. an execution of those sequence of actions, potentially with some inputs that come from user action or via automated trigger

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Adds variants of the existing Flow UI (background, nodes) for viewing a definition rather than an in-progress run
- Extracts a sharable `EntitySelector` component to allow for selecting specific entity/entities as an input for a Flow (e.g. "research more details about this entity")
- expands the existing `EntityTypeSelector` component to enable it to select multiple entity types
- improves the logic around progress log aggregation
- a few bug fixes around viewing in-progress flows, e.g. avoid crashes in the graph view

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

There are still a few outstanding UI issues which are for follow-up in H-2547:
- update the entity table to use Glide data grid instead of an HTML table
- the edge arrowhead (marker) don't change colour based on status
- the final layer of nodes in a swimlane shouldn't have source handles
- missing components from the [design](https://www.figma.com/file/gydVGka9FjNEg9E2STwhi2/HASH?type=design&node-id=11749-72632&mode=design&t=hfDS5VmHV8bjenMe-4), e.g. sidebar for in-progress flows, top breadcrumbs

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- None yet.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Click 'Run' button on a flow definition

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

https://github.com/hashintel/hash/assets/37743469/1eaa2f9e-06dc-4601-b028-ddc68bc51c07

<img width="1791" alt="Screenshot 2024-04-23 at 12 47 55" src="https://github.com/hashintel/hash/assets/37743469/5eacb527-cbbe-4594-91ba-6295cc77bc00">


<img width="2290" alt="Screenshot 2024-04-23 at 15 21 03" src="https://github.com/hashintel/hash/assets/37743469/ef9a41da-f5b5-475e-8492-8e1b9dfc5da7">
