### PR TITLE
H-3337: Align type-system data-type constraints with Node API (Part II)

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/shared/dereference-entity-type.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/dereference-entity-type.ts
@@ -1,4 +1,5 @@
 import type {
+  DataType,
   EntityType,
   OneOfSchema,
   PropertyType,
@@ -12,7 +13,6 @@ import { atLeastOne, extractVersion } from "@blockprotocol/type-system";
 import { typedEntries } from "@local/advanced-types/typed-entries";
 import type {
   BaseUrl,
-  CustomDataType,
   EntityTypeMetadata,
 } from "@local/hash-graph-types/ontology";
 import type { Subgraph } from "@local/hash-subgraph";
@@ -29,7 +29,7 @@ import {
 
 import { generateSimplifiedTypeId } from "../infer-entities/shared/generate-simplified-type-id.js";
 
-type MinimalDataType = Omit<CustomDataType, "$id" | "$schema" | "kind">;
+type MinimalDataType = Omit<DataType, "$id" | "$schema" | "kind" | "allOf">;
 
 type MinimalPropertyObject = PropertyValueObject<
   ValueOrArray<DereferencedPropertyType>

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import type {
   Conversions,
+  DataType,
   DataTypeReference,
   EntityType,
   OneOfSchema,
@@ -33,7 +34,6 @@ import type { PropertyObjectWithMetadata } from "@local/hash-graph-types/entity"
 import type {
   BaseUrl,
   ConstructDataTypeParams,
-  CustomDataType,
   DataTypeWithMetadata,
   EntityTypeWithMetadata,
   PropertyTypeWithMetadata,
@@ -413,7 +413,9 @@ type BaseCreateTypeIfNotExistsParameters = {
 const generateSystemDataTypeSchema = ({
   dataTypeId,
   ...rest
-}: ConstructDataTypeParams & { dataTypeId: VersionedUrl }): CustomDataType => {
+}: ConstructDataTypeParams & {
+  dataTypeId: VersionedUrl;
+}): DataType => {
   return {
     $id: dataTypeId,
     $schema: DATA_TYPE_META_SCHEMA,

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/editor-specs.ts
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/editor-specs.ts
@@ -1,3 +1,4 @@
+import type { DataType } from "@blockprotocol/type-system";
 import type { IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import {
   fa100,
@@ -14,7 +15,6 @@ import {
   faSquareCheck,
   faText,
 } from "@hashintel/design-system";
-import type { CustomDataType } from "@local/hash-graph-types/ontology";
 
 import type { CustomIcon } from "../../../../../../../../../components/grid/utils/custom-grid-icons";
 import type { EditorType } from "./types";
@@ -87,7 +87,7 @@ const identifierTypeTitles = ["URL", "URI"];
 
 export const getEditorSpecs = (
   editorType: EditorType,
-  dataType?: CustomDataType,
+  dataType?: DataType,
 ): EditorSpec => {
   switch (editorType) {
     case "boolean":

--- a/apps/hash-frontend/src/pages/shared/data-types-context.tsx
+++ b/apps/hash-frontend/src/pages/shared/data-types-context.tsx
@@ -64,7 +64,7 @@ export const DataTypesContextProvider = ({ children }: PropsWithChildren) => {
       ]?.inner.schema as DataTypeWithMetadata["schema"] | undefined;
 
       if (!dataType) {
-        return formatDataValue(value?.toString() ?? "null", null);
+        return formatDataValue(value?.toString() ?? "null", undefined);
       }
 
       return formatDataValue(value, dataType);

--- a/apps/hash-graph/libs/api/openapi/models/data_type.json
+++ b/apps/hash-graph/libs/api/openapi/models/data_type.json
@@ -37,6 +37,6 @@
       ]
     }
   },
-  "required": ["$schema", "kind", "$id", "title", "type"],
+  "required": ["$schema", "kind", "$id", "title"],
   "additionalProperties": true
 }

--- a/apps/hash-graph/libs/api/openapi/models/update_data_type.json
+++ b/apps/hash-graph/libs/api/openapi/models/update_data_type.json
@@ -28,6 +28,6 @@
       ]
     }
   },
-  "required": ["$schema", "kind", "title", "type"],
+  "required": ["$schema", "kind", "title"],
   "additionalProperties": true
 }

--- a/apps/hash-graph/libs/api/src/rest/data_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/data_type.rs
@@ -4,19 +4,19 @@ use alloc::sync::Arc;
 use std::collections::HashMap;
 
 use authorization::{
+    AuthorizationApi, AuthorizationApiPool,
     backend::{ModifyRelationshipOperation, PermissionAssertion},
     schema::{
         DataTypeOwnerSubject, DataTypePermission, DataTypeRelationAndSubject, DataTypeViewerSubject,
     },
     zanzibar::Consistency,
-    AuthorizationApi, AuthorizationApiPool,
 };
 use axum::{
+    Extension, Router,
     extract::Path,
     http::StatusCode,
     response::Response,
     routing::{get, post, put},
-    Extension, Router,
 };
 use error_stack::{Report, ResultExt};
 use graph::{
@@ -25,13 +25,13 @@ use graph::{
         patch_id_and_parse,
     },
     store::{
+        BaseUrlAlreadyExists, DataTypeStore, OntologyVersionDoesNotExist, StorePool,
         error::VersionedUrlAlreadyExists,
         ontology::{
             ArchiveDataTypeParams, CreateDataTypeParams, GetDataTypeSubgraphParams,
             GetDataTypesParams, GetDataTypesResponse, UnarchiveDataTypeParams,
             UpdateDataTypeEmbeddingParams, UpdateDataTypesParams,
         },
-        BaseUrlAlreadyExists, DataTypeStore, OntologyVersionDoesNotExist, StorePool,
     },
 };
 use graph_types::{
@@ -42,7 +42,7 @@ use graph_types::{
     },
     owned_by_id::OwnedById,
 };
-use hash_graph_store::{data_type::DataTypeQueryToken, ConflictBehavior};
+use hash_graph_store::{ConflictBehavior, data_type::DataTypeQueryToken};
 use hash_status::Status;
 use serde::{Deserialize, Serialize};
 use temporal_client::TemporalClient;
@@ -58,10 +58,10 @@ use utoipa::{OpenApi, ToSchema};
 
 use super::api_resource::RoutedResource;
 use crate::rest::{
+    AuthenticatedUserHeader, PermissionResponse, RestApiStore,
     json::Json,
     status::{report_to_response, status_to_response},
-    utoipa_typedef::{subgraph::Subgraph, ListOrValue, MaybeListOfDataType},
-    AuthenticatedUserHeader, PermissionResponse, RestApiStore,
+    utoipa_typedef::{ListOrValue, MaybeListOfDataType, subgraph::Subgraph},
 };
 
 #[derive(OpenApi)]
@@ -372,19 +372,16 @@ where
 
             Ok(Json(
                 store
-                    .create_data_type(
-                        actor_id,
-                        CreateDataTypeParams {
-                            schema: *schema,
-                            classification: OntologyTypeClassificationMetadata::External {
-                                fetched_at: OffsetDateTime::now_utc(),
-                            },
-                            relationships,
-                            conflict_behavior: ConflictBehavior::Fail,
-                            provenance: *provenance,
-                            conversions: conversions.clone(),
+                    .create_data_type(actor_id, CreateDataTypeParams {
+                        schema: *schema,
+                        classification: OntologyTypeClassificationMetadata::External {
+                            fetched_at: OffsetDateTime::now_utc(),
                         },
-                    )
+                        relationships,
+                        conflict_behavior: ConflictBehavior::Fail,
+                        provenance: *provenance,
+                        conversions: conversions.clone(),
+                    })
                     .await
                     .map_err(report_to_response)?,
             ))
@@ -601,15 +598,12 @@ where
         })?;
 
     store
-        .update_data_type(
-            actor_id,
-            UpdateDataTypesParams {
-                schema: data_type,
-                relationships,
-                provenance,
-                conversions,
-            },
-        )
+        .update_data_type(actor_id, UpdateDataTypesParams {
+            schema: data_type,
+            relationships,
+            provenance,
+            conversions,
+        })
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not update data type");

--- a/apps/hash-graph/libs/api/src/rest/data_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/data_type.rs
@@ -4,19 +4,19 @@ use alloc::sync::Arc;
 use std::collections::HashMap;
 
 use authorization::{
-    AuthorizationApi, AuthorizationApiPool,
     backend::{ModifyRelationshipOperation, PermissionAssertion},
     schema::{
         DataTypeOwnerSubject, DataTypePermission, DataTypeRelationAndSubject, DataTypeViewerSubject,
     },
     zanzibar::Consistency,
+    AuthorizationApi, AuthorizationApiPool,
 };
 use axum::{
-    Extension, Router,
     extract::Path,
     http::StatusCode,
     response::Response,
     routing::{get, post, put},
+    Extension, Router,
 };
 use error_stack::{Report, ResultExt};
 use graph::{
@@ -25,13 +25,13 @@ use graph::{
         patch_id_and_parse,
     },
     store::{
-        BaseUrlAlreadyExists, DataTypeStore, OntologyVersionDoesNotExist, StorePool,
         error::VersionedUrlAlreadyExists,
         ontology::{
             ArchiveDataTypeParams, CreateDataTypeParams, GetDataTypeSubgraphParams,
             GetDataTypesParams, GetDataTypesResponse, UnarchiveDataTypeParams,
             UpdateDataTypeEmbeddingParams, UpdateDataTypesParams,
         },
+        BaseUrlAlreadyExists, DataTypeStore, OntologyVersionDoesNotExist, StorePool,
     },
 };
 use graph_types::{
@@ -42,7 +42,7 @@ use graph_types::{
     },
     owned_by_id::OwnedById,
 };
-use hash_graph_store::{ConflictBehavior, data_type::DataTypeQueryToken};
+use hash_graph_store::{data_type::DataTypeQueryToken, ConflictBehavior};
 use hash_status::Status;
 use serde::{Deserialize, Serialize};
 use temporal_client::TemporalClient;
@@ -58,10 +58,10 @@ use utoipa::{OpenApi, ToSchema};
 
 use super::api_resource::RoutedResource;
 use crate::rest::{
-    AuthenticatedUserHeader, PermissionResponse, RestApiStore,
     json::Json,
     status::{report_to_response, status_to_response},
-    utoipa_typedef::{ListOrValue, MaybeListOfDataType, subgraph::Subgraph},
+    utoipa_typedef::{subgraph::Subgraph, ListOrValue, MaybeListOfDataType},
+    AuthenticatedUserHeader, PermissionResponse, RestApiStore,
 };
 
 #[derive(OpenApi)]
@@ -285,7 +285,7 @@ enum LoadExternalDataTypeRequest {
     #[serde(rename_all = "camelCase")]
     Create {
         #[schema(value_type = VAR_DATA_TYPE)]
-        schema: DataType,
+        schema: Box<DataType>,
         relationships: Vec<DataTypeRelationAndSubject>,
         #[serde(
             default,
@@ -372,16 +372,19 @@ where
 
             Ok(Json(
                 store
-                    .create_data_type(actor_id, CreateDataTypeParams {
-                        schema,
-                        classification: OntologyTypeClassificationMetadata::External {
-                            fetched_at: OffsetDateTime::now_utc(),
+                    .create_data_type(
+                        actor_id,
+                        CreateDataTypeParams {
+                            schema: *schema,
+                            classification: OntologyTypeClassificationMetadata::External {
+                                fetched_at: OffsetDateTime::now_utc(),
+                            },
+                            relationships,
+                            conflict_behavior: ConflictBehavior::Fail,
+                            provenance: *provenance,
+                            conversions: conversions.clone(),
                         },
-                        relationships,
-                        conflict_behavior: ConflictBehavior::Fail,
-                        provenance: *provenance,
-                        conversions: conversions.clone(),
-                    })
+                    )
                     .await
                     .map_err(report_to_response)?,
             ))
@@ -598,12 +601,15 @@ where
         })?;
 
     store
-        .update_data_type(actor_id, UpdateDataTypesParams {
-            schema: data_type,
-            relationships,
-            provenance,
-            conversions,
-        })
+        .update_data_type(
+            actor_id,
+            UpdateDataTypesParams {
+                schema: data_type,
+                relationships,
+                provenance,
+                conversions,
+            },
+        )
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not update data type");

--- a/apps/hash-graph/libs/api/src/rest/json_schemas/data_type.json
+++ b/apps/hash-graph/libs/api/src/rest/json_schemas/data_type.json
@@ -37,6 +37,6 @@
       ]
     }
   },
-  "required": ["$schema", "kind", "$id", "title", "type"],
+  "required": ["$schema", "kind", "$id", "title"],
   "additionalProperties": true
 }

--- a/apps/hash-graph/libs/api/src/rest/json_schemas/update_data_type.json
+++ b/apps/hash-graph/libs/api/src/rest/json_schemas/update_data_type.json
@@ -28,6 +28,6 @@
       ]
     }
   },
-  "required": ["$schema", "kind", "title", "type"],
+  "required": ["$schema", "kind", "title"],
   "additionalProperties": true
 }

--- a/libs/@blockprotocol/type-system/rust/Cargo.toml
+++ b/libs/@blockprotocol/type-system/rust/Cargo.toml
@@ -16,7 +16,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 # Public workspace dependencies
-error-stack = { workspace = true, public = true, features = ["unstable"]}
+error-stack = { workspace = true, public = true, features = ["unstable"] }
+codec = { workspace = true, public = true, features = ["serde"] }
 
 # Public third-party dependencies
 bytes = { workspace = true, public = true }
@@ -29,7 +30,6 @@ utoipa = { workspace = true, public = true, features = ["url"], optional = true 
 uuid = { workspace = true, public = true, features = ["std"] }
 
 # Private workspace dependencies
-codec = { workspace = true, features = ["serde"] }
 futures = { workspace = true }
 
 # Private third-party dependencies

--- a/libs/@blockprotocol/type-system/rust/src/lib.rs
+++ b/libs/@blockprotocol/type-system/rust/src/lib.rs
@@ -7,6 +7,7 @@
 )]
 
 extern crate alloc;
+extern crate core;
 
 pub mod url;
 

--- a/libs/@blockprotocol/type-system/rust/src/lib.rs
+++ b/libs/@blockprotocol/type-system/rust/src/lib.rs
@@ -7,7 +7,6 @@
 )]
 
 extern crate alloc;
-extern crate core;
 
 pub mod url;
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/array/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/array/raw.rs
@@ -1,12 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-/// Will serialize as a constant value `"array"`
-#[derive(Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
-#[serde(rename_all = "camelCase")]
-enum ArrayTypeTag {
-    Array,
-}
+use crate::schema::data_type::ArrayTypeTag;
 
 #[derive(Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/any_of.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/any_of.rs
@@ -1,0 +1,49 @@
+use error_stack::{Report, ReportSink, ResultExt};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+use crate::schema::{data_type::constraint::SimpleTypedValueSchema, ConstraintError, ValueLabel};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AnyOfConstraints {
+    #[cfg_attr(
+        target_arch = "wasm32",
+        tsify(type = "[SimpleTypedValueSchema, ...SimpleTypedValueSchema[]]")
+    )]
+    pub any_of: Vec<SimpleTypedValueSchema>,
+}
+
+impl AnyOfConstraints {
+    /// Checks if the provided value is valid against any of the schemas in the `any_of` list.
+    ///
+    /// # Errors
+    ///
+    /// - [`AnyOf`] if the value is not valid against any of the schemas.
+    ///
+    /// [`AnyOf`]: ConstraintError::AnyOf
+    pub fn validate_value(&self, value: &JsonValue) -> Result<(), Report<ConstraintError>> {
+        let mut status = ReportSink::<ConstraintError>::new();
+        for schema in &self.any_of {
+            if let Err(error) = schema.constraints.validate_value(value) {
+                status.capture(error);
+            } else {
+                return Ok(());
+            }
+        }
+        status.finish().change_context(ConstraintError::AnyOf)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AnyOfSchema {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "ValueLabel::is_empty")]
+    pub label: ValueLabel,
+    #[serde(flatten)]
+    pub constraints: AnyOfConstraints,
+}

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/any_of.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/any_of.rs
@@ -2,7 +2,7 @@ use error_stack::{Report, ReportSink, ResultExt};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
-use crate::schema::{data_type::constraint::SimpleTypedValueSchema, ConstraintError, ValueLabel};
+use crate::schema::{ConstraintError, ValueLabel, data_type::constraint::SimpleTypedValueSchema};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
@@ -1,26 +1,13 @@
-use error_stack::{Report, ReportSink};
+use codec::serde::constant::ConstBool;
+use error_stack::{Report, ReportSink, ResultExt, TryReportIteratorExt};
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value as JsonValue};
+use serde_json::Value as JsonValue;
 use thiserror::Error;
 
-use crate::schema::{data_type::constraint::ValueConstraints, DataTypeLabel};
+use crate::schema::{data_type::constraint::SimpleValueSchema, ConstraintError};
 
 #[derive(Debug, Error)]
 pub enum ArrayValidationError {
-    #[error(
-        "the provided value is not equal to the expected value, expected `{}` to be equal \
-         to `{}`", json!(actual), json!(expected)
-    )]
-    InvalidConstValue {
-        actual: Vec<JsonValue>,
-        expected: Vec<JsonValue>,
-    },
-    #[error("the provided value is not one of the expected values, expected `{}` to be one of `{}`", json!(actual), json!(expected))]
-    InvalidEnumValue {
-        actual: Vec<JsonValue>,
-        expected: Vec<Vec<JsonValue>>,
-    },
-
     #[error(
         "The length of the array is too short, expected `{actual}` to be greater than or equal to \
          `{expected}`"
@@ -38,13 +25,6 @@ pub enum ArrayValidationError {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged, deny_unknown_fields)]
-pub enum ItemsConstraints {
-    Boolean(bool),
-    Value(Box<ValueConstraints>),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum ArrayTypeTag {
@@ -53,133 +33,306 @@ pub enum ArrayTypeTag {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct ArraySchema {
-    pub r#type: ArrayTypeTag,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    #[serde(default, skip_serializing_if = "DataTypeLabel::is_empty")]
-    pub label: DataTypeLabel,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(target_arch = "wasm32", tsify(type = "JsonValue[]"))]
-    pub r#const: Option<Vec<JsonValue>>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    #[cfg_attr(
-        target_arch = "wasm32",
-        tsify(type = "[JsonValue[], ...JsonValue[][]]")
-    )]
-    pub r#enum: Vec<Vec<JsonValue>>,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub min_items: Option<usize>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_items: Option<usize>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(target_arch = "wasm32", tsify(type = "ValueConstraints | boolean"))]
-    pub items: Option<ItemsConstraints>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    #[cfg_attr(
-        target_arch = "wasm32",
-        tsify(type = "[ValueConstraints, ...ValueConstraints[]]")
-    )]
-    pub prefix_items: Vec<ValueConstraints>,
+#[serde(untagged, rename_all = "camelCase")]
+pub enum ArraySchema {
+    Constrained(ArrayConstraints),
+    Tuple(TupleConstraints),
 }
 
 impl ArraySchema {
+    /// Validates the provided value against the number schema.
+    ///
+    /// # Errors
+    ///
+    /// - [`ValueConstraint`] if the value does not match the expected constraints.
+    ///
+    /// [`ValueConstraint`]: ConstraintError::ValueConstraint
+    pub fn validate_value(&self, array: &[JsonValue]) -> Result<(), Report<ConstraintError>> {
+        match self {
+            Self::Constrained(constraints) => constraints
+                .validate_value(array)
+                .change_context(ConstraintError::ValueConstraint)?,
+            Self::Tuple(constraints) => constraints
+                .validate_value(array)
+                .change_context(ConstraintError::ValueConstraint)?,
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ArrayConstraints {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub items: Option<SimpleValueSchema>,
+}
+
+impl ArrayConstraints {
     /// Validates the provided value against the array constraints.
     ///
     /// # Errors
     ///
-    /// - [`InvalidConstValue`] if the value is not equal to the expected value.
-    /// - [`InvalidEnumValue`] if the value is not one of the expected values.
+    /// - [`Items`] if the value does not match the expected item constraints.
+    ///
+    /// [`Items`]: ArrayValidationError::Items
+    pub fn validate_value(
+        &self,
+        values: &[JsonValue],
+    ) -> Result<(), Report<[ArrayValidationError]>> {
+        let mut status = ReportSink::new();
+
+        if let Some(items) = &self.items {
+            status.attempt(
+                values
+                    .iter()
+                    .map(|value| items.validate_value(value))
+                    .try_collect_reports::<Vec<()>>()
+                    .change_context(ArrayValidationError::Items),
+            );
+        }
+
+        status.finish()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TupleConstraints {
+    #[cfg_attr(target_arch = "wasm32", tsify(type = "false"))]
+    pub items: ConstBool<false>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(
+        target_arch = "wasm32",
+        tsify(type = "[SimpleValueSchema, ...SimpleValueSchema[]]")
+    )]
+    pub prefix_items: Vec<SimpleValueSchema>,
+}
+
+impl TupleConstraints {
+    /// Validates the provided value against the tuple constraints.
+    ///
+    /// # Errors
+    ///
     /// - [`MinItems`] if the value has too few items.
     /// - [`MaxItems`] if the value has too many items.
-    /// - [`Items`] if the value does not match the expected item constraints.
-    /// - [`PrefixItems`] if the value does not match the expected prefix item constraints.
+    /// - [`PrefixItems`] if the value does not match the expected item constraints.
     ///
-    /// [`InvalidConstValue`]: ArrayValidationError::InvalidConstValue
-    /// [`InvalidEnumValue`]: ArrayValidationError::InvalidEnumValue
     /// [`MinItems`]: ArrayValidationError::MinItems
     /// [`MaxItems`]: ArrayValidationError::MaxItems
-    /// [`Items`]: ArrayValidationError::Items
     /// [`PrefixItems`]: ArrayValidationError::PrefixItems
     pub fn validate_value(
         &self,
         values: &[JsonValue],
     ) -> Result<(), Report<[ArrayValidationError]>> {
-        let mut validation_status = ReportSink::new();
-
-        if let Some(expected) = &self.r#const {
-            if expected != values {
-                validation_status.capture(ArrayValidationError::InvalidConstValue {
-                    expected: expected.clone(),
-                    actual: values.to_owned(),
-                });
-            }
-        }
-
-        if !self.r#enum.is_empty() && !self.r#enum.iter().any(|expected| expected == values) {
-            validation_status.capture(ArrayValidationError::InvalidEnumValue {
-                expected: self.r#enum.clone(),
-                actual: values.to_owned(),
-            });
-        }
+        let mut status = ReportSink::new();
 
         let num_values = values.len();
-
-        let mut values = values.iter();
-
-        let mut item_status = ReportSink::new();
-        for (value, constraint) in values
-            .by_ref()
-            .take(self.prefix_items.len())
-            .zip(&self.prefix_items)
-        {
-            if let Err(error) = constraint.validate_value(value) {
-                item_status.append(error);
-            }
-        }
-
-        let expected_num_items = self.prefix_items.len().max(self.min_items.unwrap_or(0));
-        if num_values < expected_num_items {
-            validation_status.capture(ArrayValidationError::MinItems {
-                actual: num_values,
-                expected: expected_num_items,
+        let num_prefix_items = self.prefix_items.len();
+        if num_values != num_prefix_items {
+            status.capture(if num_values < num_prefix_items {
+                ArrayValidationError::MinItems {
+                    actual: num_values,
+                    expected: num_prefix_items,
+                }
+            } else {
+                ArrayValidationError::MaxItems {
+                    actual: num_values,
+                    expected: num_prefix_items,
+                }
             });
         }
-        if let Some(max_items) = self.max_items {
-            if num_values > max_items {
-                validation_status.capture(ArrayValidationError::MaxItems {
-                    actual: num_values,
-                    expected: max_items,
-                });
-            }
-        }
 
-        match &self.items {
-            None | Some(ItemsConstraints::Boolean(true)) => {}
-            Some(ItemsConstraints::Boolean(false)) => {
-                if values.next().is_some() {
-                    validation_status.capture(ArrayValidationError::MaxItems {
-                        actual: num_values,
-                        expected: self.prefix_items.len(),
-                    });
-                }
-            }
-            Some(ItemsConstraints::Value(items)) => {
-                for value in values {
-                    if let Err(error) = items.validate_value(value) {
-                        item_status.append(error);
-                    }
-                }
-            }
-        }
+        status.attempt(
+            self.prefix_items
+                .iter()
+                .zip(values)
+                .map(|(schema, value)| schema.validate_value(value))
+                .try_collect_reports::<Vec<()>>()
+                .change_context(ArrayValidationError::PrefixItems),
+        );
 
-        if let Err(error) = item_status.finish() {
-            validation_status.append(error.change_context(ArrayValidationError::Items));
-        }
+        status.finish()
+    }
+}
 
-        validation_status.finish()
+#[cfg(test)]
+mod tests {
+    use serde_json::{from_value, json};
+
+    use super::*;
+    use crate::schema::{
+        data_type::constraint::{
+            tests::{check_constraints, check_constraints_error, read_schema},
+            ValueConstraints,
+        },
+        NumberValidationError,
+    };
+
+    #[test]
+    fn unconstrained() {
+        let array_schema = read_schema(&json!({
+            "type": "array",
+        }));
+
+        check_constraints(&array_schema, &json!([]));
+        check_constraints(&array_schema, &json!([1, 2, 3]));
+        check_constraints(&array_schema, &json!([1, "2", true]));
+    }
+
+    #[test]
+    fn simple_array() {
+        let array_schema = read_schema(&json!({
+            "type": "array",
+            "items": {
+                "type": "number",
+                "description": "A number",
+                "minimum": 0.0
+            },
+        }));
+
+        check_constraints(&array_schema, &json!([]));
+        check_constraints(&array_schema, &json!([1, 2, 3]));
+        check_constraints_error(
+            &array_schema,
+            &json!([1, "2", true]),
+            [ArrayValidationError::Items],
+        );
+        check_constraints_error(
+            &array_schema,
+            &json!([1, -2, 0]),
+            [ArrayValidationError::Items],
+        );
+        check_constraints_error(
+            &array_schema,
+            &json!([1, -2, -4]),
+            [
+                NumberValidationError::Minimum {
+                    actual: -2.0,
+                    expected: 0.0,
+                },
+                NumberValidationError::Minimum {
+                    actual: -4.0,
+                    expected: 0.0,
+                },
+            ],
+        );
+    }
+
+    #[test]
+    fn simple_tuple() {
+        let array_schema = read_schema(&json!({
+            "type": "array",
+            "items": false,
+            "prefixItems": [{
+                "type": "number",
+                "description": "A number",
+                "maximum": 10.0
+            }],
+        }));
+
+        check_constraints_error(
+            &array_schema,
+            &json!([]),
+            [ArrayValidationError::MinItems {
+                actual: 0,
+                expected: 1,
+            }],
+        );
+        check_constraints_error(
+            &array_schema,
+            &json!([1, 2, 3]),
+            [ArrayValidationError::MaxItems {
+                actual: 3,
+                expected: 1,
+            }],
+        );
+        check_constraints(&array_schema, &json!([1]));
+        check_constraints_error(
+            &array_schema,
+            &json!([15]),
+            [NumberValidationError::Maximum {
+                actual: 15.0,
+                expected: 10.0,
+            }],
+        );
+    }
+
+    #[test]
+    fn empty_array() {
+        let array_schema = read_schema(&json!({
+            "type": "array",
+            "items": false,
+        }));
+
+        check_constraints(&array_schema, &json!([]));
+        check_constraints_error(
+            &array_schema,
+            &json!([null]),
+            [ArrayValidationError::MaxItems {
+                actual: 1,
+                expected: 0,
+            }],
+        );
+    }
+
+    #[test]
+    fn missing_type() {
+        from_value::<ValueConstraints>(json!({
+            "items": {"type": "number"},
+        }))
+        .expect_err("Deserialized number schema without type");
+    }
+
+    #[test]
+    fn missing_nested_type() {
+        from_value::<ValueConstraints>(json!({
+            "type": "array",
+            "items": {},
+        }))
+        .expect_err("Deserialized number schema without nested type");
+    }
+
+    #[test]
+    fn additional_array_properties() {
+        from_value::<ValueConstraints>(json!({
+            "type": "array",
+            "items": {"type": "number"},
+            "additional": false,
+        }))
+        .expect_err("Deserialized array schema with additional properties");
+    }
+
+    #[test]
+    fn additional_tuple_properties() {
+        from_value::<ValueConstraints>(json!({
+            "type": "array",
+            "items": false,
+            "additional": false,
+        }))
+        .expect_err("Deserialized array schema with additional properties");
+    }
+
+    #[test]
+    fn additional_nested_properties() {
+        from_value::<ValueConstraints>(json!({
+            "type": "array",
+            "items": {
+                "type": "number",
+                "additional": false,
+            },
+        }))
+        .expect_err("Deserialized array schema with additional nested properties");
+    }
+
+    #[test]
+    fn mixed() {
+        from_value::<ValueConstraints>(json!({
+            "type": "array",
+            "items": {"type": "number"},
+            "prefixItems": [{"type": "number"}],
+        }))
+        .expect_err("Deserialized array schema with mixed properties");
     }
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
@@ -1,9 +1,9 @@
 use error_stack::{Report, ReportSink};
 use serde::{Deserialize, Serialize};
-use serde_json::{Value as JsonValue, json};
+use serde_json::{json, Value as JsonValue};
 use thiserror::Error;
 
-use crate::schema::{DataTypeLabel, data_type::constraint::ValueConstraints};
+use crate::schema::{data_type::constraint::ValueSchema, DataTypeLabel};
 
 #[derive(Debug, Error)]
 pub enum ArrayValidationError {
@@ -41,7 +41,7 @@ pub enum ArrayValidationError {
 #[serde(untagged, deny_unknown_fields)]
 pub enum ItemsConstraints {
     Boolean(bool),
-    Value(Box<ValueConstraints>),
+    Value(Box<ValueSchema>),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -83,7 +83,7 @@ pub struct ArraySchema {
         target_arch = "wasm32",
         tsify(type = "[ValueConstraints, ...ValueConstraints[]]")
     )]
-    pub prefix_items: Vec<ValueConstraints>,
+    pub prefix_items: Vec<ValueSchema>,
 }
 
 impl ArraySchema {

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
@@ -46,8 +46,16 @@ pub enum ItemsConstraints {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[serde(rename_all = "camelCase")]
+pub enum ArrayTypeTag {
+    Array,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ArraySchema {
+    pub r#type: ArrayTypeTag,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(default, skip_serializing_if = "DataTypeLabel::is_empty")]
@@ -79,6 +87,23 @@ pub struct ArraySchema {
 }
 
 impl ArraySchema {
+    /// Validates the provided value against the array constraints.
+    ///
+    /// # Errors
+    ///
+    /// - [`InvalidConstValue`] if the value is not equal to the expected value.
+    /// - [`InvalidEnumValue`] if the value is not one of the expected values.
+    /// - [`MinItems`] if the value has too few items.
+    /// - [`MaxItems`] if the value has too many items.
+    /// - [`Items`] if the value does not match the expected item constraints.
+    /// - [`PrefixItems`] if the value does not match the expected prefix item constraints.
+    ///
+    /// [`InvalidConstValue`]: ArrayValidationError::InvalidConstValue
+    /// [`InvalidEnumValue`]: ArrayValidationError::InvalidEnumValue
+    /// [`MinItems`]: ArrayValidationError::MinItems
+    /// [`MaxItems`]: ArrayValidationError::MaxItems
+    /// [`Items`]: ArrayValidationError::Items
+    /// [`PrefixItems`]: ArrayValidationError::PrefixItems
     pub fn validate_value(
         &self,
         values: &[JsonValue],

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
 use thiserror::Error;
 
-use crate::schema::{data_type::constraint::ValueSchema, DataTypeLabel};
+use crate::schema::{data_type::constraint::ValueConstraints, DataTypeLabel};
 
 #[derive(Debug, Error)]
 pub enum ArrayValidationError {
@@ -41,7 +41,7 @@ pub enum ArrayValidationError {
 #[serde(untagged, deny_unknown_fields)]
 pub enum ItemsConstraints {
     Boolean(bool),
-    Value(Box<ValueSchema>),
+    Value(Box<ValueConstraints>),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -83,7 +83,7 @@ pub struct ArraySchema {
         target_arch = "wasm32",
         tsify(type = "[ValueConstraints, ...ValueConstraints[]]")
     )]
-    pub prefix_items: Vec<ValueSchema>,
+    pub prefix_items: Vec<ValueConstraints>,
 }
 
 impl ArraySchema {

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use thiserror::Error;
 
-use crate::schema::{data_type::constraint::SimpleValueSchema, ConstraintError};
+use crate::schema::{ConstraintError, data_type::constraint::SimpleValueSchema};
 
 #[derive(Debug, Error)]
 pub enum ArrayValidationError {
@@ -163,11 +163,11 @@ mod tests {
 
     use super::*;
     use crate::schema::{
-        data_type::constraint::{
-            tests::{check_constraints, check_constraints_error, read_schema},
-            ValueConstraints,
-        },
         NumberValidationError,
+        data_type::constraint::{
+            ValueConstraints,
+            tests::{check_constraints, check_constraints_error, read_schema},
+        },
     };
 
     #[test]
@@ -194,30 +194,22 @@ mod tests {
 
         check_constraints(&array_schema, &json!([]));
         check_constraints(&array_schema, &json!([1, 2, 3]));
-        check_constraints_error(
-            &array_schema,
-            &json!([1, "2", true]),
-            [ArrayValidationError::Items],
-        );
-        check_constraints_error(
-            &array_schema,
-            &json!([1, -2, 0]),
-            [ArrayValidationError::Items],
-        );
-        check_constraints_error(
-            &array_schema,
-            &json!([1, -2, -4]),
-            [
-                NumberValidationError::Minimum {
-                    actual: -2.0,
-                    expected: 0.0,
-                },
-                NumberValidationError::Minimum {
-                    actual: -4.0,
-                    expected: 0.0,
-                },
-            ],
-        );
+        check_constraints_error(&array_schema, &json!([1, "2", true]), [
+            ArrayValidationError::Items,
+        ]);
+        check_constraints_error(&array_schema, &json!([1, -2, 0]), [
+            ArrayValidationError::Items,
+        ]);
+        check_constraints_error(&array_schema, &json!([1, -2, -4]), [
+            NumberValidationError::Minimum {
+                actual: -2.0,
+                expected: 0.0,
+            },
+            NumberValidationError::Minimum {
+                actual: -4.0,
+                expected: 0.0,
+            },
+        ]);
     }
 
     #[test]
@@ -232,31 +224,25 @@ mod tests {
             }],
         }));
 
-        check_constraints_error(
-            &array_schema,
-            &json!([]),
-            [ArrayValidationError::MinItems {
+        check_constraints_error(&array_schema, &json!([]), [
+            ArrayValidationError::MinItems {
                 actual: 0,
                 expected: 1,
-            }],
-        );
-        check_constraints_error(
-            &array_schema,
-            &json!([1, 2, 3]),
-            [ArrayValidationError::MaxItems {
+            },
+        ]);
+        check_constraints_error(&array_schema, &json!([1, 2, 3]), [
+            ArrayValidationError::MaxItems {
                 actual: 3,
                 expected: 1,
-            }],
-        );
+            },
+        ]);
         check_constraints(&array_schema, &json!([1]));
-        check_constraints_error(
-            &array_schema,
-            &json!([15]),
-            [NumberValidationError::Maximum {
+        check_constraints_error(&array_schema, &json!([15]), [
+            NumberValidationError::Maximum {
                 actual: 15.0,
                 expected: 10.0,
-            }],
-        );
+            },
+        ]);
     }
 
     #[test]
@@ -267,14 +253,12 @@ mod tests {
         }));
 
         check_constraints(&array_schema, &json!([]));
-        check_constraints_error(
-            &array_schema,
-            &json!([null]),
-            [ArrayValidationError::MaxItems {
+        check_constraints_error(&array_schema, &json!([null]), [
+            ArrayValidationError::MaxItems {
                 actual: 1,
                 expected: 0,
-            }],
-        );
+            },
+        ]);
     }
 
     #[test]

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/boolean.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/boolean.rs
@@ -1,79 +1,8 @@
-use std::collections::HashSet;
-
-use error_stack::{Report, ReportSink};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
-use thiserror::Error;
-
-use crate::schema::DataTypeLabel;
-
-#[derive(Debug, Error)]
-pub enum BooleanValidationError {
-    #[error(
-        "the provided value is not equal to the expected value, expected `{actual}` to be equal \
-         to `{expected}`"
-    )]
-    InvalidConstValue { actual: bool, expected: bool },
-    #[error("the provided value is not one of the expected values, expected `{actual}` to be one of `{}`", json!(expected))]
-    InvalidEnumValue {
-        actual: bool,
-        expected: HashSet<bool>,
-    },
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum BooleanTypeTag {
     Boolean,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct BooleanSchema {
-    pub r#type: BooleanTypeTag,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    #[serde(default, skip_serializing_if = "DataTypeLabel::is_empty")]
-    pub label: DataTypeLabel,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub r#const: Option<bool>,
-    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
-    #[cfg_attr(target_arch = "wasm32", tsify(type = "[boolean, ...boolean[]]"))]
-    pub r#enum: HashSet<bool>,
-}
-
-impl BooleanSchema {
-    /// Validates the provided value against the boolean constraints.
-    ///
-    /// # Errors
-    ///
-    /// - [`InvalidConstValue`] if the value is not equal to the expected value.
-    /// - [`InvalidEnumValue`] if the value is not one of the expected values.
-    ///
-    /// [`InvalidConstValue`]: BooleanValidationError::InvalidConstValue
-    /// [`InvalidEnumValue`]: BooleanValidationError::InvalidEnumValue
-    pub fn validate_value(&self, boolean: bool) -> Result<(), Report<[BooleanValidationError]>> {
-        let mut status = ReportSink::new();
-
-        if let Some(expected) = &self.r#const {
-            if *expected != boolean {
-                status.capture(BooleanValidationError::InvalidConstValue {
-                    expected: *expected,
-                    actual: boolean,
-                });
-            }
-        }
-
-        if !self.r#enum.is_empty() && !self.r#enum.contains(&boolean) {
-            status.capture(BooleanValidationError::InvalidEnumValue {
-                expected: self.r#enum.clone(),
-                actual: boolean,
-            });
-        }
-
-        status.finish()
-    }
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/boolean.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/boolean.rs
@@ -23,8 +23,16 @@ pub enum BooleanValidationError {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[serde(rename_all = "camelCase")]
+pub enum BooleanTypeTag {
+    Boolean,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct BooleanSchema {
+    pub r#type: BooleanTypeTag,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(default, skip_serializing_if = "DataTypeLabel::is_empty")]
@@ -38,6 +46,15 @@ pub struct BooleanSchema {
 }
 
 impl BooleanSchema {
+    /// Validates the provided value against the boolean constraints.
+    ///
+    /// # Errors
+    ///
+    /// - [`InvalidConstValue`] if the value is not equal to the expected value.
+    /// - [`InvalidEnumValue`] if the value is not one of the expected values.
+    ///
+    /// [`InvalidConstValue`]: BooleanValidationError::InvalidConstValue
+    /// [`InvalidEnumValue`]: BooleanValidationError::InvalidEnumValue
     pub fn validate_value(&self, boolean: bool) -> Result<(), Report<[BooleanValidationError]>> {
         let mut status = ReportSink::new();
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/error.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/error.rs
@@ -1,9 +1,23 @@
+use serde_json::{json, Value as JsonValue};
 use thiserror::Error;
 
 use crate::schema::JsonSchemaValueType;
 
 #[derive(Debug, Error)]
 pub enum ConstraintError {
+    #[error(
+        "the provided value is not equal to the expected value, expected `{actual}` to be equal \
+         to `{expected}`"
+    )]
+    InvalidConstValue {
+        actual: JsonValue,
+        expected: JsonValue,
+    },
+    #[error("the provided value is not one of the expected values, expected `{actual}` to be one of `{}`", json!(expected))]
+    InvalidEnumValue {
+        actual: JsonValue,
+        expected: Vec<JsonValue>,
+    },
     #[error("the value does not match the expected constraints")]
     ValueConstraint,
     #[error(

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/error.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/error.rs
@@ -1,4 +1,4 @@
-use serde_json::{json, Value as JsonValue};
+use serde_json::{Value as JsonValue, json};
 use thiserror::Error;
 
 use crate::schema::JsonSchemaValueType;

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/error.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/error.rs
@@ -1,6 +1,3 @@
-use core::net::AddrParseError;
-
-use iso8601_duration::ParseDurationError;
 use thiserror::Error;
 
 use crate::schema::JsonSchemaValueType;
@@ -17,26 +14,6 @@ pub enum ConstraintError {
         actual: JsonSchemaValueType,
         expected: JsonSchemaValueType,
     },
-}
-
-#[derive(Debug, Error)]
-pub enum StringFormatError {
-    #[error(transparent)]
-    Url(url::ParseError),
-    #[error(transparent)]
-    Uuid(uuid::Error),
-    #[error(transparent)]
-    Regex(regex::Error),
-    #[error(transparent)]
-    Email(email_address::Error),
-    #[error(transparent)]
-    IpAddress(AddrParseError),
-    #[error("The value does not match the date-time format `YYYY-MM-DDTHH:MM:SS.sssZ`")]
-    DateTime,
-    #[error("The value does not match the date format `YYYY-MM-DD`")]
-    Date,
-    #[error("The value does not match the time format `HH:MM:SS.sss`")]
-    Time,
-    #[error("{0:?}")]
-    Duration(ParseDurationError),
+    #[error("None of the provided values match the expected values")]
+    AnyOf,
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
@@ -7,7 +7,7 @@ mod number;
 mod object;
 mod string;
 
-use error_stack::{bail, Report};
+use error_stack::{Report, bail};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
@@ -24,12 +24,8 @@ use crate::schema::{DataTypeLabel, JsonSchemaValueType};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct AnyOfSchema {
-    #[cfg_attr(
-        target_arch = "wasm32",
-        tsify(type = "[ValueConstraints, ...ValueConstraints[]]")
-    )]
-    pub any_of: Vec<ValueSchema>,
+pub struct AnyOfConstraint {
+    pub any_of: Vec<ValueConstraints>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(default, skip_serializing_if = "DataTypeLabel::is_empty")]
@@ -39,17 +35,17 @@ pub struct AnyOfSchema {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(untagged, rename_all = "camelCase")]
-pub enum ValueSchema {
+pub enum ValueConstraints {
     Null(NullSchema),
     Boolean(BooleanSchema),
     Number(NumberSchema),
     String(StringSchema),
     Array(ArraySchema),
     Object(ObjectSchema),
-    AnyOf(AnyOfSchema),
+    AnyOf(AnyOfConstraint),
 }
 
-impl ValueSchema {
+impl ValueConstraints {
     /// Validates the provided value against the constraints.
     ///
     /// # Errors
@@ -133,7 +129,7 @@ impl ValueSchema {
                     })
                 }
             }
-            Self::AnyOf(AnyOfSchema { any_of, .. }) => {
+            Self::AnyOf(AnyOfConstraint { any_of, .. }) => {
                 let mut num_successes = 0;
                 let status = any_of
                     .iter()

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
@@ -7,7 +7,7 @@ mod number;
 mod object;
 mod string;
 
-use error_stack::{Report, bail};
+use error_stack::{bail, Report};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
@@ -40,7 +40,7 @@ pub struct SimpleTypedValueSchema {
 #[cfg(target_arch = "wasm32")]
 #[expect(
     dead_code,
-    reason = "Used to export type to TypeScript to Tsify generating interfaces"
+    reason = "Used to export type to TypeScript to prevent Tsify generating interfaces"
 )]
 mod wasm {
     use super::*;

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
@@ -6,19 +6,35 @@ mod number;
 mod object;
 mod string;
 
-use error_stack::{Report, ResultExt, bail};
+use error_stack::{Report, ResultExt, TryReportIteratorExt, bail};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
-pub(crate) use self::{
-    array::ArraySchema, boolean::BooleanSchema, error::ConstraintError, null::NullSchema,
-    number::NumberSchema, object::ObjectSchema, string::StringSchema,
+pub use self::{
+    array::{ArraySchema, ArrayTypeTag, ArrayValidationError},
+    boolean::{BooleanSchema, BooleanTypeTag, BooleanValidationError},
+    error::ConstraintError,
+    null::{NullSchema, NullTypeTag},
+    number::{NumberSchema, NumberTypeTag, NumberValidationError},
+    object::{ObjectSchema, ObjectTypeTag, ObjectValidationError},
+    string::{StringFormat, StringFormatError, StringSchema, StringTypeTag, StringValidationError},
 };
-use crate::schema::JsonSchemaValueType;
+use crate::schema::{DataTypeLabel, JsonSchemaValueType};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
-#[serde(tag = "type", rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AnyOfConstraint {
+    pub any_of: Vec<ValueConstraints>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "DataTypeLabel::is_empty")]
+    pub label: DataTypeLabel,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[serde(untagged, rename_all = "camelCase")]
 pub enum ValueConstraints {
     Null(NullSchema),
     Boolean(BooleanSchema),
@@ -26,9 +42,21 @@ pub enum ValueConstraints {
     String(StringSchema),
     Array(ArraySchema),
     Object(ObjectSchema),
+    AnyOf(AnyOfConstraint),
 }
 
 impl ValueConstraints {
+    /// Validates the provided value against the constraints.
+    ///
+    /// # Errors
+    ///
+    /// - [`InvalidType`] if the value does not match the expected type.
+    /// - [`ValueConstraint`] if the value does not match the expected constraints.
+    /// - [`AnyOf`] if the value does not match any of the expected schemas.
+    ///
+    /// [`InvalidType`]: ConstraintError::InvalidType
+    /// [`ValueConstraint`]: ConstraintError::ValueConstraint
+    /// [`AnyOf`]: ConstraintError::AnyOf
     pub fn validate_value(&self, value: &JsonValue) -> Result<(), Report<ConstraintError>> {
         match self {
             Self::Null(_) => {
@@ -99,6 +127,18 @@ impl ValueConstraints {
                         actual: JsonSchemaValueType::from(value),
                         expected: JsonSchemaValueType::Object,
                     })
+                }
+            }
+            Self::AnyOf(AnyOfConstraint { any_of, .. }) => {
+                let mut num_successes = 0;
+                let status = any_of
+                    .iter()
+                    .map(|schema| schema.validate_value(value).map(|()| num_successes += 1))
+                    .try_collect_reports();
+                if num_successes == 0 {
+                    status.change_context(ConstraintError::AnyOf)
+                } else {
+                    Ok(())
                 }
             }
         }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
@@ -7,7 +7,7 @@ mod number;
 mod object;
 mod string;
 
-use error_stack::{Report, bail};
+use error_stack::{bail, Report};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
@@ -64,6 +64,7 @@ mod wasm {
 #[serde(untagged, rename_all = "camelCase")]
 pub enum SimpleValueSchema {
     Typed(SimpleTypedValueSchema),
+    #[serde(skip)]
     AnyOf(AnyOfSchema),
 }
 
@@ -168,6 +169,7 @@ impl SimpleTypedValueConstraint {
 #[serde(untagged, rename_all = "camelCase")]
 pub enum ValueConstraints {
     Typed(TypedValueConstraints),
+    #[serde(skip)]
     AnyOf(AnyOfConstraints),
 }
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
@@ -1,3 +1,4 @@
+mod any_of;
 mod array;
 mod boolean;
 mod error;
@@ -6,46 +7,200 @@ mod number;
 mod object;
 mod string;
 
-use error_stack::{bail, Report, ResultExt, TryReportIteratorExt};
+use error_stack::{bail, Report};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
 pub use self::{
-    array::{ArraySchema, ArrayTypeTag, ArrayValidationError},
-    boolean::{BooleanSchema, BooleanTypeTag, BooleanValidationError},
+    any_of::{AnyOfConstraints, AnyOfSchema},
+    array::{ArrayConstraints, ArraySchema, ArrayTypeTag, ArrayValidationError, TupleConstraints},
+    boolean::BooleanTypeTag,
     error::ConstraintError,
-    null::{NullSchema, NullTypeTag},
-    number::{NumberSchema, NumberTypeTag, NumberValidationError},
-    object::{ObjectSchema, ObjectTypeTag, ObjectValidationError},
-    string::{StringFormat, StringFormatError, StringSchema, StringTypeTag, StringValidationError},
+    null::NullTypeTag,
+    number::{NumberConstraints, NumberSchema, NumberTypeTag, NumberValidationError},
+    object::ObjectTypeTag,
+    string::{
+        StringConstraints, StringFormat, StringFormatError, StringSchema, StringTypeTag,
+        StringValidationError,
+    },
 };
-use crate::schema::{DataTypeLabel, JsonSchemaValueType};
+use crate::schema::{JsonSchemaValueType, ValueLabel};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct AnyOfConstraint {
-    pub any_of: Vec<ValueConstraints>,
+#[serde(rename_all = "camelCase")]
+pub struct SimpleTypedValueSchema {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(default, skip_serializing_if = "DataTypeLabel::is_empty")]
-    pub label: DataTypeLabel,
+    #[serde(default, skip_serializing_if = "ValueLabel::is_empty")]
+    pub label: ValueLabel,
+    #[serde(flatten)]
+    pub constraints: SimpleTypedValueConstraint,
+}
+
+#[cfg(target_arch = "wasm32")]
+#[expect(
+    dead_code,
+    reason = "Used to export type to TypeScript to Tsify generating interfaces"
+)]
+mod wasm {
+    use super::*;
+
+    #[derive(tsify::Tsify)]
+    #[serde(untagged)]
+    enum SimpleTypedValueSchema {
+        Schema {
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            description: Option<String>,
+            #[serde(default)]
+            label: ValueLabel,
+            #[serde(flatten)]
+            constraints: SimpleTypedValueConstraint,
+        },
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(untagged, rename_all = "camelCase")]
-pub enum ValueConstraints {
-    Null(NullSchema),
-    Boolean(BooleanSchema),
+pub enum SimpleValueSchema {
+    Typed(SimpleTypedValueSchema),
+    AnyOf(AnyOfSchema),
+}
+
+impl SimpleValueSchema {
+    /// Forwards the value validation to the appropriate schema.
+    ///
+    /// # Errors
+    ///
+    /// - For [`Typed`] schemas, see [`TypedValueConstraints::validate_value`].
+    /// - For [`AnyOf`] schemas, see [`AnyOfConstraints::validate_value`].
+    ///
+    /// [`Typed`]: Self::Typed
+    /// [`AnyOf`]: Self::AnyOf
+    pub fn validate_value(&self, value: &JsonValue) -> Result<(), Report<ConstraintError>> {
+        match self {
+            Self::Typed(schema) => schema.constraints.validate_value(value),
+            Self::AnyOf(schema) => schema.constraints.validate_value(value),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum SimpleTypedValueConstraint {
+    Null,
+    Boolean,
     Number(NumberSchema),
     String(StringSchema),
-    Array(ArraySchema),
-    Object(ObjectSchema),
-    AnyOf(AnyOfConstraint),
+    Array,
+    Object,
+}
+
+impl SimpleTypedValueConstraint {
+    pub fn validate_value(&self, value: &JsonValue) -> Result<(), Report<ConstraintError>> {
+        match self {
+            Self::Null => {
+                if value.is_null() {
+                    Ok(())
+                } else {
+                    bail!(ConstraintError::InvalidType {
+                        actual: JsonSchemaValueType::from(value),
+                        expected: JsonSchemaValueType::Null,
+                    })
+                }
+            }
+            Self::Boolean => {
+                if value.is_boolean() {
+                    Ok(())
+                } else {
+                    bail!(ConstraintError::InvalidType {
+                        actual: JsonSchemaValueType::from(value),
+                        expected: JsonSchemaValueType::Boolean,
+                    })
+                }
+            }
+            Self::Number(schema) => {
+                if let JsonValue::Number(number) = value {
+                    schema.validate_value(number)
+                } else {
+                    bail!(ConstraintError::InvalidType {
+                        actual: JsonSchemaValueType::from(value),
+                        expected: JsonSchemaValueType::Number,
+                    })
+                }
+            }
+            Self::String(schema) => {
+                if let JsonValue::String(string) = value {
+                    schema.validate_value(string)
+                } else {
+                    bail!(ConstraintError::InvalidType {
+                        actual: JsonSchemaValueType::from(value),
+                        expected: JsonSchemaValueType::String,
+                    })
+                }
+            }
+            Self::Array => {
+                if value.is_array() {
+                    Ok(())
+                } else {
+                    bail!(ConstraintError::InvalidType {
+                        actual: JsonSchemaValueType::from(value),
+                        expected: JsonSchemaValueType::Array,
+                    })
+                }
+            }
+            Self::Object => {
+                if value.is_object() {
+                    Ok(())
+                } else {
+                    bail!(ConstraintError::InvalidType {
+                        actual: JsonSchemaValueType::from(value),
+                        expected: JsonSchemaValueType::Object,
+                    })
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged, rename_all = "camelCase")]
+pub enum ValueConstraints {
+    Typed(TypedValueConstraints),
+    AnyOf(AnyOfConstraints),
 }
 
 impl ValueConstraints {
+    /// Forwards the value validation to the appropriate schema.
+    ///
+    /// # Errors
+    ///
+    /// - For [`Typed`] schemas, see [`TypedValueConstraints::validate_value`].
+    /// - For [`AnyOf`] schemas, see [`SimpleTypedValueConstraint::validate_value`].
+    ///
+    /// [`Typed`]: Self::Typed
+    /// [`AnyOf`]: Self::AnyOf
+    pub fn validate_value(&self, value: &JsonValue) -> Result<(), Report<ConstraintError>> {
+        match self {
+            Self::Typed(constraints) => constraints.validate_value(value),
+            Self::AnyOf(constraints) => constraints.validate_value(value),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum TypedValueConstraints {
+    Null,
+    Boolean,
+    Number(NumberSchema),
+    String(StringSchema),
+    Array(ArraySchema),
+    Object,
+}
+
+impl TypedValueConstraints {
     /// Validates the provided value against the constraints.
     ///
     /// # Errors
@@ -59,7 +214,7 @@ impl ValueConstraints {
     /// [`AnyOf`]: ConstraintError::AnyOf
     pub fn validate_value(&self, value: &JsonValue) -> Result<(), Report<ConstraintError>> {
         match self {
-            Self::Null(_) => {
+            Self::Null => {
                 if value.is_null() {
                     Ok(())
                 } else {
@@ -69,11 +224,9 @@ impl ValueConstraints {
                     })
                 }
             }
-            Self::Boolean(schema) => {
-                if let JsonValue::Bool(boolean) = value {
-                    schema
-                        .validate_value(*boolean)
-                        .change_context(ConstraintError::ValueConstraint)
+            Self::Boolean => {
+                if value.is_boolean() {
+                    Ok(())
                 } else {
                     bail!(ConstraintError::InvalidType {
                         actual: JsonSchemaValueType::from(value),
@@ -83,9 +236,7 @@ impl ValueConstraints {
             }
             Self::Number(schema) => {
                 if let JsonValue::Number(number) = value {
-                    schema
-                        .validate_value(number)
-                        .change_context(ConstraintError::ValueConstraint)
+                    schema.validate_value(number)
                 } else {
                     bail!(ConstraintError::InvalidType {
                         actual: JsonSchemaValueType::from(value),
@@ -95,9 +246,7 @@ impl ValueConstraints {
             }
             Self::String(schema) => {
                 if let JsonValue::String(string) = value {
-                    schema
-                        .validate_value(string)
-                        .change_context(ConstraintError::ValueConstraint)
+                    schema.validate_value(string)
                 } else {
                     bail!(ConstraintError::InvalidType {
                         actual: JsonSchemaValueType::from(value),
@@ -107,9 +256,7 @@ impl ValueConstraints {
             }
             Self::Array(schema) => {
                 if let JsonValue::Array(array) = value {
-                    schema
-                        .validate_value(array)
-                        .change_context(ConstraintError::ValueConstraint)
+                    schema.validate_value(array)
                 } else {
                     bail!(ConstraintError::InvalidType {
                         actual: JsonSchemaValueType::from(value),
@@ -117,11 +264,9 @@ impl ValueConstraints {
                     })
                 }
             }
-            Self::Object(schema) => {
-                if let JsonValue::Object(object) = value {
-                    schema
-                        .validate_value(object)
-                        .change_context(ConstraintError::ValueConstraint)
+            Self::Object => {
+                if value.is_object() {
+                    Ok(())
                 } else {
                     bail!(ConstraintError::InvalidType {
                         actual: JsonSchemaValueType::from(value),
@@ -129,18 +274,53 @@ impl ValueConstraints {
                     })
                 }
             }
-            Self::AnyOf(AnyOfConstraint { any_of, .. }) => {
-                let mut num_successes = 0;
-                let status = any_of
-                    .iter()
-                    .map(|schema| schema.validate_value(value).map(|()| num_successes += 1))
-                    .try_collect_reports();
-                if num_successes == 0 {
-                    status.change_context(ConstraintError::AnyOf)
-                } else {
-                    Ok(())
-                }
-            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::fmt::Display;
+    use std::collections::HashSet;
+
+    use error_stack::Frame;
+    use serde_json::Value as JsonValue;
+
+    use crate::schema::data_type::constraint::ValueConstraints;
+
+    pub(crate) fn read_schema(schema: &JsonValue) -> ValueConstraints {
+        let parsed = serde_json::from_value(schema.clone()).expect("Failed to parse schema");
+        assert_eq!(
+            serde_json::to_value(&parsed).expect("Could not serialize schema"),
+            *schema
+        );
+        parsed
+    }
+
+    pub(crate) fn check_constraints(schema: &ValueConstraints, value: &JsonValue) {
+        schema
+            .validate_value(value)
+            .expect("Failed to validate value");
+    }
+
+    pub(crate) fn check_constraints_error<E: Display + Send + Sync + 'static>(
+        schema: &ValueConstraints,
+        value: &JsonValue,
+        expected_errors: impl IntoIterator<Item = E>,
+    ) {
+        let err = schema
+            .validate_value(value)
+            .expect_err("Expected validation error");
+        let errors = expected_errors
+            .into_iter()
+            .map(|error| error.to_string())
+            .collect::<HashSet<_>>();
+        let actual_errors = err
+            .frames()
+            .filter_map(Frame::downcast_ref::<E>)
+            .map(ToString::to_string)
+            .collect::<HashSet<_>>();
+
+        assert_eq!(errors, actual_errors);
     }
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/null.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/null.rs
@@ -1,27 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-use crate::schema::DataTypeLabel;
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum NullTypeTag {
     Null,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct NullSchema {
-    pub r#type: NullTypeTag,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    #[serde(default, skip_serializing_if = "DataTypeLabel::is_empty")]
-    pub label: DataTypeLabel,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub r#const: Option<()>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    #[cfg_attr(target_arch = "wasm32", tsify(type = "[null]"))]
-    pub r#enum: Vec<()>,
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/null.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/null.rs
@@ -4,8 +4,16 @@ use crate::schema::DataTypeLabel;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[serde(rename_all = "camelCase")]
+pub enum NullTypeTag {
+    Null,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct NullSchema {
+    pub r#type: NullTypeTag,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(default, skip_serializing_if = "DataTypeLabel::is_empty")]

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
@@ -1,6 +1,6 @@
-use error_stack::{bail, Report, ReportSink, ResultExt};
+use error_stack::{Report, ReportSink, ResultExt, bail};
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Number as JsonNumber, Value as JsonValue};
+use serde_json::{Number as JsonNumber, Value as JsonValue, json};
 use thiserror::Error;
 
 use crate::schema::ConstraintError;
@@ -110,10 +110,12 @@ impl NumberSchema {
     /// [`ValueConstraint`]: ConstraintError::ValueConstraint
     pub fn validate_value(&self, number: &JsonNumber) -> Result<(), Report<ConstraintError>> {
         let Some(float) = number.as_f64() else {
-            bail!(Report::new(NumberValidationError::InsufficientPrecision {
-                actual: number.clone()
-            })
-            .change_context(ConstraintError::ValueConstraint));
+            bail!(
+                Report::new(NumberValidationError::InsufficientPrecision {
+                    actual: number.clone()
+                })
+                .change_context(ConstraintError::ValueConstraint)
+            );
         };
 
         match self {
@@ -232,11 +234,11 @@ mod tests {
 
     use super::*;
     use crate::schema::{
-        data_type::constraint::{
-            tests::{check_constraints, check_constraints_error, read_schema},
-            ValueConstraints,
-        },
         JsonSchemaValueType, NumberValidationError,
+        data_type::constraint::{
+            ValueConstraints,
+            tests::{check_constraints, check_constraints_error, read_schema},
+        },
     };
 
     #[test]
@@ -277,14 +279,12 @@ mod tests {
         }));
 
         check_constraints(&number_schema, &json!(0));
-        check_constraints_error(
-            &number_schema,
-            &json!("NaN"),
-            [ConstraintError::InvalidType {
+        check_constraints_error(&number_schema, &json!("NaN"), [
+            ConstraintError::InvalidType {
                 actual: JsonSchemaValueType::String,
                 expected: JsonSchemaValueType::Number,
-            }],
-        );
+            },
+        ]);
     }
 
     #[test]
@@ -296,30 +296,24 @@ mod tests {
         }));
 
         check_constraints(&number_schema, &json!(5));
-        check_constraints_error(
-            &number_schema,
-            &json!("2"),
-            [ConstraintError::InvalidType {
+        check_constraints_error(&number_schema, &json!("2"), [
+            ConstraintError::InvalidType {
                 actual: JsonSchemaValueType::String,
                 expected: JsonSchemaValueType::Number,
-            }],
-        );
-        check_constraints_error(
-            &number_schema,
-            &json!(-2),
-            [NumberValidationError::Minimum {
+            },
+        ]);
+        check_constraints_error(&number_schema, &json!(-2), [
+            NumberValidationError::Minimum {
                 actual: -2.0,
                 expected: 0.0,
-            }],
-        );
-        check_constraints_error(
-            &number_schema,
-            &json!(15),
-            [NumberValidationError::Maximum {
+            },
+        ]);
+        check_constraints_error(&number_schema, &json!(15), [
+            NumberValidationError::Maximum {
                 actual: 15.0,
                 expected: 10.0,
-            }],
-        );
+            },
+        ]);
     }
 
     #[test]
@@ -330,14 +324,12 @@ mod tests {
         }));
 
         check_constraints(&number_schema, &json!(50));
-        check_constraints_error(
-            &number_schema,
-            &json!(10),
-            [ConstraintError::InvalidConstValue {
+        check_constraints_error(&number_schema, &json!(10), [
+            ConstraintError::InvalidConstValue {
                 actual: json!(10),
                 expected: json!(50.0),
-            }],
-        );
+            },
+        ]);
     }
 
     #[test]
@@ -348,14 +340,12 @@ mod tests {
         }));
 
         check_constraints(&number_schema, &json!(50));
-        check_constraints_error(
-            &number_schema,
-            &json!(10),
-            [ConstraintError::InvalidEnumValue {
+        check_constraints_error(&number_schema, &json!(10), [
+            ConstraintError::InvalidEnumValue {
                 actual: json!(10),
                 expected: vec![json!(20.0), json!(50.0)],
-            }],
-        );
+            },
+        ]);
     }
 
     #[test]

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
@@ -1,9 +1,9 @@
-use error_stack::{Report, ReportSink, bail};
+use error_stack::{bail, Report, ReportSink, ResultExt};
 use serde::{Deserialize, Serialize};
-use serde_json::{Number as JsonNumber, json};
+use serde_json::{json, Number as JsonNumber, Value as JsonValue};
 use thiserror::Error;
 
-use crate::schema::DataTypeLabel;
+use crate::schema::ConstraintError;
 
 #[expect(
     clippy::trivially_copy_pass_by_ref,
@@ -21,14 +21,6 @@ pub enum NumberValidationError {
          a bug report, the linear tracking issue for this error is `H-2980`"
     )]
     InsufficientPrecision { actual: JsonNumber },
-
-    #[error(
-        "the provided value is not equal to the expected value, expected `{actual}` to be equal \
-         to `{expected}`"
-    )]
-    InvalidConstValue { actual: f64, expected: f64 },
-    #[error("the provided value is not one of the expected values, expected `{actual}` to be one of `{}`", json!(expected))]
-    InvalidEnumValue { actual: f64, expected: Vec<f64> },
 
     #[error(
         "the provided value is not greater than or equal to the minimum value, expected \
@@ -63,37 +55,20 @@ pub enum NumberValidationError {
 #[serde(rename_all = "camelCase")]
 pub enum NumberTypeTag {
     Number,
-    #[serde(skip)]
-    Integer,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct NumberSchema {
-    pub r#type: NumberTypeTag,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    #[serde(default, skip_serializing_if = "DataTypeLabel::is_empty")]
-    pub label: DataTypeLabel,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub r#const: Option<f64>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    #[cfg_attr(target_arch = "wasm32", tsify(type = "[number, ...number[]]"))]
-    pub r#enum: Vec<f64>,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub minimum: Option<f64>,
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub exclusive_minimum: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub maximum: Option<f64>,
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub exclusive_maximum: bool,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub multiple_of: Option<f64>,
+#[serde(untagged, rename_all = "camelCase", deny_unknown_fields)]
+pub enum NumberSchema {
+    Constrained(NumberConstraints),
+    Const {
+        r#const: f64,
+    },
+    Enum {
+        #[cfg_attr(target_arch = "wasm32", tsify(type = "[number, ...number[]]"))]
+        r#enum: Vec<f64>,
+    },
 }
 
 #[expect(
@@ -122,72 +97,96 @@ fn float_less(lhs: f64, rhs: f64) -> bool {
 }
 
 impl NumberSchema {
+    /// Validates the provided value against the number schema.
+    ///
+    /// # Errors
+    ///
+    /// - [`InvalidConstValue`] if the value is not equal to the expected value.
+    /// - [`InvalidEnumValue`] if the value is not one of the expected values.
+    /// - [`ValueConstraint`] if the value does not match the expected constraints.
+    ///
+    /// [`InvalidConstValue`]: ConstraintError::InvalidConstValue
+    /// [`InvalidEnumValue`]: ConstraintError::InvalidEnumValue
+    /// [`ValueConstraint`]: ConstraintError::ValueConstraint
+    pub fn validate_value(&self, number: &JsonNumber) -> Result<(), Report<ConstraintError>> {
+        let Some(float) = number.as_f64() else {
+            bail!(Report::new(NumberValidationError::InsufficientPrecision {
+                actual: number.clone()
+            })
+            .change_context(ConstraintError::ValueConstraint));
+        };
+
+        match self {
+            Self::Constrained(constraints) => constraints
+                .validate_value(float)
+                .change_context(ConstraintError::ValueConstraint)?,
+            Self::Const { r#const } => {
+                if !float_eq(float, *r#const) {
+                    bail!(ConstraintError::InvalidConstValue {
+                        actual: JsonValue::Number(number.clone()),
+                        expected: json!(*r#const),
+                    });
+                }
+            }
+            Self::Enum { r#enum } => {
+                if !r#enum.iter().any(|expected| float_eq(float, *expected)) {
+                    bail!(ConstraintError::InvalidEnumValue {
+                        actual: JsonValue::Number(number.clone()),
+                        expected: r#enum.iter().map(|value| json!(*value)).collect(),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct NumberConstraints {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub minimum: Option<f64>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub exclusive_minimum: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maximum: Option<f64>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub exclusive_maximum: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub multiple_of: Option<f64>,
+}
+
+impl NumberConstraints {
     /// Validates the provided value against the number constraints.
     ///
     /// # Errors
     ///
-    /// - [`InsufficientPrecision`] if the value cannot be converted into a 64-bit representation of
-    ///   EEE floating point number.
-    /// - [`InvalidConstValue`] if the value is not equal to the expected value.
-    /// - [`InvalidEnumValue`] if the value is not one of the expected values.
     /// - [`Minimum`] if the value is less than the minimum value.
     /// - [`Maximum`] if the value is greater than the maximum value.
     /// - [`ExclusiveMinimum`] if the value is less than or equal to the minimum value.
     /// - [`ExclusiveMaximum`] if the value is greater than or equal to the maximum value.
     /// - [`MultipleOf`] if the value is not a multiple of the expected value.
     ///
-    /// [`InsufficientPrecision`]: NumberValidationError::InsufficientPrecision
-    /// [`InvalidConstValue`]: NumberValidationError::InvalidConstValue
-    /// [`InvalidEnumValue`]: NumberValidationError::InvalidEnumValue
     /// [`Minimum`]: NumberValidationError::Minimum
     /// [`Maximum`]: NumberValidationError::Maximum
     /// [`ExclusiveMinimum`]: NumberValidationError::ExclusiveMinimum
     /// [`ExclusiveMaximum`]: NumberValidationError::ExclusiveMaximum
     /// [`MultipleOf`]: NumberValidationError::MultipleOf
-    pub fn validate_value(
-        &self,
-        number: &JsonNumber,
-    ) -> Result<(), Report<[NumberValidationError]>> {
-        let Some(float) = number.as_f64() else {
-            bail![NumberValidationError::InsufficientPrecision {
-                actual: number.clone()
-            },];
-        };
-
+    pub fn validate_value(&self, number: f64) -> Result<(), Report<[NumberValidationError]>> {
         let mut status = ReportSink::new();
-
-        if let Some(expected) = self.r#const {
-            if float_eq(expected, float) {
-                status.capture(NumberValidationError::InvalidConstValue {
-                    expected,
-                    actual: float,
-                });
-            }
-        }
-
-        if !self.r#enum.is_empty()
-            && !self
-                .r#enum
-                .iter()
-                .any(|expected| float_eq(float, *expected))
-        {
-            status.capture(NumberValidationError::InvalidEnumValue {
-                expected: self.r#enum.clone(),
-                actual: float.to_owned(),
-            });
-        }
 
         if let Some(minimum) = self.minimum {
             if self.exclusive_minimum {
-                if float_less_eq(float, minimum) {
+                if float_less_eq(number, minimum) {
                     status.capture(NumberValidationError::ExclusiveMinimum {
-                        actual: float,
+                        actual: number,
                         expected: minimum,
                     });
                 }
-            } else if float_less(float, minimum) {
-                status.capture(NumberValidationError::ExclusiveMinimum {
-                    actual: float,
+            } else if float_less(number, minimum) {
+                status.capture(NumberValidationError::Minimum {
+                    actual: number,
                     expected: minimum,
                 });
             }
@@ -195,32 +194,29 @@ impl NumberSchema {
 
         if let Some(maximum) = self.maximum {
             if self.exclusive_maximum {
-                if float_less_eq(maximum, float) {
+                if float_less_eq(maximum, number) {
                     status.capture(NumberValidationError::ExclusiveMaximum {
-                        actual: float,
+                        actual: number,
                         expected: maximum,
                     });
                 }
-            } else if float_less(maximum, float) {
+            } else if float_less(maximum, number) {
                 status.capture(NumberValidationError::Maximum {
-                    actual: float,
+                    actual: number,
                     expected: maximum,
                 });
             }
         }
 
-        if let Some(expected) = self
-            .multiple_of
-            .or_else(|| matches!(self.r#type, NumberTypeTag::Integer).then_some(1.0))
-        {
+        if let Some(expected) = self.multiple_of {
             #[expect(
                 clippy::float_arithmetic,
                 clippy::modulo_arithmetic,
                 reason = "Validation requires floating point arithmetic"
             )]
-            if !float_eq(float % expected, 0.0) {
+            if !float_eq(number % expected, 0.0) {
                 status.capture(NumberValidationError::MultipleOf {
-                    actual: float,
+                    actual: number,
                     expected,
                 });
             }
@@ -232,7 +228,16 @@ impl NumberSchema {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::{from_value, json};
+
     use super::*;
+    use crate::schema::{
+        data_type::constraint::{
+            tests::{check_constraints, check_constraints_error, read_schema},
+            ValueConstraints,
+        },
+        JsonSchemaValueType, NumberValidationError,
+    };
 
     #[test]
     #[expect(clippy::float_cmp, reason = "Test case for float_eq")]
@@ -263,5 +268,132 @@ mod tests {
         assert!(float_less_eq(1.0, 1.0));
         assert!(float_less_eq(1.0, 1.0 - f64::EPSILON / 2.0));
         assert!(!float_less_eq(1.0, 1.0 - f64::EPSILON));
+    }
+
+    #[test]
+    fn unconstrained() {
+        let number_schema = read_schema(&json!({
+            "type": "number",
+        }));
+
+        check_constraints(&number_schema, &json!(0));
+        check_constraints_error(
+            &number_schema,
+            &json!("NaN"),
+            [ConstraintError::InvalidType {
+                actual: JsonSchemaValueType::String,
+                expected: JsonSchemaValueType::Number,
+            }],
+        );
+    }
+
+    #[test]
+    fn simple_number() {
+        let number_schema = read_schema(&json!({
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 10.0,
+        }));
+
+        check_constraints(&number_schema, &json!(5));
+        check_constraints_error(
+            &number_schema,
+            &json!("2"),
+            [ConstraintError::InvalidType {
+                actual: JsonSchemaValueType::String,
+                expected: JsonSchemaValueType::Number,
+            }],
+        );
+        check_constraints_error(
+            &number_schema,
+            &json!(-2),
+            [NumberValidationError::Minimum {
+                actual: -2.0,
+                expected: 0.0,
+            }],
+        );
+        check_constraints_error(
+            &number_schema,
+            &json!(15),
+            [NumberValidationError::Maximum {
+                actual: 15.0,
+                expected: 10.0,
+            }],
+        );
+    }
+
+    #[test]
+    fn constant() {
+        let number_schema = read_schema(&json!({
+            "type": "number",
+            "const": 50.0,
+        }));
+
+        check_constraints(&number_schema, &json!(50));
+        check_constraints_error(
+            &number_schema,
+            &json!(10),
+            [ConstraintError::InvalidConstValue {
+                actual: json!(10),
+                expected: json!(50.0),
+            }],
+        );
+    }
+
+    #[test]
+    fn enumeration() {
+        let number_schema = read_schema(&json!({
+            "type": "number",
+            "enum": [20.0, 50.0],
+        }));
+
+        check_constraints(&number_schema, &json!(50));
+        check_constraints_error(
+            &number_schema,
+            &json!(10),
+            [ConstraintError::InvalidEnumValue {
+                actual: json!(10),
+                expected: vec![json!(20.0), json!(50.0)],
+            }],
+        );
+    }
+
+    #[test]
+    fn missing_type() {
+        from_value::<ValueConstraints>(json!({
+            "minimum": 0.0,
+        }))
+        .expect_err("Deserialized number schema without type");
+    }
+
+    #[test]
+    fn additional_number_properties() {
+        from_value::<ValueConstraints>(json!({
+            "type": "number",
+            "additional": false,
+        }))
+        .expect_err("Deserialized number schema with additional properties");
+    }
+
+    #[test]
+    fn mixed() {
+        from_value::<ValueConstraints>(json!({
+            "type": "number",
+            "const": 50,
+            "minimum": 0,
+        }))
+        .expect_err("Deserialized number schema with mixed properties");
+        from_value::<ValueConstraints>(json!({
+            "type": "number",
+            "enum": [50],
+            "minimum": 0,
+        }))
+        .expect_err("Deserialized number schema with mixed properties");
+        from_value::<ValueConstraints>(json!({
+            "type": "number",
+            "const": 50,
+            "enum": [50],
+        }))
+        .expect_err("Deserialized number schema with mixed properties");
     }
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
@@ -105,7 +105,7 @@ fn float_multiple_of(lhs: f64, rhs: f64) -> bool {
         return false;
     }
     let quotient = lhs / rhs;
-    (quotient - quotient.floor()).abs() < f64::EPSILON
+    (quotient - quotient.round()).abs() < f64::EPSILON
 }
 
 impl NumberSchema {

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/object.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/object.rs
@@ -1,87 +1,8 @@
-use error_stack::{Report, ReportSink};
 use serde::{Deserialize, Serialize};
-use serde_json::{Map as JsonMap, Value as JsonValue, json};
-use thiserror::Error;
-
-use crate::schema::DataTypeLabel;
-
-#[derive(Debug, Error)]
-pub enum ObjectValidationError {
-    #[error(
-        "the provided value is not equal to the expected value, expected `{}` to be equal \
-         to `{}`", json!(actual), json!(expected)
-    )]
-    InvalidConstValue {
-        actual: JsonMap<String, JsonValue>,
-        expected: JsonMap<String, JsonValue>,
-    },
-    #[error("the provided value is not one of the expected values, expected `{}` to be one of `{}`", json!(actual), json!(expected))]
-    InvalidEnumValue {
-        actual: JsonMap<String, JsonValue>,
-        expected: Vec<JsonMap<String, JsonValue>>,
-    },
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum ObjectTypeTag {
     Object,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct ObjectSchema {
-    pub r#type: ObjectTypeTag,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    #[serde(default, skip_serializing_if = "DataTypeLabel::is_empty")]
-    pub label: DataTypeLabel,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(target_arch = "wasm32", tsify(type = "Record<string, JsonValue>"))]
-    pub r#const: Option<JsonMap<String, JsonValue>>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    #[cfg_attr(
-        target_arch = "wasm32",
-        tsify(type = "[Record<string, JsonValue>, ...Record<string, JsonValue>[]]")
-    )]
-    pub r#enum: Vec<JsonMap<String, JsonValue>>,
-}
-
-impl ObjectSchema {
-    /// Validates the provided value against the object constraints.
-    ///
-    /// # Errors
-    ///
-    /// - [`InvalidConstValue`] if the value is not equal to the expected value.
-    /// - [`InvalidEnumValue`] if the value is not one of the expected values.
-    ///
-    /// [`InvalidConstValue`]: ObjectValidationError::InvalidConstValue
-    /// [`InvalidEnumValue`]: ObjectValidationError::InvalidEnumValue
-    pub fn validate_value(
-        &self,
-        object: &JsonMap<String, JsonValue>,
-    ) -> Result<(), Report<[ObjectValidationError]>> {
-        let mut validation_status = ReportSink::new();
-
-        if let Some(expected) = &self.r#const {
-            if expected != object {
-                validation_status.capture(ObjectValidationError::InvalidConstValue {
-                    expected: expected.clone(),
-                    actual: object.clone(),
-                });
-            }
-        }
-
-        if !self.r#enum.is_empty() && !self.r#enum.iter().any(|expected| expected == object) {
-            validation_status.capture(ObjectValidationError::InvalidEnumValue {
-                expected: self.r#enum.clone(),
-                actual: object.clone(),
-            });
-        }
-
-        validation_status.finish()
-    }
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/object.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/object.rs
@@ -24,8 +24,16 @@ pub enum ObjectValidationError {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[serde(rename_all = "camelCase")]
+pub enum ObjectTypeTag {
+    Object,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ObjectSchema {
+    pub r#type: ObjectTypeTag,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(default, skip_serializing_if = "DataTypeLabel::is_empty")]
@@ -43,6 +51,15 @@ pub struct ObjectSchema {
 }
 
 impl ObjectSchema {
+    /// Validates the provided value against the object constraints.
+    ///
+    /// # Errors
+    ///
+    /// - [`InvalidConstValue`] if the value is not equal to the expected value.
+    /// - [`InvalidEnumValue`] if the value is not one of the expected values.
+    ///
+    /// [`InvalidConstValue`]: ObjectValidationError::InvalidConstValue
+    /// [`InvalidEnumValue`]: ObjectValidationError::InvalidEnumValue
     pub fn validate_value(
         &self,
         object: &JsonMap<String, JsonValue>,

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
@@ -5,7 +5,7 @@ use core::{
 use std::{collections::HashSet, sync::OnceLock};
 
 use email_address::EmailAddress;
-use error_stack::{bail, Report, ReportSink, ResultExt};
+use error_stack::{Report, ReportSink, ResultExt, bail};
 use iso8601_duration::{Duration, ParseDurationError};
 use regex::Regex;
 use serde::{Deserialize, Serialize};

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/conversion.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/conversion.rs
@@ -191,14 +191,7 @@ mod codec {
     use serde::{Deserialize, Serialize};
 
     use super::{ConversionExpression, ConversionValue, Operator, Variable};
-
-    #[derive(Serialize, Deserialize)]
-    #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
-    #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-    #[serde(rename_all = "camelCase")]
-    pub(super) enum NumberTypeTag {
-        Number,
-    }
+    use crate::schema::data_type::constraint::NumberTypeTag;
 
     #[derive(Serialize, Deserialize)]
     #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -107,6 +107,7 @@ mod raw {
     use std::collections::HashSet;
 
     use serde::{Deserialize, Serialize};
+    use serde_json::Value as JsonValue;
 
     use super::{DataTypeSchemaTag, DataTypeTag};
     use crate::{
@@ -218,6 +219,12 @@ mod raw {
             #[serde(flatten)]
             constraints: TupleConstraints,
         },
+        ArrayConst {
+            r#type: ArrayTypeTag,
+            #[serde(flatten)]
+            common: ValueSchemaMetadata,
+            r#const: [JsonValue; 0],
+        },
         #[serde(skip)]
         AnyOf {
             #[serde(flatten)]
@@ -327,6 +334,16 @@ mod raw {
                     ValueConstraints::Typed(TypedValueConstraints::Array(ArraySchema::Tuple(
                         constraints,
                     ))),
+                ),
+                DataType::ArrayConst {
+                    r#type: _,
+                    common,
+                    r#const,
+                } => (
+                    common,
+                    ValueConstraints::Typed(TypedValueConstraints::Array(ArraySchema::Const {
+                        r#const,
+                    })),
                 ),
                 DataType::AnyOf {
                     common,

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -25,9 +25,9 @@ mod validation;
 
 use alloc::sync::Arc;
 use core::{cmp, fmt, mem};
-use std::collections::{hash_map::RawEntryMut, HashMap, HashSet};
+use std::collections::{HashMap, HashSet, hash_map::RawEntryMut};
 
-use error_stack::{bail, Report};
+use error_stack::{Report, bail};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use thiserror::Error;
@@ -111,13 +111,13 @@ mod raw {
     use super::{DataTypeSchemaTag, DataTypeTag};
     use crate::{
         schema::{
+            ArrayTypeTag, BooleanTypeTag, DataTypeReference, NullTypeTag, NumberTypeTag,
+            ObjectTypeTag, StringTypeTag, ValueLabel,
             data_type::constraint::{
                 AnyOfConstraints, ArrayConstraints, ArraySchema, NumberConstraints, NumberSchema,
                 StringConstraints, StringSchema, TupleConstraints, TypedValueConstraints,
                 ValueConstraints,
             },
-            ArrayTypeTag, BooleanTypeTag, DataTypeReference, NullTypeTag, NumberTypeTag,
-            ObjectTypeTag, StringTypeTag, ValueLabel,
         },
         url::VersionedUrl,
     };
@@ -414,26 +414,20 @@ impl OntologyTypeResolver {
             .raw_entry_mut()
             .from_key(&data_type.id)
             .or_insert_with(|| {
-                (
-                    data_type.id.clone(),
-                    DataTypeCacheEntry {
-                        data_type,
-                        metadata: None,
-                    },
-                )
+                (data_type.id.clone(), DataTypeCacheEntry {
+                    data_type,
+                    metadata: None,
+                })
             });
     }
 
     pub fn add_closed(&mut self, data_type: Arc<DataType>, metadata: Arc<ClosedDataTypeMetadata>) {
         match self.data_types.raw_entry_mut().from_key(&data_type.id) {
             RawEntryMut::Vacant(entry) => {
-                entry.insert(
-                    data_type.id.clone(),
-                    DataTypeCacheEntry {
-                        data_type,
-                        metadata: Some(metadata),
-                    },
-                );
+                entry.insert(data_type.id.clone(), DataTypeCacheEntry {
+                    data_type,
+                    metadata: Some(metadata),
+                });
             }
             RawEntryMut::Occupied(mut entry) => {
                 entry.insert(DataTypeCacheEntry {
@@ -683,7 +677,7 @@ impl DataType {
 mod tests {
     use super::*;
     use crate::utils::tests::{
-        ensure_failed_deserialization, ensure_validation_from_str, JsonEqualityCheck,
+        JsonEqualityCheck, ensure_failed_deserialization, ensure_validation_from_str,
     };
 
     #[tokio::test]

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -684,6 +684,7 @@ mod tests {
     };
 
     #[tokio::test]
+    #[ignore = "AnyOf constraint is not exposed"]
     async fn value() {
         ensure_validation_from_str::<DataType, _>(
             graph_test_data::data_type::VALUE_V1,

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -8,7 +8,7 @@ pub use self::{
         BooleanValidationError, ConstraintError, NullSchema, NullTypeTag, NumberSchema,
         NumberTypeTag, NumberValidationError, ObjectSchema, ObjectTypeTag, ObjectValidationError,
         StringFormat, StringFormatError, StringSchema, StringTypeTag, StringValidationError,
-        ValueSchema,
+        ValueConstraints,
     },
     conversion::{
         ConversionDefinition, ConversionExpression, ConversionValue, Conversions, Operator,
@@ -110,8 +110,8 @@ mod raw {
     use crate::{
         schema::{
             data_type::constraint::{
-                AnyOfSchema, ArraySchema, BooleanSchema, NullSchema, NumberSchema, ObjectSchema,
-                StringSchema, ValueSchema,
+                AnyOfConstraint, ArraySchema, BooleanSchema, NullSchema, NumberSchema,
+                ObjectSchema, StringSchema, ValueConstraints,
             },
             DataTypeReference,
         },
@@ -180,7 +180,7 @@ mod raw {
         },
         AnyOf {
             #[serde(flatten)]
-            schema: AnyOfSchema,
+            schema: AnyOfConstraint,
             #[serde(flatten)]
             common: UnconstrainedDataType,
         },
@@ -189,13 +189,13 @@ mod raw {
     impl From<DataType> for super::DataType {
         fn from(value: DataType) -> Self {
             let (common, constraints) = match value {
-                DataType::Null { schema, common } => (common, ValueSchema::Null(schema)),
-                DataType::Boolean { schema, common } => (common, ValueSchema::Boolean(schema)),
-                DataType::Number { schema, common } => (common, ValueSchema::Number(schema)),
-                DataType::String { schema, common } => (common, ValueSchema::String(schema)),
-                DataType::Array { schema, common } => (common, ValueSchema::Array(schema)),
-                DataType::Object { schema, common } => (common, ValueSchema::Object(schema)),
-                DataType::AnyOf { schema, common } => (common, ValueSchema::AnyOf(schema)),
+                DataType::Null { schema, common } => (common, ValueConstraints::Null(schema)),
+                DataType::Boolean { schema, common } => (common, ValueConstraints::Boolean(schema)),
+                DataType::Number { schema, common } => (common, ValueConstraints::Number(schema)),
+                DataType::String { schema, common } => (common, ValueConstraints::String(schema)),
+                DataType::Array { schema, common } => (common, ValueConstraints::Array(schema)),
+                DataType::Object { schema, common } => (common, ValueConstraints::Object(schema)),
+                DataType::AnyOf { schema, common } => (common, ValueConstraints::AnyOf(schema)),
             };
 
             Self {
@@ -226,7 +226,7 @@ pub struct DataType {
     pub all_of: Vec<DataTypeReference>,
 
     #[serde(flatten)]
-    pub constraints: ValueSchema,
+    pub constraints: ValueConstraints,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -25,9 +25,9 @@ mod validation;
 
 use alloc::sync::Arc;
 use core::{cmp, fmt, mem};
-use std::collections::{hash_map::RawEntryMut, HashMap, HashSet};
+use std::collections::{HashMap, HashSet, hash_map::RawEntryMut};
 
-use error_stack::{bail, Report};
+use error_stack::{Report, bail};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use thiserror::Error;
@@ -111,13 +111,13 @@ mod raw {
     use super::{DataTypeSchemaTag, DataTypeTag};
     use crate::{
         schema::{
+            ArrayTypeTag, BooleanTypeTag, DataTypeReference, NullTypeTag, NumberTypeTag,
+            ObjectTypeTag, StringTypeTag, ValueLabel,
             data_type::constraint::{
                 AnyOfConstraints, ArrayConstraints, ArraySchema, NumberConstraints, NumberSchema,
                 StringConstraints, StringSchema, TupleConstraints, TypedValueConstraints,
                 ValueConstraints,
             },
-            ArrayTypeTag, BooleanTypeTag, DataTypeReference, NullTypeTag, NumberTypeTag,
-            ObjectTypeTag, StringTypeTag, ValueLabel,
         },
         url::VersionedUrl,
     };
@@ -411,26 +411,20 @@ impl OntologyTypeResolver {
             .raw_entry_mut()
             .from_key(&data_type.id)
             .or_insert_with(|| {
-                (
-                    data_type.id.clone(),
-                    DataTypeCacheEntry {
-                        data_type,
-                        metadata: None,
-                    },
-                )
+                (data_type.id.clone(), DataTypeCacheEntry {
+                    data_type,
+                    metadata: None,
+                })
             });
     }
 
     pub fn add_closed(&mut self, data_type: Arc<DataType>, metadata: Arc<ClosedDataTypeMetadata>) {
         match self.data_types.raw_entry_mut().from_key(&data_type.id) {
             RawEntryMut::Vacant(entry) => {
-                entry.insert(
-                    data_type.id.clone(),
-                    DataTypeCacheEntry {
-                        data_type,
-                        metadata: Some(metadata),
-                    },
-                );
+                entry.insert(data_type.id.clone(), DataTypeCacheEntry {
+                    data_type,
+                    metadata: Some(metadata),
+                });
             }
             RawEntryMut::Occupied(mut entry) => {
                 entry.insert(DataTypeCacheEntry {
@@ -680,7 +674,7 @@ impl DataType {
 mod tests {
     use super::*;
     use crate::utils::tests::{
-        ensure_failed_deserialization, ensure_validation_from_str, JsonEqualityCheck,
+        JsonEqualityCheck, ensure_failed_deserialization, ensure_validation_from_str,
     };
 
     #[tokio::test]

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -4,11 +4,11 @@ mod conversion;
 pub use self::{
     closed::{ClosedDataType, ClosedDataTypeMetadata},
     constraint::{
-        ArraySchema, ArrayTypeTag, ArrayValidationError, BooleanSchema, BooleanTypeTag,
-        BooleanValidationError, ConstraintError, NullSchema, NullTypeTag, NumberSchema,
-        NumberTypeTag, NumberValidationError, ObjectSchema, ObjectTypeTag, ObjectValidationError,
+        AnyOfConstraints, AnyOfSchema, ArrayConstraints, ArraySchema, ArrayTypeTag,
+        ArrayValidationError, BooleanTypeTag, ConstraintError, NullTypeTag, NumberConstraints,
+        NumberSchema, NumberTypeTag, NumberValidationError, ObjectTypeTag, StringConstraints,
         StringFormat, StringFormatError, StringSchema, StringTypeTag, StringValidationError,
-        ValueConstraints,
+        TupleConstraints, TypedValueConstraints,
     },
     conversion::{
         ConversionDefinition, ConversionExpression, ConversionValue, Conversions, Operator,
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use thiserror::Error;
 
-use crate::url::VersionedUrl;
+use crate::{schema::data_type::constraint::ValueConstraints, url::VersionedUrl};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
@@ -62,14 +62,14 @@ impl fmt::Display for JsonSchemaValueType {
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase")]
-pub struct DataTypeLabel {
+pub struct ValueLabel {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub left: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub right: Option<String>,
 }
 
-impl DataTypeLabel {
+impl ValueLabel {
     #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.left.is_none() && self.right.is_none()
@@ -104,24 +104,28 @@ pub enum DataTypeSchemaTag {
 }
 
 mod raw {
-    use serde::Deserialize;
+    use std::collections::HashSet;
+
+    use serde::{Deserialize, Serialize};
 
     use super::{DataTypeSchemaTag, DataTypeTag};
     use crate::{
         schema::{
             data_type::constraint::{
-                AnyOfConstraint, ArraySchema, BooleanSchema, NullSchema, NumberSchema,
-                ObjectSchema, StringSchema, ValueConstraints,
+                AnyOfConstraints, ArrayConstraints, ArraySchema, NumberConstraints, NumberSchema,
+                StringConstraints, StringSchema, TupleConstraints, TypedValueConstraints,
+                ValueConstraints,
             },
-            DataTypeReference,
+            ArrayTypeTag, BooleanTypeTag, DataTypeReference, NullTypeTag, NumberTypeTag,
+            ObjectTypeTag, StringTypeTag, ValueLabel,
         },
         url::VersionedUrl,
     };
 
-    #[derive(Deserialize)]
+    #[derive(Serialize, Deserialize)]
     #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
     #[serde(rename_all = "camelCase", deny_unknown_fields)]
-    pub struct UnconstrainedDataType {
+    pub struct ValueSchemaMetadata {
         #[serde(rename = "$schema")]
         schema: DataTypeSchemaTag,
         kind: DataTypeTag,
@@ -130,72 +134,200 @@ mod raw {
         title: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         title_plural: Option<String>,
-        #[cfg_attr(
-            target_arch = "wasm32",
-            tsify(type = "[DataTypeReference, ...DataTypeReference[]]")
-        )]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+        #[serde(default, skip_serializing_if = "ValueLabel::is_empty")]
+        label: ValueLabel,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         all_of: Vec<DataTypeReference>,
     }
 
-    #[derive(Deserialize)]
+    #[derive(Serialize, Deserialize)]
     #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
     #[serde(untagged, rename_all = "camelCase", deny_unknown_fields)]
     pub enum DataType {
         Null {
+            r#type: NullTypeTag,
             #[serde(flatten)]
-            schema: NullSchema,
-            #[serde(flatten)]
-            common: UnconstrainedDataType,
+            common: ValueSchemaMetadata,
         },
         Boolean {
+            r#type: BooleanTypeTag,
             #[serde(flatten)]
-            schema: BooleanSchema,
-            #[serde(flatten)]
-            common: UnconstrainedDataType,
+            common: ValueSchemaMetadata,
         },
         Number {
+            r#type: NumberTypeTag,
             #[serde(flatten)]
-            schema: NumberSchema,
+            common: ValueSchemaMetadata,
             #[serde(flatten)]
-            common: UnconstrainedDataType,
+            constraints: NumberConstraints,
+        },
+        NumberConst {
+            r#type: NumberTypeTag,
+            #[serde(flatten)]
+            common: ValueSchemaMetadata,
+            r#const: f64,
+        },
+        NumberEnum {
+            r#type: NumberTypeTag,
+            #[serde(flatten)]
+            common: ValueSchemaMetadata,
+            #[cfg_attr(target_arch = "wasm32", tsify(type = "[number, ...number[]]"))]
+            r#enum: Vec<f64>,
         },
         String {
+            r#type: StringTypeTag,
             #[serde(flatten)]
-            schema: StringSchema,
+            common: ValueSchemaMetadata,
             #[serde(flatten)]
-            common: UnconstrainedDataType,
+            constraints: StringConstraints,
         },
-        Array {
+        StringConst {
+            r#type: StringTypeTag,
             #[serde(flatten)]
-            schema: ArraySchema,
+            common: ValueSchemaMetadata,
+            r#const: String,
+        },
+        StringEnum {
+            r#type: StringTypeTag,
             #[serde(flatten)]
-            common: UnconstrainedDataType,
+            common: ValueSchemaMetadata,
+            #[cfg_attr(target_arch = "wasm32", tsify(type = "[string, ...string[]]"))]
+            r#enum: HashSet<String>,
         },
         Object {
+            r#type: ObjectTypeTag,
             #[serde(flatten)]
-            schema: ObjectSchema,
+            common: ValueSchemaMetadata,
+        },
+        Array {
+            r#type: ArrayTypeTag,
             #[serde(flatten)]
-            common: UnconstrainedDataType,
+            common: ValueSchemaMetadata,
+            #[serde(flatten)]
+            constraints: ArrayConstraints,
+        },
+        Tuple {
+            r#type: ArrayTypeTag,
+            #[serde(flatten)]
+            common: ValueSchemaMetadata,
+            #[serde(flatten)]
+            constraints: TupleConstraints,
         },
         AnyOf {
             #[serde(flatten)]
-            schema: AnyOfConstraint,
+            common: ValueSchemaMetadata,
             #[serde(flatten)]
-            common: UnconstrainedDataType,
+            constraints: AnyOfConstraints,
         },
     }
 
     impl From<DataType> for super::DataType {
+        #[expect(
+            clippy::too_many_lines,
+            reason = "The conversion is only required to allow `deny_unknown_fields` in serde. \
+                      The better option would be to manually implement the deserialization logic, \
+                      however, this is quite straightforward and would be a lot of code for \
+                      little benefit."
+        )]
         fn from(value: DataType) -> Self {
             let (common, constraints) = match value {
-                DataType::Null { schema, common } => (common, ValueConstraints::Null(schema)),
-                DataType::Boolean { schema, common } => (common, ValueConstraints::Boolean(schema)),
-                DataType::Number { schema, common } => (common, ValueConstraints::Number(schema)),
-                DataType::String { schema, common } => (common, ValueConstraints::String(schema)),
-                DataType::Array { schema, common } => (common, ValueConstraints::Array(schema)),
-                DataType::Object { schema, common } => (common, ValueConstraints::Object(schema)),
-                DataType::AnyOf { schema, common } => (common, ValueConstraints::AnyOf(schema)),
+                DataType::Null { r#type: _, common } => {
+                    (common, ValueConstraints::Typed(TypedValueConstraints::Null))
+                }
+                DataType::Boolean { r#type: _, common } => (
+                    common,
+                    ValueConstraints::Typed(TypedValueConstraints::Boolean),
+                ),
+                DataType::Number {
+                    r#type: _,
+                    common,
+                    constraints,
+                } => (
+                    common,
+                    ValueConstraints::Typed(TypedValueConstraints::Number(
+                        NumberSchema::Constrained(constraints),
+                    )),
+                ),
+                DataType::NumberConst {
+                    r#type: _,
+                    common,
+                    r#const,
+                } => (
+                    common,
+                    ValueConstraints::Typed(TypedValueConstraints::Number(NumberSchema::Const {
+                        r#const,
+                    })),
+                ),
+                DataType::NumberEnum {
+                    r#type: _,
+                    common,
+                    r#enum,
+                } => (
+                    common,
+                    ValueConstraints::Typed(TypedValueConstraints::Number(NumberSchema::Enum {
+                        r#enum,
+                    })),
+                ),
+                DataType::String {
+                    r#type: _,
+                    common,
+                    constraints,
+                } => (
+                    common,
+                    ValueConstraints::Typed(TypedValueConstraints::String(
+                        StringSchema::Constrained(constraints),
+                    )),
+                ),
+                DataType::StringConst {
+                    r#type: _,
+                    common,
+                    r#const,
+                } => (
+                    common,
+                    ValueConstraints::Typed(TypedValueConstraints::String(StringSchema::Const {
+                        r#const,
+                    })),
+                ),
+                DataType::StringEnum {
+                    r#type: _,
+                    common,
+                    r#enum,
+                } => (
+                    common,
+                    ValueConstraints::Typed(TypedValueConstraints::String(StringSchema::Enum {
+                        r#enum,
+                    })),
+                ),
+                DataType::Object { r#type: _, common } => (
+                    common,
+                    ValueConstraints::Typed(TypedValueConstraints::Object),
+                ),
+                DataType::Array {
+                    r#type: _,
+                    common,
+                    constraints,
+                } => (
+                    common,
+                    ValueConstraints::Typed(TypedValueConstraints::Array(
+                        ArraySchema::Constrained(constraints),
+                    )),
+                ),
+                DataType::Tuple {
+                    r#type: _,
+                    common,
+                    constraints,
+                } => (
+                    common,
+                    ValueConstraints::Typed(TypedValueConstraints::Array(ArraySchema::Tuple(
+                        constraints,
+                    ))),
+                ),
+                DataType::AnyOf {
+                    common,
+                    constraints: any_of,
+                } => (common, ValueConstraints::AnyOf(any_of)),
             };
 
             Self {
@@ -204,6 +336,8 @@ mod raw {
                 id: common.id,
                 title: common.title,
                 title_plural: common.title_plural,
+                description: common.description,
+                label: common.label,
                 all_of: common.all_of,
                 constraints,
             }
@@ -212,7 +346,11 @@ mod raw {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", from = "raw::DataType")]
+#[serde(
+    rename_all = "camelCase",
+    from = "raw::DataType",
+    // into = "raw::DataType"
+)]
 pub struct DataType {
     #[serde(rename = "$schema")]
     pub schema: DataTypeSchemaTag,
@@ -222,6 +360,10 @@ pub struct DataType {
     pub title: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title_plural: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "ValueLabel::is_empty")]
+    pub label: ValueLabel,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub all_of: Vec<DataTypeReference>,
 
@@ -525,14 +667,19 @@ impl DataType {
     ///
     /// Returns an error if the JSON value is not a valid instance of the data type.
     pub fn validate_constraints(&self, value: &JsonValue) -> Result<(), Report<ConstraintError>> {
-        self.constraints.validate_value(value)
+        match &self.constraints {
+            ValueConstraints::Typed(typed_schema) => typed_schema.validate_value(value),
+            ValueConstraints::AnyOf(constraints) => constraints.validate_value(value),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::tests::{ensure_validation_from_str, JsonEqualityCheck};
+    use crate::utils::tests::{
+        ensure_failed_deserialization, ensure_validation_from_str, JsonEqualityCheck,
+    };
 
     #[tokio::test]
     async fn value() {
@@ -602,5 +749,24 @@ mod tests {
             JsonEqualityCheck::Yes,
         )
         .await;
+    }
+
+    #[test]
+    fn additional_properties() {
+        // The error is suboptimal, but most importantly, it does error.
+        ensure_failed_deserialization::<DataType>(
+            serde_json::json!({
+              "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
+              "kind": "dataType",
+              "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/value/v/1",
+              "title": "Value",
+              "description": "A value that can be stored in a graph",
+              "anyOf": [
+                { "type": "null" }
+              ],
+              "additional": false
+            }),
+            &"data did not match any variant of untagged enum DataType",
+        );
     }
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/mod.rs
@@ -16,10 +16,14 @@ mod one_of;
 pub use self::{
     array::{PropertyArraySchema, PropertyValueArray, ValueOrArray},
     data_type::{
-        ClosedDataType, ClosedDataTypeMetadata, ConversionDefinition, ConversionExpression,
-        ConversionValue, Conversions, DataType, DataTypeLabel, DataTypeReference,
-        DataTypeValidator, JsonSchemaValueType, OntologyTypeResolver, Operator,
-        ValidateDataTypeError, Variable,
+        ArraySchema, ArrayTypeTag, ArrayValidationError, BooleanSchema, BooleanTypeTag,
+        BooleanValidationError, ClosedDataType, ClosedDataTypeMetadata, ConstraintError,
+        ConversionDefinition, ConversionExpression, ConversionValue, Conversions, DataType,
+        DataTypeLabel, DataTypeReference, DataTypeValidator, JsonSchemaValueType, NullSchema,
+        NullTypeTag, NumberSchema, NumberTypeTag, NumberValidationError, ObjectSchema,
+        ObjectTypeTag, ObjectValidationError, OntologyTypeResolver, Operator, StringFormat,
+        StringFormatError, StringSchema, StringTypeTag, StringValidationError,
+        ValidateDataTypeError, ValueConstraints, Variable,
     },
     entity_type::{
         ClosedEntityType, ClosedEntityTypeSchemaData, EntityType, EntityTypeReference,

--- a/libs/@blockprotocol/type-system/rust/src/schema/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/mod.rs
@@ -23,7 +23,7 @@ pub use self::{
         NullTypeTag, NumberSchema, NumberTypeTag, NumberValidationError, ObjectSchema,
         ObjectTypeTag, ObjectValidationError, OntologyTypeResolver, Operator, StringFormat,
         StringFormatError, StringSchema, StringTypeTag, StringValidationError,
-        ValidateDataTypeError, ValueConstraints, Variable,
+        ValidateDataTypeError, ValueSchema, Variable,
     },
     entity_type::{
         ClosedEntityType, ClosedEntityTypeSchemaData, EntityType, EntityTypeReference,

--- a/libs/@blockprotocol/type-system/rust/src/schema/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/mod.rs
@@ -16,14 +16,14 @@ mod one_of;
 pub use self::{
     array::{PropertyArraySchema, PropertyValueArray, ValueOrArray},
     data_type::{
-        ArraySchema, ArrayTypeTag, ArrayValidationError, BooleanSchema, BooleanTypeTag,
-        BooleanValidationError, ClosedDataType, ClosedDataTypeMetadata, ConstraintError,
-        ConversionDefinition, ConversionExpression, ConversionValue, Conversions, DataType,
-        DataTypeLabel, DataTypeReference, DataTypeValidator, JsonSchemaValueType, NullSchema,
-        NullTypeTag, NumberSchema, NumberTypeTag, NumberValidationError, ObjectSchema,
-        ObjectTypeTag, ObjectValidationError, OntologyTypeResolver, Operator, StringFormat,
-        StringFormatError, StringSchema, StringTypeTag, StringValidationError,
-        ValidateDataTypeError, ValueConstraints, Variable,
+        AnyOfConstraints, AnyOfSchema, ArrayConstraints, ArraySchema, ArrayTypeTag,
+        ArrayValidationError, BooleanTypeTag, ClosedDataType, ClosedDataTypeMetadata,
+        ConstraintError, ConversionDefinition, ConversionExpression, ConversionValue, Conversions,
+        DataType, DataTypeReference, DataTypeValidator, JsonSchemaValueType, NullTypeTag,
+        NumberConstraints, NumberSchema, NumberTypeTag, NumberValidationError, ObjectTypeTag,
+        OntologyTypeResolver, Operator, StringConstraints, StringFormat, StringFormatError,
+        StringSchema, StringTypeTag, StringValidationError, TupleConstraints,
+        TypedValueConstraints, ValidateDataTypeError, ValueLabel, Variable,
     },
     entity_type::{
         ClosedEntityType, ClosedEntityTypeSchemaData, EntityType, EntityTypeReference,

--- a/libs/@blockprotocol/type-system/rust/src/schema/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/mod.rs
@@ -23,7 +23,7 @@ pub use self::{
         NullTypeTag, NumberSchema, NumberTypeTag, NumberValidationError, ObjectSchema,
         ObjectTypeTag, ObjectValidationError, OntologyTypeResolver, Operator, StringFormat,
         StringFormatError, StringSchema, StringTypeTag, StringValidationError,
-        ValidateDataTypeError, ValueSchema, Variable,
+        ValidateDataTypeError, ValueConstraints, Variable,
     },
     entity_type::{
         ClosedEntityType, ClosedEntityTypeSchemaData, EntityType, EntityTypeReference,

--- a/libs/@blockprotocol/type-system/rust/src/schema/object/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/object/raw.rs
@@ -2,14 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::url::BaseUrl;
-
-#[derive(Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
-#[serde(rename_all = "camelCase")]
-enum ObjectTypeTag {
-    Object,
-}
+use crate::{schema::data_type::ObjectTypeTag, url::BaseUrl};
 
 #[derive(Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]

--- a/libs/@hashintel/type-editor/src/shared/data-types-options-context.tsx
+++ b/libs/@hashintel/type-editor/src/shared/data-types-options-context.tsx
@@ -28,7 +28,10 @@ import {
   faText,
 } from "@hashintel/design-system";
 import { theme } from "@hashintel/design-system/theme";
-import { isTupleConstraints } from "@local/hash-graph-types/ontology";
+import {
+  isArrayConstraints,
+  isTupleConstraints,
+} from "@local/hash-graph-types/ontology";
 import type { PropsWithChildren } from "react";
 import { createContext, useCallback, useContext, useMemo } from "react";
 
@@ -181,6 +184,10 @@ const getArrayDataTypeDisplay = (
       return expectedValuesDisplayMap.emptyList;
     }
     items = dataType.prefixItems;
+    // TODO: Remove when `const` is not allowed on arrays
+    //   see https://linear.app/hash/issue/H-3368/remove-const-from-array-constraints
+  } else if (!isArrayConstraints(dataType)) {
+    return expectedValuesDisplayMap.emptyList;
   } else if (!dataType.items) {
     return expectedValuesDisplayMap.mixedArray;
   } else {

--- a/libs/@hashintel/type-editor/src/shared/data-types-options-context.tsx
+++ b/libs/@hashintel/type-editor/src/shared/data-types-options-context.tsx
@@ -1,7 +1,9 @@
 import type {
+  ArrayConstraints,
   ArraySchema,
   DataType,
   SimpleValueSchema,
+  TupleConstraints,
   VersionedUrl,
 } from "@blockprotocol/type-system/slim";
 import {
@@ -28,10 +30,6 @@ import {
   faText,
 } from "@hashintel/design-system";
 import { theme } from "@hashintel/design-system/theme";
-import {
-  isArrayConstraints,
-  isTupleConstraints,
-} from "@local/hash-graph-types/ontology";
 import type { PropsWithChildren } from "react";
 import { createContext, useCallback, useContext, useMemo } from "react";
 
@@ -173,6 +171,24 @@ export type DataTypesContextValue = {
 
 export const DataTypesOptionsContext =
   createContext<DataTypesContextValue | null>(null);
+
+const isArrayConstraints = (
+  schema: ArraySchema,
+): schema is ArrayConstraints => {
+  // TODO: Remove `"items" in schema` check when `const` is not allowed on arrays
+  //   see https://linear.app/hash/issue/H-3368/remove-const-from-array-constraints
+  return (
+    "items" in schema && schema.items !== undefined && schema.items !== false
+  );
+};
+
+const isTupleConstraints = (
+  schema: ArraySchema,
+): schema is TupleConstraints => {
+  // TODO: Remove `"items" in schema` check when `const` is not allowed on arrays
+  //   see https://linear.app/hash/issue/H-3368/remove-const-from-array-constraints
+  return "items" in schema && schema.items === false;
+};
 
 const getArrayDataTypeDisplay = (
   dataType: ArraySchema,

--- a/libs/@local/codec/src/serde/constant.rs
+++ b/libs/@local/codec/src/serde/constant.rs
@@ -1,0 +1,51 @@
+use core::fmt;
+
+use serde::{
+    de::{self, Deserialize, Deserializer, Unexpected, Visitor},
+    ser::{Serialize, Serializer},
+};
+
+/// A `bool` constant.
+///
+/// Deserialization fails if the value is not `B`.
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+pub struct ConstBool<const V: bool>;
+
+impl<const V: bool> Serialize for ConstBool<V> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bool(V)
+    }
+}
+
+impl<'de, const V: bool> Deserialize<'de> for ConstBool<V> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_bool(ConstBoolVisitor::<V>)
+    }
+}
+
+struct ConstBoolVisitor<const V: bool>;
+
+impl<const V: bool> Visitor<'_> for ConstBoolVisitor<V> {
+    type Value = ConstBool<V>;
+
+    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{V}")
+    }
+
+    fn visit_bool<E>(self, boolean: bool) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        if boolean == V {
+            Ok(ConstBool::<V>)
+        } else {
+            Err(E::invalid_value(Unexpected::Bool(boolean), &self))
+        }
+    }
+}

--- a/libs/@local/codec/src/serde/mod.rs
+++ b/libs/@local/codec/src/serde/mod.rs
@@ -1,8 +1,9 @@
+pub mod constant;
 pub mod string_hash_map;
 
 mod size_hint;
 
-use ::time::format_description::well_known::{Iso8601, iso8601};
+use ::time::format_description::well_known::{iso8601, Iso8601};
 
 const CONFIG: iso8601::EncodedConfig = iso8601::Config::DEFAULT
     .set_year_is_six_digits(false)
@@ -80,7 +81,7 @@ pub mod regex {
         use alloc::borrow::Cow;
 
         use regex::Regex;
-        use serde::{Deserialize, Deserializer, Serializer, ser::SerializeSeq};
+        use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serializer};
 
         /// Serialize a sequence of [`Regex`]es.
         ///

--- a/libs/@local/codec/src/serde/mod.rs
+++ b/libs/@local/codec/src/serde/mod.rs
@@ -3,7 +3,7 @@ pub mod string_hash_map;
 
 mod size_hint;
 
-use ::time::format_description::well_known::{iso8601, Iso8601};
+use ::time::format_description::well_known::{Iso8601, iso8601};
 
 const CONFIG: iso8601::EncodedConfig = iso8601::Config::DEFAULT
     .set_year_is_six_digits(false)
@@ -81,7 +81,7 @@ pub mod regex {
         use alloc::borrow::Cow;
 
         use regex::Regex;
-        use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serializer};
+        use serde::{Deserialize, Deserializer, Serializer, ser::SerializeSeq};
 
         /// Serialize a sequence of [`Regex`]es.
         ///

--- a/libs/@local/hash-graph-types/typescript/src/ontology.ts
+++ b/libs/@local/hash-graph-types/typescript/src/ontology.ts
@@ -92,13 +92,19 @@ type OntologyElementMetadata = Subtype<
 export const isArrayConstraints = (
   schema: ArraySchema,
 ): schema is ArrayConstraints => {
-  return schema.items !== undefined && schema.items !== false;
+  // TODO: Remove `"items" in schema` check when `const` is not allowed on arrays
+  //   see https://linear.app/hash/issue/H-3368/remove-const-from-array-constraints
+  return (
+    "items" in schema && schema.items !== undefined && schema.items !== false
+  );
 };
 
 export const isTupleConstraints = (
   schema: ArraySchema,
 ): schema is TupleConstraints => {
-  return schema.items === false;
+  // TODO: Remove `"items" in schema` check when `const` is not allowed on arrays
+  //   see https://linear.app/hash/issue/H-3368/remove-const-from-array-constraints
+  return "items" in schema && schema.items === false;
 };
 
 export type ConstructDataTypeParams = DistributiveOmit<

--- a/libs/@local/hash-graph-types/typescript/src/ontology.ts
+++ b/libs/@local/hash-graph-types/typescript/src/ontology.ts
@@ -4,6 +4,15 @@ import type {
   OntologyElementMetadata as OntologyElementMetadataBp,
   PropertyTypeWithMetadata as PropertyTypeWithMetadataBp,
 } from "@blockprotocol/graph";
+import type {
+  BooleanSchema,
+  DataTypeLabel,
+  NullSchema,
+  NumberSchema,
+  ObjectSchema,
+  StringFormat,
+  StringSchema,
+} from "@blockprotocol/type-system";
 import { validateBaseUrl } from "@blockprotocol/type-system";
 import type {
   BaseUrl as BaseUrlBp,
@@ -85,93 +94,49 @@ type OntologyElementMetadata = Subtype<
   OwnedOntologyElementMetadata | ExternalOntologyElementMetadata
 >;
 
-/**
- * Non-exhaustive list of possible values for 'format'
- *
- * The presence of a format in this list does _NOT_ mean that:
- * 1. The Graph will validate it
- * 2. The frontend will treat it differently for input or display
- *
- * @see https://json-schema.org/understanding-json-schema/reference/string
- */
-type StringFormat =
-  | "date"
-  | "time"
-  | "date-time"
-  | "duration"
-  | "email"
-  | "hostname"
-  | "ipv4"
-  | "ipv6"
-  | "regex"
-  | "uri"
-  | "uuid";
+export type StringEnumConstraint = Subtype<
+  StringSchema,
+  {
+    enum: [string, ...string[]];
+    type: "string";
+  }
+>;
 
-export type StringConstraint = {
-  format?: StringFormat;
-  minLength?: number; // Int
-  maxLength?: number; // Int
-  pattern?: string; // RegExp
-  type: "string";
-};
-
-export type NumberConstraint = {
-  minimum?: number;
-  maximum?: number;
-  exclusiveMinimum?: boolean;
-  exclusiveMaximum?: boolean;
-  multipleOf?: number;
-  type: "number";
-};
-
-export type BooleanConstraint = {
-  type: "boolean";
-};
-
-export type NullConstraint = {
-  type: "null";
-};
-
-export type ObjectConstraint = {
-  type: "object";
-};
-
-export type StringEnumConstraint = {
-  enum: [string, ...string[]];
-  type: "string";
-};
-
-export type NumberEnumConstraint = {
-  enum: [number, ...number[]];
-  type: "number";
-};
+export type NumberEnumConstraint = Subtype<
+  NumberSchema,
+  {
+    enum: [number, ...number[]];
+    type: "number";
+  }
+>;
 
 /** @see https://json-schema.org/understanding-json-schema/reference/enum */
 export type EnumConstraint = StringEnumConstraint | NumberEnumConstraint;
 
-export type StringConstConstraint = {
-  const: string;
-  type: "string";
-};
+export type StringConstConstraint = Subtype<
+  StringSchema,
+  {
+    const: string;
+    type: "string";
+  }
+>;
 
-export type NumberConstConstraint = {
-  const: number;
-  type: "number";
-};
+export type NumberConstConstraint = Subtype<
+  NumberSchema,
+  {
+    const: number;
+    type: "number";
+  }
+>;
 
 export type ConstConstraint = StringConstConstraint | NumberConstConstraint;
 
-type ValueLabel = {
-  left?: string;
-  right?: string;
-};
-
 export type SingleValueConstraint =
-  | BooleanConstraint
-  | NullConstraint
-  | ObjectConstraint
-  | StringConstraint
-  | NumberConstraint
+  | BooleanSchema
+  | NullSchema
+  | ObjectSchema
+  | StringSchema
+  | NumberSchema
   | EnumConstraint
   | ConstConstraint;
 
@@ -191,7 +156,8 @@ export type ValueConstraint = (
   | SingleValueConstraint
   | ArrayConstraint
   | TupleConstraint
-) & { description?: string; label?: ValueLabel };
+  | { anyOf: [ValueConstraint, ...ValueConstraint[]] }
+) & { description?: string; label?: DataTypeLabel };
 
 export type CustomDataType = Subtype<
   DataType,

--- a/libs/@local/hash-graph-types/typescript/src/ontology.ts
+++ b/libs/@local/hash-graph-types/typescript/src/ontology.ts
@@ -4,11 +4,6 @@ import type {
   OntologyElementMetadata as OntologyElementMetadataBp,
   PropertyTypeWithMetadata as PropertyTypeWithMetadataBp,
 } from "@blockprotocol/graph";
-import type {
-  ArrayConstraints,
-  ArraySchema,
-  TupleConstraints,
-} from "@blockprotocol/type-system";
 import { validateBaseUrl } from "@blockprotocol/type-system";
 import type {
   BaseUrl as BaseUrlBp,
@@ -88,24 +83,6 @@ type OntologyElementMetadata = Subtype<
   OntologyElementMetadataBp,
   OwnedOntologyElementMetadata | ExternalOntologyElementMetadata
 >;
-
-export const isArrayConstraints = (
-  schema: ArraySchema,
-): schema is ArrayConstraints => {
-  // TODO: Remove `"items" in schema` check when `const` is not allowed on arrays
-  //   see https://linear.app/hash/issue/H-3368/remove-const-from-array-constraints
-  return (
-    "items" in schema && schema.items !== undefined && schema.items !== false
-  );
-};
-
-export const isTupleConstraints = (
-  schema: ArraySchema,
-): schema is TupleConstraints => {
-  // TODO: Remove `"items" in schema` check when `const` is not allowed on arrays
-  //   see https://linear.app/hash/issue/H-3368/remove-const-from-array-constraints
-  return "items" in schema && schema.items === false;
-};
 
 export type ConstructDataTypeParams = DistributiveOmit<
   DataType,

--- a/libs/@local/hash-graph-types/typescript/src/ontology.ts
+++ b/libs/@local/hash-graph-types/typescript/src/ontology.ts
@@ -5,14 +5,9 @@ import type {
   PropertyTypeWithMetadata as PropertyTypeWithMetadataBp,
 } from "@blockprotocol/graph";
 import type {
+  ArrayConstraints,
   ArraySchema,
-  BooleanSchema,
-  DataTypeLabel,
-  NullSchema,
-  NumberSchema,
-  ObjectSchema,
-  StringFormat,
-  StringSchema,
+  TupleConstraints,
 } from "@blockprotocol/type-system";
 import { validateBaseUrl } from "@blockprotocol/type-system";
 import type {
@@ -20,7 +15,6 @@ import type {
   DataType,
   EntityType,
   PropertyType,
-  VersionedUrl,
 } from "@blockprotocol/type-system/slim";
 import type { Brand } from "@local/advanced-types/brand";
 import type { DistributiveOmit } from "@local/advanced-types/distribute";
@@ -95,134 +89,20 @@ type OntologyElementMetadata = Subtype<
   OwnedOntologyElementMetadata | ExternalOntologyElementMetadata
 >;
 
-export type StringConstraint = Subtype<
-  StringSchema,
-  {
-    format?: StringFormat;
-    minLength?: number; // Int
-    maxLength?: number; // Int
-    pattern?: string; // RegExp
-    type: "string";
-  }
->;
+export const isArrayConstraints = (
+  schema: ArraySchema,
+): schema is ArrayConstraints => {
+  return schema.items !== undefined && schema.items !== false;
+};
 
-export type NumberConstraint = Subtype<
-  NumberSchema,
-  {
-    minimum?: number;
-    maximum?: number;
-    exclusiveMinimum?: boolean;
-    exclusiveMaximum?: boolean;
-    multipleOf?: number;
-    type: "number";
-  }
->;
-
-export type BooleanConstraint = Subtype<
-  BooleanSchema,
-  {
-    type: "boolean";
-  }
->;
-
-export type NullConstraint = Subtype<
-  NullSchema,
-  {
-    type: "null";
-  }
->;
-
-export type ObjectConstraint = Subtype<
-  ObjectSchema,
-  {
-    type: "object";
-  }
->;
-
-export type StringEnumConstraint = Subtype<
-  StringSchema,
-  {
-    enum: [string, ...string[]];
-    type: "string";
-  }
->;
-
-export type NumberEnumConstraint = Subtype<
-  NumberSchema,
-  {
-    enum: [number, ...number[]];
-    type: "number";
-  }
->;
-
-/** @see https://json-schema.org/understanding-json-schema/reference/enum */
-export type EnumConstraint = StringEnumConstraint | NumberEnumConstraint;
-
-export type StringConstConstraint = Subtype<
-  StringSchema,
-  {
-    const: string;
-    type: "string";
-  }
->;
-
-export type NumberConstConstraint = Subtype<
-  NumberSchema,
-  {
-    const: number;
-    type: "number";
-  }
->;
-
-export type ConstConstraint = StringConstConstraint | NumberConstConstraint;
-
-export type SingleValueConstraint =
-  | BooleanConstraint
-  | NullConstraint
-  | ObjectConstraint
-  | StringConstraint
-  | NumberConstraint
-  | EnumConstraint
-  | ConstConstraint;
-
-export type ArrayConstraint = Subtype<
-  ArraySchema,
-  {
-    type: "array";
-    items: ValueConstraint;
-  }
->;
-
-/** @see https://json-schema.org/understanding-json-schema/reference/array#tuple-validation */
-export type TupleConstraint = Subtype<
-  ArraySchema,
-  {
-    type: "array";
-    items: false; // disallow additional items;
-    prefixItems: [ValueConstraint, ...ValueConstraint[]];
-  }
->;
-
-export type ValueConstraint = (
-  | SingleValueConstraint
-  | ArrayConstraint
-  | TupleConstraint
-  | { anyOf: [ValueConstraint, ...ValueConstraint[]] }
-) & { description?: string; label?: DataTypeLabel };
-
-export type CustomDataType = Subtype<
-  DataType,
-  {
-    description?: string;
-    $id: VersionedUrl;
-    kind: "dataType";
-    $schema: "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type";
-    title: string;
-  } & ValueConstraint
->;
+export const isTupleConstraints = (
+  schema: ArraySchema,
+): schema is TupleConstraints => {
+  return schema.items === false;
+};
 
 export type ConstructDataTypeParams = DistributiveOmit<
-  CustomDataType,
+  DataType,
   "$id" | "kind" | "$schema"
 >;
 
@@ -242,7 +122,7 @@ export type EntityTypeMetadata = EditableOntologyElementMetadata &
 export type DataTypeWithMetadata = Subtype<
   DataTypeWithMetadataBp,
   {
-    schema: CustomDataType;
+    schema: DataType;
     metadata: OntologyElementMetadata;
   }
 >;

--- a/libs/@local/hash-graph-types/typescript/src/ontology.ts
+++ b/libs/@local/hash-graph-types/typescript/src/ontology.ts
@@ -5,6 +5,7 @@ import type {
   PropertyTypeWithMetadata as PropertyTypeWithMetadataBp,
 } from "@blockprotocol/graph";
 import type {
+  ArraySchema,
   BooleanSchema,
   DataTypeLabel,
   NullSchema,
@@ -94,6 +95,50 @@ type OntologyElementMetadata = Subtype<
   OwnedOntologyElementMetadata | ExternalOntologyElementMetadata
 >;
 
+export type StringConstraint = Subtype<
+  StringSchema,
+  {
+    format?: StringFormat;
+    minLength?: number; // Int
+    maxLength?: number; // Int
+    pattern?: string; // RegExp
+    type: "string";
+  }
+>;
+
+export type NumberConstraint = Subtype<
+  NumberSchema,
+  {
+    minimum?: number;
+    maximum?: number;
+    exclusiveMinimum?: boolean;
+    exclusiveMaximum?: boolean;
+    multipleOf?: number;
+    type: "number";
+  }
+>;
+
+export type BooleanConstraint = Subtype<
+  BooleanSchema,
+  {
+    type: "boolean";
+  }
+>;
+
+export type NullConstraint = Subtype<
+  NullSchema,
+  {
+    type: "null";
+  }
+>;
+
+export type ObjectConstraint = Subtype<
+  ObjectSchema,
+  {
+    type: "object";
+  }
+>;
+
 export type StringEnumConstraint = Subtype<
   StringSchema,
   {
@@ -132,25 +177,31 @@ export type NumberConstConstraint = Subtype<
 export type ConstConstraint = StringConstConstraint | NumberConstConstraint;
 
 export type SingleValueConstraint =
-  | BooleanSchema
-  | NullSchema
-  | ObjectSchema
-  | StringSchema
-  | NumberSchema
+  | BooleanConstraint
+  | NullConstraint
+  | ObjectConstraint
+  | StringConstraint
+  | NumberConstraint
   | EnumConstraint
   | ConstConstraint;
 
-export type ArrayConstraint = {
-  type: "array";
-  items: ValueConstraint;
-};
+export type ArrayConstraint = Subtype<
+  ArraySchema,
+  {
+    type: "array";
+    items: ValueConstraint;
+  }
+>;
 
 /** @see https://json-schema.org/understanding-json-schema/reference/array#tuple-validation */
-export type TupleConstraint = {
-  type: "array";
-  items: false; // disallow additional items;
-  prefixItems: [ValueConstraint, ...ValueConstraint[]];
-};
+export type TupleConstraint = Subtype<
+  ArraySchema,
+  {
+    type: "array";
+    items: false; // disallow additional items;
+    prefixItems: [ValueConstraint, ...ValueConstraint[]];
+  }
+>;
 
 export type ValueConstraint = (
   | SingleValueConstraint

--- a/libs/@local/hash-isomorphic-utils/src/data-types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/data-types.ts
@@ -1,5 +1,5 @@
 import type { JsonValue } from "@blockprotocol/core";
-import type { ValueConstraint } from "@local/hash-graph-types/ontology";
+import type { DataType, SimpleValueSchema } from "@blockprotocol/type-system";
 import { getJsonSchemaTypeFromValue } from "@local/hash-subgraph/stdlib";
 
 export type FormattedValuePart = {
@@ -13,7 +13,7 @@ const createFormattedParts = ({
   schema,
 }: {
   inner: string | FormattedValuePart[];
-  schema: Pick<ValueConstraint, "label"> | null;
+  schema?: Pick<DataType, "label">;
 }): FormattedValuePart[] => {
   const { left = "", right = "" } = schema?.label ?? {};
 
@@ -38,7 +38,7 @@ const createFormattedParts = ({
 
 export const formatDataValue = (
   value: JsonValue,
-  schema: ValueConstraint | null,
+  schema?: DataType | SimpleValueSchema,
 ): FormattedValuePart[] => {
   const { type } = schema ?? {
     type: getJsonSchemaTypeFromValue(value),
@@ -72,8 +72,12 @@ export const formatDataValue = (
 
     const innerValue: string = value
       .map((inner, index) => {
-        if (isTuple && index < schema.prefixItems.length) {
-          return formatDataValue(inner, schema.prefixItems[index]!);
+        if (
+          isTuple &&
+          schema.prefixItems &&
+          index < schema.prefixItems.length
+        ) {
+          return formatDataValue(inner, schema.prefixItems[index]);
         }
 
         if (schema && !schema.items) {
@@ -83,7 +87,7 @@ export const formatDataValue = (
           );
         }
 
-        return formatDataValue(inner, schema?.items ?? null);
+        return formatDataValue(inner, schema?.items);
       })
       .join("");
 

--- a/libs/@local/hash-subgraph/tests/compatibility.test/map-vertices.ts
+++ b/libs/@local/hash-subgraph/tests/compatibility.test/map-vertices.ts
@@ -1,4 +1,5 @@
 import type {
+  DataType,
   EntityType,
   OneOfSchema,
   PropertyType,
@@ -43,7 +44,6 @@ import type {
 } from "@local/hash-graph-types/entity";
 import type {
   BaseUrl,
-  CustomDataType,
   DataTypeMetadata,
   EntityTypeMetadata,
   OntologyProvenance,
@@ -62,7 +62,7 @@ import type {
 } from "../../src/main.js";
 import { isEntityId } from "../../src/main.js";
 
-const mapDataType = (dataType: DataTypeGraphApi): CustomDataType => {
+const mapDataType = (dataType: DataTypeGraphApi): DataType => {
   const idResult = validateVersionedUrl(dataType.$id);
   if (idResult.type === "Err") {
     throw new Error(
@@ -74,7 +74,7 @@ const mapDataType = (dataType: DataTypeGraphApi): CustomDataType => {
   const { inner: $id } = idResult;
 
   return {
-    ...(dataType as CustomDataType),
+    ...(dataType as DataType),
     $id,
   };
 };

--- a/libs/deer/src/error/value.rs
+++ b/libs/deer/src/error/value.rs
@@ -6,8 +6,8 @@ use core::{
 };
 
 use super::{
-    ErrorProperties, ErrorProperty, Id, Location, NAMESPACE, Namespace, Variant,
-    r#type::ExpectedType,
+    r#type::ExpectedType, ErrorProperties, ErrorProperty, Id, Location, Namespace, Variant,
+    NAMESPACE,
 };
 use crate::id;
 
@@ -110,8 +110,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        Deserialize,
         test::{to_json, to_message},
+        Deserialize,
     };
 
     #[test]

--- a/libs/deer/src/error/value.rs
+++ b/libs/deer/src/error/value.rs
@@ -6,8 +6,8 @@ use core::{
 };
 
 use super::{
-    r#type::ExpectedType, ErrorProperties, ErrorProperty, Id, Location, Namespace, Variant,
-    NAMESPACE,
+    ErrorProperties, ErrorProperty, Id, Location, NAMESPACE, Namespace, Variant,
+    r#type::ExpectedType,
 };
 use crate::id;
 
@@ -110,8 +110,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        test::{to_json, to_message},
         Deserialize,
+        test::{to_json, to_message},
     };
 
     #[test]

--- a/tests/hash-graph-test-data/rust/src/data_type/empty_list.json
+++ b/tests/hash-graph-test-data/rust/src/data_type/empty_list.json
@@ -5,5 +5,5 @@
   "title": "Empty List",
   "description": "An Empty List",
   "type": "array",
-  "const": []
+  "items": false
 }

--- a/tests/hash-graph-test-data/rust/src/data_type/mod.rs
+++ b/tests/hash-graph-test-data/rust/src/data_type/mod.rs
@@ -1,3 +1,5 @@
+pub const VALUE_V1: &str = include_str!("value.json");
+
 pub const BOOLEAN_V1: &str = include_str!("boolean.json");
 pub const EMPTY_LIST_V1: &str = include_str!("empty_list.json");
 pub const NULL_V1: &str = include_str!("null.json");

--- a/tests/hash-graph-test-data/rust/src/data_type/value.json
+++ b/tests/hash-graph-test-data/rust/src/data_type/value.json
@@ -4,12 +4,5 @@
   "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/value/v/1",
   "title": "Value",
   "description": "A value that can be stored in a graph",
-  "anyOf": [
-    { "type": "null" },
-    { "type": "boolean" },
-    { "type": "number" },
-    { "type": "string" },
-    { "type": "array" },
-    { "type": "object" }
-  ]
+  "anyOf": [{ "type": "null" }]
 }

--- a/tests/hash-graph-test-data/rust/src/data_type/value.json
+++ b/tests/hash-graph-test-data/rust/src/data_type/value.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
+  "kind": "dataType",
+  "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/value/v/1",
+  "title": "Value",
+  "description": "A value that can be stored in a graph",
+  "anyOf": [
+    { "type": "null" },
+    { "type": "boolean" },
+    { "type": "number" },
+    { "type": "string" },
+    { "type": "array" },
+    { "type": "object" }
+  ]
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The Node API exposes more constraints than the Graph. We precisely want to match the type system and the Node API. This extends the previous PR by only exposing used constraints

## 🔗 Related links

- https://github.com/hashintel/hash/pull/5180

## 🔍 What does this change?

- Only allow constraints used in the Node API
- Add tests to make sure that additional properties are not allowed

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- `compileJsonSchema(type as unknown as JsonSchema, type.title, {` to convert `DataType` to `JsonSchema` (old PR, but worth mentioning)
- Omit `allOf` from `MinimalDataType` (it would not work with OpenAI, I guess for that we want the closed schema?)
- `const` for `type: "array"` can only be `[]` now and will be removed when we do H-3368

## 🐾 Next steps

- https://github.com/hashintel/hash/pull/5232

## 🛡 What tests cover this?

Various tests were added to check constraints