### PR TITLE
H-3214: Update Rust pipeline tools

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -95,7 +95,7 @@ jobs:
         if: steps.benches.outputs.has-rust == 'true'
         uses: taiki-e/install-action@d79dff47733726f636463323dd2d82724f6c36ba # v2.42.18
         with:
-          tool: just@1.13.0,critcmp@0.1.8
+          tool: just@1.34.0,critcmp@0.1.8
 
       - name: Install Protobuf
         if: steps.benches.outputs.has-rust == 'true'
@@ -243,7 +243,7 @@ jobs:
         if: steps.benches.outputs.has-rust == 'true'
         uses: taiki-e/install-action@d79dff47733726f636463323dd2d82724f6c36ba # v2.42.18
         with:
-          tool: just@1.13.0,critcmp@0.1.8
+          tool: just@1.34.0,critcmp@0.1.8
 
       - name: Install Protobuf
         if: steps.benches.outputs.has-rust == 'true'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -107,7 +107,7 @@ jobs:
         if: always() && steps.lints.outputs.has-rust == 'true'
         uses: taiki-e/install-action@d79dff47733726f636463323dd2d82724f6c36ba # v2.42.18
         with:
-          tool: just@1.13.0,cargo-hack@0.6.28,rust-script@0.23.0,clippy-sarif@0.3.7,sarif-fmt@0.3.7
+          tool: just@1.34.0,cargo-hack@0.6.30,clippy-sarif@0.6.5,sarif-fmt@0.6.5
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,7 @@ jobs:
         if: always() && steps.tests.outputs.has-rust == 'true'
         uses: taiki-e/install-action@d79dff47733726f636463323dd2d82724f6c36ba # v2.42.18
         with:
-          tool: just@1.13.0,cargo-hack@0.6.28,cargo-nextest@0.9.68,cargo-llvm-cov@0.6.9
+          tool: just@1.34.0,cargo-hack@0.6.30,cargo-nextest@0.9.72,cargo-llvm-cov@0.6.11
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo
@@ -267,7 +267,7 @@ jobs:
         if: steps.tests.outputs.has-rust == 'true'
         uses: taiki-e/install-action@d79dff47733726f636463323dd2d82724f6c36ba # v2.42.18
         with:
-          tool: just@1.13.0,cargo-hack@0.6.28,cargo-nextest@0.9.68,cargo-llvm-cov@0.6.9
+          tool: just@1.34.0,cargo-hack@0.6.30,cargo-nextest@0.9.72,cargo-llvm-cov@0.6.11
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo

--- a/.justfile
+++ b/.justfile
@@ -104,15 +104,15 @@ install-cargo-tool tool install version:
 
 [private]
 install-cargo-hack:
-  @just install-cargo-tool 'cargo hack' cargo-hack 0.6.28
+  @just install-cargo-tool 'cargo hack' cargo-hack 0.6.30
 
 [private]
 install-cargo-nextest:
-  @just install-cargo-tool 'cargo nextest' cargo-nextest 0.9.68
+  @just install-cargo-tool 'cargo nextest' cargo-nextest 0.9.72
 
 [private]
 install-llvm-cov:
-  @just install-cargo-tool 'cargo llvm-cov' cargo-llvm-cov 0.6.9
+  @just install-cargo-tool 'cargo llvm-cov' cargo-llvm-cov 0.6.11
 
 [private]
 install-cargo-insta:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

One of our CI steps failed as it wasn't able to install `clippy-sarif`, which was a quite outdated version. Typically, they are prebuilt but if that download fails they are built instead. The newest version should pass building.