### PR TITLE
H-3274: Prevent Dockerfile warnings emitted from GitHub

### DIFF
--- a/apps/hash-ai-worker-ts/docker/Dockerfile
+++ b/apps/hash-ai-worker-ts/docker/Dockerfile
@@ -74,6 +74,6 @@ RUN mkdir -p officeParserTemp/tempfiles && \
     chown -R tsworker:hash officeParserTemp
 
 USER tsworker:hash
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 HEALTHCHECK --interval=5s --timeout=3s --start-period=10s --retries=3 CMD curl -f http://localhost:4100/health || exit 1

--- a/apps/hash-graph/docker/Dockerfile
+++ b/apps/hash-graph/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN apk add --no-cache gcc musl-dev bash protobuf-dev && \
 SHELL ["bash", "-c"]
 
 
-FROM rust as installer
+FROM rust AS installer
 
 WORKDIR /usr/local/src/
 

--- a/apps/hash-integration-worker/docker/Dockerfile
+++ b/apps/hash-integration-worker/docker/Dockerfile
@@ -71,6 +71,6 @@ RUN apt-get update && \
     install -d -m 0775 -o integrationworker -g hash /log
 
 USER integrationworker:hash
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 HEALTHCHECK --interval=5s --timeout=3s --start-period=10s --retries=3 CMD curl -f http://localhost:4300/health || exit 1

--- a/infra/docker/api/prod/Dockerfile
+++ b/infra/docker/api/prod/Dockerfile
@@ -72,6 +72,6 @@ RUN apt-get update && \
     install -d -m 0775 -o api -g hash /log
 
 USER api:hash
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 HEALTHCHECK --interval=5s --timeout=3s --start-period=10s --retries=3 CMD curl -f http://localhost:5001/health-check || exit 1


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

On [`f6d1a69` (#4892)](https://github.com/hashintel/hash/pull/4892/commits/f6d1a69fa00ddfc4211e12d393c7a6c71029d2fa#diff-abe64b7e17a62a627bc3288e2f6663b0401d814fdc940c2569e13860dff728ca) I noticed a few warnings, this adresses the concerns.