### PR TITLE
H-2842: Add debug logs around isUserHashInstanceAdmin

### DIFF
--- a/libs/@local/hash-backend-utils/src/hash-instance.ts
+++ b/libs/@local/hash-backend-utils/src/hash-instance.ts
@@ -88,16 +88,35 @@ export const isUserHashInstanceAdmin = async (
   ctx: { graphApi: GraphApi },
   authentication: { actorId: AccountId },
   { userAccountId }: { userAccountId: AccountId },
-) =>
-  getHashInstance(ctx, authentication).then((hashInstance) =>
-    ctx.graphApi
-      .checkEntityPermission(
-        userAccountId,
-        hashInstance.entity.metadata.recordId.entityId,
-        "update",
-      )
-      .then(({ data }) => data.has_permission),
+) => {
+  // eslint-disable-next-line no-console
+  console.info(`[${userAccountId}] Fetching HASH Instance entity`);
+  const hashInstance = await getHashInstance(ctx, authentication).catch(
+    (err) => {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[${userAccountId}] ERROR Fetching HASH Instance entity: ${err}`,
+      );
+      throw err;
+    },
   );
+  // eslint-disable-next-line no-console
+  console.info(`[${userAccountId}] Checking permission on instance`);
+  return ctx.graphApi
+    .checkEntityPermission(
+      userAccountId,
+      hashInstance.entity.metadata.recordId.entityId,
+      "update",
+    )
+    .then(({ data }) => data.has_permission)
+    .catch((err) => {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[${userAccountId}] ERROR Checking permission on instance: ${err}`,
+      );
+      throw err;
+    });
+};
 
 /**
  * Retrieves the accountGroupId of the instance admin account group.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A continuation of PRs attempting to debug AWS deployment failures.

The API migration fails at the same function in different files – this PR adds some debug logs around the point it fails to further narrow down the issue (which is possibly due to concurrent request volume).