### PR TITLE
H-2940, H-2941: Fix entities table render loop, event history style tweaks

### DIFF
--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/history-table/shared/chip.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/history-table/shared/chip.tsx
@@ -5,10 +5,12 @@ import type { PropsWithChildren } from "react";
 export const Chip = ({
   children,
   type,
+  showInFull,
   sx,
   value,
 }: PropsWithChildren<{
   type?: boolean;
+  showInFull?: boolean;
   sx?: SxProps<Theme>;
   value?: boolean;
 }>) => (
@@ -22,12 +24,14 @@ export const Chip = ({
         borderRadius: type ? 4 : 2,
         fontWeight: 500,
         fontSize: 12,
-        maxWidth: 200,
         px: value ? 1.2 : 1,
         py: 0.5,
-        overflow: "hidden",
-        textOverflow: "ellipsis",
         whiteSpace: "nowrap",
+        ...(showInFull
+          ? {}
+          : {
+              overflow: "hidden",
+            }),
       }),
       ...(Array.isArray(sx) ? sx : [sx]),
     ]}

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/history-table/shared/event-detail.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/history-table/shared/event-detail.tsx
@@ -21,8 +21,12 @@ export const EventDetail = ({
       return (
         <>
           <Chip>{entityLabel}</Chip>
-          <Box mx={1}>created with type</Box>
-          <Chip type>{event.entityType.title}</Chip>
+          <Box mx={1} sx={{ whiteSpace: "nowrap" }}>
+            created with type
+          </Box>
+          <Chip showInFull type>
+            {event.entityType.title}
+          </Chip>
         </>
       );
     }
@@ -33,7 +37,12 @@ export const EventDetail = ({
         case "added": {
           return (
             <>
-              <Chip type>{propertyType.title}</Chip> <Box mx={1}>added as</Box>
+              <Chip showInFull type>
+                {propertyType.title}
+              </Chip>{" "}
+              <Box mx={1} sx={{ whiteSpace: "nowrap" }}>
+                added as
+              </Box>
               <Chip value>{diff.added}</Chip>
             </>
           );
@@ -41,8 +50,12 @@ export const EventDetail = ({
         case "removed": {
           return (
             <>
-              <Chip type>{propertyType.title}</Chip>{" "}
-              <Box mx={1}>removed, was</Box>
+              <Chip showInFull type>
+                {propertyType.title}
+              </Chip>{" "}
+              <Box mx={1} sx={{ whiteSpace: "nowrap" }}>
+                removed, was
+              </Box>
               <Chip value>{diff.removed}</Chip>
             </>
           );
@@ -50,8 +63,12 @@ export const EventDetail = ({
         case "changed": {
           return (
             <>
-              <Chip type>{propertyType.title}</Chip>{" "}
-              <Box mx={1}>updated from</Box>
+              <Chip showInFull type>
+                {propertyType.title}
+              </Chip>{" "}
+              <Box mx={1} sx={{ whiteSpace: "nowrap" }}>
+                updated from
+              </Box>
               <Chip value>{diff.old}</Chip>
               <Box mx={1}>to</Box>
               <Chip value>{diff.new}</Chip>

--- a/apps/hash-frontend/src/shared/use-entity-type-entities.tsx
+++ b/apps/hash-frontend/src/shared/use-entity-type-entities.tsx
@@ -134,11 +134,15 @@ export const useEntityTypeEntities = (params: {
     [variables],
   );
 
-  const subgraph = data?.getEntitySubgraph.subgraph
-    ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
-        data.getEntitySubgraph.subgraph,
-      )
-    : undefined;
+  const subgraph = useMemo(
+    () =>
+      data?.getEntitySubgraph.subgraph
+        ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
+            data.getEntitySubgraph.subgraph,
+          )
+        : undefined,
+    [data?.getEntitySubgraph.subgraph],
+  );
 
   const entities = useMemo(
     () => (subgraph ? getRoots(subgraph) : undefined),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

1. Fix a bug where a value used as an effect dependency wasn't memoized, causing a render loop in the entities table
2. Style tweaks to the entity history table:
   a. allow chips to take up as much space as there is (rather than cutting all to `200`)
   b. when history detail at the bottom of the table is opened, scroll it into view

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- The `entities-page.spec.ts` should've caught the console errors but Playwright tests are currently disabled pending another fix

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. View entities page, check no console errors
2. View history tab for an entity

## 📹 Demo

https://github.com/hashintel/hash/assets/37743469/12f2293f-5027-4d38-bd6d-9211bf29f7c3


<!-- Add a screenshot or video showcasing your work -->
