### PR TITLE
H-3433: `harpc`: Encode `Body` errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2630,6 +2630,7 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7232,6 +7232,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/libs/@local/harpc/codec/Cargo.toml
+++ b/libs/@local/harpc/codec/Cargo.toml
@@ -25,6 +25,7 @@ futures-util = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true, public = true }
 pin-project-lite = { workspace = true, optional = true }
 memchr = { workspace = true, optional = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/libs/@local/harpc/net/Cargo.toml
+++ b/libs/@local/harpc/net/Cargo.toml
@@ -46,7 +46,7 @@ scc = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tachyonix = { workspace = true }
 thiserror = { workspace = true }
-tokio-stream = { workspace = true, features = ["time"] }
+tokio-stream = { workspace = true, features = ["time", "sync"] }
 tokio-util = { workspace = true, features = ["codec", "compat", "rt", "tracing"] }
 tracing = { workspace = true }
 

--- a/libs/@local/harpc/net/src/session/server/mod.rs
+++ b/libs/@local/harpc/net/src/session/server/mod.rs
@@ -43,6 +43,12 @@ pub enum SessionEventError {
     Lagged { amount: u64 },
 }
 
+impl From<!> for SessionEventError {
+    fn from(never: !) -> Self {
+        never
+    }
+}
+
 pub struct ListenStream {
     inner: mpsc::Receiver<Transaction>,
 

--- a/libs/@local/harpc/server/Cargo.toml
+++ b/libs/@local/harpc/server/Cargo.toml
@@ -31,7 +31,7 @@ tokio = { workspace = true, features = ["macros"] }
 tokio-util = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }
 harpc-codec = { workspace = true }
-derive_more = { version = "1.0.0", features = ["display"] }
+derive_more = { version = "1.0.0", features = ["display", "error"] }
 serde = { workspace = true, features = ["derive"] }
 
 [lints]

--- a/libs/@local/harpc/server/examples/account.rs
+++ b/libs/@local/harpc/server/examples/account.rs
@@ -208,8 +208,12 @@ async fn main() {
         })
         .register(AccountServerDelegate {
             service: AccountServiceImpl,
-        })
-        .build();
+        });
+
+    let task = router.background_task::<_, !>(stream::empty());
+    tokio::spawn(task.into_future());
+
+    let router = router.build();
 
     serve(stream::empty(), JsonCodec, router).await;
 }

--- a/libs/@local/harpc/server/examples/account.rs
+++ b/libs/@local/harpc/server/examples/account.rs
@@ -11,7 +11,7 @@ use core::fmt::Debug;
 
 use error_stack::Report;
 use frunk::HList;
-use futures::{StreamExt, TryStreamExt, pin_mut, stream};
+use futures::{StreamExt, pin_mut, stream};
 use graph_types::account::AccountId;
 use harpc_codec::{decode::Decoder, encode::Encoder, json::JsonCodec};
 use harpc_server::{router::RouterBuilder, serve::serve};
@@ -24,7 +24,9 @@ use harpc_service::{
 };
 use harpc_tower::{
     body::{Body, BodyExt},
-    layer::{boxed::BoxedResponseLayer, report::HandleReportLayer},
+    layer::{
+        body_report::HandleBodyReportLayer, boxed::BoxedResponseLayer, report::HandleReportLayer,
+    },
     request::Request,
     response::{Parts, Response},
 };
@@ -160,7 +162,7 @@ where
     type Service = Account;
 
     type Body<Source>
-        = impl Body<Control: AsRef<ResponseKind>, Error = !>
+        = impl Body<Control: AsRef<ResponseKind>, Error = <C as Encoder>::Error>
     where
         Source: Body<Control = !, Error: Send + Sync> + Send + Sync;
 
@@ -188,9 +190,7 @@ where
                 let payload = stream.next().await.unwrap().unwrap();
 
                 let account_id = self.service.create_account(&session, payload).await?;
-                let data = codec
-                    .encode(stream::iter([account_id]))
-                    .map_err(|error| panic!("ignore any error, {error:?}"));
+                let data = codec.encode(stream::iter([account_id]));
 
                 Ok(Response::from_ok(Parts::new(session_id), data))
             }
@@ -201,10 +201,11 @@ where
 #[tokio::main]
 async fn main() {
     let router = RouterBuilder::new::<()>(JsonCodec)
-        .with_builder(|builder| {
+        .with_builder(|builder, codec| {
             builder
                 .layer(BoxedResponseLayer::new())
-                .layer(HandleReportLayer::new(JsonCodec))
+                .layer(HandleReportLayer::new(*codec))
+                .layer(HandleBodyReportLayer::new(*codec))
         })
         .register(AccountServerDelegate {
             service: AccountServiceImpl,

--- a/libs/@local/harpc/server/src/router.rs
+++ b/libs/@local/harpc/server/src/router.rs
@@ -241,7 +241,7 @@ impl<R, L, S, C> RouterBuilder<R, L, S, C> {
     ///
     /// It is not necessary to spawn the task if the router is spawned, but it is **highly**
     /// recommended, as otherwise sessions will not be cleaned up, which will lead to memory leaks.
-    pub fn background_task<E, St>(&self, stream: St) -> session::Task<S, St>
+    pub fn background_task<St, E>(&self, stream: St) -> session::Task<S, St>
     where
         S: Send + Sync + 'static,
         St: Stream<Item = Result<SessionEvent, E>> + Send + 'static,

--- a/libs/@local/harpc/tower/Cargo.toml
+++ b/libs/@local/harpc/tower/Cargo.toml
@@ -40,6 +40,7 @@ tower-test = { workspace = true }
 tokio-test = { workspace = true }
 harpc-codec = { workspace = true, features = ["json"] }
 insta.workspace = true
+serde = { workspace = true, features = ["unstable"] }
 
 [lints]
 workspace = true

--- a/libs/@local/harpc/tower/src/body/encode_error.rs
+++ b/libs/@local/harpc/tower/src/body/encode_error.rs
@@ -1,0 +1,123 @@
+use core::{
+    error::Error,
+    pin::Pin,
+    task::{Context, Poll, ready},
+};
+
+use bytes::Bytes;
+use harpc_codec::encode::ErrorEncoder;
+use harpc_types::response_kind::ResponseKind;
+
+use super::{Body, Frame, full::Full};
+use crate::{
+    body::{BodyExt, controlled::Controlled},
+    either::Either,
+};
+
+pin_project_lite::pin_project! {
+    pub struct EncodeError<B, E> {
+        #[pin]
+        inner: B,
+        intermediate: Option<Controlled<ResponseKind, Full<Bytes>>>,
+        encoder: E,
+    }
+}
+
+impl<B, E> EncodeError<B, E> {
+    pub const fn new(inner: B, encoder: E) -> Self {
+        Self {
+            inner,
+            encoder,
+            intermediate: None,
+        }
+    }
+
+    fn poll_intermediate(
+        self: Pin<&mut Self>,
+        cx: &mut Context,
+    ) -> Poll<Option<Result<Frame<Either<B::Data, Bytes>, Either<B::Control, ResponseKind>>, !>>>
+    where
+        B: Body,
+    {
+        let this = self.project();
+
+        let Some(intermediate) = this.intermediate else {
+            return Poll::Ready(None);
+        };
+
+        // if we have an intermediate stream, try to poll it.
+        let error = ready!(intermediate.poll_frame_unpin(cx));
+
+        match error {
+            None => {
+                // we have exhausted the error, therefore continue with the inner stream
+                *this.intermediate = None;
+                Poll::Ready(None)
+            }
+            Some(Ok(frame)) => Poll::Ready(Some(Ok(frame
+                .map_data(Either::Right)
+                .map_control(Either::Right)))),
+        }
+    }
+}
+
+impl<B, E> Body for EncodeError<B, E>
+where
+    B: Body<Error: Error + serde::Serialize>,
+    E: ErrorEncoder + Clone,
+{
+    type Control = Either<B::Control, ResponseKind>;
+    type Data = Either<B::Data, Bytes>;
+    type Error = !;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context,
+    ) -> Poll<Option<super::BodyFrameResult<Self>>> {
+        if let Some(value) = ready!(self.as_mut().poll_intermediate(cx)) {
+            return Poll::Ready(Some(value));
+        }
+
+        let this = self.as_mut().project();
+        let frame = ready!(this.inner.poll_frame(cx));
+
+        match frame {
+            None => Poll::Ready(None),
+            Some(Ok(frame)) => Poll::Ready(Some(Ok(frame
+                .map_data(Either::Left)
+                .map_control(Either::Left)))),
+            Some(Err(error)) => {
+                let error = this.encoder.clone().encode_error(error);
+                let (code, data) = error.into_parts();
+
+                let inner = Controlled::new(ResponseKind::Err(code), Full::new(data));
+                *this.intermediate = Some(inner);
+
+                // this will never return `Poll::Pending` because we just set the intermediate
+                // stream, and it has exactly two frames.
+                let value = self.poll_intermediate(cx);
+
+                // sanity check
+                debug_assert!(value.is_ready());
+
+                value
+            }
+        }
+    }
+
+    fn state(&self) -> Option<super::BodyState> {
+        match self.intermediate {
+            // we're still in the middle of encoding an error, therefore we're not done
+            Some(_) => None,
+            None => self.inner.state(),
+        }
+    }
+
+    fn size_hint(&self) -> super::SizeHint {
+        match &self.intermediate {
+            // we're still in the middle of encoding an error, add the size hint of the error
+            Some(intermediate) => intermediate.size_hint() + self.inner.size_hint(),
+            None => self.inner.size_hint(),
+        }
+    }
+}

--- a/libs/@local/harpc/tower/src/body/encode_error.rs
+++ b/libs/@local/harpc/tower/src/body/encode_error.rs
@@ -106,18 +106,287 @@ where
     }
 
     fn state(&self) -> Option<super::BodyState> {
-        match self.intermediate {
-            // we're still in the middle of encoding an error, therefore we're not done
-            Some(_) => None,
-            None => self.inner.state(),
-        }
+        // we're still in the middle of encoding an error, therefore we're not done yet
+        self.intermediate.as_ref().map_or_else(
+            || self.inner.state(),
+            |intermediate| {
+                // if we're complete, check the inner state (as that one is going to poll next)
+                intermediate.state().and_then(|_| self.inner.state())
+            },
+        )
     }
 
     fn size_hint(&self) -> super::SizeHint {
-        match &self.intermediate {
-            // we're still in the middle of encoding an error, add the size hint of the error
-            Some(intermediate) => intermediate.size_hint() + self.inner.size_hint(),
-            None => self.inner.size_hint(),
-        }
+        // we're still in the middle of encoding an error, add the size hint of the error
+        self.intermediate.as_ref().map_or_else(
+            || self.inner.size_hint(),
+            |intermediate| intermediate.size_hint() + self.inner.size_hint(),
+        )
     }
+}
+
+#[cfg(test)]
+mod test {
+    use core::assert_matches::assert_matches;
+
+    use bytes::Bytes;
+    use harpc_codec::json::JsonCodec;
+    use harpc_types::{error_code::ErrorCode, response_kind::ResponseKind};
+
+    use crate::{
+        body::{
+            Body, BodyState, Frame, SizeHint, encode_error::EncodeError, test::poll_frame_unpin,
+        },
+        either::Either,
+        test::{PollExt, StaticBody},
+    };
+
+    #[derive(Debug, thiserror::Error, serde::Serialize)]
+    #[error("test error")]
+    struct TestError;
+
+    #[test]
+    fn encode_error() {
+        let inner = StaticBody::<Bytes, !, TestError>::new([Err(TestError)]);
+        let mut body = EncodeError::new(inner, JsonCodec);
+
+        let frame = poll_frame_unpin(&mut body)
+            .expect("should be ready")
+            .expect("should have an item")
+            .expect("should be a frame");
+
+        assert_matches!(
+            frame,
+            Frame::Control(Either::Right(ResponseKind::Err(
+                ErrorCode::INTERNAL_SERVER_ERROR
+            )))
+        );
+
+        let frame = poll_frame_unpin(&mut body)
+            .expect("should be ready")
+            .expect("should have an item")
+            .expect("should be a frame");
+
+        insta::assert_debug_snapshot!(frame, @r###"
+        Data(
+            Right(
+                b"\x01{\"message\":\"test error\",\"details\":null}",
+            ),
+        )
+        "###);
+
+        let frame = poll_frame_unpin(&mut body).expect("should be ready");
+        assert!(frame.is_none());
+    }
+
+    #[test]
+    fn passthrough_data() {
+        let inner =
+            StaticBody::<Bytes, !, !>::new([Ok(Frame::new_data(Bytes::from_static(b"test data")))]);
+        let mut body = EncodeError::new(inner, JsonCodec);
+
+        let frame = poll_frame_unpin(&mut body)
+            .expect("should be ready")
+            .expect("should have an item")
+            .expect("should be a frame");
+
+        assert_matches!(frame, Frame::Data(Either::Left(data)) if data == Bytes::from_static(b"test data"));
+
+        let frame = poll_frame_unpin(&mut body).expect("should be ready");
+        assert!(frame.is_none());
+    }
+
+    #[test]
+    fn passthrough_control() {
+        let inner = StaticBody::<Bytes, i32, !>::new([Ok(Frame::new_control(2_i32))]);
+        let mut body = EncodeError::new(inner, JsonCodec);
+
+        let frame = poll_frame_unpin(&mut body)
+            .expect("should be ready")
+            .expect("should have an item")
+            .expect("should be a frame");
+
+        assert_matches!(frame, Frame::Control(Either::Left(2)));
+
+        let frame = poll_frame_unpin(&mut body).expect("should be ready");
+        assert!(frame.is_none());
+    }
+
+    #[test]
+    fn passthrough_sizehint() {
+        const DATA: &[u8] = b"test data";
+
+        let inner = StaticBody::<Bytes, !, !>::new([Ok(Frame::new_data(Bytes::from_static(DATA)))]);
+        let mut body = EncodeError::new(inner, JsonCodec);
+
+        assert_eq!(body.size_hint(), SizeHint::with_exact(DATA.len() as u64));
+
+        let _frame = poll_frame_unpin(&mut body);
+
+        assert_eq!(body.size_hint(), SizeHint::with_exact(0));
+    }
+
+    #[test]
+    fn size_hint_on_error() {
+        const DATA: &[u8] = b"test data";
+
+        let inner = StaticBody::<Bytes, !, TestError>::new([
+            Err(TestError),
+            Ok(Frame::new_data(Bytes::from_static(DATA))),
+        ]);
+        let mut body = EncodeError::new(inner, JsonCodec);
+
+        // no error yet, so the size hint should be the size of the data
+        assert_eq!(body.size_hint(), SizeHint::with_exact(DATA.len() as u64));
+
+        let _frame = poll_frame_unpin(&mut body);
+
+        // we now have an error, therefore the size hint should include the error
+        // `40` is taken from the serialization in the unit test above
+        assert_eq!(
+            body.size_hint(),
+            SizeHint::with_exact(DATA.len() as u64 + 40)
+        );
+
+        let _frame = poll_frame_unpin(&mut body);
+
+        // once finished (2nd poll), we should have the size hint of the data again
+        assert_eq!(body.size_hint(), SizeHint::with_exact(DATA.len() as u64));
+
+        let _frame = poll_frame_unpin(&mut body);
+
+        // once finished (3rd poll), we should have the size hint of the data again
+        assert_eq!(body.size_hint(), SizeHint::with_exact(0));
+    }
+
+    #[test]
+    fn passthrough_state() {
+        let inner =
+            StaticBody::<Bytes, !, !>::new([Ok(Frame::new_data(Bytes::from_static(b"test data")))]);
+        let mut body = EncodeError::new(inner, JsonCodec);
+
+        assert_eq!(body.state(), None);
+
+        let _frame = poll_frame_unpin(&mut body);
+
+        assert_eq!(body.state(), Some(BodyState::Complete));
+    }
+
+    #[test]
+    fn state_on_error() {
+        let inner = StaticBody::<Bytes, !, TestError>::new([Err(TestError)]);
+        let mut body = EncodeError::new(inner, JsonCodec);
+
+        assert_eq!(body.state(), None);
+
+        // polling the control frame
+        let _frame = poll_frame_unpin(&mut body);
+        assert_eq!(body.state(), None);
+
+        // polling the data frame (after that we're finished)
+        let _frame = poll_frame_unpin(&mut body);
+        assert_eq!(body.state(), Some(BodyState::Complete));
+    }
+
+    #[test]
+    fn state_trailing_data_after_error() {
+        let inner = StaticBody::<Bytes, !, TestError>::new([
+            Err(TestError),
+            Ok(Frame::new_data(Bytes::from_static(b"test data"))),
+        ]);
+        let mut body = EncodeError::new(inner, JsonCodec);
+
+        assert_eq!(body.state(), None);
+
+        // polling the control frame
+        let _frame = poll_frame_unpin(&mut body);
+        assert_eq!(body.state(), None);
+
+        // polling the error data frame, but we're not finished yet
+        let _frame = poll_frame_unpin(&mut body);
+        assert_eq!(body.state(), None);
+
+        // polling the data frame
+        let _frame = poll_frame_unpin(&mut body);
+        assert_eq!(body.state(), Some(BodyState::Complete));
+    }
+
+    #[test]
+    fn size_hint_and_state_with_empty_body() {
+        let inner = StaticBody::<Bytes, !, !>::new([]);
+        let body = EncodeError::new(inner, JsonCodec);
+
+        assert_eq!(body.size_hint(), SizeHint::with_exact(0));
+        assert_eq!(body.state(), Some(BodyState::Complete));
+    }
+
+    #[test]
+    fn continues_after_error() {
+        let inner = StaticBody::<Bytes, !, TestError>::new([
+            Ok(Frame::new_data(Bytes::from_static(b"data1"))),
+            Err(TestError),
+            Ok(Frame::new_data(Bytes::from_static(b"data2"))),
+            Ok(Frame::new_control(())),
+            Ok(Frame::new_data(Bytes::from_static(b"data3"))),
+        ]);
+    }
+
+    // #[test]
+    // fn continues_inner_body_after_error() {
+    //     let test_body = TestBody {
+    //         frames: vec![
+    //             Ok(Frame::new_data(Bytes::from_static(b"data1"))),
+    //             Err(Report::new(TestError)),
+    //             Ok(Frame::new_data(Bytes::from_static(b"data2"))),
+    //             Ok(Frame::new_control(())),
+    //             Ok(Frame::new_data(Bytes::from_static(b"data3"))),
+    //         ],
+    //     };
+    //     let encoder = JsonErrorEncoder;
+    //     let mut encode_error = EncodeError::new(test_body, encoder);
+
+    //     // First data frame
+    //     let frame = poll_frame_unpin(&mut encode_error);
+    //     assert!(
+    //         matches!(frame, Poll::Ready(Some(Ok(Frame::Data(Either::Left(data)))) if data ==
+    // Bytes::from_static(b"data1")))     );
+
+    //     // Error frame (control)
+    //     let frame = poll_frame_unpin(&mut encode_error);
+    //     assert!(matches!(
+    //         frame,
+    //         Poll::Ready(Some(Ok(Frame::Control(Either::Right(ResponseKind::Err(
+    //             _
+    //         ))))))
+    //     ));
+
+    //     // Error frame (data)
+    //     let frame = poll_frame_unpin(&mut encode_error);
+    //     assert!(matches!(
+    //         frame,
+    //         Poll::Ready(Some(Ok(Frame::Data(Either::Right(_)))))
+    //     ));
+
+    //     // Second data frame (should not be lost after error)
+    //     let frame = poll_frame_unpin(&mut encode_error);
+    //     assert!(
+    //         matches!(frame, Poll::Ready(Some(Ok(Frame::Data(Either::Left(data)))) if data ==
+    // Bytes::from_static(b"data2")))     );
+
+    //     // Control frame
+    //     let frame = poll_frame_unpin(&mut encode_error);
+    //     assert!(matches!(
+    //         frame,
+    //         Poll::Ready(Some(Ok(Frame::Control(Either::Left(_)))))
+    //     ));
+
+    //     // Third data frame
+    //     let frame = poll_frame_unpin(&mut encode_error);
+    //     assert!(matches!(frame, Poll::Ready(Some(Ok(Frame::Data(Either::Left(data)))) if data ==
+    // Bytes::from_static(b"data3")));
+
+    //         // End of stream
+    //         let frame = poll_frame_unpin(&mut encode_error);
+    //         assert!(matches!(frame, Poll::Ready(None))));
+    // }
 }

--- a/libs/@local/harpc/tower/src/body/encode_report.rs
+++ b/libs/@local/harpc/tower/src/body/encode_report.rs
@@ -1,0 +1,376 @@
+use core::{
+    pin::Pin,
+    task::{Context, Poll, ready},
+};
+
+use bytes::Bytes;
+use error_stack::Report;
+use harpc_codec::encode::ErrorEncoder;
+use harpc_types::response_kind::ResponseKind;
+
+use super::{Body, full::Full};
+use crate::{
+    body::{BodyExt, controlled::Controlled},
+    either::Either,
+};
+
+pin_project_lite::pin_project! {
+    #[project = StateProj]
+    enum State<B> {
+        Inner {
+            #[pin]
+            inner: B
+        },
+        Error {
+            inner: Controlled<ResponseKind, Full<Bytes>>
+        }
+    }
+}
+
+pin_project_lite::pin_project! {
+    /// A body that encodes errors using a specified error encoder.
+    ///
+    /// # Behavior
+    ///
+    /// When an error occurs, this body replaces the underlying stream with a controlled stream
+    /// that represents the encoded error.
+    ///
+    /// # Error Handling
+    ///
+    /// Once an error is encountered, this body stops processing the inner body. This is because:
+    ///
+    /// 1. It's impossible to determine if the error occurred mid-way through a structured value.
+    /// 2. There's no reliable way to find a safe point to resume encoding after the error.
+    ///
+    /// # Safety
+    ///
+    /// This approach prevents potential cascading failures that could occur if encoding were to
+    /// continue after an error without proper delimiters or context.
+    ///
+    /// # Note
+    ///
+    /// While this method ensures safe error handling, it means that any data in the inner body
+    /// after an error will not be processed.
+    // We need a separate type for this because of the `Error` bound, `Report<C>` could implement `Error`, in that case we would have a conflicting implementation.
+    pub struct EncodeReport<B, E> {
+        #[pin]
+        state: State<B>,
+        encoder: E,
+    }
+}
+
+impl<B, E> EncodeReport<B, E> {
+    pub const fn new(inner: B, encoder: E) -> Self {
+        Self {
+            state: State::Inner { inner },
+            encoder,
+        }
+    }
+}
+
+impl<B, E, C> Body for EncodeReport<B, E>
+where
+    B: Body<Error = Report<C>>,
+    E: ErrorEncoder + Clone,
+    C: error_stack::Context,
+{
+    type Control = Either<B::Control, ResponseKind>;
+    type Data = Either<B::Data, Bytes>;
+    type Error = !;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context,
+    ) -> Poll<Option<super::BodyFrameResult<Self>>> {
+        loop {
+            let this = self.as_mut().project();
+            let state = this.state.project();
+
+            let next = match state {
+                StateProj::Inner { inner } => {
+                    let frame = ready!(inner.poll_frame(cx));
+
+                    match frame {
+                        None => None,
+                        Some(Ok(frame)) => {
+                            Some(Ok(frame.map_data(Either::Left).map_control(Either::Left)))
+                        }
+                        Some(Err(error)) => {
+                            let error = this.encoder.clone().encode_report(error);
+                            let (code, data) = error.into_parts();
+
+                            let inner = Controlled::new(ResponseKind::Err(code), Full::new(data));
+                            self.as_mut().project().state.set(State::Error { inner });
+
+                            // next iteration will poll the error stream
+                            continue;
+                        }
+                    }
+                }
+                StateProj::Error { inner } => {
+                    let frame = ready!(inner.poll_frame_unpin(cx));
+
+                    frame.map(|frame| {
+                        frame.map(|data| data.map_data(Either::Right).map_control(Either::Right))
+                    })
+                }
+            };
+
+            return Poll::Ready(next);
+        }
+    }
+
+    fn state(&self) -> Option<super::BodyState> {
+        match &self.state {
+            State::Inner { inner } => inner.state(),
+            State::Error { inner } => inner.state(),
+        }
+    }
+
+    fn size_hint(&self) -> super::SizeHint {
+        // we're still in the middle of encoding an error, add the size hint of the error
+        match &self.state {
+            State::Inner { inner } => inner.size_hint(),
+            State::Error { inner } => inner.size_hint(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use core::assert_matches::assert_matches;
+
+    use bytes::Bytes;
+    use error_stack::Report;
+    use harpc_codec::json::JsonCodec;
+    use harpc_types::{error_code::ErrorCode, response_kind::ResponseKind};
+    use insta::assert_debug_snapshot;
+
+    use crate::{
+        body::{
+            Body, BodyState, Frame, SizeHint, encode_report::EncodeReport, test::poll_frame_unpin,
+        },
+        either::Either,
+        test::{PollExt, StaticBody},
+    };
+
+    #[derive(Debug, thiserror::Error, serde::Serialize)]
+    #[error("test error")]
+    struct TestError;
+
+    #[test]
+    fn encode_error() {
+        let inner = StaticBody::<Bytes, !, Report<TestError>>::new([Err(Report::new(TestError))]);
+        let mut body = EncodeReport::new(inner, JsonCodec);
+
+        let frame = poll_frame_unpin(&mut body)
+            .expect("should be ready")
+            .expect("should have an item")
+            .expect("should be a frame");
+
+        assert_matches!(
+            frame,
+            Frame::Control(Either::Right(ResponseKind::Err(
+                ErrorCode::INTERNAL_SERVER_ERROR
+            )))
+        );
+
+        let frame = poll_frame_unpin(&mut body)
+            .expect("should be ready")
+            .expect("should have an item")
+            .expect("should be a frame");
+
+        insta::assert_debug_snapshot!(frame, @r###"
+        Data(
+            Right(
+                b"\x01[{\"context\":\"test error\",\"attachments\":[],\"sources\":[]}]",
+            ),
+        )
+        "###);
+
+        let frame = poll_frame_unpin(&mut body).expect("should be ready");
+        assert!(frame.is_none());
+    }
+
+    #[test]
+    fn passthrough_data() {
+        let inner = StaticBody::<Bytes, !, Report<TestError>>::new([Ok(Frame::new_data(
+            Bytes::from_static(b"test data"),
+        ))]);
+        let mut body = EncodeReport::new(inner, JsonCodec);
+
+        let frame = poll_frame_unpin(&mut body)
+            .expect("should be ready")
+            .expect("should have an item")
+            .expect("should be a frame");
+
+        assert_matches!(frame, Frame::Data(Either::Left(data)) if data == Bytes::from_static(b"test data"));
+
+        let frame = poll_frame_unpin(&mut body).expect("should be ready");
+        assert!(frame.is_none());
+    }
+
+    #[test]
+    fn passthrough_control() {
+        let inner =
+            StaticBody::<Bytes, i32, Report<TestError>>::new([Ok(Frame::new_control(2_i32))]);
+        let mut body = EncodeReport::new(inner, JsonCodec);
+
+        let frame = poll_frame_unpin(&mut body)
+            .expect("should be ready")
+            .expect("should have an item")
+            .expect("should be a frame");
+
+        assert_matches!(frame, Frame::Control(Either::Left(2)));
+
+        let frame = poll_frame_unpin(&mut body).expect("should be ready");
+        assert!(frame.is_none());
+    }
+
+    #[test]
+    fn passthrough_sizehint() {
+        const DATA: &[u8] = b"test data";
+
+        let inner = StaticBody::<Bytes, !, Report<TestError>>::new([Ok(Frame::new_data(
+            Bytes::from_static(DATA),
+        ))]);
+        let mut body = EncodeReport::new(inner, JsonCodec);
+
+        assert_eq!(body.size_hint(), SizeHint::with_exact(DATA.len() as u64));
+
+        let _frame = poll_frame_unpin(&mut body);
+
+        assert_eq!(body.size_hint(), SizeHint::with_exact(0));
+    }
+
+    #[test]
+    fn size_hint_on_error() {
+        const DATA: &[u8] = b"test data";
+
+        let inner = StaticBody::<Bytes, !, Report<TestError>>::new([
+            Err(Report::new(TestError)),
+            Ok(Frame::new_data(Bytes::from_static(DATA))),
+        ]);
+        let mut body = EncodeReport::new(inner, JsonCodec);
+
+        // no error yet, so the size hint should be the size of the data
+        assert_eq!(body.size_hint(), SizeHint::with_exact(DATA.len() as u64));
+
+        let _frame = poll_frame_unpin(&mut body);
+
+        // we now have an error, therefore the size hint should include the error
+        // `40` is taken from the serialization in the unit test above
+        assert_eq!(body.size_hint(), SizeHint::with_exact(57));
+
+        let _frame = poll_frame_unpin(&mut body);
+
+        // once finished (2nd poll), we've exhausted and should have a size hint of 0
+        assert_eq!(body.size_hint(), SizeHint::with_exact(0));
+    }
+
+    #[test]
+    fn passthrough_state() {
+        let inner = StaticBody::<Bytes, !, Report<TestError>>::new([Ok(Frame::new_data(
+            Bytes::from_static(b"test data"),
+        ))]);
+        let mut body = EncodeReport::new(inner, JsonCodec);
+
+        assert_eq!(body.state(), None);
+
+        let _frame = poll_frame_unpin(&mut body);
+
+        assert_eq!(body.state(), Some(BodyState::Complete));
+    }
+
+    #[test]
+    fn state_on_error() {
+        let inner = StaticBody::<Bytes, !, Report<TestError>>::new([Err(Report::new(TestError))]);
+        let mut body = EncodeReport::new(inner, JsonCodec);
+
+        assert_eq!(body.state(), None);
+
+        // polling the control frame
+        let _frame = poll_frame_unpin(&mut body);
+        assert_eq!(body.state(), None);
+
+        // polling the data frame (after that we're finished)
+        let _frame = poll_frame_unpin(&mut body);
+        assert_eq!(body.state(), Some(BodyState::Complete));
+    }
+
+    #[test]
+    fn state_trailing_data_after_error() {
+        let inner = StaticBody::<Bytes, !, Report<TestError>>::new([
+            Err(Report::new(TestError)),
+            Ok(Frame::new_data(Bytes::from_static(b"test data"))),
+        ]);
+        let mut body = EncodeReport::new(inner, JsonCodec);
+
+        assert_eq!(body.state(), None);
+
+        // polling the control frame
+        let _frame = poll_frame_unpin(&mut body);
+        assert_eq!(body.state(), None);
+
+        // polling the error data frame, we're finished, because we **cannot** continue after an
+        // error
+        let _frame = poll_frame_unpin(&mut body);
+        assert_eq!(body.state(), Some(BodyState::Complete));
+    }
+
+    #[test]
+    fn size_hint_and_state_with_empty_body() {
+        let inner = StaticBody::<Bytes, !, Report<TestError>>::new([]);
+        let body = EncodeReport::new(inner, JsonCodec);
+
+        assert_eq!(body.size_hint(), SizeHint::with_exact(0));
+        assert_eq!(body.state(), Some(BodyState::Complete));
+    }
+
+    #[test]
+    fn does_not_continue_after_error() {
+        let inner = StaticBody::<Bytes, (), Report<TestError>>::new([
+            Ok(Frame::new_data(Bytes::from_static(b"data1"))),
+            Err(Report::new(TestError)),
+            Ok(Frame::new_data(Bytes::from_static(b"data2"))),
+            Ok(Frame::new_control(())),
+            Ok(Frame::new_data(Bytes::from_static(b"data3"))),
+        ]);
+        let mut body = EncodeReport::new(inner, JsonCodec);
+
+        let frame = poll_frame_unpin(&mut body)
+            .expect("should be ready")
+            .expect("should have an item")
+            .expect("should be a frame");
+        assert_matches!(frame, Frame::Data(data) if *data.inner() == Bytes::from_static(b"data1"));
+
+        let frame = poll_frame_unpin(&mut body)
+            .expect("should be ready")
+            .expect("should have an item")
+            .expect("should be a frame");
+        assert_matches!(
+            frame,
+            Frame::Control(Either::Right(ResponseKind::Err(
+                ErrorCode::INTERNAL_SERVER_ERROR
+            )))
+        );
+
+        let frame = poll_frame_unpin(&mut body)
+            .expect("should be ready")
+            .expect("should have an item")
+            .expect("should be a frame");
+        assert_debug_snapshot!(frame, @r###"
+        Data(
+            Right(
+                b"\x01[{\"context\":\"test error\",\"attachments\":[],\"sources\":[]}]",
+            ),
+        )
+        "###);
+
+        assert!(
+            poll_frame_unpin(&mut body)
+                .expect("should be ready")
+                .is_none()
+        );
+    }
+}

--- a/libs/@local/harpc/tower/src/body/mod.rs
+++ b/libs/@local/harpc/tower/src/body/mod.rs
@@ -1,6 +1,7 @@
 pub mod boxed;
 pub mod controlled;
 pub mod empty;
+pub mod encode_error;
 pub mod full;
 pub mod limited;
 pub mod map;

--- a/libs/@local/harpc/tower/src/body/mod.rs
+++ b/libs/@local/harpc/tower/src/body/mod.rs
@@ -2,6 +2,7 @@ pub mod boxed;
 pub mod controlled;
 pub mod empty;
 pub mod encode_error;
+pub mod encode_report;
 pub mod full;
 pub mod limited;
 pub mod map;

--- a/libs/@local/harpc/tower/src/body/size_hint.rs
+++ b/libs/@local/harpc/tower/src/body/size_hint.rs
@@ -1,5 +1,7 @@
 //! Adapted and vendored from `http-body` crate (<https://docs.rs/http-body/latest/src/http_body/size_hint.rs.html>)
 
+use core::ops::Add;
+
 /// A `Body` size hint
 ///
 /// The default implementation returns:
@@ -87,5 +89,19 @@ impl SizeHint {
     pub fn set_exact(&mut self, value: u64) {
         self.lower = value;
         self.upper = Some(value);
+    }
+}
+
+impl Add for SizeHint {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        let lower = self.lower + other.lower;
+        let upper = match (self.upper, other.upper) {
+            (Some(a), Some(b)) => Some(a + b),
+            _ => None,
+        };
+
+        Self { lower, upper }
     }
 }

--- a/libs/@local/harpc/tower/src/body/size_hint.rs
+++ b/libs/@local/harpc/tower/src/body/size_hint.rs
@@ -95,10 +95,10 @@ impl SizeHint {
 impl Add for SizeHint {
     type Output = Self;
 
-    fn add(self, other: Self) -> Self {
-        let lower = self.lower + other.lower;
-        let upper = match (self.upper, other.upper) {
-            (Some(a), Some(b)) => Some(a + b),
+    fn add(self, rhs: Self) -> Self {
+        let lower = self.lower + rhs.lower;
+        let upper = match (self.upper, rhs.upper) {
+            (Some(lhs), Some(rhs)) => Some(lhs + rhs),
             _ => None,
         };
 

--- a/libs/@local/harpc/tower/src/either.rs
+++ b/libs/@local/harpc/tower/src/either.rs
@@ -109,6 +109,20 @@ where
 }
 
 impl<T> Either<T, T> {
+    pub const fn inner(&self) -> &T {
+        match self {
+            Self::Left(left) => left,
+            Self::Right(right) => right,
+        }
+    }
+
+    pub fn inner_mut(&mut self) -> &mut T {
+        match self {
+            Self::Left(left) => left,
+            Self::Right(right) => right,
+        }
+    }
+
     pub fn into_inner(self) -> T {
         match self {
             Self::Left(left) => left,

--- a/libs/@local/harpc/tower/src/layer/body_error.rs
+++ b/libs/@local/harpc/tower/src/layer/body_error.rs
@@ -38,26 +38,26 @@ pub struct HandleBodyErrorService<S, E> {
     encoder: E,
 }
 
-impl<S, E, ReqBody, ResBody> Service<Request<ReqBody>> for HandleBodyErrorService<S, E>
-where
-    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone + Send,
-    E: ErrorEncoder + Clone,
-    ReqBody: Body<Control = !>,
-    ResBody: Body<Control: AsRef<ResponseKind>>,
-{
-    type Error = S::Error;
-    type Response;
+// impl<S, E, ReqBody, ResBody> Service<Request<ReqBody>> for HandleBodyErrorService<S, E>
+// where
+//     S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone + Send,
+//     E: ErrorEncoder + Clone,
+//     ReqBody: Body<Control = !>,
+//     ResBody: Body<Control: AsRef<ResponseKind>>,
+// {
+//     type Error = S::Error;
+//     type Response;
 
-    type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
+//     type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
 
-    fn poll_ready(
-        &mut self,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), Self::Error>> {
-        todo!()
-    }
+//     fn poll_ready(
+//         &mut self,
+//         cx: &mut std::task::Context<'_>,
+//     ) -> std::task::Poll<Result<(), Self::Error>> {
+//         todo!()
+//     }
 
-    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
-        todo!()
-    }
-}
+//     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+//         todo!()
+//     }
+// }

--- a/libs/@local/harpc/tower/src/layer/body_error.rs
+++ b/libs/@local/harpc/tower/src/layer/body_error.rs
@@ -1,0 +1,63 @@
+use core::error::Error;
+
+use harpc_codec::encode::ErrorEncoder;
+use harpc_types::response_kind::ResponseKind;
+use tower::{Layer, Service};
+
+use crate::{body::Body, request::Request, response::Response};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct HandleBodyErrorLayer<E> {
+    encoder: E,
+}
+
+impl<E> HandleBodyErrorLayer<E> {
+    pub const fn new(encoder: E) -> Self {
+        Self { encoder }
+    }
+}
+
+impl<E, S> Layer<S> for HandleBodyErrorLayer<E>
+where
+    E: Clone,
+{
+    type Service = HandleBodyErrorService<S, E>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        HandleBodyErrorService {
+            inner,
+            encoder: self.encoder.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct HandleBodyErrorService<S, E> {
+    inner: S,
+
+    encoder: E,
+}
+
+impl<S, E, ReqBody, ResBody> Service<Request<ReqBody>> for HandleBodyErrorService<S, E>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone + Send,
+    E: ErrorEncoder + Clone,
+    ReqBody: Body<Control = !>,
+    ResBody: Body<Control: AsRef<ResponseKind>>,
+{
+    type Error = S::Error;
+    type Response;
+
+    type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        todo!()
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        todo!()
+    }
+}

--- a/libs/@local/harpc/tower/src/layer/body_error.rs
+++ b/libs/@local/harpc/tower/src/layer/body_error.rs
@@ -1,10 +1,4 @@
-use core::error::Error;
-
-use harpc_codec::encode::ErrorEncoder;
-use harpc_types::response_kind::ResponseKind;
-use tower::{Layer, Service};
-
-use crate::{body::Body, request::Request, response::Response};
+use tower::Layer;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct HandleBodyErrorLayer<E> {

--- a/libs/@local/harpc/tower/src/layer/error.rs
+++ b/libs/@local/harpc/tower/src/layer/error.rs
@@ -16,6 +16,7 @@ use crate::{
     response::{Parts, Response},
 };
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct HandleErrorLayer<E> {
     encoder: E,
 }

--- a/libs/@local/harpc/tower/src/layer/mod.rs
+++ b/libs/@local/harpc/tower/src/layer/mod.rs
@@ -1,4 +1,5 @@
 pub mod body_error;
+pub mod body_report;
 pub mod boxed;
 pub mod error;
 pub mod report;

--- a/libs/@local/harpc/tower/src/layer/mod.rs
+++ b/libs/@local/harpc/tower/src/layer/mod.rs
@@ -1,3 +1,4 @@
+pub mod body_error;
 pub mod boxed;
 pub mod error;
 pub mod report;

--- a/libs/@local/harpc/tower/src/lib.rs
+++ b/libs/@local/harpc/tower/src/lib.rs
@@ -4,7 +4,9 @@
     type_changing_struct_update,
     error_generic_member_access
 )]
-#![cfg_attr(test, feature(noop_waker, assert_matches))]
+#![cfg_attr(test, feature(noop_waker, assert_matches, macro_metavar_expr))]
+
+extern crate alloc;
 
 pub use self::extensions::Extensions;
 
@@ -15,6 +17,8 @@ pub mod layer;
 pub mod net;
 pub mod request;
 pub mod response;
+#[cfg(test)]
+pub(crate) mod test;
 
 // TODO: server impl of Transaction -> Request/Response stream
 // TODO: client impl of Transaction -> Request/Response stream

--- a/libs/@local/harpc/tower/src/test.rs
+++ b/libs/@local/harpc/tower/src/test.rs
@@ -1,0 +1,91 @@
+use alloc::collections::VecDeque;
+use core::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use bytes::Buf;
+
+use crate::body::{Body, BodyState, Frame, SizeHint};
+
+pin_project_lite::pin_project! {
+    pub(crate) struct StaticBody<D, C, E> {
+        frames: VecDeque<Result<Frame<D, C>, E>>,
+    }
+}
+
+impl<D, C, E> StaticBody<D, C, E> {
+    pub fn new(frames: impl IntoIterator<Item = Result<Frame<D, C>, E>>) -> Self {
+        Self {
+            frames: frames.into_iter().collect(),
+        }
+    }
+}
+
+impl<D, C, E> Body for StaticBody<D, C, E>
+where
+    D: Buf,
+{
+    type Control = C;
+    type Data = D;
+    type Error = E;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        _: &mut Context,
+    ) -> Poll<Option<crate::body::BodyFrameResult<Self>>> {
+        let this = self.project();
+        let frame = this.frames.pop_front();
+
+        Poll::Ready(frame)
+    }
+
+    fn state(&self) -> Option<BodyState> {
+        if self.frames.is_empty() {
+            Some(BodyState::Complete)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        let size: usize = self
+            .frames
+            .iter()
+            .map(Result::as_ref)
+            .filter_map(Result::ok)
+            .filter_map(Frame::data)
+            .map(D::remaining)
+            .sum();
+
+        SizeHint::with_exact(size as u64)
+    }
+}
+
+pub trait PollExt {
+    type Item;
+
+    fn unwrap(self) -> Self::Item;
+
+    fn expect(self, message: impl AsRef<str>) -> Self::Item;
+}
+
+impl<T> PollExt for Poll<T> {
+    type Item = T;
+
+    #[track_caller]
+    fn unwrap(self) -> Self::Item {
+        match self {
+            Poll::Ready(val) => val,
+            Poll::Pending => panic!("should be ready"),
+        }
+    }
+
+    #[track_caller]
+    fn expect(self, message: impl AsRef<str>) -> Self::Item {
+        match self {
+            Poll::Ready(val) => val,
+            Poll::Pending => panic!("{}", message.as_ref()),
+        }
+    }
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This enables the handling of `Body` errors through two new layers (and combinators) `HandleBodyError` and `HandleReportError`, they work pretty much the same by turning any error on the `Body` layer into `!` if required.

That allows us to remove the `ResponseBodyError` and have it be guaranteed to be `!`, this then enables a further PR that allows for boxed routers (if necessary).

This has been made possible through our change in the `Codec`.

> an open question is how to handle underlying stream errors when encoding. I'd like to layer them, but that requires a trait bound I am unsure about working out. I have other idea though that might work instead! (in another PR as to not make these too large)

> `JsonErrorRepr` is going to be hoisted up in the other PR as well, I think it's generally a good idea to have both the message of an error and the details.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this
