### PR TITLE
H-2929: Fix CI failing due to Turborepo pruning Rust crates

### DIFF
--- a/.github/actions/prune-repository/action.yml
+++ b/.github/actions/prune-repository/action.yml
@@ -24,7 +24,8 @@ runs:
           DIRECTORY=$(dirname "$line")
           echo "Processing $DIRECTORY..."
           # Create a dummy crate if it does not exist
-          if [[ ! -d "out/$DIRECTORY" ]]; then
+          # check Cargo.toml for this
+          if [[ ! -f "out/$DIRECTORY/Cargo.toml" ]]; then
             mkdir -p "out/$DIRECTORY/src"
             echo > "out/$DIRECTORY/src/lib.rs"
             echo -e "[package]\nname = \"$(yq '.package.name' -p toml -oy $line)\"" > "out/$DIRECTORY/Cargo.toml"

--- a/.github/actions/prune-repository/action.yml
+++ b/.github/actions/prune-repository/action.yml
@@ -22,18 +22,12 @@ runs:
 
         while IFS= read -r line; do
           DIRECTORY=$(dirname "$line")
-          echo "Processing $DIRECTORY..."
           # Create a dummy crate if it does not exist
-          # check Cargo.toml for this
           if [[ ! -f "out/$DIRECTORY/Cargo.toml" ]]; then
             mkdir -p "out/$DIRECTORY/src"
             echo > "out/$DIRECTORY/src/lib.rs"
             echo -e "[package]\nname = \"$(yq '.package.name' -p toml -oy $line)\"" > "out/$DIRECTORY/Cargo.toml"
-            echo "existing files:"
-            ls -Ar out/$DIRECTORY
           fi
-          cat "out/$DIRECTORY/Cargo.toml"
-          echo "Checking done"
         done < <(find $(yq '.workspace.members' -p toml -o tsv Cargo.toml | tr '*' ' ') -maxdepth 2 -name Cargo.toml)
 
     - name: Copy required files

--- a/.github/actions/prune-repository/action.yml
+++ b/.github/actions/prune-repository/action.yml
@@ -22,12 +22,17 @@ runs:
 
         while IFS= read -r line; do
           DIRECTORY=$(dirname "$line")
+          echo "Processing $DIRECTORY..."
           # Create a dummy crate if it does not exist
           if [[ ! -d "out/$DIRECTORY" ]]; then
             mkdir -p "out/$DIRECTORY/src"
             echo > "out/$DIRECTORY/src/lib.rs"
             echo -e "[package]\nname = \"$(yq '.package.name' -p toml -oy $line)\"" > "out/$DIRECTORY/Cargo.toml"
+            echo "existing files:"
+            ls -Ar out/$DIRECTORY
           fi
+          cat "out/$DIRECTORY/Cargo.toml"
+          echo "Checking done"
         done < <(find $(yq '.workspace.members' -p toml -o tsv Cargo.toml | tr '*' ' ') -maxdepth 2 -name Cargo.toml)
 
     - name: Copy required files


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Since the latest runner image, the CI is failing because turbo is pruning Rust crates even though a workaround should re-add them. If Turborepo knew that Rust is a thing, this wouldn't even be needed.