### PR TITLE
H-2935: Reduce GHA update frequency

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,7 +32,7 @@
       "additionalBranchPrefix": "gha/",
       "pinDigests": true,
       "dependencyDashboardApproval": false,
-      "schedule": ["after 5am on saturday"]
+      "schedule": ["before 2am on saturday"]
     },
     {
       "packageRules": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,15 +31,8 @@
       "commitMessageTopic": "GitHub Action `{{depName}}`",
       "additionalBranchPrefix": "gha/",
       "pinDigests": true,
-      "dependencyDashboardApproval": false
-    },
-    {
-      "packageRules": [
-        {
-          "matchPackageNames": ["taiki-e/install-action"],
-          "schedule": ["after 9pm on sunday"]
-        }
-      ]
+      "dependencyDashboardApproval": false,
+      "schedule": ["after 5am on saturday"]
     },
     {
       "packageRules": [


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Reduces the frequency with which Renovate attempts to open PRs for GitHub Actions with available updates (following work previously done to limit `taiki-e/install-action` update frequencies.