### PR TITLE
H-2587: Parallelize entity migrations, add grace period for load balancer checks

### DIFF
--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
@@ -22,7 +22,6 @@ import {
   PROPERTY_TYPE_META_SCHEMA,
 } from "@blockprotocol/type-system";
 import { NotFoundError } from "@local/hash-backend-utils/error";
-import { getWebMachineActorId } from "@local/hash-backend-utils/machine-actors";
 import type {
   DataTypeRelationAndSubject,
   UpdatePropertyType,
@@ -34,7 +33,6 @@ import {
 } from "@local/hash-isomorphic-utils/graph-queries";
 import {
   blockProtocolDataTypes,
-  googleEntityTypes,
   systemDataTypes,
   systemEntityTypes,
   systemLinkEntityTypes,
@@ -78,7 +76,7 @@ import {
   CACHED_PROPERTY_TYPE_SCHEMAS,
 } from "../../../seed-data";
 import type { ImpureGraphFunction } from "../../context-types";
-import { getEntities, updateEntity } from "../../knowledge/primitive/entity";
+import { getEntities } from "../../knowledge/primitive/entity";
 import {
   createDataType,
   getDataTypeById,
@@ -91,13 +89,13 @@ import {
   createPropertyType,
   getPropertyTypeById,
 } from "../../ontology/primitive/property-type";
-import { systemAccountId } from "../../system-account";
 import type { PrimitiveDataTypeKey } from "../system-webs-and-entities";
 import {
   getOrCreateOwningAccountGroupId,
   isSelfHostedInstance,
 } from "../system-webs-and-entities";
 import type { MigrationState } from "./types";
+import { upgradeWebEntities } from "./util/upgrade-entities";
 import { upgradeEntityTypeDependencies } from "./util/upgrade-entity-type-dependencies";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -1244,184 +1242,20 @@ export const upgradeEntitiesToNewTypeVersion: ImpureGraphFunction<
     {},
   );
 
-  for (const web of [...users, ...orgs]) {
-    const webOwnedById = extractOwnedByIdFromEntityId(
-      web.metadata.recordId.entityId,
-    );
+  await Promise.all(
+    [...users, ...orgs].map((webEntity) => {
+      const webOwnedById = extractOwnedByIdFromEntityId(
+        webEntity.metadata.recordId.entityId,
+      );
 
-    const webBotAccountId = await getWebMachineActorId(
-      context,
-      authentication,
-      {
-        ownedById: webOwnedById,
-      },
-    );
-
-    const webBotAuthentication = { actorId: webBotAccountId };
-
-    const existingEntities = await getEntities(context, webBotAuthentication, {
-      query: {
-        filter: {
-          all: [
-            {
-              any: entityTypeBaseUrls.map((baseUrl) => ({
-                equal: [
-                  { path: ["type(inheritanceDepth = 0)", "baseUrl"] },
-                  { parameter: baseUrl },
-                ],
-              })),
-            },
-            {
-              equal: [
-                { path: ["ownedById"] },
-                {
-                  parameter: webOwnedById,
-                },
-              ],
-            },
-          ],
-        },
-        graphResolveDepths: zeroedGraphResolveDepths,
-        includeDrafts: true,
-        temporalAxes: currentTimeInstantTemporalAxes,
-      },
-    }).then((subgraph) => getRoots(subgraph));
-
-    for (const entity of existingEntities) {
-      const baseUrl = extractBaseUrl(entity.metadata.entityTypeId);
-
-      const currentVersion = extractVersion(entity.metadata.entityTypeId);
-
-      const newVersion = migrationState.entityTypeVersions[baseUrl];
-
-      if (typeof newVersion === "undefined") {
-        throw new Error(
-          `Could not find the version for base URL ${baseUrl} in the migration state`,
-        );
-      }
-
-      if (currentVersion < newVersion) {
-        const newEntityTypeId = versionedUrlFromComponents(baseUrl, newVersion);
-        const currentEntityTypeId = entity.metadata.entityTypeId;
-
-        const migratePropertiesFunction = migrateProperties?.[baseUrl];
-
-        let updateAuthentication = webBotAuthentication;
-
-        const temporaryEntityTypePermissionsGranted: VersionedUrl[] = [];
-
-        if (
-          baseUrl === systemEntityTypes.userSecret.entityTypeBaseUrl ||
-          baseUrl ===
-            systemLinkEntityTypes.usesUserSecret.linkEntityTypeBaseUrl ||
-          baseUrl === googleEntityTypes.account.entityTypeBaseUrl
-        ) {
-          /**
-           *These entities are only editable by the bot that created them
-           */
-          updateAuthentication = {
-            actorId: entity.metadata.provenance.createdById,
-          };
-        }
-        if (baseUrl === systemEntityTypes.machine.entityTypeBaseUrl) {
-          /**
-           * If we are updating machine entities, we use the account ID
-           * of the machine user as the actor for the update.
-           */
-          updateAuthentication = {
-            /**
-             * The account ID of the machine entity is the creator of its
-             * first edition.
-             */
-            actorId: entity.metadata.provenance.createdById,
-          };
-
-          for (const entityTypeId of [currentEntityTypeId, newEntityTypeId]) {
-            /**
-             * We may need to temporarily grant the machine account ID the ability
-             * to instantiate entities of both the old and new entityTypeId,
-             * because an actor cannot update or remove an entity type without being able to instantiate it.
-             */
-
-            try {
-              await context.graphApi.modifyEntityTypeAuthorizationRelationships(
-                systemAccountId,
-                [
-                  {
-                    operation: "create",
-                    resource: entityTypeId,
-                    relationAndSubject: {
-                      subject: {
-                        kind: "account",
-                        subjectId: entity.metadata.provenance.createdById,
-                      },
-                      relation: "instantiator",
-                    },
-                  },
-                ],
-              );
-
-              /** If the 'create' call didn't error, the actor didn't already have the permission */
-              temporaryEntityTypePermissionsGranted.push(entityTypeId);
-            } catch {
-              /**
-               * the actor already had the permission, so we must 'touch' the permission instead.
-               * in theory we could just do nothing, but maybe 'touch' will throw some other error we need to know about
-               */
-
-              await context.graphApi.modifyEntityTypeAuthorizationRelationships(
-                systemAccountId,
-                [
-                  {
-                    operation: "touch",
-                    resource: entityTypeId,
-                    relationAndSubject: {
-                      subject: {
-                        kind: "account",
-                        subjectId: entity.metadata.provenance.createdById,
-                      },
-                      relation: "instantiator",
-                    },
-                  },
-                ],
-              );
-            }
-          }
-        }
-
-        try {
-          await updateEntity(context, updateAuthentication, {
-            entity,
-            entityTypeId: newEntityTypeId,
-            properties: migratePropertiesFunction
-              ? migratePropertiesFunction(entity.properties)
-              : entity.properties,
-          });
-        } finally {
-          for (const entityTypeId of temporaryEntityTypePermissionsGranted) {
-            /**
-             * If we updated a machine entity and granted its actor ID a
-             * new permission, we need to remove the temporary permission.
-             */
-            await context.graphApi.modifyEntityTypeAuthorizationRelationships(
-              systemAccountId,
-              [
-                {
-                  operation: "delete",
-                  resource: entityTypeId,
-                  relationAndSubject: {
-                    subject: {
-                      kind: "account",
-                      subjectId: entity.metadata.provenance.createdById,
-                    },
-                    relation: "instantiator",
-                  },
-                },
-              ],
-            );
-          }
-        }
-      }
-    }
-  }
+      return upgradeWebEntities({
+        authentication,
+        context,
+        entityTypeBaseUrls,
+        migrationState,
+        migrateProperties,
+        webOwnedById,
+      });
+    }),
+  );
 };

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util/upgrade-entities.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util/upgrade-entities.ts
@@ -1,0 +1,219 @@
+import { extractVersion, type VersionedUrl } from "@blockprotocol/type-system";
+import { getWebMachineActorId } from "@local/hash-backend-utils/machine-actors";
+import {
+  currentTimeInstantTemporalAxes,
+  zeroedGraphResolveDepths,
+} from "@local/hash-isomorphic-utils/graph-queries";
+import {
+  googleEntityTypes,
+  systemEntityTypes,
+  systemLinkEntityTypes,
+} from "@local/hash-isomorphic-utils/ontology-type-ids";
+import type {
+  AccountId,
+  BaseUrl,
+  EntityPropertiesObject,
+  OwnedById,
+} from "@local/hash-subgraph";
+import { getRoots } from "@local/hash-subgraph/stdlib";
+import {
+  extractBaseUrl,
+  versionedUrlFromComponents,
+} from "@local/hash-subgraph/type-system-patch";
+
+import type { ImpureGraphContext } from "../../../context-types";
+import { getEntities, updateEntity } from "../../../knowledge/primitive/entity";
+import { systemAccountId } from "../../../system-account";
+import type { MigrationState } from "../types";
+
+export const upgradeWebEntities = async ({
+  authentication,
+  context,
+  entityTypeBaseUrls,
+  migrationState,
+  migrateProperties,
+  webOwnedById,
+}: {
+  authentication: { actorId: AccountId };
+  context: ImpureGraphContext<false, true>;
+  entityTypeBaseUrls: BaseUrl[];
+  migrationState: MigrationState;
+  migrateProperties?: Record<
+    BaseUrl,
+    (previousProperties: EntityPropertiesObject) => EntityPropertiesObject
+  >;
+  webOwnedById: OwnedById;
+}) => {
+  const webBotAccountId = await getWebMachineActorId(context, authentication, {
+    ownedById: webOwnedById,
+  });
+
+  const webBotAuthentication = { actorId: webBotAccountId };
+
+  const existingEntities = await getEntities(context, webBotAuthentication, {
+    query: {
+      filter: {
+        all: [
+          {
+            any: entityTypeBaseUrls.map((baseUrl) => ({
+              equal: [
+                { path: ["type(inheritanceDepth = 0)", "baseUrl"] },
+                { parameter: baseUrl },
+              ],
+            })),
+          },
+          {
+            equal: [
+              { path: ["ownedById"] },
+              {
+                parameter: webOwnedById,
+              },
+            ],
+          },
+        ],
+      },
+      graphResolveDepths: zeroedGraphResolveDepths,
+      includeDrafts: true,
+      temporalAxes: currentTimeInstantTemporalAxes,
+    },
+  }).then((subgraph) => getRoots(subgraph));
+
+  await Promise.all(
+    existingEntities.map(async (entity) => {
+      const baseUrl = extractBaseUrl(entity.metadata.entityTypeId);
+
+      const currentVersion = extractVersion(entity.metadata.entityTypeId);
+
+      const newVersion = migrationState.entityTypeVersions[baseUrl];
+
+      if (typeof newVersion === "undefined") {
+        throw new Error(
+          `Could not find the version for base URL ${baseUrl} in the migration state`,
+        );
+      }
+
+      if (currentVersion < newVersion) {
+        const newEntityTypeId = versionedUrlFromComponents(baseUrl, newVersion);
+        const currentEntityTypeId = entity.metadata.entityTypeId;
+
+        const migratePropertiesFunction = migrateProperties?.[baseUrl];
+
+        let updateAuthentication = webBotAuthentication;
+
+        const temporaryEntityTypePermissionsGranted: VersionedUrl[] = [];
+
+        if (
+          baseUrl === systemEntityTypes.userSecret.entityTypeBaseUrl ||
+          baseUrl ===
+            systemLinkEntityTypes.usesUserSecret.linkEntityTypeBaseUrl ||
+          baseUrl === googleEntityTypes.account.entityTypeBaseUrl
+        ) {
+          /**
+           *These entities are only editable by the bot that created them
+           */
+          updateAuthentication = {
+            actorId: entity.metadata.provenance.createdById,
+          };
+        }
+        if (baseUrl === systemEntityTypes.machine.entityTypeBaseUrl) {
+          /**
+           * If we are updating machine entities, we use the account ID
+           * of the machine user as the actor for the update.
+           */
+          updateAuthentication = {
+            /**
+             * The account ID of the machine entity is the creator of its
+             * first edition.
+             */
+            actorId: entity.metadata.provenance.createdById,
+          };
+
+          for (const entityTypeId of [currentEntityTypeId, newEntityTypeId]) {
+            /**
+             * We may need to temporarily grant the machine account ID the ability
+             * to instantiate entities of both the old and new entityTypeId,
+             * because an actor cannot update or remove an entity type without being able to instantiate it.
+             */
+
+            try {
+              await context.graphApi.modifyEntityTypeAuthorizationRelationships(
+                systemAccountId,
+                [
+                  {
+                    operation: "create",
+                    resource: entityTypeId,
+                    relationAndSubject: {
+                      subject: {
+                        kind: "account",
+                        subjectId: entity.metadata.provenance.createdById,
+                      },
+                      relation: "instantiator",
+                    },
+                  },
+                ],
+              );
+
+              /** If the 'create' call didn't error, the actor didn't already have the permission */
+              temporaryEntityTypePermissionsGranted.push(entityTypeId);
+            } catch {
+              /**
+               * the actor already had the permission, so we must 'touch' the permission instead.
+               * in theory we could just do nothing, but maybe 'touch' will throw some other error we need to know about
+               */
+
+              await context.graphApi.modifyEntityTypeAuthorizationRelationships(
+                systemAccountId,
+                [
+                  {
+                    operation: "touch",
+                    resource: entityTypeId,
+                    relationAndSubject: {
+                      subject: {
+                        kind: "account",
+                        subjectId: entity.metadata.provenance.createdById,
+                      },
+                      relation: "instantiator",
+                    },
+                  },
+                ],
+              );
+            }
+          }
+        }
+
+        try {
+          await updateEntity(context, updateAuthentication, {
+            entity,
+            entityTypeId: newEntityTypeId,
+            properties: migratePropertiesFunction
+              ? migratePropertiesFunction(entity.properties)
+              : entity.properties,
+          });
+        } finally {
+          for (const entityTypeId of temporaryEntityTypePermissionsGranted) {
+            /**
+             * If we updated a machine entity and granted its actor ID a
+             * new permission, we need to remove the temporary permission.
+             */
+            await context.graphApi.modifyEntityTypeAuthorizationRelationships(
+              systemAccountId,
+              [
+                {
+                  operation: "delete",
+                  resource: entityTypeId,
+                  relationAndSubject: {
+                    subject: {
+                      kind: "account",
+                      subjectId: entity.metadata.provenance.createdById,
+                    },
+                    relation: "instantiator",
+                  },
+                },
+              ],
+            );
+          }
+        }
+      }
+    }),
+  );
+};

--- a/infra/terraform/hash/hash_application/api.tf
+++ b/infra/terraform/hash/hash_application/api.tf
@@ -28,7 +28,7 @@ locals {
     dependsOn   = [{ condition = "HEALTHY", containerName = local.kratos_service_container_def.name }]
     healthCheck = {
       command  = ["CMD", "/bin/sh", "-c", "curl -f http://localhost:${local.api_container_port}/health-check || exit 1"]
-      startPeriod = 60
+      startPeriod = local.app_grace_period_seconds
       retries  = 5
       interval = 20
       timeout  = 5

--- a/infra/terraform/hash/hash_application/main.tf
+++ b/infra/terraform/hash/hash_application/main.tf
@@ -1,7 +1,8 @@
 locals {
-  prefix            = "${var.prefix}-app"
-  log_group_name    = "${local.prefix}log"
-  param_prefix      = "${var.param_prefix}/app"
+  prefix                   = "${var.prefix}-app"
+  log_group_name           = "${local.prefix}log"
+  param_prefix             = "${var.param_prefix}/app"
+  app_grace_period_seconds = 180
   spicedb_task_defs = [
     {
       task_def = local.spicedb_migration_container_def
@@ -377,6 +378,7 @@ resource "aws_ecs_service" "svc" {
   enable_execute_command = true
   desired_count          = 1
   launch_type            = "FARGATE"
+  health_check_grace_period_seconds = local.app_grace_period_seconds
   network_configuration {
     subnets          = var.subnets
     assign_public_ip = true


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Further to #4371, it seems the issue with the Node API in production is that migrations are not completing before health checks are killing the service, because migrations that involve looking through entities in each web can take ~1 min to complete.

This PR attempts to fix that by:
1. Running checks/updates to entities in parallel in the migration so that migrations complete quicker 
2. Adding a grace period to the load balancer's health checks as well as the health checks in ECS

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

