### PR TITLE
GEN-156: Revert renovate PRs using wrong update behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3684,9 +3684,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3694,7 +3694,6 @@ dependencies = [
  "pin-project-lite",
  "slab",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -3988,12 +3987,11 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad7eb6319ebadebca3dacf1f85a93bc54b73dd81b9036795f73de7ddfe27d5a"
+checksum = "2a0e5d82932dfbf36df38de5df0cfe846d13430b3ae3fdc48b2e91ed692c8df7"
 dependencies = [
  "glob",
- "once_cell",
  "serde",
  "serde_derive",
  "serde_json",

--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -20,9 +20,9 @@ categories = ["rust-patterns", "no-std"]
 [dependencies]
 tracing-error = { version = "0.2", optional = true, default-features = false }
 anyhow = { version = ">=1.0.73", default-features = false, optional = true }
-eyre = { version = "0.6.12", default-features = false, optional = true }
-serde = { version = "1.0.200", default-features = false, optional = true }
-spin = { version = "0.9.8", default-features = false, optional = true, features = ['rwlock', 'once'] }
+eyre = { version = "0.6", default-features = false, optional = true }
+serde = { version = "1", default-features = false, optional = true }
+spin = { version = "0.9", default-features = false, optional = true, features = ['rwlock', 'once'] }
 
 [dev-dependencies]
 serde = { version = "1.0.200", features = ["derive"] }

--- a/libs/sarif/Cargo.toml
+++ b/libs/sarif/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["no_std", "sarif", "codeql", "serde", "static-analysis", "tools"]
 categories = ["no-std", "data-structures", "development-tools", "parsing"]
 
 [dependencies]
-serde = { version = "1.0.200", default-features = false, features = ["derive"], optional = true }
-serde_json = { version = "1.0.116", default-features = false, features = ["alloc"], optional = true }
+serde = { version = "1", default-features = false, features = ["derive"], optional = true }
+serde_json = { version = "1", default-features = false, features = ["alloc"], optional = true }
 semver = { version = "1", default-features = false }
 url = { version = "2", default-features = false }
 uuid = { version = "1", default-features = false }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Renovate added the minor version and patch version to some public dependencies which is not expected. This reverts the dependencies.

## 🔗 Related links

- https://github.com/renovatebot/renovate/discussions/28782