### PR TITLE
H-2969: Bump Rust toolchain to `nightly-2024-06-25`

### DIFF
--- a/apps/hash/README.md
+++ b/apps/hash/README.md
@@ -63,7 +63,7 @@ To run HASH locally, please follow these steps:
    ## ≥ 1.16
    
    rustc --version
-   ## ≥ 2024-06-24 (If installed through rustup, this will automatically install the required toolchain)
+   ## ≥ 2024-06-25 (If installed through rustup, this will automatically install the required toolchain)
    
    cargo --version
    ## Version matching the above rustc version

--- a/libs/antsi/rust-toolchain.toml
+++ b/libs/antsi/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-06-24"
+channel = "nightly-2024-06-25"
 components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'rust-analyzer']

--- a/libs/deer/rust-toolchain.toml
+++ b/libs/deer/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-06-24"
+channel = "nightly-2024-06-25"
 components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'miri', 'rust-analyzer']

--- a/libs/error-stack/README.md
+++ b/libs/error-stack/README.md
@@ -8,7 +8,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/error-stack)][crates.io]
 [![libs.rs](https://img.shields.io/badge/libs.rs-error--stack-orange)][libs.rs]
-[![rust-version](https://img.shields.io/static/v1?label=Rust&message=1.63.0/nightly-2024-06-24&color=blue)][rust-version]
+[![rust-version](https://img.shields.io/static/v1?label=Rust&message=1.63.0/nightly-2024-06-25&color=blue)][rust-version]
 [![documentation](https://img.shields.io/docsrs/error-stack)][documentation]
 [![license](https://img.shields.io/crates/l/error-stack)][license]
 [![discord](https://img.shields.io/discord/840573247803097118)][discord]

--- a/libs/error-stack/macros/README.md
+++ b/libs/error-stack/macros/README.md
@@ -7,7 +7,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/error-stack-macros)][crates.io]
 [![libs.rs](https://img.shields.io/badge/libs.rs-error--stack--macros-orange)][libs.rs]
-[![rust-version](https://img.shields.io/static/v1?label=Rust&message=1.63.0/nightly-2024-06-24&color=blue)][rust-version]
+[![rust-version](https://img.shields.io/static/v1?label=Rust&message=1.63.0/nightly-2024-06-25&color=blue)][rust-version]
 [![documentation](https://img.shields.io/docsrs/error-stack-macros)][documentation]
 [![license](https://img.shields.io/crates/l/error-stack)][license]
 [![discord](https://img.shields.io/discord/840573247803097118)][discord]

--- a/libs/error-stack/rust-toolchain.toml
+++ b/libs/error-stack/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Please also update the badges in `README.md`s (`error-stack` and `error-stack-macros`), and `src/lib.rs`
-channel = "nightly-2024-06-24"
+channel = "nightly-2024-06-25"
 components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'miri', 'rust-src', 'rust-analyzer']

--- a/libs/error-stack/src/lib.rs
+++ b/libs/error-stack/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! [![crates.io](https://img.shields.io/crates/v/error-stack)][crates.io]
 //! [![libs.rs](https://img.shields.io/badge/libs.rs-error--stack-orange)][libs.rs]
-//! [![rust-version](https://img.shields.io/static/v1?label=Rust&message=1.63.0/nightly-2024-06-24&color=blue)][rust-version]
+//! [![rust-version](https://img.shields.io/static/v1?label=Rust&message=1.63.0/nightly-2024-06-25&color=blue)][rust-version]
 //! [![discord](https://img.shields.io/discord/840573247803097118)][discord]
 //!
 //! [crates.io]: https://crates.io/crates/error-stack

--- a/libs/sarif/rust-toolchain.toml
+++ b/libs/sarif/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-06-24"
+channel = "nightly-2024-06-25"
 components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'rust-analyzer']

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-06-24"
+channel = "nightly-2024-06-25"
 components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'miri', 'rust-analyzer']


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

There was a regression in the latest nightly toolchain, which is fixed.

## 🔗 Related links

- https://github.com/rust-lang/rust/issues/126887
