### PR TITLE
H-2963, H-3292: Allow storing of data type conversion definitions

### DIFF
--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/006-create-first-custom-data-types.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/006-create-first-custom-data-types.migration.ts
@@ -1,3 +1,5 @@
+import { systemDataTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
+
 import type { MigrationFunction } from "../types";
 import { createSystemDataTypeIfNotExists } from "../util";
 
@@ -13,6 +15,7 @@ const migrate: MigrationFunction = async ({
       format: "uri",
       type: "string",
     },
+    conversions: {},
     webShortname: "hash",
     migrationState,
   });
@@ -25,6 +28,22 @@ const migrate: MigrationFunction = async ({
       format: "email",
       type: "string",
     },
+    conversions: {},
+    webShortname: "hash",
+    migrationState,
+  });
+
+  await createSystemDataTypeIfNotExists(context, authentication, {
+    dataTypeDefinition: {
+      title: "Meters",
+      description:
+        "The base unit of length in the International System of Units (SI).",
+      label: {
+        right: "m",
+      },
+      type: "number",
+    },
+    conversions: {},
     webShortname: "hash",
     migrationState,
   });
@@ -38,6 +57,12 @@ const migrate: MigrationFunction = async ({
         right: "mm",
       },
       type: "number",
+    },
+    conversions: {
+      [systemDataTypes.meters.dataTypeBaseUrl]: {
+        from: { expression: ["*", "self", { const: 1000, type: "number" }] },
+        to: { expression: ["/", "self", { const: 1000, type: "number" }] },
+      },
     },
     webShortname: "hash",
     migrationState,
@@ -53,19 +78,11 @@ const migrate: MigrationFunction = async ({
       },
       type: "number",
     },
-    webShortname: "hash",
-    migrationState,
-  });
-
-  await createSystemDataTypeIfNotExists(context, authentication, {
-    dataTypeDefinition: {
-      title: "Meters",
-      description:
-        "The base unit of length in the International System of Units (SI).",
-      label: {
-        right: "m",
+    conversions: {
+      [systemDataTypes.meters.dataTypeBaseUrl]: {
+        from: { expression: ["*", "self", { const: 100, type: "number" }] },
+        to: { expression: ["/", "self", { const: 100, type: "number" }] },
       },
-      type: "number",
     },
     webShortname: "hash",
     migrationState,
@@ -81,6 +98,12 @@ const migrate: MigrationFunction = async ({
       },
       type: "number",
     },
+    conversions: {
+      [systemDataTypes.meters.dataTypeBaseUrl]: {
+        from: { expression: ["/", "self", { const: 1000, type: "number" }] },
+        to: { expression: ["*", "self", { const: 1000, type: "number" }] },
+      },
+    },
     webShortname: "hash",
     migrationState,
   });
@@ -95,6 +118,14 @@ const migrate: MigrationFunction = async ({
       },
       type: "number",
     },
+    conversions: {
+      [systemDataTypes.meters.dataTypeBaseUrl]: {
+        from: {
+          expression: ["/", "self", { const: 1609.344, type: "number" }],
+        },
+        to: { expression: ["*", "self", { const: 1609.344, type: "number" }] },
+      },
+    },
     webShortname: "hash",
     migrationState,
   });
@@ -107,6 +138,7 @@ const migrate: MigrationFunction = async ({
       type: "string",
       format: "date",
     },
+    conversions: {},
     webShortname: "hash",
     migrationState,
   });
@@ -119,6 +151,7 @@ const migrate: MigrationFunction = async ({
       type: "string",
       format: "date-time",
     },
+    conversions: {},
     webShortname: "hash",
     migrationState,
   });
@@ -131,6 +164,7 @@ const migrate: MigrationFunction = async ({
       type: "string",
       format: "time",
     },
+    conversions: {},
     webShortname: "hash",
     migrationState,
   });
@@ -144,6 +178,7 @@ const migrate: MigrationFunction = async ({
       },
       type: "number",
     },
+    conversions: {},
     webShortname: "hash",
     migrationState,
   });
@@ -157,6 +192,7 @@ const migrate: MigrationFunction = async ({
       },
       type: "number",
     },
+    conversions: {},
     webShortname: "hash",
     migrationState,
   });
@@ -171,6 +207,7 @@ const migrate: MigrationFunction = async ({
       },
       type: "number",
     },
+    conversions: {},
     webShortname: "hash",
     migrationState,
   });

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/012-create-google-sheets-system-types.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/012-create-google-sheets-system-types.migration.ts
@@ -130,6 +130,7 @@ const migrate: MigrationFunction = async ({
         enum: ["human", "machine"],
         type: "string",
       },
+      conversions: {},
       webShortname: "hash",
       migrationState,
     },

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/016-add-initial-currency-data-types.dev.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/016-add-initial-currency-data-types.dev.migration.ts
@@ -12,6 +12,7 @@ const migrate: MigrationFunction = async ({
       description: "An amount denominated in US Dollars",
       type: "number",
     },
+    conversions: {},
     webShortname: "hash",
     migrationState,
   });
@@ -22,6 +23,7 @@ const migrate: MigrationFunction = async ({
       description: "An amount denominated in British pounds sterling",
       type: "number",
     },
+    conversions: {},
     webShortname: "hash",
     migrationState,
   });

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import type {
   ArraySchema,
+  Conversions,
   DataTypeReference,
   EntityType,
   ObjectSchema,
@@ -167,6 +168,7 @@ export const loadExternalDataTypeIfNotExists: ImpureGraphFunction<
           },
         },
       ],
+      conversions: {},
     });
 
     return await getDataTypeById(context, authentication, { dataTypeId });
@@ -422,12 +424,13 @@ const generateSystemDataTypeSchema = ({
 export const createSystemDataTypeIfNotExists: ImpureGraphFunction<
   {
     dataTypeDefinition: ConstructDataTypeParams;
+    conversions: Record<BaseUrl, Conversions>;
   } & BaseCreateTypeIfNotExistsParameters,
   Promise<DataTypeWithMetadata>
 > = async (
   context,
   authentication,
-  { dataTypeDefinition, migrationState, webShortname },
+  { dataTypeDefinition, conversions, migrationState, webShortname },
 ) => {
   const { title } = dataTypeDefinition;
   const baseUrl = generateSystemTypeBaseUrl({
@@ -481,6 +484,7 @@ export const createSystemDataTypeIfNotExists: ImpureGraphFunction<
       // Specify the schema so that self-hosted instances don't need network access to hash.ai
       schema: dataTypeSchema,
       relationships,
+      conversions,
     });
 
     return await getDataTypeById(context, authentication, {
@@ -496,6 +500,7 @@ export const createSystemDataTypeIfNotExists: ImpureGraphFunction<
         schema: dataTypeSchema,
         webShortname,
         relationships,
+        conversions,
       },
     ).catch((createError) => {
       // logger.warn(`Failed to create data type: ${propertyTypeId}`);

--- a/apps/hash-api/src/graph/ontology/primitive/data-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/data-type.ts
@@ -1,4 +1,8 @@
-import type { VersionedUrl } from "@blockprotocol/type-system";
+import type {
+  BaseUrl,
+  Conversions,
+  VersionedUrl,
+} from "@blockprotocol/type-system";
 import { DATA_TYPE_META_SCHEMA } from "@blockprotocol/type-system";
 import { NotFoundError } from "@local/hash-backend-utils/error";
 import type {
@@ -57,10 +61,11 @@ export const createDataType: ImpureGraphFunction<
     webShortname?: string;
     relationships: DataTypeRelationAndSubject[];
     provenance?: ProvidedOntologyEditionProvenance;
+    conversions: Record<BaseUrl, Conversions>;
   },
   Promise<DataTypeWithMetadata>
 > = async (ctx, authentication, params) => {
-  const { ownedById, webShortname, provenance } = params;
+  const { ownedById, webShortname, provenance, conversions } = params;
 
   const shortname =
     webShortname ??
@@ -90,6 +95,7 @@ export const createDataType: ImpureGraphFunction<
       ownedById,
       relationships: params.relationships,
       provenance,
+      conversions,
     },
   );
 
@@ -207,10 +213,11 @@ export const updateDataType: ImpureGraphFunction<
     schema: ConstructDataTypeParams;
     relationships: DataTypeRelationAndSubject[];
     provenance?: ProvidedOntologyEditionProvenance;
+    conversions: Record<BaseUrl, Conversions>;
   },
   Promise<DataTypeWithMetadata>
 > = async ({ graphApi }, { actorId }, params) => {
-  const { dataTypeId, schema, provenance } = params;
+  const { dataTypeId, schema, provenance, conversions } = params;
 
   const { data: metadata } = await graphApi.updateDataType(actorId, {
     typeToUpdate: dataTypeId,
@@ -221,6 +228,7 @@ export const updateDataType: ImpureGraphFunction<
     },
     relationships: params.relationships,
     provenance,
+    conversions,
   });
 
   const { recordId } = metadata;

--- a/apps/hash-graph/libs/api/src/rest/data_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/data_type.rs
@@ -1,6 +1,7 @@
 //! Web routes for CRU operations on Data Types.
 
 use alloc::sync::Arc;
+use std::collections::HashMap;
 
 use authorization::{
     backend::{ModifyRelationshipOperation, PermissionAssertion},
@@ -49,8 +50,11 @@ use serde::{Deserialize, Serialize};
 use temporal_client::TemporalClient;
 use time::OffsetDateTime;
 use type_system::{
-    schema::DataType,
-    url::{OntologyTypeVersion, VersionedUrl},
+    schema::{
+        ConversionDefinition, ConversionExpression, ConversionValue, Conversions, DataType,
+        Operator, Variable,
+    },
+    url::{BaseUrl, OntologyTypeVersion, VersionedUrl},
 };
 use utoipa::{OpenApi, ToSchema};
 
@@ -99,6 +103,13 @@ use crate::rest::{
             GetDataTypeSubgraphResponse,
             ArchiveDataTypeParams,
             UnarchiveDataTypeParams,
+
+            ConversionDefinition,
+            ConversionExpression,
+            ConversionValue,
+            Conversions,
+            Operator,
+            Variable,
 
             ValueWithMetadata,
         )
@@ -167,6 +178,7 @@ struct CreateDataTypeRequest {
         skip_serializing_if = "ProvidedOntologyEditionProvenance::is_empty"
     )]
     provenance: ProvidedOntologyEditionProvenance,
+    conversions: HashMap<BaseUrl, Conversions>,
 }
 
 #[utoipa::path(
@@ -220,6 +232,7 @@ where
         owned_by_id,
         relationships,
         provenance,
+        conversions,
     }) = body;
 
     let is_list = matches!(&schema, ListOrValue::List(_));
@@ -238,7 +251,8 @@ where
                     classification: OntologyTypeClassificationMetadata::Owned { owned_by_id },
                     relationships: relationships.clone(),
                     conflict_behavior: ConflictBehavior::Fail,
-                    provenance: provenance.clone()
+                    provenance: provenance.clone(),
+                    conversions: conversions.clone(),
                 })
             }).collect::<Result<Vec<_>, StatusCode>>()?
         )
@@ -282,6 +296,7 @@ enum LoadExternalDataTypeRequest {
             skip_serializing_if = "ProvidedOntologyEditionProvenance::is_empty"
         )]
         provenance: Box<ProvidedOntologyEditionProvenance>,
+        conversions: HashMap<BaseUrl, Conversions>,
     },
 }
 
@@ -347,6 +362,7 @@ where
             schema,
             relationships,
             provenance,
+            conversions,
         } => {
             if domain_validator.validate_url(schema.id.base_url.as_str()) {
                 let error = "Ontology type is not external".to_owned();
@@ -370,6 +386,7 @@ where
                             relationships,
                             conflict_behavior: ConflictBehavior::Fail,
                             provenance: *provenance,
+                            conversions: conversions.clone(),
                         },
                     )
                     .await
@@ -522,6 +539,7 @@ struct UpdateDataTypeRequest {
         skip_serializing_if = "ProvidedOntologyEditionProvenance::is_empty"
     )]
     provenance: ProvidedOntologyEditionProvenance,
+    conversions: HashMap<BaseUrl, Conversions>,
 }
 
 #[utoipa::path(
@@ -562,6 +580,7 @@ where
         mut type_to_update,
         relationships,
         provenance,
+        conversions,
     }) = body;
 
     type_to_update.version = OntologyTypeVersion::new(type_to_update.version.inner() + 1);
@@ -593,6 +612,7 @@ where
                 schema: data_type,
                 relationships,
                 provenance,
+                conversions,
             },
         )
         .await

--- a/apps/hash-graph/libs/graph/src/snapshot/mod.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/mod.rs
@@ -51,13 +51,14 @@ use hash_status::StatusCode;
 use postgres_types::ToSql;
 use serde::{Deserialize, Serialize};
 use tokio_postgres::error::SqlState;
-use type_system::url::VersionedUrl;
+use type_system::{schema::Conversions, url::VersionedUrl};
 
 use crate::{
     snapshot::{
         entity::{EntityEmbeddingRecord, EntitySnapshotRecord},
         ontology::{
-            DataTypeEmbeddingRecord, EntityTypeEmbeddingRecord, PropertyTypeEmbeddingRecord,
+            DataTypeConversionsRecord, DataTypeEmbeddingRecord, EntityTypeEmbeddingRecord,
+            PropertyTypeEmbeddingRecord,
         },
         restore::SnapshotRecordBatch,
     },
@@ -103,6 +104,7 @@ pub enum SnapshotEntry {
     AccountGroup(AccountGroup),
     Web(Web),
     DataType(Box<DataTypeSnapshotRecord>),
+    DataTypeConversions(Box<DataTypeConversionsRecord>),
     DataTypeEmbedding(DataTypeEmbeddingRecord),
     PropertyType(Box<PropertyTypeSnapshotRecord>),
     PropertyTypeEmbedding(PropertyTypeEmbeddingRecord),
@@ -184,6 +186,20 @@ impl SnapshotEntry {
                         context.push_appendix(format!("{id}:\n{json}"));
                     }
                 }
+            }
+            Self::DataTypeConversions(conversions) => {
+                context.push_body(format!(
+                    "data type conversions: {} -> {}: {}",
+                    conversions.source_data_type,
+                    conversions.target_data_type,
+                    conversions.conversions.to.expression
+                ));
+                context.push_body(format!(
+                    "data type conversions: {} <- {}: {}",
+                    conversions.source_data_type,
+                    conversions.target_data_type,
+                    conversions.conversions.from.expression
+                ));
             }
             Self::DataTypeEmbedding(embedding) => {
                 context.push_body(format!("data type embedding: {}", embedding.data_type_id));
@@ -382,6 +398,42 @@ impl PostgresStorePool {
         .await
         .map_err(|future_error| future_error.change_context(SnapshotDumpError::Query))?
         .map_err(|stream_error| stream_error.change_context(SnapshotDumpError::Read)))
+    }
+
+    async fn create_data_type_conversions_stream(
+        &self,
+    ) -> Result<
+        impl Stream<Item = Result<SnapshotEntry, SnapshotDumpError>> + Send,
+        SnapshotDumpError,
+    > {
+        Ok(self
+            .acquire(NoAuthorization, None)
+            .await
+            .change_context(SnapshotDumpError::Query)?
+            .as_client()
+            .query_raw(
+                r#"SELECT "base_url", "version", "target_data_type_base_url", "from", "into"
+                 FROM data_type_conversions
+                 JOIN ontology_ids ON data_type_conversions.source_data_type_ontology_id = ontology_ids.ontology_id
+                 "#,
+                [] as [&(dyn ToSql + Sync); 0],
+            )
+            .await
+            .change_context(SnapshotDumpError::Query)?
+            .map(|result| result.change_context(SnapshotDumpError::Query))
+            .map_ok(|row| {
+                SnapshotEntry::DataTypeConversions(Box::new(DataTypeConversionsRecord {
+                    source_data_type: VersionedUrl {
+                        base_url: row.get(0),
+                        version: row.get(1),
+                    },
+                    target_data_type: row.get(2),
+                    conversions: Conversions {
+                        from: row.get(3),
+                        to: row.get(4),
+                    },
+                }))
+            }))
     }
 
     async fn create_data_type_embedding_stream(
@@ -606,6 +658,12 @@ impl PostgresStorePool {
                                 metadata: record.metadata,
                             })))
                         })
+                        .forward(snapshot_record_tx.clone()),
+                );
+
+                scope.spawn(
+                    self.create_data_type_conversions_stream()
+                        .try_flatten_stream()
                         .forward(snapshot_record_tx.clone()),
                 );
             }

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/mod.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/mod.rs
@@ -12,8 +12,8 @@ pub use self::{
     },
     property_type::{property_type_channel, PropertyTypeRowBatch, PropertyTypeSender},
     record::{
-        DataTypeEmbeddingRecord, DataTypeSnapshotRecord, EntityTypeEmbeddingRecord,
-        EntityTypeSnapshotRecord, OntologyTypeSnapshotRecord, PropertyTypeEmbeddingRecord,
-        PropertyTypeSnapshotRecord,
+        DataTypeConversionsRecord, DataTypeEmbeddingRecord, DataTypeSnapshotRecord,
+        EntityTypeEmbeddingRecord, EntityTypeSnapshotRecord, OntologyTypeSnapshotRecord,
+        PropertyTypeEmbeddingRecord, PropertyTypeSnapshotRecord,
     },
 };

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/record.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/record.rs
@@ -5,8 +5,8 @@ use graph_types::{ontology::OntologyType, Embedding};
 use serde::{Deserialize, Serialize};
 use temporal_versioning::{Timestamp, TransactionTime};
 use type_system::{
-    schema::{DataType, EntityType, PropertyType},
-    url::VersionedUrl,
+    schema::{Conversions, DataType, EntityType, PropertyType},
+    url::{BaseUrl, VersionedUrl},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -36,6 +36,14 @@ pub struct DataTypeEmbeddingRecord {
     pub data_type_id: VersionedUrl,
     pub embedding: Embedding<'static>,
     pub updated_at_transaction_time: Timestamp<TransactionTime>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DataTypeConversionsRecord {
+    pub source_data_type: VersionedUrl,
+    pub target_data_type: BaseUrl,
+    pub conversions: Conversions,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/apps/hash-graph/libs/graph/src/snapshot/restore/channel.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/restore/channel.rs
@@ -28,7 +28,8 @@ use crate::{
         AuthorizationRelation, SnapshotEntry, SnapshotMetadata, SnapshotRestoreError,
     },
     store::postgres::query::rows::{
-        DataTypeEmbeddingRow, EntityEmbeddingRow, EntityTypeEmbeddingRow, PropertyTypeEmbeddingRow,
+        DataTypeConversionsRow, DataTypeEmbeddingRow, EntityEmbeddingRow, EntityTypeEmbeddingRow,
+        PropertyTypeEmbeddingRow,
     },
 };
 
@@ -38,6 +39,7 @@ pub struct SnapshotRecordSender {
     owner: OwnerSender,
     webs: WebSender,
     data_type: DataTypeSender,
+    data_type_conversions: Sender<DataTypeConversionsRow>,
     data_type_embedding: Sender<DataTypeEmbeddingRow<'static>>,
     property_type: PropertyTypeSender,
     property_type_embedding: Sender<PropertyTypeEmbeddingRow<'static>>,
@@ -64,6 +66,9 @@ impl Sink<SnapshotEntry> for SnapshotRecordSender {
             .change_context(SnapshotRestoreError::Read)?;
         ready!(self.data_type.poll_ready_unpin(cx))
             .attach_printable("could not poll data type sender")?;
+        ready!(self.data_type_conversions.poll_ready_unpin(cx))
+            .change_context(SnapshotRestoreError::Read)
+            .attach_printable("could not poll data type conversions sender")?;
         ready!(self.data_type_embedding.poll_ready_unpin(cx))
             .change_context(SnapshotRestoreError::Read)
             .attach_printable("could not poll data type embedding sender")?;
@@ -113,6 +118,18 @@ impl Sink<SnapshotEntry> for SnapshotRecordSender {
                 .data_type
                 .start_send_unpin(*data_type)
                 .attach_printable("could not send data type"),
+            SnapshotEntry::DataTypeConversions(conversions) => self
+                .data_type_conversions
+                .start_send_unpin(DataTypeConversionsRow {
+                    source_data_type_ontology_id: DataTypeId::from_url(
+                        &conversions.source_data_type,
+                    ),
+                    target_data_type_base_url: conversions.target_data_type,
+                    from: conversions.conversions.from,
+                    into: conversions.conversions.to,
+                })
+                .change_context(SnapshotRestoreError::Read)
+                .attach_printable("could not send data type conversions"),
             SnapshotEntry::DataTypeEmbedding(embedding) => self
                 .data_type_embedding
                 .start_send_unpin(DataTypeEmbeddingRow {
@@ -192,6 +209,9 @@ impl Sink<SnapshotEntry> for SnapshotRecordSender {
         ready!(self.data_type_embedding.poll_flush_unpin(cx))
             .change_context(SnapshotRestoreError::Read)
             .attach_printable("could not flush data type embedding sender")?;
+        ready!(self.data_type_conversions.poll_flush_unpin(cx))
+            .change_context(SnapshotRestoreError::Read)
+            .attach_printable("could not flush data type conversions sender")?;
         ready!(self.property_type.poll_flush_unpin(cx))
             .attach_printable("could not flush property type sender")?;
         ready!(self.property_type_embedding.poll_flush_unpin(cx))
@@ -228,6 +248,9 @@ impl Sink<SnapshotEntry> for SnapshotRecordSender {
         ready!(self.data_type.poll_close_unpin(cx))
             .attach_printable("could not close data type sender")?;
         ready!(self.data_type_embedding.poll_close_unpin(cx))
+            .change_context(SnapshotRestoreError::Read)
+            .attach_printable("could not close data type embedding sender")?;
+        ready!(self.data_type_conversions.poll_close_unpin(cx))
             .change_context(SnapshotRestoreError::Read)
             .attach_printable("could not close data type embedding sender")?;
         ready!(self.property_type.poll_close_unpin(cx))
@@ -277,10 +300,12 @@ pub fn channel(
     let (web_tx, web_rx) = web::channel(chunk_size);
     let (ontology_metadata_tx, ontology_metadata_rx) =
         ontology::ontology_metadata_channel(chunk_size);
+    let (data_type_conversions_tx, data_type_conversions_rx) = mpsc::channel(chunk_size);
     let (data_type_embedding_tx, data_type_embedding_rx) = mpsc::channel(chunk_size);
     let (data_type_tx, data_type_rx) = ontology::data_type_channel(
         chunk_size,
         ontology_metadata_tx.clone(),
+        data_type_conversions_rx,
         data_type_embedding_rx,
     );
     let (property_type_embedding_tx, property_type_embedding_rx) = mpsc::channel(chunk_size);
@@ -303,6 +328,7 @@ pub fn channel(
             metadata: metadata_tx,
             webs: web_tx,
             data_type: data_type_tx,
+            data_type_conversions: data_type_conversions_tx,
             data_type_embedding: data_type_embedding_tx,
             property_type: property_type_tx,
             property_type_embedding: property_type_embedding_tx,

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -1,6 +1,6 @@
 use alloc::sync::Arc;
 use core::mem;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
 use authorization::{
@@ -519,6 +519,7 @@ where
                             relationships: DATA_TYPE_RELATIONSHIPS,
                             conflict_behavior: ConflictBehavior::Skip,
                             provenance: ProvidedOntologyEditionProvenance::default(),
+                            conversions: HashMap::new(),
                         }),
                 )
                 .await?;
@@ -605,6 +606,7 @@ where
                                 relationships: DATA_TYPE_RELATIONSHIPS,
                                 conflict_behavior: ConflictBehavior::Skip,
                                 provenance: ProvidedOntologyEditionProvenance::default(),
+                                conversions: HashMap::new(),
                             }),
                     )
                     .await?

--- a/apps/hash-graph/libs/graph/src/store/ontology.rs
+++ b/apps/hash-graph/libs/graph/src/store/ontology.rs
@@ -1,5 +1,6 @@
 use alloc::borrow::Cow;
 use core::iter;
+use std::collections::HashMap;
 
 use authorization::schema::{
     DataTypeRelationAndSubject, EntityTypeRelationAndSubject, PropertyTypeRelationAndSubject,
@@ -17,7 +18,7 @@ use graph_types::{
 use serde::{Deserialize, Serialize};
 use temporal_versioning::{Timestamp, TransactionTime};
 use type_system::{
-    schema::{DataType, EntityType, PropertyType},
+    schema::{Conversions, DataType, EntityType, PropertyType},
     url::{BaseUrl, VersionedUrl},
 };
 
@@ -45,6 +46,8 @@ pub struct CreateDataTypeParams<R> {
     pub conflict_behavior: ConflictBehavior,
     #[serde(default, skip_serializing_if = "UserDefinedProvenanceData::is_empty")]
     pub provenance: ProvidedOntologyEditionProvenance,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub conversions: HashMap<BaseUrl, Conversions>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -114,6 +117,8 @@ pub struct UpdateDataTypesParams<R> {
     pub relationships: R,
     #[serde(default, skip_serializing_if = "UserDefinedProvenanceData::is_empty")]
     pub provenance: ProvidedOntologyEditionProvenance,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub conversions: HashMap<BaseUrl, Conversions>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/rows.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/rows.rs
@@ -14,7 +14,9 @@ use postgres_types::ToSql;
 use temporal_versioning::{DecisionTime, LeftClosedTemporalInterval, Timestamp, TransactionTime};
 use time::OffsetDateTime;
 use type_system::{
-    schema::{ClosedDataType, ClosedEntityType, DataType, EntityType, PropertyType},
+    schema::{
+        ClosedDataType, ClosedEntityType, ConversionDefinition, DataType, EntityType, PropertyType,
+    },
     url::{BaseUrl, OntologyTypeVersion},
     Valid,
 };
@@ -49,6 +51,15 @@ pub struct DataTypeEmbeddingRow<'e> {
     pub ontology_id: DataTypeId,
     pub embedding: Embedding<'e>,
     pub updated_at_transaction_time: Timestamp<TransactionTime>,
+}
+
+#[derive(Debug, ToSql)]
+#[postgres(name = "data_type_conversions")]
+pub struct DataTypeConversionsRow {
+    pub source_data_type_ontology_id: DataTypeId,
+    pub target_data_type_base_url: BaseUrl,
+    pub from: ConversionDefinition,
+    pub into: ConversionDefinition,
 }
 
 #[derive(Debug, ToSql)]

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -3072,6 +3072,78 @@
         "maximum": 1,
         "minimum": 0
       },
+      "ConversionDefinition": {
+        "type": "object",
+        "required": [
+          "expression"
+        ],
+        "properties": {
+          "expression": {
+            "$ref": "#/components/schemas/ConversionExpression"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ConversionExpression": {
+        "type": "array",
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/Operator"
+            },
+            {
+              "$ref": "#/components/schemas/ConversionValue"
+            }
+          ]
+        },
+        "maxItems": 3,
+        "minItems": 3
+      },
+      "ConversionValue": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/Variable"
+          },
+          {
+            "type": "object",
+            "required": [
+              "const",
+              "type"
+            ],
+            "properties": {
+              "const": {
+                "type": "number",
+                "format": "double"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "number"
+                ]
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/ConversionExpression"
+          }
+        ]
+      },
+      "Conversions": {
+        "type": "object",
+        "required": [
+          "from",
+          "to"
+        ],
+        "properties": {
+          "from": {
+            "$ref": "#/components/schemas/ConversionDefinition"
+          },
+          "to": {
+            "$ref": "#/components/schemas/ConversionDefinition"
+          }
+        },
+        "additionalProperties": false
+      },
       "CountEntitiesParams": {
         "type": "object",
         "required": [
@@ -3097,9 +3169,16 @@
         "required": [
           "schema",
           "ownedById",
-          "relationships"
+          "relationships",
+          "conversions"
         ],
         "properties": {
+          "conversions": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Conversions"
+            }
+          },
           "ownedById": {
             "$ref": "#/components/schemas/OwnedById"
           },
@@ -5770,9 +5849,16 @@
             "type": "object",
             "required": [
               "schema",
-              "relationships"
+              "relationships",
+              "conversions"
             ],
             "properties": {
+              "conversions": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/Conversions"
+                }
+              },
               "provenance": {
                 "$ref": "#/components/schemas/ProvidedOntologyEditionProvenance"
               },
@@ -6315,6 +6401,15 @@
         "discriminator": {
           "propertyName": "kind"
         }
+      },
+      "Operator": {
+        "type": "string",
+        "enum": [
+          "+",
+          "-",
+          "*",
+          "/"
+        ]
       },
       "Ordering": {
         "type": "string",
@@ -7804,9 +7899,16 @@
         "required": [
           "schema",
           "typeToUpdate",
-          "relationships"
+          "relationships",
+          "conversions"
         ],
         "properties": {
+          "conversions": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Conversions"
+            }
+          },
           "provenance": {
             "$ref": "#/components/schemas/ProvidedOntologyEditionProvenance"
           },
@@ -8049,6 +8151,12 @@
           "value": {}
         },
         "additionalProperties": false
+      },
+      "Variable": {
+        "type": "string",
+        "enum": [
+          "self"
+        ]
       },
       "VersionedUrl": {
         "type": "string",

--- a/apps/hash-graph/postgres_migrations/V28__data_type_conversions.sql
+++ b/apps/hash-graph/postgres_migrations/V28__data_type_conversions.sql
@@ -1,0 +1,6 @@
+CREATE TABLE data_type_conversions (
+    "source_data_type_ontology_id" UUID PRIMARY KEY REFERENCES "data_types",
+    "target_data_type_base_url" TEXT NOT NULL REFERENCES "base_urls",
+    "into" JSONB NOT NULL,
+    "from" JSONB NOT NULL
+);

--- a/apps/hash-graph/tests/ambiguous.http
+++ b/apps/hash-graph/tests/ambiguous.http
@@ -61,6 +61,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
         "minimum": 0
       }
   ],
+  "conversions": {},
   "relationships": [{
     "relation": "viewer",
     "subject": {

--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -129,6 +129,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     "description": "A unit of length",
     "minimum": 0
   },
+  "conversions": {},
   "relationships": [{
     "relation": "viewer",
     "subject": {
@@ -180,6 +181,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     "description": "An ordered sequence of characters",
     "type": "string"
   },
+  "conversions": {},
   "relationships": [{
     "relation": "viewer",
     "subject": {
@@ -274,6 +276,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     "description": "A unit of length equal to 100 centimeters",
     "minimum": 0
   },
+  "conversions": {},
   "relationships": [{
     "relation": "viewer",
     "subject": {

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/conversion.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/conversion.rs
@@ -1,0 +1,472 @@
+use core::{
+    error::Error,
+    fmt::{self, Write},
+};
+
+#[cfg(feature = "postgres")]
+use postgres_types::{private::BytesMut, FromSql, IsNull, Json, ToSql, Type};
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "utoipa")]
+use utoipa::openapi;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Conversions {
+    pub from: ConversionDefinition,
+    pub to: ConversionDefinition,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConversionDefinition {
+    pub expression: ConversionExpression,
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> FromSql<'a> for ConversionDefinition {
+    fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        Ok(Json::from_sql(ty, raw)?.0)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <Json<Self> as FromSql>::accepts(ty)
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl ToSql for ConversionDefinition {
+    postgres_types::to_sql_checked!();
+
+    fn to_sql(&self, ty: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>>
+    where
+        Self: Sized,
+    {
+        Json(self).to_sql(ty, out)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <Json<Self> as ToSql>::accepts(ty)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+pub enum Variable {
+    #[serde(rename = "self")]
+    This,
+}
+
+impl fmt::Display for Variable {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::This => fmt.write_str("self"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(from = "codec::SerializableValue", into = "codec::SerializableValue")]
+pub enum ConversionValue {
+    Variable(Variable),
+    Constant(f64),
+    Expression(Box<ConversionExpression>),
+}
+
+impl ConversionValue {
+    fn evaluate(&self, value: f64) -> f64 {
+        match self {
+            Self::Variable(Variable::This) => value,
+            Self::Constant(constant) => *constant,
+            Self::Expression(expression) => expression.evaluate(value),
+        }
+    }
+}
+
+impl fmt::Display for ConversionValue {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Variable(variable) => fmt::Display::fmt(variable, fmt),
+            Self::Constant(value) => fmt::Display::fmt(value, fmt),
+            Self::Expression(expression) => fmt::Display::fmt(expression, fmt),
+        }
+    }
+}
+
+#[cfg(feature = "utoipa")]
+impl utoipa::ToSchema<'_> for ConversionValue {
+    fn schema() -> (&'static str, openapi::RefOr<openapi::Schema>) {
+        ("ConversionValue", codec::SerializableValue::schema().1)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+pub enum Operator {
+    #[serde(rename = "+")]
+    Add,
+    #[serde(rename = "-")]
+    Subtract,
+    #[serde(rename = "*")]
+    Multiply,
+    #[serde(rename = "/")]
+    Divide,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(
+    from = "codec::SerializableExpression",
+    into = "codec::SerializableExpression"
+)]
+pub struct ConversionExpression {
+    pub lhs: ConversionValue,
+    pub operator: Operator,
+    pub rhs: ConversionValue,
+}
+
+impl ConversionExpression {
+    #[must_use]
+    #[expect(clippy::float_arithmetic)]
+    pub fn evaluate(&self, value: f64) -> f64 {
+        let lhs = self.lhs.evaluate(value);
+        let rhs = self.rhs.evaluate(value);
+
+        match self.operator {
+            Operator::Add => lhs + rhs,
+            Operator::Subtract => lhs - rhs,
+            Operator::Multiply => lhs * rhs,
+            Operator::Divide => lhs / rhs,
+        }
+    }
+}
+
+impl fmt::Display for ConversionExpression {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if matches!(&self.lhs, ConversionValue::Expression(expr) if matches!(expr.operator, Operator::Add | Operator::Subtract))
+        {
+            write!(fmt, "({}) ", self.lhs)?;
+        } else {
+            write!(fmt, "{} ", self.lhs)?;
+        }
+
+        match self.operator {
+            Operator::Add => fmt.write_char('+')?,
+            Operator::Subtract => fmt.write_char('-')?,
+            Operator::Multiply => fmt.write_char('*')?,
+            Operator::Divide => fmt.write_char('/')?,
+        }
+
+        if matches!(self.rhs, ConversionValue::Expression(_)) {
+            write!(fmt, " ({})", self.rhs)
+        } else {
+            write!(fmt, " {}", self.rhs)
+        }
+    }
+}
+
+#[cfg(feature = "utoipa")]
+impl utoipa::ToSchema<'_> for ConversionExpression {
+    fn schema() -> (&'static str, openapi::RefOr<openapi::Schema>) {
+        (
+            "ConversionExpression",
+            openapi::OneOfBuilder::new()
+                .item(openapi::Ref::from_schema_name(Operator::schema().0))
+                .item(openapi::Ref::from_schema_name(ConversionValue::schema().0))
+                .to_array_builder()
+                .min_items(Some(3))
+                .max_items(Some(3))
+                .build()
+                .into(),
+        )
+    }
+}
+
+mod codec {
+    use serde::{Deserialize, Serialize};
+
+    use super::{ConversionExpression, ConversionValue, Operator, Variable};
+
+    #[derive(Serialize, Deserialize)]
+    #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+    #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+    #[serde(rename_all = "camelCase")]
+    pub(super) enum NumberTypeTag {
+        Number,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+    #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+    #[serde(untagged, rename = "ConversionValue")]
+    pub(super) enum SerializableValue {
+        Variable(Variable),
+        Constant {
+            #[serde(rename = "const")]
+            value: f64,
+            #[cfg_attr(feature = "utoipa", schema(inline))]
+            r#type: NumberTypeTag,
+        },
+        Expression(Box<ConversionExpression>),
+    }
+
+    impl From<SerializableValue> for ConversionValue {
+        fn from(value: SerializableValue) -> Self {
+            match value {
+                SerializableValue::Variable(variable) => Self::Variable(variable),
+                SerializableValue::Constant { value, .. } => Self::Constant(value),
+                SerializableValue::Expression(expression) => Self::Expression(expression),
+            }
+        }
+    }
+
+    impl From<ConversionValue> for SerializableValue {
+        fn from(value: ConversionValue) -> Self {
+            match value {
+                ConversionValue::Variable(variable) => Self::Variable(variable),
+                ConversionValue::Constant(value) => Self::Constant {
+                    value,
+                    r#type: NumberTypeTag::Number,
+                },
+                ConversionValue::Expression(expression) => Self::Expression(expression),
+            }
+        }
+    }
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(rename = "ConversionExpression")]
+    #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+    pub(super) struct SerializableExpression(Operator, ConversionValue, ConversionValue);
+
+    impl From<SerializableExpression> for ConversionExpression {
+        fn from(SerializableExpression(operator, lhs, rhs): SerializableExpression) -> Self {
+            Self { lhs, operator, rhs }
+        }
+    }
+
+    impl From<ConversionExpression> for SerializableExpression {
+        fn from(value: ConversionExpression) -> Self {
+            Self(value.operator, value.lhs, value.rhs)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{self, json, Value as JsonValue};
+
+    use super::*;
+
+    fn test_conversion(expression: &ConversionExpression, value: JsonValue, string: &str) {
+        assert_eq!(
+            serde_json::to_value(expression).expect("failed to serialize"),
+            value
+        );
+
+        assert_eq!(
+            serde_json::from_value::<ConversionExpression>(value).expect("failed to deserialize"),
+            *expression
+        );
+
+        assert_eq!(expression.to_string(), string);
+    }
+
+    #[test]
+    fn centimeters_to_meters() {
+        let expression = ConversionExpression {
+            lhs: ConversionValue::Variable(Variable::This),
+            operator: Operator::Multiply,
+            rhs: ConversionValue::Constant(100.0),
+        };
+
+        test_conversion(
+            &expression,
+            json!([
+                "*",
+                "self",
+                { "const": 100.0, "type": "number" }
+            ]),
+            "self * 100",
+        );
+
+        assert!((expression.evaluate(1.0) - 100.0).abs() < f64::EPSILON);
+        assert!((expression.evaluate(10.0) - 1000.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn meters_to_centimeters() {
+        let expression = ConversionExpression {
+            lhs: ConversionValue::Variable(Variable::This),
+            operator: Operator::Divide,
+            rhs: ConversionValue::Constant(100.0),
+        };
+
+        test_conversion(
+            &expression,
+            json!([
+                "/",
+                "self",
+                { "const": 100.0, "type": "number" }
+            ]),
+            "self / 100",
+        );
+
+        assert!((expression.evaluate(100.0) - 1.0).abs() < f64::EPSILON);
+        assert!((expression.evaluate(1000.0) - 10.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn celsius_to_fahrenheit() {
+        let expression = ConversionExpression {
+            lhs: ConversionValue::Expression(Box::new(ConversionExpression {
+                lhs: ConversionValue::Expression(Box::new(ConversionExpression {
+                    lhs: ConversionValue::Variable(Variable::This),
+                    operator: Operator::Multiply,
+                    rhs: ConversionValue::Constant(9.0),
+                })),
+                operator: Operator::Divide,
+                rhs: ConversionValue::Constant(5.0),
+            })),
+            operator: Operator::Add,
+            rhs: ConversionValue::Constant(32.0),
+        };
+
+        test_conversion(
+            &expression,
+            json!([
+                "+",
+                [
+                    "/",
+                    [
+                        "*",
+                        "self",
+                        { "const": 9.0, "type": "number" }
+                    ],
+                    { "const": 5.0, "type": "number" }
+                ],
+                { "const": 32.0, "type": "number" },
+            ]),
+            "self * 9 / 5 + 32",
+        );
+
+        assert!((expression.evaluate(0.0) - 32.0).abs() < f64::EPSILON);
+        assert!((expression.evaluate(100.0) - 212.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn celsius_to_fahrenheit_alternative() {
+        let expression = ConversionExpression {
+            lhs: ConversionValue::Expression(Box::new(ConversionExpression {
+                lhs: ConversionValue::Variable(Variable::This),
+                operator: Operator::Multiply,
+                rhs: ConversionValue::Expression(Box::new(ConversionExpression {
+                    lhs: ConversionValue::Constant(9.0),
+                    operator: Operator::Divide,
+                    rhs: ConversionValue::Constant(5.0),
+                })),
+            })),
+            operator: Operator::Add,
+            rhs: ConversionValue::Constant(32.0),
+        };
+        test_conversion(
+            &expression,
+            json!([
+                "+",
+                [
+                    "*",
+                    "self",
+                    [
+                        "/",
+                        { "const": 9.0, "type": "number" },
+                        { "const": 5.0, "type": "number" }
+                    ]
+                ],
+                { "const": 32.0, "type": "number" },
+            ]),
+            "self * (9 / 5) + 32",
+        );
+
+        assert!((expression.evaluate(0.0) - 32.0).abs() < f64::EPSILON);
+        assert!((expression.evaluate(100.0) - 212.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn fahrenheit_to_celsius() {
+        let expression = ConversionExpression {
+            lhs: ConversionValue::Expression(Box::new(ConversionExpression {
+                lhs: ConversionValue::Expression(Box::new(ConversionExpression {
+                    lhs: ConversionValue::Variable(Variable::This),
+                    operator: Operator::Subtract,
+                    rhs: ConversionValue::Constant(32.0),
+                })),
+                operator: Operator::Multiply,
+                rhs: ConversionValue::Constant(5.0),
+            })),
+            operator: Operator::Divide,
+            rhs: ConversionValue::Constant(9.0),
+        };
+
+        test_conversion(
+            &expression,
+            json!([
+                "/",
+                [
+                    "*",
+                    [
+                        "-",
+                        "self",
+                        { "const": 32.0, "type": "number" }
+                    ],
+                    { "const": 5.0, "type": "number" }
+                ],
+                { "const": 9.0, "type": "number" },
+            ]),
+            "(self - 32) * 5 / 9",
+        );
+
+        assert!(expression.evaluate(32.0).abs() < f64::EPSILON);
+        assert!((expression.evaluate(212.0) - 100.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn fahrenheit_to_celsius_alternative() {
+        let expression = ConversionExpression {
+            lhs: ConversionValue::Expression(Box::new(ConversionExpression {
+                lhs: ConversionValue::Variable(Variable::This),
+                operator: Operator::Subtract,
+                rhs: ConversionValue::Constant(32.0),
+            })),
+            operator: Operator::Multiply,
+            rhs: ConversionValue::Expression(Box::new(ConversionExpression {
+                lhs: ConversionValue::Constant(5.0),
+                operator: Operator::Divide,
+                rhs: ConversionValue::Constant(9.0),
+            })),
+        };
+
+        test_conversion(
+            &expression,
+            json!([
+                "*",
+                [
+                    "-",
+                    "self",
+                    { "const": 32.0, "type": "number" }
+                ],
+                [
+                    "/",
+                    { "const": 5.0, "type": "number" },
+                    { "const": 9.0, "type": "number" }
+                ]
+            ]),
+            "(self - 32) * (5 / 9)",
+        );
+
+        assert!(expression.evaluate(32.0).abs() < f64::EPSILON);
+        assert!((expression.evaluate(212.0) - 100.0).abs() < f64::EPSILON);
+    }
+}

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/conversion.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/conversion.rs
@@ -1,7 +1,6 @@
-use core::{
-    error::Error,
-    fmt::{self, Write},
-};
+#[cfg(feature = "postgres")]
+use core::error::Error;
+use core::fmt::{self, Write};
 
 #[cfg(feature = "postgres")]
 use postgres_types::{private::BytesMut, FromSql, IsNull, Json, ToSql, Type};

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -1,7 +1,12 @@
 mod constraint;
+mod conversion;
 
 pub use self::{
     closed::{ClosedDataType, ClosedDataTypeMetadata},
+    conversion::{
+        ConversionDefinition, ConversionExpression, ConversionValue, Conversions, Operator,
+        Variable,
+    },
     reference::DataTypeReference,
     validation::{DataTypeValidator, ValidateDataTypeError},
 };

--- a/libs/@blockprotocol/type-system/rust/src/schema/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/mod.rs
@@ -16,8 +16,10 @@ mod one_of;
 pub use self::{
     array::{ArraySchema, ValueOrArray},
     data_type::{
-        ClosedDataType, ClosedDataTypeMetadata, DataType, DataTypeLabel, DataTypeReference,
-        DataTypeValidator, JsonSchemaValueType, OntologyTypeResolver, ValidateDataTypeError,
+        ClosedDataType, ClosedDataTypeMetadata, ConversionDefinition, ConversionExpression,
+        ConversionValue, Conversions, DataType, DataTypeLabel, DataTypeReference,
+        DataTypeValidator, JsonSchemaValueType, OntologyTypeResolver, Operator,
+        ValidateDataTypeError, Variable,
     },
     entity_type::{
         ClosedEntityType, ClosedEntityTypeSchemaData, EntityType, EntityTypeReference,

--- a/tests/hash-backend-integration/src/tests/graph/ontology/primitive/data-type.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/ontology/primitive/data-type.test.ts
@@ -100,6 +100,7 @@ describe("Data type CRU", () => {
       ownedById: testOrg.accountGroupId as OwnedById,
       schema: dataTypeSchema,
       relationships: [{ relation: "viewer", subject: { kind: "public" } }],
+      conversions: {},
     });
   });
 
@@ -130,6 +131,7 @@ describe("Data type CRU", () => {
       dataTypeId: createdDataType.schema.$id,
       schema: { ...dataTypeSchema, title: updatedTitle },
       relationships: [{ relation: "viewer", subject: { kind: "public" } }],
+      conversions: {},
     }).catch((err) => Promise.reject(err.data));
 
     expect(

--- a/tests/hash-graph-benches/util.rs
+++ b/tests/hash-graph-benches/util.rs
@@ -1,5 +1,5 @@
 use core::mem::ManuallyDrop;
-use std::{fs, path::Path};
+use std::{collections::HashMap, fs, path::Path};
 
 use authorization::{
     schema::{
@@ -308,6 +308,7 @@ pub async fn seed<D, P, E, C, A>(
                     }],
                     conflict_behavior: ConflictBehavior::Fail,
                     provenance: ProvidedOntologyEditionProvenance::default(),
+                    conversions: HashMap::new(),
                 },
             )
             .await
@@ -325,6 +326,7 @@ pub async fn seed<D, P, E, C, A>(
                                     level: 0,
                                 }],
                                 provenance: ProvidedOntologyEditionProvenance::default(),
+                                conversions: HashMap::new(),
                             },
                         )
                         .await

--- a/tests/hash-graph-integration/postgres/data_type.rs
+++ b/tests/hash-graph-integration/postgres/data_type.rs
@@ -55,6 +55,7 @@ async fn insert() {
             relationships: data_type_relationships(),
             conflict_behavior: ConflictBehavior::Fail,
             provenance: ProvidedOntologyEditionProvenance::default(),
+            conversions: HashMap::new(),
         },
     )
     .await
@@ -82,6 +83,7 @@ async fn query() {
             relationships: data_type_relationships(),
             conflict_behavior: ConflictBehavior::Fail,
             provenance: ProvidedOntologyEditionProvenance::default(),
+            conversions: HashMap::new(),
         },
     )
     .await
@@ -168,6 +170,7 @@ async fn inheritance() {
             relationships: data_type_relationships(),
             conflict_behavior: ConflictBehavior::Fail,
             provenance: ProvidedOntologyEditionProvenance::default(),
+            conversions: HashMap::new(),
         },
     )
     .await
@@ -262,6 +265,7 @@ async fn inheritance() {
             schema: centimeter_dt_v2.clone(),
             relationships: data_type_relationships(),
             provenance: ProvidedOntologyEditionProvenance::default(),
+            conversions: HashMap::new(),
         },
     )
     .await
@@ -413,6 +417,7 @@ async fn update() {
             relationships: data_type_relationships(),
             conflict_behavior: ConflictBehavior::Fail,
             provenance: ProvidedOntologyEditionProvenance::default(),
+            conversions: HashMap::new(),
         },
     )
     .await
@@ -424,6 +429,7 @@ async fn update() {
             schema: object_dt_v2.clone(),
             relationships: data_type_relationships(),
             provenance: ProvidedOntologyEditionProvenance::default(),
+            conversions: HashMap::new(),
         },
     )
     .await
@@ -482,6 +488,7 @@ async fn update() {
 }
 
 #[tokio::test]
+#[expect(clippy::too_many_lines)]
 async fn insert_same_base_url() {
     let object_dt_v1: DataType = serde_json::from_str(graph_test_data::data_type::OBJECT_V1)
         .expect("could not parse data type representation");
@@ -505,6 +512,7 @@ async fn insert_same_base_url() {
             relationships: data_type_relationships(),
             conflict_behavior: ConflictBehavior::Fail,
             provenance: ProvidedOntologyEditionProvenance::default(),
+            conversions: HashMap::new(),
         },
     )
     .await
@@ -521,6 +529,7 @@ async fn insert_same_base_url() {
                 relationships: data_type_relationships(),
                 conflict_behavior: ConflictBehavior::Fail,
                 provenance: ProvidedOntologyEditionProvenance::default(),
+                conversions: HashMap::new(),
             },
         )
         .await
@@ -541,6 +550,7 @@ async fn insert_same_base_url() {
                 relationships: data_type_relationships(),
                 conflict_behavior: ConflictBehavior::Fail,
                 provenance: ProvidedOntologyEditionProvenance::default(),
+                conversions: HashMap::new(),
             },
         )
         .await
@@ -561,6 +571,7 @@ async fn insert_same_base_url() {
                 relationships: data_type_relationships(),
                 conflict_behavior: ConflictBehavior::Fail,
                 provenance: ProvidedOntologyEditionProvenance::default(),
+                conversions: HashMap::new(),
             },
         )
         .await
@@ -581,6 +592,7 @@ async fn insert_same_base_url() {
                 relationships: data_type_relationships(),
                 conflict_behavior: ConflictBehavior::Fail,
                 provenance: ProvidedOntologyEditionProvenance::default(),
+                conversions: HashMap::new(),
             },
         )
         .await
@@ -612,6 +624,7 @@ async fn wrong_update_order() {
                 schema: object_dt_v1.clone(),
                 relationships: data_type_relationships(),
                 provenance: ProvidedOntologyEditionProvenance::default(),
+                conversions: HashMap::new(),
             },
         )
         .await
@@ -631,6 +644,7 @@ async fn wrong_update_order() {
             relationships: data_type_relationships(),
             conflict_behavior: ConflictBehavior::Fail,
             provenance: ProvidedOntologyEditionProvenance::default(),
+            conversions: HashMap::new(),
         },
     )
     .await
@@ -643,6 +657,7 @@ async fn wrong_update_order() {
                 schema: object_dt_v1.clone(),
                 relationships: data_type_relationships(),
                 provenance: ProvidedOntologyEditionProvenance::default(),
+                conversions: HashMap::new(),
             },
         )
         .await
@@ -658,6 +673,7 @@ async fn wrong_update_order() {
             schema: object_dt_v2.clone(),
             relationships: data_type_relationships(),
             provenance: ProvidedOntologyEditionProvenance::default(),
+            conversions: HashMap::new(),
         },
     )
     .await
@@ -670,6 +686,7 @@ async fn wrong_update_order() {
                 schema: object_dt_v2.clone(),
                 relationships: data_type_relationships(),
                 provenance: ProvidedOntologyEditionProvenance::default(),
+                conversions: HashMap::new(),
             },
         )
         .await
@@ -704,6 +721,7 @@ async fn update_external_with_owned() {
             relationships: data_type_relationships(),
             conflict_behavior: ConflictBehavior::Fail,
             provenance: ProvidedOntologyEditionProvenance::default(),
+            conversions: HashMap::new(),
         },
     )
     .await
@@ -716,6 +734,7 @@ async fn update_external_with_owned() {
                 schema: object_dt_v2.clone(),
                 relationships: data_type_relationships(),
                 provenance: ProvidedOntologyEditionProvenance::default(),
+                conversions: HashMap::new(),
             },
         )
         .await
@@ -735,6 +754,7 @@ async fn update_external_with_owned() {
             relationships: data_type_relationships(),
             conflict_behavior: ConflictBehavior::Fail,
             provenance: ProvidedOntologyEditionProvenance::default(),
+            conversions: HashMap::new(),
         },
     )
     .await
@@ -747,6 +767,7 @@ async fn update_external_with_owned() {
                 schema: object_dt_v2,
                 relationships: data_type_relationships(),
                 provenance: ProvidedOntologyEditionProvenance::default(),
+                conversions: HashMap::new(),
             },
         )
         .await

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -23,6 +23,8 @@ mod property_metadata;
 mod property_type;
 mod sorting;
 
+use std::collections::HashMap;
+
 use authorization::{
     schema::{
         DataTypeRelationAndSubject, DataTypeViewerSubject, EntityRelationAndSubject,
@@ -227,6 +229,7 @@ impl<A: AuthorizationApi> DatabaseTestWrapper<A> {
                         relationships: data_type_relationships(),
                         conflict_behavior: ConflictBehavior::Skip,
                         provenance: ProvidedOntologyEditionProvenance::default(),
+                        conversions: HashMap::new(),
                     }
                 }),
             )


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Conversions are supposed to be stored in the database. A conversion currently is always required to be a canonical version. The format is similar to the syntax introduced in #4828:
```typescript
type ConversionValue = Variable | { const: number; type: "number" } | ConversionExpression;

type Operator = "+" | "-" | "*" | "/";

type ConversionExpression = [Operator, ConversionValue, ConversionValue];

interface ConversionDefinition {
	expression: ConversionExpression;
}

interface Conversions {
	from: ConversionDefinition;
	to: ConversionDefinition;
}
```

e.g.
```typescript
{
	from: { 
		expression: ["/", "self", { const: 1000, type: "number" }]
	},
	to: { 
		expression: ["*", "self", { const: 1000, type: "number" }]
	},
}
```

## 🔍 What does this change?

- Define conversion format
- Add conversions to database when creating/inserting data types
- dump/restore conversions to/from snapshots
- It **does not** implement any logic around conversions when dealing with data types, this PR only stores the conversions.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph