### PR TITLE
H-3057: Fix `originType == "flow"` failing to deserialize

### DIFF
--- a/libs/@local/hash-graph-types/rust/src/knowledge/entity/provenance.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/entity/provenance.rs
@@ -98,7 +98,7 @@ pub struct SourceProvenance {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+#[serde(deny_unknown_fields, tag = "type", rename_all = "kebab-case")]
 pub enum OriginType {
     WebApp,
     MobileApp,
@@ -112,9 +112,9 @@ pub enum OriginType {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 pub struct OriginProvenance {
-    #[serde(rename = "type")]
+    #[serde(flatten)]
     pub ty: OriginType,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When the origin type is set to `flow` it fails to deserialize, this is not intended.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

Sadly, we have to remove `deny_unknown_fields` for this as this is not working with `flatten`.