### PR TITLE
H-2859: Improve `--help` output for CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ aws-sdk-s3 = { version = "1.28.0" }
 
 # Shared third-party dependencies
 bytes = "1.6.0"
-clap = { version = "4.5.4", default-features = false, features = ["std"] }
+clap = { version = "4.5.4", features = ["std", "color", "help", "usage", "error-context", "suggestions"] }
 derive-where = { version = "1.2.7", default-features = false, features = ["nightly"] }
 email_address = { version = "0.2.4", default-features = false }
 futures = { version = "0.3.30", default-features = false }

--- a/apps/hash-graph/bins/cli/src/args.rs
+++ b/apps/hash-graph/bins/cli/src/args.rs
@@ -1,4 +1,10 @@
-use clap::Parser;
+use clap::{
+    builder::{
+        styling::{AnsiColor, Effects},
+        Styles,
+    },
+    ColorChoice, CommandFactory, FromArgMatches, Parser,
+};
 use hash_tracing::TracingConfig;
 
 use crate::subcommand::Subcommand;
@@ -18,6 +24,22 @@ pub struct Args {
 impl Args {
     /// Parse the arguments passed to the program.
     pub fn parse_args() -> Self {
-        Self::parse()
+        let mut matches = Self::command()
+            .color(ColorChoice::Auto)
+            .styles(
+                Styles::styled()
+                    .header(AnsiColor::Green.on_default() | Effects::BOLD)
+                    .usage(AnsiColor::Green.on_default() | Effects::BOLD)
+                    .literal(AnsiColor::Blue.on_default() | Effects::BOLD)
+                    .placeholder(AnsiColor::Cyan.on_default())
+                    .error(AnsiColor::Red.on_default() | Effects::BOLD)
+                    .valid(AnsiColor::Green.on_default() | Effects::BOLD)
+                    .invalid(AnsiColor::Red.on_default() | Effects::BOLD),
+            )
+            .get_matches();
+        match Self::from_arg_matches_mut(&mut matches) {
+            Ok(args) => args,
+            Err(error) => error.format(&mut Self::command()).exit(),
+        }
     }
 }

--- a/libs/@local/tracing/src/logging.rs
+++ b/libs/@local/tracing/src/logging.rs
@@ -71,7 +71,7 @@ impl ConsoleStream {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "clap", derive(clap::Args))]
+#[cfg_attr(feature = "clap", derive(clap::Args), clap(next_help_heading = Some("Console logging")))]
 pub struct ConsoleConfig {
     /// Whether to enable logging to stdout/stderr
     #[cfg_attr(
@@ -215,7 +215,7 @@ impl FileRotation {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "clap", derive(clap::Args))]
+#[cfg_attr(feature = "clap", derive(clap::Args), clap(next_help_heading = Some("File logging")))]
 pub struct FileConfig {
     /// Whether to enable logging to a file
     #[cfg_attr(

--- a/libs/@local/tracing/src/opentelemetry.rs
+++ b/libs/@local/tracing/src/opentelemetry.rs
@@ -13,7 +13,7 @@ use tracing_subscriber::{registry::LookupSpan, Layer};
 
 /// Arguments for configuring the logging setup
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "clap", derive(clap::Args))]
+#[cfg_attr(feature = "clap", derive(clap::Args), clap(next_help_heading = Some("Open Telemetry")))]
 pub struct OpenTelemetryConfig {
     /// The OpenTelemetry protocol endpoint for sending traces.
     #[cfg_attr(

--- a/libs/@local/tracing/src/sentry.rs
+++ b/libs/@local/tracing/src/sentry.rs
@@ -70,7 +70,7 @@ impl TypedValueParser for OptionalSentryDsnParser {
 
 /// Arguments for configuring the logging setup
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "clap", derive(Parser))]
+#[cfg_attr(feature = "clap", derive(Parser), clap(next_help_heading = Some("Sentry")))]
 pub struct SentryConfig {
     // we need to qualify `Option` here, as otherwise `clap` tries to be too smart and only uses
     // the `value_parser` on the internal `sentry::types::Dsn`, failing.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

I was searching for a configuration in the `--help` command and especially the logging commands were pretty mixed. This put them into sections and also prints a more readable `--help` output.

<img width="497" alt="image" src="https://github.com/hashintel/hash/assets/21277928/adadcd47-b93b-4696-9bc3-819fb657ef51">
<img width="498" alt="image" src="https://github.com/hashintel/hash/assets/21277928/dcc745e1-1cf8-4292-8ff6-dba81cf5490d">

