### PR TITLE
GEN-197: Group Sigma npm packages in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -121,10 +121,16 @@
       "dependencyDashboardApproval": false
     },
     {
+      "groupName": "sigma npm packages",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["/^@sigma/", "/sigma$/"]
+    },
+    {
       "groupName": "signia npm packages",
       "matchManagers": ["npm"],
       "matchPackageNames": ["/^signia/", "/signia$/"]
     },
+    
     {
       "groupName": "Block Protocol npm packages",
       "matchManagers": ["npm"],


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Groups Sigma npm package updates together via Renovate.