### PR TITLE
GEN-51: Run Renovate through GitHub Actions

### DIFF
--- a/.github/actions/install-rust-toolchain/action.yml
+++ b/.github/actions/install-rust-toolchain/action.yml
@@ -3,7 +3,7 @@ description: "Install Rust toolchain"
 
 inputs:
   toolchain:
-    required: true
+    required: false
     description: "Rust toolchain, e.g. 'stable' or 'nightly'"
   working-directory:
     description: "Working directory to run the action in"
@@ -26,21 +26,26 @@ runs:
         else
           RUST_TOOLCHAIN_FILE="rust-toolchain.toml"
         fi
-        # extract components from the rust-toolchain.toml 
+        # extract components from the rust-toolchain.toml
         COMPONENTS="$(cat $RUST_TOOLCHAIN_FILE | yq -p toml '.toolchain.components[]')"
 
-        rustup toolchain install "${{ inputs.toolchain }}"
+        if [[ "${{ inputs.toolchain }}" != "" ]]; then
+          TOOLCHAIN_CHANNEL="${{ inputs.toolchain }}"
+        else
+          TOOLCHAIN_CHANNEL="$(cat $RUST_TOOLCHAIN_FILE | yq -p toml '.toolchain.channel')"
+        fi
+        rustup toolchain install "$TOOLCHAIN_CHANNEL"
 
         for component in $COMPONENTS; do
           # depending on the toolchain we need to conditionally skip specific components
-          if [[ ! "${{ inputs.toolchain }}" =~ $NIGHTLY_TOOLCHAIN ]]; then
+          if [[ ! "$$TOOLCHAIN_CHANNEL" =~ $NIGHTLY_TOOLCHAIN ]]; then
             # ensure that we only install components that are meant for stable
             if [[ ! $component =~ $NIGHTLY_ONLY ]]; then
-              rustup component add --toolchain "${{ inputs.toolchain }}" "$component"
+              rustup component add --toolchain "$TOOLCHAIN_CHANNEL" "$component"
             fi
           else
-            rustup component add --toolchain "${{ inputs.toolchain }}" "$component"  
+            rustup component add --toolchain "$TOOLCHAIN_CHANNEL" "$component"
           fi
         done
 
-        echo "RUSTUP_TOOLCHAIN=${{ inputs.toolchain }}" >> $GITHUB_ENV
+        echo "RUSTUP_TOOLCHAIN=$TOOLCHAIN_CHANNEL" >> $GITHUB_ENV

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,7 @@
 
   "automerge": true,
   "branchPrefix": "deps/",
+  "configMigration": true,
   "dependencyDashboard": true,
   "dependencyDashboardApproval": true,
   "dependencyDashboardTitle": "🚀 Dependency Updates",

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -11,10 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    # Further restrict this to
+    # TODO: Further restrict this to
     # - Check the PR author (not only the actor)
     # - Check the event (only commits should trigger auto-approvals)
     # - (optional) check for green CI
+    # see: https://linear.app/hash/issue/H-3313/further-restrict-auto-approval-workflow
     if: github.actor == 'hash-worker[bot]' && startsWith(github.head_ref, 'deps/')
     steps:
       - name: Renovate

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: github.actor == 'Renovate[bot]' && startsWith(github.head_ref, 'deps/')
+    if: github.actor == 'hash-worker[bot]' && startsWith(github.head_ref, 'deps/')
     steps:
       - name: Renovate
         uses: hmarr/auto-approve-action@v4

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+    # Further restrict this to
+    # - Check the PR author (not only the actor)
+    # - Check the event (only commits should trigger auto-approvals)
+    # - (optional) check for green CI
     if: github.actor == 'hash-worker[bot]' && startsWith(github.head_ref, 'deps/')
     steps:
       - name: Renovate

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,19 @@
+name: Auto-approve
+
+on:
+  pull_request_target:
+    branches:
+      - main
+
+jobs:
+  auto-approve:
+    name: Dependency bump
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: github.actor == 'Renovate[bot]' && startsWith(github.head_ref, 'deps/')
+    steps:
+      - name: Renovate
+        uses: hmarr/auto-approve-action@v4
+        with:
+          github-token: ${{ secrets.MACHINE_USER_TOKEN }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -35,34 +35,45 @@ on:
   schedule:
     # Run every 30 minutes
     - cron: "0/30 * * * *"
-  pull_request:
 
 env:
   cache_archive: renovate_cache.tar.gz
   cache_dir: /tmp/renovate/cache/renovate/repository
   cache_key: renovate-cache
+  dry_run: ${{ github.event.inputs.dryRun || 'disabled' }}
 
 concurrency:
-  cancel-in-progress: true
+  cancel-in-progress: false
   group: renovate
+
+permissions:
+  contents: write
 
 jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
-      #      - name: Get token
-      #        id: app-token
-      #        uses: actions/create-github-app-token@v1
-      #        with:
-      #          app-id: ${{ secrets.APP_ID }}
-      #          private-key: ${{ secrets.PRIVATE_KEY }}
+      - name: Get token
+        id: app-token
+        uses: actions/create-github-app-token@3378cda945da322a8db4b193e19d46352ebe2de5 # v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
-          token: ${{ secrets.MACHINE_USER_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
-      - uses: dawidd6/action-download-artifact@v2
+      - name: Install Rust toolchain
+        uses: ./.github/actions/install-rust-toolchain
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: dawidd6/action-download-artifact@268677152d06ba59fcec7a7f0b5d961b6ccd7e1e # v2
         if: github.event.inputs.repoCache != 'disabled'
         continue-on-error: true
         with:
@@ -70,6 +81,7 @@ jobs:
           path: cache-download
 
       - name: Extract renovate cache
+        if: github.event.inputs.repoCache != 'disabled'
         run: |
           if [ ! -d cache-download ] ; then
             echo "No cache found."
@@ -79,29 +91,25 @@ jobs:
           mkdir -p $cache_dir
           tar -xzf cache-download/$cache_archive -C $cache_dir
 
-          sudo chown -R runneradmin:root /tmp/renovate/
-          ls -R $cache_dir
+      - name: Install renovate
+        run: npm install -g renovate
 
       - name: Run renovate
-        uses: renovatebot/github-action@v40.2.7
-        with:
-          token: ${{ secrets.MACHINE_USER_TOKEN }}
-          configurationFile: .github/renovate.json
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
           RENOVATE_FORCE: ${{ github.event.inputs.overrideSchedule == 'true' && '{"schedule":null}' || '' }}
-          #          RENOVATE_DRY_RUN: ${{ inputs.dryRun == 'disabled' && 'null' || inputs.dryRun }}
-          RENOVATE_DRY_RUN: full
+          RENOVATE_DRY_RUN: ${{ env.dry_run == 'disabled' && 'null' || inputs.dryRun }}
           RENOVATE_PLATFORM_COMMIT: enabled
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           # TODO: Consider using S3 by setting `RENOVATE_REPOSITORY_CACHE_TYPE`
           RENOVATE_REPOSITORY_CACHE: ${{ github.event.inputs.repoCache || 'enabled' }}
+        run: renovate --token ${{ steps.app-token.outputs.token }}
 
       - name: Compress renovate cache
         run: tar -czvf $cache_archive -C $cache_dir .
 
-      - uses: actions/upload-artifact@v3
-        if: github.event.inputs.repoCache != 'disabled'
+      - uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
+        if: env.dry_run == 'disabled' && github.event.inputs.repoCache != 'disabled'
         with:
           name: ${{ env.cache_key }}
           path: ${{ env.cache_archive }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -38,8 +38,8 @@ jobs:
           configurationFile: .github/renovate.json
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
-          RENOVATE_FORCE: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}
-          RENOVATE_USERNAME: HASH
+          RENOVATE_FORCE: ${{ github.event.inputs.overrideSchedule == 'true' && '{"schedule":null}' || '' }}
+          RENOVATE_USERNAME: HASH[bot]
           RENOVATE_GIT_AUTHOR: HASH <careers@hash.dev>
           RENOVATE_PLATFORM_COMMIT: "true"
           RENOVATE_REPOSITORIES: ${{ github.repository }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -58,12 +58,10 @@ jobs:
       - name: Authenticate Vault
         id: secrets
         uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c # v3.0.0
-        env:
-          VAULT_ROLE: "dev"
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: jwt
-          role: ${{ env.VAULT_ROLE }}
+          role: dev
           secrets: |
             automation/data/pipelines/hash/dev github_worker_app_id | GITHUB_WORKER_APP_ID ;
             automation/data/pipelines/hash/dev github_worker_app_private_key | GITHUB_WORKER_APP_PRIVATE_KEY ;

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,4 +1,4 @@
-name: Fix
+name: Update dependencies
 on:
   workflow_dispatch:
     inputs:
@@ -24,7 +24,6 @@ on:
 concurrency: renovate
 jobs:
   renovate:
-    name: Update dependencies
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -35,6 +34,7 @@ jobs:
       - name: Run renovate
         uses: renovatebot/github-action@v40.2.7
         with:
+          token: ${{ secrets.MACHINE_USER_TOKEN }}
           configurationFile: .github/renovate.json
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -41,3 +41,5 @@ jobs:
           RENOVATE_FORCE: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}
           RENOVATE_USERNAME: HASH
           RENOVATE_GIT_AUTHOR: HASH <careers@hash.dev>
+          RENOVATE_PLATFORM_COMMIT: "true"
+          RENOVATE_REPOSITORIES: ${{ github.repository }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -35,7 +35,6 @@ on:
   schedule:
     # Run every 30 minutes
     - cron: "0/30 * * * *"
-  pull_request:
 
 env:
   cache_archive: renovate_cache.tar.gz

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -114,6 +114,7 @@ jobs:
           RENOVATE_PLATFORM_COMMIT: enabled
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           # TODO: Consider using S3 by setting `RENOVATE_REPOSITORY_CACHE_TYPE`
+          # see: https://linear.app/hash/issue/H-3315/use-s3-to-store-renovate-cache
           RENOVATE_REPOSITORY_CACHE: ${{ github.event.inputs.repoCache || 'enabled' }}
         run: renovate --token ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,43 @@
+name: Fix
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Override default log level"
+        required: false
+        default: "info"
+        type: choice
+        options:
+          - "debug"
+          - "info"
+          - "warn"
+          - "error"
+      overrideSchedule:
+        description: "Override all schedules"
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    # Run every 30 minutes
+    - cron: "0/30 * * * *"
+  pull_request:
+concurrency: renovate
+jobs:
+  renovate:
+    name: Update dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          token: ${{ secrets.MACHINE_USER_TOKEN }}
+
+      - name: Run renovate
+        uses: renovatebot/github-action@v40.2.7
+        with:
+          configurationFile: .github/renovate.json
+        env:
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
+          RENOVATE_FORCE: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}
+          RENOVATE_USERNAME: HASH
+          RENOVATE_GIT_AUTHOR: HASH <careers@hash.dev>

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -32,9 +32,10 @@ on:
           - extract
           - lookup
           - full
-#  schedule:
-# Run every 30 minutes
-#    - cron: "0/30 * * * *"
+  schedule:
+    # Run every 30 minutes
+    - cron: "0/30 * * * *"
+  pull_request:
 
 env:
   cache_archive: renovate_cache.tar.gz

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -2,11 +2,18 @@ name: Update dependencies
 on:
   workflow_dispatch:
     inputs:
+      repoCache:
+        description: "Reset or disable the cache?"
+        type: choice
+        default: enabled
+        options:
+          - enabled
+          - disabled
+          - reset
       logLevel:
         description: "Override default log level"
-        required: false
-        default: "info"
         type: choice
+        default: info
         options:
           - "debug"
           - "info"
@@ -14,22 +21,65 @@ on:
           - "error"
       overrideSchedule:
         description: "Override all schedules"
-        required: false
-        default: false
         type: boolean
-  schedule:
-    # Run every 30 minutes
-    - cron: "0/30 * * * *"
-  pull_request:
-concurrency: renovate
+        default: false
+      dryRun:
+        description: "Dry run mode"
+        type: choice
+        default: disabled
+        options:
+          - disabled
+          - extract
+          - lookup
+          - full
+#  schedule:
+# Run every 30 minutes
+#    - cron: "0/30 * * * *"
+
+env:
+  cache_archive: renovate_cache.tar.gz
+  cache_dir: /tmp/renovate/cache/renovate/repository
+  cache_key: renovate-cache
+
+concurrency:
+  cancel-in-progress: true
+  group: renovate
+
 jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
+      #      - name: Get token
+      #        id: app-token
+      #        uses: actions/create-github-app-token@v1
+      #        with:
+      #          app-id: ${{ secrets.APP_ID }}
+      #          private-key: ${{ secrets.PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           token: ${{ secrets.MACHINE_USER_TOKEN }}
+
+      - uses: dawidd6/action-download-artifact@v2
+        if: github.event.inputs.repoCache != 'disabled'
+        continue-on-error: true
+        with:
+          name: ${{ env.cache_key }}
+          path: cache-download
+
+      - name: Extract renovate cache
+        run: |
+          if [ ! -d cache-download ] ; then
+            echo "No cache found."
+            exit 0
+          fi
+
+          mkdir -p $cache_dir
+          tar -xzf cache-download/$cache_archive -C $cache_dir
+
+          sudo chown -R runneradmin:root /tmp/renovate/
+          ls -R $cache_dir
 
       - name: Run renovate
         uses: renovatebot/github-action@v40.2.7
@@ -39,7 +89,19 @@ jobs:
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
           RENOVATE_FORCE: ${{ github.event.inputs.overrideSchedule == 'true' && '{"schedule":null}' || '' }}
-          RENOVATE_USERNAME: HASH[bot]
-          RENOVATE_GIT_AUTHOR: HASH <careers@hash.dev>
-          RENOVATE_PLATFORM_COMMIT: "true"
+          #          RENOVATE_DRY_RUN: ${{ inputs.dryRun == 'disabled' && 'null' || inputs.dryRun }}
+          RENOVATE_DRY_RUN: full
+          RENOVATE_PLATFORM_COMMIT: enabled
           RENOVATE_REPOSITORIES: ${{ github.repository }}
+          # TODO: Consider using S3 by setting `RENOVATE_REPOSITORY_CACHE_TYPE`
+          RENOVATE_REPOSITORY_CACHE: ${{ github.event.inputs.repoCache || 'enabled' }}
+
+      - name: Compress renovate cache
+        run: tar -czvf $cache_archive -C $cache_dir .
+
+      - uses: actions/upload-artifact@v3
+        if: github.event.inputs.repoCache != 'disabled'
+        with:
+          name: ${{ env.cache_key }}
+          path: ${{ env.cache_archive }}
+          retention-days: 1

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -35,6 +35,7 @@ on:
   schedule:
     # Run every 30 minutes
     - cron: "0/30 * * * *"
+  pull_request:
 
 env:
   cache_archive: renovate_cache.tar.gz

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -53,12 +53,25 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
+      - name: Authenticate Vault
+        id: secrets
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c # v3.0.0
+        env:
+          VAULT_ROLE: "dev"
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: jwt
+          role: ${{ env.VAULT_ROLE }}
+          secrets: |
+            automation/data/pipelines/hash/dev github_worker_app_id | GITHUB_WORKER_APP_ID ;
+            automation/data/pipelines/hash/dev github_worker_app_private_key | GITHUB_WORKER_APP_PRIVATE_KEY ;
+
       - name: Get token
         id: app-token
         uses: actions/create-github-app-token@3378cda945da322a8db4b193e19d46352ebe2de5 # v1
         with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.PRIVATE_KEY }}
+          app-id: ${{ steps.secrets.outputs.GITHUB_WORKER_APP_ID }}
+          private-key: ${{ steps.secrets.outputs.GITHUB_WORKER_APP_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -49,6 +49,7 @@ concurrency:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   renovate:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With renovate being self-hosted it's possible to use a nightly version of Cargo which is required to properly generate artifacts. The hosted instance of renovate does not (and probably never will!) support nightly toolchains.

Further, we are in full control of the invocations and have access to self-hosted configurations.

## 🔍 What does this change?

- Add a workflow to run renovate every 30 min and on manual dispatch
	- The flow will authenticate with Vault and use the stored credentials for the [HASH worker bot](https://github.com/apps/hash-worker)
	- It installs Rust (the toolchain specified in `rust-toolchain.toml` and node)
	- Runs renovate
	- Stores the renovate cache (quite small) as GH artifact. In the future we might want to use S3 for that
- Add an auto-approval bot for dependencies. It will run if (and only if) the target branch is `main`, the actor (not the author of the PR) is the HASH worker, and the branch starts with `deps/`
- Allow renovate to create config-file migration PRs

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- The Rust dependency bumps still results in empty commits which is the reason why a lot of PRs are not created properly (this is a dedicated issue), but we won't get artifact-update problems with this PR
- We might need to further restrict the auto-approval constraints, but for now this should be good enough

## 🐾 Next steps

- Use S3 as Cache
- Figure out why some Rust dependencies are not bumped properly