### PR TITLE
H-3074, H-3076: Accept generics in `Entity.create`, new utility types in codegen

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/process-automatic-browsing-settings-action.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/process-automatic-browsing-settings-action.ts
@@ -1,3 +1,4 @@
+import type { Entity } from "@local/hash-graph-sdk/entity";
 import {
   getSimplifiedActionInputs,
   type OutputNameForAction,
@@ -49,7 +50,7 @@ export const processAutomaticBrowsingSettingsAction: FlowActionActivity =
     }
 
     const automaticInferenceConfig = (
-      userBrowserPluginSettings as BrowserPluginSettings
+      userBrowserPluginSettings as Entity<BrowserPluginSettings>
     ).properties[
       "https://hash.ai/@hash/types/property-type/automatic-inference-configuration/"
     ];

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/get-file-entity-from-url.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/get-file-entity-from-url.ts
@@ -242,10 +242,8 @@ export const getFileEntityFromUrl = async (params: {
       draft: false,
       ownedById: webId,
       propertyMetadata,
-      properties: {
-        "https://blockprotocol.org/@blockprotocol/types/property-type/file-url/": 4,
-      },
-      entityTypeId,
+      properties: initialProperties,
+      entityTypeId: entityTypeId as typeof systemEntityTypes.file.entityTypeId,
       relationships:
         createDefaultAuthorizationRelationships(userAuthentication),
       provenance,

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/write-google-sheet-action/get-filter-from-bp-query-entity.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/write-google-sheet-action/get-filter-from-bp-query-entity.ts
@@ -5,7 +5,7 @@ import type { Entity } from "@local/hash-graph-sdk/entity";
 import type { AccountId } from "@local/hash-graph-types/account";
 import type { EntityId } from "@local/hash-graph-types/entity";
 import { blockProtocolPropertyTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
-import type { QueryProperties } from "@local/hash-isomorphic-utils/system-types/blockprotocol/query";
+import type { Query } from "@local/hash-isomorphic-utils/system-types/blockprotocol/query";
 
 import { getLatestEntityById } from "../shared/graph-requests";
 
@@ -18,13 +18,13 @@ export const getFilterFromBlockProtocolQueryEntity = async ({
   graphApiClient: GraphApi;
   queryEntityId: EntityId;
 }) => {
-  let queryEntity: Entity<QueryProperties> | undefined;
+  let queryEntity: Entity<Query> | undefined;
   try {
     queryEntity = (await getLatestEntityById({
       graphApiClient,
       authentication,
       entityId: queryEntityId,
-    })) as Entity<QueryProperties>;
+    })) as Entity<Query>;
   } catch {
     throw new Error(`No query entity found with id ${queryEntityId}.`);
   }

--- a/apps/hash-ai-worker-ts/src/activities/shared/get-flow-context.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/get-flow-context.ts
@@ -8,7 +8,7 @@ import type { RunFlowWorkflowParams } from "@local/hash-isomorphic-utils/flows/t
 import type { FlowDataSources } from "@local/hash-isomorphic-utils/flows/types";
 import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { normalizeWhitespace } from "@local/hash-isomorphic-utils/normalize";
-import type { FileProperties } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { File } from "@local/hash-isomorphic-utils/system-types/shared";
 import {
   entityIdFromComponents,
   extractEntityUuidFromEntityId,
@@ -152,7 +152,7 @@ export const getFlowContext = async (): Promise<FlowContext> => {
   return { dataSources, userAuthentication, flowEntityId, webId, stepId };
 };
 
-export const getProvidedFiles = async (): Promise<Entity<FileProperties>[]> => {
+export const getProvidedFiles = async (): Promise<Entity<File>[]> => {
   const {
     dataSources: { files },
     flowEntityId,
@@ -166,7 +166,7 @@ export const getProvidedFiles = async (): Promise<Entity<FileProperties>[]> => {
   const filesCacheKey = `files-${flowEntityId}`;
   const cache = await getCache();
 
-  const cachedFiles = await cache.get<Entity<FileProperties>[]>(filesCacheKey);
+  const cachedFiles = await cache.get<Entity<File>[]>(filesCacheKey);
 
   if (cachedFiles) {
     return cachedFiles;
@@ -197,7 +197,7 @@ export const getProvidedFiles = async (): Promise<Entity<FileProperties>[]> => {
       temporalAxes: currentTimeInstantTemporalAxes,
     })
     .then(({ data: response }) =>
-      response.entities.map((entity) => new Entity<FileProperties>(entity)),
+      response.entities.map((entity) => new Entity<File>(entity)),
     );
 
   await cache.set(filesCacheKey, entities);
@@ -221,7 +221,7 @@ export const areUrlsTheSameAfterNormalization = (
 
 export const getProvidedFileByUrl = async (
   url: string,
-): Promise<Entity<FileProperties> | undefined> => {
+): Promise<Entity<File> | undefined> => {
   const files = await getProvidedFiles();
   return files.find((file) => {
     /**

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/007-create-api-usage-tracking.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/007-create-api-usage-tracking.migration.ts
@@ -1,7 +1,7 @@
 import type { Entity } from "@local/hash-graph-sdk/entity";
 import type { OwnedById } from "@local/hash-graph-types/web";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
-import type { ServiceFeatureProperties } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { ServiceFeature } from "@local/hash-isomorphic-utils/system-types/shared";
 import { linkEntityTypeUrl } from "@local/hash-subgraph";
 
 import { logger } from "../../../../logger";
@@ -388,7 +388,7 @@ const migrate: MigrationFunction = async ({
     {
       entityTypeId: serviceFeatureEntityType.schema.$id,
     },
-  )) as Entity<ServiceFeatureProperties>[];
+  )) as Entity<ServiceFeature>[];
 
   for (const {
     serviceName,

--- a/apps/hash-api/src/graph/knowledge/primitive/entity/after-update-entity-hooks/file-document-after-update-entity-hook-callback.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity/after-update-entity-hooks/file-document-after-update-entity-hook-callback.ts
@@ -9,9 +9,10 @@ import { getDefinedPropertyFromPatchesGetter } from "@local/hash-graph-sdk/entit
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import type { ParseTextFromFileParams } from "@local/hash-isomorphic-utils/parse-text-from-file-types";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
-import type { DOCXDocumentProperties } from "@local/hash-isomorphic-utils/system-types/docxdocument";
-import type { PDFDocumentProperties } from "@local/hash-isomorphic-utils/system-types/pdfdocument";
-import type { PPTXPresentationProperties } from "@local/hash-isomorphic-utils/system-types/pptxpresentation";
+import type { DOCXDocument } from "@local/hash-isomorphic-utils/system-types/docxdocument";
+import type { File } from "@local/hash-isomorphic-utils/system-types/file";
+import type { PDFDocument } from "@local/hash-isomorphic-utils/system-types/pdfdocument";
+import type { PPTXPresentation } from "@local/hash-isomorphic-utils/system-types/pptxpresentation";
 import { extractOwnedByIdFromEntityId } from "@local/hash-subgraph";
 
 import type { AfterUpdateEntityHookCallback } from "../update-entity-hooks";
@@ -22,10 +23,7 @@ export const entityTypesToParseTextFrom: VersionedUrl[] = [
   systemEntityTypes.pptxPresentation.entityTypeId,
 ];
 
-type FileEntityToParseProperties =
-  | DOCXDocumentProperties
-  | PDFDocumentProperties
-  | PPTXPresentationProperties;
+type FileEntityToParse = DOCXDocument | PDFDocument | PPTXPresentation;
 
 export const parseTextFromFileAfterUpdateEntityHookCallback: AfterUpdateEntityHookCallback =
   async ({
@@ -38,10 +36,10 @@ export const parseTextFromFileAfterUpdateEntityHookCallback: AfterUpdateEntityHo
     const { temporalClient } = context;
 
     const previousEntityProperties =
-      previousEntity as Entity<FileEntityToParseProperties>;
+      previousEntity as Entity<FileEntityToParse>;
 
     const getNewValueForPath =
-      getDefinedPropertyFromPatchesGetter<FileEntityToParseProperties>(
+      getDefinedPropertyFromPatchesGetter<FileEntityToParse["properties"]>(
         propertyPatches,
       );
 
@@ -56,7 +54,7 @@ export const parseTextFromFileAfterUpdateEntityHookCallback: AfterUpdateEntityHo
 
     const { textualContent, fileStorageProvider, uploadCompletedAt } =
       simplifyProperties(
-        updatedEntity.properties as FileEntityToParseProperties,
+        updatedEntity.properties as FileEntityToParse["properties"],
       );
 
     if (textualContent && newFileStorageKey === oldFileStorageKey) {
@@ -82,7 +80,7 @@ export const parseTextFromFileAfterUpdateEntityHookCallback: AfterUpdateEntityHo
       }
 
       const presignedFileDownloadUrl = await storageProvider.presignDownload({
-        entity: updatedEntity as Entity<FileEntityToParseProperties>,
+        entity: updatedEntity as Entity<File>,
         key: newFileStorageKey,
         expiresInSeconds: 60 * 60, // 1 hour
       });

--- a/apps/hash-api/src/graph/knowledge/system-types/block-collection.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/block-collection.ts
@@ -1,4 +1,5 @@
 import type { VersionedUrl } from "@blockprotocol/type-system";
+import type { Entity } from "@local/hash-graph-sdk/entity";
 import { LinkEntity } from "@local/hash-graph-sdk/entity";
 import type { EntityId } from "@local/hash-graph-types/entity";
 import { sortBlockCollectionLinks } from "@local/hash-isomorphic-utils/block-collection";
@@ -7,14 +8,8 @@ import {
   systemEntityTypes,
   systemLinkEntityTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
-import type {
-  HasSpatiallyPositionedContent,
-  HasSpatiallyPositionedContentProperties,
-} from "@local/hash-isomorphic-utils/system-types/canvas";
-import type {
-  HasDataProperties,
-  HasIndexedContentProperties,
-} from "@local/hash-isomorphic-utils/system-types/shared";
+import type { HasSpatiallyPositionedContent } from "@local/hash-isomorphic-utils/system-types/canvas";
+import type { HasIndexedContent } from "@local/hash-isomorphic-utils/system-types/shared";
 import { extractOwnedByIdFromEntityId } from "@local/hash-subgraph";
 
 import type { PositionInput } from "../../../graphql/api-types.gen";
@@ -41,7 +36,12 @@ export const getBlockCollectionBlocks: ImpureGraphFunction<
     blockCollectionEntityId: EntityId;
     blockCollectionEntityTypeId: VersionedUrl;
   },
-  Promise<{ linkEntity: LinkEntity<HasDataProperties>; rightEntity: Block }[]>
+  Promise<
+    {
+      linkEntity: LinkEntity<HasSpatiallyPositionedContent | HasIndexedContent>;
+      rightEntity: Block;
+    }[]
+  >
 > = async (
   ctx,
   authentication,
@@ -60,8 +60,8 @@ export const getBlockCollectionBlocks: ImpureGraphFunction<
         : systemLinkEntityTypes.hasIndexedContent.linkEntityTypeId,
     },
   )) as
-    | LinkEntity<HasSpatiallyPositionedContentProperties>[]
-    | LinkEntity<HasIndexedContentProperties>[];
+    | LinkEntity<HasSpatiallyPositionedContent>[]
+    | LinkEntity<HasIndexedContent>[];
 
   return await Promise.all(
     outgoingBlockDataLinks
@@ -88,7 +88,7 @@ export const addBlockToBlockCollection: ImpureGraphFunction<
     block: Block;
     position: PositionInput;
   },
-  Promise<HasSpatiallyPositionedContent | HasIndexedContentProperties>
+  Promise<Entity<HasSpatiallyPositionedContent | HasIndexedContent>>
 > = async (ctx, authentication, params) => {
   const {
     blockCollectionEntityId,
@@ -111,8 +111,8 @@ export const addBlockToBlockCollection: ImpureGraphFunction<
   });
 
   return linkEntity as
-    | HasSpatiallyPositionedContent
-    | HasIndexedContentProperties;
+    | Entity<HasSpatiallyPositionedContent>
+    | Entity<HasIndexedContent>;
 };
 
 /**

--- a/apps/hash-api/src/graph/knowledge/system-types/file.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/file.ts
@@ -11,10 +11,7 @@ import type { BaseUrl } from "@local/hash-graph-types/ontology";
 import { generateUuid } from "@local/hash-isomorphic-utils/generate-uuid";
 import { createDefaultAuthorizationRelationships } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
-import type {
-  File,
-  FileProperties,
-} from "@local/hash-isomorphic-utils/system-types/shared";
+import type { File } from "@local/hash-isomorphic-utils/system-types/shared";
 import { extractOwnedByIdFromEntityId } from "@local/hash-subgraph";
 import mime from "mime-types";
 
@@ -129,7 +126,7 @@ export const createFileFromUploadRequest: ImpureGraphFunction<
   MutationRequestFileUploadArgs,
   Promise<{
     presignedPut: PresignedPutUpload;
-    entity: Entity<FileProperties>;
+    entity: Entity<File>;
   }>,
   true,
   true
@@ -140,7 +137,7 @@ export const createFileFromUploadRequest: ImpureGraphFunction<
   const { entityTypeId, existingEntity, mimeType, ownedById } =
     await generateCommonParameters(ctx, authentication, params, name);
 
-  const initialProperties: FileProperties = {
+  const initialProperties: File["properties"] = {
     "https://blockprotocol.org/@blockprotocol/types/property-type/description/":
       description ?? undefined,
     "https://blockprotocol.org/@blockprotocol/types/property-type/file-url/":
@@ -166,7 +163,7 @@ export const createFileFromUploadRequest: ImpureGraphFunction<
       properties: initialProperties,
       entityTypeId,
       relationships: createDefaultAuthorizationRelationships(authentication),
-    })) as Entity<FileProperties>;
+    })) as Entity<File>;
   }
 
   const editionIdentifier = generateUuid();
@@ -188,7 +185,7 @@ export const createFileFromUploadRequest: ImpureGraphFunction<
         expiresInSeconds: UPLOAD_URL_EXPIRATION_SECONDS,
       });
 
-    const additionalProperties: FileProperties = {
+    const additionalProperties: File["properties"] = {
       "https://blockprotocol.org/@blockprotocol/types/property-type/file-url/":
         formatFileUrl(key),
       ...fileStorageProperties,
@@ -204,7 +201,7 @@ export const createFileFromUploadRequest: ImpureGraphFunction<
           value,
         }),
       ),
-    })) as Entity<FileProperties>;
+    })) as Entity<File>;
 
     return {
       presignedPut,
@@ -217,7 +214,7 @@ export const createFileFromUploadRequest: ImpureGraphFunction<
 
 export const createFileFromExternalUrl: ImpureGraphFunction<
   MutationCreateFileFromUrlArgs,
-  Promise<File>,
+  Promise<Entity<File>>,
   false,
   true
 > = async (ctx, authentication, params) => {
@@ -229,7 +226,7 @@ export const createFileFromExternalUrl: ImpureGraphFunction<
     await generateCommonParameters(ctx, authentication, params, filename);
 
   try {
-    const properties: FileProperties = {
+    const properties: File["properties"] = {
       "https://blockprotocol.org/@blockprotocol/types/property-type/description/":
         description ?? undefined,
       "https://blockprotocol.org/@blockprotocol/types/property-type/file-name/":
@@ -264,14 +261,14 @@ export const createFileFromExternalUrl: ImpureGraphFunction<
               path: [baseUrl as BaseUrl],
               value,
             })),
-        })) as Entity<FileProperties>)
+        })) as Entity<File>)
       : ((await createEntity(ctx, authentication, {
           ownedById,
           properties,
           entityTypeId,
           relationships:
             createDefaultAuthorizationRelationships(authentication),
-        })) as Entity<FileProperties>);
+        })) as Entity<File>);
   } catch (error) {
     throw new Error(
       `There was an error creating the file entity from a link: ${error}`,

--- a/apps/hash-api/src/graph/knowledge/system-types/notification.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/notification.ts
@@ -20,9 +20,9 @@ import {
   systemPropertyTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
-import type { CommentNotificationProperties } from "@local/hash-isomorphic-utils/system-types/commentnotification";
-import type { MentionNotificationProperties } from "@local/hash-isomorphic-utils/system-types/mentionnotification";
-import type { NotificationProperties } from "@local/hash-isomorphic-utils/system-types/notification";
+import type { CommentNotification as CommentNotificationEntity } from "@local/hash-isomorphic-utils/system-types/commentnotification";
+import type { MentionNotification as MentionNotificationEntity } from "@local/hash-isomorphic-utils/system-types/mentionnotification";
+import type { Notification as NotificationEntity } from "@local/hash-isomorphic-utils/system-types/notification";
 import {
   getOutgoingLinksForEntity,
   getRoots,
@@ -46,11 +46,11 @@ import type { User } from "./user";
 
 type Notification = {
   archived?: boolean;
-  entity: Entity<NotificationProperties>;
+  entity: Entity<NotificationEntity>;
 };
 
 export const archiveNotification: ImpureGraphFunction<
-  { notification: Notification },
+  { notification: Notification | MentionNotification | CommentNotification },
   Promise<void>,
   false,
   true
@@ -68,18 +68,18 @@ export const archiveNotification: ImpureGraphFunction<
 };
 
 export type MentionNotification = {
-  entity: Entity<MentionNotificationProperties>;
-} & Notification;
+  entity: Entity<MentionNotificationEntity>;
+} & Omit<Notification, "entity">;
 
 export const isEntityMentionNotificationEntity = (
   entity: Entity,
-): entity is Entity<MentionNotificationProperties> =>
+): entity is Entity<MentionNotificationEntity> =>
   entity.metadata.entityTypeId ===
   systemEntityTypes.mentionNotification.entityTypeId;
 
 export const getMentionNotificationFromEntity: PureGraphFunction<
   { entity: Entity },
-  Notification
+  MentionNotification
 > = ({ entity }) => {
   if (!isEntityMentionNotificationEntity(entity)) {
     throw new EntityTypeMismatchError(
@@ -125,12 +125,12 @@ export const createMentionNotification: ImpureGraphFunction<
       machineActorId: webMachineActorId,
     });
 
-  const entity = await createEntity(context, botAuthentication, {
+  const entity = (await createEntity(context, botAuthentication, {
     ownedById,
     properties: {},
     entityTypeId: systemEntityTypes.mentionNotification.entityTypeId,
     relationships: notificationEntityRelationships,
-  });
+  })) as Entity<MentionNotificationEntity>;
 
   await Promise.all(
     [
@@ -324,18 +324,18 @@ export const getMentionNotification: ImpureGraphFunction<
 };
 
 export type CommentNotification = {
-  entity: Entity<MentionNotificationProperties>;
-} & Notification;
+  entity: Entity<CommentNotificationEntity>;
+} & Omit<Notification, "entity">;
 
 export const isEntityCommentNotificationEntity = (
   entity: Entity,
-): entity is Entity<CommentNotificationProperties> =>
+): entity is Entity<CommentNotificationEntity> =>
   entity.metadata.entityTypeId ===
   systemEntityTypes.commentNotification.entityTypeId;
 
 export const getCommentNotificationFromEntity: PureGraphFunction<
   { entity: Entity },
-  Notification
+  CommentNotification
 > = ({ entity }) => {
   if (!isEntityCommentNotificationEntity(entity)) {
     throw new EntityTypeMismatchError(

--- a/apps/hash-api/src/graph/knowledge/system-types/org-membership.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/org-membership.ts
@@ -4,7 +4,7 @@ import type { EntityId } from "@local/hash-graph-types/entity";
 import type { OwnedById } from "@local/hash-graph-types/web";
 import { createOrgMembershipAuthorizationRelationships } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemLinkEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
-import type { IsMemberOfProperties } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { IsMemberOf } from "@local/hash-isomorphic-utils/system-types/shared";
 import type {
   AccountEntityId,
   AccountGroupEntityId,
@@ -30,7 +30,7 @@ import type { User } from "./user";
 import { getUserFromEntity } from "./user";
 
 export type OrgMembership = {
-  linkEntity: LinkEntity<IsMemberOfProperties>;
+  linkEntity: LinkEntity<IsMemberOf>;
 };
 
 export const getOrgMembershipFromLinkEntity: PureGraphFunction<
@@ -49,7 +49,7 @@ export const getOrgMembershipFromLinkEntity: PureGraphFunction<
   }
 
   return {
-    linkEntity,
+    linkEntity: linkEntity as LinkEntity<IsMemberOf>,
   };
 };
 

--- a/apps/hash-api/src/graph/knowledge/system-types/page.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/page.ts
@@ -22,11 +22,10 @@ import {
   pageEntityTypeIds,
 } from "@local/hash-isomorphic-utils/page-entity-type-ids";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
-import type { HasSpatiallyPositionedContentProperties } from "@local/hash-isomorphic-utils/system-types/canvas";
+import type { HasSpatiallyPositionedContent } from "@local/hash-isomorphic-utils/system-types/canvas";
 import type {
-  HasDataProperties,
-  HasIndexedContentProperties,
-  PageProperties,
+  HasIndexedContent,
+  Page as PageEntity,
 } from "@local/hash-isomorphic-utils/system-types/shared";
 import { ApolloError } from "apollo-server-errors";
 import { generateKeyBetween } from "fractional-indexing";
@@ -72,7 +71,7 @@ export const getPageFromEntity: PureGraphFunction<{ entity: Entity }, Page> = ({
   }
 
   const { title, summary, fractionalIndex, icon, archived } =
-    simplifyProperties(entity.properties as PageProperties);
+    simplifyProperties(entity.properties as PageEntity["properties"]);
 
   return {
     title,
@@ -125,7 +124,7 @@ export const createPage: ImpureGraphFunction<
 
   const fractionalIndex = generateKeyBetween(prevFractionalIndex ?? null, null);
 
-  const properties: PageProperties = {
+  const properties: PageEntity["properties"] = {
     "https://hash.ai/@hash/types/property-type/title/": title,
     "https://hash.ai/@hash/types/property-type/fractional-index/":
       fractionalIndex,
@@ -208,7 +207,7 @@ export const getPageParentPage: ImpureGraphFunction<
     linkEntity: parentPageLink,
   });
 
-  return getPageFromEntity({ entity: pageEntity as Entity<PageProperties> });
+  return getPageFromEntity({ entity: pageEntity as Entity<PageEntity> });
 };
 
 /**
@@ -444,7 +443,12 @@ export const setPageParentPage: ImpureGraphFunction<
  */
 export const getPageBlocks: ImpureGraphFunction<
   { pageEntityId: EntityId; type: "canvas" | "document" },
-  Promise<{ linkEntity: LinkEntity<HasDataProperties>; rightEntity: Block }[]>,
+  Promise<
+    {
+      linkEntity: LinkEntity<HasIndexedContent | HasSpatiallyPositionedContent>;
+      rightEntity: Block;
+    }[]
+  >,
   false,
   true
 > = async (ctx, authentication, { pageEntityId, type }) => {
@@ -460,8 +464,8 @@ export const getPageBlocks: ImpureGraphFunction<
               .linkEntityTypeId,
     },
   )) as
-    | LinkEntity<HasIndexedContentProperties>[]
-    | LinkEntity<HasSpatiallyPositionedContentProperties>[];
+    | LinkEntity<HasIndexedContent>[]
+    | LinkEntity<HasSpatiallyPositionedContent>[];
 
   return await Promise.all(
     outgoingBlockDataLinks

--- a/apps/hash-api/src/graph/knowledge/system-types/text.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/text.ts
@@ -14,7 +14,7 @@ import {
   pageEntityTypeFilter,
 } from "@local/hash-isomorphic-utils/page-entity-type-ids";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
-import type { TextProperties } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { Text as TextEntity } from "@local/hash-isomorphic-utils/system-types/shared";
 import type { TextToken } from "@local/hash-isomorphic-utils/types";
 import { extractEntityUuidFromEntityId } from "@local/hash-subgraph";
 
@@ -35,12 +35,12 @@ import { getUserById } from "./user";
 
 export type Text = {
   textualContent: TextToken[];
-  entity: Entity<TextProperties>;
+  entity: Entity<TextEntity>;
 };
 
 export const isEntityTextEntity = (
   entity: Entity,
-): entity is Entity<TextProperties> =>
+): entity is Entity<TextEntity> =>
   entity.metadata.entityTypeId === systemEntityTypes.text.entityTypeId;
 
 export const getTextFromEntity: PureGraphFunction<{ entity: Entity }, Text> = ({

--- a/apps/hash-api/src/graphql/resolvers/knowledge/block-collection/block-collection-contents.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/block-collection/block-collection-contents.ts
@@ -1,5 +1,6 @@
-import type { Entity } from "@local/hash-graph-sdk/entity";
-import type { HasData } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { Entity, LinkEntity } from "@local/hash-graph-sdk/entity";
+import type { HasSpatiallyPositionedContent } from "@local/hash-isomorphic-utils/system-types/canvas";
+import type { HasIndexedContent } from "@local/hash-isomorphic-utils/system-types/shared";
 
 import { getBlockCollectionBlocks } from "../../../../graph/knowledge/system-types/block-collection";
 import type { ResolverFn } from "../../../api-types.gen";
@@ -9,7 +10,10 @@ import type { UnresolvedBlockGQL } from "../graphql-mapping";
 import { mapBlockToGQL } from "../graphql-mapping";
 
 export const blockCollectionContents: ResolverFn<
-  { linkEntity: HasData; rightEntity: UnresolvedBlockGQL }[],
+  {
+    linkEntity: LinkEntity<HasSpatiallyPositionedContent | HasIndexedContent>;
+    rightEntity: UnresolvedBlockGQL;
+  }[],
   Entity,
   LoggedInGraphQLContext,
   Record<string, never>

--- a/apps/hash-api/src/graphql/resolvers/knowledge/file/create-file-from-url.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/file/create-file-from-url.ts
@@ -1,4 +1,4 @@
-import { Entity } from "@local/hash-graph-sdk/entity";
+import type { Entity } from "@local/hash-graph-sdk/entity";
 import type { File as FileEntity } from "@local/hash-isomorphic-utils/system-types/shared";
 
 import { createFileFromExternalUrl } from "../../../../graph/knowledge/system-types/file";

--- a/apps/hash-api/src/graphql/resolvers/knowledge/file/create-file-from-url.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/file/create-file-from-url.ts
@@ -1,4 +1,5 @@
-import type { File as FileEntityType } from "@local/hash-isomorphic-utils/system-types/shared";
+import { Entity } from "@local/hash-graph-sdk/entity";
+import type { File as FileEntity } from "@local/hash-isomorphic-utils/system-types/shared";
 
 import { createFileFromExternalUrl } from "../../../../graph/knowledge/system-types/file";
 import type {
@@ -9,7 +10,7 @@ import type { LoggedInGraphQLContext } from "../../../context";
 import { graphQLContextToImpureGraphContext } from "../../util";
 
 export const createFileFromUrl: ResolverFn<
-  Promise<FileEntityType>,
+  Promise<Entity<FileEntity>>,
   Record<string, never>,
   LoggedInGraphQLContext,
   MutationCreateFileFromUrlArgs

--- a/apps/hash-api/src/graphql/resolvers/knowledge/page/page-contents.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/page/page-contents.ts
@@ -1,5 +1,7 @@
+import type { Entity } from "@local/hash-graph-sdk/entity";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
-import type { HasData } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { HasSpatiallyPositionedContent } from "@local/hash-isomorphic-utils/system-types/canvas";
+import type { HasIndexedContent } from "@local/hash-isomorphic-utils/system-types/shared";
 
 import { getPageBlocks } from "../../../../graph/knowledge/system-types/page";
 import type { ResolverFn } from "../../../api-types.gen";
@@ -9,7 +11,10 @@ import type { UnresolvedBlockGQL, UnresolvedPageGQL } from "../graphql-mapping";
 import { mapBlockToGQL } from "../graphql-mapping";
 
 export const pageContents: ResolverFn<
-  { linkEntity: HasData; rightEntity: UnresolvedBlockGQL }[],
+  {
+    linkEntity: Entity<HasIndexedContent | HasSpatiallyPositionedContent>;
+    rightEntity: UnresolvedBlockGQL;
+  }[],
   UnresolvedPageGQL,
   LoggedInGraphQLContext,
   Record<string, never>

--- a/apps/hash-api/src/storage/index.ts
+++ b/apps/hash-api/src/storage/index.ts
@@ -19,7 +19,7 @@ import {
   systemPropertyTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
-import type { FileProperties } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { File as FileEntity } from "@local/hash-isomorphic-utils/system-types/shared";
 import { isEntityId, splitEntityId } from "@local/hash-subgraph";
 import type { Express } from "express";
 
@@ -88,7 +88,7 @@ export const setupStorageProviders = (
   return getUploadStorageProvider();
 };
 
-const isFileEntity = (entity: Entity): entity is Entity<FileProperties> =>
+const isFileEntity = (entity: Entity): entity is Entity<FileEntity> =>
   systemPropertyTypes.fileStorageKey.propertyTypeBaseUrl in entity.properties &&
   blockProtocolPropertyTypes.fileUrl.propertyTypeBaseUrl in entity.properties;
 

--- a/apps/hash-frontend/src/components/hooks/block-protocol-functions/knowledge/knowledge-shim.ts
+++ b/apps/hash-frontend/src/components/hooks/block-protocol-functions/knowledge/knowledge-shim.ts
@@ -20,7 +20,7 @@ import type {
   LinkData,
   PropertyObject,
 } from "@local/hash-graph-types/entity";
-import type { File as FileEntityType } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { File as FileEntity } from "@local/hash-isomorphic-utils/system-types/shared";
 import type { EntityRootType, Subgraph } from "@local/hash-subgraph";
 
 import type {
@@ -76,7 +76,7 @@ export type UploadFileRequestData = BpUploadFileData &
 export type UploadFileRequestCallback = MessageCallback<
   UploadFileRequestData,
   null,
-  MessageReturn<FileEntityType>,
+  MessageReturn<Entity<FileEntity>>,
   CreateResourceError
 >;
 

--- a/apps/hash-frontend/src/components/hooks/block-protocol-functions/knowledge/use-block-protocol-file-upload.ts
+++ b/apps/hash-frontend/src/components/hooks/block-protocol-functions/knowledge/use-block-protocol-file-upload.ts
@@ -1,7 +1,7 @@
 import { useMutation } from "@apollo/client";
 import { Entity } from "@local/hash-graph-sdk/entity";
 import type { OwnedById } from "@local/hash-graph-types/web";
-import type { FileProperties } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { File } from "@local/hash-isomorphic-utils/system-types/shared";
 import { useCallback } from "react";
 
 import type {
@@ -78,7 +78,7 @@ export const useBlockProtocolFileUpload = (
 
         const { createFileFromUrl: fileEntity } = result.data;
 
-        return { data: new Entity<FileProperties>(fileEntity) };
+        return { data: new Entity<File>(fileEntity) };
       }
 
       if (!("file" in fileUploadData)) {
@@ -131,7 +131,7 @@ export const useBlockProtocolFileUpload = (
 
       await uploadFileToStorageProvider(presignedPut, file);
 
-      return { data: new Entity<FileProperties>(uploadedFileEntity) };
+      return { data: new Entity<File>(uploadedFileEntity) };
     },
     [createFileFromUrlFn, ownedById, requestFileUploadFn],
   );

--- a/apps/hash-frontend/src/components/hooks/use-hash-instance.ts
+++ b/apps/hash-frontend/src/components/hooks/use-hash-instance.ts
@@ -2,10 +2,7 @@ import { useQuery } from "@apollo/client";
 import { Entity } from "@local/hash-graph-sdk/entity";
 import type { Simplified } from "@local/hash-isomorphic-utils/simplify-properties";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
-import type {
-  HASHInstance,
-  HASHInstanceProperties,
-} from "@local/hash-isomorphic-utils/system-types/hashinstance";
+import type { HASHInstance } from "@local/hash-isomorphic-utils/system-types/hashinstance";
 import { useMemo } from "react";
 
 import type {
@@ -19,7 +16,7 @@ import { getHashInstanceSettings } from "../../graphql/queries/knowledge/hash-in
  */
 export const useHashInstance = (): {
   loading: boolean;
-  hashInstance?: Simplified<HASHInstance>;
+  hashInstance?: Simplified<Entity<HASHInstance>>;
   isUserAdmin: boolean;
 } => {
   const { data, loading } = useQuery<
@@ -31,12 +28,14 @@ export const useHashInstance = (): {
 
   const { hashInstanceSettings } = data ?? {};
 
-  const hashInstance = useMemo<Simplified<HASHInstance> | undefined>(() => {
+  const hashInstance = useMemo<
+    Simplified<Entity<HASHInstance>> | undefined
+  >(() => {
     if (!hashInstanceSettings) {
       return undefined;
     }
 
-    const deserializedHashInstanceEntity = new Entity<HASHInstanceProperties>(
+    const deserializedHashInstanceEntity = new Entity<HASHInstance>(
       hashInstanceSettings.entity,
     );
 

--- a/apps/hash-frontend/src/pages/[shortname]/[page-slug].page/canvas-page/block-creation-dialog.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/[page-slug].page/canvas-page/block-creation-dialog.tsx
@@ -5,8 +5,8 @@ import type { OwnedById } from "@local/hash-graph-types/web";
 import type { HashBlockMeta } from "@local/hash-isomorphic-utils/blocks";
 import type { BlockCollection } from "@local/hash-isomorphic-utils/entity";
 import { updateBlockCollectionContents } from "@local/hash-isomorphic-utils/graphql/queries/block-collection.queries";
-import type { HasSpatiallyPositionedContentProperties } from "@local/hash-isomorphic-utils/system-types/canvas";
-import type { HasIndexedContentProperties } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { HasSpatiallyPositionedContent } from "@local/hash-isomorphic-utils/system-types/canvas";
+import type { HasIndexedContent } from "@local/hash-isomorphic-utils/system-types/shared";
 import { extractEntityUuidFromEntityId } from "@local/hash-subgraph";
 import { useApp } from "@tldraw/editor";
 import type { DialogProps } from "@tldraw/tldraw";
@@ -106,8 +106,8 @@ export const BlockCreationDialog = ({ onClose }: DialogProps) => {
           data.updateBlockCollectionContents.blockCollection.contents.map(
             (item) => ({
               linkEntity: new LinkEntity(item.linkEntity) as
-                | LinkEntity<HasIndexedContentProperties>
-                | LinkEntity<HasSpatiallyPositionedContentProperties>,
+                | LinkEntity<HasIndexedContent>
+                | LinkEntity<HasSpatiallyPositionedContent>,
               rightEntity: {
                 ...item.rightEntity,
                 blockChildEntity: new Entity(item.rightEntity.blockChildEntity),

--- a/apps/hash-frontend/src/pages/_app.page.tsx
+++ b/apps/hash-frontend/src/pages/_app.page.tsx
@@ -13,10 +13,9 @@ import wasm from "@blockprotocol/type-system/wasm";
 import type { EmotionCache } from "@emotion/react";
 import { CacheProvider } from "@emotion/react";
 import { createEmotionCache, theme } from "@hashintel/design-system/theme";
-import type { Entity } from "@local/hash-graph-sdk/entity";
 import type { FeatureFlag } from "@local/hash-isomorphic-utils/feature-flags";
 import { featureFlags } from "@local/hash-isomorphic-utils/feature-flags";
-import type { UserProperties } from "@local/hash-isomorphic-utils/system-types/user";
+import type { User } from "@local/hash-isomorphic-utils/system-types/user";
 import type { EntityRootType, Subgraph } from "@local/hash-subgraph";
 import { getRoots } from "@local/hash-subgraph/stdlib";
 import { CssBaseline, GlobalStyles, ThemeProvider } from "@mui/material";
@@ -258,14 +257,14 @@ AppWithTypeSystemContextProvider.getInitialProps = async (appContext) => {
       context: { headers: { cookie } },
     })
     .then(({ data }) =>
-      mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(data.me.subgraph),
+      mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType<User>>(
+        data.me.subgraph,
+      ),
     )
     .catch(() => undefined);
 
   const userEntity = initialAuthenticatedUserSubgraph
-    ? (getRoots<EntityRootType>(initialAuthenticatedUserSubgraph)[0] as
-        | Entity<UserProperties>
-        | undefined)
+    ? getRoots(initialAuthenticatedUserSubgraph)[0]
     : undefined;
 
   /** @todo: make additional pages publicly accessible */

--- a/apps/hash-frontend/src/pages/goals/new.page/file-settings.tsx
+++ b/apps/hash-frontend/src/pages/goals/new.page/file-settings.tsx
@@ -2,7 +2,7 @@ import { FileIconRegular, IconButton } from "@hashintel/design-system";
 import type { Entity } from "@local/hash-graph-sdk/entity";
 import type { OwnedById } from "@local/hash-graph-types/web";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
-import type { FileProperties } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { File as FileEntity } from "@local/hash-isomorphic-utils/system-types/shared";
 import type { SxProps, Theme } from "@mui/material";
 import { Box, Stack, Typography } from "@mui/material";
 import type { Dispatch, SetStateAction } from "react";
@@ -13,7 +13,7 @@ import { XMarkRegularIcon } from "../../../shared/icons/x-mark-regular-icon";
 import { FileUploadDropzone } from "../../settings/shared/file-upload-dropzone";
 
 export type FileSettingsState = {
-  fileEntities: Entity<FileProperties>[];
+  fileEntities: Entity<FileEntity>[];
 };
 
 export type FileSettingsProps = {
@@ -32,7 +32,7 @@ const UploadedFile = ({
   fileEntity,
   removeFromFlow,
 }: {
-  fileEntity: Entity<FileProperties>;
+  fileEntity: Entity<FileEntity>;
   removeFromFlow: () => void;
 }) => {
   const { fileName, fileSize } = simplifyProperties(fileEntity.properties);

--- a/apps/hash-frontend/src/pages/shared/auth-info-context.tsx
+++ b/apps/hash-frontend/src/pages/shared/auth-info-context.tsx
@@ -5,7 +5,7 @@ import type { Uuid } from "@local/hash-graph-types/branded";
 import type { Timestamp } from "@local/hash-graph-types/temporal-versioning";
 import { mapGqlSubgraphFieldsFragmentToSubgraph } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemLinkEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
-import type { IsMemberOfProperties } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { IsMemberOf } from "@local/hash-isomorphic-utils/system-types/shared";
 import type { EntityRootType, Subgraph } from "@local/hash-subgraph";
 import { extractEntityUuidFromEntityId } from "@local/hash-subgraph";
 import {
@@ -79,7 +79,7 @@ export const AuthInfoProvider: FunctionComponent<AuthInfoProviderProps> = ({
           linkEntity.metadata.entityTypeId ===
           systemLinkEntityTypes.isMemberOf.linkEntityTypeId,
       )
-      .map((linkEntity) => new LinkEntity<IsMemberOfProperties>(linkEntity));
+      .map((linkEntity) => new LinkEntity<IsMemberOf>(linkEntity));
   }, [authenticatedUserSubgraph]);
 
   const { orgs: resolvedOrgs, refetch: refetchOrgs } = useOrgsWithLinks({

--- a/apps/hash-frontend/src/pages/shared/block-collection-contents.ts
+++ b/apps/hash-frontend/src/pages/shared/block-collection-contents.ts
@@ -11,10 +11,10 @@ import {
   systemEntityTypes,
   systemLinkEntityTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
-import type { HasSpatiallyPositionedContentProperties } from "@local/hash-isomorphic-utils/system-types/canvas";
+import type { HasSpatiallyPositionedContent } from "@local/hash-isomorphic-utils/system-types/canvas";
 import type {
-  BlockProperties,
-  HasIndexedContentProperties,
+  Block,
+  HasIndexedContent,
 } from "@local/hash-isomorphic-utils/system-types/shared";
 import type { TextToken } from "@local/hash-isomorphic-utils/types";
 import type {
@@ -118,9 +118,9 @@ export const getBlockCollectionContents = (params: {
   const outgoingContentLinks = getOutgoingLinkAndTargetEntities<
     {
       linkEntity:
-        | LinkEntity<HasIndexedContentProperties>[]
-        | LinkEntity<HasSpatiallyPositionedContentProperties>[];
-      rightEntity: Entity<BlockProperties>[];
+        | LinkEntity<HasIndexedContent>[]
+        | LinkEntity<HasSpatiallyPositionedContent>[];
+      rightEntity: Entity<Block>[];
     }[]
   >(blockCollectionSubgraph, blockCollectionEntityId)
     .filter(

--- a/apps/hash-frontend/src/pages/shared/block-collection/block-context-menu/block-select-data-modal.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/block-context-menu/block-select-data-modal.tsx
@@ -4,7 +4,7 @@ import type { ModalProps } from "@hashintel/design-system";
 import { IconButton, Modal } from "@hashintel/design-system";
 import { EntityQueryEditor } from "@hashintel/query-editor";
 import type { Entity } from "@local/hash-graph-sdk/entity";
-import type { EntityId } from "@local/hash-graph-types/entity";
+import type { EntityId, PropertyObject } from "@local/hash-graph-types/entity";
 import type { BaseUrl } from "@local/hash-graph-types/ontology";
 import type { OwnedById } from "@local/hash-graph-types/web";
 import {
@@ -12,7 +12,10 @@ import {
   blockProtocolLinkEntityTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
-import type { Query } from "@local/hash-isomorphic-utils/system-types/blockprotocol/query";
+import type {
+  Query,
+  QueryProperties,
+} from "@local/hash-isomorphic-utils/system-types/blockprotocol/query";
 import {
   getOutgoingLinkAndTargetEntities,
   getRoots,
@@ -130,7 +133,7 @@ export const BlockSelectDataModal: FunctionComponent<
             properties: {
               "https://blockprotocol.org/@hash/types/property-type/query/":
                 query,
-            } as Query["properties"],
+            } satisfies QueryProperties as PropertyObject,
           },
         });
 

--- a/apps/hash-frontend/src/pages/shared/block-collection/block-context-menu/block-select-data-modal.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/block-context-menu/block-select-data-modal.tsx
@@ -12,7 +12,7 @@ import {
   blockProtocolLinkEntityTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
-import type { QueryProperties } from "@local/hash-isomorphic-utils/system-types/blockprotocol/query";
+import type { Query } from "@local/hash-isomorphic-utils/system-types/blockprotocol/query";
 import {
   getOutgoingLinkAndTargetEntities,
   getRoots,
@@ -78,7 +78,7 @@ export const BlockSelectDataModal: FunctionComponent<
           linkEntityRevisions[0]?.metadata.entityTypeId ===
           blockProtocolLinkEntityTypes.hasQuery.linkEntityTypeId,
       )
-      .map(({ rightEntity }) => rightEntity[0] as Entity<QueryProperties>);
+      .map(({ rightEntity }) => rightEntity[0] as Entity<Query>);
 
     return existingQueries[0];
   }, [blockSubgraph, blockDataEntity]);
@@ -111,7 +111,7 @@ export const BlockSelectDataModal: FunctionComponent<
                 {
                   op: "add",
                   path: [
-                    "https://blockprotocol.org/@hash/types/property-type/query/" satisfies keyof QueryProperties as BaseUrl,
+                    "https://blockprotocol.org/@hash/types/property-type/query/" satisfies keyof Query["properties"] as BaseUrl,
                   ],
                   value: query,
                 },
@@ -130,7 +130,7 @@ export const BlockSelectDataModal: FunctionComponent<
             properties: {
               "https://blockprotocol.org/@hash/types/property-type/query/":
                 query,
-            } as QueryProperties,
+            } as Query["properties"],
           },
         });
 

--- a/apps/hash-frontend/src/pages/shared/entities-table/grid-view/grid-view-item.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table/grid-view/grid-view-item.tsx
@@ -2,7 +2,7 @@ import type { Entity } from "@local/hash-graph-sdk/entity";
 import type { BaseUrl } from "@local/hash-graph-types/ontology";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
-import type { FileProperties } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { File as FileEntity } from "@local/hash-isomorphic-utils/system-types/shared";
 import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 import { Box, Typography } from "@mui/material";
 import type { FunctionComponent, ReactNode } from "react";
@@ -69,7 +69,7 @@ export const GridViewItem: FunctionComponent<{
       isSpecialEntityTypeLookup?.[entity.metadata.entityTypeId]?.isFile;
 
     if (isFileEntity) {
-      return entity as Entity<FileProperties>;
+      return entity as Entity<FileEntity>;
     }
   }, [isSpecialEntityTypeLookup, entity]);
 

--- a/apps/hash-frontend/src/pages/shared/integrations/google/google-auth-context.tsx
+++ b/apps/hash-frontend/src/pages/shared/integrations/google/google-auth-context.tsx
@@ -1,6 +1,6 @@
 import type { Entity } from "@local/hash-graph-sdk/entity";
 import { apiOrigin } from "@local/hash-isomorphic-utils/environment";
-import type { AccountProperties as GoogleAccountProperties } from "@local/hash-isomorphic-utils/system-types/google/account";
+import type { Account as GoogleAccount } from "@local/hash-isomorphic-utils/system-types/google/account";
 import Script from "next/script";
 import type { PropsWithChildren } from "react";
 import {
@@ -17,7 +17,7 @@ const googleOAuthClientId = process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID;
 
 type GoogleAuthContextReturn =
   | {
-      accounts: Entity<GoogleAccountProperties>[];
+      accounts: Entity<GoogleAccount>[];
       addGoogleAccount: () => void;
       checkAccessToken: (args: {
         googleAccountId: string;

--- a/apps/hash-frontend/src/pages/shared/integrations/google/google-auth-context/use-google-accounts.ts
+++ b/apps/hash-frontend/src/pages/shared/integrations/google/google-auth-context/use-google-accounts.ts
@@ -7,7 +7,7 @@ import {
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { googleEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
-import type { AccountProperties as GoogleAccountProperties } from "@local/hash-isomorphic-utils/system-types/google/account";
+import type { Account as GoogleAccount } from "@local/hash-isomorphic-utils/system-types/google/account";
 import type { EntityRootType } from "@local/hash-subgraph";
 import { getRoots } from "@local/hash-subgraph/stdlib";
 import { useMemo } from "react";
@@ -20,7 +20,7 @@ import { getEntitySubgraphQuery } from "../../../../../graphql/queries/knowledge
 import { useAuthenticatedUser } from "../../../auth-info-context";
 
 type UseGoogleAccountsResult = {
-  accounts: Entity<GoogleAccountProperties>[];
+  accounts: Entity<GoogleAccount>[];
   loading: boolean;
   refetch: () => void;
 };
@@ -61,14 +61,12 @@ export const useGoogleAccounts = (): UseGoogleAccountsResult => {
 
   return useMemo(() => {
     const subgraph = data
-      ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
+      ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType<GoogleAccount>>(
           data.getEntitySubgraph.subgraph,
         )
       : undefined;
 
-    const accounts = subgraph
-      ? (getRoots(subgraph) as Entity<GoogleAccountProperties>[])
-      : [];
+    const accounts = subgraph ? getRoots(subgraph) : [];
 
     return {
       accounts,

--- a/apps/hash-frontend/src/pages/shared/notifications-with-links-context.tsx
+++ b/apps/hash-frontend/src/pages/shared/notifications-with-links-context.tsx
@@ -3,7 +3,7 @@ import type { VersionedUrl } from "@blockprotocol/type-system";
 import { typedEntries, typedValues } from "@local/advanced-types/typed-entries";
 import type { Filter } from "@local/hash-graph-client";
 import type { Entity } from "@local/hash-graph-sdk/entity";
-import type { TextProperties } from "@local/hash-isomorphic-utils/entity";
+import type { TextWithTokens } from "@local/hash-isomorphic-utils/entity";
 import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import {
   currentTimeInstantTemporalAxes,
@@ -17,16 +17,16 @@ import {
 import type { SimpleProperties } from "@local/hash-isomorphic-utils/simplify-properties";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
 import type {
-  BlockProperties,
-  CommentNotificationProperties,
-  CommentProperties,
-  NotificationProperties,
-  OccurredInEntityProperties,
-  PageProperties,
+  Block as BlockProperties,
+  Comment as CommentProperties,
+  CommentNotification as CommentNotificationProperties,
+  Notification as NotificationProperties,
+  OccurredInEntity as OccurredInEntityProperties,
+  Page as PageProperties,
 } from "@local/hash-isomorphic-utils/system-types/commentnotification";
-import type { GraphChangeNotificationProperties } from "@local/hash-isomorphic-utils/system-types/graphchangenotification";
-import type { MentionNotificationProperties } from "@local/hash-isomorphic-utils/system-types/mentionnotification";
-import type { UserProperties } from "@local/hash-isomorphic-utils/system-types/user";
+import type { GraphChangeNotification as GraphChangeNotificationProperties } from "@local/hash-isomorphic-utils/system-types/graphchangenotification";
+import type { MentionNotification as MentionNotificationProperties } from "@local/hash-isomorphic-utils/system-types/mentionnotification";
+import type { User as UserProperties } from "@local/hash-isomorphic-utils/system-types/user";
 import type {
   EntityRootType,
   EntityVertex,
@@ -51,9 +51,9 @@ export type PageMentionNotification = {
   entity: Entity<MentionNotificationProperties>;
   occurredInEntity: Entity<PageProperties>;
   occurredInBlock: Entity<BlockProperties>;
-  occurredInText: Entity<TextProperties>;
+  occurredInText: Entity<TextWithTokens>;
   triggeredByUser: MinimalUser;
-} & SimpleProperties<MentionNotificationProperties>;
+} & SimpleProperties<MentionNotificationProperties["properties"]>;
 
 export type CommentMentionNotification = {
   kind: "comment-mention";
@@ -67,7 +67,7 @@ export type NewCommentNotification = {
   occurredInBlock: Entity<BlockProperties>;
   triggeredByComment: Entity<CommentProperties>;
   triggeredByUser: MinimalUser;
-} & SimpleProperties<CommentNotificationProperties>;
+} & SimpleProperties<CommentNotificationProperties["properties"]>;
 
 export type CommentReplyNotification = {
   kind: "comment-reply";
@@ -87,7 +87,7 @@ export type GraphChangeNotification = {
   occurredInEntityLabel: string;
   occurredInEntity: Entity;
   operation: string;
-} & SimpleProperties<NotificationProperties>;
+} & SimpleProperties<NotificationProperties["properties"]>;
 
 export type Notification = PageRelatedNotification | GraphChangeNotification;
 
@@ -249,10 +249,10 @@ export const useNotificationsWithLinksContextValue =
               return {
                 kind: "comment-mention",
                 readAt,
-                entity,
+                entity: entity as Entity<MentionNotificationProperties>,
                 occurredInEntity: occurredInEntity as Entity<PageProperties>,
                 occurredInBlock: occurredInBlock as Entity<BlockProperties>,
-                occurredInText: occurredInText as Entity<TextProperties>,
+                occurredInText: occurredInText as Entity<TextWithTokens>,
                 triggeredByUser,
                 occurredInComment:
                   occurredInComment as Entity<CommentProperties>,
@@ -262,10 +262,10 @@ export const useNotificationsWithLinksContextValue =
             return {
               kind: "page-mention",
               readAt,
-              entity,
+              entity: entity as Entity<MentionNotificationProperties>,
               occurredInEntity: occurredInEntity as Entity<PageProperties>,
               occurredInBlock: occurredInBlock as Entity<BlockProperties>,
-              occurredInText: occurredInText as Entity<TextProperties>,
+              occurredInText: occurredInText as Entity<TextWithTokens>,
               triggeredByUser,
             } satisfies PageMentionNotification;
           } else if (
@@ -320,11 +320,12 @@ export const useNotificationsWithLinksContextValue =
               return {
                 kind: "comment-reply",
                 readAt,
-                entity,
+                entity: entity as Entity<CommentNotificationProperties>,
                 occurredInEntity: occurredInEntity as Entity<PageProperties>,
                 occurredInBlock: occurredInBlock as Entity<BlockProperties>,
-                triggeredByComment,
-                repliedToComment,
+                triggeredByComment:
+                  triggeredByComment as Entity<CommentProperties>,
+                repliedToComment: repliedToComment as Entity<CommentProperties>,
                 triggeredByUser,
               } satisfies CommentReplyNotification;
             }
@@ -332,10 +333,11 @@ export const useNotificationsWithLinksContextValue =
             return {
               kind: "new-comment",
               readAt,
-              entity,
+              entity: entity as Entity<CommentNotificationProperties>,
               occurredInEntity: occurredInEntity as Entity<PageProperties>,
               occurredInBlock: occurredInBlock as Entity<BlockProperties>,
-              triggeredByComment,
+              triggeredByComment:
+                triggeredByComment as Entity<CommentProperties>,
               triggeredByUser,
             } satisfies NewCommentNotification;
           } else if (

--- a/apps/hash-frontend/src/pages/shared/use-flow-runs-usage.ts
+++ b/apps/hash-frontend/src/pages/shared/use-flow-runs-usage.ts
@@ -18,6 +18,7 @@ import {
   getAggregateUsageRecordsByServiceFeature,
   getAggregateUsageRecordsByTask,
 } from "@local/hash-isomorphic-utils/service-usage";
+import type { UsageRecord } from "@local/hash-isomorphic-utils/system-types/usagerecord";
 import type { EntityRootType } from "@local/hash-subgraph";
 import { extractEntityUuidFromEntityId } from "@local/hash-subgraph";
 import {
@@ -102,12 +103,11 @@ export const useFlowRunsUsage = ({
     const usageByFlowRunId: UsageByFlowRunId = {};
 
     for (const flowRunId of flowRunIds) {
-      const serviceUsageRecordSubgraph =
-        mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
-          data.getEntitySubgraph.subgraph,
-        );
+      const serviceUsageRecordSubgraph = mapGqlSubgraphFieldsFragmentToSubgraph<
+        EntityRootType<UsageRecord>
+      >(data.getEntitySubgraph.subgraph);
 
-      const usageRecordsForFlowRun = getRoots<EntityRootType>(
+      const usageRecordsForFlowRun = getRoots(
         serviceUsageRecordSubgraph,
       ).filter((usageRecord) => {
         const linkedEntities = getOutgoingLinkAndTargetEntities(

--- a/apps/hash-frontend/src/shared/file-upload-context.tsx
+++ b/apps/hash-frontend/src/shared/file-upload-context.tsx
@@ -4,7 +4,7 @@ import { Entity, LinkEntity } from "@local/hash-graph-sdk/entity";
 import type { EntityId, PropertyObject } from "@local/hash-graph-types/entity";
 import type { BaseUrl } from "@local/hash-graph-types/ontology";
 import type { OwnedById } from "@local/hash-graph-types/web";
-import type { FileProperties } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { File as FileEntity } from "@local/hash-isomorphic-utils/system-types/shared";
 import type { PropsWithChildren } from "react";
 import {
   createContext,
@@ -78,7 +78,7 @@ type FileUploadRequestData = {
 };
 
 type FileUploadEntities = {
-  fileEntity: Entity<FileProperties>;
+  fileEntity: Entity<FileEntity>;
   linkEntity?: LinkEntity;
 };
 
@@ -274,7 +274,7 @@ export const FileUploadsProvider = ({ children }: PropsWithChildren) => {
             throw new Error(errors?.[0]?.message ?? "unknown error");
           }
 
-          fileEntity = new Entity<FileProperties>(data.createFileFromUrl);
+          fileEntity = new Entity<FileEntity>(data.createFileFromUrl);
 
           if (makePublic) {
             /** @todo: make entity public as part of `createEntity` query once this is supported */
@@ -336,9 +336,7 @@ export const FileUploadsProvider = ({ children }: PropsWithChildren) => {
               throw new Error(errors?.[0]?.message ?? "unknown error");
             }
 
-            fileEntity = new Entity<FileProperties>(
-              data.requestFileUpload.entity,
-            );
+            fileEntity = new Entity<FileEntity>(data.requestFileUpload.entity);
 
             if (makePublic) {
               /** @todo: make entity public as part of `createEntity` query once this is supported */
@@ -392,7 +390,7 @@ export const FileUploadsProvider = ({ children }: PropsWithChildren) => {
                   {
                     op: "add",
                     path: [
-                      "https://hash.ai/@hash/types/property-type/upload-completed-at/" satisfies keyof FileProperties as BaseUrl,
+                      "https://hash.ai/@hash/types/property-type/upload-completed-at/" satisfies keyof FileEntity["properties"] as BaseUrl,
                     ],
                     value: uploadCompletedAt.toISOString(),
                   },

--- a/apps/hash-frontend/src/shared/notification-entities-context.tsx
+++ b/apps/hash-frontend/src/shared/notification-entities-context.tsx
@@ -126,7 +126,12 @@ export const NotificationEntitiesContextProvider: FunctionComponent<
   );
 
   const notificationEntities = useMemo<
-    | Entity<Notification | MentionNotification | CommentNotification>[]
+    | Entity<
+        | Notification
+        | MentionNotification
+        | CommentNotification
+        | GraphChangeNotification
+      >[]
     | undefined
   >(
     () =>

--- a/apps/hash-frontend/src/shared/notification-entities-context.tsx
+++ b/apps/hash-frontend/src/shared/notification-entities-context.tsx
@@ -10,7 +10,12 @@ import {
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
-import type { NotificationProperties } from "@local/hash-isomorphic-utils/system-types/commentnotification";
+import type {
+  CommentNotification,
+  Notification,
+} from "@local/hash-isomorphic-utils/system-types/commentnotification";
+import type { GraphChangeNotification } from "@local/hash-isomorphic-utils/system-types/graphchangenotification";
+import type { MentionNotification } from "@local/hash-isomorphic-utils/system-types/mentionnotification";
 import type { EntityRootType } from "@local/hash-subgraph";
 import { getRoots } from "@local/hash-subgraph/stdlib";
 import type { FunctionComponent, PropsWithChildren } from "react";
@@ -33,7 +38,12 @@ import { useAuthInfo } from "../pages/shared/auth-info-context";
 import { pollInterval } from "./poll-interval";
 
 export type NotificationEntitiesContextValues = {
-  notificationEntities?: Entity<NotificationProperties>[];
+  notificationEntities?: Entity<
+    | Notification
+    | MentionNotification
+    | CommentNotification
+    | GraphChangeNotification
+  >[];
   numberOfUnreadNotifications?: number;
   loading: boolean;
   refetch: () => Promise<void>;
@@ -108,7 +118,7 @@ export const NotificationEntitiesContextProvider: FunctionComponent<
   const notificationEntitiesSubgraph = useMemo(
     () =>
       notificationEntitiesData
-        ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
+        ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType<Notification>>(
             notificationEntitiesData.getEntitySubgraph.subgraph,
           )
         : undefined,
@@ -116,12 +126,13 @@ export const NotificationEntitiesContextProvider: FunctionComponent<
   );
 
   const notificationEntities = useMemo<
-    Entity<NotificationProperties>[] | undefined
+    | Entity<Notification | MentionNotification | CommentNotification>[]
+    | undefined
   >(
     () =>
       notificationEntitiesSubgraph
         ? getRoots(notificationEntitiesSubgraph)
-        : notificationEntitiesSubgraph,
+        : undefined,
     [notificationEntitiesSubgraph],
   );
 
@@ -148,7 +159,7 @@ export const NotificationEntitiesContextProvider: FunctionComponent<
               {
                 op: "add",
                 path: [
-                  "https://hash.ai/@hash/types/property-type/read-at/" satisfies keyof NotificationProperties as BaseUrl,
+                  "https://hash.ai/@hash/types/property-type/read-at/" satisfies keyof Notification["properties"] as BaseUrl,
                 ],
                 value: now.toISOString(),
               },
@@ -181,7 +192,7 @@ export const NotificationEntitiesContextProvider: FunctionComponent<
                 {
                   op: "add",
                   path: [
-                    "https://hash.ai/@hash/types/property-type/read-at/" satisfies keyof NotificationProperties as BaseUrl,
+                    "https://hash.ai/@hash/types/property-type/read-at/" satisfies keyof Notification["properties"] as BaseUrl,
                   ],
                   value: now.toISOString(),
                 },
@@ -209,7 +220,7 @@ export const NotificationEntitiesContextProvider: FunctionComponent<
               {
                 op: "add",
                 path: [
-                  "https://hash.ai/@hash/types/property-type/archived/" satisfies keyof NotificationProperties as BaseUrl,
+                  "https://hash.ai/@hash/types/property-type/archived/" satisfies keyof Notification["properties"] as BaseUrl,
                 ],
                 value: true,
               },
@@ -237,7 +248,7 @@ export const NotificationEntitiesContextProvider: FunctionComponent<
                 {
                   op: "add",
                   path: [
-                    "https://hash.ai/@hash/types/property-type/archived/" satisfies keyof NotificationProperties as BaseUrl,
+                    "https://hash.ai/@hash/types/property-type/archived/" satisfies keyof Notification["properties"] as BaseUrl,
                   ],
                   value: true,
                 },

--- a/apps/hash-frontend/src/shared/use-user-or-org.ts
+++ b/apps/hash-frontend/src/shared/use-user-or-org.ts
@@ -14,8 +14,8 @@ import {
   systemEntityTypes,
   systemPropertyTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
-import type { OrganizationProperties } from "@local/hash-isomorphic-utils/system-types/shared";
-import type { UserProperties } from "@local/hash-isomorphic-utils/system-types/user";
+import type { Organization } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { User } from "@local/hash-isomorphic-utils/system-types/user";
 import type {
   EntityRootType,
   GraphResolveDepths,
@@ -111,7 +111,7 @@ export const useUserOrOrg = (
 
     const rootEntity = subgraph
       ? getRoots(subgraph).reduce<
-          Entity<OrganizationProperties> | Entity<UserProperties> | undefined
+          Entity<Organization> | Entity<User> | undefined
         >((prev, currentEntity) => {
           if (
             !isEntityUserEntity(currentEntity) &&

--- a/apps/plugin-browser/src/shared/get-user.ts
+++ b/apps/plugin-browser/src/shared/get-user.ts
@@ -9,7 +9,7 @@ import {
   systemLinkEntityTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
-import type { ImageProperties } from "@local/hash-isomorphic-utils/system-types/image";
+import type { Image } from "@local/hash-isomorphic-utils/system-types/image";
 import type {
   BrowserPluginSettingsProperties,
   OrganizationProperties,
@@ -33,7 +33,7 @@ import { getFromLocalStorage, setInLocalStorage } from "./storage";
 const getAvatarForEntity = (
   subgraph: Subgraph<EntityRootType>,
   entityId: EntityId,
-): Entity<ImageProperties> | undefined => {
+): Entity<Image> | undefined => {
   const avatarLinkAndEntities = getOutgoingLinkAndTargetEntities(
     subgraph,
     entityId,
@@ -43,9 +43,7 @@ const getAvatarForEntity = (
       linkEntity[0]?.metadata.entityTypeId ===
       systemLinkEntityTypes.hasAvatar.linkEntityTypeId,
   );
-  return avatarLinkAndEntities[0]?.rightEntity[0] as
-    | Entity<ImageProperties>
-    | undefined;
+  return avatarLinkAndEntities[0]?.rightEntity[0] as Entity<Image> | undefined;
 };
 
 /**

--- a/apps/plugin-browser/src/shared/storage.ts
+++ b/apps/plugin-browser/src/shared/storage.ts
@@ -1,5 +1,6 @@
 import type { VersionedUrl } from "@blockprotocol/type-system/slim";
 import type { Subtype } from "@local/advanced-types/subtype";
+import type { Entity } from "@local/hash-graph-sdk/entity";
 import type { EntityId, EntityMetadata } from "@local/hash-graph-types/entity";
 import type { EntityTypeWithMetadata } from "@local/hash-graph-types/ontology";
 import type { OwnedById } from "@local/hash-graph-types/web";
@@ -45,7 +46,7 @@ type SimplifiedUser = {
 
 type UserAndLinkedData = SimplifiedUser & {
   avatar?: Image;
-  orgs: (Simplified<Organization> & {
+  orgs: (Simplified<Entity<Organization>> & {
     avatar?: Image;
     webOwnedById: OwnedById;
   })[];

--- a/libs/@blockprotocol/graph/src/codegen/compile/replace-interface-with-type.ts
+++ b/libs/@blockprotocol/graph/src/codegen/compile/replace-interface-with-type.ts
@@ -9,7 +9,7 @@ const replaceInterfaceWithTypeInCompiledTsType = (
   compiledTsType.replace(/interface ([a-zA-Z0-9]+)/gm, "type $1 =");
 
 /**
- * We want to be able to use generated types as generics within `Entity<Properties>` for example, so we make
+ * We want to be able to use generated types as generics within `Entity<User>` for example, so we make
  * everything consistently a `type` instead of an `interface`.
  *
  * This should be safe as:

--- a/libs/@blockprotocol/graph/src/codegen/postprocess.ts
+++ b/libs/@blockprotocol/graph/src/codegen/postprocess.ts
@@ -23,8 +23,6 @@ export const postprocess = async (context: PostprocessContext) => {
   prependImportsAndExports(context);
   prependBannerComments(context);
 
-  /* @todo - Modify the generated docs of types to include the URLs they came from */
-  /* @todo - Move documentation from the `Properties` definition to the `Entity` definition */
   /* @todo - Generate mappings of TypeURLs to prettified names (fallback to camelCased title if not overriden) */
 
   await writeToFiles(context);

--- a/libs/@blockprotocol/graph/src/codegen/postprocess/generate-entity-definitions.ts
+++ b/libs/@blockprotocol/graph/src/codegen/postprocess/generate-entity-definitions.ts
@@ -12,10 +12,15 @@ const generateEntityDefinitionForEntityType = (
 ) => {
   const typeName = title;
   const isLinkType = mustBeDefined(context.linkTypeMap[entityTypeId]);
+  const type = mustBeDefined(context.entityTypes[entityTypeId]);
 
   const entityName = entityDefinitionNameForEntityType(typeName);
 
-  const compiledContents = `\nexport type ${entityName} = {
+  const compiledContents = `\n/**
+  * ${type.description}
+  */
+  export type ${entityName} = {
+  entityTypeId: "${entityTypeId}";
   properties: ${typeName};
   propertiesWithMetadata: ${typeName}WithMetadata;
 }\n`;

--- a/libs/@blockprotocol/graph/src/codegen/postprocess/generate-entity-definitions.ts
+++ b/libs/@blockprotocol/graph/src/codegen/postprocess/generate-entity-definitions.ts
@@ -13,10 +13,12 @@ const generateEntityDefinitionForEntityType = (
   const typeName = title;
   const isLinkType = mustBeDefined(context.linkTypeMap[entityTypeId]);
 
-  const entityTypeName = isLinkType ? "LinkEntity" : "Entity";
   const entityName = entityDefinitionNameForEntityType(typeName);
 
-  const compiledContents = `\nexport type ${entityName} = ${entityTypeName}<${typeName}>\n`;
+  const compiledContents = `\nexport type ${entityName} = {
+  properties: ${typeName};
+  propertiesWithMetadata: ${typeName}WithMetadata;
+}\n`;
 
   return { entityName, isLinkType, compiledContents };
 };
@@ -24,21 +26,16 @@ const generateEntityDefinitionForEntityType = (
 const allocateEntityDefinitionToFile = (
   fileName: string,
   entityName: string,
-  isLinkType: boolean,
   compiledContents: string,
   context: PostprocessContext,
 ) => {
-  context.logTrace(
-    `Adding${isLinkType ? " link " : " "}entity definition for ${entityName}`,
-  );
+  context.logTrace(`Adding entity definition for ${entityName}`);
 
   context.defineIdentifierInFile(
     entityName,
     {
       definingPath: fileName,
-      dependentOnIdentifiers: isLinkType
-        ? ["Entity", "LinkEntity"]
-        : ["Entity"],
+      dependentOnIdentifiers: [],
       compiledContents,
     },
     true,
@@ -77,7 +74,7 @@ export const generateEntityDefinitions = (
     for (const identifier of dependentIdentifiers) {
       const entityTypeId = entityTypeIdentifiersToIds[identifier];
       if (entityTypeId) {
-        const { entityName, isLinkType, compiledContents } = mustBeDefined(
+        const { entityName, compiledContents } = mustBeDefined(
           entityTypeIdsToEntityDefinitions[entityTypeId],
         );
 
@@ -85,7 +82,6 @@ export const generateEntityDefinitions = (
           allocateEntityDefinitionToFile(
             file,
             entityName,
-            isLinkType,
             compiledContents,
             context,
           );

--- a/libs/@local/hash-backend-utils/src/file-storage.ts
+++ b/libs/@local/hash-backend-utils/src/file-storage.ts
@@ -3,7 +3,7 @@ import type { Entity } from "@local/hash-graph-sdk/entity";
 import type { EntityId } from "@local/hash-graph-types/entity";
 import { apiOrigin } from "@local/hash-isomorphic-utils/environment";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
-import type { FileProperties } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { File } from "@local/hash-isomorphic-utils/system-types/shared";
 import type { DataSource } from "apollo-datasource";
 
 export const storageTypes = ["AWS_S3", "LOCAL_FILE_SYSTEM"] as const;
@@ -63,7 +63,7 @@ export interface UploadableStorageProvider
   ): Promise<{
     presignedPut: PresignedPutUpload;
     fileStorageProperties: Pick<
-      FileProperties,
+      File["properties"],
       | "https://hash.ai/@hash/types/property-type/file-storage-bucket/"
       | "https://hash.ai/@hash/types/property-type/file-storage-endpoint/"
       | "https://hash.ai/@hash/types/property-type/file-storage-force-path-style/"
@@ -101,7 +101,7 @@ export interface PresignedStorageRequest {
 /** Parameters needed to allow the download of a stored file */
 export interface PresignedDownloadRequest {
   /** The file entity to provide a download URL for */
-  entity: Entity<FileProperties>;
+  entity: Entity<File>;
   /** File storage key * */
   key: string;
   /** Expiry delay for the download authorisation */

--- a/libs/@local/hash-backend-utils/src/flows.ts
+++ b/libs/@local/hash-backend-utils/src/flows.ts
@@ -19,7 +19,7 @@ import {
   systemPropertyTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { mapGraphApiEntityToEntity } from "@local/hash-isomorphic-utils/subgraph-mapping";
-import type { FlowRunProperties } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { FlowRun as FlowRunEntity } from "@local/hash-isomorphic-utils/system-types/shared";
 import {
   extractEntityUuidFromEntityId,
   extractOwnedByIdFromEntityId,
@@ -35,7 +35,7 @@ export const getFlowRunEntityById = async (params: {
   flowRunId: EntityUuid;
   graphApiClient: GraphApi;
   userAuthentication: { actorId: AccountId };
-}): Promise<Entity<FlowRunProperties> | null> => {
+}): Promise<Entity<FlowRunEntity> | null> => {
   const { flowRunId, graphApiClient, userAuthentication } = params;
 
   const [existingFlowEntity] = await graphApiClient
@@ -60,7 +60,7 @@ export const getFlowRunEntityById = async (params: {
           mapGraphApiEntityToEntity(
             entity,
             userAuthentication.actorId,
-          ) as Entity<FlowRunProperties>,
+          ) as Entity<FlowRunEntity>,
       ),
     );
 
@@ -215,7 +215,7 @@ export async function getFlowRuns({
         );
 
         flowRunIdToOwnedByAndName[entityUuid] = {
-          name: (entity.properties as FlowRunProperties)[
+          name: (entity.properties as FlowRunEntity["properties"])[
             "https://blockprotocol.org/@blockprotocol/types/property-type/name/"
           ],
           ownedById,

--- a/libs/@local/hash-backend-utils/src/google.ts
+++ b/libs/@local/hash-backend-utils/src/google.ts
@@ -10,7 +10,7 @@ import {
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { googleEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { mapGraphApiSubgraphToSubgraph } from "@local/hash-isomorphic-utils/subgraph-mapping";
-import type { AccountProperties as GoogleAccountProperties } from "@local/hash-isomorphic-utils/system-types/google/account";
+import type { Account as GoogleAccount } from "@local/hash-isomorphic-utils/system-types/google/account";
 import type { EntityRootType } from "@local/hash-subgraph";
 import { getRoots } from "@local/hash-subgraph/stdlib";
 import type { Auth } from "googleapis";
@@ -51,7 +51,7 @@ export const getGoogleAccountById = async ({
   userAccountId: AccountId;
   googleAccountId: string;
   graphApiClient: GraphApi;
-}): Promise<Entity<GoogleAccountProperties> | undefined> => {
+}): Promise<Entity<GoogleAccount> | undefined> => {
   const entities = await graphApiClient
     .getEntitySubgraph(userAccountId, {
       filter: {
@@ -98,7 +98,7 @@ export const getGoogleAccountById = async ({
 
   const entity = entities[0];
 
-  return entity as Entity<GoogleAccountProperties> | undefined;
+  return entity as Entity<GoogleAccount> | undefined;
 };
 
 export const getTokensForGoogleAccount = async ({

--- a/libs/@local/hash-backend-utils/src/service-usage.ts
+++ b/libs/@local/hash-backend-utils/src/service-usage.ts
@@ -90,15 +90,13 @@ export const getWebServiceUsage = async (
       includeDrafts: false,
     })
     .then(({ data }) => {
-      return mapGraphApiSubgraphToSubgraph<EntityRootType>(
+      return mapGraphApiSubgraphToSubgraph<EntityRootType<UsageRecord>>(
         data.subgraph,
         userAccountId,
       );
     });
 
-  const serviceUsageRecords = getRoots(
-    serviceUsageRecordSubgraph,
-  ) as Entity<UsageRecord>[];
+  const serviceUsageRecords = getRoots(serviceUsageRecordSubgraph);
 
   const aggregateUsageRecords = getAggregateUsageRecordsByServiceFeature({
     decisionTimeInterval,

--- a/libs/@local/hash-backend-utils/src/service-usage.ts
+++ b/libs/@local/hash-backend-utils/src/service-usage.ts
@@ -28,7 +28,7 @@ import {
   mapGraphApiEntityToEntity,
   mapGraphApiSubgraphToSubgraph,
 } from "@local/hash-isomorphic-utils/subgraph-mapping";
-import type { UsageRecordProperties } from "@local/hash-isomorphic-utils/system-types/usagerecord";
+import type { UsageRecord } from "@local/hash-isomorphic-utils/system-types/usagerecord";
 import type {
   EntityRelationAndSubject,
   EntityRootType,
@@ -96,7 +96,9 @@ export const getWebServiceUsage = async (
       );
     });
 
-  const serviceUsageRecords = getRoots(serviceUsageRecordSubgraph);
+  const serviceUsageRecords = getRoots(
+    serviceUsageRecordSubgraph,
+  ) as Entity<UsageRecord>[];
 
   const aggregateUsageRecords = getAggregateUsageRecordsByServiceFeature({
     decisionTimeInterval,
@@ -142,7 +144,7 @@ export const createUsageRecord = async (
     userAccountId: AccountId;
   },
 ) => {
-  const properties: UsageRecordProperties = {
+  const properties: UsageRecord["properties"] = {
     "https://hash.ai/@hash/types/property-type/input-unit-count/":
       inputUnitCount,
     "https://hash.ai/@hash/types/property-type/output-unit-count/":

--- a/libs/@local/hash-backend-utils/src/service-usage.ts
+++ b/libs/@local/hash-backend-utils/src/service-usage.ts
@@ -28,7 +28,10 @@ import {
   mapGraphApiEntityToEntity,
   mapGraphApiSubgraphToSubgraph,
 } from "@local/hash-isomorphic-utils/subgraph-mapping";
-import type { UsageRecord } from "@local/hash-isomorphic-utils/system-types/usagerecord";
+import type {
+  RecordsUsageOf,
+  UsageRecord,
+} from "@local/hash-isomorphic-utils/system-types/usagerecord";
 import type {
   EntityRelationAndSubject,
   EntityRootType,
@@ -269,43 +272,31 @@ export const createUsageRecord = async (
     },
   };
 
-  const createdEntities = await Entity.createMultiple(
-    context.graphApi,
-    authentication,
-    [
-      {
-        ownedById: assignUsageToWebId,
-        draft: false,
-        entityUuid: usageRecordEntityUuid,
-        properties,
-        provenance,
-        entityTypeId: systemEntityTypes.usageRecord.entityTypeId,
-        relationships: entityRelationships,
+  const [usageRecord] = await Entity.createMultiple<
+    [UsageRecord, RecordsUsageOf]
+  >(context.graphApi, authentication, [
+    {
+      ownedById: assignUsageToWebId,
+      draft: false,
+      entityUuid: usageRecordEntityUuid,
+      properties,
+      provenance,
+      entityTypeId: systemEntityTypes.usageRecord.entityTypeId,
+      relationships: entityRelationships,
+    },
+    {
+      ownedById: assignUsageToWebId,
+      draft: false,
+      properties: {},
+      provenance,
+      linkData: {
+        leftEntityId: usageRecordEntityId,
+        rightEntityId: serviceFeatureEntity.metadata.recordId.entityId,
       },
-      {
-        ownedById: assignUsageToWebId,
-        draft: false,
-        properties: {},
-        provenance,
-        linkData: {
-          leftEntityId: usageRecordEntityId,
-          rightEntityId: serviceFeatureEntity.metadata.recordId.entityId,
-        },
-        entityTypeId: systemLinkEntityTypes.recordsUsageOf.linkEntityTypeId,
-        relationships: entityRelationships,
-      },
-    ],
-  );
+      entityTypeId: systemLinkEntityTypes.recordsUsageOf.linkEntityTypeId,
+      relationships: entityRelationships,
+    },
+  ]);
 
-  const usageRecordEntity = createdEntities.find(
-    (entity) => entity.metadata.recordId.entityId === usageRecordEntityId,
-  );
-
-  if (!usageRecordEntity) {
-    throw new Error(
-      `Failed to create usage record entity for webId ${assignUsageToWebId}.`,
-    );
-  }
-
-  return usageRecordEntity;
+  return usageRecord;
 };

--- a/libs/@local/hash-backend-utils/src/user-secret.ts
+++ b/libs/@local/hash-backend-utils/src/user-secret.ts
@@ -12,8 +12,8 @@ import {
   systemLinkEntityTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { mapGraphApiSubgraphToSubgraph } from "@local/hash-isomorphic-utils/subgraph-mapping";
-import type { UsesUserSecretProperties } from "@local/hash-isomorphic-utils/system-types/google/shared";
-import type { UserSecretProperties } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { UsesUserSecret } from "@local/hash-isomorphic-utils/system-types/google/shared";
+import type { UserSecret } from "@local/hash-isomorphic-utils/system-types/shared";
 import type { EntityRootType } from "@local/hash-subgraph";
 import { extractEntityUuidFromEntityId } from "@local/hash-subgraph";
 import { getEntityRevision, getRoots } from "@local/hash-subgraph/stdlib";
@@ -30,8 +30,8 @@ export const getSecretEntitiesForIntegration = async ({
   integrationEntityId: EntityId;
 }): Promise<
   {
-    usesUserSecretLink: Entity<UsesUserSecretProperties>;
-    userSecret: Entity<UserSecretProperties>;
+    usesUserSecretLink: Entity<UsesUserSecret>;
+    userSecret: Entity<UserSecret>;
   }[]
 > => {
   return await graphApiClient
@@ -79,8 +79,8 @@ export const getSecretEntitiesForIntegration = async ({
       const linkEntities = getRoots(subgraph);
 
       const linkAndSecretPairs: {
-        usesUserSecretLink: Entity<UsesUserSecretProperties>;
-        userSecret: Entity<UserSecretProperties>;
+        usesUserSecretLink: Entity<UsesUserSecret>;
+        userSecret: Entity<UserSecret>;
       }[] = [];
 
       for (const link of linkEntities) {
@@ -117,8 +117,8 @@ export const getSecretEntitiesForIntegration = async ({
         }
 
         linkAndSecretPairs.push({
-          usesUserSecretLink: link,
-          userSecret: target as Entity<UserSecretProperties>,
+          usesUserSecretLink: link as Entity<UsesUserSecret>,
+          userSecret: target as Entity<UserSecret>,
         });
       }
 

--- a/libs/@local/hash-graph-sdk/typescript/src/entity.ts
+++ b/libs/@local/hash-graph-sdk/typescript/src/entity.ts
@@ -570,8 +570,13 @@ export class Entity<PropertyMap extends EntityProperties = EntityProperties> {
     }: PatchEntityParameters,
     /**
      * @todo H-3091: returning a specific 'this' will not be correct if the entityTypeId has been changed as part of the update.
-     *    presumably possible to fix this via a generic on the entityTypeId input and an 'extends' on the return,
-     *    or by requiring a generic passed to .patch that must match the new entityTypeId, and infer the return from the generic.
+     *    I tried using generics to enforce that a new EntityProperties must be provided if the entityTypeId is changed, but
+     *    it isn't causing a compiler error:
+     *
+     *    public async patch<NewPropertyMap extends EntityProperties = PropertyMap>(
+     *      // PatchEntityParams sets a specific VersionedUrl based on NewPropertyMap, but this is not enforced by the compiler
+     *      params: PatchEntityParameters<NewPropertyMap>,
+     *    )
      */
   ): Promise<this> {
     return graphAPI

--- a/libs/@local/hash-graph-sdk/typescript/src/entity.ts
+++ b/libs/@local/hash-graph-sdk/typescript/src/entity.ts
@@ -569,9 +569,9 @@ export class Entity<PropertyMap extends EntityProperties = EntityProperties> {
       ...params
     }: PatchEntityParameters,
     /**
-     * @todo returning a specific 'this' will not be correct if the entityTypeId has been changed as part of the update.
+     * @todo H-3091: returning a specific 'this' will not be correct if the entityTypeId has been changed as part of the update.
      *    presumably possible to fix this via a generic on the entityTypeId input and an 'extends' on the return,
-     *    but I couldn't figure it out at the first attempt.
+     *    or by requiring a generic passed to .patch that must match the new entityTypeId, and infer the return from the generic.
      */
   ): Promise<this> {
     return graphAPI

--- a/libs/@local/hash-graph-types/typescript/src/entity.ts
+++ b/libs/@local/hash-graph-types/typescript/src/entity.ts
@@ -66,16 +66,17 @@ export type EntityTemporalVersioningMetadata = Subtype<
   Record<TemporalAxis, HalfClosedInterval>
 >;
 
-export type EntityMetadata = Subtype<
-  EntityMetadataBp,
-  {
-    recordId: EntityRecordId;
-    entityTypeId: VersionedUrl;
-    temporalVersioning: EntityTemporalVersioningMetadata;
-    archived: boolean;
-    provenance: EntityProvenance;
-  }
->;
+export type EntityMetadata<EntityTypeId extends VersionedUrl = VersionedUrl> =
+  Subtype<
+    EntityMetadataBp,
+    {
+      recordId: EntityRecordId;
+      entityTypeId: EntityTypeId;
+      temporalVersioning: EntityTemporalVersioningMetadata;
+      archived: boolean;
+      provenance: EntityProvenance;
+    }
+  >;
 
 /**
  * The value of a property.
@@ -100,6 +101,12 @@ export type PropertyArray = Property[];
  */
 export type PropertyObject = {
   [key: BaseUrl]: Property;
+};
+
+export type EntityProperties = {
+  entityTypeId: VersionedUrl;
+  properties: PropertyObject;
+  propertiesWithMetadata: PropertyObjectWithMetadata;
 };
 
 /**
@@ -214,7 +221,8 @@ export type PropertyWithMetadata =
  *    ["https://example.com/address/", 0, "https://example.com/street/"]
  * @example where the 'address' property is not an array, the path to the street of the single address
  *    ["https://example.com/address/", "https://example.com/street/"]
- * @example where the 'color' property is an array of RGB tuples [number, number, number], the green value of the first color
+ * @example where the 'color' property is an array of RGB tuples [number, number, number], the green value of the first
+ *   color
  *    ["https://example.com/color/", 0, 1]
  */
 export type PropertyPath = (BaseUrl | number)[];

--- a/libs/@local/hash-isomorphic-utils/src/block-collection.ts
+++ b/libs/@local/hash-isomorphic-utils/src/block-collection.ts
@@ -1,3 +1,4 @@
+import type { Entity } from "@local/hash-graph-sdk/entity";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
 import type {
   HasSpatiallyPositionedContent,
@@ -36,8 +37,8 @@ const isSpatiallyPositionedProperties = (
 };
 
 export const sortBlockCollectionLinks = <
-  Left extends HasSpatiallyPositionedContent | HasIndexedContent,
-  Right extends HasSpatiallyPositionedContent | HasIndexedContent,
+  Left extends Entity<HasSpatiallyPositionedContent | HasIndexedContent>,
+  Right extends Entity<HasSpatiallyPositionedContent | HasIndexedContent>,
 >(
   a: Left,
   b: Right,

--- a/libs/@local/hash-isomorphic-utils/src/entity.ts
+++ b/libs/@local/hash-isomorphic-utils/src/entity.ts
@@ -1,7 +1,10 @@
 import type { Entity, LinkEntity } from "@local/hash-graph-sdk/entity";
 import type { EntityId } from "@local/hash-graph-types/entity";
 import type { HasSpatiallyPositionedContent } from "@local/hash-isomorphic-utils/system-types/canvas";
-import type { HasIndexedContent } from "@local/hash-isomorphic-utils/system-types/shared";
+import type {
+  HasIndexedContent,
+  Text,
+} from "@local/hash-isomorphic-utils/system-types/shared";
 import type { TextToken } from "@local/hash-isomorphic-utils/types";
 import type { Subgraph } from "@local/hash-subgraph";
 import { getEntityRevisionsByEntityId } from "@local/hash-subgraph/stdlib";
@@ -35,13 +38,17 @@ export type TextProperties = {
   [_ in typeof textualContentPropertyTypeBaseUrl]: TextToken[];
 };
 
-export type TextEntityType = Omit<EntityStoreType, "properties"> & {
+export type TextEntityStoreEntity = Omit<EntityStoreType, "properties"> & {
+  properties: TextProperties;
+};
+
+export type TextWithTokens = Omit<Text, "properties"> & {
   properties: TextProperties;
 };
 
 export const isRichTextProperties = (
   properties: Record<string, unknown>,
-): properties is TextEntityType["properties"] =>
+): properties is TextEntityStoreEntity["properties"] =>
   textualContentPropertyTypeBaseUrl in properties &&
   Array.isArray(
     properties[textualContentPropertyTypeBaseUrl as keyof typeof properties],

--- a/libs/@local/hash-isomorphic-utils/src/entity.ts
+++ b/libs/@local/hash-isomorphic-utils/src/entity.ts
@@ -1,7 +1,7 @@
 import type { Entity, LinkEntity } from "@local/hash-graph-sdk/entity";
 import type { EntityId } from "@local/hash-graph-types/entity";
-import type { HasSpatiallyPositionedContentProperties } from "@local/hash-isomorphic-utils/system-types/canvas";
-import type { HasIndexedContentProperties } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { HasSpatiallyPositionedContent } from "@local/hash-isomorphic-utils/system-types/canvas";
+import type { HasIndexedContent } from "@local/hash-isomorphic-utils/system-types/shared";
 import type { TextToken } from "@local/hash-isomorphic-utils/types";
 import type { Subgraph } from "@local/hash-subgraph";
 import { getEntityRevisionsByEntityId } from "@local/hash-subgraph/stdlib";
@@ -22,8 +22,8 @@ export type BlockEntity = Omit<Block, "blockChildEntity"> & {
 
 export type BlockCollectionContentItem = {
   linkEntity:
-    | LinkEntity<HasIndexedContentProperties>
-    | LinkEntity<HasSpatiallyPositionedContentProperties>;
+    | LinkEntity<HasIndexedContent>
+    | LinkEntity<HasSpatiallyPositionedContent>;
   rightEntity: BlockEntity;
 };
 

--- a/libs/@local/hash-isomorphic-utils/src/flows/mappings.ts
+++ b/libs/@local/hash-isomorphic-utils/src/flows/mappings.ts
@@ -3,14 +3,14 @@ import type { EntityUuid } from "@local/hash-graph-types/entity";
 import { extractEntityUuidFromEntityId } from "@local/hash-subgraph";
 
 import { simplifyProperties } from "../simplify-properties";
-import type { FlowDefinitionProperties } from "../system-types/flowdefinition";
-import type { FlowRunProperties } from "../system-types/flowrun";
+import type { FlowDefinition as FlowDefinitionEntity } from "../system-types/flowdefinition";
+import type { FlowRun } from "../system-types/flowrun";
 import type { TriggerDefinitionId } from "./trigger-definitions";
 import type { FlowDefinition, LocalFlowRun, OutputDefinition } from "./types";
 
 export const mapFlowDefinitionToEntityProperties = (
   flowDefinition: FlowDefinition,
-): FlowDefinitionProperties => ({
+): FlowDefinitionEntity["properties"] => ({
   "https://blockprotocol.org/@blockprotocol/types/property-type/name/":
     flowDefinition.name,
   "https://blockprotocol.org/@blockprotocol/types/property-type/description/":
@@ -28,7 +28,7 @@ export const mapFlowDefinitionToEntityProperties = (
 });
 
 export const mapFlowDefinitionEntityToFlowDefinition = (
-  entity: Entity<FlowDefinitionProperties>,
+  entity: Entity<FlowDefinitionEntity>,
 ): FlowDefinition => {
   const {
     name,
@@ -62,7 +62,7 @@ export const mapFlowDefinitionEntityToFlowDefinition = (
 
 export const mapFlowRunToEntityProperties = (
   flowRun: LocalFlowRun,
-): FlowRunProperties => ({
+): FlowRun["properties"] => ({
   "https://blockprotocol.org/@blockprotocol/types/property-type/name/":
     flowRun.name,
   "https://hash.ai/@hash/types/property-type/flow-definition-id/":
@@ -75,9 +75,7 @@ export const mapFlowRunToEntityProperties = (
   },
 });
 
-export const mapFlowEntityToFlow = (
-  entity: Entity<FlowRunProperties>,
-): LocalFlowRun => {
+export const mapFlowEntityToFlow = (entity: Entity<FlowRun>): LocalFlowRun => {
   const {
     name,
     flowDefinitionId,

--- a/libs/@local/hash-isomorphic-utils/src/generate-system-types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/generate-system-types.ts
@@ -45,24 +45,21 @@ const generateTypes = async (
     ];
   }
 
-  await codegen(
-    {
-      outputFolder: `src/system-types${subFolder ? `/${subFolder}` : ""}`,
-      targets,
-      getFetchUrlFromTypeId: (typeId) => {
-        if (typeId.startsWith("https://hash.ai/")) {
-          const rewrittenTypeId = typeId.replace(
-            "https://hash.ai/",
-            "http://localhost:3000/",
-          ) as VersionedUrl;
+  await codegen({
+    outputFolder: `src/system-types${subFolder ? `/${subFolder}` : ""}`,
+    targets,
+    getFetchUrlFromTypeId: (typeId) => {
+      if (typeId.startsWith("https://hash.ai/")) {
+        const rewrittenTypeId = typeId.replace(
+          "https://hash.ai/",
+          "http://localhost:3000/",
+        ) as VersionedUrl;
 
-          return rewrittenTypeId;
-        }
-        return typeId;
-      },
+        return rewrittenTypeId;
+      }
+      return typeId;
     },
-    "trace",
-  );
+  });
 
   // eslint-disable-next-line no-console
   console.log(`Done generating ${label} types.`);

--- a/libs/@local/hash-isomorphic-utils/src/save.ts
+++ b/libs/@local/hash-isomorphic-utils/src/save.ts
@@ -6,6 +6,7 @@ import type { EntityId } from "@local/hash-graph-types/entity";
 import type { OwnedById } from "@local/hash-graph-types/web";
 import { updateBlockCollectionContents } from "@local/hash-isomorphic-utils/graphql/queries/block-collection.queries";
 import { getEntityQuery } from "@local/hash-isomorphic-utils/graphql/queries/entity.queries";
+import type { HasSpatiallyPositionedContent } from "@local/hash-isomorphic-utils/system-types/canvas";
 import type { EntityRootType, Subgraph } from "@local/hash-subgraph";
 import {
   getOutgoingLinkAndTargetEntities,
@@ -40,10 +41,7 @@ import type {
 } from "./graphql/api-types.gen";
 import { systemEntityTypes, systemLinkEntityTypes } from "./ontology-type-ids";
 import { isEntityNode } from "./prosemirror";
-import type {
-  BlockProperties,
-  HasIndexedContentProperties,
-} from "./system-types/shared";
+import type { Block, HasIndexedContent } from "./system-types/shared";
 
 const generatePlaceholderId = () => `placeholder-${uuid()}`;
 
@@ -54,7 +52,7 @@ type BeforeBlockDraftIdAndLink = [
   string,
   {
     linkEntityId: EntityId;
-    fractionalIndex: string;
+    fractionalIndex: string | null;
   },
 ];
 
@@ -75,7 +73,9 @@ const calculateSaveActions = (
   ownedById: OwnedById,
   blocksAndLinks: {
     blockEntity: GqlBlock;
-    contentLinkEntity: LinkEntity<HasIndexedContentProperties>;
+    contentLinkEntity: LinkEntity<
+      HasIndexedContent | HasSpatiallyPositionedContent
+    >;
   }[],
   doc: Node,
   getEntityTypeForComponent: (componentId: string) => VersionedUrl,
@@ -196,15 +196,20 @@ const calculateSaveActions = (
       blockEntity.metadata.recordId.entityId,
     );
 
+    const fractionalIndex =
+      "https://hash.ai/@hash/types/property-type/fractional-index/" in
+      contentLinkEntity.properties
+        ? contentLinkEntity.properties[
+            "https://hash.ai/@hash/types/property-type/fractional-index/"
+          ]
+        : null;
+
     if (draftEntity) {
       beforeBlockDraftIds.push([
         draftEntity.draftId,
         {
           linkEntityId: contentLinkEntity.metadata.recordId.entityId,
-          fractionalIndex:
-            contentLinkEntity.properties[
-              "https://hash.ai/@hash/types/property-type/fractional-index/"
-            ],
+          fractionalIndex,
         },
       ]);
     } else {
@@ -421,7 +426,7 @@ const getDraftEntityIds = (
 };
 
 const mapEntityToGqlBlock = (
-  entity: Entity<BlockProperties>,
+  entity: Entity<Block>,
   entitySubgraph: Subgraph<EntityRootType>,
 ): GqlBlock => {
   if (entity.metadata.entityTypeId !== systemEntityTypes.block.entityTypeId) {
@@ -495,8 +500,10 @@ export const save = async ({
 
       const blocksAndLinks = getOutgoingLinkAndTargetEntities<
         {
-          linkEntity: LinkEntity<HasIndexedContentProperties>[];
-          rightEntity: Entity<BlockProperties>[];
+          linkEntity: LinkEntity<
+            HasIndexedContent | HasSpatiallyPositionedContent
+          >[];
+          rightEntity: Entity<Block>[];
         }[]
       >(subgraph, blockCollectionEntity!.metadata.recordId.entityId)
         .filter(

--- a/libs/@local/hash-isomorphic-utils/src/service-usage.ts
+++ b/libs/@local/hash-isomorphic-utils/src/service-usage.ts
@@ -4,8 +4,8 @@ import type { FlowUsageRecordCustomMetadata } from "@local/hash-isomorphic-utils
 import { systemLinkEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
 import type {
-  ServiceFeatureProperties,
-  UsageRecordProperties,
+  ServiceFeature,
+  UsageRecord,
 } from "@local/hash-isomorphic-utils/system-types/usagerecord";
 import type { EntityRootType, Subgraph } from "@local/hash-subgraph";
 import { getOutgoingLinkAndTargetEntities } from "@local/hash-subgraph/stdlib";
@@ -23,7 +23,7 @@ const getServiceFeatureForUsage = ({
   usageRecord,
 }: {
   serviceUsageRecordSubgraph: Subgraph<EntityRootType>;
-  usageRecord: Entity<UsageRecordProperties>;
+  usageRecord: Entity<UsageRecord>;
 }) => {
   const linkedEntities = getOutgoingLinkAndTargetEntities(
     serviceUsageRecordSubgraph,
@@ -42,7 +42,7 @@ const getServiceFeatureForUsage = ({
   }
 
   const serviceFeatureEntity = serviceFeatureLinkAndEntities[0]!
-    .rightEntity[0]! as Entity<ServiceFeatureProperties>;
+    .rightEntity[0]! as Entity<ServiceFeature>;
 
   const { featureName, serviceName, serviceUnitCost } = simplifyProperties(
     serviceFeatureEntity.properties,
@@ -99,7 +99,7 @@ export const getAggregateUsageRecordsByServiceFeature = ({
   serviceUsageRecordSubgraph,
 }: {
   decisionTimeInterval?: BoundedTimeInterval;
-  serviceUsageRecords: Entity<UsageRecordProperties>[];
+  serviceUsageRecords: Entity<UsageRecord>[];
   serviceUsageRecordSubgraph: Subgraph<EntityRootType>;
 }): AggregatedUsageRecord[] => {
   const aggregateUsageByServiceFeature: Record<string, AggregatedUsageRecord> =
@@ -169,7 +169,7 @@ export const getAggregateUsageRecordsByTask = ({
   serviceUsageRecords,
   serviceUsageRecordSubgraph,
 }: {
-  serviceUsageRecords: Entity<UsageRecordProperties>[];
+  serviceUsageRecords: Entity<UsageRecord>[];
   serviceUsageRecordSubgraph: Subgraph<EntityRootType>;
 }): AggregatedUsageByTask[] => {
   const aggregateUsageByTask: Record<string, AggregatedUsageByTask> = {};

--- a/libs/@local/hash-isomorphic-utils/src/system-types/blockprotocol/query.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/blockprotocol/query.ts
@@ -6,7 +6,6 @@ import type {
   ObjectMetadata,
   PropertyProvenance,
 } from "@local/hash-graph-client";
-import type { Entity } from "@local/hash-graph-sdk/entity";
 import type { Confidence } from "@local/hash-graph-types/entity";
 
 /**
@@ -24,7 +23,10 @@ export type ObjectDataTypeMetadata = {
   dataTypeId: "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1";
 };
 
-export type Query = Entity<QueryProperties>;
+export type Query = {
+  properties: QueryProperties;
+  propertiesWithMetadata: QueryPropertiesWithMetadata;
+};
 
 export type QueryOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/blockprotocol/query.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/blockprotocol/query.ts
@@ -23,7 +23,11 @@ export type ObjectDataTypeMetadata = {
   dataTypeId: "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1";
 };
 
+/**
+ *
+ */
 export type Query = {
+  entityTypeId: "https://blockprotocol.org/@hash/types/entity-type/query/v/1";
   properties: QueryProperties;
   propertiesWithMetadata: QueryPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/blockprotocol/thing.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/blockprotocol/thing.ts
@@ -4,7 +4,11 @@
 
 import type { ObjectMetadata } from "@local/hash-graph-client";
 
+/**
+ * A generic thing
+ */
 export type Thing = {
+  entityTypeId: "https://blockprotocol.org/@blockprotocol/types/entity-type/thing/v/1";
   properties: ThingProperties;
   propertiesWithMetadata: ThingPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/blockprotocol/thing.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/blockprotocol/thing.ts
@@ -3,9 +3,11 @@
  */
 
 import type { ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity } from "@local/hash-graph-sdk/entity";
 
-export type Thing = Entity<ThingProperties>;
+export type Thing = {
+  properties: ThingProperties;
+  propertiesWithMetadata: ThingPropertiesWithMetadata;
+};
 
 export type ThingOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/canvas.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/canvas.ts
@@ -110,7 +110,11 @@ export type {
   TitlePropertyValueWithMetadata,
 };
 
+/**
+ * A page in canvas format, with content in a free-form arrangement.
+ */
 export type Canvas = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/canvas/v/1";
   properties: CanvasProperties;
   propertiesWithMetadata: CanvasPropertiesWithMetadata;
 };
@@ -140,7 +144,11 @@ export type CanvasPropertiesWithMetadata = {
   value: {};
 };
 
+/**
+ * Something contained at a spatial position by something
+ */
 export type HasSpatiallyPositionedContent = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/has-spatially-positioned-content/v/1";
   properties: HasSpatiallyPositionedContentProperties;
   propertiesWithMetadata: HasSpatiallyPositionedContentPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/canvas.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/canvas.ts
@@ -3,7 +3,6 @@
  */
 
 import type { ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity, LinkEntity } from "@local/hash-graph-sdk/entity";
 
 import type {
   ArchivedPropertyValue,
@@ -111,7 +110,10 @@ export type {
   TitlePropertyValueWithMetadata,
 };
 
-export type Canvas = Entity<CanvasProperties>;
+export type Canvas = {
+  properties: CanvasProperties;
+  propertiesWithMetadata: CanvasPropertiesWithMetadata;
+};
 
 export type CanvasHasSpatiallyPositionedContentLink = {
   linkEntity: HasSpatiallyPositionedContent;
@@ -138,8 +140,10 @@ export type CanvasPropertiesWithMetadata = {
   value: {};
 };
 
-export type HasSpatiallyPositionedContent =
-  LinkEntity<HasSpatiallyPositionedContentProperties>;
+export type HasSpatiallyPositionedContent = {
+  properties: HasSpatiallyPositionedContentProperties;
+  propertiesWithMetadata: HasSpatiallyPositionedContentPropertiesWithMetadata;
+};
 
 export type HasSpatiallyPositionedContentOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/commentnotification.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/commentnotification.ts
@@ -3,7 +3,6 @@
  */
 
 import type { ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity, LinkEntity } from "@local/hash-graph-sdk/entity";
 
 import type {
   Actor,
@@ -517,7 +516,10 @@ export type {
   WebsiteURLPropertyValueWithMetadata,
 };
 
-export type CommentNotification = Entity<CommentNotificationProperties>;
+export type CommentNotification = {
+  properties: CommentNotificationProperties;
+  propertiesWithMetadata: CommentNotificationPropertiesWithMetadata;
+};
 
 export type CommentNotificationOccurredInBlockLink = {
   linkEntity: OccurredInBlock;
@@ -573,7 +575,10 @@ export type CommentNotificationTriggeredByUserLink = {
   rightEntity: User;
 };
 
-export type RepliedToComment = LinkEntity<RepliedToCommentProperties>;
+export type RepliedToComment = {
+  properties: RepliedToCommentProperties;
+  propertiesWithMetadata: RepliedToCommentPropertiesWithMetadata;
+};
 
 export type RepliedToCommentOutgoingLinkAndTarget = never;
 
@@ -593,7 +598,10 @@ export type RepliedToCommentPropertiesWithMetadata = {
   value: {};
 };
 
-export type TriggeredByComment = LinkEntity<TriggeredByCommentProperties>;
+export type TriggeredByComment = {
+  properties: TriggeredByCommentProperties;
+  propertiesWithMetadata: TriggeredByCommentPropertiesWithMetadata;
+};
 
 export type TriggeredByCommentOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/commentnotification.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/commentnotification.ts
@@ -516,7 +516,11 @@ export type {
   WebsiteURLPropertyValueWithMetadata,
 };
 
+/**
+ * A notification related to a comment.
+ */
 export type CommentNotification = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/comment-notification/v/5";
   properties: CommentNotificationProperties;
   propertiesWithMetadata: CommentNotificationPropertiesWithMetadata;
 };
@@ -575,7 +579,11 @@ export type CommentNotificationTriggeredByUserLink = {
   rightEntity: User;
 };
 
+/**
+ * The comment that something replied to.
+ */
 export type RepliedToComment = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/replied-to-comment/v/1";
   properties: RepliedToCommentProperties;
   propertiesWithMetadata: RepliedToCommentPropertiesWithMetadata;
 };
@@ -598,7 +606,11 @@ export type RepliedToCommentPropertiesWithMetadata = {
   value: {};
 };
 
+/**
+ * A comment that triggered something.
+ */
 export type TriggeredByComment = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/triggered-by-comment/v/1";
   properties: TriggeredByCommentProperties;
   propertiesWithMetadata: TriggeredByCommentPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/document.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/document.ts
@@ -3,7 +3,6 @@
  */
 
 import type { ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity } from "@local/hash-graph-sdk/entity";
 
 import type {
   ArchivedPropertyValue,
@@ -117,7 +116,10 @@ export type {
   TitlePropertyValueWithMetadata,
 };
 
-export type Document = Entity<DocumentProperties>;
+export type Document = {
+  properties: DocumentProperties;
+  propertiesWithMetadata: DocumentPropertiesWithMetadata;
+};
 
 export type DocumentHasIndexedContentLink = {
   linkEntity: HasIndexedContent;

--- a/libs/@local/hash-isomorphic-utils/src/system-types/document.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/document.ts
@@ -116,7 +116,11 @@ export type {
   TitlePropertyValueWithMetadata,
 };
 
+/**
+ * A page in document format, with content arranged in columns.
+ */
 export type Document = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/document/v/1";
   properties: DocumentProperties;
   propertiesWithMetadata: DocumentPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/docxdocument.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/docxdocument.ts
@@ -122,7 +122,11 @@ export type {
   UploadCompletedAtPropertyValueWithMetadata,
 };
 
+/**
+ * A Microsoft Word document.
+ */
 export type DOCXDocument = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/docx-document/v/1";
   properties: DOCXDocumentProperties;
   propertiesWithMetadata: DOCXDocumentPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/docxdocument.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/docxdocument.ts
@@ -3,7 +3,6 @@
  */
 
 import type { ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity } from "@local/hash-graph-sdk/entity";
 
 import type {
   BooleanDataType,
@@ -123,7 +122,10 @@ export type {
   UploadCompletedAtPropertyValueWithMetadata,
 };
 
-export type DOCXDocument = Entity<DOCXDocumentProperties>;
+export type DOCXDocument = {
+  properties: DOCXDocumentProperties;
+  propertiesWithMetadata: DOCXDocumentPropertiesWithMetadata;
+};
 
 export type DOCXDocumentOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/facebookaccount.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/facebookaccount.ts
@@ -28,7 +28,11 @@ export type {
   TextDataTypeWithMetadata,
 };
 
+/**
+ * A Facebook account.
+ */
 export type FacebookAccount = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/facebook-account/v/1";
   properties: FacebookAccountProperties;
   propertiesWithMetadata: FacebookAccountPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/facebookaccount.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/facebookaccount.ts
@@ -3,7 +3,6 @@
  */
 
 import type { ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity } from "@local/hash-graph-sdk/entity";
 
 import type {
   ProfileURLPropertyValue,
@@ -29,7 +28,10 @@ export type {
   TextDataTypeWithMetadata,
 };
 
-export type FacebookAccount = Entity<FacebookAccountProperties>;
+export type FacebookAccount = {
+  properties: FacebookAccountProperties;
+  propertiesWithMetadata: FacebookAccountPropertiesWithMetadata;
+};
 
 export type FacebookAccountOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/flowdefinition.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/flowdefinition.ts
@@ -30,7 +30,11 @@ export type {
   TriggerDefinitionIDPropertyValueWithMetadata,
 };
 
+/**
+ * The definition of a HASH flow.
+ */
 export type FlowDefinition = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/flow-definition/v/1";
   properties: FlowDefinitionProperties;
   propertiesWithMetadata: FlowDefinitionPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/flowdefinition.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/flowdefinition.ts
@@ -3,7 +3,6 @@
  */
 
 import type { ArrayMetadata, ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity } from "@local/hash-graph-sdk/entity";
 
 import type {
   DescriptionPropertyValue,
@@ -31,7 +30,10 @@ export type {
   TriggerDefinitionIDPropertyValueWithMetadata,
 };
 
-export type FlowDefinition = Entity<FlowDefinitionProperties>;
+export type FlowDefinition = {
+  properties: FlowDefinitionProperties;
+  propertiesWithMetadata: FlowDefinitionPropertiesWithMetadata;
+};
 
 export type FlowDefinitionOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/githubaccount.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/githubaccount.ts
@@ -3,7 +3,6 @@
  */
 
 import type { ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity } from "@local/hash-graph-sdk/entity";
 
 import type {
   ProfileURLPropertyValue,
@@ -29,7 +28,10 @@ export type {
   TextDataTypeWithMetadata,
 };
 
-export type GitHubAccount = Entity<GitHubAccountProperties>;
+export type GitHubAccount = {
+  properties: GitHubAccountProperties;
+  propertiesWithMetadata: GitHubAccountPropertiesWithMetadata;
+};
 
 export type GitHubAccountOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/githubaccount.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/githubaccount.ts
@@ -28,7 +28,11 @@ export type {
   TextDataTypeWithMetadata,
 };
 
+/**
+ * A GitHub account.
+ */
 export type GitHubAccount = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/github-account/v/1";
   properties: GitHubAccountProperties;
   propertiesWithMetadata: GitHubAccountPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/google/googlesheetsfile.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/google/googlesheetsfile.ts
@@ -6,7 +6,6 @@ import type {
   ObjectMetadata,
   PropertyProvenance,
 } from "@local/hash-graph-client";
-import type { Entity, LinkEntity } from "@local/hash-graph-sdk/entity";
 import type { Confidence } from "@local/hash-graph-types/entity";
 
 import type {
@@ -100,7 +99,10 @@ export type ActorTypeDataTypeMetadata = {
   dataTypeId: "https://hash.ai/@hash/types/data-type/actor-type/v/1";
 };
 
-export type AssociatedWithAccount = LinkEntity<AssociatedWithAccountProperties>;
+export type AssociatedWithAccount = {
+  properties: AssociatedWithAccountProperties;
+  propertiesWithMetadata: AssociatedWithAccountPropertiesWithMetadata;
+};
 
 export type AssociatedWithAccountOutgoingLinkAndTarget = never;
 
@@ -165,7 +167,10 @@ export type DescriptionPropertyValue = TextDataType;
 
 export type DescriptionPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
-export type File = Entity<FileProperties>;
+export type File = {
+  properties: FileProperties;
+  propertiesWithMetadata: FilePropertiesWithMetadata;
+};
 
 /**
  * A unique signature derived from a file's contents
@@ -299,7 +304,10 @@ export type FileURLPropertyValue = TextDataType;
 
 export type FileURLPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
-export type GoogleSheetsFile = Entity<GoogleSheetsFileProperties>;
+export type GoogleSheetsFile = {
+  properties: GoogleSheetsFileProperties;
+  propertiesWithMetadata: GoogleSheetsFilePropertiesWithMetadata;
+};
 
 export type GoogleSheetsFileAssociatedWithAccountLink = {
   linkEntity: AssociatedWithAccount;
@@ -379,7 +387,10 @@ export type OriginalURLPropertyValue = TextDataType;
 
 export type OriginalURLPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
-export type SpreadsheetFile = Entity<SpreadsheetFileProperties>;
+export type SpreadsheetFile = {
+  properties: SpreadsheetFileProperties;
+  propertiesWithMetadata: SpreadsheetFilePropertiesWithMetadata;
+};
 
 export type SpreadsheetFileOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/google/googlesheetsfile.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/google/googlesheetsfile.ts
@@ -99,7 +99,11 @@ export type ActorTypeDataTypeMetadata = {
   dataTypeId: "https://hash.ai/@hash/types/data-type/actor-type/v/1";
 };
 
+/**
+ * The account that something is associated with.
+ */
 export type AssociatedWithAccount = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/associated-with-account/v/1";
   properties: AssociatedWithAccountProperties;
   propertiesWithMetadata: AssociatedWithAccountPropertiesWithMetadata;
 };
@@ -167,7 +171,11 @@ export type DescriptionPropertyValue = TextDataType;
 
 export type DescriptionPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
+/**
+ * A file hosted at a URL
+ */
 export type File = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/file/v/2";
   properties: FileProperties;
   propertiesWithMetadata: FilePropertiesWithMetadata;
 };
@@ -304,7 +312,11 @@ export type FileURLPropertyValue = TextDataType;
 
 export type FileURLPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
+/**
+ * A Google Sheets file.
+ */
 export type GoogleSheetsFile = {
+  entityTypeId: "https://hash.ai/@google/types/entity-type/google-sheets-file/v/1";
   properties: GoogleSheetsFileProperties;
   propertiesWithMetadata: GoogleSheetsFilePropertiesWithMetadata;
 };
@@ -387,7 +399,11 @@ export type OriginalURLPropertyValue = TextDataType;
 
 export type OriginalURLPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
+/**
+ * A spreadsheet file.
+ */
 export type SpreadsheetFile = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/spreadsheet-file/v/1";
   properties: SpreadsheetFileProperties;
   propertiesWithMetadata: SpreadsheetFilePropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/google/shared.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/google/shared.ts
@@ -6,10 +6,12 @@ import type {
   ObjectMetadata,
   PropertyProvenance,
 } from "@local/hash-graph-client";
-import type { Entity, LinkEntity } from "@local/hash-graph-sdk/entity";
 import type { Confidence } from "@local/hash-graph-types/entity";
 
-export type Account = Entity<AccountProperties>;
+export type Account = {
+  properties: AccountProperties;
+  propertiesWithMetadata: AccountPropertiesWithMetadata;
+};
 
 /**
  * A unique identifier for a Google account.
@@ -76,7 +78,10 @@ export type ExpiredAtPropertyValue = TextDataType;
 
 export type ExpiredAtPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
-export type Link = Entity<LinkProperties>;
+export type Link = {
+  properties: LinkProperties;
+  propertiesWithMetadata: LinkPropertiesWithMetadata;
+};
 
 export type LinkOutgoingLinkAndTarget = never;
 
@@ -104,7 +109,10 @@ export type TextDataTypeMetadata = {
   dataTypeId: "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1";
 };
 
-export type UserSecret = Entity<UserSecretProperties>;
+export type UserSecret = {
+  properties: UserSecretProperties;
+  propertiesWithMetadata: UserSecretPropertiesWithMetadata;
+};
 
 export type UserSecretOutgoingLinkAndTarget = never;
 
@@ -128,7 +136,10 @@ export type UserSecretPropertiesWithMetadata = {
   };
 };
 
-export type UsesUserSecret = LinkEntity<UsesUserSecretProperties>;
+export type UsesUserSecret = {
+  properties: UsesUserSecretProperties;
+  propertiesWithMetadata: UsesUserSecretPropertiesWithMetadata;
+};
 
 export type UsesUserSecretOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/google/shared.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/google/shared.ts
@@ -8,7 +8,11 @@ import type {
 } from "@local/hash-graph-client";
 import type { Confidence } from "@local/hash-graph-types/entity";
 
+/**
+ * A Google user account.
+ */
 export type Account = {
+  entityTypeId: "https://hash.ai/@google/types/entity-type/account/v/1";
   properties: AccountProperties;
   propertiesWithMetadata: AccountPropertiesWithMetadata;
 };
@@ -78,7 +82,11 @@ export type ExpiredAtPropertyValue = TextDataType;
 
 export type ExpiredAtPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
+/**
+ * undefined
+ */
 export type Link = {
+  entityTypeId: "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1";
   properties: LinkProperties;
   propertiesWithMetadata: LinkPropertiesWithMetadata;
 };
@@ -109,7 +117,11 @@ export type TextDataTypeMetadata = {
   dataTypeId: "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1";
 };
 
+/**
+ * A secret or credential belonging to a user.
+ */
 export type UserSecret = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/user-secret/v/1";
   properties: UserSecretProperties;
   propertiesWithMetadata: UserSecretPropertiesWithMetadata;
 };
@@ -136,7 +148,11 @@ export type UserSecretPropertiesWithMetadata = {
   };
 };
 
+/**
+ * The user secret something uses.
+ */
 export type UsesUserSecret = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/uses-user-secret/v/1";
   properties: UsesUserSecretProperties;
   propertiesWithMetadata: UsesUserSecretPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/graphchangenotification.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/graphchangenotification.ts
@@ -61,7 +61,11 @@ export type {
   TextDataTypeWithMetadata,
 };
 
+/**
+ * A notification of a change to a graph
+ */
 export type GraphChangeNotification = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/graph-change-notification/v/1";
   properties: GraphChangeNotificationProperties;
   propertiesWithMetadata: GraphChangeNotificationPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/graphchangenotification.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/graphchangenotification.ts
@@ -61,7 +61,10 @@ export type {
   TextDataTypeWithMetadata,
 };
 
-export type GraphChangeNotification = Entity<GraphChangeNotificationProperties>;
+export type GraphChangeNotification = {
+  properties: GraphChangeNotificationProperties;
+  propertiesWithMetadata: GraphChangeNotificationPropertiesWithMetadata;
+};
 
 export type GraphChangeNotificationOccurredInEntityLink = {
   linkEntity: OccurredInEntity;

--- a/libs/@local/hash-isomorphic-utils/src/system-types/hashinstance.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/hashinstance.ts
@@ -8,7 +8,11 @@ import type { BooleanDataType, BooleanDataTypeWithMetadata } from "./shared";
 
 export type { BooleanDataType, BooleanDataTypeWithMetadata };
 
+/**
+ * An instance of HASH.
+ */
 export type HASHInstance = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/hash-instance/v/1";
   properties: HASHInstanceProperties;
   propertiesWithMetadata: HASHInstancePropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/hashinstance.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/hashinstance.ts
@@ -3,13 +3,15 @@
  */
 
 import type { ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity } from "@local/hash-graph-sdk/entity";
 
 import type { BooleanDataType, BooleanDataTypeWithMetadata } from "./shared";
 
 export type { BooleanDataType, BooleanDataTypeWithMetadata };
 
-export type HASHInstance = Entity<HASHInstanceProperties>;
+export type HASHInstance = {
+  properties: HASHInstanceProperties;
+  propertiesWithMetadata: HASHInstancePropertiesWithMetadata;
+};
 
 export type HASHInstanceOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/instagramaccount.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/instagramaccount.ts
@@ -28,7 +28,11 @@ export type {
   TextDataTypeWithMetadata,
 };
 
+/**
+ * An Instagram account.
+ */
 export type InstagramAccount = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/instagram-account/v/1";
   properties: InstagramAccountProperties;
   propertiesWithMetadata: InstagramAccountPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/instagramaccount.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/instagramaccount.ts
@@ -3,7 +3,6 @@
  */
 
 import type { ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity } from "@local/hash-graph-sdk/entity";
 
 import type {
   ProfileURLPropertyValue,
@@ -29,7 +28,10 @@ export type {
   TextDataTypeWithMetadata,
 };
 
-export type InstagramAccount = Entity<InstagramAccountProperties>;
+export type InstagramAccount = {
+  properties: InstagramAccountProperties;
+  propertiesWithMetadata: InstagramAccountPropertiesWithMetadata;
+};
 
 export type InstagramAccountOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/linear/attachment.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/linear/attachment.ts
@@ -412,7 +412,11 @@ export type {
   WorkflowStatePropertiesWithMetadata,
 };
 
+/**
+ * Issue attachment (e.g. support ticket, pull request).
+ */
 export type Attachment = {
+  entityTypeId: "https://hash.ai/@linear/types/entity-type/attachment/v/1";
   properties: AttachmentProperties;
   propertiesWithMetadata: AttachmentPropertiesWithMetadata;
 };
@@ -477,7 +481,11 @@ export type AttachmentURLPropertyValue = TextDataType;
 
 export type AttachmentURLPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
+/**
+ * The issue this attachment belongs to.
+ */
 export type BelongsToIssue = {
+  entityTypeId: "https://hash.ai/@linear/types/entity-type/belongs-to-issue/v/1";
   properties: BelongsToIssueProperties;
   propertiesWithMetadata: BelongsToIssuePropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/linear/attachment.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/linear/attachment.ts
@@ -6,7 +6,6 @@ import type {
   ObjectMetadata,
   PropertyProvenance,
 } from "@local/hash-graph-client";
-import type { Entity, LinkEntity } from "@local/hash-graph-sdk/entity";
 import type { Confidence } from "@local/hash-graph-types/entity";
 
 import type {
@@ -413,7 +412,10 @@ export type {
   WorkflowStatePropertiesWithMetadata,
 };
 
-export type Attachment = Entity<AttachmentProperties>;
+export type Attachment = {
+  properties: AttachmentProperties;
+  propertiesWithMetadata: AttachmentPropertiesWithMetadata;
+};
 
 export type AttachmentBelongsToIssueLink = {
   linkEntity: BelongsToIssue;
@@ -475,7 +477,10 @@ export type AttachmentURLPropertyValue = TextDataType;
 
 export type AttachmentURLPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
-export type BelongsToIssue = LinkEntity<BelongsToIssueProperties>;
+export type BelongsToIssue = {
+  properties: BelongsToIssueProperties;
+  propertiesWithMetadata: BelongsToIssuePropertiesWithMetadata;
+};
 
 export type BelongsToIssueOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/linear/shared.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/linear/shared.ts
@@ -67,7 +67,11 @@ export type AvatarURLPropertyValue = TextDataType;
 
 export type AvatarURLPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
+/**
+ * The organization the user belongs to.
+ */
 export type BelongsToOrganization = {
+  entityTypeId: "https://hash.ai/@linear/types/entity-type/belongs-to-organization/v/1";
   properties: BelongsToOrganizationProperties;
   propertiesWithMetadata: BelongsToOrganizationPropertiesWithMetadata;
 };
@@ -236,7 +240,11 @@ export type GuestPropertyValue = BooleanDataType;
 
 export type GuestPropertyValueWithMetadata = BooleanDataTypeWithMetadata;
 
+/**
+ * The user to whom the issue is assigned to.
+ */
 export type HasAssignee = {
+  entityTypeId: "https://hash.ai/@linear/types/entity-type/has-assignee/v/1";
   properties: HasAssigneeProperties;
   propertiesWithMetadata: HasAssigneePropertiesWithMetadata;
 };
@@ -259,7 +267,11 @@ export type HasAssigneePropertiesWithMetadata = {
   value: {};
 };
 
+/**
+ * The user who created something.
+ */
 export type HasCreator = {
+  entityTypeId: "https://hash.ai/@linear/types/entity-type/has-creator/v/1";
   properties: HasCreatorProperties;
   propertiesWithMetadata: HasCreatorPropertiesWithMetadata;
 };
@@ -282,7 +294,11 @@ export type HasCreatorPropertiesWithMetadata = {
   value: {};
 };
 
+/**
+ * A user who is subscribed to the issue.
+ */
 export type HasSubscriber = {
+  entityTypeId: "https://hash.ai/@linear/types/entity-type/has-subscriber/v/1";
   properties: HasSubscriberProperties;
   propertiesWithMetadata: HasSubscriberPropertiesWithMetadata;
 };
@@ -341,7 +357,11 @@ export type IsMePropertyValue = BooleanDataType;
 
 export type IsMePropertyValueWithMetadata = BooleanDataTypeWithMetadata;
 
+/**
+ * An issue.
+ */
 export type Issue = {
+  entityTypeId: "https://hash.ai/@linear/types/entity-type/issue/v/1";
   properties: IssueProperties;
   propertiesWithMetadata: IssuePropertiesWithMetadata;
 };
@@ -473,7 +493,11 @@ export type LastSeenPropertyValue = TextDataType;
 
 export type LastSeenPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
+/**
+ * undefined
+ */
 export type Link = {
+  entityTypeId: "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1";
   properties: LinkProperties;
   propertiesWithMetadata: LinkPropertiesWithMetadata;
 };
@@ -526,7 +550,11 @@ export type NumberDataTypeMetadata = {
   dataTypeId: "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1";
 };
 
+/**
+ * An organization. Organizations are root-level objects that contain user accounts and teams.
+ */
 export type Organization = {
+  entityTypeId: "https://hash.ai/@linear/types/entity-type/organization/v/1";
   properties: OrganizationProperties;
   propertiesWithMetadata: OrganizationPropertiesWithMetadata;
 };
@@ -597,7 +625,11 @@ export type OrganizationPropertiesWithMetadata = {
   };
 };
 
+/**
+ * The parent of the issue.
+ */
 export type Parent = {
+  entityTypeId: "https://hash.ai/@linear/types/entity-type/parent/v/1";
   properties: ParentProperties;
   propertiesWithMetadata: ParentPropertiesWithMetadata;
 };
@@ -693,7 +725,11 @@ export type SCIMEnabledPropertyValue = BooleanDataType;
 
 export type SCIMEnabledPropertyValueWithMetadata = BooleanDataTypeWithMetadata;
 
+/**
+ * The user who snoozed the issue.
+ */
 export type SnoozedBy = {
+  entityTypeId: "https://hash.ai/@linear/types/entity-type/snoozed-by/v/1";
   properties: SnoozedByProperties;
   propertiesWithMetadata: SnoozedByPropertiesWithMetadata;
 };
@@ -743,7 +779,11 @@ export type StartedTriageAtPropertyValue = TextDataType;
 
 export type StartedTriageAtPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
+/**
+ * The workflow state that the issue is associated with.
+ */
 export type State = {
+  entityTypeId: "https://hash.ai/@linear/types/entity-type/state/v/1";
   properties: StateProperties;
   propertiesWithMetadata: StatePropertiesWithMetadata;
 };
@@ -858,7 +898,11 @@ export type UpdatedAtPropertyValue = TextDataType;
 
 export type UpdatedAtPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
+/**
+ * A user that has access to the the resources of an organization.
+ */
 export type User = {
+  entityTypeId: "https://hash.ai/@linear/types/entity-type/user/v/1";
   properties: UserProperties;
   propertiesWithMetadata: UserPropertiesWithMetadata;
 };
@@ -937,7 +981,11 @@ export type UserPropertiesWithMetadata = {
   };
 };
 
+/**
+ * A state in a team workflow.
+ */
 export type WorkflowState = {
+  entityTypeId: "https://hash.ai/@linear/types/entity-type/workflow-state/v/1";
   properties: WorkflowStateProperties;
   propertiesWithMetadata: WorkflowStatePropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/linear/shared.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/linear/shared.ts
@@ -7,7 +7,6 @@ import type {
   ObjectMetadata,
   PropertyProvenance,
 } from "@local/hash-graph-client";
-import type { Entity, LinkEntity } from "@local/hash-graph-sdk/entity";
 import type { Confidence } from "@local/hash-graph-types/entity";
 
 /**
@@ -68,7 +67,10 @@ export type AvatarURLPropertyValue = TextDataType;
 
 export type AvatarURLPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
-export type BelongsToOrganization = LinkEntity<BelongsToOrganizationProperties>;
+export type BelongsToOrganization = {
+  properties: BelongsToOrganizationProperties;
+  propertiesWithMetadata: BelongsToOrganizationPropertiesWithMetadata;
+};
 
 export type BelongsToOrganizationOutgoingLinkAndTarget = never;
 
@@ -234,7 +236,10 @@ export type GuestPropertyValue = BooleanDataType;
 
 export type GuestPropertyValueWithMetadata = BooleanDataTypeWithMetadata;
 
-export type HasAssignee = LinkEntity<HasAssigneeProperties>;
+export type HasAssignee = {
+  properties: HasAssigneeProperties;
+  propertiesWithMetadata: HasAssigneePropertiesWithMetadata;
+};
 
 export type HasAssigneeOutgoingLinkAndTarget = never;
 
@@ -254,7 +259,10 @@ export type HasAssigneePropertiesWithMetadata = {
   value: {};
 };
 
-export type HasCreator = LinkEntity<HasCreatorProperties>;
+export type HasCreator = {
+  properties: HasCreatorProperties;
+  propertiesWithMetadata: HasCreatorPropertiesWithMetadata;
+};
 
 export type HasCreatorOutgoingLinkAndTarget = never;
 
@@ -274,7 +282,10 @@ export type HasCreatorPropertiesWithMetadata = {
   value: {};
 };
 
-export type HasSubscriber = LinkEntity<HasSubscriberProperties>;
+export type HasSubscriber = {
+  properties: HasSubscriberProperties;
+  propertiesWithMetadata: HasSubscriberPropertiesWithMetadata;
+};
 
 export type HasSubscriberOutgoingLinkAndTarget = never;
 
@@ -330,7 +341,10 @@ export type IsMePropertyValue = BooleanDataType;
 
 export type IsMePropertyValueWithMetadata = BooleanDataTypeWithMetadata;
 
-export type Issue = Entity<IssueProperties>;
+export type Issue = {
+  properties: IssueProperties;
+  propertiesWithMetadata: IssuePropertiesWithMetadata;
+};
 
 export type IssueHasAssigneeLink = {
   linkEntity: HasAssignee;
@@ -459,7 +473,10 @@ export type LastSeenPropertyValue = TextDataType;
 
 export type LastSeenPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
-export type Link = Entity<LinkProperties>;
+export type Link = {
+  properties: LinkProperties;
+  propertiesWithMetadata: LinkPropertiesWithMetadata;
+};
 
 export type LinkOutgoingLinkAndTarget = never;
 
@@ -509,7 +526,10 @@ export type NumberDataTypeMetadata = {
   dataTypeId: "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1";
 };
 
-export type Organization = Entity<OrganizationProperties>;
+export type Organization = {
+  properties: OrganizationProperties;
+  propertiesWithMetadata: OrganizationPropertiesWithMetadata;
+};
 
 export type OrganizationOutgoingLinkAndTarget = never;
 
@@ -577,7 +597,10 @@ export type OrganizationPropertiesWithMetadata = {
   };
 };
 
-export type Parent = LinkEntity<ParentProperties>;
+export type Parent = {
+  properties: ParentProperties;
+  propertiesWithMetadata: ParentPropertiesWithMetadata;
+};
 
 export type ParentOutgoingLinkAndTarget = never;
 
@@ -670,7 +693,10 @@ export type SCIMEnabledPropertyValue = BooleanDataType;
 
 export type SCIMEnabledPropertyValueWithMetadata = BooleanDataTypeWithMetadata;
 
-export type SnoozedBy = LinkEntity<SnoozedByProperties>;
+export type SnoozedBy = {
+  properties: SnoozedByProperties;
+  propertiesWithMetadata: SnoozedByPropertiesWithMetadata;
+};
 
 export type SnoozedByOutgoingLinkAndTarget = never;
 
@@ -717,7 +743,10 @@ export type StartedTriageAtPropertyValue = TextDataType;
 
 export type StartedTriageAtPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
-export type State = LinkEntity<StateProperties>;
+export type State = {
+  properties: StateProperties;
+  propertiesWithMetadata: StatePropertiesWithMetadata;
+};
 
 export type StateOutgoingLinkAndTarget = never;
 
@@ -829,7 +858,10 @@ export type UpdatedAtPropertyValue = TextDataType;
 
 export type UpdatedAtPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
-export type User = Entity<UserProperties>;
+export type User = {
+  properties: UserProperties;
+  propertiesWithMetadata: UserPropertiesWithMetadata;
+};
 
 export type UserBelongsToOrganizationLink = {
   linkEntity: BelongsToOrganization;
@@ -905,7 +937,10 @@ export type UserPropertiesWithMetadata = {
   };
 };
 
-export type WorkflowState = Entity<WorkflowStateProperties>;
+export type WorkflowState = {
+  properties: WorkflowStateProperties;
+  propertiesWithMetadata: WorkflowStatePropertiesWithMetadata;
+};
 
 export type WorkflowStateOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/linearintegration.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/linearintegration.ts
@@ -394,7 +394,11 @@ export type {
   WebsiteURLPropertyValueWithMetadata,
 };
 
+/**
+ * An instance of an integration with Linear.
+ */
 export type LinearIntegration = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/linear-integration/v/6";
   properties: LinearIntegrationProperties;
   propertiesWithMetadata: LinearIntegrationPropertiesWithMetadata;
 };
@@ -446,7 +450,11 @@ export type LinearTeamIdPropertyValue = TextDataType;
 
 export type LinearTeamIdPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
+/**
+ * Something that syncs linear data with something.
+ */
 export type SyncLinearDataWith = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/sync-linear-data-with/v/1";
   properties: SyncLinearDataWithProperties;
   propertiesWithMetadata: SyncLinearDataWithPropertiesWithMetadata;
 };
@@ -476,7 +484,11 @@ export type SyncLinearDataWithPropertiesWithMetadata = {
   };
 };
 
+/**
+ * The user secret something uses.
+ */
 export type UsesUserSecret = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/uses-user-secret/v/1";
   properties: UsesUserSecretProperties;
   propertiesWithMetadata: UsesUserSecretPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/linearintegration.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/linearintegration.ts
@@ -3,7 +3,6 @@
  */
 
 import type { ArrayMetadata, ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity, LinkEntity } from "@local/hash-graph-sdk/entity";
 
 import type {
   Actor,
@@ -395,7 +394,10 @@ export type {
   WebsiteURLPropertyValueWithMetadata,
 };
 
-export type LinearIntegration = Entity<LinearIntegrationProperties>;
+export type LinearIntegration = {
+  properties: LinearIntegrationProperties;
+  propertiesWithMetadata: LinearIntegrationPropertiesWithMetadata;
+};
 
 export type LinearIntegrationOutgoingLinkAndTarget =
   | LinearIntegrationSyncLinearDataWithLink
@@ -444,7 +446,10 @@ export type LinearTeamIdPropertyValue = TextDataType;
 
 export type LinearTeamIdPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
-export type SyncLinearDataWith = LinkEntity<SyncLinearDataWithProperties>;
+export type SyncLinearDataWith = {
+  properties: SyncLinearDataWithProperties;
+  propertiesWithMetadata: SyncLinearDataWithPropertiesWithMetadata;
+};
 
 export type SyncLinearDataWithOutgoingLinkAndTarget = never;
 
@@ -471,7 +476,10 @@ export type SyncLinearDataWithPropertiesWithMetadata = {
   };
 };
 
-export type UsesUserSecret = LinkEntity<UsesUserSecretProperties>;
+export type UsesUserSecret = {
+  properties: UsesUserSecretProperties;
+  propertiesWithMetadata: UsesUserSecretPropertiesWithMetadata;
+};
 
 export type UsesUserSecretOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/linkedinaccount.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/linkedinaccount.ts
@@ -3,7 +3,6 @@
  */
 
 import type { ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity } from "@local/hash-graph-sdk/entity";
 
 import type {
   ProfileURLPropertyValue,
@@ -29,7 +28,10 @@ export type {
   TextDataTypeWithMetadata,
 };
 
-export type LinkedInAccount = Entity<LinkedInAccountProperties>;
+export type LinkedInAccount = {
+  properties: LinkedInAccountProperties;
+  propertiesWithMetadata: LinkedInAccountPropertiesWithMetadata;
+};
 
 export type LinkedInAccountOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/linkedinaccount.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/linkedinaccount.ts
@@ -28,7 +28,11 @@ export type {
   TextDataTypeWithMetadata,
 };
 
+/**
+ * A LinkedIn account.
+ */
 export type LinkedInAccount = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/linkedin-account/v/1";
   properties: LinkedInAccountProperties;
   propertiesWithMetadata: LinkedInAccountPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/machine.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/machine.ts
@@ -3,7 +3,6 @@
  */
 
 import type { ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity } from "@local/hash-graph-sdk/entity";
 
 import type {
   Actor,
@@ -29,7 +28,10 @@ export type {
   TextDataTypeWithMetadata,
 };
 
-export type Machine = Entity<MachineProperties>;
+export type Machine = {
+  properties: MachineProperties;
+  propertiesWithMetadata: MachinePropertiesWithMetadata;
+};
 
 /**
  * A unique identifier for a machine

--- a/libs/@local/hash-isomorphic-utils/src/system-types/machine.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/machine.ts
@@ -28,7 +28,11 @@ export type {
   TextDataTypeWithMetadata,
 };
 
+/**
+ * A machine that can perform actions in the system
+ */
 export type Machine = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/machine/v/2";
   properties: MachineProperties;
   propertiesWithMetadata: MachinePropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/mentionnotification.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/mentionnotification.ts
@@ -516,7 +516,11 @@ export type {
   WebsiteURLPropertyValueWithMetadata,
 };
 
+/**
+ * A notification that a user was mentioned somewhere.
+ */
 export type MentionNotification = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/mention-notification/v/5";
   properties: MentionNotificationProperties;
   propertiesWithMetadata: MentionNotificationPropertiesWithMetadata;
 };
@@ -575,7 +579,11 @@ export type MentionNotificationTriggeredByUserLink = {
   rightEntity: User;
 };
 
+/**
+ * A comment that something occurred in.
+ */
 export type OccurredInComment = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/occurred-in-comment/v/1";
   properties: OccurredInCommentProperties;
   propertiesWithMetadata: OccurredInCommentPropertiesWithMetadata;
 };
@@ -598,7 +606,11 @@ export type OccurredInCommentPropertiesWithMetadata = {
   value: {};
 };
 
+/**
+ * Text that something occurred in.
+ */
 export type OccurredInText = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/occurred-in-text/v/1";
   properties: OccurredInTextProperties;
   propertiesWithMetadata: OccurredInTextPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/mentionnotification.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/mentionnotification.ts
@@ -3,7 +3,6 @@
  */
 
 import type { ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity, LinkEntity } from "@local/hash-graph-sdk/entity";
 
 import type {
   Actor,
@@ -517,7 +516,10 @@ export type {
   WebsiteURLPropertyValueWithMetadata,
 };
 
-export type MentionNotification = Entity<MentionNotificationProperties>;
+export type MentionNotification = {
+  properties: MentionNotificationProperties;
+  propertiesWithMetadata: MentionNotificationPropertiesWithMetadata;
+};
 
 export type MentionNotificationOccurredInBlockLink = {
   linkEntity: OccurredInBlock;
@@ -573,7 +575,10 @@ export type MentionNotificationTriggeredByUserLink = {
   rightEntity: User;
 };
 
-export type OccurredInComment = LinkEntity<OccurredInCommentProperties>;
+export type OccurredInComment = {
+  properties: OccurredInCommentProperties;
+  propertiesWithMetadata: OccurredInCommentPropertiesWithMetadata;
+};
 
 export type OccurredInCommentOutgoingLinkAndTarget = never;
 
@@ -593,7 +598,10 @@ export type OccurredInCommentPropertiesWithMetadata = {
   value: {};
 };
 
-export type OccurredInText = LinkEntity<OccurredInTextProperties>;
+export type OccurredInText = {
+  properties: OccurredInTextProperties;
+  propertiesWithMetadata: OccurredInTextPropertiesWithMetadata;
+};
 
 export type OccurredInTextOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/pdfdocument.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/pdfdocument.ts
@@ -3,7 +3,6 @@
  */
 
 import type { ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity } from "@local/hash-graph-sdk/entity";
 
 import type {
   BooleanDataType,
@@ -123,7 +122,10 @@ export type {
   UploadCompletedAtPropertyValueWithMetadata,
 };
 
-export type PDFDocument = Entity<PDFDocumentProperties>;
+export type PDFDocument = {
+  properties: PDFDocumentProperties;
+  propertiesWithMetadata: PDFDocumentPropertiesWithMetadata;
+};
 
 export type PDFDocumentOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/pdfdocument.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/pdfdocument.ts
@@ -122,7 +122,11 @@ export type {
   UploadCompletedAtPropertyValueWithMetadata,
 };
 
+/**
+ * A PDF document.
+ */
 export type PDFDocument = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/pdf-document/v/1";
   properties: PDFDocumentProperties;
   propertiesWithMetadata: PDFDocumentPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/pptxpresentation.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/pptxpresentation.ts
@@ -3,7 +3,6 @@
  */
 
 import type { ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity } from "@local/hash-graph-sdk/entity";
 
 import type {
   BooleanDataType,
@@ -123,7 +122,10 @@ export type {
   UploadCompletedAtPropertyValueWithMetadata,
 };
 
-export type PPTXPresentation = Entity<PPTXPresentationProperties>;
+export type PPTXPresentation = {
+  properties: PPTXPresentationProperties;
+  propertiesWithMetadata: PPTXPresentationPropertiesWithMetadata;
+};
 
 export type PPTXPresentationOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/pptxpresentation.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/pptxpresentation.ts
@@ -122,7 +122,11 @@ export type {
   UploadCompletedAtPropertyValueWithMetadata,
 };
 
+/**
+ * A Microsoft PowerPoint presentation.
+ */
 export type PPTXPresentation = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/pptx-presentation/v/1";
   properties: PPTXPresentationProperties;
   propertiesWithMetadata: PPTXPresentationPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/prospectiveuser.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/prospectiveuser.ts
@@ -3,7 +3,6 @@
  */
 
 import type { ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity } from "@local/hash-graph-sdk/entity";
 
 import type {
   EmailPropertyValue,
@@ -37,7 +36,10 @@ export type IntendedUsePropertyValue = TextDataType;
 
 export type IntendedUsePropertyValueWithMetadata = TextDataTypeWithMetadata;
 
-export type ProspectiveUser = Entity<ProspectiveUserProperties>;
+export type ProspectiveUser = {
+  properties: ProspectiveUserProperties;
+  propertiesWithMetadata: ProspectiveUserPropertiesWithMetadata;
+};
 
 export type ProspectiveUserOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/prospectiveuser.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/prospectiveuser.ts
@@ -36,7 +36,11 @@ export type IntendedUsePropertyValue = TextDataType;
 
 export type IntendedUsePropertyValueWithMetadata = TextDataTypeWithMetadata;
 
+/**
+ * Information about a prospective user of an application or system
+ */
 export type ProspectiveUser = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/prospective-user/v/1";
   properties: ProspectiveUserProperties;
   propertiesWithMetadata: ProspectiveUserPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/quicknote.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/quicknote.ts
@@ -82,7 +82,11 @@ export type {
   TextDataTypeWithMetadata,
 };
 
+/**
+ * A (usually) quick or short note.
+ */
 export type QuickNote = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/quick-note/v/1";
   properties: QuickNoteProperties;
   propertiesWithMetadata: QuickNotePropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/quicknote.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/quicknote.ts
@@ -3,7 +3,6 @@
  */
 
 import type { ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity } from "@local/hash-graph-sdk/entity";
 
 import type {
   ArchivedPropertyValue,
@@ -83,7 +82,10 @@ export type {
   TextDataTypeWithMetadata,
 };
 
-export type QuickNote = Entity<QuickNoteProperties>;
+export type QuickNote = {
+  properties: QuickNoteProperties;
+  propertiesWithMetadata: QuickNotePropertiesWithMetadata;
+};
 
 export type QuickNoteHasIndexedContentLink = {
   linkEntity: HasIndexedContent;

--- a/libs/@local/hash-isomorphic-utils/src/system-types/shared.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/shared.ts
@@ -10,7 +10,11 @@ import type {
 import type { Entity } from "@local/hash-graph-sdk/entity";
 import type { Confidence } from "@local/hash-graph-types/entity";
 
+/**
+ * Someone or something that can perform actions in the system
+ */
 export type Actor = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/actor/v/2";
   properties: ActorProperties;
   propertiesWithMetadata: ActorPropertiesWithMetadata;
 };
@@ -55,7 +59,11 @@ export type ArchivedPropertyValue = BooleanDataType;
 
 export type ArchivedPropertyValueWithMetadata = BooleanDataTypeWithMetadata;
 
+/**
+ * What or whom something was authored by.
+ */
 export type AuthoredBy = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/authored-by/v/1";
   properties: AuthoredByProperties;
   propertiesWithMetadata: AuthoredByPropertiesWithMetadata;
 };
@@ -86,12 +94,20 @@ export type AutomaticInferenceConfigurationPropertyValue = ObjectDataType;
 export type AutomaticInferenceConfigurationPropertyValueWithMetadata =
   ObjectDataTypeWithMetadata;
 
+/**
+ * A block that displays or otherwise uses data, part of a wider page or collection.
+ */
 export type Block = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/block/v/1";
   properties: BlockProperties;
   propertiesWithMetadata: BlockPropertiesWithMetadata;
 };
 
+/**
+ * A collection of blocks.
+ */
 export type BlockCollection = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/block-collection/v/1";
   properties: BlockCollectionProperties;
   propertiesWithMetadata: BlockCollectionPropertiesWithMetadata;
 };
@@ -147,7 +163,11 @@ export type BooleanDataTypeMetadata = {
   dataTypeId: "https://blockprotocol.org/@blockprotocol/types/data-type/boolean/v/1";
 };
 
+/**
+ * Settings for the HASH browser plugin
+ */
 export type BrowserPluginSettings = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/browser-plugin-settings/v/1";
   properties: BrowserPluginSettingsProperties;
   propertiesWithMetadata: BrowserPluginSettingsPropertiesWithMetadata;
 };
@@ -184,7 +204,11 @@ export type BrowserPluginTabPropertyValue = TextDataType;
 export type BrowserPluginTabPropertyValueWithMetadata =
   TextDataTypeWithMetadata;
 
+/**
+ * Comment associated with the issue.
+ */
 export type Comment = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/comment/v/5";
   properties: CommentProperties;
   propertiesWithMetadata: CommentPropertiesWithMetadata;
 };
@@ -279,7 +303,11 @@ export type DisplayNamePropertyValue = TextDataType;
 
 export type DisplayNamePropertyValueWithMetadata = TextDataTypeWithMetadata;
 
+/**
+ * A document file.
+ */
 export type DocumentFile = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/document-file/v/1";
   properties: DocumentFileProperties;
   propertiesWithMetadata: DocumentFilePropertiesWithMetadata;
 };
@@ -351,7 +379,11 @@ export type FeatureNamePropertyValue = TextDataType;
 
 export type FeatureNamePropertyValueWithMetadata = TextDataTypeWithMetadata;
 
+/**
+ * A file hosted at a URL
+ */
 export type File = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/file/v/2";
   properties: FileProperties;
   propertiesWithMetadata: FilePropertiesWithMetadata;
 };
@@ -489,7 +521,11 @@ export type FlowDefinitionIDPropertyValue = TextDataType;
 export type FlowDefinitionIDPropertyValueWithMetadata =
   TextDataTypeWithMetadata;
 
+/**
+ * An execution run of a flow.
+ */
 export type FlowRun = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/flow-run/v/1";
   properties: FlowRunProperties;
   propertiesWithMetadata: FlowRunPropertiesWithMetadata;
 };
@@ -527,12 +563,20 @@ export type FractionalIndexPropertyValue = TextDataType;
 
 export type FractionalIndexPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
+/**
+ * Something that something has
+ */
 export type Has = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/has/v/1";
   properties: HasProperties;
   propertiesWithMetadata: HasPropertiesWithMetadata;
 };
 
+/**
+ * The avatar something has.
+ */
 export type HasAvatar = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/has-avatar/v/1";
   properties: HasAvatarProperties;
   propertiesWithMetadata: HasAvatarPropertiesWithMetadata;
 };
@@ -554,7 +598,11 @@ export type HasAvatarPropertiesWithMetadata = {
   value: {};
 };
 
+/**
+ * The biography something has.
+ */
 export type HasBio = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/has-bio/v/1";
   properties: HasBioProperties;
   propertiesWithMetadata: HasBioPropertiesWithMetadata;
 };
@@ -576,7 +624,11 @@ export type HasBioPropertiesWithMetadata = {
   value: {};
 };
 
+/**
+ * The cover image something has.
+ */
 export type HasCoverImage = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/has-cover-image/v/1";
   properties: HasCoverImageProperties;
   propertiesWithMetadata: HasCoverImagePropertiesWithMetadata;
 };
@@ -599,7 +651,11 @@ export type HasCoverImagePropertiesWithMetadata = {
   value: {};
 };
 
+/**
+ * The data that something has.
+ */
 export type HasData = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/has-data/v/1";
   properties: HasDataProperties;
   propertiesWithMetadata: HasDataPropertiesWithMetadata;
 };
@@ -621,7 +677,11 @@ export type HasDataPropertiesWithMetadata = {
   value: {};
 };
 
+/**
+ * Something contained at an index by something
+ */
 export type HasIndexedContent = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/has-indexed-content/v/1";
   properties: HasIndexedContentProperties;
   propertiesWithMetadata: HasIndexedContentPropertiesWithMetadata;
 };
@@ -652,7 +712,11 @@ export type HasOutgoingLinkAndTarget = never;
 
 export type HasOutgoingLinksByLinkEntityTypeId = {};
 
+/**
+ * The parent something has.
+ */
 export type HasParent = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/has-parent/v/1";
   properties: HasParentProperties;
   propertiesWithMetadata: HasParentPropertiesWithMetadata;
 };
@@ -687,7 +751,11 @@ export type HasPropertiesWithMetadata = {
   value: {};
 };
 
+/**
+ * The service account something has.
+ */
 export type HasServiceAccount = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/has-service-account/v/1";
   properties: HasServiceAccountProperties;
   propertiesWithMetadata: HasServiceAccountPropertiesWithMetadata;
 };
@@ -710,7 +778,11 @@ export type HasServiceAccountPropertiesWithMetadata = {
   value: {};
 };
 
+/**
+ * The text something has.
+ */
 export type HasText = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/has-text/v/1";
   properties: HasTextProperties;
   propertiesWithMetadata: HasTextPropertiesWithMetadata;
 };
@@ -739,7 +811,11 @@ export type IconPropertyValue = TextDataType;
 
 export type IconPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
+/**
+ * An image file hosted at a URL
+ */
 export type Image = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/image/v/2";
   properties: ImageProperties;
   propertiesWithMetadata: ImagePropertiesWithMetadata;
 };
@@ -768,7 +844,11 @@ export type InputUnitCostPropertyValue = NumberDataType;
 
 export type InputUnitCostPropertyValueWithMetadata = NumberDataTypeWithMetadata;
 
+/**
+ * Something that someone or something is a member of.
+ */
 export type IsMemberOf = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/is-member-of/v/1";
   properties: IsMemberOfProperties;
   propertiesWithMetadata: IsMemberOfPropertiesWithMetadata;
 };
@@ -799,7 +879,11 @@ export type KratosIdentityIdPropertyValue = TextDataType;
 export type KratosIdentityIdPropertyValueWithMetadata =
   TextDataTypeWithMetadata;
 
+/**
+ * undefined
+ */
 export type Link = {
+  entityTypeId: "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1";
   properties: LinkProperties;
   propertiesWithMetadata: LinkPropertiesWithMetadata;
 };
@@ -846,7 +930,11 @@ export type NamePropertyValue = TextDataType;
 
 export type NamePropertyValueWithMetadata = TextDataTypeWithMetadata;
 
+/**
+ * A notification to a user.
+ */
 export type Notification = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/notification/v/1";
   properties: NotificationProperties;
   propertiesWithMetadata: NotificationPropertiesWithMetadata;
 };
@@ -901,7 +989,11 @@ export type ObjectDataTypeMetadata = {
   dataTypeId: "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1";
 };
 
+/**
+ * A block that something occurred in.
+ */
 export type OccurredInBlock = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/occurred-in-block/v/1";
   properties: OccurredInBlockProperties;
   propertiesWithMetadata: OccurredInBlockPropertiesWithMetadata;
 };
@@ -924,7 +1016,11 @@ export type OccurredInBlockPropertiesWithMetadata = {
   value: {};
 };
 
+/**
+ * An entity that something occurred in.
+ */
 export type OccurredInEntity = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/occurred-in-entity/v/2";
   properties: OccurredInEntityProperties;
   propertiesWithMetadata: OccurredInEntityPropertiesWithMetadata;
 };
@@ -951,7 +1047,11 @@ export type OccurredInEntityPropertiesWithMetadata = {
   };
 };
 
+/**
+ * An organization. Organizations are root-level objects that contain user accounts and teams.
+ */
 export type Organization = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/organization/v/2";
   properties: OrganizationProperties;
   propertiesWithMetadata: OrganizationPropertiesWithMetadata;
 };
@@ -1084,7 +1184,11 @@ export type OutputsPropertyValueWithMetadata = {
   metadata?: ArrayMetadata;
 };
 
+/**
+ * A page for displaying and potentially interacting with data.
+ */
 export type Page = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/page/v/1";
   properties: PageProperties;
   propertiesWithMetadata: PagePropertiesWithMetadata;
 };
@@ -1138,7 +1242,11 @@ export type PreferredPronounsPropertyValue = TextDataType;
 export type PreferredPronounsPropertyValueWithMetadata =
   TextDataTypeWithMetadata;
 
+/**
+ * A presentation file.
+ */
 export type PresentationFile = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/presentation-file/v/1";
   properties: PresentationFileProperties;
   propertiesWithMetadata: PresentationFilePropertiesWithMetadata;
 };
@@ -1165,7 +1273,11 @@ export type PresentationFilePropertiesWithMetadata = {
   };
 };
 
+/**
+ * A biography for display on someone or something's profile.
+ */
 export type ProfileBio = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/profile-bio/v/1";
   properties: ProfileBioProperties;
   propertiesWithMetadata: ProfileBioPropertiesWithMetadata;
 };
@@ -1216,7 +1328,11 @@ export type ResolvedAtPropertyValue = TextDataType;
 
 export type ResolvedAtPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
+/**
+ * A service account.
+ */
 export type ServiceAccount = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/service-account/v/1";
   properties: ServiceAccountProperties;
   propertiesWithMetadata: ServiceAccountPropertiesWithMetadata;
 };
@@ -1239,7 +1355,11 @@ export type ServiceAccountPropertiesWithMetadata = {
   };
 };
 
+/**
+ * A feature of a service
+ */
 export type ServiceFeature = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/service-feature/v/1";
   properties: ServiceFeatureProperties;
   propertiesWithMetadata: ServiceFeaturePropertiesWithMetadata;
 };
@@ -1320,7 +1440,11 @@ export type SummaryPropertyValue = TextDataType;
 
 export type SummaryPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
+/**
+ * An ordered sequence of characters.
+ */
 export type Text = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/text/v/1";
   properties: TextProperties;
   propertiesWithMetadata: TextPropertiesWithMetadata;
 };
@@ -1401,7 +1525,11 @@ export type TriggerPropertyValueWithMetadata = {
   };
 };
 
+/**
+ * A user that triggered something.
+ */
 export type TriggeredByUser = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/triggered-by-user/v/1";
   properties: TriggeredByUserProperties;
   propertiesWithMetadata: TriggeredByUserPropertiesWithMetadata;
 };
@@ -1432,7 +1560,11 @@ export type UploadCompletedAtPropertyValue = DateTimeDataType;
 export type UploadCompletedAtPropertyValueWithMetadata =
   DateTimeDataTypeWithMetadata;
 
+/**
+ * A user of the HASH application.
+ */
 export type User = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/user/v/5";
   properties: UserProperties;
   propertiesWithMetadata: UserPropertiesWithMetadata;
 };
@@ -1541,7 +1673,11 @@ export type UserPropertiesWithMetadata = {
   };
 };
 
+/**
+ * A secret or credential belonging to a user.
+ */
 export type UserSecret = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/user-secret/v/1";
   properties: UserSecretProperties;
   propertiesWithMetadata: UserSecretPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/shared.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/shared.ts
@@ -7,10 +7,13 @@ import type {
   ObjectMetadata,
   PropertyProvenance,
 } from "@local/hash-graph-client";
-import type { Entity, LinkEntity } from "@local/hash-graph-sdk/entity";
+import type { Entity } from "@local/hash-graph-sdk/entity";
 import type { Confidence } from "@local/hash-graph-types/entity";
 
-export type Actor = Entity<ActorProperties>;
+export type Actor = {
+  properties: ActorProperties;
+  propertiesWithMetadata: ActorPropertiesWithMetadata;
+};
 
 export type ActorOutgoingLinkAndTarget = never;
 
@@ -52,7 +55,10 @@ export type ArchivedPropertyValue = BooleanDataType;
 
 export type ArchivedPropertyValueWithMetadata = BooleanDataTypeWithMetadata;
 
-export type AuthoredBy = LinkEntity<AuthoredByProperties>;
+export type AuthoredBy = {
+  properties: AuthoredByProperties;
+  propertiesWithMetadata: AuthoredByPropertiesWithMetadata;
+};
 
 export type AuthoredByOutgoingLinkAndTarget = never;
 
@@ -80,9 +86,15 @@ export type AutomaticInferenceConfigurationPropertyValue = ObjectDataType;
 export type AutomaticInferenceConfigurationPropertyValueWithMetadata =
   ObjectDataTypeWithMetadata;
 
-export type Block = Entity<BlockProperties>;
+export type Block = {
+  properties: BlockProperties;
+  propertiesWithMetadata: BlockPropertiesWithMetadata;
+};
 
-export type BlockCollection = Entity<BlockCollectionProperties>;
+export type BlockCollection = {
+  properties: BlockCollectionProperties;
+  propertiesWithMetadata: BlockCollectionPropertiesWithMetadata;
+};
 
 export type BlockCollectionOutgoingLinkAndTarget = never;
 
@@ -135,7 +147,10 @@ export type BooleanDataTypeMetadata = {
   dataTypeId: "https://blockprotocol.org/@blockprotocol/types/data-type/boolean/v/1";
 };
 
-export type BrowserPluginSettings = Entity<BrowserPluginSettingsProperties>;
+export type BrowserPluginSettings = {
+  properties: BrowserPluginSettingsProperties;
+  propertiesWithMetadata: BrowserPluginSettingsPropertiesWithMetadata;
+};
 
 export type BrowserPluginSettingsOutgoingLinkAndTarget = never;
 
@@ -169,7 +184,10 @@ export type BrowserPluginTabPropertyValue = TextDataType;
 export type BrowserPluginTabPropertyValueWithMetadata =
   TextDataTypeWithMetadata;
 
-export type Comment = Entity<CommentProperties>;
+export type Comment = {
+  properties: CommentProperties;
+  propertiesWithMetadata: CommentPropertiesWithMetadata;
+};
 
 export type CommentAuthoredByLink = {
   linkEntity: AuthoredBy;
@@ -261,7 +279,10 @@ export type DisplayNamePropertyValue = TextDataType;
 
 export type DisplayNamePropertyValueWithMetadata = TextDataTypeWithMetadata;
 
-export type DocumentFile = Entity<DocumentFileProperties>;
+export type DocumentFile = {
+  properties: DocumentFileProperties;
+  propertiesWithMetadata: DocumentFilePropertiesWithMetadata;
+};
 
 export type DocumentFileOutgoingLinkAndTarget = never;
 
@@ -330,7 +351,10 @@ export type FeatureNamePropertyValue = TextDataType;
 
 export type FeatureNamePropertyValueWithMetadata = TextDataTypeWithMetadata;
 
-export type File = Entity<FileProperties>;
+export type File = {
+  properties: FileProperties;
+  propertiesWithMetadata: FilePropertiesWithMetadata;
+};
 
 /**
  * A unique signature derived from a file's contents
@@ -465,7 +489,10 @@ export type FlowDefinitionIDPropertyValue = TextDataType;
 export type FlowDefinitionIDPropertyValueWithMetadata =
   TextDataTypeWithMetadata;
 
-export type FlowRun = Entity<FlowRunProperties>;
+export type FlowRun = {
+  properties: FlowRunProperties;
+  propertiesWithMetadata: FlowRunPropertiesWithMetadata;
+};
 
 export type FlowRunOutgoingLinkAndTarget = never;
 
@@ -500,9 +527,15 @@ export type FractionalIndexPropertyValue = TextDataType;
 
 export type FractionalIndexPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
-export type Has = LinkEntity<HasProperties>;
+export type Has = {
+  properties: HasProperties;
+  propertiesWithMetadata: HasPropertiesWithMetadata;
+};
 
-export type HasAvatar = LinkEntity<HasAvatarProperties>;
+export type HasAvatar = {
+  properties: HasAvatarProperties;
+  propertiesWithMetadata: HasAvatarPropertiesWithMetadata;
+};
 
 export type HasAvatarOutgoingLinkAndTarget = never;
 
@@ -521,7 +554,10 @@ export type HasAvatarPropertiesWithMetadata = {
   value: {};
 };
 
-export type HasBio = LinkEntity<HasBioProperties>;
+export type HasBio = {
+  properties: HasBioProperties;
+  propertiesWithMetadata: HasBioPropertiesWithMetadata;
+};
 
 export type HasBioOutgoingLinkAndTarget = never;
 
@@ -540,7 +576,10 @@ export type HasBioPropertiesWithMetadata = {
   value: {};
 };
 
-export type HasCoverImage = LinkEntity<HasCoverImageProperties>;
+export type HasCoverImage = {
+  properties: HasCoverImageProperties;
+  propertiesWithMetadata: HasCoverImagePropertiesWithMetadata;
+};
 
 export type HasCoverImageOutgoingLinkAndTarget = never;
 
@@ -560,7 +599,10 @@ export type HasCoverImagePropertiesWithMetadata = {
   value: {};
 };
 
-export type HasData = LinkEntity<HasDataProperties>;
+export type HasData = {
+  properties: HasDataProperties;
+  propertiesWithMetadata: HasDataPropertiesWithMetadata;
+};
 
 export type HasDataOutgoingLinkAndTarget = never;
 
@@ -579,7 +621,10 @@ export type HasDataPropertiesWithMetadata = {
   value: {};
 };
 
-export type HasIndexedContent = LinkEntity<HasIndexedContentProperties>;
+export type HasIndexedContent = {
+  properties: HasIndexedContentProperties;
+  propertiesWithMetadata: HasIndexedContentPropertiesWithMetadata;
+};
 
 export type HasIndexedContentOutgoingLinkAndTarget = never;
 
@@ -607,7 +652,10 @@ export type HasOutgoingLinkAndTarget = never;
 
 export type HasOutgoingLinksByLinkEntityTypeId = {};
 
-export type HasParent = LinkEntity<HasParentProperties>;
+export type HasParent = {
+  properties: HasParentProperties;
+  propertiesWithMetadata: HasParentPropertiesWithMetadata;
+};
 
 export type HasParentOutgoingLinkAndTarget = never;
 
@@ -639,7 +687,10 @@ export type HasPropertiesWithMetadata = {
   value: {};
 };
 
-export type HasServiceAccount = LinkEntity<HasServiceAccountProperties>;
+export type HasServiceAccount = {
+  properties: HasServiceAccountProperties;
+  propertiesWithMetadata: HasServiceAccountPropertiesWithMetadata;
+};
 
 export type HasServiceAccountOutgoingLinkAndTarget = never;
 
@@ -659,7 +710,10 @@ export type HasServiceAccountPropertiesWithMetadata = {
   value: {};
 };
 
-export type HasText = LinkEntity<HasTextProperties>;
+export type HasText = {
+  properties: HasTextProperties;
+  propertiesWithMetadata: HasTextPropertiesWithMetadata;
+};
 
 export type HasTextOutgoingLinkAndTarget = never;
 
@@ -685,7 +739,10 @@ export type IconPropertyValue = TextDataType;
 
 export type IconPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
-export type Image = Entity<ImageProperties>;
+export type Image = {
+  properties: ImageProperties;
+  propertiesWithMetadata: ImagePropertiesWithMetadata;
+};
 
 export type ImageOutgoingLinkAndTarget = never;
 
@@ -711,7 +768,10 @@ export type InputUnitCostPropertyValue = NumberDataType;
 
 export type InputUnitCostPropertyValueWithMetadata = NumberDataTypeWithMetadata;
 
-export type IsMemberOf = LinkEntity<IsMemberOfProperties>;
+export type IsMemberOf = {
+  properties: IsMemberOfProperties;
+  propertiesWithMetadata: IsMemberOfPropertiesWithMetadata;
+};
 
 export type IsMemberOfOutgoingLinkAndTarget = never;
 
@@ -739,7 +799,10 @@ export type KratosIdentityIdPropertyValue = TextDataType;
 export type KratosIdentityIdPropertyValueWithMetadata =
   TextDataTypeWithMetadata;
 
-export type Link = Entity<LinkProperties>;
+export type Link = {
+  properties: LinkProperties;
+  propertiesWithMetadata: LinkPropertiesWithMetadata;
+};
 
 export type LinkOutgoingLinkAndTarget = never;
 
@@ -783,7 +846,10 @@ export type NamePropertyValue = TextDataType;
 
 export type NamePropertyValueWithMetadata = TextDataTypeWithMetadata;
 
-export type Notification = Entity<NotificationProperties>;
+export type Notification = {
+  properties: NotificationProperties;
+  propertiesWithMetadata: NotificationPropertiesWithMetadata;
+};
 
 export type NotificationOutgoingLinkAndTarget = never;
 
@@ -835,7 +901,10 @@ export type ObjectDataTypeMetadata = {
   dataTypeId: "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1";
 };
 
-export type OccurredInBlock = LinkEntity<OccurredInBlockProperties>;
+export type OccurredInBlock = {
+  properties: OccurredInBlockProperties;
+  propertiesWithMetadata: OccurredInBlockPropertiesWithMetadata;
+};
 
 export type OccurredInBlockOutgoingLinkAndTarget = never;
 
@@ -855,7 +924,10 @@ export type OccurredInBlockPropertiesWithMetadata = {
   value: {};
 };
 
-export type OccurredInEntity = LinkEntity<OccurredInEntityProperties>;
+export type OccurredInEntity = {
+  properties: OccurredInEntityProperties;
+  propertiesWithMetadata: OccurredInEntityPropertiesWithMetadata;
+};
 
 export type OccurredInEntityOutgoingLinkAndTarget = never;
 
@@ -879,7 +951,10 @@ export type OccurredInEntityPropertiesWithMetadata = {
   };
 };
 
-export type Organization = Entity<OrganizationProperties>;
+export type Organization = {
+  properties: OrganizationProperties;
+  propertiesWithMetadata: OrganizationPropertiesWithMetadata;
+};
 
 export type OrganizationHasAvatarLink = {
   linkEntity: HasAvatar;
@@ -1009,7 +1084,10 @@ export type OutputsPropertyValueWithMetadata = {
   metadata?: ArrayMetadata;
 };
 
-export type Page = Entity<PageProperties>;
+export type Page = {
+  properties: PageProperties;
+  propertiesWithMetadata: PagePropertiesWithMetadata;
+};
 
 export type PageHasParentLink = { linkEntity: HasParent; rightEntity: Page };
 
@@ -1060,7 +1138,10 @@ export type PreferredPronounsPropertyValue = TextDataType;
 export type PreferredPronounsPropertyValueWithMetadata =
   TextDataTypeWithMetadata;
 
-export type PresentationFile = Entity<PresentationFileProperties>;
+export type PresentationFile = {
+  properties: PresentationFileProperties;
+  propertiesWithMetadata: PresentationFilePropertiesWithMetadata;
+};
 
 export type PresentationFileOutgoingLinkAndTarget = never;
 
@@ -1084,7 +1165,10 @@ export type PresentationFilePropertiesWithMetadata = {
   };
 };
 
-export type ProfileBio = Entity<ProfileBioProperties>;
+export type ProfileBio = {
+  properties: ProfileBioProperties;
+  propertiesWithMetadata: ProfileBioPropertiesWithMetadata;
+};
 
 export type ProfileBioHasIndexedContentLink = {
   linkEntity: HasIndexedContent;
@@ -1132,7 +1216,10 @@ export type ResolvedAtPropertyValue = TextDataType;
 
 export type ResolvedAtPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
-export type ServiceAccount = Entity<ServiceAccountProperties>;
+export type ServiceAccount = {
+  properties: ServiceAccountProperties;
+  propertiesWithMetadata: ServiceAccountPropertiesWithMetadata;
+};
 
 export type ServiceAccountOutgoingLinkAndTarget = never;
 
@@ -1152,7 +1239,10 @@ export type ServiceAccountPropertiesWithMetadata = {
   };
 };
 
-export type ServiceFeature = Entity<ServiceFeatureProperties>;
+export type ServiceFeature = {
+  properties: ServiceFeatureProperties;
+  propertiesWithMetadata: ServiceFeaturePropertiesWithMetadata;
+};
 
 export type ServiceFeatureOutgoingLinkAndTarget = never;
 
@@ -1230,7 +1320,10 @@ export type SummaryPropertyValue = TextDataType;
 
 export type SummaryPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
-export type Text = Entity<TextProperties>;
+export type Text = {
+  properties: TextProperties;
+  propertiesWithMetadata: TextPropertiesWithMetadata;
+};
 
 /**
  * An ordered sequence of characters
@@ -1308,7 +1401,10 @@ export type TriggerPropertyValueWithMetadata = {
   };
 };
 
-export type TriggeredByUser = LinkEntity<TriggeredByUserProperties>;
+export type TriggeredByUser = {
+  properties: TriggeredByUserProperties;
+  propertiesWithMetadata: TriggeredByUserPropertiesWithMetadata;
+};
 
 export type TriggeredByUserOutgoingLinkAndTarget = never;
 
@@ -1336,7 +1432,10 @@ export type UploadCompletedAtPropertyValue = DateTimeDataType;
 export type UploadCompletedAtPropertyValueWithMetadata =
   DateTimeDataTypeWithMetadata;
 
-export type User = Entity<UserProperties>;
+export type User = {
+  properties: UserProperties;
+  propertiesWithMetadata: UserPropertiesWithMetadata;
+};
 
 export type UserHasAvatarLink = { linkEntity: HasAvatar; rightEntity: Image };
 
@@ -1442,7 +1541,10 @@ export type UserPropertiesWithMetadata = {
   };
 };
 
-export type UserSecret = Entity<UserSecretProperties>;
+export type UserSecret = {
+  properties: UserSecretProperties;
+  propertiesWithMetadata: UserSecretPropertiesWithMetadata;
+};
 
 export type UserSecretOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/spreadsheetfile.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/spreadsheetfile.ts
@@ -3,7 +3,6 @@
  */
 
 import type { ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity } from "@local/hash-graph-sdk/entity";
 
 import type {
   BooleanDataType,
@@ -105,7 +104,10 @@ export type {
   UploadCompletedAtPropertyValueWithMetadata,
 };
 
-export type SpreadsheetFile = Entity<SpreadsheetFileProperties>;
+export type SpreadsheetFile = {
+  properties: SpreadsheetFileProperties;
+  propertiesWithMetadata: SpreadsheetFilePropertiesWithMetadata;
+};
 
 export type SpreadsheetFileOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/spreadsheetfile.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/spreadsheetfile.ts
@@ -104,7 +104,11 @@ export type {
   UploadCompletedAtPropertyValueWithMetadata,
 };
 
+/**
+ * A spreadsheet file.
+ */
 export type SpreadsheetFile = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/spreadsheet-file/v/1";
   properties: SpreadsheetFileProperties;
   propertiesWithMetadata: SpreadsheetFilePropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/tiktokaccount.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/tiktokaccount.ts
@@ -28,7 +28,11 @@ export type {
   TextDataTypeWithMetadata,
 };
 
+/**
+ * A TikTok account.
+ */
 export type TikTokAccount = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/tiktok-account/v/1";
   properties: TikTokAccountProperties;
   propertiesWithMetadata: TikTokAccountPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/tiktokaccount.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/tiktokaccount.ts
@@ -3,7 +3,6 @@
  */
 
 import type { ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity } from "@local/hash-graph-sdk/entity";
 
 import type {
   ProfileURLPropertyValue,
@@ -29,7 +28,10 @@ export type {
   TextDataTypeWithMetadata,
 };
 
-export type TikTokAccount = Entity<TikTokAccountProperties>;
+export type TikTokAccount = {
+  properties: TikTokAccountProperties;
+  propertiesWithMetadata: TikTokAccountPropertiesWithMetadata;
+};
 
 export type TikTokAccountOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/twitteraccount.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/twitteraccount.ts
@@ -28,7 +28,11 @@ export type {
   TextDataTypeWithMetadata,
 };
 
+/**
+ * A Twitter account.
+ */
 export type TwitterAccount = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/twitter-account/v/1";
   properties: TwitterAccountProperties;
   propertiesWithMetadata: TwitterAccountPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/twitteraccount.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/twitteraccount.ts
@@ -3,7 +3,6 @@
  */
 
 import type { ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity } from "@local/hash-graph-sdk/entity";
 
 import type {
   ProfileURLPropertyValue,
@@ -29,7 +28,10 @@ export type {
   TextDataTypeWithMetadata,
 };
 
-export type TwitterAccount = Entity<TwitterAccountProperties>;
+export type TwitterAccount = {
+  properties: TwitterAccountProperties;
+  propertiesWithMetadata: TwitterAccountPropertiesWithMetadata;
+};
 
 export type TwitterAccountOutgoingLinkAndTarget = never;
 

--- a/libs/@local/hash-isomorphic-utils/src/system-types/usagerecord.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/usagerecord.ts
@@ -3,7 +3,7 @@
  */
 
 import type { ObjectMetadata } from "@local/hash-graph-client";
-import type { Entity, LinkEntity } from "@local/hash-graph-sdk/entity";
+import type { Entity } from "@local/hash-graph-sdk/entity";
 
 import type {
   AppliesFromPropertyValue,
@@ -109,7 +109,10 @@ export type {
   TriggerPropertyValueWithMetadata,
 };
 
-export type Created = LinkEntity<CreatedProperties>;
+export type Created = {
+  properties: CreatedProperties;
+  propertiesWithMetadata: CreatedPropertiesWithMetadata;
+};
 
 export type CreatedOutgoingLinkAndTarget = never;
 
@@ -136,7 +139,10 @@ export type CustomMetadataPropertyValue = ObjectDataType;
 export type CustomMetadataPropertyValueWithMetadata =
   ObjectDataTypeWithMetadata;
 
-export type IncurredIn = LinkEntity<IncurredInProperties>;
+export type IncurredIn = {
+  properties: IncurredInProperties;
+  propertiesWithMetadata: IncurredInPropertiesWithMetadata;
+};
 
 export type IncurredInOutgoingLinkAndTarget = never;
 
@@ -172,7 +178,10 @@ export type OutputUnitCountPropertyValue = NumberDataType;
 export type OutputUnitCountPropertyValueWithMetadata =
   NumberDataTypeWithMetadata;
 
-export type RecordsUsageOf = LinkEntity<RecordsUsageOfProperties>;
+export type RecordsUsageOf = {
+  properties: RecordsUsageOfProperties;
+  propertiesWithMetadata: RecordsUsageOfPropertiesWithMetadata;
+};
 
 export type RecordsUsageOfOutgoingLinkAndTarget = never;
 
@@ -192,7 +201,10 @@ export type RecordsUsageOfPropertiesWithMetadata = {
   value: {};
 };
 
-export type Updated = LinkEntity<UpdatedProperties>;
+export type Updated = {
+  properties: UpdatedProperties;
+  propertiesWithMetadata: UpdatedPropertiesWithMetadata;
+};
 
 export type UpdatedOutgoingLinkAndTarget = never;
 
@@ -211,7 +223,10 @@ export type UpdatedPropertiesWithMetadata = {
   value: {};
 };
 
-export type UsageRecord = Entity<UsageRecordProperties>;
+export type UsageRecord = {
+  properties: UsageRecordProperties;
+  propertiesWithMetadata: UsageRecordPropertiesWithMetadata;
+};
 
 export type UsageRecordCreatedLink = {
   linkEntity: Created;

--- a/libs/@local/hash-isomorphic-utils/src/system-types/usagerecord.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/usagerecord.ts
@@ -109,7 +109,11 @@ export type {
   TriggerPropertyValueWithMetadata,
 };
 
+/**
+ * The thing that something created.
+ */
 export type Created = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/created/v/1";
   properties: CreatedProperties;
   propertiesWithMetadata: CreatedPropertiesWithMetadata;
 };
@@ -139,7 +143,11 @@ export type CustomMetadataPropertyValue = ObjectDataType;
 export type CustomMetadataPropertyValueWithMetadata =
   ObjectDataTypeWithMetadata;
 
+/**
+ * Something that was incurred in something else.
+ */
 export type IncurredIn = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/incurred-in/v/1";
   properties: IncurredInProperties;
   propertiesWithMetadata: IncurredInPropertiesWithMetadata;
 };
@@ -178,7 +186,11 @@ export type OutputUnitCountPropertyValue = NumberDataType;
 export type OutputUnitCountPropertyValueWithMetadata =
   NumberDataTypeWithMetadata;
 
+/**
+ * The thing that something records usage of.
+ */
 export type RecordsUsageOf = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/records-usage-of/v/1";
   properties: RecordsUsageOfProperties;
   propertiesWithMetadata: RecordsUsageOfPropertiesWithMetadata;
 };
@@ -201,7 +213,11 @@ export type RecordsUsageOfPropertiesWithMetadata = {
   value: {};
 };
 
+/**
+ * The thing that something created.
+ */
 export type Updated = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/updated/v/1";
   properties: UpdatedProperties;
   propertiesWithMetadata: UpdatedPropertiesWithMetadata;
 };
@@ -223,7 +239,11 @@ export type UpdatedPropertiesWithMetadata = {
   value: {};
 };
 
+/**
+ * A record of usage of a service
+ */
 export type UsageRecord = {
+  entityTypeId: "https://hash.ai/@hash/types/entity-type/usage-record/v/2";
   properties: UsageRecordProperties;
   propertiesWithMetadata: UsageRecordPropertiesWithMetadata;
 };

--- a/libs/@local/hash-isomorphic-utils/src/text.ts
+++ b/libs/@local/hash-isomorphic-utils/src/text.ts
@@ -1,7 +1,7 @@
 import type { TextToken } from "@local/hash-isomorphic-utils/types";
 import type { Node, Schema } from "prosemirror-model";
 
-import type { TextEntityType, TextProperties } from "./entity";
+import type { TextProperties } from "./entity";
 import { textualContentPropertyTypeBaseUrl } from "./entity-store";
 import type { ComponentNode } from "./prosemirror";
 
@@ -44,7 +44,7 @@ export const textBlockNodesFromTokens = (
   });
 
 export const childrenForTextEntity = (
-  entity: Pick<TextEntityType, "properties">,
+  entity: { properties: TextProperties },
   schema: Schema,
 ): Node[] =>
   textBlockNodesFromTokens(

--- a/libs/@local/hash-subgraph/src/types/subgraph.ts
+++ b/libs/@local/hash-subgraph/src/types/subgraph.ts
@@ -5,6 +5,7 @@ import {
 } from "@blockprotocol/graph";
 import type { Subtype } from "@local/advanced-types/subtype";
 import type { Entity, SerializedEntity } from "@local/hash-graph-sdk/entity";
+import type { EntityProperties } from "@local/hash-graph-types/entity";
 import type {
   DataTypeWithMetadata,
   EntityTypeWithMetadata,
@@ -50,9 +51,11 @@ export type EntityTypeRootType = Subtype<
   }
 >;
 
-export type EntityRootType = {
+export type EntityRootType<
+  Properties extends EntityProperties = EntityProperties,
+> = {
   vertexId: EntityVertexId;
-  element: Entity;
+  element: Entity<Properties>;
 };
 
 export type SubgraphRootType =

--- a/libs/@local/hash-subgraph/src/types/subgraph/vertices.ts
+++ b/libs/@local/hash-subgraph/src/types/subgraph/vertices.ts
@@ -13,7 +13,10 @@ import {
 } from "@blockprotocol/graph";
 import type { Subtype } from "@local/advanced-types/subtype";
 import type { Entity, SerializedEntity } from "@local/hash-graph-sdk/entity";
-import type { EntityId, PropertyObject } from "@local/hash-graph-types/entity";
+import type {
+  EntityId,
+  EntityProperties,
+} from "@local/hash-graph-types/entity";
 import type {
   BaseUrl,
   DataTypeWithMetadata,
@@ -47,7 +50,9 @@ export type EntityTypeVertex = Subtype<
   }
 >;
 
-export type EntityVertex<Properties extends PropertyObject = PropertyObject> = {
+export type EntityVertex<
+  Properties extends EntityProperties = EntityProperties,
+> = {
   kind: "entity";
   inner: Entity<Properties>;
 };

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/mention-notification.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/mention-notification.test.ts
@@ -34,7 +34,7 @@ import {
   systemEntityTypes,
   systemLinkEntityTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
-import type { TextProperties } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { Text as TextEntity } from "@local/hash-isomorphic-utils/system-types/shared";
 import type { TextToken } from "@local/hash-isomorphic-utils/types";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -273,7 +273,7 @@ describe.skip("Page Mention Notification", () => {
           },
         ],
       },
-    )) as Entity<TextProperties>;
+    )) as Entity<TextEntity>;
 
     /**
      * Notifications are created after the request is resolved, so we need to wait
@@ -333,7 +333,7 @@ describe.skip("Page Mention Notification", () => {
           },
         ],
       },
-    )) as Entity<TextProperties>;
+    )) as Entity<TextEntity>;
 
     /**
      * Notifications are created after the request is resolved, so we need to wait
@@ -447,7 +447,7 @@ describe.skip("Page Mention Notification", () => {
           },
         ],
       },
-    )) as Entity<TextProperties>;
+    )) as Entity<TextEntity>;
     commentText.textualContent = updatedCommentTextualContent;
 
     /**

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/page.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/page.test.ts
@@ -25,8 +25,8 @@ import type { OwnedById } from "@local/hash-graph-types/web";
 import { createDefaultAuthorizationRelationships } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import type {
-  HasIndexedContentProperties,
-  TextProperties,
+  HasIndexedContent,
+  Text as TextEntity,
 } from "@local/hash-isomorphic-utils/system-types/shared";
 import { generateKeyBetween } from "fractional-indexing";
 import { beforeAll, describe, expect, it } from "vitest";
@@ -69,7 +69,7 @@ describe("Page", () => {
       properties: {
         "https://blockprotocol.org/@blockprotocol/types/property-type/textual-content/":
           [],
-      } as TextProperties,
+      } as TextEntity["properties"],
       relationships: createDefaultAuthorizationRelationships({
         actorId: testUser.accountId,
       }),
@@ -192,13 +192,13 @@ describe("Page", () => {
   });
 
   let testBlock1: Block;
-  let testBlockLink1: LinkEntity<HasIndexedContentProperties>;
+  let testBlockLink1: LinkEntity<HasIndexedContent>;
 
   let testBlock2: Block;
-  let testBlockLink2: LinkEntity<HasIndexedContentProperties>;
+  let testBlockLink2: LinkEntity<HasIndexedContent>;
 
   let testBlock3: Block;
-  let testBlockLink3: LinkEntity<HasIndexedContentProperties>;
+  let testBlockLink3: LinkEntity<HasIndexedContent>;
 
   let firstKey: string;
 
@@ -229,7 +229,7 @@ describe("Page", () => {
     expect(existingBlocks).toHaveLength(1);
 
     testBlock1 = existingBlocks[0]!.rightEntity!;
-    testBlockLink1 = new LinkEntity<HasIndexedContentProperties>(
+    testBlockLink1 = new LinkEntity<HasIndexedContent>(
       existingBlocks[0]!.linkEntity,
     );
 
@@ -258,7 +258,7 @@ describe("Page", () => {
           },
         },
       },
-    )) as unknown as LinkEntity<HasIndexedContentProperties>;
+    )) as unknown as LinkEntity<HasIndexedContent>;
 
     testBlockLink3 = (await addBlockToBlockCollection(
       graphContext,
@@ -279,7 +279,7 @@ describe("Page", () => {
           },
         },
       },
-    )) as unknown as LinkEntity<HasIndexedContentProperties>;
+    )) as unknown as LinkEntity<HasIndexedContent>;
 
     const blocks = (
       await getPageBlocks(graphContext, authentication, {

--- a/tests/hash-playwright/tests/shared/api-queries.ts
+++ b/tests/hash-playwright/tests/shared/api-queries.ts
@@ -5,6 +5,7 @@ import type { OwnedById } from "@local/hash-graph-types/web";
 import { apiOrigin } from "@local/hash-isomorphic-utils/environment";
 import { deserializeSubgraph } from "@local/hash-isomorphic-utils/subgraph-mapping";
 import type { User } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { EntityRootType } from "@local/hash-subgraph";
 import { getRoots } from "@local/hash-subgraph/stdlib";
 import type { APIRequestContext } from "@playwright/test";
 import type { GraphQLError } from "graphql/error";
@@ -45,7 +46,9 @@ export const getUser = async (requestContext: APIRequestContext) => {
   }).then(({ data }) => {
     return !data
       ? undefined
-      : (getRoots(deserializeSubgraph(data.me.subgraph))[0] as Entity<User>);
+      : getRoots(
+          deserializeSubgraph<EntityRootType<User>>(data.me.subgraph),
+        )[0];
   });
 };
 

--- a/tests/hash-playwright/tests/shared/api-queries.ts
+++ b/tests/hash-playwright/tests/shared/api-queries.ts
@@ -4,7 +4,7 @@ import type { LinkData, PropertyObject } from "@local/hash-graph-types/entity";
 import type { OwnedById } from "@local/hash-graph-types/web";
 import { apiOrigin } from "@local/hash-isomorphic-utils/environment";
 import { deserializeSubgraph } from "@local/hash-isomorphic-utils/subgraph-mapping";
-import type { UserProperties } from "@local/hash-isomorphic-utils/system-types/shared";
+import type { User } from "@local/hash-isomorphic-utils/system-types/shared";
 import { getRoots } from "@local/hash-subgraph/stdlib";
 import type { APIRequestContext } from "@playwright/test";
 import type { GraphQLError } from "graphql/error";
@@ -45,9 +45,7 @@ export const getUser = async (requestContext: APIRequestContext) => {
   }).then(({ data }) => {
     return !data
       ? undefined
-      : (getRoots(
-          deserializeSubgraph(data.me.subgraph),
-        )[0] as Entity<UserProperties>);
+      : (getRoots(deserializeSubgraph(data.me.subgraph))[0] as Entity<User>);
   });
 };
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Improves the typing of things returned from the Entity SDK by:
1. having `Entity.create` accept a generic which narrows the `properties` and `entityTypeId` of the created entity to a specific type (e.g. `User`, `Document`), and enforces the input `properties` and `entityTypeId` to match
2. the same for `Entity.createMultiple`, which will 
3. generate new utility types in the TS system types to support this
4. have `EntityRootType` in a `Subgraph` also accept this generic, to narrow the type of the roots of the subgraph to a specific entity type (for use when we the subgraph is the result of a query which limits the roots to a given type(s)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- H-3091: `entity.patch` will return `this`, i.e. whatever type the `entity` was instantiated as – but this is not accurate if the `entityTypeId` is changed as part of the input parameters. I have tried a couple of ways of enforcing a new type to be specified if the `entityTypeId` is changed as part of the input, but couldn't get it to work.
- At least for me, IntelliJ is not flagging missing `properties`, but `tsc` is catching it – unsure why, but as long as the compiler catches it it's alright (slightly worse DX than if the editor did, but better than the previous situation which was properties being unchecked)

<img width="950" alt="Screenshot 2024-07-11 at 11 55 22" src="https://github.com/hashintel/hash/assets/37743469/f75cfe7b-3f02-40ea-b1db-040d49f542ea">


<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- `tsc`

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

1. Typed return from `create`
<img width="565" alt="Screenshot 2024-07-11 at 11 51 31" src="https://github.com/hashintel/hash/assets/37743469/d52716f7-724e-402f-964b-182a22e20916">

2. Preserved in `patch`
<img width="575" alt="Screenshot 2024-07-11 at 11 51 16" src="https://github.com/hashintel/hash/assets/37743469/6622b968-2e1f-4fa5-ac4d-5a69f6e2925c">

3. `createMultiple` – tuple
<img width="670" alt="Screenshot 2024-07-11 at 11 49 42" src="https://github.com/hashintel/hash/assets/37743469/d323c9cb-d017-4a7c-b3ea-d911775daa12">

4. input type safety on tuple
<img width="829" alt="Screenshot 2024-07-11 at 11 52 29" src="https://github.com/hashintel/hash/assets/37743469/dccd6777-7a97-44b2-b5d9-5c747d0e7e55">

5. Mixed type array
<img width="611" alt="Screenshot 2024-07-11 at 11 50 51" src="https://github.com/hashintel/hash/assets/37743469/384f476f-1c38-4e3c-8d81-7151597b2f20">

6. Single type array
<img width="558" alt="Screenshot 2024-07-11 at 11 51 01" src="https://github.com/hashintel/hash/assets/37743469/c814b672-c44b-4f33-a8c6-470546661bd4">
 