### PR TITLE
H-2598: Fix wrong method being used to read entity types in embedding generation

### DIFF
--- a/apps/hash-ai-worker-ts/src/workflows.ts
+++ b/apps/hash-ai-worker-ts/src/workflows.ts
@@ -448,7 +448,7 @@ export const updateEntityEmbeddings = async (
       // TODO: The subgraph library does not have the required methods to do this client side so for simplicity we're
       //       just making another request here. We should add the required methods to the library and do this client
       //       side.
-      const response = await graphActivities.getEntitySubgraph({
+      const subgraph = await graphActivities.getEntityTypesSubgraph({
         authentication: params.authentication,
         request: {
           filter: {
@@ -473,7 +473,7 @@ export const updateEntityEmbeddings = async (
       });
 
       const propertyTypes = await graphActivities.getSubgraphPropertyTypes({
-        subgraph: response.subgraph,
+        subgraph,
       });
 
       const generatedEmbeddings =


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This was mistakenly changed to the wrong function and as the response is a subgraph, which is the same type for any `get*Subgraph` function`, this was not detected.

## 🔗 Related links

- [Sentry issue](https://hashintel.sentry.io/issues/5281868616)