### PR TITLE
H-3229: Validate data type IDs over inheritance

### DIFF
--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -16,7 +16,7 @@ use type_system::{
 
 use crate::{
     error::{Actual, Expected},
-    EntityProvider, EntityTypeProvider, OntologyTypeProvider, Schema, Validate,
+    DataTypeProvider, EntityProvider, EntityTypeProvider, OntologyTypeProvider, Schema, Validate,
     ValidateEntityComponents,
 };
 
@@ -54,7 +54,7 @@ pub enum EntityValidationError {
 
 impl<P> Schema<PropertyWithMetadataObject, P> for ClosedEntityType
 where
-    P: OntologyTypeProvider<PropertyType> + OntologyTypeProvider<DataType> + Sync,
+    P: OntologyTypeProvider<PropertyType> + DataTypeProvider + Sync,
 {
     type Error = EntityValidationError;
 
@@ -81,7 +81,7 @@ where
 
 impl<P> Validate<ClosedEntityType, P> for PropertyWithMetadataObject
 where
-    P: OntologyTypeProvider<PropertyType> + OntologyTypeProvider<DataType> + Sync,
+    P: OntologyTypeProvider<PropertyType> + DataTypeProvider + Sync,
 {
     type Error = EntityValidationError;
 
@@ -150,7 +150,7 @@ where
     P: EntityProvider
         + EntityTypeProvider
         + OntologyTypeProvider<PropertyType>
-        + OntologyTypeProvider<DataType>
+        + DataTypeProvider
         + Sync,
 {
     type Error = EntityValidationError;

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -285,8 +285,8 @@ mod tests {
         async fn has_children(
             &self,
             _data_type: DataTypeId,
-        ) -> Result<bool, Report<InvalidEntityType>> {
-            unimplemented!()
+        ) -> Result<bool, Report<InvalidDataType>> {
+            Ok(false)
         }
     }
 

--- a/tests/hash-graph-integration/postgres/data_type.rs
+++ b/tests/hash-graph-integration/postgres/data_type.rs
@@ -1,26 +1,36 @@
 use core::str::FromStr;
+use std::collections::{HashMap, HashSet};
 
 use graph::{
     store::{
         error::{OntologyTypeIsNotOwned, OntologyVersionDoesNotExist, VersionedUrlAlreadyExists},
+        knowledge::CreateEntityParams,
         ontology::{CreateDataTypeParams, GetDataTypesParams, UpdateDataTypesParams},
         query::Filter,
-        BaseUrlAlreadyExists, ConflictBehavior, DataTypeStore,
+        BaseUrlAlreadyExists, ConflictBehavior, DataTypeStore, EntityStore,
     },
     subgraph::temporal_axes::{
         PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved, VariableTemporalAxisUnresolved,
     },
 };
 use graph_types::{
+    knowledge::{
+        entity::ProvidedEntityEditionProvenance, ObjectMetadata, PropertyProvenance,
+        PropertyWithMetadata, PropertyWithMetadataObject, ValueMetadata, ValueWithMetadata,
+    },
     ontology::{
         DataTypeId, DataTypeWithMetadata, OntologyTypeClassificationMetadata,
         ProvidedOntologyEditionProvenance,
     },
     owned_by_id::OwnedById,
 };
+use serde_json::json;
 use temporal_versioning::TemporalBound;
 use time::OffsetDateTime;
-use type_system::{schema::DataType, url::VersionedUrl};
+use type_system::{
+    schema::DataType,
+    url::{BaseUrl, VersionedUrl},
+};
 
 use crate::{data_type_relationships, DatabaseTestWrapper};
 
@@ -134,8 +144,8 @@ async fn inheritance() {
                 graph_test_data::data_type::LENGTH_V1,
                 graph_test_data::data_type::METER_V1,
             ],
-            [],
-            [],
+            [graph_test_data::property_type::LENGTH_V1],
+            [graph_test_data::entity_type::LINE_V1],
         )
         .await
         .expect("could not seed database");
@@ -146,6 +156,8 @@ async fn inheritance() {
     let centimeter_dt_v2: DataType =
         serde_json::from_str(graph_test_data::data_type::CENTIMETER_V2)
             .expect("could not parse data type representation");
+    let meter_dt_v1: DataType = serde_json::from_str(graph_test_data::data_type::METER_V1)
+        .expect("could not parse data type representation");
 
     api.create_data_type(
         api.account_id,
@@ -255,6 +267,127 @@ async fn inheritance() {
     )
     .await
     .expect("could not update data type");
+
+    // No data type is provided. Validation for `length` fails as it's ambiguous, validation for
+    // `meter` passes. However, the creation fails as `length` has children and it could potentially
+    // be a child of `length`. Without a data type ID being specified we can't know which one to
+    // choose.
+    _ = api
+        .create_entity(
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: HashSet::from([VersionedUrl::from_str(
+                    "http://localhost:3000/@alice/types/entity-type/line/v/1",
+                )
+                .expect("couldn't construct Base URL")]),
+                properties: PropertyWithMetadataObject {
+                    value: HashMap::from([(
+                        BaseUrl::new(
+                            "http://localhost:3000/@alice/types/property-type/length/".to_owned(),
+                        )
+                        .expect("couldn't construct Base URL"),
+                        PropertyWithMetadata::Value(ValueWithMetadata {
+                            value: json!(5),
+                            metadata: ValueMetadata {
+                                provenance: PropertyProvenance::default(),
+                                confidence: None,
+                                data_type_id: None,
+                            },
+                        }),
+                    )]),
+                    metadata: ObjectMetadata::default(),
+                },
+                confidence: None,
+                link_data: None,
+                draft: false,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
+        )
+        .await
+        .expect_err("could create ambiguous entity");
+
+    // We specify `meter` as data type, it could be the child of `length` or `meter` but only one is
+    // allowed. This is expected to be lifted in the future.
+    _ = api
+        .create_entity(
+            api.account_id,
+            CreateEntityParams {
+                owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+                entity_uuid: None,
+                decision_time: None,
+                entity_type_ids: HashSet::from([VersionedUrl::from_str(
+                    "http://localhost:3000/@alice/types/entity-type/line/v/1",
+                )
+                .expect("couldn't construct Base URL")]),
+                properties: PropertyWithMetadataObject {
+                    value: HashMap::from([(
+                        BaseUrl::new(
+                            "http://localhost:3000/@alice/types/property-type/length/".to_owned(),
+                        )
+                        .expect("couldn't construct Base URL"),
+                        PropertyWithMetadata::Value(ValueWithMetadata {
+                            value: json!(10),
+                            metadata: ValueMetadata {
+                                provenance: PropertyProvenance::default(),
+                                confidence: None,
+                                data_type_id: Some(meter_dt_v1.id.clone()),
+                            },
+                        }),
+                    )]),
+                    metadata: ObjectMetadata::default(),
+                },
+                confidence: None,
+                link_data: None,
+                draft: false,
+                relationships: [],
+                provenance: ProvidedEntityEditionProvenance::default(),
+            },
+        )
+        .await
+        .expect_err("could create ambiguous entity");
+
+    // We specify `centimeter` as data type, so the validation for `length` passes, the validation
+    // for `meter` fails, and the entity is created.
+    api.create_entity(
+        api.account_id,
+        CreateEntityParams {
+            owned_by_id: OwnedById::new(api.account_id.into_uuid()),
+            entity_uuid: None,
+            decision_time: None,
+            entity_type_ids: HashSet::from([VersionedUrl::from_str(
+                "http://localhost:3000/@alice/types/entity-type/line/v/1",
+            )
+            .expect("couldn't construct Base URL")]),
+            properties: PropertyWithMetadataObject {
+                value: HashMap::from([(
+                    BaseUrl::new(
+                        "http://localhost:3000/@alice/types/property-type/length/".to_owned(),
+                    )
+                    .expect("couldn't construct Base URL"),
+                    PropertyWithMetadata::Value(ValueWithMetadata {
+                        value: json!(10),
+                        metadata: ValueMetadata {
+                            provenance: PropertyProvenance::default(),
+                            confidence: None,
+                            data_type_id: Some(centimeter_dt_v2.id.clone()),
+                        },
+                    }),
+                )]),
+                metadata: ObjectMetadata::default(),
+            },
+            confidence: None,
+            link_data: None,
+            draft: false,
+            relationships: [],
+            provenance: ProvidedEntityEditionProvenance::default(),
+        },
+    )
+    .await
+    .expect("could not create entity with child data type");
 }
 
 #[tokio::test]

--- a/tests/hash-graph-test-data/rust/src/entity_type/line.json
+++ b/tests/hash-graph-test-data/rust/src/entity_type/line.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/entity-type",
+  "kind": "entityType",
+  "$id": "http://localhost:3000/@alice/types/entity-type/line/v/1",
+  "type": "object",
+  "title": "Line",
+  "description": "A line with a length",
+  "properties": {
+    "http://localhost:3000/@alice/types/property-type/length/": {
+      "$ref": "http://localhost:3000/@alice/types/property-type/length/v/1"
+    }
+  }
+}

--- a/tests/hash-graph-test-data/rust/src/entity_type/mod.rs
+++ b/tests/hash-graph-test-data/rust/src/entity_type/mod.rs
@@ -2,14 +2,15 @@ pub mod link;
 
 pub const LINK_V1: &str = include_str!("link.json");
 
-pub const UK_ADDRESS_V1: &str = include_str!("uk_address.json");
 pub const BLOCK_V1: &str = include_str!("block.json");
 pub const BOOK_V1: &str = include_str!("book.json");
 pub const BUILDING_V1: &str = include_str!("building.json");
 pub const CHURCH_V1: &str = include_str!("church.json");
+pub const LINE_V1: &str = include_str!("line.json");
 pub const ORGANIZATION_V1: &str = include_str!("organization.json");
 pub const PAGE_V1: &str = include_str!("page_v1.json");
 pub const PAGE_V2: &str = include_str!("page_v2.json");
 pub const PERSON_V1: &str = include_str!("person.json");
 pub const PLAYLIST_V1: &str = include_str!("playlist.json");
 pub const SONG_V1: &str = include_str!("song.json");
+pub const UK_ADDRESS_V1: &str = include_str!("uk_address.json");

--- a/tests/hash-graph-test-data/rust/src/property_type/length.json
+++ b/tests/hash-graph-test-data/rust/src/property_type/length.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type",
+  "kind": "propertyType",
+  "$id": "http://localhost:3000/@alice/types/property-type/length/v/1",
+  "title": "Length",
+  "description": "A length",
+  "oneOf": [
+    {
+      "$ref": "https://hash.ai/@hash/types/data-type/length/v/1"
+    },
+    {
+      "$ref": "https://hash.ai/@hash/types/data-type/meter/v/1"
+    }
+  ]
+}

--- a/tests/hash-graph-test-data/rust/src/property_type/mod.rs
+++ b/tests/hash-graph-test-data/rust/src/property_type/mod.rs
@@ -1,7 +1,7 @@
 pub const ADDRESS_LINE_1_V1: &str = include_str!("address_line_1.json");
 pub const AGE_V1: &str = include_str!("age.json");
-pub const BUILT_AT: &str = include_str!("built_at.json");
 pub const BLURB_V1: &str = include_str!("blurb.json");
+pub const BUILT_AT: &str = include_str!("built_at.json");
 pub const CITY_V1: &str = include_str!("city.json");
 pub const CONTACT_INFORMATION_V1: &str = include_str!("contact_information.json");
 pub const CONTRIVED_PROPERTY_V1: &str = include_str!("contrived_property.json");
@@ -11,6 +11,7 @@ pub const FAVORITE_QUOTE_V1: &str = include_str!("favorite_quote.json");
 pub const FAVORITE_SONG_V1: &str = include_str!("favorite_song.json");
 pub const HOBBY_V1: &str = include_str!("hobby.json");
 pub const INTERESTS_V1: &str = include_str!("interests.json");
+pub const LENGTH_V1: &str = include_str!("length.json");
 pub const NAME_V1: &str = include_str!("name.json");
 pub const NUMBERS_V1: &str = include_str!("numbers.json");
 pub const PHONE_NUMBER_V1: &str = include_str!("phone_number.json");


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Depending on the data type the validation needs to behave differently.

We require these checks:
- If the data type ID is provided:
	- Validate the value against that data type ID
	- Check if the data type ID is an exact match:
		- validation passed ✅ 
	- Check if it’s a child (is the expected base URL one of the parent's base URL of the provided type?):
		- Validate the value against the expected type
- If the data type ID is not provided
	- Fail, if expected type has children 🛑 
		- In `oneOf` this counts as a potential candidate, so if only one other data type passes the validation this will still be ambiguous
	- Validate the value against the expected type

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


## 🛡 What tests cover this?

The test case for inheritance has been adjusted by attempting to create entities.