### PR TITLE
H-2829: Fix deployment of backend in AWS

### DIFF
--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
@@ -1241,20 +1241,18 @@ export const upgradeEntitiesToNewTypeVersion: ImpureGraphFunction<
     {},
   );
 
-  await Promise.all(
-    [...users, ...orgs].map((webEntity) => {
-      const webOwnedById = extractOwnedByIdFromEntityId(
-        webEntity.metadata.recordId.entityId,
-      );
+  for (const webEntity of [...users, ...orgs]) {
+    const webOwnedById = extractOwnedByIdFromEntityId(
+      webEntity.metadata.recordId.entityId,
+    );
 
-      return upgradeWebEntities({
-        authentication,
-        context,
-        entityTypeBaseUrls,
-        migrationState,
-        migrateProperties,
-        webOwnedById,
-      });
-    }),
-  );
+    await upgradeWebEntities({
+      authentication,
+      context,
+      entityTypeBaseUrls,
+      migrationState,
+      migrateProperties,
+      webOwnedById,
+    });
+  }
 };

--- a/infra/terraform/hash/hash_application/api.tf
+++ b/infra/terraform/hash/hash_application/api.tf
@@ -37,9 +37,6 @@ locals {
     mountPoints      = []
     volumesFrom      = []
     command          = ["ensure-system-graph-is-initialized"]
-    dependsOn   = [
-      { condition = "HEALTHY", containerName = local.kratos_service_container_def.name },
-    ]
     logConfiguration = {
       logDriver = "awslogs"
       options   = {
@@ -58,6 +55,8 @@ locals {
         { name = "HASH_TEMPORAL_SERVER_PORT", value = var.temporal_port },
         { name = "HASH_GRAPH_API_HOST", value = local.graph_container_port_dns },
         { name = "HASH_GRAPH_API_PORT", value = tostring(local.graph_container_port) },
+        { name = "HASH_KRATOS_PUBLIC_URL", value = "http://${local.kratos_public_http_port_dns}:${local.kratos_public_port}" },
+        { name = "HASH_KRATOS_ADMIN_URL", value = "http://${local.kratos_private_http_port_dns}:${local.kratos_private_port}" },
       ])
 
     secrets = [
@@ -75,8 +74,6 @@ locals {
     volumesFrom = []
     dependsOn   = [
       { condition = "SUCCESS", containerName = local.api_migration_container_def.name },
-      { condition = "HEALTHY", containerName = local.hydra_service_container_def.name },
-      { condition = "HEALTHY", containerName = local.kratos_service_container_def.name },
     ]
     healthCheck = {
       command = [
@@ -114,6 +111,10 @@ locals {
         { name = "HASH_TEMPORAL_SERVER_PORT", value = var.temporal_port },
         { name = "HASH_GRAPH_API_HOST", value = local.graph_container_port_dns },
         { name = "HASH_GRAPH_API_PORT", value = tostring(local.graph_container_port) },
+        { name = "HASH_KRATOS_PUBLIC_URL", value = "http://${local.kratos_public_http_port_dns}:${local.kratos_public_port}" },
+        { name = "HASH_KRATOS_ADMIN_URL", value = "http://${local.kratos_private_http_port_dns}:${local.kratos_private_port}" },
+        { name = "HASH_HYDRA_PUBLIC_URL", value = "http://${local.hydra_public_http_port_dns}:${local.hydra_public_port}" },
+        { name = "HASH_HYDRA_ADMIN_URL", value = "http://${local.hydra_private_http_port_dns}:${local.hydra_private_port}" },
       ])
 
     secrets = [

--- a/infra/terraform/hash/hash_application/kratos.tf
+++ b/infra/terraform/hash/hash_application/kratos.tf
@@ -1,12 +1,15 @@
 locals {
-  kratos_service_name = "kratos"
-  kratos_prefix       = "${var.prefix}-${local.kratos_service_name}"
-  kratos_param_prefix = "${local.param_prefix}/${local.kratos_service_name}"
-  kratos_public_port  = 4433
-  kratos_private_port = 4434
-  kratos_env_vars     = concat(var.kratos_env_vars, local.kratos_email_env_vars)
+  kratos_service_name           = "kratos"
+  kratos_prefix                 = "${var.prefix}-${local.kratos_service_name}"
+  kratos_param_prefix           = "${local.param_prefix}/${local.kratos_service_name}"
+  kratos_public_port            = 4433
+  kratos_private_port           = 4434
+  kratos_public_http_port_name  = local.kratos_service_name
+  kratos_public_http_port_dns   = "${local.kratos_public_http_port_name}.${aws_service_discovery_private_dns_namespace.app.name}"
+  kratos_private_http_port_name = "${local.kratos_service_name}-private"
+  kratos_private_http_port_dns  = "${local.kratos_private_http_port_name}.${aws_service_discovery_private_dns_namespace.app.name}"
+  kratos_env_vars               = concat(var.kratos_env_vars, local.kratos_email_env_vars)
 }
-
 
 
 resource "aws_ssm_parameter" "kratos_env_vars" {
@@ -19,6 +22,96 @@ resource "aws_ssm_parameter" "kratos_env_vars" {
   value     = each.value.secret ? sensitive(each.value.value) : each.value.value
   overwrite = true
   tags      = {}
+}
+
+resource "aws_security_group" "kratos" {
+  name   = local.kratos_prefix
+  vpc_id = var.vpc.id
+
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    description = "Fargate tasks must have outbound access to allow outgoing traffic and access Amazon ECS endpoints."
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    description = "Allow connections to Postgres within the VPC"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  ingress {
+    from_port   = local.kratos_public_port
+    to_port     = local.kratos_public_port
+    protocol    = "tcp"
+    description = "Allow communication via HTTP"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  ingress {
+    from_port   = local.kratos_private_port
+    to_port     = local.kratos_private_port
+    protocol    = "tcp"
+    description = "Allow communication via HTTP"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+}
+
+resource "aws_ecs_task_definition" "kratos" {
+  family                   = local.kratos_prefix
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.cpu
+  memory                   = var.memory
+  network_mode             = "awsvpc"
+  execution_role_arn       = aws_iam_role.execution_role.arn
+  task_role_arn            = aws_iam_role.task_role.arn
+  container_definitions    = jsonencode([for task_def in local.kratos_task_defs : task_def.task_def])
+  tags = {}
+}
+
+resource "aws_ecs_service" "kratos" {
+  depends_on             = [aws_iam_role.task_role]
+  name                   = local.kratos_prefix
+  cluster                = data.aws_ecs_cluster.ecs.arn
+  task_definition        = aws_ecs_task_definition.kratos.arn
+  enable_execute_command = true
+  desired_count          = 1
+  launch_type            = "FARGATE"
+
+  network_configuration {
+    subnets          = var.subnets
+    assign_public_ip = true
+    security_groups  = [
+      aws_security_group.kratos.id,
+    ]
+  }
+
+  service_connect_configuration {
+    enabled   = true
+    namespace = aws_service_discovery_private_dns_namespace.app.arn
+
+    service {
+      port_name = local.kratos_public_http_port_name
+
+      client_alias {
+        port = local.kratos_public_port
+      }
+    }
+
+    service {
+      port_name = local.kratos_private_http_port_name
+
+      client_alias {
+        port = local.kratos_private_port
+      }
+    }
+  }
+
+  tags = { Service = "${local.prefix}svc" }
 }
 
 locals {
@@ -65,15 +158,15 @@ locals {
     }
     portMappings = [
       {
+        name          = local.kratos_public_http_port_name
         appProtocol   = "http"
         containerPort = local.kratos_public_port
-        hostPort      = local.kratos_public_port
         protocol      = "tcp"
       },
       {
+        name          = local.kratos_private_http_port_name
         appProtocol   = "http"
         containerPort = local.kratos_private_port
-        hostPort      = local.kratos_private_port
         protocol      = "tcp"
       }
     ]

--- a/infra/terraform/hash/prod-usea1.tfvars
+++ b/infra/terraform/hash/prod-usea1.tfvars
@@ -62,8 +62,6 @@ hash_graph_env_vars = [
 ]
 
 hash_api_migration_env_vars = [
-  { name = "HASH_KRATOS_PUBLIC_URL", secret = false, value = "http://localhost:4433" },
-  { name = "HASH_KRATOS_ADMIN_URL", secret = false, value = "http://localhost:4434" },
   { name = "LOG_LEVEL", secret = false, value = "debug" },
 ]
 
@@ -76,11 +74,6 @@ hash_api_env_vars = [
   { name = "FILE_UPLOAD_PROVIDER", secret = false, value = "AWS_S3" },
 
   { name = "HASH_OPENSEARCH_ENABLED", secret = false, value = "false" },
-
-  { name = "HASH_KRATOS_PUBLIC_URL", secret = false, value = "http://localhost:4433" },
-  { name = "HASH_KRATOS_ADMIN_URL", secret = false, value = "http://localhost:4434" },
-  { name = "HASH_HYDRA_PUBLIC_URL", secret = false, value = "http://localhost:4444" },
-  { name = "HASH_HYDRA_ADMIN_URL", secret = false, value = "http://localhost:4445" },
 
   # TODO: remove these deprecated system org variables
   { name = "SYSTEM_ACCOUNT_NAME", secret = false, value = "HASH" },

--- a/libs/@local/hash-backend-utils/src/hash-instance.ts
+++ b/libs/@local/hash-backend-utils/src/hash-instance.ts
@@ -89,8 +89,7 @@ export const isUserHashInstanceAdmin = async (
   authentication: { actorId: AccountId },
   { userAccountId }: { userAccountId: AccountId },
 ) => {
-  // eslint-disable-next-line no-console
-  console.info(`[${userAccountId}] Fetching HASH Instance entity`);
+  // console.info(`[${userAccountId}] Fetching HASH Instance entity`);
   const hashInstance = await getHashInstance(ctx, authentication).catch(
     (err) => {
       // eslint-disable-next-line no-console
@@ -100,10 +99,8 @@ export const isUserHashInstanceAdmin = async (
       throw err;
     },
   );
-  // eslint-disable-next-line no-console
-  console.info(`[${userAccountId}] SUCCESS Fetching HASH Instance entity`);
-  // eslint-disable-next-line no-console
-  console.info(`[${userAccountId}] Checking permission on instance`);
+  // console.info(`[${userAccountId}] SUCCESS Fetching HASH Instance entity`);
+  // console.info(`[${userAccountId}] Checking permission on instance`);
   return ctx.graphApi
     .checkEntityPermission(
       userAccountId,
@@ -111,17 +108,15 @@ export const isUserHashInstanceAdmin = async (
       "update",
     )
     .then(({ data }) => {
-      // eslint-disable-next-line no-console
-      console.info(
-        `[${userAccountId}] SUCCESS Checking permission on instance`,
-      );
+      // console.info(
+      //   `[${userAccountId}] SUCCESS Checking permission on instance`,
+      // );
       return data.has_permission;
     })
     .catch((err) => {
-      // eslint-disable-next-line no-console
-      console.error(
-        `[${userAccountId}] ERROR Checking permission on instance: ${err}`,
-      );
+      // console.error(
+      //   `[${userAccountId}] ERROR Checking permission on instance: ${err}`,
+      // );
       throw err;
     });
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When migrating, about 1000 requests are made at the same time. Until we figure out how to handle this gracefully, we don't migrate in parallel.

## 🔍 What does this change?

- For easier debugging, I moved the `kratos` and `hydra` tasks to a separate service
- Disable parallel migration
- Comment out logging for getting the HASH instance. It's a helpful output but very spammy.