### PR TITLE
GEN-68: Capture source errors when converting `Error` to `Report`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -300,7 +300,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1173,7 +1173,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1457,7 +1457,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1643,7 +1643,7 @@ checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1725,7 +1725,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1842,7 +1842,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1855,7 +1855,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1875,7 +1875,7 @@ checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2191,7 +2191,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3663,7 +3663,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4459,7 +4459,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4575,7 +4575,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4670,9 +4670,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -4697,7 +4697,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4785,7 +4785,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4847,7 +4847,7 @@ dependencies = [
 name = "query-builder-derive"
 version = "0.0.0"
 dependencies = [
- "syn 2.0.60",
+ "syn 2.0.68",
  "trybuild",
  "virtue",
 ]
@@ -5083,7 +5083,7 @@ dependencies = [
  "quote",
  "refinery-core",
  "regex",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -5708,7 +5708,7 @@ checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -5719,7 +5719,7 @@ checksum = "e578a843d40b4189a4d66bba51d7684f57da5bd7c304c64e14bd63efbef49509"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -5991,25 +5991,25 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "structmeta"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ad9e09554f0456d67a69c1584c9798ba733a5b50349a6c0d0948710523922d"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
 dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "structmeta-derive"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -6046,9 +6046,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.60"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6302,19 +6302,19 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "test-strategy"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8361c808554228ad09bfed70f5c823caf8a3450b6881cc3a38eb57e8c08c1d9"
+checksum = "2bf41af45e3f54cc184831d629d41d5b2bda8297e29c81add7ae4f362ed5e01b"
 dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -6334,7 +6334,7 @@ checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -6440,7 +6440,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -6721,7 +6721,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -6870,7 +6870,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -6931,7 +6931,7 @@ checksum = "ac73887f47b9312552aa90ef477927ff014d63d1920ca8037c6c1951eab64bb1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -7077,7 +7077,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
  "url",
  "uuid",
 ]
@@ -7214,7 +7214,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
  "wasm-bindgen-shared",
 ]
 
@@ -7248,7 +7248,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7281,7 +7281,7 @@ checksum = "b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -7723,7 +7723,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -7743,5 +7743,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.68",
 ]

--- a/libs/error-stack/CHANGELOG.md
+++ b/libs/error-stack/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to `error-stack` will be documented in this file.
 
 - Support for [`defmt`](https://defmt.ferrous-systems.com)
 
+## 0.5.0 - Unreleased
+
+- Capture `source()` errors when converting `Error` to `Report` ([#4678](https://github.com/hashintel/hash/pull/4678))
+
 ## [0.4.1](https://github.com/hashintel/hash/tree/error-stack%400.4.1/libs/error-stack) - 2023-09-04
 
 ### Fixes

--- a/libs/error-stack/src/context.rs
+++ b/libs/error-stack/src/context.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 #[cfg(nightly)]
 use core::error::Request;
 use core::{error::Error, fmt};
@@ -60,7 +61,33 @@ pub trait Context: fmt::Display + fmt::Debug + Send + Sync + 'static {
     #[cfg(nightly)]
     #[allow(unused_variables)]
     fn provide<'a>(&'a self, request: &mut Request<'a>) {}
+
+    /// Returns the source of the error, if any.
+    ///
+    /// This method only exists to avoid the requirement of specialization and to get the sources
+    /// for `Error`.
+    #[doc(hidden)]
+    fn __source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
 }
+
+#[allow(clippy::field_scoped_visibility_modifiers)]
+pub(crate) struct SourceContext(pub(crate) String);
+
+impl fmt::Debug for SourceContext {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, fmt)
+    }
+}
+
+impl fmt::Display for SourceContext {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, fmt)
+    }
+}
+
+impl Context for SourceContext {}
 
 impl<C> From<C> for Report<C>
 where
@@ -77,5 +104,11 @@ impl<C: Error + Send + Sync + 'static> Context for C {
     #[cfg(nightly)]
     fn provide<'a>(&'a self, request: &mut Request<'a>) {
         Error::provide(self, request);
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    fn __source(&self) -> Option<&(dyn Error + 'static)> {
+        self.source()
     }
 }

--- a/libs/error-stack/src/context.rs
+++ b/libs/error-stack/src/context.rs
@@ -1,4 +1,4 @@
-use alloc::string::String;
+use alloc::string::{String, ToString};
 #[cfg(nightly)]
 use core::error::Request;
 use core::{error::Error, fmt};
@@ -72,8 +72,14 @@ pub trait Context: fmt::Display + fmt::Debug + Send + Sync + 'static {
     }
 }
 
-#[allow(clippy::field_scoped_visibility_modifiers)]
-pub(crate) struct SourceContext(pub(crate) String);
+/// Captures an error message as the context of a [`Report`].
+pub(crate) struct SourceContext(String);
+
+impl SourceContext {
+    pub(crate) fn from_error(value: &dyn Error) -> Self {
+        Self(value.to_string())
+    }
+}
 
 impl fmt::Debug for SourceContext {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -1,5 +1,5 @@
 #[cfg_attr(feature = "std", allow(unused_imports))]
-use alloc::{boxed::Box, vec, vec::Vec};
+use alloc::{boxed::Box, string::ToString, vec, vec::Vec};
 use core::{error::Error, fmt, marker::PhantomData, mem, panic::Location};
 #[cfg(all(rust_1_65, feature = "std"))]
 use std::backtrace::{Backtrace, BacktraceStatus};
@@ -12,6 +12,7 @@ use tracing_error::{SpanTrace, SpanTraceStatus};
 #[cfg(nightly)]
 use crate::iter::{RequestRef, RequestValue};
 use crate::{
+    context::SourceContext,
     iter::{Frames, FramesMut},
     Context, Frame,
 };
@@ -257,11 +258,30 @@ impl<C> Report<C> {
     /// [`Backtrace` and `SpanTrace` section]: #backtrace-and-spantrace
     #[inline]
     #[track_caller]
+    #[allow(clippy::missing_panics_doc)] // Reason: No panic possible
     pub fn new(context: C) -> Self
     where
         C: Context,
     {
-        Self::from_frame(Frame::from_context(context, Box::new([])))
+        if let Some(mut current_source) = context.__source() {
+            let mut sources = vec![SourceContext(current_source.to_string())];
+            let mut report = Report::new(SourceContext(current_source.to_string()));
+            while let Some(source) = current_source.source() {
+                sources.push(SourceContext(source.to_string()));
+                report = report.change_context(SourceContext(source.to_string()));
+                current_source = source;
+            }
+            let mut report = Report::from_frame(Frame::from_context(
+                sources.pop().expect("At least one context is guaranteed"),
+                Box::new([]),
+            ));
+            while let Some(source) = sources.pop() {
+                report = report.change_context(source);
+            }
+            report.change_context(context)
+        } else {
+            Self::from_frame(Frame::from_context(context, Box::new([])))
+        }
     }
 
     #[track_caller]

--- a/libs/error-stack/src/result.rs
+++ b/libs/error-stack/src/result.rs
@@ -120,7 +120,7 @@ where
     {
         match self {
             Ok(value) => Ok(value),
-            Err(error) => Err(Report::from(error).attach(attachment)),
+            Err(error) => Err(Report::new(error).attach(attachment)),
         }
     }
 
@@ -132,7 +132,7 @@ where
     {
         match self {
             Ok(value) => Ok(value),
-            Err(error) => Err(Report::from(error).attach(attachment())),
+            Err(error) => Err(Report::new(error).attach(attachment())),
         }
     }
 
@@ -143,7 +143,7 @@ where
     {
         match self {
             Ok(value) => Ok(value),
-            Err(error) => Err(Report::from(error).attach_printable(attachment)),
+            Err(error) => Err(Report::new(error).attach_printable(attachment)),
         }
     }
 
@@ -155,7 +155,7 @@ where
     {
         match self {
             Ok(value) => Ok(value),
-            Err(error) => Err(Report::from(error).attach_printable(attachment())),
+            Err(error) => Err(Report::new(error).attach_printable(attachment())),
         }
     }
 
@@ -166,7 +166,7 @@ where
     {
         match self {
             Ok(value) => Ok(value),
-            Err(error) => Err(Report::from(error).change_context(context)),
+            Err(error) => Err(Report::new(error).change_context(context)),
         }
     }
 
@@ -178,7 +178,7 @@ where
     {
         match self {
             Ok(value) => Ok(value),
-            Err(error) => Err(Report::from(error).change_context(context())),
+            Err(error) => Err(Report::new(error).change_context(context())),
         }
     }
 }

--- a/libs/error-stack/tests/test_conversion.rs
+++ b/libs/error-stack/tests/test_conversion.rs
@@ -1,12 +1,56 @@
 #![cfg(feature = "std")]
 #![cfg_attr(nightly, feature(error_generic_member_access))]
+#![allow(clippy::std_instead_of_core)]
 
-use std::io;
+use core::fmt;
+use std::{error::Error, io};
 
-use error_stack::{Report, ResultExt};
+use error_stack::{FrameKind, Report, ResultExt};
 
 fn io_error() -> Result<(), io::Error> {
     Err(io::Error::from(io::ErrorKind::Other))
+}
+
+#[derive(Debug)]
+struct OuterError {
+    inner: InnerError,
+}
+
+impl fmt::Display for OuterError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "outer error: {}", self.inner)
+    }
+}
+
+impl Error for OuterError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.inner)
+    }
+}
+
+#[derive(Debug)]
+struct InnerError {
+    inner: io::Error,
+}
+
+impl fmt::Display for InnerError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "inner error: {}", self.inner)
+    }
+}
+
+impl Error for InnerError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.inner)
+    }
+}
+
+fn error_with_sources() -> Result<(), OuterError> {
+    Err(OuterError {
+        inner: InnerError {
+            inner: io::Error::from(io::ErrorKind::Other),
+        },
+    })
 }
 
 #[test]
@@ -14,6 +58,30 @@ fn report() {
     let report = io_error().map_err(Report::new).expect_err("not an error");
     assert!(report.contains::<io::Error>());
     assert_eq!(report.current_context().kind(), io::ErrorKind::Other);
+}
+
+#[test]
+fn error() {
+    let report = error_with_sources()
+        .map_err(Report::new)
+        .expect_err("not an error");
+
+    let mut frames = report
+        .frames()
+        .skip_while(|frame| !matches!(frame.kind(), FrameKind::Context(_)));
+    assert!(frames.next().expect("no frames").is::<OuterError>());
+
+    // "inner error: other error"
+    let mut frames = frames.skip_while(|frame| !matches!(frame.kind(), FrameKind::Context(_)));
+    assert!(frames.next().is_some());
+
+    // "other error"
+    let mut frames = frames.skip_while(|frame| !matches!(frame.kind(), FrameKind::Context(_)));
+    assert!(frames.next().is_some());
+
+    // no further sources
+    let mut frames = frames.skip_while(|frame| !matches!(frame.kind(), FrameKind::Context(_)));
+    assert!(frames.next().is_none());
 }
 
 #[test]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

It's desired that source errors of `Error` are printed as part of a `Report` as well.

## 🔗 Related links

- Closes #2127

## 🔍 What does this change?

- Adds a hidden `__source` method to `Context` to close the gap between `Context` and `Error`. This allows using `Error::source` without specialization.
- Add contexts for sources returned from `Error::source` to the `Report` when creating it

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
