### PR TITLE
H-3234: Enfore synced Turborepo in CI

### DIFF
--- a/.github/scripts/rust/sync-turborepo.rs
+++ b/.github/scripts/rust/sync-turborepo.rs
@@ -311,7 +311,12 @@ impl<'a> WorkspaceMember<'a> {
         // set the package to private if the crate is private
         package_json.other_fields.insert(
             "private".to_string(),
-            json!(self.is_private()),
+            json!(
+                package_json
+                    .name
+                    .map_or(false, |name| name.starts_with("@rust/"))
+                    || self.is_private()
+            ),
         );
 
         // set the name of the package.json

--- a/.github/scripts/rust/sync-turborepo.rs
+++ b/.github/scripts/rust/sync-turborepo.rs
@@ -311,12 +311,7 @@ impl<'a> WorkspaceMember<'a> {
         // set the package to private if the crate is private
         package_json.other_fields.insert(
             "private".to_string(),
-            json!(
-                package_json
-                    .name
-                    .map_or(false, |name| name.starts_with("@rust/"))
-                    || self.is_private()
-            ),
+            json!(self.is_private()),
         );
 
         // set the name of the package.json

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -207,7 +207,7 @@ jobs:
         if: ${{ success() || failure() }}
         run: |
           cargo -Zscript run --manifest-path ".github/scripts/rust/sync-turborepo.rs" . | xargs just yarn prettier --write
-          git --no-pager diff --exit-code --color '**/Cargo.toml'
+          git --no-pager diff --exit-code --color '**/package.json'
 
       - name: Run yarn lint:dependency-version-consistency
         if: ${{ success() || failure() }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Validate package.json generated from Cargo.toml
         if: ${{ success() || failure() }}
         run: |
-          cargo -Zscript run --manifest-path ".github/scripts/rust/sync-turborepo.rs" . | xargs just yarn prettier --write
+          cargo -Zscript run --manifest-path ".github/scripts/rust/sync-turborepo.rs" . | xargs yarn prettier --write
           git --no-pager diff --exit-code --color '**/package.json'
 
       - name: Run yarn lint:dependency-version-consistency

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Validate package.json generated from Cargo.toml
         if: ${{ success() || failure() }}
         run: |
-          cargo -Zscript run --manifest-path ".github/scripts/rust/sync-turborepo.rs" . | xargs yarn prettier --write
+          cargo -Zscript run --manifest-path ".github/scripts/rust/sync-turborepo.rs" . | xargs yarn prettier --write >/dev/null
           git --no-pager diff --exit-code --color '**/package.json'
 
       - name: Run yarn lint:dependency-version-consistency

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -203,6 +203,12 @@ jobs:
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo
 
+      - name: Validate package.json generated from Cargo.toml
+        if: ${{ success() || failure() }}
+        run: |
+          cargo -Zscript run --manifest-path ".github/scripts/rust/sync-turborepo.rs" . | xargs just yarn prettier --write
+          git --no-pager diff --exit-code --color '**/Cargo.toml'
+
       - name: Run yarn lint:dependency-version-consistency
         if: ${{ success() || failure() }}
         run: |

--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -84,6 +84,3 @@ doc-scrape-examples = true
 [[test]]
 name = "common"
 test = false
-
-[package.metadata.sync.turborepo]
-ignore = true


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To avoid inconsistencies between `package.json` and `Cargo.toml` we enfore this in CI now.