### PR TITLE
H-2597: Support `WIP_` blog posts on hash.dev

### DIFF
--- a/apps/hashdotdev/src/pages/shared/mdx-utils.ts
+++ b/apps/hashdotdev/src/pages/shared/mdx-utils.ts
@@ -98,23 +98,6 @@ const parseNameFromFileName = (fileName: string): string => {
   return matches[1]!;
 };
 
-// Gets all hrefs corresponding to the MDX files in a directory
-export const getAllDocsPageHrefs = (params: {
-  folderName: string;
-}): string[] => {
-  const { folderName } = params;
-
-  const fileNames = fs.readdirSync(
-    path.join(process.cwd(), `src/_pages/${folderName}`),
-  );
-
-  return fileNames.map((fileName) => {
-    const name = parseNameFromFileName(fileName);
-
-    return `/${folderName}${name === "index" ? "" : `/${name}`}`;
-  });
-};
-
 export type DocsPageData = {
   title: string;
   subtitle?: string;

--- a/apps/hashdotdev/src/util/mdx-util.ts
+++ b/apps/hashdotdev/src/util/mdx-util.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 
-import { readdir, readdirSync, readFile } from "fs-extra";
+import { readdirSync, readFile } from "fs-extra";
 import matter from "gray-matter";
 import type { MDXRemoteSerializeResult } from "next-mdx-remote";
 import { serialize } from "next-mdx-remote/serialize";
@@ -83,13 +83,16 @@ const getImagesFromParent = (parent: Parent): Image[] => [
     .flatMap((child) => getImagesFromParent(child)),
 ];
 
+const getFileNames = (folderName: string) =>
+  readdirSync(path.join(process.cwd(), `src/_pages/${folderName}`)).filter(
+    (filename) => !filename.toLowerCase().startsWith("wip_"),
+  );
+
 // Gets all hrefs corresponding to the MDX files in a directory
 export const getAllPageHrefs = (params: { folderName: string }): string[] => {
   const { folderName } = params;
 
-  const fileNames = readdirSync(
-    path.join(process.cwd(), `src/_pages/${folderName}`),
-  );
+  const fileNames = getFileNames(folderName);
 
   return fileNames.map((fileName) => {
     const name = parseNameFromFileName(fileName);
@@ -112,9 +115,7 @@ export const getSerializedPage = async (params: {
 > => {
   const { pathToDirectory, fileNameWithoutIndex } = params;
 
-  const fileNames = await readdir(
-    path.join(process.cwd(), `src/_pages/${pathToDirectory}`),
-  );
+  const fileNames = getFileNames(pathToDirectory);
 
   const fileName = fileNames.find((fullFileName) =>
     fullFileName.endsWith(`${fileNameWithoutIndex}.mdx`),
@@ -166,9 +167,7 @@ export const getPage = <DataType extends Record<string, unknown>>(params: {
 export const getAllPages = <DataType extends Record<string, unknown>>(
   pathToDirectory: string,
 ): Page<DataType>[] => {
-  const fileNames = readdirSync(
-    path.join(process.cwd(), `src/_pages/${pathToDirectory}`),
-  );
+  const fileNames = getFileNames(pathToDirectory);
 
   return fileNames.map((fileName) =>
     getPage({


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Allows the addition of `WIP_` blog posts to the `blogs` content folder in `hashdotdev` without these appearing on the site.
