### PR TITLE
H-3362: Support links which link to other links in the types graph visualization

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/persist-entities-action.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/persist-entities-action.ts
@@ -40,7 +40,7 @@ export const persistEntitiesAction: FlowActionActivity = async ({ inputs }) => {
        * This assumes that there are no link entities which link to other link entities, which require being able to
        * create multiple entities at once in a single transaction (since they refer to each other).
        *
-       * @todo handle links pointing to other links via creating many entities at once, unblocked by H-1178
+       * @todo handle links pointing to other links via creating many entities at once, unblocked by H-1178. See also entity-result-table
        */
       if (
         (a.sourceEntityId && b.sourceEntityId) ||

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
@@ -410,7 +410,7 @@ type BaseCreateTypeIfNotExistsParameters = {
   migrationState: MigrationState;
 };
 
-const generateSystemDataTypeSchema = ({
+export const generateSystemDataTypeSchema = ({
   dataTypeId,
   ...rest
 }: ConstructDataTypeParams & { dataTypeId: VersionedUrl }): CustomDataType => {

--- a/apps/hash-frontend/src/pages/shared/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-table.tsx
@@ -87,6 +87,7 @@ export const EntitiesTable: FunctionComponent<{
 
   const [filterState, setFilterState] = useState<FilterState>({
     includeGlobal: false,
+    limitToWebs: false,
   });
   const [showSearch, setShowSearch] = useState<boolean>(false);
 

--- a/apps/hash-frontend/src/pages/shared/graph-visualizer/graph-container/graph-data-loader.tsx
+++ b/apps/hash-frontend/src/pages/shared/graph-visualizer/graph-container/graph-data-loader.tsx
@@ -181,7 +181,7 @@ export const GraphDataLoader = ({
 
     for (const edge of edges) {
       graph.addEdgeWithKey(edge.edgeId, edge.source, edge.target, {
-        color: "rgba(230, 230, 230, 1)",
+        color: "rgba(50, 50, 50, 0.5)",
         label: edge.label,
         size: edge.size,
         type: "arrow",

--- a/apps/hash-frontend/src/shared/table-header.tsx
+++ b/apps/hash-frontend/src/shared/table-header.tsx
@@ -109,6 +109,7 @@ const NoMaxWidthTooltip = styled(({ className, ...props }: TooltipProps) => (
 export type FilterState = {
   includeArchived?: boolean;
   includeGlobal: boolean;
+  limitToWebs: string[] | false;
 };
 
 export type GetAdditionalCsvDataFunction = () => Promise<{


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR introduces support for visualizing type graphs where links link to other links. 

It also makes a couple of other improvements to the types page:
1. Respect the applied filters when loading the graph visualization (previously they were only applied to the table)
2. Add code to allow for filtering to types in a specific web (not yet exposed in the UI)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

