### PR TITLE
H-3230: Ignore error-stack for turborepo-sync script

### DIFF
--- a/apps/hash-graph/bins/cli/package.json
+++ b/apps/hash-graph/bins/cli/package.json
@@ -2,6 +2,7 @@
   "name": "@rust/hash-graph",
   "version": "0.0.0-private",
   "private": true,
+  "license": "AGPL-3",
   "dependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",
     "@rust/authorization": "0.0.0-private",

--- a/apps/hash-graph/libs/api/package.json
+++ b/apps/hash-graph/libs/api/package.json
@@ -2,6 +2,7 @@
   "name": "@rust/graph-api",
   "version": "0.0.0-private",
   "private": true,
+  "license": "AGPL-3",
   "scripts": {
     "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
   },

--- a/apps/hash-graph/libs/graph/package.json
+++ b/apps/hash-graph/libs/graph/package.json
@@ -2,6 +2,7 @@
   "name": "@rust/graph",
   "version": "0.0.0-private",
   "private": true,
+  "license": "AGPL-3",
   "scripts": {
     "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
   },

--- a/apps/hash-graph/libs/query-builder-derive/package.json
+++ b/apps/hash-graph/libs/query-builder-derive/package.json
@@ -2,6 +2,7 @@
   "name": "@rust/query-builder-derive",
   "version": "0.0.0-private",
   "private": true,
+  "license": "AGPL-3",
   "scripts": {
     "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
   }

--- a/apps/hash-graph/libs/test-server/package.json
+++ b/apps/hash-graph/libs/test-server/package.json
@@ -2,6 +2,7 @@
   "name": "@rust/test-server",
   "version": "0.0.0-private",
   "private": true,
+  "license": "AGPL-3",
   "scripts": {
     "start": "../../../../target/release/hash-graph test-server --api-port 4001",
     "start:healthcheck": "../../../../target/release/hash-graph test-server --api-port 4001 --healthcheck --wait --timeout 600 --logging-console-level=warn",

--- a/apps/hash-graph/libs/type-fetcher/package.json
+++ b/apps/hash-graph/libs/type-fetcher/package.json
@@ -2,6 +2,7 @@
   "name": "@rust/type-fetcher",
   "version": "0.0.0-private",
   "private": true,
+  "license": "AGPL-3",
   "scripts": {
     "start": "../../../../target/release/hash-graph type-fetcher",
     "start:healthcheck": "../../../../target/release/hash-graph type-fetcher --healthcheck --wait --timeout 600 --logging-console-level=warn",

--- a/libs/@local/codec/package.json
+++ b/libs/@local/codec/package.json
@@ -2,6 +2,7 @@
   "name": "@rust/codec",
   "version": "0.0.0-private",
   "private": true,
+  "license": "AGPL-3",
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy"

--- a/libs/@local/harpc/net/package.json
+++ b/libs/@local/harpc/net/package.json
@@ -2,7 +2,7 @@
   "name": "@rust/harpc-net",
   "version": "0.0.0-private",
   "private": true,
-  "license": "AGPL-3.0",
+  "license": "AGPL-3",
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",

--- a/libs/@local/harpc/tower/package.json
+++ b/libs/@local/harpc/tower/package.json
@@ -2,7 +2,7 @@
   "name": "@rust/harpc-tower",
   "version": "0.0.0-private",
   "private": true,
-  "license": "AGPL-3.0",
+  "license": "AGPL-3",
   "dependencies": {
     "@rust/harpc-net": "0.0.0-private",
     "@rust/harpc-types": "0.0.0-private",

--- a/libs/@local/harpc/types/package.json
+++ b/libs/@local/harpc/types/package.json
@@ -2,7 +2,7 @@
   "name": "@rust/harpc-types",
   "version": "0.0.0-private",
   "private": true,
-  "license": "AGPL-3.0",
+  "license": "AGPL-3",
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",

--- a/libs/@local/harpc/wire-protocol/package.json
+++ b/libs/@local/harpc/wire-protocol/package.json
@@ -2,7 +2,7 @@
   "name": "@rust/harpc-wire-protocol",
   "version": "0.0.0-private",
   "private": true,
-  "license": "AGPL-3.0",
+  "license": "AGPL-3",
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",

--- a/libs/@local/hash-authorization/package.json
+++ b/libs/@local/hash-authorization/package.json
@@ -2,6 +2,7 @@
   "name": "@rust/authorization",
   "version": "0.0.0-private",
   "private": true,
+  "license": "AGPL-3",
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",

--- a/libs/@local/hash-graph-types/rust/package.json
+++ b/libs/@local/hash-graph-types/rust/package.json
@@ -2,6 +2,7 @@
   "name": "@rust/graph-types",
   "version": "0.0.0-private",
   "private": true,
+  "license": "AGPL-3",
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",

--- a/libs/@local/hash-validation/package.json
+++ b/libs/@local/hash-validation/package.json
@@ -2,6 +2,7 @@
   "name": "@rust/validation",
   "version": "0.0.0-private",
   "private": true,
+  "license": "AGPL-3",
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",

--- a/libs/@local/hql/cst/package.json
+++ b/libs/@local/hql/cst/package.json
@@ -2,7 +2,7 @@
   "name": "@rust/hql-cst",
   "version": "0.0.0-private",
   "private": true,
-  "license": "AGPL-3.0",
+  "license": "AGPL-3",
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",

--- a/libs/@local/hql/diagnostics/package.json
+++ b/libs/@local/hql/diagnostics/package.json
@@ -2,7 +2,7 @@
   "name": "@rust/hql-diagnostics",
   "version": "0.0.0-private",
   "private": true,
-  "license": "AGPL-3.0",
+  "license": "AGPL-3",
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",

--- a/libs/@local/hql/span/package.json
+++ b/libs/@local/hql/span/package.json
@@ -2,7 +2,7 @@
   "name": "@rust/hql-span",
   "version": "0.0.0-private",
   "private": true,
-  "license": "AGPL-3.0",
+  "license": "AGPL-3",
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",

--- a/libs/@local/repo-chores/rust/package.json
+++ b/libs/@local/repo-chores/rust/package.json
@@ -2,6 +2,7 @@
   "name": "@rust/repo-chores",
   "version": "0.0.0-private",
   "private": true,
+  "license": "AGPL-3",
   "scripts": {
     "analyze-benchmarks": "../../../../target/debug/repo-chores-cli benches analyze",
     "build": "cargo build",

--- a/libs/@local/temporal-client/package.json
+++ b/libs/@local/temporal-client/package.json
@@ -2,6 +2,7 @@
   "name": "@rust/temporal-client",
   "version": "0.0.0-private",
   "private": true,
+  "license": "AGPL-3",
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy"

--- a/libs/@local/temporal-versioning/package.json
+++ b/libs/@local/temporal-versioning/package.json
@@ -2,6 +2,7 @@
   "name": "@rust/temporal-versioning",
   "version": "0.0.0-private",
   "private": true,
+  "license": "AGPL-3",
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",

--- a/libs/@local/tracing/package.json
+++ b/libs/@local/tracing/package.json
@@ -2,6 +2,7 @@
   "name": "@rust/hash-tracing",
   "version": "0.0.0-private",
   "private": true,
+  "license": "AGPL-3",
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy"

--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -81,7 +81,9 @@ name = "detect"
 required-features = ['std']
 doc-scrape-examples = true
 
-
 [[test]]
 name = "common"
 test = false
+
+[package.metadata.sync.turborepo]
+ignore = true

--- a/libs/error-stack/package.json
+++ b/libs/error-stack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rust/error-stack",
   "version": "0.5.0",
-  "private": false,
+  "private": true,
   "description": "This is a Rust crate – look at Cargo.toml for details",
   "license": "MIT OR Apache-2.0",
   "scripts": {

--- a/tests/hash-graph-benches/package.json
+++ b/tests/hash-graph-benches/package.json
@@ -2,6 +2,7 @@
   "name": "@rust/graph-benches",
   "version": "0.0.0-private",
   "private": true,
+  "license": "AGPL-3",
   "scripts": {
     "bench:integration": "cargo bench",
     "test:integration": "cargo hack test --feature-powerset --all-targets"

--- a/tests/hash-graph-integration/package.json
+++ b/tests/hash-graph-integration/package.json
@@ -2,6 +2,7 @@
   "name": "@rust/graph-integration",
   "version": "0.0.0-private",
   "private": true,
+  "license": "AGPL-3",
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",

--- a/tests/hash-graph-test-data/rust/package.json
+++ b/tests/hash-graph-test-data/rust/package.json
@@ -2,6 +2,7 @@
   "name": "@rust/graph-test-data",
   "version": "0.0.0-private",
   "private": true,
+  "license": "AGPL-3",
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We only publish it through `cargo`. Also, this ran the scnc-script again and added somemissing licenes to `package.json`.