### PR TITLE
H-3044: Improve ontology type id typings

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/write-google-sheet-action/get-filter-from-bp-query-entity.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/write-google-sheet-action/get-filter-from-bp-query-entity.ts
@@ -31,7 +31,7 @@ export const getFilterFromBlockProtocolQueryEntity = async ({
 
   const multiFilter =
     queryEntity.properties[
-      blockProtocolPropertyTypes.query.propertyTypeBaseUrl
+      "https://blockprotocol.org/@hash/types/property-type/query/"
     ];
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- additional check in case another entity is used that has this optional

--- a/apps/hash-api/src/ai/gpt/gpt-query-entities.ts
+++ b/apps/hash-api/src/ai/gpt/gpt-query-entities.ts
@@ -13,7 +13,6 @@ import { frontendUrl } from "@local/hash-isomorphic-utils/environment";
 import { generateEntityPath } from "@local/hash-isomorphic-utils/frontend-paths";
 import { generateUuid } from "@local/hash-isomorphic-utils/generate-uuid";
 import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
-import { systemPropertyTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { mapGraphApiSubgraphToSubgraph } from "@local/hash-isomorphic-utils/subgraph-mapping";
 import type {
   OrganizationProperties,
@@ -280,7 +279,7 @@ export const gptQueryEntities: RequestHandler<
             type: isUser ? "User" : "Organization",
             name: (
               owningEntity.properties as UserProperties | OrganizationProperties
-            )[systemPropertyTypes.shortname.propertyTypeBaseUrl]!,
+            )["https://hash.ai/@hash/types/property-type/shortname/"]!,
             uuid: webOwnedById,
           };
 

--- a/apps/hash-api/src/generate-ontology-type-ids.ts
+++ b/apps/hash-api/src/generate-ontology-type-ids.ts
@@ -194,7 +194,6 @@ const generateOntologyIds = async () => {
 
   const graphContext: ImpureGraphContext = {
     graphApi,
-    provenance: { actorType: "human", origin: { type: "migration" } },
     temporalClient: null,
   };
 

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/011-deprecate-preferred-name.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/011-deprecate-preferred-name.migration.ts
@@ -195,11 +195,9 @@ const migrate: MigrationFunction = async ({
     entityTypeBaseUrls: baseUrls,
     migrationState,
     migrateProperties: {
-      [systemEntityTypes.user.entityTypeBaseUrl as BaseUrl]: (
-        previousUserProperties,
-      ) => {
+      [systemEntityTypes.user.entityTypeBaseUrl]: (previousUserProperties) => {
         const {
-          [systemPropertyTypes.preferredName.propertyTypeBaseUrl as BaseUrl]:
+          [systemPropertyTypes.preferredName.propertyTypeBaseUrl]:
             previousPreferredName,
           ...remainingProperties
         } = previousUserProperties;

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/015-add-flow-types.dev.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/015-add-flow-types.dev.migration.ts
@@ -1,5 +1,4 @@
 import type { EntityType } from "@blockprotocol/type-system";
-import type { BaseUrl } from "@local/hash-graph-types/ontology";
 import {
   blockProtocolPropertyTypes,
   systemEntityTypes,
@@ -104,8 +103,7 @@ const migrate: MigrationFunction = async ({
       entityTypeDefinition: {
         title: "Flow Definition",
         description: "The definition of a HASH flow.",
-        labelProperty: blockProtocolPropertyTypes.name
-          .propertyTypeBaseUrl as BaseUrl,
+        labelProperty: blockProtocolPropertyTypes.name.propertyTypeBaseUrl,
         properties: [
           {
             propertyType: blockProtocolPropertyTypes.name.propertyTypeId,
@@ -227,8 +225,7 @@ const migrate: MigrationFunction = async ({
       entityTypeDefinition: {
         title: "Flow Run",
         description: "An execution run of a flow.",
-        labelProperty: blockProtocolPropertyTypes.name
-          .propertyTypeBaseUrl as BaseUrl,
+        labelProperty: blockProtocolPropertyTypes.name.propertyTypeBaseUrl,
         properties: [
           {
             propertyType: blockProtocolPropertyTypes.name.propertyTypeId,
@@ -342,9 +339,7 @@ const migrate: MigrationFunction = async ({
    */
 
   await upgradeEntitiesToNewTypeVersion(context, authentication, {
-    entityTypeBaseUrls: [
-      systemEntityTypes.usageRecord.entityTypeBaseUrl as BaseUrl,
-    ],
+    entityTypeBaseUrls: [systemEntityTypes.usageRecord.entityTypeBaseUrl],
     migrationState,
   });
 

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/017-add-use-case-form-and-example-org.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/017-add-use-case-form-and-example-org.migration.ts
@@ -1,4 +1,3 @@
-import type { BaseUrl } from "@local/hash-graph-types/ontology";
 import { isSelfHostedInstance } from "@local/hash-isomorphic-utils/instance";
 import {
   systemEntityTypes,
@@ -96,7 +95,7 @@ const migrate: MigrationFunction = async ({
         title: "Prospective User",
         description:
           "Information about a prospective user of an application or system",
-        labelProperty: systemPropertyTypes.email.propertyTypeBaseUrl as BaseUrl,
+        labelProperty: systemPropertyTypes.email.propertyTypeBaseUrl,
         properties: [
           {
             propertyType: systemPropertyTypes.websiteUrl.propertyTypeId,
@@ -142,7 +141,7 @@ const migrate: MigrationFunction = async ({
       websiteUrl: "https://example.com",
       entityTypeVersion:
         migrationState.entityTypeVersions[
-          systemEntityTypes.organization.entityTypeBaseUrl as BaseUrl
+          systemEntityTypes.organization.entityTypeBaseUrl
         ],
     });
   }

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
@@ -836,8 +836,7 @@ export const getCurrentHashSystemEntityTypeId = ({
   entityTypeKey: keyof typeof systemEntityTypes;
   migrationState: MigrationState;
 }) => {
-  const entityTypeBaseUrl = systemEntityTypes[entityTypeKey]
-    .entityTypeBaseUrl as BaseUrl;
+  const entityTypeBaseUrl = systemEntityTypes[entityTypeKey].entityTypeBaseUrl;
 
   const entityTypeVersion =
     migrationState.entityTypeVersions[entityTypeBaseUrl];
@@ -858,8 +857,8 @@ export const getCurrentHashLinkEntityTypeId = ({
   linkEntityTypeKey: keyof typeof systemLinkEntityTypes;
   migrationState: MigrationState;
 }) => {
-  const linkEntityTypeBaseUrl = systemLinkEntityTypes[linkEntityTypeKey]
-    .linkEntityTypeBaseUrl as BaseUrl;
+  const linkEntityTypeBaseUrl =
+    systemLinkEntityTypes[linkEntityTypeKey].linkEntityTypeBaseUrl;
 
   const linkEntityTypeVersion =
     migrationState.entityTypeVersions[linkEntityTypeBaseUrl];
@@ -883,8 +882,8 @@ export const getCurrentHashPropertyTypeId = ({
   propertyTypeKey: keyof typeof systemPropertyTypes;
   migrationState: MigrationState;
 }) => {
-  const propertyTypeBaseUrl = systemPropertyTypes[propertyTypeKey]
-    .propertyTypeBaseUrl as BaseUrl;
+  const propertyTypeBaseUrl =
+    systemPropertyTypes[propertyTypeKey].propertyTypeBaseUrl;
 
   const propertyTypeVersion =
     migrationState.propertyTypeVersions[propertyTypeBaseUrl];
@@ -905,8 +904,7 @@ export const getCurrentHashDataTypeId = ({
   dataTypeKey: keyof typeof systemDataTypes;
   migrationState: MigrationState;
 }) => {
-  const dataTypeBaseUrl = systemDataTypes[dataTypeKey]
-    .dataTypeBaseUrl as BaseUrl;
+  const dataTypeBaseUrl = systemDataTypes[dataTypeKey].dataTypeBaseUrl;
 
   const dataTypeVersion = migrationState.dataTypeVersions[dataTypeBaseUrl];
 

--- a/apps/hash-api/src/graph/knowledge/system-types/comment.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/comment.ts
@@ -14,7 +14,6 @@ import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-proper
 import type { CommentProperties } from "@local/hash-isomorphic-utils/system-types/shared";
 import type { TextToken } from "@local/hash-isomorphic-utils/types";
 import type { EntityRelationAndSubject } from "@local/hash-subgraph";
-import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 
 import type {
   ImpureGraphFunction,
@@ -171,9 +170,8 @@ export const createComment: ImpureGraphFunction<
   const textEntity = await createEntity(ctx, authentication, {
     ownedById,
     properties: {
-      [extractBaseUrl(
-        blockProtocolPropertyTypes.textualContent.propertyTypeId,
-      )]: textualContent,
+      [blockProtocolPropertyTypes.textualContent.propertyTypeBaseUrl]:
+        textualContent,
     },
     entityTypeId: systemEntityTypes.text.entityTypeId,
     relationships,

--- a/apps/hash-api/src/graph/knowledge/system-types/comment.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/comment.ts
@@ -245,9 +245,8 @@ export const updateCommentText: ImpureGraphFunction<
 
   await updateEntityProperty(ctx, authentication, {
     entity: text.entity,
-    propertyTypeBaseUrl: extractBaseUrl(
-      blockProtocolPropertyTypes.textualContent.propertyTypeId,
-    ),
+    propertyTypeBaseUrl:
+      blockProtocolPropertyTypes.textualContent.propertyTypeBaseUrl,
     value: textualContent,
   });
 };
@@ -275,9 +274,8 @@ export const deleteComment: ImpureGraphFunction<
       entity: comment.entity,
       updatedProperties: [
         {
-          propertyTypeBaseUrl: extractBaseUrl(
-            systemPropertyTypes.deletedAt.propertyTypeId,
-          ),
+          propertyTypeBaseUrl:
+            systemPropertyTypes.deletedAt.propertyTypeBaseUrl,
           value: new Date().toISOString(),
         },
       ],
@@ -402,9 +400,7 @@ export const resolveComment: ImpureGraphFunction<
     entity: comment.entity,
     updatedProperties: [
       {
-        propertyTypeBaseUrl: extractBaseUrl(
-          systemPropertyTypes.resolvedAt.propertyTypeId,
-        ),
+        propertyTypeBaseUrl: systemPropertyTypes.resolvedAt.propertyTypeBaseUrl,
         value: new Date().toISOString(),
       },
     ],

--- a/apps/hash-api/src/graph/knowledge/system-types/linear-integration-entity.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/linear-integration-entity.ts
@@ -31,7 +31,6 @@ import {
   getRightEntityForLinkEntity,
   getRoots,
 } from "@local/hash-subgraph/stdlib";
-import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 
 import type {
   ImpureGraphFunction,
@@ -90,9 +89,7 @@ export const getAllLinearIntegrationsWithLinearOrgId: ImpureGraphFunction<
               {
                 path: [
                   "properties",
-                  extractBaseUrl(
-                    systemPropertyTypes.linearOrgId.propertyTypeId,
-                  ),
+                  systemPropertyTypes.linearOrgId.propertyTypeBaseUrl,
                 ],
               },
               { parameter: linearOrgId },
@@ -136,9 +133,7 @@ export const getLinearIntegrationByLinearOrgId: ImpureGraphFunction<
               {
                 path: [
                   "properties",
-                  extractBaseUrl(
-                    systemPropertyTypes.linearOrgId.propertyTypeId,
-                  ),
+                  systemPropertyTypes.linearOrgId.propertyTypeBaseUrl,
                 ],
               },
               { parameter: linearOrgId },

--- a/apps/hash-api/src/graph/knowledge/system-types/linear-user-secret.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/linear-user-secret.ts
@@ -24,7 +24,6 @@ import {
   extractOwnedByIdFromEntityId,
   splitEntityId,
 } from "@local/hash-subgraph";
-import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 
 import type {
   ImpureGraphFunction,
@@ -103,9 +102,7 @@ export const getLinearUserSecretByLinearOrgId: ImpureGraphFunction<
                   "incomingLinks",
                   "leftEntity",
                   "properties",
-                  extractBaseUrl(
-                    systemPropertyTypes.linearOrgId.propertyTypeId,
-                  ),
+                  systemPropertyTypes.linearOrgId.propertyTypeBaseUrl,
                 ],
               },
               { parameter: linearOrgId },

--- a/apps/hash-api/src/graph/knowledge/system-types/notification.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/notification.ts
@@ -27,7 +27,6 @@ import {
   getOutgoingLinksForEntity,
   getRoots,
 } from "@local/hash-subgraph/stdlib";
-import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 
 import type {
   ImpureGraphFunction,
@@ -489,7 +488,7 @@ export const getCommentNotification: ImpureGraphFunction<
                 {
                   path: [
                     "properties",
-                    extractBaseUrl(systemPropertyTypes.archived.propertyTypeId),
+                    systemPropertyTypes.archived.propertyTypeBaseUrl,
                   ],
                 },
                 // @ts-expect-error -- We need to update the type definition of `EntityStructuralQuery` to allow for this
@@ -502,7 +501,7 @@ export const getCommentNotification: ImpureGraphFunction<
                 {
                   path: [
                     "properties",
-                    extractBaseUrl(systemPropertyTypes.archived.propertyTypeId),
+                    systemPropertyTypes.archived.propertyTypeBaseUrl,
                   ],
                 },
                 { parameter: false },

--- a/apps/hash-api/src/graph/knowledge/system-types/notification.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/notification.ts
@@ -59,9 +59,7 @@ export const archiveNotification: ImpureGraphFunction<
     entity: params.notification.entity,
     updatedProperties: [
       {
-        propertyTypeBaseUrl: extractBaseUrl(
-          systemPropertyTypes.archived.propertyTypeId,
-        ),
+        propertyTypeBaseUrl: systemPropertyTypes.archived.propertyTypeBaseUrl,
         value: true,
       },
     ],

--- a/apps/hash-api/src/graph/knowledge/system-types/org.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/org.ts
@@ -3,7 +3,6 @@ import { createWebMachineActor } from "@local/hash-backend-utils/machine-actors"
 import type { Entity } from "@local/hash-graph-sdk/entity";
 import type { AccountGroupId } from "@local/hash-graph-types/account";
 import type { EntityId, EntityUuid } from "@local/hash-graph-types/entity";
-import type { BaseUrl } from "@local/hash-graph-types/ontology";
 import type { OwnedById } from "@local/hash-graph-types/web";
 import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import {
@@ -53,7 +52,7 @@ export const getOrgFromEntity: PureGraphFunction<{ entity: Entity }, Org> = ({
   if (entityTypeBaseUrl !== systemEntityTypes.organization.entityTypeBaseUrl) {
     throw new EntityTypeMismatchError(
       entity.metadata.recordId.entityId,
-      systemEntityTypes.organization.entityTypeBaseUrl as BaseUrl,
+      systemEntityTypes.organization.entityTypeBaseUrl,
       entityTypeBaseUrl,
     );
   }
@@ -139,7 +138,7 @@ export const createOrg: ImpureGraphFunction<
       typeof entityTypeVersion === "undefined"
         ? systemEntityTypes.organization.entityTypeId
         : versionedUrlFromComponents(
-            systemEntityTypes.organization.entityTypeBaseUrl as BaseUrl,
+            systemEntityTypes.organization.entityTypeBaseUrl,
             entityTypeVersion,
           ),
     entityUuid: orgAccountGroupId as string as EntityUuid,

--- a/apps/hash-api/src/graph/knowledge/system-types/user.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user.ts
@@ -23,7 +23,6 @@ import {
   extractAccountId,
   extractEntityUuidFromEntityId,
 } from "@local/hash-subgraph";
-import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 
 import type {
   KratosUserIdentity,
@@ -133,7 +132,7 @@ export const getUserByShortname: ImpureGraphFunction<
               {
                 path: [
                   "properties",
-                  extractBaseUrl(systemPropertyTypes.shortname.propertyTypeId),
+                  systemPropertyTypes.shortname.propertyTypeBaseUrl,
                 ],
               },
               { parameter: params.shortname },
@@ -186,9 +185,7 @@ export const getUserByKratosIdentityId: ImpureGraphFunction<
               {
                 path: [
                   "properties",
-                  extractBaseUrl(
-                    systemPropertyTypes.kratosIdentityId.propertyTypeId,
-                  ),
+                  systemPropertyTypes.kratosIdentityId.propertyTypeBaseUrl,
                 ],
               },
               { parameter: params.kratosIdentityId },

--- a/apps/hash-api/src/graph/system-account.ts
+++ b/apps/hash-api/src/graph/system-account.ts
@@ -1,7 +1,6 @@
 import type { Logger } from "@local/hash-backend-utils/logger";
 import { publicUserAccountId } from "@local/hash-backend-utils/public-user-account-id";
 import type { AccountId } from "@local/hash-graph-types/account";
-import type { BaseUrl } from "@local/hash-graph-types/ontology";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { versionedUrlFromComponents } from "@local/hash-subgraph/type-system-patch";
 
@@ -33,7 +32,7 @@ export const ensureHashSystemAccountExists = async (params: {
        * steps where only the first version is available.
        */
       entityTypeId: versionedUrlFromComponents(
-        systemEntityTypes.organization.entityTypeBaseUrl as BaseUrl,
+        systemEntityTypes.organization.entityTypeBaseUrl,
         1,
       ),
     });

--- a/apps/hash-api/src/graphql/resolvers/knowledge/page/update-page.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/page/update-page.ts
@@ -32,11 +32,10 @@ export const updatePageResolver: ResolverFn<
       entity: page.entity,
       updatedProperties: Object.entries(updatedProperties).map(
         ([propertyName, value]) => ({
-          propertyTypeBaseUrl: extractBaseUrl(
+          propertyTypeBaseUrl:
             systemPropertyTypes[
               propertyName as keyof MutationUpdatePageArgs["updatedProperties"]
-            ].propertyTypeId,
-          ),
+            ].propertyTypeBaseUrl,
           value: value ?? undefined,
         }),
       ),

--- a/apps/hash-api/src/graphql/resolvers/knowledge/page/update-page.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/page/update-page.ts
@@ -1,5 +1,4 @@
 import { systemPropertyTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
-import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 
 import { updateEntityProperties } from "../../../../graph/knowledge/primitive/entity";
 import {

--- a/apps/hash-api/src/integrations/linear/sync-back.ts
+++ b/apps/hash-api/src/integrations/linear/sync-back.ts
@@ -15,7 +15,6 @@ import {
   entityIdFromComponents,
   extractOwnedByIdFromEntityId,
 } from "@local/hash-subgraph";
-import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 
 import type { ImpureGraphContext } from "../../graph/context-types";
 import { getLatestEntityById } from "../../graph/knowledge/primitive/entity";
@@ -116,9 +115,7 @@ export const processEntityChange = async (
   );
 
   const linearId =
-    linearEntityToUpdate.properties[
-      extractBaseUrl(linearPropertyTypes.id.propertyTypeId)
-    ];
+    linearEntityToUpdate.properties[linearPropertyTypes.id.propertyTypeBaseUrl];
 
   if (!linearId) {
     return;

--- a/apps/hash-api/src/storage/index.ts
+++ b/apps/hash-api/src/storage/index.ts
@@ -1,4 +1,3 @@
-import { extractBaseUrl } from "@blockprotocol/type-system";
 import { getAwsS3Config } from "@local/hash-backend-utils/aws-config";
 import type {
   FileStorageProvider,
@@ -115,9 +114,7 @@ const getFileEntity = async (
             {
               path: [
                 "properties",
-                extractBaseUrl(
-                  systemPropertyTypes.fileStorageKey.propertyTypeId,
-                ),
+                systemPropertyTypes.fileStorageKey.propertyTypeBaseUrl,
               ],
             },
             { parameter: key },

--- a/apps/hash-frontend/src/components/hooks/use-update-authenticated-user.ts
+++ b/apps/hash-frontend/src/components/hooks/use-update-authenticated-user.ts
@@ -6,7 +6,6 @@ import {
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import type { EntityRootType } from "@local/hash-subgraph";
 import { getRoots } from "@local/hash-subgraph/stdlib";
-import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 import type { GraphQLError } from "graphql";
 import { useCallback, useState } from "react";
 
@@ -93,37 +92,32 @@ export const useUpdateAuthenticatedUser = () => {
                 ...currentProperties,
                 ...(params.shortname
                   ? {
-                      [extractBaseUrl(
-                        systemPropertyTypes.shortname.propertyTypeId,
-                      )]: params.shortname,
+                      [systemPropertyTypes.shortname.propertyTypeBaseUrl]:
+                        params.shortname,
                     }
                   : {}),
                 ...(params.displayName
                   ? {
-                      [extractBaseUrl(
-                        blockProtocolPropertyTypes.displayName.propertyTypeId,
-                      )]: params.displayName,
+                      [blockProtocolPropertyTypes.displayName
+                        .propertyTypeBaseUrl]: params.displayName,
                     }
                   : {}),
                 ...(typeof params.location !== "undefined"
                   ? {
-                      [extractBaseUrl(
-                        systemPropertyTypes.location.propertyTypeId,
-                      )]: params.location,
+                      [systemPropertyTypes.location.propertyTypeBaseUrl]:
+                        params.location,
                     }
                   : {}),
                 ...(typeof params.websiteUrl !== "undefined"
                   ? {
-                      [extractBaseUrl(
-                        systemPropertyTypes.websiteUrl.propertyTypeId,
-                      )]: params.websiteUrl,
+                      [systemPropertyTypes.websiteUrl.propertyTypeBaseUrl]:
+                        params.websiteUrl,
                     }
                   : {}),
                 ...(typeof params.preferredPronouns !== "undefined"
                   ? {
-                      [extractBaseUrl(
-                        systemPropertyTypes.preferredPronouns.propertyTypeId,
-                      )]: params.preferredPronouns,
+                      [systemPropertyTypes.preferredPronouns
+                        .propertyTypeBaseUrl]: params.preferredPronouns,
                     }
                   : {}),
               },

--- a/apps/hash-frontend/src/pages/[shortname].page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname].page.tsx
@@ -88,7 +88,7 @@ const ProfilePage: NextPageWithLayout = () => {
     () =>
       [
         enabledFeatureFlags.pages
-          ? (systemEntityTypes.page.entityTypeBaseUrl as BaseUrl)
+          ? systemEntityTypes.page.entityTypeBaseUrl
           : [],
         ...(profile?.pinnedEntityTypeBaseUrls ?? []),
       ].flat(),

--- a/apps/hash-frontend/src/pages/[shortname].page/edit-pinned-entity-types-modal.tsx
+++ b/apps/hash-frontend/src/pages/[shortname].page/edit-pinned-entity-types-modal.tsx
@@ -6,7 +6,6 @@ import {
   systemEntityTypes,
   systemPropertyTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
-import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 import type { ModalProps } from "@mui/material";
 import { Box, Typography, typographyClasses } from "@mui/material";
 import type { FunctionComponent, ReactElement } from "react";
@@ -144,9 +143,8 @@ export const EditPinnedEntityTypesModal: FunctionComponent<
           entityTypeId: profile.entity.metadata.entityTypeId,
           updatedProperties: {
             ...profile.entity.properties,
-            [extractBaseUrl(
-              systemPropertyTypes.pinnedEntityTypeBaseUrl.propertyTypeId,
-            )]: updatedPinnedEntityTypeBaseUrls,
+            [systemPropertyTypes.pinnedEntityTypeBaseUrl.propertyTypeBaseUrl]:
+              updatedPinnedEntityTypeBaseUrls,
           },
         },
       },

--- a/apps/hash-frontend/src/pages/[shortname].page/edit-user-profile-info-modal/user-profile-info-form.tsx
+++ b/apps/hash-frontend/src/pages/[shortname].page/edit-user-profile-info-modal/user-profile-info-form.tsx
@@ -1,13 +1,11 @@
 import { Select, TextField } from "@hashintel/design-system";
 import type { Entity, LinkEntity } from "@local/hash-graph-sdk/entity";
-import type { BaseUrl } from "@local/hash-graph-types/ontology";
 import type { OwnedById } from "@local/hash-graph-types/web";
 import {
   systemEntityTypes,
   systemLinkEntityTypes,
   systemPropertyTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
-import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 import { Box } from "@mui/material";
 import type { FunctionComponent } from "react";
 import { useCallback, useState } from "react";
@@ -102,8 +100,7 @@ export const UserProfileInfoForm: FunctionComponent<{
         data: {
           entityTypeId: systemEntityTypes[kind].entityTypeId,
           properties: {
-            [extractBaseUrl(systemPropertyTypes.profileUrl.propertyTypeId)]:
-              profileUrl,
+            [systemPropertyTypes.profileUrl.propertyTypeBaseUrl]: profileUrl,
           },
         },
       });
@@ -140,8 +137,7 @@ export const UserProfileInfoForm: FunctionComponent<{
           entityTypeId: existingServiceAccountEntity.metadata.entityTypeId,
           properties: {
             ...existingServiceAccountEntity.properties,
-            [systemPropertyTypes.profileUrl.propertyTypeBaseUrl as BaseUrl]:
-              profileUrl,
+            [systemPropertyTypes.profileUrl.propertyTypeBaseUrl]: profileUrl,
           },
         },
       });

--- a/apps/hash-frontend/src/pages/[shortname]/[page-slug].page/canvas-page/block-creation-dialog.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/[page-slug].page/canvas-page/block-creation-dialog.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from "@apollo/client";
-import type { VersionedUrl } from "@blockprotocol/type-system/dist/cjs-slim/index-slim";
+import type { VersionedUrl } from "@blockprotocol/type-system/slim";
 import { Entity, LinkEntity } from "@local/hash-graph-sdk/entity";
 import type { OwnedById } from "@local/hash-graph-types/web";
 import type { HashBlockMeta } from "@local/hash-isomorphic-utils/blocks";

--- a/apps/hash-frontend/src/pages/notes.page/editable-quick-note.tsx
+++ b/apps/hash-frontend/src/pages/notes.page/editable-quick-note.tsx
@@ -1,7 +1,6 @@
 import { useMutation, useQuery } from "@apollo/client";
 import { IconButton } from "@hashintel/design-system";
 import type { Entity } from "@local/hash-graph-sdk/entity";
-import type { BaseUrl } from "@local/hash-graph-types/ontology";
 import type { OwnedById } from "@local/hash-graph-types/web";
 import { getBlockCollectionResolveDepth } from "@local/hash-isomorphic-utils/block-collection";
 import { isHashTextBlock } from "@local/hash-isomorphic-utils/blocks";
@@ -65,7 +64,7 @@ const parseTextFromTextBlock = ({
   rightEntity,
 }: BlockCollectionContentItem) => {
   const textTokens = rightEntity.blockChildEntity.properties[
-    blockProtocolPropertyTypes.textualContent.propertyTypeBaseUrl as BaseUrl
+    blockProtocolPropertyTypes.textualContent.propertyTypeBaseUrl
   ] as TextToken[] | undefined;
 
   return (

--- a/apps/hash-frontend/src/pages/shared/block-collection-contents.ts
+++ b/apps/hash-frontend/src/pages/shared/block-collection-contents.ts
@@ -26,7 +26,6 @@ import {
   getOutgoingLinkAndTargetEntities,
   getRoots,
 } from "@local/hash-subgraph/stdlib";
-import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 
 import type { GetEntitySubgraphQueryVariables } from "../../graphql/api-types.gen";
 
@@ -96,7 +95,7 @@ export const isBlockCollectionContentsEmpty = (params: {
       systemEntityTypes.text.entityTypeId
   ) {
     const textualContent = contents[0]!.rightEntity.blockChildEntity.properties[
-      extractBaseUrl(blockProtocolPropertyTypes.textualContent.propertyTypeId)
+      blockProtocolPropertyTypes.textualContent.propertyTypeBaseUrl
     ] as TextToken[];
 
     return textualContent.length === 0;

--- a/apps/hash-frontend/src/pages/shared/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table.tsx
@@ -10,7 +10,6 @@ import { EntitiesGraphChart } from "@hashintel/block-design-system";
 import { ListRegularIcon } from "@hashintel/design-system";
 import type { Entity } from "@local/hash-graph-sdk/entity";
 import type { EntityId } from "@local/hash-graph-types/entity";
-import type { BaseUrl } from "@local/hash-graph-types/ontology";
 import { gridRowHeight } from "@local/hash-isomorphic-utils/data-grid";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { isPageEntityTypeId } from "@local/hash-isomorphic-utils/page-entity-type-ids";
@@ -82,7 +81,7 @@ const allFileEntityTypeIds = allFileEntityTypeOntologyIds.map(
 
 const allFileEntityTypeBaseUrl = allFileEntityTypeOntologyIds.map(
   ({ entityTypeBaseUrl }) => entityTypeBaseUrl,
-) as BaseUrl[];
+);
 
 const entitiesTableViews = ["Table", "Graph", "Grid"] as const;
 

--- a/apps/hash-frontend/src/pages/shared/entities-table/grid-view/grid-view-item.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table/grid-view/grid-view-item.tsx
@@ -47,18 +47,12 @@ const mimeTypeStartsWithToIcon: Record<string, ReactNode> = {
 };
 
 const entityTypeIdToIcon: Record<BaseUrl, ReactNode> = {
-  [systemEntityTypes.pptxPresentation.entityTypeBaseUrl as BaseUrl]: (
+  [systemEntityTypes.pptxPresentation.entityTypeBaseUrl]: (
     <FilePowerpointLightIcon />
   ),
-  [systemEntityTypes.pdfDocument.entityTypeBaseUrl as BaseUrl]: (
-    <FilePdfLightIcon />
-  ),
-  [systemEntityTypes.docxDocument.entityTypeBaseUrl as BaseUrl]: (
-    <FileWordLightIcon />
-  ),
-  [systemEntityTypes.image.entityTypeBaseUrl as BaseUrl]: (
-    <FileImageLightIcon />
-  ),
+  [systemEntityTypes.pdfDocument.entityTypeBaseUrl]: <FilePdfLightIcon />,
+  [systemEntityTypes.docxDocument.entityTypeBaseUrl]: <FileWordLightIcon />,
+  [systemEntityTypes.image.entityTypeBaseUrl]: <FileImageLightIcon />,
 };
 
 const defaultFileIcon = <FileLightIcon />;

--- a/apps/hash-frontend/src/pages/shared/use-create-block-collection.ts
+++ b/apps/hash-frontend/src/pages/shared/use-create-block-collection.ts
@@ -7,7 +7,6 @@ import {
   systemPropertyTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import type { BlockCollectionProperties } from "@local/hash-isomorphic-utils/system-types/shared";
-import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 import { generateKeyBetween } from "fractional-indexing";
 import { useCallback } from "react";
 
@@ -39,9 +38,8 @@ export const useCreateBlockCollection = (props: { ownedById: OwnedById }) => {
             data: {
               entityTypeId: systemEntityTypes.block.entityTypeId,
               properties: {
-                [extractBaseUrl(
-                  systemPropertyTypes.componentId.propertyTypeId,
-                )]: paragraphBlockComponentId,
+                [systemPropertyTypes.componentId.propertyTypeBaseUrl]:
+                  paragraphBlockComponentId,
               },
             },
           }).then(({ data }) => {
@@ -55,9 +53,8 @@ export const useCreateBlockCollection = (props: { ownedById: OwnedById }) => {
             data: {
               entityTypeId: systemEntityTypes.text.entityTypeId,
               properties: {
-                [extractBaseUrl(
-                  blockProtocolPropertyTypes.textualContent.propertyTypeId,
-                )]: [],
+                [blockProtocolPropertyTypes.textualContent.propertyTypeBaseUrl]:
+                  [],
               },
             },
           }).then(({ data }) => {
@@ -79,9 +76,8 @@ export const useCreateBlockCollection = (props: { ownedById: OwnedById }) => {
               rightEntityId: blockEntity.metadata.recordId.entityId,
             },
             properties: {
-              [extractBaseUrl(
-                systemPropertyTypes.fractionalIndex.propertyTypeId,
-              )]: generateKeyBetween(null, null),
+              [systemPropertyTypes.fractionalIndex.propertyTypeBaseUrl]:
+                generateKeyBetween(null, null),
             },
           },
         }),

--- a/apps/hash-frontend/src/shared/entity-types-context/hooks.ts
+++ b/apps/hash-frontend/src/shared/entity-types-context/hooks.ts
@@ -1,5 +1,4 @@
-import type { VersionedUrl } from "@blockprotocol/type-system/dist/cjs";
-import type { EntityType } from "@blockprotocol/type-system/slim";
+import type { EntityType, VersionedUrl } from "@blockprotocol/type-system/slim";
 import type {
   BaseUrl,
   EntityTypeWithMetadata,

--- a/apps/hash-integration-worker/src/linear-activities.ts
+++ b/apps/hash-integration-worker/src/linear-activities.ts
@@ -11,7 +11,6 @@ import type { GraphApi } from "@local/hash-graph-client";
 import { Entity } from "@local/hash-graph-sdk/entity";
 import type { AccountId } from "@local/hash-graph-types/account";
 import type { EntityId } from "@local/hash-graph-types/entity";
-import type { BaseUrl } from "@local/hash-graph-types/ontology";
 import type { OwnedById } from "@local/hash-graph-types/web";
 import { linearPropertyTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
@@ -115,12 +114,11 @@ const createOrUpdateHashEntity = async (params: {
 }): Promise<void> => {
   const { partialEntity, graphApiClient } = params;
 
-  const linearIdBaseUrl = linearPropertyTypes.id.propertyTypeBaseUrl as BaseUrl;
+  const linearIdBaseUrl = linearPropertyTypes.id.propertyTypeBaseUrl;
 
   const linearId = partialEntity.properties[linearIdBaseUrl];
 
-  const updatedAtBaseUrl = linearPropertyTypes.updatedAt
-    .propertyTypeBaseUrl as BaseUrl;
+  const updatedAtBaseUrl = linearPropertyTypes.updatedAt.propertyTypeBaseUrl;
 
   const updatedAt = partialEntity.properties[updatedAtBaseUrl];
 

--- a/libs/@local/hash-backend-utils/src/linear-type-mappings.ts
+++ b/libs/@local/hash-backend-utils/src/linear-type-mappings.ts
@@ -9,7 +9,6 @@ import type {
 } from "@linear/sdk/dist/_generated_documents";
 import type { Entity, LinkEntity } from "@local/hash-graph-sdk/entity";
 import type { Property } from "@local/hash-graph-types/entity";
-import type { BaseUrl } from "@local/hash-graph-types/ontology";
 import {
   blockProtocolPropertyTypes,
   linearEntityTypes,
@@ -41,7 +40,7 @@ export type SupportedLinearTypeNames = keyof SupportedLinearTypes;
 
 const getLinearIdFromEntity = (entity: Entity): string => {
   const linearId =
-    entity.properties[linearPropertyTypes.id.propertyTypeBaseUrl as BaseUrl];
+    entity.properties[linearPropertyTypes.id.propertyTypeBaseUrl];
 
   if (!linearId) {
     throw new Error(

--- a/libs/@local/hash-backend-utils/src/machine-actors.ts
+++ b/libs/@local/hash-backend-utils/src/machine-actors.ts
@@ -12,7 +12,6 @@ import {
 import { systemTypeWebShortnames } from "@local/hash-isomorphic-utils/ontology-types";
 import { mapGraphApiEntityToEntity } from "@local/hash-isomorphic-utils/subgraph-mapping";
 import type { MachineProperties } from "@local/hash-isomorphic-utils/system-types/machine";
-import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 
 export type WebMachineActorIdentifier = `system-${OwnedById}`;
 
@@ -55,9 +54,7 @@ export const getMachineActorId = async (
               {
                 path: [
                   "properties",
-                  extractBaseUrl(
-                    systemPropertyTypes.machineIdentifier.propertyTypeId,
-                  ),
+                  systemPropertyTypes.machineIdentifier.propertyTypeBaseUrl,
                 ],
               },
               { parameter: identifier },

--- a/libs/@local/hash-backend-utils/src/notifications.ts
+++ b/libs/@local/hash-backend-utils/src/notifications.ts
@@ -3,7 +3,6 @@ import type { GraphApi } from "@local/hash-graph-client";
 import { Entity } from "@local/hash-graph-sdk/entity";
 import type { AccountId } from "@local/hash-graph-types/account";
 import type { EntityId } from "@local/hash-graph-types/entity";
-import type { BaseUrl } from "@local/hash-graph-types/ontology";
 import type { Timestamp } from "@local/hash-graph-types/temporal-versioning";
 import type { OwnedById } from "@local/hash-graph-types/web";
 import {
@@ -104,8 +103,7 @@ export const createGraphChangeNotification = async (
       entityTypeId: systemEntityTypes.graphChangeNotification.entityTypeId,
       ownedById: notifiedUserAccountId as OwnedById,
       properties: {
-        [systemPropertyTypes.graphChangeType.propertyTypeBaseUrl as BaseUrl]:
-          operation,
+        [systemPropertyTypes.graphChangeType.propertyTypeBaseUrl]: operation,
       },
       relationships: notificationEntityRelationships,
     },
@@ -130,7 +128,7 @@ export const createGraphChangeNotification = async (
         rightEntityId: changedEntityId,
       },
       properties: {
-        [systemPropertyTypes.entityEditionId.propertyTypeBaseUrl as BaseUrl]:
+        [systemPropertyTypes.entityEditionId.propertyTypeBaseUrl]:
           changedEntityEditionId,
       },
       relationships: linkEntityRelationships,

--- a/libs/@local/hash-isomorphic-utils/src/entity-store.ts
+++ b/libs/@local/hash-isomorphic-utils/src/entity-store.ts
@@ -6,7 +6,6 @@ import type {
   LinkData,
   PropertyObject,
 } from "@local/hash-graph-types/entity";
-import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 import type { Draft } from "immer";
 import { produce } from "immer";
 
@@ -16,9 +15,8 @@ import { blockProtocolPropertyTypes } from "./ontology-type-ids";
 
 export type EntityStoreType = BlockEntity | Entity;
 
-export const textualContentPropertyTypeBaseUrl = extractBaseUrl(
-  blockProtocolPropertyTypes.textualContent.propertyTypeId,
-);
+export const textualContentPropertyTypeBaseUrl =
+  blockProtocolPropertyTypes.textualContent.propertyTypeBaseUrl;
 
 export type DraftEntity<Type extends EntityStoreType = EntityStoreType> = {
   metadata: {

--- a/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
@@ -20,10 +20,7 @@ import type {
   SubgraphRootType,
 } from "@local/hash-subgraph";
 import { splitEntityId } from "@local/hash-subgraph";
-import {
-  componentsFromVersionedUrl,
-  extractBaseUrl,
-} from "@local/hash-subgraph/type-system-patch";
+import { componentsFromVersionedUrl } from "@local/hash-subgraph/type-system-patch";
 
 import type { SubgraphFieldsFragment } from "./graphql/api-types.gen";
 import { systemPropertyTypes } from "./ontology-type-ids";
@@ -240,10 +237,7 @@ export const generateEntityIdFilter = ({
   return { all: conditions };
 };
 
-const archivedBaseUrl = extractBaseUrl(
-  systemPropertyTypes.archived.propertyTypeId,
-);
-
+const archivedBaseUrl = systemPropertyTypes.archived.propertyTypeBaseUrl;
 /**
  * A filter for entities which record 'archived' state as a property rather than via an 'archived' boolean
  * @todo H-611 implement entity archival properly via temporal versioning, and migrate these other approaches

--- a/libs/@local/hash-isomorphic-utils/src/ontology-type-ids.ts
+++ b/libs/@local/hash-isomorphic-utils/src/ontology-type-ids.ts
@@ -1,1460 +1,1559 @@
+import type { VersionedUrl } from "@blockprotocol/type-system/slim";
+import type { BaseUrl } from "@local/hash-graph-types/ontology";
+
 export const systemEntityTypes = {
   actor: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/actor/v/2",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/actor/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/actor/" as BaseUrl,
   },
   block: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/block/v/1",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/block/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/block/" as BaseUrl,
   },
   blockCollection: {
     entityTypeId:
       "https://hash.ai/@hash/types/entity-type/block-collection/v/1",
     entityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/block-collection/",
+      "https://hash.ai/@hash/types/entity-type/block-collection/" as BaseUrl,
   },
   browserPluginSettings: {
     entityTypeId:
       "https://hash.ai/@hash/types/entity-type/browser-plugin-settings/v/1",
     entityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/browser-plugin-settings/",
+      "https://hash.ai/@hash/types/entity-type/browser-plugin-settings/" as BaseUrl,
   },
   canvas: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/canvas/v/1",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/canvas/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/canvas/" as BaseUrl,
   },
   comment: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/comment/v/5",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/comment/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/comment/" as BaseUrl,
   },
   commentNotification: {
     entityTypeId:
       "https://hash.ai/@hash/types/entity-type/comment-notification/v/5",
     entityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/comment-notification/",
+      "https://hash.ai/@hash/types/entity-type/comment-notification/" as BaseUrl,
   },
   document: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/document/v/1",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/document/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/document/" as BaseUrl,
   },
   documentFile: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/document-file/v/1",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/document-file/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/document-file/" as BaseUrl,
   },
   docxDocument: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/docx-document/v/1",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/docx-document/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/docx-document/" as BaseUrl,
   },
   facebookAccount: {
     entityTypeId:
       "https://hash.ai/@hash/types/entity-type/facebook-account/v/1",
     entityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/facebook-account/",
+      "https://hash.ai/@hash/types/entity-type/facebook-account/" as BaseUrl,
   },
   file: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/file/v/2",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/file/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/file/" as BaseUrl,
   },
   flowDefinition: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/flow-definition/v/1",
     entityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/flow-definition/",
+      "https://hash.ai/@hash/types/entity-type/flow-definition/" as BaseUrl,
   },
   flowRun: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/flow-run/v/1",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/flow-run/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/flow-run/" as BaseUrl,
   },
   githubAccount: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/github-account/v/1",
     entityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/github-account/",
+      "https://hash.ai/@hash/types/entity-type/github-account/" as BaseUrl,
   },
   graphChangeNotification: {
     entityTypeId:
       "https://hash.ai/@hash/types/entity-type/graph-change-notification/v/1",
     entityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/graph-change-notification/",
+      "https://hash.ai/@hash/types/entity-type/graph-change-notification/" as BaseUrl,
   },
   hashInstance: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/hash-instance/v/1",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/hash-instance/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/hash-instance/" as BaseUrl,
   },
   image: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/image/v/2",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/image/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/image/" as BaseUrl,
   },
   instagramAccount: {
     entityTypeId:
       "https://hash.ai/@hash/types/entity-type/instagram-account/v/1",
     entityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/instagram-account/",
+      "https://hash.ai/@hash/types/entity-type/instagram-account/" as BaseUrl,
   },
   linearIntegration: {
     entityTypeId:
       "https://hash.ai/@hash/types/entity-type/linear-integration/v/6",
     entityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/linear-integration/",
+      "https://hash.ai/@hash/types/entity-type/linear-integration/" as BaseUrl,
   },
   linkedinAccount: {
     entityTypeId:
       "https://hash.ai/@hash/types/entity-type/linkedin-account/v/1",
     entityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/linkedin-account/",
+      "https://hash.ai/@hash/types/entity-type/linkedin-account/" as BaseUrl,
   },
   machine: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/machine/v/2",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/machine/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/machine/" as BaseUrl,
   },
   mentionNotification: {
     entityTypeId:
       "https://hash.ai/@hash/types/entity-type/mention-notification/v/5",
     entityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/mention-notification/",
+      "https://hash.ai/@hash/types/entity-type/mention-notification/" as BaseUrl,
   },
   notification: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/notification/v/1",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/notification/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/notification/" as BaseUrl,
   },
   organization: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/organization/v/2",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/organization/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/organization/" as BaseUrl,
   },
   page: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/page/v/1",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/page/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/page/" as BaseUrl,
   },
   pdfDocument: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/pdf-document/v/1",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/pdf-document/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/pdf-document/" as BaseUrl,
   },
   pptxPresentation: {
     entityTypeId:
       "https://hash.ai/@hash/types/entity-type/pptx-presentation/v/1",
     entityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/pptx-presentation/",
+      "https://hash.ai/@hash/types/entity-type/pptx-presentation/" as BaseUrl,
   },
   presentationFile: {
     entityTypeId:
       "https://hash.ai/@hash/types/entity-type/presentation-file/v/1",
     entityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/presentation-file/",
+      "https://hash.ai/@hash/types/entity-type/presentation-file/" as BaseUrl,
   },
   profileBio: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/profile-bio/v/1",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/profile-bio/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/profile-bio/" as BaseUrl,
   },
   prospectiveUser: {
     entityTypeId:
       "https://hash.ai/@hash/types/entity-type/prospective-user/v/1",
     entityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/prospective-user/",
+      "https://hash.ai/@hash/types/entity-type/prospective-user/" as BaseUrl,
   },
   quickNote: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/quick-note/v/1",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/quick-note/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/quick-note/" as BaseUrl,
   },
   serviceAccount: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/service-account/v/1",
     entityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/service-account/",
+      "https://hash.ai/@hash/types/entity-type/service-account/" as BaseUrl,
   },
   serviceFeature: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/service-feature/v/1",
     entityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/service-feature/",
+      "https://hash.ai/@hash/types/entity-type/service-feature/" as BaseUrl,
   },
   spreadsheetFile: {
     entityTypeId:
       "https://hash.ai/@hash/types/entity-type/spreadsheet-file/v/1",
     entityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/spreadsheet-file/",
+      "https://hash.ai/@hash/types/entity-type/spreadsheet-file/" as BaseUrl,
   },
   text: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/text/v/1",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/text/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/text/" as BaseUrl,
   },
   tiktokAccount: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/tiktok-account/v/1",
     entityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/tiktok-account/",
+      "https://hash.ai/@hash/types/entity-type/tiktok-account/" as BaseUrl,
   },
   twitterAccount: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/twitter-account/v/1",
     entityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/twitter-account/",
+      "https://hash.ai/@hash/types/entity-type/twitter-account/" as BaseUrl,
   },
   usageRecord: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/usage-record/v/2",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/usage-record/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/usage-record/" as BaseUrl,
   },
   user: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/user/v/5",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/user/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/user/" as BaseUrl,
   },
   userSecret: {
     entityTypeId: "https://hash.ai/@hash/types/entity-type/user-secret/v/1",
-    entityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/user-secret/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/user-secret/" as BaseUrl,
   },
-} as const;
+} as const satisfies Record<
+  string,
+  { entityTypeId: VersionedUrl; entityTypeBaseUrl: BaseUrl }
+>;
 
 export const systemLinkEntityTypes = {
   associatedWithAccount: {
     linkEntityTypeId:
       "https://hash.ai/@hash/types/entity-type/associated-with-account/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/associated-with-account/",
+      "https://hash.ai/@hash/types/entity-type/associated-with-account/" as BaseUrl,
   },
   authoredBy: {
     linkEntityTypeId: "https://hash.ai/@hash/types/entity-type/authored-by/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/authored-by/",
+      "https://hash.ai/@hash/types/entity-type/authored-by/" as BaseUrl,
   },
   created: {
     linkEntityTypeId: "https://hash.ai/@hash/types/entity-type/created/v/1",
-    linkEntityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/created/",
+    linkEntityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/created/" as BaseUrl,
   },
   has: {
     linkEntityTypeId: "https://hash.ai/@hash/types/entity-type/has/v/1",
-    linkEntityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/has/",
+    linkEntityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/has/" as BaseUrl,
   },
   hasAvatar: {
     linkEntityTypeId: "https://hash.ai/@hash/types/entity-type/has-avatar/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/has-avatar/",
+      "https://hash.ai/@hash/types/entity-type/has-avatar/" as BaseUrl,
   },
   hasBio: {
     linkEntityTypeId: "https://hash.ai/@hash/types/entity-type/has-bio/v/1",
-    linkEntityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/has-bio/",
+    linkEntityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/has-bio/" as BaseUrl,
   },
   hasCoverImage: {
     linkEntityTypeId:
       "https://hash.ai/@hash/types/entity-type/has-cover-image/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/has-cover-image/",
+      "https://hash.ai/@hash/types/entity-type/has-cover-image/" as BaseUrl,
   },
   hasData: {
     linkEntityTypeId: "https://hash.ai/@hash/types/entity-type/has-data/v/1",
-    linkEntityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/has-data/",
+    linkEntityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/has-data/" as BaseUrl,
   },
   hasIndexedContent: {
     linkEntityTypeId:
       "https://hash.ai/@hash/types/entity-type/has-indexed-content/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/has-indexed-content/",
+      "https://hash.ai/@hash/types/entity-type/has-indexed-content/" as BaseUrl,
   },
   hasParent: {
     linkEntityTypeId: "https://hash.ai/@hash/types/entity-type/has-parent/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/has-parent/",
+      "https://hash.ai/@hash/types/entity-type/has-parent/" as BaseUrl,
   },
   hasServiceAccount: {
     linkEntityTypeId:
       "https://hash.ai/@hash/types/entity-type/has-service-account/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/has-service-account/",
+      "https://hash.ai/@hash/types/entity-type/has-service-account/" as BaseUrl,
   },
   hasSpatiallyPositionedContent: {
     linkEntityTypeId:
       "https://hash.ai/@hash/types/entity-type/has-spatially-positioned-content/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/has-spatially-positioned-content/",
+      "https://hash.ai/@hash/types/entity-type/has-spatially-positioned-content/" as BaseUrl,
   },
   hasText: {
     linkEntityTypeId: "https://hash.ai/@hash/types/entity-type/has-text/v/1",
-    linkEntityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/has-text/",
+    linkEntityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/has-text/" as BaseUrl,
   },
   incurredIn: {
     linkEntityTypeId: "https://hash.ai/@hash/types/entity-type/incurred-in/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/incurred-in/",
+      "https://hash.ai/@hash/types/entity-type/incurred-in/" as BaseUrl,
   },
   isMemberOf: {
     linkEntityTypeId:
       "https://hash.ai/@hash/types/entity-type/is-member-of/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/is-member-of/",
+      "https://hash.ai/@hash/types/entity-type/is-member-of/" as BaseUrl,
   },
   occurredInBlock: {
     linkEntityTypeId:
       "https://hash.ai/@hash/types/entity-type/occurred-in-block/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/occurred-in-block/",
+      "https://hash.ai/@hash/types/entity-type/occurred-in-block/" as BaseUrl,
   },
   occurredInComment: {
     linkEntityTypeId:
       "https://hash.ai/@hash/types/entity-type/occurred-in-comment/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/occurred-in-comment/",
+      "https://hash.ai/@hash/types/entity-type/occurred-in-comment/" as BaseUrl,
   },
   occurredInEntity: {
     linkEntityTypeId:
       "https://hash.ai/@hash/types/entity-type/occurred-in-entity/v/2",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/occurred-in-entity/",
+      "https://hash.ai/@hash/types/entity-type/occurred-in-entity/" as BaseUrl,
   },
   occurredInText: {
     linkEntityTypeId:
       "https://hash.ai/@hash/types/entity-type/occurred-in-text/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/occurred-in-text/",
+      "https://hash.ai/@hash/types/entity-type/occurred-in-text/" as BaseUrl,
   },
   recordsUsageOf: {
     linkEntityTypeId:
       "https://hash.ai/@hash/types/entity-type/records-usage-of/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/records-usage-of/",
+      "https://hash.ai/@hash/types/entity-type/records-usage-of/" as BaseUrl,
   },
   repliedToComment: {
     linkEntityTypeId:
       "https://hash.ai/@hash/types/entity-type/replied-to-comment/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/replied-to-comment/",
+      "https://hash.ai/@hash/types/entity-type/replied-to-comment/" as BaseUrl,
   },
   syncLinearDataWith: {
     linkEntityTypeId:
       "https://hash.ai/@hash/types/entity-type/sync-linear-data-with/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/sync-linear-data-with/",
+      "https://hash.ai/@hash/types/entity-type/sync-linear-data-with/" as BaseUrl,
   },
   triggeredByComment: {
     linkEntityTypeId:
       "https://hash.ai/@hash/types/entity-type/triggered-by-comment/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/triggered-by-comment/",
+      "https://hash.ai/@hash/types/entity-type/triggered-by-comment/" as BaseUrl,
   },
   triggeredByUser: {
     linkEntityTypeId:
       "https://hash.ai/@hash/types/entity-type/triggered-by-user/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/triggered-by-user/",
+      "https://hash.ai/@hash/types/entity-type/triggered-by-user/" as BaseUrl,
   },
   updated: {
     linkEntityTypeId: "https://hash.ai/@hash/types/entity-type/updated/v/1",
-    linkEntityTypeBaseUrl: "https://hash.ai/@hash/types/entity-type/updated/",
+    linkEntityTypeBaseUrl:
+      "https://hash.ai/@hash/types/entity-type/updated/" as BaseUrl,
   },
   usesUserSecret: {
     linkEntityTypeId:
       "https://hash.ai/@hash/types/entity-type/uses-user-secret/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@hash/types/entity-type/uses-user-secret/",
+      "https://hash.ai/@hash/types/entity-type/uses-user-secret/" as BaseUrl,
   },
-} as const;
+} as const satisfies Record<
+  string,
+  { linkEntityTypeId: VersionedUrl; linkEntityTypeBaseUrl: BaseUrl }
+>;
 
 export const systemPropertyTypes = {
   appliesFrom: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/applies-from/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/applies-from/",
+      "https://hash.ai/@hash/types/property-type/applies-from/" as BaseUrl,
   },
   appliesUntil: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/applies-until/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/applies-until/",
+      "https://hash.ai/@hash/types/property-type/applies-until/" as BaseUrl,
   },
   archived: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/archived/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@hash/types/property-type/archived/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@hash/types/property-type/archived/" as BaseUrl,
   },
   automaticInferenceConfiguration: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/automatic-inference-configuration/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/automatic-inference-configuration/",
+      "https://hash.ai/@hash/types/property-type/automatic-inference-configuration/" as BaseUrl,
   },
   browserPluginTab: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/browser-plugin-tab/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/browser-plugin-tab/",
+      "https://hash.ai/@hash/types/property-type/browser-plugin-tab/" as BaseUrl,
   },
   componentId: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/component-id/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/component-id/",
+      "https://hash.ai/@hash/types/property-type/component-id/" as BaseUrl,
   },
   connectionSourceName: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/connection-source-name/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/connection-source-name/",
+      "https://hash.ai/@hash/types/property-type/connection-source-name/" as BaseUrl,
   },
   currentApproach: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/current-approach/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/current-approach/",
+      "https://hash.ai/@hash/types/property-type/current-approach/" as BaseUrl,
   },
   customMetadata: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/custom-metadata/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/custom-metadata/",
+      "https://hash.ai/@hash/types/property-type/custom-metadata/" as BaseUrl,
   },
   dataAudience: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/data-audience/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/data-audience/",
+      "https://hash.ai/@hash/types/property-type/data-audience/" as BaseUrl,
   },
   deletedAt: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/deleted-at/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/deleted-at/",
+      "https://hash.ai/@hash/types/property-type/deleted-at/" as BaseUrl,
   },
   draftNote: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/draft-note/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/draft-note/",
+      "https://hash.ai/@hash/types/property-type/draft-note/" as BaseUrl,
   },
   email: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/email/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@hash/types/property-type/email/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@hash/types/property-type/email/" as BaseUrl,
   },
   enabledFeatureFlags: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/enabled-feature-flags/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/enabled-feature-flags/",
+      "https://hash.ai/@hash/types/property-type/enabled-feature-flags/" as BaseUrl,
   },
   entityEditionId: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/entity-edition-id/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/entity-edition-id/",
+      "https://hash.ai/@hash/types/property-type/entity-edition-id/" as BaseUrl,
   },
   expiredAt: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/expired-at/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/expired-at/",
+      "https://hash.ai/@hash/types/property-type/expired-at/" as BaseUrl,
   },
   featureName: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/feature-name/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/feature-name/",
+      "https://hash.ai/@hash/types/property-type/feature-name/" as BaseUrl,
   },
   fileId: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/file-id/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@hash/types/property-type/file-id/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@hash/types/property-type/file-id/" as BaseUrl,
   },
   fileStorageBucket: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/file-storage-bucket/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/file-storage-bucket/",
+      "https://hash.ai/@hash/types/property-type/file-storage-bucket/" as BaseUrl,
   },
   fileStorageEndpoint: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/file-storage-endpoint/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/file-storage-endpoint/",
+      "https://hash.ai/@hash/types/property-type/file-storage-endpoint/" as BaseUrl,
   },
   fileStorageForcePathStyle: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/file-storage-force-path-style/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/file-storage-force-path-style/",
+      "https://hash.ai/@hash/types/property-type/file-storage-force-path-style/" as BaseUrl,
   },
   fileStorageKey: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/file-storage-key/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/file-storage-key/",
+      "https://hash.ai/@hash/types/property-type/file-storage-key/" as BaseUrl,
   },
   fileStorageProvider: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/file-storage-provider/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/file-storage-provider/",
+      "https://hash.ai/@hash/types/property-type/file-storage-provider/" as BaseUrl,
   },
   fileStorageRegion: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/file-storage-region/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/file-storage-region/",
+      "https://hash.ai/@hash/types/property-type/file-storage-region/" as BaseUrl,
   },
   flowDefinitionId: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/flow-definition-id/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/flow-definition-id/",
+      "https://hash.ai/@hash/types/property-type/flow-definition-id/" as BaseUrl,
   },
   fractionalIndex: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/fractional-index/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/fractional-index/",
+      "https://hash.ai/@hash/types/property-type/fractional-index/" as BaseUrl,
   },
   graphChangeType: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/graph-change-type/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/graph-change-type/",
+      "https://hash.ai/@hash/types/property-type/graph-change-type/" as BaseUrl,
   },
   heightInPixels: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/height-in-pixels/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/height-in-pixels/",
+      "https://hash.ai/@hash/types/property-type/height-in-pixels/" as BaseUrl,
   },
   icon: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/icon/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@hash/types/property-type/icon/",
-  },
-  inputTokenCost: {
-    propertyTypeId:
-      "https://hash.ai/@ftse/types/property-type/input-token-cost/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@ftse/types/property-type/input-token-cost/",
+      "https://hash.ai/@hash/types/property-type/icon/" as BaseUrl,
   },
   inputUnitCost: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/input-unit-cost/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/input-unit-cost/",
+      "https://hash.ai/@hash/types/property-type/input-unit-cost/" as BaseUrl,
   },
   inputUnitCount: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/input-unit-count/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/input-unit-count/",
+      "https://hash.ai/@hash/types/property-type/input-unit-count/" as BaseUrl,
   },
   intendedUse: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/intended-use/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/intended-use/",
+      "https://hash.ai/@hash/types/property-type/intended-use/" as BaseUrl,
   },
   kratosIdentityId: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/kratos-identity-id/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/kratos-identity-id/",
+      "https://hash.ai/@hash/types/property-type/kratos-identity-id/" as BaseUrl,
   },
   linearOrgId: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/linear-org-id/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/linear-org-id/",
+      "https://hash.ai/@hash/types/property-type/linear-org-id/" as BaseUrl,
   },
   linearTeamId: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/linear-team-id/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/linear-team-id/",
+      "https://hash.ai/@hash/types/property-type/linear-team-id/" as BaseUrl,
   },
   location: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/location/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@hash/types/property-type/location/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@hash/types/property-type/location/" as BaseUrl,
   },
   machineIdentifier: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/machine-identifier/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/machine-identifier/",
+      "https://hash.ai/@hash/types/property-type/machine-identifier/" as BaseUrl,
   },
   manualInferenceConfiguration: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/manual-inference-configuration/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/manual-inference-configuration/",
+      "https://hash.ai/@hash/types/property-type/manual-inference-configuration/" as BaseUrl,
   },
   orgSelfRegistrationIsEnabled: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/org-self-registration-is-enabled/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/org-self-registration-is-enabled/",
+      "https://hash.ai/@hash/types/property-type/org-self-registration-is-enabled/" as BaseUrl,
   },
   organizationName: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/organization-name/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/organization-name/",
+      "https://hash.ai/@hash/types/property-type/organization-name/" as BaseUrl,
   },
   outputDefinitions: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/output-definitions/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/output-definitions/",
-  },
-  outputTokenCost: {
-    propertyTypeId:
-      "https://hash.ai/@ftse/types/property-type/output-token-cost/v/1",
-    propertyTypeBaseUrl:
-      "https://hash.ai/@ftse/types/property-type/output-token-cost/",
+      "https://hash.ai/@hash/types/property-type/output-definitions/" as BaseUrl,
   },
   outputUnitCost: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/output-unit-cost/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/output-unit-cost/",
+      "https://hash.ai/@hash/types/property-type/output-unit-cost/" as BaseUrl,
   },
   outputUnitCount: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/output-unit-count/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/output-unit-count/",
+      "https://hash.ai/@hash/types/property-type/output-unit-count/" as BaseUrl,
   },
   outputs: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/outputs/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@hash/types/property-type/outputs/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@hash/types/property-type/outputs/" as BaseUrl,
   },
   pagesAreEnabled: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/pages-are-enabled/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/pages-are-enabled/",
+      "https://hash.ai/@hash/types/property-type/pages-are-enabled/" as BaseUrl,
   },
   pinnedEntityTypeBaseUrl: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/pinned-entity-type-base-url/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/pinned-entity-type-base-url/",
+      "https://hash.ai/@hash/types/property-type/pinned-entity-type-base-url/" as BaseUrl,
   },
   preferredName: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/preferred-name/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/preferred-name/",
+      "https://hash.ai/@hash/types/property-type/preferred-name/" as BaseUrl,
   },
   preferredPronouns: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/preferred-pronouns/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/preferred-pronouns/",
+      "https://hash.ai/@hash/types/property-type/preferred-pronouns/" as BaseUrl,
   },
   profileUrl: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/profile-url/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/profile-url/",
+      "https://hash.ai/@hash/types/property-type/profile-url/" as BaseUrl,
   },
   readAt: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/read-at/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@hash/types/property-type/read-at/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@hash/types/property-type/read-at/" as BaseUrl,
   },
   resolvedAt: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/resolved-at/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/resolved-at/",
+      "https://hash.ai/@hash/types/property-type/resolved-at/" as BaseUrl,
   },
   role: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/role/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@hash/types/property-type/role/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@hash/types/property-type/role/" as BaseUrl,
   },
   rotationInRads: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/rotation-in-rads/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/rotation-in-rads/",
+      "https://hash.ai/@hash/types/property-type/rotation-in-rads/" as BaseUrl,
   },
   serviceName: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/service-name/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/service-name/",
+      "https://hash.ai/@hash/types/property-type/service-name/" as BaseUrl,
   },
   serviceUnitCost: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/service-unit-cost/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/service-unit-cost/",
+      "https://hash.ai/@hash/types/property-type/service-unit-cost/" as BaseUrl,
   },
   shortname: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/shortname/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@hash/types/property-type/shortname/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@hash/types/property-type/shortname/" as BaseUrl,
   },
   step: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/step/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@hash/types/property-type/step/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@hash/types/property-type/step/" as BaseUrl,
   },
   stepDefinitions: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/step-definitions/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/step-definitions/",
+      "https://hash.ai/@hash/types/property-type/step-definitions/" as BaseUrl,
   },
   summary: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/summary/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@hash/types/property-type/summary/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@hash/types/property-type/summary/" as BaseUrl,
   },
   title: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/title/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@hash/types/property-type/title/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@hash/types/property-type/title/" as BaseUrl,
   },
   trigger: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/trigger/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@hash/types/property-type/trigger/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@hash/types/property-type/trigger/" as BaseUrl,
   },
   triggerDefinition: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/trigger-definition/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/trigger-definition/",
+      "https://hash.ai/@hash/types/property-type/trigger-definition/" as BaseUrl,
   },
   triggerDefinitionId: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/trigger-definition-id/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/trigger-definition-id/",
+      "https://hash.ai/@hash/types/property-type/trigger-definition-id/" as BaseUrl,
   },
   uploadCompletedAt: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/upload-completed-at/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/upload-completed-at/",
+      "https://hash.ai/@hash/types/property-type/upload-completed-at/" as BaseUrl,
   },
   userRegistrationByInvitationIsEnabled: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/user-registration-by-invitation-is-enabled/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/user-registration-by-invitation-is-enabled/",
+      "https://hash.ai/@hash/types/property-type/user-registration-by-invitation-is-enabled/" as BaseUrl,
   },
   userSelfRegistrationIsEnabled: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/user-self-registration-is-enabled/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/user-self-registration-is-enabled/",
+      "https://hash.ai/@hash/types/property-type/user-self-registration-is-enabled/" as BaseUrl,
   },
   vaultPath: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/vault-path/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/vault-path/",
+      "https://hash.ai/@hash/types/property-type/vault-path/" as BaseUrl,
   },
   websiteUrl: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/website-url/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/website-url/",
+      "https://hash.ai/@hash/types/property-type/website-url/" as BaseUrl,
   },
   widthInPixels: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/width-in-pixels/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/width-in-pixels/",
+      "https://hash.ai/@hash/types/property-type/width-in-pixels/" as BaseUrl,
   },
   willingToPay: {
     propertyTypeId:
       "https://hash.ai/@hash/types/property-type/willing-to-pay/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/willing-to-pay/",
+      "https://hash.ai/@hash/types/property-type/willing-to-pay/" as BaseUrl,
   },
   xPosition: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/x-position/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/x-position/",
+      "https://hash.ai/@hash/types/property-type/x-position/" as BaseUrl,
   },
   yPosition: {
     propertyTypeId: "https://hash.ai/@hash/types/property-type/y-position/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@hash/types/property-type/y-position/",
+      "https://hash.ai/@hash/types/property-type/y-position/" as BaseUrl,
   },
-} as const;
+} as const satisfies Record<
+  string,
+  { propertyTypeId: VersionedUrl; propertyTypeBaseUrl: BaseUrl }
+>;
 
 export const systemDataTypes = {
   actorType: {
     dataTypeId: "https://hash.ai/@hash/types/data-type/actor-type/v/1",
-    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/actor-type/",
+    dataTypeBaseUrl:
+      "https://hash.ai/@hash/types/data-type/actor-type/" as BaseUrl,
     title: "Actor Type",
     description: "The type of thing that can, should or will act on something.",
   },
   centimeters: {
     dataTypeId: "https://hash.ai/@hash/types/data-type/centimeters/v/1",
-    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/centimeters/",
+    dataTypeBaseUrl:
+      "https://hash.ai/@hash/types/data-type/centimeters/" as BaseUrl,
     title: "Centimeters",
     description:
       "A unit of length in the International System of Units (SI), equal to one hundredth of a meter.",
   },
   date: {
     dataTypeId: "https://hash.ai/@hash/types/data-type/date/v/1",
-    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/date/",
+    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/date/" as BaseUrl,
     title: "Date",
     description:
       "A reference to a particular day represented within a calendar system, formatted according to RFC 3339.",
   },
   datetime: {
     dataTypeId: "https://hash.ai/@hash/types/data-type/datetime/v/1",
-    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/datetime/",
+    dataTypeBaseUrl:
+      "https://hash.ai/@hash/types/data-type/datetime/" as BaseUrl,
     title: "DateTime",
     description:
       "A reference to a particular date and time, formatted according to RFC 3339.",
   },
   email: {
     dataTypeId: "https://hash.ai/@hash/types/data-type/email/v/1",
-    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/email/",
+    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/email/" as BaseUrl,
     title: "Email",
     description:
       "An identifier for an email box to which messages are delivered.",
   },
   gbp: {
     dataTypeId: "https://hash.ai/@hash/types/data-type/gbp/v/1",
-    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/gbp/",
+    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/gbp/" as BaseUrl,
     title: "GBP",
     description: "An amount denominated in British pounds sterling",
   },
   gigabytes: {
     dataTypeId: "https://hash.ai/@hash/types/data-type/gigabytes/v/1",
-    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/gigabytes/",
+    dataTypeBaseUrl:
+      "https://hash.ai/@hash/types/data-type/gigabytes/" as BaseUrl,
     title: "Gigabytes",
     description: "A unit of information equal to one billion bytes.",
   },
   gigahertz: {
     dataTypeId: "https://hash.ai/@hash/types/data-type/gigahertz/v/1",
-    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/gigahertz/",
+    dataTypeBaseUrl:
+      "https://hash.ai/@hash/types/data-type/gigahertz/" as BaseUrl,
     title: "Gigahertz",
     description: "A unit of frequency equal to one billion hertz.",
   },
   kilometers: {
     dataTypeId: "https://hash.ai/@hash/types/data-type/kilometers/v/1",
-    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/kilometers/",
+    dataTypeBaseUrl:
+      "https://hash.ai/@hash/types/data-type/kilometers/" as BaseUrl,
     title: "Kilometers",
     description:
       "A unit of length in the International System of Units (SI), equal to one thousand meters.",
   },
   meters: {
     dataTypeId: "https://hash.ai/@hash/types/data-type/meters/v/1",
-    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/meters/",
+    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/meters/" as BaseUrl,
     title: "Meters",
     description:
       "The base unit of length in the International System of Units (SI).",
   },
   miles: {
     dataTypeId: "https://hash.ai/@hash/types/data-type/miles/v/1",
-    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/miles/",
+    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/miles/" as BaseUrl,
     title: "Miles",
     description:
       "An imperial unit of length, equivalent to 1,609.344 meters in the International System of Units (SI).",
   },
   millimeters: {
     dataTypeId: "https://hash.ai/@hash/types/data-type/millimeters/v/1",
-    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/millimeters/",
+    dataTypeBaseUrl:
+      "https://hash.ai/@hash/types/data-type/millimeters/" as BaseUrl,
     title: "Millimeters",
     description:
       "A unit of length in the International System of Units (SI), equal to one thousandth of a meter.",
   },
   time: {
     dataTypeId: "https://hash.ai/@hash/types/data-type/time/v/1",
-    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/time/",
+    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/time/" as BaseUrl,
     title: "Time",
     description:
       "A reference to a particular clock time, formatted according to RFC 3339.",
   },
   uri: {
     dataTypeId: "https://hash.ai/@hash/types/data-type/uri/v/1",
-    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/uri/",
+    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/uri/" as BaseUrl,
     title: "URI",
     description: "A unique identifier for a resource (e.g. a URL, or URN).",
   },
   usd: {
     dataTypeId: "https://hash.ai/@hash/types/data-type/usd/v/1",
-    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/usd/",
+    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/usd/" as BaseUrl,
     title: "USD",
     description: "An amount denominated in US Dollars",
   },
   watts: {
     dataTypeId: "https://hash.ai/@hash/types/data-type/watts/v/1",
-    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/watts/",
+    dataTypeBaseUrl: "https://hash.ai/@hash/types/data-type/watts/" as BaseUrl,
     title: "Watts",
     description:
       "A unit of power in the International System of Units (SI) equal to one joule per second.",
   },
-} as const;
+} as const satisfies Record<
+  string,
+  {
+    dataTypeId: VersionedUrl;
+    dataTypeBaseUrl: BaseUrl;
+    title: string;
+    description: string;
+  }
+>;
 
 export const googleEntityTypes = {
   account: {
     entityTypeId: "https://hash.ai/@google/types/entity-type/account/v/1",
-    entityTypeBaseUrl: "https://hash.ai/@google/types/entity-type/account/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@google/types/entity-type/account/" as BaseUrl,
   },
   googleSheetsFile: {
     entityTypeId:
       "https://hash.ai/@google/types/entity-type/google-sheets-file/v/1",
     entityTypeBaseUrl:
-      "https://hash.ai/@google/types/entity-type/google-sheets-file/",
+      "https://hash.ai/@google/types/entity-type/google-sheets-file/" as BaseUrl,
   },
-} as const;
+} as const satisfies Record<
+  string,
+  { entityTypeId: VersionedUrl; entityTypeBaseUrl: BaseUrl }
+>;
 
-export const googleLinkEntityTypes = {} as const;
+export const googleLinkEntityTypes = {} as const satisfies Record<
+  string,
+  { linkEntityTypeId: VersionedUrl; linkEntityTypeBaseUrl: BaseUrl }
+>;
 
 export const googlePropertyTypes = {
   accountId: {
     propertyTypeId:
       "https://hash.ai/@google/types/property-type/account-id/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@google/types/property-type/account-id/",
+      "https://hash.ai/@google/types/property-type/account-id/" as BaseUrl,
   },
-} as const;
+} as const satisfies Record<
+  string,
+  { propertyTypeId: VersionedUrl; propertyTypeBaseUrl: BaseUrl }
+>;
 
 export const linearEntityTypes = {
   attachment: {
     entityTypeId: "https://hash.ai/@linear/types/entity-type/attachment/v/1",
-    entityTypeBaseUrl: "https://hash.ai/@linear/types/entity-type/attachment/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@linear/types/entity-type/attachment/" as BaseUrl,
   },
   issue: {
     entityTypeId: "https://hash.ai/@linear/types/entity-type/issue/v/1",
-    entityTypeBaseUrl: "https://hash.ai/@linear/types/entity-type/issue/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@linear/types/entity-type/issue/" as BaseUrl,
   },
   organization: {
     entityTypeId: "https://hash.ai/@linear/types/entity-type/organization/v/1",
     entityTypeBaseUrl:
-      "https://hash.ai/@linear/types/entity-type/organization/",
+      "https://hash.ai/@linear/types/entity-type/organization/" as BaseUrl,
   },
   user: {
     entityTypeId: "https://hash.ai/@linear/types/entity-type/user/v/1",
-    entityTypeBaseUrl: "https://hash.ai/@linear/types/entity-type/user/",
+    entityTypeBaseUrl:
+      "https://hash.ai/@linear/types/entity-type/user/" as BaseUrl,
   },
   workflowState: {
     entityTypeId:
       "https://hash.ai/@linear/types/entity-type/workflow-state/v/1",
     entityTypeBaseUrl:
-      "https://hash.ai/@linear/types/entity-type/workflow-state/",
+      "https://hash.ai/@linear/types/entity-type/workflow-state/" as BaseUrl,
   },
-} as const;
+} as const satisfies Record<
+  string,
+  { entityTypeId: VersionedUrl; entityTypeBaseUrl: BaseUrl }
+>;
 
 export const linearLinkEntityTypes = {
   associatedWithCycle: {
     linkEntityTypeId:
       "https://hash.ai/@linear/types/entity-type/associated-with-cycle/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@linear/types/entity-type/associated-with-cycle/",
+      "https://hash.ai/@linear/types/entity-type/associated-with-cycle/" as BaseUrl,
   },
   belongsToIssue: {
     linkEntityTypeId:
       "https://hash.ai/@linear/types/entity-type/belongs-to-issue/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@linear/types/entity-type/belongs-to-issue/",
+      "https://hash.ai/@linear/types/entity-type/belongs-to-issue/" as BaseUrl,
   },
   belongsToOrganization: {
     linkEntityTypeId:
       "https://hash.ai/@linear/types/entity-type/belongs-to-organization/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@linear/types/entity-type/belongs-to-organization/",
+      "https://hash.ai/@linear/types/entity-type/belongs-to-organization/" as BaseUrl,
   },
   hasAssignee: {
     linkEntityTypeId:
       "https://hash.ai/@linear/types/entity-type/has-assignee/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@linear/types/entity-type/has-assignee/",
+      "https://hash.ai/@linear/types/entity-type/has-assignee/" as BaseUrl,
   },
   hasCreator: {
     linkEntityTypeId:
       "https://hash.ai/@linear/types/entity-type/has-creator/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@linear/types/entity-type/has-creator/",
+      "https://hash.ai/@linear/types/entity-type/has-creator/" as BaseUrl,
   },
   hasSubscriber: {
     linkEntityTypeId:
       "https://hash.ai/@linear/types/entity-type/has-subscriber/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@linear/types/entity-type/has-subscriber/",
+      "https://hash.ai/@linear/types/entity-type/has-subscriber/" as BaseUrl,
   },
   parent: {
     linkEntityTypeId: "https://hash.ai/@linear/types/entity-type/parent/v/1",
-    linkEntityTypeBaseUrl: "https://hash.ai/@linear/types/entity-type/parent/",
+    linkEntityTypeBaseUrl:
+      "https://hash.ai/@linear/types/entity-type/parent/" as BaseUrl,
   },
   snoozedBy: {
     linkEntityTypeId:
       "https://hash.ai/@linear/types/entity-type/snoozed-by/v/1",
     linkEntityTypeBaseUrl:
-      "https://hash.ai/@linear/types/entity-type/snoozed-by/",
+      "https://hash.ai/@linear/types/entity-type/snoozed-by/" as BaseUrl,
   },
   state: {
     linkEntityTypeId: "https://hash.ai/@linear/types/entity-type/state/v/1",
-    linkEntityTypeBaseUrl: "https://hash.ai/@linear/types/entity-type/state/",
+    linkEntityTypeBaseUrl:
+      "https://hash.ai/@linear/types/entity-type/state/" as BaseUrl,
   },
-} as const;
+} as const satisfies Record<
+  string,
+  { linkEntityTypeId: VersionedUrl; linkEntityTypeBaseUrl: BaseUrl }
+>;
 
 export const linearPropertyTypes = {
   active: {
     propertyTypeId: "https://hash.ai/@linear/types/property-type/active/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@linear/types/property-type/active/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@linear/types/property-type/active/" as BaseUrl,
   },
   admin: {
     propertyTypeId: "https://hash.ai/@linear/types/property-type/admin/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@linear/types/property-type/admin/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@linear/types/property-type/admin/" as BaseUrl,
   },
   allowMembersToInvite: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/allow-members-to-invite/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/allow-members-to-invite/",
+      "https://hash.ai/@linear/types/property-type/allow-members-to-invite/" as BaseUrl,
   },
   allowedAuthService: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/allowed-auth-service/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/allowed-auth-service/",
+      "https://hash.ai/@linear/types/property-type/allowed-auth-service/" as BaseUrl,
   },
   archivedAt: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/archived-at/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/archived-at/",
+      "https://hash.ai/@linear/types/property-type/archived-at/" as BaseUrl,
   },
   attachmentUrl: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/attachment-url/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/attachment-url/",
+      "https://hash.ai/@linear/types/property-type/attachment-url/" as BaseUrl,
   },
   autoArchivedAt: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/auto-archived-at/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/auto-archived-at/",
+      "https://hash.ai/@linear/types/property-type/auto-archived-at/" as BaseUrl,
   },
   autoClosedAt: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/auto-closed-at/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/auto-closed-at/",
+      "https://hash.ai/@linear/types/property-type/auto-closed-at/" as BaseUrl,
   },
   avatarUrl: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/avatar-url/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/avatar-url/",
+      "https://hash.ai/@linear/types/property-type/avatar-url/" as BaseUrl,
   },
   branchName: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/branch-name/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/branch-name/",
+      "https://hash.ai/@linear/types/property-type/branch-name/" as BaseUrl,
   },
   canceledAt: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/canceled-at/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/canceled-at/",
+      "https://hash.ai/@linear/types/property-type/canceled-at/" as BaseUrl,
   },
   completedAt: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/completed-at/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/completed-at/",
+      "https://hash.ai/@linear/types/property-type/completed-at/" as BaseUrl,
   },
   createdAt: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/created-at/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/created-at/",
+      "https://hash.ai/@linear/types/property-type/created-at/" as BaseUrl,
   },
   createdIssueCount: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/created-issue-count/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/created-issue-count/",
+      "https://hash.ai/@linear/types/property-type/created-issue-count/" as BaseUrl,
   },
   customerTicketCount: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/customer-ticket-count/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/customer-ticket-count/",
+      "https://hash.ai/@linear/types/property-type/customer-ticket-count/" as BaseUrl,
   },
   deletionRequestedAt: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/deletion-requested-at/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/deletion-requested-at/",
+      "https://hash.ai/@linear/types/property-type/deletion-requested-at/" as BaseUrl,
   },
   disableReason: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/disable-reason/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/disable-reason/",
+      "https://hash.ai/@linear/types/property-type/disable-reason/" as BaseUrl,
   },
   displayName: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/display-name/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/display-name/",
+      "https://hash.ai/@linear/types/property-type/display-name/" as BaseUrl,
   },
   dueDate: {
     propertyTypeId: "https://hash.ai/@linear/types/property-type/due-date/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/due-date/",
+      "https://hash.ai/@linear/types/property-type/due-date/" as BaseUrl,
   },
   estimate: {
     propertyTypeId: "https://hash.ai/@linear/types/property-type/estimate/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/estimate/",
+      "https://hash.ai/@linear/types/property-type/estimate/" as BaseUrl,
   },
   fullName: {
     propertyTypeId: "https://hash.ai/@linear/types/property-type/full-name/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/full-name/",
+      "https://hash.ai/@linear/types/property-type/full-name/" as BaseUrl,
   },
   gitBranchFormat: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/git-branch-format/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/git-branch-format/",
+      "https://hash.ai/@linear/types/property-type/git-branch-format/" as BaseUrl,
   },
   gitLinkbackMessagesEnabled: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/git-linkback-messages-enabled/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/git-linkback-messages-enabled/",
+      "https://hash.ai/@linear/types/property-type/git-linkback-messages-enabled/" as BaseUrl,
   },
   gitPublicLinkbackMessagesEnabled: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/git-public-linkback-messages-enabled/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/git-public-linkback-messages-enabled/",
+      "https://hash.ai/@linear/types/property-type/git-public-linkback-messages-enabled/" as BaseUrl,
   },
   groupBySource: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/group-by-source/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/group-by-source/",
+      "https://hash.ai/@linear/types/property-type/group-by-source/" as BaseUrl,
   },
   guest: {
     propertyTypeId: "https://hash.ai/@linear/types/property-type/guest/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@linear/types/property-type/guest/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@linear/types/property-type/guest/" as BaseUrl,
   },
   id: {
     propertyTypeId: "https://hash.ai/@linear/types/property-type/id/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@linear/types/property-type/id/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@linear/types/property-type/id/" as BaseUrl,
   },
   identifier: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/identifier/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/identifier/",
+      "https://hash.ai/@linear/types/property-type/identifier/" as BaseUrl,
   },
   integrationSourceType: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/integration-source-type/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/integration-source-type/",
+      "https://hash.ai/@linear/types/property-type/integration-source-type/" as BaseUrl,
   },
   inviteHash: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/invite-hash/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/invite-hash/",
+      "https://hash.ai/@linear/types/property-type/invite-hash/" as BaseUrl,
   },
   isMe: {
     propertyTypeId: "https://hash.ai/@linear/types/property-type/is-me/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@linear/types/property-type/is-me/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@linear/types/property-type/is-me/" as BaseUrl,
   },
   issueNumber: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/issue-number/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/issue-number/",
+      "https://hash.ai/@linear/types/property-type/issue-number/" as BaseUrl,
   },
   issueUrl: {
     propertyTypeId: "https://hash.ai/@linear/types/property-type/issue-url/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/issue-url/",
+      "https://hash.ai/@linear/types/property-type/issue-url/" as BaseUrl,
   },
   lastSeen: {
     propertyTypeId: "https://hash.ai/@linear/types/property-type/last-seen/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/last-seen/",
+      "https://hash.ai/@linear/types/property-type/last-seen/" as BaseUrl,
   },
   logoUrl: {
     propertyTypeId: "https://hash.ai/@linear/types/property-type/logo-url/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/logo-url/",
+      "https://hash.ai/@linear/types/property-type/logo-url/" as BaseUrl,
   },
   markdownDescription: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/markdown-description/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/markdown-description/",
+      "https://hash.ai/@linear/types/property-type/markdown-description/" as BaseUrl,
   },
   metadata: {
     propertyTypeId: "https://hash.ai/@linear/types/property-type/metadata/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/metadata/",
+      "https://hash.ai/@linear/types/property-type/metadata/" as BaseUrl,
   },
   name: {
     propertyTypeId: "https://hash.ai/@linear/types/property-type/name/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@linear/types/property-type/name/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@linear/types/property-type/name/" as BaseUrl,
   },
   periodUploadVolume: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/period-upload-volume/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/period-upload-volume/",
+      "https://hash.ai/@linear/types/property-type/period-upload-volume/" as BaseUrl,
   },
   previousIdentifier: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/previous-identifier/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/previous-identifier/",
+      "https://hash.ai/@linear/types/property-type/previous-identifier/" as BaseUrl,
   },
   previousUrlKeys: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/previous-url-keys/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/previous-url-keys/",
+      "https://hash.ai/@linear/types/property-type/previous-url-keys/" as BaseUrl,
   },
   priority: {
     propertyTypeId: "https://hash.ai/@linear/types/property-type/priority/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/priority/",
+      "https://hash.ai/@linear/types/property-type/priority/" as BaseUrl,
   },
   priorityLabel: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/priority-label/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/priority-label/",
+      "https://hash.ai/@linear/types/property-type/priority-label/" as BaseUrl,
   },
   profileUrl: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/profile-url/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/profile-url/",
+      "https://hash.ai/@linear/types/property-type/profile-url/" as BaseUrl,
   },
   projectUpdateRemindersHour: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/project-update-reminders-hour/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/project-update-reminders-hour/",
+      "https://hash.ai/@linear/types/property-type/project-update-reminders-hour/" as BaseUrl,
   },
   roadmapEnabled: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/roadmap-enabled/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/roadmap-enabled/",
+      "https://hash.ai/@linear/types/property-type/roadmap-enabled/" as BaseUrl,
   },
   samlEnabled: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/saml-enabled/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/saml-enabled/",
+      "https://hash.ai/@linear/types/property-type/saml-enabled/" as BaseUrl,
   },
   scimEnabled: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/scim-enabled/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/scim-enabled/",
+      "https://hash.ai/@linear/types/property-type/scim-enabled/" as BaseUrl,
   },
   snoozedUntilAt: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/snoozed-until-at/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/snoozed-until-at/",
+      "https://hash.ai/@linear/types/property-type/snoozed-until-at/" as BaseUrl,
   },
   sortOrder: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/sort-order/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/sort-order/",
+      "https://hash.ai/@linear/types/property-type/sort-order/" as BaseUrl,
   },
   source: {
     propertyTypeId: "https://hash.ai/@linear/types/property-type/source/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@linear/types/property-type/source/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@linear/types/property-type/source/" as BaseUrl,
   },
   sourceType: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/source-type/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/source-type/",
+      "https://hash.ai/@linear/types/property-type/source-type/" as BaseUrl,
   },
   startedAt: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/started-at/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/started-at/",
+      "https://hash.ai/@linear/types/property-type/started-at/" as BaseUrl,
   },
   startedTriageAt: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/started-triage-at/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/started-triage-at/",
+      "https://hash.ai/@linear/types/property-type/started-triage-at/" as BaseUrl,
   },
   statusEmoji: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/status-emoji/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/status-emoji/",
+      "https://hash.ai/@linear/types/property-type/status-emoji/" as BaseUrl,
   },
   statusLabel: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/status-label/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/status-label/",
+      "https://hash.ai/@linear/types/property-type/status-label/" as BaseUrl,
   },
   statusUntilAt: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/status-until-at/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/status-until-at/",
+      "https://hash.ai/@linear/types/property-type/status-until-at/" as BaseUrl,
   },
   subIssueSortOrder: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/sub-issue-sort-order/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/sub-issue-sort-order/",
+      "https://hash.ai/@linear/types/property-type/sub-issue-sort-order/" as BaseUrl,
   },
   subtitle: {
     propertyTypeId: "https://hash.ai/@linear/types/property-type/subtitle/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/subtitle/",
+      "https://hash.ai/@linear/types/property-type/subtitle/" as BaseUrl,
   },
   timezone: {
     propertyTypeId: "https://hash.ai/@linear/types/property-type/timezone/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/timezone/",
+      "https://hash.ai/@linear/types/property-type/timezone/" as BaseUrl,
   },
   title: {
     propertyTypeId: "https://hash.ai/@linear/types/property-type/title/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@linear/types/property-type/title/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@linear/types/property-type/title/" as BaseUrl,
   },
   trashed: {
     propertyTypeId: "https://hash.ai/@linear/types/property-type/trashed/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@linear/types/property-type/trashed/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@linear/types/property-type/trashed/" as BaseUrl,
   },
   triagedAt: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/triaged-at/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/triaged-at/",
+      "https://hash.ai/@linear/types/property-type/triaged-at/" as BaseUrl,
   },
   trialEndsAt: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/trial-ends-at/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/trial-ends-at/",
+      "https://hash.ai/@linear/types/property-type/trial-ends-at/" as BaseUrl,
   },
   updatedAt: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/updated-at/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/updated-at/",
+      "https://hash.ai/@linear/types/property-type/updated-at/" as BaseUrl,
   },
   urlKey: {
     propertyTypeId: "https://hash.ai/@linear/types/property-type/url-key/v/1",
-    propertyTypeBaseUrl: "https://hash.ai/@linear/types/property-type/url-key/",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@linear/types/property-type/url-key/" as BaseUrl,
   },
   userCount: {
     propertyTypeId:
       "https://hash.ai/@linear/types/property-type/user-count/v/1",
     propertyTypeBaseUrl:
-      "https://hash.ai/@linear/types/property-type/user-count/",
+      "https://hash.ai/@linear/types/property-type/user-count/" as BaseUrl,
   },
-} as const;
+} as const satisfies Record<
+  string,
+  { propertyTypeId: VersionedUrl; propertyTypeBaseUrl: BaseUrl }
+>;
 
 export const blockProtocolEntityTypes = {
   link: {
     entityTypeId:
       "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1",
     entityTypeBaseUrl:
-      "https://blockprotocol.org/@blockprotocol/types/entity-type/link/",
+      "https://blockprotocol.org/@blockprotocol/types/entity-type/link/" as BaseUrl,
   },
   query: {
     entityTypeId: "https://blockprotocol.org/@hash/types/entity-type/query/v/1",
     entityTypeBaseUrl:
-      "https://blockprotocol.org/@hash/types/entity-type/query/",
+      "https://blockprotocol.org/@hash/types/entity-type/query/" as BaseUrl,
   },
   thing: {
     entityTypeId:
       "https://blockprotocol.org/@blockprotocol/types/entity-type/thing/v/1",
     entityTypeBaseUrl:
-      "https://blockprotocol.org/@blockprotocol/types/entity-type/thing/",
+      "https://blockprotocol.org/@blockprotocol/types/entity-type/thing/" as BaseUrl,
   },
-} as const;
+} as const satisfies Record<
+  string,
+  { entityTypeId: VersionedUrl; entityTypeBaseUrl: BaseUrl }
+>;
 
 export const blockProtocolLinkEntityTypes = {
   hasQuery: {
     linkEntityTypeId:
       "https://blockprotocol.org/@hash/types/entity-type/has-query/v/1",
     linkEntityTypeBaseUrl:
-      "https://blockprotocol.org/@hash/types/entity-type/has-query/",
+      "https://blockprotocol.org/@hash/types/entity-type/has-query/" as BaseUrl,
   },
-} as const;
+} as const satisfies Record<
+  string,
+  { linkEntityTypeId: VersionedUrl; linkEntityTypeBaseUrl: BaseUrl }
+>;
 
 export const blockProtocolPropertyTypes = {
   description: {
     propertyTypeId:
       "https://blockprotocol.org/@blockprotocol/types/property-type/description/v/1",
     propertyTypeBaseUrl:
-      "https://blockprotocol.org/@blockprotocol/types/property-type/description/",
+      "https://blockprotocol.org/@blockprotocol/types/property-type/description/" as BaseUrl,
   },
   displayName: {
     propertyTypeId:
       "https://blockprotocol.org/@blockprotocol/types/property-type/display-name/v/1",
     propertyTypeBaseUrl:
-      "https://blockprotocol.org/@blockprotocol/types/property-type/display-name/",
+      "https://blockprotocol.org/@blockprotocol/types/property-type/display-name/" as BaseUrl,
   },
   fileHash: {
     propertyTypeId:
       "https://blockprotocol.org/@blockprotocol/types/property-type/file-hash/v/1",
     propertyTypeBaseUrl:
-      "https://blockprotocol.org/@blockprotocol/types/property-type/file-hash/",
+      "https://blockprotocol.org/@blockprotocol/types/property-type/file-hash/" as BaseUrl,
   },
   fileName: {
     propertyTypeId:
       "https://blockprotocol.org/@blockprotocol/types/property-type/file-name/v/1",
     propertyTypeBaseUrl:
-      "https://blockprotocol.org/@blockprotocol/types/property-type/file-name/",
+      "https://blockprotocol.org/@blockprotocol/types/property-type/file-name/" as BaseUrl,
   },
   fileSize: {
     propertyTypeId:
       "https://blockprotocol.org/@blockprotocol/types/property-type/file-size/v/1",
     propertyTypeBaseUrl:
-      "https://blockprotocol.org/@blockprotocol/types/property-type/file-size/",
+      "https://blockprotocol.org/@blockprotocol/types/property-type/file-size/" as BaseUrl,
   },
   fileUrl: {
     propertyTypeId:
       "https://blockprotocol.org/@blockprotocol/types/property-type/file-url/v/1",
     propertyTypeBaseUrl:
-      "https://blockprotocol.org/@blockprotocol/types/property-type/file-url/",
+      "https://blockprotocol.org/@blockprotocol/types/property-type/file-url/" as BaseUrl,
   },
   mimeType: {
     propertyTypeId:
       "https://blockprotocol.org/@blockprotocol/types/property-type/mime-type/v/1",
     propertyTypeBaseUrl:
-      "https://blockprotocol.org/@blockprotocol/types/property-type/mime-type/",
+      "https://blockprotocol.org/@blockprotocol/types/property-type/mime-type/" as BaseUrl,
   },
   name: {
     propertyTypeId:
       "https://blockprotocol.org/@blockprotocol/types/property-type/name/v/1",
     propertyTypeBaseUrl:
-      "https://blockprotocol.org/@blockprotocol/types/property-type/name/",
+      "https://blockprotocol.org/@blockprotocol/types/property-type/name/" as BaseUrl,
   },
   originalFileName: {
     propertyTypeId:
       "https://blockprotocol.org/@blockprotocol/types/property-type/original-file-name/v/1",
     propertyTypeBaseUrl:
-      "https://blockprotocol.org/@blockprotocol/types/property-type/original-file-name/",
+      "https://blockprotocol.org/@blockprotocol/types/property-type/original-file-name/" as BaseUrl,
   },
   originalSource: {
     propertyTypeId:
       "https://blockprotocol.org/@blockprotocol/types/property-type/original-source/v/1",
     propertyTypeBaseUrl:
-      "https://blockprotocol.org/@blockprotocol/types/property-type/original-source/",
+      "https://blockprotocol.org/@blockprotocol/types/property-type/original-source/" as BaseUrl,
   },
   originalUrl: {
     propertyTypeId:
       "https://blockprotocol.org/@blockprotocol/types/property-type/original-url/v/1",
     propertyTypeBaseUrl:
-      "https://blockprotocol.org/@blockprotocol/types/property-type/original-url/",
+      "https://blockprotocol.org/@blockprotocol/types/property-type/original-url/" as BaseUrl,
   },
   query: {
     propertyTypeId:
       "https://blockprotocol.org/@hash/types/property-type/query/v/1",
     propertyTypeBaseUrl:
-      "https://blockprotocol.org/@hash/types/property-type/query/",
+      "https://blockprotocol.org/@hash/types/property-type/query/" as BaseUrl,
   },
   textualContent: {
     propertyTypeId:
       "https://blockprotocol.org/@blockprotocol/types/property-type/textual-content/v/2",
     propertyTypeBaseUrl:
-      "https://blockprotocol.org/@blockprotocol/types/property-type/textual-content/",
+      "https://blockprotocol.org/@blockprotocol/types/property-type/textual-content/" as BaseUrl,
   },
-} as const;
+} as const satisfies Record<
+  string,
+  { propertyTypeId: VersionedUrl; propertyTypeBaseUrl: BaseUrl }
+>;
 
 export const blockProtocolDataTypes = {
   boolean: {
     dataTypeId:
       "https://blockprotocol.org/@blockprotocol/types/data-type/boolean/v/1",
     dataTypeBaseUrl:
-      "https://blockprotocol.org/@blockprotocol/types/data-type/boolean/",
+      "https://blockprotocol.org/@blockprotocol/types/data-type/boolean/" as BaseUrl,
     title: "Boolean",
     description: "A True or False value",
   },
@@ -1462,7 +1561,7 @@ export const blockProtocolDataTypes = {
     dataTypeId:
       "https://blockprotocol.org/@blockprotocol/types/data-type/empty-list/v/1",
     dataTypeBaseUrl:
-      "https://blockprotocol.org/@blockprotocol/types/data-type/empty-list/",
+      "https://blockprotocol.org/@blockprotocol/types/data-type/empty-list/" as BaseUrl,
     title: "Empty List",
     description: "An Empty List",
   },
@@ -1470,7 +1569,7 @@ export const blockProtocolDataTypes = {
     dataTypeId:
       "https://blockprotocol.org/@blockprotocol/types/data-type/null/v/1",
     dataTypeBaseUrl:
-      "https://blockprotocol.org/@blockprotocol/types/data-type/null/",
+      "https://blockprotocol.org/@blockprotocol/types/data-type/null/" as BaseUrl,
     title: "Null",
     description: "A placeholder value representing 'nothing'",
   },
@@ -1478,7 +1577,7 @@ export const blockProtocolDataTypes = {
     dataTypeId:
       "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1",
     dataTypeBaseUrl:
-      "https://blockprotocol.org/@blockprotocol/types/data-type/number/",
+      "https://blockprotocol.org/@blockprotocol/types/data-type/number/" as BaseUrl,
     title: "Number",
     description: "An arithmetical value (in the Real number system)",
   },
@@ -1486,7 +1585,7 @@ export const blockProtocolDataTypes = {
     dataTypeId:
       "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1",
     dataTypeBaseUrl:
-      "https://blockprotocol.org/@blockprotocol/types/data-type/object/",
+      "https://blockprotocol.org/@blockprotocol/types/data-type/object/" as BaseUrl,
     title: "Object",
     description: "An opaque, untyped JSON object",
   },
@@ -1494,8 +1593,16 @@ export const blockProtocolDataTypes = {
     dataTypeId:
       "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
     dataTypeBaseUrl:
-      "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
+      "https://blockprotocol.org/@blockprotocol/types/data-type/text/" as BaseUrl,
     title: "Text",
     description: "An ordered sequence of characters",
   },
-} as const;
+} as const satisfies Record<
+  string,
+  {
+    dataTypeId: VersionedUrl;
+    dataTypeBaseUrl: BaseUrl;
+    title: string;
+    description: string;
+  }
+>;

--- a/libs/@local/hash-isomorphic-utils/src/ontology-types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/ontology-types.ts
@@ -1,6 +1,8 @@
-import type { VersionedUrl } from "@blockprotocol/type-system";
-import type { EntityTypeReference } from "@blockprotocol/type-system/dist/cjs";
-import type { EntityType } from "@blockprotocol/type-system/slim";
+import type {
+  EntityType,
+  EntityTypeReference,
+  VersionedUrl,
+} from "@blockprotocol/type-system/slim";
 import { typedEntries } from "@local/advanced-types/typed-entries";
 import type { BaseUrl } from "@local/hash-graph-types/ontology";
 import { slugifyTypeTitle } from "@local/hash-isomorphic-utils/slugify-type-title";

--- a/tests/hash-playwright/tests/inbox-page.spec.ts
+++ b/tests/hash-playwright/tests/inbox-page.spec.ts
@@ -1,7 +1,6 @@
 import {
   systemEntityTypes,
   systemLinkEntityTypes,
-  systemPropertyTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { sleep } from "@local/hash-isomorphic-utils/sleep";
 import type {
@@ -34,14 +33,16 @@ const createNotification = async ({
     user.metadata.recordId.entityId,
   );
 
+  const properties: PageProperties = {
+    "https://hash.ai/@hash/types/property-type/title/": targetEntityTitle,
+    "https://hash.ai/@hash/types/property-type/fractional-index/": "a0",
+  };
+
   const targetEntity = await createEntity(requestContext, {
     draft,
     entityTypeId: systemEntityTypes.page.entityTypeId,
     ownedById,
-    properties: {
-      [systemPropertyTypes.title.propertyTypeBaseUrl]: targetEntityTitle,
-      [systemPropertyTypes.fractionalIndex.propertyTypeBaseUrl]: "a0",
-    } as PageProperties,
+    properties,
   });
 
   const notificationEntity = await createEntity(requestContext, {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR is spun out of work I'm doing on improving entity property updates, and improves the typing of our generated "ontology type ids" objects by correctly branding the property base URLs as `BaseUrl`, removing the need to extract or assert them as being such everywhere.

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Brand base URLs in the generated ids
- Remove `extractBaseUrl` and `as BaseUrl` where we need to use those base urls

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- `tsc`
