### PR TITLE
H-2684: Fix Bench CI on push to `main`

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Find bench steps to run
         id: benches
         run: |
-          if [[ ${{ github.event_name == 'pull_request' }} ]]; then
+          if [[ "${{ github.event_name == 'pull_request' }}" == 'true' ]]; then
             echo "create-baseline=true" >> $GITHUB_OUTPUT
           else
             echo "create-baseline=false" >> $GITHUB_OUTPUT
@@ -193,7 +193,7 @@ jobs:
       - name: Find bench steps to run
         id: benches
         run: |
-          if [[ ${{ github.event_name == 'pull_request' }} ]]; then
+          if [[ "${{ github.event_name == 'pull_request' }}" == 'false' ]]; then
             echo "create-baseline=true" >> $GITHUB_OUTPUT
           else
             echo "create-baseline=false" >> $GITHUB_OUTPUT
@@ -218,9 +218,7 @@ jobs:
 
       - name: Install Protobuf
         if: steps.benches.outputs.has-rust == 'true'
-        run: |
-          echo ${{ fromJSON(steps.benches.outputs) }}
-          sudo apt install protobuf-compiler
+        run: sudo apt install protobuf-compiler
 
       - name: Checkout base branch
         if: steps.benches.outputs.create-baseline == 'true'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -136,7 +136,7 @@ jobs:
         if: steps.benches.outputs.create-baseline == 'true'
         run: |
           git fetch origin "$GITHUB_HEAD_REF"
-          git checkout FETCH_HEAD
+          git reset --hard FETCH_HEAD
 
       - name: Install Rust toolchain
         if: steps.benches.outputs.has-rust == 'true'
@@ -276,7 +276,7 @@ jobs:
         if: steps.benches.outputs.create-baseline == 'true'
         run: |
           git fetch origin "$GITHUB_HEAD_REF"
-          git checkout FETCH_HEAD
+          git reset --hard FETCH_HEAD
 
       - name: Install Rust toolchain
         if: steps.benches.outputs.has-rust == 'true'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -134,7 +134,9 @@ jobs:
 
       - name: Checkout head branch
         if: steps.benches.outputs.create-baseline == 'true'
-        run: git checkout "$GITHUB_HEAD_REF"
+        run: |
+          git fetch origin "$GITHUB_HEAD_REF"
+          git checkout FETCH_HEAD
 
       - name: Install Rust toolchain
         if: steps.benches.outputs.has-rust == 'true'
@@ -195,7 +197,6 @@ jobs:
         run: |
           if [[ "${{ github.event_name == 'pull_request' }}" == 'true' ]]; then
             echo "create-baseline=true" >> $GITHUB_OUTPUT
-            echo "$GITHUB_HEAD_REF"
           else
             echo "create-baseline=false" >> $GITHUB_OUTPUT
           fi
@@ -273,7 +274,9 @@ jobs:
 
       - name: Checkout head branch
         if: steps.benches.outputs.create-baseline == 'true'
-        run: git checkout "$GITHUB_HEAD_REF"
+        run: |
+          git fetch origin "$GITHUB_HEAD_REF"
+          git checkout FETCH_HEAD
 
       - name: Install Rust toolchain
         if: steps.benches.outputs.has-rust == 'true'
@@ -301,7 +304,7 @@ jobs:
           echo "Running services: $SERVICES"
           yarn workspace @apps/hash-external-services deploy:test up $SERVICES --wait
 
-      - name: Run benches
+      - name: Run head benches
         run: turbo run bench:integration --filter "${{ matrix.package }}"
 
       - name: Analyze benchmarks

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -209,6 +209,7 @@ jobs:
             fi
             echo "rust-toolchain=$(yq '.toolchain.channel' $RUST_TOOLCHAIN_FILE)" >> $GITHUB_OUTPUT
           fi
+          echo "$GITHUB_OUTPUT"
 
       - name: Install Rust tools
         if: steps.benches.outputs.has-rust == 'true'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -193,8 +193,9 @@ jobs:
       - name: Find bench steps to run
         id: benches
         run: |
-          if [[ "${{ github.event_name == 'pull_request' }}" == 'false' ]]; then
+          if [[ "${{ github.event_name == 'pull_request' }}" == 'true' ]]; then
             echo "create-baseline=true" >> $GITHUB_OUTPUT
+            echo "$GITHUB_HEAD_REF"
           else
             echo "create-baseline=false" >> $GITHUB_OUTPUT
           fi
@@ -300,7 +301,7 @@ jobs:
           echo "Running services: $SERVICES"
           yarn workspace @apps/hash-external-services deploy:test up $SERVICES --wait
 
-      - name: Run head benches
+      - name: Run benches
         run: turbo run bench:integration --filter "${{ matrix.package }}"
 
       - name: Analyze benchmarks

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -209,7 +209,6 @@ jobs:
             fi
             echo "rust-toolchain=$(yq '.toolchain.channel' $RUST_TOOLCHAIN_FILE)" >> $GITHUB_OUTPUT
           fi
-          echo "$GITHUB_OUTPUT"
 
       - name: Install Rust tools
         if: steps.benches.outputs.has-rust == 'true'
@@ -219,7 +218,9 @@ jobs:
 
       - name: Install Protobuf
         if: steps.benches.outputs.has-rust == 'true'
-        run: sudo apt install protobuf-compiler
+        run: |
+          echo ${{ fromJSON(steps.benches.outputs) }}
+          sudo apt install protobuf-compiler
 
       - name: Checkout base branch
         if: steps.benches.outputs.create-baseline == 'true'

--- a/turbo.json
+++ b/turbo.json
@@ -21,10 +21,12 @@
     "test:system": {},
     "test:miri": {},
     "bench:unit": {
-      "dependsOn": ["codegen"]
+      "dependsOn": ["codegen"],
+      "cache": false
     },
     "bench:integration": {
-      "dependsOn": ["codegen"]
+      "dependsOn": ["codegen"],
+      "cache": false
     },
     "dev": {
       "persistent": true,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A few issues in CI were found.

## 🔍 What does this change?

- Fix `if` statement in CI
- Fetch head branch before pull it
- Don't cache benchmarks (The results shown below don't have a diff because on main the results are cached)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing
### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change
### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph