### PR TITLE
H-3337: Align type-system data-type constraints with Node API

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -182,14 +182,14 @@ jobs:
         working-directory: ${{ matrix.directory }}
         env:
           RUSTDOCFLAGS: "--check -Z unstable-options -D warnings"
-        run: just doc
+        run: cargo doc --all-features --no-deps -Zrustdoc-scrape-examples
 
       - name: Check private documentation
         if: always() && steps.lints.outputs.has-rust == 'true'
         working-directory: ${{ matrix.directory }}
         env:
           RUSTDOCFLAGS: "--check -Z unstable-options -D warnings"
-        run: just doc --document-private-items
+        run: cargo doc --all-features --no-deps -Zrustdoc-scrape-examples  --document-private-items
 
       - name: Show disk usage
         run: df -h

--- a/.justfile
+++ b/.justfile
@@ -148,13 +148,6 @@ clippy *arguments: install-cargo-hack
   @just in-pr cargo clippy --profile {{profile}} --all-features --all-targets --no-deps {{arguments}}
   @just not-in-pr cargo hack --optional-deps --feature-powerset clippy --profile {{profile}} --all-targets --no-deps {{arguments}}
 
-# Creates the documentation for the crate
-[no-cd]
-doc *arguments:
-  @just in-pr RUSTDOCFLAGS=-Dwarnings cargo doc --all-features --workspace --no-deps -Zunstable-options -Zrustdoc-scrape-examples {{arguments}}
-  @just not-in-pr cargo doc --all-features --workspace --no-deps -Zunstable-options -Zrustdoc-scrape-examples {{arguments}}
-
-
 # Builds the crate
 [no-cd]
 build *arguments:

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/shared/strip-ids-from-dereferenced-properties.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/shared/strip-ids-from-dereferenced-properties.ts
@@ -1,4 +1,4 @@
-import type { ArraySchema } from "@blockprotocol/type-system";
+import type { PropertyValueArray } from "@blockprotocol/type-system";
 import type { JSONSchemaDefinition } from "openai/lib/jsonschema";
 
 import type { DereferencedPropertyType } from "../../shared/dereference-entity-type.js";
@@ -12,7 +12,7 @@ import type { DereferencedPropertyType } from "../../shared/dereference-entity-t
 export const stripIdsFromDereferencedProperties = (params: {
   properties: Record<
     string,
-    DereferencedPropertyType | ArraySchema<DereferencedPropertyType>
+    DereferencedPropertyType | PropertyValueArray<DereferencedPropertyType>
   >;
 }): {
   [key: string]: JSONSchemaDefinition;

--- a/apps/hash-ai-worker-ts/src/activities/shared/dereference-entity-type.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/dereference-entity-type.ts
@@ -1,9 +1,9 @@
 import type {
-  ArraySchema,
   EntityType,
-  ObjectSchema,
   OneOfSchema,
   PropertyType,
+  PropertyValueArray,
+  PropertyValueObject,
   PropertyValues,
   ValueOrArray,
   VersionedUrl,
@@ -31,14 +31,14 @@ import { generateSimplifiedTypeId } from "../infer-entities/shared/generate-simp
 
 type MinimalDataType = Omit<CustomDataType, "$id" | "$schema" | "kind">;
 
-type MinimalPropertyObject = ObjectSchema<
+type MinimalPropertyObject = PropertyValueObject<
   ValueOrArray<DereferencedPropertyType>
 > & { additionalProperties: false };
 
 export type MinimalPropertyTypeValue =
   | MinimalDataType
   | MinimalPropertyObject
-  | ArraySchema<OneOfSchema<MinimalPropertyTypeValue>>;
+  | PropertyValueArray<OneOfSchema<MinimalPropertyTypeValue>>;
 
 export type DereferencedPropertyType = Pick<
   PropertyType,
@@ -57,7 +57,7 @@ export type DereferencedEntityType<
 > = Pick<EntityType, "$id" | "description" | "links" | "required" | "title"> & {
   properties: Record<
     PropertyTypeKey,
-    DereferencedPropertyType | ArraySchema<DereferencedPropertyType>
+    DereferencedPropertyType | PropertyValueArray<DereferencedPropertyType>
   >;
   additionalProperties: false;
 } & Pick<EntityTypeMetadata, "labelProperty">;

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
@@ -4,14 +4,14 @@ import path, { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import type {
-  ArraySchema,
   Conversions,
   DataTypeReference,
   EntityType,
-  ObjectSchema,
   OneOfSchema,
   PropertyType,
   PropertyTypeReference,
+  PropertyValueArray,
+  PropertyValueObject,
   PropertyValues,
   ValueOrArray,
   VersionedUrl,
@@ -362,7 +362,7 @@ export const generateSystemPropertyTypeSchema = (
         };
         inner = dataTypeReference;
       } else if (propertyTypeObjectProperties) {
-        const propertyTypeObject: ObjectSchema<
+        const propertyTypeObject: PropertyValueObject<
           ValueOrArray<PropertyTypeReference>
         > = {
           type: "object" as const,
@@ -380,13 +380,14 @@ export const generateSystemPropertyTypeSchema = (
 
       // Optionally wrap inner in an array
       if (array) {
-        const arrayOfPropertyValues: ArraySchema<OneOfSchema<PropertyValues>> =
-          {
-            type: "array",
-            items: {
-              oneOf: [inner],
-            },
-          };
+        const arrayOfPropertyValues: PropertyValueArray<
+          OneOfSchema<PropertyValues>
+        > = {
+          type: "array",
+          items: {
+            oneOf: [inner],
+          },
+        };
         return arrayOfPropertyValues;
       } else {
         return inner;

--- a/apps/hash-frontend/src/lib/typeguards.ts
+++ b/apps/hash-frontend/src/lib/typeguards.ts
@@ -1,8 +1,8 @@
 import type {
-  ArraySchema,
-  ObjectSchema,
   OneOfSchema,
   PropertyTypeReference,
+  PropertyValueArray,
+  PropertyValueObject,
   PropertyValues,
   ValueOrArray,
 } from "@blockprotocol/type-system";
@@ -13,12 +13,14 @@ export function isNonNullable<T>(value: T): value is NonNullable<T> {
 
 export const isPropertyValueArray = (
   propertyValue: PropertyValues,
-): propertyValue is ArraySchema<OneOfSchema<PropertyValues>> => {
+): propertyValue is PropertyValueArray<OneOfSchema<PropertyValues>> => {
   return "type" in propertyValue && propertyValue.type === "array";
 };
 
-export const isPropertyValuePropertyObject = (
+export const isPropertyValueObject = (
   propertyValue: PropertyValues,
-): propertyValue is ObjectSchema<ValueOrArray<PropertyTypeReference>> => {
+): propertyValue is PropertyValueObject<
+  ValueOrArray<PropertyTypeReference>
+> => {
   return "type" in propertyValue && propertyValue.type === "object";
 };

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/inputs/number-or-text-input.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/inputs/number-or-text-input.tsx
@@ -53,9 +53,7 @@ export const NumberOrTextInput = ({
   const step =
     "multipleOf" in expectedType && expectedType.multipleOf !== undefined
       ? expectedType.multipleOf
-      : expectedType.type === "integer"
-        ? 1
-        : 0.01;
+      : 0.01;
 
   const exclusiveMinimum =
     "exclusiveMinimum" in expectedType &&

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/utils.ts
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/utils.ts
@@ -65,7 +65,7 @@ export const guessEditorTypeFromExpectedType = (
     throw new Error("Array data types are not yet handled.");
   }
 
-  return dataType.type === "integer" ? "number" : dataType.type;
+  return dataType.type;
 };
 
 export const isBlankStringOrNullish = (value: unknown) => {

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/use-rows/generate-property-rows-from-entity/generate-property-row-recursively.ts
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/use-rows/generate-property-rows-from-entity/generate-property-row-recursively.ts
@@ -10,7 +10,7 @@ import get from "lodash/get";
 
 import {
   isPropertyValueArray,
-  isPropertyValuePropertyObject,
+  isPropertyValueObject,
 } from "../../../../../../../../../lib/typeguards";
 import type { PropertyRow } from "../../types";
 import { getExpectedTypesOfPropertyType } from "./get-expected-types-of-property-type";
@@ -92,7 +92,7 @@ export const generatePropertyRowRecursively = ({
   const children: PropertyRow[] = [];
 
   const firstOneOf = propertyType.oneOf[0];
-  const isFirstOneOfNested = isPropertyValuePropertyObject(firstOneOf);
+  const isFirstOneOfNested = isPropertyValueObject(firstOneOf);
   const isFirstOneOfArray = isPropertyValueArray(firstOneOf);
 
   // if first `oneOf` of property type is nested property, it means it should have children

--- a/apps/hash-graph/libs/store/src/data_type/query.rs
+++ b/apps/hash-graph/libs/store/src/data_type/query.rs
@@ -126,7 +126,7 @@ pub enum DataTypeQueryPath<'p> {
     ///
     /// [`DataType::title()`]: type_system::schema::DataType::title
     Title,
-    /// Corresponds to [`DataType::description()`]
+    /// Corresponds to [`DataType`]'s description.
     ///
     /// ```rust
     /// # use serde::Deserialize;
@@ -136,10 +136,8 @@ pub enum DataTypeQueryPath<'p> {
     /// assert_eq!(path, DataTypeQueryPath::Description);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    ///
-    /// [`DataType::description()`]: type_system::schema::DataType::description
     Description,
-    /// Corresponds to [`DataType::json_type()`].
+    /// Corresponds to [`DataType`]'s type.
     ///
     /// ```rust
     /// # use serde::Deserialize;

--- a/apps/hash-graph/libs/store/src/data_type/query.rs
+++ b/apps/hash-graph/libs/store/src/data_type/query.rs
@@ -136,6 +136,8 @@ pub enum DataTypeQueryPath<'p> {
     /// assert_eq!(path, DataTypeQueryPath::Description);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    ///
+    /// [`DataType`]: type_system::schema::DataType
     Description,
     /// Corresponds to [`DataType`]'s type.
     ///
@@ -148,7 +150,7 @@ pub enum DataTypeQueryPath<'p> {
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     ///
-    /// [`DataType::json_type()`]: type_system::schema::DataType::json_type
+    /// [`DataType`]: type_system::schema::DataType
     Type,
     /// Only used internally and not available for deserialization.
     OntologyId,

--- a/libs/@blockprotocol/graph/src/codegen/compile/compile-schemas-to-typescript.ts
+++ b/libs/@blockprotocol/graph/src/codegen/compile/compile-schemas-to-typescript.ts
@@ -17,7 +17,7 @@ const compileIndividualSchemaToTypescript = async (
   type: DataType | PropertyType | EntityType | JsonSchema,
   context: CompileContext,
 ): Promise<CompiledTsType> =>
-  compileJsonSchema(type, type.title, {
+  compileJsonSchema(type as unknown as JsonSchema, type.title, {
     bannerComment: "",
     enableConstEnums: true,
     declareExternallyReferenced: true,

--- a/libs/@blockprotocol/type-system/rust/src/schema/array/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/array/mod.rs
@@ -5,14 +5,14 @@ use serde::{Deserialize, Serialize, Serializer};
 use crate::schema::{OneOfSchema, PropertyType, PropertyValues};
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-#[serde(from = "raw::ArraySchema<T>")]
-pub struct ArraySchema<T> {
+#[serde(from = "raw::PropertyValueArray<T>")]
+pub struct PropertyValueArray<T> {
     pub items: T,
     pub min_items: Option<usize>,
     pub max_items: Option<usize>,
 }
 
-impl<T> Serialize for ArraySchema<T>
+impl<T> Serialize for PropertyValueArray<T>
 where
     T: Serialize,
 {
@@ -30,7 +30,7 @@ where
 #[serde(untagged)]
 pub enum ValueOrArray<T> {
     Value(T),
-    Array(ArraySchema<T>),
+    Array(PropertyValueArray<T>),
 }
 
 pub trait PropertyArraySchema {
@@ -39,7 +39,7 @@ pub trait PropertyArraySchema {
     fn max_items(&self) -> Option<usize>;
 }
 
-impl PropertyArraySchema for ArraySchema<OneOfSchema<PropertyValues>> {
+impl PropertyArraySchema for PropertyValueArray<OneOfSchema<PropertyValues>> {
     fn possibilities(&self) -> &[PropertyValues] {
         &self.items.possibilities
     }
@@ -53,7 +53,7 @@ impl PropertyArraySchema for ArraySchema<OneOfSchema<PropertyValues>> {
     }
 }
 
-impl PropertyArraySchema for ArraySchema<&PropertyType> {
+impl PropertyArraySchema for PropertyValueArray<&PropertyType> {
     fn possibilities(&self) -> &[PropertyValues] {
         &self.items.one_of
     }

--- a/libs/@blockprotocol/type-system/rust/src/schema/array/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/array/raw.rs
@@ -11,7 +11,7 @@ enum ArrayTypeTag {
 #[derive(Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub(super) struct ArraySchema<T> {
+pub(super) struct PropertyValueArray<T> {
     #[serde(rename = "type")]
     _type: ArrayTypeTag,
     items: T,
@@ -21,8 +21,8 @@ pub(super) struct ArraySchema<T> {
     max_items: Option<usize>,
 }
 
-impl<T> From<ArraySchema<T>> for super::ArraySchema<T> {
-    fn from(object: ArraySchema<T>) -> Self {
+impl<T> From<PropertyValueArray<T>> for super::PropertyValueArray<T> {
+    fn from(object: PropertyValueArray<T>) -> Self {
         Self {
             items: object.items,
             min_items: object.min_items,
@@ -42,8 +42,8 @@ pub(super) struct ArraySchemaRef<'a, T> {
     max_items: Option<usize>,
 }
 
-impl<'a, T> From<&'a super::ArraySchema<T>> for ArraySchemaRef<'a, T> {
-    fn from(object: &'a super::ArraySchema<T>) -> Self {
+impl<'a, T> From<&'a super::PropertyValueArray<T>> for ArraySchemaRef<'a, T> {
+    fn from(object: &'a super::PropertyValueArray<T>) -> Self {
         Self {
             r#type: ArrayTypeTag::Array,
             items: &object.items,

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/closed.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/closed.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::{schema::DataType, url::VersionedUrl, Valid};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+// #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 pub struct ClosedDataType {
     #[serde(flatten)]
     pub schema: Arc<DataType>,

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
@@ -1,21 +1,179 @@
 use error_stack::Report;
-use serde_json::Value as JsonValue;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value as JsonValue};
+use thiserror::Error;
 
-use super::{extend_report, ConstraintError};
-use crate::schema::{DataType, JsonSchemaValueType};
+use crate::schema::{
+    data_type::constraint::{ConstraintError, ValueConstraints},
+    DataTypeLabel,
+};
 
-pub(crate) fn check_array_constraints(
-    _actual: &[JsonValue],
-    data_type: &DataType,
-    result: &mut Result<(), Report<ConstraintError>>,
-) {
-    if !data_type.json_type.contains(&JsonSchemaValueType::Array) {
-        extend_report!(
-            *result,
-            ConstraintError::InvalidType {
-                actual: JsonSchemaValueType::Array,
-                expected: data_type.json_type.clone()
+#[derive(Debug, Error)]
+pub enum ArrayValidationError {
+    #[error(
+        "the provided value is not equal to the expected value, expected `{}` to be equal \
+         to `{}`", json!(actual), json!(expected)
+    )]
+    InvalidConstValue {
+        actual: Vec<JsonValue>,
+        expected: Vec<JsonValue>,
+    },
+    #[error("the provided value is not one of the expected values, expected `{}` to be one of `{}`", json!(actual), json!(expected))]
+    InvalidEnumValue {
+        actual: Vec<JsonValue>,
+        expected: Vec<Vec<JsonValue>>,
+    },
+
+    #[error(
+        "The length of the array is too short, expected `{actual}` to be greater than or equal to \
+         `{expected}`"
+    )]
+    MinItems { actual: usize, expected: usize },
+    #[error(
+        "The length of the array is too long, expected `{actual}` to be less than or equal to \
+         `{expected}`"
+    )]
+    MaxItems { actual: usize, expected: usize },
+    #[error("The elements in the array do not match the expected item constraints")]
+    Items,
+    #[error("The elements in the tuple do not match the expected item constraints")]
+    PrefixItems,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[serde(untagged, deny_unknown_fields)]
+pub enum ItemsConstraints {
+    False(bool),
+    Value(Box<ValueConstraints>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ArraySchema {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "DataTypeLabel::is_empty")]
+    pub label: DataTypeLabel,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(target_arch = "wasm32", tsify(type = "JsonValue[]"))]
+    pub r#const: Option<Vec<JsonValue>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(
+        target_arch = "wasm32",
+        tsify(type = "[JsonValue[], ...JsonValue[][]]")
+    )]
+    pub r#enum: Vec<Vec<JsonValue>>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_items: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_items: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(target_arch = "wasm32", tsify(type = "ValueConstraints | boolean"))]
+    pub items: Option<ItemsConstraints>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(
+        target_arch = "wasm32",
+        tsify(type = "[ValueConstraints, ...ValueConstraints[]]")
+    )]
+    pub prefix_items: Vec<ValueConstraints>,
+}
+
+impl ArraySchema {
+    pub fn validate_value(&self, values: &[JsonValue]) -> Result<(), Report<ArrayValidationError>> {
+        let mut validation_status = Ok::<(), Report<ArrayValidationError>>(());
+
+        if let Some(expected) = &self.r#const {
+            if expected != values {
+                extend_report!(
+                    validation_status,
+                    ArrayValidationError::InvalidConstValue {
+                        expected: expected.clone(),
+                        actual: values.to_owned(),
+                    }
+                );
             }
-        );
+        }
+
+        if !self.r#enum.is_empty() && !self.r#enum.iter().any(|expected| expected == values) {
+            extend_report!(
+                validation_status,
+                ArrayValidationError::InvalidEnumValue {
+                    expected: self.r#enum.clone(),
+                    actual: values.to_owned(),
+                }
+            );
+        }
+
+        let num_values = values.len();
+
+        let mut values = values.iter();
+
+        let mut item_status = Ok::<(), Report<ConstraintError>>(());
+        for (value, constraint) in values
+            .by_ref()
+            .take(self.prefix_items.len())
+            .zip(&self.prefix_items)
+        {
+            if let Err(error) = constraint.validate_value(value) {
+                extend_report!(item_status, error);
+            }
+        }
+
+        let expected_num_items = self.prefix_items.len().max(self.min_items.unwrap_or(0));
+        if num_values < expected_num_items {
+            extend_report!(
+                validation_status,
+                ArrayValidationError::MinItems {
+                    actual: num_values,
+                    expected: expected_num_items,
+                }
+            );
+        }
+        if let Some(max_items) = self.max_items {
+            if num_values > max_items {
+                extend_report!(
+                    validation_status,
+                    ArrayValidationError::MaxItems {
+                        actual: num_values,
+                        expected: max_items,
+                    }
+                );
+            }
+        }
+
+        match &self.items {
+            None | Some(ItemsConstraints::False(true)) => {}
+            Some(ItemsConstraints::False(false)) => {
+                if values.next().is_some() {
+                    extend_report!(
+                        validation_status,
+                        ArrayValidationError::MaxItems {
+                            actual: num_values,
+                            expected: self.prefix_items.len(),
+                        }
+                    );
+                }
+            }
+            Some(ItemsConstraints::Value(items)) => {
+                for value in values {
+                    if let Err(error) = items.validate_value(value) {
+                        extend_report!(item_status, error);
+                    }
+                }
+            }
+        }
+
+        if let Err(error) = item_status {
+            extend_report!(
+                validation_status,
+                error.change_context(ArrayValidationError::Items)
+            );
+        }
+
+        validation_status
     }
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
@@ -41,10 +41,9 @@ pub enum ArrayValidationError {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ItemsConstraints {
-    False(bool),
+    Boolean(bool),
     Value(Box<ValueConstraints>),
 }
 
@@ -146,8 +145,8 @@ impl ArraySchema {
         }
 
         match &self.items {
-            None | Some(ItemsConstraints::False(true)) => {}
-            Some(ItemsConstraints::False(false)) => {
+            None | Some(ItemsConstraints::Boolean(true)) => {}
+            Some(ItemsConstraints::Boolean(false)) => {
                 if values.next().is_some() {
                     extend_report!(
                         validation_status,

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/boolean.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/boolean.rs
@@ -1,20 +1,68 @@
+use std::collections::HashSet;
+
 use error_stack::Report;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use thiserror::Error;
 
-use super::{extend_report, ConstraintError};
-use crate::schema::{DataType, JsonSchemaValueType};
+use crate::schema::DataTypeLabel;
 
-pub(crate) fn check_boolean_constraints(
-    _actual: bool,
-    data_type: &DataType,
-    result: &mut Result<(), Report<ConstraintError>>,
-) {
-    if !data_type.json_type.contains(&JsonSchemaValueType::Boolean) {
-        extend_report!(
-            *result,
-            ConstraintError::InvalidType {
-                actual: JsonSchemaValueType::Boolean,
-                expected: data_type.json_type.clone()
+#[derive(Debug, Error)]
+pub enum BooleanValidationError {
+    #[error(
+        "the provided value is not equal to the expected value, expected `{actual}` to be equal \
+         to `{expected}`"
+    )]
+    InvalidConstValue { actual: bool, expected: bool },
+    #[error("the provided value is not one of the expected values, expected `{actual}` to be one of `{}`", json!(expected))]
+    InvalidEnumValue {
+        actual: bool,
+        expected: HashSet<bool>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct BooleanSchema {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "DataTypeLabel::is_empty")]
+    pub label: DataTypeLabel,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub r#const: Option<bool>,
+    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    #[cfg_attr(target_arch = "wasm32", tsify(type = "[boolean, ...boolean[]]"))]
+    pub r#enum: HashSet<bool>,
+}
+
+impl BooleanSchema {
+    pub fn validate_value(&self, boolean: bool) -> Result<(), Report<BooleanValidationError>> {
+        let mut status = Ok::<(), Report<BooleanValidationError>>(());
+
+        if let Some(expected) = &self.r#const {
+            if *expected != boolean {
+                extend_report!(
+                    status,
+                    BooleanValidationError::InvalidConstValue {
+                        expected: *expected,
+                        actual: boolean,
+                    }
+                );
             }
-        );
+        }
+
+        if !self.r#enum.is_empty() && !self.r#enum.contains(&boolean) {
+            extend_report!(
+                status,
+                BooleanValidationError::InvalidEnumValue {
+                    expected: self.r#enum.clone(),
+                    actual: boolean,
+                }
+            );
+        }
+
+        status
     }
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/error.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/error.rs
@@ -1,96 +1,21 @@
 use core::net::AddrParseError;
-use std::collections::HashSet;
 
 use iso8601_duration::ParseDurationError;
-use regex::Regex;
-use serde_json::{json, Number as JsonNumber, Value as JsonValue};
 use thiserror::Error;
 
-use crate::schema::{data_type::constraint::StringFormat, JsonSchemaValueType};
+use crate::schema::JsonSchemaValueType;
 
 #[derive(Debug, Error)]
 pub enum ConstraintError {
-    // General constraints
+    #[error("the value does not match the expected constraints")]
+    ValueConstraint,
     #[error(
-        "the value provided does not match the expected type, expected `{}`, got \
-         `{actual}`", json!(expected)
+        "the value provided does not match the expected type, expected `{expected}`, got \
+         `{actual}`"
     )]
     InvalidType {
         actual: JsonSchemaValueType,
-        expected: HashSet<JsonSchemaValueType>,
-    },
-    #[error(
-        "the provided value is not equal to the expected value, expected `{actual:#}` to be equal \
-         to `{expected:#}`"
-    )]
-    Const {
-        actual: JsonValue,
-        expected: JsonValue,
-    },
-    #[error("the provided value is not one of the expected values, expected `{actual:#}` to be one of `{:#}`", JsonValue::Array(.expected.clone()))]
-    Enum {
-        actual: JsonValue,
-        expected: Vec<JsonValue>,
-    },
-
-    // Number constraints
-    #[error(
-        "the provided number cannot be converted into a 64-bit representation of IEEE floating \
-         point number, the value provided is `{actual}`. If this issue is encountered please file \
-         a bug report, the linear tracking issue for this error is `H-2980`"
-    )]
-    InsufficientPrecision { actual: JsonNumber },
-    #[error(
-        "the provided value is not greater than or equal to the minimum value, expected \
-         `{actual}` to be greater than or equal to `{expected}`"
-    )]
-    Minimum { actual: f64, expected: f64 },
-    #[error(
-        "the provided value is not less than or equal to the maximum value, expected `{actual}` \
-         to be less than or equal to `{expected}`"
-    )]
-    Maximum { actual: f64, expected: f64 },
-    #[error(
-        "the provided value is not greater than the minimum value, expected `{actual}` to be \
-         strictly greater than `{expected}`"
-    )]
-    ExclusiveMinimum { actual: f64, expected: f64 },
-    #[error(
-        "the provided value is not less than the maximum value, expected `{actual}` to be \
-         strictly less than `{expected}`"
-    )]
-    ExclusiveMaximum { actual: f64, expected: f64 },
-    #[error(
-        "the provided value is not a multiple of the expected value, expected `{actual}` to be a \
-         multiple of `{expected}`"
-    )]
-    MultipleOf { actual: f64, expected: f64 },
-
-    // String constraints
-    #[error(
-        "the provided value is not greater than or equal to the minimum length, expected \
-         the length of `{}` to be greater than or equal to `{expected}` but it is `{}`",
-        .actual,
-        .actual.len(),
-    )]
-    MinLength { actual: String, expected: usize },
-    #[error(
-        "the provided value is not less than or equal to the maximum length, expected \
-         the length of `{}` to be less than or equal to `{expected}` but it is `{}`", .actual, .actual.len(),
-    )]
-    MaxLength { actual: String, expected: usize },
-    #[error(
-        "the provided value does not match the expected pattern, expected `{actual}` to match the \
-         pattern `{}`", .expected.as_str()
-    )]
-    Pattern { actual: String, expected: Regex },
-    #[error(
-        "the provided value does not match the expected format, expected `{actual}` to match the \
-         format `{}`", .expected.as_str()
-    )]
-    Format {
-        actual: String,
-        expected: StringFormat,
+        expected: JsonSchemaValueType,
     },
 }
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
@@ -18,12 +18,101 @@ mod number;
 mod object;
 mod string;
 
+use error_stack::{bail, Report, ResultExt};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
 pub(crate) use self::{
-    array::check_array_constraints,
-    boolean::check_boolean_constraints,
-    error::ConstraintError,
-    null::check_null_constraints,
-    number::check_numeric_constraints,
-    object::check_object_constraints,
-    string::{check_string_constraints, StringFormat},
+    array::ArraySchema, boolean::BooleanSchema, error::ConstraintError, null::NullSchema,
+    number::NumberSchema, object::ObjectSchema, string::StringSchema,
 };
+use crate::schema::JsonSchemaValueType;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum ValueConstraints {
+    Null(NullSchema),
+    Boolean(BooleanSchema),
+    Number(NumberSchema),
+    String(StringSchema),
+    Array(ArraySchema),
+    Object(ObjectSchema),
+}
+
+impl ValueConstraints {
+    pub fn validate_value(&self, value: &JsonValue) -> Result<(), Report<ConstraintError>> {
+        match self {
+            Self::Null(_) => {
+                if value.is_null() {
+                    Ok(())
+                } else {
+                    bail!(ConstraintError::InvalidType {
+                        actual: JsonSchemaValueType::from(value),
+                        expected: JsonSchemaValueType::Null,
+                    })
+                }
+            }
+            Self::Boolean(schema) => {
+                if let JsonValue::Bool(boolean) = value {
+                    schema
+                        .validate_value(*boolean)
+                        .change_context(ConstraintError::ValueConstraint)
+                } else {
+                    bail!(ConstraintError::InvalidType {
+                        actual: JsonSchemaValueType::from(value),
+                        expected: JsonSchemaValueType::Boolean,
+                    })
+                }
+            }
+            Self::Number(schema) => {
+                if let JsonValue::Number(number) = value {
+                    schema
+                        .validate_value(number)
+                        .change_context(ConstraintError::ValueConstraint)
+                } else {
+                    bail!(ConstraintError::InvalidType {
+                        actual: JsonSchemaValueType::from(value),
+                        expected: JsonSchemaValueType::Number,
+                    })
+                }
+            }
+            Self::String(schema) => {
+                if let JsonValue::String(string) = value {
+                    schema
+                        .validate_value(string)
+                        .change_context(ConstraintError::ValueConstraint)
+                } else {
+                    bail!(ConstraintError::InvalidType {
+                        actual: JsonSchemaValueType::from(value),
+                        expected: JsonSchemaValueType::String,
+                    })
+                }
+            }
+            Self::Array(schema) => {
+                if let JsonValue::Array(array) = value {
+                    schema
+                        .validate_value(array)
+                        .change_context(ConstraintError::ValueConstraint)
+                } else {
+                    bail!(ConstraintError::InvalidType {
+                        actual: JsonSchemaValueType::from(value),
+                        expected: JsonSchemaValueType::Array,
+                    })
+                }
+            }
+            Self::Object(schema) => {
+                if let JsonValue::Object(object) = value {
+                    schema
+                        .validate_value(object)
+                        .change_context(ConstraintError::ValueConstraint)
+                } else {
+                    bail!(ConstraintError::InvalidType {
+                        actual: JsonSchemaValueType::from(value),
+                        expected: JsonSchemaValueType::Object,
+                    })
+                }
+            }
+        }
+    }
+}

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/null.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/null.rs
@@ -1,19 +1,19 @@
-use error_stack::Report;
+use serde::{Deserialize, Serialize};
 
-use super::{extend_report, ConstraintError};
-use crate::schema::{DataType, JsonSchemaValueType};
+use crate::schema::DataTypeLabel;
 
-pub(crate) fn check_null_constraints(
-    data_type: &DataType,
-    result: &mut Result<(), Report<ConstraintError>>,
-) {
-    if !data_type.json_type.contains(&JsonSchemaValueType::Null) {
-        extend_report!(
-            *result,
-            ConstraintError::InvalidType {
-                actual: JsonSchemaValueType::Null,
-                expected: data_type.json_type.clone()
-            }
-        );
-    }
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct NullSchema {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "DataTypeLabel::is_empty")]
+    pub label: DataTypeLabel,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub r#const: Option<()>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(target_arch = "wasm32", tsify(type = "[null]"))]
+    pub r#enum: Vec<()>,
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
@@ -1,63 +1,249 @@
-use error_stack::Report;
+use error_stack::{bail, Report};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Number as JsonNumber};
+use thiserror::Error;
 
-use super::{extend_report, ConstraintError};
-use crate::schema::{DataType, JsonSchemaValueType};
+use crate::schema::DataTypeLabel;
 
-pub(crate) fn check_numeric_constraints(
-    actual: f64,
-    data_type: &DataType,
-    result: &mut Result<(), Report<ConstraintError>>,
-) {
-    if !data_type.json_type.contains(&JsonSchemaValueType::Number)
-        && !data_type.json_type.contains(&JsonSchemaValueType::Integer)
-    {
-        extend_report!(
-            *result,
-            ConstraintError::InvalidType {
-                actual: JsonSchemaValueType::Number,
-                expected: data_type.json_type.clone()
-            }
-        );
-    }
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "Only used in serde skip_serializing_if"
+)]
+const fn is_false(value: &bool) -> bool {
+    !*value
+}
 
-    if let Some(expected) = data_type.minimum {
-        if data_type.exclusive_minimum {
-            if actual <= expected {
+#[derive(Debug, Error)]
+pub enum NumberValidationError {
+    #[error(
+        "the provided number cannot be converted into a 64-bit representation of IEEE floating \
+         point number, the value provided is `{actual}`. If this issue is encountered please file \
+         a bug report, the linear tracking issue for this error is `H-2980`"
+    )]
+    InsufficientPrecision { actual: JsonNumber },
+
+    #[error(
+        "the provided value is not equal to the expected value, expected `{actual}` to be equal \
+         to `{expected}`"
+    )]
+    InvalidConstValue { actual: f64, expected: f64 },
+    #[error("the provided value is not one of the expected values, expected `{actual}` to be one of `{}`", json!(expected))]
+    InvalidEnumValue { actual: f64, expected: Vec<f64> },
+
+    #[error(
+        "the provided value is not greater than or equal to the minimum value, expected \
+         `{actual}` to be greater than or equal to `{expected}`"
+    )]
+    Minimum { actual: f64, expected: f64 },
+    #[error(
+        "the provided value is not less than or equal to the maximum value, expected `{actual}` \
+         to be less than or equal to `{expected}`"
+    )]
+    Maximum { actual: f64, expected: f64 },
+    #[error(
+        "the provided value is not greater than the minimum value, expected `{actual}` to be \
+         strictly greater than `{expected}`"
+    )]
+    ExclusiveMinimum { actual: f64, expected: f64 },
+    #[error(
+        "the provided value is not less than the maximum value, expected `{actual}` to be \
+         strictly less than `{expected}`"
+    )]
+    ExclusiveMaximum { actual: f64, expected: f64 },
+    #[error(
+        "the provided value is not a multiple of the expected value, expected `{actual}` to be a \
+         multiple of `{expected}`"
+    )]
+    MultipleOf { actual: f64, expected: f64 },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct NumberSchema {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "DataTypeLabel::is_empty")]
+    pub label: DataTypeLabel,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub r#const: Option<f64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(target_arch = "wasm32", tsify(type = "[number, ...number[]]"))]
+    pub r#enum: Vec<f64>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub minimum: Option<f64>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub exclusive_minimum: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maximum: Option<f64>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub exclusive_maximum: bool,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub multiple_of: Option<f64>,
+}
+
+#[expect(
+    clippy::float_arithmetic,
+    reason = "Validation requires floating point arithmetic"
+)]
+fn float_eq(lhs: f64, rhs: f64) -> bool {
+    f64::abs(lhs - rhs) < f64::EPSILON
+}
+
+#[expect(
+    clippy::float_equality_without_abs,
+    reason = "False positive: This is a comparison of floating point numbers, not a check for \
+              equality"
+)]
+#[expect(
+    clippy::float_arithmetic,
+    reason = "Validation requires floating point arithmetic"
+)]
+fn float_less_eq(lhs: f64, rhs: f64) -> bool {
+    lhs - rhs < f64::EPSILON
+}
+
+fn float_less(lhs: f64, rhs: f64) -> bool {
+    float_less_eq(lhs, rhs) && !float_eq(lhs, rhs)
+}
+
+impl NumberSchema {
+    pub fn validate_value(&self, number: &JsonNumber) -> Result<(), Report<NumberValidationError>> {
+        let Some(float) = number.as_f64() else {
+            bail!(NumberValidationError::InsufficientPrecision {
+                actual: number.clone()
+            });
+        };
+
+        let mut status = Ok::<(), Report<NumberValidationError>>(());
+
+        if let Some(expected) = self.r#const {
+            if float_eq(expected, float) {
                 extend_report!(
-                    *result,
-                    ConstraintError::ExclusiveMinimum { actual, expected }
+                    status,
+                    NumberValidationError::InvalidConstValue {
+                        expected,
+                        actual: float,
+                    }
                 );
             }
-        } else if actual < expected {
-            extend_report!(*result, ConstraintError::Minimum { actual, expected });
         }
-    }
-    if let Some(expected) = data_type.maximum {
-        if data_type.exclusive_maximum {
-            if actual >= expected {
+
+        if !self.r#enum.is_empty()
+            && !self
+                .r#enum
+                .iter()
+                .any(|expected| float_eq(float, *expected))
+        {
+            extend_report!(
+                status,
+                NumberValidationError::InvalidEnumValue {
+                    expected: self.r#enum.clone(),
+                    actual: float.to_owned(),
+                }
+            );
+        }
+
+        if let Some(minimum) = self.minimum {
+            if self.exclusive_minimum {
+                if float_less_eq(float, minimum) {
+                    extend_report!(
+                        status,
+                        NumberValidationError::ExclusiveMinimum {
+                            actual: float,
+                            expected: minimum
+                        }
+                    );
+                }
+            } else if float_less(float, minimum) {
                 extend_report!(
-                    *result,
-                    ConstraintError::ExclusiveMaximum { actual, expected }
+                    status,
+                    NumberValidationError::ExclusiveMinimum {
+                        actual: float,
+                        expected: minimum
+                    }
                 );
             }
-        } else if actual > expected {
-            extend_report!(*result, ConstraintError::Maximum { actual, expected });
         }
+
+        if let Some(maximum) = self.maximum {
+            if self.exclusive_maximum {
+                if float_less_eq(maximum, float) {
+                    extend_report!(
+                        status,
+                        NumberValidationError::ExclusiveMaximum {
+                            actual: float,
+                            expected: maximum
+                        }
+                    );
+                }
+            } else if float_less(maximum, float) {
+                extend_report!(
+                    status,
+                    NumberValidationError::Maximum {
+                        actual: float,
+                        expected: maximum
+                    }
+                );
+            }
+        }
+
+        if let Some(expected) = self.multiple_of {
+            #[expect(
+                clippy::float_arithmetic,
+                clippy::modulo_arithmetic,
+                reason = "Validation requires floating point arithmetic"
+            )]
+            if float_eq(float % expected, 0.0) {
+                extend_report!(
+                    status,
+                    NumberValidationError::MultipleOf {
+                        actual: float,
+                        expected
+                    }
+                );
+            }
+        }
+
+        status
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[expect(clippy::float_cmp, reason = "Test case for float_eq")]
+    fn compare_equality() {
+        assert_ne!(0.1 + 0.2, 0.3);
+        assert!(float_eq(0.1 + 0.2, 0.3));
+
+        assert!(!float_eq(1.0, 1.0 + f64::EPSILON));
+        assert!(float_eq(1.0, 1.0 + f64::EPSILON / 2.0));
+        assert!(float_eq(1.0, 1.0));
+        assert!(float_eq(1.0, 1.0 - f64::EPSILON / 2.0));
+        assert!(!float_eq(1.0, 1.0 - f64::EPSILON));
     }
 
-    if let Some(expected) = data_type.multiple_of.or_else(|| {
-        data_type
-            .json_type
-            .contains(&JsonSchemaValueType::Integer)
-            .then_some(1.0)
-    }) {
-        #[expect(
-            clippy::float_arithmetic,
-            clippy::modulo_arithmetic,
-            reason = "Validation requires floating point arithmetic"
-        )]
-        if actual % expected >= f64::EPSILON {
-            extend_report!(*result, ConstraintError::MultipleOf { actual, expected });
-        }
+    #[test]
+    fn compare_less() {
+        assert!(float_less(1.0, 1.0 + f64::EPSILON));
+        assert!(!float_less(1.0, 1.0 + f64::EPSILON / 2.0));
+        assert!(!float_less(1.0, 1.0));
+        assert!(!float_less(1.0, 1.0 - f64::EPSILON / 2.0));
+        assert!(!float_less(1.0, 1.0 - f64::EPSILON));
+    }
+
+    #[test]
+    fn compare_less_eq() {
+        assert!(float_less_eq(1.0, 1.0 + f64::EPSILON));
+        assert!(float_less_eq(1.0, 1.0 + f64::EPSILON / 2.0));
+        assert!(float_less_eq(1.0, 1.0));
+        assert!(float_less_eq(1.0, 1.0 - f64::EPSILON / 2.0));
+        assert!(!float_less_eq(1.0, 1.0 - f64::EPSILON));
     }
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
@@ -197,7 +197,7 @@ impl NumberSchema {
                 clippy::modulo_arithmetic,
                 reason = "Validation requires floating point arithmetic"
             )]
-            if float_eq(float % expected, 0.0) {
+            if !float_eq(float % expected, 0.0) {
                 extend_report!(
                     status,
                     NumberValidationError::MultipleOf {

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -21,13 +21,12 @@ use core::{cmp, fmt, mem};
 use std::collections::{hash_map::RawEntryMut, HashMap, HashSet};
 
 use error_stack::{bail, Report};
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use thiserror::Error;
 
 use crate::{
-    schema::data_type::constraint::{extend_report, ConstraintError, StringFormat},
+    schema::data_type::constraint::{ConstraintError, ValueConstraints},
     url::VersionedUrl,
 };
 
@@ -38,7 +37,6 @@ pub enum JsonSchemaValueType {
     Null,
     Boolean,
     Number,
-    Integer,
     String,
     Array,
     Object,
@@ -50,7 +48,6 @@ impl fmt::Display for JsonSchemaValueType {
             Self::Null => fmt.write_str("null"),
             Self::Boolean => fmt.write_str("boolean"),
             Self::Number => fmt.write_str("number"),
-            Self::Integer => fmt.write_str("integer"),
             Self::String => fmt.write_str("string"),
             Self::Array => fmt.write_str("array"),
             Self::Object => fmt.write_str("object"),
@@ -102,127 +99,118 @@ pub enum DataTypeSchemaTag {
     V3,
 }
 
-#[expect(
-    clippy::trivially_copy_pass_by_ref,
-    reason = "Only used in serde skip_serializing_if"
-)]
-const fn is_false(value: &bool) -> bool {
-    !*value
+mod raw {
+    use serde::Deserialize;
+
+    use super::{DataTypeSchemaTag, DataTypeTag};
+    use crate::{
+        schema::{
+            data_type::constraint::{
+                ArraySchema, BooleanSchema, NullSchema, NumberSchema, ObjectSchema, StringSchema,
+                ValueConstraints,
+            },
+            DataTypeReference,
+        },
+        url::VersionedUrl,
+    };
+
+    #[derive(Deserialize)]
+    #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
+    pub struct UnconstrainedDataType {
+        #[serde(rename = "$schema")]
+        schema: DataTypeSchemaTag,
+        kind: DataTypeTag,
+        #[serde(rename = "$id")]
+        id: VersionedUrl,
+        title: String,
+        #[cfg_attr(
+            target_arch = "wasm32",
+            tsify(type = "[DataTypeReference, ...DataTypeReference[]]")
+        )]
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        all_of: Vec<DataTypeReference>,
+    }
+
+    #[derive(Deserialize)]
+    #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+    #[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+    pub enum DataType {
+        Null {
+            #[serde(flatten)]
+            schema: NullSchema,
+            #[serde(flatten)]
+            common: UnconstrainedDataType,
+        },
+        Boolean {
+            #[serde(flatten)]
+            schema: BooleanSchema,
+            #[serde(flatten)]
+            common: UnconstrainedDataType,
+        },
+        Number {
+            #[serde(flatten)]
+            schema: NumberSchema,
+            #[serde(flatten)]
+            common: UnconstrainedDataType,
+        },
+        String {
+            #[serde(flatten)]
+            schema: StringSchema,
+            #[serde(flatten)]
+            common: UnconstrainedDataType,
+        },
+        Array {
+            #[serde(flatten)]
+            schema: ArraySchema,
+            #[serde(flatten)]
+            common: UnconstrainedDataType,
+        },
+        Object {
+            #[serde(flatten)]
+            schema: ObjectSchema,
+            #[serde(flatten)]
+            common: UnconstrainedDataType,
+        },
+    }
+
+    impl From<DataType> for super::DataType {
+        fn from(value: DataType) -> Self {
+            let (common, constraints) = match value {
+                DataType::Null { schema, common } => (common, ValueConstraints::Null(schema)),
+                DataType::Boolean { schema, common } => (common, ValueConstraints::Boolean(schema)),
+                DataType::Number { schema, common } => (common, ValueConstraints::Number(schema)),
+                DataType::String { schema, common } => (common, ValueConstraints::String(schema)),
+                DataType::Array { schema, common } => (common, ValueConstraints::Array(schema)),
+                DataType::Object { schema, common } => (common, ValueConstraints::Object(schema)),
+            };
+
+            Self {
+                schema: common.schema,
+                kind: common.kind,
+                id: common.id,
+                title: common.title,
+                all_of: common.all_of,
+                constraints,
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
-#[serde(rename = "DataType", rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase", from = "raw::DataType")]
 pub struct DataType {
     #[serde(rename = "$schema")]
     pub schema: DataTypeSchemaTag,
     pub kind: DataTypeTag,
     #[serde(rename = "$id")]
     pub id: VersionedUrl,
-    #[cfg_attr(
-        target_arch = "wasm32",
-        tsify(type = "[DataTypeReference, ...DataTypeReference[]]")
-    )]
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub all_of: Vec<DataTypeReference>,
     pub title: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub all_of: Vec<DataTypeReference>,
 
-    #[serde(default, skip_serializing_if = "DataTypeLabel::is_empty")]
-    pub label: DataTypeLabel,
-
-    // constraints for any types
-    #[serde(rename = "type", with = "json_type")]
-    #[cfg_attr(
-        target_arch = "wasm32",
-        tsify(type = "JsonSchemaValueType | [JsonSchemaValueType, ...JsonSchemaValueType[]]")
-    )]
-    pub json_type: HashSet<JsonSchemaValueType>,
-    #[serde(rename = "const", default, skip_serializing_if = "Option::is_none")]
-    pub const_value: Option<JsonValue>,
-    #[serde(rename = "enum", default, skip_serializing_if = "Vec::is_empty")]
-    #[cfg_attr(target_arch = "wasm32", tsify(type = "[JsonValue, ...JsonValue[]]"))]
-    pub enum_values: Vec<JsonValue>,
-
-    // constraints for number types
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub multiple_of: Option<f64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub maximum: Option<f64>,
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub exclusive_maximum: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub minimum: Option<f64>,
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub exclusive_minimum: bool,
-
-    // constraints for string types
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub min_length: Option<usize>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_length: Option<usize>,
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "codec::serde::regex::option"
-    )]
-    #[cfg_attr(target_arch = "wasm32", tsify(type = "string"))]
-    pub pattern: Option<Regex>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub format: Option<StringFormat>,
-}
-
-mod json_type {
-    use std::collections::HashSet;
-
-    use serde::{Deserialize, Serialize};
-
-    use crate::schema::JsonSchemaValueType;
-
-    #[derive(Serialize, Deserialize)]
-    #[serde(untagged)]
-    enum MaybeSet {
-        Value(JsonSchemaValueType),
-        Set(HashSet<JsonSchemaValueType>),
-    }
-
-    pub(super) fn serialize<S>(
-        types: &HashSet<JsonSchemaValueType>,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        if types.len() == 1 {
-            types
-                .iter()
-                .next()
-                .expect("Set should have exactly one element")
-                .serialize(serializer)
-        } else {
-            types.serialize(serializer)
-        }
-    }
-
-    pub(super) fn deserialize<'de, D>(
-        deserializer: D,
-    ) -> Result<HashSet<JsonSchemaValueType>, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let maybe_set = MaybeSet::deserialize(deserializer)?;
-        match maybe_set {
-            MaybeSet::Value(value) => Ok(HashSet::from([value])),
-            MaybeSet::Set(set) => {
-                if set.is_empty() {
-                    Err(serde::de::Error::custom("At least one type is required"))
-                } else {
-                    Ok(set)
-                }
-            }
-        }
-    }
+    #[serde(flatten)]
+    pub constraints: ValueConstraints,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -521,77 +509,14 @@ impl DataType {
     ///
     /// Returns an error if the JSON value is not a valid instance of the data type.
     pub fn validate_constraints(&self, value: &JsonValue) -> Result<(), Report<ConstraintError>> {
-        let mut result = Ok::<(), Report<ConstraintError>>(());
-
-        if let Some(const_value) = &self.const_value {
-            if value != const_value {
-                extend_report!(
-                    result,
-                    ConstraintError::Const {
-                        actual: value.clone(),
-                        expected: const_value.clone()
-                    }
-                );
-            }
-        }
-        if !self.enum_values.is_empty() && !self.enum_values.contains(value) {
-            extend_report!(
-                result,
-                ConstraintError::Enum {
-                    actual: value.clone(),
-                    expected: self.enum_values.clone()
-                }
-            );
-        }
-
-        match value {
-            JsonValue::Null => {
-                constraint::check_null_constraints(self, &mut result);
-            }
-            JsonValue::Bool(boolean) => {
-                constraint::check_boolean_constraints(*boolean, self, &mut result);
-            }
-            JsonValue::Number(number) => {
-                if let Some(number) = number.as_f64() {
-                    constraint::check_numeric_constraints(number, self, &mut result);
-                } else {
-                    extend_report!(
-                        result,
-                        ConstraintError::InsufficientPrecision {
-                            actual: number.clone()
-                        }
-                    );
-                }
-            }
-            JsonValue::String(string) => {
-                constraint::check_string_constraints(string, self, &mut result);
-            }
-            JsonValue::Array(array) => {
-                constraint::check_array_constraints(array, self, &mut result);
-            }
-            JsonValue::Object(object) => {
-                constraint::check_object_constraints(object, self, &mut result);
-            }
-        }
-
-        result
+        self.constraints.validate_value(value)
     }
 }
 
 #[cfg(test)]
 mod tests {
-
-    use pretty_assertions::assert_eq;
-    use serde_json::json;
-
     use super::*;
-    use crate::{
-        utils::tests::{
-            ensure_failed_deserialization, ensure_failed_validation, ensure_validation,
-            ensure_validation_from_str, JsonEqualityCheck,
-        },
-        Validator,
-    };
+    use crate::utils::tests::{ensure_validation_from_str, JsonEqualityCheck};
 
     #[tokio::test]
     async fn text() {
@@ -651,427 +576,5 @@ mod tests {
             JsonEqualityCheck::Yes,
         )
         .await;
-    }
-
-    #[tokio::test]
-    #[expect(clippy::too_many_lines, reason = "Test data is included in this test")]
-    async fn inheritance() {
-        let value = Arc::new(
-            ensure_validation::<DataType, _>(
-                json!({
-                  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
-                  "kind": "dataType",
-                  "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/value/v/1",
-                  "title": "Value",
-                  "description": "Any value",
-                  "type": "string"
-                }),
-                DataTypeValidator,
-                JsonEqualityCheck::Yes,
-            )
-            .await
-            .into_inner(),
-        );
-
-        let number = Arc::new(
-            ensure_validation::<DataType, _>(
-                json!({
-                  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
-                  "kind": "dataType",
-                  "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1",
-                  "allOf": [
-                    { "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/value/v/1" }
-                  ],
-                  "title": "Number",
-                  "description": "A number",
-                  "type": "number"
-                }),
-                DataTypeValidator,
-                JsonEqualityCheck::Yes,
-            )
-            .await
-            .into_inner(),
-        );
-
-        let unsigned_number = Arc::new(ensure_validation::<DataType, _>(
-            json!({
-              "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
-              "kind": "dataType",
-              "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/unsigned-number/v/1",
-              "allOf": [
-                { "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1" }
-              ],
-              "title": "Unsigned Number",
-              "description": "A positive number",
-              "type": "integer",
-              "minimum": 0.0,
-            }),
-            DataTypeValidator,
-            JsonEqualityCheck::Yes,
-        )
-        .await
-        .into_inner());
-
-        let integer = Arc::new(ensure_validation::<DataType, _>(
-            json!({
-              "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
-              "kind": "dataType",
-              "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/integer/v/1",
-              "allOf": [
-                { "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1" }
-              ],
-              "title": "Integer",
-              "description": "An integer",
-              "type": "integer",
-              "multipleOf": 1.0
-            }),
-            DataTypeValidator,
-            JsonEqualityCheck::Yes,
-        )
-        .await
-        .into_inner());
-
-        let unsigned_integer = Arc::new(ensure_validation::<DataType, _>(
-            json!({
-              "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
-              "kind": "dataType",
-              "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/unsigned-integer/v/1",
-              "allOf": [
-                { "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/unsigned-number/v/1" },
-                { "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/integer/v/1" },
-              ],
-              "title": "Unsigned Integer",
-              "description": "A positive integer",
-              "type": "integer"
-            }),
-            DataTypeValidator,
-            JsonEqualityCheck::Yes,
-        )
-        .await
-        .into_inner());
-
-        let mut resolver = OntologyTypeResolver::default();
-        let err = resolver
-            .resolve_data_type_metadata([Arc::clone(&unsigned_integer)])
-            .expect_err("Resolved data type with unresolved references");
-        let DataTypeResolveError::MissingSchemas {
-            schemas: unresolved_schemas,
-        } = err.current_context()
-        else {
-            panic!("Expected missing schemas error");
-        };
-
-        assert_eq!(
-            *unresolved_schemas,
-            HashSet::from([unsigned_number.id.clone(), integer.id.clone()])
-        );
-
-        let data_types = [
-            Arc::clone(&value),
-            Arc::clone(&number),
-            Arc::clone(&integer),
-            Arc::clone(&unsigned_number),
-            Arc::clone(&unsigned_integer),
-        ];
-        let mut resolver = OntologyTypeResolver::default();
-        let [
-            closed_value_metadata,
-            closed_number_metadata,
-            closed_integer_metadata,
-            closed_unsigned_number_metadata,
-            closed_unsigned_integer_metadata,
-        ]: [Arc<ClosedDataTypeMetadata>; 5] = resolver
-            .resolve_data_type_metadata(data_types.iter().cloned())
-            .expect("Failed to resolve data types")
-            .try_into()
-            .expect("Failed to convert to array");
-
-        let closed_value = resolver
-            .get_closed_data_type(&value.id)
-            .expect("Failed to get closed data type");
-        assert_eq!(closed_value_metadata.inheritance_depths, HashMap::new());
-        assert_eq!(json!(closed_value.schema), json!(value));
-        assert_eq!(json!(closed_value.definitions), json!({}));
-        DataTypeValidator
-            .validate_ref(&closed_value)
-            .await
-            .expect("Failed to validate closed data type");
-
-        let closed_number = resolver
-            .get_closed_data_type(&number.id)
-            .expect("Failed to get closed data type");
-        assert_eq!(
-            closed_number_metadata.inheritance_depths,
-            HashMap::from([(value.id.clone(), 0)])
-        );
-        assert_eq!(json!(closed_number.schema), json!(number));
-        assert_eq!(
-            json!(closed_number.definitions),
-            json!({
-                value.id.to_string(): value,
-            })
-        );
-        DataTypeValidator
-            .validate_ref(&closed_number)
-            .await
-            .expect("Failed to validate closed data type");
-
-        let closed_integer = resolver
-            .get_closed_data_type(&integer.id)
-            .expect("Failed to get closed data type");
-        assert_eq!(
-            closed_integer_metadata.inheritance_depths,
-            HashMap::from([(value.id.clone(), 1), (number.id.clone(), 0)])
-        );
-        assert_eq!(json!(closed_integer.schema), json!(integer));
-        assert_eq!(
-            json!(closed_integer.definitions),
-            json!({
-                value.id.to_string(): value,
-                number.id.to_string(): number,
-            })
-        );
-        DataTypeValidator
-            .validate_ref(&closed_integer)
-            .await
-            .expect("Failed to validate closed data type");
-
-        let closed_unsigned_number = resolver
-            .get_closed_data_type(&unsigned_number.id)
-            .expect("Failed to get closed data type");
-        assert_eq!(
-            closed_unsigned_number_metadata.inheritance_depths,
-            HashMap::from([(value.id.clone(), 1), (number.id.clone(), 0)])
-        );
-        assert_eq!(json!(closed_unsigned_number.schema), json!(unsigned_number));
-        assert_eq!(
-            json!(closed_unsigned_number.definitions),
-            json!({
-                value.id.to_string(): value,
-                number.id.to_string(): number,
-            })
-        );
-        DataTypeValidator
-            .validate_ref(&closed_unsigned_number)
-            .await
-            .expect("Failed to validate closed data type");
-
-        let closed_unsigned_integer = resolver
-            .get_closed_data_type(&unsigned_integer.id)
-            .expect("Failed to get closed data type");
-        assert_eq!(
-            closed_unsigned_integer_metadata.inheritance_depths,
-            HashMap::from([
-                (value.id.clone(), 2),
-                (number.id.clone(), 1),
-                (unsigned_number.id.clone(), 0),
-                (integer.id.clone(), 0)
-            ])
-        );
-        assert_eq!(
-            json!(closed_unsigned_integer.schema),
-            json!(unsigned_integer)
-        );
-        assert_eq!(
-            json!(closed_unsigned_integer.definitions),
-            json!({
-                value.id.to_string(): value,
-                number.id.to_string(): number,
-                unsigned_number.id.to_string(): unsigned_number,
-                integer.id.to_string(): integer,
-            })
-        );
-        DataTypeValidator
-            .validate_ref(&closed_unsigned_integer)
-            .await
-            .expect("Failed to validate closed data type");
-
-        let mut resolver = OntologyTypeResolver::default();
-        resolver.add_closed(Arc::clone(&number), Arc::clone(&closed_number_metadata));
-        resolver.add_closed(Arc::clone(&integer), Arc::clone(&closed_integer_metadata));
-        assert_eq!(
-            json!(closed_value),
-            json!(value),
-            "The value data type schema should be the same as the closed schema"
-        );
-
-        let resolved_a = resolver
-            .resolve_data_type_metadata([
-                Arc::clone(&unsigned_integer),
-                Arc::clone(&unsigned_number),
-            ])
-            .expect("Failed to resolve data types");
-        assert_eq!(
-            json!(resolved_a),
-            json!([
-                closed_unsigned_integer_metadata,
-                closed_unsigned_number_metadata
-            ])
-        );
-
-        let mut resolver = OntologyTypeResolver::default();
-        resolver.add_closed(
-            Arc::clone(&unsigned_number),
-            Arc::clone(&closed_unsigned_number_metadata),
-        );
-        let resolved_b = resolver
-            .resolve_data_type_metadata([unsigned_integer, integer, number, value])
-            .expect("Failed to resolve data types");
-        assert_eq!(
-            json!(resolved_b),
-            json!([
-                closed_unsigned_integer_metadata,
-                closed_integer_metadata,
-                closed_number_metadata,
-                closed_value_metadata,
-            ])
-        );
-    }
-
-    #[tokio::test]
-    async fn cyclic_inheritance() {
-        let first = Arc::new(
-            ensure_validation::<DataType, _>(
-                json!({
-                  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
-                  "kind": "dataType",
-                  "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/first/v/1",
-                  "allOf": [
-                    { "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/second/v/1" }
-                  ],
-                  "title": "Type A",
-                  "description": "First data type inheriting from B",
-                  "type": "string"
-                }),
-                DataTypeValidator,
-                JsonEqualityCheck::Yes,
-            )
-                .await
-                .into_inner(),
-        );
-        let second = Arc::new(
-            ensure_validation::<DataType, _>(
-                json!({
-                  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
-                  "kind": "dataType",
-                  "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/second/v/1",
-                  "allOf": [
-                    { "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/first/v/1" }
-                  ],
-                  "title": "Type B",
-                  "description": "First data type inheriting from A",
-                  "type": "string"
-                }),
-                DataTypeValidator,
-                JsonEqualityCheck::Yes,
-            )
-            .await
-            .into_inner(),
-        );
-
-        let mut resolver = OntologyTypeResolver::default();
-        let [first_metadata, second_metadata]: [_; 2] = resolver
-            .resolve_data_type_metadata([Arc::clone(&first), Arc::clone(&second)])
-            .expect("Resolved data type with unresolved references")
-            .try_into()
-            .expect("Failed to return metadata array");
-
-        assert_eq!(
-            first_metadata.inheritance_depths,
-            HashMap::from([(second.id.clone(), 0)])
-        );
-        assert_eq!(
-            second_metadata.inheritance_depths,
-            HashMap::from([(first.id.clone(), 0)])
-        );
-    }
-
-    #[tokio::test]
-    async fn recursive_inheritance() {
-        let value = Arc::new(
-            ensure_validation::<DataType, _>(
-                json!({
-                  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
-                  "kind": "dataType",
-                  "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/value/v/1",
-                  "allOf": [
-                    { "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/value/v/1" }
-                  ],
-                  "title": "Value",
-                  "description": "Any value",
-                  "type": "string"
-                }),
-                DataTypeValidator,
-                JsonEqualityCheck::Yes,
-            )
-            .await
-            .into_inner(),
-        );
-
-        let mut resolver = OntologyTypeResolver::default();
-        let [metadata]: [_; 1] = resolver
-            .resolve_data_type_metadata([Arc::clone(&value)])
-            .expect("Resolved data type with unresolved references")
-            .try_into()
-            .expect("Failed to return metadata array");
-
-        assert!(metadata.inheritance_depths.is_empty());
-    }
-
-    #[tokio::test]
-    async fn invalid_enum_values() {
-        ensure_failed_validation::<DataType, _>(
-            json!(
-                {
-                  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
-                  "kind": "dataType",
-                  "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/small/v/1",
-                  "title": "Small number",
-                  "description": "A small number",
-                  "type": "number",
-                  "const": [0],
-                  "enum": [0, 1, 2, 3]
-                }
-            ),
-            DataTypeValidator,
-            JsonEqualityCheck::Yes,
-        )
-        .await;
-    }
-
-    #[test]
-    fn invalid_schema() {
-        let invalid_schema_url = "https://blockprotocol.org/types/modules/graph/0.3/schema/foo";
-
-        ensure_failed_deserialization::<DataType>(
-            json!(
-                {
-                  "$schema": invalid_schema_url,
-                  "kind": "dataType",
-                  "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
-                  "title": "Text",
-                  "description": "An ordered sequence of characters",
-                  "type": "string"
-                }
-            ),
-            &"unknown variant `https://blockprotocol.org/types/modules/graph/0.3/schema/foo`, expected `https://blockprotocol.org/types/modules/graph/0.3/schema/data-type`",
-        );
-    }
-
-    #[test]
-    fn invalid_id() {
-        ensure_failed_deserialization::<DataType>(
-            json!(
-                {
-                  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
-                  "kind": "dataType",
-                  "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1.5",
-                  "title": "Text",
-                  "description": "An ordered sequence of characters",
-                  "type": "string"
-                }
-            ),
-            &"additional end content: .5",
-        );
     }
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/validation.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/validation.rs
@@ -31,17 +31,6 @@ impl Validator<DataType> for DataTypeValidator {
         &self,
         value: &'v DataType,
     ) -> Result<&'v Valid<DataType>, Self::Error> {
-        if let Some(const_value) = &value.const_value {
-            if !value.enum_values.is_empty()
-                && (value.enum_values.len() > 1 || value.enum_values[0] != *const_value)
-            {
-                return Err(ValidateDataTypeError::EnumValuesNotCompatibleWithConst {
-                    const_value: const_value.clone(),
-                    enum_values: value.enum_values.clone(),
-                });
-            }
-        }
-
         // TODO: Implement validation for data types
         //   see https://linear.app/hash/issue/H-2976/validate-ontology-types-on-creation
         Ok(Valid::new_ref_unchecked(value))

--- a/libs/@blockprotocol/type-system/rust/src/schema/entity_type/closed.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/entity_type/closed.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     schema::{
-        entity_type::extend_links, one_of::OneOfSchema, ArraySchema, EntityType,
-        EntityTypeReference, PropertyTypeReference, ValueOrArray,
+        entity_type::extend_links, one_of::OneOfSchema, EntityType, EntityTypeReference,
+        PropertyTypeReference, PropertyValueArray, ValueOrArray,
     },
     url::{BaseUrl, VersionedUrl},
 };
@@ -25,7 +25,7 @@ pub struct ClosedEntityType {
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
     pub required: HashSet<BaseUrl>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub links: HashMap<VersionedUrl, ArraySchema<Option<OneOfSchema<EntityTypeReference>>>>,
+    pub links: HashMap<VersionedUrl, PropertyValueArray<Option<OneOfSchema<EntityTypeReference>>>>,
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
     pub all_of: HashSet<EntityTypeReference>,
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/entity_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/entity_type/mod.rs
@@ -14,7 +14,7 @@ use std::collections::{hash_map::Entry, HashMap, HashSet};
 use serde::{Deserialize, Serialize, Serializer};
 
 use crate::{
-    schema::{one_of::OneOfSchema, ArraySchema, PropertyTypeReference, ValueOrArray},
+    schema::{one_of::OneOfSchema, PropertyTypeReference, PropertyValueArray, ValueOrArray},
     url::{BaseUrl, VersionedUrl},
 };
 
@@ -27,7 +27,7 @@ pub struct EntityType {
     pub properties: HashMap<BaseUrl, ValueOrArray<PropertyTypeReference>>,
     pub required: HashSet<BaseUrl>,
     pub all_of: HashSet<EntityTypeReference>,
-    pub links: HashMap<VersionedUrl, ArraySchema<Option<OneOfSchema<EntityTypeReference>>>>,
+    pub links: HashMap<VersionedUrl, PropertyValueArray<Option<OneOfSchema<EntityTypeReference>>>>,
     #[deprecated]
     pub examples: Vec<HashMap<BaseUrl, serde_json::Value>>,
 }
@@ -71,11 +71,14 @@ impl EntityType {
 }
 
 fn extend_links(
-    current: &mut HashMap<VersionedUrl, ArraySchema<Option<OneOfSchema<EntityTypeReference>>>>,
+    current: &mut HashMap<
+        VersionedUrl,
+        PropertyValueArray<Option<OneOfSchema<EntityTypeReference>>>,
+    >,
     iter: impl IntoIterator<
         Item = (
             VersionedUrl,
-            ArraySchema<Option<OneOfSchema<EntityTypeReference>>>,
+            PropertyValueArray<Option<OneOfSchema<EntityTypeReference>>>,
         ),
     >,
 ) {

--- a/libs/@blockprotocol/type-system/rust/src/schema/entity_type/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/entity_type/raw.rs
@@ -7,7 +7,9 @@ use serde_json::Value as JsonValue;
 use tsify::Tsify;
 
 use crate::{
-    schema::{ArraySchema, EntityTypeReference, OneOfSchema, PropertyTypeReference, ValueOrArray},
+    schema::{
+        EntityTypeReference, OneOfSchema, PropertyTypeReference, PropertyValueArray, ValueOrArray,
+    },
     url::{BaseUrl, VersionedUrl},
 };
 
@@ -33,7 +35,7 @@ enum EntityTypeSchemaTag {
     V3,
 }
 
-type Links = HashMap<VersionedUrl, ArraySchema<Option<OneOfSchema<EntityTypeReference>>>>;
+type Links = HashMap<VersionedUrl, PropertyValueArray<Option<OneOfSchema<EntityTypeReference>>>>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
@@ -61,7 +63,7 @@ pub struct EntityType<'a> {
     #[cfg_attr(
         target_arch = "wasm32",
         tsify(
-            type = "Record<VersionedUrl, ArraySchema<OneOfSchema<EntityTypeReference> | \
+            type = "Record<VersionedUrl, PropertyValueArray<OneOfSchema<EntityTypeReference> | \
                     Record<string, never>>>"
         )
     )]
@@ -78,7 +80,7 @@ mod links {
     use serde::{Deserialize, Serialize};
 
     use crate::{
-        schema::{entity_type::raw::Links, ArraySchema, EntityTypeReference, OneOfSchema},
+        schema::{entity_type::raw::Links, EntityTypeReference, OneOfSchema, PropertyValueArray},
         url::VersionedUrl,
     };
 
@@ -101,7 +103,7 @@ mod links {
         for (url, val) in links {
             map.serialize_entry(
                 &url,
-                &ArraySchema {
+                &PropertyValueArray {
                     items: Maybe {
                         inner: val.items.as_ref(),
                     },
@@ -133,8 +135,8 @@ mod links {
                 A: MapAccess<'de>,
             {
                 let mut links = HashMap::new();
-                while let Some((key, value)) = map.next_entry::<VersionedUrl, ArraySchema<Maybe<OneOfSchema<EntityTypeReference>>>>()? {
-                    links.insert(key, ArraySchema {
+                while let Some((key, value)) = map.next_entry::<VersionedUrl, PropertyValueArray<Maybe<OneOfSchema<EntityTypeReference>>>>()? {
+                    links.insert(key, PropertyValueArray {
                         items: value.items.inner,
                         min_items: value.min_items,
                         max_items: value.max_items,

--- a/libs/@blockprotocol/type-system/rust/src/schema/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/mod.rs
@@ -14,7 +14,7 @@ mod object;
 mod one_of;
 
 pub use self::{
-    array::{ArraySchema, PropertyArraySchema, ValueOrArray},
+    array::{PropertyArraySchema, PropertyValueArray, ValueOrArray},
     data_type::{
         ClosedDataType, ClosedDataTypeMetadata, ConversionDefinition, ConversionExpression,
         ConversionValue, Conversions, DataType, DataTypeLabel, DataTypeReference,
@@ -26,7 +26,8 @@ pub use self::{
         EntityTypeValidationError, EntityTypeValidator,
     },
     object::{
-        ObjectSchema, ObjectSchemaValidationError, ObjectSchemaValidator, PropertyObjectSchema,
+        ObjectSchemaValidationError, ObjectSchemaValidator, PropertyObjectSchema,
+        PropertyValueObject,
     },
     one_of::{OneOfSchema, OneOfSchemaValidationError, OneOfSchemaValidator},
     property_type::{

--- a/libs/@blockprotocol/type-system/rust/src/schema/object/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/object/mod.rs
@@ -12,13 +12,13 @@ use crate::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-#[serde(from = "raw::ObjectSchema<T>")]
-pub struct ObjectSchema<T> {
+#[serde(from = "raw::PropertyValueObject<T>")]
+pub struct PropertyValueObject<T> {
     pub properties: HashMap<BaseUrl, T>,
     pub required: HashSet<BaseUrl>,
 }
 
-impl<T> Serialize for ObjectSchema<T>
+impl<T> Serialize for PropertyValueObject<T>
 where
     for<'a> raw::ObjectSchemaRef<'a, T>: Serialize,
 {
@@ -37,7 +37,7 @@ pub trait PropertyObjectSchema {
     fn required(&self) -> &HashSet<BaseUrl>;
 }
 
-impl<T> PropertyObjectSchema for ObjectSchema<T> {
+impl<T> PropertyObjectSchema for PropertyValueObject<T> {
     type Value = T;
 
     fn properties(&self) -> &HashMap<BaseUrl, Self::Value> {
@@ -101,7 +101,7 @@ mod tests {
                     "https://example.com/property_type/": { "$ref": "https://example.com/property_type/v/1" },
                 }
             }),
-            Some(ObjectSchema {
+            Some(PropertyValueObject {
                 properties: HashMap::from([(url.base_url.clone(), PropertyTypeReference { url })]),
                 required: HashSet::new(),
             }),
@@ -123,7 +123,7 @@ mod tests {
                     "https://example.com/property_type_b/": { "$ref": "https://example.com/property_type_b/v/1" },
                 }
             }),
-            Some(ObjectSchema {
+            Some(PropertyValueObject {
                 properties: HashMap::from([
                     (url_a.base_url.clone(), PropertyTypeReference { url: url_a }),
                     (url_b.base_url.clone(), PropertyTypeReference { url: url_b }),
@@ -140,7 +140,7 @@ mod tests {
         let url_b = VersionedUrl::from_str("https://example.com/property_type_b/v/1")
             .expect("invalid Versioned URL");
 
-        let object_from_json = ensure_validation::<ObjectSchema<PropertyTypeReference>, _>(
+        let object_from_json = ensure_validation::<PropertyValueObject<PropertyTypeReference>, _>(
             json!({
                 "type": "object",
                 "properties": {
@@ -158,7 +158,7 @@ mod tests {
 
         assert_eq!(
             *object_from_json,
-            ObjectSchema {
+            PropertyValueObject {
                 properties: HashMap::from([
                     (
                         url_a.base_url.clone(),
@@ -173,7 +173,7 @@ mod tests {
 
     #[test]
     fn additional_properties() {
-        ensure_failed_deserialization::<ObjectSchema<PropertyTypeReference>>(
+        ensure_failed_deserialization::<PropertyValueObject<PropertyTypeReference>>(
             json!({
                 "type": "object",
                 "properties": {
@@ -192,7 +192,7 @@ mod tests {
         let url_c = BaseUrl::new("https://example.com/property_type_c/".to_owned())
             .expect("failed to create BaseURI");
         matches!(
-            ensure_failed_validation::<ObjectSchema<PropertyTypeReference>, _>(
+            ensure_failed_validation::<PropertyValueObject<PropertyTypeReference>, _>(
                 json!({
                     "type": "object",
                     "properties": {

--- a/libs/@blockprotocol/type-system/rust/src/schema/object/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/object/raw.rs
@@ -14,7 +14,7 @@ enum ObjectTypeTag {
 #[derive(Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub(super) struct ObjectSchema<T> {
+pub(super) struct PropertyValueObject<T> {
     #[serde(rename = "type")]
     _type: ObjectTypeTag,
     properties: HashMap<BaseUrl, T>,
@@ -23,8 +23,8 @@ pub(super) struct ObjectSchema<T> {
     required: HashSet<BaseUrl>,
 }
 
-impl<T> From<ObjectSchema<T>> for super::ObjectSchema<T> {
-    fn from(object: ObjectSchema<T>) -> Self {
+impl<T> From<PropertyValueObject<T>> for super::PropertyValueObject<T> {
+    fn from(object: PropertyValueObject<T>) -> Self {
         Self {
             properties: object.properties,
             required: object.required,
@@ -41,8 +41,8 @@ pub(super) struct ObjectSchemaRef<'a, T> {
     required: &'a HashSet<BaseUrl>,
 }
 
-impl<'a, T> From<&'a super::ObjectSchema<T>> for ObjectSchemaRef<'a, T> {
-    fn from(object: &'a super::ObjectSchema<T>) -> Self {
+impl<'a, T> From<&'a super::PropertyValueObject<T>> for ObjectSchemaRef<'a, T> {
+    fn from(object: &'a super::PropertyValueObject<T>) -> Self {
         Self {
             r#type: ObjectTypeTag::Object,
             properties: &object.properties,

--- a/libs/@blockprotocol/type-system/rust/src/schema/object/validation.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/object/validation.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use thiserror::Error;
 
 use crate::{
-    schema::{object::ObjectSchema, ClosedEntityType, EntityType},
+    schema::{object::PropertyValueObject, ClosedEntityType, EntityType},
     url::BaseUrl,
     Valid, Validator,
 };
@@ -35,13 +35,13 @@ impl<T> ObjectSchemaRef<'_, T> {
     }
 }
 
-impl<T: Sync> Validator<ObjectSchema<T>> for ObjectSchemaValidator {
+impl<T: Sync> Validator<PropertyValueObject<T>> for ObjectSchemaValidator {
     type Error = ObjectSchemaValidationError;
 
     async fn validate_ref<'v>(
         &self,
-        value: &'v ObjectSchema<T>,
-    ) -> Result<&'v Valid<ObjectSchema<T>>, Self::Error> {
+        value: &'v PropertyValueObject<T>,
+    ) -> Result<&'v Valid<PropertyValueObject<T>>, Self::Error> {
         ObjectSchemaRef {
             properties: &value.properties,
             required: &value.required,

--- a/libs/@blockprotocol/type-system/rust/src/schema/property_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/property_type/mod.rs
@@ -12,7 +12,9 @@ use std::collections::HashSet;
 use serde::{Deserialize, Serialize, Serializer};
 
 use crate::{
-    schema::{ArraySchema, DataTypeReference, ObjectSchema, OneOfSchema, ValueOrArray},
+    schema::{
+        DataTypeReference, OneOfSchema, PropertyValueArray, PropertyValueObject, ValueOrArray,
+    },
     url::VersionedUrl,
 };
 
@@ -61,8 +63,8 @@ impl Serialize for PropertyType {
 )]
 pub enum PropertyValues {
     DataTypeReference(DataTypeReference),
-    PropertyTypeObject(ObjectSchema<ValueOrArray<PropertyTypeReference>>),
-    ArrayOfPropertyValues(ArraySchema<OneOfSchema<PropertyValues>>),
+    PropertyTypeObject(PropertyValueObject<ValueOrArray<PropertyTypeReference>>),
+    ArrayOfPropertyValues(PropertyValueArray<OneOfSchema<PropertyValues>>),
 }
 
 impl PropertyValues {

--- a/libs/@blockprotocol/type-system/typescript/src/native/property-type.ts
+++ b/libs/@blockprotocol/type-system/typescript/src/native/property-type.ts
@@ -1,7 +1,7 @@
 import type {
-  ArraySchema,
   OneOfSchema,
   PropertyType,
+  PropertyValueArray,
   PropertyValues,
   VersionedUrl,
 } from "@blockprotocol/type-system-rs";
@@ -16,7 +16,7 @@ export const PROPERTY_TYPE_META_SCHEMA: PropertyType["$schema"] =
  */
 export const isPropertyValuesArray = (
   propertyValues: PropertyValues,
-): propertyValues is ArraySchema<OneOfSchema<PropertyValues>> =>
+): propertyValues is PropertyValueArray<OneOfSchema<PropertyValues>> =>
   "type" in propertyValues && propertyValues.type === "array";
 
 /**

--- a/libs/@hashintel/type-editor/src/entity-type-editor/property-list-card/get-property-type-schema.ts
+++ b/libs/@hashintel/type-editor/src/entity-type-editor/property-list-card/get-property-type-schema.ts
@@ -1,10 +1,10 @@
 import type {
-  ArraySchema,
   BaseUrl,
-  ObjectSchema,
   OneOfSchema,
   PropertyType,
   PropertyTypeReference,
+  PropertyValueArray,
+  PropertyValueObject,
   PropertyValues,
   ValueOrArray,
   VersionedUrl,
@@ -25,7 +25,7 @@ const getPrimitiveSchema = ($ref: VersionedUrl): PropertyTypeReference => ({
 
 const getObjectSchema = (
   properties: Property[],
-): ObjectSchema<ValueOrArray<PropertyTypeReference>> => {
+): PropertyValueObject<ValueOrArray<PropertyTypeReference>> => {
   const propertyList: Record<BaseUrl, ValueOrArray<PropertyTypeReference>> = {};
   const requiredArray: BaseUrl[] = [];
 
@@ -58,7 +58,7 @@ const getObjectSchema = (
 const getArraySchema = (
   flattenedExpectedValues: Record<string, CustomExpectedValue>,
   { minItems, maxItems, infinity, itemIds }: ArrayExpectedValue,
-): ArraySchema<OneOfSchema<PropertyValues>> => ({
+): PropertyValueArray<OneOfSchema<PropertyValues>> => ({
   type: "array",
   items: {
     oneOf: itemIds.map((itemId) =>

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/visitor.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/visitor.rs
@@ -4,8 +4,9 @@ use error_stack::{bail, Report, ResultExt};
 use serde_json::Value as JsonValue;
 use type_system::{
     schema::{
-        ArraySchema, DataTypeReference, JsonSchemaValueType, PropertyObjectSchema, PropertyType,
-        PropertyTypeReference, PropertyValueSchema, PropertyValues, ValueOrArray,
+        DataTypeReference, JsonSchemaValueType, PropertyObjectSchema, PropertyType,
+        PropertyTypeReference, PropertyValueArray, PropertyValueSchema, PropertyValues,
+        ValueOrArray,
     },
     url::{BaseUrl, VersionedUrl},
 };
@@ -121,7 +122,7 @@ pub trait EntityVisitor: Sized + Send + Sync {
     /// By default, this forwards to [`walk_array`].
     fn visit_array<T, P>(
         &mut self,
-        schema: &ArraySchema<T>,
+        schema: &PropertyValueArray<T>,
         array: &mut PropertyWithMetadataArray,
         type_provider: &P,
     ) -> impl Future<Output = Result<(), Report<TraversalError>>> + Send
@@ -293,7 +294,7 @@ where
 /// Any error that can be returned by the visitor methods.
 pub async fn walk_array<V, S, P>(
     visitor: &mut V,
-    schema: &ArraySchema<S>,
+    schema: &PropertyValueArray<S>,
     array: &mut PropertyWithMetadataArray,
     type_provider: &P,
 ) -> Result<(), Report<TraversalError>>
@@ -406,7 +407,7 @@ where
                     })?;
                     let result = visitor
                         .visit_array(
-                            &ArraySchema {
+                            &PropertyValueArray {
                                 items: property_type.borrow(),
                                 min_items: array_schema.min_items,
                                 max_items: array_schema.max_items,

--- a/libs/@local/hash-graph-types/typescript/src/ontology.ts
+++ b/libs/@local/hash-graph-types/typescript/src/ontology.ts
@@ -121,7 +121,7 @@ export type NumberConstraint = {
   exclusiveMinimum?: boolean;
   exclusiveMaximum?: boolean;
   multipleOf?: number;
-  type: "number" | "integer";
+  type: "number";
 };
 
 export type BooleanConstraint = {
@@ -143,7 +143,7 @@ export type StringEnumConstraint = {
 
 export type NumberEnumConstraint = {
   enum: [number, ...number[]];
-  type: "number" | "integer";
+  type: "number";
 };
 
 /** @see https://json-schema.org/understanding-json-schema/reference/enum */
@@ -156,7 +156,7 @@ export type StringConstConstraint = {
 
 export type NumberConstConstraint = {
   const: number;
-  type: "number" | "integer";
+  type: "number";
 };
 
 export type ConstConstraint = StringConstConstraint | NumberConstConstraint;
@@ -184,7 +184,7 @@ export type ArrayConstraint = {
 export type TupleConstraint = {
   type: "array";
   items: false; // disallow additional items;
-  prefixItems: ValueConstraint[];
+  prefixItems: [ValueConstraint, ...ValueConstraint[]];
 };
 
 export type ValueConstraint = (

--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -25,8 +25,8 @@ use serde_json::Value as JsonValue;
 use thiserror::Error;
 use type_system::{
     schema::{
-        ArraySchema, ClosedEntityType, DataTypeReference, JsonSchemaValueType,
-        PropertyObjectSchema, PropertyType, PropertyTypeReference, PropertyValueSchema,
+        ClosedEntityType, DataTypeReference, JsonSchemaValueType, PropertyObjectSchema,
+        PropertyType, PropertyTypeReference, PropertyValueArray, PropertyValueSchema,
         PropertyValues, ValueOrArray,
     },
     url::{BaseUrl, OntologyTypeVersion, VersionedUrl},
@@ -560,7 +560,7 @@ impl EntityVisitor for EntityPreprocessor {
 
     async fn visit_array<T, P>(
         &mut self,
-        schema: &ArraySchema<T>,
+        schema: &PropertyValueArray<T>,
         array: &mut PropertyWithMetadataArray,
         type_provider: &P,
     ) -> Result<(), Report<TraversalError>>

--- a/libs/@local/hash-validation/src/test_data_type.rs
+++ b/libs/@local/hash-validation/src/test_data_type.rs
@@ -45,7 +45,8 @@ async fn integer() {
         "kind": "dataType",
         "$id": "https://localhost:4000/@alice/types/data-type/integer/v/1",
         "title": "Integer",
-        "type": "integer"
+        "type": "number",
+        "multipleOf": 1,
     }))
     .expect("failed to serialize temperature unit type");
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The Node API exposes more constraints than the Graph. The graph needs to catch up and properly handle these constraints such as `items` and `prefixItems`. This is a preparation to allow `anyOf` for the `Value` data type, which does not have a `type` specified.

## 🔍 What does this change?

- Moves constraints out of `DataType` and make them dedicated schemas. 
- Remove the `integer` type (we have `multipleOf`)
- Carefully design the Rust-side of the type system to keep `deny_unknown_fields` on `DataType`
- Expose more constraints for `type = "array"`, including `prefixItems` and `items: boolean`
- Adjust the Node API for the changes

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph