### PR TITLE
H-3372: Use logger to print error-stack warnings

### DIFF
--- a/apps/hash-graph/libs/api/Cargo.toml
+++ b/apps/hash-graph/libs/api/Cargo.toml
@@ -29,7 +29,7 @@ tower-http = { workspace = true, public = true }
 tracing = { workspace = true, public = true }
 
 # Private workspace dependencies
-error-stack = { workspace = true }
+error-stack = { workspace = true, features = ["spantrace"] }
 graph-type-defs = { workspace = true }
 hash-status = { workspace = true }
 temporal-versioning = { workspace = true }

--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -28,6 +28,7 @@ pin-project-lite = { workspace = true, optional = true }
 # Private third-party dependencies
 spin = { version = ">=0.9", default-features = false, optional = true, features = ['rwlock', 'once'] }
 tracing-error = { version = ">=0.2", optional = true, default-features = false }
+tracing = { version = ">=0.1", optional = true, default-features = false }
 
 [dev-dependencies]
 serde = { workspace = true, features = ["derive"] }
@@ -55,7 +56,8 @@ default = ["std", "backtrace"]
 std = ["anyhow?/std"]  # Enables support for `Error`
 backtrace = ["std"]  # Enables automatic capturing of `Backtrace`s (requires Rust 1.65+)
 
-spantrace = ["dep:tracing-error", "std"]  # Enables automatic capturing of `SpanTrace`s
+tracing = ["dep:tracing"]  # Uses the `tracing` library if messages would be printed to the terminal
+spantrace = ["dep:tracing-error", "tracing", "std"]  # Enables automatic capturing of `SpanTrace`s
 serde = ["dep:serde"]  # Enables serialization support
 hooks = ['dep:spin']  # Enables hooks on `no-std` platforms using spin locks
 

--- a/libs/error-stack/build.rs
+++ b/libs/error-stack/build.rs
@@ -26,4 +26,8 @@ fn main() {
     if trimmed_rustc_version >= Version::new(1, 81, 0) {
         println!("cargo:rustc-cfg=rust_1_81");
     }
+
+    if cfg!(feature = "futures") && !cfg!(feature = "unstable") {
+        println!("cargo:warning=The `futures` feature requires the `unstable` feature.");
+    }
 }

--- a/libs/error-stack/src/sink.rs
+++ b/libs/error-stack/src/sink.rs
@@ -67,7 +67,7 @@ impl Drop for Bomb {
 
         match self.0 {
             BombState::Panic => panic!("ReportSink was dropped without being consumed"),
-            #[allow(clippy::print_stderr, unused_variables)]
+            #[allow(clippy::print_stderr)]
             #[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
             BombState::Warn(location) => {
                 #[cfg(feature = "tracing")]
@@ -76,7 +76,7 @@ impl Drop for Bomb {
                     %location,
                     "`ReportSink` was dropped without being consumed"
                 );
-                #[cfg(all(not(target_arch = "wasm32"), not(feature = "tracing"), feature = "std"))]
+                #[cfg(not(feature = "tracing"))]
                 eprintln!("`ReportSink` was dropped without being consumed at {location}");
             }
             _ => {}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The warnings on the terminal are annoying and cannot easily be silenced. This adds a `tracing` feature to `error-stack` to use `tracing` instead of `eprintln!`. Also, the message alone was kind-of pointless without a location, so on a `Warn`-level it will capture the caller location as well.

Example output:
```
`ReportSink` was dropped without being consumed at /<...>/hash/libs/@local/hash-graph-types/rust/src/knowledge/property/visitor.rs:452:22
```