### PR TITLE
H-3412: Enable `cranelift` codegen backend

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,4 @@ protocol = "sparse"
 [unstable]
 public-dependency = true
 cargo-lints = true
+codegen-backend = true

--- a/.github/actions/install-rust-toolchain/action.yml
+++ b/.github/actions/install-rust-toolchain/action.yml
@@ -40,7 +40,7 @@ runs:
         for component in $COMPONENTS; do
           echo "Installing component $component"
           # depending on the toolchain we need to conditionally skip specific components
-          if [[ ! "$$TOOLCHAIN_CHANNEL" =~ $NIGHTLY_TOOLCHAIN ]]; then
+          if [[ ! "$TOOLCHAIN_CHANNEL" =~ $NIGHTLY_TOOLCHAIN ]]; then
             echo "stable toolchain detected"
             # ensure that we only install components that are meant for stable
             if [[ ! $component =~ $NIGHTLY_ONLY ]]; then

--- a/.github/actions/install-rust-toolchain/action.yml
+++ b/.github/actions/install-rust-toolchain/action.yml
@@ -18,7 +18,7 @@ runs:
       run: |
         # regex for components that are only available on nightly and should not be installed on stable
         # these are in variables due to: https://stackoverflow.com/a/56449915/9077988
-        NIGHTLY_ONLY="miri|llvm-tools|llvm-tools-preview"
+        NIGHTLY_ONLY="miri|llvm-tools|llvm-tools-preview|rustc-codegen-cranelift-preview"
         NIGHTLY_TOOLCHAIN="nightly-.*"
 
         if [[ -f "${{ inputs.working-directory }}/rust-toolchain.toml" ]]; then
@@ -37,13 +37,16 @@ runs:
         rustup toolchain install "$TOOLCHAIN_CHANNEL"
 
         for component in $COMPONENTS; do
+          echo "Installing component $component"
           # depending on the toolchain we need to conditionally skip specific components
           if [[ ! "$$TOOLCHAIN_CHANNEL" =~ $NIGHTLY_TOOLCHAIN ]]; then
+            echo "nightly toolchain detected"
             # ensure that we only install components that are meant for stable
             if [[ ! $component =~ $NIGHTLY_ONLY ]]; then
               rustup component add --toolchain "$TOOLCHAIN_CHANNEL" "$component"
             fi
           else
+            echo "stable toolchain detected"
             rustup component add --toolchain "$TOOLCHAIN_CHANNEL" "$component"
           fi
         done

--- a/.github/actions/install-rust-toolchain/action.yml
+++ b/.github/actions/install-rust-toolchain/action.yml
@@ -18,7 +18,6 @@ runs:
       run: |
         # regex for components that are only available on nightly and should not be installed on stable
         # these are in variables due to: https://stackoverflow.com/a/56449915/9077988
-        set -x
         NIGHTLY_ONLY="miri|llvm-tools|llvm-tools-preview|rustc-codegen-cranelift-preview"
         NIGHTLY_TOOLCHAIN="nightly-.*"
 
@@ -38,16 +37,13 @@ runs:
         rustup toolchain install "$TOOLCHAIN_CHANNEL"
 
         for component in $COMPONENTS; do
-          echo "Installing component $component"
           # depending on the toolchain we need to conditionally skip specific components
           if [[ ! "$TOOLCHAIN_CHANNEL" =~ $NIGHTLY_TOOLCHAIN ]]; then
-            echo "stable toolchain detected"
             # ensure that we only install components that are meant for stable
             if [[ ! $component =~ $NIGHTLY_ONLY ]]; then
               rustup component add --toolchain "$TOOLCHAIN_CHANNEL" "$component"
             fi
           else
-            echo "nightly toolchain detected"
             rustup component add --toolchain "$TOOLCHAIN_CHANNEL" "$component"
           fi
         done

--- a/.github/actions/install-rust-toolchain/action.yml
+++ b/.github/actions/install-rust-toolchain/action.yml
@@ -18,6 +18,7 @@ runs:
       run: |
         # regex for components that are only available on nightly and should not be installed on stable
         # these are in variables due to: https://stackoverflow.com/a/56449915/9077988
+        set -x
         NIGHTLY_ONLY="miri|llvm-tools|llvm-tools-preview|rustc-codegen-cranelift-preview"
         NIGHTLY_TOOLCHAIN="nightly-.*"
 
@@ -40,13 +41,13 @@ runs:
           echo "Installing component $component"
           # depending on the toolchain we need to conditionally skip specific components
           if [[ ! "$$TOOLCHAIN_CHANNEL" =~ $NIGHTLY_TOOLCHAIN ]]; then
-            echo "nightly toolchain detected"
+            echo "stable toolchain detected"
             # ensure that we only install components that are meant for stable
             if [[ ! $component =~ $NIGHTLY_ONLY ]]; then
               rustup component add --toolchain "$TOOLCHAIN_CHANNEL" "$component"
             fi
           else
-            echo "stable toolchain detected"
+            echo "nightly toolchain detected"
             rustup component add --toolchain "$TOOLCHAIN_CHANNEL" "$component"
           fi
         done

--- a/.justfile
+++ b/.justfile
@@ -156,8 +156,8 @@ build *arguments:
 # Run the test suite
 [no-cd]
 test *arguments: install-cargo-nextest install-cargo-hack
-  cargo hack --optional-deps --feature-powerset nextest run --cargo-profile {{profile}} {{arguments}}
-  cargo test --profile {{profile}} --all-features --doc
+  cargo hack --optional-deps --feature-powerset nextest run {{arguments}}
+  cargo test --all-features --doc
 
 # Run the test suite with `miri`
 [no-cd]

--- a/.justfile
+++ b/.justfile
@@ -172,8 +172,8 @@ bench *arguments:
 # Run the test suite and generate a coverage report
 [no-cd]
 coverage *arguments: install-llvm-cov
-  cargo llvm-cov nextest --all-features --all-targets --cargo-profile {{profile}} {{arguments}}
-  cargo llvm-cov --all-features --profile {{profile}} --doc {{arguments}}
+  cargo llvm-cov nextest --all-features --all-targets --cargo-profile codecov {{arguments}}
+  cargo llvm-cov --all-features --profile codecov --doc {{arguments}}
 
 # Run the test suite and optionally generate a coverage report when `$TEST_COVERAGE` is set to `true`
 [no-cd]

--- a/.justfile
+++ b/.justfile
@@ -172,8 +172,8 @@ bench *arguments:
 # Run the test suite and generate a coverage report
 [no-cd]
 coverage *arguments: install-llvm-cov
-  cargo llvm-cov nextest --all-features --all-targets --cargo-profile codecov {{arguments}}
-  cargo llvm-cov --all-features --profile codecov --doc {{arguments}}
+  cargo llvm-cov nextest --all-features --all-targets --cargo-profile coverage {{arguments}}
+  cargo llvm-cov --all-features --profile coverage --doc {{arguments}}
 
 # Run the test suite and optionally generate a coverage report when `$TEST_COVERAGE` is set to `true`
 [no-cd]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,6 +221,10 @@ winnow = { version = "=0.6.20", default-features = false }
 [profile.dev]
 codegen-backend = "cranelift"
 
+[profile.codecov]
+inherits = "dev"
+codegen-backend = "llvm"
+
 [profile.production]
 inherits = "release"
 lto = "fat"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,6 +232,7 @@ codegen-backend = "cranelift"
 [profile.test.package."*"]
 codegen-backend = "llvm"
 
+# We use `llvm-cov` which requires LLVM`
 [profile.coverage]
 inherits = "test"
 codegen-backend = "llvm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,8 +221,16 @@ winnow = { version = "=0.6.20", default-features = false }
 [profile.dev]
 codegen-backend = "cranelift"
 
+# We use LLVM for non-workspace crates, mainly due to the lack of AVX2 support in Cranelift
+[profile.dev.package."*"]
+codegen-backend = "llvm"
+
 [profile.test]
 codegen-backend = "cranelift"
+
+# We use LLVM for non-workspace crates, mainly due to the lack of AVX2 support in Cranelift
+[profile.test.package."*"]
+codegen-backend = "llvm"
 
 [profile.coverage]
 inherits = "test"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,14 +221,11 @@ winnow = { version = "=0.6.20", default-features = false }
 [profile.dev]
 codegen-backend = "cranelift"
 
-# `scc` is using SIMD instructions, which is currently not fully supported by `cranelift`
-[profile.dev.package.scc]
-codegen-backend = "llvm"
-[profile.dev.package.harpc-net]
+[profile.test]
 codegen-backend = "llvm"
 
 [profile.coverage]
-inherits = "dev"
+inherits = "test"
 codegen-backend = "llvm"
 
 [profile.production]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,6 +224,8 @@ codegen-backend = "cranelift"
 # `scc` is using SIMD instructions, which is currently not fully supported by `cranelift`
 [profile.dev.package.scc]
 codegen-backend = "llvm"
+[profile.dev.package.harpc-net]
+codegen-backend = "llvm"
 
 [profile.coverage]
 inherits = "dev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,7 +221,7 @@ winnow = { version = "=0.6.20", default-features = false }
 [profile.dev]
 codegen-backend = "cranelift"
 
-[profile.codecov]
+[profile.coverage]
 inherits = "dev"
 codegen-backend = "llvm"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,7 +222,7 @@ winnow = { version = "=0.6.20", default-features = false }
 codegen-backend = "cranelift"
 
 [profile.test]
-codegen-backend = "llvm"
+codegen-backend = "cranelift"
 
 [profile.coverage]
 inherits = "test"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,6 +221,10 @@ winnow = { version = "=0.6.20", default-features = false }
 [profile.dev]
 codegen-backend = "cranelift"
 
+# `scc` is using SIMD instructions, which is currently not fully supported by `cranelift`
+[profile.dev.package.scc]
+codegen-backend = "llvm"
+
 [profile.coverage]
 inherits = "dev"
 codegen-backend = "llvm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,6 +218,9 @@ virtue = { version = "=0.0.17", default-features = false }
 walkdir = { version = "=2.5.0", default-features = false }
 winnow = { version = "=0.6.20", default-features = false }
 
+[profile.dev]
+codegen-backend = "cranelift"
+
 [profile.production]
 inherits = "release"
 lto = "fat"

--- a/apps/hash-ai-worker-ts/docker/Dockerfile
+++ b/apps/hash-ai-worker-ts/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN turbo prune --scope='@apps/hash-ai-worker-ts' --docker && \
         echo > "/app/out/full/$(dirname "$1")/src/lib.rs" &&  \
         echo -e "[package]\nname = \"$(yq ".package.name" -p toml -oy $1)\"" > "/app/out/full/$1" \
       )' _ {} \; && \
-    cp Cargo.toml Cargo.lock /app/out/full/
+    cp -R .cargo Cargo.toml Cargo.lock /app/out/full/
 
 # Turbo isn't aware of our patches by default (it would be if we use Yarn 2+ or pnpm).
 # Therefore we manually add the patches to the pruned output to allow for the patches to be applied.

--- a/apps/hash-graph/docker/Dockerfile
+++ b/apps/hash-graph/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN turbo prune --scope='@apps/hash-graph' --docker && \
         echo > "/app/out/full/$(dirname "$1")/src/lib.rs" &&  \
         echo -e "[package]\nname = \"$(yq ".package.name" -p toml -oy $1)\"" > "/app/out/full/$1" \
       )' _ {} \; && \
-    cp Cargo.toml Cargo.lock /app/out/full/
+    cp -R .cargo Cargo.toml Cargo.lock /app/out/full/
 
 
 FROM node:20.13-alpine AS rust

--- a/apps/hash-integration-worker/docker/Dockerfile
+++ b/apps/hash-integration-worker/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN turbo prune --scope='@apps/hash-integration-worker' --docker && \
         echo > "/app/out/full/$(dirname "$1")/src/lib.rs" &&  \
         echo -e "[package]\nname = \"$(yq ".package.name" -p toml -oy $1)\"" > "/app/out/full/$1" \
       )' _ {} \; && \
-    cp Cargo.toml Cargo.lock /app/out/full/
+    cp -R .cargo Cargo.toml Cargo.lock /app/out/full/
 
 # Turbo isn't aware of our patches by default (it would be if we use Yarn 2+ or pnpm).
 # Therefore we manually add the patches to the pruned output to allow for the patches to be applied.

--- a/infra/docker/api/prod/Dockerfile
+++ b/infra/docker/api/prod/Dockerfile
@@ -14,7 +14,7 @@ RUN turbo prune --scope='@apps/hash-api' --docker && \
         echo > "/app/out/full/$(dirname "$1")/src/lib.rs" &&  \
         echo -e "[package]\nname = \"$(yq ".package.name" -p toml -oy $1)\"" > "/app/out/full/$1" \
       )' _ {} \; && \
-    cp Cargo.toml Cargo.lock /app/out/full/
+    cp -R .cargo Cargo.toml Cargo.lock /app/out/full/
 
 # Turbo isn't aware of our patches by default (it would be if we use Yarn 2+ or pnpm).
 # Therefore we manually add the patches to the pruned output to allow for the patches to be applied.

--- a/infra/docker/frontend/prod/Dockerfile
+++ b/infra/docker/frontend/prod/Dockerfile
@@ -14,7 +14,7 @@ RUN turbo prune --scope='@apps/hash-frontend' --docker && \
         echo > "/app/out/full/$(dirname "$1")/src/lib.rs" &&  \
         echo -e "[package]\nname = \"$(yq ".package.name" -p toml -oy $1)\"" > "/app/out/full/$1" \
       )' _ {} \; && \
-    cp Cargo.toml Cargo.lock /app/out/full/
+    cp -R .cargo Cargo.toml Cargo.lock /app/out/full/
 
 # Turbo isn't aware of our patches by default (it would be if we use Yarn 2+ or pnpm).
 # Therefore we manually add the patches to the pruned output to allow for the patches to be applied.

--- a/libs/antsi/rust-toolchain.toml
+++ b/libs/antsi/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2024-09-30"
-components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'rust-analyzer']
+components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'rust-analyzer', 'rustc-codegen-cranelift-preview']

--- a/libs/deer/rust-toolchain.toml
+++ b/libs/deer/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2024-09-30"
-components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'miri', 'rust-analyzer']
+components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'miri', 'rust-analyzer', 'rustc-codegen-cranelift-preview']

--- a/libs/error-stack/.justfile
+++ b/libs/error-stack/.justfile
@@ -30,8 +30,8 @@ coverage *arguments:
   @just install-cargo-nextest
   @just install-llvm-cov
 
-  RUST_BACKTRACE=1 cargo llvm-cov nextest --workspace --all-features --all-targets --cargo-profile {{profile}} {{arguments}}
-  RUST_BACKTRACE=1 cargo llvm-cov --workspace --all-features --profile {{profile}} --doc {{arguments}}
+  RUST_BACKTRACE=1 cargo llvm-cov nextest --workspace --all-features --all-targets --cargo-profile coverage {{arguments}}
+  RUST_BACKTRACE=1 cargo llvm-cov --workspace --all-features --profile coverage --doc {{arguments}}
 
 # Snapshot Tests
 # ==============

--- a/libs/error-stack/.justfile
+++ b/libs/error-stack/.justfile
@@ -23,7 +23,7 @@ test *arguments:
 
   RUST_BACKTRACE=1 cargo nextest run --all-features --all-targets --cargo-profile {{profile}} {{arguments}}
   RUST_BACKTRACE=1 cargo nextest run --no-default-features --all-targets --cargo-profile {{profile}} {{arguments}}
-  RUST_BACKTRACE=1 cargo test --profile {{profile}} --all-features --doc {{arguments}}
+  RUST_BACKTRACE=1 cargo test --all-features --doc {{arguments}}
 
 [private]
 coverage *arguments:

--- a/libs/error-stack/rust-toolchain.toml
+++ b/libs/error-stack/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Please also update the badges in `README.md`s (`error-stack` and `error-stack-macros`), and `src/lib.rs`
 channel = "nightly-2024-09-30"
-components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'miri', 'rust-src', 'rust-analyzer']
+components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'miri', 'rust-src', 'rust-analyzer', 'rustc-codegen-cranelift-preview']

--- a/libs/sarif/rust-toolchain.toml
+++ b/libs/sarif/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2024-09-30"
-components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'rust-analyzer']
+components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'rust-analyzer', 'rustc-codegen-cranelift-preview']

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2024-09-30"
-components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'miri', 'rust-analyzer']
+components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'miri', 'rust-analyzer', 'rustc-codegen-cranelift-preview']


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Using `cranelift` as backend potentially speeds up compilation for dev builds. This is good.

## 🔗 Related links

- https://github.com/rust-lang/rustc_codegen_cranelift