### PR TITLE
H-2589: Provide separate script to migrate API

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/shared/graph-api-client.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/graph-api-client.ts
@@ -1,5 +1,5 @@
 import { createGraphClient } from "@local/hash-backend-utils/create-graph-client";
-import { getRequiredEnv } from "@local/hash-isomorphic-utils/environment";
+import { getRequiredEnv } from "@local/hash-backend-utils/environment";
 
 import { logToConsole } from "../../shared/logger";
 

--- a/apps/hash-api/package.json
+++ b/apps/hash-api/package.json
@@ -9,6 +9,7 @@
     "build:docker": "docker buildx build --tag hash-api --file ../../infra/docker/api/prod/Dockerfile ../../ --load",
     "codegen": "rimraf './src/**/*.gen.*'; graphql-codegen --config codegen.config.ts",
     "dev": "NODE_ENV=development NODE_OPTIONS=--max-old-space-size=2048 tsx watch --clear-screen=false ./src/index.ts",
+    "ensure-system-graph-is-initialized": "tsx ./src/ensure-system-graph-is-initialized.ts",
     "fix:eslint": "eslint --fix .",
     "generate-hash-gpt-schema": "tsx ./src/ai/gpt/generate-hashgpt-schema.ts",
     "generate-ontology-type-ids": "tsx ./src/generate-ontology-type-ids.ts; yarn prettier --write ../../libs/@local/hash-isomorphic-utils/src/ontology-type-ids.ts",

--- a/apps/hash-api/src/auth/ory-kratos.ts
+++ b/apps/hash-api/src/auth/ory-kratos.ts
@@ -1,4 +1,4 @@
-import { getRequiredEnv } from "@local/hash-isomorphic-utils/environment";
+import { getRequiredEnv } from "@local/hash-backend-utils/environment";
 import type { Identity } from "@ory/client";
 import { Configuration } from "@ory/client";
 import type { CreateIdentityBody } from "@ory/kratos-client";

--- a/apps/hash-api/src/ensure-system-graph-is-initialized.ts
+++ b/apps/hash-api/src/ensure-system-graph-is-initialized.ts
@@ -1,0 +1,16 @@
+import { createGraphClient } from "@local/hash-backend-utils/create-graph-client";
+import { getRequiredEnv } from "@local/hash-backend-utils/environment";
+import { createTemporalClient } from "@local/hash-backend-utils/temporal";
+
+import { ensureSystemGraphIsInitialized } from "./graph/ensure-system-graph-is-initialized";
+import { logger } from "./logger";
+
+const context = {
+  graphApi: createGraphClient(logger, {
+    host: getRequiredEnv("HASH_GRAPH_API_HOST"),
+    port: parseInt(getRequiredEnv("HASH_GRAPH_API_PORT"), 10),
+  }),
+  temporalClient: await createTemporalClient(logger),
+};
+
+await ensureSystemGraphIsInitialized({ logger, context });

--- a/apps/hash-api/src/generate-ontology-type-ids.ts
+++ b/apps/hash-api/src/generate-ontology-type-ids.ts
@@ -1,13 +1,11 @@
-import "@local/hash-backend-utils/environment";
-
 import { writeFile } from "node:fs/promises";
 import * as path from "node:path";
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { createGraphClient } from "@local/hash-backend-utils/create-graph-client";
+import { getRequiredEnv } from "@local/hash-backend-utils/environment";
 import { Logger } from "@local/hash-backend-utils/logger";
-import { getRequiredEnv } from "@local/hash-isomorphic-utils/environment";
 import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import type {
   DataTypeWithMetadata,

--- a/apps/hash-api/src/index.ts
+++ b/apps/hash-api/src/index.ts
@@ -2,6 +2,7 @@
 
 import { TypeSystemInitializer } from "@blockprotocol/type-system";
 import {
+  getRequiredEnv,
   monorepoRootDir,
   realtimeSyncEnabled,
   waitOnResource,
@@ -27,7 +28,6 @@ import { OpenSearch } from "@local/hash-backend-utils/search/opensearch";
 import { GracefulShutdown } from "@local/hash-backend-utils/shutdown";
 import { createTemporalClient } from "@local/hash-backend-utils/temporal";
 import { createVaultClient } from "@local/hash-backend-utils/vault";
-import { getRequiredEnv } from "@local/hash-isomorphic-utils/environment";
 import * as Sentry from "@sentry/node";
 import bodyParser from "body-parser";
 import cors from "cors";

--- a/apps/hash-api/src/integrations/sync-back-watcher.ts
+++ b/apps/hash-api/src/integrations/sync-back-watcher.ts
@@ -1,10 +1,10 @@
+import { getRequiredEnv } from "@local/hash-backend-utils/environment";
 import { getMachineActorId } from "@local/hash-backend-utils/machine-actors";
 import { entityEditionRecordFromRealtimeMessage } from "@local/hash-backend-utils/pg-tables";
 import { RedisQueueExclusiveConsumer } from "@local/hash-backend-utils/queue/redis";
 import { AsyncRedisClient } from "@local/hash-backend-utils/redis";
 import type { Wal2JsonMsg } from "@local/hash-backend-utils/wal2json";
 import type { GraphApi } from "@local/hash-graph-client";
-import { getRequiredEnv } from "@local/hash-isomorphic-utils/environment";
 import { fullDecisionTimeAxis } from "@local/hash-isomorphic-utils/graph-queries";
 import { mapGraphApiEntityToEntity } from "@local/hash-isomorphic-utils/subgraph-mapping";
 import type { Entity } from "@local/hash-subgraph";

--- a/apps/hash-api/src/telemetry/snowplow-setup.ts
+++ b/apps/hash-api/src/telemetry/snowplow-setup.ts
@@ -1,4 +1,4 @@
-import { getRequiredEnv } from "@local/hash-isomorphic-utils/environment";
+import { getRequiredEnv } from "@local/hash-backend-utils/environment";
 import type { Emitter, Tracker } from "@snowplow/node-tracker";
 import {
   buildStructEvent,

--- a/libs/@local/hash-backend-utils/src/aws-config.ts
+++ b/libs/@local/hash-backend-utils/src/aws-config.ts
@@ -1,5 +1,5 @@
+import { getRequiredEnv } from "@local/hash-backend-utils/environment";
 import type { AwsS3StorageProviderConstructorArgs } from "@local/hash-backend-utils/file-storage/aws-s3-storage-provider";
-import { getRequiredEnv } from "@local/hash-isomorphic-utils/environment";
 
 export const getAwsRegion = (): string => getRequiredEnv("AWS_REGION");
 

--- a/libs/@local/hash-backend-utils/src/temporal.ts
+++ b/libs/@local/hash-backend-utils/src/temporal.ts
@@ -1,5 +1,5 @@
+import { getRequiredEnv } from "@local/hash-backend-utils/environment";
 import type { Logger } from "@local/hash-backend-utils/logger";
-import { getRequiredEnv } from "@local/hash-isomorphic-utils/environment";
 import { Client as TemporalClient, Connection } from "@temporalio/client";
 
 export { Client as TemporalClient } from "@temporalio/client";

--- a/libs/@local/hash-isomorphic-utils/src/environment.ts
+++ b/libs/@local/hash-isomorphic-utils/src/environment.ts
@@ -13,11 +13,3 @@ export const apiOrigin =
 
 export const apiGraphQLEndpoint = `${apiOrigin}/graphql`;
 
-/** Get a required environment variable. Throws an error if it's not set. */
-export const getRequiredEnv = (name: string) => {
-  const value = process.env[name];
-  if (value === undefined) {
-    throw new Error(`Environment variable ${name} is not set`);
-  }
-  return value;
-};

--- a/libs/@local/hash-isomorphic-utils/src/environment.ts
+++ b/libs/@local/hash-isomorphic-utils/src/environment.ts
@@ -12,4 +12,3 @@ export const apiOrigin =
   "http://localhost:5001";
 
 export const apiGraphQLEndpoint = `${apiOrigin}/graphql`;
-

--- a/tests/hash-backend-integration/src/tests/util.ts
+++ b/tests/hash-backend-integration/src/tests/util.ts
@@ -8,9 +8,9 @@ import { systemAccountId } from "@apps/hash-api/src/graph/system-account";
 import type { AuthenticationContext } from "@apps/hash-api/src/graphql/authentication-context";
 import type { VersionedUrl } from "@blockprotocol/type-system";
 import { createGraphClient } from "@local/hash-backend-utils/create-graph-client";
+import { getRequiredEnv } from "@local/hash-backend-utils/environment";
 import { Logger } from "@local/hash-backend-utils/logger";
 import type { TemporalClient } from "@local/hash-backend-utils/temporal";
-import { getRequiredEnv } from "@local/hash-isomorphic-utils/environment";
 import { vi } from "vitest";
 
 export const textDataTypeId =


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The migrations for the Node API are supposed to run in a dedicated service. This provides a script to run the migrations.


## 🔍 What does this change?

- Remove `getRequiredEnv` from isomorphic utils and use backend utils instead 
- Create script to run embeddings

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
## 🐾 Next steps

This is only one half of the work to build the API image and upload it to AWS. In the second PR, the changes to the infrastructure will be made.