### PR TITLE
GEN-202: Deprecate `error_stack::Result` and `error_stack::Context`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ version = "0.0.0"
 dependencies = [
  "codec",
  "derive-where",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "futures",
  "futures-core",
  "graph-types",
@@ -1139,7 +1139,7 @@ dependencies = [
 name = "chonky"
 version = "0.0.0"
 dependencies = [
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
 ]
 
 [[package]]
@@ -1249,7 +1249,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "derive-where",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "harpc-wire-protocol",
  "regex",
  "serde",
@@ -1644,7 +1644,7 @@ dependencies = [
  "approx",
  "deer-desert",
  "erased-serde",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "num-traits",
  "paste",
  "proptest",
@@ -1661,7 +1661,7 @@ version = "0.0.0"
 dependencies = [
  "bitvec",
  "deer",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "num-traits",
  "serde",
  "serde_json",
@@ -1673,7 +1673,7 @@ name = "deer-json"
 version = "0.0.0-reserved"
 dependencies = [
  "deer",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "justjson",
  "lexical",
  "memchr",
@@ -2021,10 +2021,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-stack"
+version = "0.5.0"
+source = "git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c#f6ecda1ec75f4aca1f738b2fbe413613a356069c"
+dependencies = [
+ "anyhow",
+ "rustc_version",
+ "serde",
+ "spin 0.9.8",
+ "tracing",
+ "tracing-error",
+]
+
+[[package]]
 name = "error-stack-macros"
 version = "0.0.0-reserved"
 dependencies = [
- "error-stack",
+ "error-stack 0.5.0",
 ]
 
 [[package]]
@@ -2441,7 +2454,7 @@ dependencies = [
  "deadpool-postgres",
  "derive-where",
  "dotenv-flow",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "futures",
  "futures-sink",
  "graph-types",
@@ -2476,7 +2489,7 @@ dependencies = [
  "axum 0.7.7",
  "axum-core 0.4.5",
  "bytes",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "graph",
  "graph-type-defs",
  "graph-types",
@@ -2532,7 +2545,7 @@ name = "graph-integration"
 version = "0.0.0"
 dependencies = [
  "authorization",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "graph",
  "graph-test-data",
  "graph-types",
@@ -2568,7 +2581,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "codec",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "futures",
  "graph-test-data",
  "postgres-types",
@@ -2639,7 +2652,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "derive-where",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "futures",
  "harpc-codec",
  "harpc-net",
@@ -2655,7 +2668,7 @@ name = "harpc-codec"
 version = "0.0.0"
 dependencies = [
  "bytes",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "futures-core",
  "futures-util",
  "harpc-types",
@@ -2675,7 +2688,7 @@ dependencies = [
  "bytes-utils",
  "codec",
  "derive_more 1.0.0",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "futures",
  "futures-core",
  "futures-io",
@@ -2715,7 +2728,7 @@ dependencies = [
  "bytes",
  "derive-where",
  "derive_more 1.0.0",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "frunk",
  "frunk_core",
  "futures",
@@ -2752,7 +2765,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "futures",
  "futures-core",
  "harpc-codec",
@@ -2787,7 +2800,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "enumflags2",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "expect-test",
  "harpc-types",
  "proptest",
@@ -2805,7 +2818,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "codec",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "futures",
  "graph",
  "graph-api",
@@ -2835,7 +2848,7 @@ dependencies = [
  "authorization",
  "bytes",
  "derive-where",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "graph-types",
  "postgres-types",
  "serde",
@@ -2861,7 +2874,7 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "clap_builder",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "opentelemetry 0.26.0",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -3050,7 +3063,7 @@ dependencies = [
  "anstyle",
  "anstyle-yansi",
  "ariadne",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "hql-span",
  "jsonptr",
  "serde",
@@ -5703,7 +5716,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "criterion",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "inferno",
  "serde",
  "serde_json",
@@ -6734,7 +6747,7 @@ dependencies = [
 name = "temporal-client"
 version = "0.0.0"
 dependencies = [
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "graph-types",
  "serde",
  "serde_json",
@@ -6926,7 +6939,7 @@ dependencies = [
  "authorization",
  "axum 0.7.7",
  "codec",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "futures",
  "graph",
  "graph-api",
@@ -7560,7 +7573,7 @@ dependencies = [
 name = "type-fetcher"
 version = "0.0.0"
 dependencies = [
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "futures",
  "include_dir",
  "reqwest",
@@ -7580,7 +7593,7 @@ dependencies = [
  "codec",
  "console_error_panic_hook",
  "email_address",
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "futures",
  "graph-test-data",
  "iso8601-duration",
@@ -7827,7 +7840,7 @@ dependencies = [
 name = "validation"
 version = "0.0.0"
 dependencies = [
- "error-stack",
+ "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
  "futures",
  "graph-test-data",
  "graph-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ type-system.path = "libs/@blockprotocol/type-system/rust"
 validation.path = "libs/@local/hash-validation"
 
 # Pinned workspace members
-error-stack = { path = "./libs/error-stack", default-features = false }
+error-stack = { git = "https://github.com/hashintel/hash", rev = "f6ecda1ec75f4aca1f738b2fbe413613a356069c", default-features = false }
 
 # Public dependencies
 ahash = { version = "=0.8.11", default-features = false }

--- a/apps/hash-graph/bins/cli/package.json
+++ b/apps/hash-graph/bins/cli/package.json
@@ -18,7 +18,6 @@
     "@blockprotocol/type-system-rs": "0.0.0-private",
     "@rust/authorization": "0.0.0-private",
     "@rust/codec": "0.0.0-private",
-    "@rust/error-stack": "0.5.0",
     "@rust/graph": "0.0.0-private",
     "@rust/graph-api": "0.0.0-private",
     "@rust/graph-types": "0.0.0-private",

--- a/apps/hash-graph/libs/api/package.json
+++ b/apps/hash-graph/libs/api/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",
     "@rust/authorization": "0.0.0-private",
-    "@rust/error-stack": "0.5.0",
     "@rust/graph": "0.0.0-private",
     "@rust/graph-type-defs": "0.0.0-private",
     "@rust/graph-types": "0.0.0-private",

--- a/apps/hash-graph/libs/graph/package.json
+++ b/apps/hash-graph/libs/graph/package.json
@@ -10,7 +10,6 @@
     "@blockprotocol/type-system-rs": "0.0.0-private",
     "@rust/authorization": "0.0.0-private",
     "@rust/codec": "0.0.0-private",
-    "@rust/error-stack": "0.5.0",
     "@rust/graph-types": "0.0.0-private",
     "@rust/hash-graph-store": "0.0.0-private",
     "@rust/hash-status": "0.0.0-private",

--- a/apps/hash-graph/libs/store/package.json
+++ b/apps/hash-graph/libs/store/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",
     "@rust/authorization": "0.0.0-private",
-    "@rust/error-stack": "0.5.0",
     "@rust/graph-types": "0.0.0-private",
     "@rust/temporal-versioning": "0.0.0-private"
   }

--- a/apps/hash-graph/libs/test-server/package.json
+++ b/apps/hash-graph/libs/test-server/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@rust/authorization": "0.0.0-private",
     "@rust/codec": "0.0.0-private",
-    "@rust/error-stack": "0.5.0",
     "@rust/graph": "0.0.0-private",
     "@rust/graph-api": "0.0.0-private",
     "@rust/graph-type-defs": "0.0.0-private",

--- a/apps/hash-graph/libs/type-fetcher/package.json
+++ b/apps/hash-graph/libs/type-fetcher/package.json
@@ -10,7 +10,6 @@
     "start:test:healthcheck": "../../../../target/debug/hash-graph type-fetcher --healthcheck --wait --timeout 300 --logging-console-level=warn"
   },
   "dependencies": {
-    "@blockprotocol/type-system-rs": "0.0.0-private",
-    "@rust/error-stack": "0.5.0"
+    "@blockprotocol/type-system-rs": "0.0.0-private"
   }
 }

--- a/libs/@blockprotocol/type-system/rust/package.json
+++ b/libs/@blockprotocol/type-system/rust/package.json
@@ -25,8 +25,7 @@
     "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
   },
   "dependencies": {
-    "@rust/codec": "0.0.0-private",
-    "@rust/error-stack": "0.5.0"
+    "@rust/codec": "0.0.0-private"
   },
   "devDependencies": {
     "@rust/graph-test-data": "0.0.0-private",

--- a/libs/@local/codec/package.json
+++ b/libs/@local/codec/package.json
@@ -8,7 +8,6 @@
     "lint:clippy": "just clippy"
   },
   "dependencies": {
-    "@rust/error-stack": "0.5.0",
     "@rust/harpc-wire-protocol": "0.0.0-private"
   }
 }

--- a/libs/@local/harpc/client/package.json
+++ b/libs/@local/harpc/client/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "license": "AGPL-3",
   "dependencies": {
-    "@rust/error-stack": "0.5.0",
     "@rust/harpc-codec": "0.0.0-private",
     "@rust/harpc-net": "0.0.0-private",
     "@rust/harpc-tower": "0.0.0-private"

--- a/libs/@local/harpc/codec/package.json
+++ b/libs/@local/harpc/codec/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "license": "AGPL-3",
   "dependencies": {
-    "@rust/error-stack": "0.5.0",
     "@rust/harpc-types": "0.0.0-private"
   }
 }

--- a/libs/@local/harpc/net/package.json
+++ b/libs/@local/harpc/net/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@rust/codec": "0.0.0-private",
-    "@rust/error-stack": "0.5.0",
     "@rust/harpc-codec": "0.0.0-private",
     "@rust/harpc-types": "0.0.0-private",
     "@rust/harpc-wire-protocol": "0.0.0-private"

--- a/libs/@local/harpc/server/package.json
+++ b/libs/@local/harpc/server/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "license": "AGPL-3",
   "dependencies": {
-    "@rust/error-stack": "0.5.0",
     "@rust/harpc-codec": "0.0.0-private",
     "@rust/harpc-net": "0.0.0-private",
     "@rust/harpc-service": "0.0.0-private",

--- a/libs/@local/harpc/tower/package.json
+++ b/libs/@local/harpc/tower/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "license": "AGPL-3",
   "dependencies": {
-    "@rust/error-stack": "0.5.0",
     "@rust/harpc-codec": "0.0.0-private",
     "@rust/harpc-net": "0.0.0-private",
     "@rust/harpc-types": "0.0.0-private"

--- a/libs/@local/harpc/wire-protocol/package.json
+++ b/libs/@local/harpc/wire-protocol/package.json
@@ -10,7 +10,6 @@
     "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
   },
   "dependencies": {
-    "@rust/error-stack": "0.5.0",
     "@rust/harpc-types": "0.0.0-private"
   }
 }

--- a/libs/@local/hash-authorization/package.json
+++ b/libs/@local/hash-authorization/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",
     "@rust/codec": "0.0.0-private",
-    "@rust/error-stack": "0.5.0",
     "@rust/graph-types": "0.0.0-private"
   }
 }

--- a/libs/@local/hash-graph-types/rust/package.json
+++ b/libs/@local/hash-graph-types/rust/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",
     "@rust/codec": "0.0.0-private",
-    "@rust/error-stack": "0.5.0",
     "@rust/temporal-versioning": "0.0.0-private"
   },
   "devDependencies": {

--- a/libs/@local/hash-validation/package.json
+++ b/libs/@local/hash-validation/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",
-    "@rust/error-stack": "0.5.0",
     "@rust/graph-types": "0.0.0-private"
   },
   "devDependencies": {

--- a/libs/@local/hql/diagnostics/package.json
+++ b/libs/@local/hql/diagnostics/package.json
@@ -9,7 +9,6 @@
     "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
   },
   "dependencies": {
-    "@rust/error-stack": "0.5.0",
     "@rust/hql-span": "0.0.0-private"
   }
 }

--- a/libs/@local/repo-chores/rust/package.json
+++ b/libs/@local/repo-chores/rust/package.json
@@ -9,8 +9,5 @@
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
     "upload-benchmarks": "../../../../target/debug/repo-chores-cli benches upload"
-  },
-  "dependencies": {
-    "@rust/error-stack": "0.5.0"
   }
 }

--- a/libs/@local/temporal-client/package.json
+++ b/libs/@local/temporal-client/package.json
@@ -8,7 +8,6 @@
     "lint:clippy": "just clippy"
   },
   "dependencies": {
-    "@rust/error-stack": "0.5.0",
     "@rust/graph-types": "0.0.0-private"
   }
 }

--- a/libs/@local/tracing/package.json
+++ b/libs/@local/tracing/package.json
@@ -6,8 +6,5 @@
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy"
-  },
-  "dependencies": {
-    "@rust/error-stack": "0.5.0"
   }
 }

--- a/libs/chonky/package.json
+++ b/libs/chonky/package.json
@@ -6,8 +6,5 @@
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
     "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
-  },
-  "dependencies": {
-    "@rust/error-stack": "0.5.0"
   }
 }

--- a/libs/deer/desert/package.json
+++ b/libs/deer/desert/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0-private",
   "private": true,
   "dependencies": {
-    "@rust/deer": "0.0.0-reserved-private",
-    "@rust/error-stack": "0.5.0"
+    "@rust/deer": "0.0.0-reserved-private"
   }
 }

--- a/libs/deer/json/package.json
+++ b/libs/deer/json/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "license": "MIT OR Apache-2.0",
   "dependencies": {
-    "@rust/deer": "0.0.0-reserved-private",
-    "@rust/error-stack": "0.5.0"
+    "@rust/deer": "0.0.0-reserved-private"
   }
 }

--- a/libs/error-stack/CHANGELOG.md
+++ b/libs/error-stack/CHANGELOG.md
@@ -21,6 +21,11 @@ All notable changes to `error-stack` will be documented in this file.
 - `extend_one` has been renamed to `push` and is only implemented on `Report<[C]>`. ([#5047](https://github.com/hashintel/hash/pull/5047))
 - `bail!(report,)` has been removed, one must now use `bail!(report)`. This is in preparation for the unstable `bail!` macro that allows to construct `Report<[C]>`. ([#5047](https://github.com/hashintel/hash/pull/5047))
 
+### Deprecations
+
+- `Context`: Use `core::error::Error` instead ([#5533](https://github.com/hashintel/hash/pull/5533))
+- `Result<T, C>`: Use `core::result::Result<T, Report<C>>` instead ([#5533](https://github.com/hashintel/hash/pull/5533))
+
 ## [0.5.0](https://github.com/hashintel/hash/tree/error-stack%400.5.0/libs/error-stack) - 2024-07-12
 
 ### Features

--- a/libs/error-stack/README.md
+++ b/libs/error-stack/README.md
@@ -22,9 +22,9 @@ Read our [announcement post] for the story behind its origins.
 The library enables building a `Report` around an error as it propagates:
 
 ```rust
-use core::fmt;
+use core::{error::Error, fmt};
 
-use error_stack::{Context, Report, ResultExt};
+use error_stack::{Report, ResultExt};
 
 #[derive(Debug)]
 struct ParseExperimentError;
@@ -35,9 +35,9 @@ impl fmt::Display for ParseExperimentError {
     }
 }
 
-impl Context for ParseExperimentError {}
+impl Error for ParseExperimentError {}
 
-fn parse_experiment(description: &str) -> Result<(u64, u64), ParseExperimentError> {
+fn parse_experiment(description: &str) -> Result<(u64, u64), Report<ParseExperimentError>> {
     let value = description
         .parse::<u64>()
         .attach_printable_lazy(|| format!("{description:?} could not be parsed as experiment"))
@@ -55,7 +55,7 @@ impl fmt::Display for ExperimentError {
     }
 }
 
-impl Context for ExperimentError {}
+impl Error for ExperimentError {}
 
 fn start_experiments(
     experiment_ids: &[usize],
@@ -75,7 +75,7 @@ fn start_experiments(
 
             Ok(move || experiment.0 * experiment.1)
         })
-        .collect::<Result<Vec<_>, ExperimentError>>()
+        .collect::<Result<Vec<_>, Report<ExperimentError>>>()
         .attach_printable("unable to set up experiments")?;
 
     Ok(experiments.iter().map(|experiment| experiment()).collect())

--- a/libs/error-stack/README.md
+++ b/libs/error-stack/README.md
@@ -24,7 +24,7 @@ The library enables building a `Report` around an error as it propagates:
 ```rust
 use core::fmt;
 
-use error_stack::{Context, Report, Result, ResultExt};
+use error_stack::{Context, Report, ResultExt};
 
 #[derive(Debug)]
 struct ParseExperimentError;
@@ -60,7 +60,7 @@ impl Context for ExperimentError {}
 fn start_experiments(
     experiment_ids: &[usize],
     experiment_descriptions: &[&str],
-) -> Result<Vec<u64>, ExperimentError> {
+) -> Result<Vec<u64>, Report<ExperimentError>> {
     let experiments = experiment_ids
         .iter()
         .map(|exp_id| {
@@ -81,7 +81,7 @@ fn start_experiments(
     Ok(experiments.iter().map(|experiment| experiment()).collect())
 }
 
-fn main() -> Result<(), ExperimentError> {
+fn main() -> Result<(), Report<ExperimentError>> {
     let experiment_ids = &[0, 2];
     let experiment_descriptions = &["10", "20", "3o"];
     start_experiments(experiment_ids, experiment_descriptions)?;

--- a/libs/error-stack/examples/demo.rs
+++ b/libs/error-stack/examples/demo.rs
@@ -3,7 +3,7 @@
 
 use core::fmt;
 
-use error_stack::{Context, Report, Result, ResultExt};
+use error_stack::{Context, Report, ResultExt};
 
 #[derive(Debug)]
 struct ParseExperimentError;
@@ -20,7 +20,7 @@ impl Context for ParseExperimentError {}
     clippy::manual_try_fold,
     reason = "false-positive, try_fold is fail-fast, our implementation is fail-slow"
 )]
-fn parse_experiment(description: &str) -> Result<Vec<(u64, u64)>, ParseExperimentError> {
+fn parse_experiment(description: &str) -> Result<Vec<(u64, u64)>, Report<ParseExperimentError>> {
     let values = description
         .split(' ')
         .map(|value| {
@@ -66,7 +66,7 @@ impl Context for ExperimentError {}
 fn start_experiments(
     experiment_ids: &[usize],
     experiment_descriptions: &[&str],
-) -> Result<Vec<u64>, [ExperimentError]> {
+) -> Result<Vec<u64>, Report<[ExperimentError]>> {
     let experiments = experiment_ids
         .iter()
         .map(|exp_id| {
@@ -88,7 +88,7 @@ fn start_experiments(
         })
         .fold(
             Ok(vec![]),
-            |accum, value: Result<_, ExperimentError>| match (accum, value) {
+            |accum, value: Result<_, Report<ExperimentError>>| match (accum, value) {
                 (Ok(mut accum), Ok(value)) => {
                     accum.extend(value);
 
@@ -108,7 +108,7 @@ fn start_experiments(
     Ok(experiments.iter().map(|experiment| experiment()).collect())
 }
 
-fn main() -> Result<(), [ExperimentError]> {
+fn main() -> Result<(), Report<[ExperimentError]>> {
     let experiment_ids = &[0, 2, 3];
     let experiment_descriptions = &["10", "20", "3o 4a"];
     start_experiments(experiment_ids, experiment_descriptions)?;

--- a/libs/error-stack/examples/demo.rs
+++ b/libs/error-stack/examples/demo.rs
@@ -1,9 +1,9 @@
 // This is the same example also used in the README.md. When updating this, don't forget updating
 // the README.md as well. This is mainly used to test the code and generate the output shown.
 
-use core::fmt;
+use core::{error::Error, fmt};
 
-use error_stack::{Context, Report, ResultExt};
+use error_stack::{Report, ResultExt};
 
 #[derive(Debug)]
 struct ParseExperimentError;
@@ -14,7 +14,7 @@ impl fmt::Display for ParseExperimentError {
     }
 }
 
-impl Context for ParseExperimentError {}
+impl Error for ParseExperimentError {}
 
 #[expect(
     clippy::manual_try_fold,
@@ -57,7 +57,7 @@ impl fmt::Display for ExperimentError {
     }
 }
 
-impl Context for ExperimentError {}
+impl Error for ExperimentError {}
 
 #[expect(
     clippy::manual_try_fold,

--- a/libs/error-stack/examples/detect.rs
+++ b/libs/error-stack/examples/detect.rs
@@ -10,7 +10,7 @@ use core::fmt::{Display, Formatter};
 use std::path::Path;
 
 use error_stack::{
-    Report, Result,
+    Report,
     fmt::{Charset, ColorMode},
 };
 
@@ -27,7 +27,7 @@ impl Display for ParseConfigError {
 
 impl core::error::Error for ParseConfigError {}
 
-fn parse_config(path: impl AsRef<Path>) -> Result<Config, ParseConfigError> {
+fn parse_config(path: impl AsRef<Path>) -> Result<Config, Report<ParseConfigError>> {
     _ = path.as_ref();
 
     /*

--- a/libs/error-stack/examples/exit_code.rs
+++ b/libs/error-stack/examples/exit_code.rs
@@ -1,13 +1,14 @@
 //! Example of using `attach` to set a custom exit code. Requires nightly and std feature.
 
+use core::error::Error;
 use std::process::{ExitCode, Termination};
 
-use error_stack::{Context, Report};
+use error_stack::Report;
 
 #[derive(Debug)]
 struct CustomError;
 
-impl Context for CustomError {}
+impl Error for CustomError {}
 
 impl core::fmt::Display for CustomError {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/libs/error-stack/examples/parse_config.rs
+++ b/libs/error-stack/examples/parse_config.rs
@@ -2,10 +2,10 @@
 // This is the same example also used in `lib.rs`. When updating this, don't forget updating the doc
 // example as well. This example is mainly used to generate the output shown in the documentation.
 
-use core::fmt;
+use core::{error::Error, fmt};
 use std::{fs, path::Path};
 
-use error_stack::{Context, Report, ResultExt};
+use error_stack::{Report, ResultExt};
 
 pub type Config = String;
 
@@ -25,7 +25,7 @@ impl fmt::Display for ParseConfigError {
     }
 }
 
-impl Context for ParseConfigError {}
+impl Error for ParseConfigError {}
 
 struct Suggestion(&'static str);
 

--- a/libs/error-stack/src/compat/anyhow.rs
+++ b/libs/error-stack/src/compat/anyhow.rs
@@ -1,13 +1,13 @@
 use anyhow::Error as AnyhowError;
 
-use crate::{Frame, IntoReportCompat, Report, Result};
+use crate::{Frame, IntoReportCompat, Report};
 
-impl<T> IntoReportCompat for core::result::Result<T, AnyhowError> {
+impl<T> IntoReportCompat for Result<T, AnyhowError> {
     type Err = AnyhowError;
     type Ok = T;
 
     #[track_caller]
-    fn into_report(self) -> Result<T, AnyhowError> {
+    fn into_report(self) -> Result<T, Report<AnyhowError>> {
         match self {
             Ok(value) => Ok(value),
             Err(anyhow) => {

--- a/libs/error-stack/src/compat/eyre.rs
+++ b/libs/error-stack/src/compat/eyre.rs
@@ -1,13 +1,13 @@
 use eyre::Report as EyreReport;
 
-use crate::{Frame, IntoReportCompat, Report, Result};
+use crate::{Frame, IntoReportCompat, Report};
 
-impl<T> IntoReportCompat for core::result::Result<T, EyreReport> {
+impl<T> IntoReportCompat for Result<T, EyreReport> {
     type Err = EyreReport;
     type Ok = T;
 
     #[track_caller]
-    fn into_report(self) -> Result<T, EyreReport> {
+    fn into_report(self) -> Result<T, Report<EyreReport>> {
         match self {
             Ok(value) => Ok(value),
             Err(eyre) => {

--- a/libs/error-stack/src/context.rs
+++ b/libs/error-stack/src/context.rs
@@ -17,7 +17,7 @@ use crate::Report;
 /// ```rust
 /// use std::{fmt, fs, io};
 ///
-/// use error_stack::{Context, Result, ResultExt, Report};
+/// use error_stack::{Context, ResultExt, Report};
 ///
 /// # type Config = ();
 /// #[derive(Debug)]
@@ -38,12 +38,12 @@ use crate::Report;
 /// // `Context` manually.
 /// impl Context for ConfigError {}
 ///
-/// pub fn read_file(path: &str) -> Result<String, io::Error> {
+/// pub fn read_file(path: &str) -> Result<String, Report<io::Error>> {
 ///     // Creates a `Report` from `io::Error`, the current context is `io::Error`
 ///     fs::read_to_string(path).map_err(Report::from)
 /// }
 ///
-/// pub fn parse_config(path: &str) -> Result<Config, ConfigError> {
+/// pub fn parse_config(path: &str) -> Result<Config, Report<ConfigError>> {
 ///     // The return type of `parse_config` requires another context. By calling `change_context`
 ///     // the context may be changed.
 ///     read_file(path).change_context(ConfigError::ParseError)?;

--- a/libs/error-stack/src/context.rs
+++ b/libs/error-stack/src/context.rs
@@ -1,3 +1,5 @@
+#![expect(deprecated, reason = "We use `Context` to maintain compatibility")]
+
 use alloc::string::{String, ToString};
 #[cfg(nightly)]
 use core::error::Request;
@@ -15,9 +17,9 @@ use crate::Report;
 /// Used for creating a [`Report`] or for switching the [`Report`]'s context:
 ///
 /// ```rust
-/// use std::{fmt, fs, io};
+/// use std::{error::Error, fmt, fs, io};
 ///
-/// use error_stack::{Context, ResultExt, Report};
+/// use error_stack::{ResultExt, Report};
 ///
 /// # type Config = ();
 /// #[derive(Debug)]
@@ -36,7 +38,7 @@ use crate::Report;
 ///
 /// // In this scenario, `Error` is not implemented for `ConfigError` for some reason, so implement
 /// // `Context` manually.
-/// impl Context for ConfigError {}
+/// impl Error for ConfigError {}
 ///
 /// pub fn read_file(path: &str) -> Result<String, Report<io::Error>> {
 ///     // Creates a `Report` from `io::Error`, the current context is `io::Error`
@@ -56,6 +58,7 @@ use crate::Report;
 /// # assert!(err.contains::<io::Error>());
 /// # assert!(err.contains::<ConfigError>());
 /// ```
+#[deprecated(note = "Use `core::error::Error` instead", since = "0.6.0")]
 pub trait Context: fmt::Display + fmt::Debug + Send + Sync + 'static {
     /// Provide values which can then be requested by [`Report`].
     #[cfg(nightly)]

--- a/libs/error-stack/src/ext/iter.rs
+++ b/libs/error-stack/src/ext/iter.rs
@@ -1,3 +1,5 @@
+#![expect(deprecated, reason = "We use `Context` to maintain compatibility")]
+
 use crate::{Context, Report};
 
 // inspired by the implementation in `std`, see: https://doc.rust-lang.org/1.81.0/src/core/iter/adapters/mod.rs.html#157

--- a/libs/error-stack/src/ext/stream.rs
+++ b/libs/error-stack/src/ext/stream.rs
@@ -8,7 +8,7 @@ use core::{
 use futures_core::{FusedFuture, FusedStream, TryStream};
 use pin_project_lite::pin_project;
 
-use crate::{Report, Result};
+use crate::Report;
 
 pin_project! {
     /// Future for the [`try_collect_reports`](TryReportStreamExt::try_collect_reports)
@@ -18,7 +18,7 @@ pin_project! {
     pub struct TryCollectReports<S, A, C> {
         #[pin]
         stream: S,
-        output: Result<A, [C]>,
+        output: Result<A, Report<[C]>>,
 
         context_len: usize,
         context_bound: usize
@@ -55,7 +55,7 @@ where
     S: TryStream<Error: Into<Report<[C]>>>,
     A: Default + Extend<S::Ok>,
 {
-    type Output = Result<A, [C]>;
+    type Output = Result<A, Report<[C]>>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut this = self.project();
@@ -123,7 +123,7 @@ pub trait TryReportStreamExt<C>: TryStream<Error: Into<Report<[C]>>> {
     /// # Examples
     ///
     /// ```
-    /// # use error_stack::{Report, Result, TryReportStreamExt};
+    /// # use error_stack::{Report, TryReportStreamExt};
     /// # use futures_util::stream;
     ///
     /// #[derive(Debug, Clone, PartialEq, Eq)]
@@ -169,7 +169,7 @@ pub trait TryReportStreamExt<C>: TryStream<Error: Into<Report<[C]>>> {
     /// once the number of accumulated errors reaches the specified `bound`.
     ///
     /// ```
-    /// # use error_stack::{Report, Result, TryReportStreamExt};
+    /// # use error_stack::{Report, TryReportStreamExt};
     /// # use futures_util::stream;
     ///
     /// #[derive(Debug, Clone, PartialEq, Eq)]

--- a/libs/error-stack/src/fmt/mod.rs
+++ b/libs/error-stack/src/fmt/mod.rs
@@ -756,7 +756,7 @@ fn collect<'a>(root: &'a Frame, prefix: &'a [&Frame]) -> (Vec<&'a Frame>, &'a [F
     (stack, next)
 }
 
-/// Partition the tree, this looks for the first `Context`,
+/// Partition the tree, this looks for the first `ontext`,
 /// then moves it up the chain and adds it to our results.
 /// Once we reach the end all remaining items on the stack are added to the prefix pile,
 /// which will be used in next iteration.

--- a/libs/error-stack/src/fmt/mod.rs
+++ b/libs/error-stack/src/fmt/mod.rs
@@ -1,3 +1,5 @@
+#![expect(deprecated, reason = "We use `Context` to maintain compatibility")]
+
 //! Implementation of formatting, to enable colors and the use of box-drawing characters use the
 //! `pretty-print` feature.
 //!

--- a/libs/error-stack/src/fmt/mod.rs
+++ b/libs/error-stack/src/fmt/mod.rs
@@ -756,7 +756,7 @@ fn collect<'a>(root: &'a Frame, prefix: &'a [&Frame]) -> (Vec<&'a Frame>, &'a [F
     (stack, next)
 }
 
-/// Partition the tree, this looks for the first `ontext`,
+/// Partition the tree, this looks for the first context frame,
 /// then moves it up the chain and adds it to our results.
 /// Once we reach the end all remaining items on the stack are added to the prefix pile,
 /// which will be used in next iteration.

--- a/libs/error-stack/src/frame/frame_impl.rs
+++ b/libs/error-stack/src/frame/frame_impl.rs
@@ -1,7 +1,7 @@
 use alloc::boxed::Box;
 #[cfg(nightly)]
-use core::error::{Error, Request};
-use core::{any::Any, fmt};
+use core::error::Request;
+use core::{any::Any, error::Error, fmt};
 
 use crate::{AttachmentKind, Context, Frame, FrameKind};
 
@@ -18,22 +18,20 @@ pub(super) trait FrameImpl: Send + Sync + 'static {
     fn provide<'a>(&'a self, request: &mut Request<'a>);
 }
 
-#[cfg(nightly)]
 impl fmt::Debug for Box<dyn FrameImpl> {
     fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
         unreachable!()
     }
 }
 
-#[cfg(nightly)]
 impl fmt::Display for Box<dyn FrameImpl> {
     fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
         unreachable!()
     }
 }
 
-#[cfg(nightly)]
 impl Error for Box<dyn FrameImpl> {
+    #[cfg(nightly)]
     fn provide<'a>(&'a self, request: &mut Request<'a>) {
         (**self).provide(request);
     }

--- a/libs/error-stack/src/frame/frame_impl.rs
+++ b/libs/error-stack/src/frame/frame_impl.rs
@@ -1,3 +1,5 @@
+#![expect(deprecated, reason = "We use `Context` to maintain compatibility")]
+
 use alloc::boxed::Box;
 #[cfg(nightly)]
 use core::error::Request;

--- a/libs/error-stack/src/frame/kind.rs
+++ b/libs/error-stack/src/frame/kind.rs
@@ -1,3 +1,4 @@
+#![expect(deprecated, reason = "We use `Context` to maintain compatibility")]
 use core::fmt::{Debug, Display};
 
 use crate::Context;

--- a/libs/error-stack/src/frame/mod.rs
+++ b/libs/error-stack/src/frame/mod.rs
@@ -3,8 +3,8 @@ mod kind;
 
 use alloc::boxed::Box;
 #[cfg(nightly)]
-use core::error::{self, Error};
-use core::{any::TypeId, fmt};
+use core::error;
+use core::{any::TypeId, error::Error, fmt};
 
 use self::frame_impl::FrameImpl;
 pub use self::kind::{AttachmentKind, FrameKind};
@@ -96,7 +96,6 @@ impl Frame {
         self.frame.as_any().type_id()
     }
 
-    #[cfg(nightly)]
     pub(crate) fn as_error(&self) -> &impl Error {
         &self.frame
     }

--- a/libs/error-stack/src/future.rs
+++ b/libs/error-stack/src/future.rs
@@ -12,7 +12,7 @@ use core::{
     task::{Context as TaskContext, Poll},
 };
 
-use crate::{Context, Result, ResultExt};
+use crate::{Context, Report, ResultExt};
 
 macro_rules! implement_future_adaptor {
     ($future:ident, $method:ident, $bound:ident $(+ $bounds:ident)* $(+ $lifetime:lifetime)*, $output:ty) => {
@@ -101,42 +101,42 @@ implement_future_adaptor!(
     FutureWithAttachment,
     attach,
     Send + Sync + 'static,
-    Result<<Fut::Output as ResultExt>::Ok, <Fut::Output as ResultExt>::Context>
+    Result<<Fut::Output as ResultExt>::Ok, Report<<Fut::Output as ResultExt>::Context>>
 );
 
 implement_lazy_future_adaptor!(
     FutureWithLazyAttachment,
     attach_lazy,
     Send + Sync + 'static,
-    Result<<Fut::Output as ResultExt>::Ok, <Fut::Output as ResultExt>::Context>
+    Result<<Fut::Output as ResultExt>::Ok, Report<<Fut::Output as ResultExt>::Context>>
 );
 
 implement_future_adaptor!(
     FutureWithPrintableAttachment,
     attach_printable,
     Display + Debug + Send + Sync + 'static,
-    Result<<Fut::Output as ResultExt>::Ok, <Fut::Output as ResultExt>::Context>
+    Result<<Fut::Output as ResultExt>::Ok, Report<<Fut::Output as ResultExt>::Context>>
 );
 
 implement_lazy_future_adaptor!(
     FutureWithLazyPrintableAttachment,
     attach_printable_lazy,
     Display + Debug + Send + Sync + 'static,
-    Result<<Fut::Output as ResultExt>::Ok, <Fut::Output as ResultExt>::Context>
+    Result<<Fut::Output as ResultExt>::Ok, Report<<Fut::Output as ResultExt>::Context>>
 );
 
 implement_future_adaptor!(
     FutureWithContext,
     change_context,
     Context,
-    Result<<Fut::Output as ResultExt>::Ok, T>
+    Result<<Fut::Output as ResultExt>::Ok, Report<T>>
 );
 
 implement_lazy_future_adaptor!(
     FutureWithLazyContext,
     change_context_lazy,
     Context,
-    Result<<Fut::Output as ResultExt>::Ok, T>
+    Result<<Fut::Output as ResultExt>::Ok, Report<T>>
 );
 
 /// Extension trait for [`Future`] to provide contextual information on [`Report`]s.

--- a/libs/error-stack/src/future.rs
+++ b/libs/error-stack/src/future.rs
@@ -1,3 +1,4 @@
+#![expect(deprecated, reason = "We use `Context` to maintain compatibility")]
 //! Extension for convenient usage of [`Report`]s returned by [`Future`] s.
 //!
 //! Extends [`Future`] with the same methods as [`ResultExt`] but calls the methods on [`poll`]ing.

--- a/libs/error-stack/src/lib.rs
+++ b/libs/error-stack/src/lib.rs
@@ -83,7 +83,7 @@
 //! # impl core::fmt::Display for AccessError {
 //! #    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { Ok(()) }
 //! # }
-//! # impl error_stack::Context for AccessError {}
+//! # impl core::error::Error for AccessError {}
 //! use error_stack::{ensure, Report};
 //!
 //! fn main() -> Result<(), Report<AccessError>> {
@@ -144,7 +144,9 @@
 //!
 //! ```rust
 //! # use std::{fmt, fs, io, path::Path};
-//! use error_stack::{Context, Report, ResultExt};
+//! use core::error::Error;
+//!
+//! use error_stack::{Report, ResultExt};
 //! # pub type Config = String;
 //!
 //! #[derive(Debug)]
@@ -157,7 +159,7 @@
 //! }
 //!
 //! // It's also possible to implement `Error` instead.
-//! impl Context for ParseConfigError {}
+//! impl Error for ParseConfigError {}
 //!
 //! // For clarification, this example is not using `error_stack::Result`.
 //! fn parse_config(path: impl AsRef<Path>) -> Result<Config, Report<ParseConfigError>> {
@@ -184,7 +186,7 @@
 //! # // we only test the snapshot on nightly, therefore report is unused (so is render)
 //! # #![cfg_attr(not(nightly), allow(dead_code, unused_variables, unused_imports))]
 //! # use std::{fs, path::Path};
-//! # use error_stack::{Context, Report, ResultExt};
+//! # use error_stack::{Report, ResultExt};
 //! # pub type Config = String;
 //! # #[derive(Debug)] struct ParseConfigError;
 //! # impl ParseConfigError { pub fn new() -> Self { Self } }
@@ -193,7 +195,7 @@
 //! #         fmt.write_str("could not parse configuration file")
 //! #     }
 //! # }
-//! # impl Context for ParseConfigError {}
+//! # impl core::error::Error for ParseConfigError {}
 //! # #[derive(Debug, PartialEq)]
 //! struct Suggestion(&'static str);
 //!
@@ -523,6 +525,8 @@ mod serde;
 #[cfg(feature = "unstable")]
 mod sink;
 
+#[expect(deprecated, reason = "`core::error::Error` is stable now")]
+pub use self::context::Context;
 #[cfg(all(feature = "unstable", feature = "futures"))]
 pub use self::ext::stream::TryReportStreamExt;
 #[cfg(feature = "unstable")]
@@ -533,7 +537,6 @@ pub use self::result::Result;
 pub use self::sink::ReportSink;
 pub use self::{
     compat::IntoReportCompat,
-    context::Context,
     frame::{AttachmentKind, Frame, FrameKind},
     macros::*,
     report::Report,

--- a/libs/error-stack/src/lib.rs
+++ b/libs/error-stack/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! ```rust
 //! # #![allow(dead_code)]
-//! use error_stack::ResultExt;
+//! use error_stack::{Report, ResultExt};
 //! // using `thiserror` is not neccessary, but convenient
 //! use thiserror::Error;
 //!
@@ -45,14 +45,14 @@
 //!     Trivial,
 //! }
 //!
-//! type AppResult<T> = error_stack::Result<T, AppError>;
+//! type AppResult<T> = Result<T, Report<AppError>>;
 //!
 //! // Errors can also be a plain `struct`, somewhat like in `anyhow`.
 //! #[derive(Error, Debug)]
 //! #[error("logic error")]
 //! struct LogicError;
 //!
-//! type LogicResult<T> = error_stack::Result<T, LogicError>;
+//! type LogicResult<T> = Result<T, Report<LogicError>>;
 //!
 //! fn do_logic() -> LogicResult<()> {
 //!     Ok(())
@@ -84,9 +84,9 @@
 //! #    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { Ok(()) }
 //! # }
 //! # impl error_stack::Context for AccessError {}
-//! use error_stack::{ensure, Result};
+//! use error_stack::{ensure, Report};
 //!
-//! fn main() -> Result<(), AccessError> {
+//! fn main() -> Result<(), Report<AccessError>> {
 //!     let user = get_user()?;
 //!     let resource = get_resource()?;
 //!
@@ -144,7 +144,7 @@
 //!
 //! ```rust
 //! # use std::{fmt, fs, io, path::Path};
-//! use error_stack::{Context, Result, ResultExt};
+//! use error_stack::{Context, Report, ResultExt};
 //! # pub type Config = String;
 //!
 //! #[derive(Debug)]
@@ -160,7 +160,7 @@
 //! impl Context for ParseConfigError {}
 //!
 //! // For clarification, this example is not using `error_stack::Result`.
-//! fn parse_config(path: impl AsRef<Path>) -> Result<Config, ParseConfigError> {
+//! fn parse_config(path: impl AsRef<Path>) -> Result<Config, Report<ParseConfigError>> {
 //!     let content = fs::read_to_string(path.as_ref())
 //!         .change_context(ParseConfigError)?;
 //!
@@ -359,9 +359,8 @@
 //!
 //! ```rust
 //! # #![cfg_attr(not(nightly), allow(unused_variables, dead_code))]
-//! # use error_stack::Result;
 //! # struct Suggestion(&'static str);
-//! # fn parse_config(_: &str) -> Result<(), std::io::Error> { Ok(()) }
+//! # fn parse_config(_: &str) -> Result<(), error_stack::Report<std::io::Error>> { Ok(()) }
 //! fn main() {
 //!     if let Err(report) = parse_config("config.json") {
 //!         # #[cfg(nightly)]
@@ -528,6 +527,8 @@ mod sink;
 pub use self::ext::stream::TryReportStreamExt;
 #[cfg(feature = "unstable")]
 pub use self::ext::{iter::TryReportIteratorExt, tuple::TryReportTupleExt};
+#[expect(deprecated, reason = "We are moving to a more explicit API")]
+pub use self::result::Result;
 #[cfg(feature = "unstable")]
 pub use self::sink::ReportSink;
 pub use self::{
@@ -536,7 +537,6 @@ pub use self::{
     frame::{AttachmentKind, Frame, FrameKind},
     macros::*,
     report::Report,
-    result::Result,
 };
 #[doc(inline)]
 pub use self::{future::FutureExt, result::ResultExt};

--- a/libs/error-stack/src/macros.rs
+++ b/libs/error-stack/src/macros.rs
@@ -82,7 +82,7 @@ pub mod __private {
 ///
 /// use error_stack::report;
 ///
-/// # fn wrapper() -> error_stack::Result<(), impl core::fmt::Debug> {
+/// # fn wrapper() -> Result<(), error_stack::Report<impl core::fmt::Debug>> {
 /// match fs::read_to_string("/path/to/file") {
 ///     Ok(content) => println!("file contents: {content}"),
 ///     Err(err) => return Err(report!(err)),
@@ -194,7 +194,7 @@ macro_rules! report {
 #[macro_export]
 macro_rules! bail {
     ($err:expr) => {{
-        return $crate::Result::Err($crate::report!($err));
+        return ::core::result::Result::Err($crate::report!($err));
     }};
 }
 
@@ -220,7 +220,7 @@ macro_rules! bail {
 /// use std::fs;
 ///
 /// use error_stack::bail;
-/// # fn wrapper() -> error_stack::Result<(), impl core::fmt::Debug> {
+/// # fn wrapper() -> Result<(), error_stack::Report<impl core::fmt::Debug>> {
 /// match fs::read_to_string("/path/to/file") {
 ///     Ok(content) => println!("file contents: {content}"),
 ///     Err(err) => bail!(err),
@@ -304,7 +304,7 @@ macro_rules! bail {
 #[macro_export]
 macro_rules! bail {
     ($err:expr) => {{
-        return $crate::Result::Err($crate::report!($err));
+        return ::core::result::Result::Err($crate::report!($err));
     }};
 
     [$($err:expr),+ $(,)?] => {{
@@ -319,7 +319,7 @@ macro_rules! bail {
             Err(error) => error,
         };
 
-        return core::result::Result::Err(error);
+        return ::core::result::Result::Err(error);
     }};
 }
 
@@ -354,9 +354,9 @@ macro_rules! bail {
 /// impl fmt::Display for PermissionDenied {
 ///     # #[allow(unused_variables)]
 ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-///         const _: &str = stringify! {
+///         # const _: &str = stringify! {
 ///         ...
-///          };
+///         # };
 ///         Ok(())
 ///     }
 /// }

--- a/libs/error-stack/src/macros.rs
+++ b/libs/error-stack/src/macros.rs
@@ -1,3 +1,5 @@
+#![expect(deprecated, reason = "We use `Context` to maintain compatibility")]
+
 pub mod __private {
     #![doc(hidden)]
     //! Implementation detail for macros.
@@ -99,9 +101,10 @@ pub mod __private {
 /// # let user = 0;
 /// # type Resource = u32;
 /// # let resource = 0;
+/// use core::error::Error;
 /// use core::fmt;
 ///
-/// use error_stack::{report, Context};
+/// use error_stack::report;
 ///
 /// #[derive(Debug)]
 /// # #[allow(dead_code)]
@@ -115,7 +118,7 @@ pub mod __private {
 ///         # }; Ok(())}
 /// }
 ///
-/// impl Context for PermissionDenied {}
+/// impl Error for PermissionDenied {}
 ///
 /// if !has_permission(&user, &resource) {
 ///     return Err(report!(PermissionDenied(user, resource)));
@@ -239,9 +242,10 @@ macro_rules! bail {
 /// # let user = 0;
 /// # type Resource = u32;
 /// # let resource = 0;
+/// use core::error::Error;
 /// use core::fmt;
 ///
-/// use error_stack::{bail, Context};
+/// use error_stack::bail;
 ///
 /// #[derive(Debug)]
 /// # #[allow(dead_code)]
@@ -256,7 +260,7 @@ macro_rules! bail {
 ///     }
 /// }
 ///
-/// impl Context for PermissionDenied {}
+/// impl Error for PermissionDenied {}
 ///
 /// if !has_permission(&user, &resource) {
 ///     bail!(PermissionDenied(user, resource));
@@ -343,9 +347,10 @@ macro_rules! bail {
 /// # let user = 0;
 /// # type Resource = u32;
 /// # let resource = 0;
-/// # use core::fmt;
+/// use core::error::Error;
+/// use core::fmt;
 ///
-/// use error_stack::{Context, ensure};
+/// use error_stack::ensure;
 ///
 /// #[derive(Debug)]
 /// # #[allow(dead_code)]
@@ -361,7 +366,7 @@ macro_rules! bail {
 ///     }
 /// }
 ///
-/// impl Context for PermissionDenied {}
+/// impl Error for PermissionDenied {}
 ///
 /// ensure!(
 ///     has_permission(&user, &resource),

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -1,3 +1,5 @@
+#![expect(deprecated, reason = "We use `Context` to maintain compatibility")]
+
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::{error::Error, fmt, marker::PhantomData, mem, panic::Location};
 #[cfg(feature = "backtrace")]
@@ -100,9 +102,9 @@ use crate::{
 /// ## Enforce a context for an error
 ///
 /// ```rust
-/// use std::{fmt, path::{Path, PathBuf}};
+/// use std::{error::Error, fmt, path::{Path, PathBuf}};
 ///
-/// use error_stack::{Context, Report, ResultExt};
+/// use error_stack::{Report, ResultExt};
 ///
 /// #[derive(Debug)]
 /// # #[derive(PartialEq)]
@@ -141,8 +143,8 @@ use crate::{
 ///     # }
 /// }
 ///
-/// impl Context for RuntimeError {}
-/// impl Context for ConfigError {}
+/// impl Error for RuntimeError {}
+/// impl Error for ConfigError {}
 ///
 /// # #[allow(unused_variables)]
 /// fn read_config(path: impl AsRef<Path>) -> Result<String, Report<ConfigError>> {
@@ -702,7 +704,7 @@ impl<C> Report<[C]> {
     /// ```rust
     /// use std::{fmt, path::Path};
     ///
-    /// use error_stack::{Context, Report, ResultExt};
+    /// use error_stack::{Report, ResultExt};
     ///
     /// #[derive(Debug)]
     /// struct IoError;
@@ -716,7 +718,7 @@ impl<C> Report<[C]> {
     ///     # }
     /// }
     ///
-    /// # impl Context for IoError {}
+    /// # impl core::error::Error for IoError {}
     ///
     /// # #[allow(unused_variables)]
     /// fn read_config(path: impl AsRef<Path>) -> Result<String, Report<IoError>> {
@@ -748,7 +750,7 @@ impl<C> Report<[C]> {
     /// ```rust
     /// use std::{fmt, path::Path};
     ///
-    /// use error_stack::{Context, Report, ResultExt};
+    /// use error_stack::{Report, ResultExt};
     ///
     /// #[derive(Debug)]
     /// struct IoError;
@@ -762,7 +764,7 @@ impl<C> Report<[C]> {
     ///     # }
     /// }
     ///
-    /// # impl Context for IoError {}
+    /// # impl core::error::Error for IoError {}
     ///
     /// # #[allow(unused_variables)]
     /// fn read_config(path: impl AsRef<Path>) -> Result<String, Report<IoError>> {

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -84,10 +84,10 @@ use crate::{
 /// ## Provide a context for an error
 ///
 /// ```rust
-/// use error_stack::{ResultExt, Result};
+/// use error_stack::ResultExt;
 ///
 /// # #[allow(dead_code)]
-/// # fn fake_main() -> Result<String, std::io::Error> {
+/// # fn fake_main() -> Result<String, error_stack::Report<std::io::Error>> {
 /// let config_path = "./path/to/config.file";
 /// let content = std::fs::read_to_string(config_path)
 ///     .attach_printable_lazy(|| format!("failed to read config file {config_path:?}"))?;
@@ -208,10 +208,10 @@ use crate::{
 /// ## Get the attached [`Backtrace`] and [`SpanTrace`]:
 ///
 /// ```rust,should_panic
-/// use error_stack::{ResultExt, Result};
+/// use error_stack::{ResultExt, Report};
 ///
 /// # #[allow(unused_variables)]
-/// # fn main() -> Result<(), std::io::Error> {
+/// # fn main() -> Result<(), Report<std::io::Error>> {
 /// let config_path = "./path/to/config.file";
 /// let content = std::fs::read_to_string(config_path)
 ///     .attach_printable_lazy(|| format!("failed to read config file {config_path:?}"));

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -393,7 +393,7 @@ impl<C> Report<C> {
     /// frames to find the current context. A [`Report`] and be made up of multiple [`Frame`]s,
     /// which stack on top of each other. Considering `PrintableA<PrintableA<Context>>`,
     /// [`Report::current_frame`] will return the "outer" layer `PrintableA`, while
-    /// [`Report::current_context`] will return the underlying `Context` (the current type
+    /// [`Report::current_context`] will return the underlying `Error` (the current type
     /// parameter of this [`Report`])
     ///
     /// A report can be made up of multiple stacks of frames and builds a "group" of them, this can
@@ -676,7 +676,7 @@ impl<C> Report<[C]> {
     /// frames to find the current context. A [`Report`] and be made up of multiple [`Frame`]s,
     /// which stack on top of each other. Considering `PrintableA<PrintableA<Context>>`,
     /// [`Report::current_frames`] will return the "outer" layer `PrintableA`, while
-    /// [`Report::current_context`] will return the underlying `Context` (the current type
+    /// [`Report::current_context`] will return the underlying `Error` (the current type
     /// parameter of this [`Report`])
     ///
     /// Using [`Extend`], [`push()`] and [`append()`], a [`Report`] can additionally be made up of

--- a/libs/error-stack/src/result.rs
+++ b/libs/error-stack/src/result.rs
@@ -1,3 +1,5 @@
+#![expect(deprecated, reason = "We use `Context` to maintain compatibility")]
+
 use core::fmt;
 
 use crate::{Context, Report};
@@ -21,7 +23,7 @@ use crate::{Context, Report};
 /// # impl core::fmt::Display for AccessError {
 /// #    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { Ok(()) }
 /// # }
-/// # impl error_stack::Context for AccessError {}
+/// # impl core::error::Error for AccessError {}
 /// use error_stack::{ensure, Report};
 ///
 /// fn main() -> Result<(), Report<AccessError>> {

--- a/libs/error-stack/src/result.rs
+++ b/libs/error-stack/src/result.rs
@@ -16,15 +16,15 @@ use crate::{Context, Report};
 /// ```rust
 /// # fn has_permission(_: (), _: ()) -> bool { true }
 /// # fn get_user() -> Result<(), AccessError> { Ok(()) }
-/// # fn get_resource() -> Result<(), AccessError> { Ok(()) }
+/// # fn get_resource() -> Result<(), Report<AccessError>> { Ok(()) }
 /// # #[derive(Debug)] enum AccessError { PermissionDenied((), ()) }
 /// # impl core::fmt::Display for AccessError {
 /// #    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { Ok(()) }
 /// # }
 /// # impl error_stack::Context for AccessError {}
-/// use error_stack::{ensure, Result};
+/// use error_stack::{ensure, Report};
 ///
-/// fn main() -> Result<(), AccessError> {
+/// fn main() -> Result<(), Report<AccessError>> {
 ///     let user = get_user()?;
 ///     let resource = get_resource()?;
 ///
@@ -38,6 +38,10 @@ use crate::{Context, Report};
 ///     # }; Ok(())
 /// }
 /// ```
+#[deprecated(
+    note = "Use `core::result::Result<T, Report<C>>` instead",
+    since = "0.6.0"
+)]
 pub type Result<T, C> = core::result::Result<T, Report<C>>;
 
 /// Extension trait for [`Result`][core::result::Result] to provide context information on
@@ -114,7 +118,7 @@ where
     type Ok = T;
 
     #[track_caller]
-    fn attach<A>(self, attachment: A) -> Result<T, C>
+    fn attach<A>(self, attachment: A) -> core::result::Result<T, Report<C>>
     where
         A: Send + Sync + 'static,
     {
@@ -125,7 +129,7 @@ where
     }
 
     #[track_caller]
-    fn attach_lazy<A, F>(self, attachment: F) -> Result<T, C>
+    fn attach_lazy<A, F>(self, attachment: F) -> core::result::Result<T, Report<C>>
     where
         A: Send + Sync + 'static,
         F: FnOnce() -> A,
@@ -137,7 +141,7 @@ where
     }
 
     #[track_caller]
-    fn attach_printable<A>(self, attachment: A) -> Result<T, C>
+    fn attach_printable<A>(self, attachment: A) -> core::result::Result<T, Report<C>>
     where
         A: fmt::Display + fmt::Debug + Send + Sync + 'static,
     {
@@ -148,7 +152,7 @@ where
     }
 
     #[track_caller]
-    fn attach_printable_lazy<A, F>(self, attachment: F) -> Result<T, C>
+    fn attach_printable_lazy<A, F>(self, attachment: F) -> core::result::Result<T, Report<C>>
     where
         A: fmt::Display + fmt::Debug + Send + Sync + 'static,
         F: FnOnce() -> A,
@@ -160,7 +164,7 @@ where
     }
 
     #[track_caller]
-    fn change_context<C2>(self, context: C2) -> Result<T, C2>
+    fn change_context<C2>(self, context: C2) -> core::result::Result<T, Report<C2>>
     where
         C2: Context,
     {
@@ -171,7 +175,7 @@ where
     }
 
     #[track_caller]
-    fn change_context_lazy<C2, F>(self, context: F) -> Result<T, C2>
+    fn change_context_lazy<C2, F>(self, context: F) -> core::result::Result<T, Report<C2>>
     where
         C2: Context,
         F: FnOnce() -> C2,
@@ -183,7 +187,7 @@ where
     }
 }
 
-impl<T, C> ResultExt for Result<T, C>
+impl<T, C> ResultExt for core::result::Result<T, Report<C>>
 where
     C: Context,
 {
@@ -241,7 +245,7 @@ where
     }
 
     #[track_caller]
-    fn change_context<C2>(self, context: C2) -> Result<T, C2>
+    fn change_context<C2>(self, context: C2) -> core::result::Result<T, Report<C2>>
     where
         C2: Context,
     {
@@ -253,7 +257,7 @@ where
     }
 
     #[track_caller]
-    fn change_context_lazy<C2, F>(self, context: F) -> Result<T, C2>
+    fn change_context_lazy<C2, F>(self, context: F) -> core::result::Result<T, Report<C2>>
     where
         C2: Context,
         F: FnOnce() -> C2,
@@ -266,7 +270,7 @@ where
     }
 }
 
-impl<T, C> ResultExt for Result<T, [C]>
+impl<T, C> ResultExt for core::result::Result<T, Report<[C]>>
 where
     C: Context,
 {
@@ -324,7 +328,7 @@ where
     }
 
     #[track_caller]
-    fn change_context<C2>(self, context: C2) -> Result<T, C2>
+    fn change_context<C2>(self, context: C2) -> core::result::Result<T, Report<C2>>
     where
         C2: Context,
     {
@@ -336,7 +340,7 @@ where
     }
 
     #[track_caller]
-    fn change_context_lazy<C2, F>(self, context: F) -> Result<T, C2>
+    fn change_context_lazy<C2, F>(self, context: F) -> core::result::Result<T, Report<C2>>
     where
         C2: Context,
         F: FnOnce() -> C2,

--- a/libs/error-stack/src/result.rs
+++ b/libs/error-stack/src/result.rs
@@ -9,7 +9,7 @@ use crate::{Context, Report};
 /// A reasonable return type to use throughout an application.
 ///
 /// The `Result` type can be used with one or two parameters, where the first parameter represents
-/// the [`Ok`] arm and the second parameter `Context` is used as in [`Report<C>`].
+/// the [`Ok`] arm and the second parameter `Error` is used as in [`Report<C>`].
 ///
 /// # Examples
 ///

--- a/libs/error-stack/src/serde.rs
+++ b/libs/error-stack/src/serde.rs
@@ -32,7 +32,7 @@ impl Serialize for SerializeAttachment<'_> {
 
         match frame.kind() {
             FrameKind::Context(_) => {
-                // TODO: for now `Context` is unsupported, upcoming PR will fix via hooks
+                // TODO: for now `Error` is unsupported, upcoming PR will fix via hooks
                 // `SerializeAttachmentList` ensures that no context is ever serialized
                 unimplemented!()
             }

--- a/libs/error-stack/src/serde.rs
+++ b/libs/error-stack/src/serde.rs
@@ -1,3 +1,5 @@
+#![expect(deprecated, reason = "We use `Context` to maintain compatibility")]
+
 //! Implementation of general [`Report`] serialization.
 //!
 //! The value can be of any type, currently only printable attachments and context are supported, in

--- a/libs/error-stack/src/sink.rs
+++ b/libs/error-stack/src/sink.rs
@@ -102,7 +102,7 @@ impl Drop for Bomb {
 /// # Examples
 ///
 /// ```
-/// use error_stack::{ReportSink, Result};
+/// use error_stack::{Report, ReportSink};
 ///
 /// #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// struct InternalError;
@@ -115,17 +115,17 @@ impl Drop for Bomb {
 ///
 /// impl core::error::Error for InternalError {}
 ///
-/// fn operation1() -> Result<u32, InternalError> {
+/// fn operation1() -> Result<u32, Report<InternalError>> {
 ///     // ...
 ///     # Ok(42)
 /// }
 ///
-/// fn operation2() -> Result<(), InternalError> {
+/// fn operation2() -> Result<(), Report<InternalError>> {
 ///     // ...
 ///     # Ok(())
 /// }
 ///
-/// fn process_data() -> Result<(), [InternalError]> {
+/// fn process_data() -> Result<(), Report<[InternalError]>> {
 ///     let mut sink = ReportSink::new();
 ///
 ///     if let Some(value) = sink.attempt(operation1()) {

--- a/libs/error-stack/tests/common.rs
+++ b/libs/error-stack/tests/common.rs
@@ -24,7 +24,7 @@ use std::backtrace::Backtrace;
 #[cfg(all(feature = "std", any(feature = "backtrace", feature = "spantrace")))]
 use std::sync::LazyLock;
 
-use error_stack::{AttachmentKind, Context, Frame, FrameKind, Report, Result};
+use error_stack::{AttachmentKind, Context, Frame, FrameKind, Report};
 #[cfg(all(
     not(feature = "std"),
     any(feature = "backtrace", feature = "spantrace")
@@ -168,19 +168,19 @@ impl fmt::Display for PrintableC {
     }
 }
 
-pub fn create_error() -> Result<(), RootError> {
+pub fn create_error() -> Result<(), Report<RootError>> {
     Err(create_report())
 }
 
-pub fn create_future() -> impl Future<Output = Result<(), RootError>> {
+pub fn create_future() -> impl Future<Output = Result<(), Report<RootError>>> {
     futures::future::err(create_report())
 }
 
-pub fn capture_ok<E>(closure: impl FnOnce() -> Result<(), E>) {
+pub fn capture_ok<E>(closure: impl FnOnce() -> Result<(), Report<E>>) {
     closure().expect("expected an OK value, found an error");
 }
 
-pub fn capture_error<E>(closure: impl FnOnce() -> Result<(), E>) -> Report<E> {
+pub fn capture_error<E>(closure: impl FnOnce() -> Result<(), Report<E>>) -> Report<E> {
     closure().expect_err("expected an error")
 }
 

--- a/libs/error-stack/tests/common.rs
+++ b/libs/error-stack/tests/common.rs
@@ -14,6 +14,7 @@ extern crate alloc;
 use core::{any::TypeId, panic::Location};
 #[expect(unused_imports)]
 use core::{
+    error::Error,
     fmt,
     future::Future,
     iter,
@@ -24,7 +25,7 @@ use std::backtrace::Backtrace;
 #[cfg(all(feature = "std", any(feature = "backtrace", feature = "spantrace")))]
 use std::sync::LazyLock;
 
-use error_stack::{AttachmentKind, Context, Frame, FrameKind, Report};
+use error_stack::{AttachmentKind, Frame, FrameKind, Report};
 #[cfg(all(
     not(feature = "std"),
     any(feature = "backtrace", feature = "spantrace")
@@ -42,7 +43,7 @@ impl fmt::Display for RootError {
     }
 }
 
-impl Context for RootError {}
+impl Error for RootError {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContextA(pub u32);
@@ -53,7 +54,7 @@ impl fmt::Display for ContextA {
     }
 }
 
-impl Context for ContextA {
+impl Error for ContextA {
     #[cfg(nightly)]
     fn provide<'a>(&'a self, request: &mut core::error::Request<'a>) {
         request.provide_ref(&self.0);
@@ -70,7 +71,7 @@ impl fmt::Display for ContextB {
     }
 }
 
-impl Context for ContextB {
+impl Error for ContextB {
     #[cfg(nightly)]
     fn provide<'a>(&'a self, request: &mut core::error::Request<'a>) {
         request.provide_ref(&self.0);
@@ -97,7 +98,7 @@ impl fmt::Display for ErrorA {
 }
 
 #[cfg(feature = "spantrace")]
-impl Context for ErrorA {
+impl Error for ErrorA {
     #[cfg(nightly)]
     fn provide<'a>(&'a self, request: &mut core::error::Request<'a>) {
         request.provide_ref(&self.1);
@@ -122,8 +123,8 @@ impl fmt::Display for ErrorB {
     }
 }
 
-#[cfg(all(nightly, feature = "backtrace"))]
-impl core::error::Error for ErrorB {
+#[cfg(feature = "backtrace")]
+impl Error for ErrorB {
     fn provide<'a>(&'a self, request: &mut core::error::Request<'a>) {
         request.provide_ref(&self.1);
     }

--- a/libs/error-stack/tests/test_debug.rs
+++ b/libs/error-stack/tests/test_debug.rs
@@ -73,12 +73,12 @@ fn snap_suffix() -> String {
 #[cfg(feature = "spantrace")]
 pub fn create_report() -> Report<RootError> {
     #[tracing::instrument]
-    fn func_b() -> error_stack::Result<(), RootError> {
+    fn func_b() -> Result<(), Report<RootError>> {
         create_error()
     }
 
     #[tracing::instrument]
-    fn func_a() -> error_stack::Result<(), RootError> {
+    fn func_a() -> Result<(), Report<RootError>> {
         func_b()
     }
 

--- a/libs/error-stack/tests/test_extend.rs
+++ b/libs/error-stack/tests/test_extend.rs
@@ -1,27 +1,30 @@
 #![cfg_attr(nightly, feature(error_generic_member_access))]
 
 mod common;
-use core::fmt::{Display, Formatter};
+use core::{
+    error::Error,
+    fmt::{Display, Formatter},
+};
 
 use common::*;
-use error_stack::{Context, Report, report};
+use error_stack::{Report, report};
 
 #[derive(Debug)]
-struct Error;
+struct MyError;
 
-impl Display for Error {
+impl Display for MyError {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> core::fmt::Result {
         fmt.write_str("Error")
     }
 }
 
-impl Context for Error {}
+impl Error for MyError {}
 
 #[test]
 fn push_append() {
-    let mut err1 = report!(Error).attach_printable("Not Supported").expand();
-    let err2 = report!(Error).attach_printable("Not Supported");
-    let mut err3 = report!(Error).attach_printable("Not Supported").expand();
+    let mut err1 = report!(MyError).attach_printable("Not Supported").expand();
+    let err2 = report!(MyError).attach_printable("Not Supported");
+    let mut err3 = report!(MyError).attach_printable("Not Supported").expand();
 
     let count = expect_count(2) * 3;
 
@@ -34,9 +37,9 @@ fn push_append() {
 
 #[test]
 fn push() {
-    let mut err1 = report!(Error).attach_printable("Not Supported").expand();
-    let err2 = report!(Error).attach_printable("Not Supported");
-    let err3 = report!(Error).attach_printable("Not Supported");
+    let mut err1 = report!(MyError).attach_printable("Not Supported").expand();
+    let err2 = report!(MyError).attach_printable("Not Supported");
+    let err3 = report!(MyError).attach_printable("Not Supported");
 
     let count = expect_count(2) * 3;
 
@@ -49,9 +52,9 @@ fn push() {
 
 #[test]
 fn extend() {
-    let mut err1 = report!(Error).attach_printable("Not Supported").expand();
-    let err2 = report!(Error).attach_printable("Not Supported");
-    let err3 = report!(Error).attach_printable("Not Supported");
+    let mut err1 = report!(MyError).attach_printable("Not Supported").expand();
+    let err2 = report!(MyError).attach_printable("Not Supported");
+    let err3 = report!(MyError).attach_printable("Not Supported");
 
     err1.extend([err2, err3]);
     assert_eq!(err1.current_frames().len(), 3);
@@ -60,9 +63,10 @@ fn extend() {
 
 #[test]
 fn collect_single() {
-    let report: Option<Report<[Error]>> = vec![report!(Error), report!(Error), report!(Error)]
-        .into_iter()
-        .collect();
+    let report: Option<Report<[MyError]>> =
+        vec![report!(MyError), report!(MyError), report!(MyError)]
+            .into_iter()
+            .collect();
 
     let report = report.expect("should be some");
     assert_eq!(report.current_frames().len(), 3);
@@ -71,10 +75,10 @@ fn collect_single() {
 
 #[test]
 fn collect_multiple() {
-    let report: Option<Report<[Error]>> = vec![
-        report!(Error).expand(),
-        report!(Error).expand(),
-        report!(Error).expand(),
+    let report: Option<Report<[MyError]>> = vec![
+        report!(MyError).expand(),
+        report!(MyError).expand(),
+        report!(MyError).expand(),
     ]
     .into_iter()
     .collect();
@@ -86,7 +90,7 @@ fn collect_multiple() {
 
 #[test]
 fn collect_none() {
-    let report: Option<Report<[Error]>> = ([] as [Report<Error>; 0]).into_iter().collect();
+    let report: Option<Report<[MyError]>> = ([] as [Report<MyError>; 0]).into_iter().collect();
 
     assert!(report.is_none());
 }

--- a/libs/error-stack/tests/test_iter.rs
+++ b/libs/error-stack/tests/test_iter.rs
@@ -2,10 +2,13 @@
 
 extern crate alloc;
 
-use core::fmt::{Display, Formatter, Write};
+use core::{
+    error::Error,
+    fmt::{Display, Formatter, Write},
+};
 
 mod common;
-use error_stack::{Context, Report, report};
+use error_stack::{Report, report};
 
 #[derive(Debug)]
 struct Char(char);
@@ -16,7 +19,7 @@ impl Display for Char {
     }
 }
 
-impl Context for Char {}
+impl Error for Char {}
 
 /// Builds the following tree:
 ///

--- a/libs/error-stack/tests/test_span_trace.rs
+++ b/libs/error-stack/tests/test_span_trace.rs
@@ -4,7 +4,7 @@
 mod common;
 
 use common::*;
-use error_stack::Result;
+use error_stack::Report;
 use tracing_error::{ErrorLayer, SpanTrace};
 use tracing_subscriber::layer::SubscriberExt;
 
@@ -23,12 +23,12 @@ fn captured() {
     install_tracing_subscriber();
 
     #[tracing::instrument]
-    fn func_b() -> Result<(), RootError> {
+    fn func_b() -> Result<(), Report<RootError>> {
         create_error()
     }
 
     #[tracing::instrument]
-    fn func_a() -> Result<(), RootError> {
+    fn func_a() -> Result<(), Report<RootError>> {
         func_b()
     }
 
@@ -62,8 +62,8 @@ fn provided() {
     }
 
     #[tracing::instrument]
-    fn func_a() -> Result<(), ErrorA> {
-        Err(error_stack::Report::new(func_b()))
+    fn func_a() -> Result<(), Report<ErrorA>> {
+        Err(Report::new(func_b()))
     }
 
     let report = capture_error(func_a);

--- a/libs/error-stack/tests/ui/macro_invalid_args.rs
+++ b/libs/error-stack/tests/ui/macro_invalid_args.rs
@@ -1,6 +1,6 @@
-use core::fmt;
+use core::{error::Error, fmt};
 
-use error_stack::{bail, ensure, report, Context, Result};
+use error_stack::{Report, bail, ensure, report};
 
 #[derive(Debug)]
 pub struct RootError;
@@ -11,47 +11,47 @@ impl fmt::Display for RootError {
     }
 }
 
-impl Context for RootError {}
+impl Error for RootError {}
 
-fn invalid_report_arg() -> Result<(), RootError> {
+fn invalid_report_arg() -> Result<(), Report<RootError>> {
     let _ = report!("Error");
 
     Ok(())
 }
 
-fn empty_report_arg() -> Result<(), RootError> {
+fn empty_report_arg() -> Result<(), Report<RootError>> {
     let _ = report!();
 
     Ok(())
 }
 
-fn invalid_bail_arg() -> Result<(), RootError> {
+fn invalid_bail_arg() -> Result<(), Report<RootError>> {
     bail!("Error")
 }
 
-fn empty_bail_arg() -> Result<(), RootError> {
+fn empty_bail_arg() -> Result<(), Report<RootError>> {
     bail!()
 }
 
-fn invalid_ensure_error_arg() -> Result<(), RootError> {
+fn invalid_ensure_error_arg() -> Result<(), Report<RootError>> {
     let _ = ensure!(true, "Error");
 
     Ok(())
 }
 
-fn invalid_ensure_condition_arg() -> Result<(), RootError> {
+fn invalid_ensure_condition_arg() -> Result<(), Report<RootError>> {
     let _ = ensure!("No boolean", RootError);
 
     Ok(())
 }
 
-fn missing_ensure_arg() -> Result<(), RootError> {
+fn missing_ensure_arg() -> Result<(), Report<RootError>> {
     let _ = ensure!(true);
 
     Ok(())
 }
 
-fn empty_ensure_arg() -> Result<(), RootError> {
+fn empty_ensure_arg() -> Result<(), Report<RootError>> {
     let _ = ensure!();
 
     Ok(())

--- a/libs/error-stack/tests/ui/must_use.rs
+++ b/libs/error-stack/tests/ui/must_use.rs
@@ -1,8 +1,8 @@
 #![deny(unused_must_use)]
 
-use core::fmt;
+use core::{error::Error, fmt};
 
-use error_stack::{Context, Report};
+use error_stack::Report;
 
 #[derive(Debug)]
 pub struct RootError;
@@ -13,7 +13,7 @@ impl fmt::Display for RootError {
     }
 }
 
-impl Context for RootError {}
+impl Error for RootError {}
 
 fn main() {
     Report::new(RootError);

--- a/tests/hash-graph-integration/package.json
+++ b/tests/hash-graph-integration/package.json
@@ -12,7 +12,6 @@
     "@apps/hash-graph": "0.0.0-private",
     "@blockprotocol/type-system-rs": "0.0.0-private",
     "@rust/authorization": "0.0.0-private",
-    "@rust/error-stack": "0.5.0",
     "@rust/graph": "0.0.0-private",
     "@rust/graph-test-data": "0.0.0-private",
     "@rust/graph-types": "0.0.0-private",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

### `Context`

`core::error::Error` is stabilized and we don't need an extra trait which is doing the same thing.

### `Result`

`error_stack::Result<T, C>` is an alias to `core::result::Report<T, Report<C>>` and sometimes saves one word when typing. However, as a Rust developer one is _very_ used to `Result` and if `Result` behaves differently or has implications, this is not good. In comparison to other libraries such as `anyhow`, `error_stack` requires the context to be set as the `Err` variant, it replaces the `Result` instead of extending it. `error-stack` prefers an explicit API interface and the `Result` alias does not help.
In addition, it's almost not possible to copy code from `error-stack` as in regular cases the target still use `core::result::Result` or a mixture.

We're going to require `as _` syntax for traits in the very near future. To avoid touching the code twice and keep this PR clean, I pinned `error-stack` in the workspace to the current commit on main. 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph