### PR TITLE
H-2799: Validate existence of properties for metadata

### DIFF
--- a/apps/hash-graph/libs/api/src/lib.rs
+++ b/apps/hash-graph/libs/api/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(lint_reasons)]
+#![feature(impl_trait_in_assoc_type)]
 
 extern crate alloc;
 

--- a/apps/hash-graph/libs/api/src/rest/entity.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity.rs
@@ -1,6 +1,7 @@
 //! Web routes for CRU operations on entities.
 
 use alloc::{borrow::Cow, sync::Arc};
+use std::collections::HashSet;
 
 use authorization::{
     backend::{ModifyRelationshipOperation, PermissionAssertion},
@@ -225,7 +226,8 @@ pub struct CreateEntityRequest {
     #[serde(default)]
     #[schema(nullable = false)]
     pub decision_time: Option<Timestamp<DecisionTime>>,
-    pub entity_type_ids: Vec<VersionedUrl>,
+    #[schema(value_type = Vec<VersionedUrl>)]
+    pub entity_type_ids: HashSet<VersionedUrl>,
     pub properties: PropertyObject,
     #[schema(nullable = false)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -362,7 +364,7 @@ where
             actor_id,
             params
                 .into_iter()
-                .map(|params| params.try_into())
+                .map(CreateEntityParams::try_from)
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(report_to_response)?,
         )

--- a/apps/hash-graph/libs/api/src/rest/entity.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity.rs
@@ -1,6 +1,6 @@
 //! Web routes for CRU operations on entities.
 
-use alloc::sync::Arc;
+use alloc::{borrow::Cow, sync::Arc};
 
 use authorization::{
     backend::{ModifyRelationshipOperation, PermissionAssertion},
@@ -19,13 +19,13 @@ use axum::{
     routing::{get, post},
     Extension, Router,
 };
-use error_stack::{Report, ResultExt};
+use error_stack::{Context, Report, ResultExt};
 use graph::{
     knowledge::{EntityQueryPath, EntityQuerySortingToken, EntityQueryToken},
     store::{
         error::{EntityDoesNotExist, RaceConditionOnUpdate},
         knowledge::{
-            CountEntitiesParams, CreateEntityRequest, DiffEntityParams, DiffEntityResult,
+            CountEntitiesParams, CreateEntityParams, DiffEntityParams, DiffEntityResult,
             GetEntitiesParams, GetEntitiesResponse, GetEntitySubgraphParams, PatchEntityParams,
             UpdateEntityEmbeddingsParams, ValidateEntityParams,
         },
@@ -46,13 +46,15 @@ use graph_types::{
         link::LinkData,
         ArrayMetadata, Confidence, ObjectMetadata, Property, PropertyDiff, PropertyMetadataElement,
         PropertyMetadataObject, PropertyObject, PropertyPatchOperation, PropertyPath,
-        PropertyPathElement, PropertyProvenance, ValueMetadata,
+        PropertyPathElement, PropertyProvenance, PropertyWithMetadataObject, ValueMetadata,
     },
     owned_by_id::OwnedById,
     Embedding,
 };
 use serde::{Deserialize, Serialize};
 use temporal_client::TemporalClient;
+use temporal_versioning::{DecisionTime, Timestamp};
+use type_system::url::VersionedUrl;
 use utoipa::{OpenApi, ToSchema};
 use validation::ValidateEntityComponents;
 
@@ -86,7 +88,7 @@ use crate::rest::{
     components(
         schemas(
             CreateEntityRequest,
-            ValidateEntityParams,
+            ValidateEntityRequest,
             CountEntitiesParams,
             EntityValidationType,
             ValidateEntityComponents,
@@ -213,6 +215,55 @@ impl RoutedResource for EntityResource {
     }
 }
 
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CreateEntityRequest {
+    pub owned_by_id: OwnedById,
+    #[serde(default)]
+    #[schema(nullable = false)]
+    pub entity_uuid: Option<EntityUuid>,
+    #[serde(default)]
+    #[schema(nullable = false)]
+    pub decision_time: Option<Timestamp<DecisionTime>>,
+    pub entity_type_ids: Vec<VersionedUrl>,
+    pub properties: PropertyObject,
+    #[schema(nullable = false)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<Confidence>,
+    #[schema(nullable = false)]
+    #[serde(default, skip_serializing_if = "PropertyMetadataObject::is_empty")]
+    pub property_metadata: PropertyMetadataObject,
+    #[serde(default)]
+    #[schema(nullable = false)]
+    pub link_data: Option<LinkData>,
+    pub draft: bool,
+    pub relationships: Vec<EntityRelationAndSubject>,
+    #[serde(default, skip_serializing_if = "UserDefinedProvenanceData::is_empty")]
+    pub provenance: ProvidedEntityEditionProvenance,
+}
+
+impl TryFrom<CreateEntityRequest> for CreateEntityParams<Vec<EntityRelationAndSubject>> {
+    type Error = Report<impl Context>;
+
+    fn try_from(value: CreateEntityRequest) -> Result<Self, Self::Error> {
+        Ok(Self {
+            owned_by_id: value.owned_by_id,
+            entity_uuid: value.entity_uuid,
+            decision_time: value.decision_time,
+            entity_type_ids: value.entity_type_ids,
+            properties: PropertyWithMetadataObject::from_parts(
+                value.properties,
+                Some(value.property_metadata),
+            )?,
+            confidence: value.confidence,
+            link_data: value.link_data,
+            draft: value.draft,
+            relationships: value.relationships,
+            provenance: value.provenance,
+        })
+    }
+}
+
 #[utoipa::path(
     post,
     path = "/entities",
@@ -257,7 +308,7 @@ where
         .map_err(report_to_response)?;
 
     store
-        .create_entity(actor_id, params)
+        .create_entity(actor_id, params.try_into().map_err(report_to_response)?)
         .await
         .map_err(report_to_response)
         .map(Json)
@@ -307,16 +358,40 @@ where
         .map_err(report_to_response)?;
 
     store
-        .create_entities(actor_id, params)
+        .create_entities(
+            actor_id,
+            params
+                .into_iter()
+                .map(|params| params.try_into())
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(report_to_response)?,
+        )
         .await
         .map_err(report_to_response)
         .map(Json)
 }
 
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ValidateEntityRequest<'a> {
+    #[serde(borrow)]
+    pub entity_types: EntityValidationType<'a>,
+    pub properties: PropertyObject,
+    #[schema(nullable = false)]
+    #[serde(default, skip_serializing_if = "PropertyMetadataObject::is_empty")]
+    pub property_metadata: PropertyMetadataObject,
+    #[serde(default)]
+    #[schema(nullable = false)]
+    pub link_data: Option<LinkData>,
+    #[serde(default)]
+    #[schema(nullable = false)]
+    pub components: ValidateEntityComponents,
+}
+
 #[utoipa::path(
     post,
     path = "/entities/validate",
-    request_body = ValidateEntityParams,
+    request_body = ValidateEntityRequest,
     tag = "Entity",
     params(
         ("X-Authenticated-User-Actor-Id" = AccountId, Header, description = "The ID of the actor which is used to authorize the request"),
@@ -344,7 +419,7 @@ where
     S: StorePool + Send + Sync,
     A: AuthorizationApiPool + Send + Sync,
 {
-    let params = ValidateEntityParams::deserialize(&body).map_err(report_to_response)?;
+    let params = ValidateEntityRequest::deserialize(&body).map_err(report_to_response)?;
 
     let authorization_api = authorization_api_pool
         .acquire()
@@ -357,7 +432,22 @@ where
         .map_err(report_to_response)?;
 
     store
-        .validate_entity(actor_id, Consistency::FullyConsistent, params)
+        .validate_entity(
+            actor_id,
+            Consistency::FullyConsistent,
+            ValidateEntityParams {
+                entity_types: params.entity_types,
+                properties: Cow::Owned(
+                    PropertyWithMetadataObject::from_parts(
+                        params.properties,
+                        Some(params.property_metadata),
+                    )
+                    .map_err(report_to_response)?,
+                ),
+                link_data: params.link_data.map(Cow::Owned),
+                components: params.components,
+            },
+        )
         .await
         .attach(hash_status::StatusCode::InvalidArgument)
         .map_err(report_to_response)?;

--- a/apps/hash-graph/libs/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/libs/graph/src/store/knowledge.rs
@@ -342,7 +342,8 @@ pub trait EntityStore {
     /// # Errors:
     ///
     /// - if the [`EntityType`] doesn't exist
-    /// - if the [`PropertyObject`] is not valid with respect to the specified [`EntityType`]
+    /// - if the [`PropertyWithMetadataObject`] is not valid with respect to the specified
+    ///   [`EntityType`]
     /// - if the account referred to by `owned_by_id` does not exist
     /// - if an [`EntityUuid`] was supplied and already exists in the store
     fn create_entity<R>(

--- a/apps/hash-graph/libs/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/libs/graph/src/store/knowledge.rs
@@ -1,5 +1,6 @@
 use alloc::borrow::Cow;
 use core::{error::Error, fmt};
+use std::collections::HashSet;
 
 use authorization::{schema::EntityRelationAndSubject, zanzibar::Consistency};
 use error_stack::Report;
@@ -37,10 +38,9 @@ use crate::{
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
-#[expect(clippy::large_enum_variant)]
 pub enum EntityValidationType<'a> {
     Schema(Vec<EntityType>),
-    Id(Cow<'a, [VersionedUrl]>),
+    Id(Cow<'a, HashSet<VersionedUrl>>),
     #[serde(skip)]
     ClosedSchema(Cow<'a, ClosedEntityType>),
 }
@@ -182,7 +182,7 @@ pub struct CreateEntityParams<R> {
     #[serde(default)]
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     pub decision_time: Option<Timestamp<DecisionTime>>,
-    pub entity_type_ids: Vec<VersionedUrl>,
+    pub entity_type_ids: HashSet<VersionedUrl>,
     pub properties: PropertyWithMetadataObject,
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -278,10 +278,9 @@ pub struct PatchEntityParams {
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     pub decision_time: Option<Timestamp<DecisionTime>>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
-    pub entity_type_ids: Vec<VersionedUrl>,
+    #[cfg_attr(feature = "utoipa", schema(value_type = Vec<VersionedUrl>))]
+    pub entity_type_ids: HashSet<VersionedUrl>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     pub properties: Vec<PropertyPatchOperation>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]

--- a/apps/hash-graph/libs/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/libs/graph/src/store/knowledge.rs
@@ -12,8 +12,7 @@ use graph_types::{
             ProvidedEntityEditionProvenance,
         },
         link::LinkData,
-        Confidence, PropertyDiff, PropertyMetadataObject, PropertyObject, PropertyPatchOperation,
-        PropertyPath,
+        Confidence, PropertyDiff, PropertyPatchOperation, PropertyPath, PropertyWithMetadataObject,
     },
     owned_by_id::OwnedById,
 };
@@ -184,13 +183,10 @@ pub struct CreateEntityParams<R> {
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     pub decision_time: Option<Timestamp<DecisionTime>>,
     pub entity_type_ids: Vec<VersionedUrl>,
-    pub properties: PropertyObject,
+    pub properties: PropertyWithMetadataObject,
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub confidence: Option<Confidence>,
-    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
-    #[serde(default, skip_serializing_if = "PropertyMetadataObject::is_empty")]
-    pub property_metadata: PropertyMetadataObject,
     #[serde(default)]
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     pub link_data: Option<LinkData>,
@@ -207,14 +203,7 @@ pub struct ValidateEntityParams<'a> {
     #[serde(borrow)]
     pub entity_types: EntityValidationType<'a>,
     #[serde(borrow)]
-    pub properties: Cow<'a, PropertyObject>,
-    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
-    #[serde(
-        borrow,
-        default,
-        skip_serializing_if = "PropertyMetadataObject::is_empty"
-    )]
-    pub property_metadata: Cow<'a, PropertyMetadataObject>,
+    pub properties: Cow<'a, PropertyWithMetadataObject>,
     #[serde(borrow, default)]
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     pub link_data: Option<Cow<'a, LinkData>>,

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -1618,7 +1618,7 @@ where
     async fn insert_entity_edition(
         &self,
         archived: bool,
-        entity_type_ids: &[VersionedUrl],
+        entity_type_ids: &HashSet<VersionedUrl>,
         properties: &PropertyObject,
         confidence: Option<Confidence>,
         provenance: &EntityEditionProvenance,

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -24,8 +24,8 @@ use graph_types::{
             EntityMetadata, EntityProvenance, EntityRecordId, EntityTemporalMetadata, EntityUuid,
             InferredEntityProvenance,
         },
-        Confidence, Property, PropertyMetadataElement, PropertyMetadataObject, PropertyObject,
-        PropertyPath, PropertyWithMetadata,
+        Confidence, PropertyMetadataObject, PropertyObject, PropertyPath,
+        PropertyWithMetadataObject,
     },
     ontology::EntityTypeId,
     owned_by_id::OwnedById,
@@ -497,31 +497,7 @@ where
         let mut entities = Vec::with_capacity(params.len());
 
         for params in params {
-            let (properties, property_metadata) = if let (
-                Property::Object(properties),
-                PropertyMetadataElement::Object {
-                    value: object_metadata,
-                    metadata,
-                },
-            ) = PropertyWithMetadata::from_parts(
-                Property::Object(params.properties),
-                Some(PropertyMetadataElement::from(params.property_metadata)),
-            )
-            .change_context(InsertionError)?
-            .into_parts()
-            {
-                (
-                    properties,
-                    PropertyMetadataObject {
-                        value: object_metadata,
-                        metadata,
-                    },
-                )
-            } else {
-                return Err(Report::new(InsertionError)
-                    .attach(StatusCode::InvalidArgument)
-                    .attach_printable("Properties must be an object"));
-            };
+            let (properties, property_metadata) = params.properties.into_parts();
 
             let decision_time = params
                 .decision_time
@@ -782,24 +758,29 @@ where
 
         let validation_params = entities
             .iter()
-            .map(|entity| ValidateEntityParams {
-                entity_types: EntityValidationType::Id(Cow::Borrowed(
-                    &entity.metadata.entity_type_ids,
-                )),
-                properties: Cow::Borrowed(&entity.properties),
-                property_metadata: Cow::Borrowed(&entity.metadata.properties),
-                link_data: entity.link_data.as_ref().map(Cow::Borrowed),
-                components: if entity.metadata.record_id.entity_id.draft_id.is_some() {
-                    ValidateEntityComponents {
-                        num_items: false,
-                        required_properties: false,
-                        ..ValidateEntityComponents::full()
-                    }
-                } else {
-                    ValidateEntityComponents::full()
-                },
+            .map(|entity| {
+                Ok(ValidateEntityParams {
+                    entity_types: EntityValidationType::Id(Cow::Borrowed(
+                        &entity.metadata.entity_type_ids,
+                    )),
+                    properties: Cow::Owned(PropertyWithMetadataObject::from_parts(
+                        entity.properties.clone(),
+                        Some(entity.metadata.properties.clone()),
+                    )?),
+                    link_data: entity.link_data.as_ref().map(Cow::Borrowed),
+                    components: if entity.metadata.record_id.entity_id.draft_id.is_some() {
+                        ValidateEntityComponents {
+                            num_items: false,
+                            required_properties: false,
+                            ..ValidateEntityComponents::full()
+                        }
+                    } else {
+                        ValidateEntityComponents::full()
+                    },
+                })
             })
-            .collect();
+            .collect::<Result<Vec<_>, _>>()
+            .change_context(InsertionError)?;
 
         transaction
             .validate_entities(actor_id, Consistency::FullyConsistent, validation_params)
@@ -935,22 +916,6 @@ where
             if let Err(error) = params
                 .properties
                 .validate(&schema, params.components, &validator_provider)
-                .await
-            {
-                if let Err(ref mut report) = status {
-                    report.extend_one(error);
-                } else {
-                    status = Err(error);
-                }
-            }
-
-            if let Err(error) = params
-                .property_metadata
-                .validate(
-                    params.properties.as_ref(),
-                    params.components,
-                    &validator_provider,
-                )
                 .await
             {
                 if let Err(ref mut report) = status {
@@ -1464,8 +1429,13 @@ where
                 Consistency::FullyConsistent,
                 ValidateEntityParams {
                     entity_types: EntityValidationType::ClosedSchema(Cow::Borrowed(&closed_schema)),
-                    properties: Cow::Borrowed(&properties),
-                    property_metadata: Cow::Borrowed(&property_metadata),
+                    properties: Cow::Owned(
+                        PropertyWithMetadataObject::from_parts(
+                            properties.clone(),
+                            Some(property_metadata.clone()),
+                        )
+                        .change_context(UpdateError)?,
+                    ),
                     link_data: link_data.as_ref().map(Cow::Borrowed),
                     components: validation_components,
                 },

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -1311,7 +1311,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ValidateEntityParams"
+                "$ref": "#/components/schemas/ValidateEntityRequest"
               }
             }
           },
@@ -7891,7 +7891,7 @@
         },
         "additionalProperties": false
       },
-      "ValidateEntityParams": {
+      "ValidateEntityRequest": {
         "type": "object",
         "required": [
           "entityTypes",

--- a/libs/@local/hash-graph-types/rust/src/knowledge/entity/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/entity/mod.rs
@@ -1,6 +1,7 @@
 mod provenance;
 
 use core::{fmt, str::FromStr};
+use std::collections::HashSet;
 
 use error_stack::{Report, ResultExt};
 #[cfg(feature = "postgres")]
@@ -92,7 +93,8 @@ impl fmt::Display for DraftId {
 pub struct EntityMetadata {
     pub record_id: EntityRecordId,
     pub temporal_versioning: EntityTemporalMetadata,
-    pub entity_type_ids: Vec<VersionedUrl>,
+    #[cfg_attr(feature = "utoipa", schema(value_type = Vec<VersionedUrl>))]
+    pub entity_type_ids: HashSet<VersionedUrl>,
     pub archived: bool,
     pub provenance: EntityProvenance,
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]

--- a/libs/@local/hash-graph-types/rust/src/knowledge/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/mod.rs
@@ -6,7 +6,8 @@ pub use self::{
     property::{
         ArrayMetadata, ObjectMetadata, Property, PropertyDiff, PropertyMetadataElement,
         PropertyMetadataObject, PropertyObject, PropertyPatchOperation, PropertyPath,
-        PropertyPathElement, PropertyProvenance, PropertyWithMetadata, ValueMetadata,
+        PropertyPathElement, PropertyProvenance, PropertyWithMetadata, PropertyWithMetadataObject,
+        ValueMetadata,
     },
 };
 

--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -5,7 +5,7 @@ use futures::{stream, StreamExt, TryStreamExt};
 use graph_types::knowledge::{
     entity::{Entity, EntityId},
     link::LinkData,
-    PropertyObject, PropertyPath,
+    PropertyPath, PropertyWithMetadataObject,
 };
 use thiserror::Error;
 use type_system::{
@@ -51,7 +51,7 @@ pub enum EntityValidationError {
     InvalidPropertyPath { path: PropertyPath<'static> },
 }
 
-impl<P> Schema<PropertyObject, P> for ClosedEntityType
+impl<P> Schema<PropertyWithMetadataObject, P> for ClosedEntityType
 where
     P: OntologyTypeProvider<PropertyType> + OntologyTypeProvider<DataType> + Sync,
 {
@@ -59,7 +59,7 @@ where
 
     async fn validate_value<'a>(
         &'a self,
-        value: &'a PropertyObject,
+        value: &'a PropertyWithMetadataObject,
         components: ValidateEntityComponents,
         provider: &'a P,
     ) -> Result<(), Report<EntityValidationError>> {
@@ -68,7 +68,7 @@ where
         //   see https://linear.app/hash/issue/BP-33
         Object::<_, 0>::new(self.properties.clone(), self.required.clone())
             .expect("`Object` was already validated")
-            .validate_value(value.properties(), components, provider)
+            .validate_value(&value.value, components, provider)
             .await
             .change_context(EntityValidationError::InvalidProperties)
             .attach_lazy(|| Expected::EntityType(self.clone()))
@@ -76,7 +76,7 @@ where
     }
 }
 
-impl<P> Validate<ClosedEntityType, P> for PropertyObject
+impl<P> Validate<ClosedEntityType, P> for PropertyWithMetadataObject
 where
     P: OntologyTypeProvider<PropertyType> + OntologyTypeProvider<DataType> + Sync,
 {
@@ -163,9 +163,24 @@ where
         if self.metadata.entity_type_ids.is_empty() {
             extend_report!(status, EntityValidationError::EmptyEntityTypes);
         }
-        if let Err(error) = self.properties.validate(schema, components, context).await {
-            extend_report!(status, error);
+
+        match PropertyWithMetadataObject::from_parts(
+            self.properties.clone(),
+            Some(self.metadata.properties.clone()),
+        ) {
+            Ok(properties) => {
+                if let Err(error) = properties.validate(schema, components, context).await {
+                    extend_report!(status, error);
+                }
+            }
+            Err(error) => {
+                extend_report!(
+                    status,
+                    error.change_context(EntityValidationError::InvalidProperties)
+                );
+            }
         }
+
         if let Err(error) = self
             .link_data
             .as_ref()

--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -1,4 +1,5 @@
 use core::borrow::Borrow;
+use std::collections::HashSet;
 
 use error_stack::{Report, ResultExt};
 use futures::{stream, StreamExt, TryStreamExt};
@@ -40,7 +41,7 @@ pub enum EntityValidationError {
     #[error("Entities without a type are not allowed")]
     EmptyEntityTypes,
     #[error("the validator was unable to read the entity type `{ids:?}`")]
-    EntityTypeRetrieval { ids: Vec<VersionedUrl> },
+    EntityTypeRetrieval { ids: HashSet<VersionedUrl> },
     #[error("the validator was unable to read the entity `{id}`")]
     EntityRetrieval { id: EntityId },
     #[error("The link type `{link_types:?}` is not allowed")]

--- a/libs/@local/hash-validation/src/error.rs
+++ b/libs/@local/hash-validation/src/error.rs
@@ -1,14 +1,18 @@
 use std::collections::HashSet;
 
 use error_stack::Report;
-use graph_types::knowledge::{Property, PropertyObject};
+use graph_types::knowledge::{PropertyWithMetadata, PropertyWithMetadataObject};
 use serde_json::Value as JsonValue;
 use type_system::{url::VersionedUrl, ClosedEntityType, DataType, PropertyType};
 
 pub fn install_error_stack_hooks() {
     Report::install_debug_hook::<Actual>(|actual, context| match actual {
         Actual::Json(json) => context.push_body(format!("actual: {json:#}")),
-        Actual::Property(json) => context.push_body(format!("actual: {json:#}")),
+        Actual::Property(json) => {
+            if let Ok(json) = serde_json::to_value(json) {
+                context.push_body(format!("actual: {json:#}"));
+            }
+        }
         Actual::Properties(properties) => {
             if let Ok(json) = serde_json::to_value(properties) {
                 context.push_body(format!("actual: {json:#}"));
@@ -60,8 +64,8 @@ pub fn install_error_stack_hooks() {
 #[derive(Debug)]
 pub enum Actual {
     Json(JsonValue),
-    Property(Property),
-    Properties(PropertyObject),
+    Property(PropertyWithMetadata),
+    Properties(PropertyWithMetadataObject),
 }
 
 #[derive(Debug)]

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -156,7 +156,9 @@ pub trait EntityProvider {
 mod tests {
     use std::collections::HashMap;
 
-    use graph_types::knowledge::{Property, PropertyObject};
+    use graph_types::knowledge::{
+        Property, PropertyObject, PropertyWithMetadata, PropertyWithMetadataObject,
+    };
     use serde_json::Value as JsonValue;
     use thiserror::Error;
     use type_system::{DataType, EntityType, PropertyType};
@@ -320,7 +322,8 @@ mod tests {
         let properties =
             serde_json::from_str::<PropertyObject>(entity).expect("failed to read entity string");
 
-        properties
+        PropertyWithMetadataObject::from_parts(properties, None)
+            .expect("failed to create property with metadata")
             .validate(&entity_type, components, &provider)
             .await
     }
@@ -349,7 +352,8 @@ mod tests {
         let property_type: PropertyType =
             serde_json::from_str(property_type).expect("failed to parse property type");
 
-        property
+        PropertyWithMetadata::from_parts(property, None)
+            .expect("failed to create property with metadata")
             .validate(&property_type, components, &provider)
             .await
     }
@@ -366,6 +370,9 @@ mod tests {
         let data_type: DataType =
             serde_json::from_str(data_type).expect("failed to parse data type");
 
-        property.validate(&data_type, components, &()).await
+        PropertyWithMetadata::from_parts(property, None)
+            .expect("failed to create property with metadata")
+            .validate(&data_type, components, &())
+            .await
     }
 }

--- a/tests/hash-graph-benches/read_scaling/knowledge/complete/entity.rs
+++ b/tests/hash-graph-benches/read_scaling/knowledge/complete/entity.rs
@@ -24,7 +24,7 @@ use graph_types::{
     knowledge::{
         entity::{EntityMetadata, ProvidedEntityEditionProvenance},
         link::LinkData,
-        PropertyMetadataObject, PropertyObject, PropertyProvenance,
+        PropertyObject, PropertyProvenance, PropertyWithMetadataObject,
     },
     owned_by_id::OwnedById,
 };
@@ -123,9 +123,9 @@ async fn seed_db<A: AuthorizationApi>(
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![entity_type.id().clone()],
-                properties,
+                properties: PropertyWithMetadataObject::from_parts(properties, None)
+                    .expect("could not create property with metadata object"),
                 confidence: None,
-                property_metadata: PropertyMetadataObject::default(),
                 link_data: None,
                 draft: false,
                 relationships: [],
@@ -150,9 +150,12 @@ async fn seed_db<A: AuthorizationApi>(
                             entity_uuid: None,
                             decision_time: None,
                             entity_type_ids: vec![link_type.id().clone()],
-                            properties: PropertyObject::empty(),
+                            properties: PropertyWithMetadataObject::from_parts(
+                                PropertyObject::empty(),
+                                None,
+                            )
+                            .expect("could not create property with metadata object"),
                             confidence: None,
-                            property_metadata: PropertyMetadataObject::default(),
                             link_data: Some(LinkData {
                                 left_entity_id: entity_a_metadata.record_id.entity_id,
                                 right_entity_id: entity_b_metadata.record_id.entity_id,

--- a/tests/hash-graph-benches/read_scaling/knowledge/complete/entity.rs
+++ b/tests/hash-graph-benches/read_scaling/knowledge/complete/entity.rs
@@ -1,4 +1,5 @@
 use core::{iter::repeat, str::FromStr};
+use std::collections::HashSet;
 
 use authorization::{schema::WebOwnerSubject, AuthorizationApi, NoAuthorization};
 use criterion::{BatchSize::SmallInput, Bencher, BenchmarkId, Criterion, SamplingMode};
@@ -122,7 +123,7 @@ async fn seed_db<A: AuthorizationApi>(
                 owned_by_id,
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![entity_type.id().clone()],
+                entity_type_ids: HashSet::from([entity_type.id().clone()]),
                 properties: PropertyWithMetadataObject::from_parts(properties, None)
                     .expect("could not create property with metadata object"),
                 confidence: None,
@@ -149,7 +150,7 @@ async fn seed_db<A: AuthorizationApi>(
                             owned_by_id,
                             entity_uuid: None,
                             decision_time: None,
-                            entity_type_ids: vec![link_type.id().clone()],
+                            entity_type_ids: HashSet::from([link_type.id().clone()]),
                             properties: PropertyWithMetadataObject::from_parts(
                                 PropertyObject::empty(),
                                 None,

--- a/tests/hash-graph-benches/read_scaling/knowledge/linkless/entity.rs
+++ b/tests/hash-graph-benches/read_scaling/knowledge/linkless/entity.rs
@@ -1,4 +1,5 @@
 use core::{iter::repeat, str::FromStr};
+use std::collections::HashSet;
 
 use authorization::{schema::WebOwnerSubject, AuthorizationApi, NoAuthorization};
 use criterion::{BatchSize::SmallInput, Bencher, BenchmarkId, Criterion};
@@ -104,7 +105,7 @@ async fn seed_db<A: AuthorizationApi>(
                 owned_by_id: OwnedById::new(account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![entity_type_id],
+                entity_type_ids: HashSet::from([entity_type_id]),
                 properties: PropertyWithMetadataObject::from_parts(properties, None)
                     .expect("could not create property with metadata object"),
                 confidence: None,

--- a/tests/hash-graph-benches/read_scaling/knowledge/linkless/entity.rs
+++ b/tests/hash-graph-benches/read_scaling/knowledge/linkless/entity.rs
@@ -19,7 +19,7 @@ use graph_types::{
     account::AccountId,
     knowledge::{
         entity::{EntityMetadata, ProvidedEntityEditionProvenance},
-        PropertyMetadataObject, PropertyObject,
+        PropertyObject, PropertyWithMetadataObject,
     },
     owned_by_id::OwnedById,
 };
@@ -105,9 +105,9 @@ async fn seed_db<A: AuthorizationApi>(
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![entity_type_id],
-                properties,
+                properties: PropertyWithMetadataObject::from_parts(properties, None)
+                    .expect("could not create property with metadata object"),
                 confidence: None,
-                property_metadata: PropertyMetadataObject::default(),
                 link_data: None,
                 draft: false,
                 relationships: [],

--- a/tests/hash-graph-benches/representative_read/seed.rs
+++ b/tests/hash-graph-benches/representative_read/seed.rs
@@ -1,5 +1,5 @@
 use core::{iter::repeat, str::FromStr};
-use std::collections::{hash_map::Entry, HashMap};
+use std::collections::{hash_map::Entry, HashMap, HashSet};
 
 use authorization::{schema::WebOwnerSubject, AuthorizationApi};
 use graph::store::{
@@ -175,7 +175,7 @@ async fn seed_db<A: AuthorizationApi>(account_id: AccountId, store_wrapper: &mut
                     owned_by_id: OwnedById::new(account_id.into_uuid()),
                     entity_uuid: None,
                     decision_time: None,
-                    entity_type_ids: vec![entity_type_id],
+                    entity_type_ids: HashSet::from([entity_type_id]),
                     properties: PropertyWithMetadataObject::from_parts(properties, None)
                         .expect("could not create property with metadata object"),
                     confidence: None,
@@ -210,7 +210,7 @@ async fn seed_db<A: AuthorizationApi>(account_id: AccountId, store_wrapper: &mut
                             owned_by_id: OwnedById::new(account_id.into_uuid()),
                             entity_uuid: None,
                             decision_time: None,
-                            entity_type_ids: vec![entity_type_id.clone()],
+                            entity_type_ids: HashSet::from([entity_type_id.clone()]),
                             properties: PropertyWithMetadataObject::from_parts(
                                 PropertyObject::empty(),
                                 None,

--- a/tests/hash-graph-benches/representative_read/seed.rs
+++ b/tests/hash-graph-benches/representative_read/seed.rs
@@ -13,7 +13,7 @@ use graph_types::{
     knowledge::{
         entity::{EntityUuid, ProvidedEntityEditionProvenance},
         link::LinkData,
-        PropertyMetadataObject, PropertyObject, PropertyProvenance,
+        PropertyObject, PropertyProvenance, PropertyWithMetadataObject,
     },
     owned_by_id::OwnedById,
 };
@@ -176,9 +176,9 @@ async fn seed_db<A: AuthorizationApi>(account_id: AccountId, store_wrapper: &mut
                     entity_uuid: None,
                     decision_time: None,
                     entity_type_ids: vec![entity_type_id],
-                    properties,
+                    properties: PropertyWithMetadataObject::from_parts(properties, None)
+                        .expect("could not create property with metadata object"),
                     confidence: None,
-                    property_metadata: PropertyMetadataObject::default(),
                     link_data: None,
                     draft: false,
                     relationships: [],
@@ -211,9 +211,12 @@ async fn seed_db<A: AuthorizationApi>(account_id: AccountId, store_wrapper: &mut
                             entity_uuid: None,
                             decision_time: None,
                             entity_type_ids: vec![entity_type_id.clone()],
-                            properties: PropertyObject::empty(),
+                            properties: PropertyWithMetadataObject::from_parts(
+                                PropertyObject::empty(),
+                                None,
+                            )
+                            .expect("could not create property with metadata object"),
                             confidence: None,
-                            property_metadata: PropertyMetadataObject::default(),
                             link_data: Some(LinkData {
                                 left_entity_id: left_entity_metadata.record_id.entity_id,
                                 right_entity_id: right_entity_metadata.record_id.entity_id,

--- a/tests/hash-graph-integration/postgres/drafts.rs
+++ b/tests/hash-graph-integration/postgres/drafts.rs
@@ -7,7 +7,7 @@ use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::{
     knowledge::{
         entity::{EntityId, ProvidedEntityEditionProvenance},
-        Property, PropertyMetadataObject, PropertyObject, PropertyPatchOperation, PropertyPath,
+        Property, PropertyObject, PropertyPatchOperation, PropertyPath, PropertyWithMetadataObject,
     },
     owned_by_id::OwnedById,
 };
@@ -87,9 +87,9 @@ async fn initial_draft() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![person_entity_type_id()],
-                properties: alice(),
+                properties: PropertyWithMetadataObject::from_parts(alice(), None)
+                    .expect("could not create property with metadata object"),
                 confidence: None,
-                property_metadata: PropertyMetadataObject::default(),
                 link_data: None,
                 draft: true,
                 relationships: [],
@@ -258,9 +258,9 @@ async fn no_initial_draft() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![person_entity_type_id()],
-                properties: alice(),
+                properties: PropertyWithMetadataObject::from_parts(alice(), None)
+                    .expect("could not create property with metadata object"),
                 confidence: None,
-                property_metadata: PropertyMetadataObject::default(),
                 link_data: None,
                 draft: false,
                 relationships: [],
@@ -416,9 +416,9 @@ async fn multiple_drafts() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![person_entity_type_id()],
-                properties: alice(),
+                properties: PropertyWithMetadataObject::from_parts(alice(), None)
+                    .expect("could not create property with metadata object"),
                 confidence: None,
-                property_metadata: PropertyMetadataObject::default(),
                 link_data: None,
                 draft: false,
                 relationships: [],

--- a/tests/hash-graph-integration/postgres/drafts.rs
+++ b/tests/hash-graph-integration/postgres/drafts.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use authorization::AuthorizationApi;
 use graph::store::{
     knowledge::{CreateEntityParams, PatchEntityParams},
@@ -86,7 +88,7 @@ async fn initial_draft() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![person_entity_type_id()],
+                entity_type_ids: HashSet::from([person_entity_type_id()]),
                 properties: PropertyWithMetadataObject::from_parts(alice(), None)
                     .expect("could not create property with metadata object"),
                 confidence: None,
@@ -126,7 +128,7 @@ async fn initial_draft() {
                     value: Property::Object(bob()),
                     metadata: None,
                 }],
-                entity_type_ids: vec![],
+                entity_type_ids: HashSet::new(),
                 archived: None,
                 draft: Some(true),
                 decision_time: None,
@@ -177,7 +179,7 @@ async fn initial_draft() {
                     value: Property::Object(charles()),
                     metadata: None,
                 }],
-                entity_type_ids: vec![],
+                entity_type_ids: HashSet::new(),
                 archived: None,
                 draft: Some(false),
                 decision_time: None,
@@ -257,7 +259,7 @@ async fn no_initial_draft() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![person_entity_type_id()],
+                entity_type_ids: HashSet::from([person_entity_type_id()]),
                 properties: PropertyWithMetadataObject::from_parts(alice(), None)
                     .expect("could not create property with metadata object"),
                 confidence: None,
@@ -302,7 +304,7 @@ async fn no_initial_draft() {
                         value: Property::Object(bob()),
                         metadata: None,
                     }],
-                    entity_type_ids: vec![],
+                    entity_type_ids: HashSet::new(),
                     archived: None,
                     draft: Some(true),
                     decision_time: None,
@@ -358,7 +360,7 @@ async fn no_initial_draft() {
                         value: Property::Object(charles()),
                         metadata: None,
                     }],
-                    entity_type_ids: vec![],
+                    entity_type_ids: HashSet::new(),
                     archived: None,
                     draft: Some(false),
                     decision_time: None,
@@ -415,7 +417,7 @@ async fn multiple_drafts() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![person_entity_type_id()],
+                entity_type_ids: HashSet::from([person_entity_type_id()]),
                 properties: PropertyWithMetadataObject::from_parts(alice(), None)
                     .expect("could not create property with metadata object"),
                 confidence: None,
@@ -460,7 +462,7 @@ async fn multiple_drafts() {
                         value: Property::Object(bob()),
                         metadata: None,
                     }],
-                    entity_type_ids: vec![],
+                    entity_type_ids: HashSet::new(),
                     archived: None,
                     draft: Some(true),
                     decision_time: None,
@@ -519,7 +521,7 @@ async fn multiple_drafts() {
                         value: Property::Object(charles()),
                         metadata: None,
                     }],
-                    entity_type_ids: vec![],
+                    entity_type_ids: HashSet::new(),
                     archived: None,
                     draft: Some(false),
                     decision_time: None,

--- a/tests/hash-graph-integration/postgres/entity.rs
+++ b/tests/hash-graph-integration/postgres/entity.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use graph::{
     store::{
         knowledge::{
@@ -57,13 +59,13 @@ async fn insert() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![VersionedUrl {
+                entity_type_ids: HashSet::from([VersionedUrl {
                     base_url: BaseUrl::new(
                         "https://blockprotocol.org/@alice/types/entity-type/person/".to_owned(),
                     )
                     .expect("couldn't construct Base URL"),
                     version: OntologyTypeVersion::new(1),
-                }],
+                }]),
                 properties: PropertyWithMetadataObject::from_parts(person.clone(), None)
                     .expect("could not create property with metadata object"),
                 confidence: None,
@@ -127,14 +129,14 @@ async fn query() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![VersionedUrl {
+                entity_type_ids: HashSet::from([VersionedUrl {
                     base_url: BaseUrl::new(
                         "https://blockprotocol.org/@alice/types/entity-type/organization/"
                             .to_owned(),
                     )
                     .expect("couldn't construct Base URL"),
                     version: OntologyTypeVersion::new(1),
-                }],
+                }]),
                 properties: PropertyWithMetadataObject::from_parts(organization.clone(), None)
                     .expect("could not create property with metadata object"),
                 confidence: None,
@@ -201,13 +203,13 @@ async fn update() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![VersionedUrl {
+                entity_type_ids: HashSet::from([VersionedUrl {
                     base_url: BaseUrl::new(
                         "https://blockprotocol.org/@alice/types/entity-type/page/".to_owned(),
                     )
                     .expect("couldn't construct Base URL"),
                     version: OntologyTypeVersion::new(1),
-                }],
+                }]),
                 properties: PropertyWithMetadataObject::from_parts(page_v1.clone(), None)
                     .expect("could not create property with metadata object"),
                 confidence: None,
@@ -230,7 +232,7 @@ async fn update() {
                     value: Property::Object(page_v2.clone()),
                     metadata: None,
                 }],
-                entity_type_ids: vec![],
+                entity_type_ids: HashSet::new(),
                 archived: None,
                 draft: None,
                 decision_time: None,

--- a/tests/hash-graph-integration/postgres/entity.rs
+++ b/tests/hash-graph-integration/postgres/entity.rs
@@ -13,8 +13,8 @@ use graph::{
 use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::{
     knowledge::{
-        entity::ProvidedEntityEditionProvenance, Property, PropertyMetadataObject, PropertyObject,
-        PropertyPatchOperation, PropertyPath,
+        entity::ProvidedEntityEditionProvenance, Property, PropertyObject, PropertyPatchOperation,
+        PropertyPath, PropertyWithMetadataObject,
     },
     owned_by_id::OwnedById,
 };
@@ -64,9 +64,9 @@ async fn insert() {
                     .expect("couldn't construct Base URL"),
                     version: OntologyTypeVersion::new(1),
                 }],
-                properties: person.clone(),
+                properties: PropertyWithMetadataObject::from_parts(person.clone(), None)
+                    .expect("could not create property with metadata object"),
                 confidence: None,
-                property_metadata: PropertyMetadataObject::default(),
                 link_data: None,
                 draft: false,
                 relationships: [],
@@ -135,9 +135,9 @@ async fn query() {
                     .expect("couldn't construct Base URL"),
                     version: OntologyTypeVersion::new(1),
                 }],
-                properties: organization.clone(),
+                properties: PropertyWithMetadataObject::from_parts(organization.clone(), None)
+                    .expect("could not create property with metadata object"),
                 confidence: None,
-                property_metadata: PropertyMetadataObject::default(),
                 link_data: None,
                 draft: false,
                 relationships: [],
@@ -208,9 +208,9 @@ async fn update() {
                     .expect("couldn't construct Base URL"),
                     version: OntologyTypeVersion::new(1),
                 }],
-                properties: page_v1.clone(),
+                properties: PropertyWithMetadataObject::from_parts(page_v1.clone(), None)
+                    .expect("could not create property with metadata object"),
                 confidence: None,
-                property_metadata: PropertyMetadataObject::default(),
                 link_data: None,
                 draft: false,
                 relationships: [],

--- a/tests/hash-graph-integration/postgres/interconnected_graph.rs
+++ b/tests/hash-graph-integration/postgres/interconnected_graph.rs
@@ -1,4 +1,5 @@
 use core::str::FromStr;
+use std::collections::HashSet;
 
 use graph::store::{knowledge::CreateEntityParams, EntityStore};
 use graph_test_data::{data_type, entity, entity_type, property_type};
@@ -47,10 +48,10 @@ async fn insert() {
         owned_by_id,
         entity_uuid: Some(alice_id),
         decision_time: None,
-        entity_type_ids: vec![
-            VersionedUrl::from_str("https://blockprotocol.org/@alice/types/entity-type/person/v/1")
-                .expect("couldn't construct Versioned URL"),
-        ],
+        entity_type_ids: HashSet::from([VersionedUrl::from_str(
+            "https://blockprotocol.org/@alice/types/entity-type/person/v/1",
+        )
+        .expect("couldn't construct Versioned URL")]),
         properties: PropertyWithMetadataObject::from_parts(
             serde_json::from_str(entity::PERSON_ALICE_V1).expect("could not parse entity"),
             None,
@@ -68,10 +69,10 @@ async fn insert() {
         owned_by_id,
         entity_uuid: Some(bob_id),
         decision_time: None,
-        entity_type_ids: vec![
-            VersionedUrl::from_str("https://blockprotocol.org/@alice/types/entity-type/person/v/1")
-                .expect("couldn't construct Versioned URL"),
-        ],
+        entity_type_ids: HashSet::from([VersionedUrl::from_str(
+            "https://blockprotocol.org/@alice/types/entity-type/person/v/1",
+        )
+        .expect("couldn't construct Versioned URL")]),
         properties: PropertyWithMetadataObject::from_parts(
             serde_json::from_str(entity::PERSON_BOB_V1).expect("could not parse entity"),
             None,
@@ -88,12 +89,10 @@ async fn insert() {
         owned_by_id: OwnedById::new(api.account_id.into_uuid()),
         entity_uuid: None,
         decision_time: None,
-        entity_type_ids: vec![
-            VersionedUrl::from_str(
-                "https://blockprotocol.org/@alice/types/entity-type/friend-of/v/1",
-            )
-            .expect("couldn't construct Versioned URL"),
-        ],
+        entity_type_ids: HashSet::from([VersionedUrl::from_str(
+            "https://blockprotocol.org/@alice/types/entity-type/friend-of/v/1",
+        )
+        .expect("couldn't construct Versioned URL")]),
         properties: PropertyWithMetadataObject::from_parts(PropertyObject::empty(), None)
             .expect("could not create property with metadata object"),
         confidence: None,

--- a/tests/hash-graph-integration/postgres/interconnected_graph.rs
+++ b/tests/hash-graph-integration/postgres/interconnected_graph.rs
@@ -6,7 +6,7 @@ use graph_types::{
     knowledge::{
         entity::{EntityId, EntityUuid, ProvidedEntityEditionProvenance},
         link::LinkData,
-        PropertyMetadataObject, PropertyObject, PropertyProvenance,
+        PropertyObject, PropertyProvenance, PropertyWithMetadataObject,
     },
     owned_by_id::OwnedById,
 };
@@ -16,6 +16,7 @@ use uuid::Uuid;
 use crate::DatabaseTestWrapper;
 
 #[tokio::test]
+#[expect(clippy::too_many_lines)]
 async fn insert() {
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database
@@ -50,9 +51,12 @@ async fn insert() {
             VersionedUrl::from_str("https://blockprotocol.org/@alice/types/entity-type/person/v/1")
                 .expect("couldn't construct Versioned URL"),
         ],
-        properties: serde_json::from_str(entity::PERSON_ALICE_V1).expect("could not parse entity"),
+        properties: PropertyWithMetadataObject::from_parts(
+            serde_json::from_str(entity::PERSON_ALICE_V1).expect("could not parse entity"),
+            None,
+        )
+        .expect("could not create property with metadata object"),
         confidence: None,
-        property_metadata: PropertyMetadataObject::default(),
         link_data: None,
         draft: false,
         relationships: [],
@@ -68,9 +72,12 @@ async fn insert() {
             VersionedUrl::from_str("https://blockprotocol.org/@alice/types/entity-type/person/v/1")
                 .expect("couldn't construct Versioned URL"),
         ],
-        properties: serde_json::from_str(entity::PERSON_BOB_V1).expect("could not parse entity"),
+        properties: PropertyWithMetadataObject::from_parts(
+            serde_json::from_str(entity::PERSON_BOB_V1).expect("could not parse entity"),
+            None,
+        )
+        .expect("could not create property with metadata object"),
         confidence: None,
-        property_metadata: PropertyMetadataObject::default(),
         link_data: None,
         draft: false,
         relationships: [],
@@ -87,9 +94,9 @@ async fn insert() {
             )
             .expect("couldn't construct Versioned URL"),
         ],
-        properties: PropertyObject::empty(),
+        properties: PropertyWithMetadataObject::from_parts(PropertyObject::empty(), None)
+            .expect("could not create property with metadata object"),
         confidence: None,
-        property_metadata: PropertyMetadataObject::default(),
         link_data: Some(LinkData {
             left_entity_id: EntityId {
                 owned_by_id,

--- a/tests/hash-graph-integration/postgres/links.rs
+++ b/tests/hash-graph-integration/postgres/links.rs
@@ -1,4 +1,5 @@
 use alloc::borrow::Cow;
+use std::collections::HashSet;
 
 use graph::{
     knowledge::EntityQueryPath,
@@ -75,7 +76,7 @@ async fn insert() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![person_type_id.clone()],
+                entity_type_ids: HashSet::from([person_type_id.clone()]),
                 properties: PropertyWithMetadataObject::from_parts(alice, None)
                     .expect("could not create property with metadata object"),
                 link_data: None,
@@ -95,7 +96,7 @@ async fn insert() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![person_type_id.clone()],
+                entity_type_ids: HashSet::from([person_type_id.clone()]),
                 properties: PropertyWithMetadataObject::from_parts(bob, None)
                     .expect("could not create property with metadata object"),
                 link_data: None,
@@ -122,7 +123,7 @@ async fn insert() {
             owned_by_id: OwnedById::new(api.account_id.into_uuid()),
             entity_uuid: None,
             decision_time: None,
-            entity_type_ids: vec![friend_of_type_id.clone()],
+            entity_type_ids: HashSet::from([friend_of_type_id.clone()]),
             properties: PropertyWithMetadataObject::from_parts(friend_of, None)
                 .expect("could not create property with metadata object"),
             link_data: Some(LinkData {
@@ -279,7 +280,7 @@ async fn get_entity_links() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![person_type_id.clone()],
+                entity_type_ids: HashSet::from([person_type_id.clone()]),
                 properties: PropertyWithMetadataObject::from_parts(alice, None)
                     .expect("could not create property with metadata object"),
                 link_data: None,
@@ -299,7 +300,7 @@ async fn get_entity_links() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![person_type_id.clone()],
+                entity_type_ids: HashSet::from([person_type_id.clone()]),
                 properties: PropertyWithMetadataObject::from_parts(bob, None)
                     .expect("could not create property with metadata object"),
                 link_data: None,
@@ -319,7 +320,7 @@ async fn get_entity_links() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![person_type_id.clone()],
+                entity_type_ids: HashSet::from([person_type_id.clone()]),
                 properties: PropertyWithMetadataObject::from_parts(charles, None)
                     .expect("could not create property with metadata object"),
                 confidence: None,
@@ -338,7 +339,7 @@ async fn get_entity_links() {
             owned_by_id: OwnedById::new(api.account_id.into_uuid()),
             entity_uuid: None,
             decision_time: None,
-            entity_type_ids: vec![friend_link_type_id.clone()],
+            entity_type_ids: HashSet::from([friend_link_type_id.clone()]),
             properties: PropertyWithMetadataObject::from_parts(PropertyObject::empty(), None)
                 .expect("could not create property with metadata object"),
             link_data: Some(LinkData {
@@ -364,7 +365,7 @@ async fn get_entity_links() {
             owned_by_id: OwnedById::new(api.account_id.into_uuid()),
             entity_uuid: None,
             decision_time: None,
-            entity_type_ids: vec![acquaintance_entity_link_type_id.clone()],
+            entity_type_ids: HashSet::from([acquaintance_entity_link_type_id.clone()]),
             properties: PropertyWithMetadataObject::from_parts(PropertyObject::empty(), None)
                 .expect("could not create property with metadata object"),
             link_data: Some(LinkData {
@@ -415,17 +416,18 @@ async fn get_entity_links() {
         .expect("could not get entities")
         .entities;
 
-    assert!(
-        links_from_source
-            .iter()
-            .any(|link_entity| link_entity.metadata.entity_type_ids[0] == friend_link_type_id)
-    );
-    assert!(
-        links_from_source
-            .iter()
-            .any(|link_entity| link_entity.metadata.entity_type_ids[0]
-                == acquaintance_entity_link_type_id)
-    );
+    assert!(links_from_source.iter().any(|link_entity| {
+        link_entity
+            .metadata
+            .entity_type_ids
+            .contains(&friend_link_type_id)
+    }));
+    assert!(links_from_source.iter().any(|link_entity| {
+        link_entity
+            .metadata
+            .entity_type_ids
+            .contains(&acquaintance_entity_link_type_id)
+    }));
 
     let link_datas = links_from_source
         .iter()
@@ -499,7 +501,7 @@ async fn remove_link() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![person_type_id.clone()],
+                entity_type_ids: HashSet::from([person_type_id.clone()]),
                 properties: PropertyWithMetadataObject::from_parts(alice, None)
                     .expect("could not create property with metadata object"),
                 link_data: None,
@@ -519,7 +521,7 @@ async fn remove_link() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![person_type_id.clone()],
+                entity_type_ids: HashSet::from([person_type_id.clone()]),
                 properties: PropertyWithMetadataObject::from_parts(bob, None)
                     .expect("could not create property with metadata object"),
                 link_data: None,
@@ -539,7 +541,7 @@ async fn remove_link() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![friend_link_type_id.clone()],
+                entity_type_ids: HashSet::from([friend_link_type_id.clone()]),
                 properties: PropertyWithMetadataObject::from_parts(PropertyObject::empty(), None)
                     .expect("could not create property with metadata object"),
                 link_data: Some(LinkData {
@@ -598,7 +600,7 @@ async fn remove_link() {
             decision_time: None,
             archived: Some(true),
             draft: None,
-            entity_type_ids: vec![],
+            entity_type_ids: HashSet::new(),
             properties: vec![],
             confidence: None,
             provenance: ProvidedEntityEditionProvenance::default(),

--- a/tests/hash-graph-integration/postgres/links.rs
+++ b/tests/hash-graph-integration/postgres/links.rs
@@ -21,8 +21,8 @@ use graph::{
 use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::{
     knowledge::{
-        entity::ProvidedEntityEditionProvenance, link::LinkData, PropertyMetadataObject,
-        PropertyObject, PropertyProvenance,
+        entity::ProvidedEntityEditionProvenance, link::LinkData, PropertyObject,
+        PropertyProvenance, PropertyWithMetadataObject,
     },
     owned_by_id::OwnedById,
 };
@@ -76,8 +76,8 @@ async fn insert() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![person_type_id.clone()],
-                properties: alice,
-                property_metadata: PropertyMetadataObject::default(),
+                properties: PropertyWithMetadataObject::from_parts(alice, None)
+                    .expect("could not create property with metadata object"),
                 link_data: None,
                 draft: false,
                 relationships: [],
@@ -96,8 +96,8 @@ async fn insert() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![person_type_id.clone()],
-                properties: bob,
-                property_metadata: PropertyMetadataObject::default(),
+                properties: PropertyWithMetadataObject::from_parts(bob, None)
+                    .expect("could not create property with metadata object"),
                 link_data: None,
                 draft: false,
                 relationships: [],
@@ -123,8 +123,8 @@ async fn insert() {
             entity_uuid: None,
             decision_time: None,
             entity_type_ids: vec![friend_of_type_id.clone()],
-            properties: friend_of,
-            property_metadata: PropertyMetadataObject::default(),
+            properties: PropertyWithMetadataObject::from_parts(friend_of, None)
+                .expect("could not create property with metadata object"),
             link_data: Some(LinkData {
                 left_entity_id: alice_metadata.record_id.entity_id,
                 right_entity_id: bob_metadata.record_id.entity_id,
@@ -280,8 +280,8 @@ async fn get_entity_links() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![person_type_id.clone()],
-                properties: alice,
-                property_metadata: PropertyMetadataObject::default(),
+                properties: PropertyWithMetadataObject::from_parts(alice, None)
+                    .expect("could not create property with metadata object"),
                 link_data: None,
                 draft: false,
                 relationships: [],
@@ -300,8 +300,8 @@ async fn get_entity_links() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![person_type_id.clone()],
-                properties: bob,
-                property_metadata: PropertyMetadataObject::default(),
+                properties: PropertyWithMetadataObject::from_parts(bob, None)
+                    .expect("could not create property with metadata object"),
                 link_data: None,
                 draft: false,
                 relationships: [],
@@ -320,9 +320,9 @@ async fn get_entity_links() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![person_type_id.clone()],
-                properties: charles,
+                properties: PropertyWithMetadataObject::from_parts(charles, None)
+                    .expect("could not create property with metadata object"),
                 confidence: None,
-                property_metadata: PropertyMetadataObject::default(),
                 link_data: None,
                 draft: false,
                 relationships: [],
@@ -339,8 +339,8 @@ async fn get_entity_links() {
             entity_uuid: None,
             decision_time: None,
             entity_type_ids: vec![friend_link_type_id.clone()],
-            properties: PropertyObject::empty(),
-            property_metadata: PropertyMetadataObject::default(),
+            properties: PropertyWithMetadataObject::from_parts(PropertyObject::empty(), None)
+                .expect("could not create property with metadata object"),
             link_data: Some(LinkData {
                 left_entity_id: alice_metadata.record_id.entity_id,
                 right_entity_id: bob_metadata.record_id.entity_id,
@@ -365,8 +365,8 @@ async fn get_entity_links() {
             entity_uuid: None,
             decision_time: None,
             entity_type_ids: vec![acquaintance_entity_link_type_id.clone()],
-            properties: PropertyObject::empty(),
-            property_metadata: PropertyMetadataObject::default(),
+            properties: PropertyWithMetadataObject::from_parts(PropertyObject::empty(), None)
+                .expect("could not create property with metadata object"),
             link_data: Some(LinkData {
                 left_entity_id: alice_metadata.record_id.entity_id,
                 right_entity_id: charles_metadata.record_id.entity_id,
@@ -500,8 +500,8 @@ async fn remove_link() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![person_type_id.clone()],
-                properties: alice,
-                property_metadata: PropertyMetadataObject::default(),
+                properties: PropertyWithMetadataObject::from_parts(alice, None)
+                    .expect("could not create property with metadata object"),
                 link_data: None,
                 draft: false,
                 relationships: [],
@@ -520,8 +520,8 @@ async fn remove_link() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![person_type_id.clone()],
-                properties: bob,
-                property_metadata: PropertyMetadataObject::default(),
+                properties: PropertyWithMetadataObject::from_parts(bob, None)
+                    .expect("could not create property with metadata object"),
                 link_data: None,
                 draft: false,
                 relationships: [],
@@ -540,8 +540,8 @@ async fn remove_link() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![friend_link_type_id.clone()],
-                properties: PropertyObject::empty(),
-                property_metadata: PropertyMetadataObject::default(),
+                properties: PropertyWithMetadataObject::from_parts(PropertyObject::empty(), None)
+                    .expect("could not create property with metadata object"),
                 link_data: Some(LinkData {
                     left_entity_id: alice_metadata.record_id.entity_id,
                     right_entity_id: bob_metadata.record_id.entity_id,

--- a/tests/hash-graph-integration/postgres/multi_type.rs
+++ b/tests/hash-graph-integration/postgres/multi_type.rs
@@ -1,4 +1,5 @@
 use core::str::FromStr;
+use std::collections::HashSet;
 
 use authorization::AuthorizationApi;
 use graph::{
@@ -78,7 +79,7 @@ async fn empty_entity() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![],
+                entity_type_ids: HashSet::new(),
                 properties: PropertyWithMetadataObject::from_parts(PropertyObject::empty(), None)
                     .expect("could not create property with metadata object"),
                 confidence: None,
@@ -105,7 +106,7 @@ async fn initial_person() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![person_entity_type_id()],
+                entity_type_ids: HashSet::from([person_entity_type_id()]),
                 properties: PropertyWithMetadataObject::from_parts(alice(), None)
                     .expect("could not create property with metadata object"),
                 confidence: None,
@@ -118,7 +119,11 @@ async fn initial_person() {
         .await
         .expect("could not create entity");
 
-    assert_eq!(entity_metadata.entity_type_ids, [person_entity_type_id()]);
+    assert!(
+        entity_metadata
+            .entity_type_ids
+            .contains(&person_entity_type_id())
+    );
 
     let entities = api
         .get_entities(
@@ -157,7 +162,7 @@ async fn initial_person() {
             PatchEntityParams {
                 entity_id: entity_metadata.record_id.entity_id,
                 decision_time: None,
-                entity_type_ids: vec![person_entity_type_id(), org_entity_type_id()],
+                entity_type_ids: HashSet::from([person_entity_type_id(), org_entity_type_id()]),
                 properties: vec![],
                 draft: None,
                 archived: None,
@@ -168,9 +173,17 @@ async fn initial_person() {
         .await
         .expect("could not create entity");
 
-    assert_eq!(
-        updated_entity.metadata.entity_type_ids,
-        [person_entity_type_id(), org_entity_type_id()]
+    assert!(
+        updated_entity
+            .metadata
+            .entity_type_ids
+            .contains(&person_entity_type_id()),
+    );
+    assert!(
+        updated_entity
+            .metadata
+            .entity_type_ids
+            .contains(&org_entity_type_id()),
     );
 
     let updated_person_entities = api
@@ -241,7 +254,7 @@ async fn create_multi() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![person_entity_type_id(), org_entity_type_id()],
+                entity_type_ids: HashSet::from([person_entity_type_id(), org_entity_type_id()]),
                 properties: PropertyWithMetadataObject::from_parts(alice(), None)
                     .expect("could not create property with metadata object"),
                 confidence: None,
@@ -254,9 +267,15 @@ async fn create_multi() {
         .await
         .expect("could not create entity");
 
-    assert_eq!(
-        entity_metadata.entity_type_ids,
-        [person_entity_type_id(), org_entity_type_id()]
+    assert!(
+        entity_metadata
+            .entity_type_ids
+            .contains(&person_entity_type_id()),
+    );
+    assert!(
+        entity_metadata
+            .entity_type_ids
+            .contains(&org_entity_type_id()),
     );
 
     let person_entities = api
@@ -319,7 +338,7 @@ async fn create_multi() {
             PatchEntityParams {
                 entity_id: entity_metadata.record_id.entity_id,
                 decision_time: None,
-                entity_type_ids: vec![person_entity_type_id()],
+                entity_type_ids: HashSet::from([person_entity_type_id()]),
                 properties: vec![],
                 draft: None,
                 archived: None,
@@ -330,9 +349,11 @@ async fn create_multi() {
         .await
         .expect("could not create entity");
 
-    assert_eq!(
-        updated_entity.metadata.entity_type_ids,
-        [person_entity_type_id()]
+    assert!(
+        updated_entity
+            .metadata
+            .entity_type_ids
+            .contains(&person_entity_type_id())
     );
 
     let updated_person_entities = api

--- a/tests/hash-graph-integration/postgres/multi_type.rs
+++ b/tests/hash-graph-integration/postgres/multi_type.rs
@@ -15,7 +15,7 @@ use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::{
     knowledge::{
         entity::{Entity, ProvidedEntityEditionProvenance},
-        PropertyMetadataObject, PropertyObject,
+        PropertyObject, PropertyWithMetadataObject,
     },
     owned_by_id::OwnedById,
 };
@@ -79,9 +79,9 @@ async fn empty_entity() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![],
-                properties: PropertyObject::empty(),
+                properties: PropertyWithMetadataObject::from_parts(PropertyObject::empty(), None)
+                    .expect("could not create property with metadata object"),
                 confidence: None,
-                property_metadata: PropertyMetadataObject::default(),
                 link_data: None,
                 draft: false,
                 relationships: [],
@@ -106,9 +106,9 @@ async fn initial_person() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![person_entity_type_id()],
-                properties: alice(),
+                properties: PropertyWithMetadataObject::from_parts(alice(), None)
+                    .expect("could not create property with metadata object"),
                 confidence: None,
-                property_metadata: PropertyMetadataObject::default(),
                 link_data: None,
                 draft: false,
                 relationships: [],
@@ -242,9 +242,9 @@ async fn create_multi() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![person_entity_type_id(), org_entity_type_id()],
-                properties: alice(),
+                properties: PropertyWithMetadataObject::from_parts(alice(), None)
+                    .expect("could not create property with metadata object"),
                 confidence: None,
-                property_metadata: PropertyMetadataObject::default(),
                 link_data: None,
                 draft: false,
                 relationships: [],

--- a/tests/hash-graph-integration/postgres/partial_updates.rs
+++ b/tests/hash-graph-integration/postgres/partial_updates.rs
@@ -15,8 +15,8 @@ use graph::{
 use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::{
     knowledge::{
-        entity::ProvidedEntityEditionProvenance, Property, PropertyMetadataObject, PropertyObject,
-        PropertyPatchOperation, PropertyPathElement,
+        entity::ProvidedEntityEditionProvenance, Property, PropertyObject, PropertyPatchOperation,
+        PropertyPathElement, PropertyWithMetadataObject,
     },
     owned_by_id::OwnedById,
 };
@@ -88,9 +88,9 @@ async fn properties_add() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![person_entity_type_id()],
-                properties: alice(),
+                properties: PropertyWithMetadataObject::from_parts(alice(), None)
+                    .expect("could not create property with metadata object"),
                 confidence: None,
-                property_metadata: PropertyMetadataObject::default(),
                 link_data: None,
                 draft: false,
                 relationships: [],
@@ -164,9 +164,9 @@ async fn properties_remove() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![person_entity_type_id()],
-                properties: alice(),
+                properties: PropertyWithMetadataObject::from_parts(alice(), None)
+                    .expect("could not create property with metadata object"),
                 confidence: None,
-                property_metadata: PropertyMetadataObject::default(),
                 link_data: None,
                 draft: false,
                 relationships: [],
@@ -236,9 +236,9 @@ async fn properties_replace() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![person_entity_type_id()],
-                properties: alice(),
+                properties: PropertyWithMetadataObject::from_parts(alice(), None)
+                    .expect("could not create property with metadata object"),
                 confidence: None,
-                property_metadata: PropertyMetadataObject::default(),
                 link_data: None,
                 draft: false,
                 relationships: [],
@@ -312,9 +312,9 @@ async fn type_ids() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![person_entity_type_id()],
-                properties: PropertyObject::empty(),
+                properties: PropertyWithMetadataObject::from_parts(PropertyObject::empty(), None)
+                    .expect("could not create property with metadata object"),
                 confidence: None,
-                property_metadata: PropertyMetadataObject::default(),
                 link_data: None,
                 draft: false,
                 relationships: [],

--- a/tests/hash-graph-integration/postgres/partial_updates.rs
+++ b/tests/hash-graph-integration/postgres/partial_updates.rs
@@ -87,7 +87,7 @@ async fn properties_add() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![person_entity_type_id()],
+                entity_type_ids: HashSet::from([person_entity_type_id()]),
                 properties: PropertyWithMetadataObject::from_parts(alice(), None)
                     .expect("could not create property with metadata object"),
                 confidence: None,
@@ -106,7 +106,7 @@ async fn properties_add() {
         PatchEntityParams {
             entity_id,
             decision_time: None,
-            entity_type_ids: vec![],
+            entity_type_ids: HashSet::new(),
             properties: vec![PropertyPatchOperation::Add {
                 path: once(PropertyPathElement::from(age_property_type_id())).collect(),
                 value: Property::Value(json!(30)),
@@ -163,7 +163,7 @@ async fn properties_remove() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![person_entity_type_id()],
+                entity_type_ids: HashSet::from([person_entity_type_id()]),
                 properties: PropertyWithMetadataObject::from_parts(alice(), None)
                     .expect("could not create property with metadata object"),
                 confidence: None,
@@ -182,7 +182,7 @@ async fn properties_remove() {
         PatchEntityParams {
             entity_id,
             decision_time: None,
-            entity_type_ids: vec![],
+            entity_type_ids: HashSet::new(),
             properties: vec![PropertyPatchOperation::Remove {
                 path: once(PropertyPathElement::from(name_property_type_id())).collect(),
             }],
@@ -235,7 +235,7 @@ async fn properties_replace() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![person_entity_type_id()],
+                entity_type_ids: HashSet::from([person_entity_type_id()]),
                 properties: PropertyWithMetadataObject::from_parts(alice(), None)
                     .expect("could not create property with metadata object"),
                 confidence: None,
@@ -254,7 +254,7 @@ async fn properties_replace() {
         PatchEntityParams {
             entity_id,
             decision_time: None,
-            entity_type_ids: vec![],
+            entity_type_ids: HashSet::new(),
             properties: vec![PropertyPatchOperation::Replace {
                 path: once(PropertyPathElement::from(name_property_type_id())).collect(),
                 value: Property::Value(json!("Bob")),
@@ -311,7 +311,7 @@ async fn type_ids() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![person_entity_type_id()],
+                entity_type_ids: HashSet::from([person_entity_type_id()]),
                 properties: PropertyWithMetadataObject::from_parts(PropertyObject::empty(), None)
                     .expect("could not create property with metadata object"),
                 confidence: None,
@@ -330,7 +330,7 @@ async fn type_ids() {
         PatchEntityParams {
             entity_id,
             decision_time: None,
-            entity_type_ids: vec![],
+            entity_type_ids: HashSet::new(),
             properties: vec![],
             draft: None,
             archived: None,
@@ -364,9 +364,11 @@ async fn type_ids() {
         .entities;
     assert_eq!(entities.len(), 1, "unexpected number of entities found");
     let entity = entities.into_iter().next().unwrap();
-    assert_eq!(
-        entity.metadata.entity_type_ids,
-        [person_entity_type_id()],
+    assert!(
+        entity
+            .metadata
+            .entity_type_ids
+            .contains(&person_entity_type_id()),
         "Entity type ids changed even though none were provided in the patch operation"
     );
 
@@ -375,7 +377,7 @@ async fn type_ids() {
         PatchEntityParams {
             entity_id,
             decision_time: None,
-            entity_type_ids: vec![person_entity_type_id(), org_entity_type_id()],
+            entity_type_ids: HashSet::from([person_entity_type_id(), org_entity_type_id()]),
             properties: vec![],
             draft: None,
             archived: None,
@@ -424,7 +426,7 @@ async fn type_ids() {
         PatchEntityParams {
             entity_id,
             decision_time: None,
-            entity_type_ids: vec![person_entity_type_id()],
+            entity_type_ids: HashSet::from([person_entity_type_id()]),
             properties: vec![],
             draft: None,
             archived: None,
@@ -459,5 +461,10 @@ async fn type_ids() {
     assert_eq!(entities.len(), 1, "unexpected number of entities found");
     let entity = entities.into_iter().next().unwrap();
 
-    assert_eq!(entity.metadata.entity_type_ids, [person_entity_type_id()],);
+    assert!(
+        entity
+            .metadata
+            .entity_type_ids
+            .contains(&person_entity_type_id())
+    );
 }

--- a/tests/hash-graph-integration/postgres/property_metadata.rs
+++ b/tests/hash-graph-integration/postgres/property_metadata.rs
@@ -13,7 +13,7 @@ use graph_types::{
         entity::{Location, ProvidedEntityEditionProvenance, SourceProvenance, SourceType},
         Confidence, ObjectMetadata, Property, PropertyMetadataElement, PropertyMetadataObject,
         PropertyObject, PropertyPatchOperation, PropertyPath, PropertyPathElement,
-        PropertyProvenance, ValueMetadata,
+        PropertyProvenance, PropertyWithMetadataObject, ValueMetadata,
     },
     owned_by_id::OwnedById,
 };
@@ -132,6 +132,7 @@ fn alice() -> PropertyObject {
 }
 
 #[tokio::test]
+#[expect(clippy::too_many_lines)]
 async fn initial_metadata() {
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = seed(&mut database).await;
@@ -161,9 +162,12 @@ async fn initial_metadata() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![person_entity_type_id()],
-                properties: alice(),
+                properties: PropertyWithMetadataObject::from_parts(
+                    alice(),
+                    Some(entity_property_metadata.clone()),
+                )
+                .expect("could not create property with metadata object"),
                 confidence: Confidence::new(0.5),
-                property_metadata: entity_property_metadata.clone(),
                 link_data: None,
                 draft: true,
                 relationships: [],
@@ -256,9 +260,9 @@ async fn no_initial_metadata() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![person_entity_type_id()],
-                properties: alice(),
+                properties: PropertyWithMetadataObject::from_parts(alice(), None)
+                    .expect("could not create property with metadata object"),
                 confidence: None,
-                property_metadata: PropertyMetadataObject::default(),
                 link_data: None,
                 draft: false,
                 relationships: [],
@@ -438,9 +442,9 @@ async fn properties_add() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![person_entity_type_id()],
-                properties: alice(),
+                properties: PropertyWithMetadataObject::from_parts(alice(), None)
+                    .expect("could not create property with metadata object"),
                 confidence: None,
-                property_metadata: PropertyMetadataObject::default(),
                 link_data: None,
                 draft: false,
                 relationships: [],
@@ -523,9 +527,9 @@ async fn properties_remove() {
                 entity_uuid: None,
                 decision_time: None,
                 entity_type_ids: vec![person_entity_type_id()],
-                properties: alice(),
+                properties: PropertyWithMetadataObject::from_parts(alice(), None)
+                    .expect("could not create property with metadata object"),
                 confidence: None,
-                property_metadata: PropertyMetadataObject::default(),
                 link_data: None,
                 draft: false,
                 relationships: [],

--- a/tests/hash-graph-integration/postgres/property_metadata.rs
+++ b/tests/hash-graph-integration/postgres/property_metadata.rs
@@ -1,6 +1,6 @@
 use alloc::borrow::Cow;
 use core::{iter::once, str::FromStr};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use authorization::AuthorizationApi;
 use graph::store::{
@@ -161,7 +161,7 @@ async fn initial_metadata() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![person_entity_type_id()],
+                entity_type_ids: HashSet::from([person_entity_type_id()]),
                 properties: PropertyWithMetadataObject::from_parts(
                     alice(),
                     Some(entity_property_metadata.clone()),
@@ -200,7 +200,7 @@ async fn initial_metadata() {
                     value: Property::Value(json!("Bob")),
                     metadata: Some(name_property_metadata.clone()),
                 }],
-                entity_type_ids: vec![],
+                entity_type_ids: HashSet::new(),
                 archived: None,
                 draft: None,
                 decision_time: None,
@@ -228,7 +228,7 @@ async fn initial_metadata() {
             PatchEntityParams {
                 entity_id: entity_metadata.record_id.entity_id,
                 properties: Vec::new(),
-                entity_type_ids: vec![],
+                entity_type_ids: HashSet::new(),
                 archived: None,
                 draft: None,
                 decision_time: None,
@@ -259,7 +259,7 @@ async fn no_initial_metadata() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![person_entity_type_id()],
+                entity_type_ids: HashSet::from([person_entity_type_id()]),
                 properties: PropertyWithMetadataObject::from_parts(alice(), None)
                     .expect("could not create property with metadata object"),
                 confidence: None,
@@ -296,7 +296,7 @@ async fn no_initial_metadata() {
             PatchEntityParams {
                 entity_id: entity_metadata.record_id.entity_id,
                 properties: Vec::new(),
-                entity_type_ids: vec![],
+                entity_type_ids: HashSet::new(),
                 archived: None,
                 draft: None,
                 decision_time: None,
@@ -315,7 +315,7 @@ async fn no_initial_metadata() {
             PatchEntityParams {
                 entity_id: entity_metadata.record_id.entity_id,
                 properties: Vec::new(),
-                entity_type_ids: vec![],
+                entity_type_ids: HashSet::new(),
                 archived: None,
                 draft: None,
                 decision_time: None,
@@ -360,7 +360,7 @@ async fn no_initial_metadata() {
                         },
                     }),
                 }],
-                entity_type_ids: vec![],
+                entity_type_ids: HashSet::new(),
                 archived: None,
                 draft: None,
                 decision_time: None,
@@ -395,7 +395,7 @@ async fn no_initial_metadata() {
             PatchEntityParams {
                 entity_id: entity_metadata.record_id.entity_id,
                 properties: Vec::new(),
-                entity_type_ids: vec![],
+                entity_type_ids: HashSet::new(),
                 archived: None,
                 draft: None,
                 decision_time: None,
@@ -441,7 +441,7 @@ async fn properties_add() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![person_entity_type_id()],
+                entity_type_ids: HashSet::from([person_entity_type_id()]),
                 properties: PropertyWithMetadataObject::from_parts(alice(), None)
                     .expect("could not create property with metadata object"),
                 confidence: None,
@@ -462,7 +462,7 @@ async fn properties_add() {
             PatchEntityParams {
                 entity_id,
                 decision_time: None,
-                entity_type_ids: vec![],
+                entity_type_ids: HashSet::new(),
                 properties: vec![PropertyPatchOperation::Add {
                     path: path.clone(),
                     value: Property::Value(json!(30)),
@@ -526,7 +526,7 @@ async fn properties_remove() {
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: None,
                 decision_time: None,
-                entity_type_ids: vec![person_entity_type_id()],
+                entity_type_ids: HashSet::from([person_entity_type_id()]),
                 properties: PropertyWithMetadataObject::from_parts(alice(), None)
                     .expect("could not create property with metadata object"),
                 confidence: None,
@@ -555,7 +555,7 @@ async fn properties_remove() {
             PatchEntityParams {
                 entity_id,
                 decision_time: None,
-                entity_type_ids: vec![],
+                entity_type_ids: HashSet::new(),
                 properties: vec![
                     PropertyPatchOperation::Add {
                         path: once(PropertyPathElement::from(interests_property_type_id()))
@@ -634,7 +634,7 @@ async fn properties_remove() {
             PatchEntityParams {
                 entity_id,
                 decision_time: None,
-                entity_type_ids: vec![],
+                entity_type_ids: HashSet::new(),
                 properties: vec![PropertyPatchOperation::Remove {
                     path: interests_path,
                 }],

--- a/tests/hash-graph-integration/postgres/sorting.rs
+++ b/tests/hash-graph-integration/postgres/sorting.rs
@@ -167,7 +167,7 @@ async fn insert<A: AuthorizationApi>(
                 owned_by_id: OwnedById::new(api.account_id.into_uuid()),
                 entity_uuid: Some(EntityUuid::new(Uuid::from_u128(idx as u128))),
                 decision_time: None,
-                entity_type_ids: vec![type_id.clone()],
+                entity_type_ids: HashSet::from([type_id.clone()]),
                 properties: PropertyWithMetadataObject::from_parts(properties.clone(), None)
                     .expect("could not create property with metadata object"),
                 confidence: None,

--- a/tests/hash-graph-integration/postgres/sorting.rs
+++ b/tests/hash-graph-integration/postgres/sorting.rs
@@ -17,7 +17,7 @@ use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::{
     knowledge::{
         entity::{EntityUuid, ProvidedEntityEditionProvenance},
-        PropertyMetadataObject, PropertyObject,
+        PropertyObject, PropertyWithMetadataObject,
     },
     owned_by_id::OwnedById,
 };
@@ -168,9 +168,9 @@ async fn insert<A: AuthorizationApi>(
                 entity_uuid: Some(EntityUuid::new(Uuid::from_u128(idx as u128))),
                 decision_time: None,
                 entity_type_ids: vec![type_id.clone()],
-                properties: properties.clone(),
+                properties: PropertyWithMetadataObject::from_parts(properties.clone(), None)
+                    .expect("could not create property with metadata object"),
                 confidence: None,
-                property_metadata: PropertyMetadataObject::default(),
                 link_data: None,
                 draft: false,
                 relationships: [],


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The layout of the property metadata needs to correspond to the properties in the entity. This adds a function to visit all nodes in metadata and executes a callback. In the validation code the callback is used to validate the path of a metadata.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph