### PR TITLE
H-3331: Validate all data type constraints

### DIFF
--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/visitor.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/visitor.rs
@@ -206,8 +206,7 @@ macro_rules! extend_report {
 
 /// Walks through a JSON value using the provided schema.
 ///
-/// Depending on the property, [`EntityVisitor::visit_one_of_property`],
-/// [`EntityVisitor::visit_one_of_array`], or [`EntityVisitor::visit_one_of_object`] is called.
+/// For all referenced data types [`EntityVisitor::visit_value`] is called.
 ///
 /// # Errors
 ///

--- a/tests/hash-graph-http/tests/ambiguous.http
+++ b/tests/hash-graph-http/tests/ambiguous.http
@@ -60,8 +60,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
         "$id": "http://localhost:3000/@alice/types/data-type/meter/v/1",
         "title": "Meter",
         "type": "number",
-        "description": "A unit of length",
-        "minimum": 0
+        "description": "A unit of length"
       }
   ],
   "conversions": {},
@@ -96,8 +95,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     "$id": "http://localhost:3000/@alice/types/data-type/millimeter/v/1",
     "title": "Millimeter",
     "type": "number",
-    "description": "A unit of length",
-    "minimum": 0
+    "description": "A unit of length"
   },
   "conversions": {
     "http://localhost:3000/@alice/types/data-type/meter/": {
@@ -133,8 +131,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     "$id": "http://localhost:3000/@alice/types/data-type/miles/v/1",
     "title": "Miles",
     "type": "number",
-    "description": "A unit of length",
-    "minimum": 0
+    "description": "A unit of length"
   },
   "conversions": {
     "http://localhost:3000/@alice/types/data-type/meter/": {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, we only validate the constraints on the same data type but not the parents.

## 🔍 What does this change?

- Add the validation for the `allOf` field in data types

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph