### PR TITLE
H-2615: Refactor `harpc/wire-protocol` to make use of `Buf/BufMut` instead of `AsyncRead/AsyncWrite`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,9 +249,9 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bb8"
@@ -1117,7 +1117,7 @@ dependencies = [
  "async-trait",
  "authorization",
  "axum 0.7.5",
- "base64 0.22.0",
+ "base64 0.22.1",
  "bytes",
  "codec",
  "error-stack",
@@ -2659,7 +2659,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -2793,7 +2793,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "rustls-pki-types",
 ]
 
@@ -4142,7 +4142,7 @@ version = "2.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d11a831e3c0b56e438a28308e7c810799e3c118417f342d30ecec080105395cd"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "log",
  "once_cell",
  "rustls 0.22.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,8 +1274,6 @@ dependencies = [
  "similar-asserts",
  "test-strategy",
  "thiserror",
- "tokio",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,7 @@ version = "0.0.0"
 dependencies = [
  "derive-where",
  "error-stack",
+ "harpc-wire-protocol",
  "serde",
  "serde_json",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ validation.path = "libs/@local/hash-validation"
 hash-tracing.path = "libs/@local/tracing"
 type-system.path = "libs/@blockprotocol/type-system/rust"
 harpc-types.path = "libs/@local/harpc/types"
-harpc-wire.path = "libs/@local/harpc/wire-protocol"
+harpc-wire-protocol.path = "libs/@local/harpc/wire-protocol"
 
 # External dependencies owned by HASH
 error-stack = { version = "0.4.1", default-features = false }

--- a/libs/@local/codec/Cargo.toml
+++ b/libs/@local/codec/Cargo.toml
@@ -19,7 +19,7 @@ time = { workspace = true, features = [
     "parsing",
     "formatting",
 ], optional = true }
-harpc-wire-protocol = { version = "0.0.0", path = "../harpc/wire-protocol", optional = true }
+harpc-wire-protocol = { workspace = true, optional = true }
 
 [features]
 bytes = [

--- a/libs/@local/codec/Cargo.toml
+++ b/libs/@local/codec/Cargo.toml
@@ -13,8 +13,21 @@ error-stack = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 tokio-util = { workspace = true, features = ["codec"], optional = true }
-time = { workspace = true, features = ["macros", "serde", "parsing", "formatting"], optional = true }
+time = { workspace = true, features = [
+    "macros",
+    "serde",
+    "parsing",
+    "formatting",
+], optional = true }
+harpc-wire-protocol = { version = "0.0.0", path = "../harpc/wire-protocol", optional = true }
 
 [features]
-bytes = ["dep:serde", "dep:derive-where", "dep:serde_json", "dep:tokio-util", "dep:error-stack"]
+bytes = [
+    "dep:serde",
+    "dep:derive-where",
+    "dep:serde_json",
+    "dep:tokio-util",
+    "dep:error-stack",
+]
 serde = ["dep:serde", "dep:time"]
+harpc = ["dep:harpc-wire-protocol", "dep:tokio-util", "dep:error-stack"]

--- a/libs/@local/codec/package.json
+++ b/libs/@local/codec/package.json
@@ -6,6 +6,8 @@
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@rust/harpc-wire-protocol": "0.0.0-private"
+  },
   "devDependencies": {}
 }

--- a/libs/@local/codec/src/harpc/mod.rs
+++ b/libs/@local/codec/src/harpc/mod.rs
@@ -1,0 +1,1 @@
+pub mod wire;

--- a/libs/@local/codec/src/harpc/mod.rs
+++ b/libs/@local/codec/src/harpc/mod.rs
@@ -1,1 +1,3 @@
+#![expect(clippy::big_endian_bytes, reason = "This is a protocol requirement")]
+
 pub mod wire;

--- a/libs/@local/codec/src/harpc/wire.rs
+++ b/libs/@local/codec/src/harpc/wire.rs
@@ -39,14 +39,12 @@ where
     type Item = T;
 
     #[expect(clippy::big_endian_bytes, reason = "This is a protocol requirement")]
+    #[expect(clippy::missing_asserts_for_indexing, reason = "false positive")]
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         if src.len() < 32 {
             // Not enough data to decode a request
             return Ok(None);
         }
-
-        // this will always be true, but will eliminate the need for a bounds check (clippy)
-        assert!(src.len() > 31);
 
         // The length marker is always at bytes 30 and 31
         let length = u16::from_be_bytes([src[30], src[31]]) as usize;

--- a/libs/@local/codec/src/harpc/wire.rs
+++ b/libs/@local/codec/src/harpc/wire.rs
@@ -12,9 +12,9 @@ use tokio_util::{
     codec::{Decoder, Encoder},
 };
 
-pub struct ProtocolEncoder<T>(PhantomData<fn() -> *const T>);
+pub struct ProtocolCodec<T>(PhantomData<fn() -> *const T>);
 
-impl<T> Encoder<T> for ProtocolEncoder<T>
+impl<T> Encoder<T> for ProtocolCodec<T>
 where
     T: Encode,
 {
@@ -29,16 +29,13 @@ where
     }
 }
 
-pub struct ProtocolDecoder<T>(PhantomData<fn() -> *const T>);
-
-impl<T> Decoder for ProtocolDecoder<T>
+impl<T> Decoder for ProtocolCodec<T>
 where
     T: Decode<Context = ()>,
 {
     type Error = Report<io::Error>;
     type Item = T;
 
-    #[expect(clippy::big_endian_bytes, reason = "This is a protocol requirement")]
     #[expect(clippy::missing_asserts_for_indexing, reason = "false positive")]
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         if src.len() < 32 {
@@ -69,8 +66,5 @@ where
     }
 }
 
-pub type RequestEncoder = ProtocolEncoder<Request>;
-pub type RequestDecoder = ProtocolDecoder<Request>;
-
-pub type ResponseEncoder = ProtocolEncoder<Response>;
-pub type ResponseDecoder = ProtocolDecoder<Response>;
+pub type RequestCodec = ProtocolCodec<Request>;
+pub type ResponseCodec = ProtocolCodec<Response>;

--- a/libs/@local/codec/src/harpc/wire.rs
+++ b/libs/@local/codec/src/harpc/wire.rs
@@ -45,6 +45,9 @@ where
             return Ok(None);
         }
 
+        // this will always be true, but will eliminate the need for a bounds check (clippy)
+        assert!(src.len() > 31);
+
         // The length marker is always at bytes 30 and 31
         let length = u16::from_be_bytes([src[30], src[31]]) as usize;
         let packet_length = length + 32;

--- a/libs/@local/codec/src/harpc/wire.rs
+++ b/libs/@local/codec/src/harpc/wire.rs
@@ -1,0 +1,75 @@
+use core::marker::PhantomData;
+use std::io;
+
+use error_stack::{Report, ResultExt};
+use harpc_wire_protocol::{
+    codec::{Buffer, Decode, Encode},
+    request::Request,
+    response::Response,
+};
+use tokio_util::{
+    bytes::BytesMut,
+    codec::{Decoder, Encoder},
+};
+
+pub struct ProtocolEncoder<T>(PhantomData<fn() -> *const T>);
+
+impl<T> Encoder<T> for ProtocolEncoder<T>
+where
+    T: Encode,
+{
+    // we need to use io::Error here, because `Encoder` requires `From<io::Error> for Error`
+    type Error = Report<io::Error>;
+
+    fn encode(&mut self, item: T, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        let mut buffer = Buffer::new(dst);
+
+        item.encode(&mut buffer)
+            .change_context(io::Error::from(io::ErrorKind::InvalidData))
+    }
+}
+
+pub struct ProtocolDecoder<T>(PhantomData<fn() -> *const T>);
+
+impl<T> Decoder for ProtocolDecoder<T>
+where
+    T: Decode<Context = ()>,
+{
+    type Error = Report<io::Error>;
+    type Item = T;
+
+    #[expect(clippy::big_endian_bytes, reason = "This is a protocol requirement")]
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        if src.len() < 32 {
+            // Not enough data to decode a request
+            return Ok(None);
+        }
+
+        // The length marker is always at bytes 30 and 31
+        let length = u16::from_be_bytes([src[30], src[31]]) as usize;
+        let packet_length = length + 32;
+
+        if src.len() < packet_length {
+            // Reserve space for the rest of the packet
+            // Not necessarily needed, but good idea performance-wise
+            src.reserve(packet_length - src.len());
+
+            // Not enough data to decode a request
+            return Ok(None);
+        }
+
+        // split of the packet into a separate buffer
+        let mut bytes = src.split_to(packet_length);
+        let mut buffer = Buffer::new(&mut bytes);
+
+        T::decode(&mut buffer, ())
+            .change_context(io::Error::from(io::ErrorKind::InvalidData))
+            .map(Some)
+    }
+}
+
+pub type RequestEncoder = ProtocolEncoder<Request>;
+pub type RequestDecoder = ProtocolDecoder<Request>;
+
+pub type ResponseEncoder = ProtocolEncoder<Response>;
+pub type ResponseDecoder = ProtocolDecoder<Response>;

--- a/libs/@local/codec/src/lib.rs
+++ b/libs/@local/codec/src/lib.rs
@@ -1,4 +1,8 @@
+#![feature(lint_reasons)]
+
 #[cfg(feature = "bytes")]
 pub mod bytes;
+#[cfg(feature = "harpc")]
+pub mod harpc;
 #[cfg(feature = "serde")]
 pub mod serde;

--- a/libs/@local/harpc/wire-protocol/Cargo.toml
+++ b/libs/@local/harpc/wire-protocol/Cargo.toml
@@ -13,11 +13,8 @@ enumflags2 = { version = "0.7.9", features = ["std"] }
 error-stack.workspace = true
 harpc-types.workspace = true
 thiserror = "1.0.59"
-tokio = { workspace = true, features = ["io-util"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt", "macros", "rt-multi-thread"] }
-uuid = { version = "1.8.0", features = ["v4"] }
 proptest = "1.4.0"
 test-strategy = "0.3.1"
 harpc-types = { workspace = true, features = ["proptest"] }

--- a/libs/@local/harpc/wire-protocol/src/codec/buffer.rs
+++ b/libs/@local/harpc/wire-protocol/src/codec/buffer.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use bytes::{Buf, BufMut, Bytes, BytesMut};
+use bytes::{Buf, BufMut, Bytes};
 use error_stack::{Report, Result};
 
 pub(crate) trait Number {

--- a/libs/@local/harpc/wire-protocol/src/codec/buffer.rs
+++ b/libs/@local/harpc/wire-protocol/src/codec/buffer.rs
@@ -116,7 +116,7 @@ where
         Ok(bytes)
     }
 
-    pub(crate) fn next_discard(&mut self, count: usize) -> Result<(), BufferError> {
+    pub(crate) fn discard(&mut self, count: usize) -> Result<(), BufferError> {
         if self.0.remaining() < count {
             return Err(Report::new(BufferError::EarlyEndOfStream));
         }
@@ -217,7 +217,7 @@ mod test {
 
         let mut pointer = &bytes[..];
         Buffer::new(&mut pointer)
-            .next_discard(4)
+            .discard(4)
             .expect("should have enough remaining capacity");
         assert_eq!(pointer.len(), 0);
     }
@@ -258,7 +258,7 @@ mod test {
 
         let mut pointer = &bytes[..3];
         let report = Buffer::new(&mut pointer)
-            .next_discard(4)
+            .discard(4)
             .expect_err("should not have enough remaining capacity");
         assert_eq!(report.current_context(), &BufferError::EarlyEndOfStream);
     }

--- a/libs/@local/harpc/wire-protocol/src/codec/decode.rs
+++ b/libs/@local/harpc/wire-protocol/src/codec/decode.rs
@@ -1,11 +1,6 @@
-use std::io;
 
-use bytes::{Buf, Bytes, BytesMut};
-use error_stack::{Context, Report};
-use tokio::{
-    io::{AsyncRead, AsyncReadExt},
-    pin,
-};
+use bytes::{Buf, Bytes};
+use error_stack::{Report};
 
 use super::buffer::{Buffer, BufferError};
 

--- a/libs/@local/harpc/wire-protocol/src/codec/decode.rs
+++ b/libs/@local/harpc/wire-protocol/src/codec/decode.rs
@@ -1,13 +1,17 @@
-
 use bytes::{Buf, Bytes};
-use error_stack::{Report};
+use error_stack::{Context, Result};
 
 use super::buffer::{Buffer, BufferError};
 
 pub trait Decode: Sized {
     type Context: Send + Sync;
-    type Error;
+    type Error: Context;
 
+    /// Decode a value from the buffer.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the contained value is invalid, or the buffer is too short.
     fn decode<B>(buffer: &mut Buffer<B>, context: Self::Context) -> Result<Self, Self::Error>
     where
         B: Buf;
@@ -15,7 +19,7 @@ pub trait Decode: Sized {
 
 impl Decode for u8 {
     type Context = ();
-    type Error = Report<BufferError>;
+    type Error = BufferError;
 
     fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
     where
@@ -27,7 +31,7 @@ impl Decode for u8 {
 
 impl Decode for u16 {
     type Context = ();
-    type Error = Report<BufferError>;
+    type Error = BufferError;
 
     fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
     where
@@ -39,7 +43,7 @@ impl Decode for u16 {
 
 impl Decode for u32 {
     type Context = ();
-    type Error = Report<BufferError>;
+    type Error = BufferError;
 
     fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
     where
@@ -51,7 +55,7 @@ impl Decode for u32 {
 
 impl Decode for Bytes {
     type Context = ();
-    type Error = Report<BufferError>;
+    type Error = BufferError;
 
     fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
     where
@@ -70,60 +74,76 @@ pub(crate) mod test {
     use bytes::Bytes;
 
     use super::Decode;
-    use crate::codec::{encode::test::encode_value, Encode};
+    use crate::codec::{encode::test::encode_value, Buffer, Encode};
 
     #[track_caller]
-    pub(crate) async fn decode_value<T>(buffer: &[u8], context: T::Context) -> T
+    pub(crate) fn decode_value<T>(bytes: impl Into<Bytes>, context: T::Context) -> T
     where
         T: Decode,
     {
-        let mut reader = std::io::Cursor::new(buffer);
+        let mut bytes = bytes.into();
+        let mut buffer = Buffer::new(&mut bytes);
 
-        let value = T::decode(&mut reader, context)
-            .await
-            .expect("able to decode value");
+        let value = T::decode(&mut buffer, context).expect("able to decode value");
 
-        // ensure that the entire buffer was consumed
-        assert_eq!(reader.position(), buffer.len() as u64);
+        assert!(bytes.is_ascii());
 
         value
     }
 
     #[track_caller]
-    pub(crate) async fn assert_decode<T>(buffer: &[u8], expected: &T, context: T::Context)
+    pub(crate) fn assert_decode<T>(bytes: impl Into<Bytes>, expected: &T, context: T::Context)
     where
-        T: Debug + PartialEq + Sync + Decode,
+        T: Debug + PartialEq + Decode,
     {
-        let value: T = decode_value(buffer, context).await;
+        let value: T = decode_value(bytes, context);
 
         similar_asserts::assert_eq!(&value, expected);
     }
 
     #[track_caller]
-    pub(crate) async fn assert_codec<T>(value: &T, context: T::Context)
-    where
-        T: Debug + PartialEq + Decode + Encode + Sync,
+    pub(crate) fn assert_decode_error<T>(
+        bytes: impl Into<Bytes>,
+        expected: &T::Error,
+        context: T::Context,
+    ) where
+        T: Decode + Debug,
+        T::Error: PartialEq,
     {
-        let buffer = encode_value(value).await;
-        let decoded = decode_value(&buffer, context).await;
+        let mut bytes = bytes.into();
+        let mut buffer = Buffer::new(&mut bytes);
+
+        let result = T::decode(&mut buffer, context).expect_err("should fail to encode");
+
+        let context = result.current_context();
+
+        assert_eq!(*context, *expected);
+    }
+
+    #[track_caller]
+    pub(crate) fn assert_codec<T>(value: &T, context: T::Context)
+    where
+        T: Debug + PartialEq + Decode + Encode,
+    {
+        let bytes = encode_value(value);
+        let decoded = decode_value(bytes, context);
 
         assert_eq!(*value, decoded);
     }
 
-    #[tokio::test]
-    async fn decode_u16() {
-        assert_decode(&[0x12, 0x23], &0x1223_u16, ()).await;
-        assert_decode(&[0x00, 0x00], &0x0000_u16, ()).await;
-        assert_decode(&[0xFF, 0xFF], &0xFFFF_u16, ()).await;
+    #[test]
+    fn decode_u16() {
+        assert_decode(&[0x12_u8, 0x23] as &[_], &0x1223_u16, ());
+        assert_decode(&[0x00_u8, 0x00] as &[_], &0x0000_u16, ());
+        assert_decode(&[0xFF_u8, 0xFF] as &[_], &0xFFFF_u16, ());
     }
 
-    #[tokio::test]
-    async fn decode_bytes() {
-        assert_decode::<Bytes>(
-            &[0x00, 0x05, 0x01, 0x02, 0x03, 0x04, 0x05],
+    #[test]
+    fn decode_bytes() {
+        assert_decode(
+            &[0x00_u8, 0x05, 0x01, 0x02, 0x03, 0x04, 0x05] as &[_],
             &Bytes::from_static(&[0x01, 0x02, 0x03, 0x04, 0x05]),
             (),
-        )
-        .await;
+        );
     }
 }

--- a/libs/@local/harpc/wire-protocol/src/codec/encode.rs
+++ b/libs/@local/harpc/wire-protocol/src/codec/encode.rs
@@ -1,13 +1,8 @@
-use std::io;
 
 use bytes::{BufMut, Bytes};
-use error_stack::{Context, Report, ResultExt};
-use tokio::{
-    io::{AsyncWrite, AsyncWriteExt},
-    pin,
-};
+use error_stack::{Report, ResultExt};
 
-use super::buffer::{Buffer, BufferError};
+use super::buffer::{Buffer};
 
 pub trait Encode {
     type Error;

--- a/libs/@local/harpc/wire-protocol/src/codec/mod.rs
+++ b/libs/@local/harpc/wire-protocol/src/codec/mod.rs
@@ -13,21 +13,21 @@ pub(crate) mod test {
     use proptest::collection::size_range;
 
     pub(crate) use super::{
-        decode::test::{assert_codec, assert_decode},
+        decode::test::{assert_codec, assert_decode, assert_decode_error},
         encode::test::{assert_encode, encode_value},
     };
 
-    #[test_strategy::proptest(async = "tokio")]
-    async fn codec_u16(value: u16) {
-        assert_codec(&value, ()).await;
+    #[test_strategy::proptest]
+    fn codec_u16(value: u16) {
+        assert_codec(&value, ());
     }
 
     // 1024 ensures that we spill over into the second length byte while still having a good
     // runtime performance.
-    #[test_strategy::proptest(async = "tokio")]
-    async fn codec_bytes(#[any(size_range(0..1024).lift())] payload: Vec<u8>) {
+    #[test_strategy::proptest]
+    fn codec_bytes(#[any(size_range(0..1024).lift())] payload: Vec<u8>) {
         let buffer = Bytes::from(payload);
 
-        assert_codec(&buffer, ()).await;
+        assert_codec(&buffer, ());
     }
 }

--- a/libs/@local/harpc/wire-protocol/src/codec/mod.rs
+++ b/libs/@local/harpc/wire-protocol/src/codec/mod.rs
@@ -1,7 +1,9 @@
+mod buffer;
 mod decode;
 mod encode;
 mod types;
 
+pub use buffer::{Buffer, BufferError};
 pub use decode::Decode;
 pub use encode::{BytesEncodeError, Encode};
 

--- a/libs/@local/harpc/wire-protocol/src/codec/types.rs
+++ b/libs/@local/harpc/wire-protocol/src/codec/types.rs
@@ -1,12 +1,7 @@
-use std::io;
 
 use bytes::{Buf, BufMut};
 use error_stack::Report;
 use harpc_types::{procedure::ProcedureId, service::ServiceId, version::Version};
-use tokio::{
-    io::{AsyncRead, AsyncWrite, AsyncWriteExt},
-    pin,
-};
 
 use super::{Buffer, BufferError, Decode};
 use crate::codec::Encode;

--- a/libs/@local/harpc/wire-protocol/src/lib.rs
+++ b/libs/@local/harpc/wire-protocol/src/lib.rs
@@ -10,7 +10,12 @@
 //!
 //! An illustration of the protocol can be seen in the `docs/` folder of the project.
 #![cfg_attr(test, feature(async_fn_track_caller))]
-#![feature(lint_reasons, associated_type_defaults)]
+#![feature(
+    lint_reasons,
+    associated_type_defaults,
+    never_type,
+    exhaustive_patterns
+)]
 
 pub mod codec;
 pub mod flags;

--- a/libs/@local/harpc/wire-protocol/src/payload.rs
+++ b/libs/@local/harpc/wire-protocol/src/payload.rs
@@ -1,8 +1,6 @@
-use std::io;
 
 use bytes::{Buf, BufMut, Bytes};
 use error_stack::Report;
-use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::codec::{Buffer, BufferError, BytesEncodeError, Decode, Encode};
 

--- a/libs/@local/harpc/wire-protocol/src/protocol.rs
+++ b/libs/@local/harpc/wire-protocol/src/protocol.rs
@@ -1,12 +1,7 @@
 use core::fmt::Display;
-use std::io;
 
 use bytes::{Buf, BufMut};
 use error_stack::{Report, ResultExt};
-use tokio::{
-    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
-    pin,
-};
 
 use crate::codec::{Buffer, Decode, Encode};
 

--- a/libs/@local/harpc/wire-protocol/src/request/begin.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/begin.rs
@@ -58,7 +58,7 @@ impl Decode for RequestBegin {
         let procedure = ProcedureDescriptor::decode(buffer, ())?;
 
         // skip 13 bytes (reserved for future use)
-        buffer.next_discard(13)?;
+        buffer.discard(13)?;
 
         let payload = Payload::decode(buffer, ())?;
 

--- a/libs/@local/harpc/wire-protocol/src/request/begin.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/begin.rs
@@ -1,9 +1,5 @@
 use bytes::{Buf, BufMut};
-use error_stack::{Report, ResultExt};
-use tokio::{
-    io::{AsyncReadExt, AsyncWrite, AsyncWriteExt},
-    pin,
-};
+use error_stack::{Report};
 
 use super::{procedure::ProcedureDescriptor, service::ServiceDescriptor};
 use crate::{

--- a/libs/@local/harpc/wire-protocol/src/request/body.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/body.rs
@@ -1,9 +1,5 @@
 use bytes::{Buf, BufMut};
-use error_stack::{Report, ResultExt};
-use tokio::{
-    io::{AsyncRead, AsyncWrite},
-    pin,
-};
+use error_stack::{Report};
 
 use super::{
     begin::RequestBegin,

--- a/libs/@local/harpc/wire-protocol/src/request/codec.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/codec.rs
@@ -1,7 +1,0 @@
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, thiserror::Error)]
-#[error("unable to encode request")]
-pub struct EncodeError;
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, thiserror::Error)]
-#[error("unable to decode request")]
-pub struct DecodeError;

--- a/libs/@local/harpc/wire-protocol/src/request/flags.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/flags.rs
@@ -1,9 +1,7 @@
-use std::io;
 
 use bytes::{Buf, BufMut};
 use enumflags2::BitFlags;
 use error_stack::Report;
-use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::body::RequestBody;
 use crate::{

--- a/libs/@local/harpc/wire-protocol/src/request/flags.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/flags.rs
@@ -1,12 +1,13 @@
 use std::io;
 
+use bytes::{Buf, BufMut};
 use enumflags2::BitFlags;
-use error_stack::Result;
+use error_stack::Report;
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::body::RequestBody;
 use crate::{
-    codec::{Decode, Encode},
+    codec::{Buffer, BufferError, Decode, Encode},
     flags::BitFlagsOp,
 };
 
@@ -60,20 +61,27 @@ impl From<RequestFlag> for RequestFlags {
 }
 
 impl Encode for RequestFlags {
-    type Error = io::Error;
+    type Error = !;
 
-    async fn encode(&self, write: impl AsyncWrite + Send) -> Result<(), Self::Error> {
-        self.0.bits().encode(write).await
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    where
+        B: BufMut,
+    {
+        let bits = self.0.bits();
+
+        bits.encode(buffer)
     }
 }
 
 impl Decode for RequestFlags {
     type Context = ();
-    type Error = io::Error;
+    type Error = Report<BufferError>;
 
-    async fn decode(read: impl AsyncRead + Send, (): ()) -> Result<Self, Self::Error> {
-        u8::decode(read, ())
-            .await
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    where
+        B: Buf,
+    {
+        u8::decode(buffer, ())
             .map(BitFlags::from_bits_truncate)
             .map(From::from)
     }

--- a/libs/@local/harpc/wire-protocol/src/request/frame.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/frame.rs
@@ -1,14 +1,14 @@
 use std::io;
 
-use error_stack::{Result, ResultExt};
+use bytes::{Buf, BufMut};
+use error_stack::{Report, ResultExt};
 use tokio::{
     io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
     pin,
 };
 
-use super::codec::EncodeError;
 use crate::{
-    codec::{Decode, Encode},
+    codec::{Buffer, BufferError, BytesEncodeError, Decode, Encode},
     payload::Payload,
 };
 
@@ -19,34 +19,33 @@ pub struct RequestFrame {
 }
 
 impl Encode for RequestFrame {
-    type Error = EncodeError;
+    type Error = Report<BytesEncodeError>;
 
-    async fn encode(&self, write: impl AsyncWrite + Send) -> Result<(), Self::Error> {
-        pin!(write);
-
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    where
+        B: BufMut,
+    {
         // write 19 empty bytes (reserved for future use)
-        write
-            .write_all(&[0; 19])
-            .await
-            .change_context(EncodeError)?;
+        buffer.push_repeat(0, 19);
 
-        self.payload.encode(write).await.change_context(EncodeError)
+        self.payload.encode(buffer)
     }
 }
 
 impl Decode for RequestFrame {
     type Context = ();
-    type Error = io::Error;
+    type Error = Report<BufferError>;
 
-    async fn decode(read: impl AsyncRead + Send, (): ()) -> Result<Self, Self::Error> {
-        pin!(read);
-
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    where
+        B: Buf,
+    {
         // skip 19 bytes (reserved for future use)
-        read.read_exact(&mut [0; 19]).await?;
+        buffer.next_discard(19)?;
 
-        Ok(Self {
-            payload: Payload::decode(read, ()).await?,
-        })
+        let payload = Payload::decode(buffer, ())?;
+
+        Ok(Self { payload })
     }
 }
 

--- a/libs/@local/harpc/wire-protocol/src/request/frame.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/frame.rs
@@ -1,11 +1,6 @@
-use std::io;
 
 use bytes::{Buf, BufMut};
-use error_stack::{Report, ResultExt};
-use tokio::{
-    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
-    pin,
-};
+use error_stack::{Report};
 
 use crate::{
     codec::{Buffer, BufferError, BytesEncodeError, Decode, Encode},

--- a/libs/@local/harpc/wire-protocol/src/request/frame.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/frame.rs
@@ -1,11 +1,14 @@
-
 use bytes::{Buf, BufMut};
-use error_stack::{Report};
+use error_stack::{Result, ResultExt};
 
 use crate::{
-    codec::{Buffer, BufferError, BytesEncodeError, Decode, Encode},
+    codec::{Buffer, BufferError, Decode, Encode},
     payload::Payload,
 };
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, thiserror::Error)]
+#[error("unable to encode request frame")]
+pub struct RequestFrameEncodeError;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
@@ -14,22 +17,26 @@ pub struct RequestFrame {
 }
 
 impl Encode for RequestFrame {
-    type Error = Report<BytesEncodeError>;
+    type Error = RequestFrameEncodeError;
 
     fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
     where
         B: BufMut,
     {
         // write 19 empty bytes (reserved for future use)
-        buffer.push_repeat(0, 19);
+        buffer
+            .push_repeat(0, 19)
+            .change_context(RequestFrameEncodeError)?;
 
-        self.payload.encode(buffer)
+        self.payload
+            .encode(buffer)
+            .change_context(RequestFrameEncodeError)
     }
 }
 
 impl Decode for RequestFrame {
     type Context = ();
-    type Error = Report<BufferError>;
+    type Error = BufferError;
 
     fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
     where
@@ -55,8 +62,8 @@ mod test {
         request::frame::RequestFrame,
     };
 
-    #[tokio::test]
-    async fn encode() {
+    #[test]
+    fn encode() {
         assert_encode(
             &RequestFrame {
                 payload: Payload::new(b"hello world" as &[_]),
@@ -65,28 +72,26 @@ mod test {
                 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
                 0x00 0x00 0x00 0x00 0x0B b'h' b'e' b'l' b'l' b'o' b' ' b'w' b'o' b'r' b'l' b'd'
             "#]],
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn decode() {
+    #[test]
+    fn decode() {
         assert_decode(
             &[
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0B, b'h', b'e', b'l', b'l', b'o', b' ', b'w',
                 b'o', b'r', b'l', b'd',
-            ],
+            ] as &[_],
             &RequestFrame {
                 payload: Payload::from_static(b"hello world" as &[_]),
             },
             (),
-        )
-        .await;
+        );
     }
 
-    #[test_strategy::proptest(async = "tokio")]
-    async fn codec(frame: RequestFrame) {
-        assert_codec(&frame, ()).await;
+    #[test_strategy::proptest]
+    fn codec(frame: RequestFrame) {
+        assert_codec(&frame, ());
     }
 }

--- a/libs/@local/harpc/wire-protocol/src/request/frame.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/frame.rs
@@ -43,7 +43,7 @@ impl Decode for RequestFrame {
         B: Buf,
     {
         // skip 19 bytes (reserved for future use)
-        buffer.next_discard(19)?;
+        buffer.discard(19)?;
 
         let payload = Payload::decode(buffer, ())?;
 

--- a/libs/@local/harpc/wire-protocol/src/request/header.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/header.rs
@@ -1,11 +1,6 @@
-use std::io;
 
 use bytes::{Buf, BufMut};
 use error_stack::{Report, ResultExt};
-use tokio::{
-    io::{AsyncRead, AsyncWrite},
-    pin,
-};
 
 use super::{body::RequestBody, flags::RequestFlags, id::RequestId};
 use crate::{

--- a/libs/@local/harpc/wire-protocol/src/request/id.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/id.rs
@@ -1,8 +1,6 @@
-use std::io;
 
 use bytes::{Buf, BufMut};
 use error_stack::Report;
-use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::codec::{Buffer, BufferError, Decode, Encode};
 

--- a/libs/@local/harpc/wire-protocol/src/request/mod.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/mod.rs
@@ -1,10 +1,6 @@
 pub use bytes::Bytes;
 use bytes::{Buf, BufMut};
 use error_stack::{Report, ResultExt};
-use tokio::{
-    io::{AsyncRead, AsyncWrite},
-    pin,
-};
 
 use self::{
     body::{RequestBody, RequestBodyContext},

--- a/libs/@local/harpc/wire-protocol/src/request/procedure.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/procedure.rs
@@ -1,6 +1,5 @@
-
 use bytes::{Buf, BufMut};
-use error_stack::Report;
+use error_stack::Result;
 use harpc_types::procedure::ProcedureId;
 
 use crate::codec::{Buffer, BufferError, Decode, Encode};
@@ -12,7 +11,7 @@ pub struct ProcedureDescriptor {
 }
 
 impl Encode for ProcedureDescriptor {
-    type Error = !;
+    type Error = BufferError;
 
     fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
     where
@@ -24,7 +23,7 @@ impl Encode for ProcedureDescriptor {
 
 impl Decode for ProcedureDescriptor {
     type Context = ();
-    type Error = Report<BufferError>;
+    type Error = BufferError;
 
     fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
     where
@@ -44,29 +43,28 @@ mod test {
     use super::{ProcedureDescriptor, ProcedureId};
     use crate::codec::test::{assert_codec, assert_decode, assert_encode};
 
-    #[tokio::test]
-    async fn encode_id() {
+    #[test]
+    fn encode_id() {
         assert_encode(
             &ProcedureId::new(0x01_02),
             expect![[r#"
                 0x01 0x02
             "#]],
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn decode_id() {
-        assert_decode(&[0x12, 0x34], &ProcedureId::new(0x12_34), ()).await;
+    #[test]
+    fn decode_id() {
+        assert_decode(&[0x12_u8, 0x34] as &[_], &ProcedureId::new(0x12_34), ());
     }
 
-    #[test_strategy::proptest(async = "tokio")]
-    async fn codec_id(id: ProcedureId) {
-        assert_codec(&id, ()).await;
+    #[test_strategy::proptest]
+    fn codec_id(id: ProcedureId) {
+        assert_codec(&id, ());
     }
 
-    #[tokio::test]
-    async fn encode() {
+    #[test]
+    fn encode() {
         assert_encode(
             &ProcedureDescriptor {
                 id: ProcedureId::new(0x01_02),
@@ -74,24 +72,22 @@ mod test {
             expect![[r#"
                 0x01 0x02
             "#]],
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn decode() {
+    #[test]
+    fn decode() {
         assert_decode(
-            &[0x12, 0x34],
+            &[0x12_u8, 0x34] as &[_],
             &ProcedureDescriptor {
                 id: ProcedureId::new(0x12_34),
             },
             (),
-        )
-        .await;
+        );
     }
 
-    #[test_strategy::proptest(async = "tokio")]
-    async fn codec(id: ProcedureDescriptor) {
-        assert_codec(&id, ()).await;
+    #[test_strategy::proptest]
+    fn codec(id: ProcedureDescriptor) {
+        assert_codec(&id, ());
     }
 }

--- a/libs/@local/harpc/wire-protocol/src/request/procedure.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/procedure.rs
@@ -1,9 +1,7 @@
-use std::io;
 
 use bytes::{Buf, BufMut};
 use error_stack::Report;
 use harpc_types::procedure::ProcedureId;
-use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::codec::{Buffer, BufferError, Decode, Encode};
 

--- a/libs/@local/harpc/wire-protocol/src/request/service.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/service.rs
@@ -1,12 +1,7 @@
-use std::io;
 
 use bytes::{Buf, BufMut};
 use error_stack::Report;
 use harpc_types::{service::ServiceId, version::Version};
-use tokio::{
-    io::{AsyncRead, AsyncWrite},
-    pin,
-};
 
 use crate::codec::{Buffer, BufferError, Decode, Encode};
 

--- a/libs/@local/harpc/wire-protocol/src/response/begin.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/begin.rs
@@ -1,9 +1,5 @@
 use bytes::{Buf, BufMut};
-use error_stack::{Report, ResultExt};
-use tokio::{
-    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
-    pin,
-};
+use error_stack::{Report};
 
 use super::kind::ResponseKind;
 use crate::{

--- a/libs/@local/harpc/wire-protocol/src/response/begin.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/begin.rs
@@ -50,7 +50,7 @@ impl Decode for ResponseBegin {
         B: Buf,
     {
         // skip 17 bytes of reserved space
-        buffer.next_discard(17)?;
+        buffer.discard(17)?;
 
         let kind = ResponseKind::decode(buffer, ())?;
 

--- a/libs/@local/harpc/wire-protocol/src/response/body.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/body.rs
@@ -1,6 +1,5 @@
 use bytes::{Buf, BufMut};
-use error_stack::{Report, ResultExt};
-use tokio::io::{AsyncRead, AsyncWrite};
+use error_stack::{Report};
 
 use super::{
     begin::ResponseBegin,

--- a/libs/@local/harpc/wire-protocol/src/response/flags.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/flags.rs
@@ -1,9 +1,7 @@
-use std::io;
 
 use bytes::{Buf, BufMut};
 use enumflags2::BitFlags;
 use error_stack::Report;
-use tokio::io::AsyncWrite;
 
 use super::body::ResponseBody;
 use crate::{

--- a/libs/@local/harpc/wire-protocol/src/response/frame.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/frame.rs
@@ -1,11 +1,6 @@
-use std::io;
 
 use bytes::{Buf, BufMut};
 use error_stack::Report;
-use tokio::{
-    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
-    pin,
-};
 
 use crate::{
     codec::{Buffer, BufferError, BytesEncodeError, Decode, Encode},

--- a/libs/@local/harpc/wire-protocol/src/response/frame.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/frame.rs
@@ -43,7 +43,7 @@ impl Decode for ResponseFrame {
         B: Buf,
     {
         // skip 19 bytes of reserved space
-        buffer.next_discard(19)?;
+        buffer.discard(19)?;
 
         let payload = Payload::decode(buffer, ())?;
 

--- a/libs/@local/harpc/wire-protocol/src/response/header.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/header.rs
@@ -1,11 +1,6 @@
-use std::io;
 
 use bytes::{Buf, BufMut};
 use error_stack::{Report, ResultExt};
-use tokio::{
-    io::{AsyncRead, AsyncWrite},
-    pin,
-};
 
 use super::{flags::ResponseFlags, ResponseBody};
 use crate::{

--- a/libs/@local/harpc/wire-protocol/src/response/kind.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/kind.rs
@@ -1,9 +1,7 @@
 use core::num::NonZero;
-use std::io;
 
 use bytes::{Buf, BufMut};
 use error_stack::Report;
-use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::codec::{Buffer, BufferError, Decode, Encode};
 

--- a/libs/@local/harpc/wire-protocol/src/response/mod.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/mod.rs
@@ -1,13 +1,9 @@
 use bytes::{Buf, BufMut};
 use error_stack::{Report, ResultExt};
-use tokio::{
-    io::{AsyncRead, AsyncWrite},
-    pin,
-};
 
 use self::{
     body::{ResponseBody, ResponseBodyContext},
-    header::{ResponseHeader, ResponseHeaderDecodeError},
+    header::{ResponseHeader},
 };
 use crate::codec::{Buffer, BytesEncodeError, Decode, Encode};
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This adjusts the `harpc/wire-protocol` to make use of synchronous code, expecting that all data is present, instead of using `AsyncRead/AsyncWrite`, this has been decided internally, as it provides greater guarantees, throughput as well as enables the use of `tokio-util` to convert between streams more easily.

Most of this diff are simply code changes to accommodate the new paradigm.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
