### PR TITLE
Remove flow activity

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities.ts
@@ -9,7 +9,7 @@ import { getWebPageByUrlAction } from "./flow-activities/get-web-page-by-url-act
 // import { getWebPageSummaryAction } from "./flow-activities/get-web-page-summary-action";
 import { inferEntitiesFromContentAction } from "./flow-activities/infer-entities-from-content-action";
 import { persistEntitiesAction } from "./flow-activities/persist-entities-action";
-import { persistEntityAction } from "./flow-activities/persist-entity-action";
+// import { persistEntityAction } from "./flow-activities/persist-entity-action";
 import { persistFlowActivity } from "./flow-activities/persist-flow-activity";
 import { processAutomaticBrowsingSettingsAction } from "./flow-activities/process-automatic-browsing-settings-action";
 // import { researchEntitiesAction } from "./flow-activities/research-entities-action";
@@ -28,7 +28,7 @@ export const createFlowActionActivities = ({
   getWebPageByUrlAction,
   processAutomaticBrowsingSettingsAction,
   inferEntitiesFromContentAction,
-  persistEntityAction,
+  // persistEntityAction,
   persistEntitiesAction,
   // getFileFromUrlAction,
   // researchEntitiesAction,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Further debugging – the reintroduction of `persistEntity` and `persistEntities` in #4572 broke the AI worker again so this PR restores `persistEntities`. If it starts working again the problem is in some code shared between `persistEntity` and `writeGoogleSheet`. 

I have a suspicion it is `getFlowContext` as it has side effects inside it (caching and creation of a Temporal client). `persistEntities` does not use it, so my next step if the AI worker builds off this PR is to change `getFlowContext` and restore `persistEntity` to see if removing the side effect fixes it.