### PR TITLE
H-3388: Add `version` to root `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "hash",
+  "version": "0.0.0-private",
   "private": true,
   "description": "HASH monorepo",
   "workspaces": {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR adds a `version` field to the repo's root `package.json`.

This is required in order to be able to add the repo as a submodule in another repo, include it as a `yarn` workspace in that repo and have the dependencies listed in the `package.json` be installed – `yarn` will ignore workspaces that don't have a `version` listed (fixed in yarn v2, which we haven't migrated to yet).