### PR TITLE
H-2981: Fix `turbo` config to account for changes in type system

### DIFF
--- a/tests/hash-graph-integration/turbo.json
+++ b/tests/hash-graph-integration/turbo.json
@@ -1,14 +1,8 @@
 {
   "extends": ["//"],
   "tasks": {
-    "start:test:migrate": {
-      "dependsOn": []
-    },
-    "start:test:healthcheck": {
-      "dependsOn": []
-    },
     "test:integration": {
-      "dependsOn": []
+      "dependsOn": ["codegen"]
     }
   }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The integration tests do not pick up changes properly, Turbo will use the cache instead. For more details see the linked [thread slack](https://hashintel.slack.com/archives/C02TWBTT3ED/p1727945579768759).

## 🔍 What does this change?

- Add `codegen` to the dependencies to the integration tests to create a virtual pipeline

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this