### PR TITLE
H-2219: Extend existing query builder to also support basic `INSERT` statements

### DIFF
--- a/apps/hash-graph/libs/graph/src/store/postgres/query/condition.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/condition.rs
@@ -5,7 +5,7 @@ use crate::store::postgres::query::{Expression, Transpile};
 /// A [`Filter`], which can be transpiled.
 ///
 /// [`Filter`]: crate::store::query::Filter
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Condition {
     All(Vec<Self>),
     Any(Vec<Self>),

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/expression/group_by_clause.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/expression/group_by_clause.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::store::postgres::query::{Expression, Transpile};
 
-#[derive(Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct GroupByExpression {
     pub expressions: Vec<Expression>,
 }

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/expression/join_clause.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/expression/join_clause.rs
@@ -5,7 +5,7 @@ use crate::store::postgres::query::{
     Alias, AliasedTable, Expression, SelectStatement, Transpile,
 };
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct JoinCondition {
     pub join: Column,
     pub on: Column,
@@ -42,13 +42,13 @@ impl JoinType {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct JoinOn {
     pub join: Column,
     pub on: Column,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct JoinExpression {
     pub join: JoinType,
     pub statement: Option<SelectStatement>,

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/expression/order_clause.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/expression/order_clause.rs
@@ -5,7 +5,7 @@ use crate::store::{
     NullOrdering, Ordering,
 };
 
-#[derive(Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct OrderByExpression {
     columns: Vec<(Expression, Ordering, Option<NullOrdering>)>,
 }

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/expression/select_clause.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/expression/select_clause.rs
@@ -2,10 +2,10 @@ use std::fmt;
 
 use crate::store::postgres::query::{Expression, Transpile};
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SelectExpression {
-    expression: Expression,
-    alias: Option<&'static str>,
+    pub expression: Expression,
+    pub alias: Option<&'static str>,
 }
 
 impl SelectExpression {

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/expression/where_clause.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/expression/where_clause.rs
@@ -5,7 +5,7 @@ use crate::store::{
     NullOrdering, Ordering,
 };
 
-#[derive(Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct WhereExpression {
     conditions: Vec<Condition>,
     cursor: Vec<(

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/expression/with_clause.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/expression/with_clause.rs
@@ -2,13 +2,13 @@ use std::fmt::{self, Write};
 
 use crate::store::postgres::query::{Statement, Table, Transpile};
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CommonTableExpression {
     table: Table,
     statement: Statement,
 }
 
-#[derive(Default, Debug, PartialEq, Eq, Hash)]
+#[derive(Default, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct WithExpression {
     common_table_expressions: Vec<CommonTableExpression>,
 }
@@ -56,6 +56,7 @@ mod tests {
     use super::*;
     use crate::store::postgres::query::{
         expression::{GroupByExpression, OrderByExpression},
+        statement::FromItem,
         test_helper::{max_version_expression, trim_whitespace},
         Alias, Expression, SelectExpression, SelectStatement, WhereExpression,
     };
@@ -74,11 +75,14 @@ mod tests {
                     SelectExpression::new(Expression::Asterisk, None),
                     SelectExpression::new(max_version_expression(), Some("latest_version")),
                 ],
-                from: Table::OntologyIds.aliased(Alias {
-                    condition_index: 0,
-                    chain_depth: 0,
-                    number: 0,
-                }),
+                from: FromItem::Table {
+                    table: Table::OntologyIds,
+                    alias: Some(Alias {
+                        condition_index: 0,
+                        chain_depth: 0,
+                        number: 0,
+                    }),
+                },
                 joins: vec![],
                 where_expression: WhereExpression::default(),
                 order_by_expression: OrderByExpression::default(),
@@ -101,11 +105,14 @@ mod tests {
                 with: WithExpression::default(),
                 distinct: Vec::new(),
                 selects: vec![SelectExpression::new(Expression::Asterisk, None)],
-                from: Table::DataTypes.aliased(Alias {
-                    condition_index: 3,
-                    chain_depth: 4,
-                    number: 5,
-                }),
+                from: FromItem::Table {
+                    table: Table::DataTypes,
+                    alias: Some(Alias {
+                        condition_index: 3,
+                        chain_depth: 4,
+                        number: 5,
+                    }),
+                },
                 joins: vec![],
                 where_expression: WhereExpression::default(),
                 order_by_expression: OrderByExpression::default(),

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/rows.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/rows.rs
@@ -20,7 +20,7 @@ use type_system::{
 
 use crate::store::postgres::{ontology::OntologyId, query::Table};
 
-pub trait PostgresRow: Sized {
+pub trait PostgresRow: ToSql + Sized {
     fn table() -> Table;
 }
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/statement/insert.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/statement/insert.rs
@@ -1,0 +1,189 @@
+use std::{fmt, fmt::Formatter};
+
+use postgres_types::ToSql;
+
+use crate::store::postgres::query::{
+    expression::{GroupByExpression, PostgresType},
+    rows::PostgresRow,
+    statement::FromItem,
+    Alias, AliasedTable, Column, Expression, Function, OrderByExpression, SelectExpression,
+    SelectStatement, Table, Transpile, WhereExpression, WithExpression,
+};
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub enum InsertValueItem {
+    Default,
+    Values(Vec<Expression>),
+    Query(Box<SelectStatement>),
+}
+
+impl Transpile for InsertValueItem {
+    fn transpile(&self, fmt: &mut Formatter) -> fmt::Result {
+        match self {
+            Self::Default => fmt.write_str(" DEFAULT VALUES"),
+            Self::Values(values) => {
+                fmt.write_str(" VALUES (\n    ")?;
+                for (idx, value) in values.iter().enumerate() {
+                    if idx > 0 {
+                        fmt.write_str(",\n    ")?;
+                    }
+                    value.transpile(fmt)?;
+                }
+                fmt.write_str("\n)")
+            }
+            Self::Query(query) => {
+                fmt.write_str("(\n    ")?;
+                query.transpile(fmt)?;
+                fmt.write_str("\n)")
+            }
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct InsertStatement {
+    pub table: Table,
+    pub alias: Option<Alias>,
+    pub columns: Vec<Column>,
+    pub values: InsertValueItem,
+}
+
+impl Transpile for InsertStatement {
+    fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("INSERT INTO ")?;
+        self.table.transpile(fmt)?;
+
+        if let Some(alias) = self.alias {
+            fmt.write_str(" AS ")?;
+            AliasedTable {
+                table: self.table,
+                alias,
+            }
+            .transpile(fmt)?;
+        }
+
+        if !self.columns.is_empty() {
+            fmt.write_str(" (\n    ")?;
+            for (idx, column) in self.columns.iter().enumerate() {
+                if idx > 0 {
+                    fmt.write_str(",\n    ")?;
+                }
+                column.transpile(fmt)?;
+            }
+            fmt.write_str("\n)")?;
+        }
+
+        self.values.transpile(fmt)
+    }
+}
+
+pub struct InsertStatementBuilder<'p> {
+    pub statement: InsertStatement,
+    pub parameters: Vec<&'p (dyn ToSql + Sync)>,
+}
+
+struct SliceWrapper<'a, T>(&'a [T]);
+
+impl<'p> InsertStatementBuilder<'p> {
+    pub fn new(table: Table) -> Self {
+        Self {
+            statement: InsertStatement {
+                table,
+                alias: None,
+                columns: Vec::new(),
+                values: InsertValueItem::Values(Vec::new()),
+            },
+            parameters: Vec::new(),
+        }
+    }
+
+    pub fn compile(self) -> (String, Vec<&'p (dyn ToSql + Sync)>) {
+        (self.statement.transpile_to_string(), self.parameters)
+    }
+
+    pub fn with_expression(mut self, column: impl Into<Column>, expression: Expression) -> Self {
+        self.add_expression(column, expression);
+        self
+    }
+
+    pub fn add_expression(
+        &mut self,
+        column: impl Into<Column>,
+        expression: Expression,
+    ) -> &mut Self {
+        self.statement.columns.push(column.into());
+        // TODO: Use a builder which knows `values` at compile time
+        let InsertValueItem::Values(values) = &mut self.statement.values else {
+            unreachable!()
+        };
+        values.push(expression);
+        self
+    }
+
+    pub fn with_value(mut self, column: impl Into<Column>, value: &'p (impl ToSql + Sync)) -> Self {
+        self.add_value(column, value);
+        self
+    }
+
+    pub fn add_value(
+        &mut self,
+        column: impl Into<Column>,
+        value: &'p (impl ToSql + Sync),
+    ) -> &mut Self {
+        self.parameters.push(value);
+        self.add_expression(column, Expression::Parameter(self.parameters.len()))
+    }
+
+    pub fn with_row(mut self, row: &'p (impl PostgresRow + Sync)) -> Self {
+        self.add_row(row);
+        self
+    }
+
+    pub fn add_row(&mut self, value: &'p (impl ToSql + Sync)) -> &mut Self {
+        self.parameters.push(value);
+        // TODO: Use a builder which knows `values` at compile time
+        let InsertValueItem::Values(values) = &mut self.statement.values else {
+            unreachable!()
+        };
+        values.push(Expression::FieldAccess(
+            Box::new(Expression::Cast(
+                Box::new(Expression::Parameter(self.parameters.len())),
+                PostgresType::Row(self.statement.table),
+            )),
+            Box::new(Expression::Asterisk),
+        ));
+        self
+    }
+
+    pub fn from_rows<R>(rows: &'p &[R]) -> Self
+    where
+        R: PostgresRow + Sync,
+    {
+        let table = R::table();
+        Self {
+            statement: InsertStatement {
+                table,
+                alias: None,
+                columns: vec![],
+                values: InsertValueItem::Query(Box::new(SelectStatement {
+                    with: WithExpression::default(),
+                    distinct: vec![],
+                    selects: vec![SelectExpression {
+                        expression: Expression::Asterisk,
+                        alias: None,
+                    }],
+                    from: FromItem::Function(Function::Unnest(Box::new(Expression::Cast(
+                        Box::new(Expression::Parameter(1)),
+                        PostgresType::Array(Box::new(PostgresType::Row(table))),
+                    )))),
+                    joins: vec![],
+                    where_expression: WhereExpression::default(),
+                    order_by_expression: OrderByExpression::default(),
+                    group_by_expression: GroupByExpression::default(),
+                    limit: None,
+                })),
+            },
+            parameters: vec![rows],
+        }
+    }
+}

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/statement/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/statement/mod.rs
@@ -1,15 +1,16 @@
+mod insert;
 mod select;
 mod window;
 
 use std::fmt;
 
 pub use self::{
-    select::{Distinctness, SelectStatement},
+    select::{Distinctness, FromItem, SelectStatement},
     window::WindowStatement,
 };
 use crate::store::postgres::query::Transpile;
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Statement {
     Select(SelectStatement),
 }

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/statement/select.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/statement/select.rs
@@ -2,16 +2,43 @@ use std::fmt::{self, Write};
 
 use crate::store::postgres::query::{
     expression::{GroupByExpression, OrderByExpression},
-    AliasedTable, Expression, JoinExpression, SelectExpression, Transpile, WhereExpression,
-    WithExpression,
+    Alias, AliasedTable, Expression, Function, JoinExpression, SelectExpression, Table, Transpile,
+    WhereExpression, WithExpression,
 };
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum FromItem {
+    Table { table: Table, alias: Option<Alias> },
+    Function(Function),
+}
+
+impl Transpile for FromItem {
+    fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Table { table, alias } => {
+                table.transpile(fmt)?;
+                if let Some(alias) = *alias {
+                    fmt.write_str(" AS ")?;
+                    AliasedTable {
+                        table: *table,
+                        alias,
+                    }
+                    .transpile(fmt)
+                } else {
+                    Ok(())
+                }
+            }
+            Self::Function(function) => function.transpile(fmt),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SelectStatement {
     pub with: WithExpression,
     pub distinct: Vec<Expression>,
     pub selects: Vec<SelectExpression>,
-    pub from: AliasedTable,
+    pub from: FromItem,
     pub joins: Vec<JoinExpression>,
     pub where_expression: WhereExpression,
     pub order_by_expression: OrderByExpression,
@@ -53,8 +80,6 @@ impl Transpile for SelectStatement {
             condition.transpile(fmt)?;
         }
         fmt.write_str("\nFROM ")?;
-        self.from.table.transpile(fmt)?;
-        fmt.write_str(" AS ")?;
         self.from.transpile(fmt)?;
 
         for join in &self.joins {
@@ -699,7 +724,7 @@ mod tests {
             WHERE "entity_temporal_metadata_0_0_0"."draft_id" IS NULL
               AND "entity_temporal_metadata_0_0_0"."transaction_time" @> $2::TIMESTAMPTZ
               AND "entity_temporal_metadata_0_0_0"."decision_time" && $3
-              AND jsonb_path_query_first("entity_editions_0_1_0"."properties", $1::text::jsonpath) = $4
+              AND jsonb_path_query_first("entity_editions_0_1_0"."properties", (($1::text)::jsonpath)) = $4
             "#,
             &[
                 &json_path,
@@ -737,7 +762,7 @@ mod tests {
             WHERE "entity_temporal_metadata_0_0_0"."draft_id" IS NULL
               AND "entity_temporal_metadata_0_0_0"."transaction_time" @> $2::TIMESTAMPTZ
               AND "entity_temporal_metadata_0_0_0"."decision_time" && $3
-              AND jsonb_path_query_first("entity_editions_0_1_0"."properties", $1::text::jsonpath) IS NULL
+              AND jsonb_path_query_first("entity_editions_0_1_0"."properties", (($1::text)::jsonpath)) IS NULL
             "#,
             &[
                 &json_path,

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/table.rs
@@ -302,7 +302,7 @@ impl Table {
         AliasedTable { table: self, alias }
     }
 
-    const fn as_str(self) -> &'static str {
+    pub const fn as_str(self) -> &'static str {
         match self {
             Self::OntologyIds => "ontology_ids",
             Self::OntologyTemporalMetadata => "ontology_temporal_metadata",
@@ -1299,6 +1299,162 @@ pub enum Column {
     EntityProperties(EntityProperties),
     EntityHasLeftEntity(EntityHasLeftEntity),
     EntityHasRightEntity(EntityHasRightEntity),
+}
+
+impl From<OntologyIds> for Column {
+    fn from(column: OntologyIds) -> Self {
+        Self::OntologyIds(column)
+    }
+}
+
+impl From<OntologyTemporalMetadata> for Column {
+    fn from(column: OntologyTemporalMetadata) -> Self {
+        Self::OntologyTemporalMetadata(column)
+    }
+}
+
+impl From<OntologyOwnedMetadata> for Column {
+    fn from(column: OntologyOwnedMetadata) -> Self {
+        Self::OntologyOwnedMetadata(column)
+    }
+}
+
+impl From<OntologyExternalMetadata> for Column {
+    fn from(column: OntologyExternalMetadata) -> Self {
+        Self::OntologyExternalMetadata(column)
+    }
+}
+
+impl From<OntologyAdditionalMetadata> for Column {
+    fn from(column: OntologyAdditionalMetadata) -> Self {
+        Self::OntologyAdditionalMetadata(column)
+    }
+}
+
+impl From<DataTypes> for Column {
+    fn from(column: DataTypes) -> Self {
+        Self::DataTypes(column)
+    }
+}
+
+impl From<DataTypeEmbeddings> for Column {
+    fn from(column: DataTypeEmbeddings) -> Self {
+        Self::DataTypeEmbeddings(column)
+    }
+}
+
+impl From<PropertyTypes> for Column {
+    fn from(column: PropertyTypes) -> Self {
+        Self::PropertyTypes(column)
+    }
+}
+
+impl From<PropertyTypeEmbeddings> for Column {
+    fn from(column: PropertyTypeEmbeddings) -> Self {
+        Self::PropertyTypeEmbeddings(column)
+    }
+}
+
+impl From<EntityTypes> for Column {
+    fn from(column: EntityTypes) -> Self {
+        Self::EntityTypes(column)
+    }
+}
+
+impl From<EntityTypeEmbeddings> for Column {
+    fn from(column: EntityTypeEmbeddings) -> Self {
+        Self::EntityTypeEmbeddings(column)
+    }
+}
+
+impl From<EntityIds> for Column {
+    fn from(column: EntityIds) -> Self {
+        Self::EntityIds(column)
+    }
+}
+
+impl From<EntityTemporalMetadata> for Column {
+    fn from(column: EntityTemporalMetadata) -> Self {
+        Self::EntityTemporalMetadata(column)
+    }
+}
+
+impl From<EntityEditions> for Column {
+    fn from(column: EntityEditions) -> Self {
+        Self::EntityEditions(column)
+    }
+}
+
+impl From<EntityEmbeddings> for Column {
+    fn from(column: EntityEmbeddings) -> Self {
+        Self::EntityEmbeddings(column)
+    }
+}
+
+impl From<PropertyTypeConstrainsValuesOn> for Column {
+    fn from(column: PropertyTypeConstrainsValuesOn) -> Self {
+        Self::PropertyTypeConstrainsValuesOn(column)
+    }
+}
+
+impl From<PropertyTypeConstrainsPropertiesOn> for Column {
+    fn from(column: PropertyTypeConstrainsPropertiesOn) -> Self {
+        Self::PropertyTypeConstrainsPropertiesOn(column)
+    }
+}
+
+impl From<EntityTypeConstrainsPropertiesOn> for Column {
+    fn from(column: EntityTypeConstrainsPropertiesOn) -> Self {
+        Self::EntityTypeConstrainsPropertiesOn(column, None)
+    }
+}
+
+impl From<EntityTypeInheritsFrom> for Column {
+    fn from(column: EntityTypeInheritsFrom) -> Self {
+        Self::EntityTypeInheritsFrom(column, None)
+    }
+}
+
+impl From<EntityTypeConstrainsLinksOn> for Column {
+    fn from(column: EntityTypeConstrainsLinksOn) -> Self {
+        Self::EntityTypeConstrainsLinksOn(column, None)
+    }
+}
+
+impl From<EntityTypeConstrainsLinkDestinationsOn> for Column {
+    fn from(column: EntityTypeConstrainsLinkDestinationsOn) -> Self {
+        Self::EntityTypeConstrainsLinkDestinationsOn(column, None)
+    }
+}
+
+impl From<EntityIsOfType> for Column {
+    fn from(column: EntityIsOfType) -> Self {
+        Self::EntityIsOfType(column, None)
+    }
+}
+
+impl From<EntityIsOfTypeIds> for Column {
+    fn from(column: EntityIsOfTypeIds) -> Self {
+        Self::EntityIsOfTypeIds(column)
+    }
+}
+
+impl From<EntityProperties> for Column {
+    fn from(column: EntityProperties) -> Self {
+        Self::EntityProperties(column)
+    }
+}
+
+impl From<EntityHasLeftEntity> for Column {
+    fn from(column: EntityHasLeftEntity) -> Self {
+        Self::EntityHasLeftEntity(column)
+    }
+}
+
+impl From<EntityHasRightEntity> for Column {
+    fn from(column: EntityHasRightEntity) -> Self {
+        Self::EntityHasRightEntity(column)
+    }
 }
 
 impl Column {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In some functions we have "almost the same query" as many as 4x times. With a builder we can just generate the bits, rather than write it multiple times (and don't need to update it in multiple locations when changing, as well). 

In addition, this simplifies writing insert statements and makes them more safe.

## 🚫 Blocked by

- #4384 

## 🔍 What does this change?

- Implement `InsertStatement`
- Generalize parts of `SelectStatement` which are shared

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph