### PR TITLE
H-2714: Fix upgrading types in migrations for self-hosted instances

### DIFF
--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
@@ -566,8 +566,8 @@ export const createSystemPropertyTypeIfNotExists: ImpureGraphFunction<
 
   if (isSelfHostedInstance) {
     /**
-     * If this is a self-hosted instance, the system types will be created as external types that don't belong to an in-instance web,
-     * although they will be created by a machine actor associated with an equivalently named web.
+     * If this is a self-hosted instance, the system types will be created as external types that don't belong to an
+     * in-instance web, although they will be created by a machine actor associated with an equivalently named web.
      */
     await context.graphApi.loadExternalPropertyType(machineActorId, {
       // Specify the schema so that self-hosted instances don't need network access to hash.ai
@@ -945,8 +945,8 @@ export const updateSystemEntityType: ImpureGraphFunction<
     );
   }
 
+  const nextEntityTypeId = versionedUrlFromComponents(baseUrl, version + 1);
   try {
-    const nextEntityTypeId = versionedUrlFromComponents(baseUrl, version + 1);
     await getEntityTypeById(context, authentication, {
       entityTypeId: nextEntityTypeId,
     });
@@ -981,13 +981,23 @@ export const updateSystemEntityType: ImpureGraphFunction<
     ),
   };
 
-  const updatedTypeMetadata = await context.graphApi
-    .updateEntityType(authentication.actorId, {
-      typeToUpdate: currentEntityTypeId,
-      schema: schemaWithConsistentSelfReferences,
-      relationships: currentRelationships,
-    })
-    .then((resp) => resp.data);
+  const updatedTypeMetadata = isSelfHostedInstance
+    ? await context.graphApi
+        .loadExternalEntityType(authentication.actorId, {
+          relationships: currentRelationships,
+          schema: {
+            ...schemaWithConsistentSelfReferences,
+            $id: nextEntityTypeId,
+          },
+        })
+        .then((resp) => resp.data)
+    : await context.graphApi
+        .updateEntityType(authentication.actorId, {
+          typeToUpdate: currentEntityTypeId,
+          schema: schemaWithConsistentSelfReferences,
+          relationships: currentRelationships,
+        })
+        .then((resp) => resp.data);
 
   const { version: newVersion } = updatedTypeMetadata.recordId;
 
@@ -1027,8 +1037,8 @@ export const updateSystemPropertyType: ImpureGraphFunction<
     );
   }
 
+  const nextPropertyTypeId = versionedUrlFromComponents(baseUrl, version + 1);
   try {
-    const nextPropertyTypeId = versionedUrlFromComponents(baseUrl, version + 1);
     await getPropertyTypeById(context, authentication, {
       propertyTypeId: nextPropertyTypeId,
     });
@@ -1046,13 +1056,23 @@ export const updateSystemPropertyType: ImpureGraphFunction<
 
   const { $id: _, ...schemaWithout$id } = newSchema;
 
-  const updatedPropertyTypeMetadata = await context.graphApi
-    .updatePropertyType(authentication.actorId, {
-      typeToUpdate: currentPropertyTypeId,
-      schema: schemaWithout$id,
-      relationships: currentRelationships,
-    })
-    .then((resp) => resp.data);
+  const updatedPropertyTypeMetadata = isSelfHostedInstance
+    ? await context.graphApi
+        .loadExternalPropertyType(authentication.actorId, {
+          relationships: currentRelationships,
+          schema: {
+            ...newSchema,
+            $id: nextPropertyTypeId,
+          },
+        })
+        .then((resp) => resp.data)
+    : await context.graphApi
+        .updatePropertyType(authentication.actorId, {
+          typeToUpdate: currentPropertyTypeId,
+          schema: schemaWithout$id,
+          relationships: currentRelationships,
+        })
+        .then((resp) => resp.data);
 
   const { version: newVersion } = updatedPropertyTypeMetadata.recordId;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes the migrations not accounting for self-hosted instances when entity types and property types are updated.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- None yet (H-2716)

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Update `.env.local`:
`SELF_HOSTED_HASH=true`
`HASH_GRAPH_ALLOWED_URL_DOMAIN_PATTERN` to not include hash.ai
2. Reset db
3. `yarn dev:graph` `yarn dev:backend:api`
4. Check migrations run through without error

