### PR TITLE
H-3432: `harpc`: Expose background task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7232,6 +7232,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/libs/@local/harpc/net/Cargo.toml
+++ b/libs/@local/harpc/net/Cargo.toml
@@ -46,7 +46,7 @@ scc = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tachyonix = { workspace = true }
 thiserror = { workspace = true }
-tokio-stream = { workspace = true, features = ["time"] }
+tokio-stream = { workspace = true, features = ["time", "sync"] }
 tokio-util = { workspace = true, features = ["codec", "compat", "rt", "tracing"] }
 tracing = { workspace = true }
 

--- a/libs/@local/harpc/net/src/session/server/mod.rs
+++ b/libs/@local/harpc/net/src/session/server/mod.rs
@@ -43,6 +43,12 @@ pub enum SessionEventError {
     Lagged { amount: u64 },
 }
 
+impl From<!> for SessionEventError {
+    fn from(never: !) -> Self {
+        never
+    }
+}
+
 pub struct ListenStream {
     inner: mpsc::Receiver<Transaction>,
 

--- a/libs/@local/harpc/server/Cargo.toml
+++ b/libs/@local/harpc/server/Cargo.toml
@@ -31,7 +31,7 @@ tokio = { workspace = true, features = ["macros"] }
 tokio-util = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }
 harpc-codec = { workspace = true }
-derive_more = { version = "1.0.0", features = ["display"] }
+derive_more = { version = "1.0.0", features = ["display", "error"] }
 serde = { workspace = true, features = ["derive"] }
 
 [lints]

--- a/libs/@local/harpc/server/examples/account.rs
+++ b/libs/@local/harpc/server/examples/account.rs
@@ -208,8 +208,12 @@ async fn main() {
         })
         .register(AccountServerDelegate {
             service: AccountServiceImpl,
-        })
-        .build();
+        });
+
+    let task = router.background_task::<_, !>(stream::empty());
+    tokio::spawn(task.into_future());
+
+    let router = router.build();
 
     serve(stream::empty(), JsonCodec, router).await;
 }

--- a/libs/@local/harpc/server/src/router.rs
+++ b/libs/@local/harpc/server/src/router.rs
@@ -241,7 +241,7 @@ impl<R, L, S, C> RouterBuilder<R, L, S, C> {
     ///
     /// It is not necessary to spawn the task if the router is spawned, but it is **highly**
     /// recommended, as otherwise sessions will not be cleaned up, which will lead to memory leaks.
-    pub fn background_task<E, St>(&self, stream: St) -> session::Task<S, St>
+    pub fn background_task<St, E>(&self, stream: St) -> session::Task<S, St>
     where
         S: Send + Sync + 'static,
         St: Stream<Item = Result<SessionEvent, E>> + Send + 'static,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This adds an ergonomic way to spawn and create the background task that's required to operate without leaking memory.

Primarily it makes the use of `tokio::sync::broadcast` an implementation detail, thought that might make sense, as the user shouldn't care what we use under the hood. It's just a stream of events.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
