### PR TITLE
H-1451: Implement bulk validation for entities

### DIFF
--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -1154,14 +1154,14 @@ where
         self.store.create_entities(actor_id, params).await
     }
 
-    async fn validate_entity(
+    async fn validate_entities(
         &self,
         actor_id: AccountId,
         consistency: Consistency<'_>,
-        params: ValidateEntityParams<'_>,
+        params: Vec<ValidateEntityParams<'_>>,
     ) -> Result<(), ValidateEntityError> {
         self.store
-            .validate_entity(actor_id, consistency, params)
+            .validate_entities(actor_id, consistency, params)
             .await
     }
 

--- a/apps/hash-graph/libs/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/libs/graph/src/store/knowledge.rs
@@ -388,6 +388,20 @@ pub trait EntityStore {
         actor_id: AccountId,
         consistency: Consistency<'_>,
         params: ValidateEntityParams<'_>,
+    ) -> impl Future<Output = Result<(), Report<ValidateEntityError>>> + Send {
+        self.validate_entities(actor_id, consistency, vec![params])
+    }
+
+    /// Validates [`Entities`][Entity].
+    ///
+    /// # Errors:
+    ///
+    /// - if the validation failed
+    fn validate_entities(
+        &self,
+        actor_id: AccountId,
+        consistency: Consistency<'_>,
+        params: Vec<ValidateEntityParams<'_>>,
     ) -> impl Future<Output = Result<(), Report<ValidateEntityError>>> + Send;
 
     /// Get a list of entities specified by the [`GetEntitiesParams`].

--- a/apps/hash-graph/libs/graph/src/store/validation.rs
+++ b/apps/hash-graph/libs/graph/src/store/validation.rs
@@ -110,10 +110,6 @@ where
     }
 }
 
-#[expect(
-    clippy::struct_field_names,
-    reason = "The fields are named after the types they contain"
-)]
 #[derive(Debug, Default)]
 pub struct StoreCache {
     data_types: CacheHashMap<DataTypeId, DataType>,

--- a/apps/hash-graph/libs/graph/src/store/validation.rs
+++ b/apps/hash-graph/libs/graph/src/store/validation.rs
@@ -119,6 +119,7 @@ pub struct StoreCache {
     data_types: CacheHashMap<DataTypeId, DataType>,
     property_types: CacheHashMap<PropertyTypeId, PropertyType>,
     entity_types: CacheHashMap<EntityTypeId, ClosedEntityType>,
+    entities: CacheHashMap<EntityId, Entity>,
 }
 
 #[derive(Debug)]
@@ -406,7 +407,10 @@ where
     A: AuthorizationApi,
 {
     #[expect(refining_impl_trait)]
-    async fn provide_entity(&self, entity_id: EntityId) -> Result<Entity, Report<QueryError>> {
+    async fn provide_entity(&self, entity_id: EntityId) -> Result<Arc<Entity>, Report<QueryError>> {
+        if let Some(cached) = self.cache.entities.get(&entity_id).await {
+            return cached;
+        }
         if let Some((authorization_api, actor_id, consistency)) = self.authorization {
             authorization_api
                 .check_entity_permission(actor_id, EntityPermission::View, entity_id, consistency)
@@ -416,7 +420,8 @@ where
                 .change_context(QueryError)?;
         }
 
-        self.store
+        let entity = self
+            .store
             .read_one(
                 &Filter::for_entity_by_entity_id(entity_id),
                 Some(
@@ -428,6 +433,7 @@ where
                 ),
                 entity_id.draft_id.is_some(),
             )
-            .await
+            .await?;
+        Ok(self.cache.entities.grant(entity_id, entity).await)
     }
 }

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -490,14 +490,14 @@ where
         self.store.create_entities(actor_id, params).await
     }
 
-    async fn validate_entity(
+    async fn validate_entities(
         &self,
         actor_id: AccountId,
         consistency: Consistency<'_>,
-        params: ValidateEntityParams<'_>,
+        params: Vec<ValidateEntityParams<'_>>,
     ) -> Result<(), ValidateEntityError> {
         self.store
-            .validate_entity(actor_id, consistency, params)
+            .validate_entities(actor_id, consistency, params)
             .await
     }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This allows validating a bunch of entities at the same time which results in reusing the store-cache.

## 🚫 Blocked by

- #4398 

## 🔍 What does this change?

- Adds a `validate_entities` function
- Default to `validate_entities` when calling `validate_entity`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph