### PR TITLE
H-2833: Add debug logs to Temporal worker

### DIFF
--- a/infra/terraform/hash/hash_application/temporal_worker_ai_ts.tf
+++ b/infra/terraform/hash/hash_application/temporal_worker_ai_ts.tf
@@ -24,7 +24,7 @@ locals {
     cpu         = 0 # let ECS divvy up the available CPU
     healthCheck = {
       command     = ["CMD", "/bin/sh", "-c", "curl -f http://localhost:4100/health || exit 1"]
-      startPeriod = 30
+      startPeriod = 10
       interval    = 10
       retries     = 10
       timeout     = 5


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Add some debug logs to the AI Temporal worker to attempt to debug why it isn't connecting to the Temporal server.

I've also made the `startPeriod` on its health check consistent with the integration worker (which does connect). I've no idea why a _longer_ grace period would make a difference but it's one of the only differences I can find between the two workers.

I've also removed the custom logger in case this was causing an issue somehow.

This is more changes than are ideal at once, but it takes a while to deploy. If this fixes it I will start removing changes until it breaks (the `startPeriod` can be reverted in AWS directly at first, to test it).