### PR TITLE
Restore code to AI worker

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities.ts
@@ -8,8 +8,8 @@ import { generateWebQueriesAction } from "./flow-activities/generate-web-queries
 import { getWebPageByUrlAction } from "./flow-activities/get-web-page-by-url-action";
 // import { getWebPageSummaryAction } from "./flow-activities/get-web-page-summary-action";
 import { inferEntitiesFromContentAction } from "./flow-activities/infer-entities-from-content-action";
-// import { persistEntitiesAction } from "./flow-activities/persist-entities-action";
-// import { persistEntityAction } from "./flow-activities/persist-entity-action";
+import { persistEntitiesAction } from "./flow-activities/persist-entities-action";
+import { persistEntityAction } from "./flow-activities/persist-entity-action";
 import { persistFlowActivity } from "./flow-activities/persist-flow-activity";
 import { processAutomaticBrowsingSettingsAction } from "./flow-activities/process-automatic-browsing-settings-action";
 // import { researchEntitiesAction } from "./flow-activities/research-entities-action";
@@ -28,8 +28,8 @@ export const createFlowActionActivities = ({
   getWebPageByUrlAction,
   processAutomaticBrowsingSettingsAction,
   inferEntitiesFromContentAction,
-  // persistEntityAction,
-  // persistEntitiesAction,
+  persistEntityAction,
+  persistEntitiesAction,
   // getFileFromUrlAction,
   // researchEntitiesAction,
   // getWebPageSummaryAction,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The AI worker works with the removal of `writeGoogleSheetAction`, but it was still broken when built off #4561 when it was absent. So there must be other activities which also cause it to break.

This PR adds a couple back so we can find out the multiple activities that cause it to break, and look for the code they share to identify the issue.