### PR TITLE
H-3237: Fix hashdotdesign page building

### DIFF
--- a/apps/hashdotdesign/vercel-build.sh
+++ b/apps/hashdotdesign/vercel-build.sh
@@ -6,4 +6,4 @@ echo "Changing dir to root"
 cd ../..
 
 echo "Building hash.design"
-turbo build --filter='@apps/hashdotdesign' --env-mode=loose
+turbo build-storybook --filter='@apps/hashdotdesign' --env-mode=loose


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`hashdotdesign` (and `hashdotdev`)'s build and install steps were overwritten in Vercel. This fixes the build command in the script file and disables the override button in vercel.