### PR TITLE
H-3074: Make `Entity.create` method generic

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/persist-entity-action.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/persist-entity-action.ts
@@ -1,5 +1,6 @@
 import type { VersionedUrl } from "@blockprotocol/type-system";
 import { getWebMachineActorId } from "@local/hash-backend-utils/machine-actors";
+import type { PropertyObject } from "@local/hash-graph-client";
 import type { CreateEntityParameters } from "@local/hash-graph-sdk/entity";
 import { Entity } from "@local/hash-graph-sdk/entity";
 import {
@@ -204,7 +205,7 @@ export const persistEntityAction: FlowActionActivity = async ({ inputs }) => {
           },
         );
       } else {
-        entity = await Entity.create(
+        [entity] = await Entity.create<[PropertyObject]>(
           graphApiClient,
           { actorId: webBotActorId },
           {

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/get-file-entity-from-url.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/get-file-entity-from-url.ts
@@ -232,7 +232,7 @@ export const getFileEntityFromUrl = async (params: {
     },
   };
 
-  const incompleteFileEntity = await Entity.create(
+  const [incompleteFileEntity] = await Entity.create<[FileProperties]>(
     graphApiClient,
     { actorId: webBotActorId },
     {
@@ -275,14 +275,14 @@ export const getFileEntityFromUrl = async (params: {
     ...fileStorageProperties,
   };
 
-  const updatedEntity = (await incompleteFileEntity.patch(
+  const updatedEntity = await incompleteFileEntity.patch(
     graphApiClient,
     { actorId: webBotActorId },
     {
       propertyPatches: propertyObjectToPatches(updatedProperties),
       provenance,
     },
-  )) as Entity<FileProperties>;
+  );
 
   try {
     await writeFileToS3URL({

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/write-google-sheet-action.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/write-google-sheet-action.ts
@@ -393,7 +393,7 @@ export const writeGoogleSheetAction: FlowActionActivity<{
       properties: fileProperties,
     };
 
-    entityToReturn = await Entity.create(
+    [entityToReturn] = await Entity.create<[GoogleSheetsFileProperties]>(
       graphApiClient,
       { actorId: webBotActorId },
       {

--- a/apps/hash-ai-worker-ts/src/shared/testing-utilities/mock-get-flow-context.ts
+++ b/apps/hash-ai-worker-ts/src/shared/testing-utilities/mock-get-flow-context.ts
@@ -38,7 +38,7 @@ const createDummyFlow = async (params: { actorId: AccountId }) => {
     },
   };
 
-  const dummyFlowEntity = await Entity.create(
+  const [dummyFlowEntity] = await Entity.create<[FlowRunProperties]>(
     graphApiClient,
     { actorId },
     {

--- a/apps/hash-api/src/graph/knowledge/primitive/entity.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity.ts
@@ -118,7 +118,7 @@ export const createEntity: ImpureGraphFunction<
     }
   }
 
-  const entity = await Entity.create(
+  const [entity] = await Entity.create<[PropertyObject]>(
     graphApi,
     { actorId },
     {

--- a/apps/hash-api/src/graph/knowledge/primitive/link-entity.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/link-entity.ts
@@ -5,6 +5,7 @@ import type {
 import { LinkEntity } from "@local/hash-graph-sdk/entity";
 import type {
   LinkData,
+  PropertyObject,
   PropertyPatchOperation,
 } from "@local/hash-graph-types/entity";
 
@@ -64,17 +65,21 @@ export const createLinkEntity: ImpureGraphFunction<
     );
   }
 
-  const linkEntity = await LinkEntity.create(context.graphApi, authentication, {
-    ownedById,
-    linkData,
-    entityTypeId: linkEntityType.schema.$id,
-    properties,
-    draft,
-    relationships,
-    confidence,
-    propertyMetadata,
-    provenance: context.provenance,
-  });
+  const [linkEntity] = await LinkEntity.create<[PropertyObject]>(
+    context.graphApi,
+    authentication,
+    {
+      ownedById,
+      linkData,
+      entityTypeId: linkEntityType.schema.$id,
+      properties,
+      draft,
+      relationships,
+      confidence,
+      propertyMetadata,
+      provenance: context.provenance,
+    },
+  );
 
   for (const afterCreateHook of afterCreateEntityHooks) {
     if (afterCreateHook.entityTypeId === linkEntity.metadata.entityTypeId) {

--- a/libs/@local/hash-backend-utils/src/notifications.ts
+++ b/libs/@local/hash-backend-utils/src/notifications.ts
@@ -13,6 +13,7 @@ import {
   systemLinkEntityTypes,
   systemPropertyTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
+import type { GraphChangeNotificationProperties } from "@local/hash-isomorphic-utils/system-types/graphchangenotification";
 import type { EntityRelationAndSubject } from "@local/hash-subgraph";
 
 export const createNotificationEntityPermissions = ({
@@ -105,7 +106,9 @@ export const createGraphChangeNotification = async (
   /**
    * We create the notification entity with the user's web bot, as we know it has the necessary permissions in the user's web
    */
-  const notificationEntity = await Entity.create(
+  const [notificationEntity] = await Entity.create<
+    [GraphChangeNotificationProperties]
+  >(
     graphApi,
     { actorId: webMachineActorId },
     {
@@ -113,7 +116,8 @@ export const createGraphChangeNotification = async (
       entityTypeId: systemEntityTypes.graphChangeNotification.entityTypeId,
       ownedById: notifiedUserAccountId as OwnedById,
       properties: {
-        [systemPropertyTypes.graphChangeType.propertyTypeBaseUrl]: operation,
+        "https://hash.ai/@hash/types/property-type/graph-change-type/":
+          operation,
       },
       provenance,
       relationships: notificationEntityRelationships,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The properties passed to create should be generic, so we keep the type safety. Also, the returned Entity should inherit the generic parameter.

## 🔗 Related links

- [Internal discussion on slack](https://hashintel.slack.com/archives/C02K2ARC1BK/p1720533180871279)

## 🔍 What does this change?

- Make `Entity.create` generic
- Remove `Entity.createMultiple`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph