### PR TITLE
H-2946: Fix benchmark uploading from CI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -190,7 +190,7 @@ jobs:
             aws/creds/dev-deploy security_token | AWS_SESSION_TOKEN;
 
       - name: Upload benchmark results
-        run: turbo run upload-benchmarks -- --artifacts-path "$(pwd)/${{ matrix.directory }}/out" --enforce-flame-graph
+        run: turbo run upload-benchmarks --env-mode=loose -- --artifacts-path "$(pwd)/${{ matrix.directory }}/out" --enforce-flame-graph
 
       - name: Upload benchmark summary
         if: steps.benches.outputs.create-baseline == 'true'
@@ -361,7 +361,7 @@ jobs:
             aws/creds/dev-deploy security_token | AWS_SESSION_TOKEN;
 
       - name: Upload benchmark results
-        run: turbo run upload-benchmarks -- --artifacts-path "$(pwd)/${{ matrix.directory }}/out" --enforce-flame-graph
+        run: turbo run upload-benchmarks --env-mode=loose -- --artifacts-path "$(pwd)/${{ matrix.directory }}/out" --enforce-flame-graph
 
       - name: Upload benchmark summary
         if: steps.benches.outputs.create-baseline == 'true'


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The benchmarks are currently failing because environment variables are not passed to the commands in strict mode in turbo.


## 🔍 What does this change?

- Set the env-mode to `loose` for uploading results

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph