### PR TITLE
Revert H-3311: Bump Rust edition back to 2024

### DIFF
--- a/.github/scripts/rust/sync-turborepo.rs
+++ b/.github/scripts/rust/sync-turborepo.rs
@@ -1,7 +1,9 @@
 #!/usr/bin/env -S cargo +nightly -Zscript
 ---
+cargo-features = ["edition2024"]
+
 [package]
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 serde = { version = "*", features = ["derive"] }

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,5 +1,5 @@
 # General
-edition = "2021" # Default: "2015"
+edition = "2024" # Default: "2015"
 unstable_features = true # Default: false
 version = "Two" # Default: "One"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2496,12 +2496,12 @@ dependencies = [
  "harpc-wire-protocol",
  "humansize",
  "libp2p",
- "libp2p-core 0.41.3",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-ping 0.44.1",
+ "libp2p-ping",
  "libp2p-stream",
- "libp2p-swarm 0.44.2",
- "libp2p-yamux 0.45.1",
+ "libp2p-swarm",
+ "libp2p-yamux",
  "multiaddr",
  "multistream-select",
  "pin-project-lite",
@@ -2788,7 +2788,7 @@ dependencies = [
  "ariadne",
  "error-stack 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hql-span",
- "jsonptr 0.6.0",
+ "jsonptr",
  "serde",
  "serde_json",
  "serde_with",
@@ -2817,7 +2817,7 @@ dependencies = [
  "hql-span",
  "insta",
  "json-number",
- "jsonptr 0.5.1",
+ "jsonptr",
  "logos",
  "serde",
  "serde_json",
@@ -3325,12 +3325,6 @@ dependencies = [
 
 [[package]]
 name = "jsonptr"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71259ee688a462beeac976f9bede505d1b42db27c0f811a99ad1086d499aebc"
-
-[[package]]
-name = "jsonptr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da813f8b5a216ec36e2d562a97d18d458a847df98d3c7f6f1f88d848cbc9381"
@@ -3487,19 +3481,19 @@ dependencies = [
  "getrandom",
  "libp2p-allow-block-list",
  "libp2p-connection-limits",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-dns",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-noise",
- "libp2p-ping 0.45.0",
+ "libp2p-ping",
  "libp2p-quic",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-upnp",
- "libp2p-yamux 0.46.0",
+ "libp2p-yamux",
  "multiaddr",
  "pin-project",
  "rw-stream-sink",
@@ -3512,9 +3506,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1027ccf8d70320ed77e984f273bc8ce952f623762cb9bf2d126df73caef8041"
 dependencies = [
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "void",
 ]
 
@@ -3524,38 +3518,10 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d003540ee8baef0d254f7b6bfd79bac3ddf774662ca0abf69186d517ef82ad8"
 dependencies = [
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "void",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.41.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a8920cbd8540059a01950c1e5c96ea8d89eb50c51cd366fc18bdf540a6e48f"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "libp2p-identity",
- "multiaddr",
- "multihash",
- "multistream-select",
- "once_cell",
- "parking_lot",
- "pin-project",
- "quick-protobuf",
- "rand",
- "rw-stream-sink",
- "smallvec",
- "thiserror",
- "tracing",
- "unsigned-varint 0.8.0",
- "void",
- "web-time",
 ]
 
 [[package]]
@@ -3595,7 +3561,7 @@ dependencies = [
  "async-trait",
  "futures",
  "hickory-resolver",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
  "parking_lot",
  "smallvec",
@@ -3613,9 +3579,9 @@ dependencies = [
  "futures",
  "futures-bounded",
  "futures-timer",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "lru",
  "quick-protobuf",
  "quick-protobuf-codec",
@@ -3653,9 +3619,9 @@ dependencies = [
  "futures",
  "hickory-proto",
  "if-watch",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "rand",
  "smallvec",
  "socket2",
@@ -3671,11 +3637,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ebafa94a717c8442d8db8d3ae5d1c6a15e30f2d347e0cd31d057ca72e42566"
 dependencies = [
  "futures",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identify",
  "libp2p-identity",
- "libp2p-ping 0.45.0",
- "libp2p-swarm 0.45.1",
+ "libp2p-ping",
+ "libp2p-swarm",
  "pin-project",
  "prometheus-client",
  "web-time",
@@ -3691,7 +3657,7 @@ dependencies = [
  "bytes",
  "curve25519-dalek",
  "futures",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
  "multiaddr",
  "multihash",
@@ -3709,24 +3675,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1de5a6cf64fba7f7e8f2102711c9c6c043a8e56b86db8cd306492c517da3fb3"
-dependencies = [
- "either",
- "futures",
- "futures-timer",
- "instant",
- "libp2p-core 0.41.3",
- "libp2p-identity",
- "libp2p-swarm 0.44.2",
- "rand",
- "tracing",
- "void",
-]
-
-[[package]]
-name = "libp2p-ping"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "005a34420359223b974ee344457095f027e51346e992d1e0dcd35173f4cdd422"
@@ -3734,9 +3682,9 @@ dependencies = [
  "either",
  "futures",
  "futures-timer",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "rand",
  "tracing",
  "void",
@@ -3753,7 +3701,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
  "libp2p-tls",
  "parking_lot",
@@ -3774,32 +3722,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d454f6647bc9054e7fede2dc86e625786c4d1304bff7afc995285f53ef9091f0"
 dependencies = [
  "futures",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.45.1",
+ "libp2p-swarm",
  "rand",
- "tracing",
- "void",
-]
-
-[[package]]
-name = "libp2p-swarm"
-version = "0.44.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80cae6cb75f89dbca53862f9ebe0b9f463aa7b302762fcfaafb9e51dcc9b0f7e"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "instant",
- "libp2p-core 0.41.3",
- "libp2p-identity",
- "lru",
- "multistream-select",
- "once_cell",
- "rand",
- "smallvec",
  "tracing",
  "void",
 ]
@@ -3814,7 +3740,7 @@ dependencies = [
  "fnv",
  "futures",
  "futures-timer",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm-derive",
  "lru",
@@ -3850,7 +3776,7 @@ dependencies = [
  "futures-timer",
  "if-watch",
  "libc",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
  "socket2",
  "tokio",
@@ -3865,7 +3791,7 @@ checksum = "47b23dddc2b9c355f73c1e36eb0c3ae86f7dc964a3715f0731cfad352db4d847"
 dependencies = [
  "futures",
  "futures-rustls",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "libp2p-identity",
  "rcgen",
  "ring 0.17.8",
@@ -3885,26 +3811,11 @@ dependencies = [
  "futures",
  "futures-timer",
  "igd-next",
- "libp2p-core 0.42.0",
- "libp2p-swarm 0.45.1",
+ "libp2p-core",
+ "libp2p-swarm",
  "tokio",
  "tracing",
  "void",
-]
-
-[[package]]
-name = "libp2p-yamux"
-version = "0.45.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200cbe50349a44760927d50b431d77bed79b9c0a3959de1af8d24a63434b71e5"
-dependencies = [
- "either",
- "futures",
- "libp2p-core 0.41.3",
- "thiserror",
- "tracing",
- "yamux 0.12.1",
- "yamux 0.13.3",
 ]
 
 [[package]]
@@ -3915,7 +3826,7 @@ checksum = "788b61c80789dba9760d8c669a5bedb642c8267555c803fabd8396e4ca5c5882"
 dependencies = [
  "either",
  "futures",
- "libp2p-core 0.42.0",
+ "libp2p-core",
  "thiserror",
  "tracing",
  "yamux 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [workspace]
 members = [
     "apps/hash-graph/bins/cli",
@@ -32,12 +34,12 @@ members = [
 default-members = [
     "apps/hash-graph/bins/*",
 ]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 authors = ["HASH"]
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 license = "AGPL-3"
 publish = false
 

--- a/apps/hash-graph/bins/cli/Cargo.toml
+++ b/apps/hash-graph/bins/cli/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "hash-graph"
 version.workspace = true

--- a/apps/hash-graph/bins/cli/src/subcommand/mod.rs
+++ b/apps/hash-graph/bins/cli/src/subcommand/mod.rs
@@ -6,7 +6,7 @@ mod snapshot;
 mod test_server;
 mod type_fetcher;
 
-use core::{future::Future, time::Duration};
+use core::time::Duration;
 
 use error_stack::{ensure, Result};
 use hash_tracing::{init_tracing, TracingConfig};

--- a/apps/hash-graph/libs/api/Cargo.toml
+++ b/apps/hash-graph/libs/api/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "graph-api"
 version.workspace = true

--- a/apps/hash-graph/libs/graph/Cargo.toml
+++ b/apps/hash-graph/libs/graph/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "graph"
 version.workspace = true

--- a/apps/hash-graph/libs/graph/src/store/crud.rs
+++ b/apps/hash-graph/libs/graph/src/store/crud.rs
@@ -6,8 +6,6 @@
 //!
 //! [`Store`]: crate::store::Store
 
-use core::future::Future;
-
 use async_trait::async_trait;
 use error_stack::Result;
 use futures::{Stream, TryStreamExt};

--- a/apps/hash-graph/libs/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/libs/graph/src/store/knowledge.rs
@@ -1,5 +1,5 @@
 use alloc::borrow::Cow;
-use core::{error::Error, fmt, future::Future};
+use core::{error::Error, fmt};
 use std::collections::HashSet;
 
 use authorization::{schema::EntityRelationAndSubject, zanzibar::Consistency};

--- a/apps/hash-graph/libs/graph/src/store/ontology.rs
+++ b/apps/hash-graph/libs/graph/src/store/ontology.rs
@@ -1,5 +1,5 @@
 use alloc::borrow::Cow;
-use core::{future::Future, iter};
+use core::iter;
 use std::collections::HashMap;
 
 use authorization::schema::{

--- a/apps/hash-graph/libs/graph/src/store/pool.rs
+++ b/apps/hash-graph/libs/graph/src/store/pool.rs
@@ -1,5 +1,4 @@
 use alloc::sync::Arc;
-use core::future::Future;
 
 use authorization::AuthorizationApi;
 use error_stack::{Context, Result};

--- a/apps/hash-graph/libs/query-builder-derive/Cargo.toml
+++ b/apps/hash-graph/libs/query-builder-derive/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "query-builder-derive"
 version.workspace = true

--- a/apps/hash-graph/libs/test-server/Cargo.toml
+++ b/apps/hash-graph/libs/test-server/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "test-server"
 version.workspace = true

--- a/apps/hash-graph/libs/type-fetcher/Cargo.toml
+++ b/apps/hash-graph/libs/type-fetcher/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "type-fetcher"
 version.workspace = true

--- a/libs/@blockprotocol/type-system/rust/Cargo.toml
+++ b/libs/@blockprotocol/type-system/rust/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "type-system"
 description = "Definitions of types within the Block Protocol Type System"

--- a/libs/@blockprotocol/type-system/rust/src/lib.rs
+++ b/libs/@blockprotocol/type-system/rust/src/lib.rs
@@ -16,7 +16,7 @@ mod utils;
 use alloc::sync::Arc;
 #[cfg(feature = "postgres")]
 use core::error::Error;
-use core::{borrow::Borrow, fmt::Debug, future::Future, ops::Deref, ptr};
+use core::{borrow::Borrow, fmt::Debug, ops::Deref, ptr};
 
 #[cfg(feature = "postgres")]
 use bytes::BytesMut;

--- a/libs/@blockprotocol/type-system/rust/src/schema/property_type/validation.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/property_type/validation.rs
@@ -1,5 +1,3 @@
-use core::future::Future;
-
 use thiserror::Error;
 
 use crate::{

--- a/libs/@local/codec/Cargo.toml
+++ b/libs/@local/codec/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "codec"
 version.workspace = true

--- a/libs/@local/harpc/net/Cargo.toml
+++ b/libs/@local/harpc/net/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "harpc-net"
 version.workspace = true

--- a/libs/@local/harpc/net/src/codec.rs
+++ b/libs/@local/harpc/net/src/codec.rs
@@ -1,5 +1,5 @@
 use alloc::sync::Arc;
-use core::{error::Error, future::Future};
+use core::error::Error;
 
 use bytes::Bytes;
 use error_stack::{Context, Report, Result};

--- a/libs/@local/harpc/net/src/session/test.rs
+++ b/libs/@local/harpc/net/src/session/test.rs
@@ -1,10 +1,5 @@
 use alloc::sync::Arc;
-use core::{
-    future::{ready, Future},
-    iter,
-    net::Ipv4Addr,
-    time::Duration,
-};
+use core::{future::ready, iter, net::Ipv4Addr, time::Duration};
 
 use bytes::Bytes;
 use error_stack::{Report, ResultExt};

--- a/libs/@local/harpc/tower/Cargo.toml
+++ b/libs/@local/harpc/tower/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "harpc-tower"
 version.workspace = true

--- a/libs/@local/harpc/tower/src/body/mod.rs
+++ b/libs/@local/harpc/tower/src/body/mod.rs
@@ -10,7 +10,6 @@ pub mod stream;
 pub mod timeout;
 
 use core::{
-    future::Future,
     ops::DerefMut,
     pin::Pin,
     task::{Context, Poll},

--- a/libs/@local/harpc/tower/src/body/timeout.rs
+++ b/libs/@local/harpc/tower/src/body/timeout.rs
@@ -1,5 +1,4 @@
 use core::{
-    future::Future,
     pin::Pin,
     task::{Context, Poll},
     time::Duration,

--- a/libs/@local/harpc/tower/src/layer/error.rs
+++ b/libs/@local/harpc/tower/src/layer/error.rs
@@ -1,7 +1,6 @@
 use core::{
     error::Error,
     fmt::{self, Debug, Display, Formatter},
-    future::Future,
     task::{Context, Poll},
 };
 

--- a/libs/@local/harpc/tower/src/layer/report.rs
+++ b/libs/@local/harpc/tower/src/layer/report.rs
@@ -1,7 +1,4 @@
-use core::{
-    future::Future,
-    task::{Context, Poll},
-};
+use core::task::{Context, Poll};
 
 use bytes::Bytes;
 use error_stack::Report;

--- a/libs/@local/harpc/types/Cargo.toml
+++ b/libs/@local/harpc/types/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "harpc-types"
 version.workspace = true

--- a/libs/@local/harpc/wire-protocol/Cargo.toml
+++ b/libs/@local/harpc/wire-protocol/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "harpc-wire-protocol"
 version.workspace = true

--- a/libs/@local/hash-authorization/Cargo.toml
+++ b/libs/@local/hash-authorization/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "authorization"
 version.workspace = true

--- a/libs/@local/hash-authorization/src/api.rs
+++ b/libs/@local/hash-authorization/src/api.rs
@@ -1,4 +1,3 @@
-use core::future::Future;
 use std::collections::HashMap;
 
 use error_stack::{Context, Result};

--- a/libs/@local/hash-authorization/src/backend/mod.rs
+++ b/libs/@local/hash-authorization/src/backend/mod.rs
@@ -1,6 +1,6 @@
 mod spicedb;
 
-use core::{error::Error, fmt, future::Future, iter::repeat};
+use core::{error::Error, fmt, iter::repeat};
 
 use error_stack::Report;
 use futures::{stream, Stream};

--- a/libs/@local/hash-graph-types/rust/Cargo.toml
+++ b/libs/@local/hash-graph-types/rust/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "graph-types"
 version.workspace = true

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/mod.rs
@@ -383,14 +383,17 @@ impl PropertyWithMetadata {
 }
 
 impl Property {
-    pub gen fn properties(&self) -> (PropertyPath<'_>, &JsonValue) {
+    // TODO: Replace with `gen fn`
+    pub fn properties(&self) -> impl Iterator<Item = (PropertyPath<'_>, &JsonValue)> {
+        let mut vec = Vec::new();
         let mut elements = PropertyPath::default();
         match self {
             Self::Array(array) => {
                 for (index, property) in array.iter().enumerate() {
                     elements.push(index);
-                    for yielded in Box::new(property.properties()) {
-                        yield yielded;
+                    for yielded in property.properties() {
+                        // yield yielded;
+                        vec.push(yielded);
                     }
                     elements.pop();
                 }
@@ -398,14 +401,19 @@ impl Property {
             Self::Object(object) => {
                 for (key, property) in object.properties() {
                     elements.push(key);
-                    for yielded in Box::new(property.properties()) {
-                        yield yielded;
+                    for yielded in property.properties() {
+                        // yield yielded;
+                        vec.push(yielded);
                     }
                     elements.pop();
                 }
             }
-            Self::Value(property) => yield (elements.clone(), property),
+            Self::Value(property) => {
+                // yield (elements.clone(), property)
+                vec.push((elements.clone(), property));
+            }
         }
+        vec.into_iter()
     }
 
     #[must_use]
@@ -433,15 +441,18 @@ impl Property {
         Some(value)
     }
 
-    gen fn diff_array<'a>(
+    // TODO: Replace with `gen fn`
+    fn diff_array<'a>(
         lhs: &'a [Self],
         rhs: &'a [Self],
         path: &mut PropertyPath<'a>,
-    ) -> PropertyDiff<'a> {
+    ) -> impl Iterator<Item = PropertyDiff<'a>> {
+        let mut vec = Vec::new();
         for (index, (lhs, rhs)) in lhs.iter().zip(rhs).enumerate() {
             path.push(index);
-            for yielded in Box::new(lhs.diff(rhs, path)) {
-                yield yielded;
+            for yielded in lhs.diff(rhs, path) {
+                // yield yielded;
+                vec.push(yielded);
             }
             path.pop();
         }
@@ -450,10 +461,14 @@ impl Property {
             Ordering::Less => {
                 for (index, property) in rhs.iter().enumerate().skip(lhs.len()) {
                     path.push(index);
-                    yield PropertyDiff::Added {
+                    // yield PropertyDiff::Added {
+                    //     path: path.clone(),
+                    //     added: Cow::Borrowed(property),
+                    // };
+                    vec.push(PropertyDiff::Added {
                         path: path.clone(),
                         added: Cow::Borrowed(property),
-                    };
+                    });
                     path.pop();
                 }
             }
@@ -461,65 +476,87 @@ impl Property {
             Ordering::Greater => {
                 for (index, property) in lhs.iter().enumerate().skip(rhs.len()) {
                     path.push(index);
-                    yield PropertyDiff::Removed {
+                    // yield PropertyDiff::Removed {
+                    //     path: path.clone(),
+                    //     removed: Cow::Borrowed(property),
+                    // };
+                    vec.push(PropertyDiff::Removed {
                         path: path.clone(),
                         removed: Cow::Borrowed(property),
-                    };
+                    });
                     path.pop();
                 }
             }
         }
+        vec.into_iter()
     }
 
-    gen fn diff_object<'a>(
+    // TODO: Replace with `gen fn`
+    fn diff_object<'a>(
         lhs: &'a HashMap<BaseUrl, Self>,
         rhs: &'a HashMap<BaseUrl, Self>,
         path: &mut PropertyPath<'a>,
-    ) -> PropertyDiff<'a> {
+    ) -> impl Iterator<Item = PropertyDiff<'a>> {
+        let mut vec = Vec::new();
         for (key, property) in lhs {
             path.push(key);
             let other_property = rhs.get(key);
             if let Some(other_property) = other_property {
-                for yielded in Box::new(property.diff(other_property, path)) {
-                    yield yielded;
+                for yielded in property.diff(other_property, path) {
+                    // yield yielded;
+                    vec.push(yielded);
                 }
             } else {
-                yield PropertyDiff::Removed {
+                // yield PropertyDiff::Removed {
+                //     path: path.clone(),
+                //     removed: Cow::Borrowed(property),
+                // };
+                vec.push(PropertyDiff::Removed {
                     path: path.clone(),
                     removed: Cow::Borrowed(property),
-                };
+                });
             }
             path.pop();
         }
         for (key, property) in rhs {
             if !lhs.contains_key(key) {
                 path.push(key);
-                yield PropertyDiff::Added {
+                // yield PropertyDiff::Added {
+                //     path: path.clone(),
+                //     added: Cow::Borrowed(property),
+                // };
+                vec.push(PropertyDiff::Added {
                     path: path.clone(),
                     added: Cow::Borrowed(property),
-                };
+                });
+
                 path.pop();
             }
         }
+        vec.into_iter()
     }
 
-    pub gen fn diff<'a>(
+    // TODO: Replace with `gen fn`
+    pub fn diff<'a>(
         &'a self,
         other: &'a Self,
         path: &mut PropertyPath<'a>,
-    ) -> PropertyDiff<'a> {
+    ) -> impl Iterator<Item = PropertyDiff<'a>> {
+        let mut vec = Vec::new();
         let mut changed = false;
         match (self, other) {
             (Self::Array(lhs), Self::Array(rhs)) => {
                 for yielded in Self::diff_array(lhs, rhs, path) {
                     changed = true;
-                    yield yielded;
+                    // yield yielded;
+                    vec.push(yielded);
                 }
             }
             (Self::Object(lhs), Self::Object(rhs)) => {
                 for yielded in Self::diff_object(lhs.properties(), rhs.properties(), path) {
                     changed = true;
-                    yield yielded;
+                    // yield yielded;
+                    vec.push(yielded);
                 }
             }
             (lhs, rhs) => {
@@ -528,12 +565,18 @@ impl Property {
         }
 
         if changed {
-            yield PropertyDiff::Changed {
+            // yield PropertyDiff::Changed {
+            //     path: path.clone(),
+            //     old: Cow::Borrowed(self),
+            //     new: Cow::Borrowed(other),
+            // };
+            vec.push(PropertyDiff::Changed {
                 path: path.clone(),
                 old: Cow::Borrowed(self),
                 new: Cow::Borrowed(other),
-            };
+            });
         }
+        vec.into_iter()
     }
 }
 

--- a/libs/@local/hash-graph-types/rust/src/lib.rs
+++ b/libs/@local/hash-graph-types/rust/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(gen_blocks)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(hash_raw_entry)]
 

--- a/libs/@local/hash-validation/Cargo.toml
+++ b/libs/@local/hash-validation/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "validation"
 version.workspace = true

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -13,7 +13,7 @@ mod entity_type;
 mod property;
 mod property_type;
 
-use core::{borrow::Borrow, future::Future};
+use core::borrow::Borrow;
 
 use error_stack::{Context, Report};
 use graph_types::{

--- a/libs/@local/hash-validation/src/property_type.rs
+++ b/libs/@local/hash-validation/src/property_type.rs
@@ -1,4 +1,4 @@
-use core::{borrow::Borrow, future::Future};
+use core::borrow::Borrow;
 use std::collections::HashMap;
 
 use error_stack::{bail, Report, ResultExt};

--- a/libs/@local/hql/cst/Cargo.toml
+++ b/libs/@local/hql/cst/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "hql-cst"
 version.workspace = true

--- a/libs/@local/hql/diagnostics/Cargo.toml
+++ b/libs/@local/hql/diagnostics/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "hql-diagnostics"
 version.workspace = true

--- a/libs/@local/hql/span/Cargo.toml
+++ b/libs/@local/hql/span/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "hql-span"
 version.workspace = true

--- a/libs/@local/hql/syntax-jexpr/Cargo.toml
+++ b/libs/@local/hql/syntax-jexpr/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "hql-syntax-jexpr"
 authors.workspace = true

--- a/libs/@local/repo-chores/rust/Cargo.toml
+++ b/libs/@local/repo-chores/rust/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "repo-chores"
 version.workspace = true

--- a/libs/@local/status/rust/Cargo.toml
+++ b/libs/@local/status/rust/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "hash-status"
 description = "The HASH Status and Error Model."

--- a/libs/@local/temporal-client/Cargo.toml
+++ b/libs/@local/temporal-client/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "temporal-client"
 version.workspace = true

--- a/libs/@local/temporal-client/src/lib.rs
+++ b/libs/@local/temporal-client/src/lib.rs
@@ -5,8 +5,6 @@ pub use self::error::{ConfigError, ConnectionError, WorkflowError};
 mod ai;
 mod error;
 
-use core::future::{Future, IntoFuture};
-
 use error_stack::{Report, ResultExt};
 use temporal_io_client::{Client, ClientOptions, ClientOptionsBuilder, RetryClient};
 use url::Url;

--- a/libs/@local/temporal-versioning/Cargo.toml
+++ b/libs/@local/temporal-versioning/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "temporal-versioning"
 version.workspace = true

--- a/libs/@local/tracing/Cargo.toml
+++ b/libs/@local/tracing/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "hash-tracing"
 version.workspace = true

--- a/libs/error-stack/src/lib.rs
+++ b/libs/error-stack/src/lib.rs
@@ -438,6 +438,8 @@
 //! In addition to [`ResultExt`], this crate also comes with [`FutureExt`], which provides the same
 //! functionality for [`Future`]s.
 //!
+//! [`Future`]: core::future::Future
+//!
 //! ### Colored output and charset selection
 //!
 //! You can override the color support by using the [`Report::set_color_mode`]. To override the

--- a/libs/error-stack/src/lib.rs
+++ b/libs/error-stack/src/lib.rs
@@ -438,8 +438,6 @@
 //! In addition to [`ResultExt`], this crate also comes with [`FutureExt`], which provides the same
 //! functionality for [`Future`]s.
 //!
-//! [`Future`]: core::future::Future
-//!
 //! ### Colored output and charset selection
 //!
 //! You can override the color support by using the [`Report::set_color_mode`]. To override the

--- a/libs/error-stack/tests/common.rs
+++ b/libs/error-stack/tests/common.rs
@@ -14,9 +14,7 @@ extern crate alloc;
 use core::{any::TypeId, panic::Location};
 #[allow(unused_imports)]
 use core::{
-    fmt,
-    future::Future,
-    iter,
+    fmt, iter,
     sync::atomic::{AtomicI8, Ordering},
 };
 #[cfg(feature = "backtrace")]

--- a/libs/error-stack/tests/common.rs
+++ b/libs/error-stack/tests/common.rs
@@ -14,7 +14,9 @@ extern crate alloc;
 use core::{any::TypeId, panic::Location};
 #[allow(unused_imports)]
 use core::{
-    fmt, iter,
+    fmt,
+    future::Future,
+    iter,
     sync::atomic::{AtomicI8, Ordering},
 };
 #[cfg(feature = "backtrace")]

--- a/tests/hash-graph-benches/Cargo.toml
+++ b/tests/hash-graph-benches/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "graph-benches"
 version.workspace = true

--- a/tests/hash-graph-integration/Cargo.toml
+++ b/tests/hash-graph-integration/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "graph-integration"
 version.workspace = true

--- a/tests/hash-graph-test-data/rust/Cargo.toml
+++ b/tests/hash-graph-test-data/rust/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "graph-test-data"
 version.workspace = true


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

I experimented around with renovate, further, and it turned out that the ability to not update the artifacts is the reason why PRs are not created. Also, I was able to create a self-hosted renovate version that is able to use nightly features.

## 🔗 Related links

- #5007 