### PR TITLE
H-3356: Add abstract flag for data types

### DIFF
--- a/apps/hash-graph/libs/graph/src/store/validation.rs
+++ b/apps/hash-graph/libs/graph/src/store/validation.rs
@@ -160,6 +160,8 @@ where
     C: AsClient,
     A: AuthorizationApi,
 {
+    type Value = Arc<DataTypeWithMetadata>;
+
     #[expect(refining_impl_trait)]
     async fn provide_type(
         &self,
@@ -345,6 +347,8 @@ where
     C: AsClient,
     A: AuthorizationApi,
 {
+    type Value = Arc<PropertyType>;
+
     #[expect(refining_impl_trait)]
     async fn provide_type(
         &self,
@@ -464,6 +468,8 @@ where
     C: AsClient,
     A: AuthorizationApi,
 {
+    type Value = Arc<ClosedEntityType>;
+
     #[expect(refining_impl_trait)]
     async fn provide_type(
         &self,

--- a/apps/hash-graph/libs/store/src/filter/mod.rs
+++ b/apps/hash-graph/libs/store/src/filter/mod.rs
@@ -519,6 +519,8 @@ mod tests {
 
     #[expect(refining_impl_trait)]
     impl OntologyTypeProvider<DataTypeWithMetadata> for TestDataTypeProvider {
+        type Value = DataTypeWithMetadata;
+
         async fn provide_type(&self, _: &VersionedUrl) -> Result<DataTypeWithMetadata, Report<!>> {
             unimplemented!()
         }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -131,8 +131,8 @@ mod raw {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         all_of: Vec<DataTypeReference>,
 
-        #[serde(default, rename = "abstract")]
-        is_abstract: bool,
+        #[serde(default)]
+        r#abstract: bool,
     }
 
     #[derive(Deserialize)]
@@ -194,7 +194,7 @@ mod raw {
                 id: common.id,
                 title: common.title,
                 all_of: common.all_of,
-                is_abstract: common.is_abstract,
+                r#abstract: common.r#abstract,
                 constraints,
             }
         }
@@ -213,8 +213,7 @@ pub struct DataType {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub all_of: Vec<DataTypeReference>,
 
-    #[serde(default, rename = "abstract")]
-    pub is_abstract: bool,
+    pub r#abstract: bool,
     #[serde(flatten)]
     pub constraints: ValueConstraints,
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -130,6 +130,9 @@ mod raw {
         )]
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         all_of: Vec<DataTypeReference>,
+
+        #[serde(default, rename = "abstract")]
+        is_abstract: bool,
     }
 
     #[derive(Deserialize)]
@@ -191,6 +194,7 @@ mod raw {
                 id: common.id,
                 title: common.title,
                 all_of: common.all_of,
+                is_abstract: common.is_abstract,
                 constraints,
             }
         }
@@ -209,6 +213,8 @@ pub struct DataType {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub all_of: Vec<DataTypeReference>,
 
+    #[serde(default, rename = "abstract")]
+    pub is_abstract: bool,
     #[serde(flatten)]
     pub constraints: ValueConstraints,
 }

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/visitor.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/visitor.rs
@@ -60,6 +60,8 @@ pub enum TraversalError {
         actual: VersionedUrl,
         expected: VersionedUrl,
     },
+    #[error("Values cannot be assigned to an abstract data type. `{id}` is abstract.")]
+    AbstractDataType { id: VersionedUrl },
     #[error("the value provided does not match the constraints of the data type")]
     ConstraintUnfulfilled,
     #[error("the property `{key}` was required, but not specified")]

--- a/libs/@local/hash-graph-types/rust/src/lib.rs
+++ b/libs/@local/hash-graph-types/rust/src/lib.rs
@@ -2,7 +2,6 @@
 #![feature(hash_raw_entry)]
 
 extern crate alloc;
-extern crate core;
 
 pub mod knowledge;
 pub mod ontology;

--- a/libs/@local/hash-graph-types/rust/src/ontology/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/ontology/mod.rs
@@ -169,10 +169,12 @@ pub struct OntologyTypeWithMetadata<S: OntologyType> {
 }
 
 pub trait OntologyTypeProvider<O> {
+    type Value: Borrow<O> + Send;
+
     fn provide_type(
         &self,
         type_id: &VersionedUrl,
-    ) -> impl Future<Output = Result<impl Borrow<O> + Send, Report<impl Context>>> + Send;
+    ) -> impl Future<Output = Result<Self::Value, Report<impl Context>>> + Send;
 }
 
 pub trait DataTypeProvider: OntologyTypeProvider<DataTypeWithMetadata> {

--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -283,7 +283,7 @@ impl EntityVisitor for ValueValidator {
         );
 
         if metadata.data_type_id.as_ref() == Some(&data_type.schema.id)
-            && data_type.schema.is_abstract
+            && data_type.schema.r#abstract
         {
             status.capture(TraversalError::AbstractDataType {
                 id: data_type.schema.id.clone(),

--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -325,20 +325,20 @@ impl EntityVisitor for EntityPreprocessor {
                     });
                 }
 
-                if let Err(error) = type_provider
+                let desired_data_type = type_provider
                     .provide_type(data_type_url)
                     .await
                     .change_context_lazy(|| TraversalError::DataTypeRetrieval {
                         id: DataTypeReference {
                             url: data_type.schema.id.clone(),
                         },
-                    })?
-                    .borrow()
-                    .schema
-                    .validate_constraints(value)
-                    .change_context(TraversalError::ConstraintUnfulfilled)
+                    })?;
+
+                if let Err(error) = ValueValidator
+                    .visit_value(desired_data_type.borrow(), value, metadata, type_provider)
+                    .await
                 {
-                    status.capture(error);
+                    status.append(error);
                 }
             }
         } else {

--- a/tests/hash-graph-http/tests/ambiguous.http
+++ b/tests/hash-graph-http/tests/ambiguous.http
@@ -49,7 +49,8 @@ X-Authenticated-User-Actor-Id: {{account_id}}
         "title": "Length",
         "type": "number",
         "description": "A unit of length",
-        "minimum": 0
+        "minimum": 0,
+        "abstract": true
       },
       {
         "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",

--- a/tests/hash-graph-test-data/rust/src/data_type/boolean.json
+++ b/tests/hash-graph-test-data/rust/src/data_type/boolean.json
@@ -4,5 +4,6 @@
   "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/boolean/v/1",
   "title": "Boolean",
   "description": "A True or False value",
-  "type": "boolean"
+  "type": "boolean",
+  "abstract": false
 }

--- a/tests/hash-graph-test-data/rust/src/data_type/centimeter_v1.json
+++ b/tests/hash-graph-test-data/rust/src/data_type/centimeter_v1.json
@@ -9,5 +9,6 @@
     {
       "$ref": "https://hash.ai/@hash/types/data-type/length/v/1"
     }
-  ]
+  ],
+  "abstract": false
 }

--- a/tests/hash-graph-test-data/rust/src/data_type/centimeter_v2.json
+++ b/tests/hash-graph-test-data/rust/src/data_type/centimeter_v2.json
@@ -9,5 +9,6 @@
     {
       "$ref": "https://hash.ai/@hash/types/data-type/length/v/1"
     }
-  ]
+  ],
+  "abstract": false
 }

--- a/tests/hash-graph-test-data/rust/src/data_type/empty_list.json
+++ b/tests/hash-graph-test-data/rust/src/data_type/empty_list.json
@@ -5,5 +5,6 @@
   "title": "Empty List",
   "description": "An Empty List",
   "type": "array",
-  "const": []
+  "const": [],
+  "abstract": false
 }

--- a/tests/hash-graph-test-data/rust/src/data_type/length.json
+++ b/tests/hash-graph-test-data/rust/src/data_type/length.json
@@ -9,5 +9,6 @@
     {
       "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1"
     }
-  ]
+  ],
+  "abstract": true
 }

--- a/tests/hash-graph-test-data/rust/src/data_type/meter.json
+++ b/tests/hash-graph-test-data/rust/src/data_type/meter.json
@@ -9,5 +9,6 @@
     {
       "$ref": "https://hash.ai/@hash/types/data-type/length/v/1"
     }
-  ]
+  ],
+  "abstract": false
 }

--- a/tests/hash-graph-test-data/rust/src/data_type/null.json
+++ b/tests/hash-graph-test-data/rust/src/data_type/null.json
@@ -4,5 +4,6 @@
   "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/null/v/1",
   "title": "Null",
   "description": "A placeholder value representing 'nothing'",
-  "type": "null"
+  "type": "null",
+  "abstract": false
 }

--- a/tests/hash-graph-test-data/rust/src/data_type/number.json
+++ b/tests/hash-graph-test-data/rust/src/data_type/number.json
@@ -4,5 +4,6 @@
   "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1",
   "title": "Number",
   "description": "An arithmetical value (in the Real number system)",
-  "type": "number"
+  "type": "number",
+  "abstract": false
 }

--- a/tests/hash-graph-test-data/rust/src/data_type/object_v1.json
+++ b/tests/hash-graph-test-data/rust/src/data_type/object_v1.json
@@ -4,5 +4,6 @@
   "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1",
   "title": "Object",
   "description": "A plain JSON object with no pre-defined structure",
-  "type": "object"
+  "type": "object",
+  "abstract": false
 }

--- a/tests/hash-graph-test-data/rust/src/data_type/object_v2.json
+++ b/tests/hash-graph-test-data/rust/src/data_type/object_v2.json
@@ -4,5 +4,6 @@
   "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/2",
   "title": "Object",
   "description": "An updated plain JSON object with no pre-defined structure",
-  "type": "object"
+  "type": "object",
+  "abstract": false
 }

--- a/tests/hash-graph-test-data/rust/src/data_type/text.json
+++ b/tests/hash-graph-test-data/rust/src/data_type/text.json
@@ -4,5 +4,6 @@
   "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
   "title": "Text",
   "description": "An ordered sequence of characters",
-  "type": "string"
+  "type": "string",
+  "abstract": false
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Some data types (such as `length`) should not be instantiated directly. For these, the `abstract` flag is useful.