### PR TITLE
H-3385: Allow updating the data type cache in the database

### DIFF
--- a/apps/hash-graph/bins/cli/src/subcommand/mod.rs
+++ b/apps/hash-graph/bins/cli/src/subcommand/mod.rs
@@ -1,5 +1,6 @@
 mod completions;
 mod migrate;
+mod reindex_cache;
 mod server;
 mod snapshot;
 #[cfg(feature = "test-server")]
@@ -21,7 +22,10 @@ pub use self::{
     snapshot::{SnapshotArgs, snapshot},
     type_fetcher::{TypeFetcherArgs, type_fetcher},
 };
-use crate::error::{GraphError, HealthcheckError};
+use crate::{
+    error::{GraphError, HealthcheckError},
+    subcommand::reindex_cache::{ReindexCacheArgs, reindex_cache},
+};
 
 /// Subcommand for the program.
 #[derive(Debug, clap::Subcommand)]
@@ -36,6 +40,11 @@ pub enum Subcommand {
     Completions(CompletionsArgs),
     /// Snapshot API for the database.
     Snapshot(SnapshotArgs),
+    /// Re-indexes the cache.
+    ///
+    /// This is only needed if the backend was changed in an uncommon way such as schemas being
+    /// updated in place. This is a rare operation and should be avoided if possible.
+    ReindexCache(ReindexCacheArgs),
     /// Test server
     #[cfg(feature = "test-server")]
     TestServer(TestServerArgs),
@@ -69,6 +78,7 @@ impl Subcommand {
                 Ok(())
             }
             Self::Snapshot(args) => block_on(snapshot(args), tracing_config),
+            Self::ReindexCache(args) => block_on(reindex_cache(args), tracing_config),
             #[cfg(feature = "test-server")]
             Self::TestServer(args) => block_on(test_server(args), tracing_config),
         }

--- a/apps/hash-graph/bins/cli/src/subcommand/reindex_cache.rs
+++ b/apps/hash-graph/bins/cli/src/subcommand/reindex_cache.rs
@@ -1,0 +1,71 @@
+use authorization::NoAuthorization;
+use clap::Parser;
+use error_stack::{Report, Result, ResultExt, ensure};
+use graph::store::{
+    DataTypeStore, DatabaseConnectionInfo, DatabasePoolConfig, PostgresStorePool, StorePool,
+};
+use tokio_postgres::NoTls;
+
+use crate::error::GraphError;
+
+#[derive(Debug, Parser)]
+#[clap(version, author, about, long_about = None)]
+pub struct ReindexCacheArgs {
+    #[clap(flatten)]
+    pub db_info: DatabaseConnectionInfo,
+
+    #[clap(flatten)]
+    pub pool_config: DatabasePoolConfig,
+
+    #[clap(flatten)]
+    pub operations: ReindexOperations,
+}
+
+#[derive(Debug, Parser)]
+#[clap(version, author, about, long_about = None, next_help_heading = Some("Reindex operations"))]
+pub struct ReindexOperations {
+    /// Reindex data types cache
+    #[clap(long)]
+    pub data_types: bool,
+}
+
+pub async fn reindex_cache(args: ReindexCacheArgs) -> Result<(), GraphError> {
+    let pool = PostgresStorePool::new(&args.db_info, &args.pool_config, NoTls)
+        .await
+        .change_context(GraphError)
+        .map_err(|report| {
+            tracing::error!(error = ?report, "Failed to connect to database");
+            report
+        })?;
+
+    let mut store = pool
+        .acquire(NoAuthorization, None)
+        .await
+        .change_context(GraphError)
+        .map_err(|report| {
+            tracing::error!(error = ?report, "Failed to acquire database connection");
+            report
+        })?;
+
+    let mut did_something = false;
+
+    if args.operations.data_types {
+        did_something = true;
+        DataTypeStore::reindex_cache(&mut store)
+            .await
+            .change_context(GraphError)
+            .map_err(|report| {
+                tracing::error!(error = ?report, "Failed to reindex data type cache");
+                report
+            })?;
+    }
+
+    ensure!(
+        did_something,
+        Report::new(GraphError).attach_printable(
+            "No reindex operation was requested. See --help for more information."
+        )
+    );
+
+    Ok(())
+}

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -920,6 +920,10 @@ where
             .update_data_type_embeddings(actor_id, params)
             .await
     }
+
+    async fn reindex_cache(&mut self) -> Result<(), UpdateError> {
+        self.store.reindex_cache().await
+    }
 }
 
 impl<S, A> PropertyTypeStore for FetchingStore<S, A>

--- a/apps/hash-graph/libs/graph/src/store/ontology.rs
+++ b/apps/hash-graph/libs/graph/src/store/ontology.rs
@@ -270,6 +270,16 @@ pub trait DataTypeStore {
 
         params: UpdateDataTypeEmbeddingParams<'_>,
     ) -> impl Future<Output = Result<(), UpdateError>> + Send;
+
+    /// Re-indexes the cache for data types.
+    ///
+    /// This is only needed if the schema of a data type has changed in place without bumping
+    /// the version. This is a rare operation and should be avoided if possible.
+    ///
+    /// # Errors
+    ///
+    /// - if re-indexing the cache fails.
+    fn reindex_cache(&mut self) -> impl Future<Output = Result<(), UpdateError>> + Send;
 }
 
 #[derive(Debug, Deserialize)]

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -402,6 +402,10 @@ impl<A: AuthorizationApi> DataTypeStore for DatabaseApi<'_, A> {
             .update_data_type_embeddings(actor_id, params)
             .await
     }
+
+    async fn reindex_cache(&mut self) -> Result<(), UpdateError> {
+        self.store.reindex_cache().await
+    }
 }
 
 impl<A: AuthorizationApi> PropertyTypeStore for DatabaseApi<'_, A> {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We change data type inheritence in quite a few PRs currently and to avoid running snapshot migrations for everything it's easier to run a command from the CLI. The functionality was borrowed from snapshots, which has to do the same functionality, but this PR also exposes the functionality to the CLI:
```
cargo run --bin hash-graph -- reindex-cache --data-types
```