### PR TITLE
H-3382: Ensure only primitive types can inherit from `Value`

### DIFF
--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/validation.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/validation.rs
@@ -51,7 +51,7 @@ static PRIMITIVE_DATA_TYPE_IDS: LazyLock<HashSet<VersionedUrl>> = LazyLock::new(
         VersionedUrl::from_str("https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1")
             .expect("Invalid URL"),
         VersionedUrl::from_str(
-            "https://blockprotocol.org/@blockprotocol/types/data-type/empty-list/v/1",
+            "https://blockprotocol.org/@blockprotocol/types/data-type/list/v/1",
         )
         .expect("Invalid URL"),
         VersionedUrl::from_str(

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/validation.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/validation.rs
@@ -50,10 +50,8 @@ static PRIMITIVE_DATA_TYPE_IDS: LazyLock<HashSet<VersionedUrl>> = LazyLock::new(
         .expect("Invalid URL"),
         VersionedUrl::from_str("https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1")
             .expect("Invalid URL"),
-        VersionedUrl::from_str(
-            "https://blockprotocol.org/@blockprotocol/types/data-type/list/v/1",
-        )
-        .expect("Invalid URL"),
+        VersionedUrl::from_str("https://blockprotocol.org/@blockprotocol/types/data-type/list/v/1")
+            .expect("Invalid URL"),
         VersionedUrl::from_str(
             "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1",
         )

--- a/tests/hash-graph-http/tests/friendship.http
+++ b/tests/hash-graph-http/tests/friendship.http
@@ -287,7 +287,7 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
     "kind": "dataType",
     "title": "Meter",
-    "allOf": [{ "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/value/v/1" }],
+    "allOf": [{ "$ref": "http://localhost:3000/@alice/types/data-type/length/v/1" }],
     "type": "number",
     "description": "A unit of length equal to 100 centimeters",
     "minimum": 0


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Every type should currently inherit from a primitive type, not from `Value` directly. This adds a validation step for this.