### PR TITLE
GEN-198: Add Dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,8 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
+    directories:
+      - "**/*"
+    schedule:
+      interval: "daily"
     labels: []

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    labels: [ ]
+    labels: []

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,4 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    labels: [ ]


### PR DESCRIPTION
We still use Dependabot for certain kinds of security-related package updates. We want to stop Dependabot adding labels we don't use (e.g. `javascript` and `dependencies`) when it opens these PRs.

Our existing labeler configuration (`labeler.yml`) will correctly pick up the labels we use that should be added to PRs opened by Dependabot (e.g. `area/deps`)

See [`labels` in the Dependabot docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#labels).
