### PR TITLE
H-2793: Use method to access property metadata in TS

### DIFF
--- a/apps/hash-api/src/graph/knowledge/primitive/link-entity.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/link-entity.ts
@@ -1,5 +1,6 @@
 import type { VersionedUrl } from "@blockprotocol/type-system";
 import type {
+  LinkData as GraphApiLinkData,
   PropertyMetadataMap,
   ProvidedEntityEditionProvenance,
 } from "@local/hash-graph-client";
@@ -12,7 +13,6 @@ import type {
 import type {
   EntityId,
   EntityPropertiesObject,
-  LinkData,
 } from "@local/hash-graph-types/entity";
 import type { OwnedById } from "@local/hash-graph-types/web";
 import type { EntityRelationAndSubject } from "@local/hash-subgraph";
@@ -92,7 +92,7 @@ export const createLinkEntity: ImpureGraphFunction<
     );
   }
 
-  const linkData: LinkData = {
+  const linkData: GraphApiLinkData = {
     leftEntityId,
     rightEntityId,
     leftEntityConfidence,

--- a/libs/@local/hash-graph-sdk/typescript/package.json
+++ b/libs/@local/hash-graph-sdk/typescript/package.json
@@ -24,11 +24,13 @@
   "dependencies": {
     "@blockprotocol/graph": "0.3.4",
     "@local/hash-graph-client": "0.0.0-private",
-    "@local/hash-graph-types": "0.0.0-private"
+    "@local/hash-graph-types": "0.0.0-private",
+    "lodash": "4.17.21"
   },
   "devDependencies": {
     "@local/eslint-config": "0.0.0-private",
     "@local/tsconfig": "0.0.0-private",
+    "@types/lodash": "4.14.188",
     "@vitest/coverage-istanbul": "1.6.0",
     "eslint": "8.57.0",
     "typescript": "5.1.6",

--- a/libs/@local/hash-graph-types/typescript/src/entity.ts
+++ b/libs/@local/hash-graph-types/typescript/src/entity.ts
@@ -10,7 +10,6 @@ import type { Brand } from "@local/advanced-types/brand";
 import type { Subtype } from "@local/advanced-types/subtype";
 import type {
   ActorType,
-  PropertyMetadataMap,
   ProvidedEntityEditionProvenanceOrigin,
   SourceProvenance,
 } from "@local/hash-graph-client";
@@ -73,8 +72,6 @@ export type EntityMetadata = Subtype<
     temporalVersioning: EntityTemporalVersioningMetadata;
     archived: boolean;
     provenance: EntityProvenance;
-    confidence?: number;
-    properties?: PropertyMetadataMap;
   }
 >;
 
@@ -83,8 +80,6 @@ export type LinkData = Subtype<
   {
     leftEntityId: EntityId;
     rightEntityId: EntityId;
-    leftEntityConfidence?: number;
-    rightEntityConfidence?: number;
   }
 >;
 

--- a/libs/@local/hash-subgraph/tests/compatibility.test/map-vertices.ts
+++ b/libs/@local/hash-subgraph/tests/compatibility.test/map-vertices.ts
@@ -349,8 +349,6 @@ const mapEntityMetadata = (
     ),
     provenance: mapEntityProvenance(metadata.provenance),
     archived: metadata.archived,
-    confidence: metadata.confidence,
-    properties: metadata.properties,
   };
 };
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The internals of property metadata are not specified and should only be accessed via a method.

## 🔍 What does this change?

- Forbid direct access to `metadata.properties` and use `propertyMetadata()` instead
- Make some more `EntityMetadata` and `LinkData` fields internal 

## 🚫 Blocked by

- #4526 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph