### PR TITLE
H-3206: Allow missing data type ID in validation if unambiguous

### DIFF
--- a/apps/hash-graph/.justfile
+++ b/apps/hash-graph/.justfile
@@ -30,3 +30,5 @@ test-integration *arguments:
   @just yarn graph:reset-database
   @just yarn httpyac send --all {{repo}}/apps/hash-graph/tests/circular-links.http
   @just yarn graph:reset-database
+  @just yarn httpyac send --all {{repo}}/apps/hash-graph/tests/ambiguous.http
+  @just yarn graph:reset-database

--- a/apps/hash-graph/tests/ambiguous.http
+++ b/apps/hash-graph/tests/ambiguous.http
@@ -1,0 +1,229 @@
+# This file either runs with JetBrains' http requests or using httpYac (https://httpyac.github.io).
+
+### Create account
+POST http://127.0.0.1:4000/accounts
+Content-Type: application/json
+X-Authenticated-User-Actor-Id: 00000000-0000-0000-0000-000000000000
+
+{}
+
+> {%
+  client.test("status", function() {
+    client.assert(response.status === 200, "Response status is not 200");
+  });
+  client.global.set("account_id", response.body.toString());
+%}
+
+### Create account web
+POST http://127.0.0.1:4000/webs
+Content-Type: application/json
+X-Authenticated-User-Actor-Id: {{account_id}}
+
+{
+   "ownedById": "{{account_id}}",
+   "owner": {
+       "kind": "account",
+       "subjectId": "{{account_id}}"
+    }
+}
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 204, "Response status is not 204");
+    });
+%}
+
+### Insert data types
+POST http://127.0.0.1:4000/data-types
+Content-Type: application/json
+Accept: application/json
+X-Authenticated-User-Actor-Id: {{account_id}}
+
+{
+  "ownedById": "{{account_id}}",
+  "schema": [
+      {
+        "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
+        "kind": "dataType",
+        "$id": "http://localhost:3000/@alice/types/data-type/meter/v/1",
+        "title": "Meter",
+        "type": "number",
+        "description": "A unit of length",
+        "minimum": 0
+      },
+      {
+        "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
+        "kind": "dataType",
+        "$id": "http://localhost:3000/@alice/types/data-type/inch/v/1",
+        "title": "Inch",
+        "type": "number",
+        "description": "A unit of length",
+        "minimum": 0
+      }
+  ],
+  "relationships": [{
+    "relation": "viewer",
+    "subject": {
+      "kind": "public"
+    }
+  }]
+}
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+    });
+%}
+
+
+### Insert property types
+POST http://127.0.0.1:4000/property-types
+Content-Type: application/json
+Accept: application/json
+X-Authenticated-User-Actor-Id: {{account_id}}
+
+{
+  "ownedById": "{{account_id}}",
+  "schema": {
+    "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type",
+    "kind": "propertyType",
+    "$id": "http://localhost:3000/@alice/types/property-type/length/v/1",
+    "title": "Length",
+    "description": "A length",
+    "oneOf": [
+      {
+        "$ref": "http://localhost:3000/@alice/types/data-type/meter/v/1"
+      },
+      {
+        "$ref": "http://localhost:3000/@alice/types/data-type/inch/v/1"
+      }
+    ]
+  },
+  "relationships": [{
+    "relation": "setting",
+    "subject": {
+      "kind": "setting",
+      "subjectId": "updateFromWeb"
+    }
+  }]
+}
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+    });
+%}
+
+
+### Insert Friendship entity link type
+POST http://127.0.0.1:4000/entity-types
+Content-Type: application/json
+Accept: application/json
+X-Authenticated-User-Actor-Id: {{account_id}}
+
+{
+  "ownedById": "{{account_id}}",
+  "schema": {
+    "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/entity-type",
+    "kind": "entityType",
+    "$id": "http://localhost:3000/@alice/types/entity-type/line/v/1",
+    "type": "object",
+    "title": "Line",
+    "description": "A line with a length",
+    "properties": {
+      "http://localhost:3000/@alice/types/property-type/length/": {
+        "$ref": "http://localhost:3000/@alice/types/property-type/length/v/1"
+      }
+    }
+  },
+  "relationships": [
+    {
+      "relation": "setting",
+      "subject": {
+        "kind": "setting",
+        "subjectId": "updateFromWeb"
+      }
+    },
+    {
+      "relation": "instantiator",
+      "subject": {
+        "kind": "account",
+        "subjectId": "{{account_id}}"
+      }
+    }
+  ]
+}
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+    });
+%}
+
+### Insert ambiuous entity
+POST http://127.0.0.1:4000/entities
+Content-Type: application/json
+Accept: application/json
+X-Authenticated-User-Actor-Id: {{account_id}}
+
+{
+  "ownedById": "{{account_id}}",
+  "entityTypeIds": ["http://localhost:3000/@alice/types/entity-type/line/v/1"],
+  "properties": {
+    "value": {
+      "http://localhost:3000/@alice/types/property-type/length/": {
+        "value": 10,
+        "metadata": {}
+      }
+    }
+  },
+  "draft": false,
+  "relationships": [{
+    "relation": "setting",
+    "subject": {
+       "kind": "setting",
+       "subjectId": "administratorFromWeb"
+    }
+  }]
+}
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 400, "Response status is not 200");
+    });
+%}
+
+### Insert entity
+POST http://127.0.0.1:4000/entities
+Content-Type: application/json
+Accept: application/json
+X-Authenticated-User-Actor-Id: {{account_id}}
+
+{
+  "ownedById": "{{account_id}}",
+  "entityTypeIds": ["http://localhost:3000/@alice/types/entity-type/line/v/1"],
+  "properties": {
+    "value": {
+      "http://localhost:3000/@alice/types/property-type/length/": {
+        "value": 10,
+        "metadata": {
+          "dataTypeId": "http://localhost:3000/@alice/types/data-type/meter/v/1"
+        }
+      }
+    }
+  },
+  "draft": false,
+  "relationships": [{
+    "relation": "setting",
+    "subject": {
+       "kind": "setting",
+       "subjectId": "administratorFromWeb"
+    }
+  }]
+}
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+    });
+%}

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -313,9 +313,10 @@ mod tests {
         let property_type: PropertyType =
             serde_json::from_str(property_type).expect("failed to parse property type");
 
-        PropertyWithMetadata::from_parts(property, None)
-            .expect("failed to create property with metadata")
-            .validate(&property_type, components, &provider)
+        let property = PropertyWithMetadata::from_parts(property, None)
+            .expect("failed to create property with metadata");
+        property_type
+            .validate_value(&property, components, &provider)
             .await
     }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

If an entity can be inserted unambiguously, there isn't strictly the requirement to specify the data type id.

## 🔍 What does this change?

- Change the `oneOf` validation of property types to act like a real `oneOf`, this implies that if a value could be inserted by satisfying two schemas it will fail
- By tightening that constraint we can make sure, that the data is not ambiguous. Normally, we wouldn't care about that and this is also the reason why we're going to replace `oneOf` with `anyOf`, but currently it's the simplest way to make sure that a missing data type ID is still an unambiguous entity.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- In theory, we want to allow `oneOf: [meter, meter]`, but this PR prevents that. With JSON schema this is forbidden anyway so it's technically more correct, but as soon as we make `dataTypeId` actually required we can lift this constraint again and make the `oneOf` an `anyOf`.
- All elements in a `oneOf` needs to be checked, we cannot exit early,

## 🛡 What tests cover this?

- A new test was added
