### PR TITLE
H-2649: Fix renovate update behavior

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,7 +17,6 @@
   "dependencyDashboardOSVVulnerabilitySummary": "none",
   "npm": { "minimumReleaseAge": "3 days" },
   "postUpdateOptions": ["yarnDedupeFewer"],
-  "rangeStrategy": "bump",
   "rebaseWhen": "conflicted",
   "semanticCommits": "disabled",
   "schedule": ["before 4am every weekday", "every weekend"],


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The behavior of `bump` changed. For most package managers, `bump` is the default but for `Rust` it is not, so this just removes the configuration to (hopefully) achieve the desired behavior.