### PR TITLE
H-3531: Properly run `lint:tsc` for eslint-config

### DIFF
--- a/libs/@local/eslint-config/generate-ignore-patterns.cjs
+++ b/libs/@local/eslint-config/generate-ignore-patterns.cjs
@@ -18,13 +18,18 @@ const monorepoRoot = path.resolve(__dirname, "../../..");
  * Given a path from a .gitignore in a parent directory, this returns the equivalent paths if written in the current
  * directory
  *
- * @param pattern
- * @param workspaceDirPrefix
- * @returns {[string]}
+ * @param {string} pattern
+ * @param {string} workspaceDirPrefix
+ * @returns {string[]}
  */
 const getEquivalentIgnorePaths = (pattern, workspaceDirPrefix) => {
   // We want to traverse the components of the workspaceDirPrefix, and consume wild cards whenever they match.
   // On some wildcards there may be a branch of equivalent paths, e.g. for a "**" wildcard
+  /**
+   * @param {string[]} pathComponents
+   * @param {string[]} patternComponents
+   * @returns {Set<string>}
+   */
   const getEquivalentPaths = (pathComponents, patternComponents) => {
     const equivalentPaths = new Set();
 

--- a/libs/@local/eslint-config/package.json
+++ b/libs/@local/eslint-config/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@local/tsconfig": "0.0.0-private",
-    "@types/eslint": "8.56.12"
+    "@types/eslint": "8.56.12",
+    "@types/node": "20.17.0"
   }
 }

--- a/libs/@local/eslint-config/package.json
+++ b/libs/@local/eslint-config/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint --report-unused-disable-directives ."
+    "lint:eslint": "eslint --report-unused-disable-directives .",
+    "lint:tsc": "tsc --noEmit"
   },
   "dependencies": {
     "@babel/core": "7.26.0",
@@ -24,5 +25,8 @@
     "eslint-plugin-typescript-sort-keys": "3.2.0",
     "eslint-plugin-unicorn": "51.0.1",
     "typescript": "5.6.3"
+  },
+  "devDependencies": {
+    "@types/eslint": "8.56.12"
   }
 }

--- a/libs/@local/eslint-config/package.json
+++ b/libs/@local/eslint-config/package.json
@@ -27,6 +27,7 @@
     "typescript": "5.6.3"
   },
   "devDependencies": {
+    "@local/tsconfig": "0.0.0-private",
     "@types/eslint": "8.56.12"
   }
 }

--- a/libs/@local/eslint-config/temporarily-disable-rules.cjs
+++ b/libs/@local/eslint-config/temporarily-disable-rules.cjs
@@ -4,6 +4,7 @@
  * @see https://github.com/hashintel/hash/pull/1384
  */
 module.exports = (ruleNames) => {
+  /** @type {import("eslint").Linter.RulesRecord} */
   const result = {};
 
   if (process.env.CHECK_TEMPORARILY_DISABLED_RULES === "true") {

--- a/libs/@local/hash-graph-client/typescript/.eslintrc.cjs
+++ b/libs/@local/hash-graph-client/typescript/.eslintrc.cjs
@@ -6,4 +6,5 @@ module.exports = {
     "typescript-sort-keys/interface": "error",
   },
   reportUnusedDisableDirectives: false,
+  settings: {},
 };

--- a/libs/@local/hash-graph-client/typescript/.eslintrc.cjs
+++ b/libs/@local/hash-graph-client/typescript/.eslintrc.cjs
@@ -6,5 +6,4 @@ module.exports = {
     "typescript-sort-keys/interface": "error",
   },
   reportUnusedDisableDirectives: false,
-  settings: {},
 };

--- a/libs/@local/hash-graph-client/typescript/tsconfig.json
+++ b/libs/@local/hash-graph-client/typescript/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@local/tsconfig/legacy-base-tsconfig-to-refactor.json",
   "include": ["./"],
+  "exclude": ["./dist"],
   "compilerOptions": {
     "module": "NodeNext",
     "moduleResolution": "NodeNext"

--- a/libs/@local/tsconfig/legacy-base-tsconfig-to-refactor.json
+++ b/libs/@local/tsconfig/legacy-base-tsconfig-to-refactor.json
@@ -33,7 +33,8 @@
       "@local/status": ["../status/typescript/pkg/src/main.ts"],
       "@local/hash-subgraph": ["../hash-subgraph/src/main.ts"],
       "@local/hash-subgraph/*": ["../hash-subgraph/src/*.ts"]
-    }
+    },
+    "outDir": "./dist"
   },
   "ts-node": {
     "transpileOnly": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -10663,7 +10663,7 @@
   resolved "https://registry.yarnpkg.com/@types/escodegen/-/escodegen-0.0.6.tgz#5230a9ce796e042cda6f086dbf19f22ea330659c"
   integrity sha512-AjwI4MvWx3HAOaZqYsjKWyEObT9lcVV0Y0V8nXo6cXzN8ZiMxVhf6F3d/UNvXVGKrEzL/Dluc5p+y9GkzlTWig==
 
-"@types/eslint@8.57.0":
+"@types/eslint@8.56.12":
   version "8.56.12"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.56.12.tgz#1657c814ffeba4d2f84c0d4ba0f44ca7ea1ca53a"
   integrity sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -10663,6 +10663,14 @@
   resolved "https://registry.yarnpkg.com/@types/escodegen/-/escodegen-0.0.6.tgz#5230a9ce796e042cda6f086dbf19f22ea330659c"
   integrity sha512-AjwI4MvWx3HAOaZqYsjKWyEObT9lcVV0Y0V8nXo6cXzN8ZiMxVhf6F3d/UNvXVGKrEzL/Dluc5p+y9GkzlTWig==
 
+"@types/eslint@8.57.0":
+  version "8.56.12"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.56.12.tgz#1657c814ffeba4d2f84c0d4ba0f44ca7ea1ca53a"
+  integrity sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==
+  dependencies:
+    "@types/estree" "*"
+    "@types/json-schema" "*"
+
 "@types/estree-jsx@^0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@types/estree-jsx/-/estree-jsx-0.0.1.tgz#c36d7a1afeb47a95a8ee0b7bc8bc705db38f919d"
@@ -10878,7 +10886,7 @@
     "@types/tough-cookie" "*"
     parse5 "^7.0.0"
 
-"@types/json-schema@^7.0.11", "@types/json-schema@^7.0.12", "@types/json-schema@^7.0.15", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
+"@types/json-schema@*", "@types/json-schema@^7.0.11", "@types/json-schema@^7.0.12", "@types/json-schema@^7.0.15", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The ESLint config was not checked for tsc. This mainly caused issues in IDEs.