### PR TITLE
H-2878, H-2879: Fix entity type conversion to link type not working

### DIFF
--- a/apps/hash-frontend/src/pages/shared/entity-type-page.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-page.tsx
@@ -238,7 +238,7 @@ export const EntityTypePage = ({
     const res = await updateEntityType(
       {
         ...schema,
-        allOf: [{ $ref: linkEntityTypeUrl }],
+        allOf: [{ $ref: linkEntityTypeUrl }, ...schema.allOf],
       },
       { icon, labelProperty: labelProperty as BaseUrl },
     );

--- a/apps/hash-frontend/src/pages/shared/entity-type-page.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-page.tsx
@@ -233,14 +233,14 @@ export const EntityTypePage = ({
     : extractVersion(entityType.schema.$id);
 
   const convertToLinkType = wrapHandleSubmit(async (data) => {
-    const entityTypeSchema = getEntityTypeFromFormData(data);
+    const { icon, labelProperty, schema } = getEntityTypeFromFormData(data);
 
     const res = await updateEntityType(
       {
-        ...entityTypeSchema,
+        ...schema,
         allOf: [{ $ref: linkEntityTypeUrl }],
       },
-      { icon: data.icon },
+      { icon, labelProperty: labelProperty as BaseUrl },
     );
 
     if (!res.errors?.length && res.data) {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When converting an entity to a link type, the `icon` and `labelProperty` are passed in the schema as well, this will let the graph return an error.

Drive-bys:
- Also pass `labelProperty` (it was not persisted before)
- Retain previous parent types (`allOf` was overwritten previously)