### PR TITLE
H-2618: Use the AI bot when persisting entities as appropriate

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/infer-entities-from-web-page-worker-agent.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/infer-entities-from-web-page-worker-agent.ts
@@ -707,12 +707,12 @@ export const inferEntitiesFromWebPageWorkerAgent = async (params: {
                         type: SourceType.Document,
                         location: {
                           uri: toolCallInput.fileUrl,
-                          /** @todo */
+                          /** @todo H-2728 get the AI to infer these from the doc */
                           name: undefined,
                           description: undefined,
                         },
                         loadedAt: accessedRemoteFile?.loadedAt,
-                        /** @todo */
+                        /** @todo H-2728 get the AI to infer these from the doc */
                         authors: undefined,
                         firstPublished: undefined,
                         lastUpdated: undefined,

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/infer-entities-from-web-page-worker-agent/tool-definitions.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/infer-entities-from-web-page-worker-agent/tool-definitions.ts
@@ -383,6 +383,9 @@ export type ToolCallArguments = Subtype<
     };
     inferEntitiesFromText: {
       text: string;
+      /**
+       * @todo H-2728 store the webpage URL from which this file was discovered as part of the provenance on the file entity
+       */
       fileUrl: string;
       validAt: string;
       prompt: string;

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/infer-entities-from-web-page-worker-agent/types.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/infer-entities-from-web-page-worker-agent/types.ts
@@ -27,6 +27,8 @@ export type AccessedRemoteFile = {
   /**
    * @todo: consider enforcing that this refers to a type that is or extends
    * the "File" system entity type
+   *
+   * @todo H-2728 add a name and description property inferred by the AI when looking at the file
    */
   entityTypeId: VersionedUrl;
   url: string;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When an entity creation or update has been generated as part of an AI process, we should use the appropriate machine actor to perform the operation. This PR does that.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
