### PR TITLE
H-2763: Add provenance data to subgraph library

### DIFF
--- a/libs/@local/hash-subgraph/src/types/element/knowledge.ts
+++ b/libs/@local/hash-subgraph/src/types/element/knowledge.ts
@@ -14,6 +14,7 @@ import type {
 import type { VersionedUrl } from "@blockprotocol/type-system/slim";
 import type { Brand } from "@local/advanced-types/brand";
 import type { Subtype } from "@local/advanced-types/subtype";
+import type { PropertyMetadataMap } from "@local/hash-graph-client";
 
 import type {
   BaseUrl,
@@ -93,6 +94,8 @@ export type EntityMetadata = Subtype<
     temporalVersioning: EntityTemporalVersioningMetadata;
     archived: boolean;
     provenance: EntityProvenance;
+    confidence?: number;
+    properties?: PropertyMetadataMap;
   }
 >;
 

--- a/libs/@local/hash-subgraph/src/types/shared.ts
+++ b/libs/@local/hash-subgraph/src/types/shared.ts
@@ -1,4 +1,10 @@
 import type {
+  ActorType,
+  ProvidedEntityEditionProvenanceOrigin,
+  SourceProvenance,
+} from "@local/hash-graph-client";
+
+import type {
   CreatedAtDecisionTime,
   CreatedAtTransactionTime,
   CreatedById,
@@ -16,6 +22,9 @@ export type OntologyProvenance = {
 export type OntologyEditionProvenance = {
   createdById: EditionCreatedById;
   archivedById?: EditionArchivedById;
+  actorType?: ActorType;
+  origin?: ProvidedEntityEditionProvenanceOrigin;
+  sources?: Array<SourceProvenance>;
 };
 
 export type EntityProvenance = {
@@ -29,4 +38,8 @@ export type EntityProvenance = {
 
 export type EntityEditionProvenance = {
   createdById: EditionCreatedById;
+  archivedById?: EditionArchivedById;
+  actorType?: ActorType;
+  origin?: ProvidedEntityEditionProvenanceOrigin;
+  sources?: Array<SourceProvenance>;
 };

--- a/libs/@local/hash-subgraph/tests/compatibility.test/map-vertices.ts
+++ b/libs/@local/hash-subgraph/tests/compatibility.test/map-vertices.ts
@@ -116,6 +116,9 @@ const mapOntologyProvenance = (
     edition: {
       createdById: metadata.edition.createdById as EditionCreatedById,
       archivedById: metadata.edition.archivedById as EditionArchivedById,
+      actorType: metadata.edition.actorType,
+      origin: metadata.edition.origin,
+      sources: metadata.edition.sources,
     },
   };
 };
@@ -131,6 +134,10 @@ const mapEntityProvenance = (
       metadata.createdAtDecisionTime as CreatedAtDecisionTime,
     edition: {
       createdById: metadata.edition.createdById as EditionCreatedById,
+      archivedById: metadata.edition.archivedById as EditionArchivedById,
+      actorType: metadata.edition.actorType,
+      origin: metadata.edition.origin,
+      sources: metadata.edition.sources,
     },
   };
 };
@@ -334,6 +341,8 @@ const mapEntityMetadata = (
     ),
     provenance: mapEntityProvenance(metadata.provenance),
     archived: metadata.archived,
+    confidence: metadata.confidence,
+    properties: metadata.properties,
   };
 };
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The fields are missing in the subgraph library, this makes them accessible.