### PR TITLE
H-2918: Revert "Move `kratos` and `hydra` tasks to separate service"

### DIFF
--- a/infra/terraform/hash/hash_application/api.tf
+++ b/infra/terraform/hash/hash_application/api.tf
@@ -37,6 +37,9 @@ locals {
     mountPoints      = []
     volumesFrom      = []
     command          = ["ensure-system-graph-is-initialized"]
+    dependsOn   = [
+      { condition = "HEALTHY", containerName = local.kratos_service_container_def.name },
+    ]
     logConfiguration = {
       logDriver = "awslogs"
       options   = {
@@ -55,8 +58,6 @@ locals {
         { name = "HASH_TEMPORAL_SERVER_PORT", value = var.temporal_port },
         { name = "HASH_GRAPH_API_HOST", value = local.graph_container_port_dns },
         { name = "HASH_GRAPH_API_PORT", value = tostring(local.graph_container_port) },
-        { name = "HASH_KRATOS_PUBLIC_URL", value = "http://${local.kratos_public_http_port_dns}:${local.kratos_public_port}" },
-        { name = "HASH_KRATOS_ADMIN_URL", value = "http://${local.kratos_private_http_port_dns}:${local.kratos_private_port}" },
       ])
 
     secrets = [
@@ -74,6 +75,8 @@ locals {
     volumesFrom = []
     dependsOn   = [
       { condition = "SUCCESS", containerName = local.api_migration_container_def.name },
+      { condition = "HEALTHY", containerName = local.hydra_service_container_def.name },
+      { condition = "HEALTHY", containerName = local.kratos_service_container_def.name },
     ]
     healthCheck = {
       command = [
@@ -111,10 +114,6 @@ locals {
         { name = "HASH_TEMPORAL_SERVER_PORT", value = var.temporal_port },
         { name = "HASH_GRAPH_API_HOST", value = local.graph_container_port_dns },
         { name = "HASH_GRAPH_API_PORT", value = tostring(local.graph_container_port) },
-        { name = "HASH_KRATOS_PUBLIC_URL", value = "http://${local.kratos_public_http_port_dns}:${local.kratos_public_port}" },
-        { name = "HASH_KRATOS_ADMIN_URL", value = "http://${local.kratos_private_http_port_dns}:${local.kratos_private_port}" },
-        { name = "HASH_HYDRA_PUBLIC_URL", value = "http://${local.hydra_public_http_port_dns}:${local.hydra_public_port}" },
-        { name = "HASH_HYDRA_ADMIN_URL", value = "http://${local.hydra_private_http_port_dns}:${local.hydra_private_port}" },
       ])
 
     secrets = [

--- a/infra/terraform/hash/hash_application/hydra.tf
+++ b/infra/terraform/hash/hash_application/hydra.tf
@@ -4,12 +4,7 @@ locals {
   hydra_param_prefix = "${local.param_prefix}/${local.hydra_service_name}"
   hydra_public_port  = 4444
   hydra_private_port = 4445
-  hydra_public_http_port_name  = local.hydra_service_name
-  hydra_public_http_port_dns   = "${local.hydra_public_http_port_name}.${aws_service_discovery_private_dns_namespace.app.name}"
-  hydra_private_http_port_name = "${local.hydra_service_name}-private"
-  hydra_private_http_port_dns  = "${local.hydra_private_http_port_name}.${aws_service_discovery_private_dns_namespace.app.name}"
 }
-
 
 resource "aws_ssm_parameter" "hydra_env_vars" {
   # Only put secrets into SSM
@@ -21,96 +16,6 @@ resource "aws_ssm_parameter" "hydra_env_vars" {
   value     = each.value.secret ? sensitive(each.value.value) : each.value.value
   overwrite = true
   tags      = {}
-}
-
-resource "aws_security_group" "hydra" {
-  name   = local.hydra_prefix
-  vpc_id = var.vpc.id
-
-  egress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    description = "Fargate tasks must have outbound access to allow outgoing traffic and access Amazon ECS endpoints."
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = 5432
-    to_port     = 5432
-    protocol    = "tcp"
-    description = "Allow connections to Postgres within the VPC"
-    cidr_blocks = [var.vpc.cidr_block]
-  }
-
-  ingress {
-    from_port   = local.hydra_public_port
-    to_port     = local.hydra_public_port
-    protocol    = "tcp"
-    description = "Allow communication via HTTP"
-    cidr_blocks = [var.vpc.cidr_block]
-  }
-
-  ingress {
-    from_port   = local.hydra_private_port
-    to_port     = local.hydra_private_port
-    protocol    = "tcp"
-    description = "Allow communication via HTTP"
-    cidr_blocks = [var.vpc.cidr_block]
-  }
-}
-
-resource "aws_ecs_task_definition" "hydra" {
-  family                   = local.hydra_prefix
-  requires_compatibilities = ["FARGATE"]
-  cpu                      = var.cpu
-  memory                   = var.memory
-  network_mode             = "awsvpc"
-  execution_role_arn       = aws_iam_role.execution_role.arn
-  task_role_arn            = aws_iam_role.task_role.arn
-  container_definitions    = jsonencode([for task_def in local.hydra_task_defs : task_def.task_def])
-  tags = {}
-}
-
-resource "aws_ecs_service" "hydra" {
-  depends_on             = [aws_iam_role.task_role]
-  name                   = local.hydra_prefix
-  cluster                = data.aws_ecs_cluster.ecs.arn
-  task_definition        = aws_ecs_task_definition.hydra.arn
-  enable_execute_command = true
-  desired_count          = 1
-  launch_type            = "FARGATE"
-
-  network_configuration {
-    subnets          = var.subnets
-    assign_public_ip = true
-    security_groups  = [
-      aws_security_group.hydra.id,
-    ]
-  }
-
-  service_connect_configuration {
-    enabled   = true
-    namespace = aws_service_discovery_private_dns_namespace.app.arn
-
-    service {
-      port_name = local.hydra_public_http_port_name
-
-      client_alias {
-        port = local.hydra_public_port
-      }
-    }
-
-    service {
-      port_name = local.hydra_private_http_port_name
-
-      client_alias {
-        port = local.hydra_private_port
-      }
-    }
-  }
-
-  tags = { Service = "${local.prefix}svc" }
 }
 
 locals {
@@ -157,15 +62,15 @@ locals {
     }
     portMappings = [
       {
-        name          = local.hydra_public_http_port_name
         appProtocol   = "http"
         containerPort = local.hydra_public_port
+        hostPort      = local.hydra_public_port
         protocol      = "tcp"
       },
       {
-        name          = local.hydra_private_http_port_name
         appProtocol   = "http"
         containerPort = local.hydra_private_port
+        hostPort      = local.hydra_private_port
         protocol      = "tcp"
       }
     ]

--- a/infra/terraform/hash/hash_application/main.tf
+++ b/infra/terraform/hash/hash_application/main.tf
@@ -13,30 +13,6 @@ locals {
       env_vars = aws_ssm_parameter.spicedb_env_vars
     },
   ]
-  kratos_task_defs = [
-    {
-      task_def = local.kratos_migration_container_def
-      env_vars = aws_ssm_parameter.kratos_env_vars
-      ecr_arn  = var.kratos_image.ecr_arn
-    },
-    {
-      task_def = local.kratos_service_container_def
-      env_vars = aws_ssm_parameter.kratos_env_vars
-      ecr_arn  = var.kratos_image.ecr_arn
-    },
-  ]
-  hydra_task_defs = [
-    {
-      task_def = local.hydra_migration_container_def
-      env_vars = aws_ssm_parameter.hydra_env_vars
-      ecr_arn  = var.hydra_image.ecr_arn
-    },
-    {
-      task_def = local.hydra_service_container_def
-      env_vars = aws_ssm_parameter.hydra_env_vars
-      ecr_arn  = var.hydra_image.ecr_arn
-    },
-  ]
   graph_task_defs = [
     {
       task_def = local.graph_migration_container_def
@@ -56,6 +32,26 @@ locals {
   ]
   task_defs = [
     {
+      task_def = local.kratos_migration_container_def
+      env_vars = aws_ssm_parameter.kratos_env_vars
+      ecr_arn  = var.kratos_image.ecr_arn
+    },
+    {
+      task_def = local.kratos_service_container_def
+      env_vars = aws_ssm_parameter.kratos_env_vars
+      ecr_arn  = var.kratos_image.ecr_arn
+    },
+    {
+      task_def = local.hydra_migration_container_def
+      env_vars = aws_ssm_parameter.hydra_env_vars
+      ecr_arn  = var.hydra_image.ecr_arn
+    },
+    {
+      task_def = local.hydra_service_container_def
+      env_vars = aws_ssm_parameter.hydra_env_vars
+      ecr_arn  = var.hydra_image.ecr_arn
+    },
+    {
       task_def = local.api_service_container_def
       env_vars = aws_ssm_parameter.api_env_vars
       ecr_arn  = var.api_image.ecr_arn
@@ -66,6 +62,8 @@ locals {
       ecr_arn  = var.api_image.ecr_arn
     },
   ]
+  # To scale up the worker we probably want to move these into a separated service. They are defined in this task
+  # to easily connect to the Graph API.
   worker_task_defs = [
     {
       task_def = local.temporal_worker_ai_ts_service_container_def
@@ -264,28 +262,6 @@ resource "aws_iam_role" "execution_role" {
             Resource = concat(
               flatten([
                 for def in local.spicedb_task_defs : [for _, env_var in def.env_vars : env_var.arn]
-              ])
-            )
-          }
-        ],
-        [
-          {
-            Effect   = "Allow"
-            Action   = ["ssm:GetParameters"]
-            Resource = concat(
-              flatten([
-                for def in local.kratos_task_defs : [for _, env_var in def.env_vars : env_var.arn]
-              ])
-            )
-          }
-        ],
-        [
-          {
-            Effect   = "Allow"
-            Action   = ["ssm:GetParameters"]
-            Resource = concat(
-              flatten([
-                for def in local.hydra_task_defs : [for _, env_var in def.env_vars : env_var.arn]
               ])
             )
           }
@@ -523,34 +499,6 @@ resource "aws_security_group" "app_sg" {
     protocol    = "tcp"
     description = "Allow outbound gRPC connections to Temporal"
     cidr_blocks = ["0.0.0.0/0"]
-  }
-  egress {
-    from_port   = local.kratos_public_port
-    to_port     = local.kratos_public_port
-    protocol    = "tcp"
-    description = "Allow connections to kratos"
-    cidr_blocks = [var.vpc.cidr_block]
-  }
-  egress {
-    from_port   = local.kratos_private_port
-    to_port     = local.kratos_private_port
-    protocol    = "tcp"
-    description = "Allow connections to kratos"
-    cidr_blocks = [var.vpc.cidr_block]
-  }
-  egress {
-    from_port   = local.hydra_public_port
-    to_port     = local.hydra_public_port
-    protocol    = "tcp"
-    description = "Allow connections to hydra"
-    cidr_blocks = [var.vpc.cidr_block]
-  }
-  egress {
-    from_port   = local.hydra_private_port
-    to_port     = local.hydra_private_port
-    protocol    = "tcp"
-    description = "Allow connections to hydra"
-    cidr_blocks = [var.vpc.cidr_block]
   }
   egress {
     from_port   = local.graph_container_port

--- a/infra/terraform/hash/prod-usea1.tfvars
+++ b/infra/terraform/hash/prod-usea1.tfvars
@@ -62,6 +62,8 @@ hash_graph_env_vars = [
 ]
 
 hash_api_migration_env_vars = [
+  { name = "HASH_KRATOS_PUBLIC_URL", secret = false, value = "http://localhost:4433" },
+  { name = "HASH_KRATOS_ADMIN_URL", secret = false, value = "http://localhost:4434" },
   { name = "LOG_LEVEL", secret = false, value = "debug" },
 ]
 
@@ -74,6 +76,11 @@ hash_api_env_vars = [
   { name = "FILE_UPLOAD_PROVIDER", secret = false, value = "AWS_S3" },
 
   { name = "HASH_OPENSEARCH_ENABLED", secret = false, value = "false" },
+
+  { name = "HASH_KRATOS_PUBLIC_URL", secret = false, value = "http://localhost:4433" },
+  { name = "HASH_KRATOS_ADMIN_URL", secret = false, value = "http://localhost:4434" },
+  { name = "HASH_HYDRA_PUBLIC_URL", secret = false, value = "http://localhost:4444" },
+  { name = "HASH_HYDRA_ADMIN_URL", secret = false, value = "http://localhost:4445" },
 
   # TODO: remove these deprecated system org variables
   { name = "SYSTEM_ACCOUNT_NAME", secret = false, value = "HASH" },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This reverts commit 4106b12f988da86b23c9ef7128a8e6f079be8915 from #4590 as it is causing some issues in production – the API is timing out, seemingly related to issues with signin/signup.
<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
