### PR TITLE
H-2801: Validate data type in entity property metadata

### DIFF
--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -1462,7 +1462,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
       "http://localhost:3000/@alice/types/property-type/height/": {
         "value": 1.8,
         "metadata": {
-          "dataTypeId": "https://blockprotocol.org/@blockprotocol/types/data-type/numer/v/1"
+          "dataTypeId": "http://localhost:3000/@alice/types/data-type/meter/v/2"
         }
       }
     }

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/mod.rs
@@ -11,7 +11,10 @@ use std::{collections::HashMap, io};
 use error_stack::Report;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
-use type_system::{url::BaseUrl, JsonSchemaValueType};
+use type_system::{
+    url::{BaseUrl, VersionedUrl},
+    JsonSchemaValueType,
+};
 
 pub use self::{
     diff::PropertyDiff,
@@ -83,6 +86,15 @@ impl PropertyWithMetadata {
             Self::Array { .. } => JsonSchemaValueType::Array,
             Self::Object { .. } => JsonSchemaValueType::Object,
             Self::Value { value, .. } => JsonSchemaValueType::from(value),
+        }
+    }
+
+    #[must_use]
+    pub const fn data_type_id(&self) -> Option<&VersionedUrl> {
+        if let Self::Value { metadata, .. } = self {
+            metadata.data_type_id.as_ref()
+        } else {
+            None
         }
     }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The specified data type needs to:

- match the actual data
- be allowed on the entity