### PR TITLE
H-2502: Add test to check that types load on `/types` page

### DIFF
--- a/tests/hash-playwright/tests/types-page.spec.ts
+++ b/tests/hash-playwright/tests/types-page.spec.ts
@@ -1,0 +1,36 @@
+import { frontendUrl } from "@local/hash-isomorphic-utils/environment";
+
+import { loginUsingTempForm } from "./shared/login-using-temp-form";
+import { expect, test } from "./shared/runtime";
+
+const pathPrefix = `${frontendUrl}/types/`;
+
+test("/types page renders and loads types", async ({ page }) => {
+  await loginUsingTempForm({
+    page,
+    userEmail: "alice@example.com",
+    userPassword: "password",
+  });
+
+  await expect(page.locator("text=Welcome to HASH")).toBeVisible();
+
+  await page.goto("/types");
+
+  await page.waitForURL((url) => url.pathname === "/types");
+
+  const hrefByTabTitle = {
+    "Entity Types": `${pathPrefix}entity-type`,
+    "Link Types": `${pathPrefix}link-type`,
+    "Property Types": `${pathPrefix}property-type`,
+    "Data Types": `${pathPrefix}data-type`,
+  };
+
+  /**
+   * Check that all tabs have a non-zero type count
+   */
+  for (const [tabTitle, href] of Object.entries(hrefByTabTitle)) {
+    await expect(page.locator(`[href*="${href}"]`)).toHaveText(
+      new RegExp(`^${tabTitle}[1-9]\\d*$`),
+    );
+  }
+});


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

There was a bug where entity types (including link types) weren't loading on the `/types` page. This has somehow disappeared since the ticket was filed, and I don't know what the underlying cause was.

This PR adds a test to confirm that at least some types load on the types page, which would have caught that bug. 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- This one.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Check that the test passes. In order to check that it is testing the correct thing, you would have to run the app locally, hardcode 0 as a tab or types count (or empty array for types loaded into the page), and check that the test fails.
