### PR TITLE
H-2651: Copy `Cargo.lock` before building Graph Docker image

### DIFF
--- a/apps/hash-graph/docker/Dockerfile
+++ b/apps/hash-graph/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN turbo prune --scope='@apps/hash-graph' --docker && \
         echo > "/app/out/full/$(dirname "$1")/src/lib.rs" &&  \
         echo -e "[package]\nname = \"$(yq ".package.name" -p toml -oy $1)\"" > "/app/out/full/$1" \
       )' _ {} \; && \
-    cp Cargo.toml /app/out/full/
+    cp Cargo.toml Cargo.lock /app/out/full/
 
 
 FROM node:20.12-alpine AS rust


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `Cargo.lock` file is pruned by turborepo because it does not know that `Rust` is a thing. This bypasses `turborepo` and copies the file manually.