### PR TITLE
GEN-196: Apply suggestions from #5181

### DIFF
--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -999,7 +999,7 @@ where
 
             if schema.schemas.is_empty() {
                 let error = Report::new(validation::EntityValidationError::EmptyEntityTypes);
-                status.add(error);
+                status.append(error);
             };
 
             let pre_process_result = EntityPreprocessor {
@@ -1013,7 +1013,7 @@ where
             .await
             .change_context(validation::EntityValidationError::InvalidProperties);
             if let Err(error) = pre_process_result {
-                status.add(error);
+                status.append(error);
             }
 
             if let Err(error) = params
@@ -1022,7 +1022,7 @@ where
                 .validate(&schema, params.components, &validator_provider)
                 .await
             {
-                status.add(error);
+                status.append(error);
             }
         }
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
@@ -112,7 +112,7 @@ impl ArraySchema {
             .zip(&self.prefix_items)
         {
             if let Err(error) = constraint.validate_value(value) {
-                item_status.add(error);
+                item_status.append(error);
             }
         }
 
@@ -145,14 +145,14 @@ impl ArraySchema {
             Some(ItemsConstraints::Value(items)) => {
                 for value in values {
                     if let Err(error) = items.validate_value(value) {
-                        item_status.add(error);
+                        item_status.append(error);
                     }
                 }
             }
         }
 
         if let Err(error) = item_status.finish() {
-            validation_status.add(error.change_context(ArrayValidationError::Items));
+            validation_status.append(error.change_context(ArrayValidationError::Items));
         }
 
         validation_status.finish()

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
@@ -240,7 +240,7 @@ impl StringSchema {
         }
         if let Some(expected) = self.format {
             if let Err(error) = expected.validate(string) {
-                status.add(error.change_context(ArrayValidationError::Format {
+                status.append(error.change_context(ArrayValidationError::Format {
                     actual: string.to_owned(),
                     expected,
                 }));

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/visitor.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/visitor.rs
@@ -226,11 +226,11 @@ where
                     .visit_value(parent.borrow(), value, metadata, type_provider)
                     .await
                 {
-                    status.add(error);
+                    status.append(error);
                 }
             }
             Err(error) => {
-                status.add(error);
+                status.append(error);
 
                 continue;
             }
@@ -305,7 +305,7 @@ where
                     .visit_one_of_property(schema.items.possibilities(), value, type_provider)
                     .await
                 {
-                    status.add(error);
+                    status.append(error);
                 }
             }
             PropertyWithMetadata::Array(array) => {
@@ -313,7 +313,7 @@ where
                     .visit_one_of_array(schema.items.possibilities(), array, type_provider)
                     .await
                 {
-                    status.add(error);
+                    status.append(error);
                 }
             }
             PropertyWithMetadata::Object(object) => {
@@ -321,7 +321,7 @@ where
                     .visit_one_of_object(schema.items.possibilities(), object, type_provider)
                     .await
                 {
-                    status.add(error);
+                    status.append(error);
                 }
             }
         }
@@ -409,7 +409,7 @@ where
                         )
                         .await;
                     if let Err(error) = result {
-                        status.add(error);
+                        status.append(error);
                     }
                 }
                 PropertyWithMetadata::Object { .. } | PropertyWithMetadata::Value(_) => {
@@ -468,7 +468,7 @@ where
                     )
                     .await
                 {
-                    status.add(error);
+                    status.append(error);
                 } else {
                     passed += 1;
                 }
@@ -532,7 +532,7 @@ where
                 if let Err(error) =
                     Box::pin(visitor.visit_array(array_schema, array, type_provider)).await
                 {
-                    status.add(error);
+                    status.append(error);
                 } else {
                     passed += 1;
                 }
@@ -597,7 +597,7 @@ where
                 if let Err(error) =
                     Box::pin(visitor.visit_object(object_schema, object, type_provider)).await
                 {
-                    status.add(error);
+                    status.append(error);
                 } else {
                     passed += 1;
                 }

--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -96,7 +96,7 @@ where
             }
 
             if let Err(error) = schema.validate_value(*link_data, components, context).await {
-                status.add(error);
+                status.append(error);
             }
         } else if is_link {
             status.capture(EntityValidationError::MissingLinkData);
@@ -134,7 +134,7 @@ where
             .validate(schema, components, context)
             .await
         {
-            status.add(error);
+            status.append(error);
         }
         if let Err(error) = self
             .metadata
@@ -142,7 +142,7 @@ where
             .validate(&self.properties, components, context)
             .await
         {
-            status.add(error);
+            status.append(error);
         }
 
         status.finish()
@@ -336,7 +336,7 @@ impl EntityVisitor for EntityPreprocessor {
             .visit_value(data_type, value, metadata, type_provider)
             .await
         {
-            status.add(error);
+            status.append(error);
         }
 
         walk_value(
@@ -483,7 +483,7 @@ impl EntityVisitor for EntityPreprocessor {
                                                 );
                                             }
                                         } else {
-                                            status.add(
+                                            status.append(
                                                 Report::new(TraversalError::InvalidType {
                                                     actual: JsonSchemaValueType::from(
                                                         &property.value,
@@ -506,7 +506,7 @@ impl EntityVisitor for EntityPreprocessor {
                                 }
                             }
                         } else {
-                            status.add(
+                            status.append(
                                 Report::new(TraversalError::InvalidType {
                                     actual: JsonSchemaValueType::from(&property.value),
                                     expected: JsonSchemaValueType::Number,
@@ -520,7 +520,7 @@ impl EntityVisitor for EntityPreprocessor {
                     }
                 }
                 Err(error) => {
-                    status.add(error);
+                    status.append(error);
                 }
             }
         } else {
@@ -529,7 +529,7 @@ impl EntityVisitor for EntityPreprocessor {
 
         if let Err(error) = walk_one_of_property_value(self, schema, property, type_provider).await
         {
-            status.add(error);
+            status.append(error);
         }
 
         status.finish()
@@ -547,7 +547,7 @@ impl EntityVisitor for EntityPreprocessor {
     {
         let mut status = ReportSink::new();
         if let Err(error) = walk_array(self, schema, array, type_provider).await {
-            status.add(error);
+            status.append(error);
         }
 
         if self.components.num_items {
@@ -585,7 +585,7 @@ impl EntityVisitor for EntityPreprocessor {
     {
         let mut status = ReportSink::new();
         if let Err(error) = walk_object(self, schema, object, type_provider).await {
-            status.add(error);
+            status.append(error);
         }
 
         if self.components.required_properties {

--- a/libs/deer/json/src/array.rs
+++ b/libs/deer/json/src/array.rs
@@ -60,7 +60,7 @@ impl<'de> deer::ArrayAccess<'de> for ArrayAccess<'_, '_, 'de> {
             // the statement after this _will_ fail and return the visitor, therefore we don't
             // need to check for EOF
             if let Err(error) = self.try_skip_comma() {
-                errors.add(error);
+                errors.append(error);
             }
         }
 

--- a/libs/deer/json/src/deserializer.rs
+++ b/libs/deer/json/src/deserializer.rs
@@ -377,7 +377,7 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
 
             if let Err(error) = self.try_skip(PeekableTokenKind::Colon, SyntaxError::ExpectedColon)
             {
-                errors.add(error);
+                errors.append(error);
             }
 
             let errors = errors.finish().change_context(DeserializerError);

--- a/libs/deer/json/src/object.rs
+++ b/libs/deer/json/src/object.rs
@@ -70,7 +70,7 @@ impl<'de> deer::ObjectAccess<'de> for ObjectAccess<'_, '_, 'de> {
             // the statement after this _will_ fail and return the visitor, therefore we don't
             // need to check for EOF
             if let Err(error) = self.try_skip_comma() {
-                errors.add(error);
+                errors.append(error);
             }
         }
 
@@ -91,12 +91,12 @@ impl<'de> deer::ObjectAccess<'de> for ObjectAccess<'_, '_, 'de> {
             let span = self.deserializer.skip(); // skip key
 
             if let Err(skip) = self.try_skip_colon() {
-                errors.add(skip);
+                errors.append(skip);
             }
 
             self.deserializer.skip(); // skip value
 
-            errors.add(
+            errors.append(
                 Report::new(SyntaxError::ObjectKeyMustBeString.into_error())
                     .attach(Span::new(span)),
             );
@@ -130,7 +130,7 @@ impl<'de> deer::ObjectAccess<'de> for ObjectAccess<'_, '_, 'de> {
         // key value are separated by `:`, if one forgets we will still error out but _try_ to
         // deserialize
         if let Err(skip) = self.try_skip_colon() {
-            errors.add(skip);
+            errors.append(skip);
         }
 
         // same as `(result, errors).into_result()`

--- a/libs/deer/src/impls/core/array.rs
+++ b/libs/deer/src/impls/core/array.rs
@@ -60,7 +60,7 @@ impl<'de, T: Deserialize<'de>, const N: usize> Visitor<'de> for ArrayVisitor<'de
                 Some(Err(error)) => {
                     let error = error.attach(Location::Array(index));
 
-                    result.add(error);
+                    result.append(error);
 
                     failed = true;
                 }
@@ -68,7 +68,7 @@ impl<'de, T: Deserialize<'de>, const N: usize> Visitor<'de> for ArrayVisitor<'de
         }
 
         if let Err(error) = array.end() {
-            result.add(error);
+            result.append(error);
         }
 
         if let Some(size_hint) = size_hint {
@@ -81,7 +81,7 @@ impl<'de, T: Deserialize<'de>, const N: usize> Visitor<'de> for ArrayVisitor<'de
                     .change_context(ArrayAccessError);
 
                 // we received less items, which means we can emit another error
-                result.add(error);
+                result.append(error);
             }
         }
 

--- a/libs/deer/src/impls/core/ops.rs
+++ b/libs/deer/src/impls/core/ops.rs
@@ -227,7 +227,7 @@ where
             end: &mut end,
         }) {
             if let Err(error) = field {
-                errors.add(error);
+                errors.append(error);
             }
         }
 

--- a/libs/deer/tests/test_bound.rs
+++ b/libs/deer/tests/test_bound.rs
@@ -74,7 +74,7 @@ impl<'de> Visitor<'de> for ArrayStatsVisitor {
                     }
                 }
                 Err(error) => {
-                    errors.add(error);
+                    errors.append(error);
                 }
             }
         }
@@ -292,7 +292,7 @@ impl<'de> Visitor<'de> for ObjectStatsVisitor {
                     }
                 }
                 Err(error) => {
-                    errors.add(error);
+                    errors.append(error);
                 }
             }
         }

--- a/libs/deer/tests/test_enum_visitor.rs
+++ b/libs/deer/tests/test_enum_visitor.rs
@@ -371,11 +371,11 @@ impl<'de> Visitor<'de> for StructEnumVisitor {
                             .attach(ExpectedLength::new(1))
                             .change_context(VisitorError);
 
-                        errors.add(error);
+                        errors.append(error);
                     }
                     Some(Ok(VariantField::Id(value))) => id = Some(value),
                     Some(Err(error)) => {
-                        errors.add(error.change_context(VisitorError));
+                        errors.append(error.change_context(VisitorError));
                     }
                 }
 
@@ -384,7 +384,7 @@ impl<'de> Visitor<'de> for StructEnumVisitor {
                         .attach(Location::Field("id"))
                         .attach(ExpectedType::new(u8::reflection()));
 
-                    errors.add(error.change_context(VisitorError));
+                    errors.append(error.change_context(VisitorError));
                 }
 
                 errors.finish().change_context(VisitorError)?;

--- a/libs/deer/tests/test_struct_visitor.rs
+++ b/libs/deer/tests/test_struct_visitor.rs
@@ -235,7 +235,7 @@ impl<'de> StructVisitor<'de> for ExampleVisitor {
             c: &mut c,
         }) {
             if let Err(error) = field {
-                errors.add(error);
+                errors.append(error);
             }
         }
 

--- a/libs/error-stack/src/lib.rs
+++ b/libs/error-stack/src/lib.rs
@@ -492,7 +492,7 @@
     allow(clippy::incompatible_msrv)
 )]
 #![cfg_attr(all(nightly, feature = "unstable"), feature(try_trait_v2))]
-#![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
+#![cfg_attr(all(doc, nightly), feature(doc_auto_cfg, doc_cfg))]
 #![cfg_attr(all(nightly, feature = "std"), feature(backtrace_frames))]
 #![cfg_attr(
     not(miri),

--- a/libs/error-stack/src/macros.rs
+++ b/libs/error-stack/src/macros.rs
@@ -273,7 +273,7 @@ macro_rules! bail {
 /// # type Resource = u32;
 /// # let create_user = 0;
 /// # let create_resource = 0;
-/// use error_stack::{bail, Context};
+/// use error_stack::bail;
 ///
 /// #[derive(Debug)]
 /// # #[allow(dead_code)]
@@ -297,6 +297,7 @@ macro_rules! bail {
 ///         PermissionDenied(user, create_resource)
 ///     ];
 /// }
+/// # Ok(())
 /// ```
 #[cfg(feature = "unstable")]
 #[cfg_attr(doc, doc(cfg(all())))]

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -414,80 +414,6 @@ impl<C> Report<C> {
         &self.frames[0]
     }
 
-    /// Adds additional information to the [`Frame`] stack.
-    ///
-    /// This behaves like [`attach_printable()`] but will not be shown when printing the [`Report`].
-    /// To benefit from seeing attachments in normal error outputs, use [`attach_printable()`]
-    ///
-    /// **Note:** [`attach_printable()`] will be deprecated when specialization is stabilized and
-    /// it becomes possible to merge these two methods.
-    ///
-    /// [`Display`]: core::fmt::Display
-    /// [`Debug`]: core::fmt::Debug
-    /// [`attach_printable()`]: Self::attach_printable
-    #[track_caller]
-    pub fn attach<A>(mut self, attachment: A) -> Self
-    where
-        A: Send + Sync + 'static,
-    {
-        let old_frames = mem::replace(self.frames.as_mut(), Vec::with_capacity(1));
-        self.frames.push(Frame::from_attachment(
-            attachment,
-            old_frames.into_boxed_slice(),
-        ));
-        self
-    }
-
-    /// Adds additional (printable) information to the [`Frame`] stack.
-    ///
-    /// This behaves like [`attach()`] but the display implementation will be called when
-    /// printing the [`Report`].
-    ///
-    /// **Note:** This will be deprecated in favor of [`attach()`] when specialization is
-    /// stabilized it becomes possible to merge these two methods.
-    ///
-    /// [`attach()`]: Self::attach
-    ///
-    /// ## Example
-    ///
-    /// ```rust
-    /// use core::fmt;
-    /// use std::fs;
-    ///
-    /// use error_stack::ResultExt;
-    ///
-    /// #[derive(Debug)]
-    /// pub struct Suggestion(&'static str);
-    ///
-    /// impl fmt::Display for Suggestion {
-    ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-    ///         fmt.write_str(self.0)
-    ///     }
-    /// }
-    ///
-    /// let error = fs::read_to_string("config.txt")
-    ///     .attach(Suggestion("better use a file which exists next time!"));
-    /// # #[cfg_attr(not(nightly), allow(unused_variables))]
-    /// let report = error.unwrap_err();
-    /// # #[cfg(nightly)]
-    /// let suggestion = report.request_ref::<Suggestion>().next().unwrap();
-    ///
-    /// # #[cfg(nightly)]
-    /// assert_eq!(suggestion.0, "better use a file which exists next time!");
-    /// ```
-    #[track_caller]
-    pub fn attach_printable<A>(mut self, attachment: A) -> Self
-    where
-        A: fmt::Display + fmt::Debug + Send + Sync + 'static,
-    {
-        let old_frames = mem::replace(self.frames.as_mut(), Vec::with_capacity(1));
-        self.frames.push(Frame::from_printable_attachment(
-            attachment,
-            old_frames.into_boxed_slice(),
-        ));
-        self
-    }
-
     /// Returns the current context of the `Report`.
     ///
     /// If the user want to get the latest context, `current_context` can be called. If the user
@@ -567,6 +493,80 @@ impl<C: ?Sized> Report<C> {
     #[must_use]
     pub(crate) fn current_frames_unchecked(&self) -> &[Frame] {
         &self.frames
+    }
+
+    /// Adds additional information to the [`Frame`] stack.
+    ///
+    /// This behaves like [`attach_printable()`] but will not be shown when printing the [`Report`].
+    /// To benefit from seeing attachments in normal error outputs, use [`attach_printable()`]
+    ///
+    /// **Note:** [`attach_printable()`] will be deprecated when specialization is stabilized and
+    /// it becomes possible to merge these two methods.
+    ///
+    /// [`Display`]: core::fmt::Display
+    /// [`Debug`]: core::fmt::Debug
+    /// [`attach_printable()`]: Self::attach_printable
+    #[track_caller]
+    pub fn attach<A>(mut self, attachment: A) -> Self
+    where
+        A: Send + Sync + 'static,
+    {
+        let old_frames = mem::replace(self.frames.as_mut(), Vec::with_capacity(1));
+        self.frames.push(Frame::from_attachment(
+            attachment,
+            old_frames.into_boxed_slice(),
+        ));
+        self
+    }
+
+    /// Adds additional (printable) information to the [`Frame`] stack.
+    ///
+    /// This behaves like [`attach()`] but the display implementation will be called when
+    /// printing the [`Report`].
+    ///
+    /// **Note:** This will be deprecated in favor of [`attach()`] when specialization is
+    /// stabilized it becomes possible to merge these two methods.
+    ///
+    /// [`attach()`]: Self::attach
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// use core::fmt;
+    /// use std::fs;
+    ///
+    /// use error_stack::ResultExt;
+    ///
+    /// #[derive(Debug)]
+    /// pub struct Suggestion(&'static str);
+    ///
+    /// impl fmt::Display for Suggestion {
+    ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+    ///         fmt.write_str(self.0)
+    ///     }
+    /// }
+    ///
+    /// let error = fs::read_to_string("config.txt")
+    ///     .attach(Suggestion("better use a file which exists next time!"));
+    /// # #[cfg_attr(not(nightly), allow(unused_variables))]
+    /// let report = error.unwrap_err();
+    /// # #[cfg(nightly)]
+    /// let suggestion = report.request_ref::<Suggestion>().next().unwrap();
+    ///
+    /// # #[cfg(nightly)]
+    /// assert_eq!(suggestion.0, "better use a file which exists next time!");
+    /// ```
+    #[track_caller]
+    pub fn attach_printable<A>(mut self, attachment: A) -> Self
+    where
+        A: fmt::Display + fmt::Debug + Send + Sync + 'static,
+    {
+        let old_frames = mem::replace(self.frames.as_mut(), Vec::with_capacity(1));
+        self.frames.push(Frame::from_printable_attachment(
+            attachment,
+            old_frames.into_boxed_slice(),
+        ));
+        self
     }
 
     /// Add a new [`Context`] object to the top of the [`Frame`] stack, changing the type of the
@@ -676,82 +676,6 @@ impl<C: ?Sized> Report<C> {
 }
 
 impl<C> Report<[C]> {
-    /// Adds additional information to the [`Frame`] stack.
-    ///
-    /// This behaves like [`attach_printable()`] but will not be shown when printing the [`Report`].
-    /// To benefit from seeing attachments in normal error outputs, use [`attach_printable()`]
-    ///
-    /// **Note:** [`attach_printable()`] will be deprecated when specialization is stabilized and
-    /// it becomes possible to merge these two methods.
-    ///
-    /// [`Display`]: core::fmt::Display
-    /// [`Debug`]: core::fmt::Debug
-    /// [`attach_printable()`]: Self::attach_printable
-    #[track_caller]
-    pub fn attach<A>(mut self, attachment: A) -> Self
-    where
-        A: Send + Sync + 'static,
-    {
-        let old_frames = mem::replace(self.frames.as_mut(), Vec::with_capacity(1));
-        self.frames.push(Frame::from_attachment(
-            attachment,
-            old_frames.into_boxed_slice(),
-        ));
-
-        self
-    }
-
-    /// Adds additional (printable) information to the [`Frame`] stack.
-    ///
-    /// This behaves like [`attach()`] but the display implementation will be called when
-    /// printing the [`Report`].
-    ///
-    /// **Note:** This will be deprecated in favor of [`attach()`] when specialization is
-    /// stabilized it becomes possible to merge these two methods.
-    ///
-    /// [`attach()`]: Self::attach
-    ///
-    /// ## Example
-    ///
-    /// ```rust
-    /// use core::fmt;
-    /// use std::fs;
-    ///
-    /// use error_stack::ResultExt;
-    ///
-    /// #[derive(Debug)]
-    /// pub struct Suggestion(&'static str);
-    ///
-    /// impl fmt::Display for Suggestion {
-    ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-    ///         fmt.write_str(self.0)
-    ///     }
-    /// }
-    ///
-    /// let error = fs::read_to_string("config.txt")
-    ///     .attach(Suggestion("better use a file which exists next time!"));
-    /// # #[cfg_attr(not(nightly), allow(unused_variables))]
-    /// let report = error.unwrap_err();
-    /// # #[cfg(nightly)]
-    /// let suggestion = report.request_ref::<Suggestion>().next().unwrap();
-    ///
-    /// # #[cfg(nightly)]
-    /// assert_eq!(suggestion.0, "better use a file which exists next time!");
-    /// ```
-    #[track_caller]
-    pub fn attach_printable<A>(mut self, attachment: A) -> Self
-    where
-        A: fmt::Display + fmt::Debug + Send + Sync + 'static,
-    {
-        let old_frames = mem::replace(self.frames.as_mut(), Vec::with_capacity(1));
-        self.frames.push(Frame::from_printable_attachment(
-            attachment,
-            old_frames.into_boxed_slice(),
-        ));
-
-        self
-    }
-
     /// Return the direct current frames of this report,
     /// to get an iterator over the topological sorting of all frames refer to [`frames()`]
     ///

--- a/libs/error-stack/src/sink.rs
+++ b/libs/error-stack/src/sink.rs
@@ -291,7 +291,7 @@ impl<C> ReportSink<C> {
     /// ```
     ///
     /// [`finish`]: ReportSink::finish
-    pub fn finish_with_default<T: Default>(mut self) -> Result<T, Report<[C]>> {
+    pub fn finish_default<T: Default>(mut self) -> Result<T, Report<[C]>> {
         self.bomb.defuse();
         self.report.map_or_else(|| Ok(T::default()), Err)
     }
@@ -600,9 +600,7 @@ mod test {
         sink.append(Report::new(TestError(0)));
         sink.append(Report::new(TestError(1)));
 
-        let report = sink
-            .finish_with_default::<u8>()
-            .expect_err("should have failed");
+        let report = sink.finish_default::<u8>().expect_err("should have failed");
 
         let contexts: BTreeSet<_> = report.current_contexts().collect();
         assert_eq!(contexts.len(), 2);
@@ -614,9 +612,7 @@ mod test {
     fn finish_with_default_ok() {
         let sink: ReportSink<TestError> = ReportSink::new();
 
-        let value = sink
-            .finish_with_default::<u8>()
-            .expect("should have succeeded");
+        let value = sink.finish_default::<u8>().expect("should have succeeded");
         assert_eq!(value, 0);
     }
 

--- a/libs/error-stack/src/sink.rs
+++ b/libs/error-stack/src/sink.rs
@@ -309,12 +309,12 @@ impl<C> ReportSink<C> {
     /// # // needed for type inference
     /// # sink.capture(io::Error::new(io::ErrorKind::Other, "I/O error"));
     /// // ... add errors ...
-    /// let result = sink.finish_with_value(42);
+    /// let result = sink.finish_ok(42);
     /// # let _result = result;
     /// ```
     ///
     /// [`finish`]: ReportSink::finish
-    pub fn finish_with_value<T>(mut self, ok: T) -> Result<T, Report<[C]>> {
+    pub fn finish_ok<T>(mut self, ok: T) -> Result<T, Report<[C]>> {
         self.bomb.defuse();
         self.report.map_or(Ok(ok), Err)
     }
@@ -627,7 +627,7 @@ mod test {
         sink.append(Report::new(TestError(0)));
         sink.append(Report::new(TestError(1)));
 
-        let report = sink.finish_with_value(8).expect_err("should have failed");
+        let report = sink.finish_ok(8).expect_err("should have failed");
 
         let contexts: BTreeSet<_> = report.current_contexts().collect();
         assert_eq!(contexts.len(), 2);
@@ -639,7 +639,7 @@ mod test {
     fn finish_with_value_ok() {
         let sink: ReportSink<TestError> = ReportSink::new();
 
-        let value = sink.finish_with_value(8).expect("should have succeeded");
+        let value = sink.finish_ok(8).expect("should have succeeded");
         assert_eq!(value, 8);
     }
 }

--- a/libs/error-stack/src/sink.rs
+++ b/libs/error-stack/src/sink.rs
@@ -11,18 +11,18 @@ use crate::Report;
 /// when methods like `&mut self` are called, marking the value as used prematurely.
 ///
 /// By moving this check to runtime, `Bomb` ensures that `ReportSink` is properly
-/// consumed. Depending on its configuration, it will either:
-/// - Panic if the `ReportSink` is dropped without being used (when set to `Panic` mode)
-/// - Emit a warning to stderr (when in `Warn` mode, which is the default)
-/// - Do nothing if properly defused (i.e., when `ReportSink` is correctly used)
+/// consumed.
 ///
 /// This runtime check complements the compile-time `#[must_use]` attribute,
 /// providing a more robust mechanism to prevent `ReportSink` not being consumed.
 #[derive(Debug, Default)]
 enum BombState {
+    /// Panic if the `ReportSink` is dropped without being used.
     Panic,
+    /// Emit a warning to stderr if the `ReportSink` is dropped without being used.
     #[default]
     Warn,
+    /// Do nothing if the `ReportSink` is properly consumed.
     Defused,
 }
 

--- a/libs/error-stack/src/sink.rs
+++ b/libs/error-stack/src/sink.rs
@@ -107,7 +107,7 @@ impl Drop for Bomb {
 ///     }
 ///
 ///     if let Err(e) = operation2() {
-///         sink.add(e);
+///         sink.append(e);
 ///     }
 ///
 ///     sink.finish()
@@ -286,7 +286,7 @@ impl<C> ReportSink<C> {
     /// # // needed for type inference
     /// # sink.capture(io::Error::new(io::ErrorKind::Other, "I/O error"));
     /// // ... add errors ...
-    /// let result: Result<Vec<String>, _> = sink.finish_with_default();
+    /// let result: Result<Vec<String>, _> = sink.finish_default();
     /// # let _result = result;
     /// ```
     ///
@@ -594,7 +594,7 @@ mod test {
     }
 
     #[test]
-    fn finish_with_default() {
+    fn finish_default() {
         let mut sink = ReportSink::new();
 
         sink.append(Report::new(TestError(0)));
@@ -609,7 +609,7 @@ mod test {
     }
 
     #[test]
-    fn finish_with_default_ok() {
+    fn finish_default_ok() {
         let sink: ReportSink<TestError> = ReportSink::new();
 
         let value = sink.finish_default::<u8>().expect("should have succeeded");

--- a/libs/error-stack/src/sink.rs
+++ b/libs/error-stack/src/sink.rs
@@ -165,7 +165,7 @@ impl<C> ReportSink<C> {
 
     /// Captures a single error or report in the sink.
     ///
-    /// This method is similar to [`add`], but allows for bare errors without prior [`Report`]
+    /// This method is similar to [`append`], but allows for bare errors without prior [`Report`]
     /// creation.
     ///
     /// # Examples
@@ -177,7 +177,7 @@ impl<C> ReportSink<C> {
     /// sink.capture(io::Error::new(io::ErrorKind::Other, "I/O error"));
     /// ```
     ///
-    /// [`add`]: ReportSink::add
+    /// [`append`]: ReportSink::append
     pub fn capture(&mut self, error: impl Into<Report<C>>) {
         let report = error.into();
 

--- a/libs/error-stack/src/sink.rs
+++ b/libs/error-stack/src/sink.rs
@@ -149,12 +149,12 @@ impl<C> ReportSink<C> {
     /// # use error_stack::{ReportSink, Report};
     /// # use std::io;
     /// let mut sink = ReportSink::new();
-    /// sink.add(Report::new(io::Error::new(
+    /// sink.append(Report::new(io::Error::new(
     ///     io::ErrorKind::Other,
     ///     "I/O error",
     /// )));
     /// ```
-    pub fn add(&mut self, report: impl Into<Report<[C]>>) {
+    pub fn append(&mut self, report: impl Into<Report<[C]>>) {
         let report = report.into();
 
         match self.report.as_mut() {
@@ -384,7 +384,7 @@ mod test {
     fn add_single() {
         let mut sink = ReportSink::new();
 
-        sink.add(Report::new(TestError(0)));
+        sink.append(Report::new(TestError(0)));
 
         let report = sink.finish().expect_err("should have failed");
 
@@ -397,8 +397,8 @@ mod test {
     fn add_multiple() {
         let mut sink = ReportSink::new();
 
-        sink.add(Report::new(TestError(0)));
-        sink.add(Report::new(TestError(1)));
+        sink.append(Report::new(TestError(0)));
+        sink.append(Report::new(TestError(1)));
 
         let report = sink.finish().expect_err("should have failed");
 
@@ -461,7 +461,7 @@ mod test {
         fn sink() -> Result<(), Report<[TestError]>> {
             let mut sink = ReportSink::new();
 
-            sink.add(Report::new(TestError(0)));
+            sink.append(Report::new(TestError(0)));
 
             sink?;
             Ok(())
@@ -480,8 +480,8 @@ mod test {
         fn sink() -> Result<(), Report<[TestError]>> {
             let mut sink = ReportSink::new();
 
-            sink.add(Report::new(TestError(0)));
-            sink.add(Report::new(TestError(1)));
+            sink.append(Report::new(TestError(0)));
+            sink.append(Report::new(TestError(1)));
 
             sink?;
             Ok(())
@@ -501,7 +501,7 @@ mod test {
         fn sink() -> Result<u8, Report<[TestError]>> {
             let mut sink = ReportSink::new();
 
-            sink.add(Report::new(TestError(0)));
+            sink.append(Report::new(TestError(0)));
 
             sink?;
             Ok(8)
@@ -521,7 +521,7 @@ mod test {
         fn sink() -> Result<(), Report<[TestError]>> {
             let mut sink = ReportSink::new_armed();
 
-            sink.add(Report::new(TestError(0)));
+            sink.append(Report::new(TestError(0)));
 
             Ok(())
         }
@@ -535,7 +535,7 @@ mod test {
         fn sink() -> Result<(), Report<[TestError]>> {
             let mut sink = ReportSink::new_armed();
 
-            sink.add(Report::new(TestError(0)));
+            sink.append(Report::new(TestError(0)));
 
             sink?;
             Ok(())
@@ -552,8 +552,8 @@ mod test {
     fn finish() {
         let mut sink = ReportSink::new();
 
-        sink.add(Report::new(TestError(0)));
-        sink.add(Report::new(TestError(1)));
+        sink.append(Report::new(TestError(0)));
+        sink.append(Report::new(TestError(1)));
 
         let report = sink.finish().expect_err("should have failed");
 
@@ -574,8 +574,8 @@ mod test {
     fn finish_with() {
         let mut sink = ReportSink::new();
 
-        sink.add(Report::new(TestError(0)));
-        sink.add(Report::new(TestError(1)));
+        sink.append(Report::new(TestError(0)));
+        sink.append(Report::new(TestError(1)));
 
         let report = sink.finish_with(|| 8).expect_err("should have failed");
 
@@ -597,8 +597,8 @@ mod test {
     fn finish_with_default() {
         let mut sink = ReportSink::new();
 
-        sink.add(Report::new(TestError(0)));
-        sink.add(Report::new(TestError(1)));
+        sink.append(Report::new(TestError(0)));
+        sink.append(Report::new(TestError(1)));
 
         let report = sink
             .finish_with_default::<u8>()
@@ -624,8 +624,8 @@ mod test {
     fn finish_with_value() {
         let mut sink = ReportSink::new();
 
-        sink.add(Report::new(TestError(0)));
-        sink.add(Report::new(TestError(1)));
+        sink.append(Report::new(TestError(0)));
+        sink.append(Report::new(TestError(1)));
 
         let report = sink.finish_with_value(8).expect_err("should have failed");
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Implements suggestions from #5181, this needed to be done in another PR, as I didn't want to redo the work done in #5200, which moves the workspace to the new `error-stack` version.

This is mostly just renames, moving around of methods and documentation improvements.

Open Question:
* Do we want to default to `Panic` for `ReportSink`?

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **Cargo**-publishable library and **I have amended the version**

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
