### PR TITLE
H-3211: Fix ignore in changeset configuration

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,15 +6,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [
-    "@apps/*",
-    "@blocks/*",
-    "@local/*",
-    "@rust/*",
-    "@tests/*",
-    "error-stack",
-    "deer"
-  ],
+  "ignore": ["@apps/*", "@blocks/*", "@local/*", "@rust/*", "@tests/*"],
   "snapshot": {
     "useCalculatedVersion": true
   },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`error-stack` and `deer` are now prepended with `@rust`