### PR TITLE
H-2975: Make all data type constraints strongly typed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,6 +1189,7 @@ dependencies = [
  "derive-where",
  "error-stack 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "harpc-wire-protocol",
+ "regex",
  "serde",
  "serde_json",
  "time",
@@ -5088,9 +5089,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6891,9 +6892,14 @@ dependencies = [
 name = "type-system"
 version = "0.0.0"
 dependencies = [
+ "codec",
  "console_error_panic_hook",
+ "email_address",
+ "error-stack 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph-test-data",
+ "iso8601-duration",
  "postgres-types",
+ "regex",
  "serde",
  "serde_json",
  "thiserror",
@@ -6901,6 +6907,7 @@ dependencies = [
  "tsify",
  "url",
  "utoipa",
+ "uuid",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]
@@ -7085,9 +7092,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
  "getrandom",
  "serde",

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/inputs/number-or-text-input.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/inputs/number-or-text-input.tsx
@@ -49,20 +49,26 @@ export const NumberOrTextInput = ({
     "minLength" in expectedType ? expectedType.minLength : undefined;
   const maxLength =
     "maxLength" in expectedType ? expectedType.maxLength : undefined;
+  const exclusiveMinimum =
+    "exclusiveMinimum" in expectedType &&
+    typeof expectedType.exclusiveMinimum === "boolean"
+      ? expectedType.exclusiveMinimum
+      : false;
   const minimum =
-    "minimum" in expectedType
-      ? expectedType.minimum
-      : "exclusiveMinimum" in expectedType &&
-          typeof expectedType.exclusiveMinimum === "number"
-        ? expectedType.exclusiveMinimum + 1
-        : undefined;
+    "minimum" in expectedType && typeof expectedType.minimum === "number"
+      ? expectedType.minimum + (exclusiveMinimum ? 1 : 0)
+      : undefined;
+
+  const exclusiveMaximum =
+    "exclusiveMaximum" in expectedType &&
+    typeof expectedType.exclusiveMaximum === "boolean"
+      ? expectedType.exclusiveMaximum
+      : false;
   const maximum =
-    "maximum" in expectedType
-      ? expectedType.maximum
-      : "exclusiveMaximum" in expectedType &&
-          typeof expectedType.exclusiveMaximum === "number"
-        ? expectedType.exclusiveMaximum - 1
-        : undefined;
+    "maximum" in expectedType && typeof expectedType.maximum === "number"
+      ? expectedType.maximum - (exclusiveMaximum ? 1 : 0)
+      : undefined;
+
   const step =
     "multipleOf" in expectedType ? expectedType.multipleOf : undefined;
 

--- a/apps/hash-graph/libs/api/src/rest/data_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/data_type.rs
@@ -36,6 +36,7 @@ use graph::{
     subgraph::identifier::DataTypeVertexId,
 };
 use graph_types::{
+    knowledge::ValueWithMetadata,
     ontology::{
         DataTypeId, DataTypeMetadata, DataTypeWithMetadata, OntologyTemporalMetadata,
         OntologyTypeClassificationMetadata, OntologyTypeMetadata, OntologyTypeReference,
@@ -98,6 +99,8 @@ use crate::rest::{
             GetDataTypeSubgraphResponse,
             ArchiveDataTypeParams,
             UnarchiveDataTypeParams,
+
+            ValueWithMetadata,
         )
     ),
     tags(

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -7246,18 +7246,7 @@
             }
           },
           {
-            "type": "object",
-            "title": "PropertyWithMetadataValue",
-            "required": [
-              "value",
-              "metadata"
-            ],
-            "properties": {
-              "metadata": {
-                "$ref": "#/components/schemas/ValueMetadata"
-              },
-              "value": {}
-            }
+            "$ref": "#/components/schemas/ValueWithMetadata"
           }
         ]
       },
@@ -8035,6 +8024,20 @@
           "provenance": {
             "$ref": "#/components/schemas/PropertyProvenance"
           }
+        },
+        "additionalProperties": false
+      },
+      "ValueWithMetadata": {
+        "type": "object",
+        "required": [
+          "value",
+          "metadata"
+        ],
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/ValueMetadata"
+          },
+          "value": {}
         },
         "additionalProperties": false
       },

--- a/libs/@blockprotocol/type-system/rust/Cargo.toml
+++ b/libs/@blockprotocol/type-system/rust/Cargo.toml
@@ -15,6 +15,8 @@ name = "type_system"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+codec = { workspace = true, features = ["serde"] }
+
 postgres-types = { workspace = true, features = ["derive", "with-serde_json-1"], optional = true }
 serde = { version = "1.0.200", features = ["derive"] }
 serde_json = "1.0.116"
@@ -22,6 +24,11 @@ thiserror = "1.0.59"
 tsify = "0.4.5"
 url = "2.5.0"
 utoipa = { version = "4.2.0", features = ["url"], optional = true }
+regex = "1.10.5"
+error-stack = "0.4.1"
+iso8601-duration = "0.2.0"
+uuid = "1.9.1"
+email_address = { version = "0.2.4", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/libs/@blockprotocol/type-system/rust/package.json
+++ b/libs/@blockprotocol/type-system/rust/package.json
@@ -23,6 +23,9 @@
     "lint:clippy": "just clippy && just clippy --target wasm32-unknown-unknown",
     "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
   },
+  "dependencies": {
+    "@rust/codec": "0.0.0-private"
+  },
   "devDependencies": {
     "@rust/graph-test-data": "0.0.0-private"
   }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
@@ -1,0 +1,21 @@
+use error_stack::Report;
+use serde_json::Value as JsonValue;
+
+use super::{extend_report, ConstraintError};
+use crate::{schema::JsonSchemaValueType, DataType};
+
+pub(crate) fn check_array_constraints(
+    _actual: &[JsonValue],
+    data_type: &DataType,
+    result: &mut Result<(), Report<ConstraintError>>,
+) {
+    if data_type.json_type != JsonSchemaValueType::Array {
+        extend_report!(
+            *result,
+            ConstraintError::InvalidType {
+                actual: JsonSchemaValueType::Array,
+                expected: data_type.json_type
+            }
+        );
+    }
+}

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/boolean.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/boolean.rs
@@ -1,0 +1,20 @@
+use error_stack::Report;
+
+use super::{extend_report, ConstraintError};
+use crate::{schema::JsonSchemaValueType, DataType};
+
+pub(crate) fn check_boolean_constraints(
+    _actual: bool,
+    data_type: &DataType,
+    result: &mut Result<(), Report<ConstraintError>>,
+) {
+    if data_type.json_type != JsonSchemaValueType::Boolean {
+        extend_report!(
+            *result,
+            ConstraintError::InvalidType {
+                actual: JsonSchemaValueType::Boolean,
+                expected: data_type.json_type
+            }
+        );
+    }
+}

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/error.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/error.rs
@@ -1,0 +1,116 @@
+use core::net::AddrParseError;
+
+use iso8601_duration::ParseDurationError;
+use regex::Regex;
+use serde_json::{Number as JsonNumber, Value as JsonValue};
+use thiserror::Error;
+
+use crate::schema::{data_type::constraint::StringFormat, JsonSchemaValueType};
+
+#[derive(Debug, Error)]
+pub enum ConstraintError {
+    // General constraints
+    #[error(
+        "the value provided does not match the expected type, expected `{expected}`, got \
+         `{actual}`"
+    )]
+    InvalidType {
+        actual: JsonSchemaValueType,
+        expected: JsonSchemaValueType,
+    },
+    #[error(
+        "the provided value is not equal to the expected value, expected `{actual:#}` to be equal \
+         to `{expected:#}`"
+    )]
+    Const {
+        actual: JsonValue,
+        expected: JsonValue,
+    },
+    #[error("the provided value is not one of the expected values, expected `{actual:#}` to be one of `{:#}`", JsonValue::Array(.expected.clone()))]
+    Enum {
+        actual: JsonValue,
+        expected: Vec<JsonValue>,
+    },
+
+    // Number constraints
+    #[error(
+        "the provided number cannot be converted into a 64-bit representation of IEEE floating \
+         point number, the value provided is `{actual}`. If this issue is encountered please file \
+         a bug report, the linear tracking issue for this error is `H-2980`"
+    )]
+    InsufficientPrecision { actual: JsonNumber },
+    #[error(
+        "the provided value is not greater than or equal to the minimum value, expected \
+         `{actual}` to be greater than or equal to `{expected}`"
+    )]
+    Minimum { actual: f64, expected: f64 },
+    #[error(
+        "the provided value is not less than or equal to the maximum value, expected `{actual}` \
+         to be less than or equal to `{expected}`"
+    )]
+    Maximum { actual: f64, expected: f64 },
+    #[error(
+        "the provided value is not greater than the minimum value, expected `{actual}` to be \
+         strictly greater than `{expected}`"
+    )]
+    ExclusiveMinimum { actual: f64, expected: f64 },
+    #[error(
+        "the provided value is not less than the maximum value, expected `{actual}` to be \
+         strictly less than `{expected}`"
+    )]
+    ExclusiveMaximum { actual: f64, expected: f64 },
+    #[error(
+        "the provided value is not a multiple of the expected value, expected `{actual}` to be a \
+         multiple of `{expected}`"
+    )]
+    MultipleOf { actual: f64, expected: f64 },
+
+    // String constraints
+    #[error(
+        "the provided value is not greater than or equal to the minimum length, expected \
+         the length of `{}` to be greater than or equal to `{expected}` but it is `{}`",
+        .actual,
+        .actual.len(),
+    )]
+    MinLength { actual: String, expected: usize },
+    #[error(
+        "the provided value is not less than or equal to the maximum length, expected \
+         the length of `{}` to be less than or equal to `{expected}` but it is `{}`", .actual, .actual.len(),
+    )]
+    MaxLength { actual: String, expected: usize },
+    #[error(
+        "the provided value does not match the expected pattern, expected `{actual}` to match the \
+         pattern `{}`", .expected.as_str()
+    )]
+    Pattern { actual: String, expected: Regex },
+    #[error(
+        "the provided value does not match the expected format, expected `{actual}` to match the \
+         format `{}`", .expected.as_str()
+    )]
+    Format {
+        actual: String,
+        expected: StringFormat,
+    },
+}
+
+#[derive(Debug, Error)]
+pub enum StringFormatError {
+    #[error(transparent)]
+    Url(url::ParseError),
+    #[error(transparent)]
+    Uuid(uuid::Error),
+    #[error(transparent)]
+    Regex(regex::Error),
+    #[error(transparent)]
+    Email(email_address::Error),
+    #[error(transparent)]
+    IpAddress(AddrParseError),
+    #[error("The value does not match the date-time format `YYYY-MM-DDTHH:MM:SS.sssZ`")]
+    DateTime,
+    #[error("The value does not match the date format `YYYY-MM-DD`")]
+    Date,
+    #[error("The value does not match the time format `HH:MM:SS.sss`")]
+    Time,
+    #[error("{0:?}")]
+    Duration(ParseDurationError),
+}

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
@@ -1,0 +1,29 @@
+macro_rules! extend_report {
+    ($status:expr, $error:expr $(,)?) => {
+        if let Err(ref mut report) = $status {
+            report.extend_one(error_stack::report!($error))
+        } else {
+            $status = Err(error_stack::report!($error))
+        }
+    };
+}
+
+pub(crate) use extend_report;
+
+mod array;
+mod boolean;
+mod error;
+mod null;
+mod number;
+mod object;
+mod string;
+
+pub(crate) use self::{
+    array::check_array_constraints,
+    boolean::check_boolean_constraints,
+    error::ConstraintError,
+    null::check_null_constraints,
+    number::check_numeric_constraints,
+    object::check_object_constraints,
+    string::{check_string_constraints, StringFormat},
+};

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/null.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/null.rs
@@ -1,0 +1,19 @@
+use error_stack::Report;
+
+use super::{extend_report, ConstraintError};
+use crate::{schema::JsonSchemaValueType, DataType};
+
+pub(crate) fn check_null_constraints(
+    data_type: &DataType,
+    result: &mut Result<(), Report<ConstraintError>>,
+) {
+    if data_type.json_type != JsonSchemaValueType::Null {
+        extend_report!(
+            *result,
+            ConstraintError::InvalidType {
+                actual: JsonSchemaValueType::Null,
+                expected: data_type.json_type
+            }
+        );
+    }
+}

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
@@ -1,0 +1,56 @@
+use error_stack::Report;
+
+use super::{extend_report, ConstraintError};
+use crate::{schema::JsonSchemaValueType, DataType};
+
+pub(crate) fn check_numeric_constraints(
+    actual: f64,
+    data_type: &DataType,
+    result: &mut Result<(), Report<ConstraintError>>,
+) {
+    if data_type.json_type != JsonSchemaValueType::Number {
+        extend_report!(
+            *result,
+            ConstraintError::InvalidType {
+                actual: JsonSchemaValueType::Number,
+                expected: data_type.json_type
+            }
+        );
+    }
+
+    if let Some(expected) = data_type.minimum {
+        if data_type.exclusive_minimum {
+            if actual <= expected {
+                extend_report!(
+                    *result,
+                    ConstraintError::ExclusiveMinimum { actual, expected }
+                );
+            }
+        } else if actual < expected {
+            extend_report!(*result, ConstraintError::Minimum { actual, expected });
+        }
+    }
+    if let Some(expected) = data_type.maximum {
+        if data_type.exclusive_maximum {
+            if actual >= expected {
+                extend_report!(
+                    *result,
+                    ConstraintError::ExclusiveMaximum { actual, expected }
+                );
+            }
+        } else if actual > expected {
+            extend_report!(*result, ConstraintError::Maximum { actual, expected });
+        }
+    }
+
+    if let Some(expected) = data_type.multiple_of {
+        #[expect(
+            clippy::float_arithmetic,
+            clippy::modulo_arithmetic,
+            reason = "Validation requires floating point arithmetic"
+        )]
+        if actual % expected >= f64::EPSILON {
+            extend_report!(*result, ConstraintError::MultipleOf { actual, expected });
+        }
+    }
+}

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
@@ -8,7 +8,10 @@ pub(crate) fn check_numeric_constraints(
     data_type: &DataType,
     result: &mut Result<(), Report<ConstraintError>>,
 ) {
-    if data_type.json_type != JsonSchemaValueType::Number {
+    if !matches!(
+        data_type.json_type,
+        JsonSchemaValueType::Number | JsonSchemaValueType::Integer
+    ) {
         extend_report!(
             *result,
             ConstraintError::InvalidType {
@@ -43,7 +46,10 @@ pub(crate) fn check_numeric_constraints(
         }
     }
 
-    if let Some(expected) = data_type.multiple_of {
+    if let Some(expected) = data_type
+        .multiple_of
+        .or_else(|| (data_type.json_type == JsonSchemaValueType::Integer).then_some(1.0))
+    {
         #[expect(
             clippy::float_arithmetic,
             clippy::modulo_arithmetic,

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/object.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/object.rs
@@ -1,0 +1,22 @@
+use error_stack::Report;
+
+use super::{extend_report, ConstraintError};
+use crate::{schema::JsonSchemaValueType, DataType};
+
+type JsonObject = serde_json::Map<String, serde_json::Value>;
+
+pub(crate) fn check_object_constraints(
+    _actual: &JsonObject,
+    data_type: &DataType,
+    result: &mut Result<(), Report<ConstraintError>>,
+) {
+    if data_type.json_type != JsonSchemaValueType::Object {
+        extend_report!(
+            *result,
+            ConstraintError::InvalidType {
+                actual: JsonSchemaValueType::Object,
+                expected: data_type.json_type
+            }
+        );
+    }
+}

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
@@ -1,0 +1,188 @@
+use core::{
+    net::{Ipv4Addr, Ipv6Addr},
+    str::FromStr,
+};
+use std::sync::OnceLock;
+
+use email_address::EmailAddress;
+use error_stack::Report;
+use iso8601_duration::Duration;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use url::{Host, Url};
+use uuid::Uuid;
+
+use super::{extend_report, ConstraintError};
+use crate::{
+    schema::{data_type::constraint::error::StringFormatError, JsonSchemaValueType},
+    DataType,
+};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[serde(rename_all = "kebab-case")]
+pub enum StringFormat {
+    Uri,
+    Hostname,
+    Ipv4,
+    Ipv6,
+    Uuid,
+    Regex,
+    Email,
+    Date,
+    Time,
+    DateTime,
+    Duration,
+}
+
+impl StringFormat {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Uri => "uri",
+            Self::Hostname => "hostname",
+            Self::Ipv4 => "ipv4",
+            Self::Ipv6 => "ipv6",
+            Self::Uuid => "uuid",
+            Self::Regex => "regex",
+            Self::Email => "email",
+            Self::Date => "date",
+            Self::Time => "time",
+            Self::DateTime => "date-time",
+            Self::Duration => "duration",
+        }
+    }
+}
+
+impl StringFormat {
+    pub fn validate(self, value: &str) -> Result<(), Report<StringFormatError>> {
+        // Only the simplest date format are supported in all three, RFC-3339, ISO-8601 and HTML
+        const DATE_REGEX_STRING: &str = r"(?P<Y>\d{4})-(?P<M>\d{2})-(?P<D>\d{2})";
+        static DATE_REGEX: OnceLock<Regex> = OnceLock::new();
+
+        // Only the simplest time format are supported in all three, RFC-3339, ISO-8601 and HTML
+        const TIME_REGEX_STRING: &str =
+            r"(?P<h>\d{2}):(?P<m>\d{2}):(?P<s>\d{2}(?:\.\d+)?)(?:(?P<Z>[+-]\d{2}):(?P<z>\d{2})|Z)";
+        static TIME_REGEX: OnceLock<Regex> = OnceLock::new();
+
+        static DATE_TIME_REGEX: OnceLock<Regex> = OnceLock::new();
+
+        match self {
+            Self::Uri => {
+                Url::parse(value).map_err(StringFormatError::Url)?;
+            }
+            Self::Hostname => {
+                Host::parse(value).map_err(StringFormatError::Url)?;
+            }
+            Self::Ipv4 => {
+                Ipv4Addr::from_str(value).map_err(StringFormatError::IpAddress)?;
+            }
+            Self::Ipv6 => {
+                Ipv6Addr::from_str(value).map_err(StringFormatError::IpAddress)?;
+            }
+            Self::Uuid => {
+                Uuid::parse_str(value).map_err(StringFormatError::Uuid)?;
+            }
+            Self::Regex => {
+                Regex::new(value).map_err(StringFormatError::Regex)?;
+            }
+            Self::Email => {
+                EmailAddress::from_str(value).map_err(StringFormatError::Email)?;
+            }
+            Self::Date => {
+                DATE_REGEX
+                    .get_or_init(|| {
+                        Regex::new(&format!("^{DATE_REGEX_STRING}$"))
+                            .expect("failed to compile date regex")
+                    })
+                    .is_match(value)
+                    .then_some(())
+                    .ok_or(StringFormatError::Date)?;
+            }
+            Self::Time => {
+                TIME_REGEX
+                    .get_or_init(|| {
+                        Regex::new(&format!("^{TIME_REGEX_STRING}$"))
+                            .expect("failed to compile time regex")
+                    })
+                    .is_match(value)
+                    .then_some(())
+                    .ok_or(StringFormatError::Time)?;
+            }
+            Self::DateTime => {
+                DATE_TIME_REGEX
+                    .get_or_init(|| {
+                        Regex::new(&format!("^{DATE_REGEX_STRING}T{TIME_REGEX_STRING}$"))
+                            .expect("failed to compile date-time regex")
+                    })
+                    .is_match(value)
+                    .then_some(())
+                    .ok_or(StringFormatError::DateTime)?;
+            }
+            Self::Duration => {
+                Duration::from_str(value).map_err(StringFormatError::Duration)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn check_string_constraints(
+    actual: &str,
+    data_type: &DataType,
+    result: &mut Result<(), Report<ConstraintError>>,
+) {
+    if data_type.json_type != JsonSchemaValueType::String {
+        extend_report!(
+            *result,
+            ConstraintError::InvalidType {
+                actual: JsonSchemaValueType::String,
+                expected: data_type.json_type
+            }
+        );
+    }
+
+    if let Some(expected) = data_type.min_length {
+        if actual.len() < expected {
+            extend_report!(
+                *result,
+                ConstraintError::MinLength {
+                    actual: actual.to_owned(),
+                    expected
+                }
+            );
+        }
+    }
+    if let Some(expected) = data_type.max_length {
+        if actual.len() > expected {
+            extend_report!(
+                *result,
+                ConstraintError::MaxLength {
+                    actual: actual.to_owned(),
+                    expected
+                }
+            );
+        }
+    }
+    if let Some(expected) = &data_type.pattern {
+        if !expected.is_match(actual) {
+            extend_report!(
+                *result,
+                ConstraintError::Pattern {
+                    actual: actual.to_owned(),
+                    expected: expected.clone()
+                }
+            );
+        }
+    }
+    if let Some(expected) = data_type.format {
+        if let Err(error) = expected.validate(actual) {
+            extend_report!(
+                *result,
+                error.change_context(ConstraintError::Format {
+                    actual: actual.to_owned(),
+                    expected
+                })
+            );
+        }
+    }
+}

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/raw.rs
@@ -29,7 +29,11 @@ pub enum DataTypeSchemaTag {
     V3,
 }
 
-fn is_false(value: &bool) -> bool {
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "Only used in serde skip_serializing_if"
+)]
+const fn is_false(value: &bool) -> bool {
     !*value
 }
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/raw.rs
@@ -35,7 +35,7 @@ fn is_false(value: &bool) -> bool {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DataType<'a> {
     #[serde(rename = "$schema")]
     pub schema: DataTypeSchemaTag,

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/validation.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/validation.rs
@@ -1,25 +1,9 @@
-use serde_json::Value as JsonValue;
 use thiserror::Error;
 
-use crate::{
-    schema::{DataType, JsonSchemaValueType},
-    Valid, Validator,
-};
+use crate::{schema::DataType, Valid, Validator};
 
 #[derive(Debug, Error)]
-pub enum ValidateDataTypeError {
-    #[error("Unexpected additional property `{0}`")]
-    UnexpectedAdditionalProperty(String),
-    #[error(
-        "Unexpected additional property type for `{property}`, expected `{expected}`, got \
-         `{actual}"
-    )]
-    UnexpectedAdditionalPropertyType {
-        property: String,
-        actual: JsonSchemaValueType,
-        expected: JsonSchemaValueType,
-    },
-}
+pub enum ValidateDataTypeError {}
 
 pub struct DataTypeValidator;
 
@@ -31,45 +15,6 @@ impl Validator<DataType> for DataTypeValidator {
         &self,
         value: &'v DataType,
     ) -> Result<&'v Valid<Self::Validated>, Self::Error> {
-        for (additional_property, property_value) in &value.additional_properties {
-            match additional_property.as_str() {
-                "const" | "enum" => {}
-                "minimum" | "maximum" | "exclusiveMinimum" | "exclusiveMaximum" | "multipleOf"
-                | "minLength" | "maxLength" => {
-                    if !matches!(property_value, JsonValue::Number(_)) {
-                        return Err(ValidateDataTypeError::UnexpectedAdditionalPropertyType {
-                            property: additional_property.clone(),
-                            actual: JsonSchemaValueType::from(property_value),
-                            expected: JsonSchemaValueType::Number,
-                        });
-                    }
-                }
-                "format" | "pattern" => {
-                    if !matches!(property_value, JsonValue::String(_)) {
-                        return Err(ValidateDataTypeError::UnexpectedAdditionalPropertyType {
-                            property: additional_property.clone(),
-                            actual: JsonSchemaValueType::from(property_value),
-                            expected: JsonSchemaValueType::String,
-                        });
-                    }
-                }
-                "label" => {
-                    if !matches!(property_value, JsonValue::Object(_)) {
-                        return Err(ValidateDataTypeError::UnexpectedAdditionalPropertyType {
-                            property: additional_property.clone(),
-                            actual: JsonSchemaValueType::from(property_value),
-                            expected: JsonSchemaValueType::Object,
-                        });
-                    }
-                }
-                _ => {
-                    return Err(ValidateDataTypeError::UnexpectedAdditionalProperty(
-                        additional_property.clone(),
-                    ));
-                }
-            }
-        }
-
         Ok(Valid::new_ref_unchecked(value))
     }
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/entity_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/entity_type/mod.rs
@@ -29,7 +29,7 @@ pub struct EntityType {
     pub all_of: HashSet<EntityTypeReference>,
     pub links: HashMap<VersionedUrl, ArraySchema<Option<OneOfSchema<EntityTypeReference>>>>,
     #[deprecated]
-    pub examples: Vec<HashMap<String, serde_json::Value>>,
+    pub examples: Vec<HashMap<BaseUrl, serde_json::Value>>,
 }
 
 impl Serialize for EntityType {

--- a/libs/@blockprotocol/type-system/rust/src/schema/entity_type/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/entity_type/raw.rs
@@ -2,6 +2,7 @@ use alloc::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 #[cfg(target_arch = "wasm32")]
 use tsify::Tsify;
 
@@ -66,7 +67,7 @@ pub struct EntityType<'a> {
     #[serde(with = "links", default, skip_serializing_if = "HashMap::is_empty")]
     links: Links,
     #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
-    examples: Cow<'a, [HashMap<String, serde_json::Value>]>,
+    examples: Cow<'a, [HashMap<BaseUrl, JsonValue>]>,
 }
 
 mod links {

--- a/libs/@blockprotocol/type-system/rust/src/schema/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/mod.rs
@@ -16,7 +16,8 @@ mod one_of;
 pub use self::{
     array::{ArraySchema, ValueOrArray},
     data_type::{
-        DataType, DataTypeReference, DataTypeValidator, JsonSchemaValueType, ValidateDataTypeError,
+        DataType, DataTypeLabel, DataTypeReference, DataTypeValidator, JsonSchemaValueType,
+        ValidateDataTypeError,
     },
     entity_type::{
         ClosedEntityType, ClosedEntityTypeSchemaData, EntityType, EntityTypeReference,

--- a/libs/@blockprotocol/type-system/rust/src/utils.rs
+++ b/libs/@blockprotocol/type-system/rust/src/utils.rs
@@ -33,6 +33,16 @@ mod wasm {
             }
         }
     }
+
+    #[derive(Tsify)]
+    #[serde(rename = "JsonValue")]
+    #[expect(dead_code, reason = "Used in the generated TypeScript types")]
+    pub struct VersionedUrlPatch(
+        #[tsify(
+            type = "null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue; }"
+        )]
+        (),
+    );
 }
 
 #[cfg(test)]

--- a/libs/@hashintel/type-editor/src/entity-type-editor/property-list-card/property-type-form/expected-value-selector.tsx
+++ b/libs/@hashintel/type-editor/src/entity-type-editor/property-list-card/property-type-form/expected-value-selector.tsx
@@ -259,14 +259,8 @@ export const ExpectedValueSelector = ({
               }
               const { description, title } = dataType;
 
-              const leftLabel =
-                "label" in dataType && "left" in dataType.label
-                  ? (dataType.label as { left: string }).left
-                  : "";
-              const rightLabel =
-                "label" in dataType && "right" in dataType.label
-                  ? (dataType.label as { right: string }).right
-                  : "";
+              const leftLabel = dataType.label?.left ?? "";
+              const rightLabel = dataType.label?.right ?? "";
 
               return (
                 (description &&

--- a/libs/@local/codec/Cargo.toml
+++ b/libs/@local/codec/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 [dependencies]
 derive-where = { workspace = true, optional = true }
 error-stack = { workspace = true, optional = true, features = ["std"] }
+regex = { version = "1.10.5", optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 tokio-util = { workspace = true, features = ["codec"], optional = true }
@@ -32,7 +33,7 @@ bytes = [
     "dep:tokio-util",
     "dep:error-stack",
 ]
-serde = ["dep:serde", "dep:time"]
+serde = ["dep:serde", "dep:time", "dep:regex"]
 harpc = ["dep:harpc-wire-protocol", "dep:tokio-util", "dep:error-stack"]
 
 [lints]

--- a/libs/@local/codec/src/serde/mod.rs
+++ b/libs/@local/codec/src/serde/mod.rs
@@ -18,3 +18,61 @@ pub mod time {
         pub use super::super::time_format::option::*;
     }
 }
+
+pub mod regex {
+    use regex::Regex;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    /// Serialize a [`Regex`] to a string.
+    ///
+    /// # Errors
+    ///
+    /// - If the serialization of the string fails.
+    pub fn serialize<S: Serializer>(regex: &Regex, serializer: S) -> Result<S::Ok, S::Error> {
+        regex.as_str().serialize(serializer)
+    }
+
+    /// Deserialize a [`Regex`] from a string.
+    ///
+    /// # Errors
+    ///
+    /// - If the deserialization of the string fails.
+    /// - If the regex pattern is invalid.
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Regex, D::Error> {
+        Regex::new(&String::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+
+    pub mod option {
+        use regex::Regex;
+        use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+        /// Serialize an optional [`Regex`] to a string.
+        ///
+        /// # Errors
+        ///
+        /// - If the serialization of the string fails.
+        pub fn serialize<S: Serializer>(
+            regex: &Option<Regex>,
+            serializer: S,
+        ) -> Result<S::Ok, S::Error> {
+            regex.as_ref().map(Regex::as_str).serialize(serializer)
+        }
+
+        /// Deserialize a [`Regex`] from an optional string.
+        ///
+        /// # Errors
+        ///
+        /// - If the deserialization of the string fails.
+        /// - If the regex pattern is invalid.
+        pub fn deserialize<'de, D: Deserializer<'de>>(
+            deserializer: D,
+        ) -> Result<Option<Regex>, D::Error> {
+            let Some(pattern) = Option::<String>::deserialize(deserializer)? else {
+                return Ok(None);
+            };
+            Regex::new(&pattern)
+                .map_err(serde::de::Error::custom)
+                .map(Some)
+        }
+    }
+}

--- a/libs/@local/hash-graph-types/rust/src/knowledge/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/mod.rs
@@ -8,7 +8,7 @@ pub use self::{
         ArrayMetadata, ObjectMetadata, PatchError, Property, PropertyDiff, PropertyMetadata,
         PropertyMetadataObject, PropertyObject, PropertyPatchOperation, PropertyPath,
         PropertyPathElement, PropertyProvenance, PropertyWithMetadata, PropertyWithMetadataObject,
-        ValueMetadata,
+        ValueMetadata, ValueWithMetadata,
     },
 };
 

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/metadata/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/metadata/mod.rs
@@ -2,7 +2,7 @@ pub use self::{
     array::ArrayMetadata,
     object::{ObjectMetadata, PropertyMetadataObject},
     provenance::PropertyProvenance,
-    value::ValueMetadata,
+    value::{ValueMetadata, ValueWithMetadata},
 };
 
 mod array;

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/metadata/value.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/metadata/value.rs
@@ -16,3 +16,11 @@ pub struct ValueMetadata {
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     pub data_type_id: Option<VersionedUrl>,
 }
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ValueWithMetadata {
+    pub value: serde_json::Value,
+    pub metadata: ValueMetadata,
+}

--- a/libs/@local/hash-graph-types/typescript/src/ontology.ts
+++ b/libs/@local/hash-graph-types/typescript/src/ontology.ts
@@ -118,8 +118,8 @@ export type StringConstraint = {
 export type NumberConstraint = {
   minimum?: number;
   maximum?: number;
-  exclusiveMinimum?: number;
-  exclusiveMaximum?: number;
+  exclusiveMinimum?: boolean;
+  exclusiveMaximum?: boolean;
   multipleOf?: number;
   type: "number" | "integer";
 };

--- a/libs/@local/hash-validation/src/data_type.rs
+++ b/libs/@local/hash-validation/src/data_type.rs
@@ -253,9 +253,9 @@ mod tests {
             .await
             .expect("validation failed");
 
-        _ = validate_data(json!(1.0), &integer_type, ValidateEntityComponents::full())
+        validate_data(json!(1.0), &integer_type, ValidateEntityComponents::full())
             .await
-            .expect_err("validation succeeded");
+            .expect("validation failed");
 
         _ = validate_data(
             json!(core::f64::consts::PI),

--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -75,7 +75,7 @@ where
         .validate_value(&value.value, components, provider)
         .await
         .change_context(EntityValidationError::InvalidProperties)
-        .attach_lazy(|| Expected::EntityType(self.clone()))
+        .attach_lazy(|| Expected::EntityType(Box::new(self.clone())))
         .attach_lazy(|| Actual::Properties(value.clone()))
     }
 }

--- a/libs/@local/hash-validation/src/error.rs
+++ b/libs/@local/hash-validation/src/error.rs
@@ -70,7 +70,7 @@ pub enum Actual {
 
 #[derive(Debug)]
 pub enum Expected {
-    EntityType(ClosedEntityType),
+    EntityType(Box<ClosedEntityType>),
     PropertyType(PropertyType),
     DataType(DataType),
 }

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -34,33 +34,6 @@ trait Schema<V: ?Sized, P: Sync> {
     ) -> impl Future<Output = Result<(), Report<Self::Error>>> + Send + 'a;
 }
 
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(transparent)]
-pub struct Valid<T> {
-    value: T,
-}
-
-impl<T> Valid<T> {
-    pub async fn new<S, C>(
-        value: T,
-        schema: S,
-        components: ValidateEntityComponents,
-        context: C,
-    ) -> Result<Self, Report<T::Error>>
-    where
-        T: Validate<S, C> + Send,
-        S: Send,
-        C: Send,
-    {
-        value.validate(&schema, components, &context).await?;
-        Ok(Self { value })
-    }
-
-    pub fn into_unvalidated(self) -> T {
-        self.value
-    }
-}
-
 const fn default_true() -> bool {
     true
 }
@@ -106,18 +79,6 @@ impl Default for ValidateEntityComponents {
     }
 }
 
-impl<T> AsRef<T> for Valid<T> {
-    fn as_ref(&self) -> &T {
-        &self.value
-    }
-}
-
-impl<T> Borrow<T> for Valid<T> {
-    fn borrow(&self) -> &T {
-        &self.value
-    }
-}
-
 pub trait Validate<S, C> {
     type Error: Context;
 
@@ -156,7 +117,8 @@ mod tests {
     use std::collections::HashMap;
 
     use graph_types::knowledge::{
-        Property, PropertyObject, PropertyWithMetadata, PropertyWithMetadataObject,
+        Property, PropertyObject, PropertyProvenance, PropertyWithMetadata,
+        PropertyWithMetadataObject, ValueMetadata, ValueWithMetadata,
     };
     use serde_json::Value as JsonValue;
     use thiserror::Error;
@@ -358,20 +320,24 @@ mod tests {
     }
 
     pub(crate) async fn validate_data(
-        data: JsonValue,
+        value: JsonValue,
         data_type: &str,
         components: ValidateEntityComponents,
     ) -> Result<(), Report<DataValidationError>> {
         install_error_stack_hooks();
 
-        let property: Property =
-            serde_json::from_value(data).expect("failed to deserialize data into property");
         let data_type: DataType =
             serde_json::from_str(data_type).expect("failed to parse data type");
 
-        PropertyWithMetadata::from_parts(property, None)
-            .expect("failed to create property with metadata")
-            .validate(&data_type, components, &())
-            .await
+        ValueWithMetadata {
+            value,
+            metadata: ValueMetadata {
+                data_type_id: None,
+                provenance: PropertyProvenance::default(),
+                confidence: None,
+            },
+        }
+        .validate(&data_type, components, &())
+        .await
     }
 }

--- a/tests/hash-graph-integration/postgres/partial_updates.rs
+++ b/tests/hash-graph-integration/postgres/partial_updates.rs
@@ -17,7 +17,7 @@ use graph_types::{
     knowledge::{
         entity::ProvidedEntityEditionProvenance, PropertyObject, PropertyPatchOperation,
         PropertyPathElement, PropertyProvenance, PropertyWithMetadata, PropertyWithMetadataObject,
-        ValueMetadata,
+        ValueMetadata, ValueWithMetadata,
     },
     owned_by_id::OwnedById,
 };
@@ -111,25 +111,25 @@ async fn properties_add() {
             properties: vec![
                 PropertyPatchOperation::Add {
                     path: once(PropertyPathElement::from(age_property_type_id())).collect(),
-                    property: PropertyWithMetadata::Value {
+                    property: PropertyWithMetadata::Value(ValueWithMetadata {
                         value: json!(30),
                         metadata: ValueMetadata {
                             confidence: None,
                             data_type_id: None,
                             provenance: PropertyProvenance::default(),
                         },
-                    },
+                    }),
                 },
                 PropertyPatchOperation::Add {
                     path: once(PropertyPathElement::from(name_property_type_id())).collect(),
-                    property: PropertyWithMetadata::Value {
+                    property: PropertyWithMetadata::Value(ValueWithMetadata {
                         value: json!("Alice Allison"),
                         metadata: ValueMetadata {
                             confidence: None,
                             data_type_id: None,
                             provenance: PropertyProvenance::default(),
                         },
-                    },
+                    }),
                 },
             ],
             draft: None,
@@ -277,14 +277,14 @@ async fn properties_replace() {
             entity_type_ids: HashSet::new(),
             properties: vec![PropertyPatchOperation::Replace {
                 path: once(PropertyPathElement::from(name_property_type_id())).collect(),
-                property: PropertyWithMetadata::Value {
+                property: PropertyWithMetadata::Value(ValueWithMetadata {
                     value: json!("Bob"),
                     metadata: ValueMetadata {
                         confidence: None,
                         data_type_id: None,
                         provenance: PropertyProvenance::default(),
                     },
-                },
+                }),
             }],
             draft: None,
             archived: None,

--- a/tests/hash-graph-integration/postgres/property_metadata.rs
+++ b/tests/hash-graph-integration/postgres/property_metadata.rs
@@ -13,7 +13,7 @@ use graph_types::{
         entity::{Location, ProvidedEntityEditionProvenance, SourceProvenance, SourceType},
         Confidence, ObjectMetadata, PropertyMetadata, PropertyMetadataObject, PropertyObject,
         PropertyPatchOperation, PropertyPath, PropertyPathElement, PropertyProvenance,
-        PropertyWithMetadata, PropertyWithMetadataObject, ValueMetadata,
+        PropertyWithMetadata, PropertyWithMetadataObject, ValueMetadata, ValueWithMetadata,
     },
     owned_by_id::OwnedById,
 };
@@ -195,10 +195,10 @@ async fn initial_metadata() {
                         name_property_type_id(),
                     )))
                     .collect(),
-                    property: PropertyWithMetadata::Value {
+                    property: PropertyWithMetadata::Value(ValueWithMetadata {
                         value: json!("Bob"),
                         metadata: name_property_metadata.clone(),
-                    },
+                    }),
                 }],
                 entity_type_ids: HashSet::new(),
                 archived: None,
@@ -356,14 +356,14 @@ async fn no_initial_metadata() {
                 entity_id: entity.metadata.record_id.entity_id,
                 properties: vec![PropertyPatchOperation::Replace {
                     path: once(PropertyPathElement::from(name_property_type_id())).collect(),
-                    property: PropertyWithMetadata::Value {
+                    property: PropertyWithMetadata::Value(ValueWithMetadata {
                         value: json!("Alice"),
                         metadata: ValueMetadata {
                             confidence: Confidence::new(0.5),
                             data_type_id: None,
                             provenance: PropertyProvenance::default(),
                         },
-                    },
+                    }),
                 }],
                 entity_type_ids: HashSet::new(),
                 archived: None,
@@ -470,14 +470,14 @@ async fn properties_add() {
                 entity_type_ids: HashSet::new(),
                 properties: vec![PropertyPatchOperation::Add {
                     path: path.clone(),
-                    property: PropertyWithMetadata::Value {
+                    property: PropertyWithMetadata::Value(ValueWithMetadata {
                         value: json!(30),
                         metadata: ValueMetadata {
                             confidence: Confidence::new(0.5),
                             data_type_id: None,
                             provenance: PropertyProvenance::default(),
                         },
-                    },
+                    }),
                 }],
                 draft: None,
                 archived: None,
@@ -575,14 +575,14 @@ async fn properties_remove() {
                     },
                     PropertyPatchOperation::Add {
                         path: film_path.clone(),
-                        property: PropertyWithMetadata::Value {
+                        property: PropertyWithMetadata::Value(ValueWithMetadata {
                             value: json!("Fight Club"),
                             metadata: ValueMetadata {
                                 confidence: Confidence::new(0.5),
                                 data_type_id: None,
                                 provenance: property_provenance_b(),
                             },
-                        },
+                        }),
                     },
                 ],
                 draft: None,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, we use `additionalProperties: true`, instead, we need strongly typed constraints.

## 🚫 Blocked at

- #4688 

## 🔍 What does this change?

- Make the constraints typed
- Use validation based on that
- fix issues that `exclusiveMaximum` and `exclusiveMinimum` is a boolean, not a number

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph