### PR TITLE
H-3290: Return conversions as part of data type queries

### DIFF
--- a/apps/hash-graph/libs/api/openapi/openapi.json
+++ b/apps/hash-graph/libs/api/openapi/openapi.json
@@ -3372,6 +3372,12 @@
               "provenance"
             ],
             "properties": {
+              "conversions": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/Conversions"
+                }
+              },
               "ownedById": {
                 "$ref": "#/components/schemas/OwnedById"
               },
@@ -3396,6 +3402,12 @@
               "provenance"
             ],
             "properties": {
+              "conversions": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/Conversions"
+                }
+              },
               "fetchedAt": {
                 "$ref": "#/components/schemas/Timestamp"
               },

--- a/apps/hash-graph/libs/graph/postgres_migrations/V30__data_type_conversion_aggrecation.sql
+++ b/apps/hash-graph/libs/graph/postgres_migrations/V30__data_type_conversion_aggrecation.sql
@@ -1,0 +1,8 @@
+CREATE VIEW data_type_conversion_aggregation AS
+    SELECT
+        source_data_type_ontology_id,
+        array_agg(target_data_type_base_url) AS target_data_type_base_urls,
+        array_agg("into") AS intos,
+        array_agg("from") AS froms
+    FROM data_type_conversions
+    GROUP BY source_data_type_ontology_id;

--- a/apps/hash-graph/libs/graph/src/ontology/data_type.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/data_type.rs
@@ -314,6 +314,12 @@ pub enum DataTypeQueryPath<'p> {
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     EditionProvenance(Option<JsonPath<'p>>),
+    /// Only used internally and not available for deserialization.
+    TargetConversionBaseUrls,
+    /// Only used internally and not available for deserialization.
+    FromConversions,
+    /// Only used internally and not available for deserialization.
+    IntoConversions,
 }
 
 impl OntologyQueryPath for DataTypeQueryPath<'_> {
@@ -337,6 +343,12 @@ impl QueryPath for DataTypeQueryPath<'_> {
             Self::Version => ParameterType::OntologyTypeVersion,
             Self::Description | Self::Title | Self::Type => ParameterType::Text,
             Self::Embedding => ParameterType::Vector(Box::new(ParameterType::F64)),
+            Self::TargetConversionBaseUrls => {
+                ParameterType::Vector(Box::new(ParameterType::BaseUrl))
+            }
+            Self::FromConversions | Self::IntoConversions => {
+                ParameterType::Vector(Box::new(ParameterType::Object))
+            }
             Self::EditionProvenance(_) => ParameterType::Any,
             Self::DataTypeEdge { path, .. } => path.expected_type(),
             Self::PropertyTypeEdge { path, .. } => path.expected_type(),
@@ -362,6 +374,9 @@ impl fmt::Display for DataTypeQueryPath<'_> {
             Self::EditionProvenance(Some(path)) => write!(fmt, "editionProvenance.{path}"),
             Self::EditionProvenance(None) => fmt.write_str("editionProvenance"),
             Self::Embedding => fmt.write_str("embedding"),
+            Self::TargetConversionBaseUrls => fmt.write_str("targetConversionBaseUrls"),
+            Self::FromConversions => fmt.write_str("fromConversions"),
+            Self::IntoConversions => fmt.write_str("toConversions"),
             Self::DataTypeEdge {
                 edge_kind, path, ..
             } => {
@@ -532,6 +547,9 @@ impl DataTypeQueryPath<'_> {
             Self::AdditionalMetadata => DataTypeQueryPath::AdditionalMetadata,
             Self::Type => DataTypeQueryPath::Type,
             Self::Embedding => DataTypeQueryPath::Embedding,
+            Self::TargetConversionBaseUrls => DataTypeQueryPath::TargetConversionBaseUrls,
+            Self::FromConversions => DataTypeQueryPath::FromConversions,
+            Self::IntoConversions => DataTypeQueryPath::IntoConversions,
             Self::EditionProvenance(path) => {
                 DataTypeQueryPath::EditionProvenance(path.map(JsonPath::into_owned))
             }

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/mod.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/mod.rs
@@ -10,9 +10,9 @@ pub use self::{
     metadata::OntologyTypeMetadataRowBatch,
     property_type::PropertyTypeRowBatch,
     record::{
-        DataTypeConversionsRecord, DataTypeEmbeddingRecord, DataTypeSnapshotRecord,
-        EntityTypeEmbeddingRecord, EntityTypeSnapshotRecord, OntologyTypeSnapshotRecord,
-        PropertyTypeEmbeddingRecord, PropertyTypeSnapshotRecord,
+        DataTypeEmbeddingRecord, DataTypeSnapshotRecord, EntityTypeEmbeddingRecord,
+        EntityTypeSnapshotRecord, OntologyTypeSnapshotRecord, PropertyTypeEmbeddingRecord,
+        PropertyTypeSnapshotRecord,
     },
 };
 pub(crate) use self::{

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/record.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/record.rs
@@ -5,8 +5,8 @@ use graph_types::{ontology::OntologyType, Embedding};
 use serde::{Deserialize, Serialize};
 use temporal_versioning::{Timestamp, TransactionTime};
 use type_system::{
-    schema::{Conversions, DataType, EntityType, PropertyType},
-    url::{BaseUrl, VersionedUrl},
+    schema::{DataType, EntityType, PropertyType},
+    url::VersionedUrl,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -36,14 +36,6 @@ pub struct DataTypeEmbeddingRecord {
     pub data_type_id: VersionedUrl,
     pub embedding: Embedding<'static>,
     pub updated_at_transaction_time: Timestamp<TransactionTime>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DataTypeConversionsRecord {
-    pub source_data_type: VersionedUrl,
-    pub target_data_type: BaseUrl,
-    pub conversions: Conversions,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/apps/hash-graph/libs/graph/src/store/postgres/crud.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/crud.rs
@@ -85,6 +85,7 @@ where
 
         compiler.add_filter(filter);
         let (statement, parameters) = compiler.compile();
+        tracing::debug!(query = statement, parameters = ?parameters);
         let stream = self
             .as_client()
             .query_raw(&statement, parameters.iter().copied())

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/data_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/data_type.rs
@@ -4,8 +4,9 @@ use crate::{
     ontology::DataTypeQueryPath,
     store::postgres::query::{
         table::{
-            Column, DataTypeEmbeddings, DataTypes, JsonField, OntologyAdditionalMetadata,
-            OntologyIds, OntologyOwnedMetadata, OntologyTemporalMetadata, ReferenceTable, Relation,
+            Column, DataTypeConversionAggregation, DataTypeEmbeddings, DataTypes, JsonField,
+            OntologyAdditionalMetadata, OntologyIds, OntologyOwnedMetadata,
+            OntologyTemporalMetadata, ReferenceTable, Relation,
         },
         PostgresQueryPath,
     },
@@ -50,6 +51,9 @@ impl PostgresQueryPath for DataTypeQueryPath<'_> {
             .collect(),
             Self::DataTypeEdge { .. } | Self::PropertyTypeEdge { .. } => {
                 unreachable!("Invalid path: {self}")
+            }
+            Self::TargetConversionBaseUrls | Self::FromConversions | Self::IntoConversions => {
+                once(Relation::DataTypeConversions).collect()
             }
         }
     }
@@ -100,6 +104,20 @@ impl PostgresQueryPath for DataTypeQueryPath<'_> {
             Self::EditionProvenance(path) => (
                 Column::OntologyTemporalMetadata(OntologyTemporalMetadata::Provenance),
                 path.as_ref().map(JsonField::JsonPath),
+            ),
+            Self::TargetConversionBaseUrls => (
+                Column::DataTypeConversionAggregation(
+                    DataTypeConversionAggregation::TargetDataTypeBaseUrls,
+                ),
+                None,
+            ),
+            Self::FromConversions => (
+                Column::DataTypeConversionAggregation(DataTypeConversionAggregation::Froms),
+                None,
+            ),
+            Self::IntoConversions => (
+                Column::DataTypeConversionAggregation(DataTypeConversionAggregation::Intos),
+                None,
             ),
         }
     }

--- a/libs/@local/hash-graph-types/rust/src/ontology/data_type.rs
+++ b/libs/@local/hash-graph-types/rust/src/ontology/data_type.rs
@@ -1,7 +1,13 @@
+use std::collections::HashMap;
+
 #[cfg(feature = "postgres")]
 use postgres_types::{FromSql, ToSql};
 use serde::{Deserialize, Serialize};
-use type_system::{schema::DataType, url::VersionedUrl};
+use type_system::{
+    schema::{Conversions, DataType},
+    url::{BaseUrl, VersionedUrl},
+};
+use utoipa::openapi::ObjectBuilder;
 #[cfg(feature = "utoipa")]
 use utoipa::{
     openapi::{schema, Ref, RefOr, Schema},
@@ -60,7 +66,7 @@ pub struct PartialDataTypeMetadata {
     pub classification: OntologyTypeClassificationMetadata,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DataTypeMetadata {
     pub record_id: OntologyTypeRecordId,
@@ -68,6 +74,8 @@ pub struct DataTypeMetadata {
     pub classification: OntologyTypeClassificationMetadata,
     pub temporal_versioning: OntologyTemporalMetadata,
     pub provenance: OntologyProvenance,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub conversions: HashMap<BaseUrl, Conversions>,
 }
 
 #[cfg(feature = "utoipa")]
@@ -91,6 +99,12 @@ impl ToSchema<'static> for DataTypeMetadata {
                             .required("temporalVersioning")
                             .property("provenance", Ref::from_schema_name("OntologyProvenance"))
                             .required("provenance")
+                            .property(
+                                "conversions",
+                                ObjectBuilder::new().additional_properties(Some(
+                                    Ref::from_schema_name("Conversions"),
+                                )),
+                            )
                             .build(),
                     )
                     .item(
@@ -107,6 +121,12 @@ impl ToSchema<'static> for DataTypeMetadata {
                             .required("temporalVersioning")
                             .property("provenance", Ref::from_schema_name("OntologyProvenance"))
                             .required("provenance")
+                            .property(
+                                "conversions",
+                                ObjectBuilder::new().additional_properties(Some(
+                                    Ref::from_schema_name("Conversions"),
+                                )),
+                            )
                             .build(),
                     )
                     .build(),

--- a/libs/@local/hash-graph-types/rust/src/ontology/data_type.rs
+++ b/libs/@local/hash-graph-types/rust/src/ontology/data_type.rs
@@ -7,10 +7,9 @@ use type_system::{
     schema::{Conversions, DataType},
     url::{BaseUrl, VersionedUrl},
 };
-use utoipa::openapi::ObjectBuilder;
 #[cfg(feature = "utoipa")]
 use utoipa::{
-    openapi::{schema, Ref, RefOr, Schema},
+    openapi::{schema, ObjectBuilder, Ref, RefOr, Schema},
     ToSchema,
 };
 use uuid::Uuid;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To display conversions defined on data types they should be queryable (i.e. returned as part of a data type query). Also, it's required to know the possible conversions when storing canonical values.

## 🔍 What does this change?

- Add a view to aggregate conversions
- Add internal query paths to query into the table
- Adjust snapshot logic to use new queries
- Add conversions to data type metadata

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph