### PR TITLE
H-3276: Flow run output tables UX improvements

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/checkpoints.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/checkpoints.ts
@@ -32,7 +32,7 @@ import type { CoordinatingAgentState } from "./shared/coordinators.js";
 export const heartbeatAndWaitCancellation = async (
   state: CoordinatingAgentState,
 ) => {
-  const secondsBetweenHeartbeats = heartbeatTimeoutSeconds - 2;
+  const secondsBetweenHeartbeats = heartbeatTimeoutSeconds - 5;
 
   const heartbeatInterval = setInterval(() => {
     Context.current().heartbeat({

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/coordinating-agent.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/coordinating-agent.ts
@@ -266,7 +266,8 @@ export const runCoordinatingAgent: FlowActionActivity<{
        * If the coordinator has decided to wait for outstanding tasks, notify the user of this.
        *
        * We don't do this if the coordinator has _also_ started other work.
-       * It doesn't need to call 'waitForOutstandingTasks' if it's starting other tasks, but it also doesn't do any harm.
+       * It doesn't need to call 'waitForOutstandingTasks' if it's starting other tasks, but it also doesn't do any
+       * harm.
        * 'waitForOutstandingTasks' is just a mechanism to allow it to respond without choosing to do anything else.
        */
       logProgress([
@@ -374,7 +375,8 @@ export const runCoordinatingAgent: FlowActionActivity<{
 
       if (!completeToolCallResult.isError) {
         /**
-         * Either there are no issues, or there were issues which we've already asked the coordinator about and it's chosen to ignore.
+         * Either there are no issues, or there were issues which we've already asked the coordinator about and it's
+         * chosen to ignore.
          */
         await createCheckpoint({ state });
         return;
@@ -388,7 +390,8 @@ export const runCoordinatingAgent: FlowActionActivity<{
       state.hasConductedCompleteCheckStep = true;
     } else {
       /**
-       * If we don't have a 'complete' tool call, reset the check step state in case of the following sequence of events:
+       * If we don't have a 'complete' tool call, reset the check step state in case of the following sequence of
+       * events:
        * 1. The coordinator makes a 'complete' call
        * 2. We identify an issue which we ask the coordinator about
        * 3. It decides to do more work rather than immediately call 'complete' again to ignore the issues identified
@@ -428,15 +431,12 @@ export const runCoordinatingAgent: FlowActionActivity<{
   /**
    * These are entities the coordinator has chosen to highlight as the result of research,
    * but we want to output all entity proposals from the task.
-   *
-   * @todo H-3273 add a column to the flow run outputs table indicating which entities the coordinator has highlighted
-   * @todo this may also be useful for further steps in a flow, e.g. for report writing or analysis
    */
-  const _submittedEntities = state.proposedEntities.filter(
-    ({ localEntityId }) => state.submittedEntityIds.includes(localEntityId),
+  const submittedEntities = state.proposedEntities.filter(({ localEntityId }) =>
+    state.submittedEntityIds.includes(localEntityId),
   );
 
-  logger.debug(`Submitted ${_submittedEntities.length} entities`);
+  logger.debug(`Submitted ${submittedEntities.length} entities`);
 
   const allProposedEntities = state.proposedEntities;
 
@@ -557,6 +557,16 @@ export const runCoordinatingAgent: FlowActionActivity<{
             payload: {
               kind: "ProposedEntity",
               value: [...allProposedEntities, ...fileEntityProposals],
+            },
+          },
+          {
+            outputName:
+              "highlightedEntities" satisfies OutputNameForAction<"researchEntities">,
+            payload: {
+              kind: "EntityId",
+              value: submittedEntities.map(
+                ({ localEntityId }) => localEntityId,
+              ),
             },
           },
         ],

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/infer-summaries-then-claims-from-text/infer-entity-claims-from-text-agent.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/infer-summaries-then-claims-from-text/infer-entity-claims-from-text-agent.ts
@@ -419,7 +419,7 @@ export const inferEntityClaimsFromTextAgent = async (params: {
 
   const llmResponse = await getLlmResponse(
     {
-      model: params.testingParams?.model ?? "claude-3-haiku-20240307",
+      model: params.testingParams?.model ?? "gpt-4o-2024-08-06",
       tools: Object.values(generateToolDefinitions({ subjectEntities })),
       toolChoice: toolNames[0],
       temperature: 0.5,

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/history-table.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/history-table.tsx
@@ -18,13 +18,13 @@ import type {
   CreateVirtualizedRowContentFn,
   VirtualizedTableColumn,
   VirtualizedTableRow,
-  VirtualizedTableSort,
 } from "../../../../../shared/virtualized-table";
 import {
   defaultCellSx,
-  headerHeight,
   VirtualizedTable,
 } from "../../../../../shared/virtualized-table";
+import { headerHeight } from "../../../../../shared/virtualized-table/header";
+import type { VirtualizedTableSort } from "../../../../../shared/virtualized-table/header/sort";
 import { Provenance } from "./history-table/provenance";
 import { EventDetail } from "./history-table/shared/event-detail";
 import type { HistoryEvent } from "./shared/types";
@@ -260,7 +260,7 @@ export const HistoryTable = ({
   subgraph: Subgraph;
 }) => {
   const [sort, setSort] = useState<VirtualizedTableSort<FieldId>>({
-    field: "time",
+    fieldId: "time",
     direction: "desc",
   });
 
@@ -269,7 +269,7 @@ export const HistoryTable = ({
 
     return events
       .sort((a, b) => {
-        if (sort.field === "time") {
+        if (sort.fieldId === "time") {
           if (sort.direction === "asc") {
             if (a.timestamp === b.timestamp) {
               return a.number.localeCompare(b.number);

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer.tsx
@@ -2,10 +2,13 @@ import "reactflow/dist/style.css";
 
 import { useApolloClient, useMutation } from "@apollo/client";
 import { IconButton, Skeleton } from "@hashintel/design-system";
+import type { EntityId } from "@local/hash-graph-types/entity";
 import type { OwnedById } from "@local/hash-graph-types/web";
+import type { OutputNameForAction } from "@local/hash-isomorphic-utils/flows/action-definitions";
 import { actionDefinitions } from "@local/hash-isomorphic-utils/flows/action-definitions";
 import { manualBrowserInferenceFlowDefinition } from "@local/hash-isomorphic-utils/flows/browser-plugin-flow-definitions";
 import { generateWorkerRunPath } from "@local/hash-isomorphic-utils/flows/frontend-paths";
+import { goalFlowDefinitionIds } from "@local/hash-isomorphic-utils/flows/goal-flow-definitions";
 import type {
   FlowDefinition as FlowDefinitionType,
   FlowInputs,
@@ -52,7 +55,6 @@ import {
   groupStepsByDependencyLayer,
 } from "./flow-visualizer/sort-graph";
 import { Topbar, topbarHeight } from "./flow-visualizer/topbar";
-import { goalFlowDefinitionIds } from "@local/hash-isomorphic-utils/flows/goal-flow-definitions";
 
 const getGraphFromFlowDefinition = (
   flowDefinition: FlowDefinitionType,
@@ -306,207 +308,225 @@ export const FlowVisualizer = () => {
     return graphsByGroup;
   }, [derivedNodes, derivedEdges, selectedFlowDefinition]);
 
-  const { logs, persistedEntities, proposedEntities } = useMemo<{
-    logs: LocalProgressLog[];
-    persistedEntities: PersistedEntity[];
-    proposedEntities: ProposedEntityOutput[];
-  }>(() => {
-    if (!selectedFlowRun) {
-      return {
-        claimEntityIds: [],
-        logs: [],
-        persistedEntities: [],
-        proposedEntities: [],
-      };
-    }
-
-    const progressLogs: LocalProgressLog[] = [
-      {
-        level: 1,
-        message: "Flow run started",
-        recordedAt: selectedFlowRun.startedAt,
-        stepId: "trigger",
-        type: "StateChange",
-      },
-    ];
-
-    const persisted: PersistedEntity[] = [];
-    const proposed: ProposedEntityOutput[] = [];
-
-    /**
-     * A map between a workerInstanceId and (1) the list of logs associated with that worker, and (2) the id of its parent
-     * This is used to help build the tree of logs grouped by worker, when 'grouped' log display is selected.
-     */
-    const workerIdToLogsAndParent: Record<
-      string,
-      { logs: LocalProgressLog[]; level: number; thread?: LogThread }
-    > = {};
-
-    for (const step of selectedFlowRun.steps) {
-      const outputs = step.outputs?.[0]?.contents?.[0]?.outputs ?? [];
-
-      for (const log of step.logs) {
-        if (
-          logDisplay === "stream" ||
-          !("parentInstanceId" in log) ||
-          !log.parentInstanceId
-        ) {
-          /**
-           * If we're in 'stream' display, or if this log doesn't have a parent worker, it should appear at the top level.
-           */
-          progressLogs.push({
-            ...log,
-            level: 1,
-          });
-
-          if ("workerInstanceId" in log) {
-            /**
-             * If the log has a workerInstanceId, it may have groups of logs nested under it,
-             * so we need to record the fact that any child workers should start a group in the top-level logs array.
-             */
-            workerIdToLogsAndParent[log.workerInstanceId] = {
-              level: 1,
-              logs: progressLogs,
-            };
-          }
-        } else {
-          /**
-           * This log has a parent worker, so we need to group it with its siblings.
-           * We also need to add the group to the parent's logs if it doesn't already exist.
-           */
-          const parentLogList = workerIdToLogsAndParent[log.parentInstanceId];
-          if (!parentLogList) {
-            throw new Error(
-              `No parent log found with id ${log.parentInstanceId}`,
-            );
-          }
-
-          const thisThread = workerIdToLogsAndParent[log.workerInstanceId];
-          if (!thisThread) {
-            let threadLabel: string;
-            if (log.type === "StartedSubCoordinator") {
-              threadLabel = `Sub-coordinator: ${log.input.goal}`;
-            } else if (log.type === "StartedLinkExplorerTask") {
-              threadLabel = `Link explorer: ${log.input.goal}`;
-            } else {
-              throw new Error(
-                `Expect new child worker threads to be started with a StartedSubCoordinator or StartedLinkExplorerTask event, got ${log.type}`,
-              );
-            }
-
-            const newThread = {
-              type: "Thread" as const,
-              label: threadLabel,
-              level: parentLogList.level,
-              threadStartedAt: log.recordedAt,
-              /**
-               * Default to closing the thread at the time the flow run was closed.
-               * If we have a specific, earlier closed event for the thread it will be overwritten when we process that child log.
-               */
-              threadClosedAt: selectedFlowRun.closedAt ?? undefined,
-              closedDueToFlowClosure: !!selectedFlowRun.closedAt,
-              threadWorkerId: log.workerInstanceId,
-              recordedAt: log.recordedAt,
-              logs: [
-                {
-                  level: parentLogList.level + 1,
-                  ...log,
-                },
-              ],
-            };
-
-            parentLogList.logs.push(newThread);
-
-            workerIdToLogsAndParent[log.workerInstanceId] = {
-              logs: newThread.logs,
-              level: newThread.level,
-              thread: newThread,
-            };
-          } else {
-            thisThread.logs.push({
-              level: parentLogList.level + 1,
-              ...log,
-            });
-
-            if (
-              log.type === "ClosedLinkExplorerTask" ||
-              log.type === "ClosedSubCoordinator"
-            ) {
-              thisThread.thread!.threadClosedAt = log.recordedAt;
-              thisThread.thread!.closedDueToFlowClosure = false;
-            }
-          }
-        }
-
-        if (outputs.length === 0) {
-          if (log.type === "ProposedEntity") {
-            proposed.push({
-              ...log.proposedEntity,
-              researchOngoing: !["CANCELLED", "FAILED", "TIMED_OUT"].includes(
-                step.status,
-              ),
-            });
-          }
-          if (log.type === "PersistedEntity" && log.persistedEntity.entity) {
-            persisted.push(log.persistedEntity);
-          }
-        }
+  const { logs, persistedEntities, proposedEntities, relevantEntityIds } =
+    useMemo<{
+      logs: LocalProgressLog[];
+      persistedEntities: PersistedEntity[];
+      proposedEntities: ProposedEntityOutput[];
+      relevantEntityIds: EntityId[];
+    }>(() => {
+      if (!selectedFlowRun) {
+        return {
+          claimEntityIds: [],
+          logs: [],
+          persistedEntities: [],
+          proposedEntities: [],
+          relevantEntityIds: [],
+        };
       }
 
-      for (const output of outputs) {
-        switch (output.payload.kind) {
-          case "ProposedEntity":
-            if (Array.isArray(output.payload.value)) {
-              proposed.push(
-                ...output.payload.value.map((entity) => ({
-                  ...entity,
-                  researchOngoing: false,
-                })),
+      const progressLogs: LocalProgressLog[] = [
+        {
+          level: 1,
+          message: "Flow run started",
+          recordedAt: selectedFlowRun.startedAt,
+          stepId: "trigger",
+          type: "StateChange",
+        },
+      ];
+
+      const persisted: PersistedEntity[] = [];
+      const proposed: ProposedEntityOutput[] = [];
+      const highlightedEntityIds: EntityId[] = [];
+
+      /**
+       * A map between a workerInstanceId and (1) the list of logs associated with that worker, and (2) the id of its parent
+       * This is used to help build the tree of logs grouped by worker, when 'grouped' log display is selected.
+       */
+      const workerIdToLogsAndParent: Record<
+        string,
+        { logs: LocalProgressLog[]; level: number; thread?: LogThread }
+      > = {};
+
+      for (const step of selectedFlowRun.steps) {
+        const outputs = step.outputs?.[0]?.contents?.[0]?.outputs ?? [];
+
+        for (const log of step.logs) {
+          if (
+            logDisplay === "stream" ||
+            !("parentInstanceId" in log) ||
+            !log.parentInstanceId
+          ) {
+            /**
+             * If we're in 'stream' display, or if this log doesn't have a parent worker, it should appear at the top level.
+             */
+            progressLogs.push({
+              ...log,
+              level: 1,
+            });
+
+            if ("workerInstanceId" in log) {
+              /**
+               * If the log has a workerInstanceId, it may have groups of logs nested under it,
+               * so we need to record the fact that any child workers should start a group in the top-level logs array.
+               */
+              workerIdToLogsAndParent[log.workerInstanceId] = {
+                level: 1,
+                logs: progressLogs,
+              };
+            }
+          } else {
+            /**
+             * This log has a parent worker, so we need to group it with its siblings.
+             * We also need to add the group to the parent's logs if it doesn't already exist.
+             */
+            const parentLogList = workerIdToLogsAndParent[log.parentInstanceId];
+            if (!parentLogList) {
+              throw new Error(
+                `No parent log found with id ${log.parentInstanceId}`,
               );
+            }
+
+            const thisThread = workerIdToLogsAndParent[log.workerInstanceId];
+            if (!thisThread) {
+              let threadLabel: string;
+              if (log.type === "StartedSubCoordinator") {
+                threadLabel = `Sub-coordinator: ${log.input.goal}`;
+              } else if (log.type === "StartedLinkExplorerTask") {
+                threadLabel = `Link explorer: ${log.input.goal}`;
+              } else {
+                throw new Error(
+                  `Expect new child worker threads to be started with a StartedSubCoordinator or StartedLinkExplorerTask event, got ${log.type}`,
+                );
+              }
+
+              const newThread = {
+                type: "Thread" as const,
+                label: threadLabel,
+                level: parentLogList.level,
+                threadStartedAt: log.recordedAt,
+                /**
+                 * Default to closing the thread at the time the flow run was closed.
+                 * If we have a specific, earlier closed event for the thread it will be overwritten when we process that child log.
+                 */
+                threadClosedAt: selectedFlowRun.closedAt ?? undefined,
+                closedDueToFlowClosure: !!selectedFlowRun.closedAt,
+                threadWorkerId: log.workerInstanceId,
+                recordedAt: log.recordedAt,
+                logs: [
+                  {
+                    level: parentLogList.level + 1,
+                    ...log,
+                  },
+                ],
+              };
+
+              parentLogList.logs.push(newThread);
+
+              workerIdToLogsAndParent[log.workerInstanceId] = {
+                logs: newThread.logs,
+                level: newThread.level,
+                thread: newThread,
+              };
             } else {
+              thisThread.logs.push({
+                level: parentLogList.level + 1,
+                ...log,
+              });
+
+              if (
+                log.type === "ClosedLinkExplorerTask" ||
+                log.type === "ClosedSubCoordinator"
+              ) {
+                thisThread.thread!.threadClosedAt = log.recordedAt;
+                thisThread.thread!.closedDueToFlowClosure = false;
+              }
+            }
+          }
+
+          if (outputs.length === 0) {
+            if (log.type === "ProposedEntity") {
               proposed.push({
-                ...output.payload.value,
-                researchOngoing: false,
+                ...log.proposedEntity,
+                researchOngoing: !["CANCELLED", "FAILED", "TIMED_OUT"].includes(
+                  step.status,
+                ),
               });
             }
-            break;
-          case "PersistedEntity":
-            if (Array.isArray(output.payload.value)) {
-              persisted.push(...output.payload.value);
-            } else if (output.payload.value.entity) {
-              persisted.push(output.payload.value);
+            if (log.type === "PersistedEntity" && log.persistedEntity.entity) {
+              persisted.push(log.persistedEntity);
             }
-            break;
-          case "PersistedEntities":
-            if (Array.isArray(output.payload.value)) {
-              persisted.push(
-                ...output.payload.value.flatMap(
-                  (innerMap) => innerMap.persistedEntities,
-                ),
-              );
-            } else {
-              persisted.push(...output.payload.value.persistedEntities);
-            }
+          }
+        }
+
+        for (const output of outputs) {
+          switch (output.payload.kind) {
+            case "ProposedEntity":
+              if (Array.isArray(output.payload.value)) {
+                proposed.push(
+                  ...output.payload.value.map((entity) => ({
+                    ...entity,
+                    researchOngoing: false,
+                  })),
+                );
+              } else {
+                proposed.push({
+                  ...output.payload.value,
+                  researchOngoing: false,
+                });
+              }
+              break;
+            case "PersistedEntity":
+              if (Array.isArray(output.payload.value)) {
+                persisted.push(...output.payload.value);
+              } else if (output.payload.value.entity) {
+                persisted.push(output.payload.value);
+              }
+              break;
+            case "PersistedEntities":
+              if (Array.isArray(output.payload.value)) {
+                persisted.push(
+                  ...output.payload.value.flatMap(
+                    (innerMap) => innerMap.persistedEntities,
+                  ),
+                );
+              } else {
+                persisted.push(...output.payload.value.persistedEntities);
+              }
+              break;
+            case "EntityId":
+              if (
+                output.outputName ===
+                ("highlightedEntities" satisfies OutputNameForAction<"researchEntities">)
+              ) {
+                if (Array.isArray(output.payload.value)) {
+                  highlightedEntityIds.push(...output.payload.value);
+                } else {
+                  highlightedEntityIds.push(output.payload.value);
+                }
+              }
+              break;
+          }
         }
       }
-    }
 
-    if (selectedFlowRun.closedAt) {
-      progressLogs.push({
-        level: 1,
-        message: `Flow run closed: ${selectedFlowRun.failureMessage?.toLowerCase() ?? selectedFlowRun.status.toLowerCase()}`,
-        recordedAt: selectedFlowRun.closedAt,
-        stepId: "closure",
-        type: "StateChange",
-      });
-    }
+      if (selectedFlowRun.closedAt) {
+        progressLogs.push({
+          level: 1,
+          message: `Flow run closed: ${selectedFlowRun.failureMessage?.toLowerCase() ?? selectedFlowRun.status.toLowerCase()}`,
+          recordedAt: selectedFlowRun.closedAt,
+          stepId: "closure",
+          type: "StateChange",
+        });
+      }
 
-    return {
-      logs: progressLogs,
-      proposedEntities: proposed,
-      persistedEntities: persisted,
-    };
-  }, [logDisplay, selectedFlowRun]);
+      return {
+        logs: progressLogs,
+        proposedEntities: proposed,
+        persistedEntities: persisted,
+        relevantEntityIds: highlightedEntityIds,
+      };
+    }, [logDisplay, selectedFlowRun]);
 
   const [startFlow] = useMutation<
     StartFlowMutation,
@@ -681,6 +701,7 @@ export const FlowVisualizer = () => {
                 key={`${flowRunStateKey}-outputs`}
                 persistedEntities={persistedEntities}
                 proposedEntities={proposedEntities}
+                relevantEntityIds={relevantEntityIds}
               />
             ) : (
               <DAG

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer.tsx
@@ -52,6 +52,7 @@ import {
   groupStepsByDependencyLayer,
 } from "./flow-visualizer/sort-graph";
 import { Topbar, topbarHeight } from "./flow-visualizer/topbar";
+import { goalFlowDefinitionIds } from "@local/hash-isomorphic-utils/flows/goal-flow-definitions";
 
 const getGraphFromFlowDefinition = (
   flowDefinition: FlowDefinitionType,
@@ -610,6 +611,10 @@ export const FlowVisualizer = () => {
     selectedFlowDefinition.trigger.triggerDefinitionId === "userTrigger" &&
     !unrunnableDefinitionIds.includes(selectedFlowDefinition.flowDefinitionId);
 
+  const isGoal = goalFlowDefinitionIds.includes(
+    selectedFlowDefinition.flowDefinitionId,
+  );
+
   return (
     <>
       {selectedFlowRun && (
@@ -636,6 +641,7 @@ export const FlowVisualizer = () => {
           <Topbar
             handleRunFlowClicked={handleRunFlowClicked}
             showRunButton={isRunnableFromHere}
+            workerType={isGoal ? "goal" : "flow"}
           />
         </Box>
         <Stack

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/activity-log.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/activity-log.tsx
@@ -41,12 +41,12 @@ import type {
   CreateVirtualizedRowContentFn,
   VirtualizedTableColumn,
   VirtualizedTableRow,
-  VirtualizedTableSort,
 } from "../../../shared/virtualized-table";
 import {
   defaultCellSx,
   VirtualizedTable,
 } from "../../../shared/virtualized-table";
+import type { VirtualizedTableSort } from "../../../shared/virtualized-table/header/sort";
 import { SectionLabel } from "./section-label";
 import { formatTimeTaken } from "./shared/format-time-taken";
 import type { LocalProgressLog, LogDisplay } from "./shared/types";
@@ -623,7 +623,7 @@ const sortLogs = (
   b: LocalProgressLog,
   sort: VirtualizedTableSort<FieldId>,
 ) => {
-  if (sort.field === "time") {
+  if (sort.fieldId === "time") {
     if (a.recordedAt === b.recordedAt) {
       return 0;
     }
@@ -655,7 +655,7 @@ export const ActivityLog = memo(
     setLogDisplay: (display: LogDisplay) => void;
   }) => {
     const [sort, setSort] = useState<VirtualizedTableSort<FieldId>>({
-      field: "time",
+      fieldId: "time",
       direction: "asc",
     });
 

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/activity-log.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/activity-log.tsx
@@ -310,7 +310,13 @@ const LogDetail = ({
 
       return (
         <Stack direction="row" alignItems="center" gap={0.5}>
-          {isPersistedEntity ? "Persisted" : "Proposed"} entity{" "}
+          {`${
+            isPersistedEntity
+              ? "Persisted"
+              : log.isUpdateToExistingProposal
+                ? "Updated proposed"
+                : "Proposed"
+          } entity `}
           <strong style={ellipsisOverflow}>{entityLabel}</strong>
         </Stack>
       );

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/dag-slide.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/dag-slide.tsx
@@ -1,4 +1,5 @@
 import { IconButton } from "@hashintel/design-system";
+import { goalFlowDefinitionIds } from "@local/hash-isomorphic-utils/flows/goal-flow-definitions";
 import type { FlowDefinition } from "@local/hash-isomorphic-utils/flows/types";
 import { Backdrop, Box, Slide, Stack } from "@mui/material";
 
@@ -9,7 +10,6 @@ import type {
   UngroupedEdgesAndNodes,
 } from "./shared/types";
 import { Topbar } from "./topbar";
-import { goalFlowDefinitionIds } from "@local/hash-isomorphic-utils/flows/goal-flow-definitions";
 
 type DagSlideProps = {
   groups: [UngroupedEdgesAndNodes] | GroupWithEdgesAndNodes[];

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/dag-slide.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/dag-slide.tsx
@@ -9,6 +9,7 @@ import type {
   UngroupedEdgesAndNodes,
 } from "./shared/types";
 import { Topbar } from "./topbar";
+import { goalFlowDefinitionIds } from "@local/hash-isomorphic-utils/flows/goal-flow-definitions";
 
 type DagSlideProps = {
   groups: [UngroupedEdgesAndNodes] | GroupWithEdgesAndNodes[];
@@ -23,6 +24,10 @@ export const DagSlide = ({
   onClose,
   selectedFlowDefinition,
 }: DagSlideProps) => {
+  const isGoal = goalFlowDefinitionIds.includes(
+    selectedFlowDefinition.flowDefinitionId,
+  );
+
   return (
     <Backdrop
       open={open}
@@ -55,6 +60,7 @@ export const DagSlide = ({
               handleRunFlowClicked={() => null}
               showRunButton={false}
               readonly
+              workerType={isGoal ? "goal" : "flow"}
             />
             <IconButton
               onClick={onClose}

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs.tsx
@@ -644,6 +644,11 @@ export const Outputs = ({
         {visibleSection === "entities" &&
           (entityDisplay === "table" ? (
             <EntityResultTable
+              dataIsLoading={
+                hasEntities &&
+                !persistedEntitiesSubgraph &&
+                !proposedEntitiesTypesSubgraph
+              }
               onEntityClick={onEntityClick}
               onEntityTypeClick={onEntityTypeClick}
               persistedEntities={persistedEntities}

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@apollo/client";
 import { buildSubgraph } from "@blockprotocol/graph/stdlib";
 import type { VersionedUrl } from "@blockprotocol/type-system";
 import type { EntityForGraphChart } from "@hashintel/block-design-system";
-import { IconButton } from "@hashintel/design-system";
+import { CheckRegularIcon, IconButton } from "@hashintel/design-system";
 import type {
   Entity as GraphApiEntity,
   Filter,
@@ -28,8 +28,8 @@ import {
   getPropertyTypes,
 } from "@local/hash-subgraph/stdlib";
 import type { SvgIconProps } from "@mui/material";
-import { Box, Stack, Typography } from "@mui/material";
-import type { FunctionComponent, PropsWithChildren } from "react";
+import { Box, Collapse, Stack, Typography } from "@mui/material";
+import type { FunctionComponent, PropsWithChildren, ReactNode } from "react";
 import { useCallback, useMemo, useState } from "react";
 
 import type {
@@ -120,54 +120,114 @@ const SectionTabContainer = ({ children }: PropsWithChildren) => (
 
 const SectionTabButton = ({
   active,
+  additionalControlElements,
+  color,
+  height,
   label,
   Icon,
   onClick,
 }: {
   active: boolean;
+  additionalControlElements?: ReactNode;
+  color: "blue" | "white";
+  height: number;
   label: string;
-  Icon: FunctionComponent<SvgIconProps>;
+  Icon?: FunctionComponent<SvgIconProps>;
   onClick: () => void;
-}) => (
-  <IconButton
-    onClick={onClick}
-    sx={({ palette }) => ({
-      background: active ? palette.common.white : palette.gray[20],
-      borderRadius: 16,
-      px: 1.2,
-      py: 0.8,
-      svg: {
-        fontSize: 14,
-      },
-      "&:hover": {
-        background: active ? palette.common.white : palette.gray[20],
-      },
-      transition: ({ transitions }) => transitions.create("background"),
-    })}
-  >
-    <Icon
-      sx={({ palette }) => ({
-        color: active ? palette.common.black : palette.gray[80],
-        display: "block",
-      })}
-    />
+}) => {
+  const additionalControlsAreDisplayed = additionalControlElements && active;
 
-    <Typography
-      component="span"
-      sx={{
-        color: ({ palette }) =>
-          active ? palette.common.black : palette.gray[80],
-        fontSize: 13,
-        fontWeight: 500,
-        ml: 1,
-        textTransform: "capitalize",
-        transition: ({ transitions }) => transitions.create("color"),
-      }}
+  return (
+    <Stack
+      direction="row"
+      sx={[
+        additionalControlsAreDisplayed
+          ? { background: ({ palette }) => palette.common.white, p: "1.5px" }
+          : {},
+        {
+          borderRadius: 16,
+          height,
+          transition: ({ transitions }) => transitions.create("background"),
+        },
+      ]}
     >
-      {label}
-    </Typography>
-  </IconButton>
-);
+      <IconButton
+        onClick={onClick}
+        sx={({ palette }) => ({
+          background:
+            color === "white"
+              ? active
+                ? palette.common.white
+                : palette.gray[20]
+              : active
+                ? palette.blue[70]
+                : palette.blue[20],
+          borderRadius: 16,
+          px: additionalControlsAreDisplayed ? "10.5px" : "12px",
+          py: 0,
+          svg: {
+            fontSize: 11,
+          },
+          "&:hover": {
+            background: active
+              ? color === "white"
+                ? palette.common.white
+                : palette.blue[70]
+              : palette.gray[20],
+          },
+          transition: ({ transitions }) => transitions.create("background"),
+        })}
+      >
+        {Icon && (
+          <Icon
+            sx={({ palette }) => ({
+              color:
+                color === "white"
+                  ? active
+                    ? palette.common.black
+                    : palette.gray[80]
+                  : active
+                    ? palette.common.white
+                    : palette.blue[70],
+              display: "block",
+              mr: 0.8,
+            })}
+          />
+        )}
+
+        <Typography
+          component="span"
+          sx={{
+            color: ({ palette }) =>
+              color === "white"
+                ? active
+                  ? palette.common.black
+                  : palette.gray[80]
+                : active
+                  ? palette.common.white
+                  : palette.blue[70],
+            fontSize: 13,
+            fontWeight: 500,
+            textTransform: "capitalize",
+            transition: ({ transitions }) => transitions.create("color"),
+          }}
+        >
+          {label}
+        </Typography>
+      </IconButton>
+      {additionalControlElements && (
+        <Collapse
+          orientation="horizontal"
+          in={active}
+          timeout={{ enter: 200, exit: 0 }}
+          s
+        >
+          {additionalControlElements}
+        </Collapse>
+      )}
+    </Stack>
+  );
+};
 
 const mockEntityFromProposedEntity = (
   proposedEntity: ProposedEntityOutput,
@@ -538,10 +598,39 @@ export const Outputs = ({
               : (["entities", "deliverables"] as const)
             ).map((section) => (
               <SectionTabButton
+                color="white"
+                height={28}
                 key={section}
+                additionalControlElements={
+                  section === "entities" ? (
+                    <Stack
+                      direction="row"
+                      alignItems="center"
+                      sx={{
+                        background: ({ palette }) => palette.blue[20],
+                        borderRadius: 16,
+                      }}
+                    >
+                      {(["graph", "table"] as const).map((option) => (
+                        <SectionTabButton
+                          color="blue"
+                          height={26}
+                          key={option}
+                          label={option}
+                          active={entityDisplay === option}
+                          Icon={
+                            entityDisplay === option
+                              ? CheckRegularIcon
+                              : outputIcons[option]
+                          }
+                          onClick={() => setEntityDisplay(option)}
+                        />
+                      ))}
+                    </Stack>
+                  ) : undefined
+                }
                 label={section}
                 active={sectionVisibility[section]}
-                Icon={outputIcons[section]}
                 onClick={() =>
                   setSectionVisibility({
                     ...sectionVisibility,
@@ -551,19 +640,6 @@ export const Outputs = ({
               />
             ))}
           </SectionTabContainer>
-          {sectionVisibility.entities && (
-            <SectionTabContainer>
-              {(["graph", "table"] as const).map((section) => (
-                <SectionTabButton
-                  key={section}
-                  label={section}
-                  active={entityDisplay === section}
-                  Icon={outputIcons[section]}
-                  onClick={() => setEntityDisplay(section)}
-                />
-              ))}
-            </SectionTabContainer>
-          )}
         </Stack>
       </Box>
       <Stack

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs.tsx
@@ -220,7 +220,6 @@ const SectionTabButton = ({
           orientation="horizontal"
           in={active}
           timeout={{ enter: 200, exit: 0 }}
-          s
         >
           {additionalControlElements}
         </Collapse>
@@ -295,12 +294,6 @@ type OutputsProps = {
   proposedEntities: ProposedEntityOutput[];
 };
 
-type SectionVisibility = {
-  claims: boolean;
-  deliverables: boolean;
-  entities: boolean;
-};
-
 export const Outputs = ({
   persistedEntities,
   proposedEntities,
@@ -313,6 +306,9 @@ export const Outputs = ({
       selectedFlowRun.flowDefinitionId as EntityUuid,
     );
 
+  const hasEntities =
+    persistedEntities.length > 0 || proposedEntities.length > 0;
+
   const deliverables = useMemo(
     () => getDeliverables(selectedFlowRun?.outputs),
     [selectedFlowRun],
@@ -322,13 +318,9 @@ export const Outputs = ({
     "table",
   );
 
-  const [sectionVisibility, setSectionVisibility] = useState<SectionVisibility>(
-    {
-      claims: hasClaims,
-      entities: !hasClaims,
-      deliverables: false,
-    },
-  );
+  const [visibleSection, setVisibleSection] = useState<
+    "claims" | "entities" | "deliverables"
+  >(hasEntities ? "entities" : "claims");
 
   const [slideOver, setSlideOver] = useState<ResultSlideOver>(null);
 
@@ -599,7 +591,7 @@ export const Outputs = ({
             ).map((section) => (
               <SectionTabButton
                 color="white"
-                height={28}
+                height={34}
                 key={section}
                 additionalControlElements={
                   section === "entities" ? (
@@ -614,7 +606,7 @@ export const Outputs = ({
                       {(["graph", "table"] as const).map((option) => (
                         <SectionTabButton
                           color="blue"
-                          height={26}
+                          height={30}
                           key={option}
                           label={option}
                           active={entityDisplay === option}
@@ -629,14 +621,10 @@ export const Outputs = ({
                     </Stack>
                   ) : undefined
                 }
+                Icon={outputIcons[section]}
                 label={section}
-                active={sectionVisibility[section]}
-                onClick={() =>
-                  setSectionVisibility({
-                    ...sectionVisibility,
-                    [section]: !sectionVisibility[section],
-                  })
-                }
+                active={section === visibleSection}
+                onClick={() => setVisibleSection(section)}
               />
             ))}
           </SectionTabContainer>
@@ -653,7 +641,7 @@ export const Outputs = ({
           zIndex: 2,
         }}
       >
-        {sectionVisibility.entities &&
+        {visibleSection === "entities" &&
           (entityDisplay === "table" ? (
             <EntityResultTable
               onEntityClick={onEntityClick}
@@ -673,13 +661,13 @@ export const Outputs = ({
               }
             />
           ))}
-        {sectionVisibility.claims && (
+        {visibleSection === "claims" && (
           <ClaimsTable
             onEntityClick={onEntityClick}
             proposedEntities={proposedEntities}
           />
         )}
-        {sectionVisibility.deliverables && (
+        {visibleSection === "deliverables" && (
           <Deliverables deliverables={deliverables} />
         )}
       </Stack>

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs.tsx
@@ -292,11 +292,13 @@ type ResultSlideOver =
 type OutputsProps = {
   persistedEntities: PersistedEntity[];
   proposedEntities: ProposedEntityOutput[];
+  relevantEntityIds: EntityId[];
 };
 
 export const Outputs = ({
   persistedEntities,
   proposedEntities,
+  relevantEntityIds,
 }: OutputsProps) => {
   const { selectedFlowRun } = useFlowRunsContext();
 
@@ -655,6 +657,7 @@ export const Outputs = ({
               persistedEntitiesSubgraph={persistedEntitiesSubgraph}
               proposedEntities={proposedEntities}
               proposedEntitiesTypesSubgraph={proposedEntitiesTypesSubgraph}
+              relevantEntityIds={relevantEntityIds}
             />
           ) : (
             <EntityResultGraph

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/claims-table.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/claims-table.tsx
@@ -641,9 +641,7 @@ export const ClaimsTable = memo(
         ) : (
           <EmptyOutputBox
             Icon={outputIcons.table}
-            label={
-              "Claims about entities discovered by this flow will appear in a table here"
-            }
+            label="Claims about entities discovered by this flow will appear in a table here"
           />
         )}
       </OutputContainer>

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/claims-table.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/claims-table.tsx
@@ -39,12 +39,12 @@ import type {
   CreateVirtualizedRowContentFn,
   VirtualizedTableColumn,
   VirtualizedTableRow,
-  VirtualizedTableSort,
 } from "../../../../shared/virtualized-table";
 import {
   defaultCellSx,
   VirtualizedTable,
 } from "../../../../shared/virtualized-table";
+import type { VirtualizedTableSort } from "../../../../shared/virtualized-table/header/sort";
 import type { ProposedEntityOutput } from "../shared/types";
 import { EmptyOutputBox } from "./shared/empty-output-box";
 import { outputIcons } from "./shared/icons";
@@ -288,7 +288,7 @@ type ClaimsTableProps = {
 export const ClaimsTable = memo(
   ({ onEntityClick, proposedEntities }: ClaimsTableProps) => {
     const [sort, setSort] = useState<VirtualizedTableSort<FieldId>>({
-      field: "subject",
+      fieldId: "subject",
       direction: "asc",
     });
 
@@ -460,20 +460,20 @@ export const ClaimsTable = memo(
       }
 
       const sortedRows = rowData.sort((a, b) => {
-        const { field, direction } = sort;
+        const { fieldId, direction } = sort;
 
         const base = direction === "asc" ? a : b;
         const target = direction === "asc" ? b : a;
 
-        if (field === "subject" || field === "object") {
+        if (fieldId === "subject" || fieldId === "object") {
           return (
-            base.data[field]?.name.localeCompare(
-              target.data[field]?.name ?? "ZZZZZZ",
-            ) ?? (target.data[field] ? 1 : 0)
+            base.data[fieldId]?.name.localeCompare(
+              target.data[fieldId]?.name ?? "ZZZZZZ",
+            ) ?? (target.data[fieldId] ? 1 : 0)
           );
         }
 
-        return base.data[field].localeCompare(target.data[field]);
+        return base.data[fieldId].localeCompare(target.data[fieldId]);
       });
 
       return {

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/entity-result-table.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/entity-result-table.tsx
@@ -810,6 +810,34 @@ export const EntityResultTable = memo(
                 ) {
                   return false;
                 }
+              } else if (fieldId.includes("/entity-type/")) {
+                if (typeof currentValue === "string") {
+                  throw new Error(
+                    `Expected Set for entity type filter, got ${currentValue}`,
+                  );
+                }
+
+                const linkTargets = row.data.outgoingLinksByLinkTypeId[fieldId];
+
+                if (!linkTargets) {
+                  if (!currentValue.has(null as unknown as string)) {
+                    /**
+                     * This row has no links of this type, and the filter does not include 'null'
+                     */
+                    return false;
+                  }
+                } else if (
+                  currentValue.isDisjointFrom(
+                    new Set(
+                      linkTargets.map(({ targetEntityId }) => targetEntityId),
+                    ),
+                  )
+                ) {
+                  /**
+                   * There are no values in common between the filter and the link targets for this type, for this row
+                   */
+                  return false;
+                }
               } else {
                 const baseUrl = extractBaseUrl(fieldId);
                 const propertyValue = row.data.properties[baseUrl];

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/entity-result-table.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/entity-result-table.tsx
@@ -356,6 +356,7 @@ const createRowContent: CreateVirtualizedRowContentFn<
 );
 
 type EntityResultTableProps = {
+  dataIsLoading: boolean;
   onEntityClick: (entityId: EntityId) => void;
   onEntityTypeClick: (entityTypeId: VersionedUrl) => void;
   persistedEntities: PersistedEntity[];
@@ -366,6 +367,7 @@ type EntityResultTableProps = {
 
 export const EntityResultTable = memo(
   ({
+    dataIsLoading,
     onEntityClick,
     onEntityTypeClick,
     persistedEntities,
@@ -378,7 +380,18 @@ export const EntityResultTable = memo(
       direction: "asc",
     });
 
-    const hasData = !!(persistedEntities.length || proposedEntities.length);
+    const hasEntities = !!(persistedEntities.length || proposedEntities.length);
+
+    const outputContainerRef = useRef<HTMLDivElement>(null);
+    const [outputContainerHeight, setOutputContainerHeight] = useState(400);
+    useLayoutEffect(() => {
+      if (
+        outputContainerRef.current &&
+        outputContainerRef.current.clientHeight !== outputContainerHeight
+      ) {
+        setOutputContainerHeight(outputContainerRef.current.clientHeight);
+      }
+    }, [outputContainerHeight]);
 
     const {
       filterDefinitions,
@@ -861,7 +874,8 @@ export const EntityResultTable = memo(
 
     return (
       <OutputContainer
-        noBorder={hasData}
+        noBorder={hasEntities}
+        ref={outputContainerRef}
         sx={{
           flex: 1,
           minWidth: 400,
@@ -873,18 +887,25 @@ export const EntityResultTable = memo(
           },
         }}
       >
-        {hasData ? (
-          <VirtualizedTable
-            columns={columns}
-            createRowContent={createRowContent}
-            filterDefinitions={filterDefinitions}
-            filterValues={filterValues}
-            setFilterValues={setFilterValues}
-            fixedColumns={3}
-            rows={rows}
-            sort={sort}
-            setSort={setSort}
-          />
+        {hasEntities ? (
+          dataIsLoading ? (
+            <TableSkeleton
+              cellHeight={43}
+              tableHeight={outputContainerHeight}
+            />
+          ) : (
+            <VirtualizedTable
+              columns={columns}
+              createRowContent={createRowContent}
+              filterDefinitions={filterDefinitions}
+              filterValues={filterValues}
+              setFilterValues={setFilterValues}
+              fixedColumns={3}
+              rows={rows}
+              sort={sort}
+              setSort={setSort}
+            />
+          )
         ) : (
           <EmptyOutputBox
             Icon={outputIcons.table}

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/entity-result-table/cells.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/entity-result-table/cells.tsx
@@ -1,0 +1,171 @@
+import { IconButton } from "@hashintel/design-system";
+import type { ValueMetadata } from "@local/hash-graph-client/api";
+import type { EntityId, PropertyValue } from "@local/hash-graph-types/entity";
+import { generateUuid } from "@local/hash-isomorphic-utils/generate-uuid";
+import { stringifyPropertyValue } from "@local/hash-isomorphic-utils/stringify-property-value";
+import {
+  Box,
+  Stack,
+  type SxProps,
+  TableCell,
+  type Theme,
+  Typography,
+} from "@mui/material";
+import { useRef, useState } from "react";
+
+import { CircleInfoIcon } from "../../../../../../shared/icons/circle-info-icon";
+import { ValueChip } from "../../../../../shared/value-chip";
+import { defaultCellSx } from "../../../../../shared/virtualized-table";
+import { SourcesPopover } from "../shared/sources-popover";
+
+export const typographySx = {
+  color: ({ palette }) => palette.common.black,
+  fontSize: 12,
+  fontWeight: 500,
+} as const satisfies SxProps<Theme>;
+
+export const cellSx = {
+  ...defaultCellSx,
+  ...typographySx,
+  background: "white",
+  "&:not(:last-child)": {
+    borderRight: ({ palette }) => `1px solid ${palette.gray[20]}`,
+  },
+} as const satisfies SxProps<Theme>;
+
+export const NoValueCell = ({
+  columnId,
+  researchOngoing,
+}: {
+  columnId: string;
+  researchOngoing: boolean;
+}) => {
+  if (!researchOngoing) {
+    return (
+      <TableCell
+        key={columnId}
+        sx={{ ...cellSx, color: ({ palette }) => palette.gray[50] }}
+      >
+        –
+      </TableCell>
+    );
+  }
+
+  return (
+    <TableCell
+      key={columnId}
+      sx={({ palette }) => ({
+        ...cellSx,
+        background: palette.blue[15],
+        color: palette.blue[70],
+      })}
+    >
+      <Stack direction="row" alignItems="center">
+        <Box
+          sx={{
+            background: ({ palette }) => palette.blue[70],
+            height: 6,
+            width: 6,
+            borderRadius: "50%",
+            mr: 1,
+          }}
+        />
+        Researching...
+      </Stack>
+    </TableCell>
+  );
+};
+
+export const LinkedEntitiesCell = ({
+  linkedEntities,
+  onEntityClick,
+}: {
+  linkedEntities: {
+    linkEntityId: EntityId;
+    targetEntityId: EntityId;
+    targetEntityLabel: string;
+  }[];
+  onEntityClick: (entityId: EntityId) => void;
+}) => {
+  return (
+    <TableCell sx={cellSx}>
+      <Stack direction="row" spacing={1}>
+        {linkedEntities.map(({ linkEntityId, targetEntityLabel }) => (
+          <Box
+            key={linkEntityId}
+            component="button"
+            onClick={() => onEntityClick(linkEntityId)}
+            sx={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              p: 0,
+              textAlign: "left",
+            }}
+          >
+            <ValueChip
+              sx={{
+                ...typographySx,
+                color: ({ palette }) => palette.blue[70],
+              }}
+            >
+              {targetEntityLabel}
+            </ValueChip>
+          </Box>
+        ))}
+      </Stack>
+    </TableCell>
+  );
+};
+
+export const PropertyValueCell = ({
+  metadata,
+  value,
+}: {
+  metadata?: ValueMetadata;
+  value: PropertyValue;
+}) => {
+  const [showMetadataTooltip, setShowMetadataTooltip] = useState(false);
+
+  const stringifiedValue = stringifyPropertyValue(value);
+  const cellRef = useRef<HTMLDivElement>(null);
+
+  const buttonId = generateUuid();
+
+  return (
+    <TableCell sx={{ ...cellSx, maxWidth: 700 }} ref={cellRef}>
+      <Stack direction="row" alignItems="center">
+        <Typography
+          sx={{
+            ...typographySx,
+            lineHeight: 1,
+            textOverflow: "ellipsis",
+            overflow: "hidden",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {stringifiedValue}
+        </Typography>
+        <IconButton
+          aria-describedby={buttonId}
+          onClick={() => setShowMetadataTooltip(true)}
+          sx={{ ml: 1 }}
+        >
+          <CircleInfoIcon
+            sx={{
+              fontSize: 12,
+              fill: ({ palette }) => palette.gray[40],
+            }}
+          />
+        </IconButton>
+      </Stack>
+      <SourcesPopover
+        buttonId={buttonId}
+        open={showMetadataTooltip}
+        cellRef={cellRef}
+        onClose={() => setShowMetadataTooltip(false)}
+        sources={metadata?.provenance?.sources ?? []}
+      />
+    </TableCell>
+  );
+};

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/shared/output-container.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/shared/output-container.tsx
@@ -1,15 +1,19 @@
 import type { SxProps, Theme } from "@mui/material";
 import { Box } from "@mui/material";
 import type { PropsWithChildren } from "react";
+import { forwardRef } from "react";
 
 import { flowSectionBorderRadius } from "../../shared/styles";
 
-export const OutputContainer = ({
-  children,
-  noBorder,
-  sx,
-}: PropsWithChildren<{ noBorder?: boolean; sx?: SxProps<Theme> }>) => (
+export const OutputContainer = forwardRef<
+  HTMLDivElement,
+  PropsWithChildren<{
+    noBorder?: boolean;
+    sx?: SxProps<Theme>;
+  }>
+>(({ children, noBorder, sx }, ref) => (
   <Box
+    ref={ref}
     sx={[
       {
         background: ({ palette }) => palette.common.white,
@@ -26,4 +30,4 @@ export const OutputContainer = ({
   >
     {children}
   </Box>
-);
+));

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/shared/table-skeleton.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/shared/table-skeleton.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from "@hashintel/design-system";
+import { Stack } from "@mui/material";
+
+export const TableSkeleton = ({
+  cellHeight,
+  tableHeight,
+}: {
+  cellHeight: number;
+  tableHeight: number;
+}) => {
+  return (
+    <Stack px={1}>
+      {Array(Math.floor(tableHeight / cellHeight))
+        .fill(0)
+        .map((_, index) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <Skeleton key={index} height={cellHeight - 6} />
+        ))}
+    </Stack>
+  );
+};

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/topbar.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/topbar.tsx
@@ -57,13 +57,14 @@ const selectSx: SxProps<Theme> = {
   },
 };
 
-const Divider = () => (
+const Divider = ({ topOffset }: { topOffset?: number }) => (
   <AngleRightRegularIcon
     sx={{
       fill: ({ palette }) => palette.gray[50],
       fontSize: 18,
       mr: 0.5,
       ml: 1,
+      mt: topOffset ?? 0,
     }}
   />
 );
@@ -152,10 +153,12 @@ export const Topbar = ({
   handleRunFlowClicked,
   readonly,
   showRunButton,
+  workerType,
 }: {
   handleRunFlowClicked: () => void;
   readonly?: boolean;
   showRunButton: boolean;
+  workerType: "goal" | "flow";
 }) => {
   const { push } = useRouter();
 
@@ -238,21 +241,17 @@ export const Topbar = ({
             Workers
           </Typography>
         </Link>
-        <Divider />
+        <Divider topOffset={0.1} />
 
-        <InfinityLightIcon
-          sx={{
-            fill: ({ palette }) => palette.gray[60],
-            fontSize: 20,
-            mr: 1,
-          }}
-        />
-        <Link href="/flows" noLinkStyle>
-          <Typography sx={typographySx} variant="smallTextParagraphs">
-            Flows
+        <Link href={`/${workerType}`} noLinkStyle sx={{ mr: 0.5 }}>
+          <Typography
+            sx={{ ...typographySx, textTransform: "capitalize" }}
+            variant="smallTextParagraphs"
+          >
+            {`${workerType}s`}
           </Typography>
         </Link>
-        <Divider />
+        <Divider topOffset={0.1} />
         <Box mr={1}>
           {readonly ? (
             <Typography sx={typographySx} variant="smallTextParagraphs">

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/topbar.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/topbar.tsx
@@ -1,7 +1,6 @@
 import { useMutation } from "@apollo/client";
 import {
   AngleRightRegularIcon,
-  InfinityLightIcon,
   PlayIconSolid,
   Select,
 } from "@hashintel/design-system";

--- a/apps/hash-frontend/src/pages/flows.page.tsx
+++ b/apps/hash-frontend/src/pages/flows.page.tsx
@@ -27,9 +27,10 @@ import type {
   CreateVirtualizedRowContentFn,
   VirtualizedTableColumn,
   VirtualizedTableRow,
-  VirtualizedTableSort,
 } from "./shared/virtualized-table";
-import { headerHeight, VirtualizedTable } from "./shared/virtualized-table";
+import { VirtualizedTable } from "./shared/virtualized-table";
+import { headerHeight } from "./shared/virtualized-table/header";
+import type { VirtualizedTableSort } from "./shared/virtualized-table/header/sort";
 
 type FieldId = "web" | "name" | "description" | "lastRunStartedAt";
 
@@ -126,7 +127,7 @@ const createRowContent: CreateVirtualizedRowContentFn<FlowSummary> = (
 
 const FlowsPageContent = () => {
   const [sort, setSort] = useState<VirtualizedTableSort<FieldId>>({
-    field: "name",
+    fieldId: "name",
     direction: "asc",
   });
 
@@ -169,7 +170,7 @@ const FlowsPageContent = () => {
       });
 
     return rowData.sort((a, b) => {
-      const field = sort.field;
+      const field = sort.fieldId;
       const direction = sort.direction === "asc" ? 1 : -1;
 
       if (field === "web") {

--- a/apps/hash-frontend/src/pages/shared/virtualized-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/virtualized-table.tsx
@@ -16,7 +16,7 @@ import type { ColumnMetadata } from "./virtualized-table/header";
 import { HeaderContent, headerHeight } from "./virtualized-table/header";
 import type {
   TableFilterProps,
-  VirtualizedTableFiltersByFieldId,
+  VirtualizedTableFilterDefinitionsByFieldId,
 } from "./virtualized-table/header/filter";
 import type {
   TableSortProps,
@@ -117,7 +117,7 @@ export type CreateVirtualizedRowContentFn<
 type VirtualizedTableProps<
   D extends Data,
   S extends VirtualizedTableSort,
-  F extends VirtualizedTableFiltersByFieldId,
+  F extends VirtualizedTableFilterDefinitionsByFieldId,
   Id extends FieldId,
   M extends ColumnMetadata,
 > = {
@@ -138,7 +138,7 @@ const heightStyle = { height: "100%" };
 export const VirtualizedTable = <
   D extends Data,
   S extends VirtualizedTableSort,
-  F extends VirtualizedTableFiltersByFieldId,
+  F extends VirtualizedTableFilterDefinitionsByFieldId,
   Id extends FieldId,
   M extends ColumnMetadata,
 >({
@@ -147,8 +147,9 @@ export const VirtualizedTable = <
   fixedColumns,
   EmptyPlaceholder,
   rows,
-  filters,
-  setFilters,
+  filterDefinitions,
+  filterValues,
+  setFilterValues,
   sort,
   setSort,
 }: VirtualizedTableProps<D, S, F, Id, M>) => {
@@ -158,13 +159,22 @@ export const VirtualizedTable = <
         ? HeaderContent({
             columns,
             fixedColumns,
-            filters,
-            setFilters,
+            filterDefinitions,
+            filterValues,
+            setFilterValues,
             sort,
             setSort,
           })
         : null,
-    [columns, fixedColumns, filters, setFilters, sort, setSort],
+    [
+      columns,
+      fixedColumns,
+      filterDefinitions,
+      filterValues,
+      setFilterValues,
+      sort,
+      setSort,
+    ],
   );
 
   const components = useMemo(

--- a/apps/hash-frontend/src/pages/shared/virtualized-table/header.tsx
+++ b/apps/hash-frontend/src/pages/shared/virtualized-table/header.tsx
@@ -44,12 +44,21 @@ export const HeaderContent = <
           left += columns[i]!.width as number;
         }
 
+        const hasFilters =
+          filters &&
+          setFilters &&
+          Object.keys(filters[column.id]?.options ?? {}).length > 1;
+
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        const hasButtons = hasFilters || column.sortable;
+
         return (
           <TableCell
             key={column.id}
             variant="head"
             sx={({ palette }) => ({
               background: palette.common.white,
+              paddingRight: hasButtons ? "8px !important" : "initial",
               width: column.width,
               minWidth:
                 typeof column.width === "number" ? column.width : undefined,
@@ -80,7 +89,7 @@ export const HeaderContent = <
                 {column.label}
               </Typography>
               <Stack direction="row" alignItems="center">
-                {filters && setFilters && (
+                {hasFilters && (
                   <FilterButton
                     columnId={column.id}
                     filters={filters}

--- a/apps/hash-frontend/src/pages/shared/virtualized-table/header.tsx
+++ b/apps/hash-frontend/src/pages/shared/virtualized-table/header.tsx
@@ -7,7 +7,7 @@ import TableRow from "@mui/material/TableRow";
 import type { VirtualizedTableColumn } from "../virtualized-table";
 import type {
   TableFilterProps,
-  VirtualizedTableFiltersByFieldId,
+  VirtualizedTableFilterDefinitionsByFieldId,
 } from "./header/filter";
 import { FilterButton } from "./header/filter";
 import type { TableSortProps, VirtualizedTableSort } from "./header/sort";
@@ -19,14 +19,15 @@ export type ColumnMetadata = Record<string, unknown>;
 
 export const HeaderContent = <
   Sort extends VirtualizedTableSort,
-  Filters extends VirtualizedTableFiltersByFieldId,
+  Filters extends VirtualizedTableFilterDefinitionsByFieldId,
   Id extends string,
   M extends ColumnMetadata,
 >({
   columns,
   fixedColumns,
-  filters,
-  setFilters,
+  filterDefinitions,
+  filterValues,
+  setFilterValues,
   sort,
   setSort,
 }: {
@@ -45,9 +46,10 @@ export const HeaderContent = <
         }
 
         const hasFilters =
-          filters &&
-          setFilters &&
-          Object.keys(filters[column.id]?.options ?? {}).length > 1;
+          filterDefinitions &&
+          filterValues &&
+          setFilterValues &&
+          Object.keys(filterDefinitions[column.id]?.options ?? {}).length > 1;
 
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         const hasButtons = hasFilters || column.sortable;
@@ -76,6 +78,7 @@ export const HeaderContent = <
             <Stack
               direction="row"
               alignItems="center"
+              gap={0.5}
               justifyContent="space-between"
             >
               <Typography
@@ -92,8 +95,9 @@ export const HeaderContent = <
                 {hasFilters && (
                   <FilterButton
                     columnId={column.id}
-                    filters={filters}
-                    setFilters={setFilters}
+                    filterDefinitions={filterDefinitions}
+                    filterValues={filterValues}
+                    setFilterValues={setFilterValues}
                   />
                 )}
                 {column.sortable && (

--- a/apps/hash-frontend/src/pages/shared/virtualized-table/header.tsx
+++ b/apps/hash-frontend/src/pages/shared/virtualized-table/header.tsx
@@ -45,11 +45,7 @@ export const HeaderContent = <
           left += columns[i]!.width as number;
         }
 
-        const hasFilters =
-          filterDefinitions &&
-          filterValues &&
-          setFilterValues &&
-          Object.keys(filterDefinitions[column.id]?.options ?? {}).length > 1;
+        const hasFilters = filterDefinitions && filterValues && setFilterValues;
 
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         const hasButtons = hasFilters || column.sortable;

--- a/apps/hash-frontend/src/pages/shared/virtualized-table/header.tsx
+++ b/apps/hash-frontend/src/pages/shared/virtualized-table/header.tsx
@@ -1,0 +1,104 @@
+import { Stack, Typography } from "@mui/material";
+// eslint-disable-next-line no-restricted-imports
+import TableCell from "@mui/material/TableCell";
+// eslint-disable-next-line no-restricted-imports
+import TableRow from "@mui/material/TableRow";
+
+import type { VirtualizedTableColumn } from "../virtualized-table";
+import type {
+  TableFilterProps,
+  VirtualizedTableFiltersByFieldId,
+} from "./header/filter";
+import { FilterButton } from "./header/filter";
+import type { TableSortProps, VirtualizedTableSort } from "./header/sort";
+import { SortButton } from "./header/sort";
+
+export const headerHeight = 43;
+
+export type ColumnMetadata = Record<string, unknown>;
+
+export const HeaderContent = <
+  Sort extends VirtualizedTableSort,
+  Filters extends VirtualizedTableFiltersByFieldId,
+  Id extends string,
+  M extends ColumnMetadata,
+>({
+  columns,
+  fixedColumns,
+  filters,
+  setFilters,
+  sort,
+  setSort,
+}: {
+  columns: VirtualizedTableColumn<Id, M>[];
+  fixedColumns?: number;
+} & TableSortProps<Sort> &
+  Partial<TableFilterProps<Filters>>) => {
+  return (
+    <TableRow>
+      {columns.map((column, index) => {
+        const isFixed = fixedColumns !== undefined && index < fixedColumns;
+
+        let left = 0;
+        for (let i = index - 1; i >= 0; i--) {
+          left += columns[i]!.width as number;
+        }
+
+        return (
+          <TableCell
+            key={column.id}
+            variant="head"
+            sx={({ palette }) => ({
+              background: palette.common.white,
+              width: column.width,
+              minWidth:
+                typeof column.width === "number" ? column.width : undefined,
+              maxWidth:
+                typeof column.width === "number" ? column.width : undefined,
+              ...(isFixed
+                ? {
+                    position: "sticky",
+                    left,
+                    zIndex: 1,
+                  }
+                : {}),
+            })}
+          >
+            <Stack
+              direction="row"
+              alignItems="center"
+              justifyContent="space-between"
+            >
+              <Typography
+                sx={[
+                  { fontSize: 14, fontWeight: 500 },
+                  ...(Array.isArray(column.textSx)
+                    ? column.textSx
+                    : [column.textSx]),
+                ]}
+              >
+                {column.label}
+              </Typography>
+              <Stack direction="row" alignItems="center">
+                {filters && setFilters && (
+                  <FilterButton
+                    columnId={column.id}
+                    filters={filters}
+                    setFilters={setFilters}
+                  />
+                )}
+                {column.sortable && (
+                  <SortButton
+                    columnId={column.id}
+                    setSort={setSort}
+                    sort={sort}
+                  />
+                )}
+              </Stack>
+            </Stack>
+          </TableCell>
+        );
+      })}
+    </TableRow>
+  );
+};

--- a/apps/hash-frontend/src/pages/shared/virtualized-table/header/filter.tsx
+++ b/apps/hash-frontend/src/pages/shared/virtualized-table/header/filter.tsx
@@ -9,6 +9,7 @@ import {
   Radio,
   RadioGroup,
   Stack,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import type { RefObject } from "react";
@@ -18,12 +19,20 @@ import { FilterLightIcon } from "../../../../shared/icons/filter-light-icon";
 
 export const missingValueString = `missing-filter-property-value-${Math.random()}`;
 
+const ellipsisOverflow = {
+  display: "block",
+  textOverflow: "ellipsis",
+  overflow: "hidden",
+  whiteSpace: "nowrap",
+};
+
 const createLabelSlotProps = (
   valueIsMissing: boolean,
 ): FormControlLabelProps["slotProps"] => ({
   typography: {
     color: ({ palette }) =>
       valueIsMissing ? palette.gray[60] : palette.gray[80],
+    ...ellipsisOverflow,
     fontSize: 14,
     fontWeight: valueIsMissing ? 400 : 500,
   },
@@ -31,6 +40,7 @@ const createLabelSlotProps = (
 
 const labelSx: FormControlLabelProps["sx"] = {
   borderRadius: 1,
+  maxWidth: "calc(100% - 44px)",
   marginRight: 0,
   marginLeft: 0.3,
   py: 1,
@@ -117,7 +127,7 @@ const FilterPopover = <Filter extends VirtualizedTableFilterDefinition>({
             borderRadius: 2,
             boxShadow: boxShadows.xl,
             maxHeight: 200,
-            maxWidth: 400,
+            maxWidth: 500,
           }),
         },
         root: {
@@ -171,7 +181,7 @@ const FilterPopover = <Filter extends VirtualizedTableFilterDefinition>({
           )}
         </Stack>
         {type === "checkboxes" ? (
-          <FormControl>
+          <FormControl sx={{ maxWidth: "100%" }}>
             {Object.values(options)
               .sort((a, b) => a.label.localeCompare(b.label))
               .map(({ label, value, count }) => (
@@ -217,7 +227,7 @@ const FilterPopover = <Filter extends VirtualizedTableFilterDefinition>({
               ))}
           </FormControl>
         ) : (
-          <FormControl>
+          <FormControl sx={{ maxWidth: "100%" }}>
             <RadioGroup
               value={currentValue}
               onChange={(event) => {

--- a/apps/hash-frontend/src/pages/shared/virtualized-table/header/filter.tsx
+++ b/apps/hash-frontend/src/pages/shared/virtualized-table/header/filter.tsx
@@ -83,12 +83,14 @@ const blueFilterButtonSx: SxProps<Theme> = ({ palette, transitions }) => ({
 
 const FilterPopover = <Filter extends VirtualizedTableFilter>({
   buttonRef,
+  isFiltered,
   filter,
   setFilter,
   open,
   onClose,
 }: {
   buttonRef: RefObject<HTMLElement>;
+  isFiltered: boolean;
   filter: Filter;
   setFilter: (filter: Filter) => void;
   open: boolean;
@@ -151,20 +153,24 @@ const FilterPopover = <Filter extends VirtualizedTableFilter>({
           >
             {header}
           </Typography>
-          <Box
-            component="button"
-            onClick={() => {
-              setFilter({
-                ...filter,
-                value:
-                  type === "checkboxes" ? new Set(initialValue) : initialValue,
-              });
-              onClose();
-            }}
-            sx={blueFilterButtonSx}
-          >
-            <Typography component="span">Reset</Typography>
-          </Box>
+          {isFiltered && (
+            <Box
+              component="button"
+              onClick={() => {
+                setFilter({
+                  ...filter,
+                  value:
+                    type === "checkboxes"
+                      ? new Set(initialValue)
+                      : initialValue,
+                });
+                onClose();
+              }}
+              sx={blueFilterButtonSx}
+            >
+              <Typography component="span">Reset</Typography>
+            </Box>
+          )}
         </Stack>
         {type === "checkboxes" ? (
           <FormControl>
@@ -301,6 +307,7 @@ export const FilterButton = <Filters extends VirtualizedTableFiltersByFieldId>({
       <FilterPopover
         buttonRef={buttonRef}
         filter={filter}
+        isFiltered={isFiltered}
         setFilter={(newFilter) =>
           setFilters({ ...filters, [columnId]: newFilter })
         }

--- a/apps/hash-frontend/src/pages/shared/virtualized-table/header/filter.tsx
+++ b/apps/hash-frontend/src/pages/shared/virtualized-table/header/filter.tsx
@@ -1,0 +1,264 @@
+import { IconButton } from "@hashintel/design-system";
+import type { FormControlLabelProps } from "@mui/material";
+import {
+  Box,
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  Popover,
+  Radio,
+  RadioGroup,
+  Stack,
+  Typography,
+} from "@mui/material";
+import type { RefObject } from "react";
+import { useRef, useState } from "react";
+
+import { FilterLightIcon } from "../../../../shared/icons/filter-light-icon";
+
+export const missingValueString = `missing-filter-property-value-${Math.random()}`;
+
+type VirtualizedTableFilterOption = {
+  label: string;
+  value: string | null;
+  count: number;
+};
+
+export type VirtualizedTableFilter = {
+  header: string;
+  options: {
+    [value: string]: VirtualizedTableFilterOption;
+  };
+} & (
+  | {
+      type: "radio-group";
+      initialValue: string;
+      value: string;
+    }
+  | {
+      type: "checkboxes";
+      initialValue: Set<string | null>;
+      value: Set<string | null>;
+    }
+);
+
+const createLabelSlotProps = (
+  valueIsMissing: boolean,
+): FormControlLabelProps["slotProps"] => ({
+  typography: {
+    color: ({ palette }) =>
+      valueIsMissing ? palette.gray[60] : palette.gray[80],
+    fontSize: 14,
+    fontWeight: valueIsMissing ? 400 : 500,
+  },
+});
+
+const labelSx: FormControlLabelProps["sx"] = {
+  borderRadius: 1,
+  marginRight: 0,
+  marginLeft: 0.3,
+  py: 1,
+  px: 1.4,
+  "&:hover": {
+    background: ({ palette }) => palette.gray[20],
+  },
+};
+
+const FilterPopover = <Filter extends VirtualizedTableFilter>({
+  buttonRef,
+  filter,
+  setFilter,
+  open,
+  onClose,
+}: {
+  buttonRef: RefObject<HTMLElement>;
+  filter: Filter;
+  setFilter: (filter: Filter) => void;
+  open: boolean;
+  onClose: () => void;
+}) => {
+  const { header, options, type, value: currentValue } = filter;
+
+  return (
+    <Popover
+      id={buttonRef.current?.id}
+      open={open}
+      anchorEl={buttonRef.current}
+      onClose={onClose}
+      anchorOrigin={{
+        vertical: "bottom",
+        horizontal: 0,
+      }}
+      slotProps={{
+        paper: {
+          sx: ({ boxShadows, palette }) => ({
+            border: `1px solid ${palette.gray[20]}`,
+            borderRadius: 2,
+            boxShadow: boxShadows.xl,
+            maxHeight: 200,
+            maxWidth: 400,
+          }),
+        },
+        root: {
+          sx: {
+            background: "none",
+          },
+        },
+      }}
+      transitionDuration={50}
+    >
+      <Box
+        sx={({ boxShadows, palette }) => ({
+          border: `1px solid. ${palette.gray[20]}`,
+          borderRadius: 2,
+          boxShadow: boxShadows.xl,
+          py: 1.8,
+          px: 0.4,
+        })}
+      >
+        <Typography
+          component="div"
+          variant="smallCaps"
+          sx={({ palette }) => ({
+            color: palette.gray[50],
+            mb: 1,
+            lineHeight: 1,
+            px: 1.4,
+          })}
+        >
+          {header}
+        </Typography>
+        {/* if the filter 'type' is checkboxes, do MUI checkboxes. otherwise, do MUI radio group  */}
+
+        {type === "checkboxes" ? (
+          <Stack>
+            <FormControl>
+              {Object.values(options)
+                .sort((a, b) => a.label.localeCompare(b.label))
+                .map(({ label, value, count }) => (
+                  <FormControlLabel
+                    key={value}
+                    control={
+                      <Checkbox
+                        onChange={(event) => {
+                          const newValue = new Set(currentValue);
+                          if (event.target.checked) {
+                            newValue.add(value);
+                          } else {
+                            newValue.delete(value);
+                          }
+                          setFilter({ ...filter, value: newValue });
+                        }}
+                        checked={currentValue.has(value)}
+                        sx={{ mr: 1.5, "& .MuiSvgIcon-root": { fontSize: 18 } }}
+                      />
+                    }
+                    label={`${label} (${count})`}
+                    slotProps={createLabelSlotProps(value === null)}
+                    sx={labelSx}
+                  />
+                ))}
+            </FormControl>
+          </Stack>
+        ) : (
+          <Stack>
+            <FormControl>
+              <RadioGroup
+                value={currentValue}
+                onChange={(event) => {
+                  setFilter({ ...filter, value: event.target.value });
+                }}
+              >
+                {Object.values(options)
+                  .sort((a, b) => a.label.localeCompare(b.label))
+                  .map(({ label, value, count }) => (
+                    <FormControlLabel
+                      key={value}
+                      value={value}
+                      control={<Radio sx={{ mr: 1.5 }} />}
+                      label={`${label} (${count})`}
+                      slotProps={createLabelSlotProps(value === null)}
+                      sx={labelSx}
+                    />
+                  ))}
+              </RadioGroup>
+            </FormControl>
+          </Stack>
+        )}
+      </Box>
+    </Popover>
+  );
+};
+
+export type VirtualizedTableFiltersByFieldId<Id extends string = string> =
+  Record<Id, VirtualizedTableFilter>;
+
+export type TableFilterProps<
+  Filters extends
+    VirtualizedTableFiltersByFieldId = VirtualizedTableFiltersByFieldId,
+> = {
+  filters: Filters;
+  setFilters: (filters: Filters) => void;
+};
+
+export const isFilterValueIncluded = (
+  value: string | null,
+  filter: VirtualizedTableFilter,
+) => {
+  if (filter.type === "radio-group") {
+    return value === filter.value;
+  }
+  return filter.value.has(value);
+};
+
+export const FilterButton = <Filters extends VirtualizedTableFiltersByFieldId>({
+  columnId,
+  filters,
+  setFilters,
+}: {
+  columnId: NonNullable<keyof Filters>;
+} & TableFilterProps<Filters>) => {
+  const filter = filters[columnId];
+
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const [showFilterPopover, setShowFilterPopover] = useState(false);
+
+  if (!filter || Object.keys(filter.options).length < 2) {
+    return null;
+  }
+
+  const { type, initialValue, value } = filter;
+
+  const isFiltered =
+    type === "radio-group"
+      ? value !== initialValue
+      : initialValue.difference(value).size > 0;
+
+  return (
+    <>
+      <IconButton
+        onClick={() => setShowFilterPopover(!showFilterPopover)}
+        ref={buttonRef}
+        sx={{ p: 0.6, "& svg": { fontSize: 14 } }}
+      >
+        <FilterLightIcon
+          sx={{
+            fill: ({ palette }) =>
+              isFiltered ? palette.blue[70] : palette.gray[50],
+            transition: ({ transitions }) => transitions.create("fill"),
+          }}
+        />
+      </IconButton>
+      <FilterPopover
+        buttonRef={buttonRef}
+        filter={filter}
+        setFilter={(newFilter) =>
+          setFilters({ ...filters, [columnId]: newFilter })
+        }
+        open={showFilterPopover}
+        onClose={() => setShowFilterPopover(false)}
+      />
+    </>
+  );
+};

--- a/apps/hash-frontend/src/pages/shared/virtualized-table/header/filter.tsx
+++ b/apps/hash-frontend/src/pages/shared/virtualized-table/header/filter.tsx
@@ -1,5 +1,5 @@
 import { IconButton } from "@hashintel/design-system";
-import type { FormControlLabelProps } from "@mui/material";
+import type { FormControlLabelProps, SxProps, Theme } from "@mui/material";
 import {
   Box,
   Checkbox,
@@ -64,6 +64,23 @@ const labelSx: FormControlLabelProps["sx"] = {
   },
 };
 
+const blueFilterButtonSx: SxProps<Theme> = ({ palette, transitions }) => ({
+  background: "transparent",
+  border: "none",
+  borderRadius: 1,
+  cursor: "pointer",
+  px: 1,
+  py: 0.5,
+  "& > span": {
+    color: palette.blue[70],
+    fontSize: 12,
+  },
+  "&:hover": {
+    background: palette.blue[20],
+  },
+  transition: transitions.create("background"),
+});
+
 const FilterPopover = <Filter extends VirtualizedTableFilter>({
   buttonRef,
   filter,
@@ -77,7 +94,7 @@ const FilterPopover = <Filter extends VirtualizedTableFilter>({
   open: boolean;
   onClose: () => void;
 }) => {
-  const { header, options, type, value: currentValue } = filter;
+  const { header, options, type, value: currentValue, initialValue } = filter;
 
   return (
     <Popover
@@ -116,28 +133,51 @@ const FilterPopover = <Filter extends VirtualizedTableFilter>({
           px: 0.4,
         })}
       >
-        <Typography
-          component="div"
-          variant="smallCaps"
-          sx={({ palette }) => ({
-            color: palette.gray[50],
-            mb: 1,
-            lineHeight: 1,
-            px: 1.4,
-          })}
+        <Stack
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
+          gap={1}
+          px={1.4}
+          mb={1}
         >
-          {header}
-        </Typography>
-        {/* if the filter 'type' is checkboxes, do MUI checkboxes. otherwise, do MUI radio group  */}
-
+          <Typography
+            component="div"
+            variant="smallCaps"
+            sx={({ palette }) => ({
+              color: palette.gray[50],
+              lineHeight: 1,
+            })}
+          >
+            {header}
+          </Typography>
+          <Box
+            component="button"
+            onClick={() => {
+              setFilter({
+                ...filter,
+                value:
+                  type === "checkboxes" ? new Set(initialValue) : initialValue,
+              });
+              onClose();
+            }}
+            sx={blueFilterButtonSx}
+          >
+            <Typography component="span">Reset</Typography>
+          </Box>
+        </Stack>
         {type === "checkboxes" ? (
-          <Stack>
-            <FormControl>
-              {Object.values(options)
-                .sort((a, b) => a.label.localeCompare(b.label))
-                .map(({ label, value, count }) => (
+          <FormControl>
+            {Object.values(options)
+              .sort((a, b) => a.label.localeCompare(b.label))
+              .map(({ label, value, count }) => (
+                <Stack
+                  key={value}
+                  direction="row"
+                  alignItems="center"
+                  sx={{ "&:hover > button": { visibility: "visible " } }}
+                >
                   <FormControlLabel
-                    key={value}
                     control={
                       <Checkbox
                         onChange={(event) => {
@@ -157,33 +197,41 @@ const FilterPopover = <Filter extends VirtualizedTableFilter>({
                     slotProps={createLabelSlotProps(value === null)}
                     sx={labelSx}
                   />
-                ))}
-            </FormControl>
-          </Stack>
+                  <Box
+                    component="button"
+                    onClick={() => {
+                      setFilter({ ...filter, value: new Set([value]) });
+                      onClose();
+                    }}
+                    sx={[blueFilterButtonSx, { visibility: "hidden" }]}
+                  >
+                    <Typography component="span">Only</Typography>
+                  </Box>
+                </Stack>
+              ))}
+          </FormControl>
         ) : (
-          <Stack>
-            <FormControl>
-              <RadioGroup
-                value={currentValue}
-                onChange={(event) => {
-                  setFilter({ ...filter, value: event.target.value });
-                }}
-              >
-                {Object.values(options)
-                  .sort((a, b) => a.label.localeCompare(b.label))
-                  .map(({ label, value, count }) => (
-                    <FormControlLabel
-                      key={value}
-                      value={value}
-                      control={<Radio sx={{ mr: 1.5 }} />}
-                      label={`${label} (${count})`}
-                      slotProps={createLabelSlotProps(value === null)}
-                      sx={labelSx}
-                    />
-                  ))}
-              </RadioGroup>
-            </FormControl>
-          </Stack>
+          <FormControl>
+            <RadioGroup
+              value={currentValue}
+              onChange={(event) => {
+                setFilter({ ...filter, value: event.target.value });
+              }}
+            >
+              {Object.values(options)
+                .sort((a, b) => a.label.localeCompare(b.label))
+                .map(({ label, value, count }) => (
+                  <FormControlLabel
+                    key={value}
+                    value={value}
+                    control={<Radio sx={{ mr: 1.5 }} />}
+                    label={`${label} (${count})`}
+                    slotProps={createLabelSlotProps(value === null)}
+                    sx={labelSx}
+                  />
+                ))}
+            </RadioGroup>
+          </FormControl>
         )}
       </Box>
     </Popover>

--- a/apps/hash-frontend/src/pages/shared/virtualized-table/header/filter.tsx
+++ b/apps/hash-frontend/src/pages/shared/virtualized-table/header/filter.tsx
@@ -295,9 +295,7 @@ export const FilterButton = <
 
   const [showFilterPopover, setShowFilterPopover] = useState(false);
 
-  if (Object.keys(filterDefinition.options).length < 2) {
-    return null;
-  }
+  const hasOnlyOneOption = Object.keys(filterDefinition.options).length < 2;
 
   const { type, initialValue } = filterDefinition;
 
@@ -316,19 +314,24 @@ export const FilterButton = <
 
   return (
     <>
-      <IconButton
-        onClick={() => setShowFilterPopover(!showFilterPopover)}
-        ref={buttonRef}
-        sx={{ p: 0.6, "& svg": { fontSize: 14 } }}
+      <Tooltip
+        title={hasOnlyOneOption ? "Only one filter option present" : ""}
+        placement="top"
       >
-        <FilterLightIcon
-          sx={{
-            fill: ({ palette }) =>
-              isFiltered ? palette.blue[70] : palette.gray[50],
-            transition: ({ transitions }) => transitions.create("fill"),
-          }}
-        />
-      </IconButton>
+        <IconButton
+          onClick={() => setShowFilterPopover(!showFilterPopover)}
+          ref={buttonRef}
+          sx={{ p: 0.6, "& svg": { fontSize: 14 } }}
+        >
+          <FilterLightIcon
+            sx={{
+              fill: ({ palette }) =>
+                isFiltered ? palette.blue[70] : palette.gray[50],
+              transition: ({ transitions }) => transitions.create("fill"),
+            }}
+          />
+        </IconButton>
+      </Tooltip>
       <FilterPopover
         buttonRef={buttonRef}
         filterDefinition={filterDefinition}

--- a/apps/hash-frontend/src/pages/shared/virtualized-table/header/filter.tsx
+++ b/apps/hash-frontend/src/pages/shared/virtualized-table/header/filter.tsx
@@ -256,7 +256,7 @@ const FilterPopover = <Filter extends VirtualizedTableFilterDefinition>({
 
 export type VirtualizedTableFilterDefinitionsByFieldId<
   Id extends string = string,
-> = Record<Id, VirtualizedTableFilterDefinition>;
+> = Record<Id, VirtualizedTableFilterDefinition | undefined>;
 
 export type VirtualizedTableFilterValuesByFieldId<Id extends string = string> =
   Record<Id, VirtualizedTableFilterValue>;
@@ -304,6 +304,10 @@ export const FilterButton = <
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   const [showFilterPopover, setShowFilterPopover] = useState(false);
+
+  if (!filterDefinition) {
+    return null;
+  }
 
   const hasOnlyOneOption = Object.keys(filterDefinition.options).length < 2;
 

--- a/apps/hash-frontend/src/pages/shared/virtualized-table/header/sort.tsx
+++ b/apps/hash-frontend/src/pages/shared/virtualized-table/header/sort.tsx
@@ -1,0 +1,49 @@
+import {
+  ArrowUpWideShortLightIcon,
+  IconButton,
+} from "@hashintel/design-system";
+
+export type VirtualizedTableSort<Id extends string = string> = {
+  fieldId: Id;
+  direction: "asc" | "desc";
+};
+
+export type TableSortProps<
+  Sort extends VirtualizedTableSort = VirtualizedTableSort,
+> = {
+  sort?: Sort;
+  setSort: (sort: Sort) => void;
+};
+
+export const SortButton = <Sort extends VirtualizedTableSort>({
+  columnId,
+  sort,
+  setSort,
+}: {
+  columnId: NonNullable<Sort["fieldId"]>;
+} & TableSortProps<Sort>) => {
+  const isSorted = sort?.fieldId === columnId;
+  const isSortedAscending = isSorted && sort.direction === "asc";
+
+  return (
+    <IconButton
+      onClick={() =>
+        setSort({
+          fieldId: columnId,
+          direction: isSortedAscending ? "desc" : "asc",
+        } as Sort)
+      }
+      sx={{ p: 0.6, "& svg": { fontSize: 15 } }}
+    >
+      <ArrowUpWideShortLightIcon
+        sx={{
+          fill: ({ palette }) =>
+            isSorted ? palette.blue[70] : palette.gray[50],
+          transform: isSortedAscending ? "rotate(180deg)" : "rotate(0deg)",
+          transition: ({ transitions }) =>
+            transitions.create(["transform", "fill"]),
+        }}
+      />
+    </IconButton>
+  );
+};

--- a/apps/hash-frontend/src/pages/shared/virtualized-table/use-filter-state.tsx
+++ b/apps/hash-frontend/src/pages/shared/virtualized-table/use-filter-state.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useRef, useState } from "react";
+import { typedEntries } from "@local/advanced-types/typed-entries";
+import { isEqual } from "lodash";
+import type {
+  VirtualizedTableFilterDefinitionsByFieldId,
+  VirtualizedTableFilterValuesByFieldId,
+} from "./header/filter";
+
+/**
+ * Maintain filter state for the virtualized table.
+ *
+ * The main purpose of this hook is to abstract away updating the filter values when the default filter values change:
+ * 1. Update to the new defaults where users have not made any changes
+ * 2. If the user has made changes, preserve their selections, while removing any options that are now invalid
+ */
+export const useVirtualizedTableFilterState = <
+  FilterValues extends VirtualizedTableFilterValuesByFieldId | null,
+>({
+  defaultFilterValues,
+  filterDefinitions,
+}: {
+  defaultFilterValues: FilterValues;
+  filterDefinitions?: VirtualizedTableFilterDefinitionsByFieldId;
+}) => {
+  const [filterValues, setFilterValues] = useState(defaultFilterValues);
+
+  const previousDefaultFilterValues = useRef<FilterValues>(defaultFilterValues);
+
+  /**
+   * Before the claims data has loaded, we don't have initialFilterValues to set filterValues to.
+   * Once it has, we initialize the filterValues with the initialFilterValues.
+   *
+   * We don't change them if filterValues exists, because the user may have set some filters,
+   * and we don't want to reset them each time new claim data arrives.
+   * This does mean that the user has to be aware that they have filters applied which may be hiding new data.
+   */
+  useEffect(() => {
+    if (!filterDefinitions) {
+      /**
+       * We don't have any definitions yet, so nothing else should have been initialized.
+       */
+      return;
+    }
+
+    if (!filterValues && defaultFilterValues) {
+      /**
+       * We may start off with no defaultFilterValues due to the way the data is loaded,
+       * in which case we initialize filterValues once defaultFilterValues is defined.
+       */
+      setFilterValues(defaultFilterValues);
+    } else if (
+      defaultFilterValues &&
+      !isEqual(defaultFilterValues, previousDefaultFilterValues.current)
+    ) {
+      /**
+       * The default filter values have changed, which may because possible values have added or removed,
+       * or because new columns have been added.
+       *
+       * We want to ensure the filterValues reflects the new options, while preserving the user's selections
+       * where possible.
+       */
+      setFilterValues((currentFilterValues) => {
+        const newFilterValues: FilterValues = {
+          ...defaultFilterValues,
+        };
+
+        if (!currentFilterValues || !previousDefaultFilterValues.current) {
+          /**
+           * It should be impossible to reach this, as we know defaultFilterValues is defined and if there's no
+           * filterValues we set it to defaultFilterValues above, previousDefaultFilterValues would have been set to
+           * defaultFilterValues. But this costs effectively nothing and is safer than a non-null assertion if the
+           * branching logic above is ever changed.
+           */
+          return newFilterValues;
+        }
+
+        for (const [columnId, defaultValue] of typedEntries(
+          defaultFilterValues,
+        )) {
+          const currentValue = currentFilterValues[columnId];
+          const filterOptions = filterDefinitions[columnId]?.options;
+          const previousFilterOptions = previousDefaultFilterValues.current;
+
+          if (!filterOptions) {
+            throw new Error(
+              `No filter options for column ${columnId}, which is present in defaultFilterValues.`,
+            );
+          }
+
+          const previousDefault = previousFilterOptions[columnId];
+
+          if (currentValue === undefined || !previousDefault) {
+            /**
+             * We didn't have this column previously, so we set it to its default.
+             */
+            newFilterValues[columnId] = defaultValue;
+          } else if (typeof currentValue === "string") {
+            /**
+             * This is a single value (radio group) filter.
+             */
+            if (filterOptions[currentValue]) {
+              /**
+               * If the currentValue is still a valid option, keep it.
+               * This does mean that if the default is changed, the new default will not be applied.
+               */
+              newFilterValues[columnId] = currentValue;
+            } else {
+              /**
+               * The currentValue is no longer valid for some reason – set the new default.
+               */
+              newFilterValues[columnId] = defaultValue;
+            }
+          } else {
+            if (typeof defaultValue === "string") {
+              throw new Error(
+                `Got string defaultValue '${defaultValue}' for columnId '${columnId}', expected Set`,
+              );
+            }
+            if (typeof previousDefault === "string") {
+              throw new Error(
+                `Got string previousDefault '${previousDefault}' for columnId '${columnId}', expected Set`,
+              );
+            }
+
+            /**
+             * This is a Set (checkbox group) filter.
+             */
+            if (currentValue === defaultValue) {
+              /**
+               * Shortcut in case the default value is the same Set in memory as the current value,
+               * meaning that it's untouched (since we don't mutate the Set when updating the filter values).
+               */
+              newFilterValues[columnId] = currentValue;
+            } else if (previousDefault.difference(currentValue).size === 0) {
+              /**
+               * The user may have deselected and reselected values, creating a new Set in memory,
+               * but their values may be functionally the same as the previous default, meaning
+               * that we want to update their values to the new default.
+               *
+               * This logic assumes that the default includes all possible values, meaning our check for equality
+               * is based on checking if the currentValue contains all values in the previous default.
+               */
+              newFilterValues[columnId] = defaultValue;
+            } else {
+              /**
+               * The user has deselected some values, so we want to preserve their selection.
+               * We need to check if each value in the current value is still a valid option.
+               *
+               * This does mean that there may be new possible values that are not selected.
+               */
+              const currentValueArray = Array.from(currentValue);
+              const newValues = new Set(currentValueArray);
+              for (const value of currentValueArray) {
+                if (!filterOptions[value]) {
+                  /**
+                   * If the value is no longer a valid option, remove it from the Set.
+                   */
+                  newValues.delete(value);
+                }
+              }
+              newFilterValues[columnId] = newValues;
+            }
+          }
+        }
+
+        return newFilterValues;
+      });
+    }
+
+    previousDefaultFilterValues.current = defaultFilterValues;
+  }, [filterDefinitions, filterValues, defaultFilterValues]);
+
+  return [filterValues, setFilterValues] as const;
+};

--- a/apps/hash-frontend/src/pages/workers.page.tsx
+++ b/apps/hash-frontend/src/pages/workers.page.tsx
@@ -52,9 +52,10 @@ import type {
   CreateVirtualizedRowContentFn,
   VirtualizedTableColumn,
   VirtualizedTableRow,
-  VirtualizedTableSort,
 } from "./shared/virtualized-table";
-import { headerHeight, VirtualizedTable } from "./shared/virtualized-table";
+import { VirtualizedTable } from "./shared/virtualized-table";
+import { headerHeight } from "./shared/virtualized-table/header";
+import type { VirtualizedTableSort } from "./shared/virtualized-table/header/sort";
 
 type FieldId =
   | "web"
@@ -279,7 +280,7 @@ const LoadingComponent = ({ columnCount }: { columnCount: number }) => (
 
 const WorkersPageContent = () => {
   const [sort, setSort] = useState<VirtualizedTableSort<FieldId>>({
-    field: "closedAt",
+    fieldId: "closedAt",
     direction: "desc",
   });
 
@@ -388,7 +389,7 @@ const WorkersPageContent = () => {
     );
 
     return rowData.sort((a, b) => {
-      const field = sort.field;
+      const field = sort.fieldId;
       const direction = sort.direction === "asc" ? 1 : -1;
 
       if (field === "web") {

--- a/apps/hash-frontend/src/shared/icons/filter-light-icon.tsx
+++ b/apps/hash-frontend/src/shared/icons/filter-light-icon.tsx
@@ -1,0 +1,11 @@
+import type { SvgIconProps } from "@mui/material";
+import { SvgIcon } from "@mui/material";
+import type { FunctionComponent } from "react";
+
+export const FilterLightIcon: FunctionComponent<SvgIconProps> = (props) => {
+  return (
+    <SvgIcon {...props} viewBox="0 0 512 512" fill="none">
+      <path d="M0 71.5C0 49.7 17.7 32 39.5 32l432.9 0C494.3 32 512 49.7 512 71.5c0 9.2-3.2 18.1-9.1 25.2L320 317.8l0 128.4c0 18.7-15.2 33.9-33.9 33.9c-7.5 0-14.8-2.5-20.8-7.1l-61-47.4c-7.8-6.1-12.4-15.4-12.4-25.3l0-82.4L9.1 96.7C3.2 89.6 0 80.7 0 71.5zM39.5 64c-4.2 0-7.5 3.4-7.5 7.5c0 1.8 .6 3.4 1.7 4.8L220.3 301.8c2.4 2.9 3.7 6.5 3.7 10.2l0 88.2 61 47.4c.3 .3 .7 .4 1.1 .4c1 0 1.9-.8 1.9-1.9L288 312c0-3.7 1.3-7.3 3.7-10.2L478.3 76.3c1.1-1.3 1.7-3 1.7-4.8c0-4.2-3.4-7.5-7.5-7.5L39.5 64z" />
+    </SvgIcon>
+  );
+};

--- a/libs/@local/hash-isomorphic-utils/src/flows/action-definitions.ts
+++ b/libs/@local/hash-isomorphic-utils/src/flows/action-definitions.ts
@@ -336,6 +336,12 @@ const actionDefinitionsAsConst = {
         array: true,
         required: true,
       },
+      {
+        payloadKind: "EntityId",
+        name: "highlightedEntities",
+        array: true,
+        required: true,
+      },
     ],
   },
   getWebPageSummary: {

--- a/libs/@local/hash-subgraph/src/stdlib.ts
+++ b/libs/@local/hash-subgraph/src/stdlib.ts
@@ -45,6 +45,10 @@ export {
   getEntityTypes,
   getEntityTypesByBaseUrl,
 } from "./stdlib/subgraph/element/entity-type.js";
+export {
+  getPossibleLinkTypesForEntityType,
+  isLinkEntityType,
+} from "./stdlib/subgraph/element/link-type.js";
 export { mapElementsIntoRevisions } from "./stdlib/subgraph/element/map-revisions.js";
 export {
   getPropertyTypeById,

--- a/libs/@local/hash-subgraph/src/stdlib/subgraph/element/link-type.ts
+++ b/libs/@local/hash-subgraph/src/stdlib/subgraph/element/link-type.ts
@@ -1,0 +1,64 @@
+import type { VersionedUrl } from "@blockprotocol/type-system/slim";
+import { typedKeys } from "@local/advanced-types/typed-entries";
+import type { EntityTypeWithMetadata } from "@local/hash-graph-types/ontology";
+
+import { linkEntityTypeUrl, type Subgraph } from "../../../main.js";
+import {
+  getEntityTypeAndParentsById,
+  getEntityTypeById,
+} from "./entity-type.js";
+
+/**
+ * Gets a map of all entityTypeIds for outgoing links from the entity type, to the full link entity types,
+ * including from any parents in the entity type's inheritance chain.
+ *
+ * The subgraph must be a result of having queried for an entity type with sufficiently high depth
+ * for constrainsLinksOn and inheritsFrom to contain all parent entity types and link entity types they reference.
+ *
+ * @param entityTypeId The entityTypeId to provide possible link types for
+ * @param subgraph a subgraph which is assumed to contain all relevant link types
+ *
+ * @throws Error if the subgraph does not contain a link entity type or parent entity type relied on by the entity type
+ *
+ * @todo this is a good candidate for moving to somewhere shared, possibly @blockprotocol/graph's stdlib
+ */
+export const getPossibleLinkTypesForEntityType = (
+  entityTypeId: VersionedUrl,
+  subgraph: Subgraph,
+) => {
+  const linkEntityTypesMap = new Map<string, EntityTypeWithMetadata>();
+  const entityTypeAndParents = getEntityTypeAndParentsById(
+    subgraph,
+    entityTypeId,
+  );
+
+  for (const entityType of entityTypeAndParents) {
+    for (const linkId of typedKeys(entityType.schema.links ?? {})) {
+      const linkEntityType = getEntityTypeById(subgraph, linkId);
+
+      if (!linkEntityType) {
+        throw new Error(
+          `Could not find link entity type ${linkId} for entity type ${entityType.schema.$id}`,
+        );
+      }
+
+      linkEntityTypesMap.set(linkId, linkEntityType);
+    }
+  }
+
+  return linkEntityTypesMap;
+};
+
+export const isLinkEntityType = (
+  entityTypeId: VersionedUrl,
+  subgraph: Subgraph,
+) => {
+  const entityTypeWithAncestors = getEntityTypeAndParentsById(
+    subgraph,
+    entityTypeId,
+  );
+
+  return entityTypeWithAncestors.some(
+    (entityType) => entityType.schema.$id === linkEntityTypeUrl,
+  );
+};

--- a/libs/@local/hash-subgraph/src/stdlib/subgraph/element/property-type.ts
+++ b/libs/@local/hash-subgraph/src/stdlib/subgraph/element/property-type.ts
@@ -329,7 +329,7 @@ const addPropertyTypesToMapFromReferences = (
 };
 
 /**
- * Gets a map of all property types referenced by the entity type to the provided map,
+ * Gets a map of all propertyTypeIds referenced by the entity type to the full property type,
  * including from any parents in its inheritance chain and nested property objects,
  *
  * The subgraph must be a result of having queried for an entity type with sufficiently high depth


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Introduce the following UX improvements to the tables in the flow run output tables:
1. Adds filters to the columns for the entities and claims tables
2. Adds loading state to the entities and claims tables
3. Show links as chips in the source entity's row, not individual rows
4. Adds a 'Relevance' column to the entities table, column allowing filtering discovered entities by which the AI has reported as most relevant to the research job
5. Move the 'graph / table' display switcher next to the 'Entities' table button
6. Fix breadcrumbs on Goals pages
7. Only show one output table at a time

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

Further testing of inference, improvements to agent behavior.
<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- None yet.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Run a flow locally.

