### PR TITLE
H-3334: Stop depending on subgraph when sorting by ontology IDs

### DIFF
--- a/apps/hash-graph/libs/api/openapi/openapi.json
+++ b/apps/hash-graph/libs/api/openapi/openapi.json
@@ -5061,7 +5061,7 @@
           "after": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/DataTypeVertexId"
+                "$ref": "#/components/schemas/VersionedUrl"
               }
             ],
             "nullable": true
@@ -5098,7 +5098,7 @@
           "cursor": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/DataTypeVertexId"
+                "$ref": "#/components/schemas/VersionedUrl"
               }
             ],
             "nullable": true
@@ -5119,7 +5119,7 @@
           "after": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/DataTypeVertexId"
+                "$ref": "#/components/schemas/VersionedUrl"
               }
             ],
             "nullable": true
@@ -5158,7 +5158,7 @@
           "cursor": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/DataTypeVertexId"
+                "$ref": "#/components/schemas/VersionedUrl"
               }
             ],
             "nullable": true
@@ -5416,7 +5416,7 @@
           "after": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/EntityTypeVertexId"
+                "$ref": "#/components/schemas/VersionedUrl"
               }
             ],
             "nullable": true
@@ -5464,7 +5464,7 @@
           "cursor": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/EntityTypeVertexId"
+                "$ref": "#/components/schemas/VersionedUrl"
               }
             ],
             "nullable": true
@@ -5499,7 +5499,7 @@
           "after": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/EntityTypeVertexId"
+                "$ref": "#/components/schemas/VersionedUrl"
               }
             ],
             "nullable": true
@@ -5544,7 +5544,7 @@
           "cursor": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/EntityTypeVertexId"
+                "$ref": "#/components/schemas/VersionedUrl"
               }
             ],
             "nullable": true
@@ -5583,7 +5583,7 @@
           "after": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/PropertyTypeVertexId"
+                "$ref": "#/components/schemas/VersionedUrl"
               }
             ],
             "nullable": true
@@ -5620,7 +5620,7 @@
           "cursor": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/PropertyTypeVertexId"
+                "$ref": "#/components/schemas/VersionedUrl"
               }
             ],
             "nullable": true
@@ -5641,7 +5641,7 @@
           "after": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/PropertyTypeVertexId"
+                "$ref": "#/components/schemas/VersionedUrl"
               }
             ],
             "nullable": true
@@ -5680,7 +5680,7 @@
           "cursor": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/PropertyTypeVertexId"
+                "$ref": "#/components/schemas/VersionedUrl"
               }
             ],
             "nullable": true

--- a/apps/hash-graph/libs/api/src/rest/data_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/data_type.rs
@@ -42,9 +42,7 @@ use graph_types::{
     },
     owned_by_id::OwnedById,
 };
-use hash_graph_store::{
-    data_type::DataTypeQueryToken, subgraph::identifier::DataTypeVertexId, ConflictBehavior,
-};
+use hash_graph_store::{data_type::DataTypeQueryToken, ConflictBehavior};
 use hash_status::Status;
 use serde::{Deserialize, Serialize};
 use temporal_client::TemporalClient;
@@ -455,7 +453,7 @@ where
 #[serde(rename_all = "camelCase")]
 struct GetDataTypeSubgraphResponse {
     subgraph: Subgraph,
-    cursor: Option<DataTypeVertexId>,
+    cursor: Option<VersionedUrl>,
 }
 
 #[utoipa::path(

--- a/apps/hash-graph/libs/api/src/rest/entity_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity_type.rs
@@ -46,9 +46,7 @@ use graph_types::{
     },
     owned_by_id::OwnedById,
 };
-use hash_graph_store::{
-    entity_type::EntityTypeQueryToken, subgraph::identifier::EntityTypeVertexId, ConflictBehavior,
-};
+use hash_graph_store::{entity_type::EntityTypeQueryToken, ConflictBehavior};
 use hash_map::HashMap;
 use serde::{Deserialize, Serialize};
 use temporal_client::TemporalClient;
@@ -747,7 +745,7 @@ where
 #[serde(rename_all = "camelCase")]
 struct GetEntityTypeSubgraphResponse {
     subgraph: Subgraph,
-    cursor: Option<EntityTypeVertexId>,
+    cursor: Option<VersionedUrl>,
     count: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(nullable = false)]

--- a/apps/hash-graph/libs/api/src/rest/property_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/property_type.rs
@@ -43,10 +43,7 @@ use graph_types::{
     },
     owned_by_id::OwnedById,
 };
-use hash_graph_store::{
-    property_type::PropertyTypeQueryToken, subgraph::identifier::PropertyTypeVertexId,
-    ConflictBehavior,
-};
+use hash_graph_store::{property_type::PropertyTypeQueryToken, ConflictBehavior};
 use hash_status::Status;
 use serde::{Deserialize, Serialize};
 use temporal_client::TemporalClient;
@@ -444,7 +441,7 @@ where
 #[serde(rename_all = "camelCase")]
 struct GetPropertyTypeSubgraphResponse {
     subgraph: Subgraph,
-    cursor: Option<PropertyTypeVertexId>,
+    cursor: Option<VersionedUrl>,
 }
 
 #[utoipa::path(

--- a/apps/hash-graph/libs/graph/src/store/ontology.rs
+++ b/apps/hash-graph/libs/graph/src/store/ontology.rs
@@ -18,12 +18,7 @@ use graph_types::{
 };
 use hash_graph_store::{
     filter::Filter,
-    subgraph::{
-        edges::GraphResolveDepths,
-        identifier::{DataTypeVertexId, EntityTypeVertexId, PropertyTypeVertexId},
-        temporal_axes::QueryTemporalAxesUnresolved,
-        Subgraph,
-    },
+    subgraph::{edges::GraphResolveDepths, temporal_axes::QueryTemporalAxesUnresolved, Subgraph},
     ConflictBehavior,
 };
 use serde::{Deserialize, Serialize};
@@ -63,7 +58,7 @@ pub struct GetDataTypeSubgraphParams<'p> {
     pub temporal_axes: QueryTemporalAxesUnresolved,
     pub include_drafts: bool,
     #[serde(default)]
-    pub after: Option<DataTypeVertexId>,
+    pub after: Option<VersionedUrl>,
     #[serde(default)]
     pub limit: Option<usize>,
     #[serde(default)]
@@ -73,7 +68,7 @@ pub struct GetDataTypeSubgraphParams<'p> {
 #[derive(Debug)]
 pub struct GetDataTypeSubgraphResponse {
     pub subgraph: Subgraph,
-    pub cursor: Option<DataTypeVertexId>,
+    pub cursor: Option<VersionedUrl>,
     pub count: Option<usize>,
 }
 
@@ -96,7 +91,7 @@ pub struct GetDataTypesParams<'p> {
     pub temporal_axes: QueryTemporalAxesUnresolved,
     pub include_drafts: bool,
     #[serde(default)]
-    pub after: Option<DataTypeVertexId>,
+    pub after: Option<VersionedUrl>,
     #[serde(default)]
     pub limit: Option<usize>,
     #[serde(default)]
@@ -108,7 +103,7 @@ pub struct GetDataTypesParams<'p> {
 #[serde(rename_all = "camelCase")]
 pub struct GetDataTypesResponse {
     pub data_types: Vec<DataTypeWithMetadata>,
-    pub cursor: Option<DataTypeVertexId>,
+    pub cursor: Option<VersionedUrl>,
     pub count: Option<usize>,
 }
 
@@ -303,7 +298,7 @@ pub struct GetPropertyTypeSubgraphParams<'p> {
     pub temporal_axes: QueryTemporalAxesUnresolved,
     pub include_drafts: bool,
     #[serde(default)]
-    pub after: Option<PropertyTypeVertexId>,
+    pub after: Option<VersionedUrl>,
     #[serde(default)]
     pub limit: Option<usize>,
     #[serde(default)]
@@ -313,7 +308,7 @@ pub struct GetPropertyTypeSubgraphParams<'p> {
 #[derive(Debug)]
 pub struct GetPropertyTypeSubgraphResponse {
     pub subgraph: Subgraph,
-    pub cursor: Option<PropertyTypeVertexId>,
+    pub cursor: Option<VersionedUrl>,
     pub count: Option<usize>,
 }
 
@@ -336,7 +331,7 @@ pub struct GetPropertyTypesParams<'p> {
     pub temporal_axes: QueryTemporalAxesUnresolved,
     pub include_drafts: bool,
     #[serde(default)]
-    pub after: Option<PropertyTypeVertexId>,
+    pub after: Option<VersionedUrl>,
     #[serde(default)]
     pub limit: Option<usize>,
     #[serde(default)]
@@ -348,7 +343,7 @@ pub struct GetPropertyTypesParams<'p> {
 #[serde(rename_all = "camelCase")]
 pub struct GetPropertyTypesResponse {
     pub property_types: Vec<PropertyTypeWithMetadata>,
-    pub cursor: Option<PropertyTypeVertexId>,
+    pub cursor: Option<VersionedUrl>,
     pub count: Option<usize>,
 }
 
@@ -543,7 +538,7 @@ pub struct GetEntityTypeSubgraphParams<'p> {
     pub filter: Filter<'p, EntityTypeWithMetadata>,
     pub graph_resolve_depths: GraphResolveDepths,
     pub temporal_axes: QueryTemporalAxesUnresolved,
-    pub after: Option<EntityTypeVertexId>,
+    pub after: Option<VersionedUrl>,
     pub limit: Option<usize>,
     pub include_drafts: bool,
     #[serde(default)]
@@ -557,7 +552,7 @@ pub struct GetEntityTypeSubgraphParams<'p> {
 #[derive(Debug)]
 pub struct GetEntityTypeSubgraphResponse {
     pub subgraph: Subgraph,
-    pub cursor: Option<EntityTypeVertexId>,
+    pub cursor: Option<VersionedUrl>,
     pub count: Option<usize>,
     pub web_ids: Option<HashMap<OwnedById, usize>>,
     pub edition_created_by_ids: Option<HashMap<EditionCreatedById, usize>>,
@@ -583,7 +578,7 @@ pub struct GetEntityTypesParams<'p> {
     pub temporal_axes: QueryTemporalAxesUnresolved,
     pub include_drafts: bool,
     #[serde(default)]
-    pub after: Option<EntityTypeVertexId>,
+    pub after: Option<VersionedUrl>,
     #[serde(default)]
     pub limit: Option<usize>,
     #[serde(default)]
@@ -599,7 +594,7 @@ pub struct GetEntityTypesParams<'p> {
 #[serde(rename_all = "camelCase")]
 pub struct GetEntityTypesResponse {
     pub entity_types: Vec<EntityTypeWithMetadata>,
-    pub cursor: Option<EntityTypeVertexId>,
+    pub cursor: Option<VersionedUrl>,
     pub count: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/query.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/query.rs
@@ -1,5 +1,3 @@
-use core::convert::identity;
-
 use graph_types::{
     knowledge::{
         entity::{Entity, EntityId, EntityMetadata, EntityProvenance, EntityRecordId, EntityUuid},
@@ -9,162 +7,18 @@ use graph_types::{
 };
 use hash_graph_store::{
     entity::EntityQueryPath,
-    filter::Parameter,
-    subgraph::{
-        edges::{EdgeDirection, KnowledgeGraphEdgeKind},
-        identifier::EntityVertexId,
-        temporal_axes::{QueryTemporalAxes, VariableAxis},
-    },
-};
-use temporal_versioning::{
-    ClosedTemporalBound, LeftClosedTemporalInterval, TemporalTagged, TimeAxis,
+    subgraph::edges::{EdgeDirection, KnowledgeGraphEdgeKind},
 };
 use tokio_postgres::Row;
 use tracing::instrument;
 use type_system::url::{BaseUrl, OntologyTypeVersion, VersionedUrl};
 use uuid::Uuid;
 
-use crate::store::{
-    crud::{Sorting, VertexIdSorting},
-    postgres::{
-        crud::QueryRecordDecode,
-        query::{
-            Distinctness, Expression, Function, PostgresRecord, PostgresSorting, SelectCompiler,
-            Table,
-        },
-    },
-    NullOrdering, Ordering,
+use crate::store::postgres::{
+    crud::QueryRecordDecode,
+    query::{Distinctness, PostgresRecord, SelectCompiler, Table},
 };
 
-#[derive(Debug, Copy, Clone)]
-pub struct EntityVertexIdIndices {
-    pub revision_id: usize,
-    pub entity_uuid: usize,
-    pub draft_id: usize,
-    pub owned_by_id: usize,
-}
-
-pub struct EntityVertexIdCursorParameters<'p> {
-    revision_id: Parameter<'p>,
-    entity_uuid: Parameter<'p>,
-    draft_id: Option<Parameter<'p>>,
-    owned_by_id: Parameter<'p>,
-}
-
-impl QueryRecordDecode for VertexIdSorting<Entity> {
-    type Indices = EntityVertexIdIndices;
-    type Output = EntityVertexId;
-
-    fn decode(row: &Row, indices: &Self::Indices) -> Self::Output {
-        let ClosedTemporalBound::Inclusive(revision_id) = *row
-            .get::<_, LeftClosedTemporalInterval<VariableAxis>>(indices.revision_id)
-            .start();
-        EntityVertexId {
-            base_id: EntityId {
-                owned_by_id: row.get(indices.owned_by_id),
-                entity_uuid: row.get(indices.entity_uuid),
-                draft_id: row.get(indices.draft_id),
-            },
-            revision_id,
-        }
-    }
-}
-
-impl<'s> PostgresSorting<'s, Entity> for VertexIdSorting<Entity> {
-    type CompilationParameters = EntityVertexIdCursorParameters<'static>;
-    type Error = !;
-
-    fn encode(&self) -> Result<Option<Self::CompilationParameters>, Self::Error> {
-        Ok(self.cursor().map(|cursor| EntityVertexIdCursorParameters {
-            owned_by_id: Parameter::Uuid(cursor.base_id.owned_by_id.into_uuid()),
-            entity_uuid: Parameter::Uuid(cursor.base_id.entity_uuid.into_uuid()),
-            draft_id: cursor
-                .base_id
-                .draft_id
-                .map(|draft_id| Parameter::Uuid(draft_id.into_uuid())),
-            revision_id: Parameter::Timestamp(cursor.revision_id.cast()),
-        }))
-    }
-
-    fn compile<'p, 'q: 'p>(
-        &self,
-        compiler: &mut SelectCompiler<'p, 'q, Entity>,
-        parameters: Option<&'p Self::CompilationParameters>,
-        temporal_axes: &QueryTemporalAxes,
-    ) -> Self::Indices {
-        let revision_id_path = match temporal_axes.variable_time_axis() {
-            TimeAxis::TransactionTime => &EntityQueryPath::TransactionTime,
-            TimeAxis::DecisionTime => &EntityQueryPath::DecisionTime,
-        };
-
-        if let Some(parameters) = parameters {
-            // We already had a cursor, add them as parameters:
-            let revision_id_expression = compiler.compile_parameter(&parameters.revision_id).0;
-            let entity_uuid_expression = compiler.compile_parameter(&parameters.entity_uuid).0;
-            let draft_id_expression = parameters
-                .draft_id
-                .as_ref()
-                .map(|draft_id| compiler.compile_parameter(draft_id).0);
-            let owned_by_id_expression = compiler.compile_parameter(&parameters.owned_by_id).0;
-
-            EntityVertexIdIndices {
-                revision_id: compiler.add_cursor_selection(
-                    revision_id_path,
-                    |column| Expression::Function(Function::Lower(Box::new(column))),
-                    Some(revision_id_expression),
-                    Ordering::Descending,
-                    None,
-                ),
-                entity_uuid: compiler.add_cursor_selection(
-                    &EntityQueryPath::Uuid,
-                    identity,
-                    Some(entity_uuid_expression),
-                    Ordering::Ascending,
-                    None,
-                ),
-                draft_id: compiler.add_cursor_selection(
-                    &EntityQueryPath::DraftId,
-                    identity,
-                    draft_id_expression,
-                    Ordering::Ascending,
-                    Some(NullOrdering::First),
-                ),
-                owned_by_id: compiler.add_cursor_selection(
-                    &EntityQueryPath::OwnedById,
-                    identity,
-                    Some(owned_by_id_expression),
-                    Ordering::Ascending,
-                    None,
-                ),
-            }
-        } else {
-            EntityVertexIdIndices {
-                revision_id: compiler.add_distinct_selection_with_ordering(
-                    revision_id_path,
-                    Distinctness::Distinct,
-                    Some((Ordering::Descending, None)),
-                ),
-                entity_uuid: compiler.add_distinct_selection_with_ordering(
-                    &EntityQueryPath::Uuid,
-                    Distinctness::Distinct,
-                    Some((Ordering::Ascending, None)),
-                ),
-                draft_id: compiler.add_distinct_selection_with_ordering(
-                    &EntityQueryPath::DraftId,
-                    Distinctness::Distinct,
-                    Some((Ordering::Ascending, Some(NullOrdering::First))),
-                ),
-                owned_by_id: compiler.add_distinct_selection_with_ordering(
-                    &EntityQueryPath::OwnedById,
-                    Distinctness::Distinct,
-                    Some((Ordering::Ascending, None)),
-                ),
-            }
-        }
-    }
-}
-
-#[derive(Debug, Copy, Clone)]
 pub struct EntityRecordRowIndices {
     pub owned_by_id: usize,
     pub entity_uuid: usize,

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
@@ -43,7 +43,7 @@ use type_system::{
 };
 
 use crate::store::{
-    crud::{QueryResult, Read, ReadPaginated, VertexIdSorting},
+    crud::{QueryResult, Read, ReadPaginated, VersionedUrlSorting},
     error::DeletionError,
     ontology::{
         ArchiveDataTypeParams, CountDataTypesParams, CreateDataTypeParams,
@@ -136,19 +136,19 @@ where
         // TODO: Remove again when subgraph logic was revisited
         //   see https://linear.app/hash/issue/H-297
         let mut visited_ontology_ids = HashSet::new();
-        let time_axis = temporal_axes.variable_time_axis();
 
-        let (data, artifacts) = ReadPaginated::<DataTypeWithMetadata>::read_paginated_vec(
-            self,
-            &params.filter,
-            Some(temporal_axes),
-            &VertexIdSorting {
-                cursor: params.after,
-            },
-            params.limit,
-            params.include_drafts,
-        )
-        .await?;
+        let (data, artifacts) =
+            ReadPaginated::<DataTypeWithMetadata, VersionedUrlSorting>::read_paginated_vec(
+                self,
+                &params.filter,
+                Some(temporal_axes),
+                &VersionedUrlSorting {
+                    cursor: params.after,
+                },
+                params.limit,
+                params.include_drafts,
+            )
+            .await?;
         let data_types = data
             .into_iter()
             .filter_map(|row| {
@@ -191,7 +191,7 @@ where
                 cursor: if params.limit.is_some() {
                     data_types
                         .last()
-                        .map(|data_type| data_type.vertex_id(time_axis))
+                        .map(|data_type| data_type.schema.id.clone())
                 } else {
                     None
                 },

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
@@ -45,7 +45,7 @@ use type_system::{
 };
 
 use crate::store::{
-    crud::{QueryResult, Read, ReadPaginated, VertexIdSorting},
+    crud::{QueryResult, Read, ReadPaginated, VersionedUrlSorting},
     error::DeletionError,
     ontology::{
         ArchiveEntityTypeParams, CountEntityTypesParams, CreateEntityTypeParams,
@@ -183,19 +183,19 @@ where
         // TODO: Remove again when subgraph logic was revisited
         //   see https://linear.app/hash/issue/H-297
         let mut visited_ontology_ids = HashSet::new();
-        let time_axis = temporal_axes.variable_time_axis();
 
-        let (data, artifacts) = ReadPaginated::<EntityTypeWithMetadata>::read_paginated_vec(
-            self,
-            &params.filter,
-            Some(temporal_axes),
-            &VertexIdSorting {
-                cursor: params.after,
-            },
-            params.limit,
-            params.include_drafts,
-        )
-        .await?;
+        let (data, artifacts) =
+            ReadPaginated::<EntityTypeWithMetadata, VersionedUrlSorting>::read_paginated_vec(
+                self,
+                &params.filter,
+                Some(temporal_axes),
+                &VersionedUrlSorting {
+                    cursor: params.after,
+                },
+                params.limit,
+                params.include_drafts,
+            )
+            .await?;
         let entity_types = data
             .into_iter()
             .filter_map(|row| {
@@ -238,7 +238,7 @@ where
                 cursor: if params.limit.is_some() {
                     entity_types
                         .last()
-                        .map(|entity_type| entity_type.vertex_id(time_axis))
+                        .map(|entity_type| entity_type.schema.id.clone())
                 } else {
                     None
                 },

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/mod.rs
@@ -16,20 +16,17 @@ use graph_types::{
     owned_by_id::OwnedById,
 };
 use hash_graph_store::{
-    data_type::DataTypeQueryPath,
-    entity_type::EntityTypeQueryPath,
-    filter::Parameter,
-    property_type::PropertyTypeQueryPath,
-    subgraph::{temporal_axes::QueryTemporalAxes, SubgraphRecord},
+    data_type::DataTypeQueryPath, entity_type::EntityTypeQueryPath, filter::Parameter,
+    property_type::PropertyTypeQueryPath, subgraph::temporal_axes::QueryTemporalAxes,
 };
 use serde::Deserialize;
 use time::OffsetDateTime;
 use tokio_postgres::{Row, Transaction};
-use type_system::url::BaseUrl;
+use type_system::url::{BaseUrl, VersionedUrl};
 
 pub use self::ontology_id::OntologyId;
 use crate::store::{
-    crud::{Sorting, VertexIdSorting},
+    crud::{Sorting, VersionedUrlSorting},
     error::DeletionError,
     postgres::{
         crud::QueryRecordDecode,
@@ -121,30 +118,29 @@ pub struct VersionedUrlIndices {
     pub base_url: usize,
     pub version: usize,
 }
+impl QueryRecordDecode for VersionedUrlSorting {
+    type Indices = VersionedUrlIndices;
+    type Output = VersionedUrl;
+
+    fn decode(row: &Row, indices: &Self::Indices) -> Self::Output {
+        VersionedUrl {
+            base_url: BaseUrl::new(row.get(indices.base_url))
+                .expect("invalid base URL returned from Postgres"),
+            version: row.get(indices.version),
+        }
+    }
+}
 
 macro_rules! impl_ontology_cursor {
     ($ty:ty, $query_path:ty) => {
-        impl QueryRecordDecode for VertexIdSorting<$ty> {
-            type Indices = VersionedUrlIndices;
-            type Output = <$ty as SubgraphRecord>::VertexId;
-
-            fn decode(row: &Row, indices: &Self::Indices) -> Self::Output {
-                Self::Output {
-                    base_id: BaseUrl::new(row.get(indices.base_url))
-                        .expect("invalid base URL returned from Postgres"),
-                    revision_id: row.get(indices.version),
-                }
-            }
-        }
-
-        impl<'s> PostgresSorting<'s, $ty> for VertexIdSorting<$ty> {
+        impl<'s> PostgresSorting<'s, $ty> for VersionedUrlSorting {
             type CompilationParameters = VersionedUrlCursorParameters<'s>;
             type Error = !;
 
             fn encode(&self) -> Result<Option<Self::CompilationParameters>, Self::Error> {
                 Ok(self.cursor().map(|cursor| VersionedUrlCursorParameters {
-                    base_url: Parameter::Text(Cow::Owned(cursor.base_id.to_string())),
-                    version: Parameter::OntologyTypeVersion(cursor.revision_id),
+                    base_url: Parameter::Text(Cow::Owned(cursor.base_url.to_string())),
+                    version: Parameter::OntologyTypeVersion(cursor.version),
                 }))
             }
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/property_type.rs
@@ -41,7 +41,7 @@ use type_system::{
 };
 
 use crate::store::{
-    crud::{QueryResult, Read, ReadPaginated, VertexIdSorting},
+    crud::{QueryResult, Read, ReadPaginated, VersionedUrlSorting},
     error::DeletionError,
     ontology::{
         ArchivePropertyTypeParams, CountPropertyTypesParams, CreatePropertyTypeParams,
@@ -131,19 +131,19 @@ where
         // TODO: Remove again when subgraph logic was revisited
         //   see https://linear.app/hash/issue/H-297
         let mut visited_ontology_ids = HashSet::new();
-        let time_axis = temporal_axes.variable_time_axis();
 
-        let (data, artifacts) = ReadPaginated::<PropertyTypeWithMetadata>::read_paginated_vec(
-            self,
-            &params.filter,
-            Some(temporal_axes),
-            &VertexIdSorting {
-                cursor: params.after,
-            },
-            params.limit,
-            params.include_drafts,
-        )
-        .await?;
+        let (data, artifacts) =
+            ReadPaginated::<PropertyTypeWithMetadata, VersionedUrlSorting>::read_paginated_vec(
+                self,
+                &params.filter,
+                Some(temporal_axes),
+                &VersionedUrlSorting {
+                    cursor: params.after,
+                },
+                params.limit,
+                params.include_drafts,
+            )
+            .await?;
         let property_types = data
             .into_iter()
             .filter_map(|row| {
@@ -188,7 +188,7 @@ where
                 cursor: if params.limit.is_some() {
                     property_types
                         .last()
-                        .map(|property_type| property_type.vertex_id(time_axis))
+                        .map(|property_type| property_type.schema.id.clone())
                 } else {
                     None
                 },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The Subgraph code restricts the VertexIdSorting logic to be locked to the vertices in the graph. To sort ontologies this is not required, we can sort by versioned URL in general. For entities, we don't use that sorting anyway.



## 🔍 What does this change?

- Removes `VertexIdSorting` for Entities
- Change `VertexIdSorting` to `VersionedUrlSorting` for ontologies

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph