### PR TITLE
H-3278: Support `parameter` conversion in paths

### DIFF
--- a/apps/hash-graph/libs/api/src/rest/data_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/data_type.rs
@@ -438,15 +438,13 @@ where
         .await
         .map_err(report_to_response)?;
 
-    // Manually deserialize the query from a JSON value to allow borrowed deserialization and better
-    // error reporting.
-    let mut request = GetDataTypesParams::deserialize(&request).map_err(report_to_response)?;
-    request
-        .filter
-        .convert_parameters()
-        .map_err(report_to_response)?;
     store
-        .get_data_types(actor_id, request)
+        .get_data_types(
+            actor_id,
+            // Manually deserialize the query from a JSON value to allow borrowed deserialization
+            // and better error reporting.
+            GetDataTypesParams::deserialize(&request).map_err(report_to_response)?,
+        )
         .await
         .map_err(report_to_response)
         .map(Json)
@@ -504,16 +502,13 @@ where
         .await
         .map_err(report_to_response)?;
 
-    // Manually deserialize the query from a JSON value to allow borrowed deserialization and better
-    // error reporting.
-    let mut request =
-        GetDataTypeSubgraphParams::deserialize(&request).map_err(report_to_response)?;
-    request
-        .filter
-        .convert_parameters()
-        .map_err(report_to_response)?;
     store
-        .get_data_type_subgraph(actor_id, request)
+        .get_data_type_subgraph(
+            actor_id,
+            // Manually deserialize the query from a JSON value to allow borrowed deserialization
+            // and better error reporting.
+            GetDataTypeSubgraphParams::deserialize(&request).map_err(report_to_response)?,
+        )
         .await
         .map_err(report_to_response)
         .map(|response| {

--- a/apps/hash-graph/libs/api/src/rest/entity.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity.rs
@@ -586,12 +586,7 @@ where
         .await
         .map_err(report_to_response)?;
 
-    let mut request = GetEntitiesRequest::deserialize(&request).map_err(report_to_response)?;
-    request
-        .filter
-        .convert_parameters()
-        .map_err(report_to_response)?;
-
+    let request = GetEntitiesRequest::deserialize(&request).map_err(report_to_response)?;
     store
         .get_entities(
             actor_id,
@@ -727,13 +722,7 @@ where
         .await
         .map_err(report_to_response)?;
 
-    let mut request =
-        GetEntitySubgraphRequest::deserialize(&request).map_err(report_to_response)?;
-    request
-        .filter
-        .convert_parameters()
-        .map_err(report_to_response)?;
-
+    let request = GetEntitySubgraphRequest::deserialize(&request).map_err(report_to_response)?;
     store
         .get_entity_subgraph(
             actor_id,
@@ -816,14 +805,11 @@ where
         .await
         .map_err(report_to_response)?;
 
-    let mut query = CountEntitiesParams::deserialize(&request).map_err(report_to_response)?;
-    query
-        .filter
-        .convert_parameters()
-        .map_err(report_to_response)?;
-
     store
-        .count_entities(actor_id, query)
+        .count_entities(
+            actor_id,
+            CountEntitiesParams::deserialize(&request).map_err(report_to_response)?,
+        )
         .await
         .map(Json)
         .map_err(report_to_response)

--- a/apps/hash-graph/libs/api/src/rest/entity_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity_type.rs
@@ -729,15 +729,13 @@ where
         .await
         .map_err(report_to_response)?;
 
-    // Manually deserialize the query from a JSON value to allow borrowed deserialization and better
-    // error reporting.
-    let mut request = GetEntityTypesParams::deserialize(&request).map_err(report_to_response)?;
-    request
-        .filter
-        .convert_parameters()
-        .map_err(report_to_response)?;
     store
-        .get_entity_types(actor_id, request)
+        .get_entity_types(
+            actor_id,
+            // Manually deserialize the query from a JSON value to allow borrowed deserialization
+            // and better error reporting.
+            GetEntityTypesParams::deserialize(&request).map_err(report_to_response)?,
+        )
         .await
         .map_err(report_to_response)
         .map(Json)
@@ -801,14 +799,11 @@ where
         .await
         .map_err(report_to_response)?;
 
-    let mut request =
-        GetEntityTypeSubgraphParams::deserialize(&request).map_err(report_to_response)?;
-    request
-        .filter
-        .convert_parameters()
-        .map_err(report_to_response)?;
     store
-        .get_entity_type_subgraph(actor_id, request)
+        .get_entity_type_subgraph(
+            actor_id,
+            GetEntityTypeSubgraphParams::deserialize(&request).map_err(report_to_response)?,
+        )
         .await
         .map_err(report_to_response)
         .map(|response| {

--- a/apps/hash-graph/libs/api/src/rest/property_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/property_type.rs
@@ -426,15 +426,13 @@ where
         .await
         .map_err(report_to_response)?;
 
-    // Manually deserialize the query from a JSON value to allow borrowed deserialization and better
-    // error reporting.
-    let mut request = GetPropertyTypesParams::deserialize(&request).map_err(report_to_response)?;
-    request
-        .filter
-        .convert_parameters()
-        .map_err(report_to_response)?;
     store
-        .get_property_types(actor_id, request)
+        .get_property_types(
+            actor_id,
+            // Manually deserialize the query from a JSON value to allow borrowed deserialization
+            // and better error reporting.
+            GetPropertyTypesParams::deserialize(&request).map_err(report_to_response)?,
+        )
         .await
         .map_err(report_to_response)
         .map(Json)
@@ -496,14 +494,11 @@ where
         .await
         .map_err(report_to_response)?;
 
-    let mut request =
-        GetPropertyTypeSubgraphParams::deserialize(&request).map_err(report_to_response)?;
-    request
-        .filter
-        .convert_parameters()
-        .map_err(report_to_response)?;
     store
-        .get_property_type_subgraph(actor_id, request)
+        .get_property_type_subgraph(
+            actor_id,
+            GetPropertyTypeSubgraphParams::deserialize(&request).map_err(report_to_response)?,
+        )
         .await
         .map_err(report_to_response)
         .map(|response| {

--- a/apps/hash-graph/libs/graph/src/ontology/data_type.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/data_type.rs
@@ -68,8 +68,8 @@ pub enum DataTypeQueryPath<'p> {
     /// let filter_value = json!({ "equal": [{ "path": ["version"] }, { "parameter": "latest" }] });
     /// let path = Filter::<DataTypeWithMetadata>::deserialize(filter_value)?;
     /// assert_eq!(path, Filter::Equal(
-    ///     Some(FilterExpression::Path(DataTypeQueryPath::Version)),
-    ///     Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed("latest")))))
+    ///     Some(FilterExpression::Path{ path: DataTypeQueryPath::Version }),
+    ///     Some(FilterExpression::Parameter { parameter: Parameter::Text(Cow::Borrowed("latest"))}))
     /// );
     /// # Ok::<(), serde_json::Error>(())
     /// ```

--- a/apps/hash-graph/libs/graph/src/ontology/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/entity_type.rs
@@ -63,8 +63,8 @@ pub enum EntityTypeQueryPath<'p> {
     /// let filter_value = json!({ "equal": [{ "path": ["version"] }, { "parameter": "latest" }] });
     /// let path = Filter::<EntityTypeWithMetadata>::deserialize(filter_value)?;
     /// assert_eq!(path, Filter::Equal(
-    ///     Some(FilterExpression::Path(EntityTypeQueryPath::Version)),
-    ///     Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed("latest")))))
+    ///     Some(FilterExpression::Path { path: EntityTypeQueryPath::Version }),
+    ///     Some(FilterExpression::Parameter { parameter: Parameter::Text(Cow::Borrowed("latest"))}))
     /// );
     /// # Ok::<(), serde_json::Error>(())
     /// ```

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -1375,10 +1375,12 @@ where
         let previous_entity = Read::<Entity>::read_one(
             &transaction,
             &Filter::Equal(
-                Some(FilterExpression::Path(EntityQueryPath::EditionId)),
-                Some(FilterExpression::Parameter(Parameter::Uuid(
-                    locked_row.entity_edition_id.into_uuid(),
-                ))),
+                Some(FilterExpression::Path {
+                    path: EntityQueryPath::EditionId,
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::Uuid(locked_row.entity_edition_id.into_uuid()),
+                }),
             ),
             Some(&QueryTemporalAxes::DecisionTime {
                 pinned: PinnedTemporalAxis::new(locked_transaction_time),

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -1380,6 +1380,7 @@ where
                 }),
                 Some(FilterExpression::Parameter {
                     parameter: Parameter::Uuid(locked_row.entity_edition_id.into_uuid()),
+                    convert: None,
                 }),
             ),
             Some(&QueryTemporalAxes::DecisionTime {

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -1049,8 +1049,18 @@ where
     async fn get_entities(
         &self,
         actor_id: AccountId,
-        params: GetEntitiesParams<'_>,
+        mut params: GetEntitiesParams<'_>,
     ) -> Result<GetEntitiesResponse<'static>, QueryError> {
+        params
+            .filter
+            .convert_parameters(&StoreProvider {
+                store: self,
+                cache: StoreCache::default(),
+                authorization: Some((actor_id, Consistency::FullyConsistent)),
+            })
+            .await
+            .change_context(QueryError)?;
+
         let temporal_axes = params.temporal_axes.resolve();
 
         let mut response = self
@@ -1092,8 +1102,18 @@ where
     async fn get_entity_subgraph(
         &self,
         actor_id: AccountId,
-        params: GetEntitySubgraphParams<'_>,
+        mut params: GetEntitySubgraphParams<'_>,
     ) -> Result<GetEntitySubgraphResponse<'static>, QueryError> {
+        params
+            .filter
+            .convert_parameters(&StoreProvider {
+                store: self,
+                cache: StoreCache::default(),
+                authorization: Some((actor_id, Consistency::FullyConsistent)),
+            })
+            .await
+            .change_context(QueryError)?;
+
         let unresolved_temporal_axes = params.temporal_axes;
         let temporal_axes = unresolved_temporal_axes.clone().resolve();
 
@@ -1202,8 +1222,18 @@ where
     async fn count_entities(
         &self,
         actor_id: AccountId,
-        params: CountEntitiesParams<'_>,
+        mut params: CountEntitiesParams<'_>,
     ) -> Result<usize, QueryError> {
+        params
+            .filter
+            .convert_parameters(&StoreProvider {
+                store: self,
+                cache: StoreCache::default(),
+                authorization: Some((actor_id, Consistency::FullyConsistent)),
+            })
+            .await
+            .change_context(QueryError)?;
+
         let temporal_axes = params.temporal_axes.resolve();
 
         let entity_ids = Read::<Entity>::read(

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
@@ -442,7 +442,9 @@ where
                 actor_id,
                 GetDataTypesParams {
                     filter: Filter::In(
-                        FilterExpression::Path(DataTypeQueryPath::OntologyId),
+                        FilterExpression::Path {
+                            path: DataTypeQueryPath::OntologyId,
+                        },
                         ParameterList::DataTypeIds(&required_parent_ids),
                     ),
                     temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
@@ -800,7 +802,9 @@ where
                 actor_id,
                 GetDataTypesParams {
                     filter: Filter::In(
-                        FilterExpression::Path(DataTypeQueryPath::OntologyId),
+                        FilterExpression::Path {
+                            path: DataTypeQueryPath::OntologyId,
+                        },
                         ParameterList::DataTypeIds(&required_parent_ids),
                     ),
                     temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
@@ -510,7 +510,9 @@ where
         let parent_schemas = self
             .read_closed_schemas(
                 &Filter::In(
-                    FilterExpression::Path(EntityTypeQueryPath::OntologyId),
+                    FilterExpression::Path {
+                        path: EntityTypeQueryPath::OntologyId,
+                    },
                     ParameterList::EntityTypeIds(&parent_entity_type_ids),
                 ),
                 Some(

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
@@ -52,8 +52,8 @@ use crate::{
             ResponseCountMap, TraversalContext,
         },
         query::{Filter, FilterExpression, ParameterList},
-        AsClient, EntityTypeStore, InsertionError, PostgresStore, QueryError, SubgraphRecord,
-        UpdateError,
+        AsClient, EntityTypeStore, InsertionError, PostgresStore, QueryError, StoreCache,
+        StoreProvider, SubgraphRecord, UpdateError,
     },
     subgraph::{
         edges::{EdgeDirection, GraphResolveDepths, OntologyEdgeKind},
@@ -759,9 +759,19 @@ where
     //       types anyway.
     async fn count_entity_types(
         &self,
-        _actor_id: AccountId,
-        params: CountEntityTypesParams<'_>,
+        actor_id: AccountId,
+        mut params: CountEntityTypesParams<'_>,
     ) -> Result<usize, QueryError> {
+        params
+            .filter
+            .convert_parameters(&StoreProvider {
+                store: self,
+                cache: StoreCache::default(),
+                authorization: Some((actor_id, Consistency::FullyConsistent)),
+            })
+            .await
+            .change_context(QueryError)?;
+
         Ok(self
             .read(
                 &params.filter,
@@ -776,8 +786,18 @@ where
     async fn get_entity_types(
         &self,
         actor_id: AccountId,
-        params: GetEntityTypesParams<'_>,
+        mut params: GetEntityTypesParams<'_>,
     ) -> Result<GetEntityTypesResponse, QueryError> {
+        params
+            .filter
+            .convert_parameters(&StoreProvider {
+                store: self,
+                cache: StoreCache::default(),
+                authorization: Some((actor_id, Consistency::FullyConsistent)),
+            })
+            .await
+            .change_context(QueryError)?;
+
         let temporal_axes = params.temporal_axes.clone().resolve();
         self.get_entity_types_impl(actor_id, params, &temporal_axes)
             .await
@@ -788,8 +808,18 @@ where
     async fn get_entity_type_subgraph(
         &self,
         actor_id: AccountId,
-        params: GetEntityTypeSubgraphParams<'_>,
+        mut params: GetEntityTypeSubgraphParams<'_>,
     ) -> Result<GetEntityTypeSubgraphResponse, QueryError> {
+        params
+            .filter
+            .convert_parameters(&StoreProvider {
+                store: self,
+                cache: StoreCache::default(),
+                authorization: Some((actor_id, Consistency::FullyConsistent)),
+            })
+            .await
+            .change_context(QueryError)?;
+
         let temporal_axes = params.temporal_axes.clone().resolve();
         let time_axis = temporal_axes.variable_time_axis();
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/compile.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/compile.rs
@@ -435,14 +435,27 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                 self.compile_filter_expression(rhs).0,
             ),
             Filter::CosineDistance(lhs, rhs, max) => match (lhs, rhs) {
-                (FilterExpression::Path { path }, FilterExpression::Parameter { parameter })
-                | (FilterExpression::Parameter { parameter }, FilterExpression::Path { path }) => {
+                (
+                    FilterExpression::Path { path },
+                    FilterExpression::Parameter { parameter, convert },
+                )
+                | (
+                    FilterExpression::Parameter { parameter, convert },
+                    FilterExpression::Path { path },
+                ) => {
                     // We don't support custom sorting yet and limit/cursor implicitly set an order.
                     // We special case the distance function to allow sorting by distance, so we
                     // need to make sure that we don't have a limit or cursor.
                     assert!(
                         self.statement.limit.is_none() && !self.artifacts.uses_cursor,
                         "Cannot use distance function with limit or cursor",
+                    );
+
+                    // `convert` should be `None` as we don't support parameter conversion at this
+                    // stage, yet.
+                    assert!(
+                        convert.is_none(),
+                        "Cannot convert parameter for distance function"
                     );
 
                     let path_alias = self.add_join_statements(path);
@@ -730,11 +743,13 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                     Some(FilterExpression::Path { path }),
                     Some(FilterExpression::Parameter {
                         parameter: Parameter::Text(parameter),
+                        convert: None,
                     }),
                 )
                 | (
                     Some(FilterExpression::Parameter {
                         parameter: Parameter::Text(parameter),
+                        convert: None,
                     }),
                     Some(FilterExpression::Path { path }),
                 ) => match (path.terminating_column().0, filter, parameter.as_ref()) {
@@ -896,7 +911,12 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                 };
                 (self.compile_path_column(path), parameter_type)
             }
-            FilterExpression::Parameter { parameter } => self.compile_parameter(parameter),
+            FilterExpression::Parameter { parameter, convert } => {
+                if convert.is_some() {
+                    unimplemented!("Cannot convert parameter at this stage");
+                }
+                self.compile_parameter(parameter)
+            }
         }
     }
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/condition.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/condition.rs
@@ -194,7 +194,9 @@ mod tests {
     fn transpile_null_condition() {
         test_condition(
             &Filter::Equal(
-                Some(FilterExpression::Path(DataTypeQueryPath::Description)),
+                Some(FilterExpression::Path {
+                    path: DataTypeQueryPath::Description,
+                }),
                 None,
             ),
             r#""data_types_0_1_0"."schema"->>'description' IS NULL"#,
@@ -204,7 +206,9 @@ mod tests {
         test_condition(
             &Filter::Equal(
                 None,
-                Some(FilterExpression::Path(DataTypeQueryPath::Description)),
+                Some(FilterExpression::Path {
+                    path: DataTypeQueryPath::Description,
+                }),
             ),
             r#""data_types_0_1_0"."schema"->>'description' IS NULL"#,
             &[],
@@ -214,7 +218,9 @@ mod tests {
 
         test_condition(
             &Filter::NotEqual(
-                Some(FilterExpression::Path(DataTypeQueryPath::Description)),
+                Some(FilterExpression::Path {
+                    path: DataTypeQueryPath::Description,
+                }),
                 None,
             ),
             r#""data_types_0_1_0"."schema"->>'description' IS NOT NULL"#,
@@ -224,7 +230,9 @@ mod tests {
         test_condition(
             &Filter::NotEqual(
                 None,
-                Some(FilterExpression::Path(DataTypeQueryPath::Description)),
+                Some(FilterExpression::Path {
+                    path: DataTypeQueryPath::Description,
+                }),
             ),
             r#""data_types_0_1_0"."schema"->>'description' IS NOT NULL"#,
             &[],
@@ -237,10 +245,14 @@ mod tests {
     fn transpile_all_condition() {
         test_condition(
             &Filter::All(vec![Filter::Equal(
-                Some(FilterExpression::Path(DataTypeQueryPath::VersionedUrl)),
-                Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                    "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
-                )))),
+                Some(FilterExpression::Path {
+                    path: DataTypeQueryPath::VersionedUrl,
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::Text(Cow::Borrowed(
+                        "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
+                    )),
+                }),
             )]),
             r#"("data_types_0_1_0"."schema"->>'$id' = $1)"#,
             &[&"https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"],
@@ -249,14 +261,22 @@ mod tests {
         test_condition(
             &Filter::All(vec![
                 Filter::Equal(
-                    Some(FilterExpression::Path(DataTypeQueryPath::BaseUrl)),
-                    Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                        "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
-                    )))),
+                    Some(FilterExpression::Path {
+                        path: DataTypeQueryPath::BaseUrl,
+                    }),
+                    Some(FilterExpression::Parameter {
+                        parameter: Parameter::Text(Cow::Borrowed(
+                            "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
+                        )),
+                    }),
                 ),
                 Filter::Equal(
-                    Some(FilterExpression::Path(DataTypeQueryPath::Version)),
-                    Some(FilterExpression::Parameter(Parameter::I32(1))),
+                    Some(FilterExpression::Path {
+                        path: DataTypeQueryPath::Version,
+                    }),
+                    Some(FilterExpression::Parameter {
+                        parameter: Parameter::I32(1),
+                    }),
                 ),
             ]),
             r#"("ontology_ids_0_1_0"."base_url" = $1) AND ("ontology_ids_0_1_0"."version" = $2)"#,
@@ -271,10 +291,14 @@ mod tests {
     fn transpile_any_condition() {
         test_condition(
             &Filter::Any(vec![Filter::Equal(
-                Some(FilterExpression::Path(DataTypeQueryPath::VersionedUrl)),
-                Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                    "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
-                )))),
+                Some(FilterExpression::Path {
+                    path: DataTypeQueryPath::VersionedUrl,
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::Text(Cow::Borrowed(
+                        "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
+                    )),
+                }),
             )]),
             r#"("data_types_0_1_0"."schema"->>'$id' = $1)"#,
             &[&"https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"],
@@ -283,14 +307,22 @@ mod tests {
         test_condition(
             &Filter::Any(vec![
                 Filter::Equal(
-                    Some(FilterExpression::Path(DataTypeQueryPath::BaseUrl)),
-                    Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                        "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
-                    )))),
+                    Some(FilterExpression::Path {
+                        path: DataTypeQueryPath::BaseUrl,
+                    }),
+                    Some(FilterExpression::Parameter {
+                        parameter: Parameter::Text(Cow::Borrowed(
+                            "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
+                        )),
+                    }),
                 ),
                 Filter::Equal(
-                    Some(FilterExpression::Path(DataTypeQueryPath::Version)),
-                    Some(FilterExpression::Parameter(Parameter::I32(1))),
+                    Some(FilterExpression::Path {
+                        path: DataTypeQueryPath::Version,
+                    }),
+                    Some(FilterExpression::Parameter {
+                        parameter: Parameter::I32(1),
+                    }),
                 ),
             ]),
             r#"(("ontology_ids_0_1_0"."base_url" = $1) OR ("ontology_ids_0_1_0"."version" = $2))"#,
@@ -305,10 +337,14 @@ mod tests {
     fn transpile_not_condition() {
         test_condition(
             &Filter::Not(Box::new(Filter::Equal(
-                Some(FilterExpression::Path(DataTypeQueryPath::VersionedUrl)),
-                Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                    "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
-                )))),
+                Some(FilterExpression::Path {
+                    path: DataTypeQueryPath::VersionedUrl,
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::Text(Cow::Borrowed(
+                        "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
+                    )),
+                }),
             ))),
             r#"NOT("data_types_0_1_0"."schema"->>'$id' = $1)"#,
             &[&"https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"],
@@ -319,8 +355,12 @@ mod tests {
     fn render_without_parameters() {
         test_condition(
             &Filter::Any(vec![Filter::Equal(
-                Some(FilterExpression::Path(DataTypeQueryPath::Description)),
-                Some(FilterExpression::Path(DataTypeQueryPath::Title)),
+                Some(FilterExpression::Path {
+                    path: DataTypeQueryPath::Description,
+                }),
+                Some(FilterExpression::Path {
+                    path: DataTypeQueryPath::Title,
+                }),
             )]),
             r#"("data_types_0_1_0"."schema"->>'description' = "data_types_0_1_0"."schema"->>'title')"#,
             &[],

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/condition.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/condition.rs
@@ -252,6 +252,7 @@ mod tests {
                     parameter: Parameter::Text(Cow::Borrowed(
                         "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
                     )),
+                    convert: None,
                 }),
             )]),
             r#"("data_types_0_1_0"."schema"->>'$id' = $1)"#,
@@ -268,6 +269,7 @@ mod tests {
                         parameter: Parameter::Text(Cow::Borrowed(
                             "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
                         )),
+                        convert: None,
                     }),
                 ),
                 Filter::Equal(
@@ -276,6 +278,7 @@ mod tests {
                     }),
                     Some(FilterExpression::Parameter {
                         parameter: Parameter::I32(1),
+                        convert: None,
                     }),
                 ),
             ]),
@@ -298,6 +301,7 @@ mod tests {
                     parameter: Parameter::Text(Cow::Borrowed(
                         "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
                     )),
+                    convert: None,
                 }),
             )]),
             r#"("data_types_0_1_0"."schema"->>'$id' = $1)"#,
@@ -314,6 +318,7 @@ mod tests {
                         parameter: Parameter::Text(Cow::Borrowed(
                             "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
                         )),
+                        convert: None,
                     }),
                 ),
                 Filter::Equal(
@@ -322,6 +327,7 @@ mod tests {
                     }),
                     Some(FilterExpression::Parameter {
                         parameter: Parameter::I32(1),
+                        convert: None,
                     }),
                 ),
             ]),
@@ -344,6 +350,7 @@ mod tests {
                     parameter: Parameter::Text(Cow::Borrowed(
                         "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
                     )),
+                    convert: None,
                 }),
             ))),
             r#"NOT("data_types_0_1_0"."schema"->>'$id' = $1)"#,

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/expression/where_clause.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/expression/where_clause.rs
@@ -148,6 +148,7 @@ mod tests {
             }),
             Some(FilterExpression::Parameter {
                 parameter: Parameter::Text(Cow::Borrowed("latest")),
+                convert: None,
             }),
         );
         where_clause.add_condition(compiler.compile_filter(&filter_a));
@@ -166,6 +167,7 @@ mod tests {
                     parameter: Parameter::Text(Cow::Borrowed(
                         "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
                     )),
+                    convert: None,
                 }),
             ),
             Filter::Equal(
@@ -174,6 +176,7 @@ mod tests {
                 }),
                 Some(FilterExpression::Parameter {
                     parameter: Parameter::I32(1),
+                    convert: None,
                 }),
             ),
         ]);
@@ -213,6 +216,7 @@ mod tests {
                 }),
                 Some(FilterExpression::Parameter {
                     parameter: Parameter::Text(Cow::Borrowed("some title")),
+                    convert: None,
                 }),
             ),
             Filter::Equal(
@@ -221,6 +225,7 @@ mod tests {
                 }),
                 Some(FilterExpression::Parameter {
                     parameter: Parameter::Text(Cow::Borrowed("some description")),
+                    convert: None,
                 }),
             ),
         ]);

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/expression/where_clause.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/expression/where_clause.rs
@@ -135,6 +135,7 @@ mod tests {
     };
 
     #[test]
+    #[expect(clippy::too_many_lines)]
     fn transpile_where_expression() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
         let mut compiler = SelectCompiler::<DataTypeWithMetadata>::new(Some(&temporal_axes), false);
@@ -142,10 +143,12 @@ mod tests {
         assert_eq!(where_clause.transpile_to_string(), "");
 
         let filter_a = Filter::Equal(
-            Some(FilterExpression::Path(DataTypeQueryPath::Version)),
-            Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                "latest",
-            )))),
+            Some(FilterExpression::Path {
+                path: DataTypeQueryPath::Version,
+            }),
+            Some(FilterExpression::Parameter {
+                parameter: Parameter::Text(Cow::Borrowed("latest")),
+            }),
         );
         where_clause.add_condition(compiler.compile_filter(&filter_a));
 
@@ -156,14 +159,22 @@ mod tests {
 
         let filter_b = Filter::All(vec![
             Filter::Equal(
-                Some(FilterExpression::Path(DataTypeQueryPath::BaseUrl)),
-                Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                    "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
-                )))),
+                Some(FilterExpression::Path {
+                    path: DataTypeQueryPath::BaseUrl,
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::Text(Cow::Borrowed(
+                        "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
+                    )),
+                }),
             ),
             Filter::Equal(
-                Some(FilterExpression::Path(DataTypeQueryPath::Version)),
-                Some(FilterExpression::Parameter(Parameter::I32(1))),
+                Some(FilterExpression::Path {
+                    path: DataTypeQueryPath::Version,
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::I32(1),
+                }),
             ),
         ]);
         where_clause.add_condition(compiler.compile_filter(&filter_b));
@@ -178,7 +189,9 @@ mod tests {
         );
 
         let filter_c = Filter::NotEqual(
-            Some(FilterExpression::Path(DataTypeQueryPath::Description)),
+            Some(FilterExpression::Path {
+                path: DataTypeQueryPath::Description,
+            }),
             None,
         );
         where_clause.add_condition(compiler.compile_filter(&filter_c));
@@ -195,16 +208,20 @@ mod tests {
 
         let filter_d = Filter::Any(vec![
             Filter::Equal(
-                Some(FilterExpression::Path(DataTypeQueryPath::Title)),
-                Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                    "some title",
-                )))),
+                Some(FilterExpression::Path {
+                    path: DataTypeQueryPath::Title,
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::Text(Cow::Borrowed("some title")),
+                }),
             ),
             Filter::Equal(
-                Some(FilterExpression::Path(DataTypeQueryPath::Description)),
-                Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                    "some description",
-                )))),
+                Some(FilterExpression::Path {
+                    path: DataTypeQueryPath::Description,
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::Text(Cow::Borrowed("some description")),
+                }),
             ),
         ]);
         where_clause.add_condition(compiler.compile_filter(&filter_d));

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/statement/select.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/statement/select.rs
@@ -180,10 +180,14 @@ mod tests {
         let mut compiler =
             SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
         compiler.add_filter(&Filter::Equal(
-            Some(FilterExpression::Path(DataTypeQueryPath::VersionedUrl)),
-            Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
-            )))),
+            Some(FilterExpression::Path {
+                path: DataTypeQueryPath::VersionedUrl,
+            }),
+            Some(FilterExpression::Parameter {
+                parameter: Parameter::Text(Cow::Borrowed(
+                    "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
+                )),
+            }),
         ));
         test_compilation(
             &compiler,
@@ -207,8 +211,12 @@ mod tests {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
         let filter = Filter::Equal(
-            Some(FilterExpression::Path(EntityQueryPath::Uuid)),
-            Some(FilterExpression::Parameter(Parameter::Uuid(Uuid::nil()))),
+            Some(FilterExpression::Path {
+                path: EntityQueryPath::Uuid,
+            }),
+            Some(FilterExpression::Parameter {
+                parameter: Parameter::Uuid(Uuid::nil()),
+            }),
         );
         compiler.add_filter(&filter);
         test_compilation(
@@ -233,8 +241,12 @@ mod tests {
     fn full_temporal() {
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(None, false);
         let filter = Filter::Equal(
-            Some(FilterExpression::Path(EntityQueryPath::Uuid)),
-            Some(FilterExpression::Parameter(Parameter::Uuid(Uuid::nil()))),
+            Some(FilterExpression::Path {
+                path: EntityQueryPath::Uuid,
+            }),
+            Some(FilterExpression::Parameter {
+                parameter: Parameter::Uuid(Uuid::nil()),
+            }),
         );
         compiler.add_filter(&filter);
         test_compilation(
@@ -258,14 +270,22 @@ mod tests {
 
         let filter = Filter::All(vec![
             Filter::Equal(
-                Some(FilterExpression::Path(DataTypeQueryPath::BaseUrl)),
-                Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                    "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
-                )))),
+                Some(FilterExpression::Path {
+                    path: DataTypeQueryPath::BaseUrl,
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::Text(Cow::Borrowed(
+                        "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
+                    )),
+                }),
             ),
             Filter::Equal(
-                Some(FilterExpression::Path(DataTypeQueryPath::Version)),
-                Some(FilterExpression::Parameter(Parameter::I32(1))),
+                Some(FilterExpression::Path {
+                    path: DataTypeQueryPath::Version,
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::I32(1),
+                }),
             ),
         ]);
         compiler.add_filter(&filter);
@@ -296,10 +316,12 @@ mod tests {
             SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
 
         compiler.add_filter(&Filter::Equal(
-            Some(FilterExpression::Path(DataTypeQueryPath::Version)),
-            Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                "latest",
-            )))),
+            Some(FilterExpression::Path {
+                path: DataTypeQueryPath::Version,
+            }),
+            Some(FilterExpression::Parameter {
+                parameter: Parameter::Text(Cow::Borrowed("latest")),
+            }),
         ));
 
         test_compilation(
@@ -325,10 +347,12 @@ mod tests {
             SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
 
         compiler.add_filter(&Filter::NotEqual(
-            Some(FilterExpression::Path(DataTypeQueryPath::Version)),
-            Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                "latest",
-            )))),
+            Some(FilterExpression::Path {
+                path: DataTypeQueryPath::Version,
+            }),
+            Some(FilterExpression::Parameter {
+                parameter: Parameter::Text(Cow::Borrowed("latest")),
+            }),
         ));
 
         test_compilation(
@@ -354,15 +378,15 @@ mod tests {
             SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
 
         compiler.add_filter(&Filter::Equal(
-            Some(FilterExpression::Path(
-                PropertyTypeQueryPath::DataTypeEdge {
+            Some(FilterExpression::Path {
+                path: PropertyTypeQueryPath::DataTypeEdge {
                     edge_kind: OntologyEdgeKind::ConstrainsValuesOn,
                     path: DataTypeQueryPath::Title,
                 },
-            )),
-            Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                "Text",
-            )))),
+            }),
+            Some(FilterExpression::Parameter {
+                parameter: Parameter::Text(Cow::Borrowed("Text")),
+            }),
         ));
 
         test_compilation(
@@ -385,24 +409,28 @@ mod tests {
 
         let filter = Filter::All(vec![
             Filter::Equal(
-                Some(FilterExpression::Path(
-                    PropertyTypeQueryPath::DataTypeEdge {
+                Some(FilterExpression::Path {
+                    path: PropertyTypeQueryPath::DataTypeEdge {
                         edge_kind: OntologyEdgeKind::ConstrainsValuesOn,
                         path: DataTypeQueryPath::BaseUrl,
                     },
-                )),
-                Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                    "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
-                )))),
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::Text(Cow::Borrowed(
+                        "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
+                    )),
+                }),
             ),
             Filter::Equal(
-                Some(FilterExpression::Path(
-                    PropertyTypeQueryPath::DataTypeEdge {
+                Some(FilterExpression::Path {
+                    path: PropertyTypeQueryPath::DataTypeEdge {
                         edge_kind: OntologyEdgeKind::ConstrainsValuesOn,
                         path: DataTypeQueryPath::Version,
                     },
-                )),
-                Some(FilterExpression::Parameter(Parameter::I32(1))),
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::I32(1),
+                }),
             ),
         ]);
         compiler.add_filter(&filter);
@@ -447,16 +475,16 @@ mod tests {
             SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
 
         let filter = Filter::Equal(
-            Some(FilterExpression::Path(
-                PropertyTypeQueryPath::PropertyTypeEdge {
+            Some(FilterExpression::Path {
+                path: PropertyTypeQueryPath::PropertyTypeEdge {
                     edge_kind: OntologyEdgeKind::ConstrainsPropertiesOn,
                     path: Box::new(PropertyTypeQueryPath::Title),
                     direction: EdgeDirection::Outgoing,
                 },
-            )),
-            Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                "Text",
-            )))),
+            }),
+            Some(FilterExpression::Parameter {
+                parameter: Parameter::Text(Cow::Borrowed("Text")),
+            }),
         );
         compiler.add_filter(&filter);
 
@@ -487,16 +515,16 @@ mod tests {
             SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
 
         let filter = Filter::Equal(
-            Some(FilterExpression::Path(
-                EntityTypeQueryPath::PropertyTypeEdge {
+            Some(FilterExpression::Path {
+                path: EntityTypeQueryPath::PropertyTypeEdge {
                     edge_kind: OntologyEdgeKind::ConstrainsPropertiesOn,
                     path: PropertyTypeQueryPath::Title,
                     inheritance_depth: Some(0),
                 },
-            )),
-            Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                "Name",
-            )))),
+            }),
+            Some(FilterExpression::Parameter {
+                parameter: Parameter::Text(Cow::Borrowed("Name")),
+            }),
         );
         compiler.add_filter(&filter);
 
@@ -527,8 +555,8 @@ mod tests {
             SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
 
         let filter = Filter::Equal(
-            Some(FilterExpression::Path(
-                EntityTypeQueryPath::EntityTypeEdge {
+            Some(FilterExpression::Path {
+                path: EntityTypeQueryPath::EntityTypeEdge {
                     edge_kind: OntologyEdgeKind::ConstrainsLinksOn,
                     path: Box::new(EntityTypeQueryPath::EntityTypeEdge {
                         edge_kind: OntologyEdgeKind::ConstrainsLinksOn,
@@ -539,10 +567,10 @@ mod tests {
                     direction: EdgeDirection::Outgoing,
                     inheritance_depth: Some(0),
                 },
-            )),
-            Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                "Friend Of",
-            )))),
+            }),
+            Some(FilterExpression::Parameter {
+                parameter: Parameter::Text(Cow::Borrowed("Friend Of")),
+            }),
         );
         compiler.add_filter(&filter);
 
@@ -579,17 +607,19 @@ mod tests {
             SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
 
         let filter = Filter::Equal(
-            Some(FilterExpression::Path(
-                EntityTypeQueryPath::EntityTypeEdge {
+            Some(FilterExpression::Path {
+                path: EntityTypeQueryPath::EntityTypeEdge {
                     edge_kind: OntologyEdgeKind::InheritsFrom,
                     path: Box::new(EntityTypeQueryPath::BaseUrl),
                     direction: EdgeDirection::Outgoing,
                     inheritance_depth: Some(0),
                 },
-            )),
-            Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                "https://blockprotocol.org/@blockprotocol/types/entity-type/link/",
-            )))),
+            }),
+            Some(FilterExpression::Parameter {
+                parameter: Parameter::Text(Cow::Borrowed(
+                    "https://blockprotocol.org/@blockprotocol/types/entity-type/link/",
+                )),
+            }),
         );
         compiler.add_filter(&filter);
 
@@ -622,10 +652,12 @@ mod tests {
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
 
         let filter = Filter::Equal(
-            Some(FilterExpression::Path(EntityQueryPath::Uuid)),
-            Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                "12345678-ABCD-4321-5678-ABCD5555DCBA",
-            )))),
+            Some(FilterExpression::Path {
+                path: EntityQueryPath::Uuid,
+            }),
+            Some(FilterExpression::Parameter {
+                parameter: Parameter::Text(Cow::Borrowed("12345678-ABCD-4321-5678-ABCD5555DCBA")),
+            }),
         );
         compiler.add_filter(&filter);
 
@@ -665,8 +697,12 @@ mod tests {
         compiler.add_selection_path(&EntityQueryPath::Properties(None));
 
         let filter = Filter::Equal(
-            Some(FilterExpression::Path(EntityQueryPath::DraftId)),
-            Some(FilterExpression::Parameter(Parameter::Uuid(Uuid::nil()))),
+            Some(FilterExpression::Path {
+                path: EntityQueryPath::DraftId,
+            }),
+            Some(FilterExpression::Parameter {
+                parameter: Parameter::Uuid(Uuid::nil()),
+            }),
         );
         compiler.add_filter(&filter);
 
@@ -705,12 +741,12 @@ mod tests {
         ))]);
 
         let filter = Filter::Equal(
-            Some(FilterExpression::Path(EntityQueryPath::Properties(Some(
-                json_path.clone(),
-            )))),
-            Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                "Bob",
-            )))),
+            Some(FilterExpression::Path {
+                path: EntityQueryPath::Properties(Some(json_path.clone())),
+            }),
+            Some(FilterExpression::Parameter {
+                parameter: Parameter::Text(Cow::Borrowed("Bob")),
+            }),
         );
         compiler.add_filter(&filter);
 
@@ -745,9 +781,9 @@ mod tests {
         ))]);
 
         let filter = Filter::Equal(
-            Some(FilterExpression::Path(EntityQueryPath::Properties(Some(
-                json_path.clone(),
-            )))),
+            Some(FilterExpression::Path {
+                path: EntityQueryPath::Properties(Some(json_path.clone())),
+            }),
             None,
         );
         compiler.add_filter(&filter);
@@ -779,16 +815,20 @@ mod tests {
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
 
         let filter = Filter::Equal(
-            Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
-                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
-                path: Box::new(EntityQueryPath::EntityEdge {
-                    edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
-                    path: Box::new(EntityQueryPath::EditionId),
-                    direction: EdgeDirection::Outgoing,
-                }),
-                direction: EdgeDirection::Incoming,
-            })),
-            Some(FilterExpression::Parameter(Parameter::I32(10))),
+            Some(FilterExpression::Path {
+                path: EntityQueryPath::EntityEdge {
+                    edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                    path: Box::new(EntityQueryPath::EntityEdge {
+                        edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
+                        path: Box::new(EntityQueryPath::EditionId),
+                        direction: EdgeDirection::Outgoing,
+                    }),
+                    direction: EdgeDirection::Incoming,
+                },
+            }),
+            Some(FilterExpression::Parameter {
+                parameter: Parameter::I32(10),
+            }),
         );
         compiler.add_filter(&filter);
 
@@ -831,16 +871,20 @@ mod tests {
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
 
         let filter = Filter::Equal(
-            Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
-                edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
-                path: Box::new(EntityQueryPath::EntityEdge {
-                    edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
-                    path: Box::new(EntityQueryPath::EditionId),
-                    direction: EdgeDirection::Outgoing,
-                }),
-                direction: EdgeDirection::Incoming,
-            })),
-            Some(FilterExpression::Parameter(Parameter::I32(10))),
+            Some(FilterExpression::Path {
+                path: EntityQueryPath::EntityEdge {
+                    edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
+                    path: Box::new(EntityQueryPath::EntityEdge {
+                        edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                        path: Box::new(EntityQueryPath::EditionId),
+                        direction: EdgeDirection::Outgoing,
+                    }),
+                    direction: EdgeDirection::Incoming,
+                },
+            }),
+            Some(FilterExpression::Parameter {
+                parameter: Parameter::I32(10),
+            }),
         );
         compiler.add_filter(&filter);
 
@@ -884,36 +928,52 @@ mod tests {
 
         let filter = Filter::All(vec![
             Filter::Equal(
-                Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
-                    edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
-                    path: Box::new(EntityQueryPath::Uuid),
-                    direction: EdgeDirection::Outgoing,
-                })),
-                Some(FilterExpression::Parameter(Parameter::Uuid(Uuid::nil()))),
+                Some(FilterExpression::Path {
+                    path: EntityQueryPath::EntityEdge {
+                        edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                        path: Box::new(EntityQueryPath::Uuid),
+                        direction: EdgeDirection::Outgoing,
+                    },
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::Uuid(Uuid::nil()),
+                }),
             ),
             Filter::Equal(
-                Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
-                    edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
-                    path: Box::new(EntityQueryPath::OwnedById),
-                    direction: EdgeDirection::Outgoing,
-                })),
-                Some(FilterExpression::Parameter(Parameter::Uuid(Uuid::nil()))),
+                Some(FilterExpression::Path {
+                    path: EntityQueryPath::EntityEdge {
+                        edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                        path: Box::new(EntityQueryPath::OwnedById),
+                        direction: EdgeDirection::Outgoing,
+                    },
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::Uuid(Uuid::nil()),
+                }),
             ),
             Filter::Equal(
-                Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
-                    edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
-                    path: Box::new(EntityQueryPath::Uuid),
-                    direction: EdgeDirection::Outgoing,
-                })),
-                Some(FilterExpression::Parameter(Parameter::Uuid(Uuid::nil()))),
+                Some(FilterExpression::Path {
+                    path: EntityQueryPath::EntityEdge {
+                        edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
+                        path: Box::new(EntityQueryPath::Uuid),
+                        direction: EdgeDirection::Outgoing,
+                    },
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::Uuid(Uuid::nil()),
+                }),
             ),
             Filter::Equal(
-                Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
-                    edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
-                    path: Box::new(EntityQueryPath::OwnedById),
-                    direction: EdgeDirection::Outgoing,
-                })),
-                Some(FilterExpression::Parameter(Parameter::Uuid(Uuid::nil()))),
+                Some(FilterExpression::Path {
+                    path: EntityQueryPath::EntityEdge {
+                        edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
+                        path: Box::new(EntityQueryPath::OwnedById),
+                        direction: EdgeDirection::Outgoing,
+                    },
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::Uuid(Uuid::nil()),
+                }),
             ),
         ]);
         compiler.add_filter(&filter);
@@ -956,32 +1016,40 @@ mod tests {
 
         let filter = Filter::All(vec![
             Filter::Equal(
-                Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
-                    edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
-                    path: Box::new(EntityQueryPath::EntityTypeEdge {
-                        edge_kind: SharedEdgeKind::IsOfType,
-                        path: EntityTypeQueryPath::BaseUrl,
-                        inheritance_depth: Some(0),
-                    }),
-                    direction: EdgeDirection::Outgoing,
-                })),
-                Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                    "https://example.com/@example-org/types/entity-type/address",
-                )))),
+                Some(FilterExpression::Path {
+                    path: EntityQueryPath::EntityEdge {
+                        edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                        path: Box::new(EntityQueryPath::EntityTypeEdge {
+                            edge_kind: SharedEdgeKind::IsOfType,
+                            path: EntityTypeQueryPath::BaseUrl,
+                            inheritance_depth: Some(0),
+                        }),
+                        direction: EdgeDirection::Outgoing,
+                    },
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::Text(Cow::Borrowed(
+                        "https://example.com/@example-org/types/entity-type/address",
+                    )),
+                }),
             ),
             Filter::Equal(
-                Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
-                    edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
-                    path: Box::new(EntityQueryPath::EntityTypeEdge {
-                        edge_kind: SharedEdgeKind::IsOfType,
-                        path: EntityTypeQueryPath::BaseUrl,
-                        inheritance_depth: Some(0),
-                    }),
-                    direction: EdgeDirection::Outgoing,
-                })),
-                Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                    "https://example.com/@example-org/types/entity-type/name",
-                )))),
+                Some(FilterExpression::Path {
+                    path: EntityQueryPath::EntityEdge {
+                        edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
+                        path: Box::new(EntityQueryPath::EntityTypeEdge {
+                            edge_kind: SharedEdgeKind::IsOfType,
+                            path: EntityTypeQueryPath::BaseUrl,
+                            inheritance_depth: Some(0),
+                        }),
+                        direction: EdgeDirection::Outgoing,
+                    },
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::Text(Cow::Borrowed(
+                        "https://example.com/@example-org/types/entity-type/name",
+                    )),
+                }),
             ),
         ]);
         compiler.add_filter(&filter);
@@ -1043,9 +1111,15 @@ mod tests {
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(None, false);
 
         let filter = Filter::CosineDistance(
-            FilterExpression::Path(EntityQueryPath::Embedding),
-            FilterExpression::Parameter(Parameter::Vector(Embedding::from(vec![0.0; 1536]))),
-            FilterExpression::Parameter(Parameter::F64(0.5)),
+            FilterExpression::Path {
+                path: EntityQueryPath::Embedding,
+            },
+            FilterExpression::Parameter {
+                parameter: Parameter::Vector(Embedding::from(vec![0.0; 1536])),
+            },
+            FilterExpression::Parameter {
+                parameter: Parameter::F64(0.5),
+            },
         );
         compiler.add_filter(&filter);
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/statement/select.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/statement/select.rs
@@ -187,6 +187,7 @@ mod tests {
                 parameter: Parameter::Text(Cow::Borrowed(
                     "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
                 )),
+                convert: None,
             }),
         ));
         test_compilation(
@@ -216,6 +217,7 @@ mod tests {
             }),
             Some(FilterExpression::Parameter {
                 parameter: Parameter::Uuid(Uuid::nil()),
+                convert: None,
             }),
         );
         compiler.add_filter(&filter);
@@ -246,6 +248,7 @@ mod tests {
             }),
             Some(FilterExpression::Parameter {
                 parameter: Parameter::Uuid(Uuid::nil()),
+                convert: None,
             }),
         );
         compiler.add_filter(&filter);
@@ -277,6 +280,7 @@ mod tests {
                     parameter: Parameter::Text(Cow::Borrowed(
                         "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
                     )),
+                    convert: None,
                 }),
             ),
             Filter::Equal(
@@ -285,6 +289,7 @@ mod tests {
                 }),
                 Some(FilterExpression::Parameter {
                     parameter: Parameter::I32(1),
+                    convert: None,
                 }),
             ),
         ]);
@@ -321,6 +326,7 @@ mod tests {
             }),
             Some(FilterExpression::Parameter {
                 parameter: Parameter::Text(Cow::Borrowed("latest")),
+                convert: None,
             }),
         ));
 
@@ -352,6 +358,7 @@ mod tests {
             }),
             Some(FilterExpression::Parameter {
                 parameter: Parameter::Text(Cow::Borrowed("latest")),
+                convert: None,
             }),
         ));
 
@@ -386,6 +393,7 @@ mod tests {
             }),
             Some(FilterExpression::Parameter {
                 parameter: Parameter::Text(Cow::Borrowed("Text")),
+                convert: None,
             }),
         ));
 
@@ -419,6 +427,7 @@ mod tests {
                     parameter: Parameter::Text(Cow::Borrowed(
                         "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
                     )),
+                    convert: None,
                 }),
             ),
             Filter::Equal(
@@ -430,6 +439,7 @@ mod tests {
                 }),
                 Some(FilterExpression::Parameter {
                     parameter: Parameter::I32(1),
+                    convert: None,
                 }),
             ),
         ]);
@@ -484,6 +494,7 @@ mod tests {
             }),
             Some(FilterExpression::Parameter {
                 parameter: Parameter::Text(Cow::Borrowed("Text")),
+                convert: None,
             }),
         );
         compiler.add_filter(&filter);
@@ -524,6 +535,7 @@ mod tests {
             }),
             Some(FilterExpression::Parameter {
                 parameter: Parameter::Text(Cow::Borrowed("Name")),
+                convert: None,
             }),
         );
         compiler.add_filter(&filter);
@@ -570,6 +582,7 @@ mod tests {
             }),
             Some(FilterExpression::Parameter {
                 parameter: Parameter::Text(Cow::Borrowed("Friend Of")),
+                convert: None,
             }),
         );
         compiler.add_filter(&filter);
@@ -619,6 +632,7 @@ mod tests {
                 parameter: Parameter::Text(Cow::Borrowed(
                     "https://blockprotocol.org/@blockprotocol/types/entity-type/link/",
                 )),
+                convert: None,
             }),
         );
         compiler.add_filter(&filter);
@@ -657,6 +671,7 @@ mod tests {
             }),
             Some(FilterExpression::Parameter {
                 parameter: Parameter::Text(Cow::Borrowed("12345678-ABCD-4321-5678-ABCD5555DCBA")),
+                convert: None,
             }),
         );
         compiler.add_filter(&filter);
@@ -702,6 +717,7 @@ mod tests {
             }),
             Some(FilterExpression::Parameter {
                 parameter: Parameter::Uuid(Uuid::nil()),
+                convert: None,
             }),
         );
         compiler.add_filter(&filter);
@@ -746,6 +762,7 @@ mod tests {
             }),
             Some(FilterExpression::Parameter {
                 parameter: Parameter::Text(Cow::Borrowed("Bob")),
+                convert: None,
             }),
         );
         compiler.add_filter(&filter);
@@ -828,6 +845,7 @@ mod tests {
             }),
             Some(FilterExpression::Parameter {
                 parameter: Parameter::I32(10),
+                convert: None,
             }),
         );
         compiler.add_filter(&filter);
@@ -884,6 +902,7 @@ mod tests {
             }),
             Some(FilterExpression::Parameter {
                 parameter: Parameter::I32(10),
+                convert: None,
             }),
         );
         compiler.add_filter(&filter);
@@ -937,6 +956,7 @@ mod tests {
                 }),
                 Some(FilterExpression::Parameter {
                     parameter: Parameter::Uuid(Uuid::nil()),
+                    convert: None,
                 }),
             ),
             Filter::Equal(
@@ -949,6 +969,7 @@ mod tests {
                 }),
                 Some(FilterExpression::Parameter {
                     parameter: Parameter::Uuid(Uuid::nil()),
+                    convert: None,
                 }),
             ),
             Filter::Equal(
@@ -961,6 +982,7 @@ mod tests {
                 }),
                 Some(FilterExpression::Parameter {
                     parameter: Parameter::Uuid(Uuid::nil()),
+                    convert: None,
                 }),
             ),
             Filter::Equal(
@@ -973,6 +995,7 @@ mod tests {
                 }),
                 Some(FilterExpression::Parameter {
                     parameter: Parameter::Uuid(Uuid::nil()),
+                    convert: None,
                 }),
             ),
         ]);
@@ -1031,6 +1054,7 @@ mod tests {
                     parameter: Parameter::Text(Cow::Borrowed(
                         "https://example.com/@example-org/types/entity-type/address",
                     )),
+                    convert: None,
                 }),
             ),
             Filter::Equal(
@@ -1049,6 +1073,7 @@ mod tests {
                     parameter: Parameter::Text(Cow::Borrowed(
                         "https://example.com/@example-org/types/entity-type/name",
                     )),
+                    convert: None,
                 }),
             ),
         ]);
@@ -1116,9 +1141,11 @@ mod tests {
             },
             FilterExpression::Parameter {
                 parameter: Parameter::Vector(Embedding::from(vec![0.0; 1536])),
+                convert: None,
             },
             FilterExpression::Parameter {
                 parameter: Parameter::F64(0.5),
+                convert: None,
             },
         );
         compiler.add_filter(&filter);

--- a/apps/hash-graph/libs/graph/src/store/postgres/traversal_context.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/traversal_context.rs
@@ -36,7 +36,9 @@ where
         for data_type in <Self as Read<DataTypeWithMetadata>>::read_vec(
             self,
             &Filter::<DataTypeWithMetadata>::In(
-                FilterExpression::Path(DataTypeQueryPath::OntologyId),
+                FilterExpression::Path {
+                    path: DataTypeQueryPath::OntologyId,
+                },
                 ParameterList::DataTypeIds(data_type_ids),
             ),
             Some(&subgraph.temporal_axes.resolved),
@@ -62,7 +64,9 @@ where
         for property_type in <Self as Read<PropertyTypeWithMetadata>>::read_vec(
             self,
             &Filter::<PropertyTypeWithMetadata>::In(
-                FilterExpression::Path(PropertyTypeQueryPath::OntologyId),
+                FilterExpression::Path {
+                    path: PropertyTypeQueryPath::OntologyId,
+                },
                 ParameterList::PropertyTypeIds(property_type_ids),
             ),
             Some(&subgraph.temporal_axes.resolved),
@@ -88,7 +92,9 @@ where
         for entity_type in <Self as Read<EntityTypeWithMetadata>>::read_vec(
             self,
             &Filter::<EntityTypeWithMetadata>::In(
-                FilterExpression::Path(EntityTypeQueryPath::OntologyId),
+                FilterExpression::Path {
+                    path: EntityTypeQueryPath::OntologyId,
+                },
                 ParameterList::EntityTypeIds(entity_type_ids),
             ),
             Some(&subgraph.temporal_axes.resolved),
@@ -115,7 +121,9 @@ where
         let entities = <Self as Read<Entity>>::read_vec(
             self,
             &Filter::<Entity>::In(
-                FilterExpression::Path(EntityQueryPath::EditionId),
+                FilterExpression::Path {
+                    path: EntityQueryPath::EditionId,
+                },
                 ParameterList::EntityEditionIds(edition_ids),
             ),
             Some(&subgraph.temporal_axes.resolved),

--- a/apps/hash-graph/libs/graph/src/store/query/filter.rs
+++ b/apps/hash-graph/libs/graph/src/store/query/filter.rs
@@ -73,16 +73,20 @@ where
     pub fn for_versioned_url(versioned_url: &'p VersionedUrl) -> Self {
         Self::All(vec![
             Self::Equal(
-                Some(FilterExpression::Path(<R::QueryPath<'p>>::base_url())),
-                Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                    versioned_url.base_url.as_str(),
-                )))),
+                Some(FilterExpression::Path {
+                    path: <R::QueryPath<'p>>::base_url(),
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::Text(Cow::Borrowed(versioned_url.base_url.as_str())),
+                }),
             ),
             Self::Equal(
-                Some(FilterExpression::Path(<R::QueryPath<'p>>::version())),
-                Some(FilterExpression::Parameter(Parameter::OntologyTypeVersion(
-                    versioned_url.version,
-                ))),
+                Some(FilterExpression::Path {
+                    path: <R::QueryPath<'p>>::version(),
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::OntologyTypeVersion(versioned_url.version),
+                }),
             ),
         ])
     }
@@ -95,12 +99,14 @@ impl<'p> Filter<'p, DataTypeWithMetadata> {
         inheritance_depth: Option<u32>,
     ) -> Self {
         Filter::In(
-            FilterExpression::Path(DataTypeQueryPath::DataTypeEdge {
-                edge_kind: OntologyEdgeKind::InheritsFrom,
-                direction: EdgeDirection::Incoming,
-                inheritance_depth,
-                path: Box::new(DataTypeQueryPath::OntologyId),
-            }),
+            FilterExpression::Path {
+                path: DataTypeQueryPath::DataTypeEdge {
+                    edge_kind: OntologyEdgeKind::InheritsFrom,
+                    direction: EdgeDirection::Incoming,
+                    inheritance_depth,
+                    path: Box::new(DataTypeQueryPath::OntologyId),
+                },
+            },
             ParameterList::DataTypeIds(data_type_ids),
         )
     }
@@ -112,15 +118,17 @@ impl<'p> Filter<'p, DataTypeWithMetadata> {
     ) -> Self {
         let data_type_id = DataTypeId::from_url(versioned_url);
         Filter::Equal(
-            Some(FilterExpression::Path(DataTypeQueryPath::DataTypeEdge {
-                edge_kind: OntologyEdgeKind::InheritsFrom,
-                direction: EdgeDirection::Outgoing,
-                inheritance_depth,
-                path: Box::new(DataTypeQueryPath::OntologyId),
-            })),
-            Some(FilterExpression::Parameter(Parameter::Uuid(
-                data_type_id.into_uuid(),
-            ))),
+            Some(FilterExpression::Path {
+                path: DataTypeQueryPath::DataTypeEdge {
+                    edge_kind: OntologyEdgeKind::InheritsFrom,
+                    direction: EdgeDirection::Outgoing,
+                    inheritance_depth,
+                    path: Box::new(DataTypeQueryPath::OntologyId),
+                },
+            }),
+            Some(FilterExpression::Parameter {
+                parameter: Parameter::Uuid(data_type_id.into_uuid()),
+            }),
         )
     }
 }
@@ -130,16 +138,20 @@ impl<'p> Filter<'p, Entity> {
     #[must_use]
     pub fn for_entity_by_entity_id(entity_id: EntityId) -> Self {
         let owned_by_id_filter = Self::Equal(
-            Some(FilterExpression::Path(EntityQueryPath::OwnedById)),
-            Some(FilterExpression::Parameter(Parameter::Uuid(
-                entity_id.owned_by_id.into_uuid(),
-            ))),
+            Some(FilterExpression::Path {
+                path: EntityQueryPath::OwnedById,
+            }),
+            Some(FilterExpression::Parameter {
+                parameter: Parameter::Uuid(entity_id.owned_by_id.into_uuid()),
+            }),
         );
         let entity_uuid_filter = Self::Equal(
-            Some(FilterExpression::Path(EntityQueryPath::Uuid)),
-            Some(FilterExpression::Parameter(Parameter::Uuid(
-                entity_id.entity_uuid.into_uuid(),
-            ))),
+            Some(FilterExpression::Path {
+                path: EntityQueryPath::Uuid,
+            }),
+            Some(FilterExpression::Parameter {
+                parameter: Parameter::Uuid(entity_id.entity_uuid.into_uuid()),
+            }),
         );
 
         if let Some(draft_id) = entity_id.draft_id {
@@ -147,10 +159,12 @@ impl<'p> Filter<'p, Entity> {
                 owned_by_id_filter,
                 entity_uuid_filter,
                 Self::Equal(
-                    Some(FilterExpression::Path(EntityQueryPath::DraftId)),
-                    Some(FilterExpression::Parameter(Parameter::Uuid(
-                        draft_id.into_uuid(),
-                    ))),
+                    Some(FilterExpression::Path {
+                        path: EntityQueryPath::DraftId,
+                    }),
+                    Some(FilterExpression::Parameter {
+                        parameter: Parameter::Uuid(draft_id.into_uuid()),
+                    }),
                 ),
             ])
         } else {
@@ -162,24 +176,28 @@ impl<'p> Filter<'p, Entity> {
     pub fn for_entity_by_type_id(entity_type_id: &'p VersionedUrl) -> Self {
         Filter::All(vec![
             Filter::Equal(
-                Some(FilterExpression::Path(EntityQueryPath::EntityTypeEdge {
-                    edge_kind: SharedEdgeKind::IsOfType,
-                    path: EntityTypeQueryPath::BaseUrl,
-                    inheritance_depth: Some(0),
-                })),
-                Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                    entity_type_id.base_url.as_str(),
-                )))),
+                Some(FilterExpression::Path {
+                    path: EntityQueryPath::EntityTypeEdge {
+                        edge_kind: SharedEdgeKind::IsOfType,
+                        path: EntityTypeQueryPath::BaseUrl,
+                        inheritance_depth: Some(0),
+                    },
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::Text(Cow::Borrowed(entity_type_id.base_url.as_str())),
+                }),
             ),
             Filter::Equal(
-                Some(FilterExpression::Path(EntityQueryPath::EntityTypeEdge {
-                    edge_kind: SharedEdgeKind::IsOfType,
-                    path: EntityTypeQueryPath::Version,
-                    inheritance_depth: Some(0),
-                })),
-                Some(FilterExpression::Parameter(Parameter::OntologyTypeVersion(
-                    entity_type_id.version,
-                ))),
+                Some(FilterExpression::Path {
+                    path: EntityQueryPath::EntityTypeEdge {
+                        edge_kind: SharedEdgeKind::IsOfType,
+                        path: EntityTypeQueryPath::Version,
+                        inheritance_depth: Some(0),
+                    },
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::OntologyTypeVersion(entity_type_id.version),
+                }),
             ),
         ])
     }
@@ -210,12 +228,12 @@ where
             Self::Not(filter) => Box::pin(filter.convert_parameters(data_type_provider)).await?,
             Self::Equal(lhs, rhs) | Self::NotEqual(lhs, rhs) => match (lhs, rhs) {
                 (
-                    Some(FilterExpression::Parameter(parameter)),
-                    Some(FilterExpression::Path(path)),
+                    Some(FilterExpression::Parameter { parameter }),
+                    Some(FilterExpression::Path { path }),
                 )
                 | (
-                    Some(FilterExpression::Path(path)),
-                    Some(FilterExpression::Parameter(parameter)),
+                    Some(FilterExpression::Path { path }),
+                    Some(FilterExpression::Parameter { parameter }),
                 ) => parameter.convert_to_parameter_type(path.expected_type())?,
                 (..) => {}
             },
@@ -223,26 +241,32 @@ where
             | Self::GreaterOrEqual(lhs, rhs)
             | Self::Less(lhs, rhs)
             | Self::LessOrEqual(lhs, rhs) => match (lhs, rhs) {
-                (FilterExpression::Parameter(parameter), FilterExpression::Path(path))
-                | (FilterExpression::Path(path), FilterExpression::Parameter(parameter)) => {
+                (FilterExpression::Parameter { parameter }, FilterExpression::Path { path })
+                | (FilterExpression::Path { path }, FilterExpression::Parameter { parameter }) => {
                     parameter.convert_to_parameter_type(path.expected_type())?;
                 }
                 (..) => {}
             },
             Self::CosineDistance(lhs, rhs, max) => {
-                if let FilterExpression::Parameter(parameter) = max {
+                if let FilterExpression::Parameter { parameter } = max {
                     parameter.convert_to_parameter_type(ParameterType::F64)?;
                 }
                 match (lhs, rhs) {
-                    (FilterExpression::Parameter(parameter), FilterExpression::Path(path))
-                    | (FilterExpression::Path(path), FilterExpression::Parameter(parameter)) => {
+                    (
+                        FilterExpression::Parameter { parameter },
+                        FilterExpression::Path { path },
+                    )
+                    | (
+                        FilterExpression::Path { path },
+                        FilterExpression::Parameter { parameter },
+                    ) => {
                         parameter.convert_to_parameter_type(path.expected_type())?;
                     }
                     (..) => {}
                 }
             }
             Self::In(lhs, rhs) => {
-                if let FilterExpression::Parameter(parameter) = lhs {
+                if let FilterExpression::Parameter { parameter } = lhs {
                     match rhs {
                         ParameterList::DataTypeIds(_)
                         | ParameterList::PropertyTypeIds(_)
@@ -257,10 +281,10 @@ where
             | Self::EndsWith(lhs, rhs)
             | Self::ContainsSegment(lhs, rhs) => {
                 // TODO: We need to find a way to support lists in addition to strings as well
-                if let FilterExpression::Parameter(parameter) = lhs {
+                if let FilterExpression::Parameter { parameter } = lhs {
                     parameter.convert_to_parameter_type(ParameterType::Text)?;
                 }
-                if let FilterExpression::Parameter(parameter) = rhs {
+                if let FilterExpression::Parameter { parameter } = rhs {
                     parameter.convert_to_parameter_type(ParameterType::Text)?;
                 }
             }
@@ -273,13 +297,10 @@ where
 /// A leaf value in a [`Filter`].
 #[derive(Deserialize)]
 #[derive_where(Debug, Clone, PartialEq; R::QueryPath<'p>)]
-#[serde(
-    rename_all = "camelCase",
-    bound = "'de: 'p, R::QueryPath<'p>: Deserialize<'de>"
-)]
+#[serde(untagged, bound = "'de: 'p, R::QueryPath<'p>: Deserialize<'de>")]
 pub enum FilterExpression<'p, R: QueryRecord> {
-    Path(R::QueryPath<'p>),
-    Parameter(Parameter<'p>),
+    Path { path: R::QueryPath<'p> },
+    Parameter { parameter: Parameter<'p> },
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
@@ -323,6 +344,7 @@ impl<'p> Parameter<'p> {
         }
     }
 
+    #[must_use]
     pub fn parameter_type(&self) -> ParameterType {
         match self {
             Parameter::Boolean(_) => ParameterType::Boolean,
@@ -700,10 +722,10 @@ mod tests {
         });
 
         test_filter_representation(
-            &Filter::NotEqual(
-                Some(FilterExpression::<DataTypeWithMetadata>::Path(
-                    DataTypeQueryPath::Description,
-                )),
+            &Filter::<DataTypeWithMetadata>::NotEqual(
+                Some(FilterExpression::Path {
+                    path: DataTypeQueryPath::Description,
+                }),
                 None,
             ),
             &expected,

--- a/tests/hash-graph-benches/representative_read/knowledge/entity.rs
+++ b/tests/hash-graph-benches/representative_read/knowledge/entity.rs
@@ -45,10 +45,12 @@ pub fn bench_get_entity_by_id<A: AuthorizationApi>(
                     actor_id,
                     GetEntitiesParams {
                         filter: Filter::Equal(
-                            Some(FilterExpression::Path(EntityQueryPath::Uuid)),
-                            Some(FilterExpression::Parameter(Parameter::Uuid(
-                                entity_uuid.into_uuid(),
-                            ))),
+                            Some(FilterExpression::Path {
+                                path: EntityQueryPath::Uuid,
+                            }),
+                            Some(FilterExpression::Parameter {
+                                parameter: Parameter::Uuid(entity_uuid.into_uuid()),
+                            }),
                         ),
                         temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                             pinned: PinnedTemporalAxisUnresolved::new(None),
@@ -85,14 +87,16 @@ pub fn bench_get_entities_by_property<A: AuthorizationApi>(
 ) {
     bencher.to_async(runtime).iter(|| async move {
         let filter = Filter::Equal(
-            Some(FilterExpression::Path(EntityQueryPath::Properties(Some(
-                JsonPath::from_path_tokens(vec![PathToken::Field(Cow::Borrowed(
-                    "https://blockprotocol.org/@alice/types/property-type/name/",
-                ))]),
-            )))),
-            Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                "Alice",
-            )))),
+            Some(FilterExpression::Path {
+                path: EntityQueryPath::Properties(Some(JsonPath::from_path_tokens(vec![
+                    PathToken::Field(Cow::Borrowed(
+                        "https://blockprotocol.org/@alice/types/property-type/name/",
+                    )),
+                ]))),
+            }),
+            Some(FilterExpression::Parameter {
+                parameter: Parameter::Text(Cow::Borrowed("Alice")),
+            }),
         );
         let response = store
             .get_entity_subgraph(
@@ -136,18 +140,20 @@ pub fn bench_get_link_by_target_by_property<A: AuthorizationApi>(
 ) {
     bencher.to_async(runtime).iter(|| async move {
         let filter = Filter::Equal(
-            Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
-                edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
-                path: Box::new(EntityQueryPath::Properties(Some(
-                    JsonPath::from_path_tokens(vec![PathToken::Field(Cow::Borrowed(
-                        "https://blockprotocol.org/@alice/types/property-type/name/",
-                    ))]),
-                ))),
-                direction: EdgeDirection::Outgoing,
-            })),
-            Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                "Alice",
-            )))),
+            Some(FilterExpression::Path {
+                path: EntityQueryPath::EntityEdge {
+                    edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
+                    path: Box::new(EntityQueryPath::Properties(Some(
+                        JsonPath::from_path_tokens(vec![PathToken::Field(Cow::Borrowed(
+                            "https://blockprotocol.org/@alice/types/property-type/name/",
+                        ))]),
+                    ))),
+                    direction: EdgeDirection::Outgoing,
+                },
+            }),
+            Some(FilterExpression::Parameter {
+                parameter: Parameter::Text(Cow::Borrowed("Alice")),
+            }),
         );
         let response = store
             .get_entity_subgraph(

--- a/tests/hash-graph-benches/representative_read/knowledge/entity.rs
+++ b/tests/hash-graph-benches/representative_read/knowledge/entity.rs
@@ -84,7 +84,7 @@ pub fn bench_get_entities_by_property<A: AuthorizationApi>(
     graph_resolve_depths: GraphResolveDepths,
 ) {
     bencher.to_async(runtime).iter(|| async move {
-        let mut filter = Filter::Equal(
+        let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityQueryPath::Properties(Some(
                 JsonPath::from_path_tokens(vec![PathToken::Field(Cow::Borrowed(
                     "https://blockprotocol.org/@alice/types/property-type/name/",
@@ -94,9 +94,6 @@ pub fn bench_get_entities_by_property<A: AuthorizationApi>(
                 "Alice",
             )))),
         );
-        filter
-            .convert_parameters()
-            .expect("failed to convert parameters");
         let response = store
             .get_entity_subgraph(
                 actor_id,
@@ -138,7 +135,7 @@ pub fn bench_get_link_by_target_by_property<A: AuthorizationApi>(
     graph_resolve_depths: GraphResolveDepths,
 ) {
     bencher.to_async(runtime).iter(|| async move {
-        let mut filter = Filter::Equal(
+        let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
                 edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
                 path: Box::new(EntityQueryPath::Properties(Some(
@@ -152,9 +149,6 @@ pub fn bench_get_link_by_target_by_property<A: AuthorizationApi>(
                 "Alice",
             )))),
         );
-        filter
-            .convert_parameters()
-            .expect("failed to convert parameters");
         let response = store
             .get_entity_subgraph(
                 actor_id,

--- a/tests/hash-graph-benches/representative_read/knowledge/entity.rs
+++ b/tests/hash-graph-benches/representative_read/knowledge/entity.rs
@@ -50,6 +50,7 @@ pub fn bench_get_entity_by_id<A: AuthorizationApi>(
                             }),
                             Some(FilterExpression::Parameter {
                                 parameter: Parameter::Uuid(entity_uuid.into_uuid()),
+                                convert: None,
                             }),
                         ),
                         temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
@@ -96,6 +97,7 @@ pub fn bench_get_entities_by_property<A: AuthorizationApi>(
             }),
             Some(FilterExpression::Parameter {
                 parameter: Parameter::Text(Cow::Borrowed("Alice")),
+                convert: None,
             }),
         );
         let response = store
@@ -153,6 +155,7 @@ pub fn bench_get_link_by_target_by_property<A: AuthorizationApi>(
             }),
             Some(FilterExpression::Parameter {
                 parameter: Parameter::Text(Cow::Borrowed("Alice")),
+                convert: None,
             }),
         );
         let response = store

--- a/tests/hash-graph-http/tests/ambiguous.http
+++ b/tests/hash-graph-http/tests/ambiguous.http
@@ -364,7 +364,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
   "filter": {
     "greater": [
       { "path": ["propertyMetadata", "value", "http://localhost:3000/@alice/types/property-type/length/", "metadata", "canonical", "http://localhost:3000/@alice/types/data-type/meter/"] },
-      { "parameter": 100 }
+      { "parameter": 1000.0, "convert": { "from": "http://localhost:3000/@alice/types/data-type/millimeter/v/1", "to": "http://localhost:3000/@alice/types/data-type/meter/v/1" } }
     ]
   },
   "conversions": [

--- a/tests/hash-graph-http/tests/friendship.http
+++ b/tests/hash-graph-http/tests/friendship.http
@@ -1679,7 +1679,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 %}
 
 ### Get all link entities
-POST http://127.0.0.1:4000/entities/query
+POST http://127.0.0.1:4000/entity-types/query
 Content-Type: application/json
 X-Authenticated-User-Actor-Id: {{account_id}}
 
@@ -1688,12 +1688,11 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     "equal": [
       {
         "path": [
-          "type",
-          "versionedUrl"
+            "inheritsFrom", "*", "baseUrl"
         ]
       },
       {
-        "parameter": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1"
+        "parameter": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/"
       }
     ]
   },
@@ -2139,6 +2138,10 @@ X-Authenticated-User-Actor-Id: {{account_id}}
        "subjectId": "administratorFromWeb"
     }
   }],
+  "linkData": {
+    "leftEntityId": "{{person_a_entity_id}}",
+    "rightEntityId": "{{person_b_entity_id}}"
+  },
   "decisionTime": "2020-01-01T00:00:00.000Z"
 }
 

--- a/tests/hash-graph-integration/postgres/links.rs
+++ b/tests/hash-graph-integration/postgres/links.rs
@@ -166,6 +166,7 @@ async fn insert() {
                                     .entity_uuid
                                     .into_uuid(),
                             ),
+                            convert: None,
                         }),
                     ),
                     Filter::Equal(
@@ -185,6 +186,7 @@ async fn insert() {
                                     .owned_by_id
                                     .into_uuid(),
                             ),
+                            convert: None,
                         }),
                     ),
                     Filter::Equal(
@@ -199,6 +201,7 @@ async fn insert() {
                             parameter: Parameter::Text(Cow::Borrowed(
                                 friend_of_type_id.base_url.as_str(),
                             )),
+                            convert: None,
                         }),
                     ),
                     Filter::Equal(
@@ -211,6 +214,7 @@ async fn insert() {
                         }),
                         Some(FilterExpression::Parameter {
                             parameter: Parameter::OntologyTypeVersion(friend_of_type_id.version),
+                            convert: None,
                         }),
                     ),
                 ]),
@@ -442,6 +446,7 @@ async fn get_entity_links() {
                                 .entity_uuid
                                 .into_uuid(),
                         ),
+                        convert: None,
                     }),
                 ),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
@@ -631,6 +636,7 @@ async fn remove_link() {
                                     .entity_uuid
                                     .into_uuid(),
                             ),
+                            convert: None,
                         }),
                     ),
                     Filter::Equal(
@@ -639,6 +645,7 @@ async fn remove_link() {
                         }),
                         Some(FilterExpression::Parameter {
                             parameter: Parameter::Boolean(false),
+                            convert: None,
                         }),
                     ),
                 ]),
@@ -692,6 +699,7 @@ async fn remove_link() {
                                     .entity_uuid
                                     .into_uuid(),
                             ),
+                            convert: None,
                         }),
                     ),
                     Filter::Equal(
@@ -700,6 +708,7 @@ async fn remove_link() {
                         }),
                         Some(FilterExpression::Parameter {
                             parameter: Parameter::Boolean(false),
+                            convert: None,
                         }),
                     ),
                 ]),

--- a/tests/hash-graph-integration/postgres/links.rs
+++ b/tests/hash-graph-integration/postgres/links.rs
@@ -150,54 +150,68 @@ async fn insert() {
             GetEntitiesParams {
                 filter: Filter::All(vec![
                     Filter::Equal(
-                        Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
-                            edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
-                            path: Box::new(EntityQueryPath::Uuid),
-                            direction: EdgeDirection::Outgoing,
-                        })),
-                        Some(FilterExpression::Parameter(Parameter::Uuid(
-                            alice_entity
-                                .metadata
-                                .record_id
-                                .entity_id
-                                .entity_uuid
-                                .into_uuid(),
-                        ))),
+                        Some(FilterExpression::Path {
+                            path: EntityQueryPath::EntityEdge {
+                                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                                path: Box::new(EntityQueryPath::Uuid),
+                                direction: EdgeDirection::Outgoing,
+                            },
+                        }),
+                        Some(FilterExpression::Parameter {
+                            parameter: Parameter::Uuid(
+                                alice_entity
+                                    .metadata
+                                    .record_id
+                                    .entity_id
+                                    .entity_uuid
+                                    .into_uuid(),
+                            ),
+                        }),
                     ),
                     Filter::Equal(
-                        Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
-                            edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
-                            path: Box::new(EntityQueryPath::OwnedById),
-                            direction: EdgeDirection::Outgoing,
-                        })),
-                        Some(FilterExpression::Parameter(Parameter::Uuid(
-                            alice_entity
-                                .metadata
-                                .record_id
-                                .entity_id
-                                .owned_by_id
-                                .into_uuid(),
-                        ))),
+                        Some(FilterExpression::Path {
+                            path: EntityQueryPath::EntityEdge {
+                                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                                path: Box::new(EntityQueryPath::OwnedById),
+                                direction: EdgeDirection::Outgoing,
+                            },
+                        }),
+                        Some(FilterExpression::Parameter {
+                            parameter: Parameter::Uuid(
+                                alice_entity
+                                    .metadata
+                                    .record_id
+                                    .entity_id
+                                    .owned_by_id
+                                    .into_uuid(),
+                            ),
+                        }),
                     ),
                     Filter::Equal(
-                        Some(FilterExpression::Path(EntityQueryPath::EntityTypeEdge {
-                            edge_kind: SharedEdgeKind::IsOfType,
-                            path: EntityTypeQueryPath::BaseUrl,
-                            inheritance_depth: Some(0),
-                        })),
-                        Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                            friend_of_type_id.base_url.as_str(),
-                        )))),
+                        Some(FilterExpression::Path {
+                            path: EntityQueryPath::EntityTypeEdge {
+                                edge_kind: SharedEdgeKind::IsOfType,
+                                path: EntityTypeQueryPath::BaseUrl,
+                                inheritance_depth: Some(0),
+                            },
+                        }),
+                        Some(FilterExpression::Parameter {
+                            parameter: Parameter::Text(Cow::Borrowed(
+                                friend_of_type_id.base_url.as_str(),
+                            )),
+                        }),
                     ),
                     Filter::Equal(
-                        Some(FilterExpression::Path(EntityQueryPath::EntityTypeEdge {
-                            edge_kind: SharedEdgeKind::IsOfType,
-                            path: EntityTypeQueryPath::Version,
-                            inheritance_depth: Some(0),
-                        })),
-                        Some(FilterExpression::Parameter(Parameter::OntologyTypeVersion(
-                            friend_of_type_id.version,
-                        ))),
+                        Some(FilterExpression::Path {
+                            path: EntityQueryPath::EntityTypeEdge {
+                                edge_kind: SharedEdgeKind::IsOfType,
+                                path: EntityTypeQueryPath::Version,
+                                inheritance_depth: Some(0),
+                            },
+                        }),
+                        Some(FilterExpression::Parameter {
+                            parameter: Parameter::OntologyTypeVersion(friend_of_type_id.version),
+                        }),
                     ),
                 ]),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
@@ -412,19 +426,23 @@ async fn get_entity_links() {
             api.account_id,
             GetEntitiesParams {
                 filter: Filter::Equal(
-                    Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
-                        edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
-                        path: Box::new(EntityQueryPath::Uuid),
-                        direction: EdgeDirection::Outgoing,
-                    })),
-                    Some(FilterExpression::Parameter(Parameter::Uuid(
-                        alice_entity
-                            .metadata
-                            .record_id
-                            .entity_id
-                            .entity_uuid
-                            .into_uuid(),
-                    ))),
+                    Some(FilterExpression::Path {
+                        path: EntityQueryPath::EntityEdge {
+                            edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                            path: Box::new(EntityQueryPath::Uuid),
+                            direction: EdgeDirection::Outgoing,
+                        },
+                    }),
+                    Some(FilterExpression::Parameter {
+                        parameter: Parameter::Uuid(
+                            alice_entity
+                                .metadata
+                                .record_id
+                                .entity_id
+                                .entity_uuid
+                                .into_uuid(),
+                        ),
+                    }),
                 ),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
@@ -597,23 +615,31 @@ async fn remove_link() {
             CountEntitiesParams {
                 filter: Filter::All(vec![
                     Filter::Equal(
-                        Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
-                            edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
-                            path: Box::new(EntityQueryPath::Uuid),
-                            direction: EdgeDirection::Outgoing,
-                        })),
-                        Some(FilterExpression::Parameter(Parameter::Uuid(
-                            alice_entity
-                                .metadata
-                                .record_id
-                                .entity_id
-                                .entity_uuid
-                                .into_uuid(),
-                        ))),
+                        Some(FilterExpression::Path {
+                            path: EntityQueryPath::EntityEdge {
+                                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                                path: Box::new(EntityQueryPath::Uuid),
+                                direction: EdgeDirection::Outgoing,
+                            },
+                        }),
+                        Some(FilterExpression::Parameter {
+                            parameter: Parameter::Uuid(
+                                alice_entity
+                                    .metadata
+                                    .record_id
+                                    .entity_id
+                                    .entity_uuid
+                                    .into_uuid(),
+                            ),
+                        }),
                     ),
                     Filter::Equal(
-                        Some(FilterExpression::Path(EntityQueryPath::Archived)),
-                        Some(FilterExpression::Parameter(Parameter::Boolean(false))),
+                        Some(FilterExpression::Path {
+                            path: EntityQueryPath::Archived,
+                        }),
+                        Some(FilterExpression::Parameter {
+                            parameter: Parameter::Boolean(false),
+                        }),
                     ),
                 ]),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
@@ -650,23 +676,31 @@ async fn remove_link() {
             CountEntitiesParams {
                 filter: Filter::All(vec![
                     Filter::Equal(
-                        Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
-                            edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
-                            path: Box::new(EntityQueryPath::Uuid),
-                            direction: EdgeDirection::Outgoing,
-                        })),
-                        Some(FilterExpression::Parameter(Parameter::Uuid(
-                            alice_entity
-                                .metadata
-                                .record_id
-                                .entity_id
-                                .entity_uuid
-                                .into_uuid(),
-                        ))),
+                        Some(FilterExpression::Path {
+                            path: EntityQueryPath::EntityEdge {
+                                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                                path: Box::new(EntityQueryPath::Uuid),
+                                direction: EdgeDirection::Outgoing,
+                            },
+                        }),
+                        Some(FilterExpression::Parameter {
+                            parameter: Parameter::Uuid(
+                                alice_entity
+                                    .metadata
+                                    .record_id
+                                    .entity_id
+                                    .entity_uuid
+                                    .into_uuid(),
+                            ),
+                        }),
                     ),
                     Filter::Equal(
-                        Some(FilterExpression::Path(EntityQueryPath::Archived)),
-                        Some(FilterExpression::Parameter(Parameter::Boolean(false))),
+                        Some(FilterExpression::Path {
+                            path: EntityQueryPath::Archived,
+                        }),
+                        Some(FilterExpression::Parameter {
+                            parameter: Parameter::Boolean(false),
+                        }),
                     ),
                 ]),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We support to convert to canonical values in the `path` value in property queries but to avoid passing in the canonical value to filter all the time, this PR adds the ability to convert parameters on demand.

## 🔍 What does this change?

- Move the usage of `convert_parameters` to the `PostgresStore` directly
- Make the `FilterExpression` untagged to allow multiple fields
- Add a `convert` value to `parameter`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing
### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 📹 Demo

Example filter for length by a different data type:
```json
{
	"filter": {
		"greater": [
			{
				"path": [
					"properties",
					"http://localhost:3000/@alice/types/property-type/length/",
					"convert",
					"http://localhost:3000/@alice/types/data-type/meter/"
				]
			},
			{
				"parameter": 1000.0,
				"convert": {
					"from": "http://localhost:3000/@alice/types/data-type/millimeter/v/1",
					"to": "http://localhost:3000/@alice/types/data-type/meter/v/1"
				}
			}
		]
	}
}
```
