### PR TITLE
H-3120: Add a `ClosedDataType` schema based on the normal `DataType` schema

### DIFF
--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/data_type/channel.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/data_type/channel.rs
@@ -76,7 +76,10 @@ impl Sink<DataTypeSnapshotRecord> for DataTypeSender {
                 schema: Valid::new_unchecked(data_type.schema.clone()),
                 // TODO: Validate ontology types in snapshots
                 //   see https://linear.app/hash/issue/H-3038
-                closed_schema: Valid::new_unchecked(ClosedDataType::new(data_type.schema)),
+                closed_schema: Valid::new_unchecked(
+                    ClosedDataType::new(data_type.schema)
+                        .change_context(SnapshotRestoreError::Read)?,
+                ),
             })
             .change_context(SnapshotRestoreError::Read)
             .attach_printable("could not send schema")?;

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
@@ -340,7 +340,10 @@ where
                     .await
                     .change_context(InsertionError)?;
                 let closed_schema = data_type_validator
-                    .validate(ClosedDataType::new(schema.clone().into_inner()))
+                    .validate(
+                        ClosedDataType::new(schema.clone().into_inner())
+                            .change_context(InsertionError)?,
+                    )
                     .await
                     .change_context(InsertionError)?;
                 transaction
@@ -582,7 +585,7 @@ where
             .await
             .change_context(UpdateError)?;
         let closed_schema = data_type_validator
-            .validate(ClosedDataType::new(schema.clone().into_inner()))
+            .validate(ClosedDataType::new(schema.clone().into_inner()).change_context(UpdateError)?)
             .await
             .change_context(UpdateError)?;
         let (ontology_id, owned_by_id, temporal_versioning) = transaction

--- a/apps/hash-graph/postgres_migrations/V27__closed_data_types_2.sql
+++ b/apps/hash-graph/postgres_migrations/V27__closed_data_types_2.sql
@@ -1,0 +1,2 @@
+UPDATE data_types
+   SET closed_schema = schema;

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -18,6 +18,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize, Serializer};
 use serde_json::Value as JsonValue;
 
+use self::raw::RawDataType;
 use crate::{
     schema::data_type::constraint::{extend_report, ConstraintError, StringFormat},
     url::VersionedUrl,
@@ -81,26 +82,28 @@ impl From<&JsonValue> for JsonSchemaValueType {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(from = "raw::DataType")]
+#[serde(from = "RawDataType::<DataTypeReference>")]
 pub struct DataType {
     pub id: VersionedUrl,
     pub title: String,
     pub description: Option<String>,
     pub label: DataTypeLabel,
 
-    // constraints for any types
+    pub all_of: Vec<DataTypeReference>,
+
+    // constraints for any type
     pub json_type: JsonSchemaValueType,
     pub const_value: Option<JsonValue>,
     pub enum_values: Vec<JsonValue>,
 
-    // constraints for number types
+    // constraints for numbers
     pub multiple_of: Option<f64>,
     pub maximum: Option<f64>,
     pub exclusive_maximum: bool,
     pub minimum: Option<f64>,
     pub exclusive_minimum: bool,
 
-    // constraints for string types
+    // constraints for strings
     pub min_length: Option<usize>,
     pub max_length: Option<usize>,
     pub pattern: Option<Regex>,
@@ -178,7 +181,7 @@ impl Serialize for DataType {
     where
         S: Serializer,
     {
-        raw::DataType::from(self).serialize(serializer)
+        raw::RawDataType::from(self).serialize(serializer)
     }
 }
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/raw.rs
@@ -9,7 +9,7 @@ use tsify::Tsify;
 use crate::{
     schema::{
         data_type::{constraint::StringFormat, DataTypeLabel},
-        JsonSchemaValueType,
+        ClosedDataType, DataTypeReference, JsonSchemaValueType,
     },
     url::VersionedUrl,
 };
@@ -39,13 +39,20 @@ const fn is_false(value: &bool) -> bool {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct DataType<'a> {
+#[serde(
+    rename_all = "camelCase",
+    deny_unknown_fields,
+    bound(deserialize = "D: Deserialize<'de>")
+)]
+pub struct RawDataType<'a, D: Clone> {
     #[serde(rename = "$schema")]
     pub schema: DataTypeSchemaTag,
     pub kind: DataTypeTag,
     #[serde(borrow = "'a", rename = "$id")]
     pub id: Cow<'a, VersionedUrl>,
+    #[cfg_attr(target_arch = "wasm32", tsify(type = "[D, ...D[]]"))]
+    #[serde(default, skip_serializing_if = "<[_]>::is_empty", borrow = "'a")]
+    pub all_of: Cow<'a, [D]>,
     pub title: Cow<'a, str>,
     #[serde(default, skip_serializing_if = "Option::is_none", borrow = "'a")]
     pub description: Option<Cow<'a, str>>,
@@ -104,12 +111,29 @@ pub struct DataType<'a> {
     pub format: Option<StringFormat>,
 }
 
-impl<'a> From<&'a super::DataType> for DataType<'a> {
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use tsify::Tsify;
+
+    use super::RawDataType;
+    use crate::schema::DataTypeReference;
+
+    #[cfg(target_arch = "wasm32")]
+    #[derive(Tsify)]
+    struct DataType<'a>(RawDataType<'a, DataTypeReference>);
+
+    #[cfg(target_arch = "wasm32")]
+    #[derive(Clone, Tsify)]
+    struct ClosedDataType<'a>(RawDataType<'a, ClosedDataType<'a>>);
+}
+
+impl<'a> From<&'a super::DataType> for RawDataType<'a, DataTypeReference> {
     fn from(data_type: &'a super::DataType) -> Self {
         Self {
             schema: DataTypeSchemaTag::V3,
             kind: DataTypeTag::DataType,
             id: Cow::Borrowed(&data_type.id),
+            all_of: Cow::Borrowed(&data_type.all_of),
             title: Cow::Borrowed(&data_type.title),
             description: data_type.description.as_deref().map(Cow::Borrowed),
             label: Cow::Borrowed(&data_type.label),
@@ -129,12 +153,63 @@ impl<'a> From<&'a super::DataType> for DataType<'a> {
     }
 }
 
-impl From<DataType<'_>> for super::DataType {
-    fn from(data_type_repr: DataType) -> Self {
+impl From<RawDataType<'_, DataTypeReference>> for super::DataType {
+    fn from(data_type_repr: RawDataType<DataTypeReference>) -> Self {
         Self {
             id: data_type_repr.id.into_owned(),
             title: data_type_repr.title.into_owned(),
             description: data_type_repr.description.map(Cow::into_owned),
+            all_of: data_type_repr.all_of.into_owned(),
+            label: data_type_repr.label.into_owned(),
+            json_type: data_type_repr.json_type,
+            const_value: data_type_repr.const_value.map(Cow::into_owned),
+            enum_values: data_type_repr.enum_values.into_owned(),
+            multiple_of: data_type_repr.multiple_of,
+            maximum: data_type_repr.maximum,
+            exclusive_maximum: data_type_repr.exclusive_maximum,
+            minimum: data_type_repr.minimum,
+            exclusive_minimum: data_type_repr.exclusive_minimum,
+            min_length: data_type_repr.min_length,
+            max_length: data_type_repr.max_length,
+            pattern: data_type_repr.pattern.clone(),
+            format: data_type_repr.format,
+        }
+    }
+}
+
+impl<'a> From<&'a ClosedDataType> for RawDataType<'a, ClosedDataType> {
+    fn from(data_type: &'a ClosedDataType) -> Self {
+        Self {
+            schema: DataTypeSchemaTag::V3,
+            kind: DataTypeTag::DataType,
+            id: Cow::Borrowed(&data_type.id),
+            all_of: Cow::Borrowed(&data_type.all_of),
+            title: Cow::Borrowed(&data_type.title),
+            description: data_type.description.as_deref().map(Cow::Borrowed),
+            label: Cow::Borrowed(&data_type.label),
+            json_type: data_type.json_type,
+            const_value: data_type.const_value.as_ref().map(Cow::Borrowed),
+            enum_values: Cow::Borrowed(&data_type.enum_values),
+            multiple_of: data_type.multiple_of,
+            maximum: data_type.maximum,
+            exclusive_maximum: data_type.exclusive_maximum,
+            minimum: data_type.minimum,
+            exclusive_minimum: data_type.exclusive_minimum,
+            min_length: data_type.min_length,
+            max_length: data_type.max_length,
+            pattern: data_type.pattern.clone(),
+            format: data_type.format,
+        }
+    }
+}
+
+impl From<RawDataType<'_, Self>> for ClosedDataType {
+    fn from(data_type_repr: RawDataType<Self>) -> Self {
+        Self {
+            id: data_type_repr.id.into_owned(),
+            title: data_type_repr.title.into_owned(),
+            description: data_type_repr.description.map(Cow::into_owned),
+            all_of: data_type_repr.all_of.into_owned(),
             label: data_type_repr.label.into_owned(),
             json_type: data_type_repr.json_type,
             const_value: data_type_repr.const_value.map(Cow::into_owned),

--- a/libs/@local/harpc/tower/package.json
+++ b/libs/@local/harpc/tower/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@rust/harpc-tower",
-  "version": "0.1.0",
-  "private": false,
+  "version": "0.0.0-private",
+  "private": true,
+  "license": "AGPL-3.0",
   "dependencies": {
     "@rust/harpc-net": "0.0.0-private",
     "@rust/harpc-types": "0.0.0-private",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The new closed schema has the same shape as DataType but with the references being replaced by the full schema - recursively.

## 🔍 What does this change?

- Add an `allOf` value to `DataType`
- Change the `ClosedDataType` to align with `DataType`
- drive-by: Fix `package.json` for `@rust/harpc-tower`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph