### PR TITLE
H-2743: Attach provenance information to properties on proposed entities

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action.ts
@@ -11,7 +11,7 @@ import type {
 } from "@local/hash-isomorphic-utils/flows/types";
 import { generateUuid } from "@local/hash-isomorphic-utils/generate-uuid";
 import type { FileProperties } from "@local/hash-isomorphic-utils/system-types/shared";
-import type { EntityId } from "@local/hash-subgraph/.";
+import type { EntityId } from "@local/hash-subgraph";
 import { StatusCode } from "@local/status";
 import dedent from "dedent";
 

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/infer-facts-from-text/infer-entity-facts-from-text.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/infer-facts-from-text/infer-entity-facts-from-text.ts
@@ -1,3 +1,4 @@
+import { generateUuid } from "@local/hash-isomorphic-utils/generate-uuid";
 import dedent from "dedent";
 
 import { logger } from "../../../shared/activity-logger";
@@ -179,6 +180,7 @@ export const inferEntityFactsFromText = async (params: {
     };
 
     const newFacts: Fact[] = input.facts.map((fact) => ({
+      factId: generateUuid(),
       text: fact.text,
       subjectEntityLocalId: subjectEntity.localId,
       objectEntityLocalId: fact.objectEntityLocalId ?? undefined,

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/infer-facts-from-text/types.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/infer-facts-from-text/types.ts
@@ -1,6 +1,7 @@
 import type { SourceProvenance } from "@local/hash-graph-client";
 
 export type Fact = {
+  factId: string;
   subjectEntityLocalId: string;
   objectEntityLocalId?: string;
   text: string;

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/propose-entities-from-facts.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/propose-entities-from-facts.ts
@@ -1,5 +1,5 @@
 import type { ProposedEntity } from "@local/hash-isomorphic-utils/flows/types";
-import type { BaseUrl } from "@local/hash-subgraph/.";
+import type { BaseUrl } from "@local/hash-subgraph";
 
 import type { DereferencedEntityTypesByTypeId } from "../../infer-entities/inference-types";
 import { logger } from "../../shared/activity-logger";

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/propose-entities-from-facts/propose-entities-from-facts.ai.test.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/propose-entities-from-facts/propose-entities-from-facts.ai.test.ts
@@ -1,11 +1,13 @@
 import "../../../../shared/testing-utilities/mock-get-flow-context";
 
+import { generateUuid } from "@local/hash-isomorphic-utils/generate-uuid";
 import { expect, test } from "vitest";
 
 import { getDereferencedEntityTypesActivity } from "../../../get-dereferenced-entity-types-activity";
 import { getFlowContext } from "../../../shared/get-flow-context";
 import { graphApiClient } from "../../../shared/graph-api-client";
 import type { LocalEntitySummary } from "../infer-facts-from-text/get-entity-summaries-from-text";
+import type { Fact } from "../infer-facts-from-text/types";
 import { proposeEntitiesFromFacts } from "../propose-entities-from-facts";
 
 const ftse350EntitySummaries: LocalEntitySummary[] = [
@@ -430,9 +432,25 @@ test(
       simplifyPropertyKeys: true,
     });
 
+    const facts = ftse350Facts.map(
+      (fact): Fact => ({
+        ...fact,
+        factId: generateUuid(),
+        sources: [
+          {
+            type: "webpage",
+            location: {
+              uri: "https://www.londonstockexchange.com/indices/ftse-350/constituents/table",
+            },
+            loadedAt: new Date().toISOString(),
+          },
+        ],
+      }),
+    );
+
     const { proposedEntities } = await proposeEntitiesFromFacts({
       entitySummaries: ftse350EntitySummaries,
-      facts: ftse350Facts,
+      facts,
       dereferencedEntityTypes,
     });
 

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/propose-entities-from-facts/propose-entity-from-facts.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/propose-entities-from-facts/propose-entity-from-facts.ts
@@ -306,13 +306,14 @@ export const proposeEntityFromFacts = async (params: {
 
   const llmResponse = await getLlmResponse(
     {
-      model: "gpt-4-0125-preview",
+      model: "gpt-4o-2024-05-13",
       tools: Object.values(
         generateToolDefinitions({
           dereferencedEntityType,
           proposeOutgoingLinkEntityTypes,
         }),
       ),
+      toolChoice: "required",
       systemPrompt: generateSystemPrompt({
         proposingOutgoingLinks,
       }),

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/propose-entities-from-facts/propose-entity-from-facts.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/propose-entities-from-facts/propose-entity-from-facts.ts
@@ -42,6 +42,12 @@ const mapPropertiesSchemaToInputPropertiesSchema = (params: {
         [simplifiedPropertyKey]: {
           type: "object",
           properties: {
+            /**
+             * @todo: attach provenance information to nested properties which have corresponding
+             * property type definitions.
+             *
+             * @see https://linear.app/hash/issue/H-2755/attach-provenance-information-to-nested-properties-when-proposing
+             */
             propertyValue: jsonSchema,
             factIdsUsedToDetermineValue: {
               type: "array",

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/011-deprecate-preferred-name.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/011-deprecate-preferred-name.migration.ts
@@ -4,7 +4,7 @@ import {
   systemEntityTypes,
   systemPropertyTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
-import type { BaseUrl } from "@local/hash-subgraph/.";
+import type { BaseUrl } from "@local/hash-subgraph";
 
 import { getEntityTypeById } from "../../../ontology/primitive/entity-type";
 import type { MigrationFunction } from "../types";

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-page-wrapper/draft-entity-banner.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-page-wrapper/draft-entity-banner.tsx
@@ -1,6 +1,6 @@
 import { FeatherRegularIcon } from "@hashintel/design-system";
 import { generateEntityPath } from "@local/hash-isomorphic-utils/frontend-paths";
-import type { Entity, EntityRootType, Subgraph } from "@local/hash-subgraph/.";
+import type { Entity, EntityRootType, Subgraph } from "@local/hash-subgraph";
 import { Box, Container, Typography } from "@mui/material";
 import { useRouter } from "next/router";
 import type { FunctionComponent } from "react";

--- a/apps/hash-frontend/src/shared/draft-entities-context.tsx
+++ b/apps/hash-frontend/src/shared/draft-entities-context.tsx
@@ -4,7 +4,7 @@ import {
   mapGqlSubgraphFieldsFragmentToSubgraph,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
-import type { Entity, EntityRootType, Subgraph } from "@local/hash-subgraph/.";
+import type { Entity, EntityRootType, Subgraph } from "@local/hash-subgraph";
 import { getRoots } from "@local/hash-subgraph/stdlib";
 import type { FunctionComponent, PropsWithChildren } from "react";
 import { createContext, useContext, useMemo, useState } from "react";


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR updates the `proposeEntitiesFromFacts` method to require the LLM to specify which facts it used to determine the value of a top-level property, so that the relevant provenance information stored on the fact can be stored on a per-property basis.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-2743

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Changes the model used in `proposeEntitiesFromFacts` to `gpt-4o-2024-05-13`, because it is cheaper and faster than the prior `gpt-4-0125-preview`. This didn't introduce any noticeable regressions.
- Adds a `factId` to facts inferred from text.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

- currently the provenance data is only attached to the top-level properties for proposed entities/links. This could also be attached to nested properties (H-2755)

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

Manual testing.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

The easiest way of testing this is by inspecting the output of running the test file corresponding to the `proposeEntityFromFacts` method, via:
```
yarn workspace @apps/hash-ai-worker-ts vitest run propose-entity-from-facts
```

Note to run the tests, you will need to copy the contents of `.env.local` to `.env.test.local` (the `dotenv-flow` package doesn't use `.env.local` when loading the env vars in the test environment)


## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

Example entity proposed from facts:
```JSON
{
  "localEntityId": "6916156b-e759-41ad-b1da-2cf7af05d223",
  "propertyMetadata": [
    {
      "path": [
        "https://blockprotocol.org/@blockprotocol/types/property-type/name/"
      ],
      "metadata": {
        "provenance": {
          "sources": [
            {
              "type": "webpage",
              "location": {
                "uri": "https://www.londonstockexchange.com/indices/ftse-350/constituents/table"
              },
              "loadedAt": "2024-05-22T15:56:24.444Z"
            }
          ]
        }
      }
    },
    {
      "path": [
        "https://hash.ai/@ftse/types/property-type/market-capitalization/"
      ],
      "metadata": {
        "provenance": {
          "sources": [
            {
              "type": "webpage",
              "location": {
                "uri": "https://www.londonstockexchange.com/indices/ftse-350/constituents/table"
              },
              "loadedAt": "2024-05-22T15:56:24.444Z"
            }
          ]
        }
      }
    }
  ],
  "summary": "HUNTING PLC, represented by the stock code HTG, has a market cap of 614.40 million GBX, a last recorded price of 452.50 GBX, and experienced a recent price change of 80.00 GBX, translating to a 21.48% increase.",
  "entityTypeId": "https://hash.ai/@ftse/types/entity-type/stock-market-constituent/v/1",
  "properties": {
    "https://blockprotocol.org/@blockprotocol/types/property-type/name/": "HUNTING PLC",
    "https://hash.ai/@ftse/types/property-type/market-capitalization/": [
      {
        "https://hash.ai/@ftse/types/property-type/value/": 614.4,
        "https://hash.ai/@ftse/types/property-type/unit/": "GBX",
        "https://hash.ai/@ftse/types/property-type/multiplier/": "million",
        "https://hash.ai/@ftse/types/property-type/measured-on/": "2024-05-22T15:56:24.444Z"
      }
    ]
  }
},
```
