### PR TITLE
H-3199: Set @rust/hql-cst package private

### DIFF
--- a/libs/@local/hql/cst/package.json
+++ b/libs/@local/hql/cst/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rust/hql-cst",
   "version": "0.1.0",
-  "private": false,
+  "private": true,
   "license": "AGPL-3.0",
   "scripts": {
     "fix:clippy": "just clippy --fix",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

So `changesets` doesn't attempt to publish it.