### PR TITLE
H-3427: Implement folding for number constraints

### DIFF
--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/closed.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/closed.rs
@@ -452,11 +452,7 @@ mod tests {
         assert_eq!(integer.r#abstract, defs.integer.r#abstract);
         assert_eq!(
             json!(integer.all_of),
-            json!([
-                defs.integer.constraints,
-                defs.number.constraints,
-                defs.value.constraints
-            ])
+            json!([defs.integer.constraints, defs.value.constraints])
         );
     }
 
@@ -475,11 +471,7 @@ mod tests {
         assert_eq!(unsigned.r#abstract, defs.unsigned.r#abstract);
         assert_eq!(
             json!(unsigned.all_of),
-            json!([
-                defs.unsigned.constraints,
-                defs.number.constraints,
-                defs.value.constraints
-            ])
+            json!([defs.unsigned.constraints, defs.value.constraints])
         );
     }
 
@@ -499,10 +491,12 @@ mod tests {
         assert_eq!(
             json!(unsigned_int.all_of),
             json!([
-                defs.unsigned_int.constraints,
-                defs.unsigned.constraints,
-                defs.integer.constraints,
-                defs.number.constraints,
+                {
+                    "type": "number",
+                    "minimum": 0.0,
+                    "maximum": 4_294_967_295.0,
+                    "multipleOf": 1.0,
+                },
                 defs.value.constraints
             ])
         );
@@ -523,11 +517,7 @@ mod tests {
         assert_eq!(small.r#abstract, defs.small.r#abstract);
         assert_eq!(
             json!(small.all_of),
-            json!([
-                defs.small.constraints,
-                defs.number.constraints,
-                defs.value.constraints
-            ])
+            json!([defs.small.constraints, defs.value.constraints])
         );
     }
 
@@ -556,12 +546,12 @@ mod tests {
         assert_eq!(
             json!(unsigned_small_int.all_of),
             json!([
-                defs.unsigned_small_int.constraints,
-                defs.small.constraints,
-                defs.unsigned_int.constraints,
-                defs.unsigned.constraints,
-                defs.integer.constraints,
-                defs.number.constraints,
+                {
+                    "type": "number",
+                    "minimum": 0.0,
+                    "maximum": 100.0,
+                    "multipleOf": 1.0,
+                },
                 defs.value.constraints
             ])
         );

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
@@ -1,13 +1,13 @@
-use error_stack::{Report, ReportSink, ResultExt, bail, ensure};
+use error_stack::{Report, ReportSink, ResultExt, TryReportIteratorExt, bail, ensure};
 use serde::{Deserialize, Serialize};
 use serde_json::{Number as JsonNumber, Value as JsonValue, json};
 use thiserror::Error;
 
 use crate::schema::{
-    ConstraintError, JsonSchemaValueType,
+    ConstraintError, JsonSchemaValueType, SingleValueConstraints,
     data_type::{
         closed::ResolveClosedDataTypeError,
-        constraint::{Constraint, ConstraintValidator},
+        constraint::{Constraint, ConstraintValidator, ValueConstraints},
     },
 };
 
@@ -120,16 +120,110 @@ impl Constraint for NumberSchema {
         other: Self,
     ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {
         Ok(match (self, other) {
-            (Self::Constrained(lhs), Self::Constrained(rhs)) => {
-                let (combined, remainder) = lhs.intersection(rhs)?;
-                (
-                    Self::Constrained(combined),
-                    remainder.map(Self::Constrained),
-                )
+            (Self::Constrained(lhs), Self::Constrained(rhs)) => lhs
+                .intersect(rhs)
+                .map(|(lhs, rhs)| (Self::Constrained(lhs), rhs.map(Self::Constrained)))?,
+            (Self::Const { r#const }, Self::Constrained(constraints))
+            | (Self::Constrained(constraints), Self::Const { r#const }) => {
+                constraints.validate_value(&r#const).change_context(
+                    ResolveClosedDataTypeError::UnsatisfiedConstraint(
+                        json!(r#const),
+                        ValueConstraints::Typed(SingleValueConstraints::Number(Self::Constrained(
+                            constraints,
+                        ))),
+                    ),
+                )?;
+
+                (Self::Const { r#const }, None)
             }
-            // TODO: Implement folding for number constraints
-            //   see https://linear.app/hash/issue/H-3427/implement-folding-for-number-constraints
-            (lhs, rhs) => (lhs, Some(rhs)),
+            (Self::Enum { r#enum }, Self::Constrained(constraints))
+            | (Self::Constrained(constraints), Self::Enum { r#enum }) => {
+                // We use the fast way to filter the values that pass the constraints and collect
+                // them. In most cases this will result in at least one value
+                // passing the constraints.
+                let passed = r#enum
+                    .iter()
+                    .filter(|&value| constraints.is_valid(value))
+                    .copied()
+                    .collect::<Vec<_>>();
+
+                match passed[..] {
+                    [] => {
+                        // We now properly capture errors to return it to the caller.
+                        let _: Vec<()> = r#enum
+                            .iter()
+                            .map(|value| {
+                                constraints.validate_value(value).change_context(
+                                    ResolveClosedDataTypeError::UnsatisfiedEnumConstraintVariant(
+                                        json!(*value),
+                                    ),
+                                )
+                            })
+                            .try_collect_reports()
+                            .change_context(
+                                ResolveClosedDataTypeError::UnsatisfiedEnumConstraint(
+                                    ValueConstraints::Typed(SingleValueConstraints::Number(
+                                        Self::Constrained(constraints.clone()),
+                                    )),
+                                ),
+                            )?;
+
+                        // This should only happen if `enum` is malformed and has no values. This
+                        // should be caught by the schema validation, however, if this still happens
+                        // we return an error as validating empty enum will always fail.
+                        bail!(ResolveClosedDataTypeError::UnsatisfiedEnumConstraint(
+                            ValueConstraints::Typed(SingleValueConstraints::Number(
+                                Self::Constrained(constraints),
+                            )),
+                        ))
+                    }
+                    [r#const] => (Self::Const { r#const }, None),
+                    [..] => (Self::Enum { r#enum: passed }, None),
+                }
+            }
+            (Self::Const { r#const: lhs }, Self::Const { r#const: rhs }) => {
+                if float_eq(lhs, rhs) {
+                    (Self::Const { r#const: lhs }, None)
+                } else {
+                    bail!(ResolveClosedDataTypeError::ConflictingConstValues(
+                        json!(lhs),
+                        json!(rhs),
+                    ))
+                }
+            }
+            (Self::Enum { r#enum: lhs }, Self::Enum { r#enum: rhs }) => {
+                let intersection = lhs
+                    .iter()
+                    .filter(|value| rhs.iter().any(|other| float_eq(**value, *other)))
+                    .copied()
+                    .collect::<Vec<_>>();
+
+                match intersection[..] {
+                    [] => bail!(ResolveClosedDataTypeError::ConflictingEnumValues(
+                        lhs.iter().map(|val| json!(*val)).collect(),
+                        rhs.iter().map(|val| json!(*val)).collect(),
+                    )),
+                    [r#const] => (Self::Const { r#const }, None),
+                    [..] => (
+                        Self::Enum {
+                            r#enum: intersection,
+                        },
+                        None,
+                    ),
+                }
+            }
+            (Self::Const { r#const }, Self::Enum { r#enum })
+            | (Self::Enum { r#enum }, Self::Const { r#const }) => {
+                ensure!(
+                    r#enum.iter().any(|value| float_eq(*value, r#const)),
+                    ResolveClosedDataTypeError::ConflictingConstEnumValue(
+                        json!(r#const),
+                        r#enum.iter().map(|val| json!(*val)).collect(),
+                    )
+                );
+
+                (Self::Const { r#const }, None)
+            }
         })
     }
 }
@@ -235,12 +329,45 @@ pub struct NumberConstraints {
 
 impl Constraint for NumberConstraints {
     fn intersection(
-        self,
+        mut self,
         other: Self,
     ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {
-        // TODO: Implement folding for number constraints
-        //   see https://linear.app/hash/issue/H-3427/implement-folding-for-number-constraints
-        Ok((self, Some(other)))
+        let mut remainder = None::<Self>;
+
+        self.minimum = match self.minimum.zip(other.minimum) {
+            Some((lhs, rhs)) => Some(if float_less_eq(lhs, rhs) { rhs } else { lhs }),
+            None => self.minimum.or(other.minimum),
+        };
+        self.exclusive_minimum = self.exclusive_minimum || other.exclusive_minimum;
+        self.maximum = match self.maximum.zip(other.maximum) {
+            Some((lhs, rhs)) => Some(if float_less_eq(lhs, rhs) { lhs } else { rhs }),
+            None => self.maximum.or(other.maximum),
+        };
+        self.exclusive_maximum = self.exclusive_maximum || other.exclusive_maximum;
+        self.multiple_of = match self.multiple_of.zip(other.multiple_of) {
+            Some((lhs, rhs)) if float_multiple_of(lhs, rhs) => Some(lhs),
+            Some((lhs, rhs)) if float_multiple_of(rhs, lhs) => Some(rhs),
+            Some((lhs, rhs)) => {
+                remainder.get_or_insert_default().multiple_of = Some(rhs);
+                Some(lhs)
+            }
+            None => self.multiple_of.or(other.multiple_of),
+        };
+
+        if let Some((minimum, maximum)) = self.minimum.zip(self.maximum) {
+            ensure!(
+                float_less_eq(minimum, maximum),
+                ResolveClosedDataTypeError::UnsatisfiableConstraint(ValueConstraints::Typed(
+                    SingleValueConstraints::Number(NumberSchema::Constrained(Self {
+                        minimum: Some(minimum),
+                        maximum: Some(maximum),
+                        ..Self::default()
+                    }),)
+                ),)
+            );
+        }
+
+        Ok((self, remainder))
     }
 }
 
@@ -327,10 +454,16 @@ mod tests {
 
     use super::*;
     use crate::schema::{
-        JsonSchemaValueType, NumberValidationError,
-        data_type::constraint::{
-            ValueConstraints,
-            tests::{check_constraints, check_constraints_error, read_schema},
+        JsonSchemaValueType, NumberValidationError, SingleValueConstraints,
+        data_type::{
+            closed::ResolveClosedDataTypeError,
+            constraint::{
+                ValueConstraints,
+                tests::{
+                    check_constraints, check_constraints_error, check_schema_intersection,
+                    check_schema_intersection_error, intersect_schemas, read_schema,
+                },
+            },
         },
     };
 
@@ -377,6 +510,103 @@ mod tests {
         assert!(!float_multiple_of(10.0, 0.0));
         assert!(float_multiple_of(0.0, 5.0));
         assert!(!float_multiple_of(0.1, 0.03));
+        assert!(float_multiple_of(5.0, 5.0));
+    }
+
+    #[test]
+    fn combine_with_non_conflicting_constraints() {
+        let constraints1 = NumberConstraints {
+            minimum: Some(1.0),
+            exclusive_minimum: false,
+            maximum: Some(10.0),
+            exclusive_maximum: false,
+            multiple_of: Some(2.0),
+        };
+        let constraints2 = NumberConstraints {
+            minimum: Some(5.0),
+            exclusive_minimum: true,
+            maximum: Some(15.0),
+            exclusive_maximum: true,
+            multiple_of: Some(4.0),
+        };
+
+        let (combined, None) = constraints1
+            .intersect(constraints2)
+            .expect("Expected combined constraints")
+        else {
+            panic!("Expected no remainder")
+        };
+        assert_eq!(combined.minimum, Some(5.0));
+        assert!(combined.exclusive_minimum);
+        assert_eq!(combined.maximum, Some(10.0));
+        assert!(combined.exclusive_maximum);
+        assert_eq!(combined.multiple_of, Some(4.0));
+    }
+
+    #[test]
+    fn combine_with_conflicting_constraints() {
+        let constraints1 = NumberConstraints {
+            minimum: Some(6.0),
+            exclusive_minimum: false,
+            maximum: None,
+            exclusive_maximum: false,
+            multiple_of: None,
+        };
+        let constraints2 = NumberConstraints {
+            minimum: None,
+            exclusive_minimum: false,
+            maximum: Some(5.0),
+            exclusive_maximum: false,
+            multiple_of: None,
+        };
+
+        let _: Report<_> = constraints1
+            .intersect(constraints2)
+            .expect_err("Expected conflicting constraints");
+    }
+
+    #[test]
+    fn combine_with_no_constraints() {
+        let constraints1 = NumberConstraints::default();
+        let constraints2 = NumberConstraints::default();
+
+        let (combined, None) = constraints1
+            .intersect(constraints2)
+            .expect("Could not combine constraints")
+        else {
+            panic!("Expected combined constraints");
+        };
+        assert_eq!(combined.minimum, None);
+        assert!(!combined.exclusive_minimum);
+        assert_eq!(combined.maximum, None);
+        assert!(!combined.exclusive_maximum);
+        assert_eq!(combined.multiple_of, None);
+    }
+
+    #[test]
+    fn combine_with_remainder() {
+        let constraints1 = NumberConstraints {
+            minimum: Some(1.0),
+            exclusive_minimum: false,
+            maximum: Some(10.0),
+            exclusive_maximum: false,
+            multiple_of: Some(2.0),
+        };
+        let constraints2 = NumberConstraints {
+            minimum: Some(5.0),
+            exclusive_minimum: true,
+            maximum: Some(15.0),
+            exclusive_maximum: true,
+            multiple_of: Some(3.0),
+        };
+
+        let (_, Some(remainder)) = constraints1
+            .intersect(constraints2)
+            .expect("Expected combined constraints")
+        else {
+            panic!("Expected remainder");
+        };
+        assert_eq!(remainder.multiple_of, Some(3.0));
     }
 
     #[test]
@@ -548,5 +778,652 @@ mod tests {
             "enum": [50],
         }))
         .expect_err("Deserialized number schema with mixed properties");
+    }
+
+    #[test]
+    fn intersect_default() {
+        check_schema_intersection(
+            [
+                json!({
+                    "type": "number",
+                }),
+                json!({
+                    "type": "number",
+                }),
+            ],
+            [json!({
+                "type": "number",
+            })],
+        );
+    }
+
+    #[test]
+    fn intersect_min_max_one() {
+        check_schema_intersection(
+            [
+                json!({
+                    "type": "number",
+                    "minimum": 5.0,
+                    "maximum": 10.0,
+                }),
+                json!({
+                    "type": "number",
+                }),
+            ],
+            [json!({
+                "type": "number",
+                "minimum": 5.0,
+                "maximum": 10.0,
+            })],
+        );
+    }
+
+    #[test]
+    fn intersect_min_max_both() {
+        check_schema_intersection(
+            [
+                json!({
+                    "type": "number",
+                    "minimum": 5.0,
+                    "maximum": 10.0,
+                }),
+                json!({
+                    "type": "number",
+                    "minimum": 7.0,
+                    "maximum": 12.0,
+                }),
+            ],
+            [json!({
+                "type": "number",
+                "minimum": 7.0,
+                "maximum": 10.0,
+            })],
+        );
+    }
+
+    #[test]
+    fn intersect_min_max_invalid() {
+        check_schema_intersection_error(
+            [
+                json!({
+                    "type": "number",
+                    "minimum": 5.0,
+                    "maximum": 10.0,
+                }),
+                json!({
+                    "type": "number",
+                    "minimum": 12.0,
+                    "maximum": 15.0,
+                }),
+            ],
+            [ResolveClosedDataTypeError::UnsatisfiableConstraint(
+                from_value(json!(
+                    {
+                        "type": "number",
+                        "minimum": 12.0,
+                        "maximum": 10.0,
+                    }
+                ))
+                .expect("Failed to parse schema"),
+            )],
+        );
+    }
+
+    #[test]
+    fn intersect_exclusive_min_max_one() {
+        check_schema_intersection(
+            [
+                json!({
+                    "type": "number",
+                    "minimum": 5.0,
+                    "exclusiveMinimum": true,
+                    "maximum": 10.0,
+                    "exclusiveMaximum": true,
+                }),
+                json!({
+                    "type": "number",
+                }),
+            ],
+            [json!({
+                "type": "number",
+                "minimum": 5.0,
+                "exclusiveMinimum": true,
+                "maximum": 10.0,
+                "exclusiveMaximum": true,
+            })],
+        );
+    }
+
+    #[test]
+    fn intersect_exclusive_min_max_both() {
+        check_schema_intersection(
+            [
+                json!({
+                    "type": "number",
+                    "minimum": 5.0,
+                    "exclusiveMinimum": true,
+                    "maximum": 10.0,
+                    "exclusiveMaximum": true,
+                }),
+                json!({
+                    "type": "number",
+                    "minimum": 7.0,
+                    "exclusiveMinimum": true,
+                    "maximum": 12.0,
+                    "exclusiveMaximum": true,
+                }),
+            ],
+            [json!({
+                "type": "number",
+                "minimum": 7.0,
+                "exclusiveMinimum": true,
+                "maximum": 10.0,
+                "exclusiveMaximum": true,
+            })],
+        );
+    }
+
+    #[test]
+    fn intersect_multiple_of_one() {
+        check_schema_intersection(
+            [
+                json!({
+                    "type": "number",
+                    "multipleOf": 5.0,
+                }),
+                json!({
+                    "type": "number",
+                }),
+            ],
+            [json!({
+                "type": "number",
+                "multipleOf": 5.0,
+            })],
+        );
+    }
+
+    #[test]
+    fn intersect_multiple_of_both_different() {
+        check_schema_intersection(
+            [
+                json!({
+                    "type": "number",
+                    "multipleOf": 5.0,
+                }),
+                json!({
+                    "type": "number",
+                    "multipleOf": 3.0,
+                }),
+            ],
+            [
+                json!({
+                    "type": "number",
+                    "multipleOf": 5.0,
+                }),
+                json!({
+                    "type": "number",
+                    "multipleOf": 3.0,
+                }),
+            ],
+        );
+    }
+
+    #[test]
+    fn intersect_multiple_of_both_different_multiple() {
+        check_schema_intersection(
+            [
+                json!({
+                    "type": "number",
+                    "multipleOf": 5.0,
+                }),
+                json!({
+                    "type": "number",
+                    "multipleOf": 10.0,
+                }),
+            ],
+            [json!({
+                "type": "number",
+                "multipleOf": 10.0,
+            })],
+        );
+
+        check_schema_intersection(
+            [
+                json!({
+                    "type": "number",
+                    "multipleOf": 10.0,
+                }),
+                json!({
+                    "type": "number",
+                    "multipleOf": 5.0,
+                }),
+            ],
+            [json!({
+                "type": "number",
+                "multipleOf": 10.0,
+            })],
+        );
+    }
+
+    #[test]
+    fn intersect_const_const_same() {
+        check_schema_intersection(
+            [
+                json!({
+                    "type": "number",
+                    "const": 5.0,
+                }),
+                json!({
+                    "type": "number",
+                    "const": 5.0,
+                }),
+            ],
+            [json!({
+                "type": "number",
+                "const": 5.0,
+            })],
+        );
+    }
+
+    #[test]
+    fn intersect_const_const_different() {
+        check_schema_intersection_error(
+            [
+                json!({
+                    "type": "number",
+                    "const": 5.0,
+                }),
+                json!({
+                    "type": "number",
+                    "const": 10.0,
+                }),
+            ],
+            [ResolveClosedDataTypeError::ConflictingConstValues(
+                json!(5.0),
+                json!(10.0),
+            )],
+        );
+    }
+
+    #[test]
+    fn intersect_const_enum_compatible() {
+        check_schema_intersection(
+            [
+                json!({
+                    "type": "number",
+                    "const": 5.0,
+                }),
+                json!({
+                    "type": "number",
+                    "enum": [5.0, 10.0],
+                }),
+            ],
+            [json!({
+                "type": "number",
+                "const": 5.0,
+            })],
+        );
+    }
+
+    #[test]
+    fn intersect_const_enum_incompatible() {
+        check_schema_intersection_error(
+            [
+                json!({
+                    "type": "number",
+                    "const": 5.0,
+                }),
+                json!({
+                    "type": "number",
+                    "enum": [10.0, 15.0],
+                }),
+            ],
+            [ResolveClosedDataTypeError::ConflictingConstEnumValue(
+                json!(5.0),
+                vec![json!(10.0), json!(15.0)],
+            )],
+        );
+    }
+
+    #[test]
+    fn intersect_enum_enum_compatible_multi() {
+        let intersection = intersect_schemas([
+            json!({
+                "type": "number",
+                "enum": [5.0, 10.0, 15.0],
+            }),
+            json!({
+                "type": "number",
+                "enum": [5.0, 15.0, 20.0],
+            }),
+            json!({
+                "type": "number",
+                "enum": [0.0, 5.0, 15.0],
+            }),
+        ])
+        .expect("Intersected invalid constraints")
+        .into_iter()
+        .map(|schema| {
+            from_value::<SingleValueConstraints>(schema).expect("Failed to deserialize schema")
+        })
+        .collect::<Vec<_>>();
+
+        // We need to manually check the intersection because the order of the enum values is not
+        // guaranteed.
+        assert_eq!(intersection.len(), 1);
+        let SingleValueConstraints::Number(NumberSchema::Enum { r#enum }) = &intersection[0] else {
+            panic!("Expected string enum schema");
+        };
+        assert_eq!(r#enum.len(), 2);
+        assert!(r#enum.contains(&5.0));
+        assert!(r#enum.contains(&15.0));
+    }
+
+    #[test]
+    fn intersect_enum_enum_compatible_single() {
+        check_schema_intersection(
+            [
+                json!({
+                    "type": "number",
+                    "enum": [5.0, 10.0, 15.0],
+                }),
+                json!({
+                    "type": "number",
+                    "enum": [5.0, 15.0, 20.0],
+                }),
+                json!({
+                    "type": "number",
+                    "enum": [5.0, 20.0],
+                }),
+            ],
+            [json!({
+                "type": "number",
+                "const": 5.0,
+            })],
+        );
+    }
+
+    #[test]
+    fn intersect_enum_enum_incompatible() {
+        check_schema_intersection_error(
+            [
+                json!({
+                    "type": "number",
+                    "enum": [5.0, 10.0, 15.0],
+                }),
+                json!({
+                    "type": "number",
+                    "enum": [20.0, 25.0, 30.0],
+                }),
+            ],
+            [ResolveClosedDataTypeError::ConflictingEnumValues(
+                vec![json!(5.0), json!(10.0), json!(15.0)],
+                vec![json!(20.0), json!(25.0), json!(30.0)],
+            )],
+        );
+    }
+
+    #[test]
+    fn intersect_const_constraint_compatible() {
+        check_schema_intersection(
+            [
+                json!({
+                    "type": "number",
+                    "const": 5.0,
+                }),
+                json!({
+                    "type": "number",
+                    "minimum": 0.0,
+                    "maximum": 10.0,
+                }),
+            ],
+            [json!({
+                "type": "number",
+                "const": 5.0,
+            })],
+        );
+
+        check_schema_intersection(
+            [
+                json!({
+                    "type": "number",
+                    "minimum": 0.0,
+                    "maximum": 10.0,
+                }),
+                json!({
+                    "type": "number",
+                    "const": 5.0,
+                }),
+            ],
+            [json!({
+                "type": "number",
+                "const": 5.0,
+            })],
+        );
+    }
+
+    #[test]
+    fn intersect_const_constraint_incompatible() {
+        check_schema_intersection_error(
+            [
+                json!({
+                    "type": "number",
+                    "const": 5.0,
+                }),
+                json!({
+                    "type": "number",
+                    "minimum": 10.0,
+                    "maximum": 15.0,
+                }),
+            ],
+            [ResolveClosedDataTypeError::UnsatisfiedConstraint(
+                json!(5.0),
+                from_value(json!({
+                    "type": "number",
+                    "minimum": 10.0,
+                    "maximum": 15.0,
+                }))
+                .expect("Failed to parse schema"),
+            )],
+        );
+
+        check_schema_intersection_error(
+            [
+                json!({
+                    "type": "number",
+                    "minimum": 10.0,
+                    "maximum": 15.0,
+                }),
+                json!({
+                    "type": "number",
+                    "const": 5.0,
+                }),
+            ],
+            [ResolveClosedDataTypeError::UnsatisfiedConstraint(
+                json!(5.0),
+                from_value(json!({
+                    "type": "number",
+                    "minimum": 10.0,
+                    "maximum": 15.0,
+                }))
+                .expect("Failed to parse schema"),
+            )],
+        );
+    }
+
+    #[test]
+    fn intersect_enum_constraint_compatible_single() {
+        check_schema_intersection(
+            [
+                json!({
+                    "type": "number",
+                    "enum": [5.0, 10.0, 15.0],
+                }),
+                json!({
+                    "type": "number",
+                    "minimum": 0.0,
+                    "maximum": 10.0,
+                    "exclusiveMaximum": true,
+                }),
+                json!({
+                    "type": "number",
+                    "minimum": 5.0,
+                    "maximum": 15.0,
+                }),
+            ],
+            [json!({
+                "type": "number",
+                "const": 5.0,
+            })],
+        );
+    }
+
+    #[test]
+    fn intersect_enum_constraint_compatible_multi() {
+        let intersection = intersect_schemas([
+            json!({
+                "type": "number",
+                "enum": [5.0, 10.0, 15.0],
+            }),
+            json!({
+                "type": "number",
+                "minimum": 10.0,
+            }),
+        ])
+        .expect("Intersected invalid constraints")
+        .into_iter()
+        .map(|schema| {
+            from_value::<SingleValueConstraints>(schema).expect("Failed to deserialize schema")
+        })
+        .collect::<Vec<_>>();
+
+        // We need to manually check the intersection because the order of the enum values is not
+        // guaranteed.
+        assert_eq!(intersection.len(), 1);
+        let SingleValueConstraints::Number(NumberSchema::Enum { r#enum }) = &intersection[0] else {
+            panic!("Expected string enum schema");
+        };
+        assert_eq!(r#enum.len(), 2);
+        assert!(r#enum.contains(&10.0));
+        assert!(r#enum.contains(&15.0));
+    }
+
+    #[test]
+    fn intersect_enum_constraint_incompatible() {
+        check_schema_intersection_error(
+            [
+                json!({
+                    "type": "number",
+                    "enum": [5.0, 10.0, 15.0],
+                }),
+                json!({
+                    "type": "number",
+                    "minimum": 20.0,
+                }),
+            ],
+            [
+                ResolveClosedDataTypeError::UnsatisfiedEnumConstraint(
+                    from_value(json!({
+                        "type": "number",
+                        "minimum": 20.0,
+                    }))
+                    .expect("Failed to parse schema"),
+                ),
+                ResolveClosedDataTypeError::UnsatisfiedEnumConstraintVariant(json!(5.0)),
+                ResolveClosedDataTypeError::UnsatisfiedEnumConstraintVariant(json!(10.0)),
+                ResolveClosedDataTypeError::UnsatisfiedEnumConstraintVariant(json!(15.0)),
+            ],
+        );
+    }
+
+    #[test]
+    fn intersect_mixed() {
+        check_schema_intersection(
+            [
+                json!({
+                    "type": "number",
+                    "minimum": 5.0,
+                }),
+                json!({
+                    "type": "number",
+                    "multipleOf": 5.0,
+                }),
+                json!({
+                    "type": "number",
+                    "maximum": 10.0,
+                }),
+                json!({
+                    "type": "number",
+                    "multipleOf": 3.0,
+                }),
+                json!({
+                    "type": "number",
+                    "maximum": 15.0,
+                }),
+                json!({
+                    "type": "number",
+                    "multipleOf": 10.0,
+                }),
+                json!({
+                    "type": "number",
+                    "minimum": 7.0,
+                    "maximum": 20.0,
+                }),
+            ],
+            [
+                json!({
+                    "type": "number",
+                    "minimum": 7.0,
+                    "maximum": 10.0,
+                    "multipleOf": 10.0,
+                }),
+                json!({
+                    "type": "number",
+                    "multipleOf": 3.0,
+                }),
+            ],
+        );
+
+        check_schema_intersection(
+            [
+                json!({
+                    "type": "number",
+                    "minimum": 5.0,
+                }),
+                json!({
+                    "type": "number",
+                    "multipleOf": 5.0,
+                }),
+                json!({
+                    "type": "number",
+                    "maximum": 10.0,
+                }),
+                json!({
+                    "type": "number",
+                    "maximum": 15.0,
+                }),
+                json!({
+                    "type": "number",
+                    "const": 10.0,
+                }),
+                json!({
+                    "type": "number",
+                    "multipleOf": 10.0,
+                }),
+                json!({
+                    "type": "number",
+                    "minimum": 10.0,
+                    "maximum": 10.0,
+                }),
+                json!({
+                    "type": "number",
+                    "multipleOf": 2.0,
+                }),
+            ],
+            [json!({
+                "type": "number",
+                "const": 10.0,
+            })],
+        );
     }
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
@@ -121,7 +121,7 @@ impl Constraint for NumberSchema {
     ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {
         Ok(match (self, other) {
             (Self::Constrained(lhs), Self::Constrained(rhs)) => lhs
-                .intersect(rhs)
+                .intersection(rhs)
                 .map(|(lhs, rhs)| (Self::Constrained(lhs), rhs.map(Self::Constrained)))?,
             (Self::Const { r#const }, Self::Constrained(constraints))
             | (Self::Constrained(constraints), Self::Const { r#const }) => {
@@ -150,7 +150,7 @@ impl Constraint for NumberSchema {
                 match passed[..] {
                     [] => {
                         // We now properly capture errors to return it to the caller.
-                        let _: Vec<()> = r#enum
+                        let () = r#enum
                             .iter()
                             .map(|value| {
                                 constraints.validate_value(value).change_context(
@@ -531,7 +531,7 @@ mod tests {
         };
 
         let (combined, None) = constraints1
-            .intersect(constraints2)
+            .intersection(constraints2)
             .expect("Expected combined constraints")
         else {
             panic!("Expected no remainder")
@@ -561,7 +561,7 @@ mod tests {
         };
 
         let _: Report<_> = constraints1
-            .intersect(constraints2)
+            .intersection(constraints2)
             .expect_err("Expected conflicting constraints");
     }
 
@@ -571,7 +571,7 @@ mod tests {
         let constraints2 = NumberConstraints::default();
 
         let (combined, None) = constraints1
-            .intersect(constraints2)
+            .intersection(constraints2)
             .expect("Could not combine constraints")
         else {
             panic!("Expected combined constraints");
@@ -601,7 +601,7 @@ mod tests {
         };
 
         let (_, Some(remainder)) = constraints1
-            .intersect(constraints2)
+            .intersection(constraints2)
             .expect("Expected combined constraints")
         else {
             panic!("Expected remainder");


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This adds the `combine` functionality for numbers. 

## 🔍 What does this change?

- Implement behavior to combine number constraints

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

Due to the mutable nature of `combine` there is quite some duplication as the `lhs` and `rhs` typically cannot be swapped simply. This probably requires some changes to H-3426

## 🛡 What tests cover this?

Various test cases were added. Also, previous tests were adjusted to take the new changes into account.