### PR TITLE
H-3299: Group Ory npm packages in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -117,6 +117,11 @@
       "matchPackagePatterns": ["@matejmazur/react-katex", "^katex"]
     },
     {
+      "groupName": "Ory npm packages",
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["^@ory/"]
+    },
+    {
       "groupName": "signia npm packages",
       "matchManagers": ["npm"],
       "matchPackagePatterns": ["^signia", "signia$"]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Ensures `@ory`-published npm packages will be treated as an update group by Renovate.
