### PR TITLE
H-2939: Handle both spreadsheet and report being chosen as deliverables 

### DIFF
--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer.tsx
@@ -156,13 +156,14 @@ const getGraphFromFlowDefinition = (
     } else {
       const nextNode = derivedNodes[i + 1];
 
-      const thisGroup = node.data.groupId;
-      const nextGroup = nextNode?.data.groupId;
+      const groupForThisNode = node.data.groupId;
+      const groupForNextNode = nextNode?.data.groupId;
 
       if (
         nextNode &&
         nextNode.parentNode !== node.id &&
-        thisGroup === nextGroup
+        groupForThisNode === groupForNextNode &&
+        layerByStepId.get(node.id) !== layerByStepId.get(nextNode.id)
       ) {
         derivedEdges.push({
           id: `${node.id}-${nextNode.id}`,

--- a/apps/hash-frontend/src/pages/shared/flow-definitions-context.tsx
+++ b/apps/hash-frontend/src/pages/shared/flow-definitions-context.tsx
@@ -13,6 +13,7 @@ import {
 } from "@local/hash-isomorphic-utils/flows/example-flow-definitions";
 import {
   goalFlowDefinition,
+  goalFlowDefinitionWithReportAndSpreadsheetDeliverable,
   goalFlowDefinitionWithReportDeliverable,
   goalFlowDefinitionWithSpreadsheetDeliverable,
 } from "@local/hash-isomorphic-utils/flows/goal-flow-definitions";
@@ -40,6 +41,7 @@ const exampleFlows: FlowDefinition[] = [
   goalFlowDefinition,
   goalFlowDefinitionWithReportDeliverable,
   goalFlowDefinitionWithSpreadsheetDeliverable,
+  goalFlowDefinitionWithReportAndSpreadsheetDeliverable,
 ];
 
 export const FlowDefinitionsContextProvider = ({

--- a/libs/@local/hash-isomorphic-utils/src/flows/goal-flow-definitions.ts
+++ b/libs/@local/hash-isomorphic-utils/src/flows/goal-flow-definitions.ts
@@ -227,6 +227,7 @@ export const goalFlowDefinitionWithReportAndSpreadsheetDeliverable: FlowDefiniti
       outputs: [
         ...goalFlowDefinition.trigger.outputs,
         ...markdownReportTriggerInputs,
+        ...googleSheetTriggerInputs,
       ],
     },
     steps: [

--- a/libs/@local/hash-isomorphic-utils/src/flows/goal-flow-definitions/google-sheets.ts
+++ b/libs/@local/hash-isomorphic-utils/src/flows/goal-flow-definitions/google-sheets.ts
@@ -1,0 +1,71 @@
+import type { DistributiveOmit } from "@local/advanced-types/distribute";
+import type {
+  InputNameForAction,
+  OutputNameForAction,
+} from "@local/hash-isomorphic-utils/flows/action-definitions";
+import type { FlowDefinition } from "@local/hash-isomorphic-utils/flows/types";
+
+export type GoogleSheetTriggerInput = "Google Account" | "Google Sheet";
+
+export const googleSheetTriggerInputs = [
+  {
+    payloadKind: "GoogleAccountId",
+    name: "Google Account" satisfies GoogleSheetTriggerInput,
+    array: false,
+    required: true,
+  },
+  {
+    payloadKind: "GoogleSheet",
+    name: "Google Sheet" satisfies GoogleSheetTriggerInput,
+    array: false,
+    required: true,
+  },
+] satisfies FlowDefinition["trigger"]["outputs"];
+
+export const googleSheetStep = {
+  kind: "action",
+  actionDefinitionId: "writeGoogleSheet",
+  description: "Save discovered entities to Google Sheet",
+  inputSources: [
+    {
+      inputName: "audience" satisfies InputNameForAction<"writeGoogleSheet">,
+      kind: "hardcoded",
+      payload: {
+        kind: "ActorType",
+        value: "human",
+      },
+    },
+    {
+      inputName:
+        "googleAccountId" satisfies InputNameForAction<"writeGoogleSheet">,
+      kind: "step-output",
+      sourceStepId: "trigger",
+      sourceStepOutputName: "Google Account" satisfies GoogleSheetTriggerInput,
+    },
+    {
+      inputName: "googleSheet" satisfies InputNameForAction<"writeGoogleSheet">,
+      kind: "step-output",
+      sourceStepId: "trigger",
+      sourceStepOutputName: "Google Sheet" satisfies GoogleSheetTriggerInput,
+    },
+    {
+      inputName: "dataToWrite" satisfies InputNameForAction<"writeGoogleSheet">,
+      kind: "step-output",
+      sourceStepId: "2",
+      sourceStepOutputName:
+        "persistedEntities" satisfies OutputNameForAction<"persistEntities">,
+    },
+  ],
+} satisfies DistributiveOmit<
+  FlowDefinition["steps"][number],
+  "stepId" | "groupId"
+>;
+
+export const googleSheetDeliverable = {
+  stepOutputName:
+    "googleSheetEntity" satisfies OutputNameForAction<"writeGoogleSheet">,
+  payloadKind: "PersistedEntity",
+  name: "googleSheetEntity" as const,
+  array: false,
+  required: true,
+} satisfies Omit<FlowDefinition["outputs"][number], "stepId">;

--- a/libs/@local/hash-isomorphic-utils/src/flows/goal-flow-definitions/markdown-report.ts
+++ b/libs/@local/hash-isomorphic-utils/src/flows/goal-flow-definitions/markdown-report.ts
@@ -1,0 +1,60 @@
+import type { DistributiveOmit } from "@local/advanced-types/distribute";
+import type {
+  InputNameForAction,
+  OutputNameForAction,
+} from "@local/hash-isomorphic-utils/flows/action-definitions";
+import type {
+  ActionStepDefinition,
+  FlowDefinition,
+} from "@local/hash-isomorphic-utils/flows/types";
+
+export type ReportTriggerInput = "Report specification";
+
+export const markdownReportTriggerInputs = [
+  {
+    payloadKind: "Text",
+    name: "Report specification" satisfies ReportTriggerInput,
+    array: false,
+    required: true,
+  },
+] satisfies FlowDefinition["trigger"]["outputs"];
+
+export const markdownReportResearchEntitiesStepInput = {
+  inputName:
+    "reportSpecification" satisfies InputNameForAction<"researchEntities">,
+  kind: "step-output",
+  sourceStepId: "trigger",
+  sourceStepOutputName: "Report specification" satisfies ReportTriggerInput,
+} as const satisfies ActionStepDefinition["inputSources"][number];
+
+export const markdownReportStep = {
+  kind: "action",
+  actionDefinitionId: "answerQuestion",
+  description: "Write report based on the research specification",
+  inputSources: [
+    {
+      inputName: "question" satisfies InputNameForAction<"answerQuestion">,
+      kind: "step-output",
+      sourceStepId: "trigger",
+      sourceStepOutputName: "Report specification",
+    },
+    {
+      inputName: "entities" satisfies InputNameForAction<"answerQuestion">,
+      kind: "step-output",
+      sourceStepId: "2",
+      sourceStepOutputName:
+        "persistedEntities" satisfies OutputNameForAction<"persistEntities">,
+    },
+  ],
+} satisfies DistributiveOmit<
+  FlowDefinition["steps"][number],
+  "stepId" | "groupId"
+>;
+
+export const markdownReportDeliverable = {
+  stepOutputName: "answer" satisfies OutputNameForAction<"answerQuestion">,
+  payloadKind: "Text",
+  name: "report" as const,
+  array: false,
+  required: true,
+} satisfies Omit<FlowDefinition["outputs"][number], "stepId">;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Handles the case where a Goal-driven flow is set up where the user selects both (a) to write to Google Sheets and (b) produce a Markdown-formatted report.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

This 'manually define a fixed flow per deliverable combination' will not scale with more deliverables. The longer-term solution is to start persisting Flow definitions in the database, and generate them dynamically as needed.

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- None yet.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Start a Flow with both spreadsheet and report selected

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
<img width="1603" alt="Screenshot 2024-06-26 at 13 10 06" src="https://github.com/hashintel/hash/assets/37743469/0af4fcb8-b0dc-4318-a9d1-22edb5c933d0">
