### PR TITLE
Introduce `ThinContext` trait for static `Context`s and zero sized types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,7 @@ checksum = "7378575ff571966e99a744addeff0bff98b8ada0dedf1956d59e634db95eaac1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
  "synstructure",
 ]
 
@@ -251,7 +251,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -324,7 +324,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -335,7 +335,7 @@ checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1209,7 +1209,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1472,7 +1472,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1520,7 +1520,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1542,7 +1542,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1701,7 +1701,7 @@ checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1745,7 +1745,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1783,7 +1783,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1874,7 +1874,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1887,7 +1887,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1907,7 +1907,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1942,6 +1942,7 @@ version = "0.5.0"
 dependencies = [
  "ansi-to-html",
  "anyhow",
+ "error-stack-derive",
  "expect-test",
  "eyre",
  "futures",
@@ -1975,15 +1976,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-stack-experimental"
-version = "0.0.0-reserved"
+name = "error-stack-derive"
+version = "0.5.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
 
 [[package]]
-name = "error-stack-macros"
+name = "error-stack-experimental"
 version = "0.0.0-reserved"
-dependencies = [
- "error-stack 0.5.0",
-]
 
 [[package]]
 name = "event-listener"
@@ -2181,7 +2184,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3780,7 +3783,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3899,7 +3902,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.8.4",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4657,7 +4660,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4757,7 +4760,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4833,7 +4836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4889,7 +4892,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4973,7 +4976,7 @@ dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5126,9 +5129,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -5268,7 +5271,7 @@ dependencies = [
  "quote",
  "refinery-core",
  "regex",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5873,7 +5876,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5884,7 +5887,7 @@ checksum = "e578a843d40b4189a4d66bba51d7684f57da5bd7c304c64e14bd63efbef49509"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5966,7 +5969,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6170,7 +6173,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6181,7 +6184,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6218,9 +6221,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.71"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6250,7 +6253,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6492,7 +6495,7 @@ dependencies = [
  "prettyplease 0.2.20",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6526,7 +6529,7 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6558,7 +6561,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6587,7 +6590,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6691,7 +6694,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7013,7 +7016,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7160,7 +7163,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7236,7 +7239,7 @@ checksum = "ac73887f47b9312552aa90ef477927ff014d63d1920ca8037c6c1951eab64bb1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7381,7 +7384,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
  "url",
  "uuid",
 ]
@@ -7507,7 +7510,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
  "wasm-bindgen-shared",
 ]
 
@@ -7541,7 +7544,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7574,7 +7577,7 @@ checksum = "b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -8042,7 +8045,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -8062,5 +8065,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.77",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1942,7 +1942,7 @@ version = "0.5.0"
 dependencies = [
  "ansi-to-html",
  "anyhow",
- "error-stack-derive",
+ "error-stack-macros",
  "expect-test",
  "eyre",
  "futures",
@@ -1976,17 +1976,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-stack-derive"
-version = "0.5.0"
+name = "error-stack-experimental"
+version = "0.0.0-reserved"
+
+[[package]]
+name = "error-stack-macros"
+version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.77",
 ]
-
-[[package]]
-name = "error-stack-experimental"
-version = "0.0.0-reserved"
 
 [[package]]
 name = "event-listener"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,24 +98,27 @@ inferno = { version = "=0.11.21", default-features = false }
 iso8601-duration = { version = "=0.2.0", default-features = false }
 json-number = { version = "=0.4.8", default-features = false }
 jsonptr = { version = "=0.6.0", default-features = false }
-multiaddr = { version = "=0.18.1", default-features = false }
-multistream-select = { version = "=0.13.0", default-features = false }
 libp2p-core = { version = "=0.42.0", default-features = false }
 libp2p-identity = { version = "=0.2.9", default-features = false }
 libp2p-ping = { version = "=0.45.0", default-features = false }
 libp2p-swarm = { version = "=0.45.1", default-features = false }
 libp2p-yamux = { version = "=0.46.0", default-features = false }
-prometheus-client = { version = "=0.22.3", default-features = false }
+multiaddr = { version = "=0.18.1", default-features = false }
+multistream-select = { version = "=0.13.0", default-features = false }
 postgres-types = { version = "=0.2.7", default-features = false }
-reqwest = { version = "=0.12.7", default-features = false, features = ["rustls-tls"] }
+prometheus-client = { version = "=0.22.3", default-features = false }
 regex = { version = "=1.10.6", default-features = false, features = ["perf", "unicode"] }
+reqwest = { version = "=0.12.7", default-features = false, features = ["rustls-tls"] }
 semver = { version = "=1.0.23", default-features = false }
 sentry-types = { version = "=0.34.0", default-features = false }
 serde = { version = "=1.0.210", default-features = false }
 serde_json = { version = "=1.0.128" }
 text-size = { version = "=1.1.1", default-features = false }
+time = { version = "=0.3.36", default-features = false }
 tokio = { version = "=1.40.0", default-features = false }
+tokio-postgres = { version = "=0.7.11", default-features = false }
 tokio-util = { version = "=0.7.12", default-features = false }
+tower-http = { version = "=0.5.2", features = ["trace"] }
 tower-layer = { version = "=0.3.3", default-features = false }
 tower-service = { version = "=0.3.3", default-features = false }
 tracing-appender = { version = "=0.2.3", default-features = false }
@@ -124,9 +127,6 @@ tracing-subscriber = { version = "=0.3.18", default-features = false }
 url = { version = "=2.5.2", default-features = false }
 utoipa = { version = "=4.2.3", default-features = false }
 uuid = { version = "=1.10.0", default-features = false }
-time = { version = "=0.3.36", default-features = false }
-tokio-postgres = { version = "=0.7.11", default-features = false }
-tower-http = { version = "=0.5.2", features = ["trace"] }
 
 # Shared third-party dependencies
 ansi-to-html = { version = "=0.2.1", default-features = false }
@@ -176,7 +176,9 @@ pin-project = { version = "=1.1.5", default-features = false }
 pin-project-lite = { version = "=0.2.14", default-features = false }
 postgres-protocol = { version = "=0.6.7", default-features = false }
 pretty_assertions = { version = "=1.4.0", default-features = false, features = ["alloc"] }
+proc-macro2 = { version = "=1.0.86", default-features = false }
 proptest = { version = "=1.5.0", default-features = false, features = ["alloc"] }
+quote = { version = "=1.0.37", default-features = false }
 rand = { version = "=0.8.5", default-features = false }
 refinery = { version = "=0.8.14", default-features = false }
 rustc_version = { version = "=0.4.1", default-features = false }
@@ -191,7 +193,7 @@ spin = { version = "=0.9", default-features = false }
 supports-color = { version = "=3.0.1", default-features = false }
 supports-unicode = { version = "=3.0.0", default-features = false }
 sval = { version = "=2.13.0", default-features = false }
-syn = { version = "=2.0.77", default-features = false }
+syn = { version = "=2.0.77", default-features = false, features = ["parsing", "proc-macro", "derive"] }
 tachyonix = { version = "=0.3.1", default-features = false }
 tarpc = { version = "=0.33", default-features = false }
 temporal-io-client = { git = "https://github.com/temporalio/sdk-core", rev = "7e3c23f" }

--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["package.json", "macros", "experimental"]
 
 [dependencies]
 # Public workspace dependencies
-error-stack-derive = { path = "./macros", version = "0.5.0" }
+error-stack-macros = { path = "./macros", version = "0.1.0" }
 
 # Public third-party dependencies
 anyhow = { version = ">=1.0.73", public = true, default-features = false, optional = true }

--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -15,6 +15,7 @@ exclude = ["package.json", "macros", "experimental"]
 
 [dependencies]
 # Public workspace dependencies
+error-stack-derive = { path = "./macros", version = "0.5.0" }
 
 # Public third-party dependencies
 anyhow = { version = ">=1.0.73", public = true, default-features = false, optional = true }

--- a/libs/error-stack/macros/Cargo.toml
+++ b/libs/error-stack/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "error-stack-derive"
-version = "0.5.0"
+name = "error-stack-macros"
+version = "0.1.0"
 edition = "2021"
 rust-version = "1.63.0"
 license = "MIT OR Apache-2.0"

--- a/libs/error-stack/macros/Cargo.toml
+++ b/libs/error-stack/macros/Cargo.toml
@@ -1,25 +1,21 @@
 [package]
-name = "error-stack-macros"
-version = "0.0.0-reserved"
-authors = { workspace = true }
+name = "error-stack-derive"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.63.0"
 license = "MIT OR Apache-2.0"
-description = "Macros for the `error-stack` crate"
-documentation = "https://docs.rs/error-stack"
-readme = "../README.md"
-repository = "https://github.com/hashintel/hash/tree/main/libs/error-stack"
+description = "procedural macros for the error-stack library"
+repository = "https://github.com/hashintel/hash/tree/main/libs/error-stack/macros"
 keywords = ["errorstack", "error-handling", "macro", "derive", "no_std"]
 categories = ["rust-patterns", "no-std"]
-publish = false
 
 [lib]
 proc-macro = true
 
 [dependencies]
-
-[dev-dependencies]
-error-stack = { path = "..", default-features = false }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
 
 [lints]
 workspace = true

--- a/libs/error-stack/macros/src/attributes.rs
+++ b/libs/error-stack/macros/src/attributes.rs
@@ -1,0 +1,72 @@
+use quote::ToTokens;
+use syn::{meta::ParseNestedMeta, parse_quote, DeriveInput, Error, LitStr, Path, Token};
+
+fn try_set_attribute<T: ToTokens>(
+    attribute: &mut Option<T>,
+    value: T,
+    name: &'static str,
+) -> Result<(), Error> {
+    if attribute.is_some() {
+        return Err(Error::new_spanned(
+            value,
+            format!("{name} already specified"),
+        ));
+    }
+    *attribute = Some(value);
+    Ok(())
+}
+
+#[derive(Default)]
+struct Builder {
+    pub(crate) display: Option<LitStr>,
+    pub(crate) crate_path: Option<Path>,
+}
+
+impl Builder {
+    fn parse_meta(&mut self, meta: ParseNestedMeta<'_>) -> Result<(), Error> {
+        if meta.path.is_ident("crate") {
+            if meta.input.parse::<Token![=]>().is_ok() {
+                let path = meta.input.parse::<Path>()?;
+                try_set_attribute(&mut self.crate_path, path, "crate")
+            } else if meta.input.is_empty() || meta.input.peek(Token![,]) {
+                try_set_attribute(&mut self.crate_path, parse_quote! { crate }, "crate")
+            } else {
+                Err(meta.error("expected `crate` or `crate = ...`"))
+            }
+        } else {
+            Ok(())
+        }
+    }
+}
+
+pub(crate) struct Attributes {
+    #[allow(unused)]
+    pub(crate) display: LitStr,
+    pub(crate) crate_path: Path,
+}
+impl Attributes {
+    pub(crate) fn parse(input: &DeriveInput) -> Result<Attributes, Error> {
+        let mut builder = Builder::default();
+
+        for attr in &input.attrs {
+            if attr.path().is_ident("display") {
+                builder.display = Some(attr.parse_args()?);
+            }
+            if attr.path().is_ident("error_stack") {
+                attr.parse_nested_meta(|meta| builder.parse_meta(meta))?;
+            }
+        }
+        let display = builder
+            .display
+            .take()
+            .unwrap_or_else(|| LitStr::new(&input.ident.to_string(), input.ident.span()));
+        let crate_path = builder
+            .crate_path
+            .take()
+            .unwrap_or_else(|| parse_quote! { ::error_stack });
+        Ok(Self {
+            display,
+            crate_path,
+        })
+    }
+}

--- a/libs/error-stack/macros/src/context.rs
+++ b/libs/error-stack/macros/src/context.rs
@@ -33,7 +33,7 @@ pub(crate) fn derive(input: &DeriveInput) -> Result<TokenStream, Error> {
     let error_stack = attributes.crate_path;
     Ok(quote! {
 
-        impl std::error::Error for #ctx {}
+        impl ::core::error::Error for #ctx {}
         impl ::core::fmt::Debug for #ctx {
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 f.write_str(stringify!(#ctx))

--- a/libs/error-stack/macros/src/context.rs
+++ b/libs/error-stack/macros/src/context.rs
@@ -1,0 +1,51 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Error, Fields};
+
+use crate::attributes::Attributes;
+
+pub(crate) fn derive(input: &DeriveInput) -> Result<TokenStream, Error> {
+    let ctx = &input.ident;
+    let attributes = Attributes::parse(input)?;
+    match &input.data {
+        Data::Struct(data_struct) => {
+            if !matches!(data_struct.fields, Fields::Unit) {
+                return Err(Error::new_spanned(
+                    &input.ident,
+                    "struct must be a zero-sized-type to implement `ThinContext`",
+                ));
+            }
+        }
+        Data::Enum(_) => {
+            return Err(Error::new_spanned(
+                &input.ident,
+                "enum `ThinContext` derives are currently unsupported",
+            ));
+        }
+        Data::Union(_) => {
+            return Err(Error::new_spanned(
+                &input.ident,
+                "union `ThinContext` derives are currently unsupported",
+            ));
+        }
+    }
+
+    let error_stack = attributes.crate_path;
+    Ok(quote! {
+
+        impl std::error::Error for #ctx {}
+        impl ::core::fmt::Debug for #ctx {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                f.write_str(stringify!(#ctx))
+            }
+        }
+        impl ::core::fmt::Display for #ctx {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                f.write_str(stringify!(#ctx))
+            }
+        }
+        impl #error_stack::context::ThinContext for #ctx {
+            const VALUE: Self = #ctx;
+        }
+    })
+}

--- a/libs/error-stack/macros/src/lib.rs
+++ b/libs/error-stack/macros/src/lib.rs
@@ -1,1 +1,28 @@
 #![doc = include_str!("../README.md")]
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+mod attributes;
+mod context;
+
+#[proc_macro_derive(ThinContext, attributes(display, bigerror))]
+pub fn derive_thin_context(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match context::derive(&input) {
+        Ok(result) => result.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+#[proc_macro_attribute]
+pub fn derive_ctx(_attr: TokenStream, input: TokenStream) -> TokenStream {
+    let input: proc_macro2::TokenStream = input.into();
+    let output = quote! {
+        #[derive(crate::ThinContext)]
+        #[bigerror(crate)]
+        #input
+    };
+    output.into()
+}

--- a/libs/error-stack/macros/src/lib.rs
+++ b/libs/error-stack/macros/src/lib.rs
@@ -1,28 +1,16 @@
 #![doc = include_str!("../README.md")]
 
 use proc_macro::TokenStream;
-use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
 
 mod attributes;
 mod context;
 
-#[proc_macro_derive(ThinContext, attributes(display, bigerror))]
+#[proc_macro_derive(ThinContext, attributes(display, error_stack))]
 pub fn derive_thin_context(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     match context::derive(&input) {
         Ok(result) => result.into(),
         Err(e) => e.to_compile_error().into(),
     }
-}
-
-#[proc_macro_attribute]
-pub fn derive_ctx(_attr: TokenStream, input: TokenStream) -> TokenStream {
-    let input: proc_macro2::TokenStream = input.into();
-    let output = quote! {
-        #[derive(crate::ThinContext)]
-        #[bigerror(crate)]
-        #input
-    };
-    output.into()
 }

--- a/libs/error-stack/src/context.rs
+++ b/libs/error-stack/src/context.rs
@@ -166,16 +166,6 @@ impl<C: 'static> IntoContext for Report<C> {
 
 pub trait ResultIntoContext: ResultExt {
     fn into_ctx<C2: ThinContext>(self) -> Result<Self::Ok, Report<C2>>;
-    // Result::and_then
-    fn and_then_ctx<U, F, C2>(self, op: F) -> Result<U, Report<C2>>
-    where
-        C2: ThinContext,
-        F: FnOnce(Self::Ok) -> Result<U, Report<C2>>;
-    // Result::map
-    fn map_ctx<U, F, C2>(self, op: F) -> Result<U, Report<C2>>
-    where
-        C2: ThinContext,
-        F: FnOnce(Self::Ok) -> U;
 }
 
 impl<T, C> ResultIntoContext for Result<T, Report<C>>
@@ -189,32 +179,6 @@ where
         match self {
             Ok(ok) => Ok(ok),
             Err(report) => Err(report.into_ctx()),
-        }
-    }
-
-    #[inline]
-    #[track_caller]
-    fn and_then_ctx<U, F, C2>(self, op: F) -> Result<U, Report<C2>>
-    where
-        C2: ThinContext,
-        F: FnOnce(T) -> Result<U, Report<C2>>,
-    {
-        match self {
-            Ok(t) => op(t),
-            Err(ctx) => Err(ctx.into_ctx()),
-        }
-    }
-
-    #[inline]
-    #[track_caller]
-    fn map_ctx<U, F, C2>(self, op: F) -> Result<U, Report<C2>>
-    where
-        C2: ThinContext,
-        F: FnOnce(T) -> U,
-    {
-        match self {
-            Ok(t) => Ok(op(t)),
-            Err(ctx) => Err(ctx.into_ctx()),
         }
     }
 }

--- a/libs/error-stack/src/fmt/mod.rs
+++ b/libs/error-stack/src/fmt/mod.rs
@@ -1019,7 +1019,7 @@ fn debug_frame(root: &Frame, prefix: &[&Frame], config: &mut Config) -> Vec<Line
         .into_iter()
         .enumerate()
         .map(|(idx, (head, mut body))| {
-            // each "paket" on the stack is made up of a head (guaranteed to be a `Context`) and
+            // each "packet" on the stack is made up of a head (guaranteed to be a `Context`) and
             // `n` attachments.
             // The attachments are rendered as direct descendants of the parent context
             let head_context = debug_context(

--- a/libs/error-stack/src/iter.rs
+++ b/libs/error-stack/src/iter.rs
@@ -10,7 +10,7 @@ use core::{
     slice::{Iter, IterMut},
 };
 
-use crate::Frame;
+use crate::{Frame, FrameKind};
 
 /// Helper function, which is used in both [`Frames`] and [`FramesMut`].
 ///
@@ -83,6 +83,16 @@ pub struct Frames<'r> {
 }
 
 impl<'r> Frames<'r> {
+    /// Returns the count of all frames that are [`Context`]s
+    pub fn count_ctx(self) -> usize {
+        self.fold(0, |mut acc, f| {
+            if let FrameKind::Context(_) = f.kind() {
+                acc += 1;
+            }
+            acc
+        })
+    }
+
     pub(crate) fn new(frames: &'r [Frame]) -> Self {
         Self {
             stack: vec![frames.iter()],

--- a/libs/error-stack/src/lib.rs
+++ b/libs/error-stack/src/lib.rs
@@ -512,13 +512,15 @@ mod macros;
 mod report;
 mod result;
 
-mod context;
+pub mod context;
 mod error;
 pub mod fmt;
 #[cfg(any(feature = "std", feature = "hooks"))]
 mod hook;
 #[cfg(feature = "serde")]
 mod serde;
+
+pub use error_stack_derive::ThinContext;
 
 pub use self::{
     compat::IntoReportCompat,

--- a/libs/error-stack/src/lib.rs
+++ b/libs/error-stack/src/lib.rs
@@ -32,7 +32,7 @@
 //! ```rust
 //! # #![allow(dead_code)]
 //! use error_stack::ResultExt;
-//! // using `thiserror` is not neccessary, but convenient
+//! // using `thiserror` is not necessary, but convenient
 //! use thiserror::Error;
 //!
 //! // Errors can enumerate variants users care about
@@ -520,7 +520,7 @@ mod hook;
 #[cfg(feature = "serde")]
 mod serde;
 
-pub use error_stack_derive::ThinContext;
+pub use error_stack_macros::ThinContext;
 
 pub use self::{
     compat::IntoReportCompat,

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -367,7 +367,7 @@ impl<C> Report<C> {
     ///
     /// impl std::fmt::Display for SystemFailure {
     ///     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    ///         f.write_str("System failure occured")
+    ///         f.write_str("System failure occurred")
     ///     }
     /// }
     ///
@@ -907,7 +907,7 @@ impl<C> Report<[C]> {
     where
         C: Send + Sync + 'static,
     {
-        // this needs a manual traveral implementation, why?
+        // this needs a manual traversal implementation, why?
         // We know that each arm has a current context, but we don't know where that context is,
         // therefore we need to search for it on each branch, but stop once we found it, that way
         // we're able to return the current context, even if it is "buried" underneath a bunch of

--- a/libs/error-stack/tests/test_change_context.rs
+++ b/libs/error-stack/tests/test_change_context.rs
@@ -45,8 +45,8 @@ fn buried_duplicate_context_does_not_affect_current_contexts() {
         .change_context(ContextA(0))
         .change_context(RootError)
         .expand();
-    let auxillary = create_report();
-    root.push(auxillary);
+    let auxiliary = create_report();
+    root.push(auxiliary);
 
     let mut root = root.attach(AttachmentA);
 

--- a/libs/error-stack/tests/thin_ctx.rs
+++ b/libs/error-stack/tests/thin_ctx.rs
@@ -1,0 +1,22 @@
+#![cfg_attr(nightly, feature(error_generic_member_access))]
+
+mod common;
+
+#[allow(clippy::wildcard_imports)]
+use common::*;
+use error_stack::{context::IntoContext, Report, ThinContext};
+
+#[derive(ThinContext)]
+struct ContextT;
+
+#[test]
+fn into_ctx() {
+    fn inner_fn() -> Result<(), Report<ContextT>> {
+        let report = create_report().change_context(ContextT);
+        Err(report.into_ctx())
+    }
+    let report = inner_fn().unwrap_err();
+    assert_eq!(report.frames().count_ctx(), 2);
+    // ensure we did not add an extra `ContextT`
+    assert_eq!(report.into_ctx::<ContextT>().frames().count_ctx(), 2);
+}

--- a/libs/error-stack/tests/thin_ctx.rs
+++ b/libs/error-stack/tests/thin_ctx.rs
@@ -4,19 +4,40 @@ mod common;
 
 #[allow(clippy::wildcard_imports)]
 use common::*;
-use error_stack::{context::IntoContext, Report, ThinContext};
+use error_stack::{
+    context::{IntoContext, ResultIntoContext},
+    Report, ThinContext,
+};
 
 #[derive(ThinContext)]
 struct ContextT;
 
+#[derive(ThinContext)]
+struct ContextT2;
+
 #[test]
 fn into_ctx() {
+    //
     fn inner_fn() -> Result<(), Report<ContextT>> {
         let report = create_report().change_context(ContextT);
+        assert_eq!(report.frames().count_ctx(), 2);
         Err(report.into_ctx())
     }
-    let report = inner_fn().unwrap_err();
-    assert_eq!(report.frames().count_ctx(), 2);
+    //
+    fn outer_fn() -> Result<(), Report<ContextT>> {
+        // since inner_fn and outer_fn produce a ZST context, there's no need to change contexts
+        // since the value of the error does not vary, but attaching another `Location` to the
+        // is useful
+        inner_fn().into_ctx()
+    }
+    let report = outer_fn();
     // ensure we did not add an extra `ContextT`
-    assert_eq!(report.into_ctx::<ContextT>().frames().count_ctx(), 2);
+    assert_eq!(report.unwrap_err().frames().count_ctx(), 2);
+
+    fn t2_fn() -> Result<(), Report<ContextT2>> {
+        // add to context depth since we are chaning the type returned
+        outer_fn().into_ctx()
+    }
+    let report = t2_fn();
+    assert_eq!(report.unwrap_err().frames().count_ctx(), 3);
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
A lot of of the value in reports is the separation of error type from metadata (contexts & attachments).
In my daily use of error-stack, I found the greatest value when the `Context` was a zero sized type, allowing things like seamless conversions of [`Option<T>` into `Report<NotFound>`](https://github.com/knox-networks/bigerror/blob/1e9c47758e4c311c4a79866b0f57f58991861857/bigerror/src/lib.rs#L465-L476) types if `NotFound` was a zero sized type.

This PR upstreams the `ThinContext` trait to allow behaviour that is only possible when a `Context` is a static value at compile time:
https://github.com/hashintel/hash/blob/5aeb3bfa66a56c9c3f7d5ee7468a4fcdd7275b7a/libs/error-stack/src/context.rs#L134-L145

This allows a report to get a value implicitly when calling `Report::change_context` greatly increasing the ergonomics of propagating errors as well as incrementing just the location of when an error could propagate multiple times:
`err.change_context(MyError)` becomes `err.into_ctx()`

## 🔗 Related links

Fork of error-stack with `ThinContext` implemented: https://github.com/knox-networks/bigerror

- ...

## 🚫 Blocked by

This adds a `#[derive(ThinContext)]` macro to the error-stack macro crate, it will need to be published for error-stack to feature this on crates.io

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

* Feature addtion to `error-stack` to scope behaviour for a subset of contexts

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**


### 📜 Does this require a change to the docs?

yes 
<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] require changes to docs which are **not** made in this PR


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] I am unsure / need advice

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

The test coverage and documentation are lacking in this branch currently. This PR is intended to test the waters for this kind of feature.

## 🛡 What tests cover this?

* `error-stack/tests/thin_ctx.rs`

-

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. run `cargo test` in error-stack

## 📹 Demo
[The test code](https://github.com/knox-networks/bigerror/blob/1e9c47758e4c311c4a79866b0f57f58991861857/bigerror/src/lib.rs#L675-L685):

```rust
#[test]
fn result_into_ctx() {
    fn output() -> Result<usize, Report<MyError>> {
        "NaN"
        .parse::<usize>()
        .map_err(ConversionError::from::<&str, usize>)
        .into_ctx()
        .attach_printable(
            "Report::into_ctx<MyError> will be called twice without creating an extra Frame!",
        )
    }

    assert_err!(output().into_ctx::<MyError>());
}
```
<!-- Add a screenshot or video showcasing your work -->
<img width="753" alt="image" src="https://github.com/user-attachments/assets/c88b84d1-d80b-4dd3-bc35-5475bb257004">