### PR TITLE
H-3239: HQL: Make span storage insertion non mutable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2897,6 +2897,7 @@ dependencies = [
 name = "hql-span"
 version = "0.0.0"
 dependencies = [
+ "orx-concurrent-vec",
  "serde",
  "serde-value",
  "serde_json",
@@ -4498,6 +4499,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19ff2cf528c6c03d9ed653d6c4ce1dc0582dc4af309790ad92f07c1cd551b0be"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "orx-concurrent-ordered-bag"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa866e2be4aa03927eddb481e7c479d5109fe3121324fb7db6d97f91adf9876"
+dependencies = [
+ "orx-fixed-vec",
+ "orx-pinned-concurrent-col",
+ "orx-pinned-vec",
+ "orx-pseudo-default",
+ "orx-split-vec",
+]
+
+[[package]]
+name = "orx-concurrent-vec"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5912426ffb660f8b61e8f0812a1d07400803cd5513969d2c7af4d69602ba8a1"
+dependencies = [
+ "orx-concurrent-ordered-bag",
+ "orx-fixed-vec",
+ "orx-pinned-concurrent-col",
+ "orx-pinned-vec",
+ "orx-pseudo-default",
+ "orx-split-vec",
+]
+
+[[package]]
+name = "orx-fixed-vec"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f69466c7c1fc2e1f00b58e39059b78c438b9fad144d1937ef177ecfc413e997"
+dependencies = [
+ "orx-pinned-vec",
+ "orx-pseudo-default",
+]
+
+[[package]]
+name = "orx-pinned-concurrent-col"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdbcb1fa05dc1676f1c9cf19f443b3d2d2ca5835911477d22fa77cad8b79208d"
+dependencies = [
+ "orx-fixed-vec",
+ "orx-pinned-vec",
+ "orx-pseudo-default",
+ "orx-split-vec",
+]
+
+[[package]]
+name = "orx-pinned-vec"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1071baf586de45722668234bddf56c52c1ece6a6153d16541bbb0505f0ac055"
+dependencies = [
+ "orx-pseudo-default",
+]
+
+[[package]]
+name = "orx-pseudo-default"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2f627c439e723fa78e410a0faba89047a8a47d0dc013da5c0e05806e8a6cddb"
+
+[[package]]
+name = "orx-split-vec"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b9dbfa8c7069ae73a890870d3aa9097a897d616751d3d0278f2b42d5214730"
+dependencies = [
+ "orx-pinned-vec",
+ "orx-pseudo-default",
 ]
 
 [[package]]

--- a/libs/@local/hql/diagnostics/examples/jexpr.rs
+++ b/libs/@local/hql/diagnostics/examples/jexpr.rs
@@ -40,7 +40,7 @@ const INVALID_IDENTIFIER: &Category = &Category {
 };
 
 fn main() {
-    let mut storage = SpanStorage::new();
+    let storage = SpanStorage::new();
 
     let parent_span = storage.insert(JsonSpan {
         range: TextRange::new(8.into(), 13.into()),

--- a/libs/@local/hql/diagnostics/src/diagnostic.rs
+++ b/libs/@local/hql/diagnostics/src/diagnostic.rs
@@ -132,7 +132,11 @@ impl<S> Diagnostic<'_, SpanNode<S>> {
         }
 
         for label in &self.labels {
-            builder.add_label(label.ariadne(&mut generator, &mut config.transform_span));
+            builder.add_label(label.ariadne(
+                config.color,
+                &mut generator,
+                &mut config.transform_span,
+            ));
         }
 
         builder = builder.with_config(config.into());

--- a/libs/@local/hql/diagnostics/src/label.rs
+++ b/libs/@local/hql/diagnostics/src/label.rs
@@ -92,6 +92,7 @@ impl Label<SpanId> {
 impl<S> Label<SpanNode<S>> {
     pub(crate) fn ariadne(
         &self,
+        enable_color: bool,
         generator: &mut ColorGenerator,
         transform: &mut impl TransformSpan<S>,
     ) -> ariadne::Label<AbsoluteDiagnosticSpan> {
@@ -101,7 +102,10 @@ impl<S> Label<SpanNode<S>> {
         let color = self
             .color
             .map_or_else(|| generator.next(), anstyle_yansi::to_yansi_color);
-        label = label.with_color(color);
+
+        if enable_color {
+            label = label.with_color(color);
+        }
 
         if let Some(order) = self.order {
             label = label.with_order(order);

--- a/libs/@local/hql/span/Cargo.toml
+++ b/libs/@local/hql/span/Cargo.toml
@@ -9,6 +9,7 @@ publish.workspace = true
 authors.workspace = true
 
 [dependencies]
+orx-concurrent-vec = "2.2.0"
 serde = { workspace = true, optional = true, features = ["derive"] }
 serde-value = { version = "0.7.0", optional = true }
 sval = "2.13.0"

--- a/libs/@local/hql/span/src/storage.rs
+++ b/libs/@local/hql/span/src/storage.rs
@@ -11,7 +11,6 @@ use crate::{tree::SpanNode, Span, SpanId};
 /// which is returned on insertion.
 #[derive(Debug)]
 pub struct SpanStorage<S> {
-    // ConcurrentVec is also used by salsa / nikomatsakis
     inner: Arc<ConcurrentVec<S>>,
 }
 

--- a/libs/@local/hql/span/src/storage.rs
+++ b/libs/@local/hql/span/src/storage.rs
@@ -11,14 +11,14 @@ use crate::{tree::SpanNode, Span, SpanId};
 /// which is returned on insertion.
 #[derive(Debug)]
 pub struct SpanStorage<S> {
-    inner: Arc<ConcurrentVec<S>>,
+    inner: ConcurrentVec<S>,
 }
 
 impl<S> SpanStorage<S> {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(ConcurrentVec::new()),
+            inner: ConcurrentVec::new(),
         }
     }
 }
@@ -86,14 +86,6 @@ where
     {
         let mut visited = Vec::new();
         self.resolve_inner(span, &mut visited)
-    }
-}
-
-impl<S> Clone for SpanStorage<S> {
-    fn clone(&self) -> Self {
-        Self {
-            inner: Arc::clone(&self.inner),
-        }
     }
 }
 

--- a/libs/@local/hql/span/src/storage.rs
+++ b/libs/@local/hql/span/src/storage.rs
@@ -1,5 +1,3 @@
-use alloc::sync::Arc;
-
 use orx_concurrent_vec::ConcurrentVec;
 
 use crate::{tree::SpanNode, Span, SpanId};


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Using `orx-concurrent-vec` `SpanStorage` is now able to have `insert(&self)`, this simplifies carrying around the storage to various parts.

To increase the benefits, the internal vector has been wrapped in `Arc`, allowing for the cloning of the storage. This is especially useful to reduce lifetimes around parsing code.

Additional as a drive-by diagnostics now only add color if requested.

The full history of the branch can be seen in `bm/hql/cst-preserve`, which will be deleted once this stack of PRs is resolved.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

