### PR TITLE
H-2613: Enable miri for HaRPC wireprotocol

### DIFF
--- a/libs/@local/harpc/wire-protocol/package.json
+++ b/libs/@local/harpc/wire-protocol/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
+    "test:miri": "just miri",
     "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
   },
   "dependencies": {

--- a/libs/@local/harpc/wire-protocol/src/codec/mod.rs
+++ b/libs/@local/harpc/wire-protocol/src/codec/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod test {
     };
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn codec_u16(value: u16) {
         assert_codec(&value, ()).await;
     }
@@ -23,6 +24,7 @@ pub(crate) mod test {
     // 1024 ensures that we spill over into the second length byte while still having a good
     // runtime performance.
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn codec_bytes(#[any(size_range(0..1024).lift())] payload: Vec<u8>) {
         let buffer = Bytes::from(payload);
 

--- a/libs/@local/harpc/wire-protocol/src/codec/types.rs
+++ b/libs/@local/harpc/wire-protocol/src/codec/types.rs
@@ -118,11 +118,13 @@ mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn codec_service_id(id: ServiceId) {
         assert_codec(&id, ()).await;
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn codec_version(version: Version) {
         assert_codec(&version, ()).await;
     }

--- a/libs/@local/harpc/wire-protocol/src/payload.rs
+++ b/libs/@local/harpc/wire-protocol/src/payload.rs
@@ -89,6 +89,7 @@ mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn encode_decode(payload: Payload) {
         assert_codec(&payload, ()).await;
     }

--- a/libs/@local/harpc/wire-protocol/src/protocol.rs
+++ b/libs/@local/harpc/wire-protocol/src/protocol.rs
@@ -198,11 +198,13 @@ mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn codec_version(version: ProtocolVersion) {
         assert_codec(&version, ()).await;
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn codec_protocol(protocol: crate::protocol::Protocol) {
         assert_codec(&protocol, ()).await;
     }

--- a/libs/@local/harpc/wire-protocol/src/request/begin.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/begin.rs
@@ -153,6 +153,7 @@ mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn codec(request: RequestBegin) {
         assert_codec(&request, ()).await;
     }

--- a/libs/@local/harpc/wire-protocol/src/request/body.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/body.rs
@@ -178,6 +178,7 @@ mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn codec(body: RequestBody) {
         let context = RequestBodyContext {
             variant: (&body).into(),

--- a/libs/@local/harpc/wire-protocol/src/request/flags.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/flags.rs
@@ -152,6 +152,7 @@ mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn codec(flags: RequestFlags) {
         assert_codec(&flags, ()).await;
     }

--- a/libs/@local/harpc/wire-protocol/src/request/frame.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/frame.rs
@@ -92,6 +92,7 @@ mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn codec(frame: RequestFrame) {
         assert_codec(&frame, ()).await;
     }

--- a/libs/@local/harpc/wire-protocol/src/request/header.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/header.rs
@@ -122,6 +122,7 @@ mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn encode_decode(header: RequestHeader) {
         assert_codec(&header, ()).await;
     }

--- a/libs/@local/harpc/wire-protocol/src/request/id.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/id.rs
@@ -120,6 +120,7 @@ pub(crate) mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn codec_id(id: RequestId) {
         assert_codec(&id, ()).await;
     }

--- a/libs/@local/harpc/wire-protocol/src/request/mod.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/mod.rs
@@ -334,6 +334,7 @@ mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn codec(request: Request) {
         // encoding partially overrides flags if they are not set correctly, to ensure that
         // encode/decode is actually lossless we need to apply the body to the header
@@ -347,6 +348,7 @@ mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn header_size(request: Request) {
         // ensure that for every request the header size is *always* 32 bytes
 

--- a/libs/@local/harpc/wire-protocol/src/request/procedure.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/procedure.rs
@@ -56,6 +56,7 @@ mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn codec_id(id: ProcedureId) {
         assert_codec(&id, ()).await;
     }
@@ -86,6 +87,7 @@ mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn codec(id: ProcedureDescriptor) {
         assert_codec(&id, ()).await;
     }

--- a/libs/@local/harpc/wire-protocol/src/request/service.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/service.rs
@@ -88,6 +88,7 @@ mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn encode_decode(service: ServiceDescriptor) {
         assert_codec(&service, ()).await;
     }

--- a/libs/@local/harpc/wire-protocol/src/response/begin.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/begin.rs
@@ -111,6 +111,7 @@ mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn codec(frame: ResponseBegin) {
         assert_codec(&frame, ()).await;
     }

--- a/libs/@local/harpc/wire-protocol/src/response/body.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/body.rs
@@ -178,6 +178,7 @@ mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn codec(body: ResponseBody) {
         let context = ResponseBodyContext {
             variant: ResponseVariant::from(&body),

--- a/libs/@local/harpc/wire-protocol/src/response/flags.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/flags.rs
@@ -118,6 +118,7 @@ mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn codec(flags: ResponseFlags) {
         assert_codec(&flags, ()).await;
     }

--- a/libs/@local/harpc/wire-protocol/src/response/frame.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/frame.rs
@@ -94,6 +94,7 @@ mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn codec(frame: ResponseFrame) {
         assert_codec(&frame, ()).await;
     }

--- a/libs/@local/harpc/wire-protocol/src/response/header.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/header.rs
@@ -127,6 +127,7 @@ mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn codec(header: ResponseHeader) {
         assert_codec(&header, ()).await;
     }

--- a/libs/@local/harpc/wire-protocol/src/response/kind.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/kind.rs
@@ -104,6 +104,7 @@ mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn codec(kind: ResponseKind) {
         assert_codec(&kind, ()).await;
     }

--- a/libs/@local/harpc/wire-protocol/src/response/mod.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/mod.rs
@@ -292,6 +292,7 @@ mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn codec(response: Response) {
         // encoding partially overrides flags if they are not set correctly, to ensure that
         // encode/decode is actually lossless we need to apply the body to the header
@@ -305,6 +306,7 @@ mod test {
     }
 
     #[test_strategy::proptest(async = "tokio")]
+    #[cfg_attr(miri, ignore)]
     async fn header_size(response: Response) {
         // ensure that for every response the header size is *always* 32 bytes
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2024-04-29"
-components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'rust-analyzer']
+components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'miri', 'rust-analyzer']


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Memory layout is tricky and `miri` is able to detect errors here.

## ⚠️ Known issues

- Proptests are not working with `miri`