### PR TITLE
H-3105: Fix `lodash/isEqual` issue

### DIFF
--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util/upgrade-entities.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util/upgrade-entities.ts
@@ -19,7 +19,7 @@ import {
   extractBaseUrl,
   versionedUrlFromComponents,
 } from "@local/hash-subgraph/type-system-patch";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 
 import type { ImpureGraphContext } from "../../../context-types";
 import {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For some reason, in AWS the migration script doesn't find `{ isEqual }` in `lodash`