### PR TITLE
Introduce experimental/unstable extension traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1979,7 +1979,11 @@ name = "error-stack-experimental"
 version = "0.0.0-reserved"
 dependencies = [
  "error-stack 0.5.0",
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
  "rustc_version",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1979,6 +1979,7 @@ name = "error-stack-experimental"
 version = "0.0.0-reserved"
 dependencies = [
  "error-stack 0.5.0",
+ "rustc_version",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,6 +1977,9 @@ dependencies = [
 [[package]]
 name = "error-stack-experimental"
 version = "0.0.0-reserved"
+dependencies = [
+ "error-stack 0.5.0",
+]
 
 [[package]]
 name = "error-stack-macros"

--- a/libs/error-stack/experimental/Cargo.toml
+++ b/libs/error-stack/experimental/Cargo.toml
@@ -14,6 +14,8 @@ categories = ["rust-patterns", "no-std"]
 publish = false
 
 [dependencies]
+# Public workspace dependencies
+error-stack = { path = "..", public = true }
 
 [lints]
 workspace = true

--- a/libs/error-stack/experimental/Cargo.toml
+++ b/libs/error-stack/experimental/Cargo.toml
@@ -17,5 +17,13 @@ publish = false
 # Public workspace dependencies
 error-stack = { path = "..", public = true }
 
+[build-dependencies]
+rustc_version = "0.4.1"
+
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+cargo-args = ["-Z", "unstable-options", "-Z", "rustdoc-scrape-examples"]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/libs/error-stack/experimental/Cargo.toml
+++ b/libs/error-stack/experimental/Cargo.toml
@@ -16,12 +16,21 @@ publish = false
 [dependencies]
 # Public workspace dependencies
 error-stack = { path = "..", public = true }
+futures-core = { workspace = true, public = true, optional = true }
+pin-project-lite = { workspace = true, optional = true }
 
 [build-dependencies]
 rustc_version = "0.4.1"
 
 [lints]
 workspace = true
+
+[features]
+stream = ["dep:futures-core", "dep:pin-project-lite"]
+
+[dev-dependencies]
+futures-util.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/libs/error-stack/experimental/build.rs
+++ b/libs/error-stack/experimental/build.rs
@@ -1,0 +1,10 @@
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    let version_meta = version_meta().expect("Could not get Rust version");
+
+    println!("cargo:rustc-check-cfg=cfg(nightly)");
+    if version_meta.channel == Channel::Nightly {
+        println!("cargo:rustc-cfg=nightly");
+    }
+}

--- a/libs/error-stack/experimental/package.json
+++ b/libs/error-stack/experimental/package.json
@@ -2,5 +2,8 @@
   "name": "@rust/error-stack-experimental",
   "version": "0.0.0-reserved-private",
   "private": true,
-  "license": "MIT OR Apache-2.0"
+  "license": "MIT OR Apache-2.0",
+  "dependencies": {
+    "@rust/error-stack": "0.5.0"
+  }
 }

--- a/libs/error-stack/experimental/src/iter.rs
+++ b/libs/error-stack/experimental/src/iter.rs
@@ -4,7 +4,11 @@ use error_stack::{Context, Report, Result};
 // except with the removal of the Try trait, as it is unstable.
 struct ReportShunt<'a, I, T, C> {
     iter: I,
+
     residual: &'a mut Option<Report<[C]>>,
+    residual_len: usize,
+    residual_bound: usize,
+
     _marker: core::marker::PhantomData<fn() -> *const T>,
 }
 
@@ -17,6 +21,10 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
+            if self.residual_len >= self.residual_bound {
+                return None;
+            }
+
             let item = self.iter.next()?;
             let item = item.map_err(Into::into);
 
@@ -29,9 +37,11 @@ where
                 }
                 (Err(residual), None) => {
                     *self.residual = Some(residual);
+                    self.residual_len += 1;
                 }
                 (Err(residual), Some(report)) => {
                     report.append(residual);
+                    self.residual_len += 1;
                 }
             }
         }
@@ -48,7 +58,11 @@ where
     }
 }
 
-fn try_process_reports<I, T, R, C, F, U>(iter: I, mut collect: F) -> Result<U, [C]>
+fn try_process_reports<I, T, R, C, F, U>(
+    iter: I,
+    bound: Option<usize>,
+    mut collect: F,
+) -> Result<U, [C]>
 where
     I: Iterator<Item = core::result::Result<T, R>>,
     R: Into<Report<[C]>>,
@@ -58,6 +72,8 @@ where
     let shunt = ReportShunt {
         iter,
         residual: &mut residual,
+        residual_len: 0,
+        residual_bound: bound.unwrap_or(usize::MAX),
         _marker: core::marker::PhantomData,
     };
 
@@ -65,10 +81,83 @@ where
     residual.map_or_else(|| Ok(value), |residual| Err(residual))
 }
 
+/// An extension trait for iterators that allows collecting items while handling errors.
+///
+/// This trait provides additional functionality to iterators that yield `Result` items,
+/// allowing them to be collected into a container while propagating any errors encountered.
 pub trait IteratorExt<C> {
+    /// The type of the successful items in the iterator.
     type Output;
 
-    fn try_collect<A>(self) -> Result<A, [C]>
+    /// Collects the successful items from the iterator into a container, or returns all errors that
+    /// occured.
+    ///
+    /// This method attempts to collect all successful items from the iterator into the specified
+    /// container type. If an error is encountered during iteration, the method immediately returns
+    /// that error, discarding any previously collected items.
+    ///
+    /// # Errors
+    ///
+    /// If any error is encountered during iteration, the method will return a `Report` containing
+    /// all errors encountered up to that point.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use error_stack::{Result, ResultExt, Report};
+    /// use std::io;
+    /// use error_stack_experimental::IteratorExt;
+    ///
+    /// fn fetch_fail() -> Result<u8, io::Error> {
+    ///    # stringify! {
+    ///    ...
+    ///    # };
+    ///    # Err(Report::from(io::Error::new(io::ErrorKind::Other, "error")))
+    /// }
+    ///
+    /// let results = [Ok(1_u8), fetch_fail(), Ok(2), fetch_fail(), fetch_fail()];
+    /// let collected: Result<Vec<_>, _> = results.into_iter().try_collect_reports();
+    /// let error = collected.expect_err("multiple calls should have failed");
+    ///
+    /// assert_eq!(error.current_contexts().count(), 3);
+    /// ```
+    fn try_collect_reports<A>(self) -> Result<A, [C]>
+    where
+        A: FromIterator<Self::Output>;
+
+    /// Collects the successful items from the iterator into a container or returns all errors up to
+    /// the specified bound.
+    ///
+    /// This method is similar to `try_collect`, but it limits the number of errors collected to the
+    /// specified `bound`. If the number of errors encountered exceeds the bound, the method stops
+    /// collecting errors and returns the collected errors up to that point.
+    ///
+    /// # Errors
+    ///
+    /// If any error is encountered during iteration, the method will return a `Report` containing
+    /// all errors encountered up to the specified bound.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use error_stack::{Result, ResultExt, Report};
+    /// use std::io;
+    /// use error_stack_experimental::IteratorExt;
+    ///
+    /// fn fetch_fail() -> Result<u8, io::Error> {
+    ///    # stringify! {
+    ///    ...
+    ///    # };
+    ///    # Err(Report::from(io::Error::new(io::ErrorKind::Other, "error")))
+    /// }
+    ///
+    /// let results = [Ok(1_u8), fetch_fail(), Ok(2), fetch_fail(), fetch_fail()];
+    /// let collected: Result<Vec<_>, _> = results.into_iter().try_collect_reports_bounded(2);
+    /// let error = collected.expect_err("should have failed");
+    ///
+    /// assert_eq!(error.current_contexts().count(), 2);
+    /// ```
+    fn try_collect_reports_bounded<A>(self, bound: usize) -> Result<A, [C]>
     where
         A: FromIterator<Self::Output>;
 }
@@ -81,10 +170,104 @@ where
 {
     type Output = T;
 
-    fn try_collect<A>(self) -> Result<A, [C]>
+    fn try_collect_reports<A>(self) -> Result<A, [C]>
     where
         A: FromIterator<Self::Output>,
     {
-        try_process_reports(self, |shunt| shunt.collect())
+        try_process_reports(self, None, |shunt| shunt.collect())
+    }
+
+    fn try_collect_reports_bounded<A>(self, bound: usize) -> Result<A, [C]>
+    where
+        A: FromIterator<Self::Output>,
+    {
+        try_process_reports(self, Some(bound), |shunt| shunt.collect())
+    }
+}
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::integer_division_remainder_used)]
+    use core::fmt;
+    use std::collections::HashSet;
+
+    use super::*;
+
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    struct CustomError(usize);
+
+    impl fmt::Display for CustomError {
+        fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(fmt, "CustomError({})", self.0)
+        }
+    }
+
+    impl core::error::Error for CustomError {}
+
+    #[test]
+    fn try_collect_multiple_errors() {
+        let iter = (0..5).map(|i| {
+            if i % 2 == 0 {
+                Ok(i)
+            } else {
+                Err(Report::new(CustomError(i)))
+            }
+        });
+
+        let result: Result<Vec<_>, [CustomError]> = iter.try_collect_reports();
+        let report = result.expect_err("should have failed");
+
+        let contexts: HashSet<_> = report.current_contexts().collect();
+        assert_eq!(contexts.len(), 2);
+        assert!(contexts.contains(&CustomError(1)));
+        assert!(contexts.contains(&CustomError(3)));
+    }
+
+    #[test]
+    fn try_collect_multiple_errors_bounded() {
+        let iter = (0..10).map(|i| {
+            if i % 2 == 0 {
+                Ok(i)
+            } else {
+                Err(Report::new(CustomError(i)))
+            }
+        });
+
+        let result: Result<Vec<_>, [CustomError]> = iter.try_collect_reports_bounded(3);
+        let report = result.expect_err("should have failed");
+
+        let contexts: HashSet<_> = report.current_contexts().collect();
+        assert_eq!(contexts.len(), 3);
+        assert!(contexts.contains(&CustomError(1)));
+        assert!(contexts.contains(&CustomError(3)));
+        assert!(contexts.contains(&CustomError(5)));
+    }
+
+    #[test]
+    fn try_collect_no_errors() {
+        let iter = (0..5).map(Result::<_, CustomError>::Ok);
+
+        let result: Result<Vec<_>, [CustomError]> = iter.try_collect_reports();
+        let values = result.expect("should have succeeded");
+
+        assert_eq!(values, [0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn try_collect_multiple_errors_expanded() {
+        let iter = (0..5).map(|i| {
+            if i % 2 == 0 {
+                Ok(i)
+            } else {
+                Err(Report::new(CustomError(i)).expand())
+            }
+        });
+
+        let result: Result<Vec<_>, [CustomError]> = iter.try_collect_reports();
+        let report = result.expect_err("should have failed");
+
+        let contexts: HashSet<_> = report.current_contexts().collect();
+        assert_eq!(contexts.len(), 2);
+        assert!(contexts.contains(&CustomError(1)));
+        assert!(contexts.contains(&CustomError(3)));
     }
 }

--- a/libs/error-stack/experimental/src/iter.rs
+++ b/libs/error-stack/experimental/src/iter.rs
@@ -1,0 +1,70 @@
+use core::ops::{ControlFlow, FromResidual, Residual, Try};
+
+use error_stack::Report;
+
+// see: https://doc.rust-lang.org/src/core/ops/try_trait.rs.html#367
+type ChangeOutputType<T: Try<Residual: Residual<V>>, V> = <T::Residual as Residual<V>>::TryType;
+
+// inspired by the implementation in `std`, see: https://doc.rust-lang.org/1.81.0/src/core/iter/adapters/mod.rs.html#157
+struct ReportShunt<'a, I, C> {
+    iter: I,
+    residual: &'a mut Option<Report<[C]>>,
+}
+
+impl<I, R, C> Iterator for ReportShunt<'_, I, C>
+where
+    I: Iterator<Item: Try<Residual = R>>,
+    R: Into<Report<[C]>>,
+{
+    type Item = <I::Item as Try>::Output;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let item = self.iter.next()?;
+
+            match (Try::branch(item), self.residual.as_mut()) {
+                (ControlFlow::Continue(output), None) => return Some(output),
+                (ControlFlow::Continue(_), Some(_)) => {
+                    // we're now just consuming the iterator to return all related errors
+                    // so we can just ignore the output
+                    continue;
+                }
+                (ControlFlow::Break(residual), None) => {
+                    *self.residual = Some(residual.into());
+                }
+                (ControlFlow::Break(residual), Some(report)) => {
+                    report.append(residual.into());
+                }
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.residual.is_some() {
+            (0, Some(0))
+        } else {
+            let (_, upper) = self.iter.size_hint();
+
+            (0, upper)
+        }
+    }
+}
+
+fn try_process_reports<I, T, R, C, F, U>(iter: I, mut f: F) -> ChangeOutputType<I::Item, U>
+where
+    I: Iterator<Item: Try<Output = T, Residual = R>>,
+    R: Into<Report<[C]>> + Residual<U, TryType: FromResidual<Report<[C]>>>,
+    for<'a> F: FnMut(ReportShunt<'a, I, C>) -> U,
+{
+    let mut residual = None;
+    let shunt = ReportShunt {
+        iter,
+        residual: &mut residual,
+    };
+
+    let value = f(shunt);
+    match residual {
+        Some(residual) => FromResidual::from_residual(residual),
+        None => Try::from_output(value),
+    }
+}

--- a/libs/error-stack/experimental/src/lib.rs
+++ b/libs/error-stack/experimental/src/lib.rs
@@ -1,8 +1,12 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
 
-pub use self::{iter::IteratorExt, result::ResultMultiExt, tuple::TupleExt};
+#[cfg(feature = "stream")]
+pub use self::stream::TryReportStreamExt;
+pub use self::{iter::TryReportIteratorExt, result::ResultMultiExt, tuple::TryReportTupleExt};
 
 mod iter;
 mod result;
+#[cfg(feature = "stream")]
+mod stream;
 mod tuple;

--- a/libs/error-stack/experimental/src/lib.rs
+++ b/libs/error-stack/experimental/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(try_trait_v2, try_trait_v2_residual, lazy_type_alias)]
 #![doc = include_str!("../README.md")]
 
 mod iter;

--- a/libs/error-stack/experimental/src/lib.rs
+++ b/libs/error-stack/experimental/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(try_trait_v2, try_trait_v2_residual, lazy_type_alias)]
 #![doc = include_str!("../README.md")]
 
 mod iter;

--- a/libs/error-stack/experimental/src/lib.rs
+++ b/libs/error-stack/experimental/src/lib.rs
@@ -1,3 +1,8 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
+
+pub use self::{iter::IteratorExt, result::ResultMultiExt, tuple::TupleExt};
 
 mod iter;
+mod result;
+mod tuple;

--- a/libs/error-stack/experimental/src/lib.rs
+++ b/libs/error-stack/experimental/src/lib.rs
@@ -1,1 +1,3 @@
 #![doc = include_str!("../README.md")]
+
+mod iter;

--- a/libs/error-stack/experimental/src/result.rs
+++ b/libs/error-stack/experimental/src/result.rs
@@ -1,0 +1,102 @@
+use error_stack::{Report, Result};
+
+/// Extension trait for accumulating errors in a `Result<T, [C]>`.
+pub trait ResultMultiExt<C> {
+    /// The type of the successful value in the `Result`.
+    type Output;
+
+    /// Accumulates an error into the `Result`.
+    ///
+    /// If the `Result` is `Ok`, it replaces it with an `Err` containing the new error.
+    /// If it's already `Err`, it appends the new error to the existing list.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use error_stack::{Report, Result};
+    /// use error_stack_experimental::ResultMultiExt;
+    ///
+    /// #[derive(Debug)]
+    /// struct CustomError;
+    ///
+    /// impl std::fmt::Display for CustomError {
+    ///     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    ///         write!(f, "Custom error")
+    ///     }
+    /// }
+    ///
+    /// impl std::error::Error for CustomError {}
+    ///
+    /// let mut result: Result<(), [CustomError]> = Ok(());
+    /// result.accumulate(Report::new(CustomError));
+    /// assert!(result.is_err());
+    ///
+    /// result.accumulate(Report::new(CustomError));
+    /// assert_eq!(result.unwrap_err().current_contexts().count(), 2);
+    /// ```
+    fn accumulate<R>(&mut self, report: R)
+    where
+        R: Into<Report<[C]>>;
+}
+
+impl<T, C> ResultMultiExt<C> for Result<T, [C]> {
+    type Output = T;
+
+    fn accumulate<R>(&mut self, report: R)
+    where
+        R: Into<Report<[C]>>,
+    {
+        match self {
+            Ok(_) => {
+                *self = Err(report.into());
+            }
+            Err(reports) => {
+                reports.append(report.into());
+            }
+        }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use error_stack::{Report, Result};
+
+    use crate::ResultMultiExt;
+
+    #[derive(Debug)]
+    struct TestError;
+
+    impl core::fmt::Display for TestError {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            write!(fmt, "Test error")
+        }
+    }
+
+    impl core::error::Error for TestError {}
+
+    #[test]
+    fn accumulate_on_ok() {
+        let mut result: Result<(), [TestError]> = Ok(());
+        result.accumulate(Report::new(TestError));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn accumulate_multiple_errors() {
+        let mut result: Result<(), [TestError]> = Ok(());
+        result.accumulate(Report::new(TestError));
+        result.accumulate(Report::new(TestError));
+        result.accumulate(Report::new(TestError));
+
+        let report = result.expect_err("should have failed");
+        assert_eq!(report.current_contexts().count(), 3);
+    }
+
+    #[test]
+    fn accumulate_on_err() {
+        let mut result: Result<(), [TestError]> = Err(Report::new(TestError).expand());
+        result.accumulate(Report::new(TestError));
+
+        let report = result.expect_err("should have failed");
+        assert_eq!(report.current_contexts().count(), 2);
+    }
+}

--- a/libs/error-stack/experimental/src/stream.rs
+++ b/libs/error-stack/experimental/src/stream.rs
@@ -1,0 +1,193 @@
+use core::{
+    future::Future,
+    mem,
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+
+use error_stack::{Report, Result};
+use futures_core::{FusedFuture, FusedStream, TryStream};
+use pin_project_lite::pin_project;
+
+pin_project! {
+    /// Future for the [`try_collect_reports`](TryReportStreamExt::try_collect_reports)
+    /// and [`try_collect_reports_bounded`](TryReportStreamExt::try_collect_reports_bounded) methods.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct TryCollectReports<S, A, C> {
+        #[pin]
+        stream: S,
+        output: Result<A, [C]>,
+
+        residual_len: usize,
+        residual_bound: usize
+    }
+}
+
+impl<S, A, C> TryCollectReports<S, A, C>
+where
+    S: TryStream,
+    A: Default + Extend<S::Ok>,
+{
+    fn new(stream: S, bound: Option<usize>) -> Self {
+        Self {
+            stream,
+            output: Ok(Default::default()),
+            residual_len: 0,
+            residual_bound: bound.unwrap_or(usize::MAX),
+        }
+    }
+}
+
+impl<S, A, C> FusedFuture for TryCollectReports<S, A, C>
+where
+    S: TryStream<Error: Into<Report<[C]>>> + FusedStream,
+    A: Default + Extend<S::Ok>,
+{
+    fn is_terminated(&self) -> bool {
+        self.stream.is_terminated()
+    }
+}
+
+impl<S, A, C> Future for TryCollectReports<S, A, C>
+where
+    S: TryStream<Error: Into<Report<[C]>>>,
+    A: Default + Extend<S::Ok>,
+{
+    type Output = Result<A, [C]>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+
+        let value = loop {
+            if *this.residual_len >= *this.residual_bound {
+                break mem::replace(this.output, Ok(A::default()));
+            }
+
+            let next = ready!(this.stream.as_mut().try_poll_next(cx));
+            match (next, &mut *this.output) {
+                (Some(Ok(value)), Ok(output)) => {
+                    output.extend(core::iter::once(value));
+                }
+                (Some(Ok(_)), Err(_)) => {
+                    // we're now just consuming the iterator to return all related errors
+                    // so we can just ignore the output
+                }
+                (Some(Err(residual)), output @ Ok(_)) => {
+                    *output = Err(residual.into());
+                    *this.residual_len += 1;
+                }
+                (Some(Err(residual)), Err(report)) => {
+                    report.append(residual.into());
+                    *this.residual_len += 1;
+                }
+                (None, output) => {
+                    break mem::replace(output, Ok(A::default()));
+                }
+            }
+        };
+
+        Poll::Ready(value)
+    }
+}
+
+/// Trait extending `TryStream` with methods for collecting error-stack results in a fail-slow
+/// manner.
+pub trait TryReportStreamExt<C>: TryStream<Error: Into<Report<[C]>>> {
+    /// Collects all successful items from the stream into a collection, accumulating all errors.
+    ///
+    /// This method will continue processing the stream even after encountering errors, collecting
+    /// all successful items and all errors until the stream is exhausted.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use error_stack::{Report, Result};
+    /// # use futures_util::stream;
+    /// # use error_stack_experimental::TryReportStreamExt;
+    ///
+    /// #[derive(Debug, Clone, PartialEq, Eq)]
+    /// pub struct UnknownError;
+    ///
+    /// impl core::fmt::Display for UnknownError {
+    ///     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    ///         f.write_str("UnknownError")
+    ///     }
+    /// }
+    ///
+    /// impl core::error::Error for UnknownError {}
+    ///
+    /// #
+    /// # async fn example() {
+    /// let stream = stream::iter([
+    ///     Ok(1),
+    ///     Err(Report::new(UnknownError)),
+    ///     Ok(2),
+    ///     Err(Report::new(UnknownError)),
+    /// ]);
+    ///
+    /// let result: Result<Vec<i32>, _> = stream.try_collect_reports().await;
+    /// let report = result.expect_err("should have failed twice");
+    ///
+    /// assert_eq!(report.current_contexts().count(), 2);
+    /// # }
+    /// #
+    /// # tokio::runtime::Runtime::new().unwrap().block_on(example());
+    /// ```
+    fn try_collect_reports<A>(self) -> TryCollectReports<Self, A, C>
+    where
+        A: Default + Extend<Self::Ok>,
+        Self: Sized,
+    {
+        TryCollectReports::new(self, None)
+    }
+
+    /// Collects successful items from the stream into a collection, accumulating errors up to a
+    /// specified bound.
+    ///
+    /// This method will continue processing the stream after encountering errors, but will stop
+    /// once the number of accumulated errors reaches the specified `bound`.
+    ///
+    /// ```
+    /// # use error_stack::{Report, Result};
+    /// # use futures_util::stream;
+    /// # use error_stack_experimental::TryReportStreamExt;
+    ///
+    /// #[derive(Debug, Clone, PartialEq, Eq)]
+    /// pub struct UnknownError;
+    ///
+    /// impl core::fmt::Display for UnknownError {
+    ///     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    ///         f.write_str("UnknownError")
+    ///     }
+    /// }
+    ///
+    /// impl core::error::Error for UnknownError {}
+    ///
+    /// #
+    /// # async fn example() {
+    /// let stream = stream::iter([
+    ///     Ok(1),
+    ///     Err(Report::new(UnknownError)),
+    ///     Ok(2),
+    ///     Err(Report::new(UnknownError)),
+    /// ]);
+    ///
+    /// let result: Result<Vec<i32>, _> = stream.try_collect_reports_bounded(1).await;
+    /// let report = result.expect_err("should have failed twice");
+    ///
+    /// assert_eq!(report.current_contexts().count(), 1);
+    /// # }
+    /// #
+    /// # tokio::runtime::Runtime::new().unwrap().block_on(example());
+    /// ```
+    fn try_collect_reports_bounded<A>(self, bound: usize) -> TryCollectReports<Self, A, C>
+    where
+        A: Default + Extend<Self::Ok>,
+        Self: Sized,
+    {
+        TryCollectReports::new(self, Some(bound))
+    }
+}
+
+impl<S, C> TryReportStreamExt<C> for S where S: TryStream<Error: Into<Report<[C]>>> {}

--- a/libs/error-stack/experimental/src/tuple.rs
+++ b/libs/error-stack/experimental/src/tuple.rs
@@ -1,0 +1,216 @@
+use error_stack::{Report, Result};
+
+/// Extends tuples with error-handling capabilities.
+///
+/// This trait provides a method to collect a tuple of `Result`s into a single `Result`
+/// containing a tuple of the successful values, or an error if any of the results failed.
+///
+/// The trait is implemented for tuples of up to 16 elements.
+pub trait TupleExt<C> {
+    /// The type of the successful output, typically a tuple of the inner types of the `Result`s.
+    type Output;
+
+    /// Attempts to collect all `Result`s in the tuple into a single `Result`.
+    ///
+    /// # Errors
+    ///
+    /// If any element is `Err`, returns the first encountered `Err`, with subsequent errors
+    /// appended to it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use error_stack::{Report, Result};
+    /// use error_stack_experimental::TupleExt;
+    ///
+    /// #[derive(Debug)]
+    /// struct CustomError;
+    ///
+    /// impl core::fmt::Display for CustomError {
+    ///     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    ///         write!(f, "Custom error")
+    ///     }
+    /// }
+    ///
+    /// impl core::error::Error for CustomError {}
+    ///
+    /// let result1: Result<i32, CustomError> = Ok(1);
+    /// let result2: Result<&'static str, CustomError> = Ok("success");
+    /// let result3: Result<bool, CustomError> = Ok(true);
+    ///
+    /// let combined = (result1, result2, result3).try_collect();
+    /// assert_eq!(combined.unwrap(), (1, "success", true));
+    ///
+    /// let result1: Result<i32, CustomError> = Ok(1);
+    /// let result2: Result<&'static str, CustomError> = Err(Report::new(CustomError));
+    /// let result3: Result<bool, CustomError> = Err(Report::new(CustomError));
+    /// let combined_with_error = (result1, result2, result3).try_collect();
+    /// assert!(combined_with_error.is_err());
+    /// ```
+    fn try_collect(self) -> Result<Self::Output, [C]>;
+}
+
+impl<T, R, C> TupleExt<C> for (core::result::Result<T, R>,)
+where
+    R: Into<Report<[C]>>,
+{
+    type Output = (T,);
+
+    fn try_collect(self) -> Result<Self::Output, [C]> {
+        let (result,) = self;
+
+        match result {
+            Ok(value) => Ok((value,)),
+            Err(report) => Err(report.into()),
+        }
+    }
+}
+
+#[rustfmt::skip]
+macro_rules! all_the_tuples {
+    ($macro:ident) => {
+        $macro!([A, AO]);
+        $macro!([A, AO], [B, BO]);
+        $macro!([A, AO], [B, BO], [C, CO]);
+        $macro!([A, AO], [B, BO], [C, CO], [D, DO]);
+        $macro!([A, AO], [B, BO], [C, CO], [D, DO], [E, EO]);
+        $macro!([A, AO], [B, BO], [C, CO], [D, DO], [E, EO], [F, FO]);
+        $macro!([A, AO], [B, BO], [C, CO], [D, DO], [E, EO], [F, FO], [G, GO]);
+        $macro!([A, AO], [B, BO], [C, CO], [D, DO], [E, EO], [F, FO], [G, GO], [H, HO]);
+        $macro!([A, AO], [B, BO], [C, CO], [D, DO], [E, EO], [F, FO], [G, GO], [H, HO], [I, IO]);
+        $macro!([A, AO], [B, BO], [C, CO], [D, DO], [E, EO], [F, FO], [G, GO], [H, HO], [I, IO], [J, JO]);
+        $macro!([A, AO], [B, BO], [C, CO], [D, DO], [E, EO], [F, FO], [G, GO], [H, HO], [I, IO], [J, JO], [K, KO]);
+        $macro!([A, AO], [B, BO], [C, CO], [D, DO], [E, EO], [F, FO], [G, GO], [H, HO], [I, IO], [J, JO], [K, KO], [L, LO]);
+        $macro!([A, AO], [B, BO], [C, CO], [D, DO], [E, EO], [F, FO], [G, GO], [H, HO], [I, IO], [J, JO], [K, KO], [L, LO], [M, MO]);
+        $macro!([A, AO], [B, BO], [C, CO], [D, DO], [E, EO], [F, FO], [G, GO], [H, HO], [I, IO], [J, JO], [K, KO], [L, LO], [M, MO], [N, NO]);
+        $macro!([A, AO], [B, BO], [C, CO], [D, DO], [E, EO], [F, FO], [G, GO], [H, HO], [I, IO], [J, JO], [K, KO], [L, LO], [M, MO], [N, NO], [O, OO]);
+        $macro!([A, AO], [B, BO], [C, CO], [D, DO], [E, EO], [F, FO], [G, GO], [H, HO], [I, IO], [J, JO], [K, KO], [L, LO], [M, MO], [N, NO], [O, OO], [P, PO]);
+    };
+}
+
+macro_rules! impl_ext {
+    ($([$type:ident, $output:ident]),+) => {
+        #[doc(hidden)]
+        impl<$($type, $output),*, T, R, Context> TupleExt<Context> for ($($type),*, core::result::Result<T, R>)
+        where
+            R: Into<Report<[Context]>>,
+            ($($type,)*): TupleExt<Context, Output = ($($output,)*)>,
+        {
+            type Output = ($($output),*, T);
+
+            #[allow(non_snake_case, clippy::min_ident_chars)]
+            fn try_collect(self) -> Result<Self::Output, [Context]> {
+                let ($($type),*, result) = self;
+                let prefix = ($($type,)*).try_collect();
+
+                match (prefix, result) {
+                    (Ok(($($type,)*)), Ok(value)) => Ok(($($type),*, value)),
+                    (Err(report), Ok(_)) => Err(report),
+                    (Ok(_), Err(report)) => Err(report.into()),
+                    (Err(mut report), Err(residual)) => {
+                        report.append(residual.into());
+                        Err(report)
+                    }
+                }
+            }
+        }
+    };
+}
+
+all_the_tuples!(impl_ext);
+
+#[cfg(test)]
+mod test {
+    use core::{error::Error, fmt::Display};
+    use std::collections::HashSet;
+
+    use error_stack::{Report, Result};
+
+    use super::TupleExt;
+
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    struct TestError(usize);
+
+    impl Display for TestError {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            fmt.write_str("TestError")
+        }
+    }
+
+    impl Error for TestError {}
+
+    #[test]
+    fn single_error() {
+        let result1: Result<i32, TestError> = Ok(1);
+        let result2: Result<String, TestError> = Ok("test".to_owned());
+        let result3: Result<bool, TestError> = Err(Report::new(TestError(0)));
+
+        let combined = (result1, result2, result3).try_collect();
+        let report = combined.expect_err("should have error");
+
+        let contexts: HashSet<_> = report.current_contexts().collect();
+        assert_eq!(contexts.len(), 1);
+        assert!(contexts.contains(&TestError(0)));
+    }
+
+    #[test]
+    fn no_error() {
+        let result1: Result<i32, TestError> = Ok(1);
+        let result2: Result<String, TestError> = Ok("test".to_owned());
+        let result3: Result<bool, TestError> = Ok(true);
+
+        let combined = (result1, result2, result3).try_collect();
+        let (ok1, ok2, ok3) = combined.expect("should have no error");
+
+        assert_eq!(ok1, 1);
+        assert_eq!(ok2, "test");
+        assert!(ok3);
+    }
+
+    #[test]
+    fn expanded_error() {
+        let result1: Result<i32, [TestError]> = Ok(1);
+        let result2: Result<String, [TestError]> = Ok("test".to_owned());
+        let result3: Result<bool, [TestError]> = Err(Report::new(TestError(0)).expand());
+
+        let combined = (result1, result2, result3).try_collect();
+        let report = combined.expect_err("should have error");
+
+        // order of contexts is not guaranteed
+        let contexts: HashSet<_> = report.current_contexts().collect();
+        assert_eq!(contexts.len(), 1);
+        assert!(contexts.contains(&TestError(0)));
+    }
+
+    #[test]
+    fn single_and_expanded_mixed() {
+        let result1: Result<i32, [TestError]> = Ok(1);
+        let result2: Result<String, TestError> = Err(Report::new(TestError(0)));
+        let result3: Result<bool, [TestError]> = Err(Report::new(TestError(1)).expand());
+
+        let combined = (result1, result2, result3).try_collect();
+        let report = combined.expect_err("should have error");
+
+        // order of contexts is not guaranteed
+        let contexts: HashSet<_> = report.current_contexts().collect();
+        assert_eq!(contexts.len(), 2);
+        assert!(contexts.contains(&TestError(0)));
+        assert!(contexts.contains(&TestError(1)));
+    }
+
+    #[test]
+    fn multiple_errors() {
+        let result1: Result<i32, TestError> = Err(Report::new(TestError(0)));
+        let result2: Result<String, TestError> = Ok("test".to_owned());
+        let result3: Result<bool, TestError> = Err(Report::new(TestError(1)));
+
+        let combined = (result1, result2, result3).try_collect();
+        let report = combined.expect_err("should have error");
+
+        // order of contexts is not guaranteed
+        let contexts: HashSet<_> = report.current_contexts().collect();
+        assert_eq!(contexts.len(), 2);
+        assert!(contexts.contains(&TestError(0)));
+        assert!(contexts.contains(&TestError(1)));
+    }
+}

--- a/libs/error-stack/experimental/src/tuple.rs
+++ b/libs/error-stack/experimental/src/tuple.rs
@@ -90,7 +90,6 @@ macro_rules! all_the_tuples {
 
 macro_rules! impl_ext {
     ($([$type:ident, $output:ident]),+) => {
-        #[doc(hidden)]
         impl<$($type, $output),*, T, R, Context> TryReportTupleExt<Context> for ($($type),*, core::result::Result<T, R>)
         where
             R: Into<Report<[Context]>>,

--- a/libs/error-stack/experimental/src/tuple.rs
+++ b/libs/error-stack/experimental/src/tuple.rs
@@ -106,8 +106,8 @@ macro_rules! impl_ext {
                     (Ok(($($type,)*)), Ok(value)) => Ok(($($type),*, value)),
                     (Err(report), Ok(_)) => Err(report),
                     (Ok(_), Err(report)) => Err(report.into()),
-                    (Err(mut report), Err(residual)) => {
-                        report.append(residual.into());
+                    (Err(mut report), Err(error)) => {
+                        report.append(error.into());
                         Err(report)
                     }
                 }

--- a/libs/error-stack/experimental/src/tuple.rs
+++ b/libs/error-stack/experimental/src/tuple.rs
@@ -6,7 +6,7 @@ use error_stack::{Report, Result};
 /// containing a tuple of the successful values, or an error if any of the results failed.
 ///
 /// The trait is implemented for tuples of up to 16 elements.
-pub trait TupleExt<C> {
+pub trait TryReportTupleExt<C> {
     /// The type of the successful output, typically a tuple of the inner types of the `Result`s.
     type Output;
 
@@ -21,7 +21,7 @@ pub trait TupleExt<C> {
     ///
     /// ```
     /// use error_stack::{Report, Result};
-    /// use error_stack_experimental::TupleExt;
+    /// use error_stack_experimental::TryReportTupleExt;
     ///
     /// #[derive(Debug)]
     /// struct CustomError;
@@ -50,7 +50,7 @@ pub trait TupleExt<C> {
     fn try_collect(self) -> Result<Self::Output, [C]>;
 }
 
-impl<T, R, C> TupleExt<C> for (core::result::Result<T, R>,)
+impl<T, R, C> TryReportTupleExt<C> for (core::result::Result<T, R>,)
 where
     R: Into<Report<[C]>>,
 {
@@ -91,10 +91,10 @@ macro_rules! all_the_tuples {
 macro_rules! impl_ext {
     ($([$type:ident, $output:ident]),+) => {
         #[doc(hidden)]
-        impl<$($type, $output),*, T, R, Context> TupleExt<Context> for ($($type),*, core::result::Result<T, R>)
+        impl<$($type, $output),*, T, R, Context> TryReportTupleExt<Context> for ($($type),*, core::result::Result<T, R>)
         where
             R: Into<Report<[Context]>>,
-            ($($type,)*): TupleExt<Context, Output = ($($output,)*)>,
+            ($($type,)*): TryReportTupleExt<Context, Output = ($($output,)*)>,
         {
             type Output = ($($output),*, T);
 
@@ -126,7 +126,7 @@ mod test {
 
     use error_stack::{Report, Result};
 
-    use super::TupleExt;
+    use super::TryReportTupleExt;
 
     #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
     struct TestError(usize);

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -876,8 +876,7 @@ impl<C> Report<[C]> {
     /// This method is similar to [`current_context`], but instead of returning a single context,
     /// it returns an iterator over all contexts in the `Report`.
     ///
-    /// The contexts are returned in the order they were added to the `Report`, with the least
-    /// recent context being the first element of the iterator.
+    /// The order of the contexts should not be relied upon, as it is not guaranteed to be stable.
     ///
     /// ## Example
     ///
@@ -914,6 +913,9 @@ impl<C> Report<[C]> {
         // attachments.
         let mut output = Vec::new();
 
+        // this implementation does some "weaving" in a sense, it goes L->R for the frames, then
+        // R->L for the sources, which means that some sources might be out of order, but this
+        // simplifies implementation.
         let mut stack = vec![self.current_frames()];
         while let Some(frames) = stack.pop() {
             for frame in frames {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This implements an experimental set of traits to be used to collecting reports in a fail slow manner these include:

* `TryReportIteratorExt`
* `ResultMultiExt` (I don't like that name at all)
* `TryReportTupleExt`
* `TryReportStreamExt` (gated behind the `stream` flag)


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
