### PR TITLE
GEN-194: Create `error-stack-experimental` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1974,6 +1974,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-stack-experimental"
+version = "0.0.0-reserved"
+
+[[package]]
 name = "error-stack-macros"
 version = "0.0.0-reserved"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "libs/deer/macros",
     "libs/error-stack",
     "libs/error-stack/macros",
+    "libs/error-stack/experimental",
     "libs/sarif",
 ]
 default-members = [

--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 repository = "https://github.com/hashintel/hash/tree/main/libs/error-stack"
 keywords = ["error", "errorstack", "error-handling", "report", "no_std"]
 categories = ["rust-patterns", "no-std"]
-exclude = ["package.json"]
+exclude = ["package.json", "macros", "experimental"]
 
 [dependencies]
 # Public workspace dependencies

--- a/libs/error-stack/experimental/Cargo.toml
+++ b/libs/error-stack/experimental/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "error-stack-experimental"
+version = "0.0.0-reserved"
+authors = { workspace = true }
+edition = "2021"
+rust-version = "1.63.0"
+license = "MIT OR Apache-2.0"
+description = "Experimental features for error-stack"
+documentation = "https://docs.rs/error-stack-experimental"
+readme = "README.md"
+repository = "https://github.com/hashintel/hash/tree/main/libs/error-stack"
+keywords = ["errorstack", "error-handling", "experimental"]
+categories = ["rust-patterns", "no-std"]
+publish = false
+
+[dependencies]

--- a/libs/error-stack/experimental/Cargo.toml
+++ b/libs/error-stack/experimental/Cargo.toml
@@ -14,3 +14,6 @@ categories = ["rust-patterns", "no-std"]
 publish = false
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/libs/error-stack/experimental/LICENSE.md
+++ b/libs/error-stack/experimental/LICENSE.md
@@ -1,0 +1,5 @@
+# License
+
+Licensed under either of the [Apache License, Version 2.0](LICENSE-APACHE.md) or [MIT license](LICENSE-MIT.md) at your option.
+
+For more information about contributing to this crate, see our top-level [CONTRIBUTING](https://github.com/hashintel/hash/blob/main/.github/CONTRIBUTING.md) policy.

--- a/libs/error-stack/experimental/README.md
+++ b/libs/error-stack/experimental/README.md
@@ -1,0 +1,19 @@
+[crates.io]: https://crates.io/crates/error-stack-experimental
+[libs.rs]: https://lib.rs/crates/error-stack-experimental
+[rust-version]: https://www.rust-lang.org
+[documentation]: https://docs.rs/error-stack-macros
+[license]: https://github.com/hashintel/hash/blob/main/libs/error-stack/LICENSE.md
+
+[![crates.io](https://img.shields.io/crates/v/error-stack-experimental)][crates.io]
+[![libs.rs](https://img.shields.io/badge/libs.rs-error--stack--experimental-orange)][libs.rs]
+[![rust-version](https://img.shields.io/static/v1?label=Rust&message=1.63.0/nightly-2024-09-09&color=blue)][rust-version]
+[![documentation](https://img.shields.io/docsrs/error-stack-experimental)][documentation]
+[![license](https://img.shields.io/crates/l/error-stack)][license]
+
+[Open issues](https://github.com/hashintel/hash/issues?q=is%3Aissue+is%3Aopen+label%3AA-error-stack) / [Discussions](https://github.com/hashintel/hash/discussions?discussions_q=label%3AA-error-stack)
+
+# error-stack-experimental
+
+`error-stack-experimental` serves as a testing ground for novel features and concepts that are not yet ready for inclusion in the main `error-stack` crate. This separate crate allows us to explore and refine new ideas without impacting the stability of the core library.
+
+While `error-stack-experimental` is designed for experimentation, it adheres to semantic versioning principles to maintain a degree of reliability for users. However, it's important to note that features introduced in this crate may be subject to removal or integration into the main crate in future updates. As such, users should approach the experimental features with caution and not rely on them as permanent components of the error handling ecosystem. To ease the transition of features from `error-stack-experimental` to `error-stack`, we aim to maintain compatibility between the two crates as much as possible, using techniques such as re-exports in case of feature promotion to allow for a deprecation window.

--- a/libs/error-stack/experimental/package.json
+++ b/libs/error-stack/experimental/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@rust/error-stack-experimental",
+  "version": "0.0.0-reserved-private",
+  "private": true,
+  "license": "MIT OR Apache-2.0"
+}

--- a/libs/error-stack/experimental/src/lib.rs
+++ b/libs/error-stack/experimental/src/lib.rs
@@ -1,0 +1,1 @@
+#![doc = include_str!("README.md")]

--- a/libs/error-stack/experimental/src/lib.rs
+++ b/libs/error-stack/experimental/src/lib.rs
@@ -1,1 +1,1 @@
-#![doc = include_str!("README.md")]
+#![doc = include_str!("../README.md")]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This crates the `error-stack-experimental` crate, which is to be used to test out new features or traits that aren't ready yet for the main `error-stack` crate.

The first set of traits that are going to be exposed in `error-stack-experimental` are going to be utility traits to make working with collections of related errors easier.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this

