### PR TITLE
H-2586: Add debug logs to Node API, increase health check grace period

### DIFF
--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types.ts
@@ -46,6 +46,7 @@ export const migrateOntologyTypes = async (params: {
        * should only be seeded in non-production environments.
        */
       if (isProdEnv && migrationFileName.endsWith(".dev.migration.ts")) {
+        params.logger.debug(`Skipping dev migration ${migrationFileName}`);
         continue;
       }
 
@@ -63,6 +64,8 @@ export const migrateOntologyTypes = async (params: {
         authentication,
         migrationState,
       });
+
+      params.logger.debug(`Processed migration ${migrationFileName}`);
     }
   }
 };

--- a/infra/terraform/hash/hash_application/api.tf
+++ b/infra/terraform/hash/hash_application/api.tf
@@ -28,6 +28,7 @@ locals {
     dependsOn   = [{ condition = "HEALTHY", containerName = local.kratos_service_container_def.name }]
     healthCheck = {
       command  = ["CMD", "/bin/sh", "-c", "curl -f http://localhost:${local.api_container_port}/health-check || exit 1"]
+      startPeriod = 60
       retries  = 5
       interval = 20
       timeout  = 5

--- a/infra/terraform/hash/hash_application/temporal_worker_ai_ts.tf
+++ b/infra/terraform/hash/hash_application/temporal_worker_ai_ts.tf
@@ -24,7 +24,7 @@ locals {
     cpu         = 0 # let ECS divvy up the available CPU
     healthCheck = {
       command     = ["CMD", "/bin/sh", "-c", "curl -f http://localhost:4100/health || exit 1"]
-      startPeriod = 10
+      startPeriod = 30
       interval    = 10
       retries     = 10
       timeout     = 5

--- a/infra/terraform/hash/prod-usea1.tfvars
+++ b/infra/terraform/hash/prod-usea1.tfvars
@@ -63,7 +63,7 @@ hash_api_env_vars = [
   { name = "FRONTEND_URL", secret = false, value = "https://app.hash.ai" },
   { name = "API_ORIGIN", secret = false, value = "https://app-api.hash.ai" },
 
-  { name = "LOG_LEVEL", secret = false, value = "info" },
+  { name = "LOG_LEVEL", secret = false, value = "debug" },
 
   { name = "FILE_UPLOAD_PROVIDER", secret = false, value = "AWS_S3" },
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Some changes to help debug what's going on in the Node API in AWS:
1. Add debug logs on the successful processing of each migration file
2. Set `LOG_LEVEL` to `debug`
3. Increase health check grace period

What we know so far is that the Node API is being killed without having completed all migration files. Theories as to what might be going on:
- Migrations are taking longer, and are causing the Node API to be considered unhealthy because it can't get through its startup work in time
  - logs will help reveal this
  - appropriate grace period will fix it 
- There's an issue in some migration file
  - logs will help debug this 

This doesn't explain why the AI worker is also failing health checks.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

See what logs reveal
