### PR TITLE
H-3389: Return better status codes for data type and property type API

### DIFF
--- a/apps/hash-graph/libs/api/src/rest/data_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/data_type.rs
@@ -25,7 +25,7 @@ use graph::{
         patch_id_and_parse,
     },
     store::{
-        BaseUrlAlreadyExists, DataTypeStore, OntologyVersionDoesNotExist, StorePool,
+        DataTypeStore, OntologyVersionDoesNotExist, StorePool,
         error::VersionedUrlAlreadyExists,
         ontology::{
             ArchiveDataTypeParams, CreateDataTypeParams, GetDataTypeSubgraphParams,
@@ -204,24 +204,21 @@ async fn create_data_type<S, A>(
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     domain_validator: Extension<DomainValidator>,
     body: Json<CreateDataTypeRequest>,
-) -> Result<Json<ListOrValue<DataTypeMetadata>>, StatusCode>
+) -> Result<Json<ListOrValue<DataTypeMetadata>>, Response>
 where
     S: StorePool + Send + Sync,
     for<'pool> S::Store<'pool, A::Api<'pool>>: RestApiStore,
     A: AuthorizationApiPool + Send + Sync,
 {
-    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
-        tracing::error!(?error, "Could not acquire access to the authorization API");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let authorization_api = authorization_api_pool
+        .acquire()
+        .await
+        .map_err(report_to_response)?;
 
     let mut store = store_pool
         .acquire(authorization_api, temporal_client.0)
         .await
-        .map_err(|report| {
-            tracing::error!(error=?report, "Could not acquire store");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+        .map_err(report_to_response)?;
 
     let Json(CreateDataTypeRequest {
         schema,
@@ -236,37 +233,26 @@ where
     let mut metadata = store
         .create_data_types(
             actor_id,
-            schema.into_iter().map(|schema| {
-                domain_validator.validate(&schema).map_err(|report| {
-                    tracing::error!(error=?report, id=%schema.id, "Data Type ID failed to validate");
-                    StatusCode::UNPROCESSABLE_ENTITY
-                })?;
+            schema
+                .into_iter()
+                .map(|schema| {
+                    domain_validator
+                        .validate(&schema)
+                        .map_err(report_to_response)?;
 
-                Ok(CreateDataTypeParams {
-                    schema,
-                    classification: OntologyTypeClassificationMetadata::Owned { owned_by_id },
-                    relationships: relationships.clone(),
-                    conflict_behavior: ConflictBehavior::Fail,
-                    provenance: provenance.clone(),
-                    conversions: conversions.clone(),
+                    Ok(CreateDataTypeParams {
+                        schema,
+                        classification: OntologyTypeClassificationMetadata::Owned { owned_by_id },
+                        relationships: relationships.clone(),
+                        conflict_behavior: ConflictBehavior::Fail,
+                        provenance: provenance.clone(),
+                        conversions: conversions.clone(),
+                    })
                 })
-            }).collect::<Result<Vec<_>, StatusCode>>()?
+                .collect::<Result<Vec<_>, Response>>()?,
         )
         .await
-        .map_err(|report| {
-            // TODO: consider adding the data type, or at least its URL in the trace
-            tracing::error!(error=?report, "Could not create data types");
-
-            if report.contains::<PermissionAssertion>() {
-                return StatusCode::FORBIDDEN;
-            }
-            if report.contains::<BaseUrlAlreadyExists>() {
-                return StatusCode::CONFLICT;
-            }
-
-            // Insertion/update errors are considered internal server errors.
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+        .map_err(report_to_response)?;
 
     if is_list {
         Ok(Json(ListOrValue::List(metadata)))
@@ -562,7 +548,7 @@ async fn update_data_type<S, A>(
     authorization_api_pool: Extension<Arc<A>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     body: Json<UpdateDataTypeRequest>,
-) -> Result<Json<DataTypeMetadata>, StatusCode>
+) -> Result<Json<DataTypeMetadata>, Response>
 where
     S: StorePool + Send + Sync,
     A: AuthorizationApiPool + Send + Sync,
@@ -577,25 +563,17 @@ where
 
     type_to_update.version = OntologyTypeVersion::new(type_to_update.version.inner() + 1);
 
-    let data_type = patch_id_and_parse(&type_to_update, schema).map_err(|report| {
-        tracing::error!(error=?report, "Couldn't patch schema and convert to Data Type");
-        StatusCode::UNPROCESSABLE_ENTITY
-        // TODO: We should probably return more information to the client
-        //   see https://linear.app/hash/issue/H-3009
-    })?;
+    let data_type = patch_id_and_parse(&type_to_update, schema).map_err(report_to_response)?;
 
-    let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
-        tracing::error!(?error, "Could not acquire access to the authorization API");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let authorization_api = authorization_api_pool
+        .acquire()
+        .await
+        .map_err(report_to_response)?;
 
     let mut store = store_pool
         .acquire(authorization_api, temporal_client.0)
         .await
-        .map_err(|report| {
-            tracing::error!(error=?report, "Could not acquire store");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+        .map_err(report_to_response)?;
 
     store
         .update_data_type(actor_id, UpdateDataTypesParams {
@@ -605,19 +583,7 @@ where
             conversions,
         })
         .await
-        .map_err(|report| {
-            tracing::error!(error=?report, "Could not update data type");
-
-            if report.contains::<PermissionAssertion>() {
-                return StatusCode::FORBIDDEN;
-            }
-            if report.contains::<OntologyVersionDoesNotExist>() {
-                return StatusCode::NOT_FOUND;
-            }
-
-            // Insertion/update errors are considered internal server errors.
-            StatusCode::INTERNAL_SERVER_ERROR
-        })
+        .map_err(report_to_response)
         .map(Json)
 }
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/data_type.rs
@@ -32,6 +32,7 @@ use hash_graph_store::{
         },
     },
 };
+use hash_status::StatusCode;
 use postgres_types::{Json, ToSql};
 use temporal_versioning::{RightBoundedTemporalInterval, Timestamp, TransactionTime};
 use tokio_postgres::{GenericClient, Row};
@@ -496,10 +497,12 @@ where
                         .change_context(InsertionError)?,
                 )
                 .await
+                .attach(StatusCode::InvalidArgument)
                 .change_context(InsertionError)?;
             let schema = data_type_validator
                 .validate_ref(&closed_schema.schema)
                 .await
+                .attach(StatusCode::InvalidArgument)
                 .change_context(InsertionError)?;
             transaction
                 .insert_data_type_with_id(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This uses the `report_to_response` function in more places. The function tries to infer the status code and prints the error to the terminal.