### PR TITLE
H-3301: Remove unused Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "type-system",
  "utoipa",
  "uuid",
 ]
@@ -398,6 +397,8 @@ checksum = "caf6cfe2881cb1fcbba9ae946fb9a6480d3b7a714ca84c74925014a89ef3387a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http",
@@ -408,12 +409,15 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
+ "hex",
  "http 0.2.12",
  "hyper 0.14.30",
+ "ring 0.17.8",
  "time",
  "tokio",
  "tracing",
  "url",
+ "zeroize",
 ]
 
 [[package]]
@@ -485,6 +489,50 @@ dependencies = [
  "sha2",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6acca681c53374bf1d9af0e317a41d12a44902ca0f2d1e10e5cb5bb98ed74f35"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79c6bdfe612503a526059c05c9ccccbf6bd9530b003673cb863e547fd7c0c9a"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
 ]
 
 [[package]]
@@ -629,13 +677,17 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "fastrand",
+ "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "http-body 1.0.0",
  "httparse",
+ "hyper 0.14.30",
+ "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
+ "rustls 0.21.12",
  "tokio",
  "tracing",
 ]
@@ -2267,7 +2319,6 @@ dependencies = [
  "bytes",
  "clap",
  "codec",
- "criterion",
  "deadpool",
  "deadpool-postgres",
  "derive-where",
@@ -2275,15 +2326,12 @@ dependencies = [
  "error-stack 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "futures-sink",
- "graph-test-data",
  "graph-types",
  "hash-status",
- "mime",
  "postgres-types",
  "refinery",
  "regex",
  "semver",
- "sentry",
  "serde",
  "serde_json",
  "tarpc",
@@ -2293,7 +2341,6 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-serde",
- "tokio-util",
  "tracing",
  "type-fetcher",
  "type-system",
@@ -2310,16 +2357,12 @@ dependencies = [
  "authorization",
  "axum 0.7.5",
  "axum-core 0.4.3",
- "base64 0.22.1",
  "bytes",
  "error-stack 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures",
  "graph",
  "graph-types",
  "hash-status",
- "hash-tracing",
  "http 1.1.0",
- "http-body-util",
  "hyper 1.4.1",
  "include_dir",
  "mime",
@@ -2348,13 +2391,11 @@ dependencies = [
  "authorization",
  "criterion",
  "criterion-macro",
- "futures",
  "graph",
  "graph-test-data",
  "graph-types",
  "rand",
  "repo-chores",
- "serde",
  "serde_json",
  "temporal-versioning",
  "tokio",
@@ -2372,20 +2413,16 @@ version = "0.0.0"
 dependencies = [
  "authorization",
  "error-stack 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures",
  "graph",
  "graph-test-data",
  "graph-types",
  "hash-tracing",
  "pretty_assertions",
- "rand",
- "serde",
  "serde_json",
  "temporal-versioning",
  "time",
  "tokio",
  "tokio-postgres",
- "tracing",
  "tracing-subscriber",
  "type-system",
  "uuid",
@@ -2404,7 +2441,6 @@ dependencies = [
  "error-stack 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "graph-test-data",
  "postgres-types",
- "pretty_assertions",
  "semver",
  "serde",
  "serde_json",
@@ -2541,13 +2577,10 @@ dependencies = [
  "futures",
  "graph",
  "graph-api",
- "graph-types",
  "hash-tracing",
  "mimalloc",
  "regex",
  "reqwest",
- "semver",
- "serde_json",
  "tarpc",
  "temporal-client 0.0.0",
  "test-server",
@@ -2558,8 +2591,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "type-fetcher",
- "type-system",
- "uuid",
  "validation",
 ]
 
@@ -2567,9 +2598,7 @@ dependencies = [
 name = "hash-status"
 version = "0.0.0"
 dependencies = [
- "error-stack 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2775,9 +2804,6 @@ version = "0.0.0"
 dependencies = [
  "orx-concurrent-vec",
  "serde",
- "serde-value",
- "serde_json",
- "sval",
  "text-size",
 ]
 
@@ -2787,7 +2813,6 @@ version = "0.0.0"
 dependencies = [
  "ariadne",
  "ecow",
- "error-stack 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hifijson",
  "hql-cst",
  "hql-diagnostics",
@@ -2800,7 +2825,6 @@ dependencies = [
  "serde_json",
  "test-fuzz",
  "text-size",
- "thiserror",
  "unicode-ident",
  "winnow",
 ]
@@ -2930,6 +2954,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.30",
+ "log",
+ "rustls 0.21.12",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -4399,21 +4439,12 @@ dependencies = [
  "lazy_static",
  "once_cell",
  "opentelemetry 0.23.0",
- "ordered-float 4.2.1",
+ "ordered-float",
  "percent-encoding",
  "rand",
  "thiserror",
  "tokio",
  "tokio-stream",
-]
-
-[[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -5002,7 +5033,6 @@ dependencies = [
 name = "query-builder-derive"
 version = "0.0.0"
 dependencies = [
- "syn 2.0.71",
  "trybuild",
  "virtue",
 ]
@@ -5324,7 +5354,7 @@ dependencies = [
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.4.1",
- "hyper-rustls",
+ "hyper-rustls 0.27.2",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -5834,16 +5864,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float 2.10.1",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5982,6 +6002,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -6173,12 +6202,6 @@ name = "supports-unicode"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
-
-[[package]]
-name = "sval"
-version = "2.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53eb957fbc79a55306d5d25d87daf3627bc3800681491cda0709eef36c748bfe"
 
 [[package]]
 name = "syn"
@@ -6640,6 +6663,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
@@ -7130,7 +7154,6 @@ dependencies = [
  "serde",
  "tarpc",
  "time",
- "tokio",
  "tracing",
  "type-system",
 ]
@@ -7359,13 +7382,10 @@ dependencies = [
 name = "validation"
 version = "0.0.0"
 dependencies = [
- "chrono",
- "email_address",
  "error-stack 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "graph-test-data",
  "graph-types",
- "iso8601-duration",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2373,7 +2373,6 @@ dependencies = [
  "temporal-client 0.0.0",
  "temporal-versioning",
  "time",
- "tower",
  "tower-http",
  "tracing",
  "tracing-opentelemetry 0.24.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1950,7 +1950,6 @@ dependencies = [
  "regex",
  "rustc_version",
  "serde",
- "serde_json",
  "spin 0.9.8",
  "supports-color",
  "supports-unicode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -284,3 +284,7 @@ separated_literal_suffix = "allow" # opposite of `clippy::unseparated_literal_su
 shadow_reuse = "allow"
 shadow_same = "allow"
 unneeded_field_pattern = "allow" # Actually, the opposite would be a great lint
+
+[workspace.metadata.cargo-shear]
+# We use the `futures` crate but the dependencies are required for public dependencies
+ignored = ["futures-core", "futures-io", "futures-sink"]

--- a/apps/hash-graph/bins/cli/Cargo.toml
+++ b/apps/hash-graph/bins/cli/Cargo.toml
@@ -17,12 +17,10 @@ codec = { workspace = true }
 error-stack = { workspace = true }
 graph = { workspace = true, features = ["clap"] }
 graph-api = { workspace = true }
-graph-types = { workspace = true }
 hash-tracing = { workspace = true, features = ["clap"] }
 temporal-client = { workspace = true }
 test-server = { workspace = true, optional = true }
 type-fetcher = { workspace = true }
-type-system = { workspace = true }
 validation = { workspace = true }
 
 # Third party dependencies
@@ -33,8 +31,6 @@ futures = { workspace = true }
 mimalloc = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["rustls-tls"] }
-semver = { workspace = true }
-serde_json = { workspace = true }
 tarpc = { workspace = true, features = ["serde1", "tokio1", "serde-transport", "tcp"] }
 time = { workspace = true }
 tokio = { workspace = true }
@@ -42,7 +38,6 @@ tokio-postgres = { workspace = true }
 tokio-serde = { workspace = true, features = ["json"] }
 tokio-util = { workspace = true, features = ["codec"] }
 tracing = { workspace = true }
-uuid = { workspace = true }
 
 [features]
 test-server = ["dep:test-server"]

--- a/apps/hash-graph/bins/cli/package.json
+++ b/apps/hash-graph/bins/cli/package.json
@@ -4,12 +4,10 @@
   "private": true,
   "license": "AGPL-3",
   "dependencies": {
-    "@blockprotocol/type-system-rs": "0.0.0-private",
     "@rust/authorization": "0.0.0-private",
     "@rust/codec": "0.0.0-private",
     "@rust/graph": "0.0.0-private",
     "@rust/graph-api": "0.0.0-private",
-    "@rust/graph-types": "0.0.0-private",
     "@rust/hash-tracing": "0.0.0-private",
     "@rust/temporal-client": "0.0.0-private",
     "@rust/test-server": "0.0.0-private",

--- a/apps/hash-graph/libs/api/Cargo.toml
+++ b/apps/hash-graph/libs/api/Cargo.toml
@@ -47,10 +47,13 @@ sentry = { workspace = true }
 serde = { workspace = true, features = ['derive'] }
 serde_json = { workspace = true }
 time = { workspace = true }
-tower = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 utoipa = { workspace = true }
 uuid = { workspace = true }
 
 [lints]
 workspace = true
+
+[package.metadata.cargo-shear]
+# Used as public dependency
+ignored = ["axum-core"]

--- a/apps/hash-graph/libs/api/Cargo.toml
+++ b/apps/hash-graph/libs/api/Cargo.toml
@@ -30,19 +30,14 @@ tower-http = { workspace = true, public = true }
 tracing = { workspace = true, public = true }
 
 # Private workspace dependencies
-codec = { workspace = true, optional = true }
 error-stack = { workspace = true }
-hash-tracing = { workspace = true }
 temporal-versioning = { workspace = true }
 type-system = { workspace = true, features = ["utoipa"] }
 validation = { workspace = true, features = ["utoipa"] }
 
 # Private third-party dependencies
 async-trait = { workspace = true }
-base64 = { workspace = true }
 bytes = { workspace = true }
-futures = { workspace = true }
-http-body-util = { workspace = true }
 hyper = { workspace = true }
 include_dir = { workspace = true }
 mime = { workspace = true }
@@ -52,9 +47,6 @@ sentry = { workspace = true }
 serde = { workspace = true, features = ['derive'] }
 serde_json = { workspace = true }
 time = { workspace = true }
-tokio = { workspace = true, features = ["macros"], optional = true }
-tokio-postgres = { workspace = true, default-features = false, optional = true }
-tokio-util = { workspace = true, features = ["io"], optional = true }
 tower = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 utoipa = { workspace = true }

--- a/apps/hash-graph/libs/api/package.json
+++ b/apps/hash-graph/libs/api/package.json
@@ -13,7 +13,6 @@
     "@rust/graph": "0.0.0-private",
     "@rust/graph-types": "0.0.0-private",
     "@rust/hash-status": "0.0.0-private",
-    "@rust/hash-tracing": "0.0.0-private",
     "@rust/temporal-client": "0.0.0-private",
     "@rust/temporal-versioning": "0.0.0-private",
     "@rust/validation": "0.0.0-private"

--- a/apps/hash-graph/libs/graph/Cargo.toml
+++ b/apps/hash-graph/libs/graph/Cargo.toml
@@ -44,26 +44,20 @@ clap = { workspace = true, features = ["derive", "env"], optional = true }
 derive-where = { workspace = true }
 dotenv-flow = { workspace = true }
 futures = { workspace = true }
-mime = { workspace = true }
 postgres-types = { workspace = true, features = ["derive", "with-serde_json-1"] }
 refinery = { workspace = true, features = ["tokio-postgres"] }
 regex = { workspace = true }
 semver = { workspace = true, features = ["serde"] }
-sentry = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tarpc = { workspace = true, features = ["serde-transport", "tcp"] }
 time = { workspace = true }
 tokio-serde = { workspace = true, features = ["json"] }
-tokio-util = { workspace = true, features = ["io"] }
 tracing = { workspace = true }
 utoipa = { workspace = true, features = ["uuid"], optional = true }
 uuid = { workspace = true, features = ["v4", "v5", "serde"] }
 
 [dev-dependencies]
-graph-test-data = { workspace = true }
-
-criterion = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 
 [features]

--- a/apps/hash-graph/libs/graph/Cargo.toml
+++ b/apps/hash-graph/libs/graph/Cargo.toml
@@ -71,3 +71,7 @@ utoipa = [
 
 [lints]
 workspace = true
+
+[package.metadata.cargo-shear]
+# Used as public dependency
+ignored = ["deadpool"]

--- a/apps/hash-graph/libs/graph/package.json
+++ b/apps/hash-graph/libs/graph/package.json
@@ -19,7 +19,6 @@
     "@rust/validation": "0.0.0-private"
   },
   "devDependencies": {
-    "@rust/graph-test-data": "0.0.0-private",
     "tsx": "4.16.2"
   }
 }

--- a/apps/hash-graph/libs/query-builder-derive/Cargo.toml
+++ b/apps/hash-graph/libs/query-builder-derive/Cargo.toml
@@ -16,7 +16,6 @@ proc-macro = true
 
 # Third-party dependencies
 virtue = { workspace = true }
-syn = { workspace = true }
 
 [dev-dependencies]
 trybuild = { workspace = true }

--- a/apps/hash-graph/libs/type-fetcher/Cargo.toml
+++ b/apps/hash-graph/libs/type-fetcher/Cargo.toml
@@ -23,7 +23,6 @@ futures = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
 tarpc = { workspace = true, features = ["tokio1"] }
-tokio = { workspace = true, features = ["macros"] }
 tracing = { workspace = true }
 
 [lints]

--- a/libs/@local/hash-authorization/Cargo.toml
+++ b/libs/@local/hash-authorization/Cargo.toml
@@ -18,7 +18,6 @@ futures-core = { workspace = true, public = true }
 # Private workspace dependencies
 codec = { workspace = true }
 error-stack = { workspace = true }
-type-system = { workspace = true }
 
 # Private third-party dependencies
 derive-where = { workspace = true }

--- a/libs/@local/hash-authorization/package.json
+++ b/libs/@local/hash-authorization/package.json
@@ -10,7 +10,6 @@
     "test:unit:disabled": "cargo hack nextest run --feature-powerset --lib && cargo test --all-features --doc"
   },
   "dependencies": {
-    "@blockprotocol/type-system-rs": "0.0.0-private",
     "@rust/codec": "0.0.0-private",
     "@rust/graph-types": "0.0.0-private"
   }

--- a/libs/@local/hash-graph-types/rust/Cargo.toml
+++ b/libs/@local/hash-graph-types/rust/Cargo.toml
@@ -33,7 +33,6 @@ uuid = { workspace = true, default-features = false, features = ["serde", "v5"] 
 
 [dev-dependencies]
 graph-test-data = { workspace = true }
-pretty_assertions = { workspace = true }
 
 [features]
 postgres = ["dep:postgres-types", "temporal-versioning/postgres"]

--- a/libs/@local/hash-validation/Cargo.toml
+++ b/libs/@local/hash-validation/Cargo.toml
@@ -19,10 +19,7 @@ error-stack = { workspace = true, features = ["hooks"] }
 type-system = { workspace = true }
 
 # Private third-party dependencies
-chrono = { workspace = true, features = ["std"] }
-email_address = { workspace = true }
 futures = { workspace = true }
-iso8601-duration = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/libs/@local/hql/span/Cargo.toml
+++ b/libs/@local/hql/span/Cargo.toml
@@ -18,15 +18,10 @@ authors.workspace = true
 # Private third-party dependencies
 orx-concurrent-vec = { workspace = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
-serde-value = { workspace = true, optional = true }
-sval = { workspace = true }
 text-size = { workspace = true }
 
 [features]
-serde = ["dep:serde", "dep:serde-value", "text-size/serde"]
+serde = ["dep:serde", "text-size/serde"]
 
 [lints]
 workspace = true
-
-[dev-dependencies]
-serde_json = { workspace = true }

--- a/libs/@local/hql/span/Cargo.toml
+++ b/libs/@local/hql/span/Cargo.toml
@@ -17,7 +17,7 @@ authors.workspace = true
 
 # Private third-party dependencies
 orx-concurrent-vec = { workspace = true }
-serde = { workspace = true, optional = true, features = ["derive"] }
+serde = { workspace = true, optional = true, features = ["alloc", "derive"] }
 text-size = { workspace = true }
 
 [features]

--- a/libs/@local/hql/syntax-jexpr/Cargo.toml
+++ b/libs/@local/hql/syntax-jexpr/Cargo.toml
@@ -22,11 +22,9 @@ text-size = { workspace = true, public = true }
 
 # Private third-party dependencies
 ecow = { workspace = true }
-error-stack = { workspace = true }
 hifijson = { workspace = true, features = ["alloc"] }
 json-number = { workspace = true }
 logos = { workspace = true, features = ["export_derive"] }
-thiserror = { workspace = true }
 unicode-ident = { workspace = true }
 winnow = { workspace = true, features = ["std"] }
 

--- a/libs/@local/status/rust/Cargo.toml
+++ b/libs/@local/status/rust/Cargo.toml
@@ -16,7 +16,7 @@ extra-dependencies = [{ name = "@local/status", version = "0.0.0-private" }]
 # Public workspace dependencies
 
 # Public third-party dependencies
-serde = { workspace = true, public = true, features = ["derive"] }
+serde = { workspace = true, public = true, features = ["alloc", "derive"] }
 
 # Private workspace dependencies
 

--- a/libs/@local/status/rust/Cargo.toml
+++ b/libs/@local/status/rust/Cargo.toml
@@ -19,10 +19,8 @@ extra-dependencies = [{ name = "@local/status", version = "0.0.0-private" }]
 serde = { workspace = true, public = true, features = ["derive"] }
 
 # Private workspace dependencies
-error-stack = { workspace = true }
 
 # Private third-party dependencies
-serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -90,3 +90,7 @@ doc-scrape-examples = true
 [[test]]
 name = "common"
 test = false
+
+[package.metadata.cargo-shear]
+# Used in doc-tests
+ignored = ["thiserror", "owo-colors"]

--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -29,7 +29,6 @@ tracing-error = { version = "0.2", optional = true, default-features = false }
 
 [dev-dependencies]
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
 futures = { workspace = true, default-features = false, features = ["executor"] }
 trybuild = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }

--- a/libs/error-stack/macros/Cargo.toml
+++ b/libs/error-stack/macros/Cargo.toml
@@ -23,3 +23,6 @@ error-stack = { path = "..", default-features = false }
 
 [lints]
 workspace = true
+
+[package.metadata.cargo-shear]
+ignored = ["error-stack"]

--- a/tests/hash-graph-benches/Cargo.toml
+++ b/tests/hash-graph-benches/Cargo.toml
@@ -46,3 +46,7 @@ path = "read_scaling/lib.rs"
 [[bench]]
 name = "representative_read"
 path = "representative_read/lib.rs"
+
+[package.metadata.cargo-shear]
+# Cargo shear does not detect these dependencies
+ignored = ["tokio-postgres", "tracing-subscriber", "repo-chores", "tracing-flame", "tracing"]

--- a/tests/hash-graph-benches/Cargo.toml
+++ b/tests/hash-graph-benches/Cargo.toml
@@ -15,20 +15,19 @@ authors.workspace = true
 autobenches = false
 
 [dev-dependencies]
+# Private workspace dependencies
+authorization = { workspace = true }
 graph = { workspace = true }
 graph-test-data = { workspace = true }
 graph-types = { workspace = true }
-temporal-versioning = { workspace = true }
-authorization = { workspace = true }
 repo-chores = { workspace = true }
-
+temporal-versioning = { workspace = true }
 type-system = { workspace = true }
 
+# Private third-party dependencies
 criterion = { workspace = true, features = ["async_tokio", "html_reports"] }
 criterion-macro = { workspace = true }
-futures = { workspace = true }
 rand = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 tokio-postgres = { workspace = true, default-features = false }

--- a/tests/hash-graph-integration/Cargo.toml
+++ b/tests/hash-graph-integration/Cargo.toml
@@ -9,27 +9,24 @@ publish.workspace = true
 authors.workspace = true
 
 [dev-dependencies]
+# Private workspace dependencies
+authorization = { workspace = true }
+error-stack = { workspace = true, features = ["spantrace"] }
 graph = { workspace = true }
 graph-test-data = { workspace = true }
 graph-types = { workspace = true }
-temporal-versioning = { workspace = true }
-authorization = { workspace = true }
 hash-tracing = { workspace = true }
-
-error-stack = { workspace = true, features = ["spantrace"] }
+temporal-versioning = { workspace = true }
 type-system = { workspace = true }
 
-futures = { workspace = true, default-features = false }
+# Private third-party dependencies
 pretty_assertions = { workspace = true }
-rand = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true, default-features = false, features = ["macros"] }
 tokio-postgres = { workspace = true, default-features = false }
-uuid = { workspace = true, features = ["v4", "serde"] }
-tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+uuid = { workspace = true, features = ["v4", "serde"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

I have not found a way to properly check this automatically, but cargo-machete does a decent jobs after some manual tweaks (it does not support Rust 2024 and has a lot of false positives, however, it detected quite a few unused dependencies)