### PR TITLE
H-2702: Find corresponding tracing data when analyzing benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3280,6 +3280,7 @@ dependencies = [
  "aws-sdk-s3",
  "clap",
  "clap_complete",
+ "criterion",
  "error-stack",
  "serde",
  "serde_json",

--- a/apps/hash-graph/bench/util.rs
+++ b/apps/hash-graph/bench/util.rs
@@ -1,4 +1,4 @@
-use std::{fs, mem::ManuallyDrop, path::Path};
+use std::{cmp, fs, mem::ManuallyDrop, path::Path};
 
 use authorization::{
     schema::{
@@ -57,12 +57,54 @@ pub fn setup_subscriber(
         fn drop(&mut self) {}
     }
 
-    let mut target_dir = Path::new("out").join("tracing").join(group_id);
+    // Taken from Criterion source code
+    fn truncate_to_character_boundary(s: &mut String, max_len: usize) {
+        let mut boundary = cmp::min(max_len, s.len());
+        while !s.is_char_boundary(boundary) {
+            boundary -= 1;
+        }
+        s.truncate(boundary);
+    }
+
+    // Taken from Criterion source code
+    pub fn make_filename_safe(string: &str) -> String {
+        const MAX_DIRECTORY_NAME_LEN: usize = 64;
+
+        let mut string = string.replace(
+            &['?', '"', '/', '\\', '*', '<', '>', ':', '|', '^'][..],
+            "_",
+        );
+
+        // Truncate to last character boundary before max length...
+        truncate_to_character_boundary(&mut string, MAX_DIRECTORY_NAME_LEN);
+
+        if cfg!(target_os = "windows") {
+            {
+                string = string
+                    // On Windows, spaces in the end of the filename are ignored and will be trimmed.
+                    //
+                    // Without trimming ourselves, creating a directory `dir ` will silently create
+                    // `dir` instead, but then operations on files like `dir /file` will fail.
+                    //
+                    // Also note that it's important to do this *after* trimming to MAX_DIRECTORY_NAME_LEN,
+                    // otherwise it can trim again to a name with a trailing space.
+                    .trim_end()
+                    // On Windows, file names are not case-sensitive, so lowercase everything.
+                    .to_lowercase();
+            }
+        }
+
+        string
+    }
+
+    let mut target_dir = Path::new("out")
+        .join("tracing")
+        .join(make_filename_safe(group_id));
     if let Some(function_id) = function_id {
-        target_dir = target_dir.join(function_id);
+        target_dir = target_dir.join(make_filename_safe(function_id));
     }
     if let Some(value_str) = value_str {
-        target_dir = target_dir.join(value_str);
+        target_dir = target_dir.join(make_filename_safe(value_str));
     }
     fs::create_dir_all(&target_dir).expect("could not create directory");
     let flame_file = target_dir.join("tracing.folded");

--- a/apps/hash-graph/bench/util.rs
+++ b/apps/hash-graph/bench/util.rs
@@ -97,9 +97,7 @@ pub fn setup_subscriber(
         string
     }
 
-    let mut target_dir = Path::new("out")
-        .join("tracing")
-        .join(make_filename_safe(group_id));
+    let mut target_dir = Path::new("out").join(make_filename_safe(group_id));
     if let Some(function_id) = function_id {
         target_dir = target_dir.join(make_filename_safe(function_id));
     }

--- a/libs/@local/repo-chores/rust/Cargo.toml
+++ b/libs/@local/repo-chores/rust/Cargo.toml
@@ -12,6 +12,7 @@ error-stack = "0.4.1"
 
 clap = { workspace = true, features = ["cargo", "derive", "env", "wrap_help"] }
 clap_complete = "4.5.2"
+criterion = "0.5.1"
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/libs/@local/repo-chores/rust/bin/cli/subcommand/benches/mod.rs
+++ b/libs/@local/repo-chores/rust/bin/cli/subcommand/benches/mod.rs
@@ -1,25 +1,29 @@
 use std::{
     error::Error,
-    io,
     path::{Path, PathBuf},
 };
 
 mod analyze;
 mod upload;
 use clap::Parser;
-use error_stack::{Report, ResultExt};
 
-fn criterion_directory() -> Result<PathBuf, Report<io::Error>> {
-    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+fn target_directory() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .and_then(Path::parent)
         .and_then(Path::parent)
         .and_then(Path::parent)
         .expect("could not find repository root directory")
         .join("target")
-        .join("criterion");
-    path.canonicalize()
-        .attach_printable_lazy(|| format!("Could not open directory `{}`", path.display()))
+        .canonicalize()
+        .expect("Could not open directory")
+}
+
+fn criterion_directory() -> PathBuf {
+    target_directory()
+        .join("criterion")
+        .canonicalize()
+        .expect("Could not open directory")
 }
 
 #[derive(Debug, clap::Subcommand)]

--- a/libs/@local/repo-chores/rust/bin/cli/subcommand/benches/upload.rs
+++ b/libs/@local/repo-chores/rust/bin/cli/subcommand/benches/upload.rs
@@ -1,11 +1,11 @@
-use std::error::Error;
+use std::{error::Error, path::PathBuf};
 
 use aws_config::BehaviorVersion;
 use clap::Parser;
 use error_stack::ResultExt;
-use repo_chores::benches::{report::Benchmark, storage::S3Storage};
+use repo_chores::benches::{analyze::BenchmarkAnalysis, report::Benchmark, storage::S3Storage};
 
-use crate::subcommand::benches::criterion_directory;
+use crate::subcommand::benches::{criterion_directory, target_directory};
 
 fn current_commit() -> Result<String, Box<dyn Error + Send + Sync>> {
     Ok(String::from_utf8(
@@ -25,20 +25,27 @@ pub(crate) struct Args {
     /// The region to use for the AWS client
     #[clap(long)]
     commit: Option<String>,
+
+    /// The path to the directory where the benchmark artifacts are stored.
+    #[clap(long)]
+    artifacts_path: Option<PathBuf>,
 }
 
 pub(super) async fn run(args: Args) -> Result<(), Box<dyn Error + Send + Sync>> {
     let config = aws_config::defaults(BehaviorVersion::latest()).load().await;
 
-    let benchmarks = Benchmark::gather(criterion_directory()?).collect::<Result<Vec<_>, _>>()?;
+    let benchmarks = Benchmark::gather(criterion_directory()).collect::<Result<Vec<_>, _>>()?;
+
+    let artifacts_path = args.artifacts_path.unwrap_or_else(target_directory);
 
     let s3 = S3Storage::new(&config, "benchmarks.hash.dev");
     let commit = args.commit.map_or_else(current_commit, Ok)?;
-    for measurement in benchmarks
-        .iter()
-        .filter_map(|report| report.measurements.get("new"))
-    {
-        s3.put_measurement(measurement, &commit).await?;
+    for benchmark in benchmarks {
+        s3.put_benchmark_analysis(
+            &BenchmarkAnalysis::from_benchmark(benchmark, "new", &artifacts_path)?,
+            &commit,
+        )
+        .await?;
     }
 
     Ok(())

--- a/libs/@local/repo-chores/rust/src/benches/analyze/mod.rs
+++ b/libs/@local/repo-chores/rust/src/benches/analyze/mod.rs
@@ -1,4 +1,50 @@
+use std::path::Path;
+
+use error_stack::{Report, ResultExt};
+
+use crate::benches::{
+    analyze::tracing::FoldedStacks,
+    report::{Benchmark, ChangeEstimates, Measurement},
+};
+
 pub mod criterion;
+pub mod tracing;
+
+#[derive(Debug)]
+pub struct BenchmarkAnalysis {
+    pub measurement: Measurement,
+    pub change: Option<ChangeEstimates>,
+    pub folded_stacks: Option<FoldedStacks>,
+}
+
+impl BenchmarkAnalysis {
+    /// Creates a new `BenchmarkAnalysis` from the given `Benchmark`.
+    ///
+    /// The benchmarks may output additional artifacts that are used to analyze the benchmark.
+    /// `artifact_output` is the path to the directory where the artifacts are stored.
+    ///
+    /// # Errors
+    ///
+    /// - if the baseline measurement is missing
+    /// - if the folded stacks cannot be read
+    pub fn from_benchmark(
+        mut benchmark: Benchmark,
+        baseline: &str,
+        artifact_output: impl AsRef<Path>,
+    ) -> Result<Self, Report<AnalyzeError>> {
+        let measurement = benchmark
+            .measurements
+            .remove(baseline)
+            .ok_or(AnalyzeError::BaselineMissing)?;
+        let folded_stacks = FoldedStacks::from_measurement(artifact_output, &measurement)
+            .change_context(AnalyzeError::ReadInput)?;
+        Ok(Self {
+            measurement,
+            change: benchmark.change,
+            folded_stacks,
+        })
+    }
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum AnalyzeError {
@@ -6,4 +52,6 @@ pub enum AnalyzeError {
     ReadInput,
     #[error("Unable to parse input file.")]
     ParseInput,
+    #[error("Baseline measurement is missing.")]
+    BaselineMissing,
 }

--- a/libs/@local/repo-chores/rust/src/benches/analyze/tracing.rs
+++ b/libs/@local/repo-chores/rust/src/benches/analyze/tracing.rs
@@ -36,7 +36,6 @@ impl FoldedStacks {
     ) -> Result<Option<Self>, Report<io::Error>> {
         let path = artifact_output
             .as_ref()
-            .join("tracing")
             .join(&measurement.info.directory_name)
             .join("tracing.folded");
 

--- a/libs/@local/repo-chores/rust/src/benches/analyze/tracing.rs
+++ b/libs/@local/repo-chores/rust/src/benches/analyze/tracing.rs
@@ -1,0 +1,62 @@
+use std::{
+    fs::File,
+    io,
+    io::{BufRead, BufReader},
+    path::Path,
+};
+
+use error_stack::Report;
+
+use crate::benches::report::Measurement;
+#[derive(Debug)]
+pub struct FoldedStacks {
+    stacks: Vec<String>,
+}
+
+impl FoldedStacks {
+    pub fn lines(&self) -> impl Iterator<Item = &str> {
+        self.stacks.iter().map(String::as_str)
+    }
+}
+
+impl FoldedStacks {
+    /// Reads the folded stacks from the given measurement.
+    ///
+    /// The folded stacks are expected to be stored in a file named `tracing.folded` in the
+    /// directory of the measurement in the given `artifact_output` directory.
+    ///
+    /// Returns `None` if the file does not exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if reading from the file fails.
+    pub fn from_measurement(
+        artifact_output: impl AsRef<Path>,
+        measurement: &Measurement,
+    ) -> Result<Option<Self>, Report<io::Error>> {
+        let path = artifact_output
+            .as_ref()
+            .join("tracing")
+            .join(&measurement.info.directory_name)
+            .join("tracing.folded");
+
+        if path.exists() {
+            Ok(Some(Self::from_file(path)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Reads the folded stacks from the given file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if reading from the file fails.
+    pub fn from_file(input: impl AsRef<Path>) -> Result<Self, Report<io::Error>> {
+        Ok(Self {
+            stacks: BufReader::new(File::open(input)?)
+                .lines()
+                .collect::<Result<_, _>>()?,
+        })
+    }
+}

--- a/libs/@local/repo-chores/rust/src/benches/report.rs
+++ b/libs/@local/repo-chores/rust/src/benches/report.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, fs::File, io::BufReader, path::Path};
 
+use criterion::Throughput;
 use error_stack::{Report, ResultExt};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use walkdir::WalkDir;
@@ -11,6 +12,7 @@ pub struct Info {
     pub title: String,
     pub full_id: String,
     pub directory_name: String,
+    pub throughput: Option<Throughput>,
     pub group_id: String,
     pub function_id: Option<String>,
     pub value_str: Option<String>,

--- a/libs/@local/repo-chores/rust/src/benches/storage.rs
+++ b/libs/@local/repo-chores/rust/src/benches/storage.rs
@@ -5,7 +5,7 @@ use aws_sdk_s3::operation::put_object::PutObjectOutput;
 use error_stack::{Report, ResultExt};
 use serde::Serialize;
 
-use crate::benches::report::Measurement;
+use crate::benches::{analyze::BenchmarkAnalysis, report::Measurement};
 
 #[derive(Debug, thiserror::Error)]
 pub enum UploadError {
@@ -47,7 +47,7 @@ impl S3Storage {
             .key(key)
             .content_type("application/json")
             .body(
-                serde_json::to_vec_pretty(body)
+                serde_json::to_vec(body)
                     .change_context(UploadError::Serialize)?
                     .into(),
             )
@@ -86,6 +86,21 @@ impl S3Storage {
             &measurement.tukey,
         )
         .await?;
+
+        Ok(())
+    }
+
+    /// Uploads the given benchmark analysis to the storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the upload fails.
+    pub async fn put_benchmark_analysis(
+        &self,
+        analysis: &BenchmarkAnalysis,
+        name: &str,
+    ) -> Result<(), Report<UploadError>> {
+        self.put_measurement(&analysis.measurement, name).await?;
 
         Ok(())
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The benchmark analyzer needs to be able to associate the generated artifacts from benchmarks with the benchmark results.

## 🚫 Blocked by

- #4464 
- #4469 

## 🔍 What does this change?

- Re-use algorithm from criterion to create artifact locations so we directly can use the `directory_name` of a measurement to read artifacts
- Read the `tracing.folded` content

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph