### PR TITLE
H-3546: Fix OpenAPI path for multi closed-entity type querying

### DIFF
--- a/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
@@ -255,7 +255,7 @@ export const getClosedMultiEntityType: ImpureGraphFunction<
   Promise<ClosedMultiEntityType>
 > = async ({ graphApi }, { actorId }, { temporalClient: _, ...request }) =>
   graphApi
-    .getClosedMultiEntityTypes(actorId, request)
+    .getClosedMultiEntityType(actorId, request)
     .then(({ data: response }) =>
       mapGraphApiClosedMultiEntityTypeToClosedMultiEntityType(
         response.entityType,

--- a/apps/hash-graph/libs/api/openapi/openapi.json
+++ b/apps/hash-graph/libs/api/openapi/openapi.json
@@ -1922,54 +1922,6 @@
         }
       }
     },
-    "/entity-types/multi": {
-      "post": {
-        "tags": [
-          "Graph",
-          "EntityType"
-        ],
-        "operationId": "get_closed_multi_entity_types",
-        "parameters": [
-          {
-            "name": "X-Authenticated-User-Actor-Id",
-            "in": "header",
-            "description": "The ID of the actor which is used to authorize the request",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/AccountId"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GetClosedMultiEntityTypeParams"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Gets a list of multi-entity types that satisfy the given query. A multi-entity type is the combination of multiple entity types.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetClosedMultiEntityTypeResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Provided query is invalid"
-          },
-          "500": {
-            "description": "Store error occurred"
-          }
-        }
-      }
-    },
     "/entity-types/query": {
       "post": {
         "tags": [
@@ -2005,6 +1957,54 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/GetEntityTypesResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Provided query is invalid"
+          },
+          "500": {
+            "description": "Store error occurred"
+          }
+        }
+      }
+    },
+    "/entity-types/query/multi": {
+      "post": {
+        "tags": [
+          "Graph",
+          "EntityType"
+        ],
+        "operationId": "get_closed_multi_entity_type",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetClosedMultiEntityTypeParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Gets a list of multi-entity types that satisfy the given query. A multi-entity type is the combination of multiple entity types.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetClosedMultiEntityTypeResponse"
                 }
               }
             }

--- a/apps/hash-graph/libs/api/src/rest/entity_type.rs
+++ b/apps/hash-graph/libs/api/src/rest/entity_type.rs
@@ -77,7 +77,7 @@ use crate::rest::{
         load_external_entity_type,
         get_entity_types,
         get_entity_type_subgraph,
-        get_closed_multi_entity_types,
+        get_closed_multi_entity_type,
         update_entity_type,
         update_entity_type_embeddings,
         archive_entity_type,
@@ -155,7 +155,7 @@ impl RoutedResource for EntityTypeResource {
                     "/query",
                     Router::new()
                         .route("/", post(get_entity_types::<S, A>))
-                        .route("/multi", post(get_closed_multi_entity_types::<S, A>))
+                        .route("/multi", post(get_closed_multi_entity_type::<S, A>))
                         .route("/subgraph", post(get_entity_type_subgraph::<S, A>)),
                 )
                 .route("/load", post(load_external_entity_type::<S, A>))
@@ -726,7 +726,7 @@ where
 
 #[utoipa::path(
     post,
-    path = "/entity-types/multi",
+    path = "/entity-types/query/multi",
     request_body = GetClosedMultiEntityTypeParams,
     tag = "EntityType",
     params(
@@ -748,7 +748,7 @@ where
     level = "info",
     skip(store_pool, authorization_api_pool, temporal_client, request)
 )]
-async fn get_closed_multi_entity_types<S, A>(
+async fn get_closed_multi_entity_type<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
     authorization_api_pool: Extension<Arc<A>>,

--- a/libs/@local/hash-graph-types/typescript/src/ontology.ts
+++ b/libs/@local/hash-graph-types/typescript/src/ontology.ts
@@ -7,6 +7,7 @@ import type {
 import { validateBaseUrl } from "@blockprotocol/type-system";
 import type {
   BaseUrl as BaseUrlBp,
+  ClosedEntityType,
   DataType,
   EntityType,
   PropertyType,
@@ -16,7 +17,6 @@ import type { DistributiveOmit } from "@local/advanced-types/distribute";
 import type { Subtype } from "@local/advanced-types/subtype";
 import type {
   ActorType,
-  ClosedEntityType,
   ProvidedEntityEditionProvenanceOrigin,
   SourceProvenance,
 } from "@local/hash-graph-client";

--- a/tests/hash-backend-integration/src/tests/graph/ontology/primitive/entity-type.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/ontology/primitive/entity-type.test.ts
@@ -5,14 +5,22 @@ import type { User } from "@apps/hash-api/src/graph/knowledge/system-types/user"
 import { joinOrg } from "@apps/hash-api/src/graph/knowledge/system-types/user";
 import {
   createEntityType,
+  getClosedEntityTypes,
+  getClosedMultiEntityType,
   getEntityTypeById,
   getEntityTypeSubgraphById,
   updateEntityType,
 } from "@apps/hash-api/src/graph/ontology/primitive/entity-type";
 import { createPropertyType } from "@apps/hash-api/src/graph/ontology/primitive/property-type";
+import type {
+  ClosedEntityType,
+  ClosedMultiEntityType,
+} from "@blockprotocol/type-system";
+import { atLeastOne } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
 import { publicUserAccountId } from "@local/hash-backend-utils/public-user-account-id";
 import type {
+  ClosedEntityTypeWithMetadata,
   EntityTypeWithMetadata,
   PropertyTypeWithMetadata,
 } from "@local/hash-graph-types/ontology";
@@ -21,6 +29,7 @@ import {
   currentTimeInstantTemporalAxes,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
+import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import type {
   ConstructEntityTypeParams,
   SystemDefinedProperties,
@@ -29,7 +38,7 @@ import {
   isOwnedOntologyElementMetadata,
   linkEntityTypeUrl,
 } from "@local/hash-subgraph";
-import { beforeAll, describe, expect, it } from "vitest";
+import { assert, beforeAll, describe, expect, it } from "vitest";
 
 import { resetGraph } from "../../../test-server";
 import {
@@ -272,6 +281,148 @@ describe("Entity type CRU", () => {
     );
 
     expect(fetchedEntityType.schema).toEqual(createdEntityType.schema);
+  });
+
+  it("can read a closed entity type", async () => {
+    const authentication = { actorId: testUser.accountId };
+
+    const userType = await getEntityTypeById(graphContext, authentication, {
+      entityTypeId: systemEntityTypes.user.entityTypeId,
+    });
+    const actorType = await getEntityTypeById(graphContext, authentication, {
+      entityTypeId: systemEntityTypes.actor.entityTypeId,
+    });
+
+    const fetchedEntityType = await getClosedEntityTypes(
+      graphContext,
+      authentication,
+      {
+        filter: {
+          equal: [
+            { path: ["versionedUrl"] },
+            { parameter: userType.schema.$id },
+          ],
+        },
+        temporalAxes: currentTimeInstantTemporalAxes,
+      },
+    );
+
+    // It's not specified how `required` is ordered, so we need to sort it before comparing
+    for (const entityType of fetchedEntityType) {
+      if (entityType.schema.required) {
+        entityType.schema.required.sort();
+      }
+    }
+
+    expect(fetchedEntityType).toEqual([
+      {
+        metadata: userType.metadata,
+        schema: {
+          $id: userType.schema.$id,
+          title: userType.schema.title,
+          description: userType.schema.description,
+          properties: {
+            ...userType.schema.properties,
+            ...actorType.schema.properties,
+          },
+          required: atLeastOne(
+            Array.from(
+              new Set([
+                ...(userType.schema.required ?? []),
+                ...(actorType.schema.required ?? []),
+              ]),
+            ).toSorted(),
+          ),
+          links: {
+            ...(userType.schema.links ?? {}),
+            ...(userType.schema.links ?? {}),
+          },
+        } satisfies ClosedEntityType,
+      },
+    ]);
+  });
+
+  it("can read a closed multi-entity type", async () => {
+    const authentication = { actorId: testUser.accountId };
+
+    const closedEntityTypes = (await getClosedEntityTypes(
+      graphContext,
+      authentication,
+      {
+        filter: {
+          any: [
+            {
+              equal: [
+                { path: ["versionedUrl"] },
+                { parameter: systemEntityTypes.user.entityTypeId },
+              ],
+            },
+            {
+              equal: [
+                { path: ["versionedUrl"] },
+                { parameter: systemEntityTypes.actor.entityTypeId },
+              ],
+            },
+          ],
+        },
+        temporalAxes: currentTimeInstantTemporalAxes,
+      },
+    )) as [ClosedEntityTypeWithMetadata, ...ClosedEntityTypeWithMetadata[]];
+
+    const closedMultiEntityType = await getClosedMultiEntityType(
+      graphContext,
+      authentication,
+      {
+        entityTypeIds: [
+          systemEntityTypes.user.entityTypeId,
+          systemEntityTypes.actor.entityTypeId,
+        ],
+        temporalAxes: currentTimeInstantTemporalAxes,
+        includeDrafts: false,
+      },
+    );
+
+    // It's not specified how `required` is ordered, so we need to sort it before comparing
+    if (closedMultiEntityType.required) {
+      closedMultiEntityType.required.sort();
+    }
+
+    const allOf = atLeastOne(
+      closedEntityTypes.map(
+        (closedEntityType) =>
+          ({
+            $id: closedEntityType.schema.$id,
+            title: closedEntityType.schema.title,
+            description: closedEntityType.schema.description,
+          }) as ClosedMultiEntityType["allOf"][0],
+      ),
+    );
+    assert(allOf !== undefined);
+
+    expect(closedMultiEntityType).toEqual({
+      allOf,
+      properties: closedEntityTypes.reduce(
+        (acc, closedEntityType) => {
+          return { ...acc, ...closedEntityType.schema.properties };
+        },
+        {} as ClosedMultiEntityType["properties"],
+      ),
+      required: atLeastOne(
+        Array.from(
+          new Set(
+            closedEntityTypes.flatMap(
+              (closedEntityType) => closedEntityType.schema.required ?? [],
+            ),
+          ),
+        ).toSorted(),
+      ),
+      links: closedEntityTypes.reduce(
+        (acc, closedEntityType) => {
+          return { ...acc, ...closedEntityType.schema.links };
+        },
+        {} as ClosedMultiEntityType["links"],
+      ),
+    } satisfies ClosedMultiEntityType);
   });
 
   const updatedTitle = "New text!";

--- a/tests/hash-graph-http/tests/friendship.http
+++ b/tests/hash-graph-http/tests/friendship.http
@@ -954,23 +954,12 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 ]
 
 ### Get all latest entity types
-POST http://127.0.0.1:4000/entity-types/query
+POST http://127.0.0.1:4000/entity-types/query/multi
 Content-Type: application/json
 X-Authenticated-User-Actor-Id: {{account_id}}
 
 {
-  "filter": {
-    "equal": [
-      {
-        "path": [
-          "version"
-        ]
-      },
-      {
-        "parameter": "latest"
-      }
-    ]
-  },
+  "entityTypeIds": ["{{person_entity_type_2_id}}"],
   "temporalAxes": {
     "pinned": {
       "axis": "transactionTime",

--- a/tests/hash-graph-http/tests/friendship.http
+++ b/tests/hash-graph-http/tests/friendship.http
@@ -954,12 +954,23 @@ X-Authenticated-User-Actor-Id: {{account_id}}
 ]
 
 ### Get all latest entity types
-POST http://127.0.0.1:4000/entity-types/query/multi
+POST http://127.0.0.1:4000/entity-types/query
 Content-Type: application/json
 X-Authenticated-User-Actor-Id: {{account_id}}
 
 {
-  "entityTypeIds": ["{{person_entity_type_2_id}}"],
+  "filter": {
+    "equal": [
+      {
+        "path": [
+          "version"
+        ]
+      },
+      {
+        "parameter": "latest"
+      }
+    ]
+  },
   "temporalAxes": {
     "pinned": {
       "axis": "transactionTime",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The path for querying multi-entity types in the OpenAPI specs is wrong so the Node API picks up he wrong endpoint.


## 🔍 What does this change?

- FIx path
- Rename the endpoint to be singular
- Add tests for closed entity type querying and closed multi-entity type querying