### PR TITLE
H-3380, H-3381: Improve error handling and data type ID inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2598,6 +2598,7 @@ dependencies = [
  "futures",
  "graph",
  "graph-api",
+ "graph-types",
  "hash-tracing",
  "mimalloc",
  "regex",

--- a/apps/hash-graph/bins/cli/Cargo.toml
+++ b/apps/hash-graph/bins/cli/Cargo.toml
@@ -19,6 +19,7 @@ codec = { workspace = true }
 error-stack = { workspace = true }
 graph = { workspace = true, features = ["clap"] }
 graph-api = { workspace = true }
+graph-types = { workspace = true }
 hash-tracing = { workspace = true, features = ["clap"] }
 temporal-client = { workspace = true }
 test-server = { workspace = true, optional = true }

--- a/apps/hash-graph/bins/cli/package.json
+++ b/apps/hash-graph/bins/cli/package.json
@@ -20,6 +20,7 @@
     "@rust/error-stack": "0.5.0",
     "@rust/graph": "0.0.0-private",
     "@rust/graph-api": "0.0.0-private",
+    "@rust/graph-types": "0.0.0-private",
     "@rust/hash-tracing": "0.0.0-private",
     "@rust/temporal-client": "0.0.0-private",
     "@rust/test-server": "0.0.0-private",

--- a/apps/hash-graph/bins/cli/src/main.rs
+++ b/apps/hash-graph/bins/cli/src/main.rs
@@ -22,7 +22,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 fn main() -> Result<(), GraphError> {
     load_env(None);
-    validation::error::install_error_stack_hooks();
+    graph_types::knowledge::property::error::install_error_stack_hooks();
 
     let Args {
         subcommand,

--- a/apps/hash-graph/libs/graph/src/store/validation.rs
+++ b/apps/hash-graph/libs/graph/src/store/validation.rs
@@ -232,51 +232,6 @@ where
     }
 
     #[expect(refining_impl_trait)]
-    async fn has_children(&self, data_type: &VersionedUrl) -> Result<bool, Report<QueryError>> {
-        let client = self.store.as_client().client();
-
-        Ok(client
-            .query_one(
-                "
-                    SELECT EXISTS (
-                        SELECT 1 FROM data_type_inherits_from
-                        WHERE target_data_type_ontology_id = $1
-                    );
-                ",
-                &[&DataTypeId::from_url(data_type)],
-            )
-            .await
-            .change_context(QueryError)?
-            .get(0))
-    }
-
-    #[expect(refining_impl_trait)]
-    async fn has_non_abstract_parents(
-        &self,
-        data_type: &VersionedUrl,
-    ) -> Result<bool, Report<QueryError>> {
-        let client = self.store.as_client().client();
-
-        Ok(client
-            .query_one(
-                "
-                    SELECT EXISTS (
-                        SELECT 1
-                        FROM data_type_inherits_from
-                        JOIN data_types
-                          ON data_types.ontology_id = target_data_type_ontology_id
-                        WHERE source_data_type_ontology_id = $1
-                          AND data_types.schema->>'abstract' = 'false'
-                    );
-                ",
-                &[&DataTypeId::from_url(data_type)],
-            )
-            .await
-            .change_context(QueryError)?
-            .get(0))
-    }
-
-    #[expect(refining_impl_trait)]
     async fn find_conversion(
         &self,
         source_data_type_id: &VersionedUrl,

--- a/apps/hash-graph/libs/store/src/filter/mod.rs
+++ b/apps/hash-graph/libs/store/src/filter/mod.rs
@@ -532,14 +532,6 @@ mod tests {
             unimplemented!()
         }
 
-        async fn has_children(&self, _: &VersionedUrl) -> Result<bool, Report<!>> {
-            unimplemented!()
-        }
-
-        async fn has_non_abstract_parents(&self, _: &VersionedUrl) -> Result<bool, Report<!>> {
-            unimplemented!()
-        }
-
         async fn find_conversion(
             &self,
             _: &VersionedUrl,

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/any_of.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/any_of.rs
@@ -30,6 +30,8 @@ impl AnyOfConstraints {
                 .attempt(schema.constraints.validate_value(value))
                 .is_some()
             {
+                // We found a valid schema, so we can return early.
+                let _: Result<(), _> = status.finish();
                 return Ok(());
             }
         }

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/error.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/error.rs
@@ -1,12 +1,13 @@
 use std::collections::HashSet;
 
 use error_stack::Report;
-use graph_types::knowledge::property::{PropertyWithMetadata, PropertyWithMetadataObject};
 use serde_json::Value as JsonValue;
 use type_system::{
     schema::{ClosedEntityType, DataType, PropertyType},
     url::VersionedUrl,
 };
+
+use crate::knowledge::property::{PropertyWithMetadata, PropertyWithMetadataObject};
 
 pub fn install_error_stack_hooks() {
     Report::install_debug_hook::<Actual>(|actual, context| match actual {

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/mod.rs
@@ -1,3 +1,4 @@
+pub mod error;
 pub mod visitor;
 
 pub use self::{

--- a/libs/@local/hash-graph-types/rust/src/knowledge/property/visitor.rs
+++ b/libs/@local/hash-graph-types/rust/src/knowledge/property/visitor.rs
@@ -15,6 +15,7 @@ use crate::{
     knowledge::property::{
         PropertyWithMetadata, PropertyWithMetadataArray, PropertyWithMetadataObject,
         PropertyWithMetadataValue, ValueMetadata,
+        error::{Actual, Expected},
     },
     ontology::{
         DataTypeProvider, DataTypeWithMetadata, OntologyTypeProvider, PropertyTypeProvider,
@@ -47,10 +48,12 @@ pub enum TraversalError {
     },
     #[error("a value was expected, but the property provided was of type `{actual}`")]
     ExpectedValue { actual: JsonSchemaValueType },
-    #[error("The property provided is ambiguous")]
+    #[error("The property provided is ambiguous, more than one schema passed the validation.")]
     AmbiguousProperty { actual: PropertyWithMetadata },
     #[error("The data type ID was not specified and is ambiguous.")]
     AmbiguousDataType,
+    #[error("Could not find a suitable data type for the property")]
+    DataTypeUnspecified,
 
     #[error(
         "the value provided does not match the data type in the metadata, expected `{expected}` \
@@ -64,6 +67,15 @@ pub enum TraversalError {
     AbstractDataType { id: VersionedUrl },
     #[error("the value provided does not match the constraints of the data type")]
     ConstraintUnfulfilled,
+    #[error("the value provided does not match the data type")]
+    DataTypeUnfulfilled,
+    #[error(
+        "the value provided does not match the property type. Exactly one constraint has to be \
+         fulfilled."
+    )]
+    PropertyTypeUnfulfilled,
+    #[error("the entity provided does not match the entity type")]
+    EntityTypeUnfulfilled,
     #[error("the property `{key}` was required, but not specified")]
     MissingRequiredProperty { key: BaseUrl },
     #[error(
@@ -260,23 +272,31 @@ where
     V: EntityVisitor,
     P: DataTypeProvider + PropertyTypeProvider + Sync,
 {
+    let mut status = ReportSink::new();
     match property {
-        PropertyWithMetadata::Value(value) => {
+        PropertyWithMetadata::Value(value) => status.attempt(
             visitor
                 .visit_one_of_property(&schema.one_of, value, type_provider)
                 .await
-        }
-        PropertyWithMetadata::Array(array) => {
+                .change_context_lazy(|| TraversalError::PropertyTypeUnfulfilled),
+        ),
+        PropertyWithMetadata::Array(array) => status.attempt(
             visitor
                 .visit_one_of_array(&schema.one_of, array, type_provider)
                 .await
-        }
-        PropertyWithMetadata::Object(object) => {
+                .change_context_lazy(|| TraversalError::PropertyTypeUnfulfilled),
+        ),
+        PropertyWithMetadata::Object(object) => status.attempt(
             visitor
                 .visit_one_of_object(&schema.one_of, object, type_provider)
                 .await
-        }
-    }
+                .change_context_lazy(|| TraversalError::PropertyTypeUnfulfilled),
+        ),
+    };
+    status
+        .finish()
+        .attach_lazy(|| Expected::PropertyType(schema.clone()))
+        .attach_lazy(|| Actual::Property(property.clone()))
 }
 
 /// Walks through an array property using the provided schema.
@@ -469,6 +489,9 @@ where
                         type_provider,
                     )
                     .await
+                    .attach_lazy(|| Expected::DataType(data_type.borrow().schema.clone()))
+                    .attach_lazy(|| Actual::Json(property.value.clone()))
+                    .change_context(TraversalError::DataTypeUnfulfilled)
                 {
                     status.append(error);
                 } else {
@@ -490,7 +513,11 @@ where
 
     match passed {
         0 => status.finish(),
-        1 => Ok(()),
+        1 => {
+            // We ignore potential errors here, as we have exactly one successful result.
+            let _: Result<(), _> = status.finish();
+            Ok(())
+        }
         _ => {
             status.capture(TraversalError::AmbiguousProperty {
                 actual: PropertyWithMetadata::Value(property.clone()),
@@ -549,7 +576,11 @@ where
 
     match passed {
         0 => status.finish(),
-        1 => Ok(()),
+        1 => {
+            // We ignore potential errors here, as we have exactly one successful result.
+            let _: Result<(), _> = status.finish();
+            Ok(())
+        }
         _ => {
             status.capture(TraversalError::AmbiguousProperty {
                 actual: PropertyWithMetadata::Array(array.clone()),
@@ -609,7 +640,11 @@ where
 
     match passed {
         0 => status.finish(),
-        1 => Ok(()),
+        1 => {
+            // We ignore potential errors here, as we have exactly one successful result.
+            let _: Result<(), _> = status.finish();
+            Ok(())
+        }
         _ => {
             status.capture(TraversalError::AmbiguousProperty {
                 actual: PropertyWithMetadata::Object(object.clone()),

--- a/libs/@local/hash-graph-types/rust/src/ontology/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/ontology/mod.rs
@@ -184,20 +184,6 @@ pub trait DataTypeProvider: OntologyTypeProvider<DataTypeWithMetadata> {
         parent: &BaseUrl,
     ) -> impl Future<Output = Result<bool, Report<impl Context>>> + Send;
 
-    // TODO: Remove when the data type ID is forced to be passed
-    //   see https://linear.app/hash/issue/H-2800/validate-that-a-data-type-id-is-always-specified
-    fn has_children(
-        &self,
-        data_type: &VersionedUrl,
-    ) -> impl Future<Output = Result<bool, Report<impl Context>>> + Send;
-
-    // TODO: Remove when the data type ID is forced to be passed
-    //   see https://linear.app/hash/issue/H-2800/validate-that-a-data-type-id-is-always-specified
-    fn has_non_abstract_parents(
-        &self,
-        data_type: &VersionedUrl,
-    ) -> impl Future<Output = Result<bool, Report<impl Context>>> + Send;
-
     fn find_conversion(
         &self,
         source_data_type_id: &VersionedUrl,

--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -380,43 +380,49 @@ impl EntityVisitor for EntityPreprocessor {
         // TODO: Remove when the data type ID is forced to be passed
         //   see https://linear.app/hash/issue/H-2800/validate-that-a-data-type-id-is-always-specified
         if property.metadata.data_type_id.is_none() {
+            let mut infer_status = ReportSink::new();
             let mut possible_data_types = HashSet::new();
 
             for values in schema {
                 if let PropertyValues::DataTypeReference(data_type_ref) = values {
-                    let has_children = type_provider
-                        .has_children(&data_type_ref.url)
-                        .await
-                        .change_context_lazy(|| TraversalError::DataTypeRetrieval {
-                            id: data_type_ref.clone(),
-                        })?;
-                    if has_children {
-                        status.capture(TraversalError::AmbiguousDataType);
-                        possible_data_types.clear();
-                        break;
-                    }
+                    let Some(data_type) = infer_status.attempt(
+                        type_provider
+                            .provide_type(&data_type_ref.url)
+                            .await
+                            .change_context_lazy(|| TraversalError::DataTypeRetrieval {
+                                id: data_type_ref.clone(),
+                            }),
+                    ) else {
+                        continue;
+                    };
 
-                    let has_non_abstract_parents = type_provider
-                        .has_non_abstract_parents(&data_type_ref.url)
-                        .await
-                        .change_context_lazy(|| TraversalError::DataTypeRetrieval {
-                            id: data_type_ref.clone(),
-                        })?;
-
-                    if has_non_abstract_parents {
-                        status.capture(TraversalError::AmbiguousDataType);
-                        possible_data_types.clear();
-                        break;
+                    if data_type.borrow().schema.r#abstract {
+                        infer_status.capture(TraversalError::AbstractDataType {
+                            id: data_type_ref.url.clone(),
+                        });
+                        continue;
                     }
 
                     possible_data_types.insert(data_type_ref.url.clone());
                 }
             }
 
+            let inferred_successfully = status
+                .attempt(
+                    infer_status
+                        .finish()
+                        .change_context(TraversalError::DataTypeUnspecified),
+                )
+                .is_some();
+
             // Only if there is really a single valid data type ID, we set it. Note, that this is
             // done before the actual validation step.
-            if possible_data_types.len() == 1 {
-                property.metadata.data_type_id = possible_data_types.into_iter().next();
+            if inferred_successfully {
+                if possible_data_types.len() == 1 {
+                    property.metadata.data_type_id = possible_data_types.into_iter().next();
+                } else {
+                    status.capture(TraversalError::AmbiguousDataType);
+                }
             }
         }
 
@@ -538,8 +544,6 @@ impl EntityVisitor for EntityPreprocessor {
                     status.append(error);
                 }
             }
-        } else {
-            status.capture(TraversalError::AmbiguousDataType);
         }
 
         if let Err(error) = walk_one_of_property_value(self, schema, property, type_provider).await

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -3,8 +3,6 @@
 
 extern crate alloc;
 
-pub mod error;
-
 pub use self::entity_type::{EntityPreprocessor, EntityValidationError};
 
 mod entity_type;
@@ -102,6 +100,7 @@ mod tests {
         knowledge::property::{
             Property, PropertyMetadata, PropertyObject, PropertyProvenance, PropertyWithMetadata,
             PropertyWithMetadataObject, PropertyWithMetadataValue, ValueMetadata,
+            error::install_error_stack_hooks,
             visitor::{EntityVisitor, TraversalError},
         },
         ontology::{
@@ -122,7 +121,6 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use crate::error::install_error_stack_hooks;
 
     fn generate_data_type_metadata(schema: DataType) -> DataTypeWithMetadata {
         let actor = AccountId::new(Uuid::nil());
@@ -313,22 +311,6 @@ mod tests {
                     .iter()
                     .any(|id| id.url.base_url == *parent),
             )
-        }
-
-        #[expect(refining_impl_trait)]
-        async fn has_children(
-            &self,
-            _data_type: &VersionedUrl,
-        ) -> Result<bool, Report<InvalidDataType>> {
-            Ok(false)
-        }
-
-        #[expect(refining_impl_trait)]
-        async fn has_non_abstract_parents(
-            &self,
-            _data_type: &VersionedUrl,
-        ) -> Result<bool, Report<InvalidDataType>> {
-            Ok(false)
         }
 
         #[expect(refining_impl_trait)]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We want to infer the data type if the schema is requesting exactly one possible data type and it's not abstract. Also, the errors reported from validation should include more information on what property/data type has failed to validate.

## 🔍 What does this change?

- Lift constraints on data type inference:
	- All potential data type IDs must be non-abstract
	- Exactly one data type ID needs to be allowed for a property
	This should cover almost every scenario we currently encounter
- Improve error layout and attachments on validation errors
- A few more locations make sure that the `ReportSink`-bomb is defused.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph