### PR TITLE
restore a different flow activity

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities.ts
@@ -4,11 +4,11 @@ import type { VaultClient } from "@local/hash-backend-utils/vault";
 // import { answerQuestionAction } from "./flow-activities/answer-question-action";
 import { generateFlowRunName } from "./flow-activities/generate-flow-run-name-activity";
 import { generateWebQueriesAction } from "./flow-activities/generate-web-queries-action";
-// import { getFileFromUrlAction } from "./flow-activities/get-file-from-url-action";
+import { getFileFromUrlAction } from "./flow-activities/get-file-from-url-action";
 import { getWebPageByUrlAction } from "./flow-activities/get-web-page-by-url-action";
 // import { getWebPageSummaryAction } from "./flow-activities/get-web-page-summary-action";
 import { inferEntitiesFromContentAction } from "./flow-activities/infer-entities-from-content-action";
-import { persistEntitiesAction } from "./flow-activities/persist-entities-action";
+// import { persistEntitiesAction } from "./flow-activities/persist-entities-action";
 // import { persistEntityAction } from "./flow-activities/persist-entity-action";
 import { persistFlowActivity } from "./flow-activities/persist-flow-activity";
 import { processAutomaticBrowsingSettingsAction } from "./flow-activities/process-automatic-browsing-settings-action";
@@ -29,8 +29,8 @@ export const createFlowActionActivities = ({
   processAutomaticBrowsingSettingsAction,
   inferEntitiesFromContentAction,
   // persistEntityAction,
-  persistEntitiesAction,
-  // getFileFromUrlAction,
+  // persistEntitiesAction,
+  getFileFromUrlAction,
   // researchEntitiesAction,
   // getWebPageSummaryAction,
   // answerQuestionAction,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The theory in #4576 has been disproven. This PR removes `persistEntitiesAction` (the presence of which causes the AI worker not to start) and adds `getFileFromUrlAction` back in to see if it causes a crash. 