### PR TITLE
H-3376: Infer data type IDs if only abstract parents exists

### DIFF
--- a/apps/hash-graph/libs/graph/src/store/validation.rs
+++ b/apps/hash-graph/libs/graph/src/store/validation.rs
@@ -251,6 +251,32 @@ where
     }
 
     #[expect(refining_impl_trait)]
+    async fn has_non_abstract_parents(
+        &self,
+        data_type: &VersionedUrl,
+    ) -> Result<bool, Report<QueryError>> {
+        let client = self.store.as_client().client();
+
+        Ok(client
+            .query_one(
+                "
+                    SELECT EXISTS (
+                        SELECT 1
+                        FROM data_type_inherits_from
+                        JOIN data_types
+                          ON data_types.ontology_id = target_data_type_ontology_id
+                        WHERE source_data_type_ontology_id = $1
+                          AND data_types.schema->>'abstract' = 'false'
+                    );
+                ",
+                &[&DataTypeId::from_url(data_type)],
+            )
+            .await
+            .change_context(QueryError)?
+            .get(0))
+    }
+
+    #[expect(refining_impl_trait)]
     async fn find_conversion(
         &self,
         source_data_type_id: &VersionedUrl,

--- a/apps/hash-graph/libs/store/src/filter/mod.rs
+++ b/apps/hash-graph/libs/store/src/filter/mod.rs
@@ -536,6 +536,10 @@ mod tests {
             unimplemented!()
         }
 
+        async fn has_non_abstract_parents(&self, _: &VersionedUrl) -> Result<bool, Report<!>> {
+            unimplemented!()
+        }
+
         async fn find_conversion(
             &self,
             _: &VersionedUrl,

--- a/libs/@local/hash-graph-types/rust/src/ontology/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/ontology/mod.rs
@@ -184,7 +184,16 @@ pub trait DataTypeProvider: OntologyTypeProvider<DataTypeWithMetadata> {
         parent: &BaseUrl,
     ) -> impl Future<Output = Result<bool, Report<impl Context>>> + Send;
 
+    // TODO: Remove when the data type ID is forced to be passed
+    //   see https://linear.app/hash/issue/H-2800/validate-that-a-data-type-id-is-always-specified
     fn has_children(
+        &self,
+        data_type: &VersionedUrl,
+    ) -> impl Future<Output = Result<bool, Report<impl Context>>> + Send;
+
+    // TODO: Remove when the data type ID is forced to be passed
+    //   see https://linear.app/hash/issue/H-2800/validate-that-a-data-type-id-is-always-specified
+    fn has_non_abstract_parents(
         &self,
         data_type: &VersionedUrl,
     ) -> impl Future<Output = Result<bool, Report<impl Context>>> + Send;

--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -377,6 +377,8 @@ impl EntityVisitor for EntityPreprocessor {
         let mut status = ReportSink::new();
 
         // We try to infer the data type ID
+        // TODO: Remove when the data type ID is forced to be passed
+        //   see https://linear.app/hash/issue/H-2800/validate-that-a-data-type-id-is-always-specified
         if property.metadata.data_type_id.is_none() {
             let mut possible_data_types = HashSet::new();
 
@@ -394,14 +396,14 @@ impl EntityVisitor for EntityPreprocessor {
                         break;
                     }
 
-                    let data_type = type_provider
-                        .provide_type(&data_type_ref.url)
+                    let has_non_abstract_parents = type_provider
+                        .has_non_abstract_parents(&data_type_ref.url)
                         .await
                         .change_context_lazy(|| TraversalError::DataTypeRetrieval {
                             id: data_type_ref.clone(),
                         })?;
 
-                    if !data_type.borrow().schema.all_of.is_empty() {
+                    if has_non_abstract_parents {
                         status.capture(TraversalError::AmbiguousDataType);
                         possible_data_types.clear();
                         break;

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -324,6 +324,14 @@ mod tests {
         }
 
         #[expect(refining_impl_trait)]
+        async fn has_non_abstract_parents(
+            &self,
+            _data_type: &VersionedUrl,
+        ) -> Result<bool, Report<InvalidDataType>> {
+            Ok(false)
+        }
+
+        #[expect(refining_impl_trait)]
         async fn find_conversion(
             &self,
             _: &VersionedUrl,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With inheritance being used for data types, it's likely that data types are ambiguous. As long as we don't always pass the data type ID we should take abstract into account when inferring the ID to get the best possible behavior.

## 🔍 What does this change?

- When checking for parents when inferring data type IDs take into account `abstract` parents

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph