### PR TITLE
H-3168: Fix API migration on AWS

### DIFF
--- a/infra/terraform/hash/hash_application/api.tf
+++ b/infra/terraform/hash/hash_application/api.tf
@@ -36,7 +36,7 @@ locals {
     cpu              = 0 # let ECS divvy up the available CPU
     mountPoints      = []
     volumesFrom      = []
-    command          = ["ensure-system-graph-is-initialized"]
+    command          = ["start:migrate"]
     dependsOn   = [
       { condition = "HEALTHY", containerName = local.kratos_service_container_def.name },
     ]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The TF file was forgotten to be updated. With this the migration should run again on AWS.