### PR TITLE
H-3106: Account for inheritance when generating `properties-with-metadata`

### DIFF
--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
@@ -137,8 +137,6 @@ export const loadExternalDataTypeIfNotExists: ImpureGraphFunction<
     throw error;
   });
 
-  console.log({ existingDataType });
-
   if (existingDataType) {
     return existingDataType;
   }

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
@@ -137,6 +137,8 @@ export const loadExternalDataTypeIfNotExists: ImpureGraphFunction<
     throw error;
   });
 
+  console.log({ existingDataType });
+
   if (existingDataType) {
     return existingDataType;
   }

--- a/libs/@blockprotocol/graph/src/codegen/initialize/metadata/generate-metadata-schema.ts
+++ b/libs/@blockprotocol/graph/src/codegen/initialize/metadata/generate-metadata-schema.ts
@@ -20,14 +20,14 @@ import {
 
 const generateMetadataSchemaTitles = ({
   title,
-}: Pick<PropertyType | DataType, "title">) => ({
+}: Pick<EntityType | PropertyType | DataType, "title">) => ({
   valueWithMetadataTitle: `${title} With Metadata`,
   metadataTitle: `${title} Metadata`,
 });
 
-const generateMetadataSchemaIdentifiers = ({
+export const generateMetadataSchemaIdentifiers = ({
   $id,
-}: Pick<PropertyType | DataType, "$id">) => ({
+}: Pick<EntityType | PropertyType | DataType, "$id">) => ({
   valueWithMetadata$id: $id.replace(
     /(\/types\/(?:entity-type|property-type|data-type)\/)/,
     /**
@@ -89,12 +89,14 @@ type EntityParentIdentifiers = {
 };
 
 type ObjectWithMetadataParams = {
+  allOf?: EntityType["allOf"];
   properties: EntityType["properties"];
   required: string[];
   entityParentIdentifiers: EntityParentIdentifiers | null;
 };
 
 export function generatePropertiesObjectWithMetadataSchema({
+  allOf,
   properties,
   required,
   entityParentIdentifiers,
@@ -102,6 +104,7 @@ export function generatePropertiesObjectWithMetadataSchema({
   entityParentIdentifiers: null;
 }): PartialJsonSchema;
 export function generatePropertiesObjectWithMetadataSchema({
+  allOf,
   properties,
   required,
   entityParentIdentifiers,
@@ -116,6 +119,7 @@ export function generatePropertiesObjectWithMetadataSchema({
  * – do not use this for properties objects defined within a property type, which may include multiple properties objects.
  */
 export function generatePropertiesObjectWithMetadataSchema({
+  allOf,
   properties,
   required,
   entityParentIdentifiers,
@@ -166,7 +170,7 @@ export function generatePropertiesObjectWithMetadataSchema({
     {},
   );
 
-  return {
+  const schema: JsonSchema | PartialJsonSchema = {
     type: "object",
     title,
     $id,
@@ -181,6 +185,12 @@ export function generatePropertiesObjectWithMetadataSchema({
     },
     required: ["value"],
   };
+
+  if (allOf) {
+    schema.allOf = allOf;
+  }
+
+  return schema;
 }
 
 const generatePropertyValueWithMetadataTree = (

--- a/libs/@blockprotocol/graph/src/codegen/initialize/traverse-and-collate-schemas.ts
+++ b/libs/@blockprotocol/graph/src/codegen/initialize/traverse-and-collate-schemas.ts
@@ -1,3 +1,4 @@
+import { atLeastOne } from "@blockprotocol/type-system";
 import type { VersionedUrl } from "@blockprotocol/type-system/slim";
 import {
   getReferencedIdsFromEntityType,
@@ -8,6 +9,7 @@ import { typedValues } from "../../util/typed-object-iter";
 import type { InitializeContext } from "../context";
 import {
   generateDataTypeWithMetadataSchema,
+  generateMetadataSchemaIdentifiers,
   generatePropertiesObjectWithMetadataSchema,
   generatePropertyTypeWithMetadataSchema,
 } from "./metadata/generate-metadata-schema";
@@ -197,7 +199,19 @@ export const traverseAndCollateSchemas = async (
 
           const { properties, required, $id, title } = type;
 
+          const parentsWithMetadataIdentifiers = type.allOf?.map((parent) => ({
+            $ref: generateMetadataSchemaIdentifiers({
+              $id: parent.$ref,
+            }).valueWithMetadata$id.replace(
+              "/with-metadata/",
+              "/properties-with-metadata/",
+            ) as VersionedUrl,
+          }));
+
           const withMetadata = generatePropertiesObjectWithMetadataSchema({
+            allOf: parentsWithMetadataIdentifiers
+              ? atLeastOne(parentsWithMetadataIdentifiers)
+              : undefined,
             properties,
             required: required ?? [],
             entityParentIdentifiers: {

--- a/libs/@local/hash-isomorphic-utils/src/system-types/canvas.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/canvas.ts
@@ -139,7 +139,11 @@ export type CanvasProperties1 = PageProperties;
 
 export type CanvasProperties2 = {};
 
-export type CanvasPropertiesWithMetadata = {
+export type CanvasPropertiesWithMetadata = CanvasPropertiesWithMetadata1 &
+  CanvasPropertiesWithMetadata2;
+export type CanvasPropertiesWithMetadata1 = PagePropertiesWithMetadata;
+
+export type CanvasPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -173,7 +177,13 @@ export type HasSpatiallyPositionedContentProperties2 = {
   "https://hash.ai/@hash/types/property-type/y-position/": YPositionPropertyValue;
 };
 
-export type HasSpatiallyPositionedContentPropertiesWithMetadata = {
+export type HasSpatiallyPositionedContentPropertiesWithMetadata =
+  HasSpatiallyPositionedContentPropertiesWithMetadata1 &
+    HasSpatiallyPositionedContentPropertiesWithMetadata2;
+export type HasSpatiallyPositionedContentPropertiesWithMetadata1 =
+  LinkPropertiesWithMetadata;
+
+export type HasSpatiallyPositionedContentPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {
     "https://hash.ai/@hash/types/property-type/height-in-pixels/": HeightInPixelsPropertyValueWithMetadata;

--- a/libs/@local/hash-isomorphic-utils/src/system-types/commentnotification.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/commentnotification.ts
@@ -559,7 +559,13 @@ export type CommentNotificationProperties1 = NotificationProperties;
 
 export type CommentNotificationProperties2 = {};
 
-export type CommentNotificationPropertiesWithMetadata = {
+export type CommentNotificationPropertiesWithMetadata =
+  CommentNotificationPropertiesWithMetadata1 &
+    CommentNotificationPropertiesWithMetadata2;
+export type CommentNotificationPropertiesWithMetadata1 =
+  NotificationPropertiesWithMetadata;
+
+export type CommentNotificationPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -601,7 +607,13 @@ export type RepliedToCommentProperties1 = LinkProperties;
 
 export type RepliedToCommentProperties2 = {};
 
-export type RepliedToCommentPropertiesWithMetadata = {
+export type RepliedToCommentPropertiesWithMetadata =
+  RepliedToCommentPropertiesWithMetadata1 &
+    RepliedToCommentPropertiesWithMetadata2;
+export type RepliedToCommentPropertiesWithMetadata1 =
+  LinkPropertiesWithMetadata;
+
+export type RepliedToCommentPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -628,7 +640,13 @@ export type TriggeredByCommentProperties1 = LinkProperties;
 
 export type TriggeredByCommentProperties2 = {};
 
-export type TriggeredByCommentPropertiesWithMetadata = {
+export type TriggeredByCommentPropertiesWithMetadata =
+  TriggeredByCommentPropertiesWithMetadata1 &
+    TriggeredByCommentPropertiesWithMetadata2;
+export type TriggeredByCommentPropertiesWithMetadata1 =
+  LinkPropertiesWithMetadata;
+
+export type TriggeredByCommentPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/document.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/document.ts
@@ -144,7 +144,11 @@ export type DocumentProperties1 = PageProperties;
 
 export type DocumentProperties2 = {};
 
-export type DocumentPropertiesWithMetadata = {
+export type DocumentPropertiesWithMetadata = DocumentPropertiesWithMetadata1 &
+  DocumentPropertiesWithMetadata2;
+export type DocumentPropertiesWithMetadata1 = PagePropertiesWithMetadata;
+
+export type DocumentPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/docxdocument.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/docxdocument.ts
@@ -144,7 +144,12 @@ export type DOCXDocumentProperties1 = DocumentFileProperties;
 
 export type DOCXDocumentProperties2 = {};
 
-export type DOCXDocumentPropertiesWithMetadata = {
+export type DOCXDocumentPropertiesWithMetadata =
+  DOCXDocumentPropertiesWithMetadata1 & DOCXDocumentPropertiesWithMetadata2;
+export type DOCXDocumentPropertiesWithMetadata1 =
+  DocumentFilePropertiesWithMetadata;
+
+export type DOCXDocumentPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/facebookaccount.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/facebookaccount.ts
@@ -50,7 +50,13 @@ export type FacebookAccountProperties1 = ServiceAccountProperties;
 
 export type FacebookAccountProperties2 = {};
 
-export type FacebookAccountPropertiesWithMetadata = {
+export type FacebookAccountPropertiesWithMetadata =
+  FacebookAccountPropertiesWithMetadata1 &
+    FacebookAccountPropertiesWithMetadata2;
+export type FacebookAccountPropertiesWithMetadata1 =
+  ServiceAccountPropertiesWithMetadata;
+
+export type FacebookAccountPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/githubaccount.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/githubaccount.ts
@@ -50,7 +50,12 @@ export type GitHubAccountProperties1 = ServiceAccountProperties;
 
 export type GitHubAccountProperties2 = {};
 
-export type GitHubAccountPropertiesWithMetadata = {
+export type GitHubAccountPropertiesWithMetadata =
+  GitHubAccountPropertiesWithMetadata1 & GitHubAccountPropertiesWithMetadata2;
+export type GitHubAccountPropertiesWithMetadata1 =
+  ServiceAccountPropertiesWithMetadata;
+
+export type GitHubAccountPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/google/googlesheetsfile.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/google/googlesheetsfile.ts
@@ -121,7 +121,13 @@ export type AssociatedWithAccountProperties1 = LinkProperties;
 
 export type AssociatedWithAccountProperties2 = {};
 
-export type AssociatedWithAccountPropertiesWithMetadata = {
+export type AssociatedWithAccountPropertiesWithMetadata =
+  AssociatedWithAccountPropertiesWithMetadata1 &
+    AssociatedWithAccountPropertiesWithMetadata2;
+export type AssociatedWithAccountPropertiesWithMetadata1 =
+  LinkPropertiesWithMetadata;
+
+export type AssociatedWithAccountPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -345,7 +351,13 @@ export type GoogleSheetsFileProperties2 = {
   "https://hash.ai/@hash/types/property-type/file-id/": FileIdPropertyValue;
 };
 
-export type GoogleSheetsFilePropertiesWithMetadata = {
+export type GoogleSheetsFilePropertiesWithMetadata =
+  GoogleSheetsFilePropertiesWithMetadata1 &
+    GoogleSheetsFilePropertiesWithMetadata2;
+export type GoogleSheetsFilePropertiesWithMetadata1 =
+  SpreadsheetFilePropertiesWithMetadata;
+
+export type GoogleSheetsFilePropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {
     "https://hash.ai/@hash/types/property-type/data-audience/": DataAudiencePropertyValueWithMetadata;
@@ -421,7 +433,12 @@ export type SpreadsheetFileProperties1 = FileProperties;
 
 export type SpreadsheetFileProperties2 = {};
 
-export type SpreadsheetFilePropertiesWithMetadata = {
+export type SpreadsheetFilePropertiesWithMetadata =
+  SpreadsheetFilePropertiesWithMetadata1 &
+    SpreadsheetFilePropertiesWithMetadata2;
+export type SpreadsheetFilePropertiesWithMetadata1 = FilePropertiesWithMetadata;
+
+export type SpreadsheetFilePropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/google/shared.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/google/shared.ts
@@ -170,7 +170,11 @@ export type UsesUserSecretProperties1 = LinkProperties;
 
 export type UsesUserSecretProperties2 = {};
 
-export type UsesUserSecretPropertiesWithMetadata = {
+export type UsesUserSecretPropertiesWithMetadata =
+  UsesUserSecretPropertiesWithMetadata1 & UsesUserSecretPropertiesWithMetadata2;
+export type UsesUserSecretPropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type UsesUserSecretPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/graphchangenotification.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/graphchangenotification.ts
@@ -93,7 +93,13 @@ export type GraphChangeNotificationProperties2 = {
   "https://hash.ai/@hash/types/property-type/graph-change-type/": GraphChangeTypePropertyValue;
 };
 
-export type GraphChangeNotificationPropertiesWithMetadata = {
+export type GraphChangeNotificationPropertiesWithMetadata =
+  GraphChangeNotificationPropertiesWithMetadata1 &
+    GraphChangeNotificationPropertiesWithMetadata2;
+export type GraphChangeNotificationPropertiesWithMetadata1 =
+  NotificationPropertiesWithMetadata;
+
+export type GraphChangeNotificationPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {
     "https://hash.ai/@hash/types/property-type/graph-change-type/": GraphChangeTypePropertyValueWithMetadata;

--- a/libs/@local/hash-isomorphic-utils/src/system-types/instagramaccount.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/instagramaccount.ts
@@ -50,7 +50,13 @@ export type InstagramAccountProperties1 = ServiceAccountProperties;
 
 export type InstagramAccountProperties2 = {};
 
-export type InstagramAccountPropertiesWithMetadata = {
+export type InstagramAccountPropertiesWithMetadata =
+  InstagramAccountPropertiesWithMetadata1 &
+    InstagramAccountPropertiesWithMetadata2;
+export type InstagramAccountPropertiesWithMetadata1 =
+  ServiceAccountPropertiesWithMetadata;
+
+export type InstagramAccountPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/linear/attachment.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/linear/attachment.ts
@@ -503,7 +503,11 @@ export type BelongsToIssueProperties1 = LinkProperties;
 
 export type BelongsToIssueProperties2 = {};
 
-export type BelongsToIssuePropertiesWithMetadata = {
+export type BelongsToIssuePropertiesWithMetadata =
+  BelongsToIssuePropertiesWithMetadata1 & BelongsToIssuePropertiesWithMetadata2;
+export type BelongsToIssuePropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type BelongsToIssuePropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/linear/shared.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/linear/shared.ts
@@ -89,7 +89,13 @@ export type BelongsToOrganizationProperties1 = LinkProperties;
 
 export type BelongsToOrganizationProperties2 = {};
 
-export type BelongsToOrganizationPropertiesWithMetadata = {
+export type BelongsToOrganizationPropertiesWithMetadata =
+  BelongsToOrganizationPropertiesWithMetadata1 &
+    BelongsToOrganizationPropertiesWithMetadata2;
+export type BelongsToOrganizationPropertiesWithMetadata1 =
+  LinkPropertiesWithMetadata;
+
+export type BelongsToOrganizationPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -262,7 +268,11 @@ export type HasAssigneeProperties1 = LinkProperties;
 
 export type HasAssigneeProperties2 = {};
 
-export type HasAssigneePropertiesWithMetadata = {
+export type HasAssigneePropertiesWithMetadata =
+  HasAssigneePropertiesWithMetadata1 & HasAssigneePropertiesWithMetadata2;
+export type HasAssigneePropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type HasAssigneePropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -289,7 +299,11 @@ export type HasCreatorProperties1 = LinkProperties;
 
 export type HasCreatorProperties2 = {};
 
-export type HasCreatorPropertiesWithMetadata = {
+export type HasCreatorPropertiesWithMetadata =
+  HasCreatorPropertiesWithMetadata1 & HasCreatorPropertiesWithMetadata2;
+export type HasCreatorPropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type HasCreatorPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -316,7 +330,11 @@ export type HasSubscriberProperties1 = LinkProperties;
 
 export type HasSubscriberProperties2 = {};
 
-export type HasSubscriberPropertiesWithMetadata = {
+export type HasSubscriberPropertiesWithMetadata =
+  HasSubscriberPropertiesWithMetadata1 & HasSubscriberPropertiesWithMetadata2;
+export type HasSubscriberPropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type HasSubscriberPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -646,7 +664,11 @@ export type ParentProperties1 = LinkProperties;
 
 export type ParentProperties2 = {};
 
-export type ParentPropertiesWithMetadata = {
+export type ParentPropertiesWithMetadata = ParentPropertiesWithMetadata1 &
+  ParentPropertiesWithMetadata2;
+export type ParentPropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type ParentPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -746,7 +768,11 @@ export type SnoozedByProperties1 = LinkProperties;
 
 export type SnoozedByProperties2 = {};
 
-export type SnoozedByPropertiesWithMetadata = {
+export type SnoozedByPropertiesWithMetadata = SnoozedByPropertiesWithMetadata1 &
+  SnoozedByPropertiesWithMetadata2;
+export type SnoozedByPropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type SnoozedByPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -800,7 +826,11 @@ export type StateProperties1 = LinkProperties;
 
 export type StateProperties2 = {};
 
-export type StatePropertiesWithMetadata = {
+export type StatePropertiesWithMetadata = StatePropertiesWithMetadata1 &
+  StatePropertiesWithMetadata2;
+export type StatePropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type StatePropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/linearintegration.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/linearintegration.ts
@@ -474,7 +474,13 @@ export type SyncLinearDataWithProperties2 = {
   "https://hash.ai/@hash/types/property-type/linear-team-id/"?: LinearTeamIdPropertyValue[];
 };
 
-export type SyncLinearDataWithPropertiesWithMetadata = {
+export type SyncLinearDataWithPropertiesWithMetadata =
+  SyncLinearDataWithPropertiesWithMetadata1 &
+    SyncLinearDataWithPropertiesWithMetadata2;
+export type SyncLinearDataWithPropertiesWithMetadata1 =
+  LinkPropertiesWithMetadata;
+
+export type SyncLinearDataWithPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {
     "https://hash.ai/@hash/types/property-type/linear-team-id/"?: {
@@ -506,7 +512,11 @@ export type UsesUserSecretProperties1 = LinkProperties;
 
 export type UsesUserSecretProperties2 = {};
 
-export type UsesUserSecretPropertiesWithMetadata = {
+export type UsesUserSecretPropertiesWithMetadata =
+  UsesUserSecretPropertiesWithMetadata1 & UsesUserSecretPropertiesWithMetadata2;
+export type UsesUserSecretPropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type UsesUserSecretPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/linkedinaccount.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/linkedinaccount.ts
@@ -50,7 +50,13 @@ export type LinkedInAccountProperties1 = ServiceAccountProperties;
 
 export type LinkedInAccountProperties2 = {};
 
-export type LinkedInAccountPropertiesWithMetadata = {
+export type LinkedInAccountPropertiesWithMetadata =
+  LinkedInAccountPropertiesWithMetadata1 &
+    LinkedInAccountPropertiesWithMetadata2;
+export type LinkedInAccountPropertiesWithMetadata1 =
+  ServiceAccountPropertiesWithMetadata;
+
+export type LinkedInAccountPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/machine.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/machine.ts
@@ -60,7 +60,11 @@ export type MachineProperties2 = {
   "https://hash.ai/@hash/types/property-type/machine-identifier/": MachineIdentifierPropertyValue;
 };
 
-export type MachinePropertiesWithMetadata = {
+export type MachinePropertiesWithMetadata = MachinePropertiesWithMetadata1 &
+  MachinePropertiesWithMetadata2;
+export type MachinePropertiesWithMetadata1 = ActorPropertiesWithMetadata;
+
+export type MachinePropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {
     "https://blockprotocol.org/@blockprotocol/types/property-type/display-name/": DisplayNamePropertyValueWithMetadata;

--- a/libs/@local/hash-isomorphic-utils/src/system-types/mentionnotification.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/mentionnotification.ts
@@ -569,7 +569,13 @@ export type MentionNotificationProperties1 = NotificationProperties;
 
 export type MentionNotificationProperties2 = {};
 
-export type MentionNotificationPropertiesWithMetadata = {
+export type MentionNotificationPropertiesWithMetadata =
+  MentionNotificationPropertiesWithMetadata1 &
+    MentionNotificationPropertiesWithMetadata2;
+export type MentionNotificationPropertiesWithMetadata1 =
+  NotificationPropertiesWithMetadata;
+
+export type MentionNotificationPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -601,7 +607,13 @@ export type OccurredInCommentProperties1 = LinkProperties;
 
 export type OccurredInCommentProperties2 = {};
 
-export type OccurredInCommentPropertiesWithMetadata = {
+export type OccurredInCommentPropertiesWithMetadata =
+  OccurredInCommentPropertiesWithMetadata1 &
+    OccurredInCommentPropertiesWithMetadata2;
+export type OccurredInCommentPropertiesWithMetadata1 =
+  LinkPropertiesWithMetadata;
+
+export type OccurredInCommentPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -628,7 +640,11 @@ export type OccurredInTextProperties1 = LinkProperties;
 
 export type OccurredInTextProperties2 = {};
 
-export type OccurredInTextPropertiesWithMetadata = {
+export type OccurredInTextPropertiesWithMetadata =
+  OccurredInTextPropertiesWithMetadata1 & OccurredInTextPropertiesWithMetadata2;
+export type OccurredInTextPropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type OccurredInTextPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/pdfdocument.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/pdfdocument.ts
@@ -144,7 +144,12 @@ export type PDFDocumentProperties1 = DocumentFileProperties;
 
 export type PDFDocumentProperties2 = {};
 
-export type PDFDocumentPropertiesWithMetadata = {
+export type PDFDocumentPropertiesWithMetadata =
+  PDFDocumentPropertiesWithMetadata1 & PDFDocumentPropertiesWithMetadata2;
+export type PDFDocumentPropertiesWithMetadata1 =
+  DocumentFilePropertiesWithMetadata;
+
+export type PDFDocumentPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/pptxpresentation.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/pptxpresentation.ts
@@ -144,7 +144,13 @@ export type PPTXPresentationProperties1 = PresentationFileProperties;
 
 export type PPTXPresentationProperties2 = {};
 
-export type PPTXPresentationPropertiesWithMetadata = {
+export type PPTXPresentationPropertiesWithMetadata =
+  PPTXPresentationPropertiesWithMetadata1 &
+    PPTXPresentationPropertiesWithMetadata2;
+export type PPTXPresentationPropertiesWithMetadata1 =
+  PresentationFilePropertiesWithMetadata;
+
+export type PPTXPresentationPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/quicknote.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/quicknote.ts
@@ -112,7 +112,12 @@ export type QuickNoteProperties2 = {
   "https://hash.ai/@hash/types/property-type/archived/"?: ArchivedPropertyValue;
 };
 
-export type QuickNotePropertiesWithMetadata = {
+export type QuickNotePropertiesWithMetadata = QuickNotePropertiesWithMetadata1 &
+  QuickNotePropertiesWithMetadata2;
+export type QuickNotePropertiesWithMetadata1 =
+  BlockCollectionPropertiesWithMetadata;
+
+export type QuickNotePropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {
     "https://hash.ai/@hash/types/property-type/archived/"?: ArchivedPropertyValueWithMetadata;

--- a/libs/@local/hash-isomorphic-utils/src/system-types/shared.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/shared.ts
@@ -81,7 +81,11 @@ export type AuthoredByProperties1 = LinkProperties;
 
 export type AuthoredByProperties2 = {};
 
-export type AuthoredByPropertiesWithMetadata = {
+export type AuthoredByPropertiesWithMetadata =
+  AuthoredByPropertiesWithMetadata1 & AuthoredByPropertiesWithMetadata2;
+export type AuthoredByPropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type AuthoredByPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -327,7 +331,11 @@ export type DocumentFileProperties2 = {
   "https://blockprotocol.org/@blockprotocol/types/property-type/textual-content/"?: TextualContentPropertyValue;
 };
 
-export type DocumentFilePropertiesWithMetadata = {
+export type DocumentFilePropertiesWithMetadata =
+  DocumentFilePropertiesWithMetadata1 & DocumentFilePropertiesWithMetadata2;
+export type DocumentFilePropertiesWithMetadata1 = FilePropertiesWithMetadata;
+
+export type DocumentFilePropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {
     "https://blockprotocol.org/@blockprotocol/types/property-type/textual-content/"?: TextualContentPropertyValueWithMetadata;
@@ -593,7 +601,11 @@ export type HasAvatarProperties1 = LinkProperties;
 
 export type HasAvatarProperties2 = {};
 
-export type HasAvatarPropertiesWithMetadata = {
+export type HasAvatarPropertiesWithMetadata = HasAvatarPropertiesWithMetadata1 &
+  HasAvatarPropertiesWithMetadata2;
+export type HasAvatarPropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type HasAvatarPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -619,7 +631,11 @@ export type HasBioProperties1 = LinkProperties;
 
 export type HasBioProperties2 = {};
 
-export type HasBioPropertiesWithMetadata = {
+export type HasBioPropertiesWithMetadata = HasBioPropertiesWithMetadata1 &
+  HasBioPropertiesWithMetadata2;
+export type HasBioPropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type HasBioPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -646,7 +662,11 @@ export type HasCoverImageProperties1 = LinkProperties;
 
 export type HasCoverImageProperties2 = {};
 
-export type HasCoverImagePropertiesWithMetadata = {
+export type HasCoverImagePropertiesWithMetadata =
+  HasCoverImagePropertiesWithMetadata1 & HasCoverImagePropertiesWithMetadata2;
+export type HasCoverImagePropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type HasCoverImagePropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -672,7 +692,11 @@ export type HasDataProperties1 = LinkProperties;
 
 export type HasDataProperties2 = {};
 
-export type HasDataPropertiesWithMetadata = {
+export type HasDataPropertiesWithMetadata = HasDataPropertiesWithMetadata1 &
+  HasDataPropertiesWithMetadata2;
+export type HasDataPropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type HasDataPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -701,7 +725,13 @@ export type HasIndexedContentProperties2 = {
   "https://hash.ai/@hash/types/property-type/fractional-index/": FractionalIndexPropertyValue;
 };
 
-export type HasIndexedContentPropertiesWithMetadata = {
+export type HasIndexedContentPropertiesWithMetadata =
+  HasIndexedContentPropertiesWithMetadata1 &
+    HasIndexedContentPropertiesWithMetadata2;
+export type HasIndexedContentPropertiesWithMetadata1 =
+  LinkPropertiesWithMetadata;
+
+export type HasIndexedContentPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {
     "https://hash.ai/@hash/types/property-type/fractional-index/": FractionalIndexPropertyValueWithMetadata;
@@ -733,7 +763,11 @@ export type HasParentProperties1 = LinkProperties;
 
 export type HasParentProperties2 = {};
 
-export type HasParentPropertiesWithMetadata = {
+export type HasParentPropertiesWithMetadata = HasParentPropertiesWithMetadata1 &
+  HasParentPropertiesWithMetadata2;
+export type HasParentPropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type HasParentPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -746,7 +780,11 @@ export type HasProperties1 = LinkProperties;
 
 export type HasProperties2 = {};
 
-export type HasPropertiesWithMetadata = {
+export type HasPropertiesWithMetadata = HasPropertiesWithMetadata1 &
+  HasPropertiesWithMetadata2;
+export type HasPropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type HasPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -773,7 +811,13 @@ export type HasServiceAccountProperties1 = LinkProperties;
 
 export type HasServiceAccountProperties2 = {};
 
-export type HasServiceAccountPropertiesWithMetadata = {
+export type HasServiceAccountPropertiesWithMetadata =
+  HasServiceAccountPropertiesWithMetadata1 &
+    HasServiceAccountPropertiesWithMetadata2;
+export type HasServiceAccountPropertiesWithMetadata1 =
+  LinkPropertiesWithMetadata;
+
+export type HasServiceAccountPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -799,7 +843,11 @@ export type HasTextProperties1 = LinkProperties;
 
 export type HasTextProperties2 = {};
 
-export type HasTextPropertiesWithMetadata = {
+export type HasTextPropertiesWithMetadata = HasTextPropertiesWithMetadata1 &
+  HasTextPropertiesWithMetadata2;
+export type HasTextPropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type HasTextPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -832,7 +880,11 @@ export type ImageProperties1 = FileProperties;
 
 export type ImageProperties2 = {};
 
-export type ImagePropertiesWithMetadata = {
+export type ImagePropertiesWithMetadata = ImagePropertiesWithMetadata1 &
+  ImagePropertiesWithMetadata2;
+export type ImagePropertiesWithMetadata1 = FilePropertiesWithMetadata;
+
+export type ImagePropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -866,7 +918,11 @@ export type IsMemberOfProperties1 = LinkProperties;
 
 export type IsMemberOfProperties2 = {};
 
-export type IsMemberOfPropertiesWithMetadata = {
+export type IsMemberOfPropertiesWithMetadata =
+  IsMemberOfPropertiesWithMetadata1 & IsMemberOfPropertiesWithMetadata2;
+export type IsMemberOfPropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type IsMemberOfPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -1011,7 +1067,12 @@ export type OccurredInBlockProperties1 = LinkProperties;
 
 export type OccurredInBlockProperties2 = {};
 
-export type OccurredInBlockPropertiesWithMetadata = {
+export type OccurredInBlockPropertiesWithMetadata =
+  OccurredInBlockPropertiesWithMetadata1 &
+    OccurredInBlockPropertiesWithMetadata2;
+export type OccurredInBlockPropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type OccurredInBlockPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -1040,7 +1101,13 @@ export type OccurredInEntityProperties2 = {
   "https://hash.ai/@hash/types/property-type/entity-edition-id/"?: EntityEditionIdPropertyValue;
 };
 
-export type OccurredInEntityPropertiesWithMetadata = {
+export type OccurredInEntityPropertiesWithMetadata =
+  OccurredInEntityPropertiesWithMetadata1 &
+    OccurredInEntityPropertiesWithMetadata2;
+export type OccurredInEntityPropertiesWithMetadata1 =
+  LinkPropertiesWithMetadata;
+
+export type OccurredInEntityPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {
     "https://hash.ai/@hash/types/property-type/entity-edition-id/"?: EntityEditionIdPropertyValueWithMetadata;
@@ -1215,7 +1282,11 @@ export type PageProperties2 = {
   "https://hash.ai/@hash/types/property-type/title/": TitlePropertyValue;
 };
 
-export type PagePropertiesWithMetadata = {
+export type PagePropertiesWithMetadata = PagePropertiesWithMetadata1 &
+  PagePropertiesWithMetadata2;
+export type PagePropertiesWithMetadata1 = BlockCollectionPropertiesWithMetadata;
+
+export type PagePropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {
     "https://hash.ai/@hash/types/property-type/archived/"?: ArchivedPropertyValueWithMetadata;
@@ -1266,7 +1337,13 @@ export type PresentationFileProperties2 = {
   "https://blockprotocol.org/@blockprotocol/types/property-type/textual-content/"?: TextualContentPropertyValue;
 };
 
-export type PresentationFilePropertiesWithMetadata = {
+export type PresentationFilePropertiesWithMetadata =
+  PresentationFilePropertiesWithMetadata1 &
+    PresentationFilePropertiesWithMetadata2;
+export type PresentationFilePropertiesWithMetadata1 =
+  FilePropertiesWithMetadata;
+
+export type PresentationFilePropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {
     "https://blockprotocol.org/@blockprotocol/types/property-type/textual-content/"?: TextualContentPropertyValueWithMetadata;
@@ -1302,7 +1379,12 @@ export type ProfileBioProperties1 = BlockCollectionProperties;
 
 export type ProfileBioProperties2 = {};
 
-export type ProfileBioPropertiesWithMetadata = {
+export type ProfileBioPropertiesWithMetadata =
+  ProfileBioPropertiesWithMetadata1 & ProfileBioPropertiesWithMetadata2;
+export type ProfileBioPropertiesWithMetadata1 =
+  BlockCollectionPropertiesWithMetadata;
+
+export type ProfileBioPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -1547,7 +1629,12 @@ export type TriggeredByUserProperties1 = LinkProperties;
 
 export type TriggeredByUserProperties2 = {};
 
-export type TriggeredByUserPropertiesWithMetadata = {
+export type TriggeredByUserPropertiesWithMetadata =
+  TriggeredByUserPropertiesWithMetadata1 &
+    TriggeredByUserPropertiesWithMetadata2;
+export type TriggeredByUserPropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type TriggeredByUserPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -1653,7 +1740,11 @@ export type UserProperties2 = {
   "https://hash.ai/@hash/types/property-type/website-url/"?: WebsiteURLPropertyValue;
 };
 
-export type UserPropertiesWithMetadata = {
+export type UserPropertiesWithMetadata = UserPropertiesWithMetadata1 &
+  UserPropertiesWithMetadata2;
+export type UserPropertiesWithMetadata1 = ActorPropertiesWithMetadata;
+
+export type UserPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {
     "https://hash.ai/@hash/types/property-type/email/": {

--- a/libs/@local/hash-isomorphic-utils/src/system-types/spreadsheetfile.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/spreadsheetfile.ts
@@ -126,7 +126,12 @@ export type SpreadsheetFileProperties1 = FileProperties;
 
 export type SpreadsheetFileProperties2 = {};
 
-export type SpreadsheetFilePropertiesWithMetadata = {
+export type SpreadsheetFilePropertiesWithMetadata =
+  SpreadsheetFilePropertiesWithMetadata1 &
+    SpreadsheetFilePropertiesWithMetadata2;
+export type SpreadsheetFilePropertiesWithMetadata1 = FilePropertiesWithMetadata;
+
+export type SpreadsheetFilePropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/tiktokaccount.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/tiktokaccount.ts
@@ -50,7 +50,12 @@ export type TikTokAccountProperties1 = ServiceAccountProperties;
 
 export type TikTokAccountProperties2 = {};
 
-export type TikTokAccountPropertiesWithMetadata = {
+export type TikTokAccountPropertiesWithMetadata =
+  TikTokAccountPropertiesWithMetadata1 & TikTokAccountPropertiesWithMetadata2;
+export type TikTokAccountPropertiesWithMetadata1 =
+  ServiceAccountPropertiesWithMetadata;
+
+export type TikTokAccountPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/twitteraccount.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/twitteraccount.ts
@@ -50,7 +50,12 @@ export type TwitterAccountProperties1 = ServiceAccountProperties;
 
 export type TwitterAccountProperties2 = {};
 
-export type TwitterAccountPropertiesWithMetadata = {
+export type TwitterAccountPropertiesWithMetadata =
+  TwitterAccountPropertiesWithMetadata1 & TwitterAccountPropertiesWithMetadata2;
+export type TwitterAccountPropertiesWithMetadata1 =
+  ServiceAccountPropertiesWithMetadata;
+
+export type TwitterAccountPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };

--- a/libs/@local/hash-isomorphic-utils/src/system-types/usagerecord.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/usagerecord.ts
@@ -130,7 +130,11 @@ export type CreatedProperties1 = LinkProperties;
 
 export type CreatedProperties2 = {};
 
-export type CreatedPropertiesWithMetadata = {
+export type CreatedPropertiesWithMetadata = CreatedPropertiesWithMetadata1 &
+  CreatedPropertiesWithMetadata2;
+export type CreatedPropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type CreatedPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -165,7 +169,11 @@ export type IncurredInProperties1 = LinkProperties;
 
 export type IncurredInProperties2 = {};
 
-export type IncurredInPropertiesWithMetadata = {
+export type IncurredInPropertiesWithMetadata =
+  IncurredInPropertiesWithMetadata1 & IncurredInPropertiesWithMetadata2;
+export type IncurredInPropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type IncurredInPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -208,7 +216,11 @@ export type RecordsUsageOfProperties1 = LinkProperties;
 
 export type RecordsUsageOfProperties2 = {};
 
-export type RecordsUsageOfPropertiesWithMetadata = {
+export type RecordsUsageOfPropertiesWithMetadata =
+  RecordsUsageOfPropertiesWithMetadata1 & RecordsUsageOfPropertiesWithMetadata2;
+export type RecordsUsageOfPropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type RecordsUsageOfPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };
@@ -234,7 +246,11 @@ export type UpdatedProperties1 = LinkProperties;
 
 export type UpdatedProperties2 = {};
 
-export type UpdatedPropertiesWithMetadata = {
+export type UpdatedPropertiesWithMetadata = UpdatedPropertiesWithMetadata1 &
+  UpdatedPropertiesWithMetadata2;
+export type UpdatedPropertiesWithMetadata1 = LinkPropertiesWithMetadata;
+
+export type UpdatedPropertiesWithMetadata2 = {
   metadata?: ObjectMetadata;
   value: {};
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#4650 introduced new `PropertiesWithMetadata` types to support passing metadata along with properties, but didn't take account of inheritance for entities.

This PR fixes that.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- `tsc`

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Look at the changes in the generated types

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
<img width="761" alt="Screenshot 2024-07-15 at 19 15 54" src="https://github.com/user-attachments/assets/10d0a66f-8dc4-446a-ae98-f023f41d55c8">
