### PR TITLE
H-2774: Show type and draft status change in entity history tab

### DIFF
--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/get-history-events.ts
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/get-history-events.ts
@@ -1,4 +1,7 @@
+import { extractBaseUrl, type VersionedUrl } from "@blockprotocol/type-system";
+import { extractVersion } from "@blockprotocol/type-system/slim";
 import { typedEntries } from "@local/advanced-types/typed-entries";
+import type { EntityTypeIdDiff } from "@local/hash-graph-client";
 import type { EntityId, PropertyPath } from "@local/hash-graph-types/entity";
 import type { BaseUrl } from "@local/hash-graph-types/ontology";
 import type { Timestamp } from "@local/hash-graph-types/temporal-versioning";
@@ -9,11 +12,8 @@ import {
   getPropertyTypeForEntity,
 } from "@local/hash-subgraph/stdlib";
 
-import { extractBaseUrl, type VersionedUrl } from "@blockprotocol/type-system";
-import type { EntityTypeIdDiff } from "@local/hash-graph-client";
-import { extractVersion } from "@blockprotocol/type-system/slim";
-import type { HistoryEvent } from "./shared/types";
 import type { EntityDiff } from "../../../../../../graphql/api-types.gen";
+import type { HistoryEvent } from "./shared/types";
 
 export const getHistoryEvents = (diffs: EntityDiff[], subgraph: Subgraph) => {
   const firstEditionIdentifier = [...subgraph.roots].sort((a, b) =>
@@ -71,7 +71,7 @@ export const getHistoryEvents = (diffs: EntityDiff[], subgraph: Subgraph) => {
       const upgradedFromEntityTypeIds: VersionedUrl[] = [];
 
       const diffsWithAdditionsFirst = [...diffData.diff.entityTypeIds].sort(
-        (a, b) => {
+        (a) => {
           return a.op === "added" ? -1 : 1;
         },
       );

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/get-history-events.ts
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/get-history-events.ts
@@ -9,11 +9,17 @@ import {
   getPropertyTypeForEntity,
 } from "@local/hash-subgraph/stdlib";
 
-import type { EntityDiff } from "../../../../../../graphql/api-types.gen";
+import { extractBaseUrl, type VersionedUrl } from "@blockprotocol/type-system";
+import type { EntityTypeIdDiff } from "@local/hash-graph-client";
+import { extractVersion } from "@blockprotocol/type-system/slim";
 import type { HistoryEvent } from "./shared/types";
+import type { EntityDiff } from "../../../../../../graphql/api-types.gen";
 
 export const getHistoryEvents = (diffs: EntityDiff[], subgraph: Subgraph) => {
-  const firstEditionIdentifier = subgraph.roots[0];
+  const firstEditionIdentifier = [...subgraph.roots].sort((a, b) =>
+    a.revisionId < b.revisionId ? -1 : 1,
+  )[0];
+
   if (!firstEditionIdentifier) {
     throw new Error("No first edition for entity found in roots");
   }
@@ -29,17 +35,6 @@ export const getHistoryEvents = (diffs: EntityDiff[], subgraph: Subgraph) => {
   }
 
   const events: HistoryEvent[] = [];
-
-  const entityTypeWithMetadata = getEntityTypeById(
-    subgraph,
-    firstEntityEdition.metadata.entityTypeId,
-  );
-
-  if (!entityTypeWithMetadata) {
-    throw new Error(
-      `Could not find entity type with id ${firstEntityEdition.metadata.entityTypeId} in subgraph`,
-    );
-  }
 
   for (
     let changedEntityIndex = diffs.length - 1;
@@ -60,24 +55,101 @@ export const getHistoryEvents = (diffs: EntityDiff[], subgraph: Subgraph) => {
       );
     }
 
-    if (diffData.diff.draftState !== undefined) {
-      /**
-       * @todo H-2774 – handle 'change draft status' events
-       */
-      const _newDraftState = diffData.diff.draftState;
-    }
+    /**
+     * The original edition is not included in the diffs, so the 0-based index needs +2 to get the nth edition with base 1
+     */
+    const editionNumber = changedEntityIndex + 2;
+
+    let subChangeNumber = 1;
+
+    const timestamp =
+      changedEntityEdition.metadata.temporalVersioning.decisionTime.start.limit;
+
+    const editionProvenance = changedEntityEdition.metadata.provenance.edition;
 
     if (diffData.diff.entityTypeIds) {
-      /**
-       * @todo H-2774 – handle 'change draft status' events
-       */
+      const upgradedFromEntityTypeIds: VersionedUrl[] = [];
+
+      const diffsWithAdditionsFirst = [...diffData.diff.entityTypeIds].sort(
+        (a, b) => {
+          return a.op === "added" ? -1 : 1;
+        },
+      );
+
+      for (const entityTypeDiff of diffsWithAdditionsFirst) {
+        const addedOrRemovedTypeId =
+          entityTypeDiff.op === "added"
+            ? (entityTypeDiff.added as VersionedUrl)
+            : (entityTypeDiff.removed as VersionedUrl);
+        const addedOrRemovedType = getEntityTypeById(
+          subgraph,
+          addedOrRemovedTypeId,
+        );
+
+        if (!addedOrRemovedType) {
+          throw new Error(
+            `Could not find entity type with id ${addedOrRemovedTypeId} in subgraph`,
+          );
+        }
+
+        if (entityTypeDiff.op === "added") {
+          const baseUrl = extractBaseUrl(entityTypeDiff.added as VersionedUrl);
+
+          const removedOldVersion = diffData.diff.entityTypeIds.find(
+            (
+              entityTypeIdDiff,
+            ): entityTypeIdDiff is EntityTypeIdDiff & { op: "removed" } =>
+              entityTypeIdDiff.op === "removed" &&
+              extractBaseUrl(entityTypeIdDiff.removed as VersionedUrl) ===
+                baseUrl,
+          );
+          if (removedOldVersion) {
+            upgradedFromEntityTypeIds.push(
+              removedOldVersion.removed as VersionedUrl,
+            );
+          }
+
+          events.push({
+            type: "type-update",
+            op: removedOldVersion ? "upgraded" : "added",
+            number: `${editionNumber}.${subChangeNumber++}`,
+            provenance: {
+              edition: editionProvenance,
+            },
+            timestamp,
+            entityType: {
+              title: addedOrRemovedType.schema.title,
+              version: addedOrRemovedType.metadata.recordId.version,
+              oldVersion: removedOldVersion
+                ? extractVersion(removedOldVersion.removed as VersionedUrl)
+                : undefined,
+            },
+          });
+        } else {
+          const removed = entityTypeDiff.removed as VersionedUrl;
+          if (upgradedFromEntityTypeIds.includes(removed)) {
+            // we already captured this as an 'upgrade' event
+            continue;
+          }
+          events.push({
+            type: "type-update",
+            op: "removed",
+            number: `${editionNumber}.${subChangeNumber++}`,
+            provenance: {
+              edition: editionProvenance,
+            },
+            timestamp,
+            entityType: {
+              title: addedOrRemovedType.schema.title,
+              version: addedOrRemovedType.metadata.recordId.version,
+            },
+          });
+        }
+      }
     }
 
     if (diffData.diff.properties) {
-      for (const [
-        changedPropertyIndex,
-        propertyDiff,
-      ] of diffData.diff.properties.entries()) {
+      for (const propertyDiff of diffData.diff.properties) {
         const propertyProvenance = changedEntityEdition.propertyMetadata(
           propertyDiff.path as PropertyPath,
         )?.provenance;
@@ -95,10 +167,7 @@ export const getHistoryEvents = (diffs: EntityDiff[], subgraph: Subgraph) => {
           );
 
           events.push({
-            /**
-             * The original entity is not included in the diffs, so the 0-based index needs +2
-             */
-            number: `${changedEntityIndex + 2}.${changedPropertyIndex + 1}`,
+            number: `${editionNumber}.${subChangeNumber++}`,
             provenance: {
               edition: changedEntityEdition.metadata.provenance.edition,
               property: propertyProvenance,
@@ -116,6 +185,19 @@ export const getHistoryEvents = (diffs: EntityDiff[], subgraph: Subgraph) => {
           );
         }
       }
+    }
+
+    if (diffData.diff.draftState !== undefined) {
+      const newDraftState = diffData.diff.draftState;
+      events.push({
+        number: `${editionNumber}.${subChangeNumber++}`,
+        provenance: {
+          edition: changedEntityEdition.metadata.provenance.edition,
+        },
+        newDraftStatus: newDraftState,
+        timestamp,
+        type: "draft-status-change",
+      });
     }
   }
 
@@ -161,11 +243,22 @@ export const getHistoryEvents = (diffs: EntityDiff[], subgraph: Subgraph) => {
     }
   }
 
+  const firstEntityType = getEntityTypeById(
+    subgraph,
+    firstEntityEdition.metadata.entityTypeId,
+  );
+
+  if (!firstEntityType) {
+    throw new Error(
+      `Could not find entity type with id ${firstEntityEdition.metadata.entityTypeId} in subgraph`,
+    );
+  }
+
   events.push({
     type: "created",
     number: "1",
     entity: firstEntityEdition,
-    entityType: entityTypeWithMetadata.schema,
+    entityType: firstEntityType.schema,
     timestamp: firstEditionIdentifier.revisionId,
     provenance: {
       edition: firstEntityEdition.metadata.provenance.edition,

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/history-table.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/history-table.tsx
@@ -102,7 +102,7 @@ const TableRow = memo(
 
     const [showProvenance, setShowProvenance] = useState(false);
 
-    const [editionNumber, changedPropertyNumber] = number.split(".");
+    const [editionNumber, subChangeNumber] = number.split(".");
 
     const provenanceRef = useRef<HTMLDivElement>(null);
 
@@ -139,14 +139,14 @@ const TableRow = memo(
               }}
             >
               <Typography sx={typographySx}>{editionNumber}</Typography>
-              {changedPropertyNumber && (
+              {subChangeNumber && (
                 <Typography
                   sx={{
                     ...typographySx,
                     color: ({ palette }) => palette.gray[60],
                   }}
                 >
-                  .{changedPropertyNumber}
+                  .{subChangeNumber}
                 </Typography>
               )}
             </Box>

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/history-table/shared/event-detail.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/history-table/shared/event-detail.tsx
@@ -78,7 +78,34 @@ export const EventDetail = ({
       }
       break;
     }
-    case "type-update":
-      return <span>Updated type</span>;
+    case "type-update": {
+      const { entityType } = event;
+      return (
+        <>
+          <Chip showInFull type>
+            {entityType.title}
+          </Chip>{" "}
+          <Box ml={1} sx={{ whiteSpace: "nowrap" }}>
+            type {event.op}
+          </Box>
+          {event.op === "upgraded" && (
+            <Box ml={0.5}>
+              from v{entityType.oldVersion} to v{entityType.version}
+            </Box>
+          )}
+        </>
+      );
+    }
+    case "draft-status-change":
+      return (
+        <span>
+          {event.newDraftStatus
+            ? "Edition created as draft"
+            : "Live edition created from draft"}
+        </span>
+      );
+    default: {
+      throw new Error("Unhandled history event type");
+    }
   }
 };

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/shared/types.ts
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/shared/types.ts
@@ -33,7 +33,20 @@ type PropertyUpdateEvent = HistoryEventBase & {
 
 type TypeUpdateEvent = HistoryEventBase & {
   type: "type-update";
-  entityType: EntityType;
+  entityType: {
+    oldVersion?: number;
+    title: string;
+    version: number;
+  };
+  op: "added" | "removed" | "upgraded";
+  provenance: {
+    edition: EntityEditionProvenance;
+  };
+};
+
+type DraftStatusChangeEvent = HistoryEventBase & {
+  type: "draft-status-change";
+  newDraftStatus: boolean;
   provenance: {
     edition: EntityEditionProvenance;
   };
@@ -42,4 +55,5 @@ type TypeUpdateEvent = HistoryEventBase & {
 export type HistoryEvent =
   | CreationEvent
   | PropertyUpdateEvent
-  | TypeUpdateEvent;
+  | TypeUpdateEvent
+  | DraftStatusChangeEvent;

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/shared/update-entity-subgraph-state-by-entity.ts
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/shared/update-entity-subgraph-state-by-entity.ts
@@ -20,7 +20,7 @@ export const updateEntitySubgraphStateByEntity = (
      *   For places where we mutate elements, we should probably store them separately from the subgraph to
      *   allow for optimistic updates without being incorrect.
      */
-    const metadata = entity.metadata;
+    const metadata = JSON.parse(JSON.stringify(entity.metadata));
     const newEntityRevisionId = new Date().toISOString() as EntityRevisionId;
     metadata.temporalVersioning.decisionTime.start.limit = newEntityRevisionId;
     metadata.temporalVersioning.transactionTime.start.limit =

--- a/libs/@local/hash-subgraph/src/types/shared/branded.ts
+++ b/libs/@local/hash-subgraph/src/types/shared/branded.ts
@@ -38,11 +38,11 @@ export const entityIdFromComponents = (
 ): EntityId => {
   const base = `${ownedById}${ENTITY_ID_DELIMITER}${entityUuid}`;
 
-  if (draftId) {
+  if (!draftId) {
     return base as EntityId;
   }
 
-  return `${ownedById}${ENTITY_ID_DELIMITER}${entityUuid}` as EntityId;
+  return `${base}${ENTITY_ID_DELIMITER}${draftId}` as EntityId;
 };
 
 export const splitEntityId = (


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In the history section of the entity editor, show rows for when:
1. A type is added, removed or upgraded on the entity
2. Draft status is changed from false to true or from true to false

Also fixes a couple of bugs related to ApolloClient state now being immutable (as it should be, but has caused errors to be thrown where we do mutate it).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

The history do not filter out drafts which may be irrelevant to the history being viewed, either because they are new drafts of a live entity being viewed which shouldn't be in its own history, or because multiple drafts in the past were created and only one was selected to be turned into the live entity – to be addressed in H-3030, H-3031.

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->


## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Make relevant changes, look at the history

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

https://github.com/hashintel/hash/assets/37743469/560c8114-861d-435a-ab30-d674a2aa706b

