### PR TITLE
H-3325: Support array in data type's type field

### DIFF
--- a/apps/hash-graph/libs/api/openapi/models/data_type.json
+++ b/apps/hash-graph/libs/api/openapi/models/data_type.json
@@ -31,7 +31,8 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "minItems": 1
         }
       ]
     }

--- a/apps/hash-graph/libs/api/openapi/models/data_type.json
+++ b/apps/hash-graph/libs/api/openapi/models/data_type.json
@@ -23,7 +23,17 @@
       "type": "string"
     },
     "type": {
-      "type": "string"
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
     }
   },
   "required": ["$schema", "kind", "$id", "title", "type"],

--- a/apps/hash-graph/libs/api/openapi/models/update_data_type.json
+++ b/apps/hash-graph/libs/api/openapi/models/update_data_type.json
@@ -22,7 +22,8 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "minItems": 1
         }
       ]
     }

--- a/apps/hash-graph/libs/api/openapi/models/update_data_type.json
+++ b/apps/hash-graph/libs/api/openapi/models/update_data_type.json
@@ -13,7 +13,19 @@
     },
     "title": { "type": "string" },
     "description": { "type": "string" },
-    "type": { "type": "string" }
+    "type": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    }
   },
   "required": ["$schema", "kind", "title", "type"],
   "additionalProperties": true

--- a/apps/hash-graph/libs/api/src/rest/json_schemas/data_type.json
+++ b/apps/hash-graph/libs/api/src/rest/json_schemas/data_type.json
@@ -31,7 +31,8 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "minItems": 1
         }
       ]
     }

--- a/apps/hash-graph/libs/api/src/rest/json_schemas/data_type.json
+++ b/apps/hash-graph/libs/api/src/rest/json_schemas/data_type.json
@@ -23,7 +23,17 @@
       "type": "string"
     },
     "type": {
-      "type": "string"
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
     }
   },
   "required": ["$schema", "kind", "$id", "title", "type"],

--- a/apps/hash-graph/libs/api/src/rest/json_schemas/update_data_type.json
+++ b/apps/hash-graph/libs/api/src/rest/json_schemas/update_data_type.json
@@ -22,7 +22,8 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "minItems": 1
         }
       ]
     }

--- a/apps/hash-graph/libs/api/src/rest/json_schemas/update_data_type.json
+++ b/apps/hash-graph/libs/api/src/rest/json_schemas/update_data_type.json
@@ -13,7 +13,19 @@
     },
     "title": { "type": "string" },
     "description": { "type": "string" },
-    "type": { "type": "string" }
+    "type": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    }
   },
   "required": ["$schema", "kind", "title", "type"],
   "additionalProperties": true

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
@@ -9,12 +9,12 @@ pub(crate) fn check_array_constraints(
     data_type: &DataType,
     result: &mut Result<(), Report<ConstraintError>>,
 ) {
-    if data_type.json_type != JsonSchemaValueType::Array {
+    if !data_type.json_type.contains(&JsonSchemaValueType::Array) {
         extend_report!(
             *result,
             ConstraintError::InvalidType {
                 actual: JsonSchemaValueType::Array,
-                expected: data_type.json_type
+                expected: data_type.json_type.clone()
             }
         );
     }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/boolean.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/boolean.rs
@@ -8,12 +8,12 @@ pub(crate) fn check_boolean_constraints(
     data_type: &DataType,
     result: &mut Result<(), Report<ConstraintError>>,
 ) {
-    if data_type.json_type != JsonSchemaValueType::Boolean {
+    if !data_type.json_type.contains(&JsonSchemaValueType::Boolean) {
         extend_report!(
             *result,
             ConstraintError::InvalidType {
                 actual: JsonSchemaValueType::Boolean,
-                expected: data_type.json_type
+                expected: data_type.json_type.clone()
             }
         );
     }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/error.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/error.rs
@@ -1,8 +1,9 @@
 use core::net::AddrParseError;
+use std::collections::HashSet;
 
 use iso8601_duration::ParseDurationError;
 use regex::Regex;
-use serde_json::{Number as JsonNumber, Value as JsonValue};
+use serde_json::{json, Number as JsonNumber, Value as JsonValue};
 use thiserror::Error;
 
 use crate::schema::{data_type::constraint::StringFormat, JsonSchemaValueType};
@@ -11,12 +12,12 @@ use crate::schema::{data_type::constraint::StringFormat, JsonSchemaValueType};
 pub enum ConstraintError {
     // General constraints
     #[error(
-        "the value provided does not match the expected type, expected `{expected}`, got \
-         `{actual}`"
+        "the value provided does not match the expected type, expected `{}`, got \
+         `{actual}`", json!(expected)
     )]
     InvalidType {
         actual: JsonSchemaValueType,
-        expected: JsonSchemaValueType,
+        expected: HashSet<JsonSchemaValueType>,
     },
     #[error(
         "the provided value is not equal to the expected value, expected `{actual:#}` to be equal \

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/null.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/null.rs
@@ -7,12 +7,12 @@ pub(crate) fn check_null_constraints(
     data_type: &DataType,
     result: &mut Result<(), Report<ConstraintError>>,
 ) {
-    if data_type.json_type != JsonSchemaValueType::Null {
+    if !data_type.json_type.contains(&JsonSchemaValueType::Null) {
         extend_report!(
             *result,
             ConstraintError::InvalidType {
                 actual: JsonSchemaValueType::Null,
-                expected: data_type.json_type
+                expected: data_type.json_type.clone()
             }
         );
     }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
@@ -8,15 +8,14 @@ pub(crate) fn check_numeric_constraints(
     data_type: &DataType,
     result: &mut Result<(), Report<ConstraintError>>,
 ) {
-    if !matches!(
-        data_type.json_type,
-        JsonSchemaValueType::Number | JsonSchemaValueType::Integer
-    ) {
+    if !data_type.json_type.contains(&JsonSchemaValueType::Number)
+        && !data_type.json_type.contains(&JsonSchemaValueType::Integer)
+    {
         extend_report!(
             *result,
             ConstraintError::InvalidType {
                 actual: JsonSchemaValueType::Number,
-                expected: data_type.json_type
+                expected: data_type.json_type.clone()
             }
         );
     }
@@ -46,10 +45,12 @@ pub(crate) fn check_numeric_constraints(
         }
     }
 
-    if let Some(expected) = data_type
-        .multiple_of
-        .or_else(|| (data_type.json_type == JsonSchemaValueType::Integer).then_some(1.0))
-    {
+    if let Some(expected) = data_type.multiple_of.or_else(|| {
+        data_type
+            .json_type
+            .contains(&JsonSchemaValueType::Integer)
+            .then_some(1.0)
+    }) {
         #[expect(
             clippy::float_arithmetic,
             clippy::modulo_arithmetic,

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/object.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/object.rs
@@ -10,12 +10,12 @@ pub(crate) fn check_object_constraints(
     data_type: &DataType,
     result: &mut Result<(), Report<ConstraintError>>,
 ) {
-    if data_type.json_type != JsonSchemaValueType::Object {
+    if !data_type.json_type.contains(&JsonSchemaValueType::Object) {
         extend_report!(
             *result,
             ConstraintError::InvalidType {
                 actual: JsonSchemaValueType::Object,
-                expected: data_type.json_type
+                expected: data_type.json_type.clone()
             }
         );
     }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
@@ -130,12 +130,12 @@ pub(crate) fn check_string_constraints(
     data_type: &DataType,
     result: &mut Result<(), Report<ConstraintError>>,
 ) {
-    if data_type.json_type != JsonSchemaValueType::String {
+    if !data_type.json_type.contains(&JsonSchemaValueType::String) {
         extend_report!(
             *result,
             ConstraintError::InvalidType {
                 actual: JsonSchemaValueType::String,
-                expected: data_type.json_type
+                expected: data_type.json_type.clone()
             }
         );
     }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -136,7 +136,7 @@ pub struct DataType {
     #[serde(rename = "type", with = "json_type")]
     #[cfg_attr(
         target_arch = "wasm32",
-        tsify(type = "JsonSchemaValueType | [JsonSchemaValueType, ...JsonSchemaValueType[]]")
+        tsify(type = "JsonSchemaValueType | JsonSchemaValueType[]")
     )]
     pub json_type: HashSet<JsonSchemaValueType>,
     #[serde(rename = "const", default, skip_serializing_if = "Option::is_none")]

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -136,7 +136,7 @@ pub struct DataType {
     #[serde(rename = "type", with = "json_type")]
     #[cfg_attr(
         target_arch = "wasm32",
-        tsify(type = "JsonSchemaValueType | JsonSchemaValueType[]")
+        tsify(type = "JsonSchemaValueType | [JsonSchemaValueType, ...JsonSchemaValueType[]]")
     )]
     pub json_type: HashSet<JsonSchemaValueType>,
     #[serde(rename = "const", default, skip_serializing_if = "Option::is_none")]

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -133,8 +133,12 @@ pub struct DataType {
     pub label: DataTypeLabel,
 
     // constraints for any types
-    #[serde(rename = "type")]
-    pub json_type: JsonSchemaValueType,
+    #[serde(rename = "type", with = "json_type")]
+    #[cfg_attr(
+        target_arch = "wasm32",
+        tsify(type = "JsonSchemaValueType | JsonSchemaValueType[]")
+    )]
+    pub json_type: HashSet<JsonSchemaValueType>,
     #[serde(rename = "const", default, skip_serializing_if = "Option::is_none")]
     pub const_value: Option<JsonValue>,
     #[serde(rename = "enum", default, skip_serializing_if = "Vec::is_empty")]
@@ -167,6 +171,51 @@ pub struct DataType {
     pub pattern: Option<Regex>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub format: Option<StringFormat>,
+}
+
+mod json_type {
+    use std::collections::HashSet;
+
+    use serde::{Deserialize, Serialize};
+
+    use crate::schema::JsonSchemaValueType;
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(untagged)]
+    enum MaybeSet {
+        Value(JsonSchemaValueType),
+        Set(HashSet<JsonSchemaValueType>),
+    }
+
+    pub(super) fn serialize<S>(
+        types: &HashSet<JsonSchemaValueType>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if types.len() == 1 {
+            types
+                .iter()
+                .next()
+                .expect("Set should have exactly one element")
+                .serialize(serializer)
+        } else {
+            types.serialize(serializer)
+        }
+    }
+
+    pub(super) fn deserialize<'de, D>(
+        deserializer: D,
+    ) -> Result<HashSet<JsonSchemaValueType>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        MaybeSet::deserialize(deserializer).map(|value| match value {
+            MaybeSet::Value(value) => HashSet::from([value]),
+            MaybeSet::Set(set) => set,
+        })
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/libs/@hashintel/type-editor/src/shared/data-types-options-context.tsx
+++ b/libs/@hashintel/type-editor/src/shared/data-types-options-context.tsx
@@ -186,9 +186,13 @@ const getArrayDataTypeDisplay = (
         `Could not find itemDataType for array data type ${dataType.$id}`,
       );
     }
-    return expectedValuesDisplayMap[
-      `${itemDataType.type}Array` as keyof typeof expectedValuesDisplayMap
-    ];
+    if (Array.isArray(itemDataType.type)) {
+      return expectedValuesDisplayMap.mixedArray;
+    } else {
+      return expectedValuesDisplayMap[
+        `${itemDataType.type}Array` as keyof typeof expectedValuesDisplayMap
+      ];
+    }
   }
 
   return expectedValuesDisplayMap.mixedArray;

--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -478,12 +478,16 @@ impl EntityVisitor for EntityPreprocessor {
                                         } else {
                                             extend_report!(
                                                 status,
-                                                TraversalError::InvalidType {
+                                                Report::new(TraversalError::InvalidType {
                                                     actual: JsonSchemaValueType::from(
                                                         &property.value
                                                     ),
                                                     expected: JsonSchemaValueType::Number,
-                                                }
+                                                })
+                                                .attach_printable(
+                                                    "Values other than numbers are not yet \
+                                                     supported for conversions"
+                                                )
                                             );
                                         }
                                     }
@@ -498,10 +502,14 @@ impl EntityVisitor for EntityPreprocessor {
                         } else {
                             extend_report!(
                                 status,
-                                TraversalError::InvalidType {
+                                Report::new(TraversalError::InvalidType {
                                     actual: JsonSchemaValueType::from(&property.value),
                                     expected: JsonSchemaValueType::Number,
-                                }
+                                })
+                                .attach_printable(
+                                    "Values other than numbers are not yet supported for \
+                                     conversions"
+                                )
                             );
                         }
                     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To enable a `Value` data type it's required that a data type may have multiple possible types.

## 🔍 What does this change?

- Make `type` a `HashSet` but (de-)serialize from/to a string if only a single element is provided
- Require, that in the case of an array at least one item is specified

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

Add the `Value` data type