### PR TITLE
H-2947: Return full entity from Graph on creation

### DIFF
--- a/apps/hash-graph/libs/api/src/rest/entity.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity.rs
@@ -275,7 +275,7 @@ impl TryFrom<CreateEntityRequest> for CreateEntityParams<Vec<EntityRelationAndSu
         ("X-Authenticated-User-Actor-Id" = AccountId, Header, description = "The ID of the actor which is used to authorize the request"),
     ),
     responses(
-        (status = 200, content_type = "application/json", description = "The metadata of the created entity", body = EntityMetadata),
+        (status = 200, content_type = "application/json", description = "The created entity", body = Entity),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Entity Type URL was not found"),
@@ -292,7 +292,7 @@ async fn create_entity<S, A>(
     authorization_api_pool: Extension<Arc<A>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Json(body): Json<serde_json::Value>,
-) -> Result<Json<EntityMetadata>, Response>
+) -> Result<Json<Entity>, Response>
 where
     S: StorePool + Send + Sync,
     A: AuthorizationApiPool + Send + Sync,
@@ -325,7 +325,7 @@ where
         ("X-Authenticated-User-Actor-Id" = AccountId, Header, description = "The ID of the actor which is used to authorize the request"),
     ),
     responses(
-        (status = 200, content_type = "application/json", description = "The metadata of the created entity", body = [EntityMetadata]),
+        (status = 200, content_type = "application/json", description = "The created entities", body = [Entity]),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Entity Type URL was not found"),
@@ -342,7 +342,7 @@ async fn create_entities<S, A>(
     authorization_api_pool: Extension<Arc<A>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Json(body): Json<serde_json::Value>,
-) -> Result<Json<Vec<EntityMetadata>>, Response>
+) -> Result<Json<Vec<Entity>>, Response>
 where
     S: StorePool + Send + Sync,
     A: AuthorizationApiPool + Send + Sync,

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -15,7 +15,7 @@ use authorization::{
 use error_stack::{Report, Result, ResultExt};
 use graph_types::{
     account::AccountId,
-    knowledge::entity::{Entity, EntityId, EntityMetadata},
+    knowledge::entity::{Entity, EntityId},
     ontology::{
         DataTypeMetadata, EntityTypeMetadata, OntologyTemporalMetadata, OntologyType,
         OntologyTypeClassificationMetadata, OntologyTypeMetadata, OntologyTypeReference,
@@ -1160,7 +1160,7 @@ where
         &mut self,
         actor_id: AccountId,
         params: Vec<CreateEntityParams<R>>,
-    ) -> Result<Vec<EntityMetadata>, InsertionError>
+    ) -> Result<Vec<Entity>, InsertionError>
     where
         R: IntoIterator<Item = EntityRelationAndSubject> + Send,
     {

--- a/apps/hash-graph/libs/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/libs/graph/src/store/knowledge.rs
@@ -8,10 +8,7 @@ use futures::TryFutureExt;
 use graph_types::{
     account::AccountId,
     knowledge::{
-        entity::{
-            Entity, EntityEmbedding, EntityId, EntityMetadata, EntityUuid,
-            ProvidedEntityEditionProvenance,
-        },
+        entity::{Entity, EntityEmbedding, EntityId, EntityUuid, ProvidedEntityEditionProvenance},
         link::LinkData,
         Confidence, PropertyDiff, PropertyPatchOperation, PropertyPath, PropertyWithMetadataObject,
     },
@@ -182,6 +179,7 @@ pub struct CreateEntityParams<R> {
     #[serde(default)]
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     pub decision_time: Option<Timestamp<DecisionTime>>,
+    #[cfg_attr(feature = "utoipa", schema(value_type = Vec<VersionedUrl>))]
     pub entity_type_ids: HashSet<VersionedUrl>,
     pub properties: PropertyWithMetadataObject,
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]
@@ -350,7 +348,7 @@ pub trait EntityStore {
         &mut self,
         actor_id: AccountId,
         params: CreateEntityParams<R>,
-    ) -> impl Future<Output = Result<EntityMetadata, Report<InsertionError>>> + Send
+    ) -> impl Future<Output = Result<Entity, Report<InsertionError>>> + Send
     where
         R: IntoIterator<Item = EntityRelationAndSubject> + Send,
     {
@@ -367,7 +365,7 @@ pub trait EntityStore {
         &mut self,
         actor_id: AccountId,
         params: Vec<CreateEntityParams<R>>,
-    ) -> impl Future<Output = Result<Vec<EntityMetadata>, Report<InsertionError>>> + Send
+    ) -> impl Future<Output = Result<Vec<Entity>, Report<InsertionError>>> + Send
     where
         R: IntoIterator<Item = EntityRelationAndSubject> + Send;
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -292,6 +292,7 @@ where
 
     #[tracing::instrument(level = "info", skip(self))]
     pub async fn delete_entities(&mut self) -> Result<(), DeletionError> {
+        tracing::debug!("Deleting all entities");
         self.as_client()
             .client()
             .simple_query(
@@ -477,7 +478,7 @@ where
         &mut self,
         actor_id: AccountId,
         params: Vec<CreateEntityParams<R>>,
-    ) -> Result<Vec<EntityMetadata>, InsertionError>
+    ) -> Result<Vec<Entity>, InsertionError>
     where
         R: IntoIterator<Item = EntityRelationAndSubject> + Send,
     {
@@ -818,7 +819,7 @@ where
                     .change_context(InsertionError)?;
             }
 
-            Ok(entities.into_iter().map(|entity| entity.metadata).collect())
+            Ok(entities)
         }
     }
 

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -839,11 +839,11 @@
         },
         "responses": {
           "200": {
-            "description": "The metadata of the created entity",
+            "description": "The created entity",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/EntityMetadata"
+                  "$ref": "#/components/schemas/Entity"
                 }
               }
             }
@@ -945,13 +945,13 @@
         },
         "responses": {
           "200": {
-            "description": "The metadata of the created entity",
+            "description": "The created entities",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/EntityMetadata"
+                    "$ref": "#/components/schemas/Entity"
                   }
                 }
               }

--- a/apps/hash-graph/tests/circular-links.http
+++ b/apps/hash-graph/tests/circular-links.http
@@ -206,7 +206,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   client.test("status", function() {
     client.assert(response.status === 200, "Response status is not 200");
   });
-  client.global.set("entity_a", response.body.recordId.entityId);
+  client.global.set("entity_a", response.body.metadata.recordId.entityId);
 %}
 
 ### Insert entity B
@@ -234,7 +234,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   client.test("status", function() {
     client.assert(response.status === 200, "Response status is not 200");
   });
-  client.global.set("entity_b", response.body.recordId.entityId);
+  client.global.set("entity_b", response.body.metadata.recordId.entityId);
 %}
 
 ### Insert entity C
@@ -262,7 +262,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   client.test("status", function() {
     client.assert(response.status === 200, "Response status is not 200");
   });
-  client.global.set("entity_c", response.body.recordId.entityId);
+  client.global.set("entity_c", response.body.metadata.recordId.entityId);
 %}
 
 ### Insert entity D
@@ -290,7 +290,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   client.test("status", function() {
     client.assert(response.status === 200, "Response status is not 200");
   });
-  client.global.set("entity_d", response.body.recordId.entityId);
+  client.global.set("entity_d", response.body.metadata.recordId.entityId);
 %}
 
 ### Insert link between A and B

--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -1277,9 +1277,9 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("person_a_entity_id", response.body.recordId.entityId);
-    client.global.set("person_a_owned_by_id", response.body.recordId.entityId.split("~")[0])
-    client.global.set("person_a_entity_uuid", response.body.recordId.entityId.split("~")[1])
+    client.global.set("person_a_entity_id", response.body.metadata.recordId.entityId);
+    client.global.set("person_a_owned_by_id", response.body.metadata.recordId.entityId.split("~")[0])
+    client.global.set("person_a_entity_uuid", response.body.metadata.recordId.entityId.split("~")[1])
 %}
 
 ### Allow the friendship entity link type to be instantiated by the account
@@ -1449,10 +1449,10 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("person_b_entity_id", response.body.recordId.entityId);
-    client.global.set("person_b_entity_uuid", response.body.recordId.entityId.split("~")[1])
-    client.global.set("person_b_transaction_time", response.body.temporalVersioning.transactionTime.start.limit);
-    client.global.set("person_b_decision_time", response.body.temporalVersioning.decisionTime.start.limit);
+    client.global.set("person_b_entity_id", response.body.metadata.recordId.entityId);
+    client.global.set("person_b_entity_uuid", response.body.metadata.recordId.entityId.split("~")[1])
+    client.global.set("person_b_transaction_time", response.body.metadata.temporalVersioning.transactionTime.start.limit);
+    client.global.set("person_b_decision_time", response.body.metadata.temporalVersioning.decisionTime.start.limit);
 %}
 
 ### Update Bob entity embeddings
@@ -1598,7 +1598,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("link_entity_id", response.body.recordId.entityId);
+    client.global.set("link_entity_id", response.body.metadata.recordId.entityId);
 %}
 
 ### Publish second person entity
@@ -2099,7 +2099,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("person_c_entity_id", response.body.recordId.entityId);
+    client.global.set("person_c_entity_id", response.body.metadata.recordId.entityId);
 %}
 
 ### Update third Person entity

--- a/libs/@local/hash-graph-sdk/typescript/package.json
+++ b/libs/@local/hash-graph-sdk/typescript/package.json
@@ -25,13 +25,11 @@
     "@blockprotocol/graph": "0.3.4",
     "@local/advanced-types": "0.0.0-private",
     "@local/hash-graph-client": "0.0.0-private",
-    "@local/hash-graph-types": "0.0.0-private",
-    "lodash": "4.17.21"
+    "@local/hash-graph-types": "0.0.0-private"
   },
   "devDependencies": {
     "@local/eslint-config": "0.0.0-private",
     "@local/tsconfig": "0.0.0-private",
-    "@types/lodash": "4.17.4",
     "@vitest/coverage-istanbul": "1.6.0",
     "eslint": "8.57.0",
     "typescript": "5.1.6",

--- a/libs/@local/hash-graph-sdk/typescript/src/entity.ts
+++ b/libs/@local/hash-graph-sdk/typescript/src/entity.ts
@@ -29,7 +29,6 @@ import type {
   CreatedAtTransactionTime,
 } from "@local/hash-graph-types/temporal-versioning";
 import type { OwnedById } from "@local/hash-graph-types/web";
-import zip from "lodash/zip";
 
 import type { AuthenticationContext } from "./authentication-context";
 
@@ -221,15 +220,8 @@ export class Entity<
           ...rest,
         })),
       )
-      .then(({ data }) =>
-        zip(params, data).map(
-          ([request, metadata]) =>
-            new Entity({
-              metadata: metadata!,
-              properties: request!.properties,
-              linkData: request!.linkData,
-            }),
-        ),
+      .then(({ data: entities }) =>
+        entities.map((entity) => new Entity(entity)),
       );
   }
 
@@ -351,15 +343,8 @@ export class LinkEntity<
           ...rest,
         })),
       )
-      .then(({ data }) =>
-        zip(params, data).map(
-          ([request, metadata]) =>
-            new LinkEntity({
-              metadata: metadata!,
-              properties: request!.properties,
-              linkData: request!.linkData,
-            }),
-        ),
+      .then(({ data: entities }) =>
+        entities.map((entity) => new LinkEntity(entity)),
       );
   }
 

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/mod.rs
@@ -37,7 +37,7 @@ pub enum Property {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[serde(tag = "type", deny_unknown_fields)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum PropertyWithMetadata {
     Array {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/tests/hash-graph-benches/read_scaling/knowledge/complete/entity.rs
+++ b/tests/hash-graph-benches/read_scaling/knowledge/complete/entity.rs
@@ -23,7 +23,7 @@ use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::{
     account::AccountId,
     knowledge::{
-        entity::{EntityMetadata, ProvidedEntityEditionProvenance},
+        entity::{Entity, ProvidedEntityEditionProvenance},
         link::LinkData,
         PropertyObject, PropertyProvenance, PropertyWithMetadataObject,
     },
@@ -40,11 +40,11 @@ use crate::util::{seed, setup, setup_subscriber, Store, StoreWrapper};
 const DB_NAME: &str = "entity_scale";
 
 struct DatastoreEntitiesMetadata {
-    pub entity_metadata_list: Vec<EntityMetadata>,
+    pub entity_list: Vec<Entity>,
     // TODO: we should also check average query time for link entities, but combining them here
     //   would affect the distribution within sampling
     #[expect(dead_code, reason = "See TODO")]
-    pub link_entity_metadata_list: Vec<EntityMetadata>,
+    pub link_entity_list: Vec<Entity>,
 }
 
 #[expect(clippy::too_many_lines)]
@@ -116,7 +116,7 @@ async fn seed_db<A: AuthorizationApi>(
 
     let owned_by_id = OwnedById::new(account_id.into_uuid());
 
-    let entity_metadata_list = transaction
+    let entity_list = transaction
         .create_entities(
             account_id,
             repeat(CreateEntityParams {
@@ -141,34 +141,32 @@ async fn seed_db<A: AuthorizationApi>(
     let link_entity_metadata_list = transaction
         .create_entities(
             account_id,
-            entity_metadata_list
+            entity_list
                 .iter()
-                .flat_map(|entity_a_metadata| {
-                    entity_metadata_list
-                        .iter()
-                        .map(|entity_b_metadata| CreateEntityParams {
-                            owned_by_id,
-                            entity_uuid: None,
-                            decision_time: None,
-                            entity_type_ids: HashSet::from([link_type.id().clone()]),
-                            properties: PropertyWithMetadataObject::from_parts(
-                                PropertyObject::empty(),
-                                None,
-                            )
-                            .expect("could not create property with metadata object"),
-                            confidence: None,
-                            link_data: Some(LinkData {
-                                left_entity_id: entity_a_metadata.record_id.entity_id,
-                                right_entity_id: entity_b_metadata.record_id.entity_id,
-                                left_entity_confidence: None,
-                                left_entity_provenance: PropertyProvenance::default(),
-                                right_entity_confidence: None,
-                                right_entity_provenance: PropertyProvenance::default(),
-                            }),
-                            draft: false,
-                            relationships: [],
-                            provenance: ProvidedEntityEditionProvenance::default(),
-                        })
+                .flat_map(|entity_a| {
+                    entity_list.iter().map(|entity_b| CreateEntityParams {
+                        owned_by_id,
+                        entity_uuid: None,
+                        decision_time: None,
+                        entity_type_ids: HashSet::from([link_type.id().clone()]),
+                        properties: PropertyWithMetadataObject::from_parts(
+                            PropertyObject::empty(),
+                            None,
+                        )
+                        .expect("could not create property with metadata object"),
+                        confidence: None,
+                        link_data: Some(LinkData {
+                            left_entity_id: entity_a.metadata.record_id.entity_id,
+                            right_entity_id: entity_b.metadata.record_id.entity_id,
+                            left_entity_confidence: None,
+                            left_entity_provenance: PropertyProvenance::default(),
+                            right_entity_confidence: None,
+                            right_entity_provenance: PropertyProvenance::default(),
+                        }),
+                        draft: false,
+                        relationships: [],
+                        provenance: ProvidedEntityEditionProvenance::default(),
+                    })
                 })
                 .collect(),
         )
@@ -189,8 +187,8 @@ async fn seed_db<A: AuthorizationApi>(
     );
 
     DatastoreEntitiesMetadata {
-        entity_metadata_list,
-        link_entity_metadata_list,
+        entity_list,
+        link_entity_list: link_entity_metadata_list,
     }
 }
 
@@ -199,7 +197,7 @@ pub fn bench_get_entity_by_id<A: AuthorizationApi>(
     runtime: &Runtime,
     store: &Store<A>,
     actor_id: AccountId,
-    entity_metadata_list: &[EntityMetadata],
+    entity_metadata_list: &[Entity],
     graph_resolve_depths: GraphResolveDepths,
 ) {
     b.to_async(runtime).iter_batched(
@@ -208,7 +206,7 @@ pub fn bench_get_entity_by_id<A: AuthorizationApi>(
             // query
             entity_metadata_list
                 .iter()
-                .map(|metadata| metadata.record_id)
+                .map(|entity| entity.metadata.record_id)
                 .choose(&mut thread_rng())
                 .expect("could not choose random entity")
         },
@@ -261,7 +259,7 @@ fn bench_scaling_read_entity_zero_depths(c: &mut Criterion) {
         let (runtime, mut store_wrapper) = setup(DB_NAME, true, true, account_id, NoAuthorization);
 
         let DatastoreEntitiesMetadata {
-            entity_metadata_list,
+            entity_list: entity_metadata_list,
             ..
         } = runtime.block_on(seed_db(account_id, &mut store_wrapper, size));
         let store = &store_wrapper.store;
@@ -271,14 +269,14 @@ fn bench_scaling_read_entity_zero_depths(c: &mut Criterion) {
         group.bench_with_input(
             BenchmarkId::new(function_id, &parameter),
             &(account_id, entity_metadata_list),
-            |b, (_account_id, entity_metadata_list)| {
+            |b, (_account_id, entity_list)| {
                 let _guard = setup_subscriber(group_id, Some(function_id), Some(&parameter));
                 bench_get_entity_by_id(
                     b,
                     &runtime,
                     store,
                     account_id,
-                    entity_metadata_list,
+                    entity_list,
                     GraphResolveDepths {
                         inherits_from: OutgoingEdgeResolveDepth::default(),
                         constrains_values_on: OutgoingEdgeResolveDepth::default(),
@@ -314,7 +312,7 @@ fn bench_scaling_read_entity_one_depth(c: &mut Criterion) {
         let (runtime, mut store_wrapper) = setup(DB_NAME, true, true, account_id, NoAuthorization);
 
         let DatastoreEntitiesMetadata {
-            entity_metadata_list,
+            entity_list: entity_metadata_list,
             ..
         } = runtime.block_on(seed_db(account_id, &mut store_wrapper, size));
         let store = &store_wrapper.store;

--- a/tests/hash-graph-benches/representative_read/seed.rs
+++ b/tests/hash-graph-benches/representative_read/seed.rs
@@ -205,31 +205,29 @@ async fn seed_db<A: AuthorizationApi>(account_id: AccountId, store_wrapper: &mut
                 entity_uuids[*left_entity_index]
                     .iter()
                     .zip(&entity_uuids[*right_entity_index])
-                    .map(
-                        |(left_entity_metadata, right_entity_metadata)| CreateEntityParams {
-                            owned_by_id: OwnedById::new(account_id.into_uuid()),
-                            entity_uuid: None,
-                            decision_time: None,
-                            entity_type_ids: HashSet::from([entity_type_id.clone()]),
-                            properties: PropertyWithMetadataObject::from_parts(
-                                PropertyObject::empty(),
-                                None,
-                            )
-                            .expect("could not create property with metadata object"),
-                            confidence: None,
-                            link_data: Some(LinkData {
-                                left_entity_id: left_entity_metadata.record_id.entity_id,
-                                right_entity_id: right_entity_metadata.record_id.entity_id,
-                                left_entity_confidence: None,
-                                left_entity_provenance: PropertyProvenance::default(),
-                                right_entity_confidence: None,
-                                right_entity_provenance: PropertyProvenance::default(),
-                            }),
-                            draft: false,
-                            relationships: [],
-                            provenance: ProvidedEntityEditionProvenance::default(),
-                        },
-                    )
+                    .map(|(left_entity, right_entity)| CreateEntityParams {
+                        owned_by_id: OwnedById::new(account_id.into_uuid()),
+                        entity_uuid: None,
+                        decision_time: None,
+                        entity_type_ids: HashSet::from([entity_type_id.clone()]),
+                        properties: PropertyWithMetadataObject::from_parts(
+                            PropertyObject::empty(),
+                            None,
+                        )
+                        .expect("could not create property with metadata object"),
+                        confidence: None,
+                        link_data: Some(LinkData {
+                            left_entity_id: left_entity.metadata.record_id.entity_id,
+                            right_entity_id: right_entity.metadata.record_id.entity_id,
+                            left_entity_confidence: None,
+                            left_entity_provenance: PropertyProvenance::default(),
+                            right_entity_confidence: None,
+                            right_entity_provenance: PropertyProvenance::default(),
+                        }),
+                        draft: false,
+                        relationships: [],
+                        provenance: ProvidedEntityEditionProvenance::default(),
+                    })
                     .collect(),
             )
             .await

--- a/tests/hash-graph-integration/postgres/drafts.rs
+++ b/tests/hash-graph-integration/postgres/drafts.rs
@@ -100,11 +100,12 @@ async fn initial_draft() {
         )
         .await
         .expect("could not create entity");
-    assert!(entity.record_id.entity_id.draft_id.is_some());
-    assert!(check_entity_exists(&api, entity.record_id.entity_id).await);
-    assert!(entity.record_id.entity_id.draft_id.is_some());
+    assert!(entity.metadata.record_id.entity_id.draft_id.is_some());
+    assert!(check_entity_exists(&api, entity.metadata.record_id.entity_id).await);
+    assert!(entity.metadata.record_id.entity_id.draft_id.is_some());
     assert!(
         entity
+            .metadata
             .provenance
             .inferred
             .first_non_draft_created_at_decision_time
@@ -112,6 +113,7 @@ async fn initial_draft() {
     );
     assert!(
         entity
+            .metadata
             .provenance
             .inferred
             .first_non_draft_created_at_transaction_time
@@ -122,7 +124,7 @@ async fn initial_draft() {
         .patch_entity(
             api.account_id,
             PatchEntityParams {
-                entity_id: entity.record_id.entity_id,
+                entity_id: entity.metadata.record_id.entity_id,
                 properties: vec![PropertyPatchOperation::Replace {
                     path: PropertyPath::default(),
                     value: Property::Object(bob()),
@@ -141,7 +143,7 @@ async fn initial_draft() {
 
     assert_eq!(
         updated_entity.metadata.record_id.entity_id,
-        entity.record_id.entity_id
+        entity.metadata.record_id.entity_id
     );
     assert!(check_entity_exists(&api, updated_entity.metadata.record_id.entity_id).await);
     assert!(
@@ -271,15 +273,16 @@ async fn no_initial_draft() {
         )
         .await
         .expect("could not create entity");
-    assert!(entity.record_id.entity_id.draft_id.is_none());
-    assert!(check_entity_exists(&api, entity.record_id.entity_id).await);
+    assert!(entity.metadata.record_id.entity_id.draft_id.is_none());
+    assert!(check_entity_exists(&api, entity.metadata.record_id.entity_id).await);
 
     let ClosedTemporalBound::Inclusive(undraft_transaction_time) =
-        entity.temporal_versioning.transaction_time.start();
+        entity.metadata.temporal_versioning.transaction_time.start();
     let ClosedTemporalBound::Inclusive(undraft_decision_time) =
-        entity.temporal_versioning.decision_time.start();
+        entity.metadata.temporal_versioning.decision_time.start();
     assert_eq!(
         entity
+            .metadata
             .provenance
             .inferred
             .first_non_draft_created_at_transaction_time,
@@ -287,6 +290,7 @@ async fn no_initial_draft() {
     );
     assert_eq!(
         entity
+            .metadata
             .provenance
             .inferred
             .first_non_draft_created_at_decision_time,
@@ -298,7 +302,7 @@ async fn no_initial_draft() {
             .patch_entity(
                 api.account_id,
                 PatchEntityParams {
-                    entity_id: entity.record_id.entity_id,
+                    entity_id: entity.metadata.record_id.entity_id,
                     properties: vec![PropertyPatchOperation::Replace {
                         path: PropertyPath::default(),
                         value: Property::Object(bob()),
@@ -316,11 +320,11 @@ async fn no_initial_draft() {
             .expect("could not update entity");
 
         assert_eq!(
-            entity.record_id.entity_id.owned_by_id,
+            entity.metadata.record_id.entity_id.owned_by_id,
             updated_entity.metadata.record_id.entity_id.owned_by_id
         );
         assert_eq!(
-            entity.record_id.entity_id.entity_uuid,
+            entity.metadata.record_id.entity_id.entity_uuid,
             updated_entity.metadata.record_id.entity_id.entity_uuid
         );
         assert!(
@@ -331,7 +335,7 @@ async fn no_initial_draft() {
                 .draft_id
                 .is_some()
         );
-        assert!(check_entity_exists(&api, entity.record_id.entity_id).await);
+        assert!(check_entity_exists(&api, entity.metadata.record_id.entity_id).await);
         assert!(check_entity_exists(&api, updated_entity.metadata.record_id.entity_id).await);
         assert_eq!(
             updated_entity
@@ -372,7 +376,7 @@ async fn no_initial_draft() {
             .expect("could not update entity");
 
         assert_eq!(
-            entity.record_id.entity_id,
+            entity.metadata.record_id.entity_id,
             updated_live_entity.metadata.record_id.entity_id
         );
         assert!(
@@ -429,14 +433,15 @@ async fn multiple_drafts() {
         )
         .await
         .expect("could not create entity");
-    assert!(entity.record_id.entity_id.draft_id.is_none());
-    assert!(check_entity_exists(&api, entity.record_id.entity_id).await);
+    assert!(entity.metadata.record_id.entity_id.draft_id.is_none());
+    assert!(check_entity_exists(&api, entity.metadata.record_id.entity_id).await);
     let ClosedTemporalBound::Inclusive(undraft_transaction_time) =
-        entity.temporal_versioning.transaction_time.start();
+        entity.metadata.temporal_versioning.transaction_time.start();
     let ClosedTemporalBound::Inclusive(undraft_decision_time) =
-        entity.temporal_versioning.decision_time.start();
+        entity.metadata.temporal_versioning.decision_time.start();
     assert_eq!(
         entity
+            .metadata
             .provenance
             .inferred
             .first_non_draft_created_at_transaction_time,
@@ -444,6 +449,7 @@ async fn multiple_drafts() {
     );
     assert_eq!(
         entity
+            .metadata
             .provenance
             .inferred
             .first_non_draft_created_at_decision_time,
@@ -456,7 +462,7 @@ async fn multiple_drafts() {
             .patch_entity(
                 api.account_id,
                 PatchEntityParams {
-                    entity_id: entity.record_id.entity_id,
+                    entity_id: entity.metadata.record_id.entity_id,
                     properties: vec![PropertyPatchOperation::Replace {
                         path: PropertyPath::default(),
                         value: Property::Object(bob()),
@@ -474,11 +480,11 @@ async fn multiple_drafts() {
             .expect("could not update entity");
 
         assert_eq!(
-            entity.record_id.entity_id.owned_by_id,
+            entity.metadata.record_id.entity_id.owned_by_id,
             updated_entity.metadata.record_id.entity_id.owned_by_id
         );
         assert_eq!(
-            entity.record_id.entity_id.entity_uuid,
+            entity.metadata.record_id.entity_id.entity_uuid,
             updated_entity.metadata.record_id.entity_id.entity_uuid
         );
         assert!(
@@ -489,7 +495,7 @@ async fn multiple_drafts() {
                 .draft_id
                 .is_some()
         );
-        assert!(check_entity_exists(&api, entity.record_id.entity_id).await);
+        assert!(check_entity_exists(&api, entity.metadata.record_id.entity_id).await);
         assert!(check_entity_exists(&api, updated_entity.metadata.record_id.entity_id).await);
         assert_eq!(
             updated_entity
@@ -533,7 +539,7 @@ async fn multiple_drafts() {
             .expect("could not update entity");
 
         assert_eq!(
-            entity.record_id.entity_id,
+            entity.metadata.record_id.entity_id,
             updated_live_entity.metadata.record_id.entity_id
         );
         assert!(!check_entity_exists(&api, draft).await);

--- a/tests/hash-graph-integration/postgres/entity.rs
+++ b/tests/hash-graph-integration/postgres/entity.rs
@@ -52,7 +52,7 @@ async fn insert() {
         .await
         .expect("could not seed database");
 
-    let metadata = api
+    let entity = api
         .create_entity(
             api.account_id,
             CreateEntityParams {
@@ -82,7 +82,7 @@ async fn insert() {
         .get_entities(
             api.account_id,
             GetEntitiesParams {
-                filter: Filter::for_entity_by_entity_id(metadata.record_id.entity_id),
+                filter: Filter::for_entity_by_entity_id(entity.metadata.record_id.entity_id),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(
@@ -122,7 +122,7 @@ async fn query() {
         .await
         .expect("could not seed database");
 
-    let metadata = api
+    let entity = api
         .create_entity(
             api.account_id,
             CreateEntityParams {
@@ -153,7 +153,7 @@ async fn query() {
         .get_entities(
             api.account_id,
             GetEntitiesParams {
-                filter: Filter::for_entity_by_entity_id(metadata.record_id.entity_id),
+                filter: Filter::for_entity_by_entity_id(entity.metadata.record_id.entity_id),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(
@@ -196,7 +196,7 @@ async fn update() {
         .await
         .expect("could not seed database:");
 
-    let v1_metadata = api
+    let v1_entity = api
         .create_entity(
             api.account_id,
             CreateEntityParams {
@@ -222,11 +222,11 @@ async fn update() {
         .await
         .expect("could not create entity");
 
-    let v2 = api
+    let v2_entity = api
         .patch_entity(
             api.account_id,
             PatchEntityParams {
-                entity_id: v1_metadata.record_id.entity_id,
+                entity_id: v1_entity.metadata.record_id.entity_id,
                 properties: vec![PropertyPatchOperation::Replace {
                     path: PropertyPath::default(),
                     value: Property::Object(page_v2.clone()),
@@ -247,7 +247,7 @@ async fn update() {
         .count_entities(
             api.account_id,
             CountEntitiesParams {
-                filter: Filter::for_entity_by_entity_id(v2.metadata.record_id.entity_id),
+                filter: Filter::for_entity_by_entity_id(v2_entity.metadata.record_id.entity_id),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(
@@ -266,7 +266,7 @@ async fn update() {
         .get_entities(
             api.account_id,
             GetEntitiesParams {
-                filter: Filter::for_entity_by_entity_id(v2.metadata.record_id.entity_id),
+                filter: Filter::for_entity_by_entity_id(v2_entity.metadata.record_id.entity_id),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(None, None),
@@ -289,13 +289,13 @@ async fn update() {
     assert_eq!(entity_v2.properties.properties(), page_v2.properties());
 
     let ClosedTemporalBound::Inclusive(entity_v1_timestamp) =
-        *v1_metadata.temporal_versioning.decision_time.start();
+        *v1_entity.metadata.temporal_versioning.decision_time.start();
 
     let mut response_v1 = api
         .get_entities(
             api.account_id,
             GetEntitiesParams {
-                filter: Filter::for_entity_by_entity_id(v1_metadata.record_id.entity_id),
+                filter: Filter::for_entity_by_entity_id(v1_entity.metadata.record_id.entity_id),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(
@@ -319,12 +319,12 @@ async fn update() {
     assert_eq!(entity_v1.properties.properties(), page_v1.properties());
 
     let ClosedTemporalBound::Inclusive(entity_v2_timestamp) =
-        *v2.metadata.temporal_versioning.decision_time.start();
+        *v2_entity.metadata.temporal_versioning.decision_time.start();
     let mut response_v2 = api
         .get_entities(
             api.account_id,
             GetEntitiesParams {
-                filter: Filter::for_entity_by_entity_id(v2.metadata.record_id.entity_id),
+                filter: Filter::for_entity_by_entity_id(v2_entity.metadata.record_id.entity_id),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
                     variable: VariableTemporalAxisUnresolved::new(

--- a/tests/hash-graph-integration/postgres/interconnected_graph.rs
+++ b/tests/hash-graph-integration/postgres/interconnected_graph.rs
@@ -117,7 +117,7 @@ async fn insert() {
         provenance: ProvidedEntityEditionProvenance::default(),
     };
 
-    let metadata = api
+    let entities = api
         .create_entities(
             api.account_id,
             vec![alice_entity, friendship_entity, bob_entity],
@@ -125,6 +125,9 @@ async fn insert() {
         .await
         .expect("could not create entity");
 
-    assert_eq!(metadata[0].record_id.entity_id.entity_uuid, alice_id);
-    assert_eq!(metadata[2].record_id.entity_id.entity_uuid, bob_id);
+    assert_eq!(
+        entities[0].metadata.record_id.entity_id.entity_uuid,
+        alice_id
+    );
+    assert_eq!(entities[2].metadata.record_id.entity_id.entity_uuid, bob_id);
 }

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -64,7 +64,7 @@ use graph::{
 };
 use graph_types::{
     account::AccountId,
-    knowledge::entity::{Entity, EntityId, EntityMetadata},
+    knowledge::entity::{Entity, EntityId},
     ontology::{
         DataTypeMetadata, EntityTypeMetadata, OntologyTemporalMetadata,
         OntologyTypeClassificationMetadata, PropertyTypeMetadata,
@@ -681,7 +681,7 @@ where
         &mut self,
         actor_id: AccountId,
         params: Vec<CreateEntityParams<R>>,
-    ) -> Result<Vec<EntityMetadata>, InsertionError>
+    ) -> Result<Vec<Entity>, InsertionError>
     where
         R: IntoIterator<Item = EntityRelationAndSubject> + Send,
     {

--- a/tests/hash-graph-integration/postgres/links.rs
+++ b/tests/hash-graph-integration/postgres/links.rs
@@ -69,7 +69,7 @@ async fn insert() {
         version: OntologyTypeVersion::new(1),
     };
 
-    let alice_metadata = api
+    let alice_entity = api
         .create_entity(
             api.account_id,
             CreateEntityParams {
@@ -89,7 +89,7 @@ async fn insert() {
         .await
         .expect("could not create entity");
 
-    let bob_metadata = api
+    let bob_entity = api
         .create_entity(
             api.account_id,
             CreateEntityParams {
@@ -127,8 +127,8 @@ async fn insert() {
             properties: PropertyWithMetadataObject::from_parts(friend_of, None)
                 .expect("could not create property with metadata object"),
             link_data: Some(LinkData {
-                left_entity_id: alice_metadata.record_id.entity_id,
-                right_entity_id: bob_metadata.record_id.entity_id,
+                left_entity_id: alice_entity.metadata.record_id.entity_id,
+                right_entity_id: bob_entity.metadata.record_id.entity_id,
                 left_entity_confidence: None,
                 left_entity_provenance: PropertyProvenance::default(),
                 right_entity_confidence: None,
@@ -155,7 +155,12 @@ async fn insert() {
                             direction: EdgeDirection::Outgoing,
                         })),
                         Some(FilterExpression::Parameter(Parameter::Uuid(
-                            alice_metadata.record_id.entity_id.entity_uuid.into_uuid(),
+                            alice_entity
+                                .metadata
+                                .record_id
+                                .entity_id
+                                .entity_uuid
+                                .into_uuid(),
                         ))),
                     ),
                     Filter::Equal(
@@ -165,7 +170,12 @@ async fn insert() {
                             direction: EdgeDirection::Outgoing,
                         })),
                         Some(FilterExpression::Parameter(Parameter::Uuid(
-                            alice_metadata.record_id.entity_id.owned_by_id.into_uuid(),
+                            alice_entity
+                                .metadata
+                                .record_id
+                                .entity_id
+                                .owned_by_id
+                                .into_uuid(),
                         ))),
                     ),
                     Filter::Equal(
@@ -216,8 +226,14 @@ async fn insert() {
 
     let link_data = link_entity.link_data.expect("entity is not a link");
 
-    assert_eq!(link_data.left_entity_id, alice_metadata.record_id.entity_id);
-    assert_eq!(link_data.right_entity_id, bob_metadata.record_id.entity_id);
+    assert_eq!(
+        link_data.left_entity_id,
+        alice_entity.metadata.record_id.entity_id
+    );
+    assert_eq!(
+        link_data.right_entity_id,
+        bob_entity.metadata.record_id.entity_id
+    );
 }
 
 #[tokio::test]
@@ -273,7 +289,7 @@ async fn get_entity_links() {
         version: OntologyTypeVersion::new(1),
     };
 
-    let alice_metadata = api
+    let alice_entity = api
         .create_entity(
             api.account_id,
             CreateEntityParams {
@@ -293,7 +309,7 @@ async fn get_entity_links() {
         .await
         .expect("could not create entity");
 
-    let bob_metadata = api
+    let bob_entity = api
         .create_entity(
             api.account_id,
             CreateEntityParams {
@@ -343,8 +359,8 @@ async fn get_entity_links() {
             properties: PropertyWithMetadataObject::from_parts(PropertyObject::empty(), None)
                 .expect("could not create property with metadata object"),
             link_data: Some(LinkData {
-                left_entity_id: alice_metadata.record_id.entity_id,
-                right_entity_id: bob_metadata.record_id.entity_id,
+                left_entity_id: alice_entity.metadata.record_id.entity_id,
+                right_entity_id: bob_entity.metadata.record_id.entity_id,
                 left_entity_confidence: None,
                 left_entity_provenance: PropertyProvenance::default(),
                 right_entity_confidence: None,
@@ -369,8 +385,8 @@ async fn get_entity_links() {
             properties: PropertyWithMetadataObject::from_parts(PropertyObject::empty(), None)
                 .expect("could not create property with metadata object"),
             link_data: Some(LinkData {
-                left_entity_id: alice_metadata.record_id.entity_id,
-                right_entity_id: charles_metadata.record_id.entity_id,
+                left_entity_id: alice_entity.metadata.record_id.entity_id,
+                right_entity_id: charles_metadata.metadata.record_id.entity_id,
                 left_entity_confidence: None,
                 left_entity_provenance: PropertyProvenance::default(),
                 right_entity_confidence: None,
@@ -396,7 +412,12 @@ async fn get_entity_links() {
                         direction: EdgeDirection::Outgoing,
                     })),
                     Some(FilterExpression::Parameter(Parameter::Uuid(
-                        alice_metadata.record_id.entity_id.entity_uuid.into_uuid(),
+                        alice_entity
+                            .metadata
+                            .record_id
+                            .entity_id
+                            .entity_uuid
+                            .into_uuid(),
                     ))),
                 ),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
@@ -436,18 +457,16 @@ async fn get_entity_links() {
     assert!(
         link_datas
             .iter()
-            .any(|link_data| link_data.left_entity_id == alice_metadata.record_id.entity_id)
+            .any(|link_data| link_data.left_entity_id == alice_entity.metadata.record_id.entity_id)
     );
     assert!(
         link_datas
             .iter()
-            .any(|link_data| link_data.right_entity_id == bob_metadata.record_id.entity_id)
+            .any(|link_data| link_data.right_entity_id == bob_entity.metadata.record_id.entity_id)
     );
-    assert!(
-        link_datas
-            .iter()
-            .any(|link_data| link_data.right_entity_id == charles_metadata.record_id.entity_id)
-    );
+    assert!(link_datas.iter().any(
+        |link_data| link_data.right_entity_id == charles_metadata.metadata.record_id.entity_id
+    ));
 }
 
 #[tokio::test]
@@ -494,7 +513,7 @@ async fn remove_link() {
         version: OntologyTypeVersion::new(1),
     };
 
-    let alice_metadata = api
+    let alice_entity = api
         .create_entity(
             api.account_id,
             CreateEntityParams {
@@ -514,7 +533,7 @@ async fn remove_link() {
         .await
         .expect("could not create entity");
 
-    let bob_metadata = api
+    let bob_entity = api
         .create_entity(
             api.account_id,
             CreateEntityParams {
@@ -545,8 +564,8 @@ async fn remove_link() {
                 properties: PropertyWithMetadataObject::from_parts(PropertyObject::empty(), None)
                     .expect("could not create property with metadata object"),
                 link_data: Some(LinkData {
-                    left_entity_id: alice_metadata.record_id.entity_id,
-                    right_entity_id: bob_metadata.record_id.entity_id,
+                    left_entity_id: alice_entity.metadata.record_id.entity_id,
+                    right_entity_id: bob_entity.metadata.record_id.entity_id,
                     left_entity_confidence: None,
                     left_entity_provenance: PropertyProvenance::default(),
                     right_entity_confidence: None,
@@ -573,7 +592,12 @@ async fn remove_link() {
                             direction: EdgeDirection::Outgoing,
                         })),
                         Some(FilterExpression::Parameter(Parameter::Uuid(
-                            alice_metadata.record_id.entity_id.entity_uuid.into_uuid(),
+                            alice_entity
+                                .metadata
+                                .record_id
+                                .entity_id
+                                .entity_uuid
+                                .into_uuid(),
                         ))),
                     ),
                     Filter::Equal(
@@ -596,7 +620,7 @@ async fn remove_link() {
     api.patch_entity(
         api.account_id,
         PatchEntityParams {
-            entity_id: link_entity_metadata.record_id.entity_id,
+            entity_id: link_entity_metadata.metadata.record_id.entity_id,
             decision_time: None,
             archived: Some(true),
             draft: None,
@@ -621,7 +645,12 @@ async fn remove_link() {
                             direction: EdgeDirection::Outgoing,
                         })),
                         Some(FilterExpression::Parameter(Parameter::Uuid(
-                            alice_metadata.record_id.entity_id.entity_uuid.into_uuid(),
+                            alice_entity
+                                .metadata
+                                .record_id
+                                .entity_id
+                                .entity_uuid
+                                .into_uuid(),
                         ))),
                     ),
                     Filter::Equal(

--- a/tests/hash-graph-integration/postgres/multi_type.rs
+++ b/tests/hash-graph-integration/postgres/multi_type.rs
@@ -99,7 +99,7 @@ async fn initial_person() {
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = seed(&mut database).await;
 
-    let entity_metadata = api
+    let entity = api
         .create_entity(
             api.account_id,
             CreateEntityParams {
@@ -120,7 +120,8 @@ async fn initial_person() {
         .expect("could not create entity");
 
     assert!(
-        entity_metadata
+        entity
+            .metadata
             .entity_type_ids
             .contains(&person_entity_type_id())
     );
@@ -147,20 +148,13 @@ async fn initial_person() {
         .expect("could not get entities")
         .entities;
 
-    assert_eq!(
-        entities,
-        [Entity {
-            metadata: entity_metadata.clone(),
-            properties: alice(),
-            link_data: None
-        }]
-    );
+    assert_eq!(entities[0], entity);
 
     let updated_entity = api
         .patch_entity(
             api.account_id,
             PatchEntityParams {
-                entity_id: entity_metadata.record_id.entity_id,
+                entity_id: entity.metadata.record_id.entity_id,
                 decision_time: None,
                 entity_type_ids: HashSet::from([person_entity_type_id(), org_entity_type_id()]),
                 properties: vec![],
@@ -247,7 +241,7 @@ async fn create_multi() {
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = seed(&mut database).await;
 
-    let entity_metadata = api
+    let entity = api
         .create_entity(
             api.account_id,
             CreateEntityParams {
@@ -268,12 +262,14 @@ async fn create_multi() {
         .expect("could not create entity");
 
     assert!(
-        entity_metadata
+        entity
+            .metadata
             .entity_type_ids
             .contains(&person_entity_type_id()),
     );
     assert!(
-        entity_metadata
+        entity
+            .metadata
             .entity_type_ids
             .contains(&org_entity_type_id()),
     );
@@ -323,20 +319,13 @@ async fn create_multi() {
         .entities;
 
     assert_eq!(person_entities, org_entities);
-    assert_eq!(
-        person_entities,
-        [Entity {
-            metadata: entity_metadata.clone(),
-            properties: alice(),
-            link_data: None
-        }]
-    );
+    assert_eq!(person_entities[0], entity);
 
     let updated_entity = api
         .patch_entity(
             api.account_id,
             PatchEntityParams {
-                entity_id: entity_metadata.record_id.entity_id,
+                entity_id: entity.metadata.record_id.entity_id,
                 decision_time: None,
                 entity_type_ids: HashSet::from([person_entity_type_id()]),
                 properties: vec![],

--- a/tests/hash-graph-integration/postgres/partial_updates.rs
+++ b/tests/hash-graph-integration/postgres/partial_updates.rs
@@ -99,7 +99,7 @@ async fn properties_add() {
         )
         .await
         .expect("could not create entity");
-    let entity_id = entity.record_id.entity_id;
+    let entity_id = entity.metadata.record_id.entity_id;
 
     api.patch_entity(
         api.account_id,
@@ -175,7 +175,7 @@ async fn properties_remove() {
         )
         .await
         .expect("could not create entity");
-    let entity_id = entity.record_id.entity_id;
+    let entity_id = entity.metadata.record_id.entity_id;
 
     api.patch_entity(
         api.account_id,
@@ -247,7 +247,7 @@ async fn properties_replace() {
         )
         .await
         .expect("could not create entity");
-    let entity_id = entity.record_id.entity_id;
+    let entity_id = entity.metadata.record_id.entity_id;
 
     api.patch_entity(
         api.account_id,
@@ -323,7 +323,7 @@ async fn type_ids() {
         )
         .await
         .expect("could not create entity");
-    let entity_id = entity.record_id.entity_id;
+    let entity_id = entity.metadata.record_id.entity_id;
 
     api.patch_entity(
         api.account_id,

--- a/tests/hash-graph-integration/postgres/property_metadata.rs
+++ b/tests/hash-graph-integration/postgres/property_metadata.rs
@@ -154,7 +154,7 @@ async fn initial_metadata() {
         },
     };
 
-    let entity_metadata = api
+    let entity = api
         .create_entity(
             api.account_id,
             CreateEntityParams {
@@ -177,8 +177,8 @@ async fn initial_metadata() {
         .await
         .expect("could not create entity");
 
-    assert_eq!(entity_metadata.confidence, Confidence::new(0.5));
-    assert_eq!(entity_metadata.properties, entity_property_metadata);
+    assert_eq!(entity.metadata.confidence, Confidence::new(0.5));
+    assert_eq!(entity.metadata.properties, entity_property_metadata);
 
     let name_property_metadata = PropertyMetadataElement::Value {
         metadata: ValueMetadata {
@@ -191,7 +191,7 @@ async fn initial_metadata() {
         .patch_entity(
             api.account_id,
             PatchEntityParams {
-                entity_id: entity_metadata.record_id.entity_id,
+                entity_id: entity.metadata.record_id.entity_id,
                 properties: vec![PropertyPatchOperation::Replace {
                     path: once(PropertyPathElement::Property(Cow::Owned(
                         name_property_type_id(),
@@ -226,7 +226,7 @@ async fn initial_metadata() {
         .patch_entity(
             api.account_id,
             PatchEntityParams {
-                entity_id: entity_metadata.record_id.entity_id,
+                entity_id: entity.metadata.record_id.entity_id,
                 properties: Vec::new(),
                 entity_type_ids: HashSet::new(),
                 archived: None,
@@ -252,7 +252,7 @@ async fn no_initial_metadata() {
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = seed(&mut database).await;
 
-    let entity_metadata = api
+    let entity = api
         .create_entity(
             api.account_id,
             CreateEntityParams {
@@ -272,9 +272,9 @@ async fn no_initial_metadata() {
         .await
         .expect("could not create entity");
 
-    assert!(entity_metadata.confidence.is_none());
+    assert!(entity.metadata.confidence.is_none());
     assert_eq!(
-        entity_metadata.properties,
+        entity.metadata.properties,
         PropertyMetadataObject {
             value: HashMap::from([(
                 name_property_type_id(),
@@ -294,7 +294,7 @@ async fn no_initial_metadata() {
         .patch_entity(
             api.account_id,
             PatchEntityParams {
-                entity_id: entity_metadata.record_id.entity_id,
+                entity_id: entity.metadata.record_id.entity_id,
                 properties: Vec::new(),
                 entity_type_ids: HashSet::new(),
                 archived: None,
@@ -307,13 +307,13 @@ async fn no_initial_metadata() {
         .await
         .expect("could not update entity");
 
-    assert_eq!(entity_metadata, updated_entity.metadata);
+    assert_eq!(entity, updated_entity);
 
     let updated_entity = api
         .patch_entity(
             api.account_id,
             PatchEntityParams {
-                entity_id: entity_metadata.record_id.entity_id,
+                entity_id: entity.metadata.record_id.entity_id,
                 properties: Vec::new(),
                 entity_type_ids: HashSet::new(),
                 archived: None,
@@ -328,7 +328,7 @@ async fn no_initial_metadata() {
 
     assert_eq!(updated_entity.metadata.confidence, Confidence::new(0.5));
     assert_eq!(
-        entity_metadata.properties,
+        entity.metadata.properties,
         PropertyMetadataObject {
             value: HashMap::from([(
                 name_property_type_id(),
@@ -348,7 +348,7 @@ async fn no_initial_metadata() {
         .patch_entity(
             api.account_id,
             PatchEntityParams {
-                entity_id: entity_metadata.record_id.entity_id,
+                entity_id: entity.metadata.record_id.entity_id,
                 properties: vec![PropertyPatchOperation::Replace {
                     path: once(PropertyPathElement::from(name_property_type_id())).collect(),
                     value: Property::Value(json!("Alice")),
@@ -393,7 +393,7 @@ async fn no_initial_metadata() {
         .patch_entity(
             api.account_id,
             PatchEntityParams {
-                entity_id: entity_metadata.record_id.entity_id,
+                entity_id: entity.metadata.record_id.entity_id,
                 properties: Vec::new(),
                 entity_type_ids: HashSet::new(),
                 archived: None,
@@ -453,7 +453,7 @@ async fn properties_add() {
         )
         .await
         .expect("could not create entity");
-    let entity_id = entity.record_id.entity_id;
+    let entity_id = entity.metadata.record_id.entity_id;
 
     let path: PropertyPath = once(PropertyPathElement::from(age_property_type_id())).collect();
     let updated_entity = api
@@ -538,7 +538,7 @@ async fn properties_remove() {
         )
         .await
         .expect("could not create entity");
-    let entity_id = entity.record_id.entity_id;
+    let entity_id = entity.metadata.record_id.entity_id;
 
     let interests_path: PropertyPath =
         once(PropertyPathElement::from(interests_property_type_id())).collect();


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We expect to pass the metadata alongside the properties, but for now we will use them in the SDK as two separate objects. The Graph already constructs an entity, so a traversal in the Node API can be avoided.

Further, it is expected that the Graph will be capable of using hooks, which might change some properties. As the SDK does not necessarily know what properties have been changed, it's good to inform it.

## 🚫 Blocked by
- #4589 

## 🔍 What does this change?

- Change the return type of `createEntity` and `createEntities` to return the full entities instead of only the metadata

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph