### PR TITLE
H-2606: Support for `Counts` for ontology types

### DIFF
--- a/apps/hash-graph/bench/representative_read/ontology/entity_type.rs
+++ b/apps/hash-graph/bench/representative_read/ontology/entity_type.rs
@@ -45,6 +45,7 @@ pub fn bench_get_entity_type_by_id<A: AuthorizationApi>(
                         after: None,
                         limit: None,
                         include_drafts: false,
+                        include_count: false,
                     },
                 )
                 .await

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -42,6 +42,7 @@ use crate::{
         },
         ontology::{
             ArchiveDataTypeParams, ArchiveEntityTypeParams, ArchivePropertyTypeParams,
+            CountDataTypesParams, CountEntityTypesParams, CountPropertyTypesParams,
             CreateDataTypeParams, CreateEntityTypeParams, CreatePropertyTypeParams,
             GetDataTypeSubgraphParams, GetDataTypeSubgraphResponse, GetDataTypesParams,
             GetDataTypesResponse, GetEntityTypeSubgraphParams, GetEntityTypeSubgraphResponse,
@@ -264,6 +265,7 @@ where
                         after: None,
                         limit: None,
                         include_drafts: true,
+                        include_count: false,
                     },
                 )
                 .await
@@ -281,6 +283,7 @@ where
                         after: None,
                         limit: None,
                         include_drafts: true,
+                        include_count: false,
                     },
                 )
                 .await
@@ -298,6 +301,7 @@ where
                         after: None,
                         limit: None,
                         include_drafts: true,
+                        include_count: false,
                     },
                 )
                 .await
@@ -839,6 +843,14 @@ where
             .await
     }
 
+    async fn count_data_types(
+        &self,
+        actor_id: AccountId,
+        params: CountDataTypesParams<'_>,
+    ) -> Result<usize, QueryError> {
+        self.store.count_data_types(actor_id, params).await
+    }
+
     async fn get_data_types(
         &self,
         actor_id: AccountId,
@@ -944,6 +956,14 @@ where
         self.store
             .create_property_types(actor_id, creation_parameters)
             .await
+    }
+
+    async fn count_property_types(
+        &self,
+        actor_id: AccountId,
+        params: CountPropertyTypesParams<'_>,
+    ) -> Result<usize, QueryError> {
+        self.store.count_property_types(actor_id, params).await
     }
 
     async fn get_property_types(
@@ -1053,6 +1073,14 @@ where
         self.store
             .create_entity_types(actor_id, creation_parameters)
             .await
+    }
+
+    async fn count_entity_types(
+        &self,
+        actor_id: AccountId,
+        params: CountEntityTypesParams<'_>,
+    ) -> Result<usize, QueryError> {
+        self.store.count_entity_types(actor_id, params).await
     }
 
     async fn get_entity_types(

--- a/apps/hash-graph/libs/graph/src/store/ontology.rs
+++ b/apps/hash-graph/libs/graph/src/store/ontology.rs
@@ -427,7 +427,7 @@ pub trait PropertyTypeStore {
         P: IntoIterator<Item = CreatePropertyTypeParams<R>, IntoIter: Send> + Send,
         R: IntoIterator<Item = PropertyTypeRelationAndSubject> + Send + Sync;
 
-    /// Count the number of [`PropertyType`]s specified by the [`CountDataTypesParams`].
+    /// Count the number of [`PropertyType`]s specified by the [`CountPropertyTypesParams`].
     ///
     /// # Errors
     ///
@@ -668,7 +668,7 @@ pub trait EntityTypeStore {
         P: IntoIterator<Item = CreateEntityTypeParams<R>, IntoIter: Send> + Send,
         R: IntoIterator<Item = EntityTypeRelationAndSubject> + Send + Sync;
 
-    /// Count the number of [`EntityType`]s specified by the [`CountDataTypesParams`].
+    /// Count the number of [`EntityType`]s specified by the [`CountEntityTypesParams`].
     ///
     /// # Errors
     ///

--- a/apps/hash-graph/libs/graph/src/store/ontology.rs
+++ b/apps/hash-graph/libs/graph/src/store/ontology.rs
@@ -59,12 +59,25 @@ pub struct GetDataTypeSubgraphParams<'p> {
     pub after: Option<DataTypeVertexId>,
     #[serde(default)]
     pub limit: Option<usize>,
+    #[serde(default)]
+    pub include_count: bool,
 }
 
 #[derive(Debug)]
 pub struct GetDataTypeSubgraphResponse {
     pub subgraph: Subgraph,
     pub cursor: Option<DataTypeVertexId>,
+    pub count: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CountDataTypesParams<'p> {
+    #[serde(borrow)]
+    pub filter: Filter<'p, DataTypeWithMetadata>,
+    pub temporal_axes: QueryTemporalAxesUnresolved,
+    pub include_drafts: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -79,6 +92,8 @@ pub struct GetDataTypesParams<'p> {
     pub after: Option<DataTypeVertexId>,
     #[serde(default)]
     pub limit: Option<usize>,
+    #[serde(default)]
+    pub include_count: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -87,6 +102,7 @@ pub struct GetDataTypesParams<'p> {
 pub struct GetDataTypesResponse {
     pub data_types: Vec<DataTypeWithMetadata>,
     pub cursor: Option<DataTypeVertexId>,
+    pub count: Option<usize>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -172,6 +188,17 @@ pub trait DataTypeStore {
     where
         P: IntoIterator<Item = CreateDataTypeParams<R>, IntoIter: Send> + Send,
         R: IntoIterator<Item = DataTypeRelationAndSubject> + Send + Sync;
+
+    /// Count the number of [`DataType`]s specified by the [`CountDataTypesParams`].
+    ///
+    /// # Errors
+    ///
+    /// - if the underlying store fails to count the data types.
+    fn count_data_types(
+        &self,
+        actor_id: AccountId,
+        params: CountDataTypesParams<'_>,
+    ) -> impl Future<Output = Result<usize, QueryError>> + Send;
 
     /// Get the [`DataTypes`] specified by the [`GetDataTypesParams`].
     ///
@@ -270,12 +297,25 @@ pub struct GetPropertyTypeSubgraphParams<'p> {
     pub after: Option<PropertyTypeVertexId>,
     #[serde(default)]
     pub limit: Option<usize>,
+    #[serde(default)]
+    pub include_count: bool,
 }
 
 #[derive(Debug)]
 pub struct GetPropertyTypeSubgraphResponse {
     pub subgraph: Subgraph,
     pub cursor: Option<PropertyTypeVertexId>,
+    pub count: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CountPropertyTypesParams<'p> {
+    #[serde(borrow)]
+    pub filter: Filter<'p, PropertyTypeWithMetadata>,
+    pub temporal_axes: QueryTemporalAxesUnresolved,
+    pub include_drafts: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -290,6 +330,8 @@ pub struct GetPropertyTypesParams<'p> {
     pub after: Option<PropertyTypeVertexId>,
     #[serde(default)]
     pub limit: Option<usize>,
+    #[serde(default)]
+    pub include_count: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -298,6 +340,7 @@ pub struct GetPropertyTypesParams<'p> {
 pub struct GetPropertyTypesResponse {
     pub property_types: Vec<PropertyTypeWithMetadata>,
     pub cursor: Option<PropertyTypeVertexId>,
+    pub count: Option<usize>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -383,6 +426,17 @@ pub trait PropertyTypeStore {
     where
         P: IntoIterator<Item = CreatePropertyTypeParams<R>, IntoIter: Send> + Send,
         R: IntoIterator<Item = PropertyTypeRelationAndSubject> + Send + Sync;
+
+    /// Count the number of [`PropertyType`]s specified by the [`CountDataTypesParams`].
+    ///
+    /// # Errors
+    ///
+    /// - if the underlying store fails to count the property types.
+    fn count_property_types(
+        &self,
+        actor_id: AccountId,
+        params: CountPropertyTypesParams<'_>,
+    ) -> impl Future<Output = Result<usize, QueryError>> + Send;
 
     /// Get the [`Subgraph`] specified by the [`GetPropertyTypeSubgraphParams`].
     ///
@@ -482,12 +536,25 @@ pub struct GetEntityTypeSubgraphParams<'p> {
     pub after: Option<EntityTypeVertexId>,
     pub limit: Option<usize>,
     pub include_drafts: bool,
+    #[serde(default)]
+    pub include_count: bool,
 }
 
 #[derive(Debug)]
 pub struct GetEntityTypeSubgraphResponse {
     pub subgraph: Subgraph,
     pub cursor: Option<EntityTypeVertexId>,
+    pub count: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CountEntityTypesParams<'p> {
+    #[serde(borrow)]
+    pub filter: Filter<'p, EntityTypeWithMetadata>,
+    pub temporal_axes: QueryTemporalAxesUnresolved,
+    pub include_drafts: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -502,6 +569,8 @@ pub struct GetEntityTypesParams<'p> {
     pub after: Option<EntityTypeVertexId>,
     #[serde(default)]
     pub limit: Option<usize>,
+    #[serde(default)]
+    pub include_count: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -510,6 +579,7 @@ pub struct GetEntityTypesParams<'p> {
 pub struct GetEntityTypesResponse {
     pub entity_types: Vec<EntityTypeWithMetadata>,
     pub cursor: Option<EntityTypeVertexId>,
+    pub count: Option<usize>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -597,6 +667,17 @@ pub trait EntityTypeStore {
     where
         P: IntoIterator<Item = CreateEntityTypeParams<R>, IntoIter: Send> + Send,
         R: IntoIterator<Item = EntityTypeRelationAndSubject> + Send + Sync;
+
+    /// Count the number of [`EntityType`]s specified by the [`CountDataTypesParams`].
+    ///
+    /// # Errors
+    ///
+    /// - if the underlying store fails to count the entity types.
+    fn count_entity_types(
+        &self,
+        actor_id: AccountId,
+        params: CountEntityTypesParams<'_>,
+    ) -> impl Future<Output = Result<usize, QueryError>> + Send;
 
     /// Get the [`Subgraph`]s specified by the [`GetEntityTypeSubgraphParams`].
     ///

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
@@ -12,7 +12,7 @@ use authorization::{
     AuthorizationApi,
 };
 use error_stack::{ensure, Report, Result, ResultExt};
-use futures::TryStreamExt;
+use futures::{FutureExt, TryStreamExt};
 use graph_types::{
     account::{AccountId, EditionArchivedById, EditionCreatedById},
     ontology::{
@@ -37,9 +37,10 @@ use crate::{
         crud::{QueryResult, ReadPaginated, VertexIdSorting},
         error::DeletionError,
         ontology::{
-            ArchiveEntityTypeParams, CreateEntityTypeParams, GetEntityTypeSubgraphParams,
-            GetEntityTypeSubgraphResponse, GetEntityTypesParams, GetEntityTypesResponse,
-            UnarchiveEntityTypeParams, UpdateEntityTypeEmbeddingParams, UpdateEntityTypesParams,
+            ArchiveEntityTypeParams, CountEntityTypesParams, CreateEntityTypeParams,
+            GetEntityTypeSubgraphParams, GetEntityTypeSubgraphResponse, GetEntityTypesParams,
+            GetEntityTypesResponse, UnarchiveEntityTypeParams, UpdateEntityTypeEmbeddingParams,
+            UpdateEntityTypesParams,
         },
         postgres::{
             crud::QueryRecordDecode,
@@ -110,78 +111,101 @@ where
             }))
     }
 
-    async fn get_entity_types_impl(
+    #[expect(clippy::manual_async_fn, reason = "This method is recursive")]
+    fn get_entity_types_impl(
         &self,
         actor_id: AccountId,
         params: GetEntityTypesParams<'_>,
         temporal_axes: &QueryTemporalAxes,
-    ) -> Result<(GetEntityTypesResponse, Zookie<'static>), QueryError> {
-        // TODO: Remove again when subgraph logic was revisited
-        //   see https://linear.app/hash/issue/H-297
-        let mut visited_ontology_ids = HashSet::new();
-        let time_axis = temporal_axes.variable_time_axis();
+    ) -> impl Future<Output = Result<(GetEntityTypesResponse, Zookie<'static>), QueryError>> + Send
+    {
+        async move {
+            #[expect(clippy::if_then_some_else_none, reason = "Function is async")]
+            let count = if params.include_count {
+                Some(
+                    self.count_entity_types(
+                        actor_id,
+                        CountEntityTypesParams {
+                            filter: params.filter.clone(),
+                            temporal_axes: params.temporal_axes.clone(),
+                            include_drafts: params.include_drafts,
+                        },
+                    )
+                    .boxed()
+                    .await?,
+                )
+            } else {
+                None
+            };
 
-        let (data, artifacts) = ReadPaginated::<EntityTypeWithMetadata>::read_paginated_vec(
-            self,
-            &params.filter,
-            Some(temporal_axes),
-            &VertexIdSorting {
-                cursor: params.after,
-            },
-            params.limit,
-            params.include_drafts,
-        )
-        .await?;
-        let entity_types = data
-            .into_iter()
-            .filter_map(|row| {
-                let entity_type = row.decode_record(&artifacts);
-                let id = EntityTypeId::from_url(entity_type.schema.id());
-                // The records are already sorted by time, so we can just take the first one
-                visited_ontology_ids.insert(id).then_some((id, entity_type))
-            })
-            .collect::<Vec<_>>();
+            // TODO: Remove again when subgraph logic was revisited
+            //   see https://linear.app/hash/issue/H-297
+            let mut visited_ontology_ids = HashSet::new();
+            let time_axis = temporal_axes.variable_time_axis();
 
-        let filtered_ids = entity_types
-            .iter()
-            .map(|(entity_type_id, _)| *entity_type_id)
-            .collect::<Vec<_>>();
-
-        let (permissions, zookie) = self
-            .authorization_api
-            .check_entity_types_permission(
-                actor_id,
-                EntityTypePermission::View,
-                filtered_ids,
-                Consistency::FullyConsistent,
-            )
-            .await
-            .change_context(QueryError)?;
-
-        let entity_types = entity_types
-            .into_iter()
-            .filter_map(|(id, entity_type)| {
-                permissions
-                    .get(&id)
-                    .copied()
-                    .unwrap_or(false)
-                    .then_some(entity_type)
-            })
-            .collect::<Vec<_>>();
-
-        Ok((
-            GetEntityTypesResponse {
-                cursor: if params.limit.is_some() {
-                    entity_types
-                        .last()
-                        .map(|entity_type| entity_type.vertex_id(time_axis))
-                } else {
-                    None
+            let (data, artifacts) = ReadPaginated::<EntityTypeWithMetadata>::read_paginated_vec(
+                self,
+                &params.filter,
+                Some(temporal_axes),
+                &VertexIdSorting {
+                    cursor: params.after,
                 },
-                entity_types,
-            },
-            zookie,
-        ))
+                params.limit,
+                params.include_drafts,
+            )
+            .await?;
+            let entity_types = data
+                .into_iter()
+                .filter_map(|row| {
+                    let entity_type = row.decode_record(&artifacts);
+                    let id = EntityTypeId::from_url(entity_type.schema.id());
+                    // The records are already sorted by time, so we can just take the first one
+                    visited_ontology_ids.insert(id).then_some((id, entity_type))
+                })
+                .collect::<Vec<_>>();
+
+            let filtered_ids = entity_types
+                .iter()
+                .map(|(entity_type_id, _)| *entity_type_id)
+                .collect::<Vec<_>>();
+
+            let (permissions, zookie) = self
+                .authorization_api
+                .check_entity_types_permission(
+                    actor_id,
+                    EntityTypePermission::View,
+                    filtered_ids,
+                    Consistency::FullyConsistent,
+                )
+                .await
+                .change_context(QueryError)?;
+
+            let entity_types = entity_types
+                .into_iter()
+                .filter_map(|(id, entity_type)| {
+                    permissions
+                        .get(&id)
+                        .copied()
+                        .unwrap_or(false)
+                        .then_some(entity_type)
+                })
+                .collect::<Vec<_>>();
+
+            Ok((
+                GetEntityTypesResponse {
+                    cursor: if params.limit.is_some() {
+                        entity_types
+                            .last()
+                            .map(|entity_type| entity_type.vertex_id(time_axis))
+                    } else {
+                        None
+                    },
+                    entity_types,
+                    count,
+                },
+                zookie,
+            ))
+        }
     }
 
     /// Internal method to read a [`EntityTypeWithMetadata`] into four [`TraversalContext`]s.
@@ -685,6 +709,26 @@ where
         }
     }
 
+    async fn count_entity_types(
+        &self,
+        actor_id: AccountId,
+        params: CountEntityTypesParams<'_>,
+    ) -> Result<usize, QueryError> {
+        self.get_entity_types(
+            actor_id,
+            GetEntityTypesParams {
+                filter: params.filter,
+                temporal_axes: params.temporal_axes,
+                include_drafts: params.include_drafts,
+                after: None,
+                limit: None,
+                include_count: false,
+            },
+        )
+        .await
+        .map(|response| response.entity_types.len())
+    }
+
     async fn get_entity_types(
         &self,
         actor_id: AccountId,
@@ -709,6 +753,7 @@ where
             GetEntityTypesResponse {
                 entity_types,
                 cursor,
+                count,
             },
             zookie,
         ) = self
@@ -720,6 +765,7 @@ where
                     after: params.after,
                     limit: params.limit,
                     include_drafts: params.include_drafts,
+                    include_count: params.include_count,
                 },
                 &temporal_axes,
             )
@@ -772,7 +818,11 @@ where
             .read_traversed_vertices(self, &mut subgraph, params.include_drafts)
             .await?;
 
-        Ok(GetEntityTypeSubgraphResponse { subgraph, cursor })
+        Ok(GetEntityTypeSubgraphResponse {
+            subgraph,
+            cursor,
+            count,
+        })
     }
 
     #[tracing::instrument(level = "info", skip(self, params))]

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -4882,6 +4882,9 @@
           "graphResolveDepths": {
             "$ref": "#/components/schemas/GraphResolveDepths"
           },
+          "includeCount": {
+            "type": "boolean"
+          },
           "includeDrafts": {
             "type": "boolean"
           },
@@ -4934,6 +4937,9 @@
           "filter": {
             "$ref": "#/components/schemas/Filter"
           },
+          "includeCount": {
+            "type": "boolean"
+          },
           "includeDrafts": {
             "type": "boolean"
           },
@@ -4954,6 +4960,11 @@
           "dataTypes"
         ],
         "properties": {
+          "count": {
+            "type": "integer",
+            "nullable": true,
+            "minimum": 0
+          },
           "cursor": {
             "allOf": [
               {
@@ -5134,6 +5145,9 @@
           "graphResolveDepths": {
             "$ref": "#/components/schemas/GraphResolveDepths"
           },
+          "includeCount": {
+            "type": "boolean"
+          },
           "includeDrafts": {
             "type": "boolean"
           },
@@ -5186,6 +5200,9 @@
           "filter": {
             "$ref": "#/components/schemas/Filter"
           },
+          "includeCount": {
+            "type": "boolean"
+          },
           "includeDrafts": {
             "type": "boolean"
           },
@@ -5206,6 +5223,11 @@
           "entityTypes"
         ],
         "properties": {
+          "count": {
+            "type": "integer",
+            "nullable": true,
+            "minimum": 0
+          },
           "cursor": {
             "allOf": [
               {
@@ -5244,6 +5266,9 @@
           },
           "graphResolveDepths": {
             "$ref": "#/components/schemas/GraphResolveDepths"
+          },
+          "includeCount": {
+            "type": "boolean"
           },
           "includeDrafts": {
             "type": "boolean"
@@ -5297,6 +5322,9 @@
           "filter": {
             "$ref": "#/components/schemas/Filter"
           },
+          "includeCount": {
+            "type": "boolean"
+          },
           "includeDrafts": {
             "type": "boolean"
           },
@@ -5317,6 +5345,11 @@
           "propertyTypes"
         ],
         "properties": {
+          "count": {
+            "type": "integer",
+            "nullable": true,
+            "minimum": 0
+          },
           "cursor": {
             "allOf": [
               {

--- a/tests/hash-graph-integration/postgres/data_type.rs
+++ b/tests/hash-graph-integration/postgres/data_type.rs
@@ -87,6 +87,7 @@ async fn query() {
                 after: None,
                 limit: None,
                 include_drafts: false,
+                include_count: false,
             },
         )
         .await
@@ -156,6 +157,7 @@ async fn update() {
                 after: None,
                 limit: None,
                 include_drafts: false,
+                include_count: false,
             },
         )
         .await
@@ -179,6 +181,7 @@ async fn update() {
                 after: None,
                 limit: None,
                 include_drafts: false,
+                include_count: false,
             },
         )
         .await

--- a/tests/hash-graph-integration/postgres/entity_type.rs
+++ b/tests/hash-graph-integration/postgres/entity_type.rs
@@ -105,6 +105,7 @@ async fn query() {
                 after: None,
                 limit: None,
                 include_drafts: false,
+                include_count: false,
             },
         )
         .await
@@ -196,6 +197,7 @@ async fn update() {
                 after: None,
                 limit: None,
                 include_drafts: false,
+                include_count: false,
             },
         )
         .await
@@ -219,6 +221,7 @@ async fn update() {
                 after: None,
                 limit: None,
                 include_drafts: false,
+                include_count: false,
             },
         )
         .await

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -43,6 +43,7 @@ use graph::{
         },
         ontology::{
             ArchiveDataTypeParams, ArchiveEntityTypeParams, ArchivePropertyTypeParams,
+            CountDataTypesParams, CountEntityTypesParams, CountPropertyTypesParams,
             CreateDataTypeParams, CreateEntityTypeParams, CreatePropertyTypeParams,
             GetDataTypeSubgraphParams, GetDataTypeSubgraphResponse, GetDataTypesParams,
             GetDataTypesResponse, GetEntityTypeSubgraphParams, GetEntityTypeSubgraphResponse,
@@ -285,20 +286,82 @@ impl<A: AuthorizationApi> DataTypeStore for DatabaseApi<'_, A> {
         self.store.create_data_types(actor_id, params).await
     }
 
+    async fn count_data_types(
+        &self,
+        actor_id: AccountId,
+        params: CountDataTypesParams<'_>,
+    ) -> Result<usize, QueryError> {
+        self.store.count_data_types(actor_id, params).await
+    }
+
     async fn get_data_types(
         &self,
         actor_id: AccountId,
-        params: GetDataTypesParams<'_>,
+        mut params: GetDataTypesParams<'_>,
     ) -> Result<GetDataTypesResponse, QueryError> {
-        self.store.get_data_types(actor_id, params).await
+        let include_count = params.include_count;
+        let has_limit = params.limit.is_some();
+        params.include_count = true;
+
+        let count = self
+            .count_data_types(
+                actor_id,
+                CountDataTypesParams {
+                    filter: params.filter.clone(),
+                    temporal_axes: params.temporal_axes.clone(),
+                    include_drafts: params.include_drafts,
+                },
+            )
+            .await?;
+
+        let mut response = self.store.get_data_types(actor_id, params).await?;
+
+        // We can ensure that `count_data_types` and `get_data_types` return the same count;
+        assert_eq!(response.count, Some(count));
+        // if the limit is not set, the count should be equal to the number of data types returned
+        if !has_limit {
+            assert_eq!(count, response.data_types.len());
+        }
+
+        if !include_count {
+            response.count = None;
+        }
+        Ok(response)
     }
 
     async fn get_data_type_subgraph(
         &self,
         actor_id: AccountId,
-        params: GetDataTypeSubgraphParams<'_>,
+        mut params: GetDataTypeSubgraphParams<'_>,
     ) -> Result<GetDataTypeSubgraphResponse, QueryError> {
-        self.store.get_data_type_subgraph(actor_id, params).await
+        let include_count = params.include_count;
+        let has_limit = params.limit.is_some();
+        params.include_count = true;
+
+        let count = self
+            .count_data_types(
+                actor_id,
+                CountDataTypesParams {
+                    filter: params.filter.clone(),
+                    temporal_axes: params.temporal_axes.clone(),
+                    include_drafts: params.include_drafts,
+                },
+            )
+            .await?;
+
+        let mut response = self.store.get_data_type_subgraph(actor_id, params).await?;
+
+        // We can ensure that `count_data_types` and `get_data_type_subgraph` return the same count;
+        assert_eq!(response.count, Some(count));
+        // if the limit is not set, the count should be equal to the number of data types returned
+        if !has_limit {
+            assert_eq!(count, response.subgraph.roots.len());
+        }
+
+        if !include_count {
+            response.count = None;
+        }
+        Ok(response)
     }
 
     async fn update_data_type<R>(
@@ -352,22 +415,88 @@ impl<A: AuthorizationApi> PropertyTypeStore for DatabaseApi<'_, A> {
         self.store.create_property_types(actor_id, params).await
     }
 
+    async fn count_property_types(
+        &self,
+        actor_id: AccountId,
+        params: CountPropertyTypesParams<'_>,
+    ) -> Result<usize, QueryError> {
+        self.store.count_property_types(actor_id, params).await
+    }
+
     async fn get_property_types(
         &self,
         actor_id: AccountId,
-        params: GetPropertyTypesParams<'_>,
+        mut params: GetPropertyTypesParams<'_>,
     ) -> Result<GetPropertyTypesResponse, QueryError> {
-        self.store.get_property_types(actor_id, params).await
+        let include_count = params.include_count;
+        let has_limit = params.limit.is_some();
+        params.include_count = true;
+
+        let count = self
+            .count_property_types(
+                actor_id,
+                CountPropertyTypesParams {
+                    filter: params.filter.clone(),
+                    temporal_axes: params.temporal_axes.clone(),
+                    include_drafts: params.include_drafts,
+                },
+            )
+            .await?;
+
+        let mut response = self.store.get_property_types(actor_id, params).await?;
+
+        // We can ensure that `count_property_types` and `get_property_types` return the same count;
+        assert_eq!(response.count, Some(count));
+        // if the limit is not set, the count should be equal to the number of property types
+        // returned
+        if !has_limit {
+            assert_eq!(count, response.property_types.len());
+        }
+
+        if !include_count {
+            response.count = None;
+        }
+        Ok(response)
     }
 
     async fn get_property_type_subgraph(
         &self,
         actor_id: AccountId,
-        params: GetPropertyTypeSubgraphParams<'_>,
+        mut params: GetPropertyTypeSubgraphParams<'_>,
     ) -> Result<GetPropertyTypeSubgraphResponse, QueryError> {
-        self.store
+        let include_count = params.include_count;
+        let has_limit = params.limit.is_some();
+        params.include_count = true;
+
+        let count = self
+            .count_property_types(
+                actor_id,
+                CountPropertyTypesParams {
+                    filter: params.filter.clone(),
+                    temporal_axes: params.temporal_axes.clone(),
+                    include_drafts: params.include_drafts,
+                },
+            )
+            .await?;
+
+        let mut response = self
+            .store
             .get_property_type_subgraph(actor_id, params)
-            .await
+            .await?;
+
+        // We can ensure that `count_property_types` and `get_property_type_subgraph` return the
+        // same count;
+        assert_eq!(response.count, Some(count));
+        // if the limit is not set, the count should be equal to the number of property types
+        // returned
+        if !has_limit {
+            assert_eq!(count, response.subgraph.roots.len());
+        }
+
+        if !include_count {
+            response.count = None;
+        }
+        Ok(response)
     }
 
     async fn update_property_type<R>(
@@ -421,20 +550,86 @@ impl<A: AuthorizationApi> EntityTypeStore for DatabaseApi<'_, A> {
         self.store.create_entity_types(actor_id, params).await
     }
 
+    async fn count_entity_types(
+        &self,
+        actor_id: AccountId,
+        params: CountEntityTypesParams<'_>,
+    ) -> Result<usize, QueryError> {
+        self.store.count_entity_types(actor_id, params).await
+    }
+
     async fn get_entity_types(
         &self,
         actor_id: AccountId,
-        params: GetEntityTypesParams<'_>,
+        mut params: GetEntityTypesParams<'_>,
     ) -> Result<GetEntityTypesResponse, QueryError> {
-        self.store.get_entity_types(actor_id, params).await
+        let include_count = params.include_count;
+        let has_limit = params.limit.is_some();
+        params.include_count = true;
+
+        let count = self
+            .count_entity_types(
+                actor_id,
+                CountEntityTypesParams {
+                    filter: params.filter.clone(),
+                    temporal_axes: params.temporal_axes.clone(),
+                    include_drafts: params.include_drafts,
+                },
+            )
+            .await?;
+
+        let mut response = self.store.get_entity_types(actor_id, params).await?;
+
+        // We can ensure that `count_entity_types` and `get_entity_types` return the same count;
+        assert_eq!(response.count, Some(count));
+        // if the limit is not set, the count should be equal to the number of entity types returned
+        if !has_limit {
+            assert_eq!(count, response.entity_types.len());
+        }
+
+        if !include_count {
+            response.count = None;
+        }
+        Ok(response)
     }
 
     async fn get_entity_type_subgraph(
         &self,
         actor_id: AccountId,
-        params: GetEntityTypeSubgraphParams<'_>,
+        mut params: GetEntityTypeSubgraphParams<'_>,
     ) -> Result<GetEntityTypeSubgraphResponse, QueryError> {
-        self.store.get_entity_type_subgraph(actor_id, params).await
+        let include_count = params.include_count;
+        let has_limit = params.limit.is_some();
+        params.include_count = true;
+
+        let count = self
+            .count_entity_types(
+                actor_id,
+                CountEntityTypesParams {
+                    filter: params.filter.clone(),
+                    temporal_axes: params.temporal_axes.clone(),
+                    include_drafts: params.include_drafts,
+                },
+            )
+            .await?;
+
+        let mut response = self
+            .store
+            .get_entity_type_subgraph(actor_id, params)
+            .await?;
+
+        // We can ensure that `count_entity_types` and `get_entity_type_subgraph` return the same
+        // count;
+        assert_eq!(response.count, Some(count));
+        // if the limit is not set, the count should be equal to the number of entity types returned
+        if !has_limit {
+            assert_eq!(count, response.subgraph.roots.len());
+        }
+
+        if !include_count {
+            response.count = None;
+        }
+        Ok(response)
     }
 
     async fn update_entity_type<R>(

--- a/tests/hash-graph-integration/postgres/property_type.rs
+++ b/tests/hash-graph-integration/postgres/property_type.rs
@@ -86,6 +86,7 @@ async fn query() {
                 after: None,
                 limit: None,
                 include_drafts: false,
+                include_count: false,
             },
         )
         .await
@@ -152,6 +153,7 @@ async fn update() {
                 after: None,
                 limit: None,
                 include_drafts: false,
+                include_count: false,
             },
         )
         .await
@@ -175,6 +177,7 @@ async fn update() {
                 after: None,
                 limit: None,
                 include_drafts: false,
+                include_count: false,
             },
         )
         .await


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When returning paginated results for ontology types it should be possible to see the total number of ontologies.

## 🚫 Blocked by

- #4484

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph