### PR TITLE
H-3279: Allow sorting by property metadata

### DIFF
--- a/apps/hash-graph/libs/api/openapi/openapi.json
+++ b/apps/hash-graph/libs/api/openapi/openapi.json
@@ -4021,6 +4021,7 @@
           "uuid",
           "archived",
           "properties",
+          "propertyMetadata",
           "label",
           "recordCreatedAtTransactionTime",
           "recordCreatedAtDecisionTime",
@@ -8270,10 +8271,7 @@
         "properties": {
           "canonical": {
             "type": "object",
-            "additionalProperties": {
-              "type": "number",
-              "format": "double"
-            }
+            "additionalProperties": {}
           },
           "confidence": {
             "allOf": [

--- a/apps/hash-graph/libs/graph/src/knowledge/query.rs
+++ b/apps/hash-graph/libs/graph/src/knowledge/query.rs
@@ -679,6 +679,7 @@ pub enum EntityQuerySortingToken {
     Uuid,
     Archived,
     Properties,
+    PropertyMetadata,
     Label,
     RecordCreatedAtTransactionTime,
     RecordCreatedAtDecisionTime,
@@ -695,9 +696,9 @@ pub struct EntityQuerySortingVisitor {
 
 impl EntityQuerySortingVisitor {
     pub const EXPECTING: &'static str =
-        "one of `uuid`, `archived`, `properties`, `label`, `recordCreatedAtTransactionTime`, \
-         `recordCreatedAtDecisionTime`, `createdAtTransactionTime`, `createdAtDecisionTime`, \
-         `typeTitle`";
+        "one of `uuid`, `archived`, `properties`, `propertyMetadata`, `label`, \
+         `recordCreatedAtTransactionTime`, `recordCreatedAtDecisionTime`, \
+         `createdAtTransactionTime`, `createdAtDecisionTime`, `typeTitle`";
 
     #[must_use]
     pub const fn new(position: usize) -> Self {
@@ -762,6 +763,19 @@ impl<'de> Visitor<'de> for EntityQuerySortingVisitor {
                     EntityQueryPath::Properties(None)
                 } else {
                     EntityQueryPath::Properties(Some(JsonPath::from_path_tokens(path_tokens)))
+                }
+            }
+            EntityQuerySortingToken::PropertyMetadata => {
+                let mut path_tokens = Vec::new();
+                while let Some(property) = seq.next_element::<PathToken<'de>>()? {
+                    path_tokens.push(property);
+                    self.position += 1;
+                }
+
+                if path_tokens.is_empty() {
+                    EntityQueryPath::PropertyMetadata(None)
+                } else {
+                    EntityQueryPath::PropertyMetadata(Some(JsonPath::from_path_tokens(path_tokens)))
                 }
             }
         })

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/metadata/value.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/metadata/value.rs
@@ -21,7 +21,7 @@ pub struct ValueMetadata {
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     pub original_data_type_id: Option<VersionedUrl>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub canonical: HashMap<BaseUrl, f64>,
+    pub canonical: HashMap<BaseUrl, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/tests/hash-graph-integration/postgres/property_metadata.rs
+++ b/tests/hash-graph-integration/postgres/property_metadata.rs
@@ -204,7 +204,7 @@ async fn initial_metadata() {
                         confidence: Confidence::new(0.5),
                         data_type_id: Some(text_data_type_id()),
                         original_data_type_id: Some(text_data_type_id()),
-                        canonical: HashMap::default(),
+                        canonical: HashMap::from([(text_data_type_id().base_url, json!("Alice"))]),
                     },
                 },
             )]),
@@ -215,13 +215,6 @@ async fn initial_metadata() {
         }
     );
 
-    let name_property_metadata = ValueMetadata {
-        provenance: property_provenance_a(),
-        confidence: Confidence::new(0.6),
-        data_type_id: None,
-        original_data_type_id: None,
-        canonical: HashMap::default(),
-    };
     let updated_entity = api
         .patch_entity(
             api.account_id,
@@ -234,7 +227,13 @@ async fn initial_metadata() {
                     .collect(),
                     property: PropertyWithMetadata::Value(PropertyWithMetadataValue {
                         value: json!("Bob"),
-                        metadata: name_property_metadata.clone(),
+                        metadata: ValueMetadata {
+                            provenance: property_provenance_a(),
+                            confidence: Confidence::new(0.6),
+                            data_type_id: None,
+                            original_data_type_id: None,
+                            canonical: HashMap::new(),
+                        },
                     }),
                 }],
                 entity_type_ids: HashSet::new(),
@@ -259,7 +258,7 @@ async fn initial_metadata() {
                         confidence: Confidence::new(0.6),
                         data_type_id: Some(text_data_type_id()),
                         original_data_type_id: Some(text_data_type_id()),
-                        canonical: HashMap::default(),
+                        canonical: HashMap::from([(text_data_type_id().base_url, json!("Bob"))]),
                     }
                 }
             )]),
@@ -332,7 +331,7 @@ async fn no_initial_metadata() {
                         confidence: None,
                         data_type_id: Some(text_data_type_id()),
                         original_data_type_id: Some(text_data_type_id()),
-                        canonical: HashMap::default(),
+                        canonical: HashMap::from([(text_data_type_id().base_url, json!("Alice"))]),
                     },
                 },
             )]),
@@ -388,7 +387,7 @@ async fn no_initial_metadata() {
                         confidence: None,
                         data_type_id: Some(text_data_type_id()),
                         original_data_type_id: Some(text_data_type_id()),
-                        canonical: HashMap::default(),
+                        canonical: HashMap::from([(text_data_type_id().base_url, json!("Alice"))]),
                     },
                 },
             )]),
@@ -437,7 +436,7 @@ async fn no_initial_metadata() {
                         confidence: Confidence::new(0.5),
                         data_type_id: Some(text_data_type_id()),
                         original_data_type_id: Some(text_data_type_id()),
-                        canonical: HashMap::default(),
+                        canonical: HashMap::from([(text_data_type_id().base_url, json!("Alice"))]),
                     },
                 },
             )]),
@@ -474,7 +473,7 @@ async fn no_initial_metadata() {
                         confidence: Confidence::new(0.5),
                         data_type_id: Some(text_data_type_id()),
                         original_data_type_id: Some(text_data_type_id()),
-                        canonical: HashMap::default(),
+                        canonical: HashMap::from([(text_data_type_id().base_url, json!("Alice"))]),
                     },
                 },
             )]),
@@ -555,7 +554,10 @@ async fn properties_add() {
                             confidence: None,
                             data_type_id: Some(text_data_type_id()),
                             original_data_type_id: Some(text_data_type_id()),
-                            canonical: HashMap::default(),
+                            canonical: HashMap::from([(
+                                text_data_type_id().base_url,
+                                json!("Alice")
+                            )]),
                         },
                     },
                 ),
@@ -567,7 +569,7 @@ async fn properties_add() {
                             confidence: Confidence::new(0.5),
                             data_type_id: Some(number_data_type_id()),
                             original_data_type_id: Some(number_data_type_id()),
-                            canonical: HashMap::default(),
+                            canonical: HashMap::from([(number_data_type_id().base_url, json!(30))]),
                         },
                     },
                 )
@@ -667,7 +669,10 @@ async fn properties_remove() {
                             confidence: None,
                             data_type_id: Some(text_data_type_id()),
                             original_data_type_id: Some(text_data_type_id()),
-                            canonical: HashMap::default(),
+                            canonical: HashMap::from([(
+                                text_data_type_id().base_url,
+                                json!("Alice")
+                            )]),
                         },
                     },
                 ),
@@ -682,7 +687,10 @@ async fn properties_remove() {
                                     confidence: Confidence::new(0.5),
                                     data_type_id: Some(text_data_type_id()),
                                     original_data_type_id: Some(text_data_type_id()),
-                                    canonical: HashMap::default(),
+                                    canonical: HashMap::from([(
+                                        text_data_type_id().base_url,
+                                        json!("Fight Club")
+                                    )]),
                                 },
                             },
                         )]),
@@ -727,7 +735,7 @@ async fn properties_remove() {
                         confidence: None,
                         data_type_id: Some(text_data_type_id()),
                         original_data_type_id: Some(text_data_type_id()),
-                        canonical: HashMap::default(),
+                        canonical: HashMap::from([(text_data_type_id().base_url, json!("Alice"))]),
                     },
                 },
             )]),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To sort by "real" units we need to sort by a canonical value stored in the database.

We only store canonical values for values which are not already in canonical form. When sorting by canonical form we also want to take the values into account which don’t need a conversions. This means we either
- need a special filter for canonical values. This requires to:
	- add a query path which is aware of the expected canonical type (e.g. `meters`) and the path to the value (needs to be distinguished)
	- Create a postgres statement `CASE X THEN A ELSE B` with:
		- `X`: check existence of `value path -> data_type_id == expected type` with `value_path` being calulated as the path for `properties` and `property_metadata` differs (we have these `value`s in between)
		- `A`: `properties->value path`
		- `B`: `property metadata -> calculated value path -> canonical -> type`
	- Use the above path in filtering/sorting (depending on the use-case)
- Always store the value` canonical[this_base_url],` so even for `meter` we would store the value twice

In this PR I went with the second approach as it's far easier.

## 🔍 What does this change?

- Always store the `canonical` for the value's base URL
- Expose `PropertyMetadata` as sorting path

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 📹 Demo

It's possible to sort by `length` e.g. by using
```json
  "sortingPaths": [
    {
      "path": ["propertyMetadata", "value", "http://localhost:3000/@alice/types/property-type/length/", "metadata", "canonical", "http://localhost:3000/@alice/types/data-type/meter/"],
      "ordering": "ascending"
    }
  ],
```
