### PR TITLE
H-3222: Make sure data types inheriting from each other can be passed in arbitrary order when creating at the same time

### DIFF
--- a/apps/hash-graph/libs/graph/src/store/postgres/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/mod.rs
@@ -392,9 +392,8 @@ where
     #[tracing::instrument(level = "debug", skip(self))]
     async fn insert_data_type_with_id(
         &self,
-        ontology_id: OntologyId,
+        ontology_id: DataTypeId,
         closed_data_type: &Valid<ClosedDataType>,
-        metadata: &ClosedDataTypeMetadata,
     ) -> Result<Option<OntologyId>, InsertionError> {
         let ontology_id = self
             .as_client()
@@ -414,6 +413,15 @@ where
             .change_context(InsertionError)?
             .map(|row| row.get(0));
 
+        Ok(ontology_id)
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    async fn insert_data_type_references(
+        &self,
+        ontology_id: DataTypeId,
+        metadata: &ClosedDataTypeMetadata,
+    ) -> Result<(), InsertionError> {
         for (target, &depth) in &metadata.inheritance_depths {
             self.as_client()
                 .query(
@@ -438,7 +446,7 @@ where
                 .change_context(InsertionError)?;
         }
 
-        Ok(ontology_id)
+        Ok(())
     }
 
     /// Inserts a [`PropertyType`] identified by [`OntologyId`], and associated with an

--- a/tests/hash-graph-integration/postgres/data_type.rs
+++ b/tests/hash-graph-integration/postgres/data_type.rs
@@ -127,11 +127,10 @@ async fn inheritance() {
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database
         .seed(
-            // TODO: Ensure that an arbitrary order is possible
-            //   see https://linear.app/hash/issue/H-3222/make-sure-data-types-inheriting-from-each-other-can-be-passed-in
+            // The order of the data types can be arbitrary
             [
-                graph_test_data::data_type::NUMBER_V1,
                 graph_test_data::data_type::LENGTH_V1,
+                graph_test_data::data_type::NUMBER_V1,
                 graph_test_data::data_type::METER_V1,
             ],
             [],


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When creating a new data type the order should not matter if they depend on each other.

## 🔍 What does this change?

- Split `inserst_data_type_with_id` into `inserst_data_type_with_id` and `insert_data_type_references`
- Collect references instead of inserting them directly
- insert references after everything else is inserted
- Drive-by: Use `DataTypeId` instead of `OntologyId`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph