### PR TITLE
H-2958: Support `anyOf` in type system

### DIFF
--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell.tsx
@@ -27,7 +27,14 @@ const guessDataTypeFromValue = (
 ) => {
   const editorType = guessEditorTypeFromValue(value, expectedTypes);
 
-  const expectedType = expectedTypes.find((type) => type.type === editorType);
+  const expectedType = expectedTypes.find((type) =>
+    "type" in type
+      ? type.type === editorType
+      : /**
+         * @todo H-3374 support anyOf in expected types. also don't need to guess the value any more, use dataTypeId from property metadata
+         */
+        type.anyOf.some((subType) => subType.type === editorType),
+  );
   if (!expectedType) {
     throw new Error(
       `Could not find guessed editor type ${editorType} among expected types ${expectedTypes
@@ -55,7 +62,14 @@ export const renderValueCell: CustomRenderer<ValueCell> = {
     const left = rect.x + getCellHorizontalPadding();
 
     const editorType = guessEditorTypeFromValue(value, expectedTypes);
-    const relevantType = expectedTypes.find((type) => type.type === editorType);
+    const relevantType = expectedTypes.find((type) =>
+      "type" in type
+        ? type.type === editorType
+        : /**
+           * @todo H-3374 support anyOf in expected types. also don't need to guess the value any more, use dataTypeId from property metadata
+           */
+          type.anyOf.some((subType) => subType.type === editorType),
+    );
 
     const editorSpec = getEditorSpecs(editorType, relevantType);
 

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/array-editor/sortable-row.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/array-editor/sortable-row.tsx
@@ -65,7 +65,15 @@ export const SortableRow = ({
 
   const editorType =
     overriddenEditorType ?? guessEditorTypeFromValue(value, expectedTypes);
-  const expectedType = expectedTypes.find((type) => type.type === editorType);
+
+  const expectedType = expectedTypes.find((type) =>
+    "type" in type
+      ? type.type === editorType
+      : /**
+         * @todo H-3374 support multiple expected data types
+         */
+        type.anyOf.some((subType) => subType.type === editorType),
+  );
 
   const editorSpec = getEditorSpecs(editorType, expectedType);
 

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/single-value-editor.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/single-value-editor.tsx
@@ -144,7 +144,15 @@ export const SingleValueEditor: ValueCellEditorComponent = (props) => {
     );
   }
 
-  const expectedType = expectedTypes.find((type) => type.type === editorType);
+  const expectedType = expectedTypes.find((type) =>
+    "type" in type
+      ? type.type === editorType
+      : /**
+         * @todo H-3374 support anyOf in expected types. also don't need to guess the value any more, use dataTypeId from property metadata
+         */
+        type.anyOf.some((subType) => subType.type === editorType),
+  );
+
   if (!expectedType) {
     throw new Error(
       `Could not find guessed editor type ${editorType} among expected types ${expectedTypes

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/use-create-get-cell-content.ts
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/use-create-get-cell-content.ts
@@ -124,8 +124,13 @@ export const useCreateGetCellContent = (
             }
 
             if (shouldShowChangeTypeCell) {
-              const currentType = row.expectedTypes.find(
-                (opt) => opt.type === guessedType,
+              const currentType = row.expectedTypes.find((opt) =>
+                "type" in opt
+                  ? opt.type === guessedType
+                  : /**
+                     * @todo H-3374 support anyOf in expected types. also don't need to guess the value any more, use dataTypeId from property metadata
+                     */
+                    opt.anyOf.some((subType) => subType.type === guessedType),
               );
               if (!currentType) {
                 throw new Error(

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/boolean.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/boolean.rs
@@ -1,8 +1,22 @@
+use error_stack::{Report, bail};
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+use crate::schema::{ConstraintError, JsonSchemaValueType};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum BooleanTypeTag {
     Boolean,
+}
+
+pub(crate) fn validate_boolean_value(value: &JsonValue) -> Result<(), Report<ConstraintError>> {
+    if value.is_boolean() {
+        Ok(())
+    } else {
+        bail!(ConstraintError::InvalidType {
+            actual: JsonSchemaValueType::from(value),
+            expected: JsonSchemaValueType::Boolean,
+        })
+    }
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
@@ -64,7 +64,6 @@ mod wasm {
 #[serde(untagged, rename_all = "camelCase")]
 pub enum SimpleValueSchema {
     Typed(SimpleTypedValueSchema),
-    #[serde(skip)]
     AnyOf(AnyOfSchema),
 }
 
@@ -169,7 +168,6 @@ impl SimpleTypedValueConstraint {
 #[serde(untagged, rename_all = "camelCase")]
 pub enum ValueConstraints {
     Typed(TypedValueConstraints),
-    #[serde(skip)]
     AnyOf(AnyOfConstraints),
 }
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
@@ -47,7 +47,7 @@ impl ValueConstraints {
     /// # Errors
     ///
     /// - For [`Typed`] schemas, see [`SingleValueConstraints::validate_value`].
-    /// - For [`AnyOf`] schemas, see [`SimpleTypedValueConstraint::validate_value`].
+    /// - For [`AnyOf`] schemas, see [`AnyOfConstraints::validate_value`].
     ///
     /// [`Typed`]: Self::Typed
     /// [`AnyOf`]: Self::AnyOf

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
@@ -7,12 +7,12 @@ mod number;
 mod object;
 mod string;
 
-use error_stack::{Report, bail};
+use error_stack::Report;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
 pub use self::{
-    any_of::{AnyOfConstraints, AnyOfSchema},
+    any_of::AnyOfConstraints,
     array::{ArrayConstraints, ArraySchema, ArrayTypeTag, ArrayValidationError, TupleConstraints},
     boolean::BooleanTypeTag,
     error::ConstraintError,
@@ -24,150 +24,20 @@ pub use self::{
         StringValidationError,
     },
 };
-use crate::schema::{JsonSchemaValueType, ValueLabel};
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SimpleTypedValueSchema {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    #[serde(default, skip_serializing_if = "ValueLabel::is_empty")]
-    pub label: ValueLabel,
-    #[serde(flatten)]
-    pub constraints: SimpleTypedValueConstraint,
-}
-
-#[cfg(target_arch = "wasm32")]
-#[expect(
-    dead_code,
-    reason = "Used to export type to TypeScript to prevent Tsify generating interfaces"
-)]
-mod wasm {
-    use super::*;
-
-    #[derive(tsify::Tsify)]
-    #[serde(untagged)]
-    enum SimpleTypedValueSchema {
-        Schema {
-            #[serde(default, skip_serializing_if = "Option::is_none")]
-            description: Option<String>,
-            #[serde(default)]
-            label: ValueLabel,
-            #[serde(flatten)]
-            constraints: SimpleTypedValueConstraint,
-        },
-    }
-}
+use crate::schema::{
+    ValueLabel,
+    data_type::constraint::{
+        array::validate_array_value, boolean::validate_boolean_value, null::validate_null_value,
+        number::validate_number_value, object::validate_object_value,
+        string::validate_string_value,
+    },
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
-#[serde(untagged, rename_all = "camelCase")]
-pub enum SimpleValueSchema {
-    Typed(SimpleTypedValueSchema),
-    AnyOf(AnyOfSchema),
-}
-
-impl SimpleValueSchema {
-    /// Forwards the value validation to the appropriate schema.
-    ///
-    /// # Errors
-    ///
-    /// - For [`Typed`] schemas, see [`TypedValueConstraints::validate_value`].
-    /// - For [`AnyOf`] schemas, see [`AnyOfConstraints::validate_value`].
-    ///
-    /// [`Typed`]: Self::Typed
-    /// [`AnyOf`]: Self::AnyOf
-    pub fn validate_value(&self, value: &JsonValue) -> Result<(), Report<ConstraintError>> {
-        match self {
-            Self::Typed(schema) => schema.constraints.validate_value(value),
-            Self::AnyOf(schema) => schema.constraints.validate_value(value),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
-#[serde(tag = "type", rename_all = "camelCase")]
-pub enum SimpleTypedValueConstraint {
-    Null,
-    Boolean,
-    Number(NumberSchema),
-    String(StringSchema),
-    Array,
-    Object,
-}
-
-impl SimpleTypedValueConstraint {
-    pub fn validate_value(&self, value: &JsonValue) -> Result<(), Report<ConstraintError>> {
-        match self {
-            Self::Null => {
-                if value.is_null() {
-                    Ok(())
-                } else {
-                    bail!(ConstraintError::InvalidType {
-                        actual: JsonSchemaValueType::from(value),
-                        expected: JsonSchemaValueType::Null,
-                    })
-                }
-            }
-            Self::Boolean => {
-                if value.is_boolean() {
-                    Ok(())
-                } else {
-                    bail!(ConstraintError::InvalidType {
-                        actual: JsonSchemaValueType::from(value),
-                        expected: JsonSchemaValueType::Boolean,
-                    })
-                }
-            }
-            Self::Number(schema) => {
-                if let JsonValue::Number(number) = value {
-                    schema.validate_value(number)
-                } else {
-                    bail!(ConstraintError::InvalidType {
-                        actual: JsonSchemaValueType::from(value),
-                        expected: JsonSchemaValueType::Number,
-                    })
-                }
-            }
-            Self::String(schema) => {
-                if let JsonValue::String(string) = value {
-                    schema.validate_value(string)
-                } else {
-                    bail!(ConstraintError::InvalidType {
-                        actual: JsonSchemaValueType::from(value),
-                        expected: JsonSchemaValueType::String,
-                    })
-                }
-            }
-            Self::Array => {
-                if value.is_array() {
-                    Ok(())
-                } else {
-                    bail!(ConstraintError::InvalidType {
-                        actual: JsonSchemaValueType::from(value),
-                        expected: JsonSchemaValueType::Array,
-                    })
-                }
-            }
-            Self::Object => {
-                if value.is_object() {
-                    Ok(())
-                } else {
-                    bail!(ConstraintError::InvalidType {
-                        actual: JsonSchemaValueType::from(value),
-                        expected: JsonSchemaValueType::Object,
-                    })
-                }
-            }
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged, rename_all = "camelCase")]
 pub enum ValueConstraints {
-    Typed(TypedValueConstraints),
+    Typed(SingleValueConstraints),
     AnyOf(AnyOfConstraints),
 }
 
@@ -176,7 +46,7 @@ impl ValueConstraints {
     ///
     /// # Errors
     ///
-    /// - For [`Typed`] schemas, see [`TypedValueConstraints::validate_value`].
+    /// - For [`Typed`] schemas, see [`SingleValueConstraints::validate_value`].
     /// - For [`AnyOf`] schemas, see [`SimpleTypedValueConstraint::validate_value`].
     ///
     /// [`Typed`]: Self::Typed
@@ -190,8 +60,9 @@ impl ValueConstraints {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(tag = "type", rename_all = "camelCase")]
-pub enum TypedValueConstraints {
+pub enum SingleValueConstraints {
     Null,
     Boolean,
     Number(NumberSchema),
@@ -200,7 +71,7 @@ pub enum TypedValueConstraints {
     Object,
 }
 
-impl TypedValueConstraints {
+impl SingleValueConstraints {
     /// Validates the provided value against the constraints.
     ///
     /// # Errors
@@ -214,67 +85,46 @@ impl TypedValueConstraints {
     /// [`AnyOf`]: ConstraintError::AnyOf
     pub fn validate_value(&self, value: &JsonValue) -> Result<(), Report<ConstraintError>> {
         match self {
-            Self::Null => {
-                if value.is_null() {
-                    Ok(())
-                } else {
-                    bail!(ConstraintError::InvalidType {
-                        actual: JsonSchemaValueType::from(value),
-                        expected: JsonSchemaValueType::Null,
-                    })
-                }
-            }
-            Self::Boolean => {
-                if value.is_boolean() {
-                    Ok(())
-                } else {
-                    bail!(ConstraintError::InvalidType {
-                        actual: JsonSchemaValueType::from(value),
-                        expected: JsonSchemaValueType::Boolean,
-                    })
-                }
-            }
-            Self::Number(schema) => {
-                if let JsonValue::Number(number) = value {
-                    schema.validate_value(number)
-                } else {
-                    bail!(ConstraintError::InvalidType {
-                        actual: JsonSchemaValueType::from(value),
-                        expected: JsonSchemaValueType::Number,
-                    })
-                }
-            }
-            Self::String(schema) => {
-                if let JsonValue::String(string) = value {
-                    schema.validate_value(string)
-                } else {
-                    bail!(ConstraintError::InvalidType {
-                        actual: JsonSchemaValueType::from(value),
-                        expected: JsonSchemaValueType::String,
-                    })
-                }
-            }
-            Self::Array(schema) => {
-                if let JsonValue::Array(array) = value {
-                    schema.validate_value(array)
-                } else {
-                    bail!(ConstraintError::InvalidType {
-                        actual: JsonSchemaValueType::from(value),
-                        expected: JsonSchemaValueType::Array,
-                    })
-                }
-            }
-            Self::Object => {
-                if value.is_object() {
-                    Ok(())
-                } else {
-                    bail!(ConstraintError::InvalidType {
-                        actual: JsonSchemaValueType::from(value),
-                        expected: JsonSchemaValueType::Object,
-                    })
-                }
-            }
+            Self::Null => validate_null_value(value),
+            Self::Boolean => validate_boolean_value(value),
+            Self::Number(schema) => validate_number_value(value, schema),
+            Self::String(schema) => validate_string_value(value, schema),
+            Self::Array(array) => validate_array_value(value, array),
+            Self::Object => validate_object_value(value),
         }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SingleValueSchema {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "ValueLabel::is_empty")]
+    pub label: ValueLabel,
+    #[serde(flatten)]
+    pub constraints: SingleValueConstraints,
+}
+
+#[cfg(target_arch = "wasm32")]
+#[expect(
+    dead_code,
+    reason = "Used to export type to TypeScript to prevent Tsify generating interfaces"
+)]
+mod wasm {
+    use super::*;
+
+    #[derive(tsify::Tsify)]
+    #[serde(untagged)]
+    enum SingleValueSchema {
+        Schema {
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            description: Option<String>,
+            #[serde(default)]
+            label: ValueLabel,
+            #[serde(flatten)]
+            constraints: SingleValueConstraints,
+        },
     }
 }
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/null.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/null.rs
@@ -1,8 +1,22 @@
+use error_stack::{Report, bail};
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+use crate::schema::{ConstraintError, JsonSchemaValueType};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum NullTypeTag {
     Null,
+}
+
+pub(crate) fn validate_null_value(value: &JsonValue) -> Result<(), Report<ConstraintError>> {
+    if value.is_null() {
+        Ok(())
+    } else {
+        bail!(ConstraintError::InvalidType {
+            actual: JsonSchemaValueType::from(value),
+            expected: JsonSchemaValueType::Null,
+        });
+    }
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Number as JsonNumber, Value as JsonValue, json};
 use thiserror::Error;
 
-use crate::schema::ConstraintError;
+use crate::schema::{ConstraintError, JsonSchemaValueType};
 
 #[expect(
     clippy::trivially_copy_pass_by_ref,
@@ -152,6 +152,20 @@ impl NumberSchema {
             }
         }
         Ok(())
+    }
+}
+
+pub(crate) fn validate_number_value(
+    value: &JsonValue,
+    schema: &NumberSchema,
+) -> Result<(), Report<ConstraintError>> {
+    if let JsonValue::Number(number) = value {
+        schema.validate_value(number)
+    } else {
+        bail!(ConstraintError::InvalidType {
+            actual: JsonSchemaValueType::from(value),
+            expected: JsonSchemaValueType::Number,
+        });
     }
 }
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/object.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/object.rs
@@ -1,8 +1,23 @@
+use error_stack::{Report, bail};
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+use crate::schema::{ConstraintError, JsonSchemaValueType};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum ObjectTypeTag {
     Object,
+}
+
+pub(crate) fn validate_object_value(value: &JsonValue) -> Result<(), Report<ConstraintError>> {
+    if value.is_object() {
+        Ok(())
+    } else {
+        bail!(ConstraintError::InvalidType {
+            actual: JsonSchemaValueType::from(value),
+            expected: JsonSchemaValueType::Object,
+        });
+    }
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 use url::{Host, Url};
 use uuid::Uuid;
 
-use crate::schema::ConstraintError;
+use crate::schema::{ConstraintError, JsonSchemaValueType};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
@@ -202,7 +202,6 @@ pub enum StringValidationError {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum StringTypeTag {
     String,
@@ -330,6 +329,20 @@ impl StringConstraints {
         }
 
         status.finish()
+    }
+}
+
+pub(crate) fn validate_string_value(
+    value: &JsonValue,
+    schema: &StringSchema,
+) -> Result<(), Report<ConstraintError>> {
+    if let JsonValue::String(string) = value {
+        schema.validate_value(string)
+    } else {
+        bail!(ConstraintError::InvalidType {
+            actual: JsonSchemaValueType::from(value),
+            expected: JsonSchemaValueType::String,
+        });
     }
 }
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -225,7 +225,6 @@ mod raw {
             common: ValueSchemaMetadata,
             r#const: [JsonValue; 0],
         },
-        #[serde(skip)]
         AnyOf {
             #[serde(flatten)]
             common: ValueSchemaMetadata,
@@ -695,7 +694,6 @@ mod tests {
     };
 
     #[tokio::test]
-    #[ignore = "AnyOf constraint is not exposed"]
     async fn value() {
         ensure_validation_from_str::<DataType, _>(
             graph_test_data::data_type::VALUE_V1,

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -4,11 +4,11 @@ mod conversion;
 pub use self::{
     closed::{ClosedDataType, ClosedDataTypeMetadata},
     constraint::{
-        AnyOfConstraints, AnyOfSchema, ArrayConstraints, ArraySchema, ArrayTypeTag,
-        ArrayValidationError, BooleanTypeTag, ConstraintError, NullTypeTag, NumberConstraints,
-        NumberSchema, NumberTypeTag, NumberValidationError, ObjectTypeTag, StringConstraints,
-        StringFormat, StringFormatError, StringSchema, StringTypeTag, StringValidationError,
-        TupleConstraints, TypedValueConstraints,
+        AnyOfConstraints, ArrayConstraints, ArraySchema, ArrayTypeTag, ArrayValidationError,
+        BooleanTypeTag, ConstraintError, NullTypeTag, NumberConstraints, NumberSchema,
+        NumberTypeTag, NumberValidationError, ObjectTypeTag, SingleValueConstraints,
+        SingleValueSchema, StringConstraints, StringFormat, StringFormatError, StringSchema,
+        StringTypeTag, StringValidationError, TupleConstraints,
     },
     conversion::{
         ConversionDefinition, ConversionExpression, ConversionValue, Conversions, Operator,
@@ -116,7 +116,7 @@ mod raw {
             ObjectTypeTag, StringTypeTag, ValueLabel,
             data_type::constraint::{
                 AnyOfConstraints, ArrayConstraints, ArraySchema, NumberConstraints, NumberSchema,
-                StringConstraints, StringSchema, TupleConstraints, TypedValueConstraints,
+                SingleValueConstraints, StringConstraints, StringSchema, TupleConstraints,
                 ValueConstraints,
             },
         },
@@ -147,7 +147,6 @@ mod raw {
     }
 
     #[derive(Serialize, Deserialize)]
-    #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
     #[serde(untagged, rename_all = "camelCase", deny_unknown_fields)]
     pub enum DataType {
         Null {
@@ -177,7 +176,6 @@ mod raw {
             r#type: NumberTypeTag,
             #[serde(flatten)]
             common: ValueSchemaMetadata,
-            #[cfg_attr(target_arch = "wasm32", tsify(type = "[number, ...number[]]"))]
             r#enum: Vec<f64>,
         },
         String {
@@ -197,7 +195,6 @@ mod raw {
             r#type: StringTypeTag,
             #[serde(flatten)]
             common: ValueSchemaMetadata,
-            #[cfg_attr(target_arch = "wasm32", tsify(type = "[string, ...string[]]"))]
             r#enum: HashSet<String>,
         },
         Object {
@@ -233,6 +230,26 @@ mod raw {
         },
     }
 
+    #[cfg(target_arch = "wasm32")]
+    #[expect(
+        dead_code,
+        reason = "Used to export type to TypeScript to prevent Tsify generating interfaces"
+    )]
+    mod wasm {
+        use super::*;
+
+        #[derive(tsify::Tsify)]
+        #[serde(untagged)]
+        enum DataType {
+            Schema {
+                #[serde(flatten)]
+                common: ValueSchemaMetadata,
+                #[serde(flatten)]
+                constraints: ValueConstraints,
+            },
+        }
+    }
+
     impl From<DataType> for super::DataType {
         #[expect(
             clippy::too_many_lines,
@@ -243,12 +260,13 @@ mod raw {
         )]
         fn from(value: DataType) -> Self {
             let (common, constraints) = match value {
-                DataType::Null { r#type: _, common } => {
-                    (common, ValueConstraints::Typed(TypedValueConstraints::Null))
-                }
+                DataType::Null { r#type: _, common } => (
+                    common,
+                    ValueConstraints::Typed(SingleValueConstraints::Null),
+                ),
                 DataType::Boolean { r#type: _, common } => (
                     common,
-                    ValueConstraints::Typed(TypedValueConstraints::Boolean),
+                    ValueConstraints::Typed(SingleValueConstraints::Boolean),
                 ),
                 DataType::Number {
                     r#type: _,
@@ -256,7 +274,7 @@ mod raw {
                     constraints,
                 } => (
                     common,
-                    ValueConstraints::Typed(TypedValueConstraints::Number(
+                    ValueConstraints::Typed(SingleValueConstraints::Number(
                         NumberSchema::Constrained(constraints),
                     )),
                 ),
@@ -266,7 +284,7 @@ mod raw {
                     r#const,
                 } => (
                     common,
-                    ValueConstraints::Typed(TypedValueConstraints::Number(NumberSchema::Const {
+                    ValueConstraints::Typed(SingleValueConstraints::Number(NumberSchema::Const {
                         r#const,
                     })),
                 ),
@@ -276,7 +294,7 @@ mod raw {
                     r#enum,
                 } => (
                     common,
-                    ValueConstraints::Typed(TypedValueConstraints::Number(NumberSchema::Enum {
+                    ValueConstraints::Typed(SingleValueConstraints::Number(NumberSchema::Enum {
                         r#enum,
                     })),
                 ),
@@ -286,7 +304,7 @@ mod raw {
                     constraints,
                 } => (
                     common,
-                    ValueConstraints::Typed(TypedValueConstraints::String(
+                    ValueConstraints::Typed(SingleValueConstraints::String(
                         StringSchema::Constrained(constraints),
                     )),
                 ),
@@ -296,7 +314,7 @@ mod raw {
                     r#const,
                 } => (
                     common,
-                    ValueConstraints::Typed(TypedValueConstraints::String(StringSchema::Const {
+                    ValueConstraints::Typed(SingleValueConstraints::String(StringSchema::Const {
                         r#const,
                     })),
                 ),
@@ -306,13 +324,13 @@ mod raw {
                     r#enum,
                 } => (
                     common,
-                    ValueConstraints::Typed(TypedValueConstraints::String(StringSchema::Enum {
+                    ValueConstraints::Typed(SingleValueConstraints::String(StringSchema::Enum {
                         r#enum,
                     })),
                 ),
                 DataType::Object { r#type: _, common } => (
                     common,
-                    ValueConstraints::Typed(TypedValueConstraints::Object),
+                    ValueConstraints::Typed(SingleValueConstraints::Object),
                 ),
                 DataType::Array {
                     r#type: _,
@@ -320,7 +338,7 @@ mod raw {
                     constraints,
                 } => (
                     common,
-                    ValueConstraints::Typed(TypedValueConstraints::Array(
+                    ValueConstraints::Typed(SingleValueConstraints::Array(
                         ArraySchema::Constrained(constraints),
                     )),
                 ),
@@ -330,7 +348,7 @@ mod raw {
                     constraints,
                 } => (
                     common,
-                    ValueConstraints::Typed(TypedValueConstraints::Array(ArraySchema::Tuple(
+                    ValueConstraints::Typed(SingleValueConstraints::Array(ArraySchema::Tuple(
                         constraints,
                     ))),
                 ),
@@ -340,7 +358,7 @@ mod raw {
                     r#const,
                 } => (
                     common,
-                    ValueConstraints::Typed(TypedValueConstraints::Array(ArraySchema::Const {
+                    ValueConstraints::Typed(SingleValueConstraints::Array(ArraySchema::Const {
                         r#const,
                     })),
                 ),
@@ -688,9 +706,12 @@ impl DataType {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::*;
     use crate::utils::tests::{
-        JsonEqualityCheck, ensure_failed_deserialization, ensure_validation_from_str,
+        JsonEqualityCheck, ensure_failed_deserialization, ensure_validation,
+        ensure_validation_from_str,
     };
 
     #[tokio::test]
@@ -757,6 +778,48 @@ mod tests {
     async fn empty_list() {
         ensure_validation_from_str::<DataType, _>(
             graph_test_data::data_type::EMPTY_LIST_V1,
+            DataTypeValidator,
+            JsonEqualityCheck::Yes,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn tuple() {
+        ensure_validation::<DataType, _>(
+            json!({
+              "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
+              "kind": "dataType",
+              "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/two-numbers/v/1",
+              "title": "Two Numbers",
+              "description": "A tuple of two numbers",
+              "type": "array",
+              "abstract": false,
+              "items": false,
+              "prefixItems": [
+                { "type": "number" },
+                { "type": "number" }
+              ]
+            }),
+            DataTypeValidator,
+            JsonEqualityCheck::Yes,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn array2() {
+        ensure_validation::<DataType, _>(
+            json!({
+              "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
+              "kind": "dataType",
+              "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/array/v/1",
+              "title": "Number List",
+              "description": "A list of numbers",
+              "type": "array",
+              "abstract": false,
+              "items": { "type": "number" },
+            }),
             DataTypeValidator,
             JsonEqualityCheck::Yes,
         )

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -808,7 +808,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn array2() {
+    async fn array() {
         ensure_validation::<DataType, _>(
             json!({
               "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",

--- a/libs/@blockprotocol/type-system/rust/src/schema/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/mod.rs
@@ -16,14 +16,14 @@ mod one_of;
 pub use self::{
     array::{PropertyArraySchema, PropertyValueArray, ValueOrArray},
     data_type::{
-        AnyOfConstraints, AnyOfSchema, ArrayConstraints, ArraySchema, ArrayTypeTag,
-        ArrayValidationError, BooleanTypeTag, ClosedDataType, ClosedDataTypeMetadata,
-        ConstraintError, ConversionDefinition, ConversionExpression, ConversionValue, Conversions,
-        DataType, DataTypeReference, DataTypeValidator, JsonSchemaValueType, NullTypeTag,
-        NumberConstraints, NumberSchema, NumberTypeTag, NumberValidationError, ObjectTypeTag,
-        OntologyTypeResolver, Operator, StringConstraints, StringFormat, StringFormatError,
-        StringSchema, StringTypeTag, StringValidationError, TupleConstraints,
-        TypedValueConstraints, ValidateDataTypeError, ValueLabel, Variable,
+        AnyOfConstraints, ArrayConstraints, ArraySchema, ArrayTypeTag, ArrayValidationError,
+        BooleanTypeTag, ClosedDataType, ClosedDataTypeMetadata, ConstraintError,
+        ConversionDefinition, ConversionExpression, ConversionValue, Conversions, DataType,
+        DataTypeReference, DataTypeValidator, JsonSchemaValueType, NullTypeTag, NumberConstraints,
+        NumberSchema, NumberTypeTag, NumberValidationError, ObjectTypeTag, OntologyTypeResolver,
+        Operator, SingleValueConstraints, SingleValueSchema, StringConstraints, StringFormat,
+        StringFormatError, StringSchema, StringTypeTag, StringValidationError, TupleConstraints,
+        ValidateDataTypeError, ValueLabel, Variable,
     },
     entity_type::{
         ClosedEntityType, ClosedEntityTypeSchemaData, EntityType, EntityTypeReference,

--- a/libs/@local/hash-isomorphic-utils/src/data-types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/data-types.ts
@@ -40,9 +40,13 @@ export const formatDataValue = (
   value: JsonValue,
   schema?: DataType | SimpleValueSchema,
 ): FormattedValuePart[] => {
-  const { type } = schema ?? {
-    type: getJsonSchemaTypeFromValue(value),
-  };
+  /**
+   * @todo H-3374 callers should always provide a schema, because the dataTypeId will be in the entity's metadata
+   */
+  const type =
+    schema && "type" in schema
+      ? schema.type
+      : getJsonSchemaTypeFromValue(value);
 
   if (type === "null") {
     return createFormattedParts({ inner: "Null", schema });

--- a/libs/@local/hash-isomorphic-utils/src/data-types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/data-types.ts
@@ -1,5 +1,5 @@
 import type { JsonValue } from "@blockprotocol/core";
-import type { DataType, SimpleValueSchema } from "@blockprotocol/type-system";
+import type { DataType, SingleValueSchema } from "@blockprotocol/type-system";
 import { getJsonSchemaTypeFromValue } from "@local/hash-subgraph/stdlib";
 
 export type FormattedValuePart = {
@@ -13,7 +13,7 @@ const createFormattedParts = ({
   schema,
 }: {
   inner: string | FormattedValuePart[];
-  schema?: Pick<DataType, "label">;
+  schema?: Pick<SingleValueSchema, "label">;
 }): FormattedValuePart[] => {
   const { left = "", right = "" } = schema?.label ?? {};
 
@@ -38,7 +38,7 @@ const createFormattedParts = ({
 
 export const formatDataValue = (
   value: JsonValue,
-  schema?: DataType | SimpleValueSchema,
+  schema?: DataType | SingleValueSchema,
 ): FormattedValuePart[] => {
   /**
    * @todo H-3374 callers should always provide a schema, because the dataTypeId will be in the entity's metadata

--- a/libs/@local/hash-subgraph/src/stdlib/subgraph/element/property-type.ts
+++ b/libs/@local/hash-subgraph/src/stdlib/subgraph/element/property-type.ts
@@ -215,8 +215,12 @@ export const guessSchemaForPropertyValue = (
           const guessedSchemas = value.map((innerValue) => {
             const jsonSchemaType = getJsonSchemaTypeFromValue(innerValue);
 
-            const dataType = possibleDataTypes.find(
-              ({ schema }) => schema.type === jsonSchemaType,
+            const dataType = possibleDataTypes.find(({ schema }) =>
+              "type" in schema
+                ? schema.type === jsonSchemaType
+                : schema.anyOf.some(
+                    (anyOfOption) => anyOfOption.type === jsonSchemaType,
+                  ),
             );
 
             if (!dataType) {
@@ -261,7 +265,11 @@ export const guessSchemaForPropertyValue = (
 
       const guessedDataType = possibleDataTypes.find(({ schema }) => {
         const jsonSchemaType = getJsonSchemaTypeFromValue(value);
-        return schema.type === jsonSchemaType;
+        return "type" in schema
+          ? schema.type === jsonSchemaType
+          : schema.anyOf.some(
+              (anyOfOption) => anyOfOption.type === jsonSchemaType,
+            );
       });
 
       return {

--- a/tests/hash-graph-test-data/rust/src/data_type/value.json
+++ b/tests/hash-graph-test-data/rust/src/data_type/value.json
@@ -4,5 +4,13 @@
   "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/value/v/1",
   "title": "Value",
   "description": "A value that can be stored in a graph",
-  "anyOf": [{ "type": "null" }]
+  "abstract": false,
+  "anyOf": [
+    { "type": "null" },
+    { "type": "boolean" },
+    { "type": "number" },
+    { "type": "string" },
+    { "type": "array" },
+    { "type": "object" }
+  ]
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To allow a `Value` type we need the type system to support `anyOf` instead of specifying a `type` for data types.

## 🔍 What does this change?

- Support `anyOf` in the type system
- Add a test for `Value`
- Add proper validation logic for `anyOf` (future-proof so in theory any type could use `anyOf`)
- Add missing documentation for validations

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph