### PR TITLE
H-3519: `harpc`: rework the `Connection` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2632,8 +2632,10 @@ name = "harpc-client"
 version = "0.0.0"
 dependencies = [
  "bytes",
+ "derive-where",
  "error-stack",
  "futures",
+ "harpc-codec",
  "harpc-net",
  "harpc-tower",
  "multiaddr",

--- a/libs/@local/harpc/client/Cargo.toml
+++ b/libs/@local/harpc/client/Cargo.toml
@@ -11,8 +11,6 @@ publish.workspace = true
 [dependencies]
 # Public workspace dependencies
 harpc-tower = { workspace = true, public = true }
-
-# Public third-party dependencies
 tower = { workspace = true, public = true }
 
 # Private workspace dependencies
@@ -25,6 +23,8 @@ futures = { workspace = true }
 multiaddr = { workspace = true }
 thiserror = { workspace = true }
 tokio-util = { workspace = true }
+harpc-codec.workspace = true
+derive-where.workspace = true
 
 [lints]
 workspace = true

--- a/libs/@local/harpc/client/Cargo.toml
+++ b/libs/@local/harpc/client/Cargo.toml
@@ -11,20 +11,22 @@ publish.workspace = true
 [dependencies]
 # Public workspace dependencies
 harpc-tower = { workspace = true, public = true }
+
+# Public third-party dependencies
 tower = { workspace = true, public = true }
 
 # Private workspace dependencies
 error-stack = { workspace = true }
+harpc-codec = { workspace = true }
 harpc-net = { workspace = true }
 
 # Private third-party dependencies
 bytes = { workspace = true }
+derive-where = { workspace = true }
 futures = { workspace = true }
 multiaddr = { workspace = true }
 thiserror = { workspace = true }
 tokio-util = { workspace = true }
-harpc-codec.workspace = true
-derive-where.workspace = true
 
 [lints]
 workspace = true

--- a/libs/@local/harpc/client/package.json
+++ b/libs/@local/harpc/client/package.json
@@ -5,6 +5,7 @@
   "license": "AGPL-3",
   "dependencies": {
     "@rust/error-stack": "0.5.0",
+    "@rust/harpc-codec": "0.0.0-private",
     "@rust/harpc-net": "0.0.0-private",
     "@rust/harpc-tower": "0.0.0-private"
   }

--- a/libs/@local/harpc/client/src/connection/default.rs
+++ b/libs/@local/harpc/client/src/connection/default.rs
@@ -1,0 +1,114 @@
+use core::{
+    marker::PhantomData,
+    task::{Context, Poll},
+};
+
+use bytes::{Buf, Bytes};
+use error_stack::Report;
+use futures::{
+    Stream, StreamExt, TryFutureExt, future,
+    stream::{self, BoxStream},
+};
+use harpc_net::session::error::ConnectionPartiallyClosedError;
+use harpc_tower::{
+    body::{Frame, stream::StreamBody},
+    net::{pack_error::PackError, unpack::Unpack},
+    request::Request,
+    response::Response,
+};
+use tower::{Layer, Service};
+
+use super::service::ConnectionService;
+
+pub(crate) struct DefaultLayer<S> {
+    _marker: PhantomData<fn() -> *const S>,
+}
+
+impl<S> DefaultLayer<S> {
+    pub(crate) fn new() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<S, St> Layer<S> for DefaultLayer<St> {
+    type Service = DefaultService<S, St>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        DefaultService {
+            inner,
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[expect(clippy::unnecessary_wraps)]
+const fn map_buffer<B>(buffer: B) -> Result<Frame<B, !>, !> {
+    Ok(Frame::Data(buffer))
+}
+
+#[derive_where::derive_where(Debug, Copy, Clone, PartialEq, Eq, Hash; S)]
+pub struct DefaultService<S, St> {
+    inner: S,
+    _marker: PhantomData<fn() -> *const St>,
+}
+
+impl<S, St, ResBody> Service<Request<St>> for DefaultService<S, St>
+where
+    S: Service<
+            Request<StreamBody<stream::Map<St, fn(St::Item) -> Result<Frame<St::Item, !>, !>>>>,
+            Response = Response<ResBody>,
+        >,
+    St: Stream<Item: Buf> + Send,
+{
+    type Error = S::Error;
+    type Future = future::MapOk<S::Future, fn(Response<ResBody>) -> Response<PackError<ResBody>>>;
+    type Response = Response<PackError<ResBody>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<St>) -> Self::Future {
+        let request = req
+            .map_body(|body| {
+                // See https://users.rust-lang.org/t/expected-fn-pointer-found-fn-item/67368 as to why we need the cast here
+                body.map(map_buffer as fn(St::Item) -> Result<Frame<St::Item, !>, !>)
+            })
+            .map_body(StreamBody::new);
+
+        self.inner
+            .call(request)
+            .map_ok(|response| response.map_body(PackError::new))
+    }
+}
+
+#[derive_where::derive_where(Debug, Clone)]
+pub struct Default<B> {
+    inner: DefaultService<ConnectionService, BoxStream<'static, B>>,
+}
+
+impl<B> Default<B> {
+    pub(crate) fn new(inner: DefaultService<ConnectionService, BoxStream<'static, B>>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<B> Service<Request<BoxStream<'static, B>>> for Default<B>
+where
+    B: Buf + Send + 'static,
+{
+    type Error = Report<ConnectionPartiallyClosedError>;
+    type Response = Response<PackError<Unpack>>;
+
+    type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<BoxStream<'static, B>>) -> Self::Future {
+        self.inner.call(req)
+    }
+}

--- a/libs/@local/harpc/client/src/connection/default.rs
+++ b/libs/@local/harpc/client/src/connection/default.rs
@@ -1,14 +1,8 @@
-use core::{
-    marker::PhantomData,
-    task::{Context, Poll},
-};
+use core::task::{Context, Poll};
 
 use bytes::Buf;
 use error_stack::Report;
-use futures::{
-    Stream, StreamExt, TryFutureExt, future,
-    stream::{self, BoxStream},
-};
+use futures::{Stream, StreamExt, TryFutureExt, future, stream};
 use harpc_net::session::error::ConnectionPartiallyClosedError;
 use harpc_tower::{
     body::{Frame, stream::StreamBody},
@@ -25,7 +19,7 @@ pub(crate) struct DefaultLayer {
 }
 
 impl DefaultLayer {
-    pub(crate) fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self { _private: () }
     }
 }

--- a/libs/@local/harpc/client/src/connection/mod.rs
+++ b/libs/@local/harpc/client/src/connection/mod.rs
@@ -8,6 +8,8 @@ use tower::Service;
 pub mod default;
 pub mod service;
 
+pub type DefaultConnection<C> = Connection<default::Default, C>;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Connection<S, C> {
     service: S,

--- a/libs/@local/harpc/client/src/connection/mod.rs
+++ b/libs/@local/harpc/client/src/connection/mod.rs
@@ -1,0 +1,45 @@
+use core::task::{Context, Poll};
+
+use bytes::Buf;
+use futures::Stream;
+use harpc_tower::request::Request;
+use tower::Service;
+
+pub mod default;
+pub mod service;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct Connection<S, C> {
+    service: S,
+    codec: C,
+}
+
+impl<S, C> Connection<S, C> {
+    pub(crate) const fn new(service: S, codec: C) -> Self {
+        Self { service, codec }
+    }
+
+    pub const fn codec(&self) -> &C {
+        &self.codec
+    }
+}
+
+// We specifically restrict the implementation to just `Request<B>` to ensure that the `Connection`
+// is only used in a client (it also simplifies trait bounds).
+impl<St, S, C> Service<Request<St>> for Connection<S, C>
+where
+    St: Stream<Item: Buf>,
+    S: Service<Request<St>>,
+{
+    type Error = S::Error;
+    type Future = S::Future;
+    type Response = S::Response;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<St>) -> Self::Future {
+        self.service.call(req)
+    }
+}

--- a/libs/@local/harpc/client/src/connection/mod.rs
+++ b/libs/@local/harpc/client/src/connection/mod.rs
@@ -24,6 +24,10 @@ impl<S, C> Connection<S, C> {
     pub const fn codec(&self) -> &C {
         &self.codec
     }
+
+    pub fn into_parts(self) -> (S, C) {
+        (self.service, self.codec)
+    }
 }
 
 // We specifically restrict the implementation to just `Request<B>` to ensure that the `Connection`

--- a/libs/@local/harpc/client/src/connection/service.rs
+++ b/libs/@local/harpc/client/src/connection/service.rs
@@ -16,13 +16,13 @@ use tower::Service;
 use crate::TransportLayerGuard;
 
 #[derive(Debug, Clone)]
-pub struct Connection {
+pub struct ConnectionService {
     inner: Arc<harpc_net::session::client::Connection>,
 
     _guard: TransportLayerGuard,
 }
 
-impl Connection {
+impl ConnectionService {
     pub(crate) fn new(
         connection: harpc_net::session::client::Connection,
         guard: TransportLayerGuard,
@@ -34,7 +34,7 @@ impl Connection {
     }
 }
 
-impl<ReqBody> Service<Request<ReqBody>> for Connection
+impl<ReqBody> Service<Request<ReqBody>> for ConnectionService
 where
     ReqBody: Body<Control = !, Error = !> + Send + 'static,
 {

--- a/libs/@local/harpc/client/src/lib.rs
+++ b/libs/@local/harpc/client/src/lib.rs
@@ -84,12 +84,11 @@ impl<C> Client<C> {
     /// # Errors
     ///
     /// Returns a `ClientError::Connect` if unable to establish a connection to the server.
-    pub async fn connect<B>(
+    pub async fn connect(
         &self,
         target: Multiaddr,
-    ) -> Result<Connection<default::Default<B>, C>, Report<ClientError>>
+    ) -> Result<Connection<default::Default, C>, Report<ClientError>>
     where
-        B: Buf + 'static,
         C: Clone + Sync,
     {
         let connection = self
@@ -102,13 +101,13 @@ impl<C> Client<C> {
         ))
     }
 
-    pub async fn connect_with<L, B>(
+    pub async fn connect_with<L>(
         &self,
         layer: L,
         target: Multiaddr,
     ) -> Result<Connection<L::Service, C>, Report<ClientError>>
     where
-        L: Layer<ConnectionService, Service: Service<Request<B>>> + Send,
+        L: Layer<ConnectionService> + Send,
         C: Clone + Sync,
     {
         let connection = self.connect_with_service(layer, target).await?;
@@ -116,14 +115,14 @@ impl<C> Client<C> {
         Ok(Connection::new(connection, self.codec.clone()))
     }
 
-    async fn connect_with_service<L, B>(
+    async fn connect_with_service<L>(
         &self,
 
         layer: L,
         target: Multiaddr,
     ) -> Result<<L as Layer<ConnectionService>>::Service, Report<ClientError>>
     where
-        L: Layer<ConnectionService, Service: Service<Request<B>>> + Send,
+        L: Layer<ConnectionService> + Send,
         C: Sync,
     {
         let connection = self

--- a/libs/@local/harpc/client/src/lib.rs
+++ b/libs/@local/harpc/client/src/lib.rs
@@ -6,21 +6,18 @@ pub mod connection;
 
 use alloc::sync::Arc;
 
-use bytes::Buf;
 use error_stack::{Report, ResultExt};
-use futures::Stream;
 use harpc_net::{
     session::client::{SessionConfig, SessionLayer},
     transport::{TransportConfig, TransportLayer},
 };
-use harpc_tower::request::Request;
 use multiaddr::Multiaddr;
 use tokio_util::sync::{CancellationToken, DropGuard};
-use tower::{Layer, Service};
+use tower::Layer;
 
 use self::connection::{
     Connection,
-    default::{self, DefaultLayer, DefaultService},
+    default::{self, DefaultLayer},
     service::ConnectionService,
 };
 

--- a/libs/@local/harpc/client/src/lib.rs
+++ b/libs/@local/harpc/client/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(never_type, impl_trait_in_assoc_type)]
+#![feature(never_type, impl_trait_in_assoc_type, type_alias_impl_trait)]
 
 extern crate alloc;
 
@@ -6,15 +6,23 @@ pub mod connection;
 
 use alloc::sync::Arc;
 
+use bytes::Buf;
 use error_stack::{Report, ResultExt};
+use futures::Stream;
 use harpc_net::{
     session::client::{SessionConfig, SessionLayer},
     transport::{TransportConfig, TransportLayer},
 };
+use harpc_tower::request::Request;
 use multiaddr::Multiaddr;
 use tokio_util::sync::{CancellationToken, DropGuard};
+use tower::{Layer, Service};
 
-use self::connection::Connection;
+use self::connection::{
+    Connection,
+    default::{self, DefaultLayer, DefaultService},
+    service::ConnectionService,
+};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub struct ClientConfig {
@@ -41,19 +49,20 @@ pub(crate) struct TransportLayerGuard(
 );
 
 #[derive(Debug, Clone)]
-pub struct Client {
+pub struct Client<C> {
     session: Arc<SessionLayer>,
+    codec: C,
 
     guard: TransportLayerGuard,
 }
 
-impl Client {
+impl<C> Client<C> {
     /// Creates a new `Client` with the given configuration.
     ///
     /// # Errors
     ///
     /// Returns a `ClientError::StartTransportLayer` if unable to start the transport layer.
-    pub fn new(config: ClientConfig) -> Result<Self, Report<ClientError>> {
+    pub fn new(config: ClientConfig, codec: C) -> Result<Self, Report<ClientError>> {
         let token = CancellationToken::new();
 
         let transport = TransportLayer::tcp(config.transport, token.clone())
@@ -65,6 +74,7 @@ impl Client {
 
         Ok(Self {
             session: Arc::new(session),
+            codec,
             guard: TransportLayerGuard(guard),
         })
     }
@@ -74,13 +84,57 @@ impl Client {
     /// # Errors
     ///
     /// Returns a `ClientError::Connect` if unable to establish a connection to the server.
-    pub async fn connect(&self, target: Multiaddr) -> Result<Connection, Report<ClientError>> {
+    pub async fn connect<B>(
+        &self,
+        target: Multiaddr,
+    ) -> Result<Connection<default::Default<B>, C>, Report<ClientError>>
+    where
+        B: Buf + 'static,
+        C: Clone + Sync,
+    {
+        let connection = self
+            .connect_with_service(DefaultLayer::new(), target)
+            .await?;
+
+        Ok(Connection::new(
+            default::Default::new(connection),
+            self.codec.clone(),
+        ))
+    }
+
+    pub async fn connect_with<L, B>(
+        &self,
+        layer: L,
+        target: Multiaddr,
+    ) -> Result<Connection<L::Service, C>, Report<ClientError>>
+    where
+        L: Layer<ConnectionService, Service: Service<Request<B>>> + Send,
+        C: Clone + Sync,
+    {
+        let connection = self.connect_with_service(layer, target).await?;
+
+        Ok(Connection::new(connection, self.codec.clone()))
+    }
+
+    async fn connect_with_service<L, B>(
+        &self,
+
+        layer: L,
+        target: Multiaddr,
+    ) -> Result<<L as Layer<ConnectionService>>::Service, Report<ClientError>>
+    where
+        L: Layer<ConnectionService, Service: Service<Request<B>>> + Send,
+        C: Sync,
+    {
         let connection = self
             .session
             .dial(target)
             .await
             .change_context(ClientError::Connect)?;
 
-        Ok(Connection::new(connection, self.guard.clone()))
+        let inner = ConnectionService::new(connection, self.guard.clone());
+        let connection = layer.layer(inner);
+
+        Ok(connection)
     }
 }

--- a/libs/@local/harpc/server/examples/account.rs
+++ b/libs/@local/harpc/server/examples/account.rs
@@ -16,14 +16,11 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use error_stack::{FutureExt as _, Report, ResultExt};
 use frunk::HList;
 use futures::{
-    FutureExt, Stream, StreamExt, TryFutureExt, TryStreamExt, pin_mut,
+    Stream, StreamExt, TryFutureExt, TryStreamExt, pin_mut,
     stream::{self, BoxStream},
 };
 use graph_types::account::AccountId;
-use harpc_client::{
-    Client, ClientConfig,
-    connection::{Connection, DefaultConnection, default},
-};
+use harpc_client::{Client, ClientConfig, connection::Connection};
 use harpc_codec::{decode::Decoder, encode::Encoder, json::JsonCodec};
 use harpc_net::session::server::SessionId;
 use harpc_server::{Server, ServerConfig, router::RouterBuilder, serve::serve};

--- a/libs/@local/harpc/tower/src/request.rs
+++ b/libs/@local/harpc/tower/src/request.rs
@@ -74,4 +74,11 @@ impl<B> Request<B> {
     pub fn extensions_mut(&mut self) -> &mut Extensions {
         &mut self.head.extensions
     }
+
+    pub fn map_body<B2>(self, closure: impl FnOnce(B) -> B2) -> Request<B2> {
+        Request {
+            head: self.head,
+            body: closure(self.body),
+        }
+    }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Reworks the connection client to be more general, it is not instead a `Connection<S, C>`, where `S` is the inner service and `C` is the codec used.

This is a usability improvement, because previously you needed to layer the connection service. This wasn't very ergonomic.

Now a default service exists that creates that layer (created with `connection`), but one can also create their own connection with a tower layer via `connection_with`.

(this also allows for easier type erasure - in the future - we can create a `BoxedConnection` (`C` would need a proxy trait like `erased_serde`, because we're making use of GATs)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this
