### PR TITLE
H-3073: Use `multipleOf` to determine exclusive min/max in data type validation

### DIFF
--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/inputs/number-or-text-input.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/inputs/number-or-text-input.tsx
@@ -49,6 +49,14 @@ export const NumberOrTextInput = ({
     "minLength" in expectedType ? expectedType.minLength : undefined;
   const maxLength =
     "maxLength" in expectedType ? expectedType.maxLength : undefined;
+
+  const step =
+    "multipleOf" in expectedType && expectedType.multipleOf !== undefined
+      ? expectedType.multipleOf
+      : expectedType.type === "integer"
+        ? 1
+        : 0.01;
+
   const exclusiveMinimum =
     "exclusiveMinimum" in expectedType &&
     typeof expectedType.exclusiveMinimum === "boolean"
@@ -56,7 +64,7 @@ export const NumberOrTextInput = ({
       : false;
   const minimum =
     "minimum" in expectedType && typeof expectedType.minimum === "number"
-      ? expectedType.minimum + (exclusiveMinimum ? 1 : 0)
+      ? expectedType.minimum + (exclusiveMinimum ? step : 0)
       : undefined;
 
   const exclusiveMaximum =
@@ -66,11 +74,8 @@ export const NumberOrTextInput = ({
       : false;
   const maximum =
     "maximum" in expectedType && typeof expectedType.maximum === "number"
-      ? expectedType.maximum - (exclusiveMaximum ? 1 : 0)
+      ? expectedType.maximum - (exclusiveMaximum ? step : 0)
       : undefined;
-
-  const step =
-    "multipleOf" in expectedType ? expectedType.multipleOf : undefined;
 
   const jsonStringFormat =
     "format" in expectedType ? expectedType.format : undefined;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, only `1` is added/substracted from the minimum/maximum. This does not take into account `type === "number"` so this will fix this by using the `step` here.

## 🚫 Blocked by

- #4688 
- #4689