### PR TITLE
H-2556: Don't try publishing Rust packages to `npm`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,6 +10,7 @@
     "@apps/*",
     "@blocks/*",
     "@local/*",
+    "@rust/*",
     "@tests/*",
     "error-stack",
     "deer"

--- a/apps/hash-graph/libs/query-builder-derive/package.json
+++ b/apps/hash-graph/libs/query-builder-derive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rust/query-builder-derive",
   "version": "0.1.0",
-  "private": false,
+  "private": true,
   "dependencies": {},
   "devDependencies": {}
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Mark rogue `@rust/` package as `private` and ignore `@rust/` packages in Changeset config.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->
We'll know if it doesn't work because changeset will try and publish the package again. Not really worth testing locally.