### PR TITLE
H-2920: Temporary migration to fix incomplete user accounts

### DIFF
--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/018-fix-incomplete-user-accounts.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/018-fix-incomplete-user-accounts.migration.ts
@@ -1,0 +1,58 @@
+import { isSelfHostedInstance } from "@local/hash-isomorphic-utils/instance";
+
+import {
+  createUser,
+  getUserByKratosIdentityId,
+} from "../../../knowledge/system-types/user";
+import type { MigrationFunction } from "../types";
+
+const migrate: MigrationFunction = async ({
+  context,
+  authentication,
+  migrationState,
+}) => {
+  if (isSelfHostedInstance) {
+    /**
+     * Fix is only relevant to hosted HASH, i.e. the instance at https://[app].hash.ai
+     */
+    return migrationState;
+  }
+
+  const incompleteUsers = process.env.INCOMPLETE_USER_ACCOUNTS;
+
+  if (!incompleteUsers) {
+    return migrationState;
+  }
+
+  try {
+    const incompleteUserSets = JSON.parse(incompleteUsers) as [
+      string,
+      string,
+    ][];
+    for (const user of incompleteUserSets) {
+      const kratosIdentityId = user[0];
+
+      const existingUser = await getUserByKratosIdentityId(
+        context,
+        authentication,
+        {
+          kratosIdentityId,
+        },
+      );
+      if (!existingUser) {
+        await createUser(context, authentication, {
+          emails: [user[1]],
+          kratosIdentityId,
+        });
+      }
+    }
+
+    return migrationState;
+  } catch (err) {
+    throw new Error(
+      `Could not parse incomplete user accounts: ${(err as Error).message}`,
+    );
+  }
+};
+
+export default migrate;

--- a/infra/terraform/hash/hash_application/main.tf
+++ b/infra/terraform/hash/hash_application/main.tf
@@ -62,8 +62,6 @@ locals {
       ecr_arn  = var.api_image.ecr_arn
     },
   ]
-  # To scale up the worker we probably want to move these into a separated service. They are defined in this task
-  # to easily connect to the Graph API.
   worker_task_defs = [
     {
       task_def = local.temporal_worker_ai_ts_service_container_def

--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -298,6 +298,10 @@ module "application" {
   ])
   api_image              = module.api_ecr
   api_migration_env_vars = concat(var.hash_api_migration_env_vars, [
+    {
+      name  = "INCOMPLETE_USER_ACCOUNTS", secret = true,
+      value = sensitive(data.vault_kv_secret_v2.secrets.data["incomplete_user_accounts"])
+    },
   ])
   api_env_vars = concat(var.hash_api_env_vars, [
     {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes incomplete user accounts which were created during the period when registration could not be completed (fixed by #4613).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

The commit will be reverted once the migration is run.
<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Add a variable to your `.env.local`

`INCOMPLETE_USER_ACCOUNTS=[["some-uuid", "email@example.com"]]`

2. When running `yarn dev:backend:api` the user account should be created. It will not be able to login unless you have created a Kratos identity for it with `some-uuid` as the identity uuid

