### PR TITLE
H-3284, H-3287: Allow sorting Entities by entity type's properties

### DIFF
--- a/apps/hash-graph/libs/api/src/rest/entity.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity.rs
@@ -447,21 +447,46 @@ fn generate_sorting_paths(
                 }
             },
             |mut paths| {
-                paths.push(EntityQuerySortingRecord {
-                    path: temporal_axes_sorting_path.clone(),
-                    ordering: Ordering::Descending,
-                    nulls: None,
-                });
-                paths.push(EntityQuerySortingRecord {
-                    path: EntityQueryPath::Uuid,
-                    ordering: Ordering::Ascending,
-                    nulls: None,
-                });
-                paths.push(EntityQuerySortingRecord {
-                    path: EntityQueryPath::OwnedById,
-                    ordering: Ordering::Ascending,
-                    nulls: None,
-                });
+                let mut has_temporal_axis = false;
+                let mut has_uuid = false;
+                let mut has_owned_by_id = false;
+
+                for path in &paths {
+                    if path.path == EntityQueryPath::TransactionTime
+                        || path.path == EntityQueryPath::DecisionTime
+                    {
+                        has_temporal_axis = true;
+                    }
+                    if path.path == EntityQueryPath::Uuid {
+                        has_uuid = true;
+                    }
+                    if path.path == EntityQueryPath::OwnedById {
+                        has_owned_by_id = true;
+                    }
+                }
+
+                if !has_temporal_axis {
+                    paths.push(EntityQuerySortingRecord {
+                        path: temporal_axes_sorting_path.clone(),
+                        ordering: Ordering::Descending,
+                        nulls: None,
+                    });
+                }
+                if !has_uuid {
+                    paths.push(EntityQuerySortingRecord {
+                        path: EntityQueryPath::Uuid,
+                        ordering: Ordering::Ascending,
+                        nulls: None,
+                    });
+                }
+                if !has_owned_by_id {
+                    paths.push(EntityQuerySortingRecord {
+                        path: EntityQueryPath::OwnedById,
+                        ordering: Ordering::Ascending,
+                        nulls: None,
+                    });
+                }
+
                 paths
             },
         )

--- a/apps/hash-graph/libs/graph/src/knowledge/query.rs
+++ b/apps/hash-graph/libs/graph/src/knowledge/query.rs
@@ -324,7 +324,7 @@ pub enum EntityQueryPath<'p> {
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     Properties(Option<JsonPath<'p>>),
-    /// The property defined as [`label`] property in the corresponding entity type.
+    /// The property defined as [`label_property`] in the corresponding entity type metadata.
     ///
     /// ```rust
     /// # use serde::Deserialize;
@@ -339,6 +339,24 @@ pub enum EntityQueryPath<'p> {
     /// );
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    ///
+    /// It's possible to specify the inheritance search depths:
+    ///
+    /// ```rust
+    /// # use serde::Deserialize;
+    /// # use serde_json::json;
+    /// # use graph::knowledge::EntityQueryPath;
+    /// let path = EntityQueryPath::deserialize(json!(["label(inheritanceDepth = 10)"]))?;
+    /// assert_eq!(
+    ///     path,
+    ///     EntityQueryPath::Label {
+    ///         inheritance_depth: Some(10)
+    ///     }
+    /// );
+    /// # Ok::<(), serde_json::Error>(())
+    /// ```
+    ///
+    /// [`label_property`]: graph_types::ontology::EntityTypeMetadata::label_property
     Label { inheritance_depth: Option<u32> },
     /// Corresponds to the provenance data of the [`Entity`].
     ///

--- a/apps/hash-graph/libs/graph/src/knowledge/query.rs
+++ b/apps/hash-graph/libs/graph/src/knowledge/query.rs
@@ -682,7 +682,7 @@ impl EntityQuerySortingVisitor {
     pub const EXPECTING: &'static str =
         "one of `uuid`, `archived`, `properties`, `label`, `recordCreatedAtTransactionTime`, \
          `recordCreatedAtDecisionTime`, `createdAtTransactionTime`, `createdAtDecisionTime`, \
-         `TypeTitle`";
+         `typeTitle`";
 
     #[must_use]
     pub const fn new(position: usize) -> Self {

--- a/apps/hash-graph/libs/graph/src/knowledge/query.rs
+++ b/apps/hash-graph/libs/graph/src/knowledge/query.rs
@@ -324,6 +324,22 @@ pub enum EntityQueryPath<'p> {
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     Properties(Option<JsonPath<'p>>),
+    /// The property defined as [`label`] property in the corresponding entity type.
+    ///
+    /// ```rust
+    /// # use serde::Deserialize;
+    /// # use serde_json::json;
+    /// # use graph::knowledge::EntityQueryPath;
+    /// let path = EntityQueryPath::deserialize(json!(["label"]))?;
+    /// assert_eq!(
+    ///     path,
+    ///     EntityQueryPath::Label {
+    ///         inheritance_depth: None
+    ///     }
+    /// );
+    /// # Ok::<(), serde_json::Error>(())
+    /// ```
+    Label { inheritance_depth: Option<u32> },
     /// Corresponds to the provenance data of the [`Entity`].
     ///
     /// Deserializes from `["provenance", ...]` where `...` is a path to a provenance entry of an
@@ -387,6 +403,7 @@ impl fmt::Display for EntityQueryPath<'_> {
             Self::Properties(None) => fmt.write_str("properties"),
             Self::Provenance(Some(path)) => write!(fmt, "provenance.{path}"),
             Self::Provenance(None) => fmt.write_str("provenance"),
+            Self::Label { .. } => fmt.write_str("label"),
             Self::EditionProvenance(Some(path)) => write!(fmt, "editionProvenance.{path}"),
             Self::EditionProvenance(None) => fmt.write_str("editionProvenance"),
             Self::PropertyMetadata(Some(path)) => write!(fmt, "propertyMetadata.{path}"),
@@ -441,6 +458,7 @@ impl QueryPath for EntityQueryPath<'_> {
                 ParameterType::Vector(Box::new(ParameterType::OntologyTypeVersion))
             }
             Self::Properties(_)
+            | Self::Label { .. }
             | Self::Provenance(_)
             | Self::EditionProvenance(_)
             | Self::PropertyMetadata(_)
@@ -470,6 +488,7 @@ pub enum EntityQueryToken {
     OwnedById,
     Type,
     Properties,
+    Label,
     Provenance,
     EditionProvenance,
     Embedding,
@@ -486,10 +505,10 @@ pub struct EntityQueryPathVisitor {
 }
 
 impl EntityQueryPathVisitor {
-    pub const EXPECTING: &'static str = "one of `uuid`, `editionId`, `draftId`, `archived`, \
-                                         `ownedById`, `type`, `properties`, `provenance`, \
-                                         `editionProvenance`, `embedding`, `incomingLinks`, \
-                                         `outgoingLinks`, `leftEntity`, `rightEntity`";
+    pub const EXPECTING: &'static str =
+        "one of `uuid`, `editionId`, `draftId`, `archived`, `ownedById`, `type`, `properties`, \
+         `label`, `provenance`, `editionProvenance`, `embedding`, `incomingLinks`, \
+         `outgoingLinks`, `leftEntity`, `rightEntity`";
 
     #[must_use]
     pub const fn new(position: usize) -> Self {
@@ -543,6 +562,13 @@ impl<'de> Visitor<'de> for EntityQueryPathVisitor {
                     EntityQueryPath::Properties(Some(JsonPath::from_path_tokens(path_tokens)))
                 }
             }
+            EntityQueryToken::Label => EntityQueryPath::Label {
+                inheritance_depth: parameters
+                    .remove("inheritanceDepth")
+                    .map(u32::from_str)
+                    .transpose()
+                    .map_err(de::Error::custom)?,
+            },
             EntityQueryToken::Provenance => {
                 let mut path_tokens = Vec::new();
                 while let Some(property) = seq.next_element::<PathToken<'de>>()? {
@@ -617,12 +643,15 @@ impl<'de: 'p, 'p> Deserialize<'de> for EntityQueryPath<'p> {
 #[cfg_attr(feature = "utoipa", derive(ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub enum EntityQuerySortingToken {
+    Uuid,
     Archived,
     Properties,
+    Label,
     RecordCreatedAtTransactionTime,
     RecordCreatedAtDecisionTime,
     CreatedAtTransactionTime,
     CreatedAtDecisionTime,
+    TypeTitle,
 }
 
 /// Deserializes an [`EntityQueryPath`] from a string sequence.
@@ -633,8 +662,9 @@ pub struct EntityQuerySortingVisitor {
 
 impl EntityQuerySortingVisitor {
     pub const EXPECTING: &'static str =
-        "one of `archived`, `properties`, `recordCreatedAtTransactionTime`, \
-         `recordCreatedAtDecisionTime`, `createdAtTransactionTime`, `createdAtDecisionTime`";
+        "one of `uuid`, `archived`, `properties`, `label`, `recordCreatedAtTransactionTime`, \
+         `recordCreatedAtDecisionTime`, `createdAtTransactionTime`, `createdAtDecisionTime`, \
+         `TypeTitle`";
 
     #[must_use]
     pub const fn new(position: usize) -> Self {
@@ -653,12 +683,14 @@ impl<'de> Visitor<'de> for EntityQuerySortingVisitor {
     where
         A: SeqAccess<'de>,
     {
-        let token: EntityQuerySortingToken = seq
+        let query_token: String = seq
             .next_element()?
             .ok_or_else(|| de::Error::invalid_length(self.position, &self))?;
+        let (token, mut parameters) = parse_query_token(&query_token)?;
         self.position += 1;
 
         Ok(match token {
+            EntityQuerySortingToken::Uuid => EntityQueryPath::Uuid,
             EntityQuerySortingToken::Archived => EntityQueryPath::Archived,
             EntityQuerySortingToken::RecordCreatedAtTransactionTime => {
                 EntityQueryPath::TransactionTime
@@ -674,6 +706,18 @@ impl<'de> Visitor<'de> for EntityQuerySortingVisitor {
                     PathToken::Field(Cow::Borrowed("createdAtDecisionTime")),
                 ])))
             }
+            EntityQuerySortingToken::TypeTitle => EntityQueryPath::EntityTypeEdge {
+                edge_kind: SharedEdgeKind::IsOfType,
+                path: EntityTypeQueryPath::Title,
+                inheritance_depth: Some(0),
+            },
+            EntityQuerySortingToken::Label => EntityQueryPath::Label {
+                inheritance_depth: parameters
+                    .remove("inheritanceDepth")
+                    .map(u32::from_str)
+                    .transpose()
+                    .map_err(de::Error::custom)?,
+            },
             EntityQuerySortingToken::Properties => {
                 let mut path_tokens = Vec::new();
                 while let Some(property) = seq.next_element::<PathToken<'de>>()? {
@@ -735,6 +779,7 @@ impl<'de: 'p, 'p> EntityQueryPath<'p> {
                 direction,
             },
             Self::Properties(path) => EntityQueryPath::Properties(path.map(JsonPath::into_owned)),
+            Self::Label { inheritance_depth } => EntityQueryPath::Label { inheritance_depth },
             Self::Embedding => EntityQueryPath::Embedding,
             Self::EntityConfidence => EntityQueryPath::EntityConfidence,
             Self::LeftEntityConfidence => EntityQueryPath::LeftEntityConfidence,

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/entity.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/entity.rs
@@ -2,6 +2,7 @@ use core::iter::once;
 
 use crate::{
     knowledge::EntityQueryPath,
+    ontology::EntityTypeQueryPath,
     store::postgres::query::{
         table::{
             Column, EntityEditions, EntityEmbeddings, EntityHasLeftEntity, EntityHasRightEntity,
@@ -31,6 +32,7 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
                 vec![Relation::RightEntity]
             }
             Self::Properties(_)
+            | Self::Label { .. }
             | Self::EditionProvenance(_)
             | Self::Archived
             | Self::EntityConfidence
@@ -87,6 +89,7 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
         }
     }
 
+    #[expect(clippy::too_many_lines)]
     fn terminating_column(&self) -> (Column, Option<JsonField<'_>>) {
         match self {
             Self::OwnedById => (
@@ -155,6 +158,12 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
                 Column::EntityEditions(EntityEditions::Properties),
                 path.as_ref().map(JsonField::JsonPath),
             ),
+            Self::Label { inheritance_depth } => (
+                Column::EntityEditions(EntityEditions::Properties),
+                Some(JsonField::Label {
+                    inheritance_depth: *inheritance_depth,
+                }),
+            ),
             Self::Provenance(path) => (
                 Column::EntityIds(EntityIds::Provenance),
                 path.as_ref().map(JsonField::JsonPath),
@@ -185,5 +194,13 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
                 None,
             ),
         }
+    }
+
+    fn label_property_path(inheritance_depth: Option<u32>) -> Option<Self> {
+        Some(Self::EntityTypeEdge {
+            edge_kind: SharedEdgeKind::IsOfType,
+            path: EntityTypeQueryPath::LabelProperty,
+            inheritance_depth,
+        })
     }
 }

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/mod.rs
@@ -71,12 +71,17 @@ pub trait PostgresRecord: QueryRecord + QueryRecordDecode<Output = Self> {
 }
 
 /// An absolute path inside of a query pointing to an attribute.
-pub trait PostgresQueryPath {
+pub trait PostgresQueryPath: Sized {
     /// Returns a list of [`Relation`]s required to traverse this path.
     fn relations(&self) -> Vec<Relation>;
 
     /// The [`Column`] where this path ends.
     fn terminating_column(&self) -> (Column, Option<JsonField<'_>>);
+
+    #[expect(unused_variables, reason = "No-op")]
+    fn label_property_path(inheritance_depth: Option<u32>) -> Option<Self> {
+        None
+    }
 }
 
 /// Renders the object into a Postgres compatible format.

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/table.rs
@@ -383,6 +383,7 @@ pub enum JsonField<'p> {
     JsonPath(&'p JsonPath<'p>),
     JsonPathParameter(usize),
     StaticText(&'static str),
+    Label { inheritance_depth: Option<u32> },
 }
 
 impl<'p> JsonField<'p> {
@@ -397,6 +398,7 @@ impl<'p> JsonField<'p> {
             ),
             Self::JsonPathParameter(index) => (JsonField::JsonPathParameter(index), None),
             Self::StaticText(text) => (JsonField::StaticText(text), None),
+            Self::Label { inheritance_depth } => (JsonField::Label { inheritance_depth }, None),
         }
     }
 }
@@ -556,30 +558,6 @@ impl DatabaseColumn for OntologyTemporalMetadata {
             Self::OntologyId => "ontology_id",
             Self::TransactionTime => "transaction_time",
             Self::Provenance => "provenance",
-        }
-    }
-}
-
-fn transpile_json_field(
-    path: JsonField<'static>,
-    name: &'static str,
-    table: &impl Transpile,
-    fmt: &mut fmt::Formatter,
-) -> fmt::Result {
-    match path {
-        JsonField::JsonPath(path) => {
-            write!(fmt, "jsonb_path_query_first(")?;
-            table.transpile(fmt)?;
-            write!(fmt, r#"."{name}", {path})"#)
-        }
-        JsonField::JsonPathParameter(index) => {
-            write!(fmt, "jsonb_path_query_first(")?;
-            table.transpile(fmt)?;
-            write!(fmt, r#"."{name}", ${index}::text::jsonpath)"#)
-        }
-        JsonField::StaticText(field) => {
-            table.transpile(fmt)?;
-            write!(fmt, r#"."{name}"->>'{field}'"#)
         }
     }
 }

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -4006,12 +4006,15 @@
       "EntityQuerySortingToken": {
         "type": "string",
         "enum": [
+          "uuid",
           "archived",
           "properties",
+          "label",
           "recordCreatedAtTransactionTime",
           "recordCreatedAtDecisionTime",
           "createdAtTransactionTime",
-          "createdAtDecisionTime"
+          "createdAtDecisionTime",
+          "typeTitle"
         ]
       },
       "EntityQueryToken": {
@@ -4025,6 +4028,7 @@
           "ownedById",
           "type",
           "properties",
+          "label",
           "provenance",
           "editionProvenance",
           "embedding",

--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -1324,9 +1324,9 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "sortingPaths": [
     {
       "path": [
-        "recordCreatedAtTransactionTime"
+        "label"
       ],
-      "ordering": "descending"
+      "ordering": "ascending"
     }
   ],
   "filter": {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We want to allow sorting entities by e.g. it's type's title, so we can sort by

- label
- type title
- entity ID

## 🔍 What does this change?

- Add sorting paths for the above
- Add logic to dynamically use `label` property (returns `null` if not present)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph