### PR TITLE
H-2538: Create test for creating a graph of interlinked entities in one transaction

### DIFF
--- a/tests/hash-graph-integration/postgres/interconnected_graph.rs
+++ b/tests/hash-graph-integration/postgres/interconnected_graph.rs
@@ -1,0 +1,124 @@
+use std::str::FromStr;
+
+use graph::store::{knowledge::CreateEntityParams, EntityStore};
+use graph_test_data::{data_type, entity, entity_type, property_type};
+use graph_types::{
+    knowledge::{
+        entity::{EntityId, EntityUuid, ProvidedEntityEditionProvenance},
+        link::LinkData,
+        PropertyMetadataMap, PropertyObject,
+    },
+    owned_by_id::OwnedById,
+};
+use type_system::url::VersionedUrl;
+use uuid::Uuid;
+
+use crate::DatabaseTestWrapper;
+
+#[tokio::test]
+async fn insert() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = database
+        .seed(
+            [data_type::TEXT_V1, data_type::NUMBER_V1],
+            [
+                property_type::NAME_V1,
+                property_type::AGE_V1,
+                property_type::FAVORITE_SONG_V1,
+                property_type::FAVORITE_FILM_V1,
+                property_type::HOBBY_V1,
+                property_type::INTERESTS_V1,
+            ],
+            [
+                entity_type::LINK_V1,
+                entity_type::link::FRIEND_OF_V1,
+                entity_type::link::ACQUAINTANCE_OF_V1,
+                entity_type::PERSON_V1,
+            ],
+        )
+        .await
+        .expect("could not seed database");
+
+    let owned_by_id = OwnedById::new(api.account_id.into_uuid());
+
+    let alice_id = EntityUuid::new(Uuid::new_v4());
+    let alice_entity = CreateEntityParams {
+        owned_by_id,
+        entity_uuid: Some(alice_id),
+        decision_time: None,
+        entity_type_ids: vec![
+            VersionedUrl::from_str("https://blockprotocol.org/@alice/types/entity-type/person/v/1")
+                .expect("couldn't construct Versioned URL"),
+        ],
+        properties: serde_json::from_str(entity::PERSON_ALICE_V1).expect("could not parse entity"),
+        confidence: None,
+        property_metadata: PropertyMetadataMap::default(),
+        link_data: None,
+        draft: false,
+        relationships: [],
+        provenance: ProvidedEntityEditionProvenance::default(),
+    };
+
+    let bob_id = EntityUuid::new(Uuid::new_v4());
+    let bob_entity = CreateEntityParams {
+        owned_by_id,
+        entity_uuid: Some(bob_id),
+        decision_time: None,
+        entity_type_ids: vec![
+            VersionedUrl::from_str("https://blockprotocol.org/@alice/types/entity-type/person/v/1")
+                .expect("couldn't construct Versioned URL"),
+        ],
+        properties: serde_json::from_str(entity::PERSON_BOB_V1).expect("could not parse entity"),
+        confidence: None,
+        property_metadata: PropertyMetadataMap::default(),
+        link_data: None,
+        draft: false,
+        relationships: [],
+        provenance: ProvidedEntityEditionProvenance::default(),
+    };
+
+    let friendship_entity = CreateEntityParams {
+        owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+        entity_uuid: None,
+        decision_time: None,
+        entity_type_ids: vec![
+            VersionedUrl::from_str(
+                "https://blockprotocol.org/@alice/types/entity-type/friend-of/v/1",
+            )
+            .expect("couldn't construct Versioned URL"),
+        ],
+        properties: PropertyObject::empty(),
+        confidence: None,
+        property_metadata: PropertyMetadataMap::default(),
+        link_data: Some(LinkData {
+            left_entity_id: EntityId {
+                owned_by_id,
+                entity_uuid: alice_id,
+                draft_id: None,
+            },
+            right_entity_id: EntityId {
+                owned_by_id,
+                entity_uuid: bob_id,
+                draft_id: None,
+            },
+            left_entity_confidence: None,
+            left_entity_provenance: Default::default(),
+            right_entity_confidence: None,
+            right_entity_provenance: Default::default(),
+        }),
+        draft: false,
+        relationships: [],
+        provenance: ProvidedEntityEditionProvenance::default(),
+    };
+
+    let metadata = api
+        .create_entities(
+            api.account_id,
+            vec![alice_entity, friendship_entity, bob_entity],
+        )
+        .await
+        .expect("could not create entity");
+
+    assert_eq!(metadata[0].record_id.entity_id.entity_uuid, alice_id);
+    assert_eq!(metadata[2].record_id.entity_id.entity_uuid, bob_id);
+}

--- a/tests/hash-graph-integration/postgres/interconnected_graph.rs
+++ b/tests/hash-graph-integration/postgres/interconnected_graph.rs
@@ -6,7 +6,7 @@ use graph_types::{
     knowledge::{
         entity::{EntityId, EntityUuid, ProvidedEntityEditionProvenance},
         link::LinkData,
-        PropertyMetadataMap, PropertyObject,
+        PropertyMetadataMap, PropertyObject, PropertyProvenance,
     },
     owned_by_id::OwnedById,
 };
@@ -102,9 +102,9 @@ async fn insert() {
                 draft_id: None,
             },
             left_entity_confidence: None,
-            left_entity_provenance: Default::default(),
+            left_entity_provenance: PropertyProvenance::default(),
             right_entity_confidence: None,
-            right_entity_provenance: Default::default(),
+            right_entity_provenance: PropertyProvenance::default(),
         }),
         draft: false,
         relationships: [],

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -13,6 +13,7 @@ mod data_type;
 mod drafts;
 mod entity;
 mod entity_type;
+mod interconnected_graph;
 mod links;
 mod multi_type;
 mod partial_updates;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds a test that an two linked entities can be created in one transaction.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph