### PR TITLE
H-2164: Use same pagination/sorting approach for ontology types as for entities

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/graph.ts
+++ b/apps/hash-ai-worker-ts/src/activities/graph.ts
@@ -3,7 +3,7 @@ import type {
   EntityQueryCursor,
   GetDataTypeSubgraphRequest,
   GetEntitySubgraphRequest,
-  GetEntityTypeSubgraphRequest,
+  GetEntityTypeSubgraphParams,
   GetPropertyTypeSubgraphRequest,
   GraphApi,
   UpdateDataTypeEmbeddingParams,
@@ -111,7 +111,7 @@ export const createGraphActivities = ({
     authentication: {
       actorId: AccountId;
     };
-    request: GetEntityTypeSubgraphRequest;
+    request: GetEntityTypeSubgraphParams;
   }): Promise<Subgraph<EntityTypeRootType>> {
     return graphApiClient
       .getEntityTypeSubgraph(params.authentication.actorId, params.request)

--- a/apps/hash-ai-worker-ts/src/activities/graph.ts
+++ b/apps/hash-ai-worker-ts/src/activities/graph.ts
@@ -1,10 +1,10 @@
 import { getHashInstanceAdminAccountGroupId } from "@local/hash-backend-utils/hash-instance";
 import type {
   EntityQueryCursor,
-  GetDataTypeSubgraphRequest,
+  GetDataTypeSubgraphParams,
   GetEntitySubgraphRequest,
   GetEntityTypeSubgraphParams,
-  GetPropertyTypeSubgraphRequest,
+  GetPropertyTypeSubgraphParams,
   GraphApi,
   UpdateDataTypeEmbeddingParams,
   UpdateEntityEmbeddingsParams,
@@ -79,7 +79,7 @@ export const createGraphActivities = ({
     authentication: {
       actorId: AccountId;
     };
-    request: GetDataTypeSubgraphRequest;
+    request: GetDataTypeSubgraphParams;
   }): Promise<Subgraph<DataTypeRootType>> {
     return graphApiClient
       .getDataTypeSubgraph(params.authentication.actorId, params.request)
@@ -95,7 +95,7 @@ export const createGraphActivities = ({
     authentication: {
       actorId: AccountId;
     };
-    request: GetPropertyTypeSubgraphRequest;
+    request: GetPropertyTypeSubgraphParams;
   }): Promise<Subgraph<PropertyTypeRootType>> {
     return graphApiClient
       .getPropertyTypeSubgraph(params.authentication.actorId, params.request)

--- a/apps/hash-api/src/graph/ontology/primitive/data-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/data-type.ts
@@ -4,8 +4,8 @@ import { NotFoundError } from "@local/hash-backend-utils/error";
 import type {
   ArchiveDataTypeParams,
   DataTypePermission,
-  GetDataTypesRequest,
-  GetDataTypeSubgraphRequest,
+  GetDataTypesParams,
+  GetDataTypeSubgraphParams,
   ModifyRelationshipOperation,
   OntologyTemporalMetadata,
   ProvidedOntologyEditionProvenance,
@@ -95,7 +95,7 @@ export const createDataType: ImpureGraphFunction<
 };
 
 export const getDataTypes: ImpureGraphFunction<
-  Omit<GetDataTypesRequest, "includeDrafts">,
+  Omit<GetDataTypesParams, "includeDrafts">,
   Promise<DataTypeWithMetadata[]>
 > = async ({ graphApi }, { actorId }, request) =>
   graphApi
@@ -110,7 +110,7 @@ export const getDataTypes: ImpureGraphFunction<
  * @param params.query the structural query to filter data types by.
  */
 export const getDataTypeSubgraph: ImpureGraphFunction<
-  Omit<GetDataTypeSubgraphRequest, "includeDrafts">,
+  Omit<GetDataTypeSubgraphParams, "includeDrafts">,
   Promise<Subgraph<DataTypeRootType>>
 > = async ({ graphApi }, { actorId }, request) => {
   return await graphApi
@@ -158,14 +158,14 @@ export const getDataTypeById: ImpureGraphFunction<
  * If the type does not already exist within the Graph, and is an externally-hosted type, this will also load the type into the Graph.
  */
 export const getDataTypeSubgraphById: ImpureGraphFunction<
-  Omit<GetDataTypeSubgraphRequest, "filter" | "includeDrafts"> & {
+  Omit<GetDataTypeSubgraphParams, "filter" | "includeDrafts"> & {
     dataTypeId: VersionedUrl;
   },
   Promise<Subgraph<DataTypeRootType>>
 > = async (context, authentication, params) => {
   const { graphResolveDepths, temporalAxes, dataTypeId } = params;
 
-  const request: Omit<GetDataTypeSubgraphRequest, "includeDrafts"> = {
+  const request: Omit<GetDataTypeSubgraphParams, "includeDrafts"> = {
     filter: {
       equal: [{ path: ["versionedUrl"] }, { parameter: dataTypeId }],
     },

--- a/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
@@ -7,8 +7,8 @@ import type {
   ArchiveEntityTypeParams,
   EntityType,
   EntityTypePermission,
-  GetEntityTypesRequest,
-  GetEntityTypeSubgraphRequest,
+  GetEntityTypesParams,
+  GetEntityTypeSubgraphParams,
   ModifyRelationshipOperation,
   OntologyTemporalMetadata,
   ProvidedOntologyEditionProvenance,
@@ -183,7 +183,7 @@ export const createEntityType: ImpureGraphFunction<
  * @param params.query the structural query to filter entity types by.
  */
 export const getEntityTypeSubgraph: ImpureGraphFunction<
-  Omit<GetEntityTypeSubgraphRequest, "includeDrafts"> & {
+  Omit<GetEntityTypeSubgraphParams, "includeDrafts"> & {
     temporalClient?: TemporalClient;
   },
   Promise<Subgraph<EntityTypeRootType>>
@@ -203,7 +203,7 @@ export const getEntityTypeSubgraph: ImpureGraphFunction<
 };
 
 export const getEntityTypes: ImpureGraphFunction<
-  Omit<GetEntityTypesRequest, "includeDrafts"> & {
+  Omit<GetEntityTypesParams, "includeDrafts"> & {
     temporalClient?: TemporalClient;
   },
   Promise<EntityTypeWithMetadata[]>
@@ -252,14 +252,14 @@ export const getEntityTypeById: ImpureGraphFunction<
  * If the type does not already exist within the Graph, and is an externally-hosted type, this will also load the type into the Graph.
  */
 export const getEntityTypeSubgraphById: ImpureGraphFunction<
-  Omit<GetEntityTypeSubgraphRequest, "filter" | "includeDrafts"> & {
+  Omit<GetEntityTypeSubgraphParams, "filter" | "includeDrafts"> & {
     entityTypeId: VersionedUrl;
   },
   Promise<Subgraph<EntityTypeRootType>>
 > = async (context, authentication, params) => {
   const { graphResolveDepths, temporalAxes, entityTypeId } = params;
 
-  const request: GetEntityTypeSubgraphRequest = {
+  const request: GetEntityTypeSubgraphParams = {
     filter: {
       equal: [{ path: ["versionedUrl"] }, { parameter: entityTypeId }],
     },

--- a/apps/hash-api/src/graph/ontology/primitive/property-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/property-type.ts
@@ -3,8 +3,8 @@ import { PROPERTY_TYPE_META_SCHEMA } from "@blockprotocol/type-system";
 import { NotFoundError } from "@local/hash-backend-utils/error";
 import type {
   ArchivePropertyTypeParams,
-  GetPropertyTypesRequest,
-  GetPropertyTypeSubgraphRequest,
+  GetPropertyTypesParams,
+  GetPropertyTypeSubgraphParams,
   ModifyRelationshipOperation,
   OntologyTemporalMetadata,
   PropertyTypePermission,
@@ -90,7 +90,7 @@ export const createPropertyType: ImpureGraphFunction<
 };
 
 export const getPropertyTypes: ImpureGraphFunction<
-  Omit<GetPropertyTypesRequest, "includeDrafts">,
+  Omit<GetPropertyTypesParams, "includeDrafts">,
   Promise<PropertyTypeWithMetadata[]>
 > = async ({ graphApi }, { actorId }, request) =>
   graphApi
@@ -105,7 +105,7 @@ export const getPropertyTypes: ImpureGraphFunction<
  * @param params.query the structural query to filter property types by.
  */
 export const getPropertyTypeSubgraph: ImpureGraphFunction<
-  Omit<GetPropertyTypeSubgraphRequest, "includeDrafts">,
+  Omit<GetPropertyTypeSubgraphParams, "includeDrafts">,
   Promise<Subgraph<PropertyTypeRootType>>
 > = async ({ graphApi }, { actorId }, request) =>
   graphApi
@@ -149,14 +149,14 @@ export const getPropertyTypeById: ImpureGraphFunction<
  * If the type does not already exist within the Graph, and is an externally-hosted type, this will also load the type into the Graph.
  */
 export const getPropertyTypeSubgraphById: ImpureGraphFunction<
-  Omit<GetPropertyTypeSubgraphRequest, "filter" | "includeDrafts"> & {
+  Omit<GetPropertyTypeSubgraphParams, "filter" | "includeDrafts"> & {
     propertyTypeId: VersionedUrl;
   },
   Promise<Subgraph<PropertyTypeRootType>>
 > = async (context, authentication, params) => {
   const { graphResolveDepths, temporalAxes, propertyTypeId } = params;
 
-  const request: Omit<GetPropertyTypeSubgraphRequest, "includeDrafts"> = {
+  const request: Omit<GetPropertyTypeSubgraphParams, "includeDrafts"> = {
     filter: {
       equal: [{ path: ["versionedUrl"] }, { parameter: propertyTypeId }],
     },

--- a/apps/hash-graph/libs/graph/src/store/ontology.rs
+++ b/apps/hash-graph/libs/graph/src/store/ontology.rs
@@ -475,6 +475,7 @@ pub struct GetEntityTypeSubgraphParams<'p> {
 #[derive(Debug)]
 pub struct GetEntityTypeSubgraphResponse {
     pub subgraph: Subgraph,
+    pub cursor: Option<EntityTypeVertexId>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -484,9 +485,11 @@ pub struct GetEntityTypesParams<'p> {
     #[serde(borrow)]
     pub filter: Filter<'p, EntityTypeWithMetadata>,
     pub temporal_axes: QueryTemporalAxesUnresolved,
-    pub after: Option<EntityTypeVertexId>,
-    pub limit: Option<usize>,
     pub include_drafts: bool,
+    #[serde(default)]
+    pub after: Option<EntityTypeVertexId>,
+    #[serde(default)]
+    pub limit: Option<usize>,
 }
 
 #[derive(Debug, Serialize)]
@@ -494,6 +497,7 @@ pub struct GetEntityTypesParams<'p> {
 #[serde(rename_all = "camelCase")]
 pub struct GetEntityTypesResponse {
     pub entity_types: Vec<EntityTypeWithMetadata>,
+    pub cursor: Option<EntityTypeVertexId>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/hash-graph/libs/graph/src/store/ontology.rs
+++ b/apps/hash-graph/libs/graph/src/store/ontology.rs
@@ -54,14 +54,17 @@ pub struct GetDataTypeSubgraphParams<'p> {
     pub filter: Filter<'p, DataTypeWithMetadata>,
     pub graph_resolve_depths: GraphResolveDepths,
     pub temporal_axes: QueryTemporalAxesUnresolved,
-    pub after: Option<DataTypeVertexId>,
-    pub limit: Option<usize>,
     pub include_drafts: bool,
+    #[serde(default)]
+    pub after: Option<DataTypeVertexId>,
+    #[serde(default)]
+    pub limit: Option<usize>,
 }
 
 #[derive(Debug)]
 pub struct GetDataTypeSubgraphResponse {
     pub subgraph: Subgraph,
+    pub cursor: Option<DataTypeVertexId>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -71,9 +74,11 @@ pub struct GetDataTypesParams<'p> {
     #[serde(borrow)]
     pub filter: Filter<'p, DataTypeWithMetadata>,
     pub temporal_axes: QueryTemporalAxesUnresolved,
-    pub after: Option<DataTypeVertexId>,
-    pub limit: Option<usize>,
     pub include_drafts: bool,
+    #[serde(default)]
+    pub after: Option<DataTypeVertexId>,
+    #[serde(default)]
+    pub limit: Option<usize>,
 }
 
 #[derive(Debug, Serialize)]
@@ -81,6 +86,7 @@ pub struct GetDataTypesParams<'p> {
 #[serde(rename_all = "camelCase")]
 pub struct GetDataTypesResponse {
     pub data_types: Vec<DataTypeWithMetadata>,
+    pub cursor: Option<DataTypeVertexId>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -259,14 +265,17 @@ pub struct GetPropertyTypeSubgraphParams<'p> {
     pub filter: Filter<'p, PropertyTypeWithMetadata>,
     pub graph_resolve_depths: GraphResolveDepths,
     pub temporal_axes: QueryTemporalAxesUnresolved,
-    pub after: Option<PropertyTypeVertexId>,
-    pub limit: Option<usize>,
     pub include_drafts: bool,
+    #[serde(default)]
+    pub after: Option<PropertyTypeVertexId>,
+    #[serde(default)]
+    pub limit: Option<usize>,
 }
 
 #[derive(Debug)]
 pub struct GetPropertyTypeSubgraphResponse {
     pub subgraph: Subgraph,
+    pub cursor: Option<PropertyTypeVertexId>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -276,9 +285,11 @@ pub struct GetPropertyTypesParams<'p> {
     #[serde(borrow)]
     pub filter: Filter<'p, PropertyTypeWithMetadata>,
     pub temporal_axes: QueryTemporalAxesUnresolved,
-    pub after: Option<PropertyTypeVertexId>,
-    pub limit: Option<usize>,
     pub include_drafts: bool,
+    #[serde(default)]
+    pub after: Option<PropertyTypeVertexId>,
+    #[serde(default)]
+    pub limit: Option<usize>,
 }
 
 #[derive(Debug, Serialize)]
@@ -286,6 +297,7 @@ pub struct GetPropertyTypesParams<'p> {
 #[serde(rename_all = "camelCase")]
 pub struct GetPropertyTypesResponse {
     pub property_types: Vec<PropertyTypeWithMetadata>,
+    pub cursor: Option<PropertyTypeVertexId>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
@@ -169,18 +169,16 @@ where
             })
             .collect::<Vec<_>>();
 
-        let cursor = if params.limit.is_some() {
-            entity_types
-                .last()
-                .map(|entity_type| entity_type.vertex_id(time_axis))
-        } else {
-            None
-        };
-
         Ok((
             GetEntityTypesResponse {
+                cursor: if params.limit.is_some() {
+                    entity_types
+                        .last()
+                        .map(|entity_type| entity_type.vertex_id(time_axis))
+                } else {
+                    None
+                },
                 entity_types,
-                cursor,
             },
             zookie,
         ))

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -540,7 +540,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GetDataTypesRequest"
+                "$ref": "#/components/schemas/GetDataTypesParams"
               }
             }
           },
@@ -549,14 +549,6 @@
         "responses": {
           "200": {
             "description": "Gets a a list of data types that satisfy the given query.",
-            "headers": {
-              "Link": {
-                "schema": {
-                  "type": "string"
-                },
-                "description": "The link to be used to query the next page of data types"
-              }
-            },
             "content": {
               "application/json": {
                 "schema": {
@@ -596,7 +588,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GetDataTypeSubgraphRequest"
+                "$ref": "#/components/schemas/GetDataTypeSubgraphParams"
               }
             }
           },
@@ -605,14 +597,6 @@
         "responses": {
           "200": {
             "description": "Gets a subgraph rooted at all data types that satisfy the given query, each resolved to the requested depth.",
-            "headers": {
-              "Link": {
-                "schema": {
-                  "type": "string"
-                },
-                "description": "The link to be used to query the next page of data types"
-              }
-            },
             "content": {
               "application/json": {
                 "schema": {
@@ -2518,7 +2502,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GetPropertyTypesRequest"
+                "$ref": "#/components/schemas/GetPropertyTypesParams"
               }
             }
           },
@@ -2527,14 +2511,6 @@
         "responses": {
           "200": {
             "description": "Gets a a list of property types that satisfy the given query.",
-            "headers": {
-              "Link": {
-                "schema": {
-                  "type": "string"
-                },
-                "description": "The link to be used to query the next page of property types"
-              }
-            },
             "content": {
               "application/json": {
                 "schema": {
@@ -2574,7 +2550,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GetPropertyTypeSubgraphRequest"
+                "$ref": "#/components/schemas/GetPropertyTypeSubgraphParams"
               }
             }
           },
@@ -4883,7 +4859,7 @@
           }
         ]
       },
-      "GetDataTypeSubgraphRequest": {
+      "GetDataTypeSubgraphParams": {
         "type": "object",
         "required": [
           "filter",
@@ -4892,6 +4868,14 @@
           "includeDrafts"
         ],
         "properties": {
+          "after": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DataTypeVertexId"
+              }
+            ],
+            "nullable": true
+          },
           "filter": {
             "$ref": "#/components/schemas/Filter"
           },
@@ -4900,6 +4884,11 @@
           },
           "includeDrafts": {
             "type": "boolean"
+          },
+          "limit": {
+            "type": "integer",
+            "nullable": true,
+            "minimum": 0
           },
           "temporalAxes": {
             "$ref": "#/components/schemas/QueryTemporalAxesUnresolved"
@@ -4913,12 +4902,20 @@
           "subgraph"
         ],
         "properties": {
+          "cursor": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DataTypeVertexId"
+              }
+            ],
+            "nullable": true
+          },
           "subgraph": {
             "$ref": "#/components/schemas/Subgraph"
           }
         }
       },
-      "GetDataTypesRequest": {
+      "GetDataTypesParams": {
         "type": "object",
         "required": [
           "filter",
@@ -4926,11 +4923,24 @@
           "includeDrafts"
         ],
         "properties": {
+          "after": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DataTypeVertexId"
+              }
+            ],
+            "nullable": true
+          },
           "filter": {
             "$ref": "#/components/schemas/Filter"
           },
           "includeDrafts": {
             "type": "boolean"
+          },
+          "limit": {
+            "type": "integer",
+            "nullable": true,
+            "minimum": 0
           },
           "temporalAxes": {
             "$ref": "#/components/schemas/QueryTemporalAxesUnresolved"
@@ -4944,6 +4954,14 @@
           "dataTypes"
         ],
         "properties": {
+          "cursor": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DataTypeVertexId"
+              }
+            ],
+            "nullable": true
+          },
           "dataTypes": {
             "type": "array",
             "items": {
@@ -5204,7 +5222,7 @@
           }
         }
       },
-      "GetPropertyTypeSubgraphRequest": {
+      "GetPropertyTypeSubgraphParams": {
         "type": "object",
         "required": [
           "filter",
@@ -5213,6 +5231,14 @@
           "includeDrafts"
         ],
         "properties": {
+          "after": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PropertyTypeVertexId"
+              }
+            ],
+            "nullable": true
+          },
           "filter": {
             "$ref": "#/components/schemas/Filter"
           },
@@ -5221,6 +5247,11 @@
           },
           "includeDrafts": {
             "type": "boolean"
+          },
+          "limit": {
+            "type": "integer",
+            "nullable": true,
+            "minimum": 0
           },
           "temporalAxes": {
             "$ref": "#/components/schemas/QueryTemporalAxesUnresolved"
@@ -5234,12 +5265,20 @@
           "subgraph"
         ],
         "properties": {
+          "cursor": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PropertyTypeVertexId"
+              }
+            ],
+            "nullable": true
+          },
           "subgraph": {
             "$ref": "#/components/schemas/Subgraph"
           }
         }
       },
-      "GetPropertyTypesRequest": {
+      "GetPropertyTypesParams": {
         "type": "object",
         "required": [
           "filter",
@@ -5247,11 +5286,24 @@
           "includeDrafts"
         ],
         "properties": {
+          "after": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PropertyTypeVertexId"
+              }
+            ],
+            "nullable": true
+          },
           "filter": {
             "$ref": "#/components/schemas/Filter"
           },
           "includeDrafts": {
             "type": "boolean"
+          },
+          "limit": {
+            "type": "integer",
+            "nullable": true,
+            "minimum": 0
           },
           "temporalAxes": {
             "$ref": "#/components/schemas/QueryTemporalAxesUnresolved"
@@ -5265,6 +5317,14 @@
           "propertyTypes"
         ],
         "properties": {
+          "cursor": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PropertyTypeVertexId"
+              }
+            ],
+            "nullable": true
+          },
           "propertyTypes": {
             "type": "array",
             "items": {

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -1960,7 +1960,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GetEntityTypesRequest"
+                "$ref": "#/components/schemas/GetEntityTypesParams"
               }
             }
           },
@@ -1969,14 +1969,6 @@
         "responses": {
           "200": {
             "description": "Gets a a list of entity types that satisfy the given query.",
-            "headers": {
-              "Link": {
-                "schema": {
-                  "type": "string"
-                },
-                "description": "The link to be used to query the next page of entity types"
-              }
-            },
             "content": {
               "application/json": {
                 "schema": {
@@ -2016,7 +2008,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GetEntityTypeSubgraphRequest"
+                "$ref": "#/components/schemas/GetEntityTypeSubgraphParams"
               }
             }
           },
@@ -2025,14 +2017,6 @@
         "responses": {
           "200": {
             "description": "A subgraph rooted at entity types that satisfy the given query, each resolved to the requested depth.",
-            "headers": {
-              "Link": {
-                "schema": {
-                  "type": "string"
-                },
-                "description": "The link to be used to query the next page of entity types"
-              }
-            },
             "content": {
               "application/json": {
                 "schema": {
@@ -5109,7 +5093,7 @@
           }
         }
       },
-      "GetEntityTypeSubgraphRequest": {
+      "GetEntityTypeSubgraphParams": {
         "type": "object",
         "required": [
           "filter",
@@ -5118,6 +5102,14 @@
           "includeDrafts"
         ],
         "properties": {
+          "after": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntityTypeVertexId"
+              }
+            ],
+            "nullable": true
+          },
           "filter": {
             "$ref": "#/components/schemas/Filter"
           },
@@ -5126,6 +5118,11 @@
           },
           "includeDrafts": {
             "type": "boolean"
+          },
+          "limit": {
+            "type": "integer",
+            "nullable": true,
+            "minimum": 0
           },
           "temporalAxes": {
             "$ref": "#/components/schemas/QueryTemporalAxesUnresolved"
@@ -5139,12 +5136,20 @@
           "subgraph"
         ],
         "properties": {
+          "cursor": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntityTypeVertexId"
+              }
+            ],
+            "nullable": true
+          },
           "subgraph": {
             "$ref": "#/components/schemas/Subgraph"
           }
         }
       },
-      "GetEntityTypesRequest": {
+      "GetEntityTypesParams": {
         "type": "object",
         "required": [
           "filter",
@@ -5152,11 +5157,24 @@
           "includeDrafts"
         ],
         "properties": {
+          "after": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntityTypeVertexId"
+              }
+            ],
+            "nullable": true
+          },
           "filter": {
             "$ref": "#/components/schemas/Filter"
           },
           "includeDrafts": {
             "type": "boolean"
+          },
+          "limit": {
+            "type": "integer",
+            "nullable": true,
+            "minimum": 0
           },
           "temporalAxes": {
             "$ref": "#/components/schemas/QueryTemporalAxesUnresolved"
@@ -5170,6 +5188,14 @@
           "entityTypes"
         ],
         "properties": {
+          "cursor": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntityTypeVertexId"
+              }
+            ],
+            "nullable": true
+          },
           "entityTypes": {
             "type": "array",
             "items": {

--- a/tests/hash-backend-integration/src/tests/subgraph/friendship.test.ts
+++ b/tests/hash-backend-integration/src/tests/subgraph/friendship.test.ts
@@ -23,10 +23,10 @@ import {
 } from "@apps/hash-api/src/graph/ontology/primitive/property-type";
 import type { VersionedUrl } from "@blockprotocol/type-system";
 import type {
-  GetDataTypesRequest,
+  GetDataTypesParams,
   GetEntitySubgraphRequest,
   GetEntityTypesParams,
-  GetPropertyTypesRequest,
+  GetPropertyTypesParams,
 } from "@local/hash-graph-client";
 import {
   currentTimeInstantTemporalAxes,
@@ -245,7 +245,7 @@ describe("Ontology queries", () => {
     const dataTypeId: VersionedUrl =
       "http://localhost:3000/@alice/types/data-type/number/v/1";
 
-    const request: GetDataTypesRequest = {
+    const request: GetDataTypesParams = {
       filter: {
         equal: [
           {
@@ -344,7 +344,7 @@ describe("Ontology queries", () => {
     const propertyTypeId: VersionedUrl =
       "http://localhost:3000/@alice/types/property-type/name/v/1";
 
-    const request: GetPropertyTypesRequest = {
+    const request: GetPropertyTypesParams = {
       filter: {
         equal: [
           {

--- a/tests/hash-backend-integration/src/tests/subgraph/friendship.test.ts
+++ b/tests/hash-backend-integration/src/tests/subgraph/friendship.test.ts
@@ -25,7 +25,7 @@ import type { VersionedUrl } from "@blockprotocol/type-system";
 import type {
   GetDataTypesRequest,
   GetEntitySubgraphRequest,
-  GetEntityTypesRequest,
+  GetEntityTypesParams,
   GetPropertyTypesRequest,
 } from "@local/hash-graph-client";
 import {
@@ -465,7 +465,7 @@ it("archives/unarchives entity types", async () => {
   const entityTypeId: VersionedUrl =
     "http://localhost:3000/@alice/types/entity-type/person/v/1";
 
-  const request: GetEntityTypesRequest = {
+  const request: GetEntityTypesParams = {
     filter: {
       equal: [
         {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Previously, we used a header as pagination parameters/response, this aligns the interface of ontology types to the entity interface.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph