### PR TITLE
H-2829: Don't run the migrations in parallel

### DIFF
--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util/upgrade-entities.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util/upgrade-entities.ts
@@ -91,128 +91,93 @@ export const upgradeWebEntities = async ({
     },
   ).then((subgraph) => getRoots(subgraph));
 
-  await Promise.all(
-    existingEntities.map(async (entity) => {
-      const baseUrl = extractBaseUrl(entity.metadata.entityTypeId);
+  for (const entity of existingEntities) {
+    const baseUrl = extractBaseUrl(entity.metadata.entityTypeId);
 
-      const currentVersion = extractVersion(entity.metadata.entityTypeId);
+    const currentVersion = extractVersion(entity.metadata.entityTypeId);
 
-      const newVersion = migrationState.entityTypeVersions[baseUrl];
+    const newVersion = migrationState.entityTypeVersions[baseUrl];
 
-      if (typeof newVersion === "undefined") {
-        throw new Error(
-          `Could not find the version for base URL ${baseUrl} in the migration state`,
-        );
+    if (typeof newVersion === "undefined") {
+      throw new Error(
+        `Could not find the version for base URL ${baseUrl} in the migration state`,
+      );
+    }
+
+    if (currentVersion < newVersion) {
+      const newEntityTypeId = versionedUrlFromComponents(baseUrl, newVersion);
+      const currentEntityTypeId = entity.metadata.entityTypeId;
+
+      const migratePropertiesFunction = migrateProperties?.[baseUrl];
+
+      let updateAuthentication = webBotAuthentication;
+
+      const temporaryEntityTypePermissionsGranted: VersionedUrl[] = [];
+
+      if (
+        baseUrl === systemEntityTypes.userSecret.entityTypeBaseUrl ||
+        baseUrl ===
+          systemLinkEntityTypes.usesUserSecret.linkEntityTypeBaseUrl ||
+        baseUrl === googleEntityTypes.account.entityTypeBaseUrl
+      ) {
+        /**
+         *These entities are only editable by the bot that created them
+         */
+        updateAuthentication = {
+          actorId: entity.metadata.provenance.createdById,
+        };
       }
-
-      if (currentVersion < newVersion) {
-        const newEntityTypeId = versionedUrlFromComponents(baseUrl, newVersion);
-        const currentEntityTypeId = entity.metadata.entityTypeId;
-
-        const migratePropertiesFunction = migrateProperties?.[baseUrl];
-
-        let updateAuthentication = webBotAuthentication;
-
-        const temporaryEntityTypePermissionsGranted: VersionedUrl[] = [];
-
-        if (
-          baseUrl === systemEntityTypes.userSecret.entityTypeBaseUrl ||
-          baseUrl ===
-            systemLinkEntityTypes.usesUserSecret.linkEntityTypeBaseUrl ||
-          baseUrl === googleEntityTypes.account.entityTypeBaseUrl
-        ) {
+      if (baseUrl === systemEntityTypes.machine.entityTypeBaseUrl) {
+        /**
+         * If we are updating machine entities, we use the account ID
+         * of the machine user as the actor for the update.
+         */
+        updateAuthentication = {
           /**
-           *These entities are only editable by the bot that created them
+           * The account ID of the machine entity is the creator of its
+           * first edition.
            */
-          updateAuthentication = {
-            actorId: entity.metadata.provenance.createdById,
-          };
-        }
-        if (baseUrl === systemEntityTypes.machine.entityTypeBaseUrl) {
+          actorId: entity.metadata.provenance.createdById,
+        };
+
+        for (const entityTypeId of [currentEntityTypeId, newEntityTypeId]) {
           /**
-           * If we are updating machine entities, we use the account ID
-           * of the machine user as the actor for the update.
+           * We may need to temporarily grant the machine account ID the ability
+           * to instantiate entities of both the old and new entityTypeId,
+           * because an actor cannot update or remove an entity type without being able to instantiate it.
            */
-          updateAuthentication = {
-            /**
-             * The account ID of the machine entity is the creator of its
-             * first edition.
-             */
-            actorId: entity.metadata.provenance.createdById,
-          };
 
-          for (const entityTypeId of [currentEntityTypeId, newEntityTypeId]) {
-            /**
-             * We may need to temporarily grant the machine account ID the ability
-             * to instantiate entities of both the old and new entityTypeId,
-             * because an actor cannot update or remove an entity type without being able to instantiate it.
-             */
-
-            try {
-              await context.graphApi.modifyEntityTypeAuthorizationRelationships(
-                systemAccountId,
-                [
-                  {
-                    operation: "create",
-                    resource: entityTypeId,
-                    relationAndSubject: {
-                      subject: {
-                        kind: "account",
-                        subjectId: entity.metadata.provenance.createdById,
-                      },
-                      relation: "instantiator",
-                    },
-                  },
-                ],
-              );
-
-              /** If the 'create' call didn't error, the actor didn't already have the permission */
-              temporaryEntityTypePermissionsGranted.push(entityTypeId);
-            } catch {
-              /**
-               * the actor already had the permission, so we must 'touch' the permission instead.
-               * in theory we could just do nothing, but maybe 'touch' will throw some other error we need to know about
-               */
-
-              await context.graphApi.modifyEntityTypeAuthorizationRelationships(
-                systemAccountId,
-                [
-                  {
-                    operation: "touch",
-                    resource: entityTypeId,
-                    relationAndSubject: {
-                      subject: {
-                        kind: "account",
-                        subjectId: entity.metadata.provenance.createdById,
-                      },
-                      relation: "instantiator",
-                    },
-                  },
-                ],
-              );
-            }
-          }
-        }
-
-        try {
-          await updateEntity(context, updateAuthentication, {
-            entity,
-            entityTypeId: newEntityTypeId,
-            properties: migratePropertiesFunction
-              ? migratePropertiesFunction(entity.properties)
-              : entity.properties,
-          });
-        } finally {
-          for (const entityTypeId of temporaryEntityTypePermissionsGranted) {
-            /**
-             * If we updated a machine entity and granted its actor ID a
-             * new permission, we need to remove the temporary permission.
-             */
+          try {
             await context.graphApi.modifyEntityTypeAuthorizationRelationships(
               systemAccountId,
               [
                 {
-                  operation: "delete",
+                  operation: "create",
+                  resource: entityTypeId,
+                  relationAndSubject: {
+                    subject: {
+                      kind: "account",
+                      subjectId: entity.metadata.provenance.createdById,
+                    },
+                    relation: "instantiator",
+                  },
+                },
+              ],
+            );
+
+            /** If the 'create' call didn't error, the actor didn't already have the permission */
+            temporaryEntityTypePermissionsGranted.push(entityTypeId);
+          } catch {
+            /**
+             * the actor already had the permission, so we must 'touch' the permission instead.
+             * in theory we could just do nothing, but maybe 'touch' will throw some other error we need to know about
+             */
+
+            await context.graphApi.modifyEntityTypeAuthorizationRelationships(
+              systemAccountId,
+              [
+                {
+                  operation: "touch",
                   resource: entityTypeId,
                   relationAndSubject: {
                     subject: {
@@ -227,6 +192,39 @@ export const upgradeWebEntities = async ({
           }
         }
       }
-    }),
-  );
+
+      try {
+        await updateEntity(context, updateAuthentication, {
+          entity,
+          entityTypeId: newEntityTypeId,
+          properties: migratePropertiesFunction
+            ? migratePropertiesFunction(entity.properties)
+            : entity.properties,
+        });
+      } finally {
+        for (const entityTypeId of temporaryEntityTypePermissionsGranted) {
+          /**
+           * If we updated a machine entity and granted its actor ID a
+           * new permission, we need to remove the temporary permission.
+           */
+          await context.graphApi.modifyEntityTypeAuthorizationRelationships(
+            systemAccountId,
+            [
+              {
+                operation: "delete",
+                resource: entityTypeId,
+                relationAndSubject: {
+                  subject: {
+                    kind: "account",
+                    subjectId: entity.metadata.provenance.createdById,
+                  },
+                  relation: "instantiator",
+                },
+              },
+            ],
+          );
+        }
+      }
+    }
+  }
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A lot migrations are running in parallel. To track down further the issue about the timeout we encounter, this avoids running the migrations in parallel.