### PR TITLE
H-3308: Pass `null` for `dataTypeId` if not known

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/infer-entities-from-content-action.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/infer-entities-from-content-action.ts
@@ -184,7 +184,7 @@ export const inferEntitiesFromContentAction: FlowActionActivity = async ({
         ).reduce<PropertyMetadataObject>(
           (acc, propertyKey) => {
             acc.value[propertyKey] = {
-              metadata: { provenance: { sources: [source] } },
+              metadata: { dataTypeId: null, provenance: { sources: [source] } },
             };
 
             return acc;

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/propose-entities-from-claims/propose-entity-from-claims-agent.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/propose-entities-from-claims/propose-entity-from-claims-agent.ts
@@ -148,7 +148,10 @@ const generatePropertyMetadata = (params: {
     }
 
     propertyMetadata.value[baseUrl] = {
-      metadata: { provenance: { sources: sourcesUsedToDetermineValue } },
+      metadata: {
+        dataTypeId: null,
+        provenance: { sources: sourcesUsedToDetermineValue },
+      },
     };
   }
 

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/entity-result-table.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/entity-result-table.tsx
@@ -403,7 +403,7 @@ const TableRow = memo(
             return (
               <PropertyValueCell
                 key={column.id}
-                metadata={metadata}
+                metadata={{ dataTypeId: null, ...metadata }}
                 value={propertyValue}
               />
             );

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -8117,6 +8117,9 @@
       },
       "ValueMetadata": {
         "type": "object",
+        "required": [
+          "dataTypeId"
+        ],
         "properties": {
           "confidence": {
             "allOf": [
@@ -8130,7 +8133,8 @@
               {
                 "$ref": "#/components/schemas/VersionedUrl"
               }
-            ]
+            ],
+            "nullable": true
           },
           "provenance": {
             "$ref": "#/components/schemas/PropertyProvenance"

--- a/apps/hash-graph/tests/ambiguous.http
+++ b/apps/hash-graph/tests/ambiguous.http
@@ -174,7 +174,9 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     "value": {
       "http://localhost:3000/@alice/types/property-type/length/": {
         "value": 10,
-        "metadata": {}
+        "metadata": {
+          "dataTypeId": null
+        }
       }
     }
   },

--- a/libs/@local/hash-graph-sdk/typescript/src/entity.ts
+++ b/libs/@local/hash-graph-sdk/typescript/src/entity.ts
@@ -313,7 +313,9 @@ export const mergePropertiesAndMetadata = (
       // If the keys are not base urls, we treat the object as a value
       return {
         value: property,
-        metadata: {},
+        metadata: {
+          dataTypeId: null,
+        },
       } satisfies PropertyValueWithMetadata;
     }
     if (isObjectMetadata(metadata)) {
@@ -361,7 +363,9 @@ export const mergePropertiesAndMetadata = (
   if (!metadata) {
     return {
       value: property,
-      metadata: {},
+      metadata: {
+        dataTypeId: null,
+      },
     } satisfies PropertyValueWithMetadata;
   }
 

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/metadata/value.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/metadata/value.rs
@@ -12,8 +12,8 @@ pub struct ValueMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     pub confidence: Option<Confidence>,
-    #[serde(default)]
-    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
+    #[serde(with = "core::option::Option")]
+    #[cfg_attr(feature = "utoipa", schema(required = true))]
     pub data_type_id: Option<VersionedUrl>,
 }
 

--- a/libs/@local/hash-graph-types/typescript/src/entity.ts
+++ b/libs/@local/hash-graph-types/typescript/src/entity.ts
@@ -125,7 +125,7 @@ export type Property = PropertyValue | PropertyArray | PropertyObject;
  */
 export type PropertyMetadataValue = {
   metadata: Omit<ValueMetadata, "dataTypeId"> & {
-    dataTypeId?: VersionedUrl;
+    dataTypeId: VersionedUrl | null;
   };
 };
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Instead of omitting the data type ID if unknown should pass `null` so the graph can distinguish between values which are shaped as properties and values.