### PR TITLE
H-3357: Fix loading speed + state for createdBy/updatedBy columns on entities table

### DIFF
--- a/apps/hash-frontend/src/pages/shared/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table.tsx
@@ -342,6 +342,16 @@ export const EntitiesTable: FunctionComponent<{
             const actor =
               columnId === "lastEditedBy" ? row.lastEditedBy : row.createdBy;
 
+            if (actor === "loading") {
+              return {
+                kind: GridCellKind.Text,
+                readonly: true,
+                allowOverlay: false,
+                displayData: "Loading...",
+                data: "Loading...",
+              };
+            }
+
             const actorName = actor ? actor.displayName : undefined;
 
             const actorIcon = actor
@@ -481,10 +491,10 @@ export const EntitiesTable: FunctionComponent<{
     const lastEditedBySet = new Set<MinimalActor>();
     const createdBySet = new Set<MinimalActor>();
     for (const row of rows ?? []) {
-      if (row.lastEditedBy) {
+      if (row.lastEditedBy && row.lastEditedBy !== "loading") {
         lastEditedBySet.add(row.lastEditedBy);
       }
-      if (row.createdBy) {
+      if (row.createdBy && row.createdBy !== "loading") {
         createdBySet.add(row.createdBy);
       }
     }
@@ -566,7 +576,7 @@ export const EntitiesTable: FunctionComponent<{
         selectedFilterItemIds: selectedLastEditedByAccountIds,
         setSelectedFilterItemIds: setSelectedLastEditedByAccountIds,
         isRowFiltered: (row) =>
-          row.lastEditedBy
+          row.lastEditedBy && row.lastEditedBy !== "loading"
             ? !selectedLastEditedByAccountIds.includes(
                 row.lastEditedBy.accountId,
               )
@@ -581,7 +591,7 @@ export const EntitiesTable: FunctionComponent<{
         selectedFilterItemIds: selectedCreatedByAccountIds,
         setSelectedFilterItemIds: setSelectedCreatedByAccountIds,
         isRowFiltered: (row) =>
-          row.createdBy
+          row.createdBy && row.createdBy !== "loading"
             ? !selectedCreatedByAccountIds.includes(row.createdBy.accountId)
             : false,
       },

--- a/apps/hash-frontend/src/pages/shared/entities-table/use-entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table/use-entities-table.tsx
@@ -31,9 +31,9 @@ export interface TypeEntitiesRow {
   entityTypeVersion: string;
   archived?: boolean;
   lastEdited: string;
-  lastEditedBy?: MinimalActor;
+  lastEditedBy?: MinimalActor | "loading";
   created: string;
-  createdBy?: MinimalActor;
+  createdBy?: MinimalActor | "loading";
   web: string;
   properties?: {
     [k: string]: string;
@@ -73,7 +73,9 @@ export const useEntitiesTable = (params: {
     [entities],
   );
 
-  const { actors } = useActors({ accountIds: editorActorIds });
+  const { actors, loading: actorsLoading } = useActors({
+    accountIds: editorActorIds,
+  });
 
   const getOwnerForEntity = useGetOwnerForEntity();
 
@@ -203,20 +205,25 @@ export const useEntitiesTable = (params: {
               "yyyy-MM-dd HH:mm",
             );
 
-            const lastEditedBy = actors?.find(
-              ({ accountId }) =>
-                accountId === entity.metadata.provenance.edition.createdById,
-            );
+            const lastEditedBy = actorsLoading
+              ? "loading"
+              : actors?.find(
+                  ({ accountId }) =>
+                    accountId ===
+                    entity.metadata.provenance.edition.createdById,
+                );
 
             const created = format(
               new Date(entity.metadata.provenance.createdAtDecisionTime),
               "yyyy-MM-dd HH:mm",
             );
 
-            const createdBy = actors?.find(
-              ({ accountId }) =>
-                accountId === entity.metadata.provenance.createdById,
-            );
+            const createdBy = actorsLoading
+              ? "loading"
+              : actors?.find(
+                  ({ accountId }) =>
+                    accountId === entity.metadata.provenance.createdById,
+                );
 
             return {
               rowId: entityId,
@@ -256,6 +263,8 @@ export const useEntitiesTable = (params: {
 
     return { columns, rows };
   }, [
+    actors,
+    actorsLoading,
     entities,
     entityTypes,
     getOwnerForEntity,
@@ -266,6 +275,5 @@ export const useEntitiesTable = (params: {
     hidePageArchivedColumn,
     hidePropertiesColumns,
     isViewingPages,
-    actors,
   ]);
 };

--- a/apps/hash-frontend/src/shared/use-actors.ts
+++ b/apps/hash-frontend/src/shared/use-actors.ts
@@ -51,20 +51,22 @@ export const useActors = (params: {
       includePermissions: false,
       request: {
         filter: {
-          any: (params.accountIds ?? []).map((accountId) => ({
-            all: [
-              {
-                equal: [
-                  { path: ["editionProvenance", "createdById"] },
-                  { parameter: accountId },
-                ],
-              },
-              generateVersionedUrlMatchingFilter(
-                systemEntityTypes.machine.entityTypeId,
-                { ignoreParents: true },
-              ),
-            ],
-          })),
+          any: (params.accountIds ? [...new Set(params.accountIds)] : []).map(
+            (accountId) => ({
+              all: [
+                {
+                  equal: [
+                    { path: ["editionProvenance", "createdById"] },
+                    { parameter: accountId },
+                  ],
+                },
+                generateVersionedUrlMatchingFilter(
+                  systemEntityTypes.machine.entityTypeId,
+                  { ignoreParents: true },
+                ),
+              ],
+            }),
+          ),
         },
         graphResolveDepths: zeroedGraphResolveDepths,
         temporalAxes: currentTimeInstantTemporalAxes,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When loading a large number of entities in the entities table, the `createdBy`/`updatedBy` columns could take several seconds to load in afterwards. They load later than the entities table because we currently have to fetch the users (and bots) separately once we can get their ids from the entity data.

This PR makes that subsequent 'fetch the users/bots' quicker by deduplicating the ids requested. It also adds a loading state for the cell while the data is populating (at the moment just the text 'Loading...').

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- That the entities table renders at all is covered by a test.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Visit `/entities` on the preview deployment

