### PR TITLE
H-2753: Update Renovate schedule for LLM provider SDKs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -89,6 +89,18 @@
       "dependencyDashboardApproval": false
     },
     {
+      "groupName": "LLM provider SDK npm packages",
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": [
+        "^@openai/",
+        "^@anthropic/",
+        "groq-sdk"
+      ],
+      "automerge": false,
+      "dependencyDashboardApproval": false,
+      "minimumReleaseAge": "0 days"
+    },
+    {
       "groupName": "Block Protocol npm packages",
       "matchManagers": ["npm"],
       "matchPackagePatterns": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -91,14 +91,11 @@
     {
       "groupName": "LLM provider SDK npm packages",
       "matchManagers": ["npm"],
-      "matchPackagePatterns": [
-        "^@openai/",
-        "^@anthropic/",
-        "groq-sdk"
-      ],
+      "matchPackagePatterns": ["^@openai/", "^@anthropic/", "groq-sdk"],
       "automerge": false,
       "dependencyDashboardApproval": false,
-      "minimumReleaseAge": "0 days"
+      "minimumReleaseAge": "0 days",
+      "schedule": ["after 1am"]
     },
     {
       "groupName": "Block Protocol npm packages",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We want to ensure we're always using the latest version of the LLM provider SDKs we rely on, without:

- waiting the normal 3 day period `npm` unpublishing safeguards would normally have us delay updating for
- having to manually trigger these to be updated via the repository's [dependency update dashboard](https://github.com/hashintel/hash/issues/3037).

Further rationale in this [chat thread](https://hashintel.slack.com/archives/C02TWBTT3ED/p1716322500100909) (_internal link_). To this end, we want PRs to be opened, _but not set to automerge_, so that their changelogs can be reviewed by a member of our team (and any relevant features taken advantage of) before merging in.

As well as supporting `@openai/` and `@anthropic/` npm namespaces, this PR pre-emptively adds handling for the `groq-sdk` package to this Renovate schedule, as well.

## 🚫 Blocked by

A review of the Renovate logic used here, to make sure it functions as expected, would be appreciated. In particular my setting of `minimumReleaseDate` to `"0 days"`. If there is a better solution for overriding the default 3-day wait we apply to `npm` updates, please feel free to suggest a change.