### PR TITLE
H-2916: Allow org admins to have dedicated permissions

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response.ts
@@ -161,6 +161,7 @@ export const getLlmResponse = async <T extends LlmParams>(
                     subject: {
                       kind: "accountGroup",
                       subjectId: hashInstanceAdminGroupId,
+                      subjectSet: "member",
                     },
                   },
                 ],

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/014-add-instance-admin-permission.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/014-add-instance-admin-permission.migration.ts
@@ -48,6 +48,7 @@ const migrate: MigrationFunction = async ({
           subject: {
             kind: "accountGroup",
             subjectId: hashInstanceAdminsAccountGroupId,
+            subjectSet: "member",
           },
         },
       },

--- a/apps/hash-api/src/graph/knowledge/system-types/hash-instance.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/hash-instance.ts
@@ -85,6 +85,7 @@ export const createHashInstance: ImpureGraphFunction<
         subject: {
           kind: "accountGroup",
           subjectId: hashInstanceAdminsAccountGroupId,
+          subjectSet: "member",
         },
       },
     ],

--- a/apps/hash-api/src/graph/knowledge/system-types/user.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user.ts
@@ -380,6 +380,7 @@ export const createUser: ImpureGraphFunction<
           subject: {
             kind: "accountGroup",
             subjectId: hashInstanceAdminsAccountGroupId,
+            subjectSet: "member",
           },
         },
         {

--- a/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -547,6 +547,7 @@ const parseGqlAuthorizationViewerInput = ({
     return {
       kind: "accountGroup",
       subjectId: viewer as AccountGroupId,
+      subjectSet: "member",
     } as const;
   }
 };

--- a/apps/hash-api/src/graphql/resolvers/knowledge/user/submit-early-access-form.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/user/submit-early-access-form.ts
@@ -47,6 +47,7 @@ export const submitEarlyAccessFormResolver: ResolverFn<
           subject: {
             kind: "accountGroup",
             subjectId: adminAccountGroupId,
+            subjectSet: "member",
           },
         },
         {

--- a/apps/hash-graph/libs/api/src/rest/entity.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity.rs
@@ -99,6 +99,7 @@ use crate::rest::{
 
             EntityRelationAndSubject,
             EntityPermission,
+            EntitySubjectSet,
             EntitySettingSubject,
             EntityOwnerSubject,
             EntityAdministratorSubject,

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -3636,6 +3636,7 @@
             "type": "object",
             "required": [
               "subjectId",
+              "subjectSet",
               "kind"
             ],
             "properties": {
@@ -3647,6 +3648,9 @@
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
+              },
+              "subjectSet": {
+                "$ref": "#/components/schemas/EntitySubjectSet"
               }
             }
           }
@@ -3708,6 +3712,7 @@
             "type": "object",
             "required": [
               "subjectId",
+              "subjectSet",
               "kind"
             ],
             "properties": {
@@ -3719,6 +3724,9 @@
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
+              },
+              "subjectSet": {
+                "$ref": "#/components/schemas/EntitySubjectSet"
               }
             }
           }
@@ -4073,6 +4081,13 @@
         "discriminator": {
           "propertyName": "kind"
         }
+      },
+      "EntitySubjectSet": {
+        "type": "string",
+        "enum": [
+          "administrator",
+          "member"
+        ]
       },
       "EntityTemporalMetadata": {
         "type": "object",
@@ -4573,6 +4588,7 @@
             "type": "object",
             "required": [
               "subjectId",
+              "subjectSet",
               "kind"
             ],
             "properties": {
@@ -4584,6 +4600,9 @@
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
+              },
+              "subjectSet": {
+                "$ref": "#/components/schemas/EntitySubjectSet"
               }
             }
           }

--- a/libs/@local/hash-authorization/schemas/v1__initial_schema.zed
+++ b/libs/@local/hash-authorization/schemas/v1__initial_schema.zed
@@ -64,15 +64,15 @@ definition graph/entity {
     relation level_00_owner: graph/web
 
 	// Administration
-	relation level_00_administrator: graph/account | graph/account_group#member
+	relation level_00_administrator: graph/account | graph/account_group#member | graph/account_group#administrator
 	// the `level_00_owner` relation in the web is an account or an account group. In addition to the manually specified admin on an entity,
 	//   - For account webs: the account who is owning the web will have full access, always
 	//   - For account group webs: if the setting `admin` is set the org admin will have full access
 	permission full_access = level_00_administrator + (level_00_setting->level_00_administrator & level_00_owner->administrator)
 
 	// Permissions
-	relation level_00_editor: graph/account | graph/account_group#member
-	relation level_00_viewer: graph/account | graph/account_group#member | graph/account:*
+	relation level_00_editor: graph/account | graph/account_group#member | graph/account_group#administrator
+	relation level_00_viewer: graph/account | graph/account_group#member | graph/account_group#administrator | graph/account:*
 
 	permission update = full_access + level_00_editor + (level_00_setting->level_00_update & level_00_owner->update_entity)
 	permission view = update + level_00_viewer + (level_00_setting->level_00_view & level_00_owner->view_entity)

--- a/libs/@local/hash-authorization/src/schema/entity.rs
+++ b/libs/@local/hash-authorization/src/schema/entity.rs
@@ -87,10 +87,11 @@ pub enum EntitySubject {
     AccountGroup(AccountGroupId),
 }
 
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum EntitySubjectSet {
-    #[default]
+    Administrator,
     Member,
 }
 
@@ -212,7 +213,7 @@ pub enum EntityAdministratorSubject {
     AccountGroup {
         #[serde(rename = "subjectId")]
         id: AccountGroupId,
-        #[serde(skip)]
+        #[serde(rename = "subjectSet")]
         set: EntitySubjectSet,
     },
 }
@@ -228,7 +229,7 @@ pub enum EntityEditorSubject {
     AccountGroup {
         #[serde(rename = "subjectId")]
         id: AccountGroupId,
-        #[serde(skip)]
+        #[serde(rename = "subjectSet")]
         set: EntitySubjectSet,
     },
 }
@@ -245,7 +246,7 @@ pub enum EntityViewerSubject {
     AccountGroup {
         #[serde(rename = "subjectId")]
         id: AccountGroupId,
-        #[serde(skip)]
+        #[serde(rename = "subjectSet")]
         set: EntitySubjectSet,
     },
 }

--- a/libs/@local/hash-backend-utils/src/service-usage.ts
+++ b/libs/@local/hash-backend-utils/src/service-usage.ts
@@ -293,6 +293,7 @@ export const createUsageRecord = async (
       subject: {
         kind: "accountGroup",
         subjectId: hashInstanceAdminGroupId,
+        subjectSet: "member",
       },
     },
   ];


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, we only allow account group members to have permissions on entities. This extends to the account group admins and makes specifying the subject set required.