### PR TITLE
H-3426: Implement folding for data type constraints

### DIFF
--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/any_of.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/any_of.rs
@@ -2,7 +2,13 @@ use error_stack::{Report, ReportSink, ResultExt};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
-use crate::schema::{ConstraintError, SingleValueSchema, data_type::constraint::Constraint};
+use crate::schema::{
+    ConstraintError, SingleValueSchema,
+    data_type::{
+        closed::ResolveClosedDataTypeError,
+        constraint::{Constraint, ConstraintValidator},
+    },
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
@@ -15,7 +21,15 @@ pub struct AnyOfConstraints {
     pub any_of: Vec<SingleValueSchema>,
 }
 
-impl Constraint<JsonValue> for AnyOfConstraints {
+impl Constraint for AnyOfConstraints {
+    fn combine(&mut self, other: Self) -> Result<Option<Self>, Report<ResolveClosedDataTypeError>> {
+        // TODO: Implement folding for anyOf constraints
+        //   see https://linear.app/hash/issue/H-3430/implement-folding-for-anyof-constraints
+        Ok(Some(other))
+    }
+}
+
+impl ConstraintValidator<JsonValue> for AnyOfConstraints {
     type Error = ConstraintError;
 
     fn is_valid(&self, value: &JsonValue) -> bool {

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/any_of.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/any_of.rs
@@ -22,7 +22,7 @@ pub struct AnyOfConstraints {
 }
 
 impl Constraint for AnyOfConstraints {
-    fn combine(
+    fn intersection(
         self,
         other: Self,
     ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/any_of.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/any_of.rs
@@ -22,10 +22,13 @@ pub struct AnyOfConstraints {
 }
 
 impl Constraint for AnyOfConstraints {
-    fn combine(&mut self, other: Self) -> Result<Option<Self>, Report<ResolveClosedDataTypeError>> {
+    fn combine(
+        self,
+        other: Self,
+    ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {
         // TODO: Implement folding for anyOf constraints
         //   see https://linear.app/hash/issue/H-3430/implement-folding-for-anyof-constraints
-        Ok(Some(other))
+        Ok((self, Some(other)))
     }
 }
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
@@ -47,19 +47,19 @@ pub enum ArrayItemConstraints {
 }
 
 impl Constraint for ArrayItemConstraints {
-    fn combine(
+    fn intersection(
         self,
         other: Self,
     ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {
         match (self, other) {
             (Self::Boolean(lhs), Self::Boolean(rhs)) => lhs
-                .combine(rhs)
+                .intersection(rhs)
                 .map(|(lhs, rhs)| (Self::Boolean(lhs), rhs.map(Self::Boolean))),
             (Self::Number(lhs), Self::Number(rhs)) => lhs
-                .combine(rhs)
+                .intersection(rhs)
                 .map(|(lhs, rhs)| (Self::Number(lhs), rhs.map(Self::Number))),
             (Self::String(lhs), Self::String(rhs)) => lhs
-                .combine(rhs)
+                .intersection(rhs)
                 .map(|(lhs, rhs)| (Self::String(lhs), rhs.map(Self::String))),
             _ => bail!(ResolveClosedDataTypeError::IntersectedDifferentTypes),
         }
@@ -128,13 +128,13 @@ pub enum ArraySchema {
 }
 
 impl Constraint for ArraySchema {
-    fn combine(
+    fn intersection(
         self,
         other: Self,
     ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {
         Ok(match (self, other) {
             (Self::Constrained(lhs), Self::Constrained(rhs)) => {
-                let (combined, remainder) = lhs.combine(rhs)?;
+                let (combined, remainder) = lhs.intersection(rhs)?;
                 (
                     Self::Constrained(combined),
                     remainder.map(Self::Constrained),
@@ -151,7 +151,7 @@ impl Constraint for ArraySchema {
                 (Self::Constrained(lhs), Some(Self::Tuple(rhs)))
             }
             (Self::Tuple(lhs), Self::Tuple(rhs)) => {
-                let (combined, remainder) = lhs.combine(rhs)?;
+                let (combined, remainder) = lhs.intersection(rhs)?;
                 (Self::Tuple(combined), remainder.map(Self::Tuple))
             }
         })
@@ -213,7 +213,7 @@ pub struct ArrayConstraints {
 }
 
 impl Constraint for ArrayConstraints {
-    fn combine(
+    fn intersection(
         self,
         other: Self,
     ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {
@@ -264,7 +264,7 @@ pub struct TupleConstraints {
 }
 
 impl Constraint for TupleConstraints {
-    fn combine(
+    fn intersection(
         self,
         other: Self,
     ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/boolean.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/boolean.rs
@@ -2,7 +2,10 @@ use error_stack::{Report, bail};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
-use crate::schema::{Constraint, ConstraintError, JsonSchemaValueType};
+use crate::schema::{
+    ConstraintError, ConstraintValidator, JsonSchemaValueType,
+    data_type::{closed::ResolveClosedDataTypeError, constraint::Constraint},
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
@@ -16,7 +19,16 @@ pub enum BooleanTypeTag {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct BooleanSchema;
 
-impl Constraint<JsonValue> for BooleanSchema {
+impl Constraint for BooleanSchema {
+    fn combine(
+        &mut self,
+        _other: Self,
+    ) -> Result<Option<Self>, Report<ResolveClosedDataTypeError>> {
+        Ok(None)
+    }
+}
+
+impl ConstraintValidator<JsonValue> for BooleanSchema {
     type Error = ConstraintError;
 
     fn is_valid(&self, value: &JsonValue) -> bool {

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/boolean.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/boolean.rs
@@ -20,7 +20,7 @@ pub enum BooleanTypeTag {
 pub struct BooleanSchema;
 
 impl Constraint for BooleanSchema {
-    fn combine(
+    fn intersection(
         self,
         _other: Self,
     ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/boolean.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/boolean.rs
@@ -21,10 +21,10 @@ pub struct BooleanSchema;
 
 impl Constraint for BooleanSchema {
     fn combine(
-        &mut self,
+        self,
         _other: Self,
-    ) -> Result<Option<Self>, Report<ResolveClosedDataTypeError>> {
-        Ok(None)
+    ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {
+        Ok((self, None))
     }
 }
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
@@ -82,10 +82,10 @@ impl ValueConstraints {
     ) -> Result<Vec<Self>, Report<ResolveClosedDataTypeError>> {
         schemas
             .into_iter()
-            .try_fold(Vec::<Self>::new(), |folded, constraints| {
+            .try_fold(Vec::<Self>::new(), |mut folded, constraints| {
                 let mut next = Some(constraints);
 
-                let mut new_constraints = folded
+                folded = folded
                     .into_iter()
                     .map(|existing| {
                         if let Some(to_combine) = next.take() {
@@ -101,10 +101,10 @@ impl ValueConstraints {
                     .collect::<Result<Vec<_>, _>>()?;
 
                 if let Some(remainder) = next {
-                    new_constraints.push(remainder);
+                    folded.push(remainder);
                 }
 
-                Ok(new_constraints)
+                Ok(folded)
             })
     }
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/mod.rs
@@ -83,7 +83,6 @@ impl ValueConstraints {
         schemas
             .into_iter()
             .try_fold(Vec::<Self>::new(), |folded, constraints| {
-                // let mut new_constraints = Vec::new();
                 let mut next = Some(constraints);
 
                 let mut new_constraints = folded
@@ -94,7 +93,7 @@ impl ValueConstraints {
                             if let Some(remainder) = remainder {
                                 next = Some(remainder);
                             }
-                            Ok::<_, Report<ResolveClosedDataTypeError>>(combined)
+                            Ok::<_, Report<_>>(combined)
                         } else {
                             Ok(existing)
                         }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/null.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/null.rs
@@ -2,7 +2,10 @@ use error_stack::{Report, bail};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
-use crate::schema::{Constraint, ConstraintError, JsonSchemaValueType};
+use crate::schema::{
+    ConstraintError, ConstraintValidator, JsonSchemaValueType,
+    data_type::{closed::ResolveClosedDataTypeError, constraint::Constraint},
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
@@ -16,7 +19,16 @@ pub enum NullTypeTag {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct NullSchema;
 
-impl Constraint<JsonValue> for NullSchema {
+impl Constraint for NullSchema {
+    fn combine(
+        &mut self,
+        _other: Self,
+    ) -> Result<Option<Self>, Report<ResolveClosedDataTypeError>> {
+        Ok(None)
+    }
+}
+
+impl ConstraintValidator<JsonValue> for NullSchema {
     type Error = ConstraintError;
 
     fn is_valid(&self, value: &JsonValue) -> bool {

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/null.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/null.rs
@@ -21,10 +21,10 @@ pub struct NullSchema;
 
 impl Constraint for NullSchema {
     fn combine(
-        &mut self,
+        self,
         _other: Self,
-    ) -> Result<Option<Self>, Report<ResolveClosedDataTypeError>> {
-        Ok(None)
+    ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {
+        Ok((self, None))
     }
 }
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/null.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/null.rs
@@ -20,7 +20,7 @@ pub enum NullTypeTag {
 pub struct NullSchema;
 
 impl Constraint for NullSchema {
-    fn combine(
+    fn intersection(
         self,
         _other: Self,
     ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
@@ -115,15 +115,22 @@ fn float_multiple_of(lhs: f64, rhs: f64) -> bool {
 }
 
 impl Constraint for NumberSchema {
-    fn combine(&mut self, other: Self) -> Result<Option<Self>, Report<ResolveClosedDataTypeError>> {
-        match (&mut *self, other) {
+    fn combine(
+        self,
+        other: Self,
+    ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {
+        Ok(match (self, other) {
             (Self::Constrained(lhs), Self::Constrained(rhs)) => {
-                Ok(lhs.combine(rhs)?.map(Self::Constrained))
+                let (combined, remainder) = lhs.combine(rhs)?;
+                (
+                    Self::Constrained(combined),
+                    remainder.map(Self::Constrained),
+                )
             }
             // TODO: Implement folding for number constraints
             //   see https://linear.app/hash/issue/H-3427/implement-folding-for-number-constraints
-            (_, rhs) => Ok(Some(rhs)),
-        }
+            (lhs, rhs) => (lhs, Some(rhs)),
+        })
     }
 }
 
@@ -227,10 +234,13 @@ pub struct NumberConstraints {
 }
 
 impl Constraint for NumberConstraints {
-    fn combine(&mut self, other: Self) -> Result<Option<Self>, Report<ResolveClosedDataTypeError>> {
+    fn combine(
+        self,
+        other: Self,
+    ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {
         // TODO: Implement folding for number constraints
         //   see https://linear.app/hash/issue/H-3427/implement-folding-for-number-constraints
-        Ok(Some(other))
+        Ok((self, Some(other)))
     }
 }
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
@@ -1,9 +1,15 @@
-use error_stack::{Report, ReportSink, ResultExt, bail};
+use error_stack::{Report, ReportSink, ResultExt, bail, ensure};
 use serde::{Deserialize, Serialize};
 use serde_json::{Number as JsonNumber, Value as JsonValue, json};
 use thiserror::Error;
 
-use crate::schema::{ConstraintError, JsonSchemaValueType, data_type::constraint::Constraint};
+use crate::schema::{
+    ConstraintError, JsonSchemaValueType,
+    data_type::{
+        closed::ResolveClosedDataTypeError,
+        constraint::{Constraint, ConstraintValidator},
+    },
+};
 
 #[expect(
     clippy::trivially_copy_pass_by_ref,
@@ -108,7 +114,20 @@ fn float_multiple_of(lhs: f64, rhs: f64) -> bool {
     (quotient - quotient.round()).abs() < f64::EPSILON
 }
 
-impl Constraint<JsonValue> for NumberSchema {
+impl Constraint for NumberSchema {
+    fn combine(&mut self, other: Self) -> Result<Option<Self>, Report<ResolveClosedDataTypeError>> {
+        match (&mut *self, other) {
+            (Self::Constrained(lhs), Self::Constrained(rhs)) => {
+                Ok(lhs.combine(rhs)?.map(Self::Constrained))
+            }
+            // TODO: Implement folding for number constraints
+            //   see https://linear.app/hash/issue/H-3427/implement-folding-for-number-constraints
+            (_, rhs) => Ok(Some(rhs)),
+        }
+    }
+}
+
+impl ConstraintValidator<JsonValue> for NumberSchema {
     type Error = ConstraintError;
 
     fn is_valid(&self, value: &JsonValue) -> bool {
@@ -131,7 +150,7 @@ impl Constraint<JsonValue> for NumberSchema {
     }
 }
 
-impl Constraint<JsonNumber> for NumberSchema {
+impl ConstraintValidator<JsonNumber> for NumberSchema {
     type Error = ConstraintError;
 
     fn is_valid(&self, value: &JsonNumber) -> bool {
@@ -153,7 +172,7 @@ impl Constraint<JsonNumber> for NumberSchema {
     }
 }
 
-impl Constraint<f64> for NumberSchema {
+impl ConstraintValidator<f64> for NumberSchema {
     type Error = ConstraintError;
 
     fn is_valid(&self, value: &f64) -> bool {
@@ -178,19 +197,20 @@ impl Constraint<f64> for NumberSchema {
                 }
             }
             Self::Enum { r#enum } => {
-                if !r#enum.iter().any(|expected| float_eq(*value, *expected)) {
-                    bail!(ConstraintError::InvalidEnumValue {
+                ensure!(
+                    r#enum.iter().any(|expected| float_eq(*value, *expected)),
+                    ConstraintError::InvalidEnumValue {
                         actual: json!(*value),
                         expected: r#enum.iter().map(|value| json!(*value)).collect(),
-                    });
-                }
+                    }
+                );
             }
         }
         Ok(())
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct NumberConstraints {
@@ -206,7 +226,15 @@ pub struct NumberConstraints {
     pub multiple_of: Option<f64>,
 }
 
-impl Constraint<f64> for NumberConstraints {
+impl Constraint for NumberConstraints {
+    fn combine(&mut self, other: Self) -> Result<Option<Self>, Report<ResolveClosedDataTypeError>> {
+        // TODO: Implement folding for number constraints
+        //   see https://linear.app/hash/issue/H-3427/implement-folding-for-number-constraints
+        Ok(Some(other))
+    }
+}
+
+impl ConstraintValidator<f64> for NumberConstraints {
     type Error = [NumberValidationError];
 
     fn is_valid(&self, value: &f64) -> bool {

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
@@ -115,13 +115,13 @@ fn float_multiple_of(lhs: f64, rhs: f64) -> bool {
 }
 
 impl Constraint for NumberSchema {
-    fn combine(
+    fn intersection(
         self,
         other: Self,
     ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {
         Ok(match (self, other) {
             (Self::Constrained(lhs), Self::Constrained(rhs)) => {
-                let (combined, remainder) = lhs.combine(rhs)?;
+                let (combined, remainder) = lhs.intersection(rhs)?;
                 (
                     Self::Constrained(combined),
                     remainder.map(Self::Constrained),
@@ -234,7 +234,7 @@ pub struct NumberConstraints {
 }
 
 impl Constraint for NumberConstraints {
-    fn combine(
+    fn intersection(
         self,
         other: Self,
     ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/object.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/object.rs
@@ -28,12 +28,19 @@ pub enum ObjectSchema {
 }
 
 impl Constraint for ObjectSchema {
-    fn combine(&mut self, other: Self) -> Result<Option<Self>, Report<ResolveClosedDataTypeError>> {
-        match (&mut *self, other) {
+    fn combine(
+        self,
+        other: Self,
+    ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {
+        Ok(match (self, other) {
             (Self::Constrained(lhs), Self::Constrained(rhs)) => {
-                Ok(lhs.combine(rhs)?.map(Self::Constrained))
+                let (combined, remainder) = lhs.combine(rhs)?;
+                (
+                    Self::Constrained(combined),
+                    remainder.map(Self::Constrained),
+                )
             }
-        }
+        })
     }
 }
 
@@ -90,10 +97,10 @@ pub struct ObjectConstraints {}
 
 impl Constraint for ObjectConstraints {
     fn combine(
-        &mut self,
+        self,
         _other: Self,
-    ) -> Result<Option<Self>, Report<ResolveClosedDataTypeError>> {
-        Ok(None)
+    ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {
+        Ok((self, None))
     }
 }
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/object.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/object.rs
@@ -5,7 +5,10 @@ use thiserror::Error;
 
 type JsonObject = serde_json::Map<String, JsonValue>;
 
-use crate::schema::{Constraint, ConstraintError, JsonSchemaValueType};
+use crate::schema::{
+    ConstraintError, ConstraintValidator, JsonSchemaValueType,
+    data_type::{closed::ResolveClosedDataTypeError, constraint::Constraint},
+};
 
 #[derive(Debug, Error)]
 pub enum ObjectValidationError {}
@@ -24,7 +27,17 @@ pub enum ObjectSchema {
     Constrained(ObjectConstraints),
 }
 
-impl Constraint<JsonValue> for ObjectSchema {
+impl Constraint for ObjectSchema {
+    fn combine(&mut self, other: Self) -> Result<Option<Self>, Report<ResolveClosedDataTypeError>> {
+        match (&mut *self, other) {
+            (Self::Constrained(lhs), Self::Constrained(rhs)) => {
+                Ok(lhs.combine(rhs)?.map(Self::Constrained))
+            }
+        }
+    }
+}
+
+impl ConstraintValidator<JsonValue> for ObjectSchema {
     type Error = ConstraintError;
 
     fn is_valid(&self, value: &JsonValue) -> bool {
@@ -47,7 +60,7 @@ impl Constraint<JsonValue> for ObjectSchema {
     }
 }
 
-impl Constraint<JsonObject> for ObjectSchema {
+impl ConstraintValidator<JsonObject> for ObjectSchema {
     type Error = ConstraintError;
 
     fn is_valid(&self, value: &JsonObject) -> bool {
@@ -75,7 +88,16 @@ impl Constraint<JsonObject> for ObjectSchema {
 )]
 pub struct ObjectConstraints {}
 
-impl Constraint<JsonObject> for ObjectConstraints {
+impl Constraint for ObjectConstraints {
+    fn combine(
+        &mut self,
+        _other: Self,
+    ) -> Result<Option<Self>, Report<ResolveClosedDataTypeError>> {
+        Ok(None)
+    }
+}
+
+impl ConstraintValidator<JsonObject> for ObjectConstraints {
     type Error = [ObjectValidationError];
 
     fn is_valid(&self, _value: &JsonObject) -> bool {

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/object.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/object.rs
@@ -28,13 +28,13 @@ pub enum ObjectSchema {
 }
 
 impl Constraint for ObjectSchema {
-    fn combine(
+    fn intersection(
         self,
         other: Self,
     ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {
         Ok(match (self, other) {
             (Self::Constrained(lhs), Self::Constrained(rhs)) => {
-                let (combined, remainder) = lhs.combine(rhs)?;
+                let (combined, remainder) = lhs.intersection(rhs)?;
                 (
                     Self::Constrained(combined),
                     remainder.map(Self::Constrained),
@@ -96,7 +96,7 @@ impl ConstraintValidator<JsonObject> for ObjectSchema {
 pub struct ObjectConstraints {}
 
 impl Constraint for ObjectConstraints {
-    fn combine(
+    fn intersection(
         self,
         _other: Self,
     ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
@@ -228,13 +228,13 @@ pub enum StringSchema {
 }
 
 impl Constraint for StringSchema {
-    fn combine(
+    fn intersection(
         self,
         other: Self,
     ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {
         Ok(match (self, other) {
             (Self::Constrained(lhs), Self::Constrained(rhs)) => {
-                let (combined, remainder) = lhs.combine(rhs)?;
+                let (combined, remainder) = lhs.intersection(rhs)?;
                 (
                     Self::Constrained(combined),
                     remainder.map(Self::Constrained),
@@ -327,7 +327,7 @@ pub struct StringConstraints {
 }
 
 impl Constraint for StringConstraints {
-    fn combine(
+    fn intersection(
         self,
         other: Self,
     ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
@@ -228,15 +228,22 @@ pub enum StringSchema {
 }
 
 impl Constraint for StringSchema {
-    fn combine(&mut self, other: Self) -> Result<Option<Self>, Report<ResolveClosedDataTypeError>> {
-        match (&mut *self, other) {
+    fn combine(
+        self,
+        other: Self,
+    ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {
+        Ok(match (self, other) {
             (Self::Constrained(lhs), Self::Constrained(rhs)) => {
-                Ok(lhs.combine(rhs)?.map(Self::Constrained))
+                let (combined, remainder) = lhs.combine(rhs)?;
+                (
+                    Self::Constrained(combined),
+                    remainder.map(Self::Constrained),
+                )
             }
             // TODO: Implement folding for string constraints
             //   see https://linear.app/hash/issue/H-3428/implement-folding-for-string-constraints
-            (_, rhs) => Ok(Some(rhs)),
-        }
+            (lhs, rhs) => (lhs, Some(rhs)),
+        })
     }
 }
 
@@ -319,13 +326,14 @@ pub struct StringConstraints {
     pub format: Option<StringFormat>,
 }
 
-// TODO: Implement folding for string constraints
-//   see https://linear.app/hash/issue/H-3428/implement-folding-for-string-constraints
 impl Constraint for StringConstraints {
-    fn combine(&mut self, other: Self) -> Result<Option<Self>, Report<ResolveClosedDataTypeError>> {
+    fn combine(
+        self,
+        other: Self,
+    ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {
         // TODO: Implement folding for string constraints
         //   see https://linear.app/hash/issue/H-3428/implement-folding-for-string-constraints
-        Ok(Some(other))
+        Ok((self, Some(other)))
     }
 }
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -5,11 +5,11 @@ pub use self::{
     closed::{ClosedDataType, DataTypeResolveData, InheritanceDepth, ResolvedDataType},
     constraint::{
         AnyOfConstraints, ArrayConstraints, ArraySchema, ArrayTypeTag, ArrayValidationError,
-        BooleanSchema, BooleanTypeTag, Constraint, ConstraintError, NullSchema, NullTypeTag,
-        NumberConstraints, NumberSchema, NumberTypeTag, NumberValidationError, ObjectConstraints,
-        ObjectSchema, ObjectTypeTag, ObjectValidationError, SingleValueConstraints,
-        SingleValueSchema, StringConstraints, StringFormat, StringFormatError, StringSchema,
-        StringTypeTag, StringValidationError, TupleConstraints,
+        BooleanSchema, BooleanTypeTag, ConstraintError, ConstraintValidator, NullSchema,
+        NullTypeTag, NumberConstraints, NumberSchema, NumberTypeTag, NumberValidationError,
+        ObjectConstraints, ObjectSchema, ObjectTypeTag, ObjectValidationError,
+        SingleValueConstraints, SingleValueSchema, StringConstraints, StringFormat,
+        StringFormatError, StringSchema, StringTypeTag, StringValidationError, TupleConstraints,
     },
     conversion::{
         ConversionDefinition, ConversionExpression, ConversionValue, Conversions, Operator,

--- a/libs/@blockprotocol/type-system/rust/src/schema/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/mod.rs
@@ -19,7 +19,7 @@ pub use self::{
     array::{PropertyArraySchema, PropertyValueArray, ValueOrArray},
     data_type::{
         AnyOfConstraints, ArrayConstraints, ArraySchema, ArrayTypeTag, ArrayValidationError,
-        BooleanSchema, BooleanTypeTag, ClosedDataType, Constraint, ConstraintError,
+        BooleanSchema, BooleanTypeTag, ClosedDataType, ConstraintError, ConstraintValidator,
         ConversionDefinition, ConversionExpression, ConversionValue, Conversions, DataType,
         DataTypeEdge, DataTypeReference, DataTypeResolveData, DataTypeValidator, InheritanceDepth,
         JsonSchemaValueType, NullSchema, NullTypeTag, NumberConstraints, NumberSchema,

--- a/libs/@local/hash-validation/src/entity_type.rs
+++ b/libs/@local/hash-validation/src/entity_type.rs
@@ -25,9 +25,9 @@ use serde_json::Value as JsonValue;
 use thiserror::Error;
 use type_system::{
     schema::{
-        ClosedEntityType, Constraint, DataTypeReference, JsonSchemaValueType, PropertyObjectSchema,
-        PropertyType, PropertyTypeReference, PropertyValueArray, PropertyValueSchema,
-        PropertyValues, ValueOrArray,
+        ClosedEntityType, ConstraintValidator, DataTypeReference, JsonSchemaValueType,
+        PropertyObjectSchema, PropertyType, PropertyTypeReference, PropertyValueArray,
+        PropertyValueSchema, PropertyValues, ValueOrArray,
     },
     url::{BaseUrl, OntologyTypeVersion, VersionedUrl},
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When data types are resolved the constraints should be folded and minimized. This is the groundwork and logic to be used when combining different constraints.

## 🔍 What does this change?

- It's not a good idea to implement `combine` on `Constraint` as `Constraint` is generic and `combine` would not use the generic parameter. Instead, I renamed `Constraint` to `ConstraintValidator` and added a new `Constraint` trait. This adds a `combine` method which takes a mutable reference to a constraint and consumes another constraint. If they can be fully combined, `None` is returned, otherwise `Some` with the remaining constraints. If the constraints cannot be combined at all because it would be unsatisfiable it will error.
- Add `fold_intersections` function to construct a vector of all intersections using the `combine` method. This Is used to shrink the `allOf` constraints in the closed data types.

This PR is still in draft as I have another PR in the queue to implement the number combination logic and need some more testing around the behavior and signatures. Probably I'm replacing the mutable reference with an owned value. Methods with mutable references returning a results need to be careful to not change the value if they return an error (side-effects), in most cases this is not desired.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

- H-3427: Implement folding for number constraints
- H-3428: Implement folding for string constraints
- H-3429: Implement folding for array constraints
- H-3430: Implement folding for anyOf constraints

## 🛡 What tests cover this?

Tests will be added in the follow-ups