### PR TITLE
H-721: Remove `async-trait` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2383,7 +2383,6 @@ name = "graph"
 version = "0.0.0"
 dependencies = [
  "async-scoped",
- "async-trait",
  "authorization",
  "bytes",
  "clap",

--- a/apps/hash-graph/libs/api/src/rest/mod.rs
+++ b/apps/hash-graph/libs/api/src/rest/mod.rs
@@ -120,17 +120,16 @@ impl<S> FromRequestParts<S> for AuthenticatedUserHeader {
 pub struct PermissionResponse {
     has_permission: bool,
 }
-#[async_trait]
+
 pub trait RestApiStore: Store + TypeFetcher {
-    async fn load_external_type(
+    fn load_external_type(
         &mut self,
         actor_id: AccountId,
         domain_validator: &DomainValidator,
         reference: OntologyTypeReference<'_>,
-    ) -> Result<OntologyTypeMetadata, Response>;
+    ) -> impl Future<Output = Result<OntologyTypeMetadata, Response>> + Send;
 }
 
-#[async_trait]
 impl<S> RestApiStore for S
 where
     S: Store + TypeFetcher + Send,

--- a/apps/hash-graph/libs/graph/Cargo.toml
+++ b/apps/hash-graph/libs/graph/Cargo.toml
@@ -34,7 +34,6 @@ type-system = { workspace = true, features = ["postgres"] }
 
 # Private third-party dependencies
 async-scoped = { workspace = true, features = ["use-tokio"] }
-async-trait = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"], optional = true }
 derive-where = { workspace = true }

--- a/apps/hash-graph/libs/graph/src/snapshot/entity/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/entity/batch.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use authorization::{AuthorizationApi, backend::ZanzibarBackend, schema::EntityRelationAndSubject};
 use error_stack::{Report, ResultExt};
 use graph_types::{
@@ -36,7 +35,6 @@ pub enum EntityRowBatch {
     Relations(Vec<(EntityUuid, EntityRelationAndSubject)>),
 }
 
-#[async_trait]
 impl<C, A> WriteBatch<C, A> for EntityRowBatch
 where
     C: AsClient,

--- a/apps/hash-graph/libs/graph/src/snapshot/mod.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/mod.rs
@@ -20,7 +20,6 @@ mod web;
 use core::future::ready;
 
 use async_scoped::TokioScope;
-use async_trait::async_trait;
 use authorization::{
     AuthorizationApi, NoAuthorization,
     backend::ZanzibarBackend,
@@ -229,14 +228,18 @@ impl SnapshotEntry {
     }
 }
 
-#[async_trait]
 trait WriteBatch<C, A> {
-    async fn begin(postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError>;
-    async fn write(self, postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError>;
-    async fn commit(
+    fn begin(
+        postgres_client: &mut PostgresStore<C, A>,
+    ) -> impl Future<Output = Result<(), InsertionError>> + Send;
+    fn write(
+        self,
+        postgres_client: &mut PostgresStore<C, A>,
+    ) -> impl Future<Output = Result<(), InsertionError>> + Send;
+    fn commit(
         postgres_client: &mut PostgresStore<C, A>,
         validation: bool,
-    ) -> Result<(), InsertionError>;
+    ) -> impl Future<Output = Result<(), InsertionError>> + Send;
 }
 
 pub struct SnapshotStore<C, A>(PostgresStore<C, A>);

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/data_type/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/data_type/batch.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use async_trait::async_trait;
 use authorization::{
     AuthorizationApi, backend::ZanzibarBackend, schema::DataTypeRelationAndSubject,
 };
@@ -23,7 +22,6 @@ pub enum DataTypeRowBatch {
     Embeddings(Vec<DataTypeEmbeddingRow<'static>>),
 }
 
-#[async_trait]
 impl<C, A> WriteBatch<C, A> for DataTypeRowBatch
 where
     C: AsClient,

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/entity_type/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/entity_type/batch.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use async_trait::async_trait;
 use authorization::{
     AuthorizationApi, backend::ZanzibarBackend, schema::EntityTypeRelationAndSubject,
 };
@@ -33,7 +32,6 @@ pub enum EntityTypeRowBatch {
     Embeddings(Vec<EntityTypeEmbeddingRow<'static>>),
 }
 
-#[async_trait]
 impl<C, A> WriteBatch<C, A> for EntityTypeRowBatch
 where
     C: AsClient,

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/metadata/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/metadata/batch.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use error_stack::{Result, ResultExt};
 use tokio_postgres::GenericClient;
 
@@ -20,7 +19,6 @@ pub enum OntologyTypeMetadataRowBatch {
     ExternalMetadata(Vec<OntologyExternalMetadataRow>),
 }
 
-#[async_trait]
 impl<C, A> WriteBatch<C, A> for OntologyTypeMetadataRowBatch
 where
     C: AsClient,

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/property_type/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/property_type/batch.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use async_trait::async_trait;
 use authorization::{backend::ZanzibarBackend, schema::PropertyTypeRelationAndSubject};
 use error_stack::{Result, ResultExt};
 use graph_types::ontology::PropertyTypeId;
@@ -25,7 +24,6 @@ pub enum PropertyTypeRowBatch {
     Embeddings(Vec<PropertyTypeEmbeddingRow<'static>>),
 }
 
-#[async_trait]
 impl<C, A> WriteBatch<C, A> for PropertyTypeRowBatch
 where
     C: AsClient,

--- a/apps/hash-graph/libs/graph/src/snapshot/owner/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/owner/batch.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use authorization::{backend::ZanzibarBackend, schema::AccountGroupRelationAndSubject};
 use error_stack::{Result, ResultExt};
 use graph_types::account::AccountGroupId;
@@ -18,7 +17,6 @@ pub enum AccountRowBatch {
     AccountGroupAccountRelations(Vec<(AccountGroupId, AccountGroupRelationAndSubject)>),
 }
 
-#[async_trait]
 impl<C, A> WriteBatch<C, A> for AccountRowBatch
 where
     C: AsClient,

--- a/apps/hash-graph/libs/graph/src/snapshot/restore/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/restore/batch.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use authorization::{AuthorizationApi, backend::ZanzibarBackend};
 use error_stack::Result;
 
@@ -26,7 +25,6 @@ pub enum SnapshotRecordBatch {
     Entities(EntityRowBatch),
 }
 
-#[async_trait]
 impl<C, A> WriteBatch<C, A> for SnapshotRecordBatch
 where
     C: AsClient,

--- a/apps/hash-graph/libs/graph/src/snapshot/web/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/web/batch.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use authorization::{backend::ZanzibarBackend, schema::WebRelationAndSubject};
 use error_stack::{Result, ResultExt};
 use graph_types::owned_by_id::OwnedById;
@@ -14,7 +13,6 @@ pub enum WebBatch {
     Relations(Vec<(OwnedById, WebRelationAndSubject)>),
 }
 
-#[async_trait]
 impl<C, A> WriteBatch<C, A> for WebBatch
 where
     C: AsClient,

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -2,7 +2,6 @@ use alloc::sync::Arc;
 use core::mem;
 use std::collections::{HashMap, HashSet};
 
-use async_trait::async_trait;
 use authorization::{
     AuthorizationApi,
     schema::{
@@ -51,7 +50,7 @@ use crate::{
     ontology::domain_validator::DomainValidator,
     store::{
         DataTypeStore, EntityStore, EntityTypeStore, InsertionError, PropertyTypeStore, QueryError,
-        StoreError, StorePool, UpdateError,
+        StoreError, StorePool, UpdateError, async_trait,
         crud::{QueryResult, Read, ReadPaginated, Sorting},
         knowledge::{
             CountEntitiesParams, CreateEntityParams, GetEntitiesParams, GetEntitiesResponse,
@@ -73,14 +72,13 @@ use crate::{
     },
 };
 
-#[async_trait]
 pub trait TypeFetcher {
     /// Fetches the provided type reference and inserts it to the Graph.
-    async fn insert_external_ontology_type(
+    fn insert_external_ontology_type(
         &mut self,
         actor_id: AccountId,
         reference: OntologyTypeReference<'_>,
-    ) -> Result<OntologyTypeMetadata, InsertionError>;
+    ) -> impl Future<Output = Result<OntologyTypeMetadata, InsertionError>> + Send;
 }
 
 #[derive(Clone)]
@@ -675,7 +673,6 @@ where
     }
 }
 
-#[async_trait]
 impl<S, A> TypeFetcher for FetchingStore<S, A>
 where
     A: ToSocketAddrs + Send + Sync,

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -2,6 +2,7 @@ use alloc::sync::Arc;
 use core::mem;
 use std::collections::{HashMap, HashSet};
 
+use async_trait::async_trait;
 use authorization::{
     AuthorizationApi,
     schema::{
@@ -50,7 +51,7 @@ use crate::{
     ontology::domain_validator::DomainValidator,
     store::{
         DataTypeStore, EntityStore, EntityTypeStore, InsertionError, PropertyTypeStore, QueryError,
-        StoreError, StorePool, UpdateError, async_trait,
+        StoreError, StorePool, UpdateError,
         crud::{QueryResult, Read, ReadPaginated, Sorting},
         knowledge::{
             CountEntitiesParams, CreateEntityParams, GetEntitiesParams, GetEntitiesResponse,

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -2,7 +2,6 @@ use alloc::sync::Arc;
 use core::mem;
 use std::collections::{HashMap, HashSet};
 
-use async_trait::async_trait;
 use authorization::{
     AuthorizationApi,
     schema::{
@@ -738,7 +737,6 @@ where
     }
 }
 
-#[async_trait]
 impl<S, A, R> Read<R> for FetchingStore<S, A>
 where
     A: Send + Sync,

--- a/apps/hash-graph/libs/graph/src/store/migration.rs
+++ b/apps/hash-graph/libs/graph/src/store/migration.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use error_stack::Result;
 
 use super::error::MigrationError;
@@ -54,12 +53,19 @@ impl Migration {
 ///
 /// In addition to the errors described in the methods of this trait, further errors might also be
 /// raised depending on the implementation, e.g. connection issues.
-#[async_trait]
 pub trait StoreMigration: Sync {
-    async fn run_migrations(&mut self) -> Result<Vec<Migration>, MigrationError>;
+    fn run_migrations(
+        &mut self,
+    ) -> impl Future<Output = Result<Vec<Migration>, MigrationError>> + Send;
 
-    async fn all_migrations(&mut self) -> Result<Vec<Migration>, MigrationError>;
+    fn all_migrations(
+        &mut self,
+    ) -> impl Future<Output = Result<Vec<Migration>, MigrationError>> + Send;
 
-    async fn applied_migrations(&mut self) -> Result<Vec<Migration>, MigrationError>;
-    async fn missing_migrations(&mut self) -> Result<Vec<Migration>, MigrationError>;
+    fn applied_migrations(
+        &mut self,
+    ) -> impl Future<Output = Result<Vec<Migration>, MigrationError>> + Send;
+    fn missing_migrations(
+        &mut self,
+    ) -> impl Future<Output = Result<Vec<Migration>, MigrationError>> + Send;
 }

--- a/apps/hash-graph/libs/graph/src/store/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/mod.rs
@@ -11,7 +11,6 @@ mod validation;
 mod fetcher;
 pub(crate) mod postgres;
 
-use async_trait::async_trait;
 use hash_graph_store::account::AccountStore;
 use serde::Deserialize;
 #[cfg(feature = "utoipa")]
@@ -41,11 +40,11 @@ pub use self::{
 ///
 /// In addition to the errors described in the methods of this trait, further errors might also be
 /// raised depending on the implementation, e.g. connection issues.
-#[async_trait]
 pub trait Store:
     AccountStore + DataTypeStore + PropertyTypeStore + EntityTypeStore + EntityStore
 {
 }
+
 impl<S> Store for S where
     S: AccountStore + DataTypeStore + PropertyTypeStore + EntityTypeStore + EntityStore
 {

--- a/apps/hash-graph/libs/graph/src/store/postgres/crud.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/crud.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use error_stack::{Report, ResultExt};
 use futures::{Stream, StreamExt, TryStreamExt};
 use hash_graph_store::{filter::Filter, subgraph::temporal_axes::QueryTemporalAxes};
@@ -99,7 +98,6 @@ where
     }
 }
 
-#[async_trait]
 impl<Cl, A, R> Read<R> for PostgresStore<Cl, A>
 where
     Cl: AsClient,

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -513,7 +513,10 @@ where
             let num_returned_entities = entities.len();
 
             let (permitted_ids, zookie) = if let Some((permitted_ids, zookie)) = &permissions {
-                (Cow::Borrowed(permitted_ids), Cow::Borrowed(zookie))
+                (
+                    Cow::<HashSet<EntityUuid>>::Borrowed(permitted_ids),
+                    Cow::<Zookie>::Borrowed(zookie),
+                )
             } else {
                 // TODO: The subgraph structure differs from the API interface. At the API the
                 //       vertices are stored in a nested `HashMap` and here it's flattened. We need

--- a/apps/hash-graph/libs/graph/src/store/postgres/migration.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/migration.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use error_stack::{Result, ResultExt};
 use tokio_postgres::Client;
 
@@ -31,7 +30,6 @@ impl Migration {
     }
 }
 
-#[async_trait]
 impl<C, A> StoreMigration for PostgresStore<C, A>
 where
     C: AsClient<Client = Client>,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

It's not needed anymore (except to implement third-party crates for `axum`)

## 🔍 What does this change?

- Remove `#[async_trait]` for all define traits