### PR TITLE
H-3317: Change dependencies to be precise in Rust

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -248,6 +248,11 @@
     },
     {
       "matchManagers": ["cargo"],
+      "groupName": "`tower` Rust crates",
+      "matchPackageNames": ["/^tower[-_]?/"]
+    },
+    {
+      "matchManagers": ["cargo"],
       "groupName": "`criterion` Rust crates",
       "matchPackageNames": ["/^criterion[-_]?/"]
     },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,7 +2534,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tokio-util",
- "tower 0.5.1",
+ "tower 0.5.0",
  "tower-layer",
  "tower-service",
  "tower-test",
@@ -5879,12 +5879,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.122"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
- "memchr",
  "ryu",
  "serde",
 ]
@@ -6914,9 +6913,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+checksum = "36b837f86b25d7c0d7988f00a54e74739be6477f2aac6201b8f429a7569991b7"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -6951,9 +6950,9 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.3"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tower-test"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,151 +68,151 @@ type-system.path = "libs/@blockprotocol/type-system/rust"
 validation.path = "libs/@local/hash-validation"
 
 # Pinned workspace members
-error-stack = { version = "0.5.0", default-features = false }
+error-stack = { version = "=0.5.0", default-features = false }
 
 # Public dependencies
-ahash = { version = "0.8.11", default-features = false }
-ariadne = { version = "0.4.1", default-features = false }
-aws-types = { version = "1.3.3", default-features = false }
+ahash = { version = "=0.8.11", default-features = false }
+ariadne = { version = "=0.4.1", default-features = false }
+aws-types = { version = "=1.3.3", default-features = false }
 axum = "0.7.5"
 axum-core = "0.4.3"
-bumpalo = { version = "3.16.0", default-features = false }
+bumpalo = { version = "=3.16.0", default-features = false }
 bytes = "1.6.0"
-clap_builder = { version = "4.5.9", default-features = false, features = ["std"] }
-criterion = { version = "0.5.1" }
-deadpool = { version = "0.12.1", default-features = false }
-deadpool-postgres = { version = "0.14.0", default-features = false }
-ecow = { version = "0.2.2", default-features = false }
-email_address = { version = "0.2.5", default-features = false }
-enumflags2 = { version = "0.7.10", default-features = false }
-erased-serde = { version = "0.4.5", default-features = false }
-futures-core = { version = "0.3.30", default-features = false }
-futures-io = { version = "0.3.30", default-features = false }
-futures-sink = { version = "0.3.30", default-features = false }
-futures-util = { version = "0.3.30", default-features = false }
-hashbrown = { version = "0.14.5", features = ["nightly"] }
-http = { version = "1.1.0", default-features = false }
-inferno = { version = "0.11.19", default-features = false }
-iso8601-duration = { version = "0.2.0", default-features = false }
-json-number = { version = "0.4.8", default-features = false }
-jsonptr = { version = "0.6.0", default-features = false }
-multiaddr = { version = "0.18.1", default-features = false }
-multistream-select = { version = "0.13.0", default-features = false }
-libp2p-core = { version = "0.42.0", default-features = false }
-libp2p-identity = { version = "0.2.9", default-features = false }
-libp2p-ping = { version = "0.45.0", default-features = false }
-libp2p-swarm = { version = "0.45.0", default-features = false }
-libp2p-yamux = { version = "0.46.0", default-features = false }
-prometheus-client = { version = "0.22.2", default-features = false }
-postgres-types = { version = "0.2.6", default-features = false }
-reqwest = { version = "0.12.5", default-features = false, features = ["rustls-tls"] }
-regex = { version = "1.10.5", default-features = false, features = ["perf", "unicode"] }
-semver = { version = "1.0.23", default-features = false }
-sentry-types = { version = "0.34.0", default-features = false }
-serde = { version = "1.0.204", default-features = false }
-serde_json = { version = "1.0.120" }
-text-size = { version = "1.1.1", default-features = false }
-tokio = { version = "1.38.0", default-features = false }
-tokio-util = { version = "0.7.11", default-features = false }
-tower-layer = { version = "0.3.2", default-features = false }
-tower-service = { version = "0.3.2", default-features = false }
-tracing-appender = { version = "0.2.3", default-features = false }
-tracing-core = { version = "0.1.32", default-features = false }
-tracing-subscriber = { version = "0.3.18", default-features = false }
-url = { version = "2.5.2", default-features = false }
-utoipa = { version = "4.2.3", default-features = false }
-uuid = { version = "1.10.0", default-features = false }
-time = { version = "0.3.36", default-features = false }
-tokio-postgres = { version = "0.7.10", default-features = false }
-tower-http = { version = "0.5.2", features = ["trace"] }
+clap_builder = { version = "=4.5.9", default-features = false, features = ["std"] }
+criterion = { version = "=0.5.1" }
+deadpool = { version = "=0.12.1", default-features = false }
+deadpool-postgres = { version = "=0.14.0", default-features = false }
+ecow = { version = "=0.2.2", default-features = false }
+email_address = { version = "=0.2.5", default-features = false }
+enumflags2 = { version = "=0.7.10", default-features = false }
+erased-serde = { version = "=0.4.5", default-features = false }
+futures-core = { version = "=0.3.30", default-features = false }
+futures-io = { version = "=0.3.30", default-features = false }
+futures-sink = { version = "=0.3.30", default-features = false }
+futures-util = { version = "=0.3.30", default-features = false }
+hashbrown = { version = "=0.14.5", features = ["nightly"] }
+http = { version = "=1.1.0", default-features = false }
+inferno = { version = "=0.11.19", default-features = false }
+iso8601-duration = { version = "=0.2.0", default-features = false }
+json-number = { version = "=0.4.8", default-features = false }
+jsonptr = { version = "=0.6.0", default-features = false }
+multiaddr = { version = "=0.18.1", default-features = false }
+multistream-select = { version = "=0.13.0", default-features = false }
+libp2p-core = { version = "=0.42.0", default-features = false }
+libp2p-identity = { version = "=0.2.9", default-features = false }
+libp2p-ping = { version = "=0.45.0", default-features = false }
+libp2p-swarm = { version = "=0.45.1", default-features = false }
+libp2p-yamux = { version = "=0.46.0", default-features = false }
+prometheus-client = { version = "=0.22.2", default-features = false }
+postgres-types = { version = "=0.2.6", default-features = false }
+reqwest = { version = "=0.12.5", default-features = false, features = ["rustls-tls"] }
+regex = { version = "=1.10.5", default-features = false, features = ["perf", "unicode"] }
+semver = { version = "=1.0.23", default-features = false }
+sentry-types = { version = "=0.34.0", default-features = false }
+serde = { version = "=1.0.204", default-features = false }
+serde_json = { version = "=1.0.120" }
+text-size = { version = "=1.1.1", default-features = false }
+tokio = { version = "=1.38.0", default-features = false }
+tokio-util = { version = "=0.7.11", default-features = false }
+tower-layer = { version = "=0.3.3", default-features = false }
+tower-service = { version = "=0.3.2", default-features = false }
+tracing-appender = { version = "=0.2.3", default-features = false }
+tracing-core = { version = "=0.1.32", default-features = false }
+tracing-subscriber = { version = "=0.3.18", default-features = false }
+url = { version = "=2.5.2", default-features = false }
+utoipa = { version = "=4.2.3", default-features = false }
+uuid = { version = "=1.10.0", default-features = false }
+time = { version = "=0.3.36", default-features = false }
+tokio-postgres = { version = "=0.7.10", default-features = false }
+tower-http = { version = "=0.5.2", features = ["trace"] }
 
 # Shared third-party dependencies
-ansi-to-html = { version = "0.2.1", default-features = false }
-anstyle = { version = "1.0.8", default-features = false }
-anstyle-yansi = { version = "2.0.1", default-features = false }
-approx = { version = "0.5.1", default-features = false }
-async-scoped = { version = "0.9.0", default-features = false }
-async-trait = { version = "0.1.81", default-features = false }
-aws-config = { version = "1.5.4" }
-aws-sdk-s3 = { version = "1.40.0", default-features = false }
-base64 = { version = "0.22.1", default-features = false }
-bitvec = { version = "1.0.1", default-features = false }
-bytes-utils = { version = "0.1.4", default-features = false }
-chrono = { version = "0.4.38", default-features = false }
-clap = { version = "4.5.9", features = ["std", "color", "help", "usage", "error-context", "suggestions"] }
-clap_complete = { version = "4.5.8", default-features = false }
-coverage-helper = { version = "0.2.2", default-features = false }
-criterion-macro = { version = "0.4.0", default-features = false }
-derive-where = { version = "1.2.7", default-features = false, features = ["nightly"] }
-dotenv-flow = { version = "0.16.2", default-features = false }
-expect-test = { version = "1.5.0", default-features = false }
-futures = { version = "0.3.30", default-features = false }
-hifijson = { version = "0.2.2", default-features = false }
-http-body-util = { version = "0.1.2", default-features = false }
-humansize = { version = "2.1.3", default-features = false }
-hyper = { version = "1.4.1", default-features = false }
-include_dir = { version = "0.7.4", default-features = false }
-insta = { version = "1.39.0", default-features = false }
-jsonschema = { version = "0.18.0", default-features = false }
-justjson = { version = "0.3.0", default-features = false }
-lexical = { version = "6.1.1", default-features = false }
-libp2p = { version = "0.54.0", default-features = false }
-libp2p-stream = { version = "0.2.0-alpha", default-features = false }
-logos = { version = "0.14.1", default-features = false }
-memchr = { version = "2.7.4", default-features = false }
-mimalloc = { version = "0.1.43", default-features = false }
-mime = { version = "0.3.17", default-features = false }
-num-traits = { version = "0.2.19", default-features = false }
-once_cell = { version = "1.19.0", default-features = false }
-opentelemetry = { version = "0.23.0", default-features = false }
-opentelemetry-otlp = { version = "0.16.0", default-features = false }
-opentelemetry_sdk = { version = "0.23.0", default-features = false }
-orx-concurrent-vec = { version = "2.2.0", default-features = false }
-owo-colors = { version = "4.0.0", default-features = false }
-paste = { version = "1.0.15", default-features = false }
-pin-project = { version = "1.1.5", default-features = false }
-pin-project-lite = { version = "0.2.14", default-features = false }
-postgres-protocol = { version = "0.6.6", default-features = false }
-pretty_assertions = { version = "1.4.0", default-features = false, features = ["alloc"] }
-proptest = { version = "1.5.0", default-features = false, features = ["alloc"] }
-rand = { version = "0.8.5", default-features = false }
-refinery = { version = "0.8.14", default-features = false }
-rustc_version = { version = "0.4.0", default-features = false }
-scc = { version = "2.1.2", default-features = false }
-sentry = { version = "0.34.0", default-features = false, features = ["backtrace", "contexts", "debug-images", "panic", "reqwest", "rustls", "tracing", "tower-http"] }
-seq-macro = { version = "0.3.5", default-features = false }
-serde-value = { version = "0.7.0", default-features = false }
-serde_plain = { version = "1.0.2", default-features = false }
-serde_with = { version = "3.9.0", default-features = false }
-similar-asserts = { version = "1.5.0", default-features = false }
-spin = { version = "0.9", default-features = false }
-supports-color = { version = "3.0.0", default-features = false }
-supports-unicode = { version = "3.0.0", default-features = false }
-sval = { version = "2.13.0", default-features = false }
-syn = { version = "2.0.70", default-features = false }
-tachyonix = { version = "0.3.0", default-features = false }
-tarpc = { version = "0.33", default-features = false }
+ansi-to-html = { version = "=0.2.1", default-features = false }
+anstyle = { version = "=1.0.8", default-features = false }
+anstyle-yansi = { version = "=2.0.1", default-features = false }
+approx = { version = "=0.5.1", default-features = false }
+async-scoped = { version = "=0.9.0", default-features = false }
+async-trait = { version = "=0.1.81", default-features = false }
+aws-config = { version = "=1.5.4" }
+aws-sdk-s3 = { version = "=1.40.0", default-features = false }
+base64 = { version = "=0.22.1", default-features = false }
+bitvec = { version = "=1.0.1", default-features = false }
+bytes-utils = { version = "=0.1.4", default-features = false }
+chrono = { version = "=0.4.38", default-features = false }
+clap = { version = "=4.5.9", features = ["std", "color", "help", "usage", "error-context", "suggestions"] }
+clap_complete = { version = "=4.5.8", default-features = false }
+coverage-helper = { version = "=0.2.2", default-features = false }
+criterion-macro = { version = "=0.4.0", default-features = false }
+derive-where = { version = "=1.2.7", default-features = false, features = ["nightly"] }
+dotenv-flow = { version = "=0.16.2", default-features = false }
+expect-test = { version = "=1.5.0", default-features = false }
+futures = { version = "=0.3.30", default-features = false }
+hifijson = { version = "=0.2.2", default-features = false }
+http-body-util = { version = "=0.1.2", default-features = false }
+humansize = { version = "=2.1.3", default-features = false }
+hyper = { version = "=1.4.1", default-features = false }
+include_dir = { version = "=0.7.4", default-features = false }
+insta = { version = "=1.39.0", default-features = false }
+jsonschema = { version = "=0.18.0", default-features = false }
+justjson = { version = "=0.3.0", default-features = false }
+lexical = { version = "=6.1.1", default-features = false }
+libp2p = { version = "=0.54.1", default-features = false }
+libp2p-stream = { version = "=0.2.0-alpha", default-features = false }
+logos = { version = "=0.14.1", default-features = false }
+memchr = { version = "=2.7.4", default-features = false }
+mimalloc = { version = "=0.1.43", default-features = false }
+mime = { version = "=0.3.17", default-features = false }
+num-traits = { version = "=0.2.19", default-features = false }
+once_cell = { version = "=1.19.0", default-features = false }
+opentelemetry = { version = "=0.23.0", default-features = false }
+opentelemetry-otlp = { version = "=0.16.0", default-features = false }
+opentelemetry_sdk = { version = "=0.23.0", default-features = false }
+orx-concurrent-vec = { version = "=2.2.0", default-features = false }
+owo-colors = { version = "=4.0.0", default-features = false }
+paste = { version = "=1.0.15", default-features = false }
+pin-project = { version = "=1.1.5", default-features = false }
+pin-project-lite = { version = "=0.2.14", default-features = false }
+postgres-protocol = { version = "=0.6.6", default-features = false }
+pretty_assertions = { version = "=1.4.0", default-features = false, features = ["alloc"] }
+proptest = { version = "=1.5.0", default-features = false, features = ["alloc"] }
+rand = { version = "=0.8.5", default-features = false }
+refinery = { version = "=0.8.14", default-features = false }
+rustc_version = { version = "=0.4.0", default-features = false }
+scc = { version = "=2.1.2", default-features = false }
+sentry = { version = "=0.34.0", default-features = false, features = ["backtrace", "contexts", "debug-images", "panic", "reqwest", "rustls", "tracing", "tower-http"] }
+seq-macro = { version = "=0.3.5", default-features = false }
+serde-value = { version = "=0.7.0", default-features = false }
+serde_plain = { version = "=1.0.2", default-features = false }
+serde_with = { version = "=3.9.0", default-features = false }
+similar-asserts = { version = "=1.5.0", default-features = false }
+spin = { version = "=0.9", default-features = false }
+supports-color = { version = "=3.0.0", default-features = false }
+supports-unicode = { version = "=3.0.0", default-features = false }
+sval = { version = "=2.13.0", default-features = false }
+syn = { version = "=2.0.70", default-features = false }
+tachyonix = { version = "=0.3.0", default-features = false }
+tarpc = { version = "=0.33", default-features = false }
 temporal-io-client = { git = "https://github.com/temporalio/sdk-core", rev = "7e3c23f" }
 temporal-io-sdk-core-protos = { git = "https://github.com/temporalio/sdk-core", rev = "7e3c23f" }
-test-fuzz = { version = "6.0.0", default-features = false }
-test-log = { version = "0.2.16", default-features = false }
-test-strategy = { version = "0.4.0", default-features = false }
-thiserror = { version = "1.0.63", default-features = false }
-tokio-serde = { version = "0.8.0", default-features = false }
-tokio-stream = { version = "0.1.15", default-features = false }
-tokio-test = { version = "0.4.4", default-features = false }
-tower = { version = "0.5.0", default-features = false }
-tower-test = { version = "0.4.0", default-features = false }
-tracing = { version = "0.1.40", default-features = false }
-tracing-error = { version = "0.2.0", default-features = false }
-tracing-flame = { version = "0.2.0", default-features = false }
-tracing-opentelemetry = { version = "0.24.0", default-features = false }
-trybuild = { version = "1.0.97", default-features = false }
-tsify = { version = "0.4.5", default-features = false }
-unicode-ident = { version = "1.0.12", default-features = false }
-virtue = { version = "0.0.17", default-features = false }
-walkdir = { version = "2.5.0", default-features = false }
-winnow = { version = "0.6.18", default-features = false }
+test-fuzz = { version = "=6.0.0", default-features = false }
+test-log = { version = "=0.2.16", default-features = false }
+test-strategy = { version = "=0.4.0", default-features = false }
+thiserror = { version = "=1.0.63", default-features = false }
+tokio-serde = { version = "=0.8.0", default-features = false }
+tokio-stream = { version = "=0.1.15", default-features = false }
+tokio-test = { version = "=0.4.4", default-features = false }
+tower = { version = "=0.5.0", default-features = false }
+tower-test = { version = "=0.4.0", default-features = false }
+tracing = { version = "=0.1.40", default-features = false }
+tracing-error = { version = "=0.2.0", default-features = false }
+tracing-flame = { version = "=0.2.0", default-features = false }
+tracing-opentelemetry = { version = "=0.24.0", default-features = false }
+trybuild = { version = "=1.0.97", default-features = false }
+tsify = { version = "=0.4.5", default-features = false }
+unicode-ident = { version = "=1.0.12", default-features = false }
+virtue = { version = "=0.0.17", default-features = false }
+walkdir = { version = "=2.5.0", default-features = false }
+winnow = { version = "=0.6.18", default-features = false }
 
 [profile.production]
 inherits = "release"

--- a/libs/sarif/src/schema/log.rs
+++ b/libs/sarif/src/schema/log.rs
@@ -218,7 +218,7 @@ impl<'s> Extend<Run<'s>> for SarifLog<'s> {
 #[cfg(test)]
 #[cfg(feature = "serde")]
 pub(crate) mod tests {
-    use alloc::borrow::Cow;
+    use alloc::{borrow::Cow, vec};
 
     use coverage_helper::test;
     use semver::Version;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `Cargo.lock` does not fully match the `Cargo.toml` because it may use later versions. This also helps with the issue renovate has to open Rust PRs