### PR TITLE
H-3221: Enable data type inheritance in Graph API

### DIFF
--- a/apps/hash-graph/libs/api/src/rest/data_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/data_type.rs
@@ -227,14 +227,7 @@ where
     let mut metadata = store
         .create_data_types(
             actor_id,
-            schema.into_iter().inspect(|schema| {
-                // TODO: Enable data type inheritance
-                //   see https://linear.app/hash/issue/H-3221/enable-data-type-inheritance-in-graph-api
-                assert!(
-                    schema.all_of.is_empty(),
-                    "Data Type schema contains `allOf` which is not supported, yet"
-                );
-            }).map(|schema| {
+            schema.into_iter().map(|schema| {
                 domain_validator.validate(&schema).map_err(|report| {
                     tracing::error!(error=?report, id=%schema.id, "Data Type ID failed to validate");
                     StatusCode::UNPROCESSABLE_ENTITY
@@ -364,13 +357,6 @@ where
                     vec![],
                 )));
             }
-
-            // TODO: Enable data type inheritance
-            //   see https://linear.app/hash/issue/H-3221/enable-data-type-inheritance-in-graph-api
-            assert!(
-                schema.all_of.is_empty(),
-                "Data Type schema contains `allOf` which is not supported, yet"
-            );
 
             Ok(Json(
                 store


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The API package currently panics as soon as a data type schema contains a non-empty allOf field.

## 🚫 Blocked by

- https://github.com/hashintel/hash/pull/4804
- https://github.com/hashintel/hash/pull/4814
- https://github.com/hashintel/hash/pull/4818

Nice-to-have but not needed
- H-3159: Resolve closed data types when loading snapshots
- H-3082: Allow querying of closed data schema (resolving works without it)

## 🔍 What does this change?

Allows usage of `allOf` outside of the graph

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph