### PR TITLE
H-3271: Add `yarn install` hook post-checkout/merge, make hooks opt-in

### DIFF
--- a/.config/husky/post-checkout
+++ b/.config/husky/post-checkout
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+yarn install

--- a/.config/husky/post-merge
+++ b/.config/husky/post-merge
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+yarn install

--- a/.config/husky/post-rewrite
+++ b/.config/husky/post-rewrite
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+yarn install

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,7 +31,7 @@ These apply across all projects:
   - Always include a link to the issue or discussion proposing the change.
   - Write tests to accompany your PR, or ask for help/guidance if this is a blocker.
   - Make sure that your PR doesn’t break existing tests.
-  - The repository follows a set of linting rules. Many of them can be applied automatically by running `yarn install` and `yarn fix`.
+  - The repository follows a set of linting rules. Many of them can be applied automatically by running `yarn install` and `yarn fix` and checked by running `yarn lint` (which includes a `tsc` check not covered or reported by `yarn fix`).
   - Sign our _Contributor License Agreement_ at the CLA Assistant's prompting. (To learn more, read [why we have a CLA])
 - Once you have receive a pull request review, please bear the following in mind:
   - reviewers may make suggestions for _optional_ changes which are not required to get your code merged. It should be obvious which suggestions are optional, and which are required changes. If it is not obvious, ask for clarification.

--- a/apps/hash/README.md
+++ b/apps/hash/README.md
@@ -86,6 +86,8 @@ To run HASH locally, please follow these steps:
 
 1. [Clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) this repository and **navigate to the root of the repository folder** in your terminal.
 
+1. (Optional) run `yarn install:hooks` to install git hooks that will (1) run `yarn install` when changing branches and (2) do basic formatting pre-commit.
+
 1. Install dependencies:
 
    ```sh
@@ -355,6 +357,10 @@ This is achieved by maintaining two parallel exports definitions for each packag
 
 1. The `exports` field in `package.json` should point to the transpiled JavaScript (and `typesVersions` to the type definition files)
 1. The `paths` map in the base TSConfig should map the same import paths to their TypeScript source
+
+A probably more straightforward approach we will move to in future is adding bundlers for all TypeScript applications, which would meet the same goals.
+Assuming this involves pointing `exports` fields in `package.json` to the original TypeScript files, any packages published to `npm` would need prepublish steps
+to update `exports` to point to the transpiled JavaScript in their `dist/` folder.
 
 During development (e.g. running `yarn dev` for an application), the `paths` override will be in effect, meaning that the source TypeScript
 is being run directly, and modifying any dependent file in the repo will trigger a reload of the application (assuming `tsx watch` or equivalent is used).

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "fix:markdownlint": "markdownlint --dot --fix .",
     "fix:prettier": "prettier --write  --ignore-unknown .",
     "fix:yarn-deduplicate": "yarn install && yarn-deduplicate --strategy=fewer && yarn install",
+    "install:hooks": "husky install .config/husky",
     "lint": "npm-run-all --continue-on-error \"lint:*\"",
     "@TODO.2": "Upgrade or remove these blocks and remove the --ignore-package options (also @TODO.1)",
     "lint:dependency-version-consistency": "check-dependency-version-consistency . --ignore-dep=@blockprotocol/graph --ignore-package=@apps/hashdotdev --ignore-package=@blocks/embed --ignore-package=@blocks/person",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "lint:prettier": "prettier --check --ignore-unknown .",
     "lint:tsc": "turbo --continue lint:tsc --",
     "lint:yarn-deduplicate": "yarn-deduplicate --fail --list --strategy=fewer",
-    "postinstall": "turbo run postinstall; patch-package --error-on-warn && husky install .config/husky",
+    "postinstall": "turbo run postinstall; patch-package --error-on-warn",
     "seed-data:opensearch": "yarn workspace @apps/hash-search-loader clear-opensearch",
     "seed-data:redis": "yarn workspace @apps/hash-realtime clear-redis",
     "seed-data": "concurrently \"yarn:seed-data:*\"",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR adds a git hook (via [husky](https://github.com/typicode/husky)) to install `yarn` dependencies after changing branches, merging branches, or rebasing. 

The motivation for this is to avoid occasional small amounts of time lost to issues which are caused by not installing dependencies when moving between branches.

Because this is a polyglot monorepo, and running `yarn` on checkout etc is more intrusive than existing `pre-commit` git hooks, this PR also moves the git hooks to _opt in_ via `yarn install:hooks`, and documents this in the HASH `README.md`.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Checkout the branch, check that `yarn` runs automatically
