### PR TITLE
H-3084, H-3115, H-3116: Show prompt, resolved questions for flow run

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/handle-web-search-tool-call.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/handle-web-search-tool-call.ts
@@ -99,19 +99,22 @@ export const handleWebSearchToolCall = async (params: {
         };
       }
 
-      const { outputs: webPageSummaryOutputs } =
-        webPageSummaryResponse.contents[0]!;
+      const responseContent = webPageSummaryResponse.contents[0];
 
-      const summaryOutput = webPageSummaryOutputs.find(
+      const webPageSummaryOutputs = responseContent?.outputs;
+
+      const summaryOutput = webPageSummaryOutputs?.find(
         ({ outputName }) =>
           outputName ===
           ("summary" satisfies OutputNameForAction<"getWebPageSummary">),
       );
 
       if (!summaryOutput) {
-        throw new Error(
-          `No summary output was found when calling "getSummariesOfWebPages" for the web page at url ${url}.`,
-        );
+        return {
+          url,
+          title,
+          summary: `An unexpected error occurred trying to summarize the web page at url ${url}.`,
+        };
       }
 
       const summary = summaryOutput.payload.value as string;

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/activity-log.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/activity-log.tsx
@@ -234,6 +234,9 @@ const createColumns = (rowCount: number): VirtualizedTableColumn<FieldId>[] => [
 
 const TableRow = memo(
   ({ index, log }: { index: number; log: LocalProgressLog }) => {
+    const todaysDate = format(new Date(), "yyyy-MM-dd");
+    const logDate = format(new Date(log.recordedAt), "yyyy-MM-dd");
+
     return (
       <>
         <TableCell sx={{ ...defaultCellSx, fontSize: 13 }}>
@@ -246,9 +249,21 @@ const TableRow = memo(
             fontFamily: "monospace",
           }}
         >
-          {format(new Date(log.recordedAt), "yyyy-MM-dd")}
-          <br />
-          <strong>{format(new Date(log.recordedAt), "h:mm:ss a")}</strong>
+          {todaysDate !== logDate && (
+            <>
+              {format(new Date(log.recordedAt), "yyyy-MM-dd")}
+              <br />
+            </>
+          )}
+          <Tooltip
+            title={
+              todaysDate === logDate
+                ? format(new Date(log.recordedAt), "yyyy-MM-dd h:mm:ss a")
+                : ""
+            }
+          >
+            <strong>{format(new Date(log.recordedAt), "h:mm:ss a")}</strong>
+          </Tooltip>
         </TableCell>
         <TableCell sx={{ ...defaultCellSx, fontSize: 13, lineHeight: 1.4 }}>
           <Box sx={{ position: "relative", pr: 3, maxWidth: "auto" }}>

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/flow-run-sidebar.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/flow-run-sidebar.tsx
@@ -57,6 +57,7 @@ export const FlowRunSidebar = ({
     flowRunIds: [flowRunId],
   });
   const [showUsageBreakdown, setShowUsageBreakdown] = useState(false);
+  const [showResearchPrompt, setShowResearchPrompt] = useState(false);
 
   const { selectedFlowRun } = useFlowRunsContext();
 
@@ -108,29 +109,52 @@ export const FlowRunSidebar = ({
                   part.text
                 )}
                 {index === nameParts.length - 1 && researchPrompt && (
-                  <Tooltip title={researchPrompt}>
-                    <Box
-                      component="span"
+                  <Box
+                    aria-label="Show research prompt"
+                    component="button"
+                    onClick={() => setShowResearchPrompt(!showResearchPrompt)}
+                    sx={{
+                      background: "none",
+                      border: "none",
+                      cursor: "pointer",
+                      display: "inline-block",
+                      height: 12,
+                      ml: 0.4,
+                      p: 0,
+                      top: 3,
+                      position: "relative",
+                      "&:hover svg": {
+                        color: ({ palette }) => palette.common.black,
+                      },
+                    }}
+                  >
+                    <CaretDownSolidIcon
                       sx={{
-                        display: "inline-block",
-                        height: 12,
-                        top: 1,
-                        position: "relative",
+                        color: ({ palette }) => palette.gray[50],
+                        fontSize: 14,
+                        transform: !showResearchPrompt
+                          ? "rotate(-90deg)"
+                          : "translateY(-1px)",
+                        transition: ({ transitions }) =>
+                          transitions.create("transform"),
                       }}
-                    >
-                      <CircleInfoIcon
-                        sx={{
-                          fontSize: 12,
-                          fill: ({ palette }) => palette.gray[40],
-                          ml: 0.8,
-                        }}
-                      />
-                    </Box>
-                  </Tooltip>
+                    />
+                  </Box>
                 )}
               </Box>
             ))}
           </Typography>
+          {researchPrompt && (
+            <Collapse in={showResearchPrompt}>
+              <Typography
+                component="p"
+                variant="smallTextParagraphs"
+                sx={{ fontWeight: 300, lineHeight: 1.3, mt: 1 }}
+              >
+                “{researchPrompt}”
+              </Typography>
+            </Collapse>
+          )}
         </SidebarSection>
       </Box>
       <Box>

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/flow-run-sidebar.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/flow-run-sidebar.tsx
@@ -9,12 +9,11 @@ import {
   type GoalFlowTriggerInput,
 } from "@local/hash-isomorphic-utils/flows/goal-flow-definitions";
 import type { FlowDefinition } from "@local/hash-isomorphic-utils/flows/types";
-import { Box, Collapse, Stack, Tooltip, Typography } from "@mui/material";
+import { Box, Collapse, Stack, Typography } from "@mui/material";
 import type { PropsWithChildren } from "react";
 import { useMemo, useState } from "react";
 
 import type { FlowRun } from "../../../../graphql/api-types.gen";
-import { CircleInfoIcon } from "../../../../shared/icons/circle-info-icon";
 import { Link } from "../../../../shared/ui/link";
 import { useFlowRunsContext } from "../../../shared/flow-runs-context";
 import { useFlowRunsUsage } from "../../../shared/use-flow-runs-usage";

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/flow-run-sidebar.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/flow-run-sidebar.tsx
@@ -6,14 +6,15 @@ import {
 import type { EntityUuid } from "@local/hash-graph-types/entity";
 import {
   goalFlowDefinitionIds,
-  GoalFlowTriggerInput,
+  type GoalFlowTriggerInput,
 } from "@local/hash-isomorphic-utils/flows/goal-flow-definitions";
 import type { FlowDefinition } from "@local/hash-isomorphic-utils/flows/types";
-import { Box, Collapse, Stack, Typography } from "@mui/material";
+import { Box, Collapse, Stack, Tooltip, Typography } from "@mui/material";
 import type { PropsWithChildren } from "react";
-import { Fragment, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 import type { FlowRun } from "../../../../graphql/api-types.gen";
+import { CircleInfoIcon } from "../../../../shared/icons/circle-info-icon";
 import { Link } from "../../../../shared/ui/link";
 import { useFlowRunsContext } from "../../../shared/flow-runs-context";
 import { useFlowRunsUsage } from "../../../shared/use-flow-runs-usage";
@@ -71,7 +72,7 @@ export const FlowRunSidebar = ({
     }));
   }, [name]);
 
-  const researchPrompt = selectedFlowRun?.inputs[0].flowTrigger?.outputs?.find(
+  const researchPrompt = selectedFlowRun?.inputs[0].flowTrigger.outputs?.find(
     (input) =>
       input.outputName === ("Research guidance" satisfies GoalFlowTriggerInput),
   )?.payload.value as string | undefined;
@@ -92,27 +93,44 @@ export const FlowRunSidebar = ({
             variant="smallTextParagraphs"
             sx={{ lineHeight: 1.2, wordBreak: "break-word" }}
           >
-            {nameParts.map((part, index) =>
-              part.url ? (
+            {nameParts.map((part, index) => (
+              <Box
+                component="span"
                 // eslint-disable-next-line react/no-array-index-key
-                <Link href={part.text} key={index} target="_blank">
-                  {part.text}
-                </Link>
-              ) : (
-                // eslint-disable-next-line react/no-array-index-key
-                <Fragment key={index}>{part.text}</Fragment>
-              ),
-            )}
+                key={index}
+                sx={{ display: "inline-block", marginRight: "2px" }}
+              >
+                {part.url ? (
+                  <Link href={part.text} target="_blank">
+                    {part.text}
+                  </Link>
+                ) : (
+                  part.text
+                )}
+                {index === nameParts.length - 1 && researchPrompt && (
+                  <Tooltip title={researchPrompt}>
+                    <Box
+                      component="span"
+                      sx={{
+                        display: "inline-block",
+                        height: 12,
+                        top: 1,
+                        position: "relative",
+                      }}
+                    >
+                      <CircleInfoIcon
+                        sx={{
+                          fontSize: 12,
+                          fill: ({ palette }) => palette.gray[40],
+                          ml: 0.8,
+                        }}
+                      />
+                    </Box>
+                  </Tooltip>
+                )}
+              </Box>
+            ))}
           </Typography>
-          {researchPrompt && (
-            <Typography
-              component="p"
-              variant="smallTextParagraphs"
-              sx={{ fontWeight: 300, mt: 1 }}
-            >
-              "{researchPrompt}"
-            </Typography>
-          )}
         </SidebarSection>
       </Box>
       <Box>

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/flow-run-sidebar.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/flow-run-sidebar.tsx
@@ -195,14 +195,13 @@ export const FlowRunSidebar = ({
           </Box>
         </SidebarSection>
       </Box>
-      {!selectedFlowRun?.closedAt && (
-        <Box sx={{ mt: 2 }}>
-          <SectionLabel text="Manager" />
-          <SidebarSection>
-            <Manager />
-          </SidebarSection>
-        </Box>
-      )}
+
+      <Box sx={{ mt: 2 }}>
+        <SectionLabel text="Manager" />
+        <SidebarSection>
+          <Manager />
+        </SidebarSection>
+      </Box>
       {isUsageAvailable && usage ? (
         <Box sx={{ mt: 2 }}>
           <SectionLabel text="Cost" />

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/flow-run-sidebar.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/flow-run-sidebar.tsx
@@ -4,7 +4,10 @@ import {
   IconButton,
 } from "@hashintel/design-system";
 import type { EntityUuid } from "@local/hash-graph-types/entity";
-import { goalFlowDefinitionIds } from "@local/hash-isomorphic-utils/flows/goal-flow-definitions";
+import {
+  goalFlowDefinitionIds,
+  GoalFlowTriggerInput,
+} from "@local/hash-isomorphic-utils/flows/goal-flow-definitions";
 import type { FlowDefinition } from "@local/hash-isomorphic-utils/flows/types";
 import { Box, Collapse, Stack, Typography } from "@mui/material";
 import type { PropsWithChildren } from "react";
@@ -68,6 +71,11 @@ export const FlowRunSidebar = ({
     }));
   }, [name]);
 
+  const researchPrompt = selectedFlowRun?.inputs[0].flowTrigger?.outputs?.find(
+    (input) =>
+      input.outputName === ("Research guidance" satisfies GoalFlowTriggerInput),
+  )?.payload.value as string | undefined;
+
   return (
     <Box sx={{ ml: 3, minWidth: 320, width: 320 }}>
       <Box sx={{ mb: 2 }}>
@@ -82,7 +90,7 @@ export const FlowRunSidebar = ({
           <Typography
             component="p"
             variant="smallTextParagraphs"
-            sx={{ lineHeight: 1.2, mb: 0.7, wordBreak: "break-word" }}
+            sx={{ lineHeight: 1.2, wordBreak: "break-word" }}
           >
             {nameParts.map((part, index) =>
               part.url ? (
@@ -96,6 +104,15 @@ export const FlowRunSidebar = ({
               ),
             )}
           </Typography>
+          {researchPrompt && (
+            <Typography
+              component="p"
+              variant="smallTextParagraphs"
+              sx={{ fontWeight: 300, mt: 1 }}
+            >
+              "{researchPrompt}"
+            </Typography>
+          )}
         </SidebarSection>
       </Box>
       <Box>

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/flow-run-sidebar/manager.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/flow-run-sidebar/manager.tsx
@@ -67,7 +67,7 @@ export const Manager = () => {
 
   return (
     <>
-      {showQuestionModal && !!outstandingQuestionsRequest && flowIsClosed && (
+      {showQuestionModal && !!outstandingQuestionsRequest && !flowIsClosed && (
         <QuestionModal
           inputRequest={outstandingQuestionsRequest}
           open

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/flow-run-sidebar/manager.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/flow-run-sidebar/manager.tsx
@@ -1,4 +1,5 @@
 import { CircleCheckRegularIcon } from "@hashintel/design-system";
+import type { ExternalInputRequest } from "@local/hash-isomorphic-utils/flows/types";
 import type { SxProps, Theme } from "@mui/material";
 import { Stack, Typography } from "@mui/material";
 import { useMemo, useState } from "react";
@@ -6,17 +7,19 @@ import { useMemo, useState } from "react";
 import { CircleInfoIcon } from "../../../../../shared/icons/circle-info-icon";
 import { useFlowRunsContext } from "../../../../shared/flow-runs-context";
 import { QuestionModal } from "../shared/question-modal";
+import type { ResolvedQuestionRequest } from "./manager/resolved-questions-modal";
+import { ResolvedQuestionsModal } from "./manager/resolved-questions-modal";
 
 const iconSx: SxProps<Theme> = {
   mr: 1.5,
   fontSize: 18,
 };
 
-const SuccessIcon = () => (
+const SuccessIcon = ({ closed }: { closed?: boolean }) => (
   <CircleCheckRegularIcon
     sx={{
       ...iconSx,
-      color: ({ palette }) => palette.green[80],
+      color: ({ palette }) => (closed ? palette.gray[50] : palette.green[80]),
     }}
   />
 );
@@ -25,43 +28,77 @@ export const Manager = () => {
   const { selectedFlowRun } = useFlowRunsContext();
 
   const [showQuestionModal, setShowQuestionModal] = useState(false);
+  const [showResolvedQuestionsModal, setShowResolvedQuestionsModal] =
+    useState(false);
 
-  const outstandingInputRequest = useMemo(() => {
-    return selectedFlowRun?.inputRequests.find(
-      (request) => request.type === "human-input" && !request.resolvedAt,
-    );
+  const {
+    outstandingQuestionsRequest,
+    resolvedQuestionsRequests,
+    resolvedQuestionsCount,
+  } = useMemo(() => {
+    let outstandingRequest: ExternalInputRequest | undefined;
+    const resolvedRequests: ResolvedQuestionRequest[] = [];
+
+    let answersProvidedCount: number = 0;
+
+    for (const inputRequest of selectedFlowRun?.inputRequests ?? []) {
+      if (inputRequest.type === "human-input") {
+        if (!inputRequest.resolvedAt && !outstandingRequest) {
+          outstandingRequest = inputRequest;
+        } else if (inputRequest.resolvedAt && inputRequest.answers) {
+          resolvedRequests.push({
+            ...inputRequest,
+            resolvedAt: inputRequest.resolvedAt,
+            answers: inputRequest.answers,
+          });
+          answersProvidedCount += inputRequest.data.questions.length;
+        }
+      }
+    }
+
+    return {
+      outstandingQuestionsRequest: outstandingRequest,
+      resolvedQuestionsRequests: resolvedRequests,
+      resolvedQuestionsCount: answersProvidedCount,
+    };
   }, [selectedFlowRun]);
+
+  const flowIsClosed = !!selectedFlowRun?.closedAt;
 
   return (
     <>
-      {showQuestionModal && !!outstandingInputRequest && (
+      {showQuestionModal && !!outstandingQuestionsRequest && flowIsClosed && (
         <QuestionModal
-          inputRequest={outstandingInputRequest}
+          inputRequest={outstandingQuestionsRequest}
           open
           onClose={() => setShowQuestionModal(false)}
         />
       )}
-      <Stack
-        direction="row"
-        alignItems="center"
-        sx={{
-          borderBottom: ({ palette }) => `1px solid ${palette.gray[20]}`,
-          pb: 2,
-          mb: 2,
-        }}
-      >
-        <SuccessIcon />
+      {showResolvedQuestionsModal && !!resolvedQuestionsRequests.length && (
+        <ResolvedQuestionsModal
+          resolvedQuestionRequests={resolvedQuestionsRequests}
+          open
+          onClose={() => setShowResolvedQuestionsModal(false)}
+        />
+      )}
+      <Stack direction="row" alignItems="center">
+        <SuccessIcon closed={flowIsClosed} />
         <Typography variant="smallTextParagraphs">
-          Actively managing this flow
+          {flowIsClosed ? "Flow is closed" : "Actively managing this flow"}
         </Typography>
       </Stack>
-      {outstandingInputRequest ? (
+      {selectedFlowRun?.closedAt ? null : outstandingQuestionsRequest ? (
         <Stack
           direction="row"
           alignItems="center"
           role="button"
           onClick={() => setShowQuestionModal(true)}
-          sx={{ cursor: "pointer" }}
+          sx={{
+            cursor: "pointer",
+            borderTop: ({ palette }) => `1px solid ${palette.gray[20]}`,
+            pt: 2,
+            mt: 2,
+          }}
         >
           <CircleInfoIcon
             sx={{ fill: ({ palette }) => palette.yellow[80], ...iconSx }}
@@ -74,10 +111,39 @@ export const Manager = () => {
           </Typography>
         </Stack>
       ) : (
-        <Stack direction="row" alignItems="center">
+        <Stack
+          direction="row"
+          alignItems="center"
+          sx={{
+            borderTop: ({ palette }) => `1px solid ${palette.gray[20]}`,
+            pt: 2,
+            mt: 2,
+          }}
+        >
           <SuccessIcon />
           <Typography variant="smallTextParagraphs">
             No outstanding input requests
+          </Typography>
+        </Stack>
+      )}
+      {resolvedQuestionsCount > 0 && (
+        <Stack
+          direction="row"
+          alignItems="center"
+          role="button"
+          onClick={() => setShowResolvedQuestionsModal(true)}
+          sx={{
+            cursor: "pointer",
+            borderTop: ({ palette }) => `1px solid ${palette.gray[20]}`,
+            pt: 2,
+            mt: 2,
+          }}
+        >
+          <CircleInfoIcon
+            sx={{ fill: ({ palette }) => palette.blue[60], ...iconSx }}
+          />
+          <Typography variant="smallTextParagraphs">
+            {resolvedQuestionsCount} resolved questions
           </Typography>
         </Stack>
       )}

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/flow-run-sidebar/manager/resolved-questions-modal.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/flow-run-sidebar/manager/resolved-questions-modal.tsx
@@ -1,0 +1,106 @@
+import type { ExternalInputRequest } from "@local/hash-isomorphic-utils/flows/types";
+import { Box, Typography } from "@mui/material";
+import { useMemo } from "react";
+
+import { Modal } from "../../../../../../shared/ui/modal";
+
+const ResolvedQuestion = ({
+  answer,
+  question,
+}: {
+  answer: string;
+  question: string;
+}) => {
+  return (
+    <Box mb={3}>
+      <Typography
+        component="label"
+        variant="smallTextLabels"
+        sx={{
+          color: ({ palette }) => palette.gray[80],
+          display: "block",
+          fontWeight: 600,
+          lineHeight: 1.4,
+          mb: 1,
+        }}
+      >
+        {question}
+      </Typography>
+      <Typography
+        component="label"
+        variant="smallTextParagraphs"
+        sx={{
+          color: ({ palette }) => palette.gray[70],
+          display: "block",
+          fontWeight: 500,
+          lineHeight: 1.4,
+        }}
+      >
+        {answer}
+      </Typography>
+    </Box>
+  );
+};
+
+export type ResolvedQuestionRequest = ExternalInputRequest<"human-input"> &
+  Required<Pick<ExternalInputRequest, "answers" | "resolvedAt">>;
+
+type ResolvedQuestionsModalProps = {
+  resolvedQuestionRequests: ResolvedQuestionRequest[];
+  open: boolean;
+  onClose: () => void;
+};
+
+export const ResolvedQuestionsModal = ({
+  resolvedQuestionRequests,
+  open,
+  onClose,
+}: ResolvedQuestionsModalProps) => {
+  const multipleQuestions = resolvedQuestionRequests.length > 0;
+
+  const resolvedQuestions = useMemo(() => {
+    const questions: {
+      question: string;
+      answer: string;
+      resolvedAt: string;
+    }[] = [];
+
+    for (const request of resolvedQuestionRequests) {
+      for (const [index, question] of request.data.questions.entries()) {
+        const answer = request.answers[index];
+        if (answer === undefined) {
+          throw new Error(
+            `No answer found at index ${index} for question ${question}. All answers: ${request.answers}`,
+          );
+        }
+
+        questions.push({
+          question,
+          answer,
+          resolvedAt: request.resolvedAt,
+        });
+      }
+    }
+
+    return questions;
+  }, [resolvedQuestionRequests]);
+
+  return (
+    <Modal
+      contentStyle={{ p: { xs: 0, md: 0 }, outlineStyle: "none" }}
+      open={open}
+      onClose={onClose}
+      header={{
+        title: `You previously answered 
+            ${multipleQuestions ? "these questions" : "this question"}`,
+      }}
+    >
+      <Box px={2.5} py={2}>
+        {resolvedQuestions.map((resolvedQuestion, index) => (
+          // eslint-disable-next-line react/no-array-index-key -- no better alternative, questions may include duplicates
+          <ResolvedQuestion key={index} {...resolvedQuestion} />
+        ))}
+      </Box>
+    </Modal>
+  );
+};

--- a/apps/hash-frontend/src/pages/shared/virtualized-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/virtualized-table.tsx
@@ -273,10 +273,12 @@ export const VirtualizedTable = <
     [EmptyPlaceholder],
   );
 
+  const context = useMemo(() => ({ columns: columns ?? [] }), [columns]);
+
   return (
     <Box style={{ borderRadius, height, width: "100%" }}>
       <TableVirtuoso
-        context={{ columns: columns ?? [] }}
+        context={context}
         data={rows}
         components={components}
         fixedHeaderContent={fixedHeaderContent}

--- a/libs/@local/harpc/tower/package.json
+++ b/libs/@local/harpc/tower/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rust/harpc-tower",
   "version": "0.1.0",
-  "private": false,
+  "private": true,
   "dependencies": {
     "@rust/harpc-net": "0.0.0-private",
     "@rust/harpc-types": "0.0.0-private",

--- a/libs/@local/hash-isomorphic-utils/src/flows/types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/flows/types.ts
@@ -474,7 +474,9 @@ export type ExternalInputResponseWithoutUser = DistributiveOmit<
   "resolvedBy"
 >;
 
-export type ExternalInputRequest = ExternalInputRequestSignal & {
+export type ExternalInputRequest<
+  RequestType extends ExternalInputRequestType = ExternalInputRequestType,
+> = ExternalInputRequestSignal<RequestType> & {
   /** The answers given by the human, if it was a request for human input */
   answers?: string[];
   /** The time at which the request was resolved */


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A few improvements to flow run visualization:
1. Show the original research prompt in a toggle
2. Show resolved Q&A
3. Hide the date on activity log entries from today, show date in tooltip

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


## 📹 Demo

**Goal prompt toggle**

https://github.com/user-attachments/assets/0d7cf983-8a97-4393-96ab-50f55ab7089f

**Resolved questions, activity log date**

https://github.com/user-attachments/assets/1b33a045-70f4-432c-af4f-32731dbc018c

