### PR TITLE
H-3390: Fix integration test using wrong parent for object data type update

### DIFF
--- a/tests/hash-graph-test-data/rust/src/data_type/object_v2.json
+++ b/tests/hash-graph-test-data/rust/src/data_type/object_v2.json
@@ -4,7 +4,7 @@
   "$id": "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/2",
   "allOf": [
     {
-      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/value/v/1"
+      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1"
     }
   ],
   "title": "Object",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We only allow whitelisted primitives to inherit from `value`, `object/v/2` is not part of it.