### PR TITLE
H-2731: Temporarily make Playwright tests not required

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -594,7 +594,7 @@ jobs:
           [[ ${{ needs.integration-tests.result }} =~ success|skipped ]]
       - name: Check system tests
         run: |
-          [[ ${{ needs.system-tests.result }} =~ success|skipped ]]
+          [[ ${{ needs.system-tests.result }} =~ success|skipped|failure ]]
       - name: Check publish results
         run: |
           [[ ${{ needs.publish.result }} =~ success|skipped ]]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We encounter a disk-storage error in PW tests as the docker images are too big. This temporarily disables the requirement to pass CI.