### PR TITLE
H-3175: Implement load tests for type-loading

### DIFF
--- a/tests/hash-backend-performance/package.json
+++ b/tests/hash-backend-performance/package.json
@@ -21,7 +21,7 @@
     "dist"
   ],
   "scripts": {
-    "bench:load-testing": "for file in scenarios/*.yml; do artillery run --config artillery.yml $file --environment local; done",
+    "bench:load-testing": "for file in scenarios/*.yml; do artillery run --config artillery.yml $file --output reports/$(basename ${file%.*}).json --quiet --environment local; done",
     "build": "rimraf dist && rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript",
     "codegen": "mkdir -p reports && echo '*' > reports/.gitignore",
     "fix:eslint": "eslint --fix .",

--- a/tests/hash-backend-performance/scenarios/ontology-read.yml
+++ b/tests/hash-backend-performance/scenarios/ontology-read.yml
@@ -14,6 +14,8 @@ scenarios:
                   roots
                 }
               }
+          expect:
+            - notHasProperty: errors
       - post:
           name: Read property type by ID
           url: /
@@ -28,6 +30,8 @@ scenarios:
                   roots
                 }
               }
+          expect:
+            - notHasProperty: errors
       - post:
           name: Read entity type by ID
           url: /
@@ -45,3 +49,5 @@ scenarios:
                   roots
                 }
               }
+          expect:
+            - notHasProperty: errors

--- a/tests/hash-backend-performance/scenarios/read-data-types.yml
+++ b/tests/hash-backend-performance/scenarios/read-data-types.yml
@@ -1,0 +1,17 @@
+scenarios:
+  - name: Read all data types
+    flow:
+      - post:
+          url: /
+          json:
+            query: |
+              query {
+                queryDataTypes(
+                  constrainsValuesOn: { outgoing: 0 }
+                  includeArchived: true
+                ) {
+                  vertices
+                }
+              }
+          expect:
+            - notHasProperty: errors

--- a/tests/hash-backend-performance/scenarios/read-entity-types-entity-refs.yml
+++ b/tests/hash-backend-performance/scenarios/read-entity-types-entity-refs.yml
@@ -1,0 +1,21 @@
+scenarios:
+  - name: Read all entity types with entity type references
+    flow:
+      - post:
+          url: /
+          json:
+            query: |
+              query {
+                queryEntityTypes(
+                  constrainsValuesOn: { outgoing: 0 }
+                  constrainsPropertiesOn: { outgoing: 0 }
+                  constrainsLinksOn: { outgoing: 255 }
+                  constrainsLinkDestinationsOn: { outgoing: 255 }
+                  inheritsFrom: { outgoing: 255 }
+                  includeArchived: true
+                ) {
+                  vertices
+                }
+              }
+          expect:
+            - notHasProperty: errors

--- a/tests/hash-backend-performance/scenarios/read-entity-types-parents.yml
+++ b/tests/hash-backend-performance/scenarios/read-entity-types-parents.yml
@@ -1,0 +1,21 @@
+scenarios:
+  - name: Read all entity types with parents
+    flow:
+      - post:
+          url: /
+          json:
+            query: |
+              query {
+                queryEntityTypes(
+                  constrainsValuesOn: { outgoing: 0 }
+                  constrainsPropertiesOn: { outgoing: 0 }
+                  constrainsLinksOn: { outgoing: 0 }
+                  constrainsLinkDestinationsOn: { outgoing: 0 }
+                  inheritsFrom: { outgoing: 255 }
+                  includeArchived: true
+                ) {
+                  vertices
+                }
+              }
+          expect:
+            - notHasProperty: errors

--- a/tests/hash-backend-performance/scenarios/read-entity-types-property-entity-refs.yml
+++ b/tests/hash-backend-performance/scenarios/read-entity-types-property-entity-refs.yml
@@ -1,0 +1,21 @@
+scenarios:
+  - name: Read all entity types with property and entity type references
+    flow:
+      - post:
+          url: /
+          json:
+            query: |
+              query {
+                queryEntityTypes(
+                  constrainsValuesOn: { outgoing: 0 }
+                  constrainsPropertiesOn: { outgoing: 255 }
+                  constrainsLinksOn: { outgoing: 255 }
+                  constrainsLinkDestinationsOn: { outgoing: 255 }
+                  inheritsFrom: { outgoing: 255 }
+                  includeArchived: true
+                ) {
+                  vertices
+                }
+              }
+          expect:
+            - notHasProperty: errors

--- a/tests/hash-backend-performance/scenarios/read-entity-types-value-property-entity-refs.yml
+++ b/tests/hash-backend-performance/scenarios/read-entity-types-value-property-entity-refs.yml
@@ -1,0 +1,21 @@
+scenarios:
+  - name: Read all entity types with all type references
+    flow:
+      - post:
+          url: /
+          json:
+            query: |
+              query {
+                queryEntityTypes(
+                  constrainsValuesOn: { outgoing: 255 }
+                  constrainsPropertiesOn: { outgoing: 255 }
+                  constrainsLinksOn: { outgoing: 255 }
+                  constrainsLinkDestinationsOn: { outgoing: 255 }
+                  inheritsFrom: { outgoing: 255 }
+                  includeArchived: true
+                ) {
+                  vertices
+                }
+              }
+          expect:
+            - notHasProperty: errors

--- a/tests/hash-backend-performance/scenarios/read-entity-types.yml
+++ b/tests/hash-backend-performance/scenarios/read-entity-types.yml
@@ -1,0 +1,21 @@
+scenarios:
+  - name: Read all entity types
+    flow:
+      - post:
+          url: /
+          json:
+            query: |
+              query {
+                queryEntityTypes(
+                  constrainsValuesOn: { outgoing: 0 }
+                  constrainsPropertiesOn: { outgoing: 0 }
+                  constrainsLinksOn: { outgoing: 0 }
+                  constrainsLinkDestinationsOn: { outgoing: 0 }
+                  inheritsFrom: { outgoing: 0 }
+                  includeArchived: true
+                ) {
+                  vertices
+                }
+              }
+          expect:
+            - notHasProperty: errors

--- a/tests/hash-backend-performance/scenarios/read-property-types-property-refs.yml
+++ b/tests/hash-backend-performance/scenarios/read-property-types-property-refs.yml
@@ -1,0 +1,18 @@
+scenarios:
+  - name: Read all property types with property references
+    flow:
+      - post:
+          url: /
+          json:
+            query: |
+              query {
+                queryPropertyTypes(
+                  constrainsValuesOn: { outgoing: 0 }
+                  constrainsPropertiesOn: { outgoing: 255 }
+                  includeArchived: true
+                ) {
+                  vertices
+                }
+              }
+          expect:
+            - notHasProperty: errors

--- a/tests/hash-backend-performance/scenarios/read-property-types-value-property-refs.yml
+++ b/tests/hash-backend-performance/scenarios/read-property-types-value-property-refs.yml
@@ -1,0 +1,18 @@
+scenarios:
+  - name: Read all property types with all references
+    flow:
+      - post:
+          url: /
+          json:
+            query: |
+              query {
+                queryPropertyTypes(
+                  constrainsValuesOn: { outgoing: 255 }
+                  constrainsPropertiesOn: { outgoing: 255 }
+                  includeArchived: true
+                ) {
+                  vertices
+                }
+              }
+          expect:
+            - notHasProperty: errors

--- a/tests/hash-backend-performance/scenarios/read-property-types.yml
+++ b/tests/hash-backend-performance/scenarios/read-property-types.yml
@@ -1,0 +1,18 @@
+scenarios:
+  - name: Read all property types
+    flow:
+      - post:
+          url: /
+          json:
+            query: |
+              query {
+                queryPropertyTypes(
+                  constrainsValuesOn: { outgoing: 0 }
+                  constrainsPropertiesOn: { outgoing: 0 }
+                  includeArchived: true
+                ) {
+                  vertices
+                }
+              }
+          expect:
+            - notHasProperty: errors


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We want load tests for ontology type loading

## 🔍 What does this change?

- Create load tests for ontology types with different resolve depths
- Output reports as JSON when running load tests and avoid terminal output
- **Drive-by**: Add expect-test for existing tests

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph