### PR TITLE
H-3361: Fix `yarn graph:reset-database` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "start:frontend": "turbo run start start:healthcheck --filter @apps/hash-frontend --env-mode=loose --ui tui --continue",
     "start:worker": "turbo run start start:healthcheck --filter '@apps/hash-*-worker*' --env-mode=loose --ui tui --continue",
     "start:test": "turbo run start:test start:test:healthcheck --env-mode=loose --ui tui --continue",
-    "graph:reset-database": "yarn workspace @apps/hash-graph reset-database",
+    "graph:reset-database": "yarn workspace @rust/graph-http-tests reset-database",
     "external-services": "turbo deploy --filter '@apps/hash-external-services' --",
     "external-services:offline": "turbo deploy:offline --filter '@apps/hash-external-services' --",
     "external-services:test": "turbo deploy:test --filter '@apps/hash-external-services' --",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The command was moved but the root package.json was not updated.

The new location is `@rust/graph-http-tests` instead of `@apps/hash-graph`