### PR TITLE
H-2880: Use `derive_where` instead of `derivative`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,17 +1327,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive-where"
 version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1873,7 +1862,7 @@ dependencies = [
  "clap",
  "codec",
  "criterion",
- "derivative",
+ "derive-where",
  "dotenv-flow",
  "error-stack 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
@@ -4749,7 +4738,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "codec",
- "derivative",
+ "derive-where",
  "postgres-protocol",
  "postgres-types",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,10 +60,9 @@ repo-chores.path = "libs/@local/repo-chores/rust"
 # External dependencies owned by HASH
 error-stack = { version = "0.4.1", default-features = false }
 
+# Shared third-party dependencies
 aws-config = { version = "1.4.0" }
 aws-sdk-s3 = { version = "1.28.0" }
-
-# Shared third-party dependencies
 bytes = "1.6.0"
 clap = { version = "4.5.4", features = ["std", "color", "help", "usage", "error-context", "suggestions"] }
 derive-where = { version = "1.2.7", default-features = false, features = ["nightly"] }

--- a/apps/hash-graph/libs/graph/Cargo.toml
+++ b/apps/hash-graph/libs/graph/Cargo.toml
@@ -38,7 +38,7 @@ async-scoped = { version = "0.9.0", features = ["use-tokio"] }
 bb8-postgres = "0.8.1"
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"], optional = true }
-derivative = "2.2.0"
+derive-where = { workspace = true }
 dotenv-flow = "0.16.2"
 futures = { workspace = true }
 mime = "0.3.17"

--- a/apps/hash-graph/libs/graph/src/store/config.rs
+++ b/apps/hash-graph/libs/graph/src/store/config.rs
@@ -1,5 +1,7 @@
 use core::{fmt, num::NonZero};
 
+use derive_where::derive_where;
+
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 pub enum DatabaseType {
@@ -8,6 +10,7 @@ pub enum DatabaseType {
 }
 
 #[derive(Clone, PartialEq, Eq)]
+#[derive_where(Debug)]
 #[cfg_attr(feature = "clap", derive(clap::Args))]
 pub struct DatabaseConnectionInfo {
     /// The database type to connect to.
@@ -39,6 +42,7 @@ pub struct DatabaseConnectionInfo {
             global = true
         )
     )]
+    #[derive_where(skip)]
     password: String,
 
     /// The host to connect to.
@@ -76,19 +80,6 @@ pub struct DatabaseConnectionInfo {
         )
     )]
     database: String,
-}
-
-impl fmt::Debug for DatabaseConnectionInfo {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("DatabaseConnectionInfo")
-            .field("database_type", &self.database_type)
-            .field("user", &self.user)
-            .field("password", &"***")
-            .field("host", &self.host)
-            .field("port", &self.port)
-            .field("database", &self.database)
-            .finish()
-    }
 }
 
 impl DatabaseConnectionInfo {

--- a/apps/hash-graph/libs/graph/src/store/query/filter.rs
+++ b/apps/hash-graph/libs/graph/src/store/query/filter.rs
@@ -1,7 +1,7 @@
 use alloc::borrow::Cow;
 use core::{fmt, mem, str::FromStr};
 
-use derivative::Derivative;
+use derive_where::derive_where;
 use error_stack::{bail, Context, Report, ResultExt};
 use graph_types::{
     knowledge::entity::{Entity, EntityId},
@@ -24,12 +24,8 @@ use crate::{
 };
 
 /// A set of conditions used for queries.
-#[derive(Derivative, Deserialize)]
-#[derivative(
-    Debug(bound = "R::QueryPath<'p>: fmt::Debug"),
-    PartialEq(bound = "R::QueryPath<'p>: PartialEq"),
-    Clone(bound = "R::QueryPath<'p>: Clone")
-)]
+#[derive(Deserialize)]
+#[derive_where(Debug, Clone, PartialEq; R::QueryPath<'p>)]
 #[serde(
     rename_all = "camelCase",
     bound = "'de: 'p, R::QueryPath<'p>: Deserialize<'de>"
@@ -223,12 +219,8 @@ where
 }
 
 /// A leaf value in a [`Filter`].
-#[derive(Derivative, Deserialize)]
-#[derivative(
-    Debug(bound = "R::QueryPath<'p>: fmt::Debug"),
-    PartialEq(bound = "R::QueryPath<'p>: PartialEq"),
-    Clone(bound = "R::QueryPath<'p>: Clone")
-)]
+#[derive(Deserialize)]
+#[derive_where(Debug, Clone, PartialEq; R::QueryPath<'p>)]
 #[serde(
     rename_all = "camelCase",
     bound = "'de: 'p, R::QueryPath<'p>: Deserialize<'de>"

--- a/apps/hash-graph/libs/graph/src/subgraph/temporal_axes.rs
+++ b/apps/hash-graph/libs/graph/src/subgraph/temporal_axes.rs
@@ -1,9 +1,4 @@
-#![expect(
-    clippy::allow_attributes,
-    reason = "derivative does not support expect"
-)]
-
-use derivative::Derivative;
+use derive_where::derive_where;
 use serde::{Deserialize, Serialize};
 use temporal_versioning::{
     DecisionTime, LeftClosedTemporalInterval, LimitedTemporalBound, RightBoundedTemporalInterval,
@@ -87,14 +82,8 @@ impl<A: Default> PinnedTemporalAxisUnresolved<A> {
     }
 }
 
-#[derive(Derivative, Serialize, Deserialize)]
-#[derivative(
-    Debug(bound = ""),
-    Clone(bound = ""),
-    PartialEq(bound = ""),
-    Eq(bound = ""),
-    Hash(bound = "")
-)]
+#[derive_where(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", bound = "", deny_unknown_fields)]
 pub struct RightBoundedTemporalIntervalUnresolved<A> {
     pub start: Option<TemporalBound<A>>,

--- a/libs/@local/hash-authorization/Cargo.toml
+++ b/libs/@local/hash-authorization/Cargo.toml
@@ -18,7 +18,7 @@ serde = { workspace = true, features = ["derive", "unstable"] }
 tokio.workspace = true
 tracing = { workspace = true }
 
-derive-where = { version = "1.2.7", default-features = false, features = ["nightly"] }
+derive-where = { workspace = true }
 futures = { version = "0.3.30", default-features = false }
 serde_json = { version = "1.0.116" }
 serde_plain = "1.0.2"

--- a/libs/@local/temporal-versioning/Cargo.toml
+++ b/libs/@local/temporal-versioning/Cargo.toml
@@ -17,7 +17,7 @@ postgres-types = { version = "0.2.6", default-features = false, features = ["wit
 time = { version = "0.3.36", default-features = false, features = ["serde", "parsing", "formatting", "macros"] }
 tracing = { workspace = true, optional = true }
 
-derivative = "2.2.0"
+derive-where = { workspace = true }
 postgres-protocol = { version = "0.6.6", default-features = false, optional = true }
 
 [features]

--- a/libs/@local/temporal-versioning/src/temporal_bound.rs
+++ b/libs/@local/temporal-versioning/src/temporal_bound.rs
@@ -1,11 +1,6 @@
-#![expect(
-    clippy::allow_attributes,
-    reason = "derivative does not support expect"
-)]
-
 use core::ops::Bound;
 
-use derivative::Derivative;
+use derive_where::derive_where;
 use serde::{Deserialize, Serialize};
 
 use crate::{IntervalBound, TemporalTagged, Timestamp};
@@ -13,15 +8,9 @@ use crate::{IntervalBound, TemporalTagged, Timestamp};
 // We cannot use `Clone(bound = "")` as the implementation with `Copy(bound = "")` is wrong
 // https://rust-lang.github.io/rust-clippy/master/index.html#/incorrect_clone_impl_on_copy_type
 // The implementation must simply be `*self` and no clone should occur.
-#[derive(Derivative, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
+#[derive_where(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derivative(
-    Debug(bound = ""),
-    Copy(bound = ""),
-    PartialEq(bound = ""),
-    Eq(bound = ""),
-    Hash(bound = "")
-)]
 #[serde(rename_all = "camelCase", bound = "", tag = "kind", content = "limit")]
 pub enum TemporalBound<A> {
     #[cfg_attr(feature = "utoipa", schema(title = "UnboundedBound"))]
@@ -30,12 +19,6 @@ pub enum TemporalBound<A> {
     Inclusive(Timestamp<A>),
     #[cfg_attr(feature = "utoipa", schema(title = "ExclusiveBound"))]
     Exclusive(Timestamp<A>),
-}
-
-impl<A> Clone for TemporalBound<A> {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 
 impl<A> TemporalTagged for TemporalBound<A> {
@@ -77,27 +60,15 @@ impl<A> IntervalBound<Timestamp<A>> for TemporalBound<A> {
     }
 }
 
-#[derive(Derivative, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derivative(
-    Debug(bound = ""),
-    Copy(bound = ""),
-    PartialEq(bound = ""),
-    Eq(bound = ""),
-    Hash(bound = "")
-)]
+#[derive_where(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase", bound = "", tag = "kind", content = "limit")]
 pub enum LimitedTemporalBound<A> {
     #[cfg_attr(feature = "utoipa", schema(title = "InclusiveBound"))]
     Inclusive(Timestamp<A>),
     #[cfg_attr(feature = "utoipa", schema(title = "ExclusiveBound"))]
     Exclusive(Timestamp<A>),
-}
-
-impl<A> Clone for LimitedTemporalBound<A> {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 
 impl<A> TemporalTagged for LimitedTemporalBound<A> {
@@ -138,15 +109,9 @@ impl<A> IntervalBound<Timestamp<A>> for LimitedTemporalBound<A> {
     }
 }
 
-#[derive(Derivative, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derivative(
-    Debug(bound = ""),
-    Copy(bound = ""),
-    PartialEq(bound = ""),
-    Eq(bound = ""),
-    Hash(bound = "")
-)]
+#[derive_where(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase", bound = "", tag = "kind", content = "limit")]
 pub enum ClosedTemporalBound<A> {
     #[cfg_attr(feature = "utoipa", schema(title = "InclusiveBound"))]
@@ -158,12 +123,6 @@ impl<A> From<ClosedTemporalBound<A>> for Timestamp<A> {
         match bound {
             ClosedTemporalBound::Inclusive(limit) => limit,
         }
-    }
-}
-
-impl<A> Clone for ClosedTemporalBound<A> {
-    fn clone(&self) -> Self {
-        *self
     }
 }
 
@@ -204,27 +163,15 @@ impl<A> IntervalBound<Timestamp<A>> for ClosedTemporalBound<A> {
     }
 }
 
-#[derive(Derivative, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derivative(
-    Debug(bound = ""),
-    Copy(bound = ""),
-    PartialEq(bound = ""),
-    Eq(bound = ""),
-    Hash(bound = "")
-)]
+#[derive_where(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase", bound = "", tag = "kind", content = "limit")]
 pub enum OpenTemporalBound<A> {
     #[cfg_attr(feature = "utoipa", schema(title = "ExclusiveBound"))]
     Exclusive(Timestamp<A>),
     #[cfg_attr(feature = "utoipa", schema(title = "UnboundedBound"))]
     Unbounded,
-}
-
-impl<A> Clone for OpenTemporalBound<A> {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 
 impl<A> TemporalTagged for OpenTemporalBound<A> {

--- a/libs/@local/temporal-versioning/src/timestamp.rs
+++ b/libs/@local/temporal-versioning/src/timestamp.rs
@@ -1,10 +1,10 @@
-use core::{cmp::Ordering, fmt, marker::PhantomData, str::FromStr};
+use core::{fmt, marker::PhantomData, str::FromStr};
 #[cfg(feature = "postgres")]
 use std::error::Error;
 
 #[cfg(feature = "postgres")]
 use bytes::BytesMut;
-use derivative::Derivative;
+use derive_where::derive_where;
 #[cfg(feature = "postgres")]
 use postgres_types::{FromSql, ToSql, Type};
 use serde::{Deserialize, Serialize};
@@ -21,32 +21,14 @@ use crate::TemporalTagged;
 // A generic parameter is used here to avoid implementing the same struct multiple times or using
 // macros. It's reused in other time-related structs as well. This implies that trait bounds are
 // not required for trait implementations.
-#[derive(Derivative, Serialize, Deserialize)]
-#[derivative(
-    Copy(bound = ""),
-    PartialEq(bound = ""),
-    Eq(bound = ""),
-    Hash(bound = ""),
-    Ord(bound = "")
-)]
+#[derive(Serialize, Deserialize)]
+#[derive_where(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(transparent, bound = "")]
 pub struct Timestamp<A> {
     #[serde(skip)]
     axis: PhantomData<A>,
     #[serde(with = "codec::serde::time")]
     time: OffsetDateTime,
-}
-
-impl<A> PartialOrd for Timestamp<A> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<A> Clone for Timestamp<A> {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 
 impl<A> fmt::Debug for Timestamp<A> {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`derive_where` generates more idiomatic code, is easier to write, and supports more features.