### PR TITLE
GEN-201: Remove `once-cell` dev-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2004,7 +2004,6 @@ dependencies = [
  "futures-core",
  "futures-util",
  "insta",
- "once_cell",
  "owo-colors",
  "pin-project-lite",
  "regex",

--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -40,7 +40,6 @@ insta = { workspace = true, features = ["filters", "ron"] }
 regex = { workspace = true }
 expect-test = { workspace = true }
 ansi-to-html = { workspace = true }
-once_cell = { workspace = true }
 supports-color = { workspace = true }
 supports-unicode = { workspace = true }
 owo-colors = { workspace = true }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We removed the usage of `once-cell` before, but didn't remove the dev-dependency on it.