### PR TITLE
H-2733: Update cargo tools

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -107,7 +107,7 @@ jobs:
         if: always() && steps.lints.outputs.has-rust == 'true'
         uses: taiki-e/install-action@689459d9ffef015a7fbaef7f3b6b9f053f80a64d # v2.33.26
         with:
-          tool: just@1.13.0,cargo-hack@0.6.7,rust-script@0.23.0,clippy-sarif@0.3.7,sarif-fmt@0.3.7
+          tool: just@1.13.0,cargo-hack@0.9.28,rust-script@0.23.0,clippy-sarif@0.3.7,sarif-fmt@0.3.7
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -107,7 +107,7 @@ jobs:
         if: always() && steps.lints.outputs.has-rust == 'true'
         uses: taiki-e/install-action@689459d9ffef015a7fbaef7f3b6b9f053f80a64d # v2.33.26
         with:
-          tool: just@1.13.0,cargo-hack@0.9.28,rust-script@0.23.0,clippy-sarif@0.3.7,sarif-fmt@0.3.7
+          tool: just@1.13.0,cargo-hack@0.6.28,rust-script@0.23.0,clippy-sarif@0.3.7,sarif-fmt@0.3.7
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,7 +170,7 @@ jobs:
         if: always() && steps.tests.outputs.has-rust == 'true'
         uses: taiki-e/install-action@689459d9ffef015a7fbaef7f3b6b9f053f80a64d # v2.33.26
         with:
-          tool: just@1.13.0,cargo-hack@0.9.28,cargo-nextest@0.9.68,cargo-llvm-cov@0.6.9
+          tool: just@1.13.0,cargo-hack@0.6.28,cargo-nextest@0.9.68,cargo-llvm-cov@0.6.9
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo
@@ -287,7 +287,7 @@ jobs:
         if: always() && steps.tests.outputs.has-rust == 'true'
         uses: taiki-e/install-action@689459d9ffef015a7fbaef7f3b6b9f053f80a64d # v2.33.26
         with:
-          tool: just@1.13.0,cargo-hack@0.9.28,cargo-nextest@0.9.68,cargo-llvm-cov@0.6.9
+          tool: just@1.13.0,cargo-hack@0.6.28,cargo-nextest@0.9.68,cargo-llvm-cov@0.6.9
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo
@@ -417,7 +417,7 @@ jobs:
         if: always() && steps.tests.outputs.has-rust == 'true'
         uses: taiki-e/install-action@689459d9ffef015a7fbaef7f3b6b9f053f80a64d # v2.33.26
         with:
-          tool: just@1.13.0,cargo-hack@0.9.28,cargo-nextest@0.9.68,cargo-llvm-cov@0.6.9
+          tool: just@1.13.0,cargo-hack@0.6.28,cargo-nextest@0.9.68,cargo-llvm-cov@0.6.9
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,7 +170,7 @@ jobs:
         if: always() && steps.tests.outputs.has-rust == 'true'
         uses: taiki-e/install-action@689459d9ffef015a7fbaef7f3b6b9f053f80a64d # v2.33.26
         with:
-          tool: just@1.13.0,cargo-hack@0.6.7,cargo-nextest@0.9.37,cargo-llvm-cov@0.5.9
+          tool: just@1.13.0,cargo-hack@0.9.28,cargo-nextest@0.9.68,cargo-llvm-cov@0.6.9
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo
@@ -287,7 +287,7 @@ jobs:
         if: always() && steps.tests.outputs.has-rust == 'true'
         uses: taiki-e/install-action@689459d9ffef015a7fbaef7f3b6b9f053f80a64d # v2.33.26
         with:
-          tool: just@1.13.0,cargo-hack@0.6.7,cargo-nextest@0.9.37,cargo-llvm-cov@0.5.9
+          tool: just@1.13.0,cargo-hack@0.9.28,cargo-nextest@0.9.68,cargo-llvm-cov@0.6.9
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo
@@ -417,7 +417,7 @@ jobs:
         if: always() && steps.tests.outputs.has-rust == 'true'
         uses: taiki-e/install-action@689459d9ffef015a7fbaef7f3b6b9f053f80a64d # v2.33.26
         with:
-          tool: just@1.13.0,cargo-hack@0.6.7,cargo-nextest@0.9.37,cargo-llvm-cov@0.5.9
+          tool: just@1.13.0,cargo-hack@0.9.28,cargo-nextest@0.9.68,cargo-llvm-cov@0.6.9
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo

--- a/.justfile
+++ b/.justfile
@@ -104,19 +104,19 @@ install-cargo-tool tool install version:
 
 [private]
 install-cargo-hack:
-  @just install-cargo-tool 'cargo hack' cargo-hack 0.6.7
+  @just install-cargo-tool 'cargo hack' cargo-hack 0.6.28
 
 [private]
 install-cargo-nextest:
-  @just install-cargo-tool 'cargo nextest' cargo-nextest 0.9.37
+  @just install-cargo-tool 'cargo nextest' cargo-nextest 0.9.68
 
 [private]
 install-llvm-cov:
-  @just install-cargo-tool 'cargo llvm-cov' cargo-llvm-cov 0.5.9
+  @just install-cargo-tool 'cargo llvm-cov' cargo-llvm-cov 0.6.9
 
 [private]
 install-cargo-insta:
-  @just install-cargo-tool 'cargo insta' cargo-insta 1.18.2
+  @just install-cargo-tool 'cargo insta' cargo-insta 1.39.0
 
 
 ######################################################################


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

While attempting to fix tests for the latest Rust toolchain bump I noticed that the cargo tools are quite outdated (installing them locally doesn't work with the specified versions)