### PR TITLE
H-2953: Pass metadata alongside properties to Graph in patches

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/graph-requests.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/graph-requests.ts
@@ -1,11 +1,12 @@
 import { typedEntries } from "@local/advanced-types/typed-entries";
-import type {
-  GraphApi,
-  PropertyPatchOperation,
-} from "@local/hash-graph-client";
+import type { GraphApi } from "@local/hash-graph-client";
 import type { Entity } from "@local/hash-graph-sdk/entity";
 import type { AccountId } from "@local/hash-graph-types/account";
-import type { EntityId, PropertyObject } from "@local/hash-graph-types/entity";
+import type {
+  EntityId,
+  PropertyObject,
+  PropertyPatchOperation,
+} from "@local/hash-graph-types/entity";
 import {
   currentTimeInstantTemporalAxes,
   zeroedGraphResolveDepths,

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -6805,17 +6805,10 @@
             "type": "object",
             "required": [
               "path",
-              "value",
+              "property",
               "op"
             ],
             "properties": {
-              "metadata": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/PropertyMetadata"
-                  }
-                ]
-              },
               "op": {
                 "type": "string",
                 "enum": [
@@ -6825,8 +6818,8 @@
               "path": {
                 "$ref": "#/components/schemas/PropertyPath"
               },
-              "value": {
-                "$ref": "#/components/schemas/Property"
+              "property": {
+                "$ref": "#/components/schemas/PropertyWithMetadata"
               }
             }
           },
@@ -6852,17 +6845,10 @@
             "type": "object",
             "required": [
               "path",
-              "value",
+              "property",
               "op"
             ],
             "properties": {
-              "metadata": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/PropertyMetadata"
-                  }
-                ]
-              },
               "op": {
                 "type": "string",
                 "enum": [
@@ -6872,8 +6858,8 @@
               "path": {
                 "$ref": "#/components/schemas/PropertyPath"
               },
-              "value": {
-                "$ref": "#/components/schemas/Property"
+              "property": {
+                "$ref": "#/components/schemas/PropertyWithMetadata"
               }
             }
           }

--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -1399,7 +1399,12 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     {
       "op": "replace",
       "path": ["http://localhost:3000/@alice/types/property-type/name/"],
-      "value": "Alice Allison 3"
+      "property": {
+        "value": "Alice Allison 3",
+        "metadata": {
+          "dataTypeId": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"
+        }
+      }
     }
   ]
 }
@@ -2156,7 +2161,12 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     {
       "op": "replace",
       "path": ["http://localhost:3000/@alice/types/property-type/name/"],
-      "value": "Charles 2 draft"
+      "property": {
+        "value": "Charles 2 draft",
+        "metadata": {
+          "dataTypeId": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"
+        }
+      }
     }
   ]
 }
@@ -2181,7 +2191,12 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     {
       "op": "replace",
       "path": ["http://localhost:3000/@alice/types/property-type/name/"],
-      "value": "Charles 2"
+      "property": {
+        "value": "Charles 2",
+        "metadata": {
+          "dataTypeId": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"
+        }
+      }
     }
   ],
   "draft": false

--- a/libs/@local/hash-graph-sdk/typescript/src/entity.ts
+++ b/libs/@local/hash-graph-sdk/typescript/src/entity.ts
@@ -156,6 +156,10 @@ const mergePropertiesAndMetadata = (
       const returnedValues: Record<BaseUrl, PropertyWithMetadata> = {};
       let isPropertyObject = true;
       for (const [key, value] of typedEntries(property)) {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- It's possible for values to be undefined
+        if (value === undefined) {
+          continue;
+        }
         if (!isBaseUrl(key)) {
           isPropertyObject = false;
           break;

--- a/libs/@local/hash-graph-types/rust/src/knowledge/entity/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/entity/mod.rs
@@ -1,3 +1,4 @@
+rewriting static
 mod diff;
 mod provenance;
 
@@ -143,17 +144,9 @@ impl Entity {
 
         for operation in operations {
             match operation {
-                PropertyPatchOperation::Add {
-                    path,
-                    value,
-                    metadata,
-                } => {
+                PropertyPatchOperation::Add { path, property } => {
                     properties_with_metadata
-                        .add(
-                            path,
-                            PropertyWithMetadata::from_parts(value, metadata)
-                                .change_context(PatchError)?,
-                        )
+                        .add(path, property)
                         .change_context(PatchError)?;
                 }
                 PropertyPatchOperation::Remove { path } => {
@@ -161,17 +154,9 @@ impl Entity {
                         .remove(&path)
                         .change_context(PatchError)?;
                 }
-                PropertyPatchOperation::Replace {
-                    path,
-                    value,
-                    metadata,
-                } => {
+                PropertyPatchOperation::Replace { path, property } => {
                     properties_with_metadata
-                        .replace(
-                            &path,
-                            PropertyWithMetadata::from_parts(value, metadata)
-                                .change_context(PatchError)?,
-                        )
+                        .replace(&path, property)
                         .change_context(PatchError)?;
                 }
             }

--- a/libs/@local/hash-graph-types/rust/src/knowledge/entity/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/entity/mod.rs
@@ -1,4 +1,3 @@
-rewriting static
 mod diff;
 mod provenance;
 

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/patch.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/patch.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 use thiserror::Error;
 
-use crate::knowledge::{Property, PropertyMetadata, PropertyPath};
+use crate::knowledge::{PropertyPath, PropertyWithMetadata};
 
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
@@ -9,22 +9,17 @@ use crate::knowledge::{Property, PropertyMetadata, PropertyPath};
 pub enum PropertyPatchOperation {
     Add {
         path: PropertyPath<'static>,
-        value: Property,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        #[cfg_attr(feature = "utoipa", schema(nullable = false))]
-        metadata: Option<PropertyMetadata>,
+        property: PropertyWithMetadata,
     },
     Remove {
         path: PropertyPath<'static>,
     },
     Replace {
         path: PropertyPath<'static>,
-        value: Property,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        #[cfg_attr(feature = "utoipa", schema(nullable = false))]
-        metadata: Option<PropertyMetadata>,
+        property: PropertyWithMetadata,
     },
 }
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Error)]
 #[error("Failed to apply patch")]
 pub struct PatchError;

--- a/libs/@local/hash-graph-types/typescript/src/entity.ts
+++ b/libs/@local/hash-graph-types/typescript/src/entity.ts
@@ -231,3 +231,27 @@ export type EntityEditionProvenance = {
   origin?: ProvidedEntityEditionProvenanceOrigin;
   sources?: Array<SourceProvenance>;
 };
+
+type AddPropertyPatchOperation = {
+  op: "add";
+  path: PropertyPath;
+  value: PropertyValue;
+  metadata?: PropertyMetadata;
+};
+
+type RemovePropertyPatchOperation = {
+  op: "remove";
+  path: PropertyPath;
+};
+
+type ReplacePropertyPatchOperation = {
+  op: "replace";
+  path: PropertyPath;
+  value: PropertyValue;
+  metadata?: PropertyMetadata;
+};
+
+export type PropertyPatchOperation =
+  | AddPropertyPatchOperation
+  | RemovePropertyPatchOperation
+  | ReplacePropertyPatchOperation;

--- a/tests/hash-graph-integration/postgres/drafts.rs
+++ b/tests/hash-graph-integration/postgres/drafts.rs
@@ -9,7 +9,8 @@ use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::{
     knowledge::{
         entity::{EntityId, ProvidedEntityEditionProvenance},
-        Property, PropertyObject, PropertyPatchOperation, PropertyPath, PropertyWithMetadataObject,
+        Property, PropertyObject, PropertyPatchOperation, PropertyPath, PropertyWithMetadata,
+        PropertyWithMetadataObject,
     },
     owned_by_id::OwnedById,
 };
@@ -127,8 +128,8 @@ async fn initial_draft() {
                 entity_id: entity.metadata.record_id.entity_id,
                 properties: vec![PropertyPatchOperation::Replace {
                     path: PropertyPath::default(),
-                    value: Property::Object(bob()),
-                    metadata: None,
+                    property: PropertyWithMetadata::from_parts(Property::Object(bob()), None)
+                        .expect("could not create property with metadata"),
                 }],
                 entity_type_ids: HashSet::new(),
                 archived: None,
@@ -178,8 +179,8 @@ async fn initial_draft() {
                 entity_id: updated_entity.metadata.record_id.entity_id,
                 properties: vec![PropertyPatchOperation::Replace {
                     path: PropertyPath::default(),
-                    value: Property::Object(charles()),
-                    metadata: None,
+                    property: PropertyWithMetadata::from_parts(Property::Object(charles()), None)
+                        .expect("could not create property with metadata"),
                 }],
                 entity_type_ids: HashSet::new(),
                 archived: None,
@@ -305,8 +306,8 @@ async fn no_initial_draft() {
                     entity_id: entity.metadata.record_id.entity_id,
                     properties: vec![PropertyPatchOperation::Replace {
                         path: PropertyPath::default(),
-                        value: Property::Object(bob()),
-                        metadata: None,
+                        property: PropertyWithMetadata::from_parts(Property::Object(bob()), None)
+                            .expect("could not create property with metadata"),
                     }],
                     entity_type_ids: HashSet::new(),
                     archived: None,
@@ -361,8 +362,11 @@ async fn no_initial_draft() {
                     entity_id: updated_entity.metadata.record_id.entity_id,
                     properties: vec![PropertyPatchOperation::Replace {
                         path: PropertyPath::default(),
-                        value: Property::Object(charles()),
-                        metadata: None,
+                        property: PropertyWithMetadata::from_parts(
+                            Property::Object(charles()),
+                            None,
+                        )
+                        .expect("could not create property with metadata"),
                     }],
                     entity_type_ids: HashSet::new(),
                     archived: None,
@@ -465,8 +469,8 @@ async fn multiple_drafts() {
                     entity_id: entity.metadata.record_id.entity_id,
                     properties: vec![PropertyPatchOperation::Replace {
                         path: PropertyPath::default(),
-                        value: Property::Object(bob()),
-                        metadata: None,
+                        property: PropertyWithMetadata::from_parts(Property::Object(bob()), None)
+                            .expect("could not create property with metadata"),
                     }],
                     entity_type_ids: HashSet::new(),
                     archived: None,
@@ -524,8 +528,11 @@ async fn multiple_drafts() {
                     entity_id: draft,
                     properties: vec![PropertyPatchOperation::Replace {
                         path: PropertyPath::default(),
-                        value: Property::Object(charles()),
-                        metadata: None,
+                        property: PropertyWithMetadata::from_parts(
+                            Property::Object(charles()),
+                            None,
+                        )
+                        .expect("could not create property with metadata"),
                     }],
                     entity_type_ids: HashSet::new(),
                     archived: None,

--- a/tests/hash-graph-integration/postgres/entity.rs
+++ b/tests/hash-graph-integration/postgres/entity.rs
@@ -16,7 +16,7 @@ use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::{
     knowledge::{
         entity::ProvidedEntityEditionProvenance, Property, PropertyObject, PropertyPatchOperation,
-        PropertyPath, PropertyWithMetadataObject,
+        PropertyPath, PropertyWithMetadata, PropertyWithMetadataObject,
     },
     owned_by_id::OwnedById,
 };
@@ -229,8 +229,11 @@ async fn update() {
                 entity_id: v1_entity.metadata.record_id.entity_id,
                 properties: vec![PropertyPatchOperation::Replace {
                     path: PropertyPath::default(),
-                    value: Property::Object(page_v2.clone()),
-                    metadata: None,
+                    property: PropertyWithMetadata::from_parts(
+                        Property::Object(page_v2.clone()),
+                        None,
+                    )
+                    .expect("could not create property with metadata"),
                 }],
                 entity_type_ids: HashSet::new(),
                 archived: None,

--- a/tests/hash-graph-integration/postgres/partial_updates.rs
+++ b/tests/hash-graph-integration/postgres/partial_updates.rs
@@ -15,8 +15,9 @@ use graph::{
 use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::{
     knowledge::{
-        entity::ProvidedEntityEditionProvenance, Property, PropertyObject, PropertyPatchOperation,
-        PropertyPathElement, PropertyWithMetadataObject,
+        entity::ProvidedEntityEditionProvenance, PropertyObject, PropertyPatchOperation,
+        PropertyPathElement, PropertyProvenance, PropertyWithMetadata, PropertyWithMetadataObject,
+        ValueMetadata,
     },
     owned_by_id::OwnedById,
 };
@@ -109,8 +110,14 @@ async fn properties_add() {
             entity_type_ids: HashSet::new(),
             properties: vec![PropertyPatchOperation::Add {
                 path: once(PropertyPathElement::from(age_property_type_id())).collect(),
-                value: Property::Value(json!(30)),
-                metadata: None,
+                property: PropertyWithMetadata::Value {
+                    value: json!(30),
+                    metadata: ValueMetadata {
+                        confidence: None,
+                        data_type_id: None,
+                        provenance: PropertyProvenance::default(),
+                    },
+                },
             }],
             draft: None,
             archived: None,
@@ -257,8 +264,14 @@ async fn properties_replace() {
             entity_type_ids: HashSet::new(),
             properties: vec![PropertyPatchOperation::Replace {
                 path: once(PropertyPathElement::from(name_property_type_id())).collect(),
-                value: Property::Value(json!("Bob")),
-                metadata: None,
+                property: PropertyWithMetadata::Value {
+                    value: json!("Bob"),
+                    metadata: ValueMetadata {
+                        confidence: None,
+                        data_type_id: None,
+                        provenance: PropertyProvenance::default(),
+                    },
+                },
             }],
             draft: None,
             archived: None,

--- a/tests/hash-graph-integration/postgres/property_metadata.rs
+++ b/tests/hash-graph-integration/postgres/property_metadata.rs
@@ -13,7 +13,7 @@ use graph_types::{
         entity::{Location, ProvidedEntityEditionProvenance, SourceProvenance, SourceType},
         Confidence, ObjectMetadata, Property, PropertyMetadata, PropertyMetadataObject,
         PropertyObject, PropertyPatchOperation, PropertyPath, PropertyPathElement,
-        PropertyProvenance, PropertyWithMetadataObject, ValueMetadata,
+        PropertyProvenance, PropertyWithMetadata, PropertyWithMetadataObject, ValueMetadata,
     },
     owned_by_id::OwnedById,
 };
@@ -197,8 +197,8 @@ async fn initial_metadata() {
                         name_property_type_id(),
                     )))
                     .collect(),
-                    value: Property::Value(json!("Bob")),
-                    metadata: Some(name_property_metadata.clone()),
+                    property: PropertyWithMetadata::from_parts(Property::Value(json!("Bob")), None)
+                        .expect("could not create property with metadata"),
                 }],
                 entity_type_ids: HashSet::new(),
                 archived: None,
@@ -351,14 +351,14 @@ async fn no_initial_metadata() {
                 entity_id: entity.metadata.record_id.entity_id,
                 properties: vec![PropertyPatchOperation::Replace {
                     path: once(PropertyPathElement::from(name_property_type_id())).collect(),
-                    value: Property::Value(json!("Alice")),
-                    metadata: Some(PropertyMetadata::Value {
+                    property: PropertyWithMetadata::Value {
+                        value: json!("Alice"),
                         metadata: ValueMetadata {
                             confidence: Confidence::new(0.5),
                             data_type_id: None,
                             provenance: PropertyProvenance::default(),
                         },
-                    }),
+                    },
                 }],
                 entity_type_ids: HashSet::new(),
                 archived: None,
@@ -465,14 +465,14 @@ async fn properties_add() {
                 entity_type_ids: HashSet::new(),
                 properties: vec![PropertyPatchOperation::Add {
                     path: path.clone(),
-                    value: Property::Value(json!(30)),
-                    metadata: Some(PropertyMetadata::Value {
+                    property: PropertyWithMetadata::Value {
+                        value: json!(30),
                         metadata: ValueMetadata {
                             confidence: Confidence::new(0.5),
                             data_type_id: None,
                             provenance: PropertyProvenance::default(),
                         },
-                    }),
+                    },
                 }],
                 draft: None,
                 archived: None,
@@ -560,25 +560,24 @@ async fn properties_remove() {
                     PropertyPatchOperation::Add {
                         path: once(PropertyPathElement::from(interests_property_type_id()))
                             .collect(),
-                        value: Property::Object(PropertyObject::new(HashMap::new())),
-                        metadata: Some(PropertyMetadata::Object {
+                        property: PropertyWithMetadata::Object {
                             value: HashMap::new(),
                             metadata: ObjectMetadata {
                                 confidence: Confidence::new(0.4),
                                 provenance: property_provenance_a(),
                             },
-                        }),
+                        },
                     },
                     PropertyPatchOperation::Add {
                         path: film_path.clone(),
-                        value: Property::Value(json!("Fight Club")),
-                        metadata: Some(PropertyMetadata::Value {
+                        property: PropertyWithMetadata::Value {
+                            value: json!("Fight Club"),
                             metadata: ValueMetadata {
                                 confidence: Confidence::new(0.5),
                                 data_type_id: None,
                                 provenance: property_provenance_b(),
                             },
-                        }),
+                        },
                     },
                 ],
                 draft: None,

--- a/tests/hash-graph-integration/postgres/property_metadata.rs
+++ b/tests/hash-graph-integration/postgres/property_metadata.rs
@@ -11,9 +11,9 @@ use graph_test_data::{data_type, entity, entity_type, property_type};
 use graph_types::{
     knowledge::{
         entity::{Location, ProvidedEntityEditionProvenance, SourceProvenance, SourceType},
-        Confidence, ObjectMetadata, Property, PropertyMetadata, PropertyMetadataObject,
-        PropertyObject, PropertyPatchOperation, PropertyPath, PropertyPathElement,
-        PropertyProvenance, PropertyWithMetadata, PropertyWithMetadataObject, ValueMetadata,
+        Confidence, ObjectMetadata, PropertyMetadata, PropertyMetadataObject, PropertyObject,
+        PropertyPatchOperation, PropertyPath, PropertyPathElement, PropertyProvenance,
+        PropertyWithMetadata, PropertyWithMetadataObject, ValueMetadata,
     },
     owned_by_id::OwnedById,
 };
@@ -180,12 +180,10 @@ async fn initial_metadata() {
     assert_eq!(entity.metadata.confidence, Confidence::new(0.5));
     assert_eq!(entity.metadata.properties, entity_property_metadata);
 
-    let name_property_metadata = PropertyMetadata::Value {
-        metadata: ValueMetadata {
-            provenance: property_provenance_a(),
-            confidence: Confidence::new(0.6),
-            data_type_id: None,
-        },
+    let name_property_metadata = ValueMetadata {
+        provenance: property_provenance_a(),
+        confidence: Confidence::new(0.6),
+        data_type_id: None,
     };
     let updated_entity = api
         .patch_entity(
@@ -197,8 +195,10 @@ async fn initial_metadata() {
                         name_property_type_id(),
                     )))
                     .collect(),
-                    property: PropertyWithMetadata::from_parts(Property::Value(json!("Bob")), None)
-                        .expect("could not create property with metadata"),
+                    property: PropertyWithMetadata::Value {
+                        value: json!("Bob"),
+                        metadata: name_property_metadata.clone(),
+                    },
                 }],
                 entity_type_ids: HashSet::new(),
                 archived: None,
@@ -214,7 +214,12 @@ async fn initial_metadata() {
     assert_eq!(
         updated_entity.metadata.properties,
         PropertyMetadataObject {
-            value: HashMap::from([(name_property_type_id(), name_property_metadata)]),
+            value: HashMap::from([(
+                name_property_type_id(),
+                PropertyMetadata::Value {
+                    metadata: name_property_metadata
+                }
+            )]),
             metadata: ObjectMetadata {
                 provenance: PropertyProvenance::default(),
                 confidence: Confidence::new(0.8),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Initially, this was planned after H-2927 but as some operations do a create-or-update operation it makes sense to allow passing the metadata in a compound object when patching entities.

## 🚫 Blocked by

- #4630 

## 🔍 What does this change?

- Change API to require `property: PropertyWithMetadata` instead of `value` and `metadata`
- Abstract this away in the Graph SDK

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph