### PR TITLE
H-3311: Use Rust edition 2021

### DIFF
--- a/.github/scripts/rust/sync-turborepo.rs
+++ b/.github/scripts/rust/sync-turborepo.rs
@@ -1,9 +1,7 @@
 #!/usr/bin/env -S cargo +nightly -Zscript
 ---
-cargo-features = ["edition2024"]
-
 [package]
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 serde = { version = "*", features = ["derive"] }

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,5 +1,5 @@
 # General
-edition = "2024" # Default: "2015"
+edition = "2021" # Default: "2015"
 unstable_features = true # Default: false
 version = "Two" # Default: "One"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [workspace]
 members = [
     "apps/hash-graph/bins/cli",
@@ -34,12 +32,12 @@ members = [
 default-members = [
     "apps/hash-graph/bins/*",
 ]
-resolver = "3"
+resolver = "2"
 
 [workspace.package]
 authors = ["HASH"]
 version = "0.0.0"
-edition = "2024"
+edition = "2021"
 license = "AGPL-3"
 publish = false
 

--- a/apps/hash-graph/bins/cli/Cargo.toml
+++ b/apps/hash-graph/bins/cli/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "hash-graph"
 version.workspace = true

--- a/apps/hash-graph/bins/cli/src/subcommand/mod.rs
+++ b/apps/hash-graph/bins/cli/src/subcommand/mod.rs
@@ -6,7 +6,7 @@ mod snapshot;
 mod test_server;
 mod type_fetcher;
 
-use core::time::Duration;
+use core::{future::Future, time::Duration};
 
 use error_stack::{ensure, Result};
 use hash_tracing::{init_tracing, TracingConfig};

--- a/apps/hash-graph/libs/api/Cargo.toml
+++ b/apps/hash-graph/libs/api/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "graph-api"
 version.workspace = true

--- a/apps/hash-graph/libs/graph/Cargo.toml
+++ b/apps/hash-graph/libs/graph/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "graph"
 version.workspace = true

--- a/apps/hash-graph/libs/graph/src/store/crud.rs
+++ b/apps/hash-graph/libs/graph/src/store/crud.rs
@@ -6,6 +6,8 @@
 //!
 //! [`Store`]: crate::store::Store
 
+use core::future::Future;
+
 use async_trait::async_trait;
 use error_stack::Result;
 use futures::{Stream, TryStreamExt};

--- a/apps/hash-graph/libs/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/libs/graph/src/store/knowledge.rs
@@ -1,5 +1,5 @@
 use alloc::borrow::Cow;
-use core::{error::Error, fmt};
+use core::{error::Error, fmt, future::Future};
 use std::collections::HashSet;
 
 use authorization::{schema::EntityRelationAndSubject, zanzibar::Consistency};

--- a/apps/hash-graph/libs/graph/src/store/ontology.rs
+++ b/apps/hash-graph/libs/graph/src/store/ontology.rs
@@ -1,5 +1,5 @@
 use alloc::borrow::Cow;
-use core::iter;
+use core::{future::Future, iter};
 use std::collections::HashMap;
 
 use authorization::schema::{

--- a/apps/hash-graph/libs/graph/src/store/pool.rs
+++ b/apps/hash-graph/libs/graph/src/store/pool.rs
@@ -1,4 +1,5 @@
 use alloc::sync::Arc;
+use core::future::Future;
 
 use authorization::AuthorizationApi;
 use error_stack::{Context, Result};

--- a/apps/hash-graph/libs/query-builder-derive/Cargo.toml
+++ b/apps/hash-graph/libs/query-builder-derive/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "query-builder-derive"
 version.workspace = true

--- a/apps/hash-graph/libs/test-server/Cargo.toml
+++ b/apps/hash-graph/libs/test-server/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "test-server"
 version.workspace = true

--- a/apps/hash-graph/libs/type-fetcher/Cargo.toml
+++ b/apps/hash-graph/libs/type-fetcher/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "type-fetcher"
 version.workspace = true

--- a/libs/@blockprotocol/type-system/rust/Cargo.toml
+++ b/libs/@blockprotocol/type-system/rust/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "type-system"
 description = "Definitions of types within the Block Protocol Type System"

--- a/libs/@blockprotocol/type-system/rust/src/lib.rs
+++ b/libs/@blockprotocol/type-system/rust/src/lib.rs
@@ -16,7 +16,7 @@ mod utils;
 use alloc::sync::Arc;
 #[cfg(feature = "postgres")]
 use core::error::Error;
-use core::{borrow::Borrow, fmt::Debug, ops::Deref, ptr};
+use core::{borrow::Borrow, fmt::Debug, future::Future, ops::Deref, ptr};
 
 #[cfg(feature = "postgres")]
 use bytes::BytesMut;

--- a/libs/@blockprotocol/type-system/rust/src/schema/property_type/validation.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/property_type/validation.rs
@@ -1,3 +1,5 @@
+use core::future::Future;
+
 use thiserror::Error;
 
 use crate::{

--- a/libs/@local/codec/Cargo.toml
+++ b/libs/@local/codec/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "codec"
 version.workspace = true

--- a/libs/@local/harpc/net/Cargo.toml
+++ b/libs/@local/harpc/net/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "harpc-net"
 version.workspace = true

--- a/libs/@local/harpc/net/src/codec.rs
+++ b/libs/@local/harpc/net/src/codec.rs
@@ -1,5 +1,5 @@
 use alloc::sync::Arc;
-use core::error::Error;
+use core::{error::Error, future::Future};
 
 use bytes::Bytes;
 use error_stack::{Context, Report, Result};

--- a/libs/@local/harpc/net/src/session/test.rs
+++ b/libs/@local/harpc/net/src/session/test.rs
@@ -1,5 +1,10 @@
 use alloc::sync::Arc;
-use core::{future::ready, iter, net::Ipv4Addr, time::Duration};
+use core::{
+    future::{ready, Future},
+    iter,
+    net::Ipv4Addr,
+    time::Duration,
+};
 
 use bytes::Bytes;
 use error_stack::{Report, ResultExt};

--- a/libs/@local/harpc/tower/Cargo.toml
+++ b/libs/@local/harpc/tower/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "harpc-tower"
 version.workspace = true

--- a/libs/@local/harpc/tower/src/body/mod.rs
+++ b/libs/@local/harpc/tower/src/body/mod.rs
@@ -10,6 +10,7 @@ pub mod stream;
 pub mod timeout;
 
 use core::{
+    future::Future,
     ops::DerefMut,
     pin::Pin,
     task::{Context, Poll},

--- a/libs/@local/harpc/tower/src/body/timeout.rs
+++ b/libs/@local/harpc/tower/src/body/timeout.rs
@@ -1,4 +1,5 @@
 use core::{
+    future::Future,
     pin::Pin,
     task::{Context, Poll},
     time::Duration,

--- a/libs/@local/harpc/tower/src/layer/error.rs
+++ b/libs/@local/harpc/tower/src/layer/error.rs
@@ -1,6 +1,7 @@
 use core::{
     error::Error,
     fmt::{self, Debug, Display, Formatter},
+    future::Future,
     task::{Context, Poll},
 };
 

--- a/libs/@local/harpc/tower/src/layer/report.rs
+++ b/libs/@local/harpc/tower/src/layer/report.rs
@@ -1,4 +1,7 @@
-use core::task::{Context, Poll};
+use core::{
+    future::Future,
+    task::{Context, Poll},
+};
 
 use bytes::Bytes;
 use error_stack::Report;

--- a/libs/@local/harpc/types/Cargo.toml
+++ b/libs/@local/harpc/types/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "harpc-types"
 version.workspace = true

--- a/libs/@local/harpc/wire-protocol/Cargo.toml
+++ b/libs/@local/harpc/wire-protocol/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "harpc-wire-protocol"
 version.workspace = true

--- a/libs/@local/hash-authorization/Cargo.toml
+++ b/libs/@local/hash-authorization/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "authorization"
 version.workspace = true

--- a/libs/@local/hash-authorization/src/api.rs
+++ b/libs/@local/hash-authorization/src/api.rs
@@ -1,3 +1,4 @@
+use core::future::Future;
 use std::collections::HashMap;
 
 use error_stack::{Context, Result};

--- a/libs/@local/hash-authorization/src/backend/mod.rs
+++ b/libs/@local/hash-authorization/src/backend/mod.rs
@@ -1,6 +1,6 @@
 mod spicedb;
 
-use core::{error::Error, fmt, iter::repeat};
+use core::{error::Error, fmt, future::Future, iter::repeat};
 
 use error_stack::Report;
 use futures::{stream, Stream};

--- a/libs/@local/hash-graph-types/rust/Cargo.toml
+++ b/libs/@local/hash-graph-types/rust/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "graph-types"
 version.workspace = true

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/mod.rs
@@ -383,14 +383,17 @@ impl PropertyWithMetadata {
 }
 
 impl Property {
-    pub gen fn properties(&self) -> (PropertyPath<'_>, &JsonValue) {
+    // TODO: Replace with `gen fn`
+    pub fn properties(&self) -> impl Iterator<Item = (PropertyPath<'_>, &JsonValue)> {
+        let mut vec = Vec::new();
         let mut elements = PropertyPath::default();
         match self {
             Self::Array(array) => {
                 for (index, property) in array.iter().enumerate() {
                     elements.push(index);
-                    for yielded in Box::new(property.properties()) {
-                        yield yielded;
+                    for yielded in property.properties() {
+                        // yield yielded;
+                        vec.push(yielded);
                     }
                     elements.pop();
                 }
@@ -398,14 +401,19 @@ impl Property {
             Self::Object(object) => {
                 for (key, property) in object.properties() {
                     elements.push(key);
-                    for yielded in Box::new(property.properties()) {
-                        yield yielded;
+                    for yielded in property.properties() {
+                        // yield yielded;
+                        vec.push(yielded);
                     }
                     elements.pop();
                 }
             }
-            Self::Value(property) => yield (elements.clone(), property),
+            Self::Value(property) => {
+                // yield (elements.clone(), property)
+                vec.push((elements.clone(), property));
+            }
         }
+        vec.into_iter()
     }
 
     #[must_use]
@@ -433,15 +441,18 @@ impl Property {
         Some(value)
     }
 
-    gen fn diff_array<'a>(
+    // TODO: Replace with `gen fn`
+    fn diff_array<'a>(
         lhs: &'a [Self],
         rhs: &'a [Self],
         path: &mut PropertyPath<'a>,
-    ) -> PropertyDiff<'a> {
+    ) -> impl Iterator<Item = PropertyDiff<'a>> {
+        let mut vec = Vec::new();
         for (index, (lhs, rhs)) in lhs.iter().zip(rhs).enumerate() {
             path.push(index);
-            for yielded in Box::new(lhs.diff(rhs, path)) {
-                yield yielded;
+            for yielded in lhs.diff(rhs, path) {
+                // yield yielded;
+                vec.push(yielded);
             }
             path.pop();
         }
@@ -450,10 +461,14 @@ impl Property {
             Ordering::Less => {
                 for (index, property) in rhs.iter().enumerate().skip(lhs.len()) {
                     path.push(index);
-                    yield PropertyDiff::Added {
+                    // yield PropertyDiff::Added {
+                    //     path: path.clone(),
+                    //     added: Cow::Borrowed(property),
+                    // };
+                    vec.push(PropertyDiff::Added {
                         path: path.clone(),
                         added: Cow::Borrowed(property),
-                    };
+                    });
                     path.pop();
                 }
             }
@@ -461,65 +476,87 @@ impl Property {
             Ordering::Greater => {
                 for (index, property) in lhs.iter().enumerate().skip(rhs.len()) {
                     path.push(index);
-                    yield PropertyDiff::Removed {
+                    // yield PropertyDiff::Removed {
+                    //     path: path.clone(),
+                    //     removed: Cow::Borrowed(property),
+                    // };
+                    vec.push(PropertyDiff::Removed {
                         path: path.clone(),
                         removed: Cow::Borrowed(property),
-                    };
+                    });
                     path.pop();
                 }
             }
         }
+        vec.into_iter()
     }
 
-    gen fn diff_object<'a>(
+    // TODO: Replace with `gen fn`
+    fn diff_object<'a>(
         lhs: &'a HashMap<BaseUrl, Self>,
         rhs: &'a HashMap<BaseUrl, Self>,
         path: &mut PropertyPath<'a>,
-    ) -> PropertyDiff<'a> {
+    ) -> impl Iterator<Item = PropertyDiff<'a>> {
+        let mut vec = Vec::new();
         for (key, property) in lhs {
             path.push(key);
             let other_property = rhs.get(key);
             if let Some(other_property) = other_property {
-                for yielded in Box::new(property.diff(other_property, path)) {
-                    yield yielded;
+                for yielded in property.diff(other_property, path) {
+                    // yield yielded;
+                    vec.push(yielded);
                 }
             } else {
-                yield PropertyDiff::Removed {
+                // yield PropertyDiff::Removed {
+                //     path: path.clone(),
+                //     removed: Cow::Borrowed(property),
+                // };
+                vec.push(PropertyDiff::Removed {
                     path: path.clone(),
                     removed: Cow::Borrowed(property),
-                };
+                });
             }
             path.pop();
         }
         for (key, property) in rhs {
             if !lhs.contains_key(key) {
                 path.push(key);
-                yield PropertyDiff::Added {
+                // yield PropertyDiff::Added {
+                //     path: path.clone(),
+                //     added: Cow::Borrowed(property),
+                // };
+                vec.push(PropertyDiff::Added {
                     path: path.clone(),
                     added: Cow::Borrowed(property),
-                };
+                });
+
                 path.pop();
             }
         }
+        vec.into_iter()
     }
 
-    pub gen fn diff<'a>(
+    // TODO: Replace with `gen fn`
+    pub fn diff<'a>(
         &'a self,
         other: &'a Self,
         path: &mut PropertyPath<'a>,
-    ) -> PropertyDiff<'a> {
+    ) -> impl Iterator<Item = PropertyDiff<'a>> {
+        let mut vec = Vec::new();
         let mut changed = false;
         match (self, other) {
             (Self::Array(lhs), Self::Array(rhs)) => {
                 for yielded in Self::diff_array(lhs, rhs, path) {
                     changed = true;
-                    yield yielded;
+                    // yield yielded;
+                    vec.push(yielded);
                 }
             }
             (Self::Object(lhs), Self::Object(rhs)) => {
                 for yielded in Self::diff_object(lhs.properties(), rhs.properties(), path) {
                     changed = true;
-                    yield yielded;
+                    // yield yielded;
+                    vec.push(yielded);
                 }
             }
             (lhs, rhs) => {
@@ -528,12 +565,18 @@ impl Property {
         }
 
         if changed {
-            yield PropertyDiff::Changed {
+            // yield PropertyDiff::Changed {
+            //     path: path.clone(),
+            //     old: Cow::Borrowed(self),
+            //     new: Cow::Borrowed(other),
+            // };
+            vec.push(PropertyDiff::Changed {
                 path: path.clone(),
                 old: Cow::Borrowed(self),
                 new: Cow::Borrowed(other),
-            };
+            });
         }
+        vec.into_iter()
     }
 }
 

--- a/libs/@local/hash-validation/Cargo.toml
+++ b/libs/@local/hash-validation/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "validation"
 version.workspace = true

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -13,7 +13,7 @@ mod entity_type;
 mod property;
 mod property_type;
 
-use core::borrow::Borrow;
+use core::{borrow::Borrow, future::Future};
 
 use error_stack::{Context, Report};
 use graph_types::{

--- a/libs/@local/hash-validation/src/property_type.rs
+++ b/libs/@local/hash-validation/src/property_type.rs
@@ -1,4 +1,4 @@
-use core::borrow::Borrow;
+use core::{borrow::Borrow, future::Future};
 use std::collections::HashMap;
 
 use error_stack::{bail, Report, ResultExt};

--- a/libs/@local/hql/cst/Cargo.toml
+++ b/libs/@local/hql/cst/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "hql-cst"
 version.workspace = true

--- a/libs/@local/hql/diagnostics/Cargo.toml
+++ b/libs/@local/hql/diagnostics/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "hql-diagnostics"
 version.workspace = true

--- a/libs/@local/hql/span/Cargo.toml
+++ b/libs/@local/hql/span/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "hql-span"
 version.workspace = true

--- a/libs/@local/hql/syntax-jexpr/Cargo.toml
+++ b/libs/@local/hql/syntax-jexpr/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "hql-syntax-jexpr"
 authors.workspace = true

--- a/libs/@local/repo-chores/rust/Cargo.toml
+++ b/libs/@local/repo-chores/rust/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "repo-chores"
 version.workspace = true

--- a/libs/@local/status/rust/Cargo.toml
+++ b/libs/@local/status/rust/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "hash-status"
 description = "The HASH Status and Error Model."

--- a/libs/@local/temporal-client/Cargo.toml
+++ b/libs/@local/temporal-client/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "temporal-client"
 version.workspace = true

--- a/libs/@local/temporal-client/src/lib.rs
+++ b/libs/@local/temporal-client/src/lib.rs
@@ -5,6 +5,8 @@ pub use self::error::{ConfigError, ConnectionError, WorkflowError};
 mod ai;
 mod error;
 
+use core::future::{Future, IntoFuture};
+
 use error_stack::{Report, ResultExt};
 use temporal_io_client::{Client, ClientOptions, ClientOptionsBuilder, RetryClient};
 use url::Url;

--- a/libs/@local/temporal-versioning/Cargo.toml
+++ b/libs/@local/temporal-versioning/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "temporal-versioning"
 version.workspace = true

--- a/libs/@local/tracing/Cargo.toml
+++ b/libs/@local/tracing/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "hash-tracing"
 version.workspace = true

--- a/tests/hash-graph-benches/Cargo.toml
+++ b/tests/hash-graph-benches/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "graph-benches"
 version.workspace = true

--- a/tests/hash-graph-integration/Cargo.toml
+++ b/tests/hash-graph-integration/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "graph-integration"
 version.workspace = true

--- a/tests/hash-graph-test-data/rust/Cargo.toml
+++ b/tests/hash-graph-test-data/rust/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "graph-test-data"
 version.workspace = true


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently use the unstable 2024 edition. We don't have issues with that directly, however, some tools like renovate have issues with unstable features. To prevent issues we can use the old edition.

## 🔍 What does this change?

- Replace `gen fn` with vector-based approach (to be reverted with edition 2024 but it should not have meaningful impact currently)
- Use faster approach to count types (2024 is smarter about lifetimes)
- Add missing imports
