### PR TITLE
H-3532: Expose querying multi-entity types

### DIFF
--- a/apps/hash-api/src/graph/ontology/primitive/data-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/data-type.ts
@@ -25,7 +25,7 @@ import type { OwnedById } from "@local/hash-graph-types/web";
 import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { generateTypeId } from "@local/hash-isomorphic-utils/ontology-types";
 import {
-  mapGraphApiDataTypeToDataType,
+  mapGraphApiDataTypesToDataTypes,
   mapGraphApiSubgraphToSubgraph,
 } from "@local/hash-isomorphic-utils/subgraph-mapping";
 import type {
@@ -109,7 +109,7 @@ export const getDataTypes: ImpureGraphFunction<
   graphApi
     .getDataTypes(actorId, { includeDrafts: false, ...request })
     .then(({ data: response }) =>
-      mapGraphApiDataTypeToDataType(response.dataTypes),
+      mapGraphApiDataTypesToDataTypes(response.dataTypes),
     );
 
 /**

--- a/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
@@ -12,7 +12,7 @@ import type {
   EntityTypePermission,
   GetEntityTypesParams,
   GetEntityTypeSubgraphParams,
-  GetMultiEntityTypeParams,
+  GetClosedMultiEntityTypeParams,
   ModifyRelationshipOperation,
   OntologyTemporalMetadata,
   ProvidedOntologyEditionProvenance,
@@ -31,7 +31,7 @@ import { generateTypeId } from "@local/hash-isomorphic-utils/ontology-types";
 import {
   mapGraphApiClosedEntityTypesToClosedEntityTypes,
   mapGraphApiEntityTypesToEntityTypes,
-  mapGraphApiMultiEntityTypeToMultiEntityType,
+  mapGraphApiClosedMultiEntityTypeToClosedMultiEntityType,
   mapGraphApiSubgraphToSubgraph,
 } from "@local/hash-isomorphic-utils/subgraph-mapping";
 import type {
@@ -249,15 +249,17 @@ export const getClosedEntityTypes: ImpureGraphFunction<
 };
 
 export const getClosedMultiEntityType: ImpureGraphFunction<
-  GetMultiEntityTypeParams & {
+  GetClosedMultiEntityTypeParams & {
     temporalClient?: TemporalClient;
   },
   Promise<ClosedMultiEntityType>
 > = async ({ graphApi }, { actorId }, { temporalClient: _, ...request }) =>
   graphApi
-    .getMultiEntityTypes(actorId, request)
+    .getClosedMultiEntityTypes(actorId, request)
     .then(({ data: response }) =>
-      mapGraphApiMultiEntityTypeToMultiEntityType(response.entityType),
+      mapGraphApiClosedMultiEntityTypeToClosedMultiEntityType(
+        response.entityType,
+      ),
     );
 
 /**

--- a/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
@@ -10,9 +10,9 @@ import type {
   ArchiveEntityTypeParams,
   EntityType,
   EntityTypePermission,
+  GetClosedMultiEntityTypeParams,
   GetEntityTypesParams,
   GetEntityTypeSubgraphParams,
-  GetClosedMultiEntityTypeParams,
   ModifyRelationshipOperation,
   OntologyTemporalMetadata,
   ProvidedOntologyEditionProvenance,
@@ -30,8 +30,8 @@ import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/gra
 import { generateTypeId } from "@local/hash-isomorphic-utils/ontology-types";
 import {
   mapGraphApiClosedEntityTypesToClosedEntityTypes,
-  mapGraphApiEntityTypesToEntityTypes,
   mapGraphApiClosedMultiEntityTypeToClosedMultiEntityType,
+  mapGraphApiEntityTypesToEntityTypes,
   mapGraphApiSubgraphToSubgraph,
 } from "@local/hash-isomorphic-utils/subgraph-mapping";
 import type {

--- a/apps/hash-api/src/graph/ontology/primitive/property-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/property-type.ts
@@ -21,7 +21,7 @@ import type { OwnedById } from "@local/hash-graph-types/web";
 import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { generateTypeId } from "@local/hash-isomorphic-utils/ontology-types";
 import {
-  mapGraphApiPropertyTypeToPropertyType,
+  mapGraphApiPropertyTypesToPropertyTypes,
   mapGraphApiSubgraphToSubgraph,
 } from "@local/hash-isomorphic-utils/subgraph-mapping";
 import type { ConstructPropertyTypeParams } from "@local/hash-isomorphic-utils/types";
@@ -98,7 +98,7 @@ export const getPropertyTypes: ImpureGraphFunction<
   graphApi
     .getPropertyTypes(actorId, { includeDrafts: false, ...request })
     .then(({ data: response }) =>
-      mapGraphApiPropertyTypeToPropertyType(response.propertyTypes),
+      mapGraphApiPropertyTypesToPropertyTypes(response.propertyTypes),
     );
 
 /**

--- a/apps/hash-graph/libs/api/openapi/models/closed_multi_entity_type.json
+++ b/apps/hash-graph/libs/api/openapi/models/closed_multi_entity_type.json
@@ -1,0 +1,50 @@
+{
+  "title": "Closed Entity Type",
+  "description": "Specifies the closed structure of a Block Protocol entity type",
+  "type": "object",
+  "properties": {
+    "allOf": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "$id": {
+            "$ref": "./shared.json#/definitions/VersionedUrl"
+          },
+          "title": {
+            "type": "string"
+          },
+          "titlePlural": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "allOf": {
+            "type": "array",
+            "items": {
+              "$ref": "./shared.json#/definitions/EntityTypeDisplayMetadata"
+            },
+            "minItems": 1
+          }
+        },
+        "additionalProperties": false
+      },
+      "minItems": 1
+    },
+    "properties": {
+      "$ref": "./shared.json#/definitions/PropertyTypeObject"
+    },
+    "required": {
+      "type": "array",
+      "items": {
+        "$ref": "./shared.json#/definitions/BaseUrl"
+      }
+    },
+    "links": {
+      "$ref": "./shared.json#/definitions/LinkTypeObject"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["$id", "title", "description", "properties"]
+}

--- a/apps/hash-graph/libs/api/openapi/models/closed_multi_entity_type.json
+++ b/apps/hash-graph/libs/api/openapi/models/closed_multi_entity_type.json
@@ -1,6 +1,6 @@
 {
-  "title": "Closed Entity Type",
-  "description": "Specifies the closed structure of a Block Protocol entity type",
+  "title": "Closed Multi-Entity Type",
+  "description": "Specifies the closed structure which combines multiple entity types",
   "type": "object",
   "properties": {
     "allOf": {

--- a/apps/hash-graph/libs/api/openapi/openapi.json
+++ b/apps/hash-graph/libs/api/openapi/openapi.json
@@ -1928,7 +1928,7 @@
           "Graph",
           "EntityType"
         ],
-        "operationId": "get_multi_entity_types",
+        "operationId": "get_closed_multi_entity_types",
         "parameters": [
           {
             "name": "X-Authenticated-User-Actor-Id",
@@ -1944,7 +1944,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GetMultiEntityTypeParams"
+                "$ref": "#/components/schemas/GetClosedMultiEntityTypeParams"
               }
             }
           },
@@ -1952,11 +1952,11 @@
         },
         "responses": {
           "200": {
-            "description": "Gets a a list of multi entity types that satisfy the given query.",
+            "description": "Gets a list of multi-entity types that satisfy the given query. A multi-entity type is the combination of multiple entity types.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GetMultiEntityTypeResponse"
+                  "$ref": "#/components/schemas/GetClosedMultiEntityTypeResponse"
                 }
               }
             }
@@ -5062,6 +5062,40 @@
           }
         ]
       },
+      "GetClosedMultiEntityTypeParams": {
+        "type": "object",
+        "required": [
+          "entityTypeIds",
+          "temporalAxes",
+          "includeDrafts"
+        ],
+        "properties": {
+          "entityTypeIds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VersionedUrl"
+            }
+          },
+          "includeDrafts": {
+            "type": "boolean"
+          },
+          "temporalAxes": {
+            "$ref": "#/components/schemas/QueryTemporalAxesUnresolved"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetClosedMultiEntityTypeResponse": {
+        "type": "object",
+        "required": [
+          "entityType"
+        ],
+        "properties": {
+          "entityType": {
+            "$ref": "./models/closed_multi_entity_type.json"
+          }
+        }
+      },
       "GetDataTypeSubgraphParams": {
         "type": "object",
         "required": [
@@ -5590,40 +5624,6 @@
               "type": "integer",
               "minimum": 0
             }
-          }
-        }
-      },
-      "GetMultiEntityTypeParams": {
-        "type": "object",
-        "required": [
-          "entityTypeIds",
-          "temporalAxes",
-          "includeDrafts"
-        ],
-        "properties": {
-          "entityTypeIds": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/VersionedUrl"
-            }
-          },
-          "includeDrafts": {
-            "type": "boolean"
-          },
-          "temporalAxes": {
-            "$ref": "#/components/schemas/QueryTemporalAxesUnresolved"
-          }
-        },
-        "additionalProperties": false
-      },
-      "GetMultiEntityTypeResponse": {
-        "type": "object",
-        "required": [
-          "entityType"
-        ],
-        "properties": {
-          "entityType": {
-            "$ref": "./models/closed_multi_entity_type.json"
           }
         }
       },

--- a/apps/hash-graph/libs/api/openapi/openapi.json
+++ b/apps/hash-graph/libs/api/openapi/openapi.json
@@ -1922,6 +1922,54 @@
         }
       }
     },
+    "/entity-types/multi": {
+      "post": {
+        "tags": [
+          "Graph",
+          "EntityType"
+        ],
+        "operationId": "get_multi_entity_types",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetMultiEntityTypeParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Gets a a list of multi entity types that satisfy the given query.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetMultiEntityTypeResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Provided query is invalid"
+          },
+          "500": {
+            "description": "Store error occurred"
+          }
+        }
+      }
+    },
     "/entity-types/query": {
       "post": {
         "tags": [
@@ -5542,6 +5590,40 @@
               "type": "integer",
               "minimum": 0
             }
+          }
+        }
+      },
+      "GetMultiEntityTypeParams": {
+        "type": "object",
+        "required": [
+          "entityTypeIds",
+          "temporalAxes",
+          "includeDrafts"
+        ],
+        "properties": {
+          "entityTypeIds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VersionedUrl"
+            }
+          },
+          "includeDrafts": {
+            "type": "boolean"
+          },
+          "temporalAxes": {
+            "$ref": "#/components/schemas/QueryTemporalAxesUnresolved"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetMultiEntityTypeResponse": {
+        "type": "object",
+        "required": [
+          "entityType"
+        ],
+        "properties": {
+          "entityType": {
+            "$ref": "./models/closed_multi_entity_type.json"
           }
         }
       },

--- a/apps/hash-graph/libs/api/openapi/openapi.json
+++ b/apps/hash-graph/libs/api/openapi/openapi.json
@@ -14,10 +14,7 @@
   "paths": {
     "/account_groups": {
       "post": {
-        "tags": [
-          "Graph",
-          "Account Group"
-        ],
+        "tags": ["Graph", "Account Group"],
         "operationId": "create_account_group",
         "parameters": [
           {
@@ -59,10 +56,7 @@
     },
     "/account_groups/{account_group_id}/members/{account_id}": {
       "post": {
-        "tags": [
-          "Graph",
-          "Account Group"
-        ],
+        "tags": ["Graph", "Account Group"],
         "operationId": "add_account_group_member",
         "parameters": [
           {
@@ -106,10 +100,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Graph",
-          "Account Group"
-        ],
+        "tags": ["Graph", "Account Group"],
         "operationId": "remove_account_group_member",
         "parameters": [
           {
@@ -155,10 +146,7 @@
     },
     "/account_groups/{account_group_id}/permissions/{permission}": {
       "get": {
-        "tags": [
-          "Graph",
-          "Account Group"
-        ],
+        "tags": ["Graph", "Account Group"],
         "operationId": "check_account_group_permission",
         "parameters": [
           {
@@ -208,10 +196,7 @@
     },
     "/accounts": {
       "post": {
-        "tags": [
-          "Graph",
-          "Account"
-        ],
+        "tags": ["Graph", "Account"],
         "operationId": "create_account",
         "parameters": [
           {
@@ -253,10 +238,7 @@
     },
     "/data-types": {
       "post": {
-        "tags": [
-          "Graph",
-          "DataType"
-        ],
+        "tags": ["Graph", "DataType"],
         "operationId": "create_data_type",
         "parameters": [
           {
@@ -302,10 +284,7 @@
         }
       },
       "put": {
-        "tags": [
-          "Graph",
-          "DataType"
-        ],
+        "tags": ["Graph", "DataType"],
         "operationId": "update_data_type",
         "parameters": [
           {
@@ -374,10 +353,7 @@
     },
     "/data-types/archive": {
       "put": {
-        "tags": [
-          "Graph",
-          "DataType"
-        ],
+        "tags": ["Graph", "DataType"],
         "operationId": "archive_data_type",
         "parameters": [
           {
@@ -428,10 +404,7 @@
     },
     "/data-types/embeddings": {
       "post": {
-        "tags": [
-          "Graph",
-          "DataType"
-        ],
+        "tags": ["Graph", "DataType"],
         "operationId": "update_data_type_embeddings",
         "parameters": [
           {
@@ -469,10 +442,7 @@
     },
     "/data-types/load": {
       "post": {
-        "tags": [
-          "Graph",
-          "DataType"
-        ],
+        "tags": ["Graph", "DataType"],
         "operationId": "load_external_data_type",
         "parameters": [
           {
@@ -520,10 +490,7 @@
     },
     "/data-types/query": {
       "post": {
-        "tags": [
-          "Graph",
-          "DataType"
-        ],
+        "tags": ["Graph", "DataType"],
         "operationId": "get_data_types",
         "parameters": [
           {
@@ -568,10 +535,7 @@
     },
     "/data-types/query/subgraph": {
       "post": {
-        "tags": [
-          "Graph",
-          "DataType"
-        ],
+        "tags": ["Graph", "DataType"],
         "operationId": "get_data_type_subgraph",
         "parameters": [
           {
@@ -616,10 +580,7 @@
     },
     "/data-types/relationships": {
       "post": {
-        "tags": [
-          "Graph",
-          "DataType"
-        ],
+        "tags": ["Graph", "DataType"],
         "operationId": "modify_data_type_authorization_relationships",
         "parameters": [
           {
@@ -657,10 +618,7 @@
     },
     "/data-types/unarchive": {
       "put": {
-        "tags": [
-          "Graph",
-          "DataType"
-        ],
+        "tags": ["Graph", "DataType"],
         "operationId": "unarchive_data_type",
         "parameters": [
           {
@@ -711,10 +669,7 @@
     },
     "/data-types/{data_type_id}/permissions/{permission}": {
       "get": {
-        "tags": [
-          "Graph",
-          "DataType"
-        ],
+        "tags": ["Graph", "DataType"],
         "operationId": "check_data_type_permission",
         "parameters": [
           {
@@ -764,10 +719,7 @@
     },
     "/data-types/{data_type_id}/relationships": {
       "get": {
-        "tags": [
-          "Graph",
-          "DataType"
-        ],
+        "tags": ["Graph", "DataType"],
         "operationId": "get_data_type_authorization_relationships",
         "parameters": [
           {
@@ -811,10 +763,7 @@
     },
     "/entities": {
       "post": {
-        "tags": [
-          "Graph",
-          "Entity"
-        ],
+        "tags": ["Graph", "Entity"],
         "operationId": "create_entity",
         "parameters": [
           {
@@ -860,10 +809,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Graph",
-          "Entity"
-        ],
+        "tags": ["Graph", "Entity"],
         "operationId": "patch_entity",
         "parameters": [
           {
@@ -914,10 +860,7 @@
     },
     "/entities/bulk": {
       "post": {
-        "tags": [
-          "Graph",
-          "Entity"
-        ],
+        "tags": ["Graph", "Entity"],
         "operationId": "create_entities",
         "parameters": [
           {
@@ -971,10 +914,7 @@
     },
     "/entities/diff": {
       "post": {
-        "tags": [
-          "Graph",
-          "Entity"
-        ],
+        "tags": ["Graph", "Entity"],
         "operationId": "diff_entity",
         "parameters": [
           {
@@ -1022,10 +962,7 @@
     },
     "/entities/embeddings": {
       "post": {
-        "tags": [
-          "Graph",
-          "Entity"
-        ],
+        "tags": ["Graph", "Entity"],
         "operationId": "update_entity_embeddings",
         "parameters": [
           {
@@ -1063,10 +1000,7 @@
     },
     "/entities/query": {
       "post": {
-        "tags": [
-          "Graph",
-          "Entity"
-        ],
+        "tags": ["Graph", "Entity"],
         "operationId": "get_entities",
         "parameters": [
           {
@@ -1132,10 +1066,7 @@
     },
     "/entities/query/count": {
       "post": {
-        "tags": [
-          "Graph",
-          "Entity"
-        ],
+        "tags": ["Graph", "Entity"],
         "operationId": "count_entities",
         "parameters": [
           {
@@ -1181,10 +1112,7 @@
     },
     "/entities/query/subgraph": {
       "post": {
-        "tags": [
-          "Graph",
-          "Entity"
-        ],
+        "tags": ["Graph", "Entity"],
         "operationId": "get_entity_subgraph",
         "parameters": [
           {
@@ -1250,10 +1178,7 @@
     },
     "/entities/relationships": {
       "post": {
-        "tags": [
-          "Graph",
-          "Entity"
-        ],
+        "tags": ["Graph", "Entity"],
         "operationId": "modify_entity_authorization_relationships",
         "parameters": [
           {
@@ -1291,10 +1216,7 @@
     },
     "/entities/validate": {
       "post": {
-        "tags": [
-          "Graph",
-          "Entity"
-        ],
+        "tags": ["Graph", "Entity"],
         "operationId": "validate_entity",
         "parameters": [
           {
@@ -1335,10 +1257,7 @@
     },
     "/entities/{entity_id}/administrators/{administrator}": {
       "post": {
-        "tags": [
-          "Graph",
-          "Entity"
-        ],
+        "tags": ["Graph", "Entity"],
         "operationId": "add_entity_administrator",
         "parameters": [
           {
@@ -1379,10 +1298,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Graph",
-          "Entity"
-        ],
+        "tags": ["Graph", "Entity"],
         "operationId": "remove_entity_administrator",
         "parameters": [
           {
@@ -1425,10 +1341,7 @@
     },
     "/entities/{entity_id}/editors/{editor}": {
       "post": {
-        "tags": [
-          "Graph",
-          "Entity"
-        ],
+        "tags": ["Graph", "Entity"],
         "operationId": "add_entity_editor",
         "parameters": [
           {
@@ -1469,10 +1382,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Graph",
-          "Entity"
-        ],
+        "tags": ["Graph", "Entity"],
         "operationId": "remove_entity_editor",
         "parameters": [
           {
@@ -1515,10 +1425,7 @@
     },
     "/entities/{entity_id}/permissions/{permission}": {
       "get": {
-        "tags": [
-          "Graph",
-          "Entity"
-        ],
+        "tags": ["Graph", "Entity"],
         "operationId": "check_entity_permission",
         "parameters": [
           {
@@ -1568,10 +1475,7 @@
     },
     "/entities/{entity_id}/relationships": {
       "get": {
-        "tags": [
-          "Graph",
-          "Entity"
-        ],
+        "tags": ["Graph", "Entity"],
         "operationId": "get_entity_authorization_relationships",
         "parameters": [
           {
@@ -1615,10 +1519,7 @@
     },
     "/entity-types": {
       "post": {
-        "tags": [
-          "Graph",
-          "EntityType"
-        ],
+        "tags": ["Graph", "EntityType"],
         "operationId": "create_entity_type",
         "parameters": [
           {
@@ -1685,10 +1586,7 @@
         }
       },
       "put": {
-        "tags": [
-          "Graph",
-          "EntityType"
-        ],
+        "tags": ["Graph", "EntityType"],
         "operationId": "update_entity_type",
         "parameters": [
           {
@@ -1757,10 +1655,7 @@
     },
     "/entity-types/archive": {
       "put": {
-        "tags": [
-          "Graph",
-          "EntityType"
-        ],
+        "tags": ["Graph", "EntityType"],
         "operationId": "archive_entity_type",
         "parameters": [
           {
@@ -1811,10 +1706,7 @@
     },
     "/entity-types/embeddings": {
       "post": {
-        "tags": [
-          "Graph",
-          "EntityType"
-        ],
+        "tags": ["Graph", "EntityType"],
         "operationId": "update_entity_type_embeddings",
         "parameters": [
           {
@@ -1852,10 +1744,7 @@
     },
     "/entity-types/load": {
       "post": {
-        "tags": [
-          "Graph",
-          "EntityType"
-        ],
+        "tags": ["Graph", "EntityType"],
         "operationId": "load_external_entity_type",
         "parameters": [
           {
@@ -1924,10 +1813,7 @@
     },
     "/entity-types/multi": {
       "post": {
-        "tags": [
-          "Graph",
-          "EntityType"
-        ],
+        "tags": ["Graph", "EntityType"],
         "operationId": "get_closed_multi_entity_types",
         "parameters": [
           {
@@ -1972,10 +1858,7 @@
     },
     "/entity-types/query": {
       "post": {
-        "tags": [
-          "Graph",
-          "EntityType"
-        ],
+        "tags": ["Graph", "EntityType"],
         "operationId": "get_entity_types",
         "parameters": [
           {
@@ -2020,10 +1903,7 @@
     },
     "/entity-types/query/subgraph": {
       "post": {
-        "tags": [
-          "Graph",
-          "EntityType"
-        ],
+        "tags": ["Graph", "EntityType"],
         "operationId": "get_entity_type_subgraph",
         "parameters": [
           {
@@ -2068,10 +1948,7 @@
     },
     "/entity-types/relationships": {
       "post": {
-        "tags": [
-          "Graph",
-          "EntityType"
-        ],
+        "tags": ["Graph", "EntityType"],
         "operationId": "modify_entity_type_authorization_relationships",
         "parameters": [
           {
@@ -2109,10 +1986,7 @@
     },
     "/entity-types/unarchive": {
       "put": {
-        "tags": [
-          "Graph",
-          "EntityType"
-        ],
+        "tags": ["Graph", "EntityType"],
         "operationId": "unarchive_entity_type",
         "parameters": [
           {
@@ -2163,10 +2037,7 @@
     },
     "/entity-types/{entity_type_id}/permissions/{permission}": {
       "get": {
-        "tags": [
-          "Graph",
-          "EntityType"
-        ],
+        "tags": ["Graph", "EntityType"],
         "operationId": "check_entity_type_permission",
         "parameters": [
           {
@@ -2216,10 +2087,7 @@
     },
     "/entity-types/{entity_type_id}/relationships": {
       "get": {
-        "tags": [
-          "Graph",
-          "EntityType"
-        ],
+        "tags": ["Graph", "EntityType"],
         "operationId": "get_entity_type_authorization_relationships",
         "parameters": [
           {
@@ -2263,10 +2131,7 @@
     },
     "/property-types": {
       "post": {
-        "tags": [
-          "Graph",
-          "PropertyType"
-        ],
+        "tags": ["Graph", "PropertyType"],
         "operationId": "create_property_type",
         "parameters": [
           {
@@ -2312,10 +2177,7 @@
         }
       },
       "put": {
-        "tags": [
-          "Graph",
-          "PropertyType"
-        ],
+        "tags": ["Graph", "PropertyType"],
         "operationId": "update_property_type",
         "parameters": [
           {
@@ -2384,10 +2246,7 @@
     },
     "/property-types/archive": {
       "put": {
-        "tags": [
-          "Graph",
-          "PropertyType"
-        ],
+        "tags": ["Graph", "PropertyType"],
         "operationId": "archive_property_type",
         "parameters": [
           {
@@ -2438,10 +2297,7 @@
     },
     "/property-types/embeddings": {
       "post": {
-        "tags": [
-          "Graph",
-          "PropertyType"
-        ],
+        "tags": ["Graph", "PropertyType"],
         "operationId": "update_property_type_embeddings",
         "parameters": [
           {
@@ -2479,10 +2335,7 @@
     },
     "/property-types/load": {
       "post": {
-        "tags": [
-          "Graph",
-          "PropertyType"
-        ],
+        "tags": ["Graph", "PropertyType"],
         "operationId": "load_external_property_type",
         "parameters": [
           {
@@ -2530,10 +2383,7 @@
     },
     "/property-types/query": {
       "post": {
-        "tags": [
-          "Graph",
-          "PropertyType"
-        ],
+        "tags": ["Graph", "PropertyType"],
         "operationId": "get_property_types",
         "parameters": [
           {
@@ -2578,10 +2428,7 @@
     },
     "/property-types/query/subgraph": {
       "post": {
-        "tags": [
-          "Graph",
-          "PropertyType"
-        ],
+        "tags": ["Graph", "PropertyType"],
         "operationId": "get_property_type_subgraph",
         "parameters": [
           {
@@ -2634,10 +2481,7 @@
     },
     "/property-types/relationships": {
       "post": {
-        "tags": [
-          "Graph",
-          "PropertyType"
-        ],
+        "tags": ["Graph", "PropertyType"],
         "operationId": "modify_property_type_authorization_relationships",
         "parameters": [
           {
@@ -2675,10 +2519,7 @@
     },
     "/property-types/unarchive": {
       "put": {
-        "tags": [
-          "Graph",
-          "PropertyType"
-        ],
+        "tags": ["Graph", "PropertyType"],
         "operationId": "unarchive_property_type",
         "parameters": [
           {
@@ -2729,10 +2570,7 @@
     },
     "/property-types/{property_type_id}/permissions/{permission}": {
       "get": {
-        "tags": [
-          "Graph",
-          "PropertyType"
-        ],
+        "tags": ["Graph", "PropertyType"],
         "operationId": "check_property_type_permission",
         "parameters": [
           {
@@ -2782,10 +2620,7 @@
     },
     "/property-types/{property_type_id}/relationships": {
       "get": {
-        "tags": [
-          "Graph",
-          "PropertyType"
-        ],
+        "tags": ["Graph", "PropertyType"],
         "operationId": "get_property_type_authorization_relationships",
         "parameters": [
           {
@@ -2829,10 +2664,7 @@
     },
     "/webs": {
       "post": {
-        "tags": [
-          "Graph",
-          "Web"
-        ],
+        "tags": ["Graph", "Web"],
         "operationId": "create_web",
         "parameters": [
           {
@@ -2867,10 +2699,7 @@
     },
     "/webs/relationships": {
       "post": {
-        "tags": [
-          "Graph",
-          "Web"
-        ],
+        "tags": ["Graph", "Web"],
         "operationId": "modify_web_authorization_relationships",
         "parameters": [
           {
@@ -2908,10 +2737,7 @@
     },
     "/webs/{web_id}/permissions/{permission}": {
       "get": {
-        "tags": [
-          "Graph",
-          "Web"
-        ],
+        "tags": ["Graph", "Web"],
         "operationId": "check_web_permission",
         "parameters": [
           {
@@ -2961,10 +2787,7 @@
     },
     "/webs/{web_id}/relationships": {
       "get": {
-        "tags": [
-          "Graph",
-          "Web"
-        ],
+        "tags": ["Graph", "Web"],
         "operationId": "get_web_authorization_relationships",
         "parameters": [
           {
@@ -3015,10 +2838,7 @@
       },
       "AccountGroupPermission": {
         "type": "string",
-        "enum": [
-          "add_member",
-          "remove_member"
-        ]
+        "enum": ["add_member", "remove_member"]
       },
       "AccountId": {
         "type": "string",
@@ -3026,17 +2846,11 @@
       },
       "ActorType": {
         "type": "string",
-        "enum": [
-          "human",
-          "ai",
-          "machine"
-        ]
+        "enum": ["human", "ai", "machine"]
       },
       "ArchiveDataTypeParams": {
         "type": "object",
-        "required": [
-          "dataTypeId"
-        ],
+        "required": ["dataTypeId"],
         "properties": {
           "dataTypeId": {
             "$ref": "#/components/schemas/VersionedUrl"
@@ -3046,9 +2860,7 @@
       },
       "ArchiveEntityTypeParams": {
         "type": "object",
-        "required": [
-          "entityTypeId"
-        ],
+        "required": ["entityTypeId"],
         "properties": {
           "entityTypeId": {
             "$ref": "#/components/schemas/VersionedUrl"
@@ -3058,9 +2870,7 @@
       },
       "ArchivePropertyTypeParams": {
         "type": "object",
-        "required": [
-          "propertyTypeId"
-        ],
+        "required": ["propertyTypeId"],
         "properties": {
           "propertyTypeId": {
             "$ref": "#/components/schemas/VersionedUrl"
@@ -3093,16 +2903,11 @@
           {
             "type": "object",
             "title": "InclusiveBound",
-            "required": [
-              "kind",
-              "limit"
-            ],
+            "required": ["kind", "limit"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "inclusive"
-                ]
+                "enum": ["inclusive"]
               },
               "limit": {
                 "$ref": "#/components/schemas/Timestamp"
@@ -3122,9 +2927,7 @@
       },
       "ConversionDefinition": {
         "type": "object",
-        "required": [
-          "expression"
-        ],
+        "required": ["expression"],
         "properties": {
           "expression": {
             "$ref": "#/components/schemas/ConversionExpression"
@@ -3154,10 +2957,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "const",
-              "type"
-            ],
+            "required": ["const", "type"],
             "properties": {
               "const": {
                 "type": "number",
@@ -3165,9 +2965,7 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "number"
-                ]
+                "enum": ["number"]
               }
             }
           },
@@ -3178,10 +2976,7 @@
       },
       "Conversions": {
         "type": "object",
-        "required": [
-          "from",
-          "to"
-        ],
+        "required": ["from", "to"],
         "properties": {
           "from": {
             "$ref": "#/components/schemas/ConversionDefinition"
@@ -3194,11 +2989,7 @@
       },
       "CountEntitiesParams": {
         "type": "object",
-        "required": [
-          "filter",
-          "temporalAxes",
-          "includeDrafts"
-        ],
+        "required": ["filter", "temporalAxes", "includeDrafts"],
         "properties": {
           "filter": {
             "$ref": "#/components/schemas/Filter"
@@ -3214,12 +3005,7 @@
       },
       "CreateDataTypeRequest": {
         "type": "object",
-        "required": [
-          "schema",
-          "ownedById",
-          "relationships",
-          "conversions"
-        ],
+        "required": ["schema", "ownedById", "relationships", "conversions"],
         "properties": {
           "conversions": {
             "type": "object",
@@ -3322,11 +3108,7 @@
       },
       "CreateEntityTypeRequest": {
         "type": "object",
-        "required": [
-          "schema",
-          "ownedById",
-          "relationships"
-        ],
+        "required": ["schema", "ownedById", "relationships"],
         "properties": {
           "ownedById": {
             "$ref": "#/components/schemas/OwnedById"
@@ -3358,11 +3140,7 @@
       },
       "CreatePropertyTypeRequest": {
         "type": "object",
-        "required": [
-          "schema",
-          "ownedById",
-          "relationships"
-        ],
+        "required": ["schema", "ownedById", "relationships"],
         "properties": {
           "ownedById": {
             "$ref": "#/components/schemas/OwnedById"
@@ -3464,16 +3242,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "web"
-                ]
+                "enum": ["web"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/OwnedById"
@@ -3487,10 +3260,7 @@
       },
       "DataTypePermission": {
         "type": "string",
-        "enum": [
-          "update",
-          "view"
-        ]
+        "enum": ["update", "view"]
       },
       "DataTypeQueryToken": {
         "type": "string",
@@ -3513,16 +3283,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "owner"
-                ]
+                "enum": ["owner"]
               },
               "subject": {
                 "$ref": "#/components/schemas/DataTypeOwnerSubject"
@@ -3531,16 +3296,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "viewer"
-                ]
+                "enum": ["viewer"]
               },
               "subject": {
                 "$ref": "#/components/schemas/DataTypeViewerSubject"
@@ -3554,10 +3314,7 @@
       },
       "DataTypeVertexId": {
         "type": "object",
-        "required": [
-          "baseId",
-          "revisionId"
-        ],
+        "required": ["baseId", "revisionId"],
         "properties": {
           "baseId": {
             "$ref": "#/components/schemas/BaseUrl"
@@ -3571,15 +3328,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "kind"
-            ],
+            "required": ["kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "public"
-                ]
+                "enum": ["public"]
               }
             }
           }
@@ -3587,10 +3340,7 @@
       },
       "DataTypeWithMetadata": {
         "type": "object",
-        "required": [
-          "schema",
-          "metadata"
-        ],
+        "required": ["schema", "metadata"],
         "properties": {
           "metadata": {
             "$ref": "#/components/schemas/DataTypeMetadata"
@@ -3603,9 +3353,7 @@
       "DecisionTime": {
         "type": "string",
         "description": "Time axis for the decision time.\n\nThis is used as the generic argument to time-related structs and can be used as tag value.",
-        "enum": [
-          "decisionTime"
-        ]
+        "enum": ["decisionTime"]
       },
       "DiffEntityParams": {
         "type": "object",
@@ -3682,10 +3430,7 @@
       },
       "EdgeResolveDepths": {
         "type": "object",
-        "required": [
-          "incoming",
-          "outgoing"
-        ],
+        "required": ["incoming", "outgoing"],
         "properties": {
           "incoming": {
             "type": "integer",
@@ -3737,10 +3482,7 @@
       "Entity": {
         "type": "object",
         "description": "A record of an [`Entity`] that has been persisted in the datastore, with its associated\nmetadata.",
-        "required": [
-          "properties",
-          "metadata"
-        ],
+        "required": ["properties", "metadata"],
         "properties": {
           "linkData": {
             "allOf": [
@@ -3761,16 +3503,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "account"
-                ]
+                "enum": ["account"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountId"
@@ -3779,17 +3516,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "subjectSet",
-              "kind"
-            ],
+            "required": ["subjectId", "subjectSet", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "accountGroup"
-                ]
+                "enum": ["accountGroup"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
@@ -3815,9 +3546,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "createdById"
-            ],
+            "required": ["createdById"],
             "properties": {
               "archivedById": {
                 "allOf": [
@@ -3837,16 +3566,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "account"
-                ]
+                "enum": ["account"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountId"
@@ -3855,17 +3579,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "subjectSet",
-              "kind"
-            ],
+            "required": ["subjectId", "subjectSet", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "accountGroup"
-                ]
+                "enum": ["accountGroup"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
@@ -3882,9 +3600,7 @@
       },
       "EntityEmbedding": {
         "type": "object",
-        "required": [
-          "embedding"
-        ],
+        "required": ["embedding"],
         "properties": {
           "embedding": {
             "$ref": "#/components/schemas/Embedding"
@@ -3904,10 +3620,7 @@
       },
       "EntityIdWithInterval": {
         "type": "object",
-        "required": [
-          "entityId",
-          "interval"
-        ],
+        "required": ["entityId", "interval"],
         "properties": {
           "entityId": {
             "$ref": "#/components/schemas/EntityId"
@@ -3963,16 +3676,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "web"
-                ]
+                "enum": ["web"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/OwnedById"
@@ -3986,11 +3694,7 @@
       },
       "EntityPermission": {
         "type": "string",
-        "enum": [
-          "full_access",
-          "update",
-          "view"
-        ]
+        "enum": ["full_access", "update", "view"]
       },
       "EntityProvenance": {
         "allOf": [
@@ -3999,9 +3703,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "edition"
-            ],
+            "required": ["edition"],
             "properties": {
               "edition": {
                 "$ref": "#/components/schemas/EntityEditionProvenance"
@@ -4034,11 +3736,7 @@
       },
       "EntityQuerySortingRecord": {
         "type": "object",
-        "required": [
-          "path",
-          "ordering",
-          "nulls"
-        ],
+        "required": ["path", "ordering", "nulls"],
         "properties": {
           "nulls": {
             "$ref": "#/components/schemas/NullOrdering"
@@ -4088,10 +3786,7 @@
       },
       "EntityRecordId": {
         "type": "object",
-        "required": [
-          "entityId",
-          "editionId"
-        ],
+        "required": ["entityId", "editionId"],
         "properties": {
           "editionId": {
             "$ref": "#/components/schemas/EntityEditionId"
@@ -4105,16 +3800,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "setting"
-                ]
+                "enum": ["setting"]
               },
               "subject": {
                 "$ref": "#/components/schemas/EntitySettingSubject"
@@ -4123,16 +3813,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "owner"
-                ]
+                "enum": ["owner"]
               },
               "subject": {
                 "$ref": "#/components/schemas/EntityOwnerSubject"
@@ -4141,16 +3826,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "administrator"
-                ]
+                "enum": ["administrator"]
               },
               "subject": {
                 "$ref": "#/components/schemas/EntityAdministratorSubject"
@@ -4159,16 +3839,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "editor"
-                ]
+                "enum": ["editor"]
               },
               "subject": {
                 "$ref": "#/components/schemas/EntityEditorSubject"
@@ -4177,16 +3852,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "viewer"
-                ]
+                "enum": ["viewer"]
               },
               "subject": {
                 "$ref": "#/components/schemas/EntityViewerSubject"
@@ -4200,26 +3870,17 @@
       },
       "EntitySetting": {
         "type": "string",
-        "enum": [
-          "administratorFromWeb",
-          "updateFromWeb",
-          "viewFromWeb"
-        ]
+        "enum": ["administratorFromWeb", "updateFromWeb", "viewFromWeb"]
       },
       "EntitySettingSubject": {
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "setting"
-                ]
+                "enum": ["setting"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/EntitySetting"
@@ -4233,17 +3894,11 @@
       },
       "EntitySubjectSet": {
         "type": "string",
-        "enum": [
-          "administrator",
-          "member"
-        ]
+        "enum": ["administrator", "member"]
       },
       "EntityTemporalMetadata": {
         "type": "object",
-        "required": [
-          "decisionTime",
-          "transactionTime"
-        ],
+        "required": ["decisionTime", "transactionTime"],
         "properties": {
           "decisionTime": {
             "$ref": "#/components/schemas/LeftClosedTemporalInterval"
@@ -4258,16 +3913,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "account"
-                ]
+                "enum": ["account"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountId"
@@ -4276,16 +3926,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "accountGroup"
-                ]
+                "enum": ["accountGroup"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
@@ -4299,10 +3944,7 @@
       },
       "EntityTypeEmbedding": {
         "type": "object",
-        "required": [
-          "entityTypeId",
-          "embedding"
-        ],
+        "required": ["entityTypeId", "embedding"],
         "properties": {
           "embedding": {
             "$ref": "#/components/schemas/Embedding"
@@ -4316,34 +3958,24 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "added",
-              "op"
-            ],
+            "required": ["added", "op"],
             "properties": {
               "added": {
                 "$ref": "#/components/schemas/VersionedUrl"
               },
               "op": {
                 "type": "string",
-                "enum": [
-                  "added"
-                ]
+                "enum": ["added"]
               }
             }
           },
           {
             "type": "object",
-            "required": [
-              "removed",
-              "op"
-            ],
+            "required": ["removed", "op"],
             "properties": {
               "op": {
                 "type": "string",
-                "enum": [
-                  "removed"
-                ]
+                "enum": ["removed"]
               },
               "removed": {
                 "$ref": "#/components/schemas/VersionedUrl"
@@ -4359,30 +3991,21 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "kind"
-            ],
+            "required": ["kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "public"
-                ]
+                "enum": ["public"]
               }
             }
           },
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "account"
-                ]
+                "enum": ["account"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountId"
@@ -4391,16 +4014,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "accountGroup"
-                ]
+                "enum": ["accountGroup"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
@@ -4468,16 +4086,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "web"
-                ]
+                "enum": ["web"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/OwnedById"
@@ -4491,11 +4104,7 @@
       },
       "EntityTypePermission": {
         "type": "string",
-        "enum": [
-          "update",
-          "view",
-          "instantiate"
-        ]
+        "enum": ["update", "view", "instantiate"]
       },
       "EntityTypeQueryToken": {
         "type": "string",
@@ -4522,16 +4131,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "owner"
-                ]
+                "enum": ["owner"]
               },
               "subject": {
                 "$ref": "#/components/schemas/EntityTypeOwnerSubject"
@@ -4540,16 +4144,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "setting"
-                ]
+                "enum": ["setting"]
               },
               "subject": {
                 "$ref": "#/components/schemas/EntityTypeSettingSubject"
@@ -4558,16 +4157,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "editor"
-                ]
+                "enum": ["editor"]
               },
               "subject": {
                 "$ref": "#/components/schemas/EntityTypeEditorSubject"
@@ -4576,16 +4170,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "viewer"
-                ]
+                "enum": ["viewer"]
               },
               "subject": {
                 "$ref": "#/components/schemas/EntityTypeViewerSubject"
@@ -4594,16 +4183,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "instantiator"
-                ]
+                "enum": ["instantiator"]
               },
               "subject": {
                 "$ref": "#/components/schemas/EntityTypeInstantiatorSubject"
@@ -4617,24 +4201,17 @@
       },
       "EntityTypeSetting": {
         "type": "string",
-        "enum": [
-          "updateFromWeb"
-        ]
+        "enum": ["updateFromWeb"]
       },
       "EntityTypeSettingSubject": {
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "setting"
-                ]
+                "enum": ["setting"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/EntityTypeSetting"
@@ -4648,10 +4225,7 @@
       },
       "EntityTypeVertexId": {
         "type": "object",
-        "required": [
-          "baseId",
-          "revisionId"
-        ],
+        "required": ["baseId", "revisionId"],
         "properties": {
           "baseId": {
             "$ref": "#/components/schemas/BaseUrl"
@@ -4665,15 +4239,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "kind"
-            ],
+            "required": ["kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "public"
-                ]
+                "enum": ["public"]
               }
             }
           }
@@ -4681,10 +4251,7 @@
       },
       "EntityTypeWithMetadata": {
         "type": "object",
-        "required": [
-          "schema",
-          "metadata"
-        ],
+        "required": ["schema", "metadata"],
         "properties": {
           "metadata": {
             "$ref": "#/components/schemas/EntityTypeMetadata"
@@ -4706,10 +4273,7 @@
       },
       "EntityVertexId": {
         "type": "object",
-        "required": [
-          "baseId",
-          "revisionId"
-        ],
+        "required": ["baseId", "revisionId"],
         "properties": {
           "baseId": {
             "$ref": "#/components/schemas/EntityId"
@@ -4723,30 +4287,21 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "kind"
-            ],
+            "required": ["kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "public"
-                ]
+                "enum": ["public"]
               }
             }
           },
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "account"
-                ]
+                "enum": ["account"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountId"
@@ -4755,17 +4310,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "subjectSet",
-              "kind"
-            ],
+            "required": ["subjectId", "subjectSet", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "accountGroup"
-                ]
+                "enum": ["accountGroup"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
@@ -4785,9 +4334,7 @@
           {
             "type": "object",
             "title": "AllFilter",
-            "required": [
-              "all"
-            ],
+            "required": ["all"],
             "properties": {
               "all": {
                 "type": "array",
@@ -4800,9 +4347,7 @@
           {
             "type": "object",
             "title": "AnyFilter",
-            "required": [
-              "any"
-            ],
+            "required": ["any"],
             "properties": {
               "any": {
                 "type": "array",
@@ -4815,9 +4360,7 @@
           {
             "type": "object",
             "title": "NotFilter",
-            "required": [
-              "not"
-            ],
+            "required": ["not"],
             "properties": {
               "not": {
                 "$ref": "#/components/schemas/Filter"
@@ -4827,9 +4370,7 @@
           {
             "type": "object",
             "title": "EqualFilter",
-            "required": [
-              "equal"
-            ],
+            "required": ["equal"],
             "properties": {
               "equal": {
                 "type": "array",
@@ -4844,9 +4385,7 @@
           {
             "type": "object",
             "title": "NotEqualFilter",
-            "required": [
-              "notEqual"
-            ],
+            "required": ["notEqual"],
             "properties": {
               "notEqual": {
                 "type": "array",
@@ -4861,9 +4400,7 @@
           {
             "type": "object",
             "title": "GreaterFilter",
-            "required": [
-              "notEqual"
-            ],
+            "required": ["notEqual"],
             "properties": {
               "greater": {
                 "type": "array",
@@ -4878,9 +4415,7 @@
           {
             "type": "object",
             "title": "GreaterOrEqualFilter",
-            "required": [
-              "notEqual"
-            ],
+            "required": ["notEqual"],
             "properties": {
               "greaterOrEqual": {
                 "type": "array",
@@ -4895,9 +4430,7 @@
           {
             "type": "object",
             "title": "LessFilter",
-            "required": [
-              "notEqual"
-            ],
+            "required": ["notEqual"],
             "properties": {
               "less": {
                 "type": "array",
@@ -4912,9 +4445,7 @@
           {
             "type": "object",
             "title": "LessOrEqualFilter",
-            "required": [
-              "notEqual"
-            ],
+            "required": ["notEqual"],
             "properties": {
               "lessOrEqual": {
                 "type": "array",
@@ -4929,9 +4460,7 @@
           {
             "type": "object",
             "title": "CosineDistanceFilter",
-            "required": [
-              "cosineDistance"
-            ],
+            "required": ["cosineDistance"],
             "properties": {
               "cosineDistance": {
                 "type": "array",
@@ -4946,9 +4475,7 @@
           {
             "type": "object",
             "title": "StartsWithFilter",
-            "required": [
-              "startsWith"
-            ],
+            "required": ["startsWith"],
             "properties": {
               "startsWith": {
                 "type": "array",
@@ -4963,9 +4490,7 @@
           {
             "type": "object",
             "title": "EndsWithFilter",
-            "required": [
-              "endsWith"
-            ],
+            "required": ["endsWith"],
             "properties": {
               "endsWith": {
                 "type": "array",
@@ -4980,9 +4505,7 @@
           {
             "type": "object",
             "title": "ContainsSegmentFilter",
-            "required": [
-              "containsSegment"
-            ],
+            "required": ["containsSegment"],
             "properties": {
               "containsSegment": {
                 "type": "array",
@@ -5001,9 +4524,7 @@
           {
             "type": "object",
             "title": "PathExpression",
-            "required": [
-              "path"
-            ],
+            "required": ["path"],
             "properties": {
               "path": {
                 "type": "array",
@@ -5038,16 +4559,11 @@
           {
             "type": "object",
             "title": "ParameterExpression",
-            "required": [
-              "parameter"
-            ],
+            "required": ["parameter"],
             "properties": {
               "convert": {
                 "type": "object",
-                "required": [
-                  "from",
-                  "to"
-                ],
+                "required": ["from", "to"],
                 "properties": {
                   "from": {
                     "$ref": "#/components/schemas/VersionedUrl"
@@ -5064,11 +4580,7 @@
       },
       "GetClosedMultiEntityTypeParams": {
         "type": "object",
-        "required": [
-          "entityTypeIds",
-          "temporalAxes",
-          "includeDrafts"
-        ],
+        "required": ["entityTypeIds", "temporalAxes", "includeDrafts"],
         "properties": {
           "entityTypeIds": {
             "type": "array",
@@ -5087,9 +4599,7 @@
       },
       "GetClosedMultiEntityTypeResponse": {
         "type": "object",
-        "required": [
-          "entityType"
-        ],
+        "required": ["entityType"],
         "properties": {
           "entityType": {
             "$ref": "./models/closed_multi_entity_type.json"
@@ -5138,9 +4648,7 @@
       },
       "GetDataTypeSubgraphResponse": {
         "type": "object",
-        "required": [
-          "subgraph"
-        ],
+        "required": ["subgraph"],
         "properties": {
           "cursor": {
             "allOf": [
@@ -5157,11 +4665,7 @@
       },
       "GetDataTypesParams": {
         "type": "object",
-        "required": [
-          "filter",
-          "temporalAxes",
-          "includeDrafts"
-        ],
+        "required": ["filter", "temporalAxes", "includeDrafts"],
         "properties": {
           "after": {
             "allOf": [
@@ -5193,9 +4697,7 @@
       },
       "GetDataTypesResponse": {
         "type": "object",
-        "required": [
-          "dataTypes"
-        ],
+        "required": ["dataTypes"],
         "properties": {
           "count": {
             "type": "integer",
@@ -5220,11 +4722,7 @@
       },
       "GetEntitiesRequest": {
         "type": "object",
-        "required": [
-          "filter",
-          "temporalAxes",
-          "includeDrafts"
-        ],
+        "required": ["filter", "temporalAxes", "includeDrafts"],
         "properties": {
           "conversions": {
             "type": "array",
@@ -5281,9 +4779,7 @@
       },
       "GetEntitiesResponse": {
         "type": "object",
-        "required": [
-          "entities"
-        ],
+        "required": ["entities"],
         "properties": {
           "count": {
             "type": "integer",
@@ -5401,9 +4897,7 @@
       },
       "GetEntitySubgraphResponse": {
         "type": "object",
-        "required": [
-          "subgraph"
-        ],
+        "required": ["subgraph"],
         "properties": {
           "count": {
             "type": "integer",
@@ -5499,9 +4993,7 @@
       },
       "GetEntityTypeSubgraphResponse": {
         "type": "object",
-        "required": [
-          "subgraph"
-        ],
+        "required": ["subgraph"],
         "properties": {
           "count": {
             "type": "integer",
@@ -5537,11 +5029,7 @@
       },
       "GetEntityTypesParams": {
         "type": "object",
-        "required": [
-          "filter",
-          "temporalAxes",
-          "includeDrafts"
-        ],
+        "required": ["filter", "temporalAxes", "includeDrafts"],
         "properties": {
           "after": {
             "allOf": [
@@ -5582,9 +5070,7 @@
       },
       "GetEntityTypesResponse": {
         "type": "object",
-        "required": [
-          "entityTypes"
-        ],
+        "required": ["entityTypes"],
         "properties": {
           "closedEntityTypes": {
             "type": "array",
@@ -5669,9 +5155,7 @@
       },
       "GetPropertyTypeSubgraphResponse": {
         "type": "object",
-        "required": [
-          "subgraph"
-        ],
+        "required": ["subgraph"],
         "properties": {
           "cursor": {
             "allOf": [
@@ -5688,11 +5172,7 @@
       },
       "GetPropertyTypesParams": {
         "type": "object",
-        "required": [
-          "filter",
-          "temporalAxes",
-          "includeDrafts"
-        ],
+        "required": ["filter", "temporalAxes", "includeDrafts"],
         "properties": {
           "after": {
             "allOf": [
@@ -5724,9 +5204,7 @@
       },
       "GetPropertyTypesResponse": {
         "type": "object",
-        "required": [
-          "propertyTypes"
-        ],
+        "required": ["propertyTypes"],
         "properties": {
           "count": {
             "type": "integer",
@@ -5859,10 +5337,7 @@
       },
       "InsertWebIdParams": {
         "type": "object",
-        "required": [
-          "ownedById",
-          "owner"
-        ],
+        "required": ["ownedById", "owner"],
         "properties": {
           "ownedById": {
             "$ref": "#/components/schemas/OwnedById"
@@ -5875,21 +5350,14 @@
       },
       "KnowledgeGraphEdgeKind": {
         "type": "string",
-        "enum": [
-          "HAS_LEFT_ENTITY",
-          "HAS_RIGHT_ENTITY"
-        ]
+        "enum": ["HAS_LEFT_ENTITY", "HAS_RIGHT_ENTITY"]
       },
       "KnowledgeGraphOutwardEdge": {
         "oneOf": [
           {
             "type": "object",
             "title": "KnowledgeGraphToKnowledgeGraphOutwardEdge",
-            "required": [
-              "kind",
-              "reversed",
-              "rightEndpoint"
-            ],
+            "required": ["kind", "reversed", "rightEndpoint"],
             "properties": {
               "kind": {
                 "$ref": "#/components/schemas/KnowledgeGraphEdgeKind"
@@ -5905,11 +5373,7 @@
           {
             "type": "object",
             "title": "KnowledgeGraphToOntologyOutwardEdge",
-            "required": [
-              "kind",
-              "reversed",
-              "rightEndpoint"
-            ],
+            "required": ["kind", "reversed", "rightEndpoint"],
             "properties": {
               "kind": {
                 "$ref": "#/components/schemas/SharedEdgeKind"
@@ -5929,19 +5393,14 @@
           {
             "type": "object",
             "title": "EntityVertex",
-            "required": [
-              "kind",
-              "inner"
-            ],
+            "required": ["kind", "inner"],
             "properties": {
               "inner": {
                 "$ref": "#/components/schemas/Entity"
               },
               "kind": {
                 "type": "string",
-                "enum": [
-                  "entity"
-                ]
+                "enum": ["entity"]
               }
             }
           }
@@ -5961,10 +5420,7 @@
       },
       "LeftClosedTemporalInterval": {
         "type": "object",
-        "required": [
-          "start",
-          "end"
-        ],
+        "required": ["start", "end"],
         "properties": {
           "end": {
             "$ref": "#/components/schemas/OpenTemporalBound"
@@ -5979,16 +5435,11 @@
           {
             "type": "object",
             "title": "InclusiveBound",
-            "required": [
-              "kind",
-              "limit"
-            ],
+            "required": ["kind", "limit"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "inclusive"
-                ]
+                "enum": ["inclusive"]
               },
               "limit": {
                 "$ref": "#/components/schemas/Timestamp"
@@ -5998,16 +5449,11 @@
           {
             "type": "object",
             "title": "ExclusiveBound",
-            "required": [
-              "kind",
-              "limit"
-            ],
+            "required": ["kind", "limit"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "exclusive"
-                ]
+                "enum": ["exclusive"]
               },
               "limit": {
                 "$ref": "#/components/schemas/Timestamp"
@@ -6022,10 +5468,7 @@
       "LinkData": {
         "type": "object",
         "description": "The associated information for 'Link' entities",
-        "required": [
-          "leftEntityId",
-          "rightEntityId"
-        ],
+        "required": ["leftEntityId", "rightEntityId"],
         "properties": {
           "leftEntityConfidence": {
             "allOf": [
@@ -6060,9 +5503,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "dataTypeId"
-            ],
+            "required": ["dataTypeId"],
             "properties": {
               "dataTypeId": {
                 "$ref": "#/components/schemas/VersionedUrl"
@@ -6071,11 +5512,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "schema",
-              "relationships",
-              "conversions"
-            ],
+            "required": ["schema", "relationships", "conversions"],
             "properties": {
               "conversions": {
                 "type": "object",
@@ -6103,9 +5540,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "entityTypeId"
-            ],
+            "required": ["entityTypeId"],
             "properties": {
               "entityTypeId": {
                 "$ref": "#/components/schemas/VersionedUrl"
@@ -6114,10 +5549,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "schema",
-              "relationships"
-            ],
+            "required": ["schema", "relationships"],
             "properties": {
               "provenance": {
                 "$ref": "#/components/schemas/ProvidedOntologyEditionProvenance"
@@ -6139,9 +5571,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "propertyTypeId"
-            ],
+            "required": ["propertyTypeId"],
             "properties": {
               "propertyTypeId": {
                 "$ref": "#/components/schemas/VersionedUrl"
@@ -6150,10 +5580,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "schema",
-              "relationships"
-            ],
+            "required": ["schema", "relationships"],
             "properties": {
               "provenance": {
                 "$ref": "#/components/schemas/ProvidedOntologyEditionProvenance"
@@ -6232,11 +5659,7 @@
       },
       "ModifyDataTypeAuthorizationRelationship": {
         "type": "object",
-        "required": [
-          "operation",
-          "resource",
-          "relationAndSubject"
-        ],
+        "required": ["operation", "resource", "relationAndSubject"],
         "properties": {
           "operation": {
             "$ref": "#/components/schemas/ModifyRelationshipOperation"
@@ -6251,11 +5674,7 @@
       },
       "ModifyEntityAuthorizationRelationship": {
         "type": "object",
-        "required": [
-          "operation",
-          "resource",
-          "relationSubject"
-        ],
+        "required": ["operation", "resource", "relationSubject"],
         "properties": {
           "operation": {
             "$ref": "#/components/schemas/ModifyRelationshipOperation"
@@ -6270,11 +5689,7 @@
       },
       "ModifyEntityTypeAuthorizationRelationship": {
         "type": "object",
-        "required": [
-          "operation",
-          "resource",
-          "relationAndSubject"
-        ],
+        "required": ["operation", "resource", "relationAndSubject"],
         "properties": {
           "operation": {
             "$ref": "#/components/schemas/ModifyRelationshipOperation"
@@ -6289,11 +5704,7 @@
       },
       "ModifyPropertyTypeAuthorizationRelationship": {
         "type": "object",
-        "required": [
-          "operation",
-          "resource",
-          "relationAndSubject"
-        ],
+        "required": ["operation", "resource", "relationAndSubject"],
         "properties": {
           "operation": {
             "$ref": "#/components/schemas/ModifyRelationshipOperation"
@@ -6309,19 +5720,11 @@
       "ModifyRelationshipOperation": {
         "type": "string",
         "description": "Used for mutating a single relationship within the service.",
-        "enum": [
-          "touch",
-          "create",
-          "delete"
-        ]
+        "enum": ["touch", "create", "delete"]
       },
       "ModifyWebAuthorizationRelationship": {
         "type": "object",
-        "required": [
-          "operation",
-          "resource",
-          "relationAndSubject"
-        ],
+        "required": ["operation", "resource", "relationAndSubject"],
         "properties": {
           "operation": {
             "$ref": "#/components/schemas/ModifyRelationshipOperation"
@@ -6336,10 +5739,7 @@
       },
       "NullOrdering": {
         "type": "string",
-        "enum": [
-          "first",
-          "last"
-        ]
+        "enum": ["first", "last"]
       },
       "NullableTimestamp": {
         "type": "string",
@@ -6379,9 +5779,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "createdById"
-            ],
+            "required": ["createdById"],
             "properties": {
               "archivedById": {
                 "allOf": [
@@ -6402,11 +5800,7 @@
           {
             "type": "object",
             "title": "OntologyToOntologyOutwardEdge",
-            "required": [
-              "kind",
-              "reversed",
-              "rightEndpoint"
-            ],
+            "required": ["kind", "reversed", "rightEndpoint"],
             "properties": {
               "kind": {
                 "$ref": "#/components/schemas/OntologyEdgeKind"
@@ -6422,11 +5816,7 @@
           {
             "type": "object",
             "title": "OntologyToKnowledgeGraphOutwardEdge",
-            "required": [
-              "kind",
-              "reversed",
-              "rightEndpoint"
-            ],
+            "required": ["kind", "reversed", "rightEndpoint"],
             "properties": {
               "kind": {
                 "$ref": "#/components/schemas/SharedEdgeKind"
@@ -6443,9 +5833,7 @@
       },
       "OntologyProvenance": {
         "type": "object",
-        "required": [
-          "edition"
-        ],
+        "required": ["edition"],
         "properties": {
           "edition": {
             "$ref": "#/components/schemas/OntologyEditionProvenance"
@@ -6455,9 +5843,7 @@
       },
       "OntologyTemporalMetadata": {
         "type": "object",
-        "required": [
-          "transactionTime"
-        ],
+        "required": ["transactionTime"],
         "properties": {
           "transactionTime": {
             "$ref": "#/components/schemas/LeftClosedTemporalInterval"
@@ -6467,10 +5853,7 @@
       },
       "OntologyTypeRecordId": {
         "type": "object",
-        "required": [
-          "baseUrl",
-          "version"
-        ],
+        "required": ["baseUrl", "version"],
         "properties": {
           "baseUrl": {
             "type": "string"
@@ -6505,57 +5888,42 @@
           {
             "type": "object",
             "title": "DataTypeVertex",
-            "required": [
-              "kind",
-              "inner"
-            ],
+            "required": ["kind", "inner"],
             "properties": {
               "inner": {
                 "$ref": "#/components/schemas/DataTypeWithMetadata"
               },
               "kind": {
                 "type": "string",
-                "enum": [
-                  "dataType"
-                ]
+                "enum": ["dataType"]
               }
             }
           },
           {
             "type": "object",
             "title": "PropertyTypeVertex",
-            "required": [
-              "kind",
-              "inner"
-            ],
+            "required": ["kind", "inner"],
             "properties": {
               "inner": {
                 "$ref": "#/components/schemas/PropertyTypeWithMetadata"
               },
               "kind": {
                 "type": "string",
-                "enum": [
-                  "propertyType"
-                ]
+                "enum": ["propertyType"]
               }
             }
           },
           {
             "type": "object",
             "title": "EntityTypeVertex",
-            "required": [
-              "kind",
-              "inner"
-            ],
+            "required": ["kind", "inner"],
             "properties": {
               "inner": {
                 "$ref": "#/components/schemas/EntityTypeWithMetadata"
               },
               "kind": {
                 "type": "string",
-                "enum": [
-                  "entityType"
-                ]
+                "enum": ["entityType"]
               }
             }
           }
@@ -6578,16 +5946,11 @@
           {
             "type": "object",
             "title": "ExclusiveBound",
-            "required": [
-              "kind",
-              "limit"
-            ],
+            "required": ["kind", "limit"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "exclusive"
-                ]
+                "enum": ["exclusive"]
               },
               "limit": {
                 "$ref": "#/components/schemas/Timestamp"
@@ -6597,15 +5960,11 @@
           {
             "type": "object",
             "title": "UnboundedBound",
-            "required": [
-              "kind"
-            ],
+            "required": ["kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "unbounded"
-                ]
+                "enum": ["unbounded"]
               }
             }
           }
@@ -6616,27 +5975,17 @@
       },
       "Operator": {
         "type": "string",
-        "enum": [
-          "+",
-          "-",
-          "*",
-          "/"
-        ]
+        "enum": ["+", "-", "*", "/"]
       },
       "Ordering": {
         "type": "string",
-        "enum": [
-          "ascending",
-          "descending"
-        ]
+        "enum": ["ascending", "descending"]
       },
       "OriginProvenance": {
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "apiKeyPublicId": {
                 "type": "string"
@@ -6658,9 +6007,7 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "web-app"
-                ]
+                "enum": ["web-app"]
               },
               "userAgent": {
                 "type": "string"
@@ -6673,9 +6020,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "apiKeyPublicId": {
                 "type": "string"
@@ -6697,9 +6042,7 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "mobile-app"
-                ]
+                "enum": ["mobile-app"]
               },
               "userAgent": {
                 "type": "string"
@@ -6712,9 +6055,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "apiKeyPublicId": {
                 "type": "string"
@@ -6736,9 +6077,7 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "browser-extension"
-                ]
+                "enum": ["browser-extension"]
               },
               "userAgent": {
                 "type": "string"
@@ -6751,9 +6090,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "apiKeyPublicId": {
                 "type": "string"
@@ -6775,9 +6112,7 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "api"
-                ]
+                "enum": ["api"]
               },
               "userAgent": {
                 "type": "string"
@@ -6790,9 +6125,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "apiKeyPublicId": {
                 "type": "string"
@@ -6820,9 +6153,7 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "flow"
-                ]
+                "enum": ["flow"]
               },
               "userAgent": {
                 "type": "string"
@@ -6835,9 +6166,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "apiKeyPublicId": {
                 "type": "string"
@@ -6859,9 +6188,7 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "migration"
-                ]
+                "enum": ["migration"]
               },
               "userAgent": {
                 "type": "string"
@@ -6876,9 +6203,7 @@
       },
       "OutgoingEdgeResolveDepth": {
         "type": "object",
-        "required": [
-          "outgoing"
-        ],
+        "required": ["outgoing"],
         "properties": {
           "outgoing": {
             "type": "integer",
@@ -6894,9 +6219,7 @@
       },
       "PatchEntityParams": {
         "type": "object",
-        "required": [
-          "entityId"
-        ],
+        "required": ["entityId"],
         "properties": {
           "archived": {
             "type": "boolean"
@@ -6941,9 +6264,7 @@
       },
       "PermissionResponse": {
         "type": "object",
-        "required": [
-          "has_permission"
-        ],
+        "required": ["has_permission"],
         "properties": {
           "has_permission": {
             "type": "boolean"
@@ -6968,20 +6289,14 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "path",
-              "added",
-              "op"
-            ],
+            "required": ["path", "added", "op"],
             "properties": {
               "added": {
                 "$ref": "#/components/schemas/Property"
               },
               "op": {
                 "type": "string",
-                "enum": [
-                  "added"
-                ]
+                "enum": ["added"]
               },
               "path": {
                 "$ref": "#/components/schemas/PropertyPath"
@@ -6990,17 +6305,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "path",
-              "removed",
-              "op"
-            ],
+            "required": ["path", "removed", "op"],
             "properties": {
               "op": {
                 "type": "string",
-                "enum": [
-                  "removed"
-                ]
+                "enum": ["removed"]
               },
               "path": {
                 "$ref": "#/components/schemas/PropertyPath"
@@ -7012,12 +6321,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "path",
-              "old",
-              "new",
-              "op"
-            ],
+            "required": ["path", "old", "new", "op"],
             "properties": {
               "new": {
                 "$ref": "#/components/schemas/Property"
@@ -7027,9 +6331,7 @@
               },
               "op": {
                 "type": "string",
-                "enum": [
-                  "changed"
-                ]
+                "enum": ["changed"]
               },
               "path": {
                 "$ref": "#/components/schemas/PropertyPath"
@@ -7076,9 +6378,7 @@
           {
             "type": "object",
             "title": "PropertyMetadataValue",
-            "required": [
-              "metadata"
-            ],
+            "required": ["metadata"],
             "properties": {
               "metadata": {
                 "$ref": "#/components/schemas/ValueMetadata"
@@ -7112,17 +6412,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "path",
-              "property",
-              "op"
-            ],
+            "required": ["path", "property", "op"],
             "properties": {
               "op": {
                 "type": "string",
-                "enum": [
-                  "add"
-                ]
+                "enum": ["add"]
               },
               "path": {
                 "$ref": "#/components/schemas/PropertyPath"
@@ -7134,16 +6428,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "path",
-              "op"
-            ],
+            "required": ["path", "op"],
             "properties": {
               "op": {
                 "type": "string",
-                "enum": [
-                  "remove"
-                ]
+                "enum": ["remove"]
               },
               "path": {
                 "$ref": "#/components/schemas/PropertyPath"
@@ -7152,17 +6441,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "path",
-              "property",
-              "op"
-            ],
+            "required": ["path", "property", "op"],
             "properties": {
               "op": {
                 "type": "string",
-                "enum": [
-                  "replace"
-                ]
+                "enum": ["replace"]
               },
               "path": {
                 "$ref": "#/components/schemas/PropertyPath"
@@ -7210,16 +6493,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "account"
-                ]
+                "enum": ["account"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountId"
@@ -7228,16 +6506,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "accountGroup"
-                ]
+                "enum": ["accountGroup"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
@@ -7251,10 +6524,7 @@
       },
       "PropertyTypeEmbedding": {
         "type": "object",
-        "required": [
-          "propertyTypeId",
-          "embedding"
-        ],
+        "required": ["propertyTypeId", "embedding"],
         "properties": {
           "embedding": {
             "$ref": "#/components/schemas/Embedding"
@@ -7320,16 +6590,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "web"
-                ]
+                "enum": ["web"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/OwnedById"
@@ -7343,10 +6608,7 @@
       },
       "PropertyTypePermission": {
         "type": "string",
-        "enum": [
-          "update",
-          "view"
-        ]
+        "enum": ["update", "view"]
       },
       "PropertyTypeQueryToken": {
         "type": "string",
@@ -7368,16 +6630,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "owner"
-                ]
+                "enum": ["owner"]
               },
               "subject": {
                 "$ref": "#/components/schemas/PropertyTypeOwnerSubject"
@@ -7386,16 +6643,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "setting"
-                ]
+                "enum": ["setting"]
               },
               "subject": {
                 "$ref": "#/components/schemas/PropertyTypeSettingSubject"
@@ -7404,16 +6656,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "editor"
-                ]
+                "enum": ["editor"]
               },
               "subject": {
                 "$ref": "#/components/schemas/PropertyTypeEditorSubject"
@@ -7422,16 +6669,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "viewer"
-                ]
+                "enum": ["viewer"]
               },
               "subject": {
                 "$ref": "#/components/schemas/PropertyTypeViewerSubject"
@@ -7445,24 +6687,17 @@
       },
       "PropertyTypeSetting": {
         "type": "string",
-        "enum": [
-          "updateFromWeb"
-        ]
+        "enum": ["updateFromWeb"]
       },
       "PropertyTypeSettingSubject": {
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "setting"
-                ]
+                "enum": ["setting"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/PropertyTypeSetting"
@@ -7476,10 +6711,7 @@
       },
       "PropertyTypeVertexId": {
         "type": "object",
-        "required": [
-          "baseId",
-          "revisionId"
-        ],
+        "required": ["baseId", "revisionId"],
         "properties": {
           "baseId": {
             "$ref": "#/components/schemas/BaseUrl"
@@ -7493,15 +6725,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "kind"
-            ],
+            "required": ["kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "public"
-                ]
+                "enum": ["public"]
               }
             }
           }
@@ -7509,10 +6737,7 @@
       },
       "PropertyTypeWithMetadata": {
         "type": "object",
-        "required": [
-          "schema",
-          "metadata"
-        ],
+        "required": ["schema", "metadata"],
         "properties": {
           "metadata": {
             "$ref": "#/components/schemas/PropertyTypeMetadata"
@@ -7567,10 +6792,7 @@
       },
       "PropertyWithMetadataValue": {
         "type": "object",
-        "required": [
-          "value",
-          "metadata"
-        ],
+        "required": ["value", "metadata"],
         "properties": {
           "metadata": {
             "$ref": "#/components/schemas/ValueMetadata"
@@ -7633,10 +6855,7 @@
       },
       "QueryConversion": {
         "type": "object",
-        "required": [
-          "path",
-          "dataTypeId"
-        ],
+        "required": ["path", "dataTypeId"],
         "properties": {
           "dataTypeId": {
             "$ref": "#/components/schemas/VersionedUrl"
@@ -7652,18 +6871,12 @@
           {
             "type": "object",
             "title": "QueryTemporalAxesDecisionTime",
-            "required": [
-              "pinned",
-              "variable"
-            ],
+            "required": ["pinned", "variable"],
             "properties": {
               "pinned": {
                 "type": "object",
                 "title": "PinnedTransactionAxis",
-                "required": [
-                  "axis",
-                  "timestamp"
-                ],
+                "required": ["axis", "timestamp"],
                 "properties": {
                   "axis": {
                     "$ref": "#/components/schemas/TransactionTime"
@@ -7677,10 +6890,7 @@
               "variable": {
                 "type": "object",
                 "title": "VariableDecisionAxis",
-                "required": [
-                  "axis",
-                  "interval"
-                ],
+                "required": ["axis", "interval"],
                 "properties": {
                   "axis": {
                     "$ref": "#/components/schemas/DecisionTime"
@@ -7695,18 +6905,12 @@
           {
             "type": "object",
             "title": "QueryTemporalAxesTransactionTime",
-            "required": [
-              "pinned",
-              "variable"
-            ],
+            "required": ["pinned", "variable"],
             "properties": {
               "pinned": {
                 "type": "object",
                 "title": "PinnedDecisionAxis",
-                "required": [
-                  "axis",
-                  "timestamp"
-                ],
+                "required": ["axis", "timestamp"],
                 "properties": {
                   "axis": {
                     "$ref": "#/components/schemas/DecisionTime"
@@ -7720,10 +6924,7 @@
               "variable": {
                 "type": "object",
                 "title": "VariableTransactionAxis",
-                "required": [
-                  "axis",
-                  "interval"
-                ],
+                "required": ["axis", "interval"],
                 "properties": {
                   "axis": {
                     "$ref": "#/components/schemas/TransactionTime"
@@ -7743,18 +6944,12 @@
           {
             "type": "object",
             "title": "QueryTemporalAxesUnresolvedDecisionTime",
-            "required": [
-              "pinned",
-              "variable"
-            ],
+            "required": ["pinned", "variable"],
             "properties": {
               "pinned": {
                 "type": "object",
                 "title": "UnresolvedPinnedTransactionAxis",
-                "required": [
-                  "axis",
-                  "timestamp"
-                ],
+                "required": ["axis", "timestamp"],
                 "properties": {
                   "axis": {
                     "$ref": "#/components/schemas/TransactionTime"
@@ -7767,10 +6962,7 @@
               "variable": {
                 "type": "object",
                 "title": "UnresolvedVariableDecisionAxis",
-                "required": [
-                  "axis",
-                  "interval"
-                ],
+                "required": ["axis", "interval"],
                 "properties": {
                   "axis": {
                     "$ref": "#/components/schemas/DecisionTime"
@@ -7785,18 +6977,12 @@
           {
             "type": "object",
             "title": "QueryTemporalAxesUnresolvedTransactionTime",
-            "required": [
-              "pinned",
-              "variable"
-            ],
+            "required": ["pinned", "variable"],
             "properties": {
               "pinned": {
                 "type": "object",
                 "title": "UnresolvedPinnedDecisionAxis",
-                "required": [
-                  "axis",
-                  "timestamp"
-                ],
+                "required": ["axis", "timestamp"],
                 "properties": {
                   "axis": {
                     "$ref": "#/components/schemas/DecisionTime"
@@ -7809,10 +6995,7 @@
               "variable": {
                 "type": "object",
                 "title": "UnresolvedVariableTransactionAxis",
-                "required": [
-                  "axis",
-                  "interval"
-                ],
+                "required": ["axis", "interval"],
                 "properties": {
                   "axis": {
                     "$ref": "#/components/schemas/TransactionTime"
@@ -7829,10 +7012,7 @@
       },
       "RightBoundedTemporalInterval": {
         "type": "object",
-        "required": [
-          "start",
-          "end"
-        ],
+        "required": ["start", "end"],
         "properties": {
           "end": {
             "$ref": "#/components/schemas/LimitedTemporalBound"
@@ -7844,22 +7024,16 @@
       },
       "Selector": {
         "type": "string",
-        "enum": [
-          "*"
-        ]
+        "enum": ["*"]
       },
       "SharedEdgeKind": {
         "type": "string",
-        "enum": [
-          "IS_OF_TYPE"
-        ]
+        "enum": ["IS_OF_TYPE"]
       },
       "SourceProvenance": {
         "type": "object",
         "description": "The source material used in producing a value.",
-        "required": [
-          "type"
-        ],
+        "required": ["type"],
         "properties": {
           "authors": {
             "type": "array",
@@ -7912,20 +7086,11 @@
       "SourceType": {
         "type": "string",
         "description": "The type of source material which was used to produce a value.",
-        "enum": [
-          "webpage",
-          "document"
-        ]
+        "enum": ["webpage", "document"]
       },
       "Subgraph": {
         "type": "object",
-        "required": [
-          "roots",
-          "vertices",
-          "edges",
-          "depths",
-          "temporalAxes"
-        ],
+        "required": ["roots", "vertices", "edges", "depths", "temporalAxes"],
         "properties": {
           "depths": {
             "$ref": "#/components/schemas/GraphResolveDepths"
@@ -7949,10 +7114,7 @@
       },
       "SubgraphTemporalAxes": {
         "type": "object",
-        "required": [
-          "initial",
-          "resolved"
-        ],
+        "required": ["initial", "resolved"],
         "properties": {
           "initial": {
             "$ref": "#/components/schemas/QueryTemporalAxesUnresolved"
@@ -7967,31 +7129,22 @@
           {
             "type": "object",
             "title": "UnboundedBound",
-            "required": [
-              "kind"
-            ],
+            "required": ["kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "unbounded"
-                ]
+                "enum": ["unbounded"]
               }
             }
           },
           {
             "type": "object",
             "title": "InclusiveBound",
-            "required": [
-              "kind",
-              "limit"
-            ],
+            "required": ["kind", "limit"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "inclusive"
-                ]
+                "enum": ["inclusive"]
               },
               "limit": {
                 "$ref": "#/components/schemas/Timestamp"
@@ -8001,16 +7154,11 @@
           {
             "type": "object",
             "title": "ExclusiveBound",
-            "required": [
-              "kind",
-              "limit"
-            ],
+            "required": ["kind", "limit"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "exclusive"
-                ]
+                "enum": ["exclusive"]
               },
               "limit": {
                 "$ref": "#/components/schemas/Timestamp"
@@ -8029,15 +7177,11 @@
       "TransactionTime": {
         "type": "string",
         "description": "Time axis for the transaction time.\n\nThis is used as the generic argument to time-related structs and can be used as tag value.",
-        "enum": [
-          "transactionTime"
-        ]
+        "enum": ["transactionTime"]
       },
       "UnarchiveDataTypeParams": {
         "type": "object",
-        "required": [
-          "dataTypeId"
-        ],
+        "required": ["dataTypeId"],
         "properties": {
           "dataTypeId": {
             "$ref": "#/components/schemas/VersionedUrl"
@@ -8050,9 +7194,7 @@
       },
       "UnarchiveEntityTypeParams": {
         "type": "object",
-        "required": [
-          "entityTypeId"
-        ],
+        "required": ["entityTypeId"],
         "properties": {
           "entityTypeId": {
             "$ref": "#/components/schemas/VersionedUrl"
@@ -8065,9 +7207,7 @@
       },
       "UnarchivePropertyTypeParams": {
         "type": "object",
-        "required": [
-          "propertyTypeId"
-        ],
+        "required": ["propertyTypeId"],
         "properties": {
           "propertyTypeId": {
             "$ref": "#/components/schemas/VersionedUrl"
@@ -8080,10 +7220,7 @@
       },
       "UnresolvedRightBoundedTemporalInterval": {
         "type": "object",
-        "required": [
-          "start",
-          "end"
-        ],
+        "required": ["start", "end"],
         "properties": {
           "end": {
             "oneOf": [
@@ -8129,12 +7266,7 @@
       },
       "UpdateDataTypeRequest": {
         "type": "object",
-        "required": [
-          "schema",
-          "typeToUpdate",
-          "relationships",
-          "conversions"
-        ],
+        "required": ["schema", "typeToUpdate", "relationships", "conversions"],
         "properties": {
           "conversions": {
             "type": "object",
@@ -8217,11 +7349,7 @@
       },
       "UpdateEntityTypeRequest": {
         "type": "object",
-        "required": [
-          "schema",
-          "typeToUpdate",
-          "relationships"
-        ],
+        "required": ["schema", "typeToUpdate", "relationships"],
         "properties": {
           "provenance": {
             "$ref": "#/components/schemas/ProvidedOntologyEditionProvenance"
@@ -8267,11 +7395,7 @@
       },
       "UpdatePropertyTypeRequest": {
         "type": "object",
-        "required": [
-          "schema",
-          "typeToUpdate",
-          "relationships"
-        ],
+        "required": ["schema", "typeToUpdate", "relationships"],
         "properties": {
           "provenance": {
             "$ref": "#/components/schemas/ProvidedOntologyEditionProvenance"
@@ -8308,10 +7432,7 @@
       },
       "ValidateEntityParams": {
         "type": "object",
-        "required": [
-          "entityTypes",
-          "properties"
-        ],
+        "required": ["entityTypes", "properties"],
         "properties": {
           "components": {
             "allOf": [
@@ -8338,9 +7459,7 @@
       },
       "ValueMetadata": {
         "type": "object",
-        "required": [
-          "dataTypeId"
-        ],
+        "required": ["dataTypeId"],
         "properties": {
           "canonical": {
             "type": "object",
@@ -8376,9 +7495,7 @@
       },
       "Variable": {
         "type": "string",
-        "enum": [
-          "self"
-        ]
+        "enum": ["self"]
       },
       "VersionedUrl": {
         "type": "string",
@@ -8414,15 +7531,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "kind"
-            ],
+            "required": ["kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "public"
-                ]
+                "enum": ["public"]
               }
             }
           }
@@ -8432,16 +7545,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "account"
-                ]
+                "enum": ["account"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountId"
@@ -8450,16 +7558,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "accountGroup"
-                ]
+                "enum": ["accountGroup"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
@@ -8475,16 +7578,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "account"
-                ]
+                "enum": ["account"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountId"
@@ -8493,16 +7591,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "accountGroup"
-                ]
+                "enum": ["accountGroup"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
@@ -8518,15 +7611,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "kind"
-            ],
+            "required": ["kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "public"
-                ]
+                "enum": ["public"]
               }
             }
           }
@@ -8536,30 +7625,21 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "kind"
-            ],
+            "required": ["kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "public"
-                ]
+                "enum": ["public"]
               }
             }
           },
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "account"
-                ]
+                "enum": ["account"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountId"
@@ -8568,16 +7648,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "accountGroup"
-                ]
+                "enum": ["accountGroup"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
@@ -8593,16 +7668,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "account"
-                ]
+                "enum": ["account"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountId"
@@ -8611,16 +7681,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subjectId",
-              "kind"
-            ],
+            "required": ["subjectId", "kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "accountGroup"
-                ]
+                "enum": ["accountGroup"]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
@@ -8648,15 +7713,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "kind"
-            ],
+            "required": ["kind"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "public"
-                ]
+                "enum": ["public"]
               }
             }
           }
@@ -8666,16 +7727,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "owner"
-                ]
+                "enum": ["owner"]
               },
               "subject": {
                 "$ref": "#/components/schemas/WebOwnerSubject"
@@ -8684,16 +7740,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "entityCreator"
-                ]
+                "enum": ["entityCreator"]
               },
               "subject": {
                 "$ref": "#/components/schemas/WebEntityCreatorSubject"
@@ -8702,16 +7753,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "entityEditor"
-                ]
+                "enum": ["entityEditor"]
               },
               "subject": {
                 "$ref": "#/components/schemas/WebEntityEditorSubject"
@@ -8720,16 +7766,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "entityViewer"
-                ]
+                "enum": ["entityViewer"]
               },
               "subject": {
                 "$ref": "#/components/schemas/WebEntityViewerSubject"
@@ -8738,16 +7779,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "entityTypeViewer"
-                ]
+                "enum": ["entityTypeViewer"]
               },
               "subject": {
                 "$ref": "#/components/schemas/WebEntityTypeViewerSubject"
@@ -8756,16 +7792,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "propertyTypeViewer"
-                ]
+                "enum": ["propertyTypeViewer"]
               },
               "subject": {
                 "$ref": "#/components/schemas/WebPropertyTypeViewerSubject"
@@ -8774,16 +7805,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "subject",
-              "relation"
-            ],
+            "required": ["subject", "relation"],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": [
-                  "dataTypeViewer"
-                ]
+                "enum": ["dataTypeViewer"]
               },
               "subject": {
                 "$ref": "#/components/schemas/WebDataTypeViewerSubject"

--- a/apps/hash-graph/libs/api/openapi/openapi.json
+++ b/apps/hash-graph/libs/api/openapi/openapi.json
@@ -14,7 +14,10 @@
   "paths": {
     "/account_groups": {
       "post": {
-        "tags": ["Graph", "Account Group"],
+        "tags": [
+          "Graph",
+          "Account Group"
+        ],
         "operationId": "create_account_group",
         "parameters": [
           {
@@ -56,7 +59,10 @@
     },
     "/account_groups/{account_group_id}/members/{account_id}": {
       "post": {
-        "tags": ["Graph", "Account Group"],
+        "tags": [
+          "Graph",
+          "Account Group"
+        ],
         "operationId": "add_account_group_member",
         "parameters": [
           {
@@ -100,7 +106,10 @@
         }
       },
       "delete": {
-        "tags": ["Graph", "Account Group"],
+        "tags": [
+          "Graph",
+          "Account Group"
+        ],
         "operationId": "remove_account_group_member",
         "parameters": [
           {
@@ -146,7 +155,10 @@
     },
     "/account_groups/{account_group_id}/permissions/{permission}": {
       "get": {
-        "tags": ["Graph", "Account Group"],
+        "tags": [
+          "Graph",
+          "Account Group"
+        ],
         "operationId": "check_account_group_permission",
         "parameters": [
           {
@@ -196,7 +208,10 @@
     },
     "/accounts": {
       "post": {
-        "tags": ["Graph", "Account"],
+        "tags": [
+          "Graph",
+          "Account"
+        ],
         "operationId": "create_account",
         "parameters": [
           {
@@ -238,7 +253,10 @@
     },
     "/data-types": {
       "post": {
-        "tags": ["Graph", "DataType"],
+        "tags": [
+          "Graph",
+          "DataType"
+        ],
         "operationId": "create_data_type",
         "parameters": [
           {
@@ -284,7 +302,10 @@
         }
       },
       "put": {
-        "tags": ["Graph", "DataType"],
+        "tags": [
+          "Graph",
+          "DataType"
+        ],
         "operationId": "update_data_type",
         "parameters": [
           {
@@ -353,7 +374,10 @@
     },
     "/data-types/archive": {
       "put": {
-        "tags": ["Graph", "DataType"],
+        "tags": [
+          "Graph",
+          "DataType"
+        ],
         "operationId": "archive_data_type",
         "parameters": [
           {
@@ -404,7 +428,10 @@
     },
     "/data-types/embeddings": {
       "post": {
-        "tags": ["Graph", "DataType"],
+        "tags": [
+          "Graph",
+          "DataType"
+        ],
         "operationId": "update_data_type_embeddings",
         "parameters": [
           {
@@ -442,7 +469,10 @@
     },
     "/data-types/load": {
       "post": {
-        "tags": ["Graph", "DataType"],
+        "tags": [
+          "Graph",
+          "DataType"
+        ],
         "operationId": "load_external_data_type",
         "parameters": [
           {
@@ -490,7 +520,10 @@
     },
     "/data-types/query": {
       "post": {
-        "tags": ["Graph", "DataType"],
+        "tags": [
+          "Graph",
+          "DataType"
+        ],
         "operationId": "get_data_types",
         "parameters": [
           {
@@ -535,7 +568,10 @@
     },
     "/data-types/query/subgraph": {
       "post": {
-        "tags": ["Graph", "DataType"],
+        "tags": [
+          "Graph",
+          "DataType"
+        ],
         "operationId": "get_data_type_subgraph",
         "parameters": [
           {
@@ -580,7 +616,10 @@
     },
     "/data-types/relationships": {
       "post": {
-        "tags": ["Graph", "DataType"],
+        "tags": [
+          "Graph",
+          "DataType"
+        ],
         "operationId": "modify_data_type_authorization_relationships",
         "parameters": [
           {
@@ -618,7 +657,10 @@
     },
     "/data-types/unarchive": {
       "put": {
-        "tags": ["Graph", "DataType"],
+        "tags": [
+          "Graph",
+          "DataType"
+        ],
         "operationId": "unarchive_data_type",
         "parameters": [
           {
@@ -669,7 +711,10 @@
     },
     "/data-types/{data_type_id}/permissions/{permission}": {
       "get": {
-        "tags": ["Graph", "DataType"],
+        "tags": [
+          "Graph",
+          "DataType"
+        ],
         "operationId": "check_data_type_permission",
         "parameters": [
           {
@@ -719,7 +764,10 @@
     },
     "/data-types/{data_type_id}/relationships": {
       "get": {
-        "tags": ["Graph", "DataType"],
+        "tags": [
+          "Graph",
+          "DataType"
+        ],
         "operationId": "get_data_type_authorization_relationships",
         "parameters": [
           {
@@ -763,7 +811,10 @@
     },
     "/entities": {
       "post": {
-        "tags": ["Graph", "Entity"],
+        "tags": [
+          "Graph",
+          "Entity"
+        ],
         "operationId": "create_entity",
         "parameters": [
           {
@@ -809,7 +860,10 @@
         }
       },
       "patch": {
-        "tags": ["Graph", "Entity"],
+        "tags": [
+          "Graph",
+          "Entity"
+        ],
         "operationId": "patch_entity",
         "parameters": [
           {
@@ -860,7 +914,10 @@
     },
     "/entities/bulk": {
       "post": {
-        "tags": ["Graph", "Entity"],
+        "tags": [
+          "Graph",
+          "Entity"
+        ],
         "operationId": "create_entities",
         "parameters": [
           {
@@ -914,7 +971,10 @@
     },
     "/entities/diff": {
       "post": {
-        "tags": ["Graph", "Entity"],
+        "tags": [
+          "Graph",
+          "Entity"
+        ],
         "operationId": "diff_entity",
         "parameters": [
           {
@@ -962,7 +1022,10 @@
     },
     "/entities/embeddings": {
       "post": {
-        "tags": ["Graph", "Entity"],
+        "tags": [
+          "Graph",
+          "Entity"
+        ],
         "operationId": "update_entity_embeddings",
         "parameters": [
           {
@@ -1000,7 +1063,10 @@
     },
     "/entities/query": {
       "post": {
-        "tags": ["Graph", "Entity"],
+        "tags": [
+          "Graph",
+          "Entity"
+        ],
         "operationId": "get_entities",
         "parameters": [
           {
@@ -1066,7 +1132,10 @@
     },
     "/entities/query/count": {
       "post": {
-        "tags": ["Graph", "Entity"],
+        "tags": [
+          "Graph",
+          "Entity"
+        ],
         "operationId": "count_entities",
         "parameters": [
           {
@@ -1112,7 +1181,10 @@
     },
     "/entities/query/subgraph": {
       "post": {
-        "tags": ["Graph", "Entity"],
+        "tags": [
+          "Graph",
+          "Entity"
+        ],
         "operationId": "get_entity_subgraph",
         "parameters": [
           {
@@ -1178,7 +1250,10 @@
     },
     "/entities/relationships": {
       "post": {
-        "tags": ["Graph", "Entity"],
+        "tags": [
+          "Graph",
+          "Entity"
+        ],
         "operationId": "modify_entity_authorization_relationships",
         "parameters": [
           {
@@ -1216,7 +1291,10 @@
     },
     "/entities/validate": {
       "post": {
-        "tags": ["Graph", "Entity"],
+        "tags": [
+          "Graph",
+          "Entity"
+        ],
         "operationId": "validate_entity",
         "parameters": [
           {
@@ -1257,7 +1335,10 @@
     },
     "/entities/{entity_id}/administrators/{administrator}": {
       "post": {
-        "tags": ["Graph", "Entity"],
+        "tags": [
+          "Graph",
+          "Entity"
+        ],
         "operationId": "add_entity_administrator",
         "parameters": [
           {
@@ -1298,7 +1379,10 @@
         }
       },
       "delete": {
-        "tags": ["Graph", "Entity"],
+        "tags": [
+          "Graph",
+          "Entity"
+        ],
         "operationId": "remove_entity_administrator",
         "parameters": [
           {
@@ -1341,7 +1425,10 @@
     },
     "/entities/{entity_id}/editors/{editor}": {
       "post": {
-        "tags": ["Graph", "Entity"],
+        "tags": [
+          "Graph",
+          "Entity"
+        ],
         "operationId": "add_entity_editor",
         "parameters": [
           {
@@ -1382,7 +1469,10 @@
         }
       },
       "delete": {
-        "tags": ["Graph", "Entity"],
+        "tags": [
+          "Graph",
+          "Entity"
+        ],
         "operationId": "remove_entity_editor",
         "parameters": [
           {
@@ -1425,7 +1515,10 @@
     },
     "/entities/{entity_id}/permissions/{permission}": {
       "get": {
-        "tags": ["Graph", "Entity"],
+        "tags": [
+          "Graph",
+          "Entity"
+        ],
         "operationId": "check_entity_permission",
         "parameters": [
           {
@@ -1475,7 +1568,10 @@
     },
     "/entities/{entity_id}/relationships": {
       "get": {
-        "tags": ["Graph", "Entity"],
+        "tags": [
+          "Graph",
+          "Entity"
+        ],
         "operationId": "get_entity_authorization_relationships",
         "parameters": [
           {
@@ -1519,7 +1615,10 @@
     },
     "/entity-types": {
       "post": {
-        "tags": ["Graph", "EntityType"],
+        "tags": [
+          "Graph",
+          "EntityType"
+        ],
         "operationId": "create_entity_type",
         "parameters": [
           {
@@ -1586,7 +1685,10 @@
         }
       },
       "put": {
-        "tags": ["Graph", "EntityType"],
+        "tags": [
+          "Graph",
+          "EntityType"
+        ],
         "operationId": "update_entity_type",
         "parameters": [
           {
@@ -1655,7 +1757,10 @@
     },
     "/entity-types/archive": {
       "put": {
-        "tags": ["Graph", "EntityType"],
+        "tags": [
+          "Graph",
+          "EntityType"
+        ],
         "operationId": "archive_entity_type",
         "parameters": [
           {
@@ -1706,7 +1811,10 @@
     },
     "/entity-types/embeddings": {
       "post": {
-        "tags": ["Graph", "EntityType"],
+        "tags": [
+          "Graph",
+          "EntityType"
+        ],
         "operationId": "update_entity_type_embeddings",
         "parameters": [
           {
@@ -1744,7 +1852,10 @@
     },
     "/entity-types/load": {
       "post": {
-        "tags": ["Graph", "EntityType"],
+        "tags": [
+          "Graph",
+          "EntityType"
+        ],
         "operationId": "load_external_entity_type",
         "parameters": [
           {
@@ -1813,7 +1924,10 @@
     },
     "/entity-types/multi": {
       "post": {
-        "tags": ["Graph", "EntityType"],
+        "tags": [
+          "Graph",
+          "EntityType"
+        ],
         "operationId": "get_closed_multi_entity_types",
         "parameters": [
           {
@@ -1858,7 +1972,10 @@
     },
     "/entity-types/query": {
       "post": {
-        "tags": ["Graph", "EntityType"],
+        "tags": [
+          "Graph",
+          "EntityType"
+        ],
         "operationId": "get_entity_types",
         "parameters": [
           {
@@ -1903,7 +2020,10 @@
     },
     "/entity-types/query/subgraph": {
       "post": {
-        "tags": ["Graph", "EntityType"],
+        "tags": [
+          "Graph",
+          "EntityType"
+        ],
         "operationId": "get_entity_type_subgraph",
         "parameters": [
           {
@@ -1948,7 +2068,10 @@
     },
     "/entity-types/relationships": {
       "post": {
-        "tags": ["Graph", "EntityType"],
+        "tags": [
+          "Graph",
+          "EntityType"
+        ],
         "operationId": "modify_entity_type_authorization_relationships",
         "parameters": [
           {
@@ -1986,7 +2109,10 @@
     },
     "/entity-types/unarchive": {
       "put": {
-        "tags": ["Graph", "EntityType"],
+        "tags": [
+          "Graph",
+          "EntityType"
+        ],
         "operationId": "unarchive_entity_type",
         "parameters": [
           {
@@ -2037,7 +2163,10 @@
     },
     "/entity-types/{entity_type_id}/permissions/{permission}": {
       "get": {
-        "tags": ["Graph", "EntityType"],
+        "tags": [
+          "Graph",
+          "EntityType"
+        ],
         "operationId": "check_entity_type_permission",
         "parameters": [
           {
@@ -2087,7 +2216,10 @@
     },
     "/entity-types/{entity_type_id}/relationships": {
       "get": {
-        "tags": ["Graph", "EntityType"],
+        "tags": [
+          "Graph",
+          "EntityType"
+        ],
         "operationId": "get_entity_type_authorization_relationships",
         "parameters": [
           {
@@ -2131,7 +2263,10 @@
     },
     "/property-types": {
       "post": {
-        "tags": ["Graph", "PropertyType"],
+        "tags": [
+          "Graph",
+          "PropertyType"
+        ],
         "operationId": "create_property_type",
         "parameters": [
           {
@@ -2177,7 +2312,10 @@
         }
       },
       "put": {
-        "tags": ["Graph", "PropertyType"],
+        "tags": [
+          "Graph",
+          "PropertyType"
+        ],
         "operationId": "update_property_type",
         "parameters": [
           {
@@ -2246,7 +2384,10 @@
     },
     "/property-types/archive": {
       "put": {
-        "tags": ["Graph", "PropertyType"],
+        "tags": [
+          "Graph",
+          "PropertyType"
+        ],
         "operationId": "archive_property_type",
         "parameters": [
           {
@@ -2297,7 +2438,10 @@
     },
     "/property-types/embeddings": {
       "post": {
-        "tags": ["Graph", "PropertyType"],
+        "tags": [
+          "Graph",
+          "PropertyType"
+        ],
         "operationId": "update_property_type_embeddings",
         "parameters": [
           {
@@ -2335,7 +2479,10 @@
     },
     "/property-types/load": {
       "post": {
-        "tags": ["Graph", "PropertyType"],
+        "tags": [
+          "Graph",
+          "PropertyType"
+        ],
         "operationId": "load_external_property_type",
         "parameters": [
           {
@@ -2383,7 +2530,10 @@
     },
     "/property-types/query": {
       "post": {
-        "tags": ["Graph", "PropertyType"],
+        "tags": [
+          "Graph",
+          "PropertyType"
+        ],
         "operationId": "get_property_types",
         "parameters": [
           {
@@ -2428,7 +2578,10 @@
     },
     "/property-types/query/subgraph": {
       "post": {
-        "tags": ["Graph", "PropertyType"],
+        "tags": [
+          "Graph",
+          "PropertyType"
+        ],
         "operationId": "get_property_type_subgraph",
         "parameters": [
           {
@@ -2481,7 +2634,10 @@
     },
     "/property-types/relationships": {
       "post": {
-        "tags": ["Graph", "PropertyType"],
+        "tags": [
+          "Graph",
+          "PropertyType"
+        ],
         "operationId": "modify_property_type_authorization_relationships",
         "parameters": [
           {
@@ -2519,7 +2675,10 @@
     },
     "/property-types/unarchive": {
       "put": {
-        "tags": ["Graph", "PropertyType"],
+        "tags": [
+          "Graph",
+          "PropertyType"
+        ],
         "operationId": "unarchive_property_type",
         "parameters": [
           {
@@ -2570,7 +2729,10 @@
     },
     "/property-types/{property_type_id}/permissions/{permission}": {
       "get": {
-        "tags": ["Graph", "PropertyType"],
+        "tags": [
+          "Graph",
+          "PropertyType"
+        ],
         "operationId": "check_property_type_permission",
         "parameters": [
           {
@@ -2620,7 +2782,10 @@
     },
     "/property-types/{property_type_id}/relationships": {
       "get": {
-        "tags": ["Graph", "PropertyType"],
+        "tags": [
+          "Graph",
+          "PropertyType"
+        ],
         "operationId": "get_property_type_authorization_relationships",
         "parameters": [
           {
@@ -2664,7 +2829,10 @@
     },
     "/webs": {
       "post": {
-        "tags": ["Graph", "Web"],
+        "tags": [
+          "Graph",
+          "Web"
+        ],
         "operationId": "create_web",
         "parameters": [
           {
@@ -2699,7 +2867,10 @@
     },
     "/webs/relationships": {
       "post": {
-        "tags": ["Graph", "Web"],
+        "tags": [
+          "Graph",
+          "Web"
+        ],
         "operationId": "modify_web_authorization_relationships",
         "parameters": [
           {
@@ -2737,7 +2908,10 @@
     },
     "/webs/{web_id}/permissions/{permission}": {
       "get": {
-        "tags": ["Graph", "Web"],
+        "tags": [
+          "Graph",
+          "Web"
+        ],
         "operationId": "check_web_permission",
         "parameters": [
           {
@@ -2787,7 +2961,10 @@
     },
     "/webs/{web_id}/relationships": {
       "get": {
-        "tags": ["Graph", "Web"],
+        "tags": [
+          "Graph",
+          "Web"
+        ],
         "operationId": "get_web_authorization_relationships",
         "parameters": [
           {
@@ -2838,7 +3015,10 @@
       },
       "AccountGroupPermission": {
         "type": "string",
-        "enum": ["add_member", "remove_member"]
+        "enum": [
+          "add_member",
+          "remove_member"
+        ]
       },
       "AccountId": {
         "type": "string",
@@ -2846,11 +3026,17 @@
       },
       "ActorType": {
         "type": "string",
-        "enum": ["human", "ai", "machine"]
+        "enum": [
+          "human",
+          "ai",
+          "machine"
+        ]
       },
       "ArchiveDataTypeParams": {
         "type": "object",
-        "required": ["dataTypeId"],
+        "required": [
+          "dataTypeId"
+        ],
         "properties": {
           "dataTypeId": {
             "$ref": "#/components/schemas/VersionedUrl"
@@ -2860,7 +3046,9 @@
       },
       "ArchiveEntityTypeParams": {
         "type": "object",
-        "required": ["entityTypeId"],
+        "required": [
+          "entityTypeId"
+        ],
         "properties": {
           "entityTypeId": {
             "$ref": "#/components/schemas/VersionedUrl"
@@ -2870,7 +3058,9 @@
       },
       "ArchivePropertyTypeParams": {
         "type": "object",
-        "required": ["propertyTypeId"],
+        "required": [
+          "propertyTypeId"
+        ],
         "properties": {
           "propertyTypeId": {
             "$ref": "#/components/schemas/VersionedUrl"
@@ -2903,11 +3093,16 @@
           {
             "type": "object",
             "title": "InclusiveBound",
-            "required": ["kind", "limit"],
+            "required": [
+              "kind",
+              "limit"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["inclusive"]
+                "enum": [
+                  "inclusive"
+                ]
               },
               "limit": {
                 "$ref": "#/components/schemas/Timestamp"
@@ -2927,7 +3122,9 @@
       },
       "ConversionDefinition": {
         "type": "object",
-        "required": ["expression"],
+        "required": [
+          "expression"
+        ],
         "properties": {
           "expression": {
             "$ref": "#/components/schemas/ConversionExpression"
@@ -2957,7 +3154,10 @@
           },
           {
             "type": "object",
-            "required": ["const", "type"],
+            "required": [
+              "const",
+              "type"
+            ],
             "properties": {
               "const": {
                 "type": "number",
@@ -2965,7 +3165,9 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["number"]
+                "enum": [
+                  "number"
+                ]
               }
             }
           },
@@ -2976,7 +3178,10 @@
       },
       "Conversions": {
         "type": "object",
-        "required": ["from", "to"],
+        "required": [
+          "from",
+          "to"
+        ],
         "properties": {
           "from": {
             "$ref": "#/components/schemas/ConversionDefinition"
@@ -2989,7 +3194,11 @@
       },
       "CountEntitiesParams": {
         "type": "object",
-        "required": ["filter", "temporalAxes", "includeDrafts"],
+        "required": [
+          "filter",
+          "temporalAxes",
+          "includeDrafts"
+        ],
         "properties": {
           "filter": {
             "$ref": "#/components/schemas/Filter"
@@ -3005,7 +3214,12 @@
       },
       "CreateDataTypeRequest": {
         "type": "object",
-        "required": ["schema", "ownedById", "relationships", "conversions"],
+        "required": [
+          "schema",
+          "ownedById",
+          "relationships",
+          "conversions"
+        ],
         "properties": {
           "conversions": {
             "type": "object",
@@ -3108,7 +3322,11 @@
       },
       "CreateEntityTypeRequest": {
         "type": "object",
-        "required": ["schema", "ownedById", "relationships"],
+        "required": [
+          "schema",
+          "ownedById",
+          "relationships"
+        ],
         "properties": {
           "ownedById": {
             "$ref": "#/components/schemas/OwnedById"
@@ -3140,7 +3358,11 @@
       },
       "CreatePropertyTypeRequest": {
         "type": "object",
-        "required": ["schema", "ownedById", "relationships"],
+        "required": [
+          "schema",
+          "ownedById",
+          "relationships"
+        ],
         "properties": {
           "ownedById": {
             "$ref": "#/components/schemas/OwnedById"
@@ -3242,11 +3464,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["web"]
+                "enum": [
+                  "web"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/OwnedById"
@@ -3260,7 +3487,10 @@
       },
       "DataTypePermission": {
         "type": "string",
-        "enum": ["update", "view"]
+        "enum": [
+          "update",
+          "view"
+        ]
       },
       "DataTypeQueryToken": {
         "type": "string",
@@ -3283,11 +3513,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["owner"]
+                "enum": [
+                  "owner"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/DataTypeOwnerSubject"
@@ -3296,11 +3531,16 @@
           },
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["viewer"]
+                "enum": [
+                  "viewer"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/DataTypeViewerSubject"
@@ -3314,7 +3554,10 @@
       },
       "DataTypeVertexId": {
         "type": "object",
-        "required": ["baseId", "revisionId"],
+        "required": [
+          "baseId",
+          "revisionId"
+        ],
         "properties": {
           "baseId": {
             "$ref": "#/components/schemas/BaseUrl"
@@ -3328,11 +3571,15 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["kind"],
+            "required": [
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["public"]
+                "enum": [
+                  "public"
+                ]
               }
             }
           }
@@ -3340,7 +3587,10 @@
       },
       "DataTypeWithMetadata": {
         "type": "object",
-        "required": ["schema", "metadata"],
+        "required": [
+          "schema",
+          "metadata"
+        ],
         "properties": {
           "metadata": {
             "$ref": "#/components/schemas/DataTypeMetadata"
@@ -3353,7 +3603,9 @@
       "DecisionTime": {
         "type": "string",
         "description": "Time axis for the decision time.\n\nThis is used as the generic argument to time-related structs and can be used as tag value.",
-        "enum": ["decisionTime"]
+        "enum": [
+          "decisionTime"
+        ]
       },
       "DiffEntityParams": {
         "type": "object",
@@ -3430,7 +3682,10 @@
       },
       "EdgeResolveDepths": {
         "type": "object",
-        "required": ["incoming", "outgoing"],
+        "required": [
+          "incoming",
+          "outgoing"
+        ],
         "properties": {
           "incoming": {
             "type": "integer",
@@ -3482,7 +3737,10 @@
       "Entity": {
         "type": "object",
         "description": "A record of an [`Entity`] that has been persisted in the datastore, with its associated\nmetadata.",
-        "required": ["properties", "metadata"],
+        "required": [
+          "properties",
+          "metadata"
+        ],
         "properties": {
           "linkData": {
             "allOf": [
@@ -3503,11 +3761,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["account"]
+                "enum": [
+                  "account"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountId"
@@ -3516,11 +3779,17 @@
           },
           {
             "type": "object",
-            "required": ["subjectId", "subjectSet", "kind"],
+            "required": [
+              "subjectId",
+              "subjectSet",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["accountGroup"]
+                "enum": [
+                  "accountGroup"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
@@ -3546,7 +3815,9 @@
           },
           {
             "type": "object",
-            "required": ["createdById"],
+            "required": [
+              "createdById"
+            ],
             "properties": {
               "archivedById": {
                 "allOf": [
@@ -3566,11 +3837,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["account"]
+                "enum": [
+                  "account"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountId"
@@ -3579,11 +3855,17 @@
           },
           {
             "type": "object",
-            "required": ["subjectId", "subjectSet", "kind"],
+            "required": [
+              "subjectId",
+              "subjectSet",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["accountGroup"]
+                "enum": [
+                  "accountGroup"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
@@ -3600,7 +3882,9 @@
       },
       "EntityEmbedding": {
         "type": "object",
-        "required": ["embedding"],
+        "required": [
+          "embedding"
+        ],
         "properties": {
           "embedding": {
             "$ref": "#/components/schemas/Embedding"
@@ -3620,7 +3904,10 @@
       },
       "EntityIdWithInterval": {
         "type": "object",
-        "required": ["entityId", "interval"],
+        "required": [
+          "entityId",
+          "interval"
+        ],
         "properties": {
           "entityId": {
             "$ref": "#/components/schemas/EntityId"
@@ -3676,11 +3963,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["web"]
+                "enum": [
+                  "web"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/OwnedById"
@@ -3694,7 +3986,11 @@
       },
       "EntityPermission": {
         "type": "string",
-        "enum": ["full_access", "update", "view"]
+        "enum": [
+          "full_access",
+          "update",
+          "view"
+        ]
       },
       "EntityProvenance": {
         "allOf": [
@@ -3703,7 +3999,9 @@
           },
           {
             "type": "object",
-            "required": ["edition"],
+            "required": [
+              "edition"
+            ],
             "properties": {
               "edition": {
                 "$ref": "#/components/schemas/EntityEditionProvenance"
@@ -3736,7 +4034,11 @@
       },
       "EntityQuerySortingRecord": {
         "type": "object",
-        "required": ["path", "ordering", "nulls"],
+        "required": [
+          "path",
+          "ordering",
+          "nulls"
+        ],
         "properties": {
           "nulls": {
             "$ref": "#/components/schemas/NullOrdering"
@@ -3786,7 +4088,10 @@
       },
       "EntityRecordId": {
         "type": "object",
-        "required": ["entityId", "editionId"],
+        "required": [
+          "entityId",
+          "editionId"
+        ],
         "properties": {
           "editionId": {
             "$ref": "#/components/schemas/EntityEditionId"
@@ -3800,11 +4105,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["setting"]
+                "enum": [
+                  "setting"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/EntitySettingSubject"
@@ -3813,11 +4123,16 @@
           },
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["owner"]
+                "enum": [
+                  "owner"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/EntityOwnerSubject"
@@ -3826,11 +4141,16 @@
           },
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["administrator"]
+                "enum": [
+                  "administrator"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/EntityAdministratorSubject"
@@ -3839,11 +4159,16 @@
           },
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["editor"]
+                "enum": [
+                  "editor"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/EntityEditorSubject"
@@ -3852,11 +4177,16 @@
           },
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["viewer"]
+                "enum": [
+                  "viewer"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/EntityViewerSubject"
@@ -3870,17 +4200,26 @@
       },
       "EntitySetting": {
         "type": "string",
-        "enum": ["administratorFromWeb", "updateFromWeb", "viewFromWeb"]
+        "enum": [
+          "administratorFromWeb",
+          "updateFromWeb",
+          "viewFromWeb"
+        ]
       },
       "EntitySettingSubject": {
         "oneOf": [
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["setting"]
+                "enum": [
+                  "setting"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/EntitySetting"
@@ -3894,11 +4233,17 @@
       },
       "EntitySubjectSet": {
         "type": "string",
-        "enum": ["administrator", "member"]
+        "enum": [
+          "administrator",
+          "member"
+        ]
       },
       "EntityTemporalMetadata": {
         "type": "object",
-        "required": ["decisionTime", "transactionTime"],
+        "required": [
+          "decisionTime",
+          "transactionTime"
+        ],
         "properties": {
           "decisionTime": {
             "$ref": "#/components/schemas/LeftClosedTemporalInterval"
@@ -3913,11 +4258,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["account"]
+                "enum": [
+                  "account"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountId"
@@ -3926,11 +4276,16 @@
           },
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["accountGroup"]
+                "enum": [
+                  "accountGroup"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
@@ -3944,7 +4299,10 @@
       },
       "EntityTypeEmbedding": {
         "type": "object",
-        "required": ["entityTypeId", "embedding"],
+        "required": [
+          "entityTypeId",
+          "embedding"
+        ],
         "properties": {
           "embedding": {
             "$ref": "#/components/schemas/Embedding"
@@ -3958,24 +4316,34 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["added", "op"],
+            "required": [
+              "added",
+              "op"
+            ],
             "properties": {
               "added": {
                 "$ref": "#/components/schemas/VersionedUrl"
               },
               "op": {
                 "type": "string",
-                "enum": ["added"]
+                "enum": [
+                  "added"
+                ]
               }
             }
           },
           {
             "type": "object",
-            "required": ["removed", "op"],
+            "required": [
+              "removed",
+              "op"
+            ],
             "properties": {
               "op": {
                 "type": "string",
-                "enum": ["removed"]
+                "enum": [
+                  "removed"
+                ]
               },
               "removed": {
                 "$ref": "#/components/schemas/VersionedUrl"
@@ -3991,21 +4359,30 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["kind"],
+            "required": [
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["public"]
+                "enum": [
+                  "public"
+                ]
               }
             }
           },
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["account"]
+                "enum": [
+                  "account"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountId"
@@ -4014,11 +4391,16 @@
           },
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["accountGroup"]
+                "enum": [
+                  "accountGroup"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
@@ -4086,11 +4468,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["web"]
+                "enum": [
+                  "web"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/OwnedById"
@@ -4104,7 +4491,11 @@
       },
       "EntityTypePermission": {
         "type": "string",
-        "enum": ["update", "view", "instantiate"]
+        "enum": [
+          "update",
+          "view",
+          "instantiate"
+        ]
       },
       "EntityTypeQueryToken": {
         "type": "string",
@@ -4131,11 +4522,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["owner"]
+                "enum": [
+                  "owner"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/EntityTypeOwnerSubject"
@@ -4144,11 +4540,16 @@
           },
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["setting"]
+                "enum": [
+                  "setting"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/EntityTypeSettingSubject"
@@ -4157,11 +4558,16 @@
           },
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["editor"]
+                "enum": [
+                  "editor"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/EntityTypeEditorSubject"
@@ -4170,11 +4576,16 @@
           },
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["viewer"]
+                "enum": [
+                  "viewer"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/EntityTypeViewerSubject"
@@ -4183,11 +4594,16 @@
           },
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["instantiator"]
+                "enum": [
+                  "instantiator"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/EntityTypeInstantiatorSubject"
@@ -4201,17 +4617,24 @@
       },
       "EntityTypeSetting": {
         "type": "string",
-        "enum": ["updateFromWeb"]
+        "enum": [
+          "updateFromWeb"
+        ]
       },
       "EntityTypeSettingSubject": {
         "oneOf": [
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["setting"]
+                "enum": [
+                  "setting"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/EntityTypeSetting"
@@ -4225,7 +4648,10 @@
       },
       "EntityTypeVertexId": {
         "type": "object",
-        "required": ["baseId", "revisionId"],
+        "required": [
+          "baseId",
+          "revisionId"
+        ],
         "properties": {
           "baseId": {
             "$ref": "#/components/schemas/BaseUrl"
@@ -4239,11 +4665,15 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["kind"],
+            "required": [
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["public"]
+                "enum": [
+                  "public"
+                ]
               }
             }
           }
@@ -4251,7 +4681,10 @@
       },
       "EntityTypeWithMetadata": {
         "type": "object",
-        "required": ["schema", "metadata"],
+        "required": [
+          "schema",
+          "metadata"
+        ],
         "properties": {
           "metadata": {
             "$ref": "#/components/schemas/EntityTypeMetadata"
@@ -4273,7 +4706,10 @@
       },
       "EntityVertexId": {
         "type": "object",
-        "required": ["baseId", "revisionId"],
+        "required": [
+          "baseId",
+          "revisionId"
+        ],
         "properties": {
           "baseId": {
             "$ref": "#/components/schemas/EntityId"
@@ -4287,21 +4723,30 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["kind"],
+            "required": [
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["public"]
+                "enum": [
+                  "public"
+                ]
               }
             }
           },
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["account"]
+                "enum": [
+                  "account"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountId"
@@ -4310,11 +4755,17 @@
           },
           {
             "type": "object",
-            "required": ["subjectId", "subjectSet", "kind"],
+            "required": [
+              "subjectId",
+              "subjectSet",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["accountGroup"]
+                "enum": [
+                  "accountGroup"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
@@ -4334,7 +4785,9 @@
           {
             "type": "object",
             "title": "AllFilter",
-            "required": ["all"],
+            "required": [
+              "all"
+            ],
             "properties": {
               "all": {
                 "type": "array",
@@ -4347,7 +4800,9 @@
           {
             "type": "object",
             "title": "AnyFilter",
-            "required": ["any"],
+            "required": [
+              "any"
+            ],
             "properties": {
               "any": {
                 "type": "array",
@@ -4360,7 +4815,9 @@
           {
             "type": "object",
             "title": "NotFilter",
-            "required": ["not"],
+            "required": [
+              "not"
+            ],
             "properties": {
               "not": {
                 "$ref": "#/components/schemas/Filter"
@@ -4370,7 +4827,9 @@
           {
             "type": "object",
             "title": "EqualFilter",
-            "required": ["equal"],
+            "required": [
+              "equal"
+            ],
             "properties": {
               "equal": {
                 "type": "array",
@@ -4385,7 +4844,9 @@
           {
             "type": "object",
             "title": "NotEqualFilter",
-            "required": ["notEqual"],
+            "required": [
+              "notEqual"
+            ],
             "properties": {
               "notEqual": {
                 "type": "array",
@@ -4400,7 +4861,9 @@
           {
             "type": "object",
             "title": "GreaterFilter",
-            "required": ["notEqual"],
+            "required": [
+              "notEqual"
+            ],
             "properties": {
               "greater": {
                 "type": "array",
@@ -4415,7 +4878,9 @@
           {
             "type": "object",
             "title": "GreaterOrEqualFilter",
-            "required": ["notEqual"],
+            "required": [
+              "notEqual"
+            ],
             "properties": {
               "greaterOrEqual": {
                 "type": "array",
@@ -4430,7 +4895,9 @@
           {
             "type": "object",
             "title": "LessFilter",
-            "required": ["notEqual"],
+            "required": [
+              "notEqual"
+            ],
             "properties": {
               "less": {
                 "type": "array",
@@ -4445,7 +4912,9 @@
           {
             "type": "object",
             "title": "LessOrEqualFilter",
-            "required": ["notEqual"],
+            "required": [
+              "notEqual"
+            ],
             "properties": {
               "lessOrEqual": {
                 "type": "array",
@@ -4460,7 +4929,9 @@
           {
             "type": "object",
             "title": "CosineDistanceFilter",
-            "required": ["cosineDistance"],
+            "required": [
+              "cosineDistance"
+            ],
             "properties": {
               "cosineDistance": {
                 "type": "array",
@@ -4475,7 +4946,9 @@
           {
             "type": "object",
             "title": "StartsWithFilter",
-            "required": ["startsWith"],
+            "required": [
+              "startsWith"
+            ],
             "properties": {
               "startsWith": {
                 "type": "array",
@@ -4490,7 +4963,9 @@
           {
             "type": "object",
             "title": "EndsWithFilter",
-            "required": ["endsWith"],
+            "required": [
+              "endsWith"
+            ],
             "properties": {
               "endsWith": {
                 "type": "array",
@@ -4505,7 +4980,9 @@
           {
             "type": "object",
             "title": "ContainsSegmentFilter",
-            "required": ["containsSegment"],
+            "required": [
+              "containsSegment"
+            ],
             "properties": {
               "containsSegment": {
                 "type": "array",
@@ -4524,7 +5001,9 @@
           {
             "type": "object",
             "title": "PathExpression",
-            "required": ["path"],
+            "required": [
+              "path"
+            ],
             "properties": {
               "path": {
                 "type": "array",
@@ -4559,11 +5038,16 @@
           {
             "type": "object",
             "title": "ParameterExpression",
-            "required": ["parameter"],
+            "required": [
+              "parameter"
+            ],
             "properties": {
               "convert": {
                 "type": "object",
-                "required": ["from", "to"],
+                "required": [
+                  "from",
+                  "to"
+                ],
                 "properties": {
                   "from": {
                     "$ref": "#/components/schemas/VersionedUrl"
@@ -4580,7 +5064,11 @@
       },
       "GetClosedMultiEntityTypeParams": {
         "type": "object",
-        "required": ["entityTypeIds", "temporalAxes", "includeDrafts"],
+        "required": [
+          "entityTypeIds",
+          "temporalAxes",
+          "includeDrafts"
+        ],
         "properties": {
           "entityTypeIds": {
             "type": "array",
@@ -4599,7 +5087,9 @@
       },
       "GetClosedMultiEntityTypeResponse": {
         "type": "object",
-        "required": ["entityType"],
+        "required": [
+          "entityType"
+        ],
         "properties": {
           "entityType": {
             "$ref": "./models/closed_multi_entity_type.json"
@@ -4648,7 +5138,9 @@
       },
       "GetDataTypeSubgraphResponse": {
         "type": "object",
-        "required": ["subgraph"],
+        "required": [
+          "subgraph"
+        ],
         "properties": {
           "cursor": {
             "allOf": [
@@ -4665,7 +5157,11 @@
       },
       "GetDataTypesParams": {
         "type": "object",
-        "required": ["filter", "temporalAxes", "includeDrafts"],
+        "required": [
+          "filter",
+          "temporalAxes",
+          "includeDrafts"
+        ],
         "properties": {
           "after": {
             "allOf": [
@@ -4697,7 +5193,9 @@
       },
       "GetDataTypesResponse": {
         "type": "object",
-        "required": ["dataTypes"],
+        "required": [
+          "dataTypes"
+        ],
         "properties": {
           "count": {
             "type": "integer",
@@ -4722,7 +5220,11 @@
       },
       "GetEntitiesRequest": {
         "type": "object",
-        "required": ["filter", "temporalAxes", "includeDrafts"],
+        "required": [
+          "filter",
+          "temporalAxes",
+          "includeDrafts"
+        ],
         "properties": {
           "conversions": {
             "type": "array",
@@ -4779,7 +5281,9 @@
       },
       "GetEntitiesResponse": {
         "type": "object",
-        "required": ["entities"],
+        "required": [
+          "entities"
+        ],
         "properties": {
           "count": {
             "type": "integer",
@@ -4897,7 +5401,9 @@
       },
       "GetEntitySubgraphResponse": {
         "type": "object",
-        "required": ["subgraph"],
+        "required": [
+          "subgraph"
+        ],
         "properties": {
           "count": {
             "type": "integer",
@@ -4993,7 +5499,9 @@
       },
       "GetEntityTypeSubgraphResponse": {
         "type": "object",
-        "required": ["subgraph"],
+        "required": [
+          "subgraph"
+        ],
         "properties": {
           "count": {
             "type": "integer",
@@ -5029,7 +5537,11 @@
       },
       "GetEntityTypesParams": {
         "type": "object",
-        "required": ["filter", "temporalAxes", "includeDrafts"],
+        "required": [
+          "filter",
+          "temporalAxes",
+          "includeDrafts"
+        ],
         "properties": {
           "after": {
             "allOf": [
@@ -5070,7 +5582,9 @@
       },
       "GetEntityTypesResponse": {
         "type": "object",
-        "required": ["entityTypes"],
+        "required": [
+          "entityTypes"
+        ],
         "properties": {
           "closedEntityTypes": {
             "type": "array",
@@ -5155,7 +5669,9 @@
       },
       "GetPropertyTypeSubgraphResponse": {
         "type": "object",
-        "required": ["subgraph"],
+        "required": [
+          "subgraph"
+        ],
         "properties": {
           "cursor": {
             "allOf": [
@@ -5172,7 +5688,11 @@
       },
       "GetPropertyTypesParams": {
         "type": "object",
-        "required": ["filter", "temporalAxes", "includeDrafts"],
+        "required": [
+          "filter",
+          "temporalAxes",
+          "includeDrafts"
+        ],
         "properties": {
           "after": {
             "allOf": [
@@ -5204,7 +5724,9 @@
       },
       "GetPropertyTypesResponse": {
         "type": "object",
-        "required": ["propertyTypes"],
+        "required": [
+          "propertyTypes"
+        ],
         "properties": {
           "count": {
             "type": "integer",
@@ -5337,7 +5859,10 @@
       },
       "InsertWebIdParams": {
         "type": "object",
-        "required": ["ownedById", "owner"],
+        "required": [
+          "ownedById",
+          "owner"
+        ],
         "properties": {
           "ownedById": {
             "$ref": "#/components/schemas/OwnedById"
@@ -5350,14 +5875,21 @@
       },
       "KnowledgeGraphEdgeKind": {
         "type": "string",
-        "enum": ["HAS_LEFT_ENTITY", "HAS_RIGHT_ENTITY"]
+        "enum": [
+          "HAS_LEFT_ENTITY",
+          "HAS_RIGHT_ENTITY"
+        ]
       },
       "KnowledgeGraphOutwardEdge": {
         "oneOf": [
           {
             "type": "object",
             "title": "KnowledgeGraphToKnowledgeGraphOutwardEdge",
-            "required": ["kind", "reversed", "rightEndpoint"],
+            "required": [
+              "kind",
+              "reversed",
+              "rightEndpoint"
+            ],
             "properties": {
               "kind": {
                 "$ref": "#/components/schemas/KnowledgeGraphEdgeKind"
@@ -5373,7 +5905,11 @@
           {
             "type": "object",
             "title": "KnowledgeGraphToOntologyOutwardEdge",
-            "required": ["kind", "reversed", "rightEndpoint"],
+            "required": [
+              "kind",
+              "reversed",
+              "rightEndpoint"
+            ],
             "properties": {
               "kind": {
                 "$ref": "#/components/schemas/SharedEdgeKind"
@@ -5393,14 +5929,19 @@
           {
             "type": "object",
             "title": "EntityVertex",
-            "required": ["kind", "inner"],
+            "required": [
+              "kind",
+              "inner"
+            ],
             "properties": {
               "inner": {
                 "$ref": "#/components/schemas/Entity"
               },
               "kind": {
                 "type": "string",
-                "enum": ["entity"]
+                "enum": [
+                  "entity"
+                ]
               }
             }
           }
@@ -5420,7 +5961,10 @@
       },
       "LeftClosedTemporalInterval": {
         "type": "object",
-        "required": ["start", "end"],
+        "required": [
+          "start",
+          "end"
+        ],
         "properties": {
           "end": {
             "$ref": "#/components/schemas/OpenTemporalBound"
@@ -5435,11 +5979,16 @@
           {
             "type": "object",
             "title": "InclusiveBound",
-            "required": ["kind", "limit"],
+            "required": [
+              "kind",
+              "limit"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["inclusive"]
+                "enum": [
+                  "inclusive"
+                ]
               },
               "limit": {
                 "$ref": "#/components/schemas/Timestamp"
@@ -5449,11 +5998,16 @@
           {
             "type": "object",
             "title": "ExclusiveBound",
-            "required": ["kind", "limit"],
+            "required": [
+              "kind",
+              "limit"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["exclusive"]
+                "enum": [
+                  "exclusive"
+                ]
               },
               "limit": {
                 "$ref": "#/components/schemas/Timestamp"
@@ -5468,7 +6022,10 @@
       "LinkData": {
         "type": "object",
         "description": "The associated information for 'Link' entities",
-        "required": ["leftEntityId", "rightEntityId"],
+        "required": [
+          "leftEntityId",
+          "rightEntityId"
+        ],
         "properties": {
           "leftEntityConfidence": {
             "allOf": [
@@ -5503,7 +6060,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["dataTypeId"],
+            "required": [
+              "dataTypeId"
+            ],
             "properties": {
               "dataTypeId": {
                 "$ref": "#/components/schemas/VersionedUrl"
@@ -5512,7 +6071,11 @@
           },
           {
             "type": "object",
-            "required": ["schema", "relationships", "conversions"],
+            "required": [
+              "schema",
+              "relationships",
+              "conversions"
+            ],
             "properties": {
               "conversions": {
                 "type": "object",
@@ -5540,7 +6103,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["entityTypeId"],
+            "required": [
+              "entityTypeId"
+            ],
             "properties": {
               "entityTypeId": {
                 "$ref": "#/components/schemas/VersionedUrl"
@@ -5549,7 +6114,10 @@
           },
           {
             "type": "object",
-            "required": ["schema", "relationships"],
+            "required": [
+              "schema",
+              "relationships"
+            ],
             "properties": {
               "provenance": {
                 "$ref": "#/components/schemas/ProvidedOntologyEditionProvenance"
@@ -5571,7 +6139,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["propertyTypeId"],
+            "required": [
+              "propertyTypeId"
+            ],
             "properties": {
               "propertyTypeId": {
                 "$ref": "#/components/schemas/VersionedUrl"
@@ -5580,7 +6150,10 @@
           },
           {
             "type": "object",
-            "required": ["schema", "relationships"],
+            "required": [
+              "schema",
+              "relationships"
+            ],
             "properties": {
               "provenance": {
                 "$ref": "#/components/schemas/ProvidedOntologyEditionProvenance"
@@ -5659,7 +6232,11 @@
       },
       "ModifyDataTypeAuthorizationRelationship": {
         "type": "object",
-        "required": ["operation", "resource", "relationAndSubject"],
+        "required": [
+          "operation",
+          "resource",
+          "relationAndSubject"
+        ],
         "properties": {
           "operation": {
             "$ref": "#/components/schemas/ModifyRelationshipOperation"
@@ -5674,7 +6251,11 @@
       },
       "ModifyEntityAuthorizationRelationship": {
         "type": "object",
-        "required": ["operation", "resource", "relationSubject"],
+        "required": [
+          "operation",
+          "resource",
+          "relationSubject"
+        ],
         "properties": {
           "operation": {
             "$ref": "#/components/schemas/ModifyRelationshipOperation"
@@ -5689,7 +6270,11 @@
       },
       "ModifyEntityTypeAuthorizationRelationship": {
         "type": "object",
-        "required": ["operation", "resource", "relationAndSubject"],
+        "required": [
+          "operation",
+          "resource",
+          "relationAndSubject"
+        ],
         "properties": {
           "operation": {
             "$ref": "#/components/schemas/ModifyRelationshipOperation"
@@ -5704,7 +6289,11 @@
       },
       "ModifyPropertyTypeAuthorizationRelationship": {
         "type": "object",
-        "required": ["operation", "resource", "relationAndSubject"],
+        "required": [
+          "operation",
+          "resource",
+          "relationAndSubject"
+        ],
         "properties": {
           "operation": {
             "$ref": "#/components/schemas/ModifyRelationshipOperation"
@@ -5720,11 +6309,19 @@
       "ModifyRelationshipOperation": {
         "type": "string",
         "description": "Used for mutating a single relationship within the service.",
-        "enum": ["touch", "create", "delete"]
+        "enum": [
+          "touch",
+          "create",
+          "delete"
+        ]
       },
       "ModifyWebAuthorizationRelationship": {
         "type": "object",
-        "required": ["operation", "resource", "relationAndSubject"],
+        "required": [
+          "operation",
+          "resource",
+          "relationAndSubject"
+        ],
         "properties": {
           "operation": {
             "$ref": "#/components/schemas/ModifyRelationshipOperation"
@@ -5739,7 +6336,10 @@
       },
       "NullOrdering": {
         "type": "string",
-        "enum": ["first", "last"]
+        "enum": [
+          "first",
+          "last"
+        ]
       },
       "NullableTimestamp": {
         "type": "string",
@@ -5779,7 +6379,9 @@
           },
           {
             "type": "object",
-            "required": ["createdById"],
+            "required": [
+              "createdById"
+            ],
             "properties": {
               "archivedById": {
                 "allOf": [
@@ -5800,7 +6402,11 @@
           {
             "type": "object",
             "title": "OntologyToOntologyOutwardEdge",
-            "required": ["kind", "reversed", "rightEndpoint"],
+            "required": [
+              "kind",
+              "reversed",
+              "rightEndpoint"
+            ],
             "properties": {
               "kind": {
                 "$ref": "#/components/schemas/OntologyEdgeKind"
@@ -5816,7 +6422,11 @@
           {
             "type": "object",
             "title": "OntologyToKnowledgeGraphOutwardEdge",
-            "required": ["kind", "reversed", "rightEndpoint"],
+            "required": [
+              "kind",
+              "reversed",
+              "rightEndpoint"
+            ],
             "properties": {
               "kind": {
                 "$ref": "#/components/schemas/SharedEdgeKind"
@@ -5833,7 +6443,9 @@
       },
       "OntologyProvenance": {
         "type": "object",
-        "required": ["edition"],
+        "required": [
+          "edition"
+        ],
         "properties": {
           "edition": {
             "$ref": "#/components/schemas/OntologyEditionProvenance"
@@ -5843,7 +6455,9 @@
       },
       "OntologyTemporalMetadata": {
         "type": "object",
-        "required": ["transactionTime"],
+        "required": [
+          "transactionTime"
+        ],
         "properties": {
           "transactionTime": {
             "$ref": "#/components/schemas/LeftClosedTemporalInterval"
@@ -5853,7 +6467,10 @@
       },
       "OntologyTypeRecordId": {
         "type": "object",
-        "required": ["baseUrl", "version"],
+        "required": [
+          "baseUrl",
+          "version"
+        ],
         "properties": {
           "baseUrl": {
             "type": "string"
@@ -5888,42 +6505,57 @@
           {
             "type": "object",
             "title": "DataTypeVertex",
-            "required": ["kind", "inner"],
+            "required": [
+              "kind",
+              "inner"
+            ],
             "properties": {
               "inner": {
                 "$ref": "#/components/schemas/DataTypeWithMetadata"
               },
               "kind": {
                 "type": "string",
-                "enum": ["dataType"]
+                "enum": [
+                  "dataType"
+                ]
               }
             }
           },
           {
             "type": "object",
             "title": "PropertyTypeVertex",
-            "required": ["kind", "inner"],
+            "required": [
+              "kind",
+              "inner"
+            ],
             "properties": {
               "inner": {
                 "$ref": "#/components/schemas/PropertyTypeWithMetadata"
               },
               "kind": {
                 "type": "string",
-                "enum": ["propertyType"]
+                "enum": [
+                  "propertyType"
+                ]
               }
             }
           },
           {
             "type": "object",
             "title": "EntityTypeVertex",
-            "required": ["kind", "inner"],
+            "required": [
+              "kind",
+              "inner"
+            ],
             "properties": {
               "inner": {
                 "$ref": "#/components/schemas/EntityTypeWithMetadata"
               },
               "kind": {
                 "type": "string",
-                "enum": ["entityType"]
+                "enum": [
+                  "entityType"
+                ]
               }
             }
           }
@@ -5946,11 +6578,16 @@
           {
             "type": "object",
             "title": "ExclusiveBound",
-            "required": ["kind", "limit"],
+            "required": [
+              "kind",
+              "limit"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["exclusive"]
+                "enum": [
+                  "exclusive"
+                ]
               },
               "limit": {
                 "$ref": "#/components/schemas/Timestamp"
@@ -5960,11 +6597,15 @@
           {
             "type": "object",
             "title": "UnboundedBound",
-            "required": ["kind"],
+            "required": [
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["unbounded"]
+                "enum": [
+                  "unbounded"
+                ]
               }
             }
           }
@@ -5975,17 +6616,27 @@
       },
       "Operator": {
         "type": "string",
-        "enum": ["+", "-", "*", "/"]
+        "enum": [
+          "+",
+          "-",
+          "*",
+          "/"
+        ]
       },
       "Ordering": {
         "type": "string",
-        "enum": ["ascending", "descending"]
+        "enum": [
+          "ascending",
+          "descending"
+        ]
       },
       "OriginProvenance": {
         "oneOf": [
           {
             "type": "object",
-            "required": ["type"],
+            "required": [
+              "type"
+            ],
             "properties": {
               "apiKeyPublicId": {
                 "type": "string"
@@ -6007,7 +6658,9 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["web-app"]
+                "enum": [
+                  "web-app"
+                ]
               },
               "userAgent": {
                 "type": "string"
@@ -6020,7 +6673,9 @@
           },
           {
             "type": "object",
-            "required": ["type"],
+            "required": [
+              "type"
+            ],
             "properties": {
               "apiKeyPublicId": {
                 "type": "string"
@@ -6042,7 +6697,9 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["mobile-app"]
+                "enum": [
+                  "mobile-app"
+                ]
               },
               "userAgent": {
                 "type": "string"
@@ -6055,7 +6712,9 @@
           },
           {
             "type": "object",
-            "required": ["type"],
+            "required": [
+              "type"
+            ],
             "properties": {
               "apiKeyPublicId": {
                 "type": "string"
@@ -6077,7 +6736,9 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["browser-extension"]
+                "enum": [
+                  "browser-extension"
+                ]
               },
               "userAgent": {
                 "type": "string"
@@ -6090,7 +6751,9 @@
           },
           {
             "type": "object",
-            "required": ["type"],
+            "required": [
+              "type"
+            ],
             "properties": {
               "apiKeyPublicId": {
                 "type": "string"
@@ -6112,7 +6775,9 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["api"]
+                "enum": [
+                  "api"
+                ]
               },
               "userAgent": {
                 "type": "string"
@@ -6125,7 +6790,9 @@
           },
           {
             "type": "object",
-            "required": ["type"],
+            "required": [
+              "type"
+            ],
             "properties": {
               "apiKeyPublicId": {
                 "type": "string"
@@ -6153,7 +6820,9 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["flow"]
+                "enum": [
+                  "flow"
+                ]
               },
               "userAgent": {
                 "type": "string"
@@ -6166,7 +6835,9 @@
           },
           {
             "type": "object",
-            "required": ["type"],
+            "required": [
+              "type"
+            ],
             "properties": {
               "apiKeyPublicId": {
                 "type": "string"
@@ -6188,7 +6859,9 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["migration"]
+                "enum": [
+                  "migration"
+                ]
               },
               "userAgent": {
                 "type": "string"
@@ -6203,7 +6876,9 @@
       },
       "OutgoingEdgeResolveDepth": {
         "type": "object",
-        "required": ["outgoing"],
+        "required": [
+          "outgoing"
+        ],
         "properties": {
           "outgoing": {
             "type": "integer",
@@ -6219,7 +6894,9 @@
       },
       "PatchEntityParams": {
         "type": "object",
-        "required": ["entityId"],
+        "required": [
+          "entityId"
+        ],
         "properties": {
           "archived": {
             "type": "boolean"
@@ -6264,7 +6941,9 @@
       },
       "PermissionResponse": {
         "type": "object",
-        "required": ["has_permission"],
+        "required": [
+          "has_permission"
+        ],
         "properties": {
           "has_permission": {
             "type": "boolean"
@@ -6289,14 +6968,20 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["path", "added", "op"],
+            "required": [
+              "path",
+              "added",
+              "op"
+            ],
             "properties": {
               "added": {
                 "$ref": "#/components/schemas/Property"
               },
               "op": {
                 "type": "string",
-                "enum": ["added"]
+                "enum": [
+                  "added"
+                ]
               },
               "path": {
                 "$ref": "#/components/schemas/PropertyPath"
@@ -6305,11 +6990,17 @@
           },
           {
             "type": "object",
-            "required": ["path", "removed", "op"],
+            "required": [
+              "path",
+              "removed",
+              "op"
+            ],
             "properties": {
               "op": {
                 "type": "string",
-                "enum": ["removed"]
+                "enum": [
+                  "removed"
+                ]
               },
               "path": {
                 "$ref": "#/components/schemas/PropertyPath"
@@ -6321,7 +7012,12 @@
           },
           {
             "type": "object",
-            "required": ["path", "old", "new", "op"],
+            "required": [
+              "path",
+              "old",
+              "new",
+              "op"
+            ],
             "properties": {
               "new": {
                 "$ref": "#/components/schemas/Property"
@@ -6331,7 +7027,9 @@
               },
               "op": {
                 "type": "string",
-                "enum": ["changed"]
+                "enum": [
+                  "changed"
+                ]
               },
               "path": {
                 "$ref": "#/components/schemas/PropertyPath"
@@ -6378,7 +7076,9 @@
           {
             "type": "object",
             "title": "PropertyMetadataValue",
-            "required": ["metadata"],
+            "required": [
+              "metadata"
+            ],
             "properties": {
               "metadata": {
                 "$ref": "#/components/schemas/ValueMetadata"
@@ -6412,11 +7112,17 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["path", "property", "op"],
+            "required": [
+              "path",
+              "property",
+              "op"
+            ],
             "properties": {
               "op": {
                 "type": "string",
-                "enum": ["add"]
+                "enum": [
+                  "add"
+                ]
               },
               "path": {
                 "$ref": "#/components/schemas/PropertyPath"
@@ -6428,11 +7134,16 @@
           },
           {
             "type": "object",
-            "required": ["path", "op"],
+            "required": [
+              "path",
+              "op"
+            ],
             "properties": {
               "op": {
                 "type": "string",
-                "enum": ["remove"]
+                "enum": [
+                  "remove"
+                ]
               },
               "path": {
                 "$ref": "#/components/schemas/PropertyPath"
@@ -6441,11 +7152,17 @@
           },
           {
             "type": "object",
-            "required": ["path", "property", "op"],
+            "required": [
+              "path",
+              "property",
+              "op"
+            ],
             "properties": {
               "op": {
                 "type": "string",
-                "enum": ["replace"]
+                "enum": [
+                  "replace"
+                ]
               },
               "path": {
                 "$ref": "#/components/schemas/PropertyPath"
@@ -6493,11 +7210,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["account"]
+                "enum": [
+                  "account"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountId"
@@ -6506,11 +7228,16 @@
           },
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["accountGroup"]
+                "enum": [
+                  "accountGroup"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
@@ -6524,7 +7251,10 @@
       },
       "PropertyTypeEmbedding": {
         "type": "object",
-        "required": ["propertyTypeId", "embedding"],
+        "required": [
+          "propertyTypeId",
+          "embedding"
+        ],
         "properties": {
           "embedding": {
             "$ref": "#/components/schemas/Embedding"
@@ -6590,11 +7320,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["web"]
+                "enum": [
+                  "web"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/OwnedById"
@@ -6608,7 +7343,10 @@
       },
       "PropertyTypePermission": {
         "type": "string",
-        "enum": ["update", "view"]
+        "enum": [
+          "update",
+          "view"
+        ]
       },
       "PropertyTypeQueryToken": {
         "type": "string",
@@ -6630,11 +7368,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["owner"]
+                "enum": [
+                  "owner"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/PropertyTypeOwnerSubject"
@@ -6643,11 +7386,16 @@
           },
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["setting"]
+                "enum": [
+                  "setting"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/PropertyTypeSettingSubject"
@@ -6656,11 +7404,16 @@
           },
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["editor"]
+                "enum": [
+                  "editor"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/PropertyTypeEditorSubject"
@@ -6669,11 +7422,16 @@
           },
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["viewer"]
+                "enum": [
+                  "viewer"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/PropertyTypeViewerSubject"
@@ -6687,17 +7445,24 @@
       },
       "PropertyTypeSetting": {
         "type": "string",
-        "enum": ["updateFromWeb"]
+        "enum": [
+          "updateFromWeb"
+        ]
       },
       "PropertyTypeSettingSubject": {
         "oneOf": [
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["setting"]
+                "enum": [
+                  "setting"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/PropertyTypeSetting"
@@ -6711,7 +7476,10 @@
       },
       "PropertyTypeVertexId": {
         "type": "object",
-        "required": ["baseId", "revisionId"],
+        "required": [
+          "baseId",
+          "revisionId"
+        ],
         "properties": {
           "baseId": {
             "$ref": "#/components/schemas/BaseUrl"
@@ -6725,11 +7493,15 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["kind"],
+            "required": [
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["public"]
+                "enum": [
+                  "public"
+                ]
               }
             }
           }
@@ -6737,7 +7509,10 @@
       },
       "PropertyTypeWithMetadata": {
         "type": "object",
-        "required": ["schema", "metadata"],
+        "required": [
+          "schema",
+          "metadata"
+        ],
         "properties": {
           "metadata": {
             "$ref": "#/components/schemas/PropertyTypeMetadata"
@@ -6792,7 +7567,10 @@
       },
       "PropertyWithMetadataValue": {
         "type": "object",
-        "required": ["value", "metadata"],
+        "required": [
+          "value",
+          "metadata"
+        ],
         "properties": {
           "metadata": {
             "$ref": "#/components/schemas/ValueMetadata"
@@ -6855,7 +7633,10 @@
       },
       "QueryConversion": {
         "type": "object",
-        "required": ["path", "dataTypeId"],
+        "required": [
+          "path",
+          "dataTypeId"
+        ],
         "properties": {
           "dataTypeId": {
             "$ref": "#/components/schemas/VersionedUrl"
@@ -6871,12 +7652,18 @@
           {
             "type": "object",
             "title": "QueryTemporalAxesDecisionTime",
-            "required": ["pinned", "variable"],
+            "required": [
+              "pinned",
+              "variable"
+            ],
             "properties": {
               "pinned": {
                 "type": "object",
                 "title": "PinnedTransactionAxis",
-                "required": ["axis", "timestamp"],
+                "required": [
+                  "axis",
+                  "timestamp"
+                ],
                 "properties": {
                   "axis": {
                     "$ref": "#/components/schemas/TransactionTime"
@@ -6890,7 +7677,10 @@
               "variable": {
                 "type": "object",
                 "title": "VariableDecisionAxis",
-                "required": ["axis", "interval"],
+                "required": [
+                  "axis",
+                  "interval"
+                ],
                 "properties": {
                   "axis": {
                     "$ref": "#/components/schemas/DecisionTime"
@@ -6905,12 +7695,18 @@
           {
             "type": "object",
             "title": "QueryTemporalAxesTransactionTime",
-            "required": ["pinned", "variable"],
+            "required": [
+              "pinned",
+              "variable"
+            ],
             "properties": {
               "pinned": {
                 "type": "object",
                 "title": "PinnedDecisionAxis",
-                "required": ["axis", "timestamp"],
+                "required": [
+                  "axis",
+                  "timestamp"
+                ],
                 "properties": {
                   "axis": {
                     "$ref": "#/components/schemas/DecisionTime"
@@ -6924,7 +7720,10 @@
               "variable": {
                 "type": "object",
                 "title": "VariableTransactionAxis",
-                "required": ["axis", "interval"],
+                "required": [
+                  "axis",
+                  "interval"
+                ],
                 "properties": {
                   "axis": {
                     "$ref": "#/components/schemas/TransactionTime"
@@ -6944,12 +7743,18 @@
           {
             "type": "object",
             "title": "QueryTemporalAxesUnresolvedDecisionTime",
-            "required": ["pinned", "variable"],
+            "required": [
+              "pinned",
+              "variable"
+            ],
             "properties": {
               "pinned": {
                 "type": "object",
                 "title": "UnresolvedPinnedTransactionAxis",
-                "required": ["axis", "timestamp"],
+                "required": [
+                  "axis",
+                  "timestamp"
+                ],
                 "properties": {
                   "axis": {
                     "$ref": "#/components/schemas/TransactionTime"
@@ -6962,7 +7767,10 @@
               "variable": {
                 "type": "object",
                 "title": "UnresolvedVariableDecisionAxis",
-                "required": ["axis", "interval"],
+                "required": [
+                  "axis",
+                  "interval"
+                ],
                 "properties": {
                   "axis": {
                     "$ref": "#/components/schemas/DecisionTime"
@@ -6977,12 +7785,18 @@
           {
             "type": "object",
             "title": "QueryTemporalAxesUnresolvedTransactionTime",
-            "required": ["pinned", "variable"],
+            "required": [
+              "pinned",
+              "variable"
+            ],
             "properties": {
               "pinned": {
                 "type": "object",
                 "title": "UnresolvedPinnedDecisionAxis",
-                "required": ["axis", "timestamp"],
+                "required": [
+                  "axis",
+                  "timestamp"
+                ],
                 "properties": {
                   "axis": {
                     "$ref": "#/components/schemas/DecisionTime"
@@ -6995,7 +7809,10 @@
               "variable": {
                 "type": "object",
                 "title": "UnresolvedVariableTransactionAxis",
-                "required": ["axis", "interval"],
+                "required": [
+                  "axis",
+                  "interval"
+                ],
                 "properties": {
                   "axis": {
                     "$ref": "#/components/schemas/TransactionTime"
@@ -7012,7 +7829,10 @@
       },
       "RightBoundedTemporalInterval": {
         "type": "object",
-        "required": ["start", "end"],
+        "required": [
+          "start",
+          "end"
+        ],
         "properties": {
           "end": {
             "$ref": "#/components/schemas/LimitedTemporalBound"
@@ -7024,16 +7844,22 @@
       },
       "Selector": {
         "type": "string",
-        "enum": ["*"]
+        "enum": [
+          "*"
+        ]
       },
       "SharedEdgeKind": {
         "type": "string",
-        "enum": ["IS_OF_TYPE"]
+        "enum": [
+          "IS_OF_TYPE"
+        ]
       },
       "SourceProvenance": {
         "type": "object",
         "description": "The source material used in producing a value.",
-        "required": ["type"],
+        "required": [
+          "type"
+        ],
         "properties": {
           "authors": {
             "type": "array",
@@ -7086,11 +7912,20 @@
       "SourceType": {
         "type": "string",
         "description": "The type of source material which was used to produce a value.",
-        "enum": ["webpage", "document"]
+        "enum": [
+          "webpage",
+          "document"
+        ]
       },
       "Subgraph": {
         "type": "object",
-        "required": ["roots", "vertices", "edges", "depths", "temporalAxes"],
+        "required": [
+          "roots",
+          "vertices",
+          "edges",
+          "depths",
+          "temporalAxes"
+        ],
         "properties": {
           "depths": {
             "$ref": "#/components/schemas/GraphResolveDepths"
@@ -7114,7 +7949,10 @@
       },
       "SubgraphTemporalAxes": {
         "type": "object",
-        "required": ["initial", "resolved"],
+        "required": [
+          "initial",
+          "resolved"
+        ],
         "properties": {
           "initial": {
             "$ref": "#/components/schemas/QueryTemporalAxesUnresolved"
@@ -7129,22 +7967,31 @@
           {
             "type": "object",
             "title": "UnboundedBound",
-            "required": ["kind"],
+            "required": [
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["unbounded"]
+                "enum": [
+                  "unbounded"
+                ]
               }
             }
           },
           {
             "type": "object",
             "title": "InclusiveBound",
-            "required": ["kind", "limit"],
+            "required": [
+              "kind",
+              "limit"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["inclusive"]
+                "enum": [
+                  "inclusive"
+                ]
               },
               "limit": {
                 "$ref": "#/components/schemas/Timestamp"
@@ -7154,11 +8001,16 @@
           {
             "type": "object",
             "title": "ExclusiveBound",
-            "required": ["kind", "limit"],
+            "required": [
+              "kind",
+              "limit"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["exclusive"]
+                "enum": [
+                  "exclusive"
+                ]
               },
               "limit": {
                 "$ref": "#/components/schemas/Timestamp"
@@ -7177,11 +8029,15 @@
       "TransactionTime": {
         "type": "string",
         "description": "Time axis for the transaction time.\n\nThis is used as the generic argument to time-related structs and can be used as tag value.",
-        "enum": ["transactionTime"]
+        "enum": [
+          "transactionTime"
+        ]
       },
       "UnarchiveDataTypeParams": {
         "type": "object",
-        "required": ["dataTypeId"],
+        "required": [
+          "dataTypeId"
+        ],
         "properties": {
           "dataTypeId": {
             "$ref": "#/components/schemas/VersionedUrl"
@@ -7194,7 +8050,9 @@
       },
       "UnarchiveEntityTypeParams": {
         "type": "object",
-        "required": ["entityTypeId"],
+        "required": [
+          "entityTypeId"
+        ],
         "properties": {
           "entityTypeId": {
             "$ref": "#/components/schemas/VersionedUrl"
@@ -7207,7 +8065,9 @@
       },
       "UnarchivePropertyTypeParams": {
         "type": "object",
-        "required": ["propertyTypeId"],
+        "required": [
+          "propertyTypeId"
+        ],
         "properties": {
           "propertyTypeId": {
             "$ref": "#/components/schemas/VersionedUrl"
@@ -7220,7 +8080,10 @@
       },
       "UnresolvedRightBoundedTemporalInterval": {
         "type": "object",
-        "required": ["start", "end"],
+        "required": [
+          "start",
+          "end"
+        ],
         "properties": {
           "end": {
             "oneOf": [
@@ -7266,7 +8129,12 @@
       },
       "UpdateDataTypeRequest": {
         "type": "object",
-        "required": ["schema", "typeToUpdate", "relationships", "conversions"],
+        "required": [
+          "schema",
+          "typeToUpdate",
+          "relationships",
+          "conversions"
+        ],
         "properties": {
           "conversions": {
             "type": "object",
@@ -7349,7 +8217,11 @@
       },
       "UpdateEntityTypeRequest": {
         "type": "object",
-        "required": ["schema", "typeToUpdate", "relationships"],
+        "required": [
+          "schema",
+          "typeToUpdate",
+          "relationships"
+        ],
         "properties": {
           "provenance": {
             "$ref": "#/components/schemas/ProvidedOntologyEditionProvenance"
@@ -7395,7 +8267,11 @@
       },
       "UpdatePropertyTypeRequest": {
         "type": "object",
-        "required": ["schema", "typeToUpdate", "relationships"],
+        "required": [
+          "schema",
+          "typeToUpdate",
+          "relationships"
+        ],
         "properties": {
           "provenance": {
             "$ref": "#/components/schemas/ProvidedOntologyEditionProvenance"
@@ -7432,7 +8308,10 @@
       },
       "ValidateEntityParams": {
         "type": "object",
-        "required": ["entityTypes", "properties"],
+        "required": [
+          "entityTypes",
+          "properties"
+        ],
         "properties": {
           "components": {
             "allOf": [
@@ -7459,7 +8338,9 @@
       },
       "ValueMetadata": {
         "type": "object",
-        "required": ["dataTypeId"],
+        "required": [
+          "dataTypeId"
+        ],
         "properties": {
           "canonical": {
             "type": "object",
@@ -7495,7 +8376,9 @@
       },
       "Variable": {
         "type": "string",
-        "enum": ["self"]
+        "enum": [
+          "self"
+        ]
       },
       "VersionedUrl": {
         "type": "string",
@@ -7531,11 +8414,15 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["kind"],
+            "required": [
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["public"]
+                "enum": [
+                  "public"
+                ]
               }
             }
           }
@@ -7545,11 +8432,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["account"]
+                "enum": [
+                  "account"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountId"
@@ -7558,11 +8450,16 @@
           },
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["accountGroup"]
+                "enum": [
+                  "accountGroup"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
@@ -7578,11 +8475,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["account"]
+                "enum": [
+                  "account"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountId"
@@ -7591,11 +8493,16 @@
           },
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["accountGroup"]
+                "enum": [
+                  "accountGroup"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
@@ -7611,11 +8518,15 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["kind"],
+            "required": [
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["public"]
+                "enum": [
+                  "public"
+                ]
               }
             }
           }
@@ -7625,21 +8536,30 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["kind"],
+            "required": [
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["public"]
+                "enum": [
+                  "public"
+                ]
               }
             }
           },
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["account"]
+                "enum": [
+                  "account"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountId"
@@ -7648,11 +8568,16 @@
           },
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["accountGroup"]
+                "enum": [
+                  "accountGroup"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
@@ -7668,11 +8593,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["account"]
+                "enum": [
+                  "account"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountId"
@@ -7681,11 +8611,16 @@
           },
           {
             "type": "object",
-            "required": ["subjectId", "kind"],
+            "required": [
+              "subjectId",
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["accountGroup"]
+                "enum": [
+                  "accountGroup"
+                ]
               },
               "subjectId": {
                 "$ref": "#/components/schemas/AccountGroupId"
@@ -7713,11 +8648,15 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["kind"],
+            "required": [
+              "kind"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["public"]
+                "enum": [
+                  "public"
+                ]
               }
             }
           }
@@ -7727,11 +8666,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["owner"]
+                "enum": [
+                  "owner"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/WebOwnerSubject"
@@ -7740,11 +8684,16 @@
           },
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["entityCreator"]
+                "enum": [
+                  "entityCreator"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/WebEntityCreatorSubject"
@@ -7753,11 +8702,16 @@
           },
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["entityEditor"]
+                "enum": [
+                  "entityEditor"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/WebEntityEditorSubject"
@@ -7766,11 +8720,16 @@
           },
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["entityViewer"]
+                "enum": [
+                  "entityViewer"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/WebEntityViewerSubject"
@@ -7779,11 +8738,16 @@
           },
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["entityTypeViewer"]
+                "enum": [
+                  "entityTypeViewer"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/WebEntityTypeViewerSubject"
@@ -7792,11 +8756,16 @@
           },
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["propertyTypeViewer"]
+                "enum": [
+                  "propertyTypeViewer"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/WebPropertyTypeViewerSubject"
@@ -7805,11 +8774,16 @@
           },
           {
             "type": "object",
-            "required": ["subject", "relation"],
+            "required": [
+              "subject",
+              "relation"
+            ],
             "properties": {
               "relation": {
                 "type": "string",
-                "enum": ["dataTypeViewer"]
+                "enum": [
+                  "dataTypeViewer"
+                ]
               },
               "subject": {
                 "$ref": "#/components/schemas/WebDataTypeViewerSubject"

--- a/apps/hash-graph/libs/api/src/rest/entity_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity_type.rs
@@ -770,7 +770,7 @@ where
         .map_err(report_to_response)?;
 
     store
-        .get_multi_entity_types(
+        .get_closed_multi_entity_types(
             actor_id,
             // Manually deserialize the query from a JSON value to allow borrowed deserialization
             // and better error reporting.

--- a/apps/hash-graph/libs/api/src/rest/json_schemas/closed_multi_entity_type.json
+++ b/apps/hash-graph/libs/api/src/rest/json_schemas/closed_multi_entity_type.json
@@ -1,0 +1,50 @@
+{
+  "title": "Closed Entity Type",
+  "description": "Specifies the closed structure of a Block Protocol entity type",
+  "type": "object",
+  "properties": {
+    "allOf": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "$id": {
+            "$ref": "./shared.json#/definitions/VersionedUrl"
+          },
+          "title": {
+            "type": "string"
+          },
+          "titlePlural": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "allOf": {
+            "type": "array",
+            "items": {
+              "$ref": "./shared.json#/definitions/EntityTypeDisplayMetadata"
+            },
+            "minItems": 1
+          }
+        },
+        "additionalProperties": false
+      },
+      "minItems": 1
+    },
+    "properties": {
+      "$ref": "./shared.json#/definitions/PropertyTypeObject"
+    },
+    "required": {
+      "type": "array",
+      "items": {
+        "$ref": "./shared.json#/definitions/BaseUrl"
+      }
+    },
+    "links": {
+      "$ref": "./shared.json#/definitions/LinkTypeObject"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["$id", "title", "description", "properties"]
+}

--- a/apps/hash-graph/libs/api/src/rest/json_schemas/closed_multi_entity_type.json
+++ b/apps/hash-graph/libs/api/src/rest/json_schemas/closed_multi_entity_type.json
@@ -1,6 +1,6 @@
 {
-  "title": "Closed Entity Type",
-  "description": "Specifies the closed structure of a Block Protocol entity type",
+  "title": "Closed Multi-Entity Type",
+  "description": "Specifies the closed structure which combines multiple entity types",
   "type": "object",
   "properties": {
     "allOf": {

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -1092,12 +1092,14 @@ where
         self.store.get_entity_types(actor_id, params).await
     }
 
-    async fn get_multi_entity_types(
+    async fn get_closed_multi_entity_types(
         &self,
         actor_id: AccountId,
         params: GetClosedMultiEntityTypeParams,
     ) -> Result<GetClosedMultiEntityTypeResponse, QueryError> {
-        self.store.get_multi_entity_types(actor_id, params).await
+        self.store
+            .get_closed_multi_entity_types(actor_id, params)
+            .await
     }
 
     async fn get_entity_type_subgraph(

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -63,7 +63,8 @@ use crate::{
             CreateDataTypeParams, CreateEntityTypeParams, CreatePropertyTypeParams,
             GetDataTypeSubgraphParams, GetDataTypeSubgraphResponse, GetDataTypesParams,
             GetDataTypesResponse, GetEntityTypeSubgraphParams, GetEntityTypeSubgraphResponse,
-            GetEntityTypesParams, GetEntityTypesResponse, GetPropertyTypeSubgraphParams,
+            GetEntityTypesParams, GetEntityTypesResponse, GetMultiEntityTypeParams,
+            GetMultiEntityTypeResponse, GetPropertyTypeSubgraphParams,
             GetPropertyTypeSubgraphResponse, GetPropertyTypesParams, GetPropertyTypesResponse,
             UnarchiveDataTypeParams, UnarchiveEntityTypeParams, UnarchivePropertyTypeParams,
             UpdateDataTypeEmbeddingParams, UpdateDataTypesParams, UpdateEntityTypeEmbeddingParams,
@@ -1089,6 +1090,14 @@ where
         params: GetEntityTypesParams<'_>,
     ) -> Result<GetEntityTypesResponse, QueryError> {
         self.store.get_entity_types(actor_id, params).await
+    }
+
+    async fn get_multi_entity_types(
+        &self,
+        actor_id: AccountId,
+        params: GetMultiEntityTypeParams,
+    ) -> Result<GetMultiEntityTypeResponse, QueryError> {
+        self.store.get_multi_entity_types(actor_id, params).await
     }
 
     async fn get_entity_type_subgraph(

--- a/apps/hash-graph/libs/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/libs/graph/src/store/fetcher.rs
@@ -61,10 +61,10 @@ use crate::{
             ArchiveDataTypeParams, ArchiveEntityTypeParams, ArchivePropertyTypeParams,
             CountDataTypesParams, CountEntityTypesParams, CountPropertyTypesParams,
             CreateDataTypeParams, CreateEntityTypeParams, CreatePropertyTypeParams,
+            GetClosedMultiEntityTypeParams, GetClosedMultiEntityTypeResponse,
             GetDataTypeSubgraphParams, GetDataTypeSubgraphResponse, GetDataTypesParams,
             GetDataTypesResponse, GetEntityTypeSubgraphParams, GetEntityTypeSubgraphResponse,
-            GetEntityTypesParams, GetEntityTypesResponse, GetMultiEntityTypeParams,
-            GetMultiEntityTypeResponse, GetPropertyTypeSubgraphParams,
+            GetEntityTypesParams, GetEntityTypesResponse, GetPropertyTypeSubgraphParams,
             GetPropertyTypeSubgraphResponse, GetPropertyTypesParams, GetPropertyTypesResponse,
             UnarchiveDataTypeParams, UnarchiveEntityTypeParams, UnarchivePropertyTypeParams,
             UpdateDataTypeEmbeddingParams, UpdateDataTypesParams, UpdateEntityTypeEmbeddingParams,
@@ -1095,8 +1095,8 @@ where
     async fn get_multi_entity_types(
         &self,
         actor_id: AccountId,
-        params: GetMultiEntityTypeParams,
-    ) -> Result<GetMultiEntityTypeResponse, QueryError> {
+        params: GetClosedMultiEntityTypeParams,
+    ) -> Result<GetClosedMultiEntityTypeResponse, QueryError> {
         self.store.get_multi_entity_types(actor_id, params).await
     }
 

--- a/apps/hash-graph/libs/graph/src/store/ontology.rs
+++ b/apps/hash-graph/libs/graph/src/store/ontology.rs
@@ -24,7 +24,9 @@ use hash_graph_store::{
 use serde::{Deserialize, Serialize};
 use temporal_versioning::{Timestamp, TransactionTime};
 use type_system::{
-    schema::{ClosedEntityType, Conversions, DataType, EntityType, PropertyType},
+    schema::{
+        ClosedEntityType, ClosedMultiEntityType, Conversions, DataType, EntityType, PropertyType,
+    },
     url::{BaseUrl, VersionedUrl},
 };
 
@@ -621,6 +623,23 @@ pub struct GetEntityTypesResponse {
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GetMultiEntityTypeParams {
+    pub entity_type_ids: Vec<VersionedUrl>,
+    pub temporal_axes: QueryTemporalAxesUnresolved,
+    pub include_drafts: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct GetMultiEntityTypeResponse {
+    #[cfg_attr(feature = "utoipa", schema(value_type = VAR_CLOSED_MULTI_ENTITY_TYPE))]
+    pub entity_type: ClosedMultiEntityType,
+}
+
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct UpdateEntityTypesParams<R> {
     pub schema: EntityType,
     pub relationships: R,
@@ -724,18 +743,27 @@ pub trait EntityTypeStore {
         params: GetEntityTypeSubgraphParams<'_>,
     ) -> impl Future<Output = Result<GetEntityTypeSubgraphResponse, QueryError>> + Send;
 
-    /// Get the [`EntityTypes`] specified by the [`GetEntityTypesParams`].
+    /// Get the [`EntityType`]s specified by the [`GetEntityTypesParams`].
     ///
     /// # Errors
     ///
     /// - if the requested [`EntityType`] doesn't exist.
-    ///
-    /// [`EntityTypes`]: EntityType
     fn get_entity_types(
         &self,
         actor_id: AccountId,
         params: GetEntityTypesParams<'_>,
     ) -> impl Future<Output = Result<GetEntityTypesResponse, QueryError>> + Send;
+
+    /// Get the [`ClosedMultiEntityType`] specified by the [`GetMultiEntityTypeParams`].
+    ///
+    /// # Errors
+    ///
+    /// - if the requested [`EntityType`] doesn't exist.
+    fn get_multi_entity_types(
+        &self,
+        actor_id: AccountId,
+        params: GetMultiEntityTypeParams,
+    ) -> impl Future<Output = Result<GetMultiEntityTypeResponse, QueryError>> + Send;
 
     /// Update the definition of an existing [`EntityType`].
     ///

--- a/apps/hash-graph/libs/graph/src/store/ontology.rs
+++ b/apps/hash-graph/libs/graph/src/store/ontology.rs
@@ -623,7 +623,7 @@ pub struct GetEntityTypesResponse {
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct GetMultiEntityTypeParams {
+pub struct GetClosedMultiEntityTypeParams {
     pub entity_type_ids: Vec<VersionedUrl>,
     pub temporal_axes: QueryTemporalAxesUnresolved,
     pub include_drafts: bool,
@@ -632,7 +632,7 @@ pub struct GetMultiEntityTypeParams {
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
-pub struct GetMultiEntityTypeResponse {
+pub struct GetClosedMultiEntityTypeResponse {
     #[cfg_attr(feature = "utoipa", schema(value_type = VAR_CLOSED_MULTI_ENTITY_TYPE))]
     pub entity_type: ClosedMultiEntityType,
 }
@@ -762,8 +762,8 @@ pub trait EntityTypeStore {
     fn get_multi_entity_types(
         &self,
         actor_id: AccountId,
-        params: GetMultiEntityTypeParams,
-    ) -> impl Future<Output = Result<GetMultiEntityTypeResponse, QueryError>> + Send;
+        params: GetClosedMultiEntityTypeParams,
+    ) -> impl Future<Output = Result<GetClosedMultiEntityTypeResponse, QueryError>> + Send;
 
     /// Update the definition of an existing [`EntityType`].
     ///

--- a/apps/hash-graph/libs/graph/src/store/ontology.rs
+++ b/apps/hash-graph/libs/graph/src/store/ontology.rs
@@ -754,12 +754,12 @@ pub trait EntityTypeStore {
         params: GetEntityTypesParams<'_>,
     ) -> impl Future<Output = Result<GetEntityTypesResponse, QueryError>> + Send;
 
-    /// Get the [`ClosedMultiEntityType`] specified by the [`GetMultiEntityTypeParams`].
+    /// Get the [`ClosedMultiEntityType`] specified by the [`GetClosedMultiEntityTypeParams`].
     ///
     /// # Errors
     ///
     /// - if the requested [`EntityType`] doesn't exist.
-    fn get_multi_entity_types(
+    fn get_closed_multi_entity_types(
         &self,
         actor_id: AccountId,
         params: GetClosedMultiEntityTypeParams,

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
@@ -56,9 +56,10 @@ use crate::store::{
     error::DeletionError,
     ontology::{
         ArchiveEntityTypeParams, CountEntityTypesParams, CreateEntityTypeParams,
+        GetClosedMultiEntityTypeParams, GetClosedMultiEntityTypeResponse,
         GetEntityTypeSubgraphParams, GetEntityTypeSubgraphResponse, GetEntityTypesParams,
-        GetEntityTypesResponse, GetMultiEntityTypeParams, GetMultiEntityTypeResponse,
-        UnarchiveEntityTypeParams, UpdateEntityTypeEmbeddingParams, UpdateEntityTypesParams,
+        GetEntityTypesResponse, UnarchiveEntityTypeParams, UpdateEntityTypeEmbeddingParams,
+        UpdateEntityTypesParams,
     },
     postgres::{
         ResponseCountMap, TraversalContext,
@@ -874,8 +875,8 @@ where
     async fn get_multi_entity_types(
         &self,
         actor_id: AccountId,
-        params: GetMultiEntityTypeParams,
-    ) -> Result<GetMultiEntityTypeResponse, QueryError> {
+        params: GetClosedMultiEntityTypeParams,
+    ) -> Result<GetClosedMultiEntityTypeResponse, QueryError> {
         let entity_type_ids = params
             .entity_type_ids
             .iter()
@@ -901,7 +902,7 @@ where
             .await
             .change_context(QueryError)?;
 
-        Ok(GetMultiEntityTypeResponse {
+        Ok(GetClosedMultiEntityTypeResponse {
             entity_type: ClosedMultiEntityType::from_multi_type_closed_schema(
                 response
                     .closed_entity_types

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
@@ -42,7 +42,7 @@ use tracing::instrument;
 use type_system::{
     Valid, Validator,
     schema::{
-        ClosedEntityType, DataTypeUuid, EntityType, EntityTypeResolveData,
+        ClosedEntityType, ClosedMultiEntityType, DataTypeUuid, EntityType, EntityTypeResolveData,
         EntityTypeToPropertyTypeEdge, EntityTypeUuid, EntityTypeValidator, InheritanceDepth,
         OntologyTypeResolver, OntologyTypeUuid, PropertyTypeUuid,
     },
@@ -57,8 +57,8 @@ use crate::store::{
     ontology::{
         ArchiveEntityTypeParams, CountEntityTypesParams, CreateEntityTypeParams,
         GetEntityTypeSubgraphParams, GetEntityTypeSubgraphResponse, GetEntityTypesParams,
-        GetEntityTypesResponse, UnarchiveEntityTypeParams, UpdateEntityTypeEmbeddingParams,
-        UpdateEntityTypesParams,
+        GetEntityTypesResponse, GetMultiEntityTypeParams, GetMultiEntityTypeResponse,
+        UnarchiveEntityTypeParams, UpdateEntityTypeEmbeddingParams, UpdateEntityTypesParams,
     },
     postgres::{
         ResponseCountMap, TraversalContext,
@@ -869,6 +869,46 @@ where
             );
         };
         Ok(response)
+    }
+
+    async fn get_multi_entity_types(
+        &self,
+        actor_id: AccountId,
+        params: GetMultiEntityTypeParams,
+    ) -> Result<GetMultiEntityTypeResponse, QueryError> {
+        let entity_type_ids = params
+            .entity_type_ids
+            .iter()
+            .map(EntityTypeUuid::from_url)
+            .collect::<Vec<_>>();
+        let response = self
+            .get_entity_types(actor_id, GetEntityTypesParams {
+                filter: Filter::In(
+                    FilterExpression::Path {
+                        path: EntityTypeQueryPath::OntologyId,
+                    },
+                    ParameterList::EntityTypeIds(&entity_type_ids),
+                ),
+                temporal_axes: params.temporal_axes,
+                include_drafts: params.include_drafts,
+                after: None,
+                limit: None,
+                include_count: false,
+                include_closed: true,
+                include_web_ids: false,
+                include_edition_created_by_ids: false,
+            })
+            .await
+            .change_context(QueryError)?;
+
+        Ok(GetMultiEntityTypeResponse {
+            entity_type: ClosedMultiEntityType::from_multi_type_closed_schema(
+                response
+                    .closed_entity_types
+                    .expect("Response should include closed entity types"),
+            )
+            .change_context(QueryError)?,
+        })
     }
 
     #[tracing::instrument(level = "info", skip(self))]

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
@@ -872,7 +872,7 @@ where
         Ok(response)
     }
 
-    async fn get_multi_entity_types(
+    async fn get_closed_multi_entity_types(
         &self,
         actor_id: AccountId,
         params: GetClosedMultiEntityTypeParams,

--- a/libs/@local/hash-graph-client/typescript/turbo.json
+++ b/libs/@local/hash-graph-client/typescript/turbo.json
@@ -11,6 +11,7 @@
     "codegen": {
       "inputs": [
         "../../../../apps/hash-graph/libs/api/openapi/openapi.json",
+        "../../../../apps/hash-graph/libs/api/openapi/models/**",
         "opeenapitools.json"
       ],
       "outputs": [

--- a/libs/@local/hash-isomorphic-utils/src/subgraph-mapping.ts
+++ b/libs/@local/hash-isomorphic-utils/src/subgraph-mapping.ts
@@ -220,11 +220,11 @@ export const mapGraphApiClosedEntityTypesToClosedEntityTypes = (
   entityTypes: GraphApiClosedEntityType[],
 ) => entityTypes as ClosedEntityType[];
 
-export const mapGraphApiMultiEntityTypeToMultiEntityType = (
+export const mapGraphApiClosedMultiEntityTypeToClosedMultiEntityType = (
   entityType: GraphApiClosedMultiEntityType,
 ) => entityType as ClosedMultiEntityType;
 
-export const mapGraphApiMultiEntityTypesToMultiEntityTypes = (
+export const mapGraphApiClosedMultiEntityTypesToClosedMultiEntityTypes = (
   entityTypes: GraphApiClosedMultiEntityType[],
 ) => entityTypes as ClosedMultiEntityType[];
 

--- a/libs/@local/hash-isomorphic-utils/src/subgraph-mapping.ts
+++ b/libs/@local/hash-isomorphic-utils/src/subgraph-mapping.ts
@@ -1,7 +1,11 @@
-import type { ClosedEntityType } from "@blockprotocol/type-system";
+import type {
+  ClosedEntityType,
+  ClosedMultiEntityType,
+} from "@blockprotocol/type-system";
 import { typedEntries } from "@local/advanced-types/typed-entries";
 import type {
   ClosedEntityType as GraphApiClosedEntityType,
+  ClosedMultiEntityType as GraphApiClosedMultiEntityType,
   DataTypeWithMetadata as GraphApiDataTypeWithMetadata,
   Entity as GraphApiEntity,
   EntityTypeWithMetadata as GraphApiEntityTypeWithMetadata,
@@ -208,18 +212,26 @@ export const deserializeSubgraph = <RootType extends SubgraphRootType>(
   temporalAxes: subgraph.temporalAxes,
 });
 
-export const mapGraphApiEntityTypeToEntityType = (
+export const mapGraphApiEntityTypesToEntityTypes = (
   entityTypes: GraphApiEntityTypeWithMetadata[],
 ) => entityTypes as EntityTypeWithMetadata[];
 
-export const mapGraphApiClosedEntityTypeToClosedEntityType = (
+export const mapGraphApiClosedEntityTypesToClosedEntityTypes = (
   entityTypes: GraphApiClosedEntityType[],
 ) => entityTypes as ClosedEntityType[];
 
-export const mapGraphApiPropertyTypeToPropertyType = (
+export const mapGraphApiMultiEntityTypeToMultiEntityType = (
+  entityType: GraphApiClosedMultiEntityType,
+) => entityType as ClosedMultiEntityType;
+
+export const mapGraphApiMultiEntityTypesToMultiEntityTypes = (
+  entityTypes: GraphApiClosedMultiEntityType[],
+) => entityTypes as ClosedMultiEntityType[];
+
+export const mapGraphApiPropertyTypesToPropertyTypes = (
   entityTypes: GraphApiPropertyTypeWithMetadata[],
 ) => entityTypes as PropertyTypeWithMetadata[];
 
-export const mapGraphApiDataTypeToDataType = (
+export const mapGraphApiDataTypesToDataTypes = (
   entityTypes: GraphApiDataTypeWithMetadata[],
 ) => entityTypes as DataTypeWithMetadata[];

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -589,12 +589,14 @@ impl<A: AuthorizationApi> EntityTypeStore for DatabaseApi<'_, A> {
         Ok(response)
     }
 
-    async fn get_multi_entity_types(
+    async fn get_closed_multi_entity_types(
         &self,
         actor_id: AccountId,
         params: GetClosedMultiEntityTypeParams,
     ) -> Result<GetClosedMultiEntityTypeResponse, QueryError> {
-        self.store.get_multi_entity_types(actor_id, params).await
+        self.store
+            .get_closed_multi_entity_types(actor_id, params)
+            .await
     }
 
     async fn get_entity_type_subgraph(

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -53,10 +53,10 @@ use graph::{
             ArchiveDataTypeParams, ArchiveEntityTypeParams, ArchivePropertyTypeParams,
             CountDataTypesParams, CountEntityTypesParams, CountPropertyTypesParams,
             CreateDataTypeParams, CreateEntityTypeParams, CreatePropertyTypeParams,
+            GetClosedMultiEntityTypeParams, GetClosedMultiEntityTypeResponse,
             GetDataTypeSubgraphParams, GetDataTypeSubgraphResponse, GetDataTypesParams,
             GetDataTypesResponse, GetEntityTypeSubgraphParams, GetEntityTypeSubgraphResponse,
-            GetEntityTypesParams, GetEntityTypesResponse, GetMultiEntityTypeParams,
-            GetMultiEntityTypeResponse, GetPropertyTypeSubgraphParams,
+            GetEntityTypesParams, GetEntityTypesResponse, GetPropertyTypeSubgraphParams,
             GetPropertyTypeSubgraphResponse, GetPropertyTypesParams, GetPropertyTypesResponse,
             UnarchiveDataTypeParams, UnarchiveEntityTypeParams, UnarchivePropertyTypeParams,
             UpdateDataTypeEmbeddingParams, UpdateDataTypesParams, UpdateEntityTypeEmbeddingParams,
@@ -592,8 +592,8 @@ impl<A: AuthorizationApi> EntityTypeStore for DatabaseApi<'_, A> {
     async fn get_multi_entity_types(
         &self,
         actor_id: AccountId,
-        params: GetMultiEntityTypeParams,
-    ) -> Result<GetMultiEntityTypeResponse, QueryError> {
+        params: GetClosedMultiEntityTypeParams,
+    ) -> Result<GetClosedMultiEntityTypeResponse, QueryError> {
         self.store.get_multi_entity_types(actor_id, params).await
     }
 

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -55,7 +55,8 @@ use graph::{
             CreateDataTypeParams, CreateEntityTypeParams, CreatePropertyTypeParams,
             GetDataTypeSubgraphParams, GetDataTypeSubgraphResponse, GetDataTypesParams,
             GetDataTypesResponse, GetEntityTypeSubgraphParams, GetEntityTypeSubgraphResponse,
-            GetEntityTypesParams, GetEntityTypesResponse, GetPropertyTypeSubgraphParams,
+            GetEntityTypesParams, GetEntityTypesResponse, GetMultiEntityTypeParams,
+            GetMultiEntityTypeResponse, GetPropertyTypeSubgraphParams,
             GetPropertyTypeSubgraphResponse, GetPropertyTypesParams, GetPropertyTypesResponse,
             UnarchiveDataTypeParams, UnarchiveEntityTypeParams, UnarchivePropertyTypeParams,
             UpdateDataTypeEmbeddingParams, UpdateDataTypesParams, UpdateEntityTypeEmbeddingParams,
@@ -586,6 +587,14 @@ impl<A: AuthorizationApi> EntityTypeStore for DatabaseApi<'_, A> {
             response.count = None;
         }
         Ok(response)
+    }
+
+    async fn get_multi_entity_types(
+        &self,
+        actor_id: AccountId,
+        params: GetMultiEntityTypeParams,
+    ) -> Result<GetMultiEntityTypeResponse, QueryError> {
+        self.store.get_multi_entity_types(actor_id, params).await
     }
 
     async fn get_entity_type_subgraph(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For entities we need to combine entity types.

## 🔍 What does this change?

This is a small endpoint to allow merging entity types at all. It's not supposed to be a long-time solution (the types ideally should be returned alongside the entities), however, this allows viewing the entity types in the first place.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing
### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph