### PR TITLE
H-3285, H-3286: Optionally return set of distinct values for entity (type) queries

### DIFF
--- a/apps/hash-graph/libs/api/src/rest/entity.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity.rs
@@ -1,6 +1,7 @@
 //! Web routes for CRU operations on entities.
 
 use alloc::sync::Arc;
+use std::collections::HashMap;
 
 use authorization::{
     backend::{ModifyRelationshipOperation, PermissionAssertion},
@@ -36,6 +37,7 @@ use graph::{
     subgraph::{edges::GraphResolveDepths, temporal_axes::QueryTemporalAxesUnresolved},
 };
 use graph_types::{
+    account::{CreatedById, EditionCreatedById},
     knowledge::{
         entity::{
             ActorType, Entity, EntityEditionId, EntityEditionProvenance, EntityEmbedding, EntityId,
@@ -54,6 +56,7 @@ use graph_types::{
 };
 use serde::{Deserialize, Serialize};
 use temporal_client::TemporalClient;
+use type_system::url::VersionedUrl;
 use utoipa::{OpenApi, ToSchema};
 use validation::ValidateEntityComponents;
 
@@ -477,6 +480,10 @@ fn generate_sorting_paths(
 
 #[derive(Debug, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "Parameter struct deserialized from JSON"
+)]
 struct GetEntitiesRequest<'q, 's, 'p> {
     #[serde(borrow)]
     filter: Filter<'q, Entity>,
@@ -489,6 +496,14 @@ struct GetEntitiesRequest<'q, 's, 'p> {
     cursor: Option<EntityQueryCursor<'s>>,
     #[serde(default)]
     include_count: bool,
+    #[serde(default)]
+    include_web_ids: bool,
+    #[serde(default)]
+    include_created_by_ids: bool,
+    #[serde(default)]
+    include_edition_created_by_ids: bool,
+    #[serde(default)]
+    include_type_ids: bool,
 }
 
 #[utoipa::path(
@@ -558,6 +573,10 @@ where
                 include_drafts: request.include_drafts,
                 include_count: request.include_count,
                 temporal_axes: request.temporal_axes,
+                include_web_ids: request.include_web_ids,
+                include_created_by_ids: request.include_created_by_ids,
+                include_edition_created_by_ids: request.include_edition_created_by_ids,
+                include_type_ids: request.include_type_ids,
             },
         )
         .await
@@ -566,6 +585,10 @@ where
                 entities: response.entities,
                 cursor: response.cursor.map(EntityQueryCursor::into_owned),
                 count: response.count,
+                web_ids: response.web_ids,
+                created_by_ids: response.created_by_ids,
+                edition_created_by_ids: response.edition_created_by_ids,
+                type_ids: response.type_ids,
             })
         })
         .map_err(report_to_response)
@@ -573,6 +596,10 @@ where
 
 #[derive(Debug, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "Parameter struct deserialized from JSON"
+)]
 struct GetEntitySubgraphRequest<'q, 's, 'p> {
     #[serde(borrow)]
     filter: Filter<'q, Entity>,
@@ -586,6 +613,14 @@ struct GetEntitySubgraphRequest<'q, 's, 'p> {
     cursor: Option<EntityQueryCursor<'s>>,
     #[serde(default)]
     include_count: bool,
+    #[serde(default)]
+    include_web_ids: bool,
+    #[serde(default)]
+    include_created_by_ids: bool,
+    #[serde(default)]
+    include_edition_created_by_ids: bool,
+    #[serde(default)]
+    include_type_ids: bool,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -595,6 +630,18 @@ struct GetEntitySubgraphResponse<'r> {
     #[serde(borrow)]
     cursor: Option<EntityQueryCursor<'r>>,
     count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    web_ids: Option<HashMap<OwnedById, usize>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    created_by_ids: Option<HashMap<CreatedById, usize>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    edition_created_by_ids: Option<HashMap<EditionCreatedById, usize>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    type_ids: Option<HashMap<VersionedUrl, usize>>,
 }
 
 #[utoipa::path(
@@ -666,6 +713,10 @@ where
                 include_drafts: request.include_drafts,
                 include_count: request.include_count,
                 temporal_axes: request.temporal_axes,
+                include_web_ids: request.include_web_ids,
+                include_created_by_ids: request.include_created_by_ids,
+                include_edition_created_by_ids: request.include_edition_created_by_ids,
+                include_type_ids: request.include_type_ids,
             },
         )
         .await
@@ -674,6 +725,10 @@ where
                 subgraph: response.subgraph.into(),
                 cursor: response.cursor.map(EntityQueryCursor::into_owned),
                 count: response.count,
+                web_ids: response.web_ids,
+                created_by_ids: response.created_by_ids,
+                edition_created_by_ids: response.edition_created_by_ids,
+                type_ids: response.type_ids,
             })
         })
         .map_err(report_to_response)

--- a/apps/hash-graph/libs/api/src/rest/entity_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity_type.rs
@@ -38,6 +38,7 @@ use graph::{
     subgraph::identifier::EntityTypeVertexId,
 };
 use graph_types::{
+    account::EditionCreatedById,
     ontology::{
         EntityTypeEmbedding, EntityTypeId, EntityTypeMetadata, EntityTypeWithMetadata,
         OntologyTemporalMetadata, OntologyTypeClassificationMetadata, OntologyTypeMetadata,
@@ -749,6 +750,13 @@ where
 struct GetEntityTypeSubgraphResponse {
     subgraph: Subgraph,
     cursor: Option<EntityTypeVertexId>,
+    count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    web_ids: Option<HashMap<OwnedById, usize>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    edition_created_by_ids: Option<HashMap<EditionCreatedById, usize>>,
 }
 
 #[utoipa::path(
@@ -809,6 +817,9 @@ where
             Json(GetEntityTypeSubgraphResponse {
                 subgraph: Subgraph::from(response.subgraph),
                 cursor: response.cursor,
+                count: response.count,
+                web_ids: response.web_ids,
+                edition_created_by_ids: response.edition_created_by_ids,
             })
         })
 }

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -302,6 +302,8 @@ where
                         limit: None,
                         include_drafts: true,
                         include_count: false,
+                        include_web_ids: false,
+                        include_edition_created_by_ids: false,
                     },
                 )
                 .await

--- a/apps/hash-graph/libs/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/libs/graph/src/store/knowledge.rs
@@ -1,12 +1,12 @@
 use alloc::borrow::Cow;
 use core::{error::Error, fmt};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use authorization::{schema::EntityRelationAndSubject, zanzibar::Consistency};
 use error_stack::Report;
 use futures::TryFutureExt;
 use graph_types::{
-    account::AccountId,
+    account::{AccountId, CreatedById, EditionCreatedById},
     knowledge::{
         entity::{Entity, EntityEmbedding, EntityId, EntityUuid, ProvidedEntityEditionProvenance},
         link::LinkData,
@@ -214,19 +214,19 @@ pub struct ValidateEntityParams<'a> {
     pub components: ValidateEntityComponents,
 }
 
-#[derive(Debug, Deserialize)]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[derive(Debug)]
+#[expect(clippy::struct_excessive_bools, reason = "Parameter struct")]
 pub struct GetEntitiesParams<'a> {
-    #[serde(borrow)]
     pub filter: Filter<'a, Entity>,
     pub temporal_axes: QueryTemporalAxesUnresolved,
-    #[serde(borrow)]
     pub sorting: EntityQuerySorting<'static>,
     pub limit: Option<usize>,
     pub include_drafts: bool,
-    #[serde(default)]
     pub include_count: bool,
+    pub include_web_ids: bool,
+    pub include_created_by_ids: bool,
+    pub include_edition_created_by_ids: bool,
+    pub include_type_ids: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -236,22 +236,34 @@ pub struct GetEntitiesResponse<'r> {
     pub entities: Vec<Entity>,
     pub cursor: Option<EntityQueryCursor<'r>>,
     pub count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    pub web_ids: Option<HashMap<OwnedById, usize>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    pub created_by_ids: Option<HashMap<CreatedById, usize>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    pub edition_created_by_ids: Option<HashMap<EditionCreatedById, usize>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    pub type_ids: Option<HashMap<VersionedUrl, usize>>,
 }
 
-#[derive(Debug, Deserialize)]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[derive(Debug)]
+#[expect(clippy::struct_excessive_bools, reason = "Parameter struct")]
 pub struct GetEntitySubgraphParams<'a> {
-    #[serde(borrow)]
     pub filter: Filter<'a, Entity>,
     pub temporal_axes: QueryTemporalAxesUnresolved,
     pub graph_resolve_depths: GraphResolveDepths,
-    #[serde(borrow)]
     pub sorting: EntityQuerySorting<'static>,
     pub limit: Option<usize>,
     pub include_drafts: bool,
-    #[serde(default)]
     pub include_count: bool,
+    pub include_web_ids: bool,
+    pub include_created_by_ids: bool,
+    pub include_edition_created_by_ids: bool,
+    pub include_type_ids: bool,
 }
 
 #[derive(Debug)]
@@ -259,6 +271,10 @@ pub struct GetEntitySubgraphResponse<'r> {
     pub subgraph: Subgraph,
     pub cursor: Option<EntityQueryCursor<'r>>,
     pub count: Option<usize>,
+    pub web_ids: Option<HashMap<OwnedById, usize>>,
+    pub created_by_ids: Option<HashMap<CreatedById, usize>>,
+    pub edition_created_by_ids: Option<HashMap<EditionCreatedById, usize>>,
+    pub type_ids: Option<HashMap<VersionedUrl, usize>>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/hash-graph/libs/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/libs/graph/src/store/knowledge.rs
@@ -237,16 +237,16 @@ pub struct GetEntitiesResponse<'r> {
     pub cursor: Option<EntityQueryCursor<'r>>,
     pub count: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(nullable = false)]
+    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     pub web_ids: Option<HashMap<OwnedById, usize>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(nullable = false)]
+    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     pub created_by_ids: Option<HashMap<CreatedById, usize>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(nullable = false)]
+    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     pub edition_created_by_ids: Option<HashMap<EditionCreatedById, usize>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(nullable = false)]
+    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     pub type_ids: Option<HashMap<VersionedUrl, usize>>,
 }
 

--- a/apps/hash-graph/libs/graph/src/store/ontology.rs
+++ b/apps/hash-graph/libs/graph/src/store/ontology.rs
@@ -7,12 +7,13 @@ use authorization::schema::{
 };
 use error_stack::Result;
 use graph_types::{
-    account::AccountId,
+    account::{AccountId, EditionCreatedById},
     ontology::{
         DataTypeMetadata, DataTypeWithMetadata, EntityTypeMetadata, EntityTypeWithMetadata,
         OntologyTemporalMetadata, OntologyTypeClassificationMetadata, PropertyTypeMetadata,
         PropertyTypeWithMetadata, ProvidedOntologyEditionProvenance,
     },
+    owned_by_id::OwnedById,
     Embedding,
 };
 use serde::{Deserialize, Serialize};
@@ -534,6 +535,7 @@ pub struct CreateEntityTypeParams<R> {
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[expect(clippy::struct_excessive_bools, reason = "Parameter struct")]
 pub struct GetEntityTypeSubgraphParams<'p> {
     #[serde(borrow)]
     pub filter: Filter<'p, EntityTypeWithMetadata>,
@@ -544,6 +546,10 @@ pub struct GetEntityTypeSubgraphParams<'p> {
     pub include_drafts: bool,
     #[serde(default)]
     pub include_count: bool,
+    #[serde(default)]
+    pub include_web_ids: bool,
+    #[serde(default)]
+    pub include_edition_created_by_ids: bool,
 }
 
 #[derive(Debug)]
@@ -551,6 +557,8 @@ pub struct GetEntityTypeSubgraphResponse {
     pub subgraph: Subgraph,
     pub cursor: Option<EntityTypeVertexId>,
     pub count: Option<usize>,
+    pub web_ids: Option<HashMap<OwnedById, usize>>,
+    pub edition_created_by_ids: Option<HashMap<EditionCreatedById, usize>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -566,6 +574,7 @@ pub struct CountEntityTypesParams<'p> {
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[expect(clippy::struct_excessive_bools, reason = "Parameter struct")]
 pub struct GetEntityTypesParams<'p> {
     #[serde(borrow)]
     pub filter: Filter<'p, EntityTypeWithMetadata>,
@@ -577,6 +586,10 @@ pub struct GetEntityTypesParams<'p> {
     pub limit: Option<usize>,
     #[serde(default)]
     pub include_count: bool,
+    #[serde(default)]
+    pub include_web_ids: bool,
+    #[serde(default)]
+    pub include_edition_created_by_ids: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -586,6 +599,12 @@ pub struct GetEntityTypesResponse {
     pub entity_types: Vec<EntityTypeWithMetadata>,
     pub cursor: Option<EntityTypeVertexId>,
     pub count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    pub web_ids: Option<HashMap<OwnedById, usize>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    pub edition_created_by_ids: Option<HashMap<EditionCreatedById, usize>>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/hash-graph/libs/graph/src/store/ontology.rs
+++ b/apps/hash-graph/libs/graph/src/store/ontology.rs
@@ -600,10 +600,10 @@ pub struct GetEntityTypesResponse {
     pub cursor: Option<EntityTypeVertexId>,
     pub count: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(nullable = false)]
+    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     pub web_ids: Option<HashMap<OwnedById, usize>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(nullable = false)]
+    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     pub edition_created_by_ids: Option<HashMap<EditionCreatedById, usize>>,
 }
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -66,7 +66,7 @@ use crate::{
                 },
                 InsertStatementBuilder, ReferenceTable, Table,
             },
-            TraversalContext,
+            ResponseCountMap, TraversalContext,
         },
         query::{Filter, FilterExpression, Parameter, ParameterList},
         validation::StoreProvider,
@@ -322,45 +322,85 @@ where
     ) -> Result<(GetEntitiesResponse<'static>, Zookie<'static>), QueryError> {
         let mut root_entities = Vec::new();
 
-        let (permissions, count) = if params.include_count {
-            let entity_ids = Read::<Entity>::read(
-                self,
-                &params.filter,
-                Some(temporal_axes),
-                params.include_drafts,
-            )
-            .await?
-            .map_ok(|entity| entity.metadata.record_id.entity_id)
-            .try_collect::<Vec<_>>()
-            .await?;
+        let (permissions, count, web_ids, created_by_ids, edition_created_by_ids, type_ids) =
+            if params.include_count
+                || params.include_web_ids
+                || params.include_created_by_ids
+                || params.include_edition_created_by_ids
+                || params.include_type_ids
+            {
+                let mut web_ids = params.include_web_ids.then(ResponseCountMap::default);
+                let mut created_by_ids = params
+                    .include_created_by_ids
+                    .then(ResponseCountMap::default);
+                let mut edition_created_by_ids = params
+                    .include_edition_created_by_ids
+                    .then(ResponseCountMap::default);
+                let mut include_type_ids = params.include_type_ids.then(ResponseCountMap::default);
 
-            let span = tracing::trace_span!("post_filter_entities");
-            let _s = span.enter();
-
-            let (permissions, zookie) = self
-                .authorization_api
-                .check_entities_permission(
-                    actor_id,
-                    EntityPermission::View,
-                    entity_ids.iter().copied(),
-                    Consistency::FullyConsistent,
+                let entity_ids = Read::<Entity>::read(
+                    self,
+                    &params.filter,
+                    Some(temporal_axes),
+                    params.include_drafts,
                 )
-                .await
-                .change_context(QueryError)?;
+                .await?
+                .map_ok(|entity| {
+                    if let Some(web_ids) = &mut web_ids {
+                        web_ids.increment(&entity.metadata.record_id.entity_id.owned_by_id);
+                    }
+                    if let Some(created_by_ids) = &mut created_by_ids {
+                        created_by_ids
+                            .increment(&entity.metadata.provenance.inferred.created_by_id);
+                    }
+                    if let Some(edition_created_by_ids) = &mut edition_created_by_ids {
+                        edition_created_by_ids
+                            .increment(&entity.metadata.provenance.edition.created_by_id);
+                    }
+                    if let Some(include_type_ids) = &mut include_type_ids {
+                        for entity_type_id in &entity.metadata.entity_type_ids {
+                            include_type_ids.increment(entity_type_id);
+                        }
+                    }
+                    entity.metadata.record_id.entity_id
+                })
+                .try_collect::<Vec<_>>()
+                .await?;
 
-            let permitted_ids = permissions
-                .into_iter()
-                .filter_map(|(entity_id, has_permission)| has_permission.then_some(entity_id))
-                .collect::<HashSet<_>>();
+                let span = tracing::trace_span!("post_filter_entities");
+                let _s = span.enter();
 
-            let count = entity_ids
-                .into_iter()
-                .filter(|id| permitted_ids.contains(&id.entity_uuid))
-                .count();
-            (Some((permitted_ids, zookie)), Some(count))
-        } else {
-            (None, None)
-        };
+                let (permissions, zookie) = self
+                    .authorization_api
+                    .check_entities_permission(
+                        actor_id,
+                        EntityPermission::View,
+                        entity_ids.iter().copied(),
+                        Consistency::FullyConsistent,
+                    )
+                    .await
+                    .change_context(QueryError)?;
+
+                let permitted_ids = permissions
+                    .into_iter()
+                    .filter_map(|(entity_id, has_permission)| has_permission.then_some(entity_id))
+                    .collect::<HashSet<_>>();
+
+                let count = entity_ids
+                    .into_iter()
+                    .filter(|id| permitted_ids.contains(&id.entity_uuid))
+                    .count();
+                (
+                    Some((permitted_ids, zookie)),
+                    Some(count),
+                    web_ids.map(HashMap::from),
+                    created_by_ids.map(HashMap::from),
+                    edition_created_by_ids.map(HashMap::from),
+                    include_type_ids.map(HashMap::from),
+                )
+            } else {
+                (None, None, None, None, None, None)
+            };
 
         let (latest_zookie, last) = loop {
             // We query one more than requested to determine if there are more entities to return.
@@ -462,6 +502,10 @@ where
                     .collect(),
                 cursor: last,
                 count,
+                web_ids,
+                created_by_ids,
+                edition_created_by_ids,
+                type_ids,
             },
             latest_zookie.into_owned(),
         ))
@@ -968,6 +1012,10 @@ where
                 entities: root_entities,
                 cursor,
                 count,
+                web_ids,
+                created_by_ids,
+                edition_created_by_ids,
+                type_ids,
             },
             zookie,
         ) = self
@@ -980,6 +1028,10 @@ where
                     limit: params.limit,
                     include_drafts: params.include_drafts,
                     include_count: false,
+                    include_web_ids: params.include_web_ids,
+                    include_created_by_ids: params.include_created_by_ids,
+                    include_edition_created_by_ids: params.include_edition_created_by_ids,
+                    include_type_ids: params.include_type_ids,
                 },
                 &temporal_axes,
             )
@@ -1036,6 +1088,10 @@ where
             subgraph,
             cursor,
             count,
+            web_ids,
+            created_by_ids,
+            edition_created_by_ids,
+            type_ids,
         })
     }
 

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -5162,7 +5162,19 @@
           "includeCount": {
             "type": "boolean"
           },
+          "includeCreatedByIds": {
+            "type": "boolean"
+          },
           "includeDrafts": {
+            "type": "boolean"
+          },
+          "includeEditionCreatedByIds": {
+            "type": "boolean"
+          },
+          "includeTypeIds": {
+            "type": "boolean"
+          },
+          "includeWebIds": {
             "type": "boolean"
           },
           "limit": {
@@ -5194,6 +5206,13 @@
             "nullable": true,
             "minimum": 0
           },
+          "createdByIds": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
           "cursor": {
             "allOf": [
               {
@@ -5202,10 +5221,31 @@
             ],
             "nullable": true
           },
+          "editionCreatedByIds": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
           "entities": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Entity"
+            }
+          },
+          "typeIds": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "webIds": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "minimum": 0
             }
           }
         }
@@ -5236,7 +5276,19 @@
           "includeCount": {
             "type": "boolean"
           },
+          "includeCreatedByIds": {
+            "type": "boolean"
+          },
           "includeDrafts": {
+            "type": "boolean"
+          },
+          "includeEditionCreatedByIds": {
+            "type": "boolean"
+          },
+          "includeTypeIds": {
+            "type": "boolean"
+          },
+          "includeWebIds": {
             "type": "boolean"
           },
           "limit": {
@@ -5268,6 +5320,13 @@
             "nullable": true,
             "minimum": 0
           },
+          "createdByIds": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
           "cursor": {
             "allOf": [
               {
@@ -5276,8 +5335,29 @@
             ],
             "nullable": true
           },
+          "editionCreatedByIds": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
           "subgraph": {
             "$ref": "#/components/schemas/Subgraph"
+          },
+          "typeIds": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "webIds": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "minimum": 0
+            }
           }
         }
       },
@@ -5310,6 +5390,12 @@
           "includeDrafts": {
             "type": "boolean"
           },
+          "includeEditionCreatedByIds": {
+            "type": "boolean"
+          },
+          "includeWebIds": {
+            "type": "boolean"
+          },
           "limit": {
             "type": "integer",
             "nullable": true,
@@ -5327,6 +5413,11 @@
           "subgraph"
         ],
         "properties": {
+          "count": {
+            "type": "integer",
+            "nullable": true,
+            "minimum": 0
+          },
           "cursor": {
             "allOf": [
               {
@@ -5335,8 +5426,22 @@
             ],
             "nullable": true
           },
+          "editionCreatedByIds": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
           "subgraph": {
             "$ref": "#/components/schemas/Subgraph"
+          },
+          "webIds": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "minimum": 0
+            }
           }
         }
       },
@@ -5363,6 +5468,12 @@
             "type": "boolean"
           },
           "includeDrafts": {
+            "type": "boolean"
+          },
+          "includeEditionCreatedByIds": {
+            "type": "boolean"
+          },
+          "includeWebIds": {
             "type": "boolean"
           },
           "limit": {
@@ -5395,10 +5506,24 @@
             ],
             "nullable": true
           },
+          "editionCreatedByIds": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
           "entityTypes": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/EntityTypeWithMetadata"
+            }
+          },
+          "webIds": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "minimum": 0
             }
           }
         }

--- a/tests/hash-graph-benches/read_scaling/knowledge/complete/entity.rs
+++ b/tests/hash-graph-benches/read_scaling/knowledge/complete/entity.rs
@@ -231,6 +231,10 @@ pub fn bench_get_entity_by_id<A: AuthorizationApi>(
                         limit: None,
                         include_count: false,
                         include_drafts: false,
+                        include_web_ids: false,
+                        include_created_by_ids: false,
+                        include_edition_created_by_ids: false,
+                        include_type_ids: false,
                     },
                 )
                 .await

--- a/tests/hash-graph-benches/read_scaling/knowledge/linkless/entity.rs
+++ b/tests/hash-graph-benches/read_scaling/knowledge/linkless/entity.rs
@@ -172,6 +172,10 @@ pub fn bench_get_entity_by_id<A: AuthorizationApi>(
                         limit: None,
                         include_count: false,
                         include_drafts: false,
+                        include_web_ids: false,
+                        include_created_by_ids: false,
+                        include_edition_created_by_ids: false,
+                        include_type_ids: false,
                     },
                 )
                 .await

--- a/tests/hash-graph-benches/representative_read/knowledge/entity.rs
+++ b/tests/hash-graph-benches/representative_read/knowledge/entity.rs
@@ -61,6 +61,10 @@ pub fn bench_get_entity_by_id<A: AuthorizationApi>(
                         limit: None,
                         include_count: false,
                         include_drafts: false,
+                        include_web_ids: false,
+                        include_created_by_ids: false,
+                        include_edition_created_by_ids: false,
+                        include_type_ids: false,
                     },
                 )
                 .await
@@ -112,6 +116,10 @@ pub fn bench_get_entities_by_property<A: AuthorizationApi>(
                     limit: None,
                     include_count: false,
                     include_drafts: false,
+                    include_web_ids: false,
+                    include_created_by_ids: false,
+                    include_edition_created_by_ids: false,
+                    include_type_ids: false,
                 },
             )
             .await
@@ -165,6 +173,10 @@ pub fn bench_get_link_by_target_by_property<A: AuthorizationApi>(
                     limit: None,
                     include_count: false,
                     include_drafts: false,
+                    include_web_ids: false,
+                    include_created_by_ids: false,
+                    include_edition_created_by_ids: false,
+                    include_type_ids: false,
                 },
             )
             .await

--- a/tests/hash-graph-benches/representative_read/ontology/entity_type.rs
+++ b/tests/hash-graph-benches/representative_read/ontology/entity_type.rs
@@ -46,6 +46,8 @@ pub fn bench_get_entity_type_by_id<A: AuthorizationApi>(
                         limit: None,
                         include_drafts: false,
                         include_count: false,
+                        include_web_ids: false,
+                        include_edition_created_by_ids: false,
                     },
                 )
                 .await

--- a/tests/hash-graph-integration/postgres/entity.rs
+++ b/tests/hash-graph-integration/postgres/entity.rs
@@ -97,6 +97,10 @@ async fn insert() {
                 limit: None,
                 include_count: true,
                 include_drafts: false,
+                include_web_ids: false,
+                include_created_by_ids: false,
+                include_edition_created_by_ids: false,
+                include_type_ids: false,
             },
         )
         .await
@@ -168,6 +172,10 @@ async fn query() {
                 limit: None,
                 include_count: true,
                 include_drafts: false,
+                include_web_ids: false,
+                include_created_by_ids: false,
+                include_edition_created_by_ids: false,
+                include_type_ids: false,
             },
         )
         .await
@@ -281,6 +289,10 @@ async fn update() {
                 limit: None,
                 include_count: false,
                 include_drafts: false,
+                include_web_ids: false,
+                include_created_by_ids: false,
+                include_edition_created_by_ids: false,
+                include_type_ids: false,
             },
         )
         .await
@@ -313,6 +325,10 @@ async fn update() {
                 limit: None,
                 include_count: true,
                 include_drafts: false,
+                include_web_ids: false,
+                include_created_by_ids: false,
+                include_edition_created_by_ids: false,
+                include_type_ids: false,
             },
         )
         .await
@@ -342,6 +358,10 @@ async fn update() {
                 limit: None,
                 include_count: true,
                 include_drafts: false,
+                include_web_ids: false,
+                include_created_by_ids: false,
+                include_edition_created_by_ids: false,
+                include_type_ids: false,
             },
         )
         .await

--- a/tests/hash-graph-integration/postgres/entity_type.rs
+++ b/tests/hash-graph-integration/postgres/entity_type.rs
@@ -106,6 +106,8 @@ async fn query() {
                 limit: None,
                 include_drafts: false,
                 include_count: false,
+                include_web_ids: false,
+                include_edition_created_by_ids: false,
             },
         )
         .await
@@ -198,6 +200,8 @@ async fn update() {
                 limit: None,
                 include_drafts: false,
                 include_count: false,
+                include_web_ids: false,
+                include_edition_created_by_ids: false,
             },
         )
         .await
@@ -222,6 +226,8 @@ async fn update() {
                 limit: None,
                 include_drafts: false,
                 include_count: false,
+                include_web_ids: false,
+                include_edition_created_by_ids: false,
             },
         )
         .await

--- a/tests/hash-graph-integration/postgres/links.rs
+++ b/tests/hash-graph-integration/postgres/links.rs
@@ -213,6 +213,10 @@ async fn insert() {
                 limit: None,
                 include_count: true,
                 include_drafts: false,
+                include_web_ids: false,
+                include_created_by_ids: false,
+                include_edition_created_by_ids: false,
+                include_type_ids: false,
             },
         )
         .await
@@ -431,6 +435,10 @@ async fn get_entity_links() {
                 limit: None,
                 include_count: false,
                 include_drafts: false,
+                include_web_ids: false,
+                include_created_by_ids: false,
+                include_edition_created_by_ids: false,
+                include_type_ids: false,
             },
         )
         .await

--- a/tests/hash-graph-integration/postgres/multi_type.rs
+++ b/tests/hash-graph-integration/postgres/multi_type.rs
@@ -142,6 +142,10 @@ async fn initial_person() {
                 limit: None,
                 include_count: true,
                 include_drafts: false,
+                include_web_ids: false,
+                include_created_by_ids: false,
+                include_edition_created_by_ids: false,
+                include_type_ids: false,
             },
         )
         .await
@@ -196,6 +200,10 @@ async fn initial_person() {
                 limit: None,
                 include_count: true,
                 include_drafts: false,
+                include_web_ids: false,
+                include_created_by_ids: false,
+                include_edition_created_by_ids: false,
+                include_type_ids: false,
             },
         )
         .await
@@ -218,6 +226,10 @@ async fn initial_person() {
                 limit: None,
                 include_count: true,
                 include_drafts: false,
+                include_web_ids: false,
+                include_created_by_ids: false,
+                include_edition_created_by_ids: false,
+                include_type_ids: false,
             },
         )
         .await
@@ -290,6 +302,10 @@ async fn create_multi() {
                 limit: None,
                 include_count: true,
                 include_drafts: false,
+                include_web_ids: false,
+                include_created_by_ids: false,
+                include_edition_created_by_ids: false,
+                include_type_ids: false,
             },
         )
         .await
@@ -312,6 +328,10 @@ async fn create_multi() {
                 limit: None,
                 include_count: true,
                 include_drafts: false,
+                include_web_ids: false,
+                include_created_by_ids: false,
+                include_edition_created_by_ids: false,
+                include_type_ids: false,
             },
         )
         .await
@@ -361,6 +381,10 @@ async fn create_multi() {
                 limit: None,
                 include_count: true,
                 include_drafts: false,
+                include_web_ids: false,
+                include_created_by_ids: false,
+                include_edition_created_by_ids: false,
+                include_type_ids: false,
             },
         )
         .await

--- a/tests/hash-graph-integration/postgres/partial_updates.rs
+++ b/tests/hash-graph-integration/postgres/partial_updates.rs
@@ -157,6 +157,10 @@ async fn properties_add() {
                 limit: None,
                 include_count: false,
                 include_drafts: false,
+                include_web_ids: false,
+                include_created_by_ids: false,
+                include_edition_created_by_ids: false,
+                include_type_ids: false,
             },
         )
         .await
@@ -231,6 +235,10 @@ async fn properties_remove() {
                 limit: None,
                 include_count: false,
                 include_drafts: false,
+                include_web_ids: false,
+                include_created_by_ids: false,
+                include_edition_created_by_ids: false,
+                include_type_ids: false,
             },
         )
         .await
@@ -311,6 +319,10 @@ async fn properties_replace() {
                 limit: None,
                 include_count: false,
                 include_drafts: false,
+                include_web_ids: false,
+                include_created_by_ids: false,
+                include_edition_created_by_ids: false,
+                include_type_ids: false,
             },
         )
         .await
@@ -383,6 +395,10 @@ async fn type_ids() {
                 limit: None,
                 include_count: false,
                 include_drafts: false,
+                include_web_ids: false,
+                include_created_by_ids: false,
+                include_edition_created_by_ids: false,
+                include_type_ids: false,
             },
         )
         .await
@@ -430,6 +446,10 @@ async fn type_ids() {
                 limit: None,
                 include_count: false,
                 include_drafts: false,
+                include_web_ids: false,
+                include_created_by_ids: false,
+                include_edition_created_by_ids: false,
+                include_type_ids: false,
             },
         )
         .await
@@ -479,6 +499,10 @@ async fn type_ids() {
                 limit: None,
                 include_count: false,
                 include_drafts: false,
+                include_web_ids: false,
+                include_created_by_ids: false,
+                include_edition_created_by_ids: false,
+                include_type_ids: false,
             },
         )
         .await

--- a/tests/hash-graph-integration/postgres/sorting.rs
+++ b/tests/hash-graph-integration/postgres/sorting.rs
@@ -62,6 +62,10 @@ async fn test_root_sorting<A: AuthorizationApi>(
             entities: new_entities,
             count,
             cursor: new_cursor,
+            web_ids: _,
+            created_by_ids: _,
+            edition_created_by_ids: _,
+            type_ids: _,
         } = api
             .get_entities(
                 api.account_id,
@@ -78,6 +82,10 @@ async fn test_root_sorting<A: AuthorizationApi>(
                     limit: Some(chunk_size),
                     include_count: true,
                     include_drafts: false,
+                    include_web_ids: false,
+                    include_created_by_ids: false,
+                    include_edition_created_by_ids: false,
+                    include_type_ids: false,
                 },
             )
             .await


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When requested, a set (+ count) of all possible values should be returned independent of pagination.

## 🔍 What does this change?

Allow specifying a set of distinct values (+ count) for:
- `web` (only entities and owned types)
- `createdById` (only entities, we currently don't store the initial creator of a type)
- `editionCreatedById` (corresponds to `updatedById`)
- `types` (only entities)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph