### PR TITLE
H-3180: Read user entity after logging in

### DIFF
--- a/tests/hash-backend-performance/artillery.yml
+++ b/tests/hash-backend-performance/artillery.yml
@@ -1,6 +1,6 @@
 config:
   target: http://localhost:5001/graphql
-  processor: ./dist/cjs/main.cjs
+  processor: ./dist/esm/main.mjs
   plugins:
     expect:
       expectDefault200: true

--- a/tests/hash-backend-performance/package.json
+++ b/tests/hash-backend-performance/package.json
@@ -6,14 +6,14 @@
   "license": "AGPL-3.0",
   "type": "module",
   "exports": {
-    ".": "./dist/cjs/main.js"
+    ".": "./dist/esm/main.mjs"
   },
-  "main": "./dist/cjs/main.cjs",
-  "types": "./dist/cjs/main.d.ts",
+  "main": "./dist/esm/main.mjs",
+  "types": "./dist/esm/main.d.ts",
   "typesVersions": {
     "*": {
       "*": [
-        "./dist/cjs/main.d.ts"
+        "./dist/esm/main.d.ts"
       ]
     }
   },

--- a/tests/hash-backend-performance/package.json
+++ b/tests/hash-backend-performance/package.json
@@ -30,6 +30,12 @@
     "test:integration": "for file in scenarios/*.yml; do artillery run --config artillery.yml $file --environment functional; done"
   },
   "dependencies": {
+    "@local/hash-backend-utils": "0.0.0-private",
+    "@local/hash-graph-client": "0.0.0-private",
+    "@local/hash-graph-sdk": "0.0.0-private",
+    "@local/hash-graph-types": "0.0.0-private",
+    "@local/hash-isomorphic-utils": "0.0.0-private",
+    "@local/hash-subgraph": "0.0.0-private",
     "@ory/client": "1.1.41",
     "artillery": "2.0.18"
   },

--- a/tests/hash-backend-performance/rollup.config.ts
+++ b/tests/hash-backend-performance/rollup.config.ts
@@ -19,6 +19,7 @@ const bundles: RollupOptions[] = [
     plugins: [
       commonjs(),
       typescript({
+        declaration: true,
         outDir: OUT_DIR,
         rootDir: "src",
         sourceMap: !PRODUCTION,

--- a/tests/hash-backend-performance/rollup.config.ts
+++ b/tests/hash-backend-performance/rollup.config.ts
@@ -4,15 +4,15 @@ import typescript from "@rollup/plugin-typescript";
 import type { RollupOptions } from "rollup";
 
 const PRODUCTION = !process.env.ROLLUP_WATCH;
-const OUT_DIR = "dist/cjs";
+const OUT_DIR = "dist/esm";
 
 const bundles: RollupOptions[] = [
   {
     input: "src/main.ts",
     output: {
       dir: OUT_DIR,
-      entryFileNames: "[name].cjs",
-      format: "cjs",
+      entryFileNames: "[name].mjs",
+      format: "module",
       name: "hash-backend-performance",
       sourcemap: !PRODUCTION,
     },
@@ -27,7 +27,7 @@ const bundles: RollupOptions[] = [
       }),
       nodeResolve(),
     ],
-    external: ["@ory/client"],
+    external: ["@ory/client", /^@local\/.*/],
   },
 ];
 export default bundles;

--- a/tests/hash-backend-performance/scenarios/login.yml
+++ b/tests/hash-backend-performance/scenarios/login.yml
@@ -10,11 +10,14 @@ scenarios:
               query {
                 me {
                   subgraph {
-                    roots
                     vertices
                   }
                 }
               }
-          match:
-            json: $.data.me
-            as: me
+          capture:
+            - json: $.data.me.subgraph.vertices.*.*.inner.metadata.recordId.entityId
+              as: entityId
+          expect:
+            - equals:
+                - "{{ entityId }}"
+                - "{{ session.ownedById }}~{{ session.ownedById }}"

--- a/tests/hash-backend-performance/src/graph.ts
+++ b/tests/hash-backend-performance/src/graph.ts
@@ -1,0 +1,97 @@
+import { createGraphClient } from "@local/hash-backend-utils/create-graph-client";
+import { Logger } from "@local/hash-backend-utils/logger";
+import { publicUserAccountId } from "@local/hash-backend-utils/public-user-account-id";
+import type { GraphApi } from "@local/hash-graph-client";
+import type { GetEntitiesRequest } from "@local/hash-graph-client/api";
+import type { AuthenticationContext } from "@local/hash-graph-sdk/authentication-context";
+import type { Entity } from "@local/hash-graph-sdk/entity";
+import {
+  systemEntityTypes,
+  systemPropertyTypes,
+} from "@local/hash-isomorphic-utils/ontology-type-ids";
+import { mapGraphApiEntityToEntity } from "@local/hash-isomorphic-utils/subgraph-mapping";
+import type { User } from "@local/hash-isomorphic-utils/system-types/shared";
+
+const GRAPH_API_HOST = "127.0.0.1";
+const GRAPH_API_PORT = 4000;
+
+let graphApi: GraphApi | undefined;
+const getGraphApiClient = () => {
+  if (!graphApi) {
+    graphApi = createGraphClient(
+      new Logger({ mode: "dev", serviceName: "hash-backend-performance" }),
+      {
+        host: GRAPH_API_HOST,
+        port: GRAPH_API_PORT,
+      },
+    );
+  }
+
+  return graphApi;
+};
+
+export const getUser = async (params: {
+  authentication: AuthenticationContext;
+  filter: GetEntitiesRequest["filter"];
+  includeDrafts?: boolean;
+}): Promise<Entity<User> | undefined> => {
+  const [userEntity, ...unexpectedEntities] = await getGraphApiClient()
+    .getEntities(publicUserAccountId, {
+      filter: {
+        all: [
+          {
+            equal: [
+              { path: ["type", "versionedUrl"] },
+              { parameter: systemEntityTypes.user.entityTypeId },
+            ],
+          },
+          params.filter,
+        ],
+      },
+      temporalAxes: {
+        pinned: {
+          axis: "transactionTime",
+          timestamp: null,
+        },
+
+        variable: {
+          axis: "decisionTime",
+          interval: {
+            start: null,
+            end: null,
+          },
+        },
+      },
+      includeDrafts: params.includeDrafts ?? false,
+    })
+    .then(({ data: { entities } }) =>
+      entities.map((entity) => mapGraphApiEntityToEntity<User>(entity, null)),
+    );
+
+  if (unexpectedEntities.length > 0) {
+    throw new Error(`Critical: More than one user entity found in the graph.`);
+  }
+
+  return userEntity;
+};
+
+export const getUserByKratosIdentityId = async (params: {
+  authentication: AuthenticationContext;
+  kratosIdentityId: string;
+  includeDrafts?: boolean;
+}): Promise<Entity<User> | undefined> =>
+  getUser({
+    authentication: params.authentication,
+    filter: {
+      equal: [
+        {
+          path: [
+            "properties",
+            systemPropertyTypes.kratosIdentityId.propertyTypeBaseUrl,
+          ],
+        },
+        { parameter: params.kratosIdentityId },
+      ],
+    },
+    includeDrafts: params.includeDrafts,
+  });

--- a/tests/hash-backend-performance/src/session.ts
+++ b/tests/hash-backend-performance/src/session.ts
@@ -1,5 +1,12 @@
+import { publicUserAccountId } from "@local/hash-backend-utils/public-user-account-id";
+import type { OwnedById } from "@local/hash-graph-types/web";
+import type { SimpleProperties } from "@local/hash-isomorphic-utils/simplify-properties";
+import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
+import type { User } from "@local/hash-isomorphic-utils/system-types/shared";
+import { extractOwnedByIdFromEntityId } from "@local/hash-subgraph";
 import { Configuration, FrontendApi } from "@ory/client";
 
+import { getUserByKratosIdentityId } from "./graph";
 import type { BeforeRequest, RequestParams } from "./types";
 
 const API_ORIGIN = "http://127.0.0.1:5001";
@@ -9,6 +16,8 @@ type LoginContext = {
   session: {
     token: string;
     expiresAt?: string;
+    user: SimpleProperties<User["properties"]>;
+    ownedById: OwnedById;
   };
 };
 
@@ -67,9 +76,19 @@ export const refreshSessionToken: BeforeRequest<LoginContext> = async (
     throw new Error("Login failed");
   }
 
+  const user = await getUserByKratosIdentityId({
+    authentication: { actorId: publicUserAccountId },
+    kratosIdentityId: fullLogin.session.identity.id,
+  });
+  if (!user) {
+    throw new Error("User not found");
+  }
+
   context.vars.session = {
     token: fullLogin.session_token,
     expiresAt: fullLogin.session.expires_at,
+    user: simplifyProperties(user.properties),
+    ownedById: extractOwnedByIdFromEntityId(user.entityId),
   };
   setAuthorizationHeader(request, context.vars.session.token);
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Reading the owned-by-id from a subgraph is not trivial (and probably not possible using JsonPath).

## 🔍 What does this change?

- Allows hooks to connect to the graph directly
- Reads the user entity after login
- stores the user properties and the owned-by-id in the session
- asserts, that the `me` query returns the correct entity
- changes rollup to emit an ESM module instead of CJS

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph