### PR TITLE
H-2834: Fix Sentry capturing errors from Temporal workflows

### DIFF
--- a/apps/hash-ai-worker-ts/scripts/bundle-workflow-code.ts
+++ b/apps/hash-ai-worker-ts/scripts/bundle-workflow-code.ts
@@ -14,6 +14,11 @@ const require = createRequire(import.meta.url);
 async function bundle() {
   const { code } = await bundleWorkflowCode({
     workflowsPath: require.resolve("../src/workflows"),
+    workflowInterceptorModules: [
+      require.resolve(
+        "@local/hash-backend-utils/temporal/interceptors/workflows/sentry",
+      ),
+    ],
   });
   const codePath = path.join(__dirname, "../dist/workflow-bundle.js");
 

--- a/apps/hash-integration-worker/scripts/bundle-workflow-code.ts
+++ b/apps/hash-integration-worker/scripts/bundle-workflow-code.ts
@@ -14,6 +14,11 @@ const require = createRequire(import.meta.url);
 async function bundle() {
   const { code } = await bundleWorkflowCode({
     workflowsPath: require.resolve("../src/workflows"),
+    workflowInterceptorModules: [
+      require.resolve(
+        "@local/hash-backend-utils/temporal/interceptors/workflows/sentry",
+      ),
+    ],
   });
   const codePath = path.join(__dirname, "../dist/workflow-bundle.js");
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When bundling workflow code for a Temporal worker, we need to specify any interceptors we are using when bundling the code.

I noticed this issue when looking at logs to debug a Temporal worker not connecting to the server in production, though I do not think it is related (it is just preventing Sentry from capturing errors which are thrown from workflows – it is definitely capturing errors thrown from activities).

```
[WARN] Ignoring WorkerOptions.interceptors.workflowModules because WorkerOptions.workflowBundle is set.
To use workflow interceptors with a workflowBundle, pass them in the call to bundleWorkflowCode.
```

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
