### PR TITLE
H-2742: Specify revision for crc32c crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,8 +1009,7 @@ dependencies = [
 [[package]]
 name = "crc32c"
 version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89254598aa9b9fa608de44b3ae54c810f0f06d755e24c50177f1f8f31ff50ce2"
+source = "git+https://github.com/zowens/crc32c?rev=04eabbc6ef33e0afe529da729e65916c48f9d032#04eabbc6ef33e0afe529da729e65916c48f9d032"
 dependencies = [
  "rustc_version",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,3 +81,6 @@ uuid = { version = "1.8.0", default-features = false }
 inherits = "release"
 lto = "fat"
 strip = "none"
+
+[patch.crates-io]
+crc32c = { git = "https://github.com/zowens/crc32c", rev = "04eabbc6ef33e0afe529da729e65916c48f9d032" }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Since a recent nightly toolchain version compiling crc32c fails to compile on ARM.

## 🔗 Related links

- https://github.com/zowens/crc32c/issues/62
- https://github.com/zowens/crc32c/issues/63

## 🔍 What does this change?

- Patch the dependency to the latest revision (two commits after the latest release) which fixed the issue

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

- Revert this PR when a new version of `crc32c` was released