### PR TITLE
H-3061: Disable caching for building frontend

### DIFF
--- a/apps/hash-frontend/turbo.json
+++ b/apps/hash-frontend/turbo.json
@@ -7,7 +7,8 @@
       "dependsOn": ["^build"]
     },
     "build": {
-      "outputs": ["./.next/**"],
+      // "outputs": ["./.next/**"],
+      "cache": false,
       "dependsOn": ["^build", "codegen"]
     },
     "start": {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The output of the build command of the frontend is probably a big part of the cache. We disable the caching of that command and see how slow the CI might become.