### PR TITLE
H-2912: Fix loading Workers page, improve check for instance admin

### DIFF
--- a/apps/hash-api/src/graphql/resolvers/index.ts
+++ b/apps/hash-api/src/graphql/resolvers/index.ts
@@ -52,7 +52,7 @@ import {
 import { getEntityDiffsResolver } from "./knowledge/entity/get-entity-diffs";
 import { createFileFromUrl } from "./knowledge/file/create-file-from-url";
 import { requestFileUpload } from "./knowledge/file/request-file-upload";
-import { hashInstanceEntityResolver } from "./knowledge/hash-instance/hash-instance";
+import { hashInstanceSettingsResolver } from "./knowledge/hash-instance/hash-instance";
 import { createOrgResolver } from "./knowledge/org/create-org";
 import { pageContents } from "./knowledge/page";
 import {
@@ -127,7 +127,7 @@ export const resolvers: Omit<Resolvers, "Query" | "Mutation"> & {
       getEntityAuthorizationRelationshipsResolver,
     ),
     getEntitySubgraph: getEntitySubgraphResolver,
-    hashInstanceEntity: hashInstanceEntityResolver,
+    hashInstanceSettings: hashInstanceSettingsResolver,
     // Integration
     getLinearOrganization: loggedInAndSignedUpMiddleware(
       getLinearOrganizationResolver,

--- a/apps/hash-api/src/graphql/resolvers/knowledge/hash-instance/hash-instance.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/hash-instance/hash-instance.ts
@@ -1,12 +1,12 @@
 import { getHashInstance } from "@local/hash-backend-utils/hash-instance";
-import type { SerializedEntity } from "@local/hash-graph-sdk/entity";
 
-import type { ResolverFn } from "../../../api-types.gen";
+import { checkEntityPermission } from "../../../../graph/knowledge/primitive/entity";
+import type { HashInstanceSettings, ResolverFn } from "../../../api-types.gen";
 import type { GraphQLContext } from "../../../context";
 import { graphQLContextToImpureGraphContext } from "../../util";
 
-export const hashInstanceEntityResolver: ResolverFn<
-  Promise<SerializedEntity>,
+export const hashInstanceSettingsResolver: ResolverFn<
+  Promise<HashInstanceSettings>,
   Record<string, never>,
   GraphQLContext,
   Record<string, never>
@@ -14,7 +14,21 @@ export const hashInstanceEntityResolver: ResolverFn<
   const { authentication } = graphQLContext;
   const context = graphQLContextToImpureGraphContext(graphQLContext);
 
-  const hashInstance = await getHashInstance(context, authentication);
+  const { entity } = await getHashInstance(context, authentication);
 
-  return hashInstance.entity.toJSON();
+  const isUserAdmin = graphQLContext.user
+    ? await checkEntityPermission(
+        graphQLContextToImpureGraphContext(graphQLContext),
+        graphQLContext.authentication,
+        {
+          entityId: entity.metadata.recordId.entityId,
+          permission: "update",
+        },
+      )
+    : false;
+
+  return {
+    entity: entity.toJSON(),
+    isUserAdmin,
+  };
 };

--- a/apps/hash-frontend/src/components/hooks/use-hash-instance.ts
+++ b/apps/hash-frontend/src/components/hooks/use-hash-instance.ts
@@ -9,10 +9,10 @@ import type {
 import { useMemo } from "react";
 
 import type {
-  GetHashInstanceEntityQueryQuery,
-  GetHashInstanceEntityQueryQueryVariables,
+  GetHashInstanceSettingsQueryQuery,
+  GetHashInstanceSettingsQueryQueryVariables,
 } from "../../graphql/api-types.gen";
-import { getHashInstanceEntityQuery } from "../../graphql/queries/knowledge/hash-instance.queries";
+import { getHashInstanceSettings } from "../../graphql/queries/knowledge/hash-instance.queries";
 
 /**
  * Retrieves the HASH instance.
@@ -20,33 +20,35 @@ import { getHashInstanceEntityQuery } from "../../graphql/queries/knowledge/hash
 export const useHashInstance = (): {
   loading: boolean;
   hashInstance?: Simplified<HASHInstance>;
+  isUserAdmin: boolean;
 } => {
   const { data, loading } = useQuery<
-    GetHashInstanceEntityQueryQuery,
-    GetHashInstanceEntityQueryQueryVariables
-  >(getHashInstanceEntityQuery, {
+    GetHashInstanceSettingsQueryQuery,
+    GetHashInstanceSettingsQueryQueryVariables
+  >(getHashInstanceSettings, {
     fetchPolicy: "cache-and-network",
   });
 
-  const { hashInstanceEntity } = data ?? {};
+  const { hashInstanceSettings } = data ?? {};
 
   const hashInstance = useMemo<Simplified<HASHInstance> | undefined>(() => {
-    if (!hashInstanceEntity) {
+    if (!hashInstanceSettings) {
       return undefined;
     }
 
     const deserializedHashInstanceEntity = new Entity<HASHInstanceProperties>(
-      hashInstanceEntity,
+      hashInstanceSettings.entity,
     );
 
     return {
       metadata: deserializedHashInstanceEntity.metadata,
       properties: simplifyProperties(deserializedHashInstanceEntity.properties),
     };
-  }, [hashInstanceEntity]);
+  }, [hashInstanceSettings]);
 
   return {
     loading,
     hashInstance,
+    isUserAdmin: !!hashInstanceSettings?.isUserAdmin,
   };
 };

--- a/apps/hash-frontend/src/graphql/queries/knowledge/hash-instance.queries.ts
+++ b/apps/hash-frontend/src/graphql/queries/knowledge/hash-instance.queries.ts
@@ -1,8 +1,10 @@
 import { gql } from "@apollo/client";
 
-export const getHashInstanceEntityQuery = gql`
-  query getHashInstanceEntityQuery {
-    # This is a scalar, which has no selection.
-    hashInstanceEntity
+export const getHashInstanceSettings = gql`
+  query getHashInstanceSettingsQuery {
+    hashInstanceSettings {
+      entity
+      isUserAdmin
+    }
   }
 `;

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar.tsx
@@ -78,7 +78,7 @@ export const PageSidebar: FunctionComponent = () => {
         ? [
             {
               title: "Workers",
-              path: "/goals",
+              path: enabledFeatureFlags.ai ? "/goals" : "/flows",
               icon: <BoltLightIcon sx={{ fontSize: 16 }} />,
               tooltipTitle: "",
               activeIfPathMatches: /^\/@([^/]+)\/(flows|workers)\//,

--- a/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/knowledge/hash-instance.typedef.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/knowledge/hash-instance.typedef.ts
@@ -1,10 +1,15 @@
 import { gql } from "apollo-server-express";
 
 export const hashInstanceTypedef = gql`
+  type HashInstanceSettings {
+    entity: SerializedEntity!
+    isUserAdmin: Boolean!
+  }
+
   extend type Query {
     """
-    Get the HASH instance entity.
+    Get the HASH instance settings
     """
-    hashInstanceEntity: SerializedEntity!
+    hashInstanceSettings: HashInstanceSettings
   }
 `;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes a few things related to viewing feature flagged pages:
1. The 'Goals' page should not be visible if the AI feature flag is not enabled, but the other Flows pages should. The 'Workers' link in the sidebar needing fixing to go to 'Flows' if the user didn't have AI enabled, rather than goals
2. Admins should bypass all feature flags, but admin status wasn't being checked server-side
3. In service of fixing (2), make it easier / quicker to check admin status

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Log in as `admin@example.com` and check that you can click on the 'Workers' link in the sidebar and it loads a page