### PR TITLE
H-2831: Add Slack notification on early access form submission

### DIFF
--- a/apps/hash-api/src/graphql/resolvers/knowledge/user/submit-early-access-form.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/user/submit-early-access-form.ts
@@ -1,6 +1,7 @@
 import { getHashInstanceAdminAccountGroupId } from "@local/hash-backend-utils/hash-instance";
 import type { OwnedById } from "@local/hash-graph-types/web";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
+import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
 
 import { createEntity } from "../../../../graph/knowledge/primitive/entity";
 import { systemAccountId } from "../../../../graph/system-account";
@@ -49,13 +50,19 @@ export const submitEarlyAccessFormResolver: ResolverFn<
           },
         },
         {
+          relation: "viewer",
+          subject: {
+            kind: "account",
+            subjectId: user.accountId,
+          },
+        },
+        {
           relation: "setting",
           subject: {
             kind: "setting",
             subjectId: "administratorFromWeb",
           },
         },
-
         {
           relation: "setting",
           subject: {
@@ -66,6 +73,43 @@ export const submitEarlyAccessFormResolver: ResolverFn<
       ],
     },
   );
+
+  if (process.env.ACCESS_FORM_SLACK_WEBHOOK_URL) {
+    const simpleProperties = simplifyProperties(properties);
+    const slackMessage = {
+      blocks: [
+        {
+          type: "header",
+          text: {
+            type: "plain_text",
+            text: "Early Access Form Submission",
+          },
+        },
+        {
+          type: "section",
+          fields: [
+            {
+              type: "mrkdwn",
+              text: Object.entries(simpleProperties)
+                .map(([key, value]) => `*${key}*: ${value}`)
+                .join("\n"),
+            },
+          ],
+        },
+        {
+          type: "divider",
+        },
+      ],
+    };
+
+    void fetch(process.env.ACCESS_FORM_SLACK_WEBHOOK_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(slackMessage),
+    });
+  }
 
   return true;
 };

--- a/apps/hash-frontend/src/pages/index.page/logged-out.tsx
+++ b/apps/hash-frontend/src/pages/index.page/logged-out.tsx
@@ -24,10 +24,10 @@ export const LoggedOut = () => {
         </HomepageBigText>
         <HomepageBigText>on the waitlist</HomepageBigText>
         <HomepageSmallCaps>
-          Stay tuned
+          Sign up
           <Box
             component="span"
-            sx={{ color: ({ palette }) => palette.blue[70], ml: 0.8 }}
+            sx={{ color: ({ palette }) => palette.blue[70], ml: 0.7 }}
           >
             for access
           </Box>

--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -301,6 +301,10 @@ module "application" {
   ])
   api_env_vars = concat(var.hash_api_env_vars, [
     {
+      name  = "ACCESS_FORM_SLACK_WEBHOOK_URL", secret = true,
+      value = sensitive(data.vault_kv_secret_v2.secrets.data["access_form_slack_webhook_url"])
+    },
+    {
       name  = "MAILCHIMP_API_KEY", secret = true,
       value = sensitive(data.vault_kv_secret_v2.secrets.data["mailchimp_api_key"])
     },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Notify Slack when the early access form is submitted (hosted HASH only).

Also fixes a couple of bugs:
1. In order that a returning user can see the form entity (and thus know they have already submitted it), the permission needs to be explicitly granted to the user to view, since they don't yet own the web
2. Fix copy

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Get the appropriate webhook URL from the "Notify HASH" app in our Slack workspace, set the environment variable, and submit the form.
