### PR TITLE
H-3348: Use `tsify-next` instead of `tsify`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2310,9 +2310,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gloo-utils"
-version = "0.1.7"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037fcb07216cb3a30f7292bd0176b050b7b9a052ba830ef7d5d65f6dc64ba58e"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
 dependencies = [
  "js-sys",
  "serde",
@@ -5997,9 +5997,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.28.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e578a843d40b4189a4d66bba51d7684f57da5bd7c304c64e14bd63efbef49509"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7259,23 +7259,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "tsify"
-version = "0.4.5"
+name = "tsify-next"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b26cf145f2f3b9ff84e182c448eaf05468e247f148cf3d2a7d67d78ff023a0"
+checksum = "2f4a645dca4ee0800f5ab60ce166deba2db6a0315de795a2691e138a3d55d756"
 dependencies = [
  "gloo-utils",
  "serde",
  "serde_json",
- "tsify-macros",
+ "tsify-next-macros",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "tsify-macros"
-version = "0.4.5"
+name = "tsify-next-macros"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a94b0f0954b3e59bfc2c246b4c8574390d94a4ad4ad246aaf2fb07d7dfd3b47"
+checksum = "0d5c06f8a51d759bb58129e30b2631739e7e1e4579fad1f30ac09a6c88e488a6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7315,7 +7315,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tsify",
+ "tsify-next",
  "url",
  "utoipa",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,7 +210,7 @@ tracing-error = { version = "=0.2.0", default-features = false }
 tracing-flame = { version = "=0.2.0", default-features = false }
 tracing-opentelemetry = { version = "=0.24.0", default-features = false }
 trybuild = { version = "=1.0.99", default-features = false }
-tsify = { version = "=0.4.5", default-features = false }
+tsify-next = { version = "=0.5.4", default-features = false }
 unicode-ident = { version = "=1.0.13", default-features = false }
 virtue = { version = "=0.0.17", default-features = false }
 walkdir = { version = "=2.5.0", default-features = false }

--- a/libs/@blockprotocol/type-system/rust/Cargo.toml
+++ b/libs/@blockprotocol/type-system/rust/Cargo.toml
@@ -36,7 +36,7 @@ futures = { workspace = true }
 regex = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["derive", "rc"] }
 thiserror = { workspace = true }
-tsify = { workspace = true, features = ["json"] }
+tsify-next = { workspace = true, features = ["json"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/libs/@blockprotocol/type-system/rust/src/schema/array/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/array/mod.rs
@@ -26,7 +26,7 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(untagged)]
 pub enum ValueOrArray<T> {
     Value(T),

--- a/libs/@blockprotocol/type-system/rust/src/schema/array/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/array/raw.rs
@@ -2,14 +2,14 @@ use serde::{Deserialize, Serialize};
 
 /// Will serialize as a constant value `"array"`
 #[derive(Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase")]
 enum ArrayTypeTag {
     Array,
 }
 
 #[derive(Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub(super) struct ArraySchema<T> {
     #[serde(rename = "type")]

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/closed.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/closed.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::{schema::DataType, url::VersionedUrl, Valid};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 pub struct ClosedDataType {
     #[serde(flatten)]
     pub schema: Arc<DataType>,

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
@@ -18,7 +18,7 @@ use crate::schema::{
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "kebab-case")]
 pub enum StringFormat {
     Uri,

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/conversion.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/conversion.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::openapi;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Conversions {
@@ -20,7 +20,7 @@ pub struct Conversions {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ConversionDefinition {
@@ -55,7 +55,7 @@ impl ToSql for ConversionDefinition {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub enum Variable {
     #[serde(rename = "self")]
@@ -106,7 +106,7 @@ impl utoipa::ToSchema<'_> for ConversionValue {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub enum Operator {
     #[serde(rename = "+")]
@@ -193,7 +193,7 @@ mod codec {
     use super::{ConversionExpression, ConversionValue, Operator, Variable};
 
     #[derive(Serialize, Deserialize)]
-    #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+    #[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
     #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
     #[serde(rename_all = "camelCase")]
     pub(super) enum NumberTypeTag {
@@ -201,7 +201,7 @@ mod codec {
     }
 
     #[derive(Serialize, Deserialize)]
-    #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+    #[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
     #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
     #[serde(untagged, rename = "ConversionValue")]
     pub(super) enum SerializableValue {
@@ -240,7 +240,7 @@ mod codec {
 
     #[derive(Serialize, Deserialize)]
     #[serde(rename = "ConversionExpression")]
-    #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+    #[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
     pub(super) struct SerializableExpression(Operator, ConversionValue, ConversionValue);
 
     impl From<SerializableExpression> for ConversionExpression {

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -32,7 +32,7 @@ use crate::{
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "kebab-case")]
 pub enum JsonSchemaValueType {
     Null,
@@ -59,7 +59,7 @@ impl fmt::Display for JsonSchemaValueType {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub struct DataTypeLabel {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -88,14 +88,14 @@ impl From<&JsonValue> for JsonSchemaValueType {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum DataTypeTag {
     DataType,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum DataTypeSchemaTag {
     #[serde(rename = "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type")]
@@ -111,7 +111,7 @@ const fn is_false(value: &bool) -> bool {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename = "DataType", rename_all = "camelCase", deny_unknown_fields)]
 pub struct DataType {
     #[serde(rename = "$schema")]

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/reference.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/reference.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::url::VersionedUrl;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(deny_unknown_fields)]
 #[repr(transparent)]
 pub struct DataTypeReference {

--- a/libs/@blockprotocol/type-system/rust/src/schema/entity_type/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/entity_type/raw.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 #[cfg(target_arch = "wasm32")]
-use tsify::Tsify;
+use tsify_next::Tsify;
 
 use crate::{
     schema::{ArraySchema, EntityTypeReference, OneOfSchema, PropertyTypeReference, ValueOrArray},

--- a/libs/@blockprotocol/type-system/rust/src/schema/entity_type/reference.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/entity_type/reference.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::url::VersionedUrl;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(deny_unknown_fields)]
 #[repr(transparent)]
 pub struct EntityTypeReference {

--- a/libs/@blockprotocol/type-system/rust/src/schema/object/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/object/raw.rs
@@ -5,14 +5,14 @@ use serde::{Deserialize, Serialize};
 use crate::url::BaseUrl;
 
 #[derive(Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase")]
 enum ObjectTypeTag {
     Object,
 }
 
 #[derive(Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub(super) struct ObjectSchema<T> {
     #[serde(rename = "type")]

--- a/libs/@blockprotocol/type-system/rust/src/schema/one_of/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/one_of/mod.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 pub use self::validation::{OneOfSchemaValidationError, OneOfSchemaValidator};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct OneOfSchema<T> {
     #[serde(rename = "oneOf")]

--- a/libs/@blockprotocol/type-system/rust/src/schema/property_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/property_type/mod.rs
@@ -53,7 +53,7 @@ impl Serialize for PropertyType {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(
     untagged,
     expecting = "Expected a data type reference, a property type object, or an array of property \

--- a/libs/@blockprotocol/type-system/rust/src/schema/property_type/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/property_type/raw.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::{schema::PropertyValues, url::VersionedUrl};
 
 #[derive(Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase")]
 enum PropertyTypeSchemaTag {
     #[serde(rename = "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type")]
@@ -13,14 +13,14 @@ enum PropertyTypeSchemaTag {
 }
 
 #[derive(Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase")]
 enum PropertyTypeTag {
     PropertyType,
 }
 
 #[derive(Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropertyType<'a> {
     #[serde(rename = "$schema")]

--- a/libs/@blockprotocol/type-system/rust/src/schema/property_type/reference.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/property_type/reference.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::url::VersionedUrl;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(deny_unknown_fields)]
 #[repr(transparent)]
 pub struct PropertyTypeReference {

--- a/libs/@blockprotocol/type-system/rust/src/url/error.rs
+++ b/libs/@blockprotocol/type-system/rust/src/url/error.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 #[cfg(target_arch = "wasm32")]
-use tsify::Tsify;
+use tsify_next::Tsify;
 
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Error)]

--- a/libs/@blockprotocol/type-system/rust/src/url/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/url/mod.rs
@@ -16,7 +16,7 @@ mod error;
 // #[cfg(target_arch = "wasm32")]
 // mod wasm;
 
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "postgres", derive(ToSql), postgres(transparent))]
 #[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub struct BaseUrl(String);
@@ -176,7 +176,7 @@ pub struct VersionedUrl {
 }
 
 #[cfg(target_arch = "wasm32")]
-#[derive(tsify::Tsify)]
+#[derive(tsify_next::Tsify)]
 #[serde(rename = "VersionedUrl")]
 #[expect(dead_code, reason = "Used in the generated TypeScript types")]
 pub struct VersionedUrlPatch(#[tsify(type = "`${BaseUrl}v/${number}`")] String);

--- a/libs/@blockprotocol/type-system/rust/src/url/wasm.rs
+++ b/libs/@blockprotocol/type-system/rust/src/url/wasm.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use tsify::Tsify;
+use tsify_next::Tsify;
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 
 use crate::url::{BaseUrl, VersionedUrl};

--- a/libs/@blockprotocol/type-system/rust/src/utils.rs
+++ b/libs/@blockprotocol/type-system/rust/src/utils.rs
@@ -1,7 +1,7 @@
 #[cfg(target_arch = "wasm32")]
 mod wasm {
     use serde::{Deserialize, Serialize};
-    use tsify::Tsify;
+    use tsify_next::Tsify;
 
     #[cfg(debug_assertions)]
     pub fn set_panic_hook() {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We encountered issues with `Tsify`. As that crate is unmaintained, we use a fork that aims to fix issues.