### PR TITLE
GEN-199: Stop Dependabot opening non-security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
     schedule:
       interval: "daily"
     labels: []
+    open-pull-requests-limit: 0


### PR DESCRIPTION
We use Renovate for non-security updates, so don't need Dependabot trying to do it's own thang here, too.

See the docs around `open-pull-requests-limit: 0` [here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit).