### PR TITLE
H-3252: Entity and types table UI improvements, bug fixes

### DIFF
--- a/apps/hash-frontend/src/components/grid/grid.tsx
+++ b/apps/hash-frontend/src/components/grid/grid.tsx
@@ -41,7 +41,9 @@ import { defaultSortRows } from "./utils/sorting";
 import { useDrawHeader } from "./utils/use-draw-header";
 import { useRenderGridPortal } from "./utils/use-render-grid-portal";
 
-export type GridProps<T extends Row & { rowId: string }> = Omit<
+export type GridRow = Row & { rowId: string };
+
+export type GridProps<T extends GridRow> = Omit<
   DataEditorProps,
   | "onColumnResize"
   | "onColumnResizeEnd"
@@ -65,7 +67,11 @@ export type GridProps<T extends Row & { rowId: string }> = Omit<
   resizable?: boolean;
   rows?: T[];
   selectedRows?: T[];
-  sortRows?: (rows: T[], sort: ColumnSort<string>) => T[];
+  sortRows?: (
+    rows: T[],
+    sort: ColumnSort<Extract<keyof T, string>>,
+    previousSort?: ColumnSort<Extract<keyof T, string>>,
+  ) => T[];
   sortable?: boolean;
 };
 
@@ -75,7 +81,7 @@ export const gridHeaderHeightWithBorder = gridHeaderHeight + 1;
 
 export const gridHorizontalScrollbarHeight = 17;
 
-export const Grid = <T extends Row & { rowId: string }>({
+export const Grid = <T extends GridRow>({
   createGetCellContent,
   createOnCellEdited,
   columnFilters,
@@ -116,9 +122,9 @@ export const Grid = <T extends Row & { rowId: string }>({
     return () => InteractableManager.deleteInteractables(tableId);
   }, []);
 
-  const [sorts, setSorts] = useState<ColumnSort<string>[]>(
+  const [sorts, setSorts] = useState<ColumnSort<Extract<keyof T, string>>[]>(
     columns.map((column) => ({
-      columnKey: column.id,
+      columnKey: column.id as Extract<keyof T, string>,
       direction: "asc",
     })),
   );

--- a/apps/hash-frontend/src/components/grid/grid.tsx
+++ b/apps/hash-frontend/src/components/grid/grid.tsx
@@ -512,7 +512,7 @@ export const Grid = <T extends Row & { rowId: string }>({
         drawHeader={drawHeader ?? defaultDrawHeader}
         onHeaderClicked={handleHeaderClicked}
         getCellContent={
-          sortedAndFilteredRows
+          sortedAndFilteredRows?.length
             ? createGetCellContent(sortedAndFilteredRows)
             : getSkeletonCellContent
         }
@@ -521,7 +521,7 @@ export const Grid = <T extends Row & { rowId: string }>({
             ? createOnCellEdited?.(sortedAndFilteredRows)
             : undefined
         }
-        rows={sortedAndFilteredRows ? sortedAndFilteredRows.length : 1}
+        rows={sortedAndFilteredRows?.length ? sortedAndFilteredRows.length : 1}
         maxColumnWidth={1000}
         verticalBorder={
           typeof rest.verticalBorder === "undefined"

--- a/apps/hash-frontend/src/components/grid/utils/sorting.ts
+++ b/apps/hash-frontend/src/components/grid/utils/sorting.ts
@@ -14,12 +14,7 @@ export const defaultSortRows = <T extends Row>(
   sort: ColumnSort<string>,
   previousSort?: ColumnSort<string>,
 ) => {
-  /**
-   * cloning the array, we want to return a new array,
-   * so React can run effects & update state properly
-   */
-  const clone = [...rows] as T[];
-  return clone.sort((row1, row2) => {
+  return rows.toSorted((row1, row2) => {
     // we sort only by alphabetical order for now
     const value1 = String(row1[sort.columnKey]);
     const value2 = String(row2[sort.columnKey]);

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/history-table/shared/event-detail.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/history-table/shared/event-detail.tsx
@@ -1,10 +1,10 @@
 import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
+import { stringifyPropertyValue } from "@local/hash-isomorphic-utils/stringify-property-value";
 import type { EntityRootType, Subgraph } from "@local/hash-subgraph";
 import { Box } from "@mui/material";
 
 import { ValueChip } from "../../../../../../../shared/value-chip";
 import type { HistoryEvent } from "../../shared/types";
-import { stringifyPropertyValue } from "@local/hash-isomorphic-utils/stringify-property-value";
 
 export const EventDetail = ({
   event,

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/history-table/shared/event-detail.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/history-table/shared/event-detail.tsx
@@ -4,6 +4,7 @@ import { Box } from "@mui/material";
 
 import { ValueChip } from "../../../../../../../shared/value-chip";
 import type { HistoryEvent } from "../../shared/types";
+import { stringifyPropertyValue } from "@local/hash-isomorphic-utils/stringify-property-value";
 
 export const EventDetail = ({
   event,
@@ -43,7 +44,9 @@ export const EventDetail = ({
               <Box mx={1} sx={{ whiteSpace: "nowrap" }}>
                 added as
               </Box>
-              <ValueChip tooltip={diff.added}>{diff.added}</ValueChip>
+              <ValueChip tooltip={diff.added}>
+                {stringifyPropertyValue(diff.added)}
+              </ValueChip>
             </>
           );
         }
@@ -56,7 +59,7 @@ export const EventDetail = ({
               <Box mx={1} sx={{ whiteSpace: "nowrap" }}>
                 removed, was
               </Box>
-              <ValueChip>{diff.removed}</ValueChip>
+              <ValueChip>{stringifyPropertyValue(diff.removed)}</ValueChip>
             </>
           );
         }
@@ -69,9 +72,9 @@ export const EventDetail = ({
               <Box mx={1} sx={{ whiteSpace: "nowrap" }}>
                 updated from
               </Box>
-              <ValueChip>{diff.old}</ValueChip>
+              <ValueChip>{stringifyPropertyValue(diff.old)}</ValueChip>
               <Box mx={1}>to</Box>
-              <ValueChip>{diff.new}</ValueChip>
+              <ValueChip>{stringifyPropertyValue(diff.new)}</ValueChip>
             </>
           );
         }

--- a/apps/hash-frontend/src/pages/shared/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table.tsx
@@ -296,7 +296,7 @@ export const EntitiesTable: FunctionComponent<{
                 onClick: () => {
                   if (isViewingPages) {
                     void router.push(
-                      `/${row.namespace}/${extractEntityUuidFromEntityId(
+                      `/${row.web}/${extractEntityUuidFromEntityId(
                         row.entityId,
                       )}`,
                     );
@@ -306,7 +306,7 @@ export const EntitiesTable: FunctionComponent<{
                 },
               },
             };
-          } else if (["namespace", "entityTypeVersion"].includes(columnId)) {
+          } else if (["web", "entityTypeVersion"].includes(columnId)) {
             const cellValue = row[columnId];
             const stringValue = String(cellValue);
 
@@ -321,7 +321,7 @@ export const EntitiesTable: FunctionComponent<{
                 icon: null,
                 value: stringValue,
                 onClick: () => {
-                  if (columnId === "namespace") {
+                  if (columnId === "web") {
                     void router.push(`/${cellValue}`);
                   } else {
                     setSelectedEntityTypeId(row.entityTypeId);
@@ -409,21 +409,19 @@ export const EntitiesTable: FunctionComponent<{
 
   const theme = useTheme();
 
-  const namespaces = useMemo(
+  const webs = useMemo(
     () =>
       rows
-        ?.map(({ namespace }) => namespace)
-        .filter((namespace, index, all) => all.indexOf(namespace) === index) ??
-      [],
+        ?.map(({ web }) => web)
+        .filter((web, index, all) => all.indexOf(web) === index) ?? [],
     [rows],
   );
 
-  const [selectedNamespaces, setSelectedNamespaces] =
-    useState<string[]>(namespaces);
+  const [selectedWebs, setSelectedWebs] = useState<string[]>(webs);
 
   useEffect(() => {
-    setSelectedNamespaces(namespaces);
-  }, [namespaces]);
+    setSelectedWebs(webs);
+  }, [webs]);
 
   const sortRows = useCallback<
     NonNullable<GridProps<TypeEntitiesRow>["sortRows"]>
@@ -533,14 +531,14 @@ export const EntitiesTable: FunctionComponent<{
   const columnFilters = useMemo<ColumnFilter<string, TypeEntitiesRow>[]>(
     () => [
       {
-        columnKey: "namespace",
-        filterItems: namespaces.map((namespace) => ({
-          id: namespace,
-          label: namespace,
+        columnKey: "web",
+        filterItems: webs.map((web) => ({
+          id: web,
+          label: web,
         })),
-        selectedFilterItemIds: selectedNamespaces,
-        setSelectedFilterItemIds: setSelectedNamespaces,
-        isRowFiltered: (row) => !selectedNamespaces.includes(row.namespace),
+        selectedFilterItemIds: selectedWebs,
+        setSelectedFilterItemIds: setSelectedWebs,
+        isRowFiltered: (row) => !selectedWebs.includes(row.web),
       },
       {
         columnKey: "entityTypeVersion",
@@ -606,8 +604,8 @@ export const EntitiesTable: FunctionComponent<{
     ],
     [
       createdByActors,
-      namespaces,
-      selectedNamespaces,
+      webs,
+      selectedWebs,
       entityTypeVersions,
       selectedEntityTypeVersions,
       lastEditedByActors,

--- a/apps/hash-frontend/src/pages/shared/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table.tsx
@@ -216,6 +216,7 @@ export const EntitiesTable: FunctionComponent<{
     entityTypes,
     propertyTypes,
     subgraph,
+    hidePageArchivedColumn: !filterState.includeArchived,
     hideEntityTypeVersionColumn,
     hidePropertiesColumns,
     isViewingPages,

--- a/apps/hash-frontend/src/pages/shared/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table.tsx
@@ -134,7 +134,10 @@ export const EntitiesTable: FunctionComponent<{
       /**
        * Otherwise we check the fetched `entityTypes` as a fallback.
        */
-      entityTypes?.every(({ $id }) => isSpecialEntityTypeLookup?.[$id]?.isFile),
+      (entityTypes?.length &&
+        entityTypes.every(
+          ({ $id }) => isSpecialEntityTypeLookup?.[$id]?.isFile,
+        )),
     [entityTypeBaseUrl, entityTypeId, entityTypes, isSpecialEntityTypeLookup],
   );
 
@@ -180,7 +183,8 @@ export const EntitiesTable: FunctionComponent<{
 
   const isViewingPages = useMemo(
     () =>
-      entities?.every(({ metadata }) =>
+      !!entities?.length &&
+      entities.every(({ metadata }) =>
         isPageEntityTypeId(metadata.entityTypeId),
       ),
     [entities],
@@ -738,7 +742,7 @@ export const EntitiesTable: FunctionComponent<{
                  }px + ${theme.spacing(5)} + ${theme.spacing(5)})),
                 calc(
                  ${gridHeaderHeightWithBorder}px +
-                 (${rows ? rows.length : 1} * ${gridRowHeight}px) +
+                 (${rows?.length ? rows.length : 1} * ${gridRowHeight}px) +
                  ${gridHorizontalScrollbarHeight}px)
                )`}
             createGetCellContent={createGetCellContent}

--- a/apps/hash-frontend/src/pages/shared/entities-table/text-icon-cell.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table/text-icon-cell.tsx
@@ -2,14 +2,17 @@ import type { CustomCell, CustomRenderer } from "@glideapps/glide-data-grid";
 import { GridCellKind } from "@glideapps/glide-data-grid";
 import { customColors } from "@hashintel/design-system/theme";
 
-import { getCellHorizontalPadding } from "../../../components/grid/utils";
+import {
+  getCellHorizontalPadding,
+  getYCenter,
+} from "../../../components/grid/utils";
 import type { CustomIcon } from "../../../components/grid/utils/custom-grid-icons";
 import { drawTextWithIcon } from "../../../components/grid/utils/draw-text-with-icon";
 
 export interface TextIconCellProps {
   readonly kind: "text-icon-cell";
   value: string;
-  icon: CustomIcon;
+  icon: CustomIcon | null;
   onClick?: () => void;
 }
 
@@ -32,23 +35,29 @@ export const createRenderTextIconCell = (params?: {
         ? firstColumnLeftPadding
         : getCellHorizontalPadding();
 
-    const iconLeft = rect.x + columnPadding;
+    const left = rect.x + columnPadding;
 
     // prepare to fill text
     ctx.font = theme.baseFontStyle;
 
     const color = args.highlighted ? customColors.blue[70] : theme.textHeader;
 
-    drawTextWithIcon({
-      args,
-      icon,
-      text: value,
-      left: iconLeft,
-      iconSize: 12,
-      gap: 8,
-      textColor: color,
-      iconColor: color,
-    });
+    if (icon) {
+      drawTextWithIcon({
+        args,
+        icon,
+        text: value,
+        left,
+        iconSize: 12,
+        gap: 8,
+        textColor: color,
+        iconColor: color,
+      });
+    } else {
+      const yCenter = getYCenter(args);
+      ctx.fillStyle = color;
+      ctx.fillText(value, left, yCenter);
+    }
   },
   onClick: (args) => {
     args.cell.data.onClick?.();

--- a/apps/hash-frontend/src/pages/shared/entities-table/use-entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table/use-entities-table.tsx
@@ -29,12 +29,12 @@ export interface TypeEntitiesRow {
   entityLabel: string;
   entityTypeId: VersionedUrl;
   entityTypeVersion: string;
-  namespace: string;
   archived?: boolean;
   lastEdited: string;
   lastEditedBy?: MinimalActor;
   created: string;
   createdBy?: MinimalActor;
+  web: string;
   properties?: {
     [k: string]: string;
   };
@@ -126,9 +126,9 @@ export const useEntitiesTable = (params: {
             },
           ]),
       {
-        title: "Namespace",
-        id: "namespace",
-        width: 250,
+        title: "Web",
+        id: "web",
+        width: 200,
       },
       ...(isViewingPages && !hidePageArchivedColumn
         ? [
@@ -225,7 +225,7 @@ export const useEntitiesTable = (params: {
               entityLabel,
               entityTypeId: entityType.$id,
               entityTypeVersion: `${entityType.title} v${extractVersion(entityType.$id)}`,
-              namespace: `@${entityNamespace}`,
+              web: `@${entityNamespace}`,
               archived: isPage
                 ? simplifyProperties(entity.properties as PageProperties)
                     .archived

--- a/apps/hash-frontend/src/pages/shared/entities-table/use-entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table/use-entities-table.tsx
@@ -28,6 +28,8 @@ export interface TypeEntitiesRow {
   archived?: boolean;
   lastEdited: string;
   lastEditedBy?: MinimalActor;
+  created: string;
+  createdBy?: MinimalActor;
   properties?: {
     [k: string]: string;
   };
@@ -139,6 +141,16 @@ export const useEntitiesTable = (params: {
         id: "lastEditedBy",
         width: 200,
       },
+      {
+        title: "Created",
+        id: "created",
+        width: 200,
+      },
+      {
+        title: "Created By",
+        id: "createdBy",
+        width: 200,
+      },
       /** @todo: uncomment this when we have additional types for entities */
       // {
       //   title: "Additional Types",
@@ -182,13 +194,23 @@ export const useEntitiesTable = (params: {
                 accountId === entity.metadata.provenance.edition.createdById,
             );
 
+            const created = format(
+              new Date(entity.metadata.provenance.createdAtDecisionTime),
+              "yyyy-MM-dd HH:mm",
+            );
+
+            const createdBy = actors?.find(
+              ({ accountId }) =>
+                accountId === entity.metadata.provenance.createdById,
+            );
+
             return {
               rowId: entityId,
               entityId,
               entity,
               entityLabel,
               entityTypeVersion: entityType
-                ? `v${extractVersion(entityType.$id)} ${entityType.title}`
+                ? `${entityType.title} v${extractVersion(entityType.$id)}`
                 : "",
               namespace: `@${entityNamespace}`,
               archived: isPage
@@ -197,6 +219,8 @@ export const useEntitiesTable = (params: {
                 : undefined,
               lastEdited,
               lastEditedBy,
+              created,
+              createdBy,
               /** @todo: uncomment this when we have additional types for entities */
               // additionalTypes: "",
               ...propertyColumns.reduce((fields, column) => {
@@ -226,6 +250,7 @@ export const useEntitiesTable = (params: {
     subgraph,
     entitiesHaveSameType,
     hideEntityTypeVersionColumn,
+    hidePageArchivedColumn,
     hidePropertiesColumns,
     isViewingPages,
     actors,

--- a/apps/hash-frontend/src/pages/shared/entities-table/use-entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table/use-entities-table.tsx
@@ -41,6 +41,7 @@ export const useEntitiesTable = (params: {
   entityTypes?: EntityType[];
   propertyTypes?: PropertyType[];
   subgraph?: Subgraph<EntityRootType>;
+  hidePageArchivedColumn?: boolean;
   hideEntityTypeVersionColumn?: boolean;
   hidePropertiesColumns: boolean;
   isViewingPages?: boolean;
@@ -50,6 +51,7 @@ export const useEntitiesTable = (params: {
     entityTypes,
     propertyTypes,
     subgraph,
+    hidePageArchivedColumn = false,
     hideEntityTypeVersionColumn = false,
     hidePropertiesColumns,
     isViewingPages = false,
@@ -118,7 +120,7 @@ export const useEntitiesTable = (params: {
         id: "namespace",
         width: 250,
       },
-      ...(isViewingPages
+      ...(isViewingPages && !hidePageArchivedColumn
         ? [
             {
               title: "Archived",

--- a/apps/hash-frontend/src/pages/types/[[...type-kind]].page/types-table.tsx
+++ b/apps/hash-frontend/src/pages/types/[[...type-kind]].page/types-table.tsx
@@ -127,13 +127,17 @@ export const TypesTable: FunctionComponent<{
         title: "Web",
         width: 280,
       },
-      {
-        id: "archived",
-        title: "Archived",
-        width: 200,
-      },
+      ...(filterState.includeArchived
+        ? [
+            {
+              id: "archived",
+              title: "Archived",
+              width: 200,
+            } as const,
+          ]
+        : []),
     ],
-    [kind],
+    [filterState.includeArchived, kind],
   );
 
   const { users } = useUsers();

--- a/apps/hash-frontend/src/pages/types/[[...type-kind]].page/types-table.tsx
+++ b/apps/hash-frontend/src/pages/types/[[...type-kind]].page/types-table.tsx
@@ -13,6 +13,7 @@ import type {
 import { gridRowHeight } from "@local/hash-isomorphic-utils/data-grid";
 import { isExternalOntologyElementMetadata } from "@local/hash-subgraph";
 import { Box, useTheme } from "@mui/material";
+import { format } from "date-fns";
 import { useRouter } from "next/router";
 import type { FunctionComponent } from "react";
 import { useCallback, useMemo, useRef, useState } from "react";
@@ -22,6 +23,7 @@ import {
   gridHeaderHeightWithBorder,
   gridHorizontalScrollbarHeight,
 } from "../../../components/grid/grid";
+import type { CustomIcon } from "../../../components/grid/utils/custom-grid-icons";
 import { useOrgs } from "../../../components/hooks/use-orgs";
 import { useUsers } from "../../../components/hooks/use-users";
 import { extractOwnedById } from "../../../lib/user-and-org";
@@ -31,9 +33,17 @@ import { isTypeArchived } from "../../../shared/is-archived";
 import { HEADER_HEIGHT } from "../../../shared/layout/layout-with-header/page-header";
 import type { FilterState } from "../../../shared/table-header";
 import { TableHeader, tableHeaderHeight } from "../../../shared/table-header";
+import {
+  isAiMachineActor,
+  type MinimalActor,
+  useActors,
+} from "../../../shared/use-actors";
 import { useAuthenticatedUser } from "../../shared/auth-info-context";
+import type { ChipCell } from "../../shared/chip-cell";
+import { renderChipCell } from "../../shared/chip-cell";
 import type { TextIconCell } from "../../shared/entities-table/text-icon-cell";
 import { createRenderTextIconCell } from "../../shared/entities-table/text-icon-cell";
+import { TypeSlideOverStack } from "../../shared/entity-type-page/type-slide-over-stack";
 import { TOP_CONTEXT_BAR_HEIGHT } from "../../shared/top-context-bar";
 
 const typesTableColumnIds = [
@@ -41,6 +51,8 @@ const typesTableColumnIds = [
   "kind",
   "webShortname",
   "archived",
+  "lastEdited",
+  "lastEditedBy",
 ] as const;
 
 type LinkColumnId = (typeof typesTableColumnIds)[number];
@@ -52,6 +64,8 @@ type TypesTableColumn = {
 export type TypesTableRow = {
   rowId: string;
   kind: "entity-type" | "property-type" | "link-type" | "data-type";
+  lastEdited: string;
+  lastEditedBy?: MinimalActor;
   typeId: VersionedUrl;
   title: string;
   external: boolean;
@@ -103,6 +117,9 @@ export const TypesTable: FunctionComponent<{
     includeGlobal: false,
   });
 
+  const [selectedEntityTypeId, setSelectedEntityTypeId] =
+    useState<VersionedUrl | null>(null);
+
   const { isSpecialEntityTypeLookup } = useEntityTypesContextRequired();
 
   const typesTableColumns = useMemo<TypesTableColumn[]>(
@@ -136,12 +153,32 @@ export const TypesTable: FunctionComponent<{
             } as const,
           ]
         : []),
+      {
+        title: "Last Edited",
+        id: "lastEdited",
+        width: 200,
+      },
+      {
+        title: "Last Edited By",
+        id: "lastEditedBy",
+        width: 200,
+      },
     ],
     [filterState.includeArchived, kind],
   );
 
   const { users } = useUsers();
   const { orgs } = useOrgs();
+
+  const editorActorIds = useMemo(
+    () =>
+      types?.flatMap(({ metadata }) => [
+        metadata.provenance.edition.createdById,
+      ]),
+    [types],
+  );
+
+  const { actors } = useActors({ accountIds: editorActorIds });
 
   const namespaces = useMemo(
     () => (users && orgs ? [...users, ...orgs] : undefined),
@@ -175,10 +212,24 @@ export const TypesTable: FunctionComponent<{
             (workspace) => extractOwnedById(workspace) === namespaceOwnedById,
           )?.shortname;
 
+          const lastEdited = format(
+            new Date(
+              type.metadata.temporalVersioning.transactionTime.start.limit,
+            ),
+            "yyyy-MM-dd HH:mm",
+          );
+
+          const lastEditedBy = actors?.find(
+            ({ accountId }) =>
+              accountId === type.metadata.provenance.edition.createdById,
+          );
+
           return {
             rowId: type.schema.$id,
             typeId: type.schema.$id,
             title: type.schema.title,
+            lastEdited,
+            lastEditedBy,
             kind:
               type.schema.kind === "entityType"
                 ? isSpecialEntityTypeLookup?.[type.schema.$id]?.isFile
@@ -197,12 +248,19 @@ export const TypesTable: FunctionComponent<{
             (filterState.includeGlobal ? true : !external) &&
             (filterState.includeArchived ? true : !archived),
         ),
-    [internalWebIds, isSpecialEntityTypeLookup, types, namespaces, filterState],
+    [
+      actors,
+      internalWebIds,
+      isSpecialEntityTypeLookup,
+      types,
+      namespaces,
+      filterState,
+    ],
   );
 
   const createGetCellContent = useCallback(
     (rows: TypesTableRow[]) =>
-      ([colIndex, rowIndex]: Item): TextCell | TextIconCell => {
+      ([colIndex, rowIndex]: Item): TextCell | TextIconCell | ChipCell => {
         const row = rows[rowIndex];
 
         if (!row) {
@@ -227,8 +285,13 @@ export const TypesTable: FunctionComponent<{
                 kind: "text-icon-cell",
                 icon: "bpAsterisk",
                 value: row.title,
-                onClick: () =>
-                  router.push(generateLinkParameters(row.typeId).href),
+                onClick: () => {
+                  if (row.kind === "entity-type") {
+                    setSelectedEntityTypeId(row.typeId);
+                  } else {
+                    void router.push(generateLinkParameters(row.typeId).href);
+                  }
+                },
               },
             };
           case "kind":
@@ -262,6 +325,48 @@ export const TypesTable: FunctionComponent<{
               data: value,
             };
           }
+          case "lastEdited": {
+            return {
+              kind: GridCellKind.Text,
+              readonly: true,
+              allowOverlay: false,
+              displayData: String(row.lastEdited),
+              data: row.lastEdited,
+            };
+          }
+          case "lastEditedBy": {
+            const actor = row.lastEditedBy;
+
+            const actorName = actor ? actor.displayName : undefined;
+
+            const actorIcon = actor
+              ? ((actor.kind === "machine"
+                  ? isAiMachineActor(actor)
+                    ? "wandMagicSparklesRegular"
+                    : "hashSolid"
+                  : "userRegular") satisfies CustomIcon)
+              : undefined;
+
+            return {
+              kind: GridCellKind.Custom,
+              readonly: true,
+              allowOverlay: false,
+              copyData: String(actorName),
+              data: {
+                kind: "chip-cell",
+                chips: actorName
+                  ? [
+                      {
+                        text: actorName,
+                        icon: actorIcon,
+                      },
+                    ]
+                  : [],
+                color: "gray",
+                variant: "filled",
+              },
+            };
+          }
         }
       },
     [typesTableColumns, router],
@@ -272,53 +377,62 @@ export const TypesTable: FunctionComponent<{
   const currentlyDisplayedRowsRef = useRef<TypesTableRow[] | null>(null);
 
   return (
-    <Box>
-      <TableHeader
-        internalWebIds={internalWebIds}
-        itemLabelPlural="types"
-        items={types}
-        title={typesTablesToTitle[kind]}
-        columns={typesTableColumns}
-        currentlyDisplayedRowsRef={currentlyDisplayedRowsRef}
-        filterState={filterState}
-        setFilterState={setFilterState}
-        selectedItems={types?.filter((type) =>
-          selectedRows.some(({ typeId }) => type.schema.$id === typeId),
-        )}
-        onBulkActionCompleted={() => setSelectedRows([])}
-      />
-      <Grid
-        showSearch={showSearch}
-        onSearchClose={() => setShowSearch(false)}
-        columns={typesTableColumns}
-        dataLoading={!types}
-        rows={filteredRows}
-        enableCheckboxSelection
-        selectedRows={selectedRows}
-        currentlyDisplayedRowsRef={currentlyDisplayedRowsRef}
-        onSelectedRowsChange={(updatedSelectedRows) =>
-          setSelectedRows(updatedSelectedRows)
-        }
-        sortable
-        firstColumnLeftPadding={16}
-        createGetCellContent={createGetCellContent}
-        // define max height if there are lots of rows
-        height={`
+    <>
+      {selectedEntityTypeId && (
+        <TypeSlideOverStack
+          rootTypeId={selectedEntityTypeId}
+          onClose={() => setSelectedEntityTypeId(null)}
+        />
+      )}
+      <Box>
+        <TableHeader
+          internalWebIds={internalWebIds}
+          itemLabelPlural="types"
+          items={types}
+          title={typesTablesToTitle[kind]}
+          columns={typesTableColumns}
+          currentlyDisplayedRowsRef={currentlyDisplayedRowsRef}
+          filterState={filterState}
+          setFilterState={setFilterState}
+          selectedItems={types?.filter((type) =>
+            selectedRows.some(({ typeId }) => type.schema.$id === typeId),
+          )}
+          onBulkActionCompleted={() => setSelectedRows([])}
+        />
+        <Grid
+          showSearch={showSearch}
+          onSearchClose={() => setShowSearch(false)}
+          columns={typesTableColumns}
+          dataLoading={!types}
+          rows={filteredRows}
+          enableCheckboxSelection
+          selectedRows={selectedRows}
+          currentlyDisplayedRowsRef={currentlyDisplayedRowsRef}
+          onSelectedRowsChange={(updatedSelectedRows) =>
+            setSelectedRows(updatedSelectedRows)
+          }
+          sortable
+          firstColumnLeftPadding={16}
+          createGetCellContent={createGetCellContent}
+          // define max height if there are lots of rows
+          height={`
           min(
             calc(100vh - (${
               HEADER_HEIGHT + TOP_CONTEXT_BAR_HEIGHT + 170 + tableHeaderHeight
             }px + ${theme.spacing(5)}) - ${theme.spacing(5)}),
             calc(
               ${gridHeaderHeightWithBorder}px +
-              (${filteredRows ? filteredRows.length : 1} * ${gridRowHeight}px) +
+              (${filteredRows?.length ? filteredRows.length : 1} * ${gridRowHeight}px) +
               ${gridHorizontalScrollbarHeight}px
             )
           )`}
-        customRenderers={[
-          createRenderTextIconCell({ firstColumnLeftPadding: 16 }),
-        ]}
-        freezeColumns={1}
-      />
-    </Box>
+          customRenderers={[
+            createRenderTextIconCell({ firstColumnLeftPadding: 16 }),
+            renderChipCell,
+          ]}
+          freezeColumns={1}
+        />
+      </Box>
+    </>
   );
 };

--- a/apps/hash-frontend/src/pages/types/[[...type-kind]].page/types-table.tsx
+++ b/apps/hash-frontend/src/pages/types/[[...type-kind]].page/types-table.tsx
@@ -352,11 +352,19 @@ export const TypesTable: FunctionComponent<{
               : typeNamespaceFromTypeId(row.typeId);
 
             return {
-              kind: GridCellKind.Text,
-              readonly: true,
+              kind: GridCellKind.Custom,
               allowOverlay: false,
-              displayData: String(value),
-              data: value,
+              readonly: true,
+              cursor: "pointer",
+              copyData: value,
+              data: {
+                kind: "text-icon-cell",
+                icon: null,
+                value,
+                onClick: () => {
+                  void router.push(`/${value}`);
+                },
+              },
             };
           }
           case "archived": {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The following UX improvements on the entities and type tables:
- Hide the `archived` column when viewing **pages** and 'include archived' is not selected
- Hide the `archived` column when viewing **types** and 'include archived' is not selected
- Add `createdBy`/`created` columns to the entities table
- Add `lastEditedBy`/`lastEdited` columns to the types table
- On the entities table, show the entity in a slideover when the entity's name is clicked
- On the entities table, show the type of entity in a slideover when the type is clicked
- On the types table, show entity types in a slideover when clicked
- Rename 'namespace' to 'web' on the entities table
- On the entities and types tables, allow clicking the web to go to its profile

Bug fixes:
- Fix sorting by `lastEditedBy` on the entities table
- Fix showing 'No results' on tables if no results are found (previously nothing was shown)
- Fix crash when viewing an entity history item with a nested property object

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

- `created`/`createdBy` cannot yet be exposed on the types table as the API does not expose the fields (H-3249)

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- Existing 'does the table render' tests

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. View the preview deployment, go to types / entities pages
