### PR TITLE
H-2612: Make `dev` depend on `hash-graph-client#codegen`

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -21,7 +21,8 @@
     "test:system": {},
     "test:miri": {},
     "dev": {
-      "persistent": true
+      "persistent": true,
+      "dependsOn": ["@local/hash-graph-client#codegen"]
     },
     "lint": {
       "dependsOn": ["codegen"]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

It's easy to miss the codegen step. For Node development this is unlikely to be an issue, but it is when the Rust code changed and `yarn dev` is required for testing.