### PR TITLE
H-3181: Add identifiers for workers in flows, group activity log by worker

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action.ts
@@ -296,6 +296,18 @@ export const researchEntitiesAction: FlowActionActivity<{
 
   const { flowEntityId, stepId, webId } = await getFlowContext();
 
+  logProgress([
+    {
+      type: "StartedCoordinator",
+      input: {
+        goal: input.prompt,
+      },
+      recordedAt: new Date().toISOString(),
+      stepId,
+      ...workerIdentifiers,
+    },
+  ]);
+
   const providedFileEntities = await getProvidedFiles();
 
   const providedFiles: CoordinatingAgentState["resourcesNotVisited"] =
@@ -1104,6 +1116,18 @@ export const researchEntitiesAction: FlowActionActivity<{
 
   logger.debug(`Proposed Entities: ${stringify(allProposedEntities)}`);
   logger.debug(`File Entities Proposed: ${stringify(fileEntityProposals)}`);
+
+  logProgress([
+    {
+      type: "ClosedCoordinator",
+      output: {
+        entityCount: allProposedEntities.length + fileEntityProposals.length,
+      },
+      recordedAt: new Date().toISOString(),
+      stepId,
+      ...workerIdentifiers,
+    },
+  ]);
 
   return {
     code: StatusCode.Ok,

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/coordinating-agent.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/coordinating-agent.ts
@@ -4,7 +4,6 @@ import type {
   ProposedEntity,
   StepInput,
 } from "@local/hash-isomorphic-utils/flows/types";
-import { Context } from "@temporalio/activity";
 import dedent from "dedent";
 
 import { getDereferencedEntityTypesActivity } from "../../get-dereferenced-entity-types-activity.js";
@@ -24,7 +23,6 @@ import type {
   ParsedLlmToolCall,
 } from "../../shared/get-llm-response/types.js";
 import { graphApiClient } from "../../shared/graph-api-client.js";
-import { logProgress } from "../../shared/log-progress.js";
 import { mapActionInputEntitiesToEntities } from "../../shared/map-action-input-entities-to-entities.js";
 import { stringify } from "../../shared/stringify.js";
 import type { LocalEntitySummary } from "../shared/infer-claims-from-text/get-entity-summaries-from-text.js";

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/coordinating-agent.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/coordinating-agent.ts
@@ -523,15 +523,6 @@ const createInitialPlan = async (params: {
     const { plan } =
       updatePlanToolCall.input as CoordinatorToolCallArguments["updatePlan"];
 
-    logProgress([
-      {
-        recordedAt: new Date().toISOString(),
-        stepId: Context.current().info.activityId,
-        type: "CreatedPlan",
-        plan,
-      },
-    ]);
-
     return { plan, questionsAndAnswers };
   }
 

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/handle-web-search-tool-call.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/handle-web-search-tool-call.ts
@@ -6,6 +6,7 @@ import {
 import type {
   StepInput,
   WebSearchResult,
+  WorkerIdentifiers,
 } from "@local/hash-isomorphic-utils/flows/types";
 import { StatusCode } from "@local/status";
 import { Context } from "@temporalio/activity";
@@ -18,8 +19,11 @@ import type { ResourceSummary } from "./types.js";
 
 export const handleWebSearchToolCall = async (params: {
   input: CoordinatorToolCallArguments["webSearch"];
+  workerIdentifiers: WorkerIdentifiers;
 }): Promise<ResourceSummary[] | { error: string }> => {
-  const { query, explanation } = params.input;
+  const { input, workerIdentifiers } = params;
+
+  const { query, explanation } = input;
 
   const response = await webSearchAction({
     inputs: [
@@ -48,6 +52,7 @@ export const handleWebSearchToolCall = async (params: {
       recordedAt: new Date().toISOString(),
       stepId: Context.current().info.activityId,
       explanation,
+      ...workerIdentifiers,
     },
   ]);
 

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/link-follower-agent.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/link-follower-agent.ts
@@ -2,6 +2,7 @@ import { getAwsS3Config } from "@local/hash-backend-utils/aws-config";
 import { AwsS3StorageProvider } from "@local/hash-backend-utils/file-storage/aws-s3-storage-provider";
 import type { SourceProvenance } from "@local/hash-graph-client";
 import { SourceType } from "@local/hash-graph-client";
+import type { WorkerIdentifiers } from "@local/hash-isomorphic-utils/flows/types";
 import dedent from "dedent";
 import { MetadataMode } from "llamaindex";
 
@@ -24,7 +25,6 @@ import { chooseRelevantLinksFromContent } from "./link-follower-agent/choose-rel
 import { filterAndRankTextChunksAgent } from "./link-follower-agent/filter-and-rank-text-chunks-agent.js";
 import { getLinkFollowerNextToolCalls } from "./link-follower-agent/get-link-follower-next-tool-calls.js";
 import { indexPdfFile } from "./link-follower-agent/llama-index/index-pdf-file.js";
-import { WorkerIdentifiers } from "@local/hash-isomorphic-utils/flows/types";
 
 type ResourceToExplore = {
   url: string;

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/link-follower-agent/link-follower-agent.ai.test.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/link-follower-agent/link-follower-agent.ai.test.ts
@@ -20,17 +20,24 @@ test.skip(
     });
 
     const status = await linkFollowerAgent({
-      task: "Obtain the full list of current members of Church Lab",
-      entityTypes: Object.values(dereferencedEntityTypes).map(
-        ({ schema }) => schema,
-      ),
-      existingEntitiesOfInterest: [],
-      initialResource: {
-        url: "https://churchlab.hms.harvard.edu/index.php/lab-members#current",
-        exampleOfExpectedContent: "Current Members: ...",
-        descriptionOfExpectedContent:
-          "The current members of the lab are listed on the page.",
-        reason: "The page should include the current members of the lab.",
+      input: {
+        task: "Obtain the full list of current members of Church Lab",
+        entityTypes: Object.values(dereferencedEntityTypes).map(
+          ({ schema }) => schema,
+        ),
+        existingEntitiesOfInterest: [],
+        initialResource: {
+          url: "https://churchlab.hms.harvard.edu/index.php/lab-members#current",
+          exampleOfExpectedContent: "Current Members: ...",
+          descriptionOfExpectedContent:
+            "The current members of the lab are listed on the page.",
+          reason: "The page should include the current members of the lab.",
+        },
+      },
+      workerIdentifiers: {
+        workerType: "Link explorer",
+        workerInstanceId: "linkFollowerAgent",
+        parentInstanceId: null,
       },
     });
 
@@ -57,17 +64,24 @@ test.skip(
     });
 
     const status = await linkFollowerAgent({
-      task: 'Obtain the full list of authors of the Sora article titled "Video Generation Models as World Simulators"',
-      entityTypes: Object.values(dereferencedEntityTypes).map(
-        ({ schema }) => schema,
-      ),
-      existingEntitiesOfInterest: [],
-      initialResource: {
-        url: "https://openai.com/index/video-generation-models-as-world-simulators/",
-        exampleOfExpectedContent: "Authors: ...",
-        descriptionOfExpectedContent:
-          "The authors of the article are listed at the bottom of the page.",
-        reason: "The article should include the authors.",
+      input: {
+        task: 'Obtain the full list of authors of the Sora article titled "Video Generation Models as World Simulators"',
+        entityTypes: Object.values(dereferencedEntityTypes).map(
+          ({ schema }) => schema,
+        ),
+        existingEntitiesOfInterest: [],
+        initialResource: {
+          url: "https://openai.com/index/video-generation-models-as-world-simulators/",
+          exampleOfExpectedContent: "Authors: ...",
+          descriptionOfExpectedContent:
+            "The authors of the article are listed at the bottom of the page.",
+          reason: "The article should include the authors.",
+        },
+      },
+      workerIdentifiers: {
+        workerType: "Link explorer",
+        workerInstanceId: "linkFollowerAgent",
+        parentInstanceId: null,
       },
     });
 
@@ -96,17 +110,24 @@ test.skip(
     });
 
     const status = await linkFollowerAgent({
-      task: "Get all the stock market constituents of the FTSE350.",
-      entityTypes: Object.values(dereferencedEntityTypes).map(
-        ({ schema }) => schema,
-      ),
-      existingEntitiesOfInterest: [],
-      initialResource: {
-        url: "https://www.londonstockexchange.com/indices/ftse-350/constituents/table",
-        exampleOfExpectedContent: "Constituents: ...",
-        descriptionOfExpectedContent:
-          "The constituents of the FTSE350 are listed on the page.",
-        reason: "The page should include the constituents of the FTSE350.",
+      input: {
+        task: "Get all the stock market constituents of the FTSE350.",
+        entityTypes: Object.values(dereferencedEntityTypes).map(
+          ({ schema }) => schema,
+        ),
+        existingEntitiesOfInterest: [],
+        initialResource: {
+          url: "https://www.londonstockexchange.com/indices/ftse-350/constituents/table",
+          exampleOfExpectedContent: "Constituents: ...",
+          descriptionOfExpectedContent:
+            "The constituents of the FTSE350 are listed on the page.",
+          reason: "The page should include the constituents of the FTSE350.",
+        },
+      },
+      workerIdentifiers: {
+        workerType: "Link explorer",
+        workerInstanceId: "linkFollowerAgent",
+        parentInstanceId: null,
       },
     });
 
@@ -135,18 +156,25 @@ test.skip(
     });
 
     const status = await linkFollowerAgent({
-      task: "Identify the top 3 graphics cards suitable for AI model processing, including their specifications and features.",
-      entityTypes: Object.values(dereferencedEntityTypes).map(
-        ({ schema }) => schema,
-      ),
-      existingEntitiesOfInterest: [],
-      initialResource: {
-        url: "https://www.gpu-mart.com/blog/best-gpus-for-deep-learning-2023",
-        exampleOfExpectedContent: "Graphics Cards: ...",
-        descriptionOfExpectedContent:
-          "The top 3 graphics cards for AI model processing are listed on the page.",
-        reason:
-          "The page should include the top 3 graphics cards for AI model processing.",
+      input: {
+        task: "Identify the top 3 graphics cards suitable for AI model processing, including their specifications and features.",
+        entityTypes: Object.values(dereferencedEntityTypes).map(
+          ({ schema }) => schema,
+        ),
+        existingEntitiesOfInterest: [],
+        initialResource: {
+          url: "https://www.gpu-mart.com/blog/best-gpus-for-deep-learning-2023",
+          exampleOfExpectedContent: "Graphics Cards: ...",
+          descriptionOfExpectedContent:
+            "The top 3 graphics cards for AI model processing are listed on the page.",
+          reason:
+            "The page should include the top 3 graphics cards for AI model processing.",
+        },
+      },
+      workerIdentifiers: {
+        workerType: "Link explorer",
+        workerInstanceId: "linkFollowerAgent",
+        parentInstanceId: null,
       },
     });
 
@@ -175,17 +203,25 @@ test.skip(
     });
 
     const status = await linkFollowerAgent({
-      task: "Get the list of investors of Marks and Spencer's, based on the 2023 annual investors report PDF file.",
-      entityTypes: Object.values(dereferencedEntityTypes).map(
-        ({ schema }) => schema,
-      ),
-      existingEntitiesOfInterest: [],
-      initialResource: {
-        url: "https://corporate.marksandspencer.com/investors",
-        exampleOfExpectedContent: "Investors: ...",
-        descriptionOfExpectedContent:
-          "The investors of Marks and Spencer's are listed on the page.",
-        reason: "The page should include the investors of Marks and Spencer's.",
+      input: {
+        task: "Get the list of investors of Marks and Spencer's, based on the 2023 annual investors report PDF file.",
+        entityTypes: Object.values(dereferencedEntityTypes).map(
+          ({ schema }) => schema,
+        ),
+        existingEntitiesOfInterest: [],
+        initialResource: {
+          url: "https://corporate.marksandspencer.com/investors",
+          exampleOfExpectedContent: "Investors: ...",
+          descriptionOfExpectedContent:
+            "The investors of Marks and Spencer's are listed on the page.",
+          reason:
+            "The page should include the investors of Marks and Spencer's.",
+        },
+      },
+      workerIdentifiers: {
+        workerType: "Link explorer",
+        workerInstanceId: "linkFollowerAgent",
+        parentInstanceId: null,
       },
     });
 

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/sub-task-agent.ai.test.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/sub-task-agent.ai.test.ts
@@ -97,6 +97,11 @@ test(
           testName: "github-url",
         }),
       },
+      workerIdentifiers: {
+        workerType: "Subtask",
+        workerInstanceId: "subtask1",
+        parentInstanceId: null,
+      },
     });
 
     expect(status).toBeDefined();

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/propose-entities-from-claims.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/propose-entities-from-claims.ts
@@ -1,5 +1,8 @@
 import type { BaseUrl } from "@local/hash-graph-types/ontology";
-import type { ProposedEntity } from "@local/hash-isomorphic-utils/flows/types";
+import type {
+  ProposedEntity,
+  WorkerIdentifiers,
+} from "@local/hash-isomorphic-utils/flows/types";
 
 import type { DereferencedEntityTypesByTypeId } from "../../infer-entities/inference-types.js";
 import { logger } from "../../shared/activity-logger.js";
@@ -18,6 +21,7 @@ export const proposeEntitiesFromClaims = async (params: {
   existingEntitySummaries?: ExistingEntitySummary[];
   claims: Claim[];
   dereferencedEntityTypes: DereferencedEntityTypesByTypeId;
+  workerIdentifiers: WorkerIdentifiers;
 }): Promise<{ proposedEntities: ProposedEntity[] }> => {
   const {
     entitySummaries,
@@ -25,6 +29,7 @@ export const proposeEntitiesFromClaims = async (params: {
     dereferencedEntityTypes,
     claims,
     potentialLinkTargetEntitySummaries,
+    workerIdentifiers,
   } = params;
 
   const { stepId } = await getFlowContext();
@@ -178,6 +183,7 @@ export const proposeEntitiesFromClaims = async (params: {
       proposedEntity: entity,
       stepId,
       recordedAt: now,
+      ...workerIdentifiers,
     })),
   );
 

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/propose-entities-from-claims/propose-entities-from-claims.ai.test.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/propose-entities-from-claims/propose-entities-from-claims.ai.test.ts
@@ -601,6 +601,11 @@ test.skip(
       claims,
       dereferencedEntityTypes,
       potentialLinkTargetEntitySummaries: [],
+      workerIdentifiers: {
+        workerInstanceId: generateUuid(),
+        parentInstanceId: null,
+        workerType: "Coordinator",
+      },
     });
 
     // eslint-disable-next-line no-console

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/propose-entities.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/propose-entities.ts
@@ -592,6 +592,9 @@ export const proposeEntities = async (params: {
                     recordedAt: now,
                     type: "ProposedEntity",
                     stepId: Context.current().info.activityId,
+                    workerType: "Link explorer",
+                    parentInstanceId: null,
+                    workerInstanceId: "browser-plugin-flow",
                   })),
               ),
             );

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/flow-run-sidebar/group-status.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/flow-run-sidebar/group-status.tsx
@@ -1,7 +1,9 @@
 import { CaretDownSolidIcon } from "@hashintel/design-system";
 import { Box, Collapse, Stack, Typography } from "@mui/material";
 import { useEffect, useMemo, useState } from "react";
+
 import { useStatusForSteps } from "../../../../shared/flow-runs-context";
+import { formatTimeTaken } from "../shared/format-time-taken";
 import type {
   GroupWithEdgesAndNodes,
   UngroupedEdgesAndNodes,
@@ -13,7 +15,6 @@ import {
   SuccessIcon,
   WaitingIcon,
 } from "./group-status/group-step-status";
-import { formatTimeTaken } from "../shared/format-time-taken";
 
 export const GroupStatus = ({
   groupData,

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/flow-run-sidebar/group-status.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/flow-run-sidebar/group-status.tsx
@@ -1,9 +1,6 @@
 import { CaretDownSolidIcon } from "@hashintel/design-system";
 import { Box, Collapse, Stack, Typography } from "@mui/material";
-import { differenceInMilliseconds, intervalToDuration } from "date-fns";
 import { useEffect, useMemo, useState } from "react";
-
-import { isNonNullable } from "../../../../../lib/typeguards";
 import { useStatusForSteps } from "../../../../shared/flow-runs-context";
 import type {
   GroupWithEdgesAndNodes,
@@ -16,24 +13,7 @@ import {
   SuccessIcon,
   WaitingIcon,
 } from "./group-status/group-step-status";
-
-const pad = (num: number) => String(num).padStart(2, "0");
-
-const formatTimeTaken = (scheduledAt: string, closedAt?: string) => {
-  const start = new Date(scheduledAt);
-
-  const elapsed = differenceInMilliseconds(
-    closedAt ? new Date(closedAt) : new Date(),
-    start,
-  );
-
-  const duration = intervalToDuration({ start: 0, end: elapsed });
-
-  return [duration.hours, duration.minutes, duration.seconds]
-    .filter(isNonNullable)
-    .map(pad)
-    .join(":");
-};
+import { formatTimeTaken } from "../shared/format-time-taken";
 
 export const GroupStatus = ({
   groupData,

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/shared/format-time-taken.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/shared/format-time-taken.tsx
@@ -1,0 +1,21 @@
+import { differenceInMilliseconds, intervalToDuration } from "date-fns";
+
+import { isNonNullable } from "../../../../../lib/typeguards";
+
+const pad = (num: number) => String(num).padStart(2, "0");
+
+export const formatTimeTaken = (scheduledAt: string, closedAt?: string) => {
+  const start = new Date(scheduledAt);
+
+  const elapsed = differenceInMilliseconds(
+    closedAt ? new Date(closedAt) : new Date(),
+    start,
+  );
+
+  const duration = intervalToDuration({ start: 0, end: elapsed });
+
+  return [duration.hours, duration.minutes, duration.seconds]
+    .filter(isNonNullable)
+    .map(pad)
+    .join(":");
+};

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/shared/types.ts
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/shared/types.ts
@@ -62,20 +62,20 @@ export type StateChangeLog = ProgressLogBase & {
 
 export type LogDisplay = "grouped" | "stream";
 
-export type StandaloneLog = (StepProgressLog | StateChangeLog) & {
-  level: number;
-  number: string;
-};
+export type StandaloneLog = StepProgressLog | StateChangeLog;
 
 export type LogThread = {
-  level: number;
-  number: string;
+  label: string;
+  type: "Thread";
   threadStartedAt?: Date;
   threadClosedAt?: Date;
-  entries?: LocalProgressLog[];
+  logs: LocalProgressLog[];
 };
 
-export type LocalProgressLog = StandaloneLog | LogThread;
+export type LocalProgressLog = (StandaloneLog | LogThread) & {
+  level: number;
+  number: string;
+};
 
 export type ProposedEntityOutput = Omit<ProposedEntity, "provenance"> & {
   researchOngoing: boolean;

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/shared/types.ts
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/shared/types.ts
@@ -62,20 +62,24 @@ export type StateChangeLog = ProgressLogBase & {
 
 export type LogDisplay = "grouped" | "stream";
 
-export type StandaloneLog = StepProgressLog | StateChangeLog;
+type CommonLogFields = {
+  level: number;
+  number: string;
+};
+
+export type StandaloneLog = (StepProgressLog | StateChangeLog) &
+  CommonLogFields;
 
 export type LogThread = {
   label: string;
   type: "Thread";
-  threadStartedAt?: Date;
-  threadClosedAt?: Date;
+  recordedAt: string;
+  threadStartedAt: string;
+  threadClosedAt?: string;
   logs: LocalProgressLog[];
-};
+} & CommonLogFields;
 
-export type LocalProgressLog = (StandaloneLog | LogThread) & {
-  level: number;
-  number: string;
-};
+export type LocalProgressLog = StandaloneLog | LogThread;
 
 export type ProposedEntityOutput = Omit<ProposedEntity, "provenance"> & {
   researchOngoing: boolean;

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/shared/types.ts
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/shared/types.ts
@@ -64,7 +64,6 @@ export type LogDisplay = "grouped" | "stream";
 
 type CommonLogFields = {
   level: number;
-  number: string;
 };
 
 export type StandaloneLog = (StepProgressLog | StateChangeLog) &
@@ -74,8 +73,10 @@ export type LogThread = {
   label: string;
   type: "Thread";
   recordedAt: string;
+  threadWorkerId: string;
   threadStartedAt: string;
   threadClosedAt?: string;
+  closedDueToFlowClosure?: boolean;
   logs: LocalProgressLog[];
 } & CommonLogFields;
 

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/shared/types.ts
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/shared/types.ts
@@ -60,7 +60,22 @@ export type StateChangeLog = ProgressLogBase & {
   type: "StateChange";
 };
 
-export type LocalProgressLog = StepProgressLog | StateChangeLog;
+export type LogDisplay = "grouped" | "stream";
+
+export type StandaloneLog = (StepProgressLog | StateChangeLog) & {
+  level: number;
+  number: string;
+};
+
+export type LogThread = {
+  level: number;
+  number: string;
+  threadStartedAt?: Date;
+  threadClosedAt?: Date;
+  entries?: LocalProgressLog[];
+};
+
+export type LocalProgressLog = StandaloneLog | LogThread;
 
 export type ProposedEntityOutput = Omit<ProposedEntity, "provenance"> & {
   researchOngoing: boolean;

--- a/apps/hash-frontend/src/pages/shared/virtualized-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/virtualized-table.tsx
@@ -285,6 +285,7 @@ export const VirtualizedTable = <
         followOutput="smooth"
         increaseViewportBy={50}
         itemContent={createRowContent}
+        overscan={{ main: 100, reverse: 100 }}
         style={heightStyle}
       />
     </Box>

--- a/libs/@local/hash-isomorphic-utils/src/flows/types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/flows/types.ts
@@ -403,6 +403,21 @@ export type VisitedWebPageLog = WorkerProgressLogBase & {
   type: "VisitedWebPage";
 };
 
+export type StartedCoordinatorLog = WorkerProgressLogBase & {
+  input: {
+    goal: string;
+  };
+  type: "StartedCoordinator";
+};
+
+export type ClosedCoordinatorLog = WorkerProgressLogBase & {
+  errorMessage?: string;
+  output: {
+    entityCount: number;
+  };
+  type: "ClosedCoordinator";
+};
+
 export type StartedSubTaskLog = WorkerProgressLogBase & {
   explanation: string;
   input: {
@@ -474,12 +489,14 @@ export type PersistedEntityLog = ProgressLogBase & {
 };
 
 export type StepProgressLog =
+  | ClosedCoordinatorLog
   | ClosedLinkExplorerTaskLog
   | ClosedSubTaskLog
   | InferredClaimsFromTextLog
   | PersistedEntityLog
   | ProposedEntityLog
   | QueriedWebLog
+  | StartedCoordinatorLog
   | StartedLinkExplorerTaskLog
   | StartedSubTaskLog
   | ViewedFile

--- a/libs/@local/hash-isomorphic-utils/src/flows/types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/flows/types.ts
@@ -376,30 +376,86 @@ export type ProgressLogBase = {
   stepId: string;
 };
 
-export type QueriedWebLog = ProgressLogBase & {
+export type WorkerType = "Coordinator" | "Subtask" | "Link explorer";
+
+export type WorkerIdentifiers = {
+  workerType: WorkerType;
+  workerInstanceId: string;
+  parentInstanceId: string | null;
+};
+
+export type WorkerProgressLogBase = ProgressLogBase & WorkerIdentifiers;
+
+export type QueriedWebLog = WorkerProgressLogBase & {
   explanation: string;
   query: string;
   type: "QueriedWeb";
 };
 
-export type CreatedPlanLog = ProgressLogBase & {
+export type CreatedPlanLog = WorkerProgressLogBase & {
   plan: string;
   type: "CreatedPlan";
 };
 
-export type VisitedWebPageLog = ProgressLogBase & {
+export type VisitedWebPageLog = WorkerProgressLogBase & {
   explanation: string;
   webPage: Pick<WebPage, "url" | "title">;
   type: "VisitedWebPage";
 };
 
-export type StartedSubTaskLog = ProgressLogBase & {
+export type StartedSubTaskLog = WorkerProgressLogBase & {
   explanation: string;
-  goal: string;
+  input: {
+    goal: string;
+    entityTypeTitles: string[];
+  };
   type: "StartedSubTask";
 };
 
-export type ViewedFile = {
+export type ClosedSubTaskLog = WorkerProgressLogBase & {
+  errorMessage?: string;
+  explanation: string;
+  goal: string;
+  output: {
+    claimCount: number;
+    entityCount: number;
+  };
+  type: "ClosedSubTask";
+};
+
+export type StartedLinkExplorerTaskLog = WorkerProgressLogBase & {
+  explanation: string;
+  input: {
+    goal: string;
+  };
+  type: "StartedLinkExplorerTask";
+};
+
+export type ClosedLinkExplorerTaskLog = WorkerProgressLogBase & {
+  errorMessage?: string;
+  goal: string;
+  output: {
+    claimCount: number;
+    entityCount: number;
+    resourcesExploredCount: number;
+    suggestionForNextSteps: string;
+  };
+  type: "ClosedLinkExplorerTask";
+};
+
+export type InferredClaimsFromTextLog = WorkerProgressLogBase & {
+  output: {
+    claimCount: number;
+    entityCount: number;
+    resource: {
+      title?: string;
+      url: string;
+    };
+  };
+  type: "InferredClaimsFromText";
+};
+
+export type ViewedFile = WorkerProgressLogBase & {
   explanation: string;
   file: Pick<WebPage, "url" | "title">;
   recordedAt: string;
@@ -407,7 +463,7 @@ export type ViewedFile = {
   type: "ViewedFile";
 };
 
-export type ProposedEntityLog = ProgressLogBase & {
+export type ProposedEntityLog = WorkerProgressLogBase & {
   proposedEntity: Omit<ProposedEntity, "provenance">;
   type: "ProposedEntity";
 };
@@ -418,13 +474,17 @@ export type PersistedEntityLog = ProgressLogBase & {
 };
 
 export type StepProgressLog =
-  | CreatedPlanLog
+  | ClosedLinkExplorerTaskLog
+  | ClosedSubTaskLog
+  | InferredClaimsFromTextLog
   | PersistedEntityLog
   | ProposedEntityLog
-  | VisitedWebPageLog
-  | ViewedFile
   | QueriedWebLog
-  | StartedSubTaskLog;
+  | StartedLinkExplorerTaskLog
+  | StartedSubTaskLog
+  | ViewedFile
+  | VisitedWebPageLog
+  | CreatedPlanLog;
 
 export type ProgressLogSignal = {
   attempt: number;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR improves flow logging by:
- Adding an identifier for a worker (and its parent) to activity logs
- Adding new logs for the starting and closing of worker tasks (e.g. sub-task, link explorer)
- Adds the ability to display logs grouped by worker in the flow run UI

Actions taken by the research coordinator appear at the top level, with any activity by workers it spawns grouped in a toggleable list (see demo).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- None yet

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Run a flow, see logs

## 📹 Demo

https://github.com/user-attachments/assets/938c5e2a-3fa3-4910-82db-b413fa9ff66a


<!-- Add a screenshot or video showcasing your work -->
