### PR TITLE
H-3078: Set concurrent limits for branches and PRs for renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,6 +27,8 @@
   "semanticCommits": "disabled",
   "schedule": ["before 4am every weekday", "every weekend"],
   "assigneesFromCodeOwners": true,
+  "prConcurrentLimit": 15,
+  "branchConcurrentLimit": 0,
 
   "packageRules": [
     {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In the renovate logs there are several “Reached branch limit - skipping branch creation” messages. This sets the maximum amount of branches to unlimited  as we have a few branches lying around all the time. Also, it explicitly sets the PR limit.