### PR TITLE
H-3384: Replace `empty-list` with `list`

### DIFF
--- a/apps/hash-graph/libs/type-fetcher/predefined_types/data_types/list_v1.json
+++ b/apps/hash-graph/libs/type-fetcher/predefined_types/data_types/list_v1.json
@@ -1,14 +1,13 @@
 {
   "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
   "kind": "dataType",
-  "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/empty-list/v/1",
+  "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/list/v/1",
   "allOf": [
     {
       "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/value/v/1"
     }
   ],
-  "title": "Empty List",
-  "description": "An Empty List",
-  "type": "array",
-  "items": false
+  "title": "List",
+  "description": "An ordered list of values",
+  "type": "array"
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -719,9 +719,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn empty_list() {
+    async fn list() {
         ensure_validation_from_str::<DataType, _>(
-            graph_test_data::data_type::EMPTY_LIST_V1,
+            graph_test_data::data_type::LIST_V1,
             DataTypeValidator,
             JsonEqualityCheck::Yes,
         )
@@ -737,7 +737,7 @@ mod tests {
               "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/two-numbers/v/1",
               "title": "Two Numbers",
               "description": "A tuple of two numbers",
-              "allOf": [{ "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/value/v/1" }],
+              "allOf": [{ "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/list/v/1" }],
               "type": "array",
               "abstract": false,
               "items": false,
@@ -761,7 +761,7 @@ mod tests {
               "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/array/v/1",
               "title": "Number List",
               "description": "A list of numbers",
-              "allOf": [{ "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/value/v/1" }],
+              "allOf": [{ "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/list/v/1" }],
               "type": "array",
               "abstract": false,
               "items": { "type": "number" },

--- a/libs/@blockprotocol/type-system/rust/src/url/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/url/mod.rs
@@ -295,7 +295,7 @@ mod tests {
 
     #[test]
     fn versioned_url() {
-        let input_str = "https://blockprotocol.org/@blockprotocol/types/data-type/empty-list/v/1";
+        let input_str = "https://blockprotocol.org/@blockprotocol/types/data-type/list/v/1";
         let url = VersionedUrl::from_str(input_str).expect("parsing versioned URL failed");
         assert_eq!(&url.to_string(), input_str);
     }

--- a/libs/@local/hash-isomorphic-utils/src/ontology-type-ids.ts
+++ b/libs/@local/hash-isomorphic-utils/src/ontology-type-ids.ts
@@ -1590,11 +1590,11 @@ export const blockProtocolDataTypes = {
   },
   emptyList: {
     dataTypeId:
-      "https://blockprotocol.org/@blockprotocol/types/data-type/empty-list/v/1",
+      "https://blockprotocol.org/@blockprotocol/types/data-type/list/v/1",
     dataTypeBaseUrl:
-      "https://blockprotocol.org/@blockprotocol/types/data-type/empty-list/" as BaseUrl,
-    title: "Empty List",
-    description: "An Empty List",
+      "https://blockprotocol.org/@blockprotocol/types/data-type/list/" as BaseUrl,
+    title: "List",
+    description: "An ordered list of values",
   },
   null: {
     dataTypeId:

--- a/libs/@local/hash-validation/src/test_data_type.rs
+++ b/libs/@local/hash-validation/src/test_data_type.rs
@@ -115,21 +115,21 @@ async fn string() {
 async fn array() {
     validate_data(
         json!([]),
-        graph_test_data::data_type::EMPTY_LIST_V1,
+        graph_test_data::data_type::LIST_V1,
         [graph_test_data::data_type::VALUE_V1],
         ValidateEntityComponents::full(),
     )
     .await
     .expect("validation failed");
 
-    _ = validate_data(
+    validate_data(
         json!(["foo", "bar"]),
-        graph_test_data::data_type::EMPTY_LIST_V1,
+        graph_test_data::data_type::LIST_V1,
         [graph_test_data::data_type::VALUE_V1],
         ValidateEntityComponents::full(),
     )
     .await
-    .expect_err("validation succeeded");
+    .expect("validation failed");
 }
 
 #[tokio::test]

--- a/tests/hash-graph-benches/representative_read/seed.rs
+++ b/tests/hash-graph-benches/representative_read/seed.rs
@@ -27,7 +27,7 @@ use crate::util::{StoreWrapper, seed};
 const SEED_DATA_TYPES: [&str; 7] = [
     data_type::VALUE_V1,
     data_type::BOOLEAN_V1,
-    data_type::EMPTY_LIST_V1,
+    data_type::LIST_V1,
     data_type::NULL_V1,
     data_type::NUMBER_V1,
     data_type::OBJECT_V1,

--- a/tests/hash-graph-integration/postgres/data_type.rs
+++ b/tests/hash-graph-integration/postgres/data_type.rs
@@ -65,7 +65,7 @@ async fn insert() {
 
 #[tokio::test]
 async fn query() {
-    let empty_list_dt: DataType = serde_json::from_str(graph_test_data::data_type::EMPTY_LIST_V1)
+    let list_v1: DataType = serde_json::from_str(graph_test_data::data_type::LIST_V1)
         .expect("could not parse data type representation");
 
     let mut database = DatabaseTestWrapper::new().await;
@@ -75,7 +75,7 @@ async fn query() {
         .expect("could not seed database");
 
     api.create_data_type(api.account_id, CreateDataTypeParams {
-        schema: empty_list_dt.clone(),
+        schema: list_v1.clone(),
         classification: OntologyTypeClassificationMetadata::Owned {
             owned_by_id: OwnedById::new(api.account_id.into_uuid()),
         },
@@ -89,7 +89,7 @@ async fn query() {
 
     let data_types = api
         .get_data_types(api.account_id, GetDataTypesParams {
-            filter: Filter::for_versioned_url(&empty_list_dt.id),
+            filter: Filter::for_versioned_url(&list_v1.id),
             temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                 pinned: PinnedTemporalAxisUnresolved::new(None),
                 variable: VariableTemporalAxisUnresolved::new(Some(TemporalBound::Unbounded), None),
@@ -108,7 +108,7 @@ async fn query() {
         1,
         "expected one data type, got {data_types:?}"
     );
-    assert_eq!(data_types[0].schema.id, empty_list_dt.id);
+    assert_eq!(data_types[0].schema.id, list_v1.id);
 }
 
 #[tokio::test]

--- a/tests/hash-graph-test-data/rust/src/data_type/list.json
+++ b/tests/hash-graph-test-data/rust/src/data_type/list.json
@@ -1,15 +1,14 @@
 {
   "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
   "kind": "dataType",
-  "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/empty-list/v/1",
+  "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/list/v/1",
   "allOf": [
     {
       "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/value/v/1"
     }
   ],
-  "title": "Empty List",
-  "description": "An Empty List",
+  "title": "List",
+  "description": "An ordered list of values",
   "type": "array",
-  "items": false,
   "abstract": false
 }

--- a/tests/hash-graph-test-data/rust/src/data_type/mod.rs
+++ b/tests/hash-graph-test-data/rust/src/data_type/mod.rs
@@ -1,7 +1,7 @@
 pub const VALUE_V1: &str = include_str!("value.json");
 
 pub const BOOLEAN_V1: &str = include_str!("boolean.json");
-pub const EMPTY_LIST_V1: &str = include_str!("empty_list.json");
+pub const LIST_V1: &str = include_str!("list.json");
 pub const NULL_V1: &str = include_str!("null.json");
 pub const NUMBER_V1: &str = include_str!("number.json");
 pub const OBJECT_V1: &str = include_str!("object_v1.json");


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We don't need `empty-list` anymore but don't have a base list type, so we replace them.

## 🔗 Related links

## 🔍 What does this change?

- Rename `empty-list` to `list` and adjust locations

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph