### PR TITLE
H-3235: Group various Renovate updates, exclude `tldraw`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -155,7 +155,7 @@
     {
       "groupName": "emoji-mart npm packages",
       "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^@emoji-mart/", "^emoji-mart", "emoji-mart$"],
+      "matchPackagePatterns": ["^@emoji-mart/", "^emoji-mart", "emoji-mart$"]
     },
     {
       "groupName": "OpenTelemetry npm packages",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -101,7 +101,7 @@
     {
       "groupName": "LLM provider SDK npm packages",
       "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^@openai/", "^@anthropic/", "groq-sdk"],
+      "matchPackagePatterns": ["^@openai/", "^@anthropic-ai/", "groq-sdk"],
       "automerge": false,
       "dependencyDashboardApproval": false,
       "minimumReleaseAge": "0 days",
@@ -158,10 +158,20 @@
       "matchPackagePatterns": ["^@emoji-mart/", "^emoji-mart", "emoji-mart$"]
     },
     {
+      "groupName": "Lodash npm packages",
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["^@types/lodash", "^lodash", "lodash$"]
+    },
+    {
       "groupName": "OpenTelemetry npm packages",
       "matchManagers": ["npm"],
       "matchPackagePatterns": ["^@opentelemetry/"],
       "assignees": ["TimDiekmann"]
+    },
+    {
+      "groupName": "changesets npm packages",
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["^@changesets/"]
     },
     {
       "groupName": "Playwright npm packages",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -153,6 +153,11 @@
       "dependencyDashboardApproval": false
     },
     {
+      "groupName": "emoji-mart npm packages",
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["^@emoji-mart/", "^emoji-mart", "emoji-mart$"],
+    },
+    {
       "groupName": "OpenTelemetry npm packages",
       "matchManagers": ["npm"],
       "matchPackagePatterns": ["^@opentelemetry/"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -135,6 +135,12 @@
       "matchPackagePatterns": ["^@graphql/", "^graphql-", "graphql$"]
     },
     {
+      "description": "Exclude tldraw from updates due to non-OSS license in later releases",
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["^@tldraw/"],
+      "enabled": false
+    },
+    {
       "automerge": false,
       "matchManagers": ["npm"],
       "matchPackagePatterns": ["typescript"],


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Improves our Renovate update process.
