### PR TITLE
H-2539: Add support in graph for Provenance Metadata for types

### DIFF
--- a/apps/hash-graph/libs/api/src/rest/data_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/data_type.rs
@@ -279,7 +279,7 @@ enum LoadExternalDataTypeRequest {
             default,
             skip_serializing_if = "ProvidedOntologyEditionProvenance::is_empty"
         )]
-        provenance: ProvidedOntologyEditionProvenance,
+        provenance: Box<ProvidedOntologyEditionProvenance>,
     },
 }
 
@@ -367,7 +367,7 @@ where
                             },
                             relationships,
                             conflict_behavior: ConflictBehavior::Fail,
-                            provenance,
+                            provenance: *provenance,
                         },
                     )
                     .await

--- a/apps/hash-graph/libs/api/src/rest/entity_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity_type.rs
@@ -550,7 +550,7 @@ enum LoadExternalEntityTypeRequest {
             default,
             skip_serializing_if = "ProvidedOntologyEditionProvenance::is_empty"
         )]
-        provenance: ProvidedOntologyEditionProvenance,
+        provenance: Box<ProvidedOntologyEditionProvenance>,
     },
 }
 
@@ -673,7 +673,7 @@ where
                             },
                             relationships,
                             conflict_behavior: ConflictBehavior::Fail,
-                            provenance,
+                            provenance: *provenance,
                         },
                     )
                     .await

--- a/apps/hash-graph/libs/api/src/rest/property_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/property_type.rs
@@ -285,7 +285,7 @@ enum LoadExternalPropertyTypeRequest {
             default,
             skip_serializing_if = "ProvidedOntologyEditionProvenance::is_empty"
         )]
-        provenance: ProvidedOntologyEditionProvenance,
+        provenance: Box<ProvidedOntologyEditionProvenance>,
     },
 }
 
@@ -373,7 +373,7 @@ where
                             },
                             relationships,
                             conflict_behavior: ConflictBehavior::Fail,
-                            provenance,
+                            provenance: *provenance,
                         },
                     )
                     .await

--- a/apps/hash-graph/libs/graph/src/snapshot/restore/channel.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/restore/channel.rs
@@ -111,7 +111,7 @@ impl Sink<SnapshotEntry> for SnapshotRecordSender {
                 .attach_printable("could not send account group"),
             SnapshotEntry::DataType(data_type) => self
                 .data_type
-                .start_send_unpin(data_type)
+                .start_send_unpin(*data_type)
                 .attach_printable("could not send data type"),
             SnapshotEntry::DataTypeEmbedding(embedding) => self
                 .data_type_embedding
@@ -124,7 +124,7 @@ impl Sink<SnapshotEntry> for SnapshotRecordSender {
                 .attach_printable("could not send data type embedding"),
             SnapshotEntry::PropertyType(property_type) => self
                 .property_type
-                .start_send_unpin(property_type)
+                .start_send_unpin(*property_type)
                 .attach_printable("could not send property type"),
             SnapshotEntry::PropertyTypeEmbedding(embedding) => self
                 .property_type_embedding
@@ -137,7 +137,7 @@ impl Sink<SnapshotEntry> for SnapshotRecordSender {
                 .attach_printable("could not send property type embedding"),
             SnapshotEntry::EntityType(entity_type) => self
                 .entity_type
-                .start_send_unpin(entity_type)
+                .start_send_unpin(*entity_type)
                 .attach_printable("could not send entity type"),
             SnapshotEntry::EntityTypeEmbedding(embedding) => self
                 .entity_type_embedding

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -7191,9 +7191,25 @@
       "ProvidedOntologyEditionProvenance": {
         "type": "object",
         "properties": {
-          "__placeholder": {
-            "default": null,
-            "nullable": true
+          "actorType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ActorType"
+              }
+            ]
+          },
+          "origin": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OriginProvenance"
+              }
+            ]
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SourceProvenance"
+            }
           }
         },
         "additionalProperties": false

--- a/libs/@local/hash-graph-types/rust/src/ontology/provenance.rs
+++ b/libs/@local/hash-graph-types/rust/src/ontology/provenance.rs
@@ -7,7 +7,10 @@ use bytes::BytesMut;
 use postgres_types::{FromSql, IsNull, Json, ToSql, Type};
 use serde::{Deserialize, Serialize};
 
-use crate::account::{EditionArchivedById, EditionCreatedById};
+use crate::{
+    account::{EditionArchivedById, EditionCreatedById},
+    knowledge::entity::{ActorType, OriginProvenance, SourceProvenance},
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
@@ -20,9 +23,14 @@ pub struct OntologyProvenance {
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct ProvidedOntologyEditionProvenance {
-    /// This field is only used to generate a TS type.
-    #[serde(default, rename = "__placeholder")]
-    __placeholder: (),
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sources: Vec<SourceProvenance>,
+    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor_type: Option<ActorType>,
+    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin: Option<OriginProvenance>,
 }
 
 impl ProvidedOntologyEditionProvenance {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Relatively high-priority given its utility in the context of type inference.


## 🔍 What does this change?

- Add provenance fields for `actorType`, `sources`, and `origin` to ontology types

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph