### PR TITLE
H-3164: Add artillery scenario to login and query `me`

### DIFF
--- a/tests/hash-backend-performance/scenarios/login.yml
+++ b/tests/hash-backend-performance/scenarios/login.yml
@@ -1,0 +1,39 @@
+scenarios:
+  - name: Login
+    flow:
+      - get:
+          name: Init response
+          url: http://localhost:5001/auth/self-service/login/api
+          match:
+            json: $.id
+            as: flowId
+      - post:
+          name: Login
+          url: http://localhost:5001/auth/self-service/login?flow={{ flowId }}
+          json:
+            method: password
+            identifier: alice@example.com
+            password: password
+          match:
+            json: $.session_token
+            as: sessionToken
+      - loop:
+          - post:
+              name: Me query
+              url: /
+              headers:
+                Authorization: Bearer {{ sessionToken }}
+              json:
+                query: |
+                  query {
+                    me {
+                      subgraph {
+                        roots,
+                        vertices
+                      }
+                    }
+                  }
+              match:
+                json: $.data.me
+                as: me
+        count: 10


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Most queries require a logged in user

## 🚫 Blocked by

- #4756 
- #4752 

## 🔍 What does this change?

Add a simple scenario to
- login
- query `me`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph