### PR TITLE
H-1127: Avoid warnings in hash-graph-client codegen

### DIFF
--- a/apps/hash-graph/libs/api/src/rest/json_schemas/status_definitions.json
+++ b/apps/hash-graph/libs/api/src/rest/json_schemas/status_definitions.json
@@ -38,7 +38,7 @@
           "title": "domain"
         },
         "metadata": {
-          "$ref": "#/definitions/Object",
+          "$ref": "#/definitions/ErrorInfoMetadata",
           "description": "Additional structured details about this error.\n\nKeys should match /[a-zA-Z0-9-_]/ and be limited to 64 characters in length. When\nidentifying the current value of an exceeded limit, the units should be contained in the\nkey, not the value.  For example, rather than {\"instanceLimit\": \"100/request\"}, should be\nreturned as, {\"instanceLimitPerRequest\": \"100\"}, if the client exceeds the number of\ninstances that can be created in a single (batch) request.",
           "title": "metadata"
         }
@@ -87,7 +87,7 @@
       },
       "required": ["description", "resourceName", "resourceType"]
     },
-    "Object": {
+    "ErrorInfoMetadata": {
       "description": "Construct a type with a set of properties K of type T",
       "title": "Record<string,any>",
       "type": "object"

--- a/apps/hash-graph/openapi/models/status_definitions.json
+++ b/apps/hash-graph/openapi/models/status_definitions.json
@@ -38,7 +38,7 @@
           "title": "domain"
         },
         "metadata": {
-          "$ref": "#/definitions/Object",
+          "$ref": "#/definitions/ErrorInfoMetadata",
           "description": "Additional structured details about this error.\n\nKeys should match /[a-zA-Z0-9-_]/ and be limited to 64 characters in length. When\nidentifying the current value of an exceeded limit, the units should be contained in the\nkey, not the value.  For example, rather than {\"instanceLimit\": \"100/request\"}, should be\nreturned as, {\"instanceLimitPerRequest\": \"100\"}, if the client exceeds the number of\ninstances that can be created in a single (batch) request.",
           "title": "metadata"
         }
@@ -87,7 +87,7 @@
       },
       "required": ["description", "resourceName", "resourceType"]
     },
-    "Object": {
+    "ErrorInfoMetadata": {
       "description": "Construct a type with a set of properties K of type T",
       "title": "Record<string,any>",
       "type": "object"

--- a/libs/@local/hash-graph-client/typescript/package.json
+++ b/libs/@local/hash-graph-client/typescript/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "main": "index.ts",
   "scripts": {
-    "codegen": "redocly bundle -o openapi.bundle.json ../../../../apps/hash-graph/openapi/openapi.json && openapi-generator-cli generate && rm openapi.bundle.json"
+    "codegen": "redocly bundle -o openapi.bundle.json ../../../../apps/hash-graph/openapi/openapi.json && JAVA_OPTS='-Dlog.level=warn' openapi-generator-cli generate && rm openapi.bundle.json"
   },
   "dependencies": {
     "@openapitools/openapi-generator-cli": "2.5.2",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The codegen script of @local/hash-graph-client is noisy and contains warnings. The warnings should be avoided and unnecessary output be removed. Especially with the new `turbo` version, this is even more annoying.

## 🔍 What does this change?

- Avoid warnings
- Hide INFO level logs
