### PR TITLE
H-2773: Don't start sync back watcher if Linear integration disabled

### DIFF
--- a/apps/hash-api/src/index.ts
+++ b/apps/hash-api/src/index.ts
@@ -67,6 +67,7 @@ import { ensureSystemGraphIsInitialized } from "./graph/ensure-system-graph-is-i
 import { ensureHashSystemAccountExists } from "./graph/system-account";
 import { createApolloServer } from "./graphql/create-apollo-server";
 import { registerOpenTelemetryTracing } from "./graphql/opentelemetry";
+import { enabledIntegrations } from "./integrations/enabled-integrations";
 import { checkGoogleAccessToken } from "./integrations/google/check-access-token";
 import { getGoogleAccessToken } from "./integrations/google/get-access-token";
 import { googleOAuthCallback } from "./integrations/google/oauth-callback";
@@ -627,7 +628,7 @@ const main = async () => {
     });
   });
 
-  if (realtimeSyncEnabled) {
+  if (realtimeSyncEnabled && enabledIntegrations.linear) {
     const integrationSyncBackWatcher =
       await createIntegrationSyncBackWatcher(graphApi);
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

There's a loop in the Node API which checks for Redis messages related to changes to Linear-related entities, to write them back out to Linear.

If the Linear integration is not enabled this loop should not start.

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- ...

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

