### PR TITLE
H-2761: Fix frontend environment variables

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,7 +84,7 @@ jobs:
         run: yarn sentry-cli login --auth-token ${{ steps.secrets.outputs.SENTRY_AUTH_TOKEN }}
 
       - name: Build sourcemaps
-        run: turbo run sentry:sourcemaps --filter --env-mode=loose "${{ matrix.package }}"
+        run: turbo run sentry:sourcemaps --env-mode=loose --filter "${{ matrix.package }}"
 
   passed:
     name: Deployments passed

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,7 +84,7 @@ jobs:
         run: yarn sentry-cli login --auth-token ${{ steps.secrets.outputs.SENTRY_AUTH_TOKEN }}
 
       - name: Build sourcemaps
-        run: turbo run sentry:sourcemaps --filter "${{ matrix.package }}"
+        run: turbo run sentry:sourcemaps --filter --env-mode=loose "${{ matrix.package }}"
 
   passed:
     name: Deployments passed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,7 +190,7 @@ jobs:
         env:
           TEST_COVERAGE: ${{ github.event_name != 'merge_group' }}
         run: |
-          turbo run test:unit --filter "${{ matrix.package }}"
+          turbo run test:unit --env-mode=loose --filter "${{ matrix.package }}"
           echo "TRIMMED_PACKAGE_NAME=$(echo "${{ matrix.package }}" | sed 's|@||g' | sed 's|/|.|g')" >> $GITHUB_ENV
 
       - name: Show disk usage
@@ -246,7 +246,7 @@ jobs:
       - name: Find test steps to run
         id: tests
         run: |
-          TEST_TASKS=$(turbo run test:integration --dry-run=json --filter "${{ matrix.package }}" | jq -c '.tasks[]')
+          TEST_TASKS=$(turbo run test:integration --env-mode=loose --dry-run=json --filter "${{ matrix.package }}" | jq -c '.tasks[]')
           REQUIRES_GRAPH=$(echo "$TEST_TASKS" | jq -s '[.[] | select((.package == "@apps/hash-graph" or .package == "@rust/graph") and .task == "build")] != []')
           REQUIRES_AI_WORKER_TS=$(echo "$TEST_TASKS" | jq -s '[.[] | select(.package == "@apps/hash-ai-worker-ts" and .task == "build")] != []')
           REQUIRES_INTEGRATION_WORKER=$(echo "$TEST_TASKS" | jq -s '[.[] | select(.package == "@apps/hash-worker-integration" and .task == "build")] != []')
@@ -346,7 +346,7 @@ jobs:
       - name: Run tests
         continue-on-error: ${{ steps.tests.outputs.allow-failure == 'true' }}
         run: |
-          turbo run test:integration --filter "${{ matrix.package }}"
+          turbo run test:integration --env-mode=loose --filter "${{ matrix.package }}"
           echo "TRIMMED_PACKAGE_NAME=$(echo "${{ matrix.package }}" | sed 's|@||g' | sed 's|/|.|g')" >> $GITHUB_ENV
 
       - name: Show disk usage
@@ -463,7 +463,7 @@ jobs:
 
       - name: Migrate HASH-API
         run: |
-          turbo run build --filter "@apps/hash-api"
+          turbo run build --env-mode=loose --filter "@apps/hash-api"
           yarn workspace @apps/hash-api ensure-system-graph-is-initialized
 
       - name: Launch HASH-API
@@ -473,7 +473,7 @@ jobs:
 
       - name: Launch frontend
         run: |
-          turbo run build --filter "@apps/hash-frontend"
+          turbo run build --env-mode=loose --filter "@apps/hash-frontend"
           yarn workspace @apps/hash-frontend start 2>&1 | tee var/logs/frontend.log &
           yarn wait-on --timeout 60000 http://0.0.0.0:3000
 
@@ -482,7 +482,7 @@ jobs:
 
       - name: Run tests
         run: |
-          turbo run test:system --filter "${{ matrix.package }}"
+          turbo run test:system --env-mode=loose --filter "${{ matrix.package }}"
 
       - name: Show disk usage
         run: df -h

--- a/apps/hash-ai-worker-ts/docker/Dockerfile
+++ b/apps/hash-ai-worker-ts/docker/Dockerfile
@@ -52,7 +52,7 @@ RUN yarn install --frozen-lockfile --prefer-offline && \
 
 COPY --from=base /app/out/full/ .
 
-RUN yarn turbo build --filter '@apps/hash-ai-worker-ts' && rm -rf target/
+RUN yarn turbo build --filter '@apps/hash-ai-worker-ts' --env-mode=loose && rm -rf target/
 
 
 FROM node:20.13-slim AS runner

--- a/apps/hash-frontend/vercel-build.sh
+++ b/apps/hash-frontend/vercel-build.sh
@@ -9,4 +9,4 @@ echo "Changing dir to root"
 cd ../..
 
 echo "Building frontend"
-turbo build --filter='@apps/hash-frontend'
+turbo build --filter='@apps/hash-frontend' --env-mode=loose

--- a/apps/hash-integration-worker/docker/Dockerfile
+++ b/apps/hash-integration-worker/docker/Dockerfile
@@ -52,7 +52,7 @@ RUN yarn install --frozen-lockfile --prefer-offline && \
 
 COPY --from=base /app/out/full/ .
 
-RUN yarn turbo build --filter '@apps/hash-integration-worker' && rm -rf target/
+RUN yarn turbo build --filter '@apps/hash-integration-worker' --env-mode=loose && rm -rf target/
 
 
 FROM node:20.13-slim AS runner

--- a/apps/hashdotdesign/vercel-build.sh
+++ b/apps/hashdotdesign/vercel-build.sh
@@ -6,4 +6,4 @@ echo "Changing dir to root"
 cd ../..
 
 echo "Building hash.design"
-turbo build --filter='@apps/hashdotdesign'
+turbo build --filter='@apps/hashdotdesign' --env-mode=loose

--- a/apps/hashdotdev/vercel-build.sh
+++ b/apps/hashdotdev/vercel-build.sh
@@ -6,4 +6,4 @@ echo "Changing dir to root"
 cd ../..
 
 echo "Building hash.design"
-turbo build --filter='@apps/hashdotdev'
+turbo build --filter='@apps/hashdotdev' --env-mode=loose

--- a/infra/docker/api/prod/Dockerfile
+++ b/infra/docker/api/prod/Dockerfile
@@ -52,7 +52,7 @@ RUN yarn install --frozen-lockfile --prefer-offline && \
 
 COPY --from=base /app/out/full/ .
 
-RUN yarn turbo build --filter '@apps/hash-api' && rm -rf target/
+RUN yarn turbo build --filter '@apps/hash-api' --env-mode=loose && rm -rf target/
 
 
 FROM node:20.13-slim AS runner

--- a/package.json
+++ b/package.json
@@ -51,12 +51,12 @@
     "seed-data:redis": "yarn workspace @apps/hash-realtime clear-redis",
     "seed-data": "concurrently \"yarn:seed-data:*\"",
     "test": "npm-run-all --continue-on-error \"test:*\"",
-    "test:unit": "turbo run test:unit --",
-    "test:integration": "turbo run test:integration --",
-    "test:system": "turbo run test:system --",
+    "test:unit": "turbo run test:unit --env-mode=loose --",
+    "test:integration": "turbo run test:integration --env-mode=loose --",
+    "test:system": "turbo runtest:system --env-mode=loose --",
     "bench": "npm-run-all --continue-on-error \"bench:*\"",
-    "bench:unit": "turbo run bench:unit --",
-    "bench:integration": "turbo run bench:integration --",
+    "bench:unit": "turbo run bench:unit --env-mode=loose --",
+    "bench:integration": "turbo run bench:integration --env-mode=loose --",
     "prune-node-modules": "find . -type d -name \"node_modules\" -exec rm -rf {} +"
   },
   "lint-staged": {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The upgrade to Turbo 2 (#4584) broke https://app.hash.ai because it [enables environment variable strict mode](https://turbo.build/repo/docs/crafting-your-repository/using-environment-variables#strict-mode) by default, meaning that environment variables not defined in workspaces' `turbo.json` will not be provided to its `turbo` commands (rationale: cache can be invalidated when a value changes if turbo is aware of it).

This PR sets loose mode back, which is what we were implicitly using before, to get it working again.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## How to test this

See what API the preview deployment attempts to contact.

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

- We should take advantage of strict mode – H-2936.