### PR TITLE
GEN-115: Don't compile backtrace support if feature is disabled

### DIFF
--- a/libs/error-stack/.justfile
+++ b/libs/error-stack/.justfile
@@ -6,17 +6,16 @@ set fallback
 default:
   @just usage
 
-# TODO: add `--ignore-unknown-features` to `cargo hack` and pass `--workspace`
 cargo-hack-groups := '--group-features eyre,hooks --group-features anyhow,serde'
 profile := env_var_or_default('PROFILE', "dev")
+repo := `git rev-parse --show-toplevel`
 
 [private]
 clippy *arguments:
   @just install-cargo-hack
-  @just install-rust-script
 
-  @CLIPPY_CONF_DIR=../../.config just in-pr cargo clippy --profile {{profile}} --workspace --all-features --all-targets --no-deps {{arguments}}
-  @CLIPPY_CONF_DIR=../../.config just not-in-pr cargo hack --optional-deps --feature-powerset {{cargo-hack-groups}} --ignore-unknown-features clippy --profile {{profile}} --all-targets --no-deps {{arguments}}
+  @CLIPPY_CONF_DIR={{repo}} just in-pr cargo clippy --profile {{profile}} --all-features --all-targets --no-deps {{arguments}}
+  @CLIPPY_CONF_DIR={{repo}} just not-in-pr cargo hack --optional-deps --feature-powerset {{cargo-hack-groups}} --ignore-unknown-features clippy --profile {{profile}} --all-targets --no-deps {{arguments}}
 
 [private]
 test *arguments:
@@ -24,7 +23,7 @@ test *arguments:
   @just install-cargo-hack
 
   RUST_BACKTRACE=1 cargo hack --optional-deps --feature-powerset {{cargo-hack-groups}} nextest run --cargo-profile {{profile}} {{arguments}}
-  RUST_BACKTRACE=1 cargo test --profile {{profile}} --workspace --all-features --doc {{arguments}}
+  RUST_BACKTRACE=1 cargo test --profile {{profile}} --all-features --doc {{arguments}}
 
 [private]
 coverage *arguments:

--- a/libs/error-stack/CHANGELOG.md
+++ b/libs/error-stack/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to `error-stack` will be documented in this file.
 
 - Support for [`defmt`](https://defmt.ferrous-systems.com)
 
+## 0.5.0 - Unreleased
+
+### Features
+
+- Don't compile backtrace support if feature is disabled ([#4685](https://github.com/hashintel/hash/pull/4685))
+
 ## [0.4.1](https://github.com/hashintel/hash/tree/error-stack%400.4.1/libs/error-stack) - 2023-09-04
 
 ### Fixes

--- a/libs/error-stack/CHANGELOG.md
+++ b/libs/error-stack/CHANGELOG.md
@@ -8,9 +8,9 @@ All notable changes to `error-stack` will be documented in this file.
 
 ## 0.5.0 - Unreleased
 
-### Features
+### Breaking Changes
 
-- Don't compile backtrace support if feature is disabled ([#4685](https://github.com/hashintel/hash/pull/4685))
+- `Backtrace`s are not included in the `std` feature anymore. Instead, the `backtrace` feature is used which is enabled by default ([#4685](https://github.com/hashintel/hash/pull/4685))
 
 ## [0.4.1](https://github.com/hashintel/hash/tree/error-stack%400.4.1/libs/error-stack) - 2023-09-04
 

--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -41,8 +41,9 @@ thiserror = "1.0.59"
 rustc_version = "0.4"
 
 [features]
-default = ["std"]
+default = ["backtrace"]
 
+backtrace = ["std"]
 spantrace = ["dep:tracing-error", "std"]
 std = ["anyhow?/std"]
 eyre = ["dep:eyre", "std"]

--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -41,14 +41,17 @@ thiserror = "1.0.59"
 rustc_version = "0.4"
 
 [features]
-default = ["backtrace"]
+default = ["std", "backtrace"]
 
-backtrace = ["std"]
-spantrace = ["dep:tracing-error", "std"]
-std = ["anyhow?/std"]
-eyre = ["dep:eyre", "std"]
-serde = ["dep:serde"]
-hooks = ['dep:spin']
+std = ["anyhow?/std"]  # Enables support for `Error`
+backtrace = ["std"]  # Enables automatic capturing of `Backtrace`s (requires Rust 1.65+)
+
+spantrace = ["dep:tracing-error", "std"]  # Enables automatic capturing of `SpanTrace`s
+serde = ["dep:serde"]  # Enables serialization support
+hooks = ['dep:spin']  # Enables hooks on `no-std` platforms using spin locks
+
+anyhow = ["dep:anyhow"]  # Provides `into_report` to convert `anyhow::Error` to `Report`
+eyre = ["dep:eyre", "std"]  # Provides `into_report` to convert `eyre::Report` to `Report`
 
 [lints]
 workspace = true

--- a/libs/error-stack/build.rs
+++ b/libs/error-stack/build.rs
@@ -10,7 +10,7 @@ fn main() {
     }
 
     let rustc_version = version_meta.semver;
-    let trimmed_rustc_version = Version::new(
+    let _trimmed_rustc_version = Version::new(
         rustc_version.major,
         rustc_version.minor,
         rustc_version.patch,

--- a/libs/error-stack/build.rs
+++ b/libs/error-stack/build.rs
@@ -15,9 +15,4 @@ fn main() {
         rustc_version.minor,
         rustc_version.patch,
     );
-
-    println!("cargo:rustc-check-cfg=cfg(rust_1_65)");
-    if trimmed_rustc_version >= Version::new(1, 65, 0) {
-        println!("cargo:rustc-cfg=rust_1_65");
-    }
 }

--- a/libs/error-stack/build.rs
+++ b/libs/error-stack/build.rs
@@ -1,8 +1,9 @@
-#![allow(clippy::unwrap_used)]
+use std::process::exit;
+
 use rustc_version::{version_meta, Channel, Version};
 
 fn main() {
-    let version_meta = version_meta().unwrap();
+    let version_meta = version_meta().expect("Could not get Rust version");
 
     println!("cargo:rustc-check-cfg=cfg(nightly)");
     if version_meta.channel == Channel::Nightly {
@@ -10,9 +11,14 @@ fn main() {
     }
 
     let rustc_version = version_meta.semver;
-    let _trimmed_rustc_version = Version::new(
+    let trimmed_rustc_version = Version::new(
         rustc_version.major,
         rustc_version.minor,
         rustc_version.patch,
     );
+
+    if cfg!(feature = "backtrace") && trimmed_rustc_version < Version::new(1, 65, 0) {
+        println!("cargo:warning=The `backtrace` feature requires Rust 1.65.0 or later.");
+        exit(1);
+    }
 }

--- a/libs/error-stack/src/fmt/hook.rs
+++ b/libs/error-stack/src/fmt/hook.rs
@@ -453,7 +453,7 @@ impl Hooks {
 }
 
 mod default {
-    #[cfg(any(all(feature = "std", rust_1_65), feature = "spantrace"))]
+    #[cfg(any(feature = "backtrace", feature = "spantrace"))]
     use alloc::format;
     #[cfg_attr(feature = "std", allow(unused_imports))]
     use alloc::string::ToString;
@@ -461,7 +461,7 @@ mod default {
         panic::Location,
         sync::atomic::{AtomicBool, Ordering},
     };
-    #[cfg(all(rust_1_65, feature = "std"))]
+    #[cfg(feature = "backtrace")]
     use std::backtrace::Backtrace;
     #[cfg(feature = "std")]
     use std::sync::Once;
@@ -502,7 +502,7 @@ mod default {
 
             Report::install_debug_hook::<Location>(location);
 
-            #[cfg(all(feature = "std", rust_1_65))]
+            #[cfg(feature = "backtrace")]
             Report::install_debug_hook::<Backtrace>(backtrace);
 
             #[cfg(feature = "spantrace")]
@@ -514,7 +514,7 @@ mod default {
         context.push_body(LocationAttachment::new(location, context.color_mode()).to_string());
     }
 
-    #[cfg(all(feature = "std", rust_1_65))]
+    #[cfg(feature = "backtrace")]
     fn backtrace(backtrace: &Backtrace, context: &mut HookContext<Backtrace>) {
         let idx = context.increment_counter();
 

--- a/libs/error-stack/src/lib.rs
+++ b/libs/error-stack/src/lib.rs
@@ -372,8 +372,9 @@
 //! ### Automatic Backtraces
 //!
 //! When on a Rust 1.65 or later, [`Report`] will try to capture a [`Backtrace`] if `RUST_BACKTRACE`
-//! or `RUST_BACKTRACE_LIB` is set. If on a nightly toolchain, it will use the [`Backtrace`] if
-//! provided by the base [`Context`], and will try to capture one otherwise.
+//! or `RUST_BACKTRACE_LIB` is set and the `backtrace` feature is enabled (by default this is the
+//! case). If on a nightly toolchain, it will use the [`Backtrace`] if provided by the base
+//! [`Context`], and will try to capture one otherwise.
 //!
 //! Unlike some other approaches, this does not require the user modifying their custom error types
 //! to be aware of backtraces, and doesn't require manual implementations to forward calls down any
@@ -452,13 +453,14 @@
 //!
 //! ### Feature Flags
 //!
-//!  Feature       | Description                                                        | default
-//! ---------------|--------------------------------------------------------------------|----------
-//! `std`          | Enables support for [`Error`], and, on Rust 1.65+, [`Backtrace`]   | enabled
-//! `spantrace`    | Enables automatic capturing of [`SpanTrace`]s                      | disabled
-//! `hooks`        | Enables hooks on `no-std` platforms using spin locks               | disabled
-//! `anyhow`       | Provides `into_report` to convert [`anyhow::Error`] to [`Report`]  | disabled
-//! `eyre`         | Provides `into_report` to convert [`eyre::Report`] to [`Report`]   | disabled
+//!  Feature       | Description                                                         | default
+//! ---------------|---------------------------------------------------------------------|----------
+//! `std`          | Enables support for [`Error`]                                       | enabled
+//! `backtrace`    | Enables automatic capturing of [`Backtraces`]s (requires Rust 1.65) | enabled
+//! `spantrace`    | Enables automatic capturing of [`SpanTrace`]s                       | disabled
+//! `hooks`        | Enables hooks on `no-std` platforms using spin locks                | disabled
+//! `anyhow`       | Provides `into_report` to convert [`anyhow::Error`] to [`Report`]   | disabled
+//! `eyre`         | Provides `into_report` to convert [`eyre::Report`] to [`Report`]    | disabled
 //!
 //!
 //! [`set_debug_hook`]: Report::set_debug_hook

--- a/libs/error-stack/src/lib.rs
+++ b/libs/error-stack/src/lib.rs
@@ -456,7 +456,7 @@
 //!  Feature       | Description                                                         | default
 //! ---------------|---------------------------------------------------------------------|----------
 //! `std`          | Enables support for [`Error`]                                       | enabled
-//! `backtrace`    | Enables automatic capturing of [`Backtraces`]s (requires Rust 1.65) | enabled
+//! `backtrace`    | Enables automatic capturing of [`Backtrace`]s (requires Rust 1.65+) | enabled
 //! `spantrace`    | Enables automatic capturing of [`SpanTrace`]s                       | disabled
 //! `hooks`        | Enables hooks on `no-std` platforms using spin locks                | disabled
 //! `anyhow`       | Provides `into_report` to convert [`anyhow::Error`] to [`Report`]   | disabled

--- a/libs/error-stack/src/lib.rs
+++ b/libs/error-stack/src/lib.rs
@@ -459,6 +459,7 @@
 //! `backtrace`    | Enables automatic capturing of [`Backtrace`]s (requires Rust 1.65+) | enabled
 //! `spantrace`    | Enables automatic capturing of [`SpanTrace`]s                       | disabled
 //! `hooks`        | Enables hooks on `no-std` platforms using spin locks                | disabled
+//! `serde`        | Enables serialization support for [`Report`]                        | disabled
 //! `anyhow`       | Provides `into_report` to convert [`anyhow::Error`] to [`Report`]   | disabled
 //! `eyre`         | Provides `into_report` to convert [`eyre::Report`] to [`Report`]    | disabled
 //!

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -274,13 +274,13 @@ impl<C> Report<C> {
         #[cfg(not(nightly))]
         let location = Some(Location::caller());
 
-        #[cfg(all(nightly, feature = "std"))]
+        #[cfg(all(nightly, feature = "backtrace"))]
         let backtrace = core::error::request_ref::<Backtrace>(&frame.as_error())
             .filter(|backtrace| backtrace.status() == BacktraceStatus::Captured)
             .is_none()
             .then(Backtrace::capture);
 
-        #[cfg(all(rust_1_65, not(nightly), feature = "std"))]
+        #[cfg(all(not(nightly), feature = "backtrace"))]
         let backtrace = Some(Backtrace::capture());
 
         #[cfg(all(nightly, feature = "spantrace"))]
@@ -302,7 +302,7 @@ impl<C> Report<C> {
             report = report.attach(*location);
         }
 
-        #[cfg(all(rust_1_65, feature = "std"))]
+        #[cfg(feature = "backtrace")]
         if let Some(backtrace) =
             backtrace.filter(|bt| matches!(bt.status(), BacktraceStatus::Captured))
         {

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -1,7 +1,7 @@
 #[cfg_attr(feature = "std", allow(unused_imports))]
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::{error::Error, fmt, marker::PhantomData, mem, panic::Location};
-#[cfg(all(rust_1_65, feature = "std"))]
+#[cfg(feature = "backtrace")]
 use std::backtrace::{Backtrace, BacktraceStatus};
 #[cfg(feature = "std")]
 use std::process::ExitCode;

--- a/libs/error-stack/tests/common.rs
+++ b/libs/error-stack/tests/common.rs
@@ -19,7 +19,7 @@ use core::{
     iter,
     sync::atomic::{AtomicI8, Ordering},
 };
-#[cfg(all(rust_1_65, feature = "std"))]
+#[cfg(feature = "backtrace")]
 use std::backtrace::Backtrace;
 
 use error_stack::{AttachmentKind, Context, Frame, FrameKind, Report, Result};
@@ -100,31 +100,31 @@ impl Context for ErrorA {
 }
 
 #[derive(Debug)]
-#[cfg(all(rust_1_65, feature = "std"))]
+#[cfg(feature = "backtrace")]
 pub struct ErrorB(pub u32, std::backtrace::Backtrace);
 
-#[cfg(all(rust_1_65, feature = "std"))]
+#[cfg(feature = "backtrace")]
 impl ErrorB {
     pub fn new(value: u32) -> Self {
         Self(value, Backtrace::force_capture())
     }
 }
 
-#[cfg(all(rust_1_65, feature = "std"))]
+#[cfg(feature = "backtrace")]
 impl fmt::Display for ErrorB {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.write_str("error B")
     }
 }
 
-#[cfg(all(nightly, feature = "std"))]
+#[cfg(all(nightly, feature = "backtrace"))]
 impl core::error::Error for ErrorB {
     fn provide<'a>(&'a self, request: &mut core::error::Request<'a>) {
         request.provide_ref(&self.1);
     }
 }
 
-#[cfg(all(rust_1_65, feature = "std"))]
+#[cfg(feature = "backtrace")]
 impl ErrorB {
     pub const fn backtrace(&self) -> &Backtrace {
         &self.1
@@ -186,7 +186,7 @@ pub fn messages<E>(report: &Report<E>) -> Vec<String> {
             FrameKind::Context(context) => context.to_string(),
             FrameKind::Attachment(AttachmentKind::Printable(attachment)) => attachment.to_string(),
             FrameKind::Attachment(AttachmentKind::Opaque(_)) => {
-                #[cfg(all(rust_1_65, feature = "std"))]
+                #[cfg(feature = "backtrace")]
                 if frame.type_id() == TypeId::of::<Backtrace>() {
                     return String::from("Backtrace");
                 }
@@ -209,7 +209,7 @@ pub fn frame_kinds<E>(report: &Report<E>) -> Vec<FrameKind> {
     remove_builtin_frames(report).map(Frame::kind).collect()
 }
 
-#[cfg(all(rust_1_65, feature = "std"))]
+#[cfg(feature = "backtrace")]
 pub fn supports_backtrace() -> bool {
     static STATE: Lazy<bool> = Lazy::new(|| {
         let bt = std::backtrace::Backtrace::capture();
@@ -249,7 +249,7 @@ pub fn remove_builtin_messages<S: AsRef<str>>(
 
 pub fn remove_builtin_frames<E>(report: &Report<E>) -> impl Iterator<Item = &Frame> {
     report.frames().filter(|frame| {
-        #[cfg(all(rust_1_65, feature = "std"))]
+        #[cfg(feature = "backtrace")]
         if frame.type_id() == TypeId::of::<Backtrace>() {
             return false;
         }
@@ -266,7 +266,7 @@ pub fn remove_builtin_frames<E>(report: &Report<E>) -> impl Iterator<Item = &Fra
 #[allow(unused_mut)]
 #[allow(clippy::missing_const_for_fn)]
 pub fn expect_count(mut count: usize) -> usize {
-    #[cfg(all(rust_1_65, feature = "std"))]
+    #[cfg(feature = "backtrace")]
     if supports_backtrace() {
         count += 1;
     }

--- a/libs/error-stack/tests/snapshots/test_debug__full__complex.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__full__complex.snap
@@ -3,7 +3,7 @@ source: libs/error-stack/tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴at libs/error-stack/tests/test_debug.rs:433:14
+├╴at libs/error-stack/tests/test_debug.rs:429:14
 ├╴printable A
 │
 ╰┬▶ root error

--- a/libs/error-stack/tests/snapshots/test_debug__full__hook_provider.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__full__hook_provider.snap
@@ -5,7 +5,7 @@ expression: "format!(\"{report:?}\")"
 context D
 ├╴usize: 420
 ├╴&'static str: Invalid User Input
-├╴at libs/error-stack/tests/test_debug.rs:588:38
+├╴at libs/error-stack/tests/test_debug.rs:584:38
 │
 ╰─▶ root error
     ├╴at libs/error-stack/tests/common.rs:9:5

--- a/libs/error-stack/tests/snapshots/test_debug__full__linear.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__full__linear.snap
@@ -3,11 +3,11 @@ source: libs/error-stack/tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context B
-├╴at libs/error-stack/tests/test_debug.rs:278:14
+├╴at libs/error-stack/tests/test_debug.rs:274:14
 ├╴printable C
 │
 ├─▶ context A
-│   ├╴at libs/error-stack/tests/test_debug.rs:275:14
+│   ├╴at libs/error-stack/tests/test_debug.rs:271:14
 │   ├╴printable B
 │   ╰╴1 additional opaque attachment
 │

--- a/libs/error-stack/tests/snapshots/test_debug__full__linear_ext.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__full__linear_ext.snap
@@ -3,11 +3,11 @@ source: libs/error-stack/tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 context B
-├╴at libs/error-stack/tests/test_debug.rs:295:14
+├╴at libs/error-stack/tests/test_debug.rs:291:14
 ├╴printable C
 │
 ├─▶ context A
-│   ├╴at libs/error-stack/tests/test_debug.rs:292:14
+│   ├╴at libs/error-stack/tests/test_debug.rs:288:14
 │   ├╴printable B
 │   ╰╴1 additional opaque attachment
 │

--- a/libs/error-stack/tests/snapshots/test_debug__full__multiline_context.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__full__multiline_context.snap
@@ -3,20 +3,20 @@ source: libs/error-stack/tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 context B
-├╴at libs/error-stack/tests/test_debug.rs:320:14
+├╴at libs/error-stack/tests/test_debug.rs:316:14
 ├╴printable C
 │
 ├─▶ A multiline
 │   context that might have
 │   a bit more info
-│   ├╴at libs/error-stack/tests/test_debug.rs:317:14
+│   ├╴at libs/error-stack/tests/test_debug.rs:313:14
 │   ├╴printable B
 │   ╰╴1 additional opaque attachment
 │
 ╰─▶ A multiline
     context that might have
     a bit more info
-    ├╴at libs/error-stack/tests/test_debug.rs:316:22
+    ├╴at libs/error-stack/tests/test_debug.rs:312:22
     ╰╴backtrace (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/libs/error-stack/tests/snapshots/test_debug__full__sources.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__full__sources.snap
@@ -3,7 +3,7 @@ source: libs/error-stack/tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴at libs/error-stack/tests/test_debug.rs:365:14
+├╴at libs/error-stack/tests/test_debug.rs:361:14
 ├╴1 additional opaque attachment
 │
 ╰┬▶ root error

--- a/libs/error-stack/tests/snapshots/test_debug__full__sources_transparent.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__full__sources_transparent.snap
@@ -3,7 +3,7 @@ source: libs/error-stack/tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴at libs/error-stack/tests/test_debug.rs:406:18
+├╴at libs/error-stack/tests/test_debug.rs:402:18
 ├╴1 additional opaque attachment
 │
 ╰┬▶ root error

--- a/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace.snap
@@ -1,42 +1,42 @@
 ---
-source: tests/test_debug.rs
+source: libs/error-stack/tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴at tests/test_debug.rs:206:10
+├╴at libs/error-stack/tests/test_debug.rs:206:10
 ├╴2
 ├╴1
 │
 ╰┬▶ context A
- │  ├╴at tests/test_debug.rs:200:10
+ │  ├╴at libs/error-stack/tests/test_debug.rs:200:10
  │  ├╴4
  │  ├╴3
  │  │
  │  ╰─▶ root error
- │      ├╴at tests/common.rs:5:5
+ │      ├╴at libs/error-stack/tests/common.rs:9:5
  │      ├╴span trace with 2 frames (1)
  │      ╰╴6
  │
  ╰▶ context A
-    ├╴at tests/test_debug.rs:195:10
+    ├╴at libs/error-stack/tests/test_debug.rs:195:10
     ├╴5
     ├╴3
     │
     ├─▶ context A
-    │   ├╴at tests/test_debug.rs:193:10
+    │   ├╴at libs/error-stack/tests/test_debug.rs:193:10
     │   ╰╴7
     │
     ╰┬▶ context A
-     │  ├╴at tests/test_debug.rs:184:34
+     │  ├╴at libs/error-stack/tests/test_debug.rs:184:34
      │  ├╴9
      │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴at tests/common.rs:5:5
+     │      ├╴at libs/error-stack/tests/common.rs:9:5
      │      ╰╴span trace with 2 frames (2)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:178:10
+     │  ├╴at libs/error-stack/tests/test_debug.rs:178:10
      │  ├╴13
      │  ├╴10
      │  ├╴16
@@ -44,11 +44,11 @@ context A
      │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴at tests/common.rs:5:5
+     │      ├╴at libs/error-stack/tests/common.rs:9:5
      │      ╰╴span trace with 2 frames (3)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:164:10
+     │  ├╴at libs/error-stack/tests/test_debug.rs:164:10
      │  ├╴15
      │  ├╴14
      │  ├╴10
@@ -57,30 +57,30 @@ context A
      │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴at tests/common.rs:5:5
+     │      ├╴at libs/error-stack/tests/common.rs:9:5
      │      ╰╴span trace with 2 frames (4)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:174:10
+     │  ├╴at libs/error-stack/tests/test_debug.rs:174:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴at tests/common.rs:5:5
+     │      ├╴at libs/error-stack/tests/common.rs:9:5
      │      ╰╴span trace with 2 frames (5)
      │
      ╰▶ context A
-        ├╴at tests/test_debug.rs:170:10
+        ├╴at libs/error-stack/tests/test_debug.rs:170:10
         ├╴12
         ├╴9
         ├╴8
         │
         ├─▶ context A
-        │   ╰╴at tests/test_debug.rs:169:10
+        │   ╰╴at libs/error-stack/tests/test_debug.rs:169:10
         │
         ╰─▶ root error
-            ├╴at tests/common.rs:5:5
+            ├╴at libs/error-stack/tests/common.rs:9:5
             ╰╴span trace with 2 frames (6)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace.snap
@@ -1,42 +1,42 @@
 ---
-source: tests/test_debug.rs
+source: libs/error-stack/tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 context A
-├╴at tests/test_debug.rs:206:10
+├╴at libs/error-stack/tests/test_debug.rs:206:10
 ├╴2
 ├╴1
 │
 ╰┬▶ context A
- │  ├╴at tests/test_debug.rs:200:10
+ │  ├╴at libs/error-stack/tests/test_debug.rs:200:10
  │  ├╴4
  │  ├╴3
  │  │
  │  ╰─▶ root error
- │      ├╴at tests/common.rs:5:5
+ │      ├╴at libs/error-stack/tests/common.rs:9:5
  │      ├╴span trace with 2 frames (1)
  │      ╰╴6
  │
  ╰▶ context A
-    ├╴at tests/test_debug.rs:195:10
+    ├╴at libs/error-stack/tests/test_debug.rs:195:10
     ├╴5
     ├╴3
     │
     ├─▶ context A
-    │   ├╴at tests/test_debug.rs:193:10
+    │   ├╴at libs/error-stack/tests/test_debug.rs:193:10
     │   ╰╴7
     │
     ╰┬▶ context A
-     │  ├╴at tests/test_debug.rs:184:34
+     │  ├╴at libs/error-stack/tests/test_debug.rs:184:34
      │  ├╴9
      │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴at tests/common.rs:5:5
+     │      ├╴at libs/error-stack/tests/common.rs:9:5
      │      ╰╴span trace with 2 frames (2)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:178:10
+     │  ├╴at libs/error-stack/tests/test_debug.rs:178:10
      │  ├╴13
      │  ├╴10
      │  ├╴16
@@ -44,11 +44,11 @@ context A
      │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴at tests/common.rs:5:5
+     │      ├╴at libs/error-stack/tests/common.rs:9:5
      │      ╰╴span trace with 2 frames (3)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:164:10
+     │  ├╴at libs/error-stack/tests/test_debug.rs:164:10
      │  ├╴15
      │  ├╴14
      │  ├╴10
@@ -57,30 +57,30 @@ context A
      │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴at tests/common.rs:5:5
+     │      ├╴at libs/error-stack/tests/common.rs:9:5
      │      ╰╴span trace with 2 frames (4)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:174:10
+     │  ├╴at libs/error-stack/tests/test_debug.rs:174:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴at tests/common.rs:5:5
+     │      ├╴at libs/error-stack/tests/common.rs:9:5
      │      ╰╴span trace with 2 frames (5)
      │
      ╰▶ context A
-        ├╴at tests/test_debug.rs:170:10
+        ├╴at libs/error-stack/tests/test_debug.rs:170:10
         ├╴12
         ├╴9
         ├╴8
         │
         ├─▶ context A
-        │   ╰╴at tests/test_debug.rs:169:10
+        │   ╰╴at libs/error-stack/tests/test_debug.rs:169:10
         │
         ╰─▶ root error
-            ├╴at tests/common.rs:5:5
+            ├╴at libs/error-stack/tests/common.rs:9:5
             ╰╴span trace with 2 frames (6)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/libs/error-stack/tests/test_backtrace.rs
+++ b/libs/error-stack/tests/test_backtrace.rs
@@ -1,4 +1,4 @@
-#![cfg(all(rust_1_65, feature = "std"))]
+#![cfg(feature = "backtrace")]
 #![cfg_attr(
     nightly,
     feature(backtrace_frames, error_generic_member_access),

--- a/libs/error-stack/tests/test_compatibility.rs
+++ b/libs/error-stack/tests/test_compatibility.rs
@@ -11,7 +11,7 @@ use core::error;
 #[allow(clippy::wildcard_imports)]
 use common::*;
 use error_stack::IntoReportCompat;
-#[cfg(all(nightly, feature = "std"))]
+#[cfg(all(nightly, feature = "backtrace"))]
 use error_stack::Report;
 
 #[test]
@@ -78,7 +78,7 @@ fn anyhow_nostd() {
 }
 
 #[test]
-#[cfg(all(nightly, feature = "std", feature = "anyhow"))]
+#[cfg(all(nightly, feature = "backtrace", feature = "anyhow"))]
 fn anyhow_backtrace() {
     let error = anyhow::anyhow!("test error");
     let error_backtrace = error.backtrace();
@@ -172,7 +172,7 @@ fn eyre() {
 }
 
 #[test]
-#[cfg(all(nightly, feature = "eyre", feature = "std"))]
+#[cfg(all(nightly, feature = "eyre", feature = "backtrace"))]
 #[ignore = "bug: `eyre` currently does not provide a backtrace`"]
 fn eyre_backtrace() {
     install_eyre_hook();

--- a/libs/error-stack/tests/test_debug.rs
+++ b/libs/error-stack/tests/test_debug.rs
@@ -229,7 +229,7 @@ fn sources_nested_alternate() {
 }
 
 mod full {
-    #![cfg(all(any(feature = "std", feature = "hooks"), feature = "spantrace"))]
+    #![cfg(all(feature = "backtrace", feature = "spantrace"))]
     //! Why so many cfg guards?
     //! What was found during initial development of the feature was,
     //! that a complete test of all tests with snapshots on every possible feature combination

--- a/libs/error-stack/tests/test_debug.rs
+++ b/libs/error-stack/tests/test_debug.rs
@@ -28,12 +28,12 @@ fn setup_tracing() {
 #[cfg(not(feature = "spantrace"))]
 const fn setup_tracing() {}
 
-#[cfg(not(all(rust_1_65, feature = "std")))]
+#[cfg(not(feature = "backtrace"))]
 fn setup_backtrace() {
     std::env::set_var("RUST_LIB_BACKTRACE", "0");
 }
 
-#[cfg(all(rust_1_65, feature = "std"))]
+#[cfg(feature = "backtrace")]
 fn setup_backtrace() {
     std::env::set_var("RUST_LIB_BACKTRACE", "1");
 }
@@ -58,7 +58,7 @@ fn snap_suffix() -> String {
         suffix.push("spantrace");
     }
 
-    #[cfg(all(rust_1_65, feature = "std"))]
+    #[cfg(feature = "backtrace")]
     if supports_backtrace() {
         suffix.push("backtrace");
     }
@@ -229,11 +229,7 @@ fn sources_nested_alternate() {
 }
 
 mod full {
-    #![cfg(all(
-        rust_1_65,
-        any(feature = "std", feature = "hooks"),
-        feature = "spantrace"
-    ))]
+    #![cfg(all(any(feature = "std", feature = "hooks"), feature = "spantrace"))]
     //! Why so many cfg guards?
     //! What was found during initial development of the feature was,
     //! that a complete test of all tests with snapshots on every possible feature combination


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In some contexts, such as with `panic_immediate_abort` set, backtraces should not be compiled into the binary. Currently, the `std` feature determines if backtraces are enabled or not. Making this a dedicated feature flag helps reduce the binary size.

## 🔗 Related links

- Closes https://github.com/hashintel/hash/issues/3353


## 🔍 What does this change?

- Guard `Backtrace` behind the `backtrace` feature