### PR TITLE
H-2764: Add optional `userAgent` string field to origin provenance

### DIFF
--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -6260,6 +6260,9 @@
                   "web-app"
                 ]
               },
+              "userAgent": {
+                "type": "string"
+              },
               "version": {
                 "type": "string",
                 "description": "The origin version, in whatever format the origin natively\nprovides."
@@ -6295,6 +6298,9 @@
                 "enum": [
                   "mobile-app"
                 ]
+              },
+              "userAgent": {
+                "type": "string"
               },
               "version": {
                 "type": "string",
@@ -6332,6 +6338,9 @@
                   "browser-extension"
                 ]
               },
+              "userAgent": {
+                "type": "string"
+              },
               "version": {
                 "type": "string",
                 "description": "The origin version, in whatever format the origin natively\nprovides."
@@ -6367,6 +6376,9 @@
                 "enum": [
                   "api"
                 ]
+              },
+              "userAgent": {
+                "type": "string"
               },
               "version": {
                 "type": "string",
@@ -6410,6 +6422,9 @@
                   "flow"
                 ]
               },
+              "userAgent": {
+                "type": "string"
+              },
               "version": {
                 "type": "string",
                 "description": "The origin version, in whatever format the origin natively\nprovides."
@@ -6445,6 +6460,9 @@
                 "enum": [
                   "migration"
                 ]
+              },
+              "userAgent": {
+                "type": "string"
               },
               "version": {
                 "type": "string",

--- a/libs/@local/hash-graph-types/rust/src/knowledge/entity/provenance.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/entity/provenance.rs
@@ -132,12 +132,14 @@ pub struct OriginProvenance {
     pub session_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_key_public_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_agent: Option<String>,
 }
 
 #[cfg(feature = "utoipa")]
 impl<'__s> ToSchema<'__s> for OriginProvenance {
     fn schema() -> (&'__s str, RefOr<Schema>) {
-        let common_types: [(&'static str, RefOr<Schema>); 7] = [
+        let common_types: [(&'static str, RefOr<Schema>); 8] = [
             (
                 "id",
                 RefOr::T(Schema::from(
@@ -181,6 +183,12 @@ provides.",
             ),
             (
                 "apiKeyPublicId",
+                RefOr::T(Schema::from(
+                    ObjectBuilder::new().schema_type(SchemaType::String),
+                )),
+            ),
+            (
+                "userAgent",
                 RefOr::T(Schema::from(
                     ObjectBuilder::new().schema_type(SchemaType::String),
                 )),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We want to allow tracking the user agent for an origin