### PR TITLE
H-2962: Allow querying inheritance for data types

### DIFF
--- a/apps/hash-graph/libs/api/src/rest/data_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/data_type.rs
@@ -227,7 +227,14 @@ where
     let mut metadata = store
         .create_data_types(
             actor_id,
-            schema.into_iter().map(|schema| {
+            schema.into_iter().inspect(|schema| {
+                // TODO: Enable data type inheritance
+                //   see https://linear.app/hash/issue/H-3221/enable-data-type-inheritance-in-graph-api
+                assert!(
+                    schema.all_of.is_empty(),
+                    "Data Type schema contains `allOf` which is not supported, yet"
+                );
+            }).map(|schema| {
                 domain_validator.validate(&schema).map_err(|report| {
                     tracing::error!(error=?report, id=%schema.id, "Data Type ID failed to validate");
                     StatusCode::UNPROCESSABLE_ENTITY
@@ -357,6 +364,13 @@ where
                     vec![],
                 )));
             }
+
+            // TODO: Enable data type inheritance
+            //   see https://linear.app/hash/issue/H-3221/enable-data-type-inheritance-in-graph-api
+            assert!(
+                schema.all_of.is_empty(),
+                "Data Type schema contains `allOf` which is not supported, yet"
+            );
 
             Ok(Json(
                 store

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -204,7 +204,7 @@ where
                         );
 
                         traversal_context.add_entity_type_id(
-                            edge.right_endpoint_ontology_id,
+                            EntityTypeId::from(edge.right_endpoint_ontology_id),
                             edge.resolve_depths,
                             edge.traversal_interval,
                         )
@@ -850,15 +850,11 @@ where
                 EntityValidationType::ClosedSchema(schema) => schema,
                 EntityValidationType::Schema(schemas) => Cow::Owned(schemas.into_iter().collect()),
                 EntityValidationType::Id(entity_type_url) => {
-                    let (ontology_type_ids, ontology_type_uuids): (Vec<_>, Vec<_>) =
-                        entity_type_url
-                            .as_ref()
-                            .iter()
-                            .map(|url| {
-                                let id = EntityTypeId::from_url(url);
-                                (id, id.into_uuid())
-                            })
-                            .unzip();
+                    let ontology_type_ids = entity_type_url
+                        .as_ref()
+                        .iter()
+                        .map(EntityTypeId::from_url)
+                        .collect::<Vec<_>>();
 
                     if !self
                         .authorization_api
@@ -883,7 +879,7 @@ where
                         .read_closed_schemas(
                             &Filter::In(
                                 FilterExpression::Path(EntityTypeQueryPath::OntologyId),
-                                ParameterList::Uuid(&ontology_type_uuids),
+                                ParameterList::EntityTypeIds(&ontology_type_ids),
                             ),
                             Some(
                                 &QueryTemporalAxesUnresolved::DecisionTime {

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
@@ -208,7 +208,7 @@ where
     pub(crate) async fn traverse_data_types(
         &self,
         mut data_type_queue: Vec<(
-            OntologyId,
+            DataTypeId,
             GraphResolveDepths,
             RightBoundedTemporalInterval<VariableAxis>,
         )>,
@@ -221,7 +221,7 @@ where
             let mut edges_to_traverse =
                 HashMap::<OntologyEdgeKind, OntologyTypeTraversalData>::new();
 
-            for (entity_type_ontology_id, graph_resolve_depths, traversal_interval) in
+            for (data_type_ontology_id, graph_resolve_depths, traversal_interval) in
                 mem::take(&mut data_type_queue)
             {
                 for edge_kind in [
@@ -232,7 +232,7 @@ where
                         .decrement_depth_for_edge(edge_kind, EdgeDirection::Outgoing)
                     {
                         edges_to_traverse.entry(edge_kind).or_default().push(
-                            entity_type_ontology_id,
+                            OntologyId::from(data_type_ontology_id),
                             new_graph_resolve_depths,
                             traversal_interval,
                         );
@@ -275,7 +275,7 @@ where
                             );
 
                             traversal_context.add_data_type_id(
-                                edge.right_endpoint_ontology_id,
+                                DataTypeId::from(edge.right_endpoint_ontology_id),
                                 edge.resolve_depths,
                                 edge.traversal_interval,
                             )
@@ -587,7 +587,7 @@ where
                 .into_iter()
                 .map(|id| {
                     (
-                        OntologyId::from(id),
+                        id,
                         subgraph.depths,
                         subgraph.temporal_axes.resolved.variable_interval(),
                     )

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
@@ -17,6 +17,7 @@ use graph_types::{
         DataTypeId, EntityTypeId, EntityTypeMetadata, EntityTypeWithMetadata,
         OntologyEditionProvenance, OntologyProvenance, OntologyTemporalMetadata,
         OntologyTypeClassificationMetadata, OntologyTypeRecordId, PartialEntityTypeMetadata,
+        PropertyTypeId,
     },
     Embedding,
 };
@@ -29,7 +30,6 @@ use type_system::{
     url::{BaseUrl, OntologyTypeVersion, VersionedUrl},
     Validator,
 };
-use uuid::Uuid;
 
 use crate::{
     ontology::EntityTypeQueryPath,
@@ -215,7 +215,7 @@ where
     pub(crate) async fn traverse_entity_types(
         &self,
         mut entity_type_queue: Vec<(
-            OntologyId,
+            EntityTypeId,
             GraphResolveDepths,
             RightBoundedTemporalInterval<VariableAxis>,
         )>,
@@ -244,7 +244,7 @@ where
                         .decrement_depth_for_edge(edge_kind, EdgeDirection::Outgoing)
                     {
                         edges_to_traverse.entry(edge_kind).or_default().push(
-                            entity_type_ontology_id,
+                            OntologyId::from(entity_type_ontology_id),
                             new_graph_resolve_depths,
                             traversal_interval,
                         );
@@ -281,7 +281,7 @@ where
                         );
 
                         traversal_context.add_property_type_id(
-                            edge.right_endpoint_ontology_id,
+                            PropertyTypeId::from(edge.right_endpoint_ontology_id),
                             edge.resolve_depths,
                             edge.traversal_interval,
                         )
@@ -334,7 +334,7 @@ where
                             );
 
                             traversal_context.add_entity_type_id(
-                                edge.right_endpoint_ontology_id,
+                                EntityTypeId::from(edge.right_endpoint_ontology_id),
                                 edge.resolve_depths,
                                 edge.traversal_interval,
                             )
@@ -451,20 +451,15 @@ where
     ) -> Result<Vec<EntityTypeInsertion>, QueryError> {
         let entity_types = entity_types
             .into_iter()
-            .map(|entity_type| {
-                (
-                    EntityTypeId::from_url(&entity_type.id).into_uuid(),
-                    entity_type,
-                )
-            })
-            .collect::<Vec<(Uuid, EntityType)>>();
+            .map(|entity_type| (EntityTypeId::from_url(&entity_type.id), entity_type))
+            .collect::<Vec<_>>();
 
         // We need all types that the provided types inherit from so we can create the closed
         // schemas
         let parent_entity_type_ids = entity_types
             .iter()
             .flat_map(|(_, schema)| &schema.all_of)
-            .map(|reference| EntityTypeId::from_url(&reference.url).into_uuid())
+            .map(|reference| EntityTypeId::from_url(&reference.url))
             .collect::<Vec<_>>();
 
         // We read all relevant schemas from the graph
@@ -472,7 +467,7 @@ where
             .read_closed_schemas(
                 &Filter::In(
                     FilterExpression::Path(EntityTypeQueryPath::OntologyId),
-                    ParameterList::Uuid(&parent_entity_type_ids),
+                    ParameterList::EntityTypeIds(&parent_entity_type_ids),
                 ),
                 Some(
                     &QueryTemporalAxesUnresolved::DecisionTime {
@@ -489,12 +484,7 @@ where
         // The types we check either come from the graph or are provided by the user
         let mut available_schemas: HashMap<_, _> = entity_types
             .iter()
-            .map(|(id, schema)| {
-                (
-                    EntityTypeId::new(*id),
-                    ClosedEntityType::from(schema.clone()),
-                )
-            })
+            .map(|(id, schema)| (*id, ClosedEntityType::from(schema.clone())))
             .chain(parent_schemas)
             .collect();
 
@@ -504,7 +494,7 @@ where
                 Ok(EntityTypeInsertion {
                     schema,
                     closed_schema: Self::create_closed_entity_type(
-                        EntityTypeId::new(entity_type_id),
+                        entity_type_id,
                         &mut available_schemas,
                     )?,
                 })
@@ -813,7 +803,7 @@ where
                 .into_iter()
                 .map(|id| {
                     (
-                        OntologyId::from(id),
+                        id,
                         subgraph.depths,
                         subgraph.temporal_axes.resolved.variable_interval(),
                     )

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/property_type.rs
@@ -212,7 +212,7 @@ where
     pub(crate) async fn traverse_property_types(
         &self,
         mut property_type_queue: Vec<(
-            OntologyId,
+            PropertyTypeId,
             GraphResolveDepths,
             RightBoundedTemporalInterval<VariableAxis>,
         )>,
@@ -239,7 +239,7 @@ where
                         .decrement_depth_for_edge(edge_kind, EdgeDirection::Outgoing)
                     {
                         edges_to_traverse.entry(edge_kind).or_default().push(
-                            property_type_ontology_id,
+                            OntologyId::from(property_type_ontology_id),
                             new_graph_resolve_depths,
                             traversal_interval,
                         );
@@ -271,7 +271,7 @@ where
                         );
 
                         traversal_context.add_data_type_id(
-                            edge.right_endpoint_ontology_id,
+                            DataTypeId::from(edge.right_endpoint_ontology_id),
                             edge.resolve_depths,
                             edge.traversal_interval,
                         )
@@ -303,7 +303,7 @@ where
                         );
 
                         traversal_context.add_property_type_id(
-                            edge.right_endpoint_ontology_id,
+                            PropertyTypeId::from(edge.right_endpoint_ontology_id),
                             edge.resolve_depths,
                             edge.traversal_interval,
                         )
@@ -624,7 +624,7 @@ where
                 .into_iter()
                 .map(|id| {
                     (
-                        OntologyId::from(id),
+                        id,
                         subgraph.depths,
                         subgraph.temporal_axes.resolved.variable_interval(),
                     )

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/compile.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/compile.rs
@@ -886,7 +886,19 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
         parameters: &'p ParameterList<'f>,
     ) -> (Expression, ParameterType) {
         let parameter_type = match parameters {
-            ParameterList::Uuid(uuids) => {
+            ParameterList::DataTypeIds(uuids) => {
+                self.artifacts.parameters.push(uuids);
+                ParameterType::Uuid
+            }
+            ParameterList::PropertyTypeIds(uuids) => {
+                self.artifacts.parameters.push(uuids);
+                ParameterType::Uuid
+            }
+            ParameterList::EntityTypeIds(uuids) => {
+                self.artifacts.parameters.push(uuids);
+                ParameterType::Uuid
+            }
+            ParameterList::EntityEditionIds(uuids) => {
                 self.artifacts.parameters.push(uuids);
                 ParameterType::Uuid
             }

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -3376,6 +3376,8 @@
           "title",
           "description",
           "type",
+          "inheritsFrom",
+          "children",
           "editionProvenance",
           "embedding"
         ]

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -750,10 +750,10 @@ mod tests {
                 value.id.to_string(): value,
             })
         );
-        // DataTypeValidator
-        //     .validate_ref(&closed_number)
-        //     .await
-        //     .expect("Failed to validate closed data type");
+        DataTypeValidator
+            .validate_ref(&closed_number)
+            .await
+            .expect("Failed to validate closed data type");
 
         let closed_integer = resolver
             .get_closed_data_type(&integer.id)
@@ -770,10 +770,10 @@ mod tests {
                 number.id.to_string(): number,
             })
         );
-        // DataTypeValidator
-        //     .validate_ref(&closed_integer)
-        //     .await
-        //     .expect("Failed to validate closed data type");
+        DataTypeValidator
+            .validate_ref(&closed_integer)
+            .await
+            .expect("Failed to validate closed data type");
 
         let closed_unsigned_number = resolver
             .get_closed_data_type(&unsigned_number.id)
@@ -790,10 +790,10 @@ mod tests {
                 number.id.to_string(): number,
             })
         );
-        // DataTypeValidator
-        //     .validate_ref(&closed_unsigned_number)
-        //     .await
-        //     .expect("Failed to validate closed data type");
+        DataTypeValidator
+            .validate_ref(&closed_unsigned_number)
+            .await
+            .expect("Failed to validate closed data type");
 
         let closed_unsigned_integer = resolver
             .get_closed_data_type(&unsigned_integer.id)
@@ -820,10 +820,10 @@ mod tests {
                 integer.id.to_string(): integer,
             })
         );
-        // DataTypeValidator
-        //     .validate_ref(&closed_unsigned_integer)
-        //     .await
-        //     .expect("Failed to validate closed data type");
+        DataTypeValidator
+            .validate_ref(&closed_unsigned_integer)
+            .await
+            .expect("Failed to validate closed data type");
 
         let mut resolver = OntologyTypeResolver::default();
         resolver.add_closed(Arc::clone(&number), Arc::clone(&closed_number_metadata));

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/validation.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/validation.rs
@@ -20,8 +20,6 @@ pub enum ValidateDataTypeError {
     MissingDataType { data_type_id: VersionedUrl },
     #[error("Cyclic data type reference detected for type `{data_type_id}`")]
     CyclicDataTypeReference { data_type_id: VersionedUrl },
-    #[error("Data type inheritance is not supported yet")]
-    InheritanceNotSupported,
 }
 
 pub struct DataTypeValidator;
@@ -78,10 +76,6 @@ impl Validator<ClosedDataType> for DataTypeValidator {
                     .data_type_references()
                     .map(|(reference, _)| reference),
             );
-        }
-
-        if !value.schema.all_of.is_empty() {
-            return Err(ValidateDataTypeError::InheritanceNotSupported);
         }
 
         // TODO: Implement validation for data types

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -9,6 +9,7 @@
 )]
 
 extern crate alloc;
+extern crate core;
 
 mod data_type;
 mod drafts;

--- a/tests/hash-graph-test-data/rust/src/data_type/centimeter.json
+++ b/tests/hash-graph-test-data/rust/src/data_type/centimeter.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
+  "kind": "dataType",
+  "$id": "https://hash.ai/@hash/types/data-type/centimeter/v/1",
+  "title": "Centimeter",
+  "description": "A length in centimeters",
+  "type": "number",
+  "allOf": [
+    {
+      "$ref": "https://hash.ai/@hash/types/data-type/length/v/1"
+    }
+  ]
+}

--- a/tests/hash-graph-test-data/rust/src/data_type/length.json
+++ b/tests/hash-graph-test-data/rust/src/data_type/length.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
+  "kind": "dataType",
+  "$id": "https://hash.ai/@hash/types/data-type/length/v/1",
+  "title": "Length",
+  "description": "A length in a unit of measure",
+  "type": "number",
+  "allOf": [
+    {
+      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1"
+    }
+  ]
+}

--- a/tests/hash-graph-test-data/rust/src/data_type/meter.json
+++ b/tests/hash-graph-test-data/rust/src/data_type/meter.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
+  "kind": "dataType",
+  "$id": "https://hash.ai/@hash/types/data-type/meter/v/1",
+  "title": "Meter",
+  "description": "A length in meters",
+  "type": "number",
+  "allOf": [
+    {
+      "$ref": "https://hash.ai/@hash/types/data-type/length/v/1"
+    }
+  ]
+}

--- a/tests/hash-graph-test-data/rust/src/data_type/mod.rs
+++ b/tests/hash-graph-test-data/rust/src/data_type/mod.rs
@@ -5,3 +5,8 @@ pub const NUMBER_V1: &str = include_str!("number.json");
 pub const OBJECT_V1: &str = include_str!("object_v1.json");
 pub const OBJECT_V2: &str = include_str!("object_v2.json");
 pub const TEXT_V1: &str = include_str!("text.json");
+
+// Data types with inheritance
+pub const LENGTH_V1: &str = include_str!("length.json");
+pub const METER_V1: &str = include_str!("meter.json");
+pub const CENTIMETER_V1: &str = include_str!("centimeter.json");


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We need to query for
- parent types if we resolve data types on creation
- children when we validate the types

## 🔍 What does this change?

- In most areas replace `OntologyId` with `DataTypeId`/`PropertyTypeId`/`EntityTypeId`. The latter are newtype wrapper, but they provide more safety.
- Add a data type query path for inheritance
- Add a predefined filter to
    - read parents of data types (depending on the depth, multi in/multi out)
    - read children of a data type (depending on the depth, single in, multi out) 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing
### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
## 🛡 What tests cover this?

A few test cases were added