### PR TITLE
H-2669: Fix horizontal scroll for Flows, prevent double Goal submission

### DIFF
--- a/apps/hash-frontend/src/pages/goals/new.page.tsx
+++ b/apps/hash-frontend/src/pages/goals/new.page.tsx
@@ -98,13 +98,17 @@ const NewGoalPageContent = () => {
   const getOwner = useGetOwnerForEntity();
   const { push } = useRouter();
 
-  const [startFlow] = useMutation<
+  const [startFlow, { called }] = useMutation<
     StartFlowMutation,
     StartFlowMutationVariables
   >(startFlowMutation);
 
   const createGoal = async (event: FormEvent) => {
     event.preventDefault();
+
+    if (!called || !goal.trim()) {
+      return;
+    }
 
     const triggerOutputs = [
       {
@@ -273,12 +277,19 @@ const NewGoalPageContent = () => {
             }}
           >
             <Button
-              disabled={!goal.trim()}
+              disabled={!goal.trim() || called}
               onClick={createGoal}
               size="medium"
               type="submit"
             >
-              Continue <ArrowRightIconRegular sx={{ fontSize: 16, ml: 1 }} />
+              {called ? (
+                "Starting..."
+              ) : (
+                <>
+                  Continue
+                  <ArrowRightIconRegular sx={{ fontSize: 16, ml: 1 }} />
+                </>
+              )}
             </Button>
           </Box>
         </Box>

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar.tsx
@@ -56,6 +56,7 @@ export const LayoutWithSidebar: FunctionComponent<LayoutWithSidebarProps> = ({
             width: "100%",
             position: "relative",
             marginLeft: `-${SIDEBAR_WIDTH}px`,
+            overflowX: "hidden",
             transition: theme.transitions.create("margin", {
               easing: theme.transitions.easing.easeOut,
               duration: theme.transitions.duration.enteringScreen,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

1. Fix an issue where a Flow DAG view could overflow the page horizontally without a scrollbar appearing, when the sidebar was open
2. Prevent the button to create a new goal being pressed after it's already been pressed once

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Go to Workers -> Flows -> select a flow. Make the screen small enough so that the DAG is wider than the space it has, check a horizontal scrollbar appears
2. Go to Workers -> Goals -> New. Submit the form and check the button / form can't be submitted again
