### PR TITLE
H-2886: Change postgres pool from `bb8` to `deadpool`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,30 +901,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
-name = "bb8"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b10cf871f3ff2ce56432fddc2615ac7acc3aa22ca321f8fea800846fbb32f188"
-dependencies = [
- "async-trait",
- "futures-util",
- "parking_lot",
- "tokio",
-]
-
-[[package]]
-name = "bb8-postgres"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ac82c42eb30889b5c4ee4763a24b8c566518171ebea648cd7e3bc532c60680"
-dependencies = [
- "async-trait",
- "bb8",
- "tokio",
- "tokio-postgres",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,6 +1508,37 @@ dependencies = [
  "data-encoding",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6541a3916932fe57768d4be0b1ffb5ec7cbf74ca8c903fdfd5c0fe8aa958f0ed"
+dependencies = [
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-postgres"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ab8a4ea925ce79678034870834602a2980f4b88c09e97feb266496dbb4493d2"
+dependencies = [
+ "async-trait",
+ "deadpool",
+ "getrandom",
+ "tokio",
+ "tokio-postgres",
+ "tracing",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63dfa964fe2a66f3fde91fc70b267fe193d822c7e603e2a675a49a7f46ad3f49"
 
 [[package]]
 name = "debugid"
@@ -2324,11 +2331,11 @@ dependencies = [
  "async-scoped",
  "async-trait",
  "authorization",
- "bb8-postgres",
  "bytes",
  "clap",
  "codec",
  "criterion",
+ "deadpool-postgres",
  "derive-where",
  "dotenv-flow",
  "error-stack 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6419,7 +6426,6 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util/upgrade-entities.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util/upgrade-entities.ts
@@ -93,130 +93,132 @@ export const upgradeWebEntities = async ({
     },
   ).then((subgraph) => getRoots(subgraph));
 
-  for (const entity of existingEntities) {
-    const baseUrl = extractBaseUrl(entity.metadata.entityTypeId);
+  await Promise.all(
+    existingEntities.map(async (entity) => {
+      const baseUrl = extractBaseUrl(entity.metadata.entityTypeId);
 
-    const currentVersion = extractVersion(entity.metadata.entityTypeId);
+      const currentVersion = extractVersion(entity.metadata.entityTypeId);
 
-    const newVersion = migrationState.entityTypeVersions[baseUrl];
+      const newVersion = migrationState.entityTypeVersions[baseUrl];
 
-    if (typeof newVersion === "undefined") {
-      throw new Error(
-        `Could not find the version for base URL ${baseUrl} in the migration state`,
-      );
-    }
-
-    if (currentVersion < newVersion) {
-      const newEntityTypeId = versionedUrlFromComponents(baseUrl, newVersion);
-      const currentEntityTypeId = entity.metadata.entityTypeId;
-
-      const migratePropertiesFunction = migrateProperties?.[baseUrl];
-
-      let updateAuthentication = webBotAuthentication;
-
-      const temporaryEntityTypePermissionsGranted: VersionedUrl[] = [];
-
-      if (
-        baseUrl === systemEntityTypes.userSecret.entityTypeBaseUrl ||
-        baseUrl ===
-          systemLinkEntityTypes.usesUserSecret.linkEntityTypeBaseUrl ||
-        baseUrl === googleEntityTypes.account.entityTypeBaseUrl
-      ) {
-        /**
-         *These entities are only editable by the bot that created them
-         */
-        updateAuthentication = {
-          actorId: entity.metadata.provenance.createdById,
-        };
+      if (typeof newVersion === "undefined") {
+        throw new Error(
+          `Could not find the version for base URL ${baseUrl} in the migration state`,
+        );
       }
-      if (baseUrl === systemEntityTypes.machine.entityTypeBaseUrl) {
-        /**
-         * If we are updating machine entities, we use the account ID
-         * of the machine user as the actor for the update.
-         */
-        updateAuthentication = {
+
+      if (currentVersion < newVersion) {
+        const newEntityTypeId = versionedUrlFromComponents(baseUrl, newVersion);
+        const currentEntityTypeId = entity.metadata.entityTypeId;
+
+        const migratePropertiesFunction = migrateProperties?.[baseUrl];
+
+        let updateAuthentication = webBotAuthentication;
+
+        const temporaryEntityTypePermissionsGranted: VersionedUrl[] = [];
+
+        if (
+          baseUrl === systemEntityTypes.userSecret.entityTypeBaseUrl ||
+          baseUrl ===
+            systemLinkEntityTypes.usesUserSecret.linkEntityTypeBaseUrl ||
+          baseUrl === googleEntityTypes.account.entityTypeBaseUrl
+        ) {
           /**
-           * The account ID of the machine entity is the creator of its
-           * first edition.
+           *These entities are only editable by the bot that created them
            */
-          actorId: entity.metadata.provenance.createdById,
-        };
-
-        for (const entityTypeId of [currentEntityTypeId, newEntityTypeId]) {
+          updateAuthentication = {
+            actorId: entity.metadata.provenance.createdById,
+          };
+        }
+        if (baseUrl === systemEntityTypes.machine.entityTypeBaseUrl) {
           /**
-           * We may need to temporarily grant the machine account ID the ability
-           * to instantiate entities of both the old and new entityTypeId,
-           * because an actor cannot update or remove an entity type without being able to instantiate it.
+           * If we are updating machine entities, we use the account ID
+           * of the machine user as the actor for the update.
            */
-          const relationships = await context.graphApi
-            .getEntityTypeAuthorizationRelationships(
-              systemAccountId,
-              entityTypeId,
-            )
-            .then(({ data }) => data);
+          updateAuthentication = {
+            /**
+             * The account ID of the machine entity is the creator of its
+             * first edition.
+             */
+            actorId: entity.metadata.provenance.createdById,
+          };
 
-          const relationAndSubject = {
-            subject: {
-              kind: "account",
-              subjectId: entity.metadata.provenance.createdById,
-            },
-            relation: "instantiator",
-          } as const;
+          for (const entityTypeId of [currentEntityTypeId, newEntityTypeId]) {
+            /**
+             * We may need to temporarily grant the machine account ID the ability
+             * to instantiate entities of both the old and new entityTypeId,
+             * because an actor cannot update or remove an entity type without being able to instantiate it.
+             */
+            const relationships = await context.graphApi
+              .getEntityTypeAuthorizationRelationships(
+                systemAccountId,
+                entityTypeId,
+              )
+              .then(({ data }) => data);
 
-          if (
-            !relationships.find((relationship) =>
-              isEqual(relationship, relationAndSubject),
-            )
-          ) {
+            const relationAndSubject = {
+              subject: {
+                kind: "account",
+                subjectId: entity.metadata.provenance.createdById,
+              },
+              relation: "instantiator",
+            } as const;
+
+            if (
+              !relationships.find((relationship) =>
+                isEqual(relationship, relationAndSubject),
+              )
+            ) {
+              await context.graphApi.modifyEntityTypeAuthorizationRelationships(
+                systemAccountId,
+                [
+                  {
+                    operation: "create",
+                    resource: entityTypeId,
+                    relationAndSubject,
+                  },
+                ],
+              );
+              temporaryEntityTypePermissionsGranted.push(entityTypeId);
+            }
+          }
+        }
+
+        try {
+          await updateEntity(context, updateAuthentication, {
+            entity,
+            entityTypeId: newEntityTypeId,
+            propertyPatches: migratePropertiesFunction
+              ? propertyObjectToPatches(
+                  migratePropertiesFunction(entity.properties),
+                )
+              : undefined,
+          });
+        } finally {
+          for (const entityTypeId of temporaryEntityTypePermissionsGranted) {
+            /**
+             * If we updated a machine entity and granted its actor ID a
+             * new permission, we need to remove the temporary permission.
+             */
             await context.graphApi.modifyEntityTypeAuthorizationRelationships(
               systemAccountId,
               [
                 {
-                  operation: "create",
+                  operation: "delete",
                   resource: entityTypeId,
-                  relationAndSubject,
+                  relationAndSubject: {
+                    subject: {
+                      kind: "account",
+                      subjectId: entity.metadata.provenance.createdById,
+                    },
+                    relation: "instantiator",
+                  },
                 },
               ],
             );
-            temporaryEntityTypePermissionsGranted.push(entityTypeId);
           }
         }
       }
-
-      try {
-        await updateEntity(context, updateAuthentication, {
-          entity,
-          entityTypeId: newEntityTypeId,
-          propertyPatches: migratePropertiesFunction
-            ? propertyObjectToPatches(
-                migratePropertiesFunction(entity.properties),
-              )
-            : undefined,
-        });
-      } finally {
-        for (const entityTypeId of temporaryEntityTypePermissionsGranted) {
-          /**
-           * If we updated a machine entity and granted its actor ID a
-           * new permission, we need to remove the temporary permission.
-           */
-          await context.graphApi.modifyEntityTypeAuthorizationRelationships(
-            systemAccountId,
-            [
-              {
-                operation: "delete",
-                resource: entityTypeId,
-                relationAndSubject: {
-                  subject: {
-                    kind: "account",
-                    subjectId: entity.metadata.provenance.createdById,
-                  },
-                  relation: "instantiator",
-                },
-              },
-            ],
-          );
-        }
-      }
-    }
-  }
+    }),
+  );
 };

--- a/apps/hash-graph/libs/api/src/rest/test_server.rs
+++ b/apps/hash-graph/libs/api/src/rest/test_server.rs
@@ -25,7 +25,6 @@ use graph::{
 use graph_types::account::AccountId;
 use hash_status::{Status, StatusCode};
 use tokio::io;
-use tokio_postgres::NoTls;
 use tokio_util::{codec::FramedRead, io::StreamReader};
 use uuid::Uuid;
 
@@ -35,7 +34,7 @@ use crate::{
 };
 
 /// Create routes for interacting with entities.
-pub fn routes<A>(store_pool: PostgresStorePool<NoTls>, authorization_api: A) -> Router
+pub fn routes<A>(store_pool: PostgresStorePool, authorization_api: A) -> Router
 where
     A: AuthorizationApi + ZanzibarBackend + Clone + Send + Sync + 'static,
 {
@@ -91,7 +90,7 @@ fn report_to_response<C>(report: &Report<C>, code: impl Into<String>) -> Respons
 }
 
 async fn restore_snapshot<A>(
-    store_pool: Extension<Arc<PostgresStorePool<NoTls>>>,
+    store_pool: Extension<Arc<PostgresStorePool>>,
     authorization_api: Extension<Arc<A>>,
     snapshot: Body,
 ) -> Result<Response, Response>
@@ -130,7 +129,7 @@ where
 }
 
 async fn delete_accounts<A>(
-    pool: Extension<Arc<PostgresStorePool<NoTls>>>,
+    pool: Extension<Arc<PostgresStorePool>>,
     authorization_api: Extension<Arc<A>>,
 ) -> Result<Response, Response>
 where
@@ -176,7 +175,7 @@ where
 }
 
 async fn delete_data_types<A>(
-    pool: Extension<Arc<PostgresStorePool<NoTls>>>,
+    pool: Extension<Arc<PostgresStorePool>>,
     authorization_api: Extension<Arc<A>>,
 ) -> Result<Response, Response>
 where
@@ -223,7 +222,7 @@ where
 }
 
 async fn delete_property_types<A>(
-    pool: Extension<Arc<PostgresStorePool<NoTls>>>,
+    pool: Extension<Arc<PostgresStorePool>>,
     authorization_api: Extension<Arc<A>>,
 ) -> Result<Response, Response>
 where
@@ -259,7 +258,7 @@ where
 }
 
 async fn delete_entity_types<A>(
-    pool: Extension<Arc<PostgresStorePool<NoTls>>>,
+    pool: Extension<Arc<PostgresStorePool>>,
     authorization_api: Extension<Arc<A>>,
 ) -> Result<Response, Response>
 where
@@ -295,7 +294,7 @@ where
 }
 
 async fn delete_entities<A>(
-    pool: Extension<Arc<PostgresStorePool<NoTls>>>,
+    pool: Extension<Arc<PostgresStorePool>>,
     authorization_api: Extension<Arc<A>>,
 ) -> Result<Response, Response>
 where

--- a/apps/hash-graph/libs/graph/Cargo.toml
+++ b/apps/hash-graph/libs/graph/Cargo.toml
@@ -35,7 +35,7 @@ tracing = { workspace = true }
 
 async-trait = "0.1.81"
 async-scoped = { version = "0.9.0", features = ["use-tokio"] }
-bb8-postgres = "0.8.1"
+deadpool-postgres = { version = "0.14.0", default-features = false }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"], optional = true }
 derive-where = { workspace = true }

--- a/apps/hash-graph/libs/graph/src/snapshot/mod.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/mod.rs
@@ -50,11 +50,7 @@ use graph_types::{
 use hash_status::StatusCode;
 use postgres_types::ToSql;
 use serde::{Deserialize, Serialize};
-use tokio_postgres::{
-    error::SqlState,
-    tls::{MakeTlsConnect, TlsConnect},
-    Socket,
-};
+use tokio_postgres::error::SqlState;
 use type_system::url::VersionedUrl;
 
 use crate::{
@@ -253,14 +249,7 @@ impl<C, A> SnapshotStore<C, A> {
     }
 }
 
-impl<Tls: Clone + Send + Sync + 'static> PostgresStorePool<Tls>
-where
-    Tls: MakeTlsConnect<
-            Socket,
-            Stream: Send + Sync,
-            TlsConnect: Send + TlsConnect<Socket, Future: Send>,
-        >,
-{
+impl PostgresStorePool {
     async fn read_accounts(
         &self,
     ) -> Result<impl Stream<Item = Result<Account, SnapshotDumpError>> + Send, SnapshotDumpError>

--- a/apps/hash-graph/libs/graph/src/store/config.rs
+++ b/apps/hash-graph/libs/graph/src/store/config.rs
@@ -179,63 +179,7 @@ pub struct DatabasePoolConfig {
             global = true
         )
     )]
-    pub max_connections: NonZero<u32>,
-
-    /// Sets the minimum idle connection count maintained by the pool.
-    ///
-    /// If set, the pool will try to maintain at least this many idle connections at all times,
-    /// while respecting the value of `max_connections`.
-    #[cfg_attr(
-        feature = "clap",
-        clap(long, env = "HASH_GRAPH_PG_MIN_IDLE_CONNECTIONS", global = true)
-    )]
-    pub min_idle_connections: Option<NonZero<u32>>,
-
-    /// Sets the maximum lifetime of connections in the pool in seconds.
-    ///
-    /// If set, connections will be closed at the next reaping after surviving past this duration.
-    ///
-    /// If a connection reaches its maximum lifetime while checked out it will be closed when it is
-    /// returned to the pool.
-    #[cfg_attr(
-        feature = "clap",
-        clap(
-            long,
-            default_value_t = Self::default().max_connection_lifetime,
-            env = "HASH_GRAPH_PG_MAX_CONNECTION_LIFETIME",
-            global = true
-        )
-    )]
-    pub max_connection_lifetime: NonZero<u64>,
-
-    /// Sets the connection timeout used by the pool in seconds.
-    ///
-    /// Acquiring a connection will wait this long before giving up and returning an error.
-    #[cfg_attr(
-        feature = "clap",
-        clap(
-            long,
-            default_value_t = Self::default().connection_timeout,
-            env = "HASH_GRAPH_PG_CONNECTION_TIMEOUT",
-            global = true
-        )
-    )]
-    pub connection_timeout: NonZero<u64>,
-
-    /// Sets the idle timeout used by the pool in seconds.
-    ///
-    /// If set, idle connections in excess of `min_idle_connections` will be closed at the next
-    /// reaping after remaining idle past this duration.
-    #[cfg_attr(
-        feature = "clap",
-        clap(
-            long,
-            default_value_t = Self::default().connection_idle_timeout,
-            env = "HASH_GRAPH_PG_CONNECTION_IDLE_TIMEOUT",
-            global = true
-        )
-    )]
-    pub connection_idle_timeout: NonZero<u64>,
+    pub max_connections: NonZero<usize>,
 }
 
 impl Default for DatabasePoolConfig {
@@ -243,10 +187,6 @@ impl Default for DatabasePoolConfig {
     fn default() -> Self {
         Self {
             max_connections: NonZero::new(10).unwrap(),
-            min_idle_connections: None,
-            max_connection_lifetime: NonZero::new(30 * 60).unwrap(),
-            connection_timeout: NonZero::new(30).unwrap(),
-            connection_idle_timeout: NonZero::new(10 * 60).unwrap(),
         }
     }
 }

--- a/apps/hash-graph/libs/graph/src/store/postgres/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/mod.rs
@@ -1,9 +1,7 @@
 mod crud;
 mod knowledge;
-mod ontology;
-
-// mod database;
 mod migration;
+mod ontology;
 mod pool;
 pub(crate) mod query;
 mod traversal_context;

--- a/tests/hash-graph-benches/util.rs
+++ b/tests/hash-graph-benches/util.rs
@@ -34,7 +34,7 @@ use tracing_flame::FlameLayer;
 use tracing_subscriber::{prelude::*, registry::Registry};
 use type_system::schema::{DataType, EntityType, PropertyType};
 
-type Pool = PostgresStorePool<NoTls>;
+type Pool = PostgresStorePool;
 pub type Store<A> = <Pool as StorePool>::Store<'static, A>;
 
 // TODO - deduplicate with integration/postgres.rs

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -78,8 +78,8 @@ use type_system::schema::{DataType, EntityType, PropertyType};
 use uuid::Uuid;
 
 pub struct DatabaseTestWrapper<A: AuthorizationApi> {
-    _pool: PostgresStorePool<NoTls>,
-    connection: <PostgresStorePool<NoTls> as StorePool>::Store<'static, A>,
+    _pool: PostgresStorePool,
+    connection: <PostgresStorePool as StorePool>::Store<'static, A>,
 }
 
 pub struct DatabaseApi<'pool, A: AuthorizationApi> {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We encountered quite a few timeouts with `bb8` and `deadpool` seems to run more stable. This changes the pool implementation, so we can try out `deadpool`.

## 🔍 What does this change?

- change postgres pool from `bb8` to `deadpool`
- Minor fix in migration script to avoid error in Graph API

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph