### PR TITLE
H-3548: Use in-tree version of `error-stack` again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ version = "0.0.0"
 dependencies = [
  "codec",
  "derive-where",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "futures",
  "futures-core",
  "graph-types",
@@ -1139,7 +1139,7 @@ dependencies = [
 name = "chonky"
 version = "0.0.0"
 dependencies = [
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
 ]
 
 [[package]]
@@ -1249,7 +1249,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "derive-where",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "harpc-wire-protocol",
  "regex",
  "serde",
@@ -1644,7 +1644,7 @@ dependencies = [
  "approx",
  "deer-desert",
  "erased-serde",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "num-traits",
  "paste",
  "proptest",
@@ -1661,7 +1661,7 @@ version = "0.0.0"
 dependencies = [
  "bitvec",
  "deer",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "num-traits",
  "serde",
  "serde_json",
@@ -1673,7 +1673,7 @@ name = "deer-json"
 version = "0.0.0-reserved"
 dependencies = [
  "deer",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "justjson",
  "lexical",
  "memchr",
@@ -2020,23 +2020,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-stack"
-version = "0.5.0"
-source = "git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c#f6ecda1ec75f4aca1f738b2fbe413613a356069c"
-dependencies = [
- "anyhow",
- "rustc_version",
- "serde",
- "spin 0.9.8",
- "tracing",
- "tracing-error",
-]
-
-[[package]]
 name = "error-stack-macros"
 version = "0.0.0-reserved"
 dependencies = [
- "error-stack 0.5.0",
+ "error-stack",
 ]
 
 [[package]]
@@ -2453,7 +2440,7 @@ dependencies = [
  "deadpool-postgres",
  "derive-where",
  "dotenv-flow",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "futures",
  "futures-sink",
  "graph-types",
@@ -2488,7 +2475,7 @@ dependencies = [
  "axum 0.7.7",
  "axum-core 0.4.5",
  "bytes",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "graph",
  "graph-type-defs",
  "graph-types",
@@ -2544,7 +2531,7 @@ name = "graph-integration"
 version = "0.0.0"
 dependencies = [
  "authorization",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "graph",
  "graph-test-data",
  "graph-types",
@@ -2580,7 +2567,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "codec",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "futures",
  "graph-test-data",
  "postgres-types",
@@ -2651,7 +2638,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "derive-where",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "futures",
  "harpc-codec",
  "harpc-net",
@@ -2667,7 +2654,7 @@ name = "harpc-codec"
 version = "0.0.0"
 dependencies = [
  "bytes",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "futures-core",
  "futures-util",
  "harpc-types",
@@ -2687,7 +2674,7 @@ dependencies = [
  "bytes-utils",
  "codec",
  "derive_more 1.0.0",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "futures",
  "futures-core",
  "futures-io",
@@ -2727,7 +2714,7 @@ dependencies = [
  "bytes",
  "derive-where",
  "derive_more 1.0.0",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "frunk",
  "frunk_core",
  "futures",
@@ -2764,7 +2751,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "futures",
  "futures-core",
  "harpc-codec",
@@ -2799,7 +2786,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "enumflags2",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "expect-test",
  "harpc-types",
  "proptest",
@@ -2817,7 +2804,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "codec",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "futures",
  "graph",
  "graph-api",
@@ -2847,7 +2834,7 @@ dependencies = [
  "authorization",
  "bytes",
  "derive-where",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "graph-types",
  "postgres-types",
  "serde",
@@ -2873,7 +2860,7 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "clap_builder",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "opentelemetry 0.26.0",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -3062,7 +3049,7 @@ dependencies = [
  "anstyle",
  "anstyle-yansi",
  "ariadne",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "hql-span",
  "jsonptr",
  "serde",
@@ -5715,7 +5702,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "criterion",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "inferno",
  "serde",
  "serde_json",
@@ -6746,7 +6733,7 @@ dependencies = [
 name = "temporal-client"
 version = "0.0.0"
 dependencies = [
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "graph-types",
  "serde",
  "serde_json",
@@ -6938,7 +6925,7 @@ dependencies = [
  "authorization",
  "axum 0.7.7",
  "codec",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "futures",
  "graph",
  "graph-api",
@@ -7572,7 +7559,7 @@ dependencies = [
 name = "type-fetcher"
 version = "0.0.0"
 dependencies = [
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "futures",
  "include_dir",
  "reqwest",
@@ -7592,7 +7579,7 @@ dependencies = [
  "codec",
  "console_error_panic_hook",
  "email_address",
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "futures",
  "graph-test-data",
  "iso8601-duration",
@@ -7839,7 +7826,7 @@ dependencies = [
 name = "validation"
 version = "0.0.0"
 dependencies = [
- "error-stack 0.5.0 (git+https://github.com/hashintel/hash?rev=f6ecda1ec75f4aca1f738b2fbe413613a356069c)",
+ "error-stack",
  "futures",
  "graph-test-data",
  "graph-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ type-system.path = "libs/@blockprotocol/type-system/rust"
 validation.path = "libs/@local/hash-validation"
 
 # Pinned workspace members
-error-stack = { git = "https://github.com/hashintel/hash", rev = "f6ecda1ec75f4aca1f738b2fbe413613a356069c", default-features = false }
+error-stack = { path = "./libs/error-stack", default-features = false }
 
 # Public dependencies
 ahash = { version = "=0.8.11", default-features = false }

--- a/apps/hash-graph/bins/cli/package.json
+++ b/apps/hash-graph/bins/cli/package.json
@@ -18,6 +18,7 @@
     "@blockprotocol/type-system-rs": "0.0.0-private",
     "@rust/authorization": "0.0.0-private",
     "@rust/codec": "0.0.0-private",
+    "@rust/error-stack": "0.5.0",
     "@rust/graph": "0.0.0-private",
     "@rust/graph-api": "0.0.0-private",
     "@rust/graph-types": "0.0.0-private",

--- a/apps/hash-graph/bins/cli/src/error.rs
+++ b/apps/hash-graph/bins/cli/src/error.rs
@@ -1,8 +1,8 @@
-use core::fmt;
+use core::{error::Error, fmt};
 
 #[derive(Debug)]
 pub struct GraphError;
-impl ::core::error::Error for GraphError {}
+impl Error for GraphError {}
 
 impl fmt::Display for GraphError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -25,4 +25,4 @@ impl fmt::Display for HealthcheckError {
     }
 }
 
-impl ::core::error::Error for HealthcheckError {}
+impl Error for HealthcheckError {}

--- a/apps/hash-graph/bins/cli/src/error.rs
+++ b/apps/hash-graph/bins/cli/src/error.rs
@@ -1,6 +1,5 @@
 use core::fmt;
 
-
 #[derive(Debug)]
 pub struct GraphError;
 impl ::core::error::Error for GraphError {}

--- a/apps/hash-graph/bins/cli/src/error.rs
+++ b/apps/hash-graph/bins/cli/src/error.rs
@@ -4,7 +4,7 @@ use error_stack::Context;
 
 #[derive(Debug)]
 pub struct GraphError;
-impl Context for GraphError {}
+impl ::core::error::Error for GraphError {}
 
 impl fmt::Display for GraphError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -27,4 +27,4 @@ impl fmt::Display for HealthcheckError {
     }
 }
 
-impl Context for HealthcheckError {}
+impl ::core::error::Error for HealthcheckError {}

--- a/apps/hash-graph/bins/cli/src/error.rs
+++ b/apps/hash-graph/bins/cli/src/error.rs
@@ -1,6 +1,5 @@
 use core::fmt;
 
-use error_stack::Context;
 
 #[derive(Debug)]
 pub struct GraphError;

--- a/apps/hash-graph/bins/cli/src/main.rs
+++ b/apps/hash-graph/bins/cli/src/main.rs
@@ -12,7 +12,7 @@ mod args;
 mod error;
 mod subcommand;
 
-use error_stack::Result;
+use error_stack::Report;
 use graph::load_env;
 use hash_tracing::sentry::{init, release_name};
 
@@ -21,7 +21,7 @@ use self::{args::Args, error::GraphError};
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-fn main() -> Result<(), GraphError> {
+fn main() -> Result<(), Report<GraphError>> {
     load_env(None);
     graph_types::knowledge::property::error::install_error_stack_hooks();
 

--- a/apps/hash-graph/bins/cli/src/subcommand/migrate.rs
+++ b/apps/hash-graph/bins/cli/src/subcommand/migrate.rs
@@ -1,6 +1,6 @@
 use authorization::NoAuthorization;
 use clap::Parser;
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use graph::store::{
     DatabaseConnectionInfo, DatabasePoolConfig, PostgresStorePool, StoreMigration as _,
     StorePool as _,
@@ -19,7 +19,7 @@ pub struct MigrateArgs {
     pub pool_config: DatabasePoolConfig,
 }
 
-pub async fn migrate(args: MigrateArgs) -> Result<(), GraphError> {
+pub async fn migrate(args: MigrateArgs) -> Result<(), Report<GraphError>> {
     let pool = PostgresStorePool::new(&args.db_info, &args.pool_config, NoTls)
         .await
         .change_context(GraphError)

--- a/apps/hash-graph/bins/cli/src/subcommand/mod.rs
+++ b/apps/hash-graph/bins/cli/src/subcommand/mod.rs
@@ -9,7 +9,7 @@ mod type_fetcher;
 
 use core::time::Duration;
 
-use error_stack::{Result, ensure};
+use error_stack::{Report, ensure};
 use hash_tracing::{TracingConfig, init_tracing};
 use tokio::{runtime::Handle, time::sleep};
 
@@ -51,9 +51,9 @@ pub enum Subcommand {
 }
 
 fn block_on(
-    future: impl Future<Output = Result<(), GraphError>>,
+    future: impl Future<Output = Result<(), Report<GraphError>>>,
     tracing_config: TracingConfig,
-) -> Result<(), GraphError> {
+) -> Result<(), Report<GraphError>> {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
@@ -68,7 +68,7 @@ fn block_on(
 }
 
 impl Subcommand {
-    pub(crate) fn execute(self, tracing_config: TracingConfig) -> Result<(), GraphError> {
+    pub(crate) fn execute(self, tracing_config: TracingConfig) -> Result<(), Report<GraphError>> {
         match self {
             Self::Server(args) => block_on(server(args), tracing_config),
             Self::Migrate(args) => block_on(migrate(args), tracing_config),
@@ -89,10 +89,10 @@ pub async fn wait_healthcheck<F, Ret>(
     func: F,
     wait: bool,
     wait_timeout: Option<Duration>,
-) -> Result<(), HealthcheckError>
+) -> Result<(), Report<HealthcheckError>>
 where
     F: Fn() -> Ret + Send,
-    Ret: Future<Output = Result<(), HealthcheckError>> + Send,
+    Ret: Future<Output = Result<(), Report<HealthcheckError>>> + Send,
 {
     let expected_end_time = wait_timeout.map(|timeout| std::time::Instant::now() + timeout);
 

--- a/apps/hash-graph/bins/cli/src/subcommand/reindex_cache.rs
+++ b/apps/hash-graph/bins/cli/src/subcommand/reindex_cache.rs
@@ -1,6 +1,6 @@
 use authorization::NoAuthorization;
 use clap::Parser;
-use error_stack::{Report, Result, ResultExt as _, ensure};
+use error_stack::{Report, ResultExt as _, ensure};
 use graph::store::{
     DatabaseConnectionInfo, DatabasePoolConfig, PostgresStorePool, StorePool as _,
     knowledge::EntityStore as _, ontology::EntityTypeStore as _,
@@ -37,7 +37,7 @@ pub struct ReindexOperations {
     pub entities: bool,
 }
 
-pub async fn reindex_cache(args: ReindexCacheArgs) -> Result<(), GraphError> {
+pub async fn reindex_cache(args: ReindexCacheArgs) -> Result<(), Report<GraphError>> {
     let pool = PostgresStorePool::new(&args.db_info, &args.pool_config, NoTls)
         .await
         .change_context(GraphError)

--- a/apps/hash-graph/bins/cli/src/subcommand/server.rs
+++ b/apps/hash-graph/bins/cli/src/subcommand/server.rs
@@ -12,7 +12,7 @@ use authorization::{
     zanzibar::ZanzibarClient,
 };
 use clap::Parser;
-use error_stack::{Report, Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use graph::{
     ontology::domain_validator::DomainValidator,
     store::{
@@ -51,7 +51,7 @@ impl fmt::Display for ApiAddress {
 impl TryFrom<ApiAddress> for SocketAddr {
     type Error = Report<AddrParseError>;
 
-    fn try_from(address: ApiAddress) -> Result<Self, AddrParseError> {
+    fn try_from(address: ApiAddress) -> Result<Self, Report<AddrParseError>> {
         address
             .to_string()
             .parse::<Self>()
@@ -134,7 +134,7 @@ pub struct ServerArgs {
     pub temporal_port: u16,
 }
 
-pub async fn server(args: ServerArgs) -> Result<(), GraphError> {
+pub async fn server(args: ServerArgs) -> Result<(), Report<GraphError>> {
     if args.healthcheck {
         return wait_healthcheck(
             || healthcheck(args.api_address.clone()),
@@ -218,7 +218,7 @@ pub async fn server(args: ServerArgs) -> Result<(), GraphError> {
     Ok(())
 }
 
-pub async fn healthcheck(address: ApiAddress) -> Result<(), HealthcheckError> {
+pub async fn healthcheck(address: ApiAddress) -> Result<(), Report<HealthcheckError>> {
     let request_url = format!("http://{address}/api-doc/openapi.json");
 
     timeout(

--- a/apps/hash-graph/bins/cli/src/subcommand/test_server.rs
+++ b/apps/hash-graph/bins/cli/src/subcommand/test_server.rs
@@ -6,7 +6,7 @@ use authorization::{
     zanzibar::ZanzibarClient,
 };
 use clap::Parser;
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use graph::{
     snapshot::SnapshotEntry,
     store::{DatabaseConnectionInfo, DatabasePoolConfig, PostgresStorePool},
@@ -58,7 +58,7 @@ pub struct TestServerArgs {
     pub spicedb_grpc_preshared_key: Option<String>,
 }
 
-pub async fn test_server(args: TestServerArgs) -> Result<(), GraphError> {
+pub async fn test_server(args: TestServerArgs) -> Result<(), Report<GraphError>> {
     SnapshotEntry::install_error_stack_hook();
 
     if args.healthcheck {
@@ -109,7 +109,7 @@ pub async fn test_server(args: TestServerArgs) -> Result<(), GraphError> {
     Ok(())
 }
 
-pub async fn healthcheck(address: ApiAddress) -> Result<(), HealthcheckError> {
+pub async fn healthcheck(address: ApiAddress) -> Result<(), Report<HealthcheckError>> {
     let request_url = format!("http://{address}/snapshot");
 
     timeout(

--- a/apps/hash-graph/bins/cli/src/subcommand/type_fetcher.rs
+++ b/apps/hash-graph/bins/cli/src/subcommand/type_fetcher.rs
@@ -2,7 +2,7 @@ use core::time::Duration;
 use std::collections::HashMap;
 
 use clap::Parser;
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use futures::{StreamExt as _, future};
 use tarpc::{
     serde_transport::Transport,
@@ -52,7 +52,7 @@ pub struct TypeFetcherArgs {
     pub timeout: Option<u64>,
 }
 
-pub async fn type_fetcher(args: TypeFetcherArgs) -> Result<(), GraphError> {
+pub async fn type_fetcher(args: TypeFetcherArgs) -> Result<(), Report<GraphError>> {
     if args.healthcheck {
         return wait_healthcheck(
             || healthcheck(args.address.clone()),
@@ -104,7 +104,7 @@ pub async fn type_fetcher(args: TypeFetcherArgs) -> Result<(), GraphError> {
     Ok(())
 }
 
-async fn healthcheck(address: TypeFetcherAddress) -> Result<(), HealthcheckError> {
+async fn healthcheck(address: TypeFetcherAddress) -> Result<(), Report<HealthcheckError>> {
     let transport = tarpc::serde_transport::tcp::connect(
         (address.type_fetcher_host, address.type_fetcher_port),
         tarpc::tokio_serde::formats::Json::default,

--- a/apps/hash-graph/libs/api/package.json
+++ b/apps/hash-graph/libs/api/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",
     "@rust/authorization": "0.0.0-private",
+    "@rust/error-stack": "0.5.0",
     "@rust/graph": "0.0.0-private",
     "@rust/graph-type-defs": "0.0.0-private",
     "@rust/graph-types": "0.0.0-private",

--- a/apps/hash-graph/libs/api/src/rest/status.rs
+++ b/apps/hash-graph/libs/api/src/rest/status.rs
@@ -29,7 +29,7 @@ where
 
 pub(crate) fn report_to_response<C>(report: impl Into<Report<[C]>>) -> Response
 where
-    C: Context,
+    C: ::core::error::Error + Send + Sync + 'static,
 {
     let report = report.into();
     let status_code = report

--- a/apps/hash-graph/libs/api/src/rest/status.rs
+++ b/apps/hash-graph/libs/api/src/rest/status.rs
@@ -5,7 +5,7 @@ use axum::{
     Json,
     response::{IntoResponse as _, Response},
 };
-use error_stack::{Context, Report};
+use error_stack::Report;
 use graph::store::error::BaseUrlAlreadyExists;
 use hash_status::{Status, StatusCode};
 use serde::Serialize;

--- a/apps/hash-graph/libs/api/src/rest/status.rs
+++ b/apps/hash-graph/libs/api/src/rest/status.rs
@@ -1,4 +1,4 @@
-use core::fmt::Debug;
+use core::{error::Error, fmt::Debug};
 
 use authorization::backend::PermissionAssertion;
 use axum::{
@@ -29,7 +29,7 @@ where
 
 pub(crate) fn report_to_response<C>(report: impl Into<Report<[C]>>) -> Response
 where
-    C: ::core::error::Error + Send + Sync + 'static,
+    C: Error + Send + Sync + 'static,
 {
     let report = report.into();
     let status_code = report

--- a/apps/hash-graph/libs/graph/package.json
+++ b/apps/hash-graph/libs/graph/package.json
@@ -10,6 +10,7 @@
     "@blockprotocol/type-system-rs": "0.0.0-private",
     "@rust/authorization": "0.0.0-private",
     "@rust/codec": "0.0.0-private",
+    "@rust/error-stack": "0.5.0",
     "@rust/graph-types": "0.0.0-private",
     "@rust/hash-graph-store": "0.0.0-private",
     "@rust/hash-status": "0.0.0-private",

--- a/apps/hash-graph/libs/graph/src/ontology/domain_validator.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/domain_validator.rs
@@ -7,7 +7,7 @@ use type_system::schema::{DataType, EntityType, PropertyType};
 #[derive(Debug)]
 pub struct DomainValidationError;
 
-impl Context for DomainValidationError {}
+impl ::core::error::Error for DomainValidationError {}
 
 impl fmt::Display for DomainValidationError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/apps/hash-graph/libs/graph/src/ontology/domain_validator.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/domain_validator.rs
@@ -1,4 +1,4 @@
-use core::fmt;
+use core::{error::Error, fmt};
 
 use error_stack::{Report, ResultExt as _};
 use regex::{Captures, Regex};
@@ -7,7 +7,7 @@ use type_system::schema::{DataType, EntityType, PropertyType};
 #[derive(Debug)]
 pub struct DomainValidationError;
 
-impl ::core::error::Error for DomainValidationError {}
+impl Error for DomainValidationError {}
 
 impl fmt::Display for DomainValidationError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/apps/hash-graph/libs/graph/src/ontology/domain_validator.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/domain_validator.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use error_stack::{Context, Report, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use regex::{Captures, Regex};
 use type_system::schema::{DataType, EntityType, PropertyType};
 

--- a/apps/hash-graph/libs/graph/src/ontology/domain_validator.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/domain_validator.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use error_stack::{Context, ResultExt as _};
+use error_stack::{Context, Report, ResultExt as _};
 use regex::{Captures, Regex};
 use type_system::schema::{DataType, EntityType, PropertyType};
 
@@ -21,7 +21,7 @@ pub trait ValidateOntologyType<T> {
     /// # Errors
     ///
     /// - [`DomainValidationError`], if the base URL doesn't match or the kind is invalid
-    fn validate(&self, ontology_type: &T) -> error_stack::Result<(), DomainValidationError>;
+    fn validate(&self, ontology_type: &T) -> Result<(), Report<DomainValidationError>>;
 }
 
 #[expect(dead_code, reason = "We currently don't validate the shortname")]
@@ -60,10 +60,7 @@ impl DomainValidator {
         self.0.is_match(url)
     }
 
-    fn captures<'a>(
-        &'a self,
-        url: &'a str,
-    ) -> error_stack::Result<Captures<'a>, DomainValidationError> {
+    fn captures<'a>(&'a self, url: &'a str) -> Result<Captures<'a>, Report<DomainValidationError>> {
         Ok(self.0.captures(url).ok_or(DomainValidationError)?)
     }
 
@@ -75,7 +72,7 @@ impl DomainValidator {
     fn extract_shortname_and_kind<'a>(
         &'a self,
         url: &'a str,
-    ) -> error_stack::Result<ShortNameAndKind<'a>, DomainValidationError> {
+    ) -> Result<ShortNameAndKind<'a>, Report<DomainValidationError>> {
         let captures = self.captures(url)?;
 
         let short_name = captures
@@ -95,7 +92,7 @@ impl DomainValidator {
 }
 
 impl ValidateOntologyType<DataType> for DomainValidator {
-    fn validate(&self, ontology_type: &DataType) -> error_stack::Result<(), DomainValidationError> {
+    fn validate(&self, ontology_type: &DataType) -> Result<(), Report<DomainValidationError>> {
         let base_url = &ontology_type.id.base_url;
 
         if !self.validate_url(base_url.as_str()) {
@@ -122,10 +119,7 @@ impl ValidateOntologyType<DataType> for DomainValidator {
 }
 
 impl ValidateOntologyType<PropertyType> for DomainValidator {
-    fn validate(
-        &self,
-        ontology_type: &PropertyType,
-    ) -> error_stack::Result<(), DomainValidationError> {
+    fn validate(&self, ontology_type: &PropertyType) -> Result<(), Report<DomainValidationError>> {
         let base_url = &ontology_type.id.base_url;
 
         if !self.validate_url(base_url.as_str()) {
@@ -153,10 +147,7 @@ impl ValidateOntologyType<PropertyType> for DomainValidator {
 }
 
 impl ValidateOntologyType<EntityType> for DomainValidator {
-    fn validate(
-        &self,
-        ontology_type: &EntityType,
-    ) -> error_stack::Result<(), DomainValidationError> {
+    fn validate(&self, ontology_type: &EntityType) -> Result<(), Report<DomainValidationError>> {
         let base_url = &ontology_type.id.base_url;
 
         if !self.validate_url(base_url.as_str()) {

--- a/apps/hash-graph/libs/graph/src/ontology/mod.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/mod.rs
@@ -4,7 +4,7 @@ pub mod domain_validator;
 
 use core::fmt;
 
-use error_stack::{Context as _, Report, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use serde::Deserialize;
 use type_system::url::VersionedUrl;
 

--- a/apps/hash-graph/libs/graph/src/ontology/mod.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/mod.rs
@@ -4,7 +4,7 @@ pub mod domain_validator;
 
 use core::fmt;
 
-use error_stack::{Context, Report, ResultExt as _};
+use error_stack::{Context as _, Report, ResultExt as _};
 use serde::Deserialize;
 use type_system::url::VersionedUrl;
 

--- a/apps/hash-graph/libs/graph/src/ontology/mod.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/mod.rs
@@ -2,7 +2,7 @@
 
 pub mod domain_validator;
 
-use core::fmt;
+use core::{error::Error, fmt};
 
 use error_stack::{Report, ResultExt as _};
 use serde::Deserialize;
@@ -11,7 +11,7 @@ use type_system::url::VersionedUrl;
 #[derive(Debug)]
 pub struct PatchAndParseError;
 
-impl ::core::error::Error for PatchAndParseError {}
+impl Error for PatchAndParseError {}
 
 impl fmt::Display for PatchAndParseError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/apps/hash-graph/libs/graph/src/ontology/mod.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/mod.rs
@@ -11,7 +11,7 @@ use type_system::url::VersionedUrl;
 #[derive(Debug)]
 pub struct PatchAndParseError;
 
-impl Context for PatchAndParseError {}
+impl ::core::error::Error for PatchAndParseError {}
 
 impl fmt::Display for PatchAndParseError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/apps/hash-graph/libs/graph/src/ontology/mod.rs
+++ b/apps/hash-graph/libs/graph/src/ontology/mod.rs
@@ -4,7 +4,7 @@ pub mod domain_validator;
 
 use core::fmt;
 
-use error_stack::{Context, Result, ResultExt as _};
+use error_stack::{Context, Report, ResultExt as _};
 use serde::Deserialize;
 use type_system::url::VersionedUrl;
 
@@ -36,7 +36,7 @@ impl fmt::Display for PatchAndParseError {
 pub fn patch_id_and_parse<T>(
     id: &VersionedUrl,
     mut value: serde_json::Value,
-) -> Result<T, PatchAndParseError>
+) -> Result<T, Report<PatchAndParseError>>
 where
     for<'de> T: Deserialize<'de>,
 {

--- a/apps/hash-graph/libs/graph/src/snapshot/mod.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/mod.rs
@@ -33,7 +33,7 @@ use authorization::{
         types::{RelationshipFilter, ResourceFilter},
     },
 };
-use error_stack::{Context, Report, ResultExt as _, ensure};
+use error_stack::{Report, ResultExt as _, ensure};
 use futures::{
     Sink, SinkExt as _, Stream, StreamExt as _, TryFutureExt as _, TryStreamExt as _,
     channel::mpsc, stream,
@@ -545,7 +545,11 @@ impl PostgresStorePool {
     #[expect(clippy::too_many_lines)]
     pub fn dump_snapshot(
         &self,
-        sink: impl Sink<SnapshotEntry, Error = Report<impl ::core::error::Error + Send + Sync + 'static>> + Send + 'static,
+        sink: impl Sink<
+            SnapshotEntry,
+            Error = Report<impl ::core::error::Error + Send + Sync + 'static>,
+        > + Send
+        + 'static,
         authorization_api: &(impl ZanzibarBackend + Sync),
         settings: SnapshotDumpSettings,
     ) -> Result<(), Report<SnapshotDumpError>> {
@@ -808,7 +812,10 @@ where
     /// - If writing a record into the datastore fails
     pub async fn restore_snapshot(
         &mut self,
-        snapshot: impl Stream<Item = Result<SnapshotEntry, Report<impl ::core::error::Error + Send + Sync + 'static>>> + Send + 'static,
+        snapshot: impl Stream<
+            Item = Result<SnapshotEntry, Report<impl ::core::error::Error + Send + Sync + 'static>>,
+        > + Send
+        + 'static,
         chunk_size: usize,
         validation: bool,
     ) -> Result<(), Report<SnapshotRestoreError>> {

--- a/apps/hash-graph/libs/graph/src/snapshot/mod.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/mod.rs
@@ -33,7 +33,7 @@ use authorization::{
         types::{RelationshipFilter, ResourceFilter},
     },
 };
-use error_stack::{Context, Report, Result, ResultExt as _, ensure};
+use error_stack::{Context, Report, ResultExt as _, ensure};
 use futures::{
     Sink, SinkExt as _, Stream, StreamExt as _, TryFutureExt as _, TryStreamExt as _,
     channel::mpsc, stream,
@@ -239,15 +239,15 @@ impl SnapshotEntry {
 trait WriteBatch<C, A> {
     fn begin(
         postgres_client: &mut PostgresStore<C, A>,
-    ) -> impl Future<Output = Result<(), InsertionError>> + Send;
+    ) -> impl Future<Output = Result<(), Report<InsertionError>>> + Send;
     fn write(
         self,
         postgres_client: &mut PostgresStore<C, A>,
-    ) -> impl Future<Output = Result<(), InsertionError>> + Send;
+    ) -> impl Future<Output = Result<(), Report<InsertionError>>> + Send;
     fn commit(
         postgres_client: &mut PostgresStore<C, A>,
         validation: bool,
-    ) -> impl Future<Output = Result<(), InsertionError>> + Send;
+    ) -> impl Future<Output = Result<(), Report<InsertionError>>> + Send;
 }
 
 pub struct SnapshotStore<C, A>(PostgresStore<C, A>);
@@ -279,8 +279,10 @@ pub struct SnapshotDumpSettings {
 impl PostgresStorePool {
     async fn read_accounts(
         &self,
-    ) -> Result<impl Stream<Item = Result<Account, SnapshotDumpError>> + Send, SnapshotDumpError>
-    {
+    ) -> Result<
+        impl Stream<Item = Result<Account, Report<SnapshotDumpError>>> + Send,
+        Report<SnapshotDumpError>,
+    > {
         // TODO: Make accounts a first-class `Record` type
         //   see https://linear.app/hash/issue/H-752
         Ok(self
@@ -300,8 +302,8 @@ impl PostgresStorePool {
         &'a self,
         authorization_api: &'a (impl ZanzibarBackend + Sync),
     ) -> Result<
-        impl Stream<Item = Result<AccountGroup, SnapshotDumpError>> + Send + 'a,
-        SnapshotDumpError,
+        impl Stream<Item = Result<AccountGroup, Report<SnapshotDumpError>>> + Send + 'a,
+        Report<SnapshotDumpError>,
     > {
         // TODO: Make account groups a first-class `Record` type
         //   see https://linear.app/hash/issue/H-752
@@ -337,8 +339,10 @@ impl PostgresStorePool {
     async fn read_webs<'a>(
         &'a self,
         authorization_api: &'a (impl ZanzibarBackend + Sync),
-    ) -> Result<impl Stream<Item = Result<Web, SnapshotDumpError>> + Send + 'a, SnapshotDumpError>
-    {
+    ) -> Result<
+        impl Stream<Item = Result<Web, Report<SnapshotDumpError>>> + Send + 'a,
+        Report<SnapshotDumpError>,
+    > {
         Ok(self
             .acquire(NoAuthorization, None)
             .await
@@ -370,7 +374,10 @@ impl PostgresStorePool {
     /// Convenience function to create a stream of snapshot entries.
     async fn create_dump_stream<'pool, T>(
         &'pool self,
-    ) -> Result<impl Stream<Item = Result<T, SnapshotDumpError>> + Send + 'pool, SnapshotDumpError>
+    ) -> Result<
+        impl Stream<Item = Result<T, Report<SnapshotDumpError>>> + Send + 'pool,
+        Report<SnapshotDumpError>,
+    >
     where
         <Self as StorePool>::Store<'pool, NoAuthorization>: Read<T>,
         T: QueryRecord + 'pool,
@@ -392,8 +399,8 @@ impl PostgresStorePool {
     async fn create_data_type_embedding_stream(
         &self,
     ) -> Result<
-        impl Stream<Item = Result<SnapshotEntry, SnapshotDumpError>> + Send,
-        SnapshotDumpError,
+        impl Stream<Item = Result<SnapshotEntry, Report<SnapshotDumpError>>> + Send,
+        Report<SnapshotDumpError>,
     > {
         Ok(self
             .acquire(NoAuthorization, None)
@@ -424,8 +431,8 @@ impl PostgresStorePool {
     async fn create_property_type_embedding_stream(
         &self,
     ) -> Result<
-        impl Stream<Item = Result<SnapshotEntry, SnapshotDumpError>> + Send,
-        SnapshotDumpError,
+        impl Stream<Item = Result<SnapshotEntry, Report<SnapshotDumpError>>> + Send,
+        Report<SnapshotDumpError>,
     > {
         Ok(self
             .acquire(NoAuthorization, None)
@@ -456,8 +463,8 @@ impl PostgresStorePool {
     async fn create_entity_type_embedding_stream(
         &self,
     ) -> Result<
-        impl Stream<Item = Result<SnapshotEntry, SnapshotDumpError>> + Send,
-        SnapshotDumpError,
+        impl Stream<Item = Result<SnapshotEntry, Report<SnapshotDumpError>>> + Send,
+        Report<SnapshotDumpError>,
     > {
         Ok(self
             .acquire(NoAuthorization, None)
@@ -488,8 +495,8 @@ impl PostgresStorePool {
     async fn create_entity_embedding_stream(
         &self,
     ) -> Result<
-        impl Stream<Item = Result<SnapshotEntry, SnapshotDumpError>> + Send,
-        SnapshotDumpError,
+        impl Stream<Item = Result<SnapshotEntry, Report<SnapshotDumpError>>> + Send,
+        Report<SnapshotDumpError>,
     > {
         Ok(self
             .acquire(NoAuthorization, None)
@@ -541,7 +548,7 @@ impl PostgresStorePool {
         sink: impl Sink<SnapshotEntry, Error = Report<impl Context>> + Send + 'static,
         authorization_api: &(impl ZanzibarBackend + Sync),
         settings: SnapshotDumpSettings,
-    ) -> Result<(), SnapshotDumpError> {
+    ) -> Result<(), Report<SnapshotDumpError>> {
         let (snapshot_record_tx, snapshot_record_rx) = mpsc::channel(settings.chunk_size);
         let snapshot_record_tx = snapshot_record_tx
             .sink_map_err(|error| Report::new(error).change_context(SnapshotDumpError::Write));
@@ -801,10 +808,10 @@ where
     /// - If writing a record into the datastore fails
     pub async fn restore_snapshot(
         &mut self,
-        snapshot: impl Stream<Item = Result<SnapshotEntry, impl Context>> + Send + 'static,
+        snapshot: impl Stream<Item = Result<SnapshotEntry, Report<impl Context>>> + Send + 'static,
         chunk_size: usize,
         validation: bool,
-    ) -> Result<(), SnapshotRestoreError> {
+    ) -> Result<(), Report<SnapshotRestoreError>> {
         tracing::info!("snapshot restore started");
 
         let (snapshot_record_tx, snapshot_record_rx, metadata_rx) = restore::channel(chunk_size);

--- a/apps/hash-graph/libs/graph/src/snapshot/mod.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/mod.rs
@@ -545,7 +545,7 @@ impl PostgresStorePool {
     #[expect(clippy::too_many_lines)]
     pub fn dump_snapshot(
         &self,
-        sink: impl Sink<SnapshotEntry, Error = Report<impl Context>> + Send + 'static,
+        sink: impl Sink<SnapshotEntry, Error = Report<impl ::core::error::Error + Send + Sync + 'static>> + Send + 'static,
         authorization_api: &(impl ZanzibarBackend + Sync),
         settings: SnapshotDumpSettings,
     ) -> Result<(), Report<SnapshotDumpError>> {
@@ -808,7 +808,7 @@ where
     /// - If writing a record into the datastore fails
     pub async fn restore_snapshot(
         &mut self,
-        snapshot: impl Stream<Item = Result<SnapshotEntry, Report<impl Context>>> + Send + 'static,
+        snapshot: impl Stream<Item = Result<SnapshotEntry, Report<impl ::core::error::Error + Send + Sync + 'static>>> + Send + 'static,
         chunk_size: usize,
         validation: bool,
     ) -> Result<(), Report<SnapshotRestoreError>> {

--- a/apps/hash-graph/libs/graph/src/snapshot/mod.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/mod.rs
@@ -17,7 +17,7 @@ mod ontology;
 mod restore;
 mod web;
 
-use core::future::ready;
+use core::{error::Error, future::ready};
 
 use async_scoped::TokioScope;
 use authorization::{
@@ -545,10 +545,8 @@ impl PostgresStorePool {
     #[expect(clippy::too_many_lines)]
     pub fn dump_snapshot(
         &self,
-        sink: impl Sink<
-            SnapshotEntry,
-            Error = Report<impl ::core::error::Error + Send + Sync + 'static>,
-        > + Send
+        sink: impl Sink<SnapshotEntry, Error = Report<impl Error + Send + Sync + 'static>>
+        + Send
         + 'static,
         authorization_api: &(impl ZanzibarBackend + Sync),
         settings: SnapshotDumpSettings,
@@ -812,9 +810,8 @@ where
     /// - If writing a record into the datastore fails
     pub async fn restore_snapshot(
         &mut self,
-        snapshot: impl Stream<
-            Item = Result<SnapshotEntry, Report<impl ::core::error::Error + Send + Sync + 'static>>,
-        > + Send
+        snapshot: impl Stream<Item = Result<SnapshotEntry, Report<impl Error + Send + Sync + 'static>>>
+        + Send
         + 'static,
         chunk_size: usize,
         validation: bool,

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/data_type/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/data_type/batch.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use authorization::{
     AuthorizationApi, backend::ZanzibarBackend, schema::DataTypeRelationAndSubject,
 };
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use hash_graph_store::{data_type::DataTypeStore as _, error::InsertionError};
 use tokio_postgres::GenericClient as _;
 use type_system::schema::DataTypeUuid;
@@ -28,7 +28,9 @@ where
     C: AsClient,
     A: AuthorizationApi + ZanzibarBackend + Send + Sync,
 {
-    async fn begin(postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError> {
+    async fn begin(
+        postgres_client: &mut PostgresStore<C, A>,
+    ) -> Result<(), Report<InsertionError>> {
         postgres_client
             .as_client()
             .client()
@@ -53,7 +55,10 @@ where
         Ok(())
     }
 
-    async fn write(self, postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError> {
+    async fn write(
+        self,
+        postgres_client: &mut PostgresStore<C, A>,
+    ) -> Result<(), Report<InsertionError>> {
         let client = postgres_client.as_client().client();
         match self {
             Self::Schema(data_types) => {
@@ -129,7 +134,7 @@ where
     async fn commit(
         postgres_client: &mut PostgresStore<C, A>,
         _validation: bool,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<(), Report<InsertionError>> {
         postgres_client
             .as_client()
             .client()

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/entity_type/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/entity_type/batch.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use authorization::{
     AuthorizationApi, backend::ZanzibarBackend, schema::EntityTypeRelationAndSubject,
 };
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use hash_graph_store::error::InsertionError;
 use tokio_postgres::GenericClient as _;
 use type_system::schema::EntityTypeUuid;
@@ -28,7 +28,9 @@ where
     C: AsClient,
     A: ZanzibarBackend + AuthorizationApi,
 {
-    async fn begin(postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError> {
+    async fn begin(
+        postgres_client: &mut PostgresStore<C, A>,
+    ) -> Result<(), Report<InsertionError>> {
         postgres_client
             .as_client()
             .client()
@@ -49,7 +51,10 @@ where
         Ok(())
     }
 
-    async fn write(self, postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError> {
+    async fn write(
+        self,
+        postgres_client: &mut PostgresStore<C, A>,
+    ) -> Result<(), Report<InsertionError>> {
         let client = postgres_client.as_client().client();
         match self {
             Self::Schema(entity_types) => {
@@ -109,7 +114,7 @@ where
     async fn commit(
         postgres_client: &mut PostgresStore<C, A>,
         _validation: bool,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<(), Report<InsertionError>> {
         postgres_client
             .as_client()
             .client()

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/metadata/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/metadata/batch.rs
@@ -1,4 +1,4 @@
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use hash_graph_store::error::InsertionError;
 use tokio_postgres::GenericClient as _;
 
@@ -25,7 +25,9 @@ where
     C: AsClient,
     A: Send + Sync,
 {
-    async fn begin(postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError> {
+    async fn begin(
+        postgres_client: &mut PostgresStore<C, A>,
+    ) -> Result<(), Report<InsertionError>> {
         postgres_client
             .as_client()
             .client()
@@ -54,7 +56,10 @@ where
         Ok(())
     }
 
-    async fn write(self, postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError> {
+    async fn write(
+        self,
+        postgres_client: &mut PostgresStore<C, A>,
+    ) -> Result<(), Report<InsertionError>> {
         let client = postgres_client.as_client().client();
         match self {
             Self::Ids(ontology_ids) => {
@@ -131,7 +136,7 @@ where
     async fn commit(
         postgres_client: &mut PostgresStore<C, A>,
         _validation: bool,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<(), Report<InsertionError>> {
         postgres_client
             .as_client()
             .client()

--- a/apps/hash-graph/libs/graph/src/snapshot/ontology/property_type/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/ontology/property_type/batch.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use authorization::{backend::ZanzibarBackend, schema::PropertyTypeRelationAndSubject};
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use hash_graph_store::error::InsertionError;
 use tokio_postgres::GenericClient as _;
 use type_system::schema::PropertyTypeUuid;
@@ -30,7 +30,9 @@ where
     C: AsClient,
     A: ZanzibarBackend + Send + Sync,
 {
-    async fn begin(postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError> {
+    async fn begin(
+        postgres_client: &mut PostgresStore<C, A>,
+    ) -> Result<(), Report<InsertionError>> {
         postgres_client
             .as_client()
             .client()
@@ -59,7 +61,10 @@ where
         Ok(())
     }
 
-    async fn write(self, postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError> {
+    async fn write(
+        self,
+        postgres_client: &mut PostgresStore<C, A>,
+    ) -> Result<(), Report<InsertionError>> {
         let client = postgres_client.as_client().client();
         match self {
             Self::Schema(property_types) => {
@@ -153,7 +158,7 @@ where
     async fn commit(
         postgres_client: &mut PostgresStore<C, A>,
         _validation: bool,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<(), Report<InsertionError>> {
         postgres_client
             .as_client()
             .client()

--- a/apps/hash-graph/libs/graph/src/snapshot/owner/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/owner/batch.rs
@@ -1,5 +1,5 @@
 use authorization::{backend::ZanzibarBackend, schema::AccountGroupRelationAndSubject};
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use graph_types::account::AccountGroupId;
 use hash_graph_store::error::InsertionError;
 use tokio_postgres::GenericClient as _;
@@ -23,7 +23,9 @@ where
     C: AsClient,
     A: ZanzibarBackend + Send + Sync,
 {
-    async fn begin(postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError> {
+    async fn begin(
+        postgres_client: &mut PostgresStore<C, A>,
+    ) -> Result<(), Report<InsertionError>> {
         postgres_client
             .as_client()
             .client()
@@ -43,7 +45,10 @@ where
         Ok(())
     }
 
-    async fn write(self, postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError> {
+    async fn write(
+        self,
+        postgres_client: &mut PostgresStore<C, A>,
+    ) -> Result<(), Report<InsertionError>> {
         let client = postgres_client.as_client().client();
         match self {
             Self::Accounts(accounts) => {
@@ -94,7 +99,7 @@ where
     async fn commit(
         postgres_client: &mut PostgresStore<C, A>,
         _validation: bool,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<(), Report<InsertionError>> {
         postgres_client
             .as_client()
             .client()

--- a/apps/hash-graph/libs/graph/src/snapshot/restore/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/restore/batch.rs
@@ -1,5 +1,5 @@
 use authorization::{AuthorizationApi, backend::ZanzibarBackend};
-use error_stack::Result;
+use error_stack::Report;
 use hash_graph_store::error::InsertionError;
 
 use crate::{
@@ -31,7 +31,9 @@ where
     C: AsClient,
     A: AuthorizationApi + ZanzibarBackend,
 {
-    async fn begin(postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError> {
+    async fn begin(
+        postgres_client: &mut PostgresStore<C, A>,
+    ) -> Result<(), Report<InsertionError>> {
         AccountRowBatch::begin(postgres_client).await?;
         WebBatch::begin(postgres_client).await?;
         OntologyTypeMetadataRowBatch::begin(postgres_client).await?;
@@ -42,7 +44,10 @@ where
         Ok(())
     }
 
-    async fn write(self, postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError> {
+    async fn write(
+        self,
+        postgres_client: &mut PostgresStore<C, A>,
+    ) -> Result<(), Report<InsertionError>> {
         match self {
             Self::Accounts(account) => account.write(postgres_client).await,
             Self::Webs(web) => web.write(postgres_client).await,
@@ -57,7 +62,7 @@ where
     async fn commit(
         postgres_client: &mut PostgresStore<C, A>,
         validation: bool,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<(), Report<InsertionError>> {
         AccountRowBatch::commit(postgres_client, validation).await?;
         WebBatch::commit(postgres_client, validation).await?;
         OntologyTypeMetadataRowBatch::commit(postgres_client, validation).await?;

--- a/apps/hash-graph/libs/graph/src/snapshot/web/batch.rs
+++ b/apps/hash-graph/libs/graph/src/snapshot/web/batch.rs
@@ -1,5 +1,5 @@
 use authorization::{backend::ZanzibarBackend, schema::WebRelationAndSubject};
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use graph_types::owned_by_id::OwnedById;
 use hash_graph_store::error::InsertionError;
 use tokio_postgres::GenericClient as _;
@@ -19,7 +19,9 @@ where
     C: AsClient,
     A: ZanzibarBackend + Send + Sync,
 {
-    async fn begin(postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError> {
+    async fn begin(
+        postgres_client: &mut PostgresStore<C, A>,
+    ) -> Result<(), Report<InsertionError>> {
         postgres_client
             .as_client()
             .client()
@@ -36,7 +38,10 @@ where
         Ok(())
     }
 
-    async fn write(self, postgres_client: &mut PostgresStore<C, A>) -> Result<(), InsertionError> {
+    async fn write(
+        self,
+        postgres_client: &mut PostgresStore<C, A>,
+    ) -> Result<(), Report<InsertionError>> {
         let client = postgres_client.as_client().client();
         match self {
             Self::Webs(webs) => {
@@ -70,7 +75,7 @@ where
     async fn commit(
         postgres_client: &mut PostgresStore<C, A>,
         _validation: bool,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<(), Report<InsertionError>> {
         postgres_client
             .as_client()
             .client()

--- a/apps/hash-graph/libs/graph/src/store/crud.rs
+++ b/apps/hash-graph/libs/graph/src/store/crud.rs
@@ -6,7 +6,7 @@
 //!
 //! [`Store`]: crate::store::Store
 
-use error_stack::Result;
+use error_stack::Report;
 use futures::{Stream, TryFutureExt as _, TryStreamExt};
 use hash_graph_store::{
     error::QueryError,
@@ -107,7 +107,7 @@ impl<'f, R: QueryRecord> ReadParameter<'f, R, ()> {
     pub async fn read(
         &self,
         store: &impl Read<R>,
-    ) -> Result<impl Stream<Item = Result<R, QueryError>>, QueryError> {
+    ) -> Result<impl Stream<Item = Result<R, Report<QueryError>>>, Report<QueryError>> {
         store
             .read(
                 self.filters.unwrap_or(&Filter::All(Vec::new())),
@@ -120,7 +120,7 @@ impl<'f, R: QueryRecord> ReadParameter<'f, R, ()> {
     /// # Errors
     ///
     /// Returns an error if reading the records fails.
-    pub async fn read_vec(&self, store: &impl Read<R>) -> Result<Vec<R>, QueryError> {
+    pub async fn read_vec(&self, store: &impl Read<R>) -> Result<Vec<R>, Report<QueryError>> {
         self.read(store).await?.try_collect().await
     }
 }
@@ -152,7 +152,9 @@ impl<R: QueryRecord, S: Sorting> ReadParameter<'_, R, S> {
 pub trait ReadPaginated<R: QueryRecord, S: Sorting + Sync>: Read<R> {
     type QueryResult: QueryResult<R, S> + Send;
 
-    type ReadPaginatedStream: Stream<Item = Result<Self::QueryResult, QueryError>> + Send + Sync;
+    type ReadPaginatedStream: Stream<Item = Result<Self::QueryResult, Report<QueryError>>>
+        + Send
+        + Sync;
 
     #[expect(
         clippy::type_complexity,
@@ -171,7 +173,7 @@ pub trait ReadPaginated<R: QueryRecord, S: Sorting + Sync>: Read<R> {
                 Self::ReadPaginatedStream,
                 <Self::QueryResult as QueryResult<R, S>>::Indices,
             ),
-            QueryError,
+            Report<QueryError>,
         >,
     > + Send;
 
@@ -193,7 +195,7 @@ pub trait ReadPaginated<R: QueryRecord, S: Sorting + Sync>: Read<R> {
                 Vec<Self::QueryResult>,
                 <Self::QueryResult as QueryResult<R, S>>::Indices,
             ),
-            QueryError,
+            Report<QueryError>,
         >,
     > + Send {
         async move {
@@ -209,14 +211,14 @@ pub trait ReadPaginated<R: QueryRecord, S: Sorting + Sync>: Read<R> {
 ///
 /// [`Store`]: crate::store::Store
 pub trait Read<R: QueryRecord>: Sync {
-    type ReadStream: Stream<Item = Result<R, QueryError>> + Send + Sync;
+    type ReadStream: Stream<Item = Result<R, Report<QueryError>>> + Send + Sync;
 
     fn read(
         &self,
         filter: &Filter<'_, R>,
         temporal_axes: Option<&QueryTemporalAxes>,
         include_drafts: bool,
-    ) -> impl Future<Output = Result<Self::ReadStream, QueryError>> + Send;
+    ) -> impl Future<Output = Result<Self::ReadStream, Report<QueryError>>> + Send;
 
     #[instrument(level = "info", skip(self, filter))]
     fn read_vec(
@@ -224,7 +226,7 @@ pub trait Read<R: QueryRecord>: Sync {
         filter: &Filter<'_, R>,
         temporal_axes: Option<&QueryTemporalAxes>,
         include_drafts: bool,
-    ) -> impl Future<Output = Result<Vec<R>, QueryError>> + Send {
+    ) -> impl Future<Output = Result<Vec<R>, Report<QueryError>>> + Send {
         self.read(filter, temporal_axes, include_drafts)
             .and_then(TryStreamExt::try_collect)
     }
@@ -234,7 +236,7 @@ pub trait Read<R: QueryRecord>: Sync {
         filter: &Filter<'_, R>,
         temporal_axes: Option<&QueryTemporalAxes>,
         include_drafts: bool,
-    ) -> impl Future<Output = Result<R, QueryError>> + Send;
+    ) -> impl Future<Output = Result<R, Report<QueryError>>> + Send;
 }
 
 // TODO: Add remaining CRUD traits

--- a/apps/hash-graph/libs/graph/src/store/error.rs
+++ b/apps/hash-graph/libs/graph/src/store/error.rs
@@ -1,6 +1,5 @@
 use core::fmt;
 
-
 #[derive(Debug)]
 pub struct StoreError;
 

--- a/apps/hash-graph/libs/graph/src/store/error.rs
+++ b/apps/hash-graph/libs/graph/src/store/error.rs
@@ -1,6 +1,5 @@
 use core::fmt;
 
-use error_stack::Context;
 
 #[derive(Debug)]
 pub struct StoreError;

--- a/apps/hash-graph/libs/graph/src/store/error.rs
+++ b/apps/hash-graph/libs/graph/src/store/error.rs
@@ -5,7 +5,7 @@ use error_stack::Context;
 #[derive(Debug)]
 pub struct StoreError;
 
-impl Context for StoreError {}
+impl ::core::error::Error for StoreError {}
 
 impl fmt::Display for StoreError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -23,7 +23,7 @@ impl fmt::Display for DeletionError {
     }
 }
 
-impl Context for DeletionError {}
+impl ::core::error::Error for DeletionError {}
 
 #[derive(Debug)]
 #[must_use]
@@ -35,7 +35,7 @@ impl fmt::Display for BaseUrlAlreadyExists {
     }
 }
 
-impl Context for BaseUrlAlreadyExists {}
+impl ::core::error::Error for BaseUrlAlreadyExists {}
 
 #[derive(Debug)]
 #[must_use]
@@ -47,7 +47,7 @@ impl fmt::Display for EntityDoesNotExist {
     }
 }
 
-impl Context for EntityDoesNotExist {}
+impl ::core::error::Error for EntityDoesNotExist {}
 
 #[derive(Debug)]
 #[must_use]
@@ -59,7 +59,7 @@ impl fmt::Display for RaceConditionOnUpdate {
     }
 }
 
-impl Context for RaceConditionOnUpdate {}
+impl ::core::error::Error for RaceConditionOnUpdate {}
 
 #[derive(Debug)]
 #[must_use]
@@ -71,7 +71,7 @@ impl fmt::Display for VersionedUrlAlreadyExists {
     }
 }
 
-impl Context for VersionedUrlAlreadyExists {}
+impl ::core::error::Error for VersionedUrlAlreadyExists {}
 
 #[derive(Debug)]
 #[must_use]
@@ -83,7 +83,7 @@ impl fmt::Display for OntologyVersionDoesNotExist {
     }
 }
 
-impl Context for OntologyVersionDoesNotExist {}
+impl ::core::error::Error for OntologyVersionDoesNotExist {}
 
 #[derive(Debug)]
 #[must_use]
@@ -95,12 +95,12 @@ impl fmt::Display for OntologyTypeIsNotOwned {
     }
 }
 
-impl Context for OntologyTypeIsNotOwned {}
+impl ::core::error::Error for OntologyTypeIsNotOwned {}
 
 #[derive(Debug)]
 pub struct MigrationError;
 
-impl Context for MigrationError {}
+impl ::core::error::Error for MigrationError {}
 
 impl fmt::Display for MigrationError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/apps/hash-graph/libs/graph/src/store/error.rs
+++ b/apps/hash-graph/libs/graph/src/store/error.rs
@@ -1,9 +1,9 @@
-use core::fmt;
+use core::{error::Error, fmt};
 
 #[derive(Debug)]
 pub struct StoreError;
 
-impl ::core::error::Error for StoreError {}
+impl Error for StoreError {}
 
 impl fmt::Display for StoreError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -21,7 +21,7 @@ impl fmt::Display for DeletionError {
     }
 }
 
-impl ::core::error::Error for DeletionError {}
+impl Error for DeletionError {}
 
 #[derive(Debug)]
 #[must_use]
@@ -33,7 +33,7 @@ impl fmt::Display for BaseUrlAlreadyExists {
     }
 }
 
-impl ::core::error::Error for BaseUrlAlreadyExists {}
+impl Error for BaseUrlAlreadyExists {}
 
 #[derive(Debug)]
 #[must_use]
@@ -45,7 +45,7 @@ impl fmt::Display for EntityDoesNotExist {
     }
 }
 
-impl ::core::error::Error for EntityDoesNotExist {}
+impl Error for EntityDoesNotExist {}
 
 #[derive(Debug)]
 #[must_use]
@@ -57,7 +57,7 @@ impl fmt::Display for RaceConditionOnUpdate {
     }
 }
 
-impl ::core::error::Error for RaceConditionOnUpdate {}
+impl Error for RaceConditionOnUpdate {}
 
 #[derive(Debug)]
 #[must_use]
@@ -69,7 +69,7 @@ impl fmt::Display for VersionedUrlAlreadyExists {
     }
 }
 
-impl ::core::error::Error for VersionedUrlAlreadyExists {}
+impl Error for VersionedUrlAlreadyExists {}
 
 #[derive(Debug)]
 #[must_use]
@@ -81,7 +81,7 @@ impl fmt::Display for OntologyVersionDoesNotExist {
     }
 }
 
-impl ::core::error::Error for OntologyVersionDoesNotExist {}
+impl Error for OntologyVersionDoesNotExist {}
 
 #[derive(Debug)]
 #[must_use]
@@ -93,12 +93,12 @@ impl fmt::Display for OntologyTypeIsNotOwned {
     }
 }
 
-impl ::core::error::Error for OntologyTypeIsNotOwned {}
+impl Error for OntologyTypeIsNotOwned {}
 
 #[derive(Debug)]
 pub struct MigrationError;
 
-impl ::core::error::Error for MigrationError {}
+impl Error for MigrationError {}
 
 impl fmt::Display for MigrationError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/apps/hash-graph/libs/graph/src/store/migration.rs
+++ b/apps/hash-graph/libs/graph/src/store/migration.rs
@@ -1,4 +1,4 @@
-use error_stack::Result;
+use error_stack::Report;
 
 use super::error::MigrationError;
 
@@ -56,16 +56,16 @@ impl Migration {
 pub trait StoreMigration: Sync {
     fn run_migrations(
         &mut self,
-    ) -> impl Future<Output = Result<Vec<Migration>, MigrationError>> + Send;
+    ) -> impl Future<Output = Result<Vec<Migration>, Report<MigrationError>>> + Send;
 
     fn all_migrations(
         &mut self,
-    ) -> impl Future<Output = Result<Vec<Migration>, MigrationError>> + Send;
+    ) -> impl Future<Output = Result<Vec<Migration>, Report<MigrationError>>> + Send;
 
     fn applied_migrations(
         &mut self,
-    ) -> impl Future<Output = Result<Vec<Migration>, MigrationError>> + Send;
+    ) -> impl Future<Output = Result<Vec<Migration>, Report<MigrationError>>> + Send;
     fn missing_migrations(
         &mut self,
-    ) -> impl Future<Output = Result<Vec<Migration>, MigrationError>> + Send;
+    ) -> impl Future<Output = Result<Vec<Migration>, Report<MigrationError>>> + Send;
 }

--- a/apps/hash-graph/libs/graph/src/store/ontology.rs
+++ b/apps/hash-graph/libs/graph/src/store/ontology.rs
@@ -3,7 +3,7 @@ use core::iter;
 use std::collections::HashMap;
 
 use authorization::schema::{EntityTypeRelationAndSubject, PropertyTypeRelationAndSubject};
-use error_stack::Result;
+use error_stack::Report;
 use graph_types::{
     Embedding,
     account::{AccountId, EditionCreatedById},
@@ -155,7 +155,7 @@ pub trait PropertyTypeStore {
         &mut self,
         actor_id: AccountId,
         params: CreatePropertyTypeParams<R>,
-    ) -> impl Future<Output = Result<PropertyTypeMetadata, InsertionError>> + Send
+    ) -> impl Future<Output = Result<PropertyTypeMetadata, Report<InsertionError>>> + Send
     where
         Self: Send,
         R: IntoIterator<Item = PropertyTypeRelationAndSubject> + Send + Sync,
@@ -181,7 +181,7 @@ pub trait PropertyTypeStore {
         &mut self,
         actor_id: AccountId,
         params: P,
-    ) -> impl Future<Output = Result<Vec<PropertyTypeMetadata>, InsertionError>> + Send
+    ) -> impl Future<Output = Result<Vec<PropertyTypeMetadata>, Report<InsertionError>>> + Send
     where
         P: IntoIterator<Item = CreatePropertyTypeParams<R>, IntoIter: Send> + Send,
         R: IntoIterator<Item = PropertyTypeRelationAndSubject> + Send + Sync;
@@ -195,7 +195,7 @@ pub trait PropertyTypeStore {
         &self,
         actor_id: AccountId,
         params: CountPropertyTypesParams<'_>,
-    ) -> impl Future<Output = Result<usize, QueryError>> + Send;
+    ) -> impl Future<Output = Result<usize, Report<QueryError>>> + Send;
 
     /// Get the [`Subgraph`] specified by the [`GetPropertyTypeSubgraphParams`].
     ///
@@ -206,7 +206,7 @@ pub trait PropertyTypeStore {
         &self,
         actor_id: AccountId,
         params: GetPropertyTypeSubgraphParams<'_>,
-    ) -> impl Future<Output = Result<GetPropertyTypeSubgraphResponse, QueryError>> + Send;
+    ) -> impl Future<Output = Result<GetPropertyTypeSubgraphResponse, Report<QueryError>>> + Send;
 
     /// Get the [`PropertyTypes`] specified by the [`GetPropertyTypesParams`].
     ///
@@ -219,7 +219,7 @@ pub trait PropertyTypeStore {
         &self,
         actor_id: AccountId,
         params: GetPropertyTypesParams<'_>,
-    ) -> impl Future<Output = Result<GetPropertyTypesResponse, QueryError>> + Send;
+    ) -> impl Future<Output = Result<GetPropertyTypesResponse, Report<QueryError>>> + Send;
 
     /// Update the definition of an existing [`PropertyType`].
     ///
@@ -230,7 +230,7 @@ pub trait PropertyTypeStore {
         &mut self,
         actor_id: AccountId,
         params: UpdatePropertyTypesParams<R>,
-    ) -> impl Future<Output = Result<PropertyTypeMetadata, UpdateError>> + Send
+    ) -> impl Future<Output = Result<PropertyTypeMetadata, Report<UpdateError>>> + Send
     where
         R: IntoIterator<Item = PropertyTypeRelationAndSubject> + Send + Sync;
 
@@ -244,7 +244,7 @@ pub trait PropertyTypeStore {
         actor_id: AccountId,
 
         params: ArchivePropertyTypeParams<'_>,
-    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
+    ) -> impl Future<Output = Result<OntologyTemporalMetadata, Report<UpdateError>>> + Send;
 
     /// Restores the definition of an existing [`PropertyType`].
     ///
@@ -256,14 +256,14 @@ pub trait PropertyTypeStore {
         actor_id: AccountId,
 
         params: UnarchivePropertyTypeParams<'_>,
-    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
+    ) -> impl Future<Output = Result<OntologyTemporalMetadata, Report<UpdateError>>> + Send;
 
     fn update_property_type_embeddings(
         &mut self,
         actor_id: AccountId,
 
         params: UpdatePropertyTypeEmbeddingParams<'_>,
-    ) -> impl Future<Output = Result<(), UpdateError>> + Send;
+    ) -> impl Future<Output = Result<(), Report<UpdateError>>> + Send;
 }
 
 #[derive(Debug, Deserialize)]
@@ -435,7 +435,7 @@ pub trait EntityTypeStore {
         &mut self,
         actor_id: AccountId,
         params: CreateEntityTypeParams<R>,
-    ) -> impl Future<Output = Result<EntityTypeMetadata, InsertionError>> + Send
+    ) -> impl Future<Output = Result<EntityTypeMetadata, Report<InsertionError>>> + Send
     where
         Self: Send,
         R: IntoIterator<Item = EntityTypeRelationAndSubject> + Send + Sync,
@@ -461,7 +461,7 @@ pub trait EntityTypeStore {
         &mut self,
         actor_id: AccountId,
         params: P,
-    ) -> impl Future<Output = Result<Vec<EntityTypeMetadata>, InsertionError>> + Send
+    ) -> impl Future<Output = Result<Vec<EntityTypeMetadata>, Report<InsertionError>>> + Send
     where
         P: IntoIterator<Item = CreateEntityTypeParams<R>, IntoIter: Send> + Send,
         R: IntoIterator<Item = EntityTypeRelationAndSubject> + Send + Sync;
@@ -475,7 +475,7 @@ pub trait EntityTypeStore {
         &self,
         actor_id: AccountId,
         params: CountEntityTypesParams<'_>,
-    ) -> impl Future<Output = Result<usize, QueryError>> + Send;
+    ) -> impl Future<Output = Result<usize, Report<QueryError>>> + Send;
 
     /// Get the [`Subgraph`]s specified by the [`GetEntityTypeSubgraphParams`].
     ///
@@ -486,7 +486,7 @@ pub trait EntityTypeStore {
         &self,
         actor_id: AccountId,
         params: GetEntityTypeSubgraphParams<'_>,
-    ) -> impl Future<Output = Result<GetEntityTypeSubgraphResponse, QueryError>> + Send;
+    ) -> impl Future<Output = Result<GetEntityTypeSubgraphResponse, Report<QueryError>>> + Send;
 
     /// Get the [`EntityType`]s specified by the [`GetEntityTypesParams`].
     ///
@@ -497,7 +497,7 @@ pub trait EntityTypeStore {
         &self,
         actor_id: AccountId,
         params: GetEntityTypesParams<'_>,
-    ) -> impl Future<Output = Result<GetEntityTypesResponse, QueryError>> + Send;
+    ) -> impl Future<Output = Result<GetEntityTypesResponse, Report<QueryError>>> + Send;
 
     /// Get the [`ClosedMultiEntityType`] specified by the [`GetClosedMultiEntityTypeParams`].
     ///
@@ -508,7 +508,7 @@ pub trait EntityTypeStore {
         &self,
         actor_id: AccountId,
         params: GetClosedMultiEntityTypeParams,
-    ) -> impl Future<Output = Result<GetClosedMultiEntityTypeResponse, QueryError>> + Send;
+    ) -> impl Future<Output = Result<GetClosedMultiEntityTypeResponse, Report<QueryError>>> + Send;
 
     /// Update the definition of an existing [`EntityType`].
     ///
@@ -519,7 +519,7 @@ pub trait EntityTypeStore {
         &mut self,
         actor_id: AccountId,
         params: UpdateEntityTypesParams<R>,
-    ) -> impl Future<Output = Result<EntityTypeMetadata, UpdateError>> + Send
+    ) -> impl Future<Output = Result<EntityTypeMetadata, Report<UpdateError>>> + Send
     where
         R: IntoIterator<Item = EntityTypeRelationAndSubject> + Send + Sync;
 
@@ -533,7 +533,7 @@ pub trait EntityTypeStore {
         actor_id: AccountId,
 
         params: ArchiveEntityTypeParams,
-    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
+    ) -> impl Future<Output = Result<OntologyTemporalMetadata, Report<UpdateError>>> + Send;
 
     /// Restores the definition of an existing [`EntityType`].
     ///
@@ -545,14 +545,14 @@ pub trait EntityTypeStore {
         actor_id: AccountId,
 
         params: UnarchiveEntityTypeParams,
-    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
+    ) -> impl Future<Output = Result<OntologyTemporalMetadata, Report<UpdateError>>> + Send;
 
     fn update_entity_type_embeddings(
         &mut self,
         actor_id: AccountId,
 
         params: UpdateEntityTypeEmbeddingParams<'_>,
-    ) -> impl Future<Output = Result<(), UpdateError>> + Send;
+    ) -> impl Future<Output = Result<(), Report<UpdateError>>> + Send;
 
     /// Re-indexes the cache for entity types.
     ///
@@ -562,6 +562,7 @@ pub trait EntityTypeStore {
     /// # Errors
     ///
     /// - if re-indexing the cache fails.
-    fn reindex_entity_type_cache(&mut self)
-    -> impl Future<Output = Result<(), UpdateError>> + Send;
+    fn reindex_entity_type_cache(
+        &mut self,
+    ) -> impl Future<Output = Result<(), Report<UpdateError>>> + Send;
 }

--- a/apps/hash-graph/libs/graph/src/store/pool.rs
+++ b/apps/hash-graph/libs/graph/src/store/pool.rs
@@ -9,7 +9,7 @@ use crate::store::Store;
 /// Managed pool to keep track about [`Store`]s.
 pub trait StorePool {
     /// The error returned when acquiring a [`Store`].
-    type Error: Context;
+    type Error: ::core::error::Error + Send + Sync + 'static;
 
     /// The store returned when acquiring.
     type Store<'pool, A: AuthorizationApi>: Store + Send + Sync;

--- a/apps/hash-graph/libs/graph/src/store/pool.rs
+++ b/apps/hash-graph/libs/graph/src/store/pool.rs
@@ -1,4 +1,5 @@
 use alloc::sync::Arc;
+use core::error::Error;
 
 use authorization::AuthorizationApi;
 use error_stack::Report;
@@ -9,7 +10,7 @@ use crate::store::Store;
 /// Managed pool to keep track about [`Store`]s.
 pub trait StorePool {
     /// The error returned when acquiring a [`Store`].
-    type Error: ::core::error::Error + Send + Sync + 'static;
+    type Error: Error + Send + Sync + 'static;
 
     /// The store returned when acquiring.
     type Store<'pool, A: AuthorizationApi>: Store + Send + Sync;

--- a/apps/hash-graph/libs/graph/src/store/pool.rs
+++ b/apps/hash-graph/libs/graph/src/store/pool.rs
@@ -1,7 +1,7 @@
 use alloc::sync::Arc;
 
 use authorization::AuthorizationApi;
-use error_stack::{Context as _, Report};
+use error_stack::Report;
 use temporal_client::TemporalClient;
 
 use crate::store::Store;

--- a/apps/hash-graph/libs/graph/src/store/pool.rs
+++ b/apps/hash-graph/libs/graph/src/store/pool.rs
@@ -1,7 +1,7 @@
 use alloc::sync::Arc;
 
 use authorization::AuthorizationApi;
-use error_stack::{Context, Result};
+use error_stack::{Context, Report};
 use temporal_client::TemporalClient;
 
 use crate::store::Store;
@@ -19,7 +19,7 @@ pub trait StorePool {
         &self,
         authorization_api: A,
         temporal_client: Option<Arc<TemporalClient>>,
-    ) -> impl Future<Output = Result<Self::Store<'_, A>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Self::Store<'_, A>, Report<Self::Error>>> + Send;
 
     /// Retrieves an owned [`Store`] from the pool.
     ///
@@ -32,5 +32,5 @@ pub trait StorePool {
         &self,
         authorization_api: A,
         temporal_client: Option<Arc<TemporalClient>>,
-    ) -> impl Future<Output = Result<Self::Store<'static, A>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Self::Store<'static, A>, Report<Self::Error>>> + Send;
 }

--- a/apps/hash-graph/libs/graph/src/store/pool.rs
+++ b/apps/hash-graph/libs/graph/src/store/pool.rs
@@ -1,7 +1,7 @@
 use alloc::sync::Arc;
 
 use authorization::AuthorizationApi;
-use error_stack::{Context, Report};
+use error_stack::{Context as _, Report};
 use temporal_client::TemporalClient;
 
 use crate::store::Store;

--- a/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/knowledge/entity/read.rs
@@ -1,7 +1,7 @@
 use alloc::borrow::Cow;
 use core::mem::swap;
 
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use graph_types::{
     knowledge::entity::{EntityEditionId, EntityId, EntityUuid},
     owned_by_id::OwnedById,
@@ -92,8 +92,10 @@ where
         &self,
         traversal_data: &'t EntityEdgeTraversalData,
         depth: Option<u32>,
-    ) -> Result<impl Iterator<Item = (OntologyTypeUuid, SharedEdgeTraversal)> + 't, QueryError>
-    {
+    ) -> Result<
+        impl Iterator<Item = (OntologyTypeUuid, SharedEdgeTraversal)> + 't,
+        Report<QueryError>,
+    > {
         let (pinned_axis, variable_axis) = match traversal_data.variable_axis {
             TimeAxis::DecisionTime => ("transaction_time", "decision_time"),
             TimeAxis::TransactionTime => ("decision_time", "transaction_time"),
@@ -177,7 +179,8 @@ where
         traversal_data: &'t EntityEdgeTraversalData,
         reference_table: ReferenceTable,
         edge_direction: EdgeDirection,
-    ) -> Result<impl Iterator<Item = (EntityId, KnowledgeEdgeTraversal)> + 't, QueryError> {
+    ) -> Result<impl Iterator<Item = (EntityId, KnowledgeEdgeTraversal)> + 't, Report<QueryError>>
+    {
         let (pinned_axis, variable_axis) = match traversal_data.variable_axis {
             TimeAxis::DecisionTime => ("transaction_time", "decision_time"),
             TimeAxis::TransactionTime => ("decision_time", "transaction_time"),

--- a/apps/hash-graph/libs/graph/src/store/postgres/migration.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/migration.rs
@@ -1,4 +1,4 @@
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use tokio_postgres::Client;
 
 use super::{AsClient, PostgresStore};
@@ -35,7 +35,7 @@ where
     C: AsClient<Client = Client>,
     A: Send + Sync,
 {
-    async fn run_migrations(&mut self) -> Result<Vec<Migration>, MigrationError> {
+    async fn run_migrations(&mut self) -> Result<Vec<Migration>, Report<MigrationError>> {
         Ok(embedded::migrations::runner()
             .run_async(self.as_mut_client())
             .await
@@ -46,7 +46,7 @@ where
             .collect())
     }
 
-    async fn all_migrations(&mut self) -> Result<Vec<Migration>, MigrationError> {
+    async fn all_migrations(&mut self) -> Result<Vec<Migration>, Report<MigrationError>> {
         Ok(embedded::migrations::runner()
             .get_migrations()
             .iter()
@@ -54,7 +54,7 @@ where
             .collect())
     }
 
-    async fn applied_migrations(&mut self) -> Result<Vec<Migration>, MigrationError> {
+    async fn applied_migrations(&mut self) -> Result<Vec<Migration>, Report<MigrationError>> {
         Ok(embedded::migrations::runner()
             .get_applied_migrations_async(self.as_mut_client())
             .await
@@ -64,7 +64,7 @@ where
             .collect())
     }
 
-    async fn missing_migrations(&mut self) -> Result<Vec<Migration>, MigrationError> {
+    async fn missing_migrations(&mut self) -> Result<Vec<Migration>, Report<MigrationError>> {
         let all_migrations = self.all_migrations().await?;
         let applied_migrations = self.all_migrations().await?;
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/mod.rs
@@ -19,7 +19,7 @@ use authorization::{
         WebOwnerSubject, WebPropertyTypeViewerSubject, WebRelationAndSubject, WebSubjectSet,
     },
 };
-use error_stack::{Report, Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use graph_types::{
     account::{AccountGroupId, AccountId, EditionArchivedById},
     ontology::{
@@ -136,7 +136,7 @@ where
         base_url: &BaseUrl,
         on_conflict: ConflictBehavior,
         location: OntologyLocation,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<(), Report<InsertionError>> {
         match on_conflict {
             ConflictBehavior::Fail => {
                 self.as_client()
@@ -213,7 +213,7 @@ where
         &self,
         ontology_id: &VersionedUrl,
         on_conflict: ConflictBehavior,
-    ) -> Result<Option<OntologyTypeUuid>, InsertionError> {
+    ) -> Result<Option<OntologyTypeUuid>, Report<InsertionError>> {
         let query: &str = match on_conflict {
             ConflictBehavior::Skip => {
                 "
@@ -261,7 +261,7 @@ where
         &self,
         ontology_id: OntologyTypeUuid,
         provenance: &OntologyEditionProvenance,
-    ) -> Result<LeftClosedTemporalInterval<TransactionTime>, InsertionError> {
+    ) -> Result<LeftClosedTemporalInterval<TransactionTime>, Report<InsertionError>> {
         let query = "
               INSERT INTO ontology_temporal_metadata (
                 ontology_id,
@@ -282,7 +282,7 @@ where
         &self,
         id: &VersionedUrl,
         archived_by_id: EditionArchivedById,
-    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+    ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         let query = "
           UPDATE ontology_temporal_metadata
           SET
@@ -340,7 +340,7 @@ where
         &self,
         id: &VersionedUrl,
         provenance: &OntologyEditionProvenance,
-    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+    ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         let query = "
           INSERT INTO ontology_temporal_metadata (
             ontology_id,
@@ -382,7 +382,7 @@ where
         &self,
         ontology_id: OntologyTypeUuid,
         owned_by_id: OwnedById,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<(), Report<InsertionError>> {
         let query = "
                 INSERT INTO ontology_owned_metadata (
                     ontology_id,
@@ -402,7 +402,7 @@ where
         &self,
         ontology_id: OntologyTypeUuid,
         fetched_at: OffsetDateTime,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<(), Report<InsertionError>> {
         let query = "
               INSERT INTO ontology_external_metadata (
                 ontology_id,
@@ -433,7 +433,7 @@ where
         ontology_id: DataTypeUuid,
         data_type: &Valid<DataType>,
         closed_data_type: &Valid<ClosedDataType>,
-    ) -> Result<Option<OntologyTypeUuid>, InsertionError> {
+    ) -> Result<Option<OntologyTypeUuid>, Report<InsertionError>> {
         let ontology_id = self
             .as_client()
             .query_opt(
@@ -460,7 +460,7 @@ where
         &self,
         ontology_id: DataTypeUuid,
         metadata: &DataTypeResolveData,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<(), Report<InsertionError>> {
         for (target, depth) in metadata.inheritance_depths() {
             self.as_client()
                 .query(
@@ -490,7 +490,7 @@ where
         ontology_id: DataTypeUuid,
         target_data_type: &BaseUrl,
         conversions: &Conversions,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<(), Report<InsertionError>> {
         self.as_client()
             .query(
                 r#"
@@ -532,7 +532,7 @@ where
         &self,
         ontology_id: OntologyTypeUuid,
         property_type: &Valid<PropertyType>,
-    ) -> Result<Option<OntologyTypeUuid>, InsertionError> {
+    ) -> Result<Option<OntologyTypeUuid>, Report<InsertionError>> {
         Ok(self
             .as_client()
             .query_opt(
@@ -565,7 +565,7 @@ where
         ontology_id: EntityTypeUuid,
         entity_type: &Valid<EntityType>,
         closed_entity_type: &Valid<ClosedEntityType>,
-    ) -> Result<Option<OntologyTypeUuid>, InsertionError> {
+    ) -> Result<Option<OntologyTypeUuid>, Report<InsertionError>> {
         Ok(self
             .as_client()
             .query_opt(
@@ -590,7 +590,7 @@ where
         &self,
         property_type: &PropertyType,
         ontology_id: OntologyTypeUuid,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<(), Report<InsertionError>> {
         for property_type in property_type.property_type_references() {
             self.as_client()
                 .query_one(
@@ -645,7 +645,7 @@ where
         &self,
         entity_type_uuid: EntityTypeUuid,
         metadata: &EntityTypeResolveData,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<(), Report<InsertionError>> {
         for (target_id, depth) in metadata.inheritance_depths() {
             self.as_client()
                 .query_one(
@@ -731,7 +731,7 @@ where
     async fn entity_type_reference_ids<'p, I>(
         &self,
         referenced_entity_types: I,
-    ) -> Result<Vec<OntologyTypeUuid>, QueryError>
+    ) -> Result<Vec<OntologyTypeUuid>, Report<QueryError>>
     where
         I: IntoIterator<Item = &'p EntityTypeReference> + Send,
         I::IntoIter: Send,
@@ -748,7 +748,7 @@ where
     async fn property_type_reference_ids<'p, I>(
         &self,
         referenced_property_types: I,
-    ) -> Result<Vec<OntologyTypeUuid>, QueryError>
+    ) -> Result<Vec<OntologyTypeUuid>, Report<QueryError>>
     where
         I: IntoIterator<Item = &'p PropertyTypeReference> + Send,
         I::IntoIter: Send,
@@ -765,7 +765,7 @@ where
     async fn data_type_reference_ids<'p, I>(
         &self,
         referenced_data_types: I,
-    ) -> Result<Vec<OntologyTypeUuid>, QueryError>
+    ) -> Result<Vec<OntologyTypeUuid>, Report<QueryError>>
     where
         I: IntoIterator<Item = &'p DataTypeReference> + Send,
         I::IntoIter: Send,
@@ -784,7 +784,10 @@ where
     ///
     /// - if the entry referred to by `url` does not exist.
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn ontology_id_by_url(&self, url: &VersionedUrl) -> Result<OntologyTypeUuid, QueryError> {
+    async fn ontology_id_by_url(
+        &self,
+        url: &VersionedUrl,
+    ) -> Result<OntologyTypeUuid, Report<QueryError>> {
         Ok(self
             .client
             .as_client()
@@ -807,7 +810,7 @@ where
     /// - if the underlying client cannot start a transaction
     pub async fn transaction(
         &mut self,
-    ) -> Result<PostgresStore<tokio_postgres::Transaction<'_>, &'_ mut A>, StoreError> {
+    ) -> Result<PostgresStore<tokio_postgres::Transaction<'_>, &'_ mut A>, Report<StoreError>> {
         Ok(PostgresStore::new(
             self.client
                 .as_mut_client()
@@ -843,7 +846,7 @@ where
         classification: &OntologyTypeClassificationMetadata,
         on_conflict: ConflictBehavior,
         provenance: &OntologyProvenance,
-    ) -> Result<Option<(OntologyTypeUuid, OntologyTemporalMetadata)>, InsertionError> {
+    ) -> Result<Option<(OntologyTypeUuid, OntologyTemporalMetadata)>, Report<InsertionError>> {
         match classification {
             OntologyTypeClassificationMetadata::Owned { owned_by_id } => {
                 self.create_base_url(&ontology_id.base_url, on_conflict, OntologyLocation::Owned)
@@ -899,7 +902,7 @@ where
         &self,
         url: &VersionedUrl,
         provenance: &OntologyEditionProvenance,
-    ) -> Result<(OntologyTypeUuid, OwnedById, OntologyTemporalMetadata), UpdateError> {
+    ) -> Result<(OntologyTypeUuid, OwnedById, OntologyTemporalMetadata), Report<UpdateError>> {
         let previous_version = OntologyTypeVersion::new(
             url.version
                 .inner()
@@ -975,14 +978,14 @@ where
     /// # Errors
     ///
     /// - if the underlying client cannot commit the transaction
-    pub async fn commit(self) -> Result<(), StoreError> {
+    pub async fn commit(self) -> Result<(), Report<StoreError>> {
         self.client.commit().await.change_context(StoreError)
     }
 
     /// # Errors
     ///
     /// - if the underlying client cannot rollback the transaction
-    pub async fn rollback(self) -> Result<(), StoreError> {
+    pub async fn rollback(self) -> Result<(), Report<StoreError>> {
         self.client.rollback().await.change_context(StoreError)
     }
 }
@@ -993,7 +996,7 @@ impl<C: AsClient, A: AuthorizationApi> AccountStore for PostgresStore<C, A> {
         &mut self,
         actor_id: AccountId,
         params: InsertAccountIdParams,
-    ) -> Result<(), AccountInsertionError> {
+    ) -> Result<(), Report<AccountInsertionError>> {
         self.as_client()
             .query("INSERT INTO accounts (account_id) VALUES ($1);", &[
                 &params.account_id
@@ -1009,7 +1012,7 @@ impl<C: AsClient, A: AuthorizationApi> AccountStore for PostgresStore<C, A> {
         &mut self,
         actor_id: AccountId,
         params: InsertAccountGroupIdParams,
-    ) -> Result<(), AccountGroupInsertionError> {
+    ) -> Result<(), Report<AccountGroupInsertionError>> {
         let transaction = self
             .transaction()
             .await
@@ -1072,7 +1075,7 @@ impl<C: AsClient, A: AuthorizationApi> AccountStore for PostgresStore<C, A> {
         &mut self,
         actor_id: AccountId,
         params: InsertWebIdParams,
-    ) -> Result<(), WebInsertionError> {
+    ) -> Result<(), Report<WebInsertionError>> {
         let transaction = self.transaction().await.change_context(WebInsertionError)?;
 
         transaction
@@ -1167,7 +1170,7 @@ impl<C: AsClient, A: AuthorizationApi> AccountStore for PostgresStore<C, A> {
     async fn identify_owned_by_id(
         &self,
         owned_by_id: OwnedById,
-    ) -> Result<WebOwnerSubject, QueryWebError> {
+    ) -> Result<WebOwnerSubject, Report<QueryWebError>> {
         let row = self
             .as_client()
             .query_one(
@@ -1210,7 +1213,10 @@ where
     A: Send + Sync,
 {
     #[tracing::instrument(level = "trace", skip(self))]
-    pub async fn delete_accounts(&mut self, actor_id: AccountId) -> Result<(), DeletionError> {
+    pub async fn delete_accounts(
+        &mut self,
+        actor_id: AccountId,
+    ) -> Result<(), Report<DeletionError>> {
         self.as_client()
             .client()
             .simple_query("DELETE FROM webs;")

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/entity_type.rs
@@ -10,7 +10,7 @@ use authorization::{
     },
     zanzibar::{Consistency, Zookie},
 };
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use futures::{StreamExt as _, TryStreamExt as _};
 use graph_types::{
     Embedding,
@@ -81,7 +81,7 @@ where
         actor_id: AccountId,
         authorization_api: &A,
         zookie: &Zookie<'static>,
-    ) -> Result<impl Iterator<Item = T>, QueryError>
+    ) -> Result<impl Iterator<Item = T>, Report<QueryError>>
     where
         I: Into<EntityTypeUuid> + Send,
         T: Send,
@@ -119,8 +119,8 @@ where
         &self,
         entity_types: &[EntityTypeUuid],
     ) -> Result<
-        impl Iterator<Item = Result<(EntityTypeUuid, EntityTypeResolveData), QueryError>>,
-        QueryError,
+        impl Iterator<Item = Result<(EntityTypeUuid, EntityTypeResolveData), Report<QueryError>>>,
+        Report<QueryError>,
     > {
         Ok(self
             .as_client()
@@ -228,7 +228,7 @@ where
         actor_id: AccountId,
         params: GetEntityTypesParams<'_>,
         temporal_axes: &QueryTemporalAxes,
-    ) -> Result<(GetEntityTypesResponse, Zookie<'static>), QueryError> {
+    ) -> Result<(GetEntityTypesResponse, Zookie<'static>), Report<QueryError>> {
         let (count, web_ids, edition_created_by_ids) = if params.include_count
             || params.include_web_ids
             || params.include_edition_created_by_ids
@@ -379,7 +379,7 @@ where
         actor_id: AccountId,
         zookie: &Zookie<'static>,
         subgraph: &mut Subgraph,
-    ) -> Result<(), QueryError> {
+    ) -> Result<(), Report<QueryError>> {
         let mut property_type_queue = Vec::new();
 
         while !entity_type_queue.is_empty() {
@@ -513,7 +513,7 @@ where
     }
 
     #[tracing::instrument(level = "info", skip(self))]
-    pub async fn delete_entity_types(&mut self) -> Result<(), DeletionError> {
+    pub async fn delete_entity_types(&mut self) -> Result<(), Report<DeletionError>> {
         let transaction = self.transaction().await.change_context(DeletionError)?;
 
         transaction
@@ -563,7 +563,7 @@ where
         &mut self,
         actor_id: AccountId,
         params: P,
-    ) -> Result<Vec<EntityTypeMetadata>, InsertionError>
+    ) -> Result<Vec<EntityTypeMetadata>, Report<InsertionError>>
     where
         P: IntoIterator<Item = CreateEntityTypeParams<R>, IntoIter: Send> + Send,
         R: IntoIterator<Item = EntityTypeRelationAndSubject> + Send + Sync,
@@ -710,7 +710,7 @@ where
 
                 Ok((closed_schema, closed_metadata))
             })
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<Vec<_>, Report<_>>>()?;
 
         let entity_type_validator = EntityTypeValidator;
         for ((entity_type_id, entity_type), (closed_schema, _resolve_data)) in
@@ -799,7 +799,7 @@ where
         &self,
         actor_id: AccountId,
         mut params: CountEntityTypesParams<'_>,
-    ) -> Result<usize, QueryError> {
+    ) -> Result<usize, Report<QueryError>> {
         params
             .filter
             .convert_parameters(&StoreProvider {
@@ -825,7 +825,7 @@ where
         &self,
         actor_id: AccountId,
         mut params: GetEntityTypesParams<'_>,
-    ) -> Result<GetEntityTypesResponse, QueryError> {
+    ) -> Result<GetEntityTypesResponse, Report<QueryError>> {
         let include_closed = params.include_closed;
         params
             .filter
@@ -875,7 +875,7 @@ where
         &self,
         actor_id: AccountId,
         params: GetClosedMultiEntityTypeParams,
-    ) -> Result<GetClosedMultiEntityTypeResponse, QueryError> {
+    ) -> Result<GetClosedMultiEntityTypeResponse, Report<QueryError>> {
         let entity_type_ids = params
             .entity_type_ids
             .iter()
@@ -916,7 +916,7 @@ where
         &self,
         actor_id: AccountId,
         mut params: GetEntityTypeSubgraphParams<'_>,
-    ) -> Result<GetEntityTypeSubgraphResponse, QueryError> {
+    ) -> Result<GetEntityTypeSubgraphResponse, Report<QueryError>> {
         params
             .filter
             .convert_parameters(&StoreProvider {
@@ -1019,7 +1019,7 @@ where
         &mut self,
         actor_id: AccountId,
         params: UpdateEntityTypesParams<R>,
-    ) -> Result<EntityTypeMetadata, UpdateError>
+    ) -> Result<EntityTypeMetadata, Report<UpdateError>>
     where
         R: IntoIterator<Item = EntityTypeRelationAndSubject> + Send + Sync,
     {
@@ -1220,7 +1220,7 @@ where
         &mut self,
         actor_id: AccountId,
         params: ArchiveEntityTypeParams<'_>,
-    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+    ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         self.archive_ontology_type(&params.entity_type_id, EditionArchivedById::new(actor_id))
             .await
     }
@@ -1230,7 +1230,7 @@ where
         &mut self,
         actor_id: AccountId,
         params: UnarchiveEntityTypeParams<'_>,
-    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+    ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         self.unarchive_ontology_type(&params.entity_type_id, &OntologyEditionProvenance {
             created_by_id: EditionCreatedById::new(actor_id),
             archived_by_id: None,
@@ -1244,7 +1244,7 @@ where
         &mut self,
         _: AccountId,
         params: UpdateEntityTypeEmbeddingParams<'_>,
-    ) -> Result<(), UpdateError> {
+    ) -> Result<(), Report<UpdateError>> {
         #[derive(Debug, ToSql)]
         #[postgres(name = "entity_type_embeddings")]
         pub struct EntityTypeEmbeddingsRow<'a> {
@@ -1312,7 +1312,7 @@ where
     }
 
     #[tracing::instrument(level = "info", skip(self))]
-    async fn reindex_entity_type_cache(&mut self) -> Result<(), UpdateError> {
+    async fn reindex_entity_type_cache(&mut self) -> Result<(), Report<UpdateError>> {
         tracing::info!("Reindexing entity type cache");
         let transaction = self.transaction().await.change_context(UpdateError)?;
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/property_type.rs
@@ -10,7 +10,7 @@ use authorization::{
     },
     zanzibar::{Consistency, Zookie},
 };
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use futures::StreamExt as _;
 use graph_types::{
     Embedding,
@@ -71,7 +71,7 @@ where
         actor_id: AccountId,
         authorization_api: &A,
         zookie: &Zookie<'static>,
-    ) -> Result<impl Iterator<Item = T>, QueryError>
+    ) -> Result<impl Iterator<Item = T>, Report<QueryError>>
     where
         I: Into<PropertyTypeUuid> + Send,
         T: Send,
@@ -109,7 +109,7 @@ where
         actor_id: AccountId,
         params: GetPropertyTypesParams<'_>,
         temporal_axes: &QueryTemporalAxes,
-    ) -> Result<(GetPropertyTypesResponse, Zookie<'static>), QueryError> {
+    ) -> Result<(GetPropertyTypesResponse, Zookie<'static>), Report<QueryError>> {
         #[expect(clippy::if_then_some_else_none, reason = "Function is async")]
         let count = if params.include_count {
             Some(
@@ -210,7 +210,7 @@ where
         actor_id: AccountId,
         zookie: &Zookie<'static>,
         subgraph: &mut Subgraph,
-    ) -> Result<(), QueryError> {
+    ) -> Result<(), Report<QueryError>> {
         let mut data_type_queue = Vec::new();
         let mut edges_to_traverse = HashMap::<OntologyEdgeKind, OntologyTypeTraversalData>::new();
 
@@ -315,7 +315,7 @@ where
     }
 
     #[tracing::instrument(level = "info", skip(self))]
-    pub async fn delete_property_types(&mut self) -> Result<(), DeletionError> {
+    pub async fn delete_property_types(&mut self) -> Result<(), Report<DeletionError>> {
         let transaction = self.transaction().await.change_context(DeletionError)?;
 
         transaction
@@ -363,7 +363,7 @@ where
         &mut self,
         actor_id: AccountId,
         params: P,
-    ) -> Result<Vec<PropertyTypeMetadata>, InsertionError>
+    ) -> Result<Vec<PropertyTypeMetadata>, Report<InsertionError>>
     where
         P: IntoIterator<Item = CreatePropertyTypeParams<R>, IntoIter: Send> + Send,
         R: IntoIterator<Item = PropertyTypeRelationAndSubject> + Send + Sync,
@@ -524,7 +524,7 @@ where
         &self,
         actor_id: AccountId,
         mut params: CountPropertyTypesParams<'_>,
-    ) -> Result<usize, QueryError> {
+    ) -> Result<usize, Report<QueryError>> {
         params
             .filter
             .convert_parameters(&StoreProvider {
@@ -550,7 +550,7 @@ where
         &self,
         actor_id: AccountId,
         mut params: GetPropertyTypesParams<'_>,
-    ) -> Result<GetPropertyTypesResponse, QueryError> {
+    ) -> Result<GetPropertyTypesResponse, Report<QueryError>> {
         params
             .filter
             .convert_parameters(&StoreProvider {
@@ -572,7 +572,7 @@ where
         &self,
         actor_id: AccountId,
         mut params: GetPropertyTypeSubgraphParams<'_>,
-    ) -> Result<GetPropertyTypeSubgraphResponse, QueryError> {
+    ) -> Result<GetPropertyTypeSubgraphResponse, Report<QueryError>> {
         params
             .filter
             .convert_parameters(&StoreProvider {
@@ -667,7 +667,7 @@ where
         &mut self,
         actor_id: AccountId,
         params: UpdatePropertyTypesParams<R>,
-    ) -> Result<PropertyTypeMetadata, UpdateError>
+    ) -> Result<PropertyTypeMetadata, Report<UpdateError>>
     where
         R: IntoIterator<Item = PropertyTypeRelationAndSubject> + Send + Sync,
     {
@@ -808,7 +808,7 @@ where
         &mut self,
         actor_id: AccountId,
         params: ArchivePropertyTypeParams<'_>,
-    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+    ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         self.archive_ontology_type(&params.property_type_id, EditionArchivedById::new(actor_id))
             .await
     }
@@ -818,7 +818,7 @@ where
         &mut self,
         actor_id: AccountId,
         params: UnarchivePropertyTypeParams<'_>,
-    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+    ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         self.unarchive_ontology_type(&params.property_type_id, &OntologyEditionProvenance {
             created_by_id: EditionCreatedById::new(actor_id),
             archived_by_id: None,
@@ -832,7 +832,7 @@ where
         &mut self,
         _: AccountId,
         params: UpdatePropertyTypeEmbeddingParams<'_>,
-    ) -> Result<(), UpdateError> {
+    ) -> Result<(), Report<UpdateError>> {
         #[derive(Debug, ToSql)]
         #[postgres(name = "property_type_embeddings")]
         pub struct PropertyTypeEmbeddingsRow<'a> {

--- a/apps/hash-graph/libs/graph/src/store/postgres/ontology/read.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/ontology/read.rs
@@ -1,6 +1,6 @@
 use alloc::borrow::Cow;
 
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use futures::{Stream, StreamExt as _};
 use graph_types::ontology::EntityTypeWithMetadata;
 use hash_graph_store::{
@@ -63,8 +63,8 @@ impl<C: AsClient, A: Send + Sync> PostgresStore<C, A> {
         filter: &Filter<'f, EntityTypeWithMetadata>,
         temporal_axes: Option<&'f QueryTemporalAxes>,
     ) -> Result<
-        impl Stream<Item = Result<(EntityTypeUuid, ClosedEntityType), QueryError>>,
-        QueryError,
+        impl Stream<Item = Result<(EntityTypeUuid, ClosedEntityType), Report<QueryError>>>,
+        Report<QueryError>,
     > {
         let mut compiler = SelectCompiler::new(temporal_axes, false);
 
@@ -98,7 +98,7 @@ impl<C: AsClient, A: Send + Sync> PostgresStore<C, A> {
         reference_table: ReferenceTable,
     ) -> Result<
         impl Iterator<Item = (OntologyTypeUuid, OntologyEdgeTraversal<L, R>)> + 'r,
-        QueryError,
+        Report<QueryError>,
     >
     where
         L: From<VersionedUrl>,

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/mod.rs
@@ -105,7 +105,7 @@ pub trait PostgresSorting<'s, R: QueryRecord>:
 {
     type CompilationParameters: Send;
 
-    type Error: Context + Send + Sync + 'static;
+    type Error: ::core::error::Error + Send + Sync + 'static + Send + Sync + 'static;
 
     fn encode(&self) -> Result<Option<Self::CompilationParameters>, Self::Error>;
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/mod.rs
@@ -104,7 +104,7 @@ pub trait PostgresSorting<'s, R: QueryRecord>:
 {
     type CompilationParameters: Send;
 
-    type Error: ::core::error::Error + Send + Sync + 'static + Send + Sync + 'static;
+    type Error: Error + Send + Sync + 'static + Send + Sync + 'static;
 
     fn encode(&self) -> Result<Option<Self::CompilationParameters>, Self::Error>;
 

--- a/apps/hash-graph/libs/graph/src/store/postgres/query/mod.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/query/mod.rs
@@ -21,7 +21,6 @@ use core::{
 };
 
 use bytes::BytesMut;
-use error_stack::Context;
 use graph_types::knowledge::entity::Entity;
 use hash_graph_store::{
     filter::{ParameterConversionError, QueryRecord},

--- a/apps/hash-graph/libs/graph/src/store/postgres/traversal_context.rs
+++ b/apps/hash-graph/libs/graph/src/store/postgres/traversal_context.rs
@@ -1,7 +1,7 @@
 use core::hash::Hash;
 use std::collections::HashMap;
 
-use error_stack::Result;
+use error_stack::Report;
 use graph_types::{
     knowledge::entity::{Entity, EntityEditionId},
     ontology::{DataTypeWithMetadata, EntityTypeWithMetadata, PropertyTypeWithMetadata},
@@ -35,7 +35,7 @@ where
         &self,
         data_type_ids: &[DataTypeUuid],
         subgraph: &mut Subgraph,
-    ) -> Result<(), QueryError> {
+    ) -> Result<(), Report<QueryError>> {
         for data_type in <Self as Read<DataTypeWithMetadata>>::read_vec(
             self,
             &Filter::<DataTypeWithMetadata>::In(
@@ -63,7 +63,7 @@ where
         &self,
         property_type_ids: &[PropertyTypeUuid],
         subgraph: &mut Subgraph,
-    ) -> Result<(), QueryError> {
+    ) -> Result<(), Report<QueryError>> {
         for property_type in <Self as Read<PropertyTypeWithMetadata>>::read_vec(
             self,
             &Filter::<PropertyTypeWithMetadata>::In(
@@ -91,7 +91,7 @@ where
         &self,
         entity_type_ids: &[EntityTypeUuid],
         subgraph: &mut Subgraph,
-    ) -> Result<(), QueryError> {
+    ) -> Result<(), Report<QueryError>> {
         for entity_type in <Self as Read<EntityTypeWithMetadata>>::read_vec(
             self,
             &Filter::<EntityTypeWithMetadata>::In(
@@ -120,7 +120,7 @@ where
         edition_ids: &[EntityEditionId],
         subgraph: &mut Subgraph,
         include_drafts: bool,
-    ) -> Result<(), QueryError> {
+    ) -> Result<(), Report<QueryError>> {
         let entities = <Self as Read<Entity>>::read_vec(
             self,
             &Filter::<Entity>::In(
@@ -254,7 +254,7 @@ impl TraversalContext {
         store: &PostgresStore<C, A>,
         subgraph: &mut Subgraph,
         include_drafts: bool,
-    ) -> Result<(), QueryError> {
+    ) -> Result<(), Report<QueryError>> {
         if !self.data_types.0.is_empty() {
             store
                 .read_data_types_by_ids(

--- a/apps/hash-graph/libs/store/package.json
+++ b/apps/hash-graph/libs/store/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",
     "@rust/authorization": "0.0.0-private",
+    "@rust/error-stack": "0.5.0",
     "@rust/graph-types": "0.0.0-private",
     "@rust/temporal-versioning": "0.0.0-private"
   }

--- a/apps/hash-graph/libs/store/src/error.rs
+++ b/apps/hash-graph/libs/store/src/error.rs
@@ -12,7 +12,7 @@ impl fmt::Display for InsertionError {
     }
 }
 
-impl Context for InsertionError {}
+impl ::core::error::Error for InsertionError {}
 
 #[derive(Debug, Clone)]
 #[must_use]
@@ -24,7 +24,7 @@ impl fmt::Display for QueryError {
     }
 }
 
-impl Context for QueryError {}
+impl ::core::error::Error for QueryError {}
 
 #[derive(Debug)]
 #[must_use]
@@ -36,7 +36,7 @@ impl fmt::Display for UpdateError {
     }
 }
 
-impl Context for UpdateError {}
+impl ::core::error::Error for UpdateError {}
 
 #[derive(Debug)]
 #[must_use]

--- a/apps/hash-graph/libs/store/src/error.rs
+++ b/apps/hash-graph/libs/store/src/error.rs
@@ -1,4 +1,4 @@
-use core::fmt;
+use core::{error::Error, fmt};
 
 #[derive(Debug)]
 #[must_use]
@@ -10,7 +10,7 @@ impl fmt::Display for InsertionError {
     }
 }
 
-impl ::core::error::Error for InsertionError {}
+impl Error for InsertionError {}
 
 #[derive(Debug, Clone)]
 #[must_use]
@@ -22,7 +22,7 @@ impl fmt::Display for QueryError {
     }
 }
 
-impl ::core::error::Error for QueryError {}
+impl Error for QueryError {}
 
 #[derive(Debug)]
 #[must_use]
@@ -34,7 +34,7 @@ impl fmt::Display for UpdateError {
     }
 }
 
-impl ::core::error::Error for UpdateError {}
+impl Error for UpdateError {}
 
 #[derive(Debug)]
 #[must_use]

--- a/apps/hash-graph/libs/store/src/error.rs
+++ b/apps/hash-graph/libs/store/src/error.rs
@@ -1,6 +1,5 @@
 use core::fmt;
 
-
 #[derive(Debug)]
 #[must_use]
 pub struct InsertionError;

--- a/apps/hash-graph/libs/store/src/error.rs
+++ b/apps/hash-graph/libs/store/src/error.rs
@@ -1,6 +1,5 @@
 use core::fmt;
 
-use error_stack::Context;
 
 #[derive(Debug)]
 #[must_use]

--- a/apps/hash-graph/libs/store/src/filter/parameter.rs
+++ b/apps/hash-graph/libs/store/src/filter/parameter.rs
@@ -176,7 +176,7 @@ impl fmt::Display for ParameterConversionError {
     }
 }
 
-impl Context for ParameterConversionError {}
+impl ::core::error::Error for ParameterConversionError {}
 
 impl Parameter<'_> {
     #[expect(

--- a/apps/hash-graph/libs/store/src/filter/parameter.rs
+++ b/apps/hash-graph/libs/store/src/filter/parameter.rs
@@ -1,5 +1,5 @@
 use alloc::borrow::Cow;
-use core::{fmt, mem, str::FromStr as _};
+use core::{error::Error, fmt, mem, str::FromStr as _};
 
 use error_stack::{Report, ResultExt as _, bail};
 use graph_types::{Embedding, knowledge::entity::EntityEditionId};
@@ -176,7 +176,7 @@ impl fmt::Display for ParameterConversionError {
     }
 }
 
-impl ::core::error::Error for ParameterConversionError {}
+impl Error for ParameterConversionError {}
 
 impl Parameter<'_> {
     #[expect(

--- a/apps/hash-graph/libs/store/src/filter/parameter.rs
+++ b/apps/hash-graph/libs/store/src/filter/parameter.rs
@@ -1,7 +1,7 @@
 use alloc::borrow::Cow;
 use core::{fmt, mem, str::FromStr as _};
 
-use error_stack::{Context, Report, ResultExt as _, bail};
+use error_stack::{Report, ResultExt as _, bail};
 use graph_types::{Embedding, knowledge::entity::EntityEditionId};
 use serde::Deserialize;
 use serde_json::{Number as JsonNumber, Value as JsonValue};

--- a/apps/hash-graph/libs/test-server/package.json
+++ b/apps/hash-graph/libs/test-server/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@rust/authorization": "0.0.0-private",
     "@rust/codec": "0.0.0-private",
+    "@rust/error-stack": "0.5.0",
     "@rust/graph": "0.0.0-private",
     "@rust/graph-api": "0.0.0-private",
     "@rust/graph-type-defs": "0.0.0-private",

--- a/apps/hash-graph/libs/test-server/src/lib.rs
+++ b/apps/hash-graph/libs/test-server/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate alloc;
 
 use alloc::sync::Arc;
+use core::error::Error;
 use std::collections::HashMap;
 
 use authorization::{
@@ -53,9 +54,7 @@ where
     clippy::needless_pass_by_value,
     reason = "This is used inside of error-mapping functions only"
 )]
-fn store_acquisition_error(
-    report: Report<impl ::core::error::Error + Send + Sync + 'static>,
-) -> Response {
+fn store_acquisition_error(report: Report<impl Error + Send + Sync + 'static>) -> Response {
     tracing::error!(error=?report, "Could not acquire store");
     status_to_response(Status::new(
         StatusCode::Internal,

--- a/apps/hash-graph/libs/test-server/src/lib.rs
+++ b/apps/hash-graph/libs/test-server/src/lib.rs
@@ -18,7 +18,7 @@ use axum::{
     response::Response,
     routing::{delete, post},
 };
-use error_stack::{Context, Report};
+use error_stack::Report;
 use futures::TryStreamExt as _;
 use graph::{
     snapshot::SnapshotStore,
@@ -53,7 +53,9 @@ where
     clippy::needless_pass_by_value,
     reason = "This is used inside of error-mapping functions only"
 )]
-fn store_acquisition_error(report: Report<impl ::core::error::Error + Send + Sync + 'static>) -> Response {
+fn store_acquisition_error(
+    report: Report<impl ::core::error::Error + Send + Sync + 'static>,
+) -> Response {
     tracing::error!(error=?report, "Could not acquire store");
     status_to_response(Status::new(
         StatusCode::Internal,

--- a/apps/hash-graph/libs/test-server/src/lib.rs
+++ b/apps/hash-graph/libs/test-server/src/lib.rs
@@ -53,7 +53,7 @@ where
     clippy::needless_pass_by_value,
     reason = "This is used inside of error-mapping functions only"
 )]
-fn store_acquisition_error(report: Report<impl Context>) -> Response {
+fn store_acquisition_error(report: Report<impl ::core::error::Error + Send + Sync + 'static>) -> Response {
     tracing::error!(error=?report, "Could not acquire store");
     status_to_response(Status::new(
         StatusCode::Internal,

--- a/apps/hash-graph/libs/type-fetcher/package.json
+++ b/apps/hash-graph/libs/type-fetcher/package.json
@@ -10,6 +10,7 @@
     "start:test:healthcheck": "../../../../target/debug/hash-graph type-fetcher --healthcheck --wait --timeout 300 --logging-console-level=warn"
   },
   "dependencies": {
-    "@blockprotocol/type-system-rs": "0.0.0-private"
+    "@blockprotocol/type-system-rs": "0.0.0-private",
+    "@rust/error-stack": "0.5.0"
   }
 }

--- a/libs/@blockprotocol/type-system/rust/package.json
+++ b/libs/@blockprotocol/type-system/rust/package.json
@@ -25,7 +25,8 @@
     "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
   },
   "dependencies": {
-    "@rust/codec": "0.0.0-private"
+    "@rust/codec": "0.0.0-private",
+    "@rust/error-stack": "0.5.0"
   },
   "devDependencies": {
     "@rust/graph-test-data": "0.0.0-private",

--- a/libs/@local/codec/package.json
+++ b/libs/@local/codec/package.json
@@ -8,6 +8,7 @@
     "lint:clippy": "just clippy"
   },
   "dependencies": {
+    "@rust/error-stack": "0.5.0",
     "@rust/harpc-wire-protocol": "0.0.0-private"
   }
 }

--- a/libs/@local/harpc/client/package.json
+++ b/libs/@local/harpc/client/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "license": "AGPL-3",
   "dependencies": {
+    "@rust/error-stack": "0.5.0",
     "@rust/harpc-codec": "0.0.0-private",
     "@rust/harpc-net": "0.0.0-private",
     "@rust/harpc-tower": "0.0.0-private"

--- a/libs/@local/harpc/codec/package.json
+++ b/libs/@local/harpc/codec/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "license": "AGPL-3",
   "dependencies": {
+    "@rust/error-stack": "0.5.0",
     "@rust/harpc-types": "0.0.0-private"
   }
 }

--- a/libs/@local/harpc/net/package.json
+++ b/libs/@local/harpc/net/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@rust/codec": "0.0.0-private",
+    "@rust/error-stack": "0.5.0",
     "@rust/harpc-codec": "0.0.0-private",
     "@rust/harpc-types": "0.0.0-private",
     "@rust/harpc-wire-protocol": "0.0.0-private"

--- a/libs/@local/harpc/net/src/session/client/connection/mod.rs
+++ b/libs/@local/harpc/net/src/session/client/connection/mod.rs
@@ -77,7 +77,7 @@ struct ConnectionResponseDelegateTask<S> {
 
 impl<S> ConnectionResponseDelegateTask<S>
 where
-    S: Stream<Item = error_stack::Result<Response, io::Error>> + Send,
+    S: Stream<Item = Result<Response, Report<io::Error>>> + Send,
 {
     pub(crate) async fn route(
         config: SessionConfig,
@@ -338,7 +338,7 @@ impl Connection {
         service: ServiceDescriptor,
         procedure: ProcedureDescriptor,
         payload: impl Stream<Item = Bytes> + Send + 'static,
-    ) -> error_stack::Result<ResponseStream, ConnectionPartiallyClosedError> {
+    ) -> Result<ResponseStream, Report<ConnectionPartiallyClosedError>> {
         // While not strictly necessary (as the transaction will immediately terminate if the
         // underlying connection is closed) and the `ResponseStream` will return `None` it is a good
         // indicator to the user that the connection is unhealthy, and as to why, as these tasks

--- a/libs/@local/harpc/net/src/session/client/mod.rs
+++ b/libs/@local/harpc/net/src/session/client/mod.rs
@@ -2,7 +2,7 @@ mod config;
 mod connection;
 mod transaction;
 
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use libp2p::Multiaddr;
 use tokio_util::sync::CancellationToken;
 
@@ -45,7 +45,7 @@ impl SessionLayer {
     /// # Errors
     ///
     /// Returns an error if the dial fails.
-    pub async fn dial(&self, address: Multiaddr) -> Result<Connection, SessionError> {
+    pub async fn dial(&self, address: Multiaddr) -> Result<Connection, Report<SessionError>> {
         let peer = self
             .transport
             .lookup_peer(address)

--- a/libs/@local/harpc/net/src/session/server/connection/mod.rs
+++ b/libs/@local/harpc/net/src/session/server/connection/mod.rs
@@ -6,6 +6,7 @@ use alloc::sync::Arc;
 use core::{error::Error, fmt::Debug, future};
 use std::io;
 
+use error_stack::Report;
 use futures::{FutureExt as _, Sink, Stream, StreamExt as _, stream};
 use harpc_codec::error::NetworkError;
 use harpc_types::response_kind::ResponseKind;
@@ -215,7 +216,7 @@ impl ConnectionTask {
         cancel: CancellationToken,
     ) where
         T: Sink<Response, Error: Debug + Send> + Send + 'static,
-        U: Stream<Item = error_stack::Result<Request, io::Error>> + Send,
+        U: Stream<Item = Result<Request, Report<io::Error>>> + Send,
     {
         let stream = stream.fuse();
         let stream = StreamNotifyClose::new(stream);

--- a/libs/@local/harpc/net/src/session/server/connection/test.rs
+++ b/libs/@local/harpc/net/src/session/server/connection/test.rs
@@ -4,6 +4,7 @@ use core::{assert_matches::assert_matches, num::NonZero, time::Duration};
 use std::io;
 
 use bytes::Bytes;
+use error_stack::Report;
 use futures::{StreamExt as _, prelude::sink::SinkExt as _};
 use harpc_types::{error_code::ErrorCode, response_kind::ResponseKind};
 use harpc_wire_protocol::{
@@ -68,7 +69,7 @@ struct Setup {
     output: mpsc::Receiver<Transaction>,
     events: broadcast::Receiver<SessionEvent>,
 
-    stream: mpsc::Sender<error_stack::Result<Request, io::Error>>,
+    stream: mpsc::Sender<Result<Request, Report<io::Error>>>,
     sink: mpsc::Receiver<Response>,
 
     handle: JoinHandle<()>,

--- a/libs/@local/harpc/net/src/session/server/test.rs
+++ b/libs/@local/harpc/net/src/session/server/test.rs
@@ -198,7 +198,7 @@ impl EchoService {
     async fn handle(
         mut sink: TransactionSink,
         mut stream: TransactionStream,
-    ) -> error_stack::Result<(), EchoError> {
+    ) -> Result<(), Report<EchoError>> {
         while let Some(bytes) = stream.next().await {
             sink.send(Ok(bytes)).await.change_context(EchoError::Sink)?;
         }
@@ -268,7 +268,7 @@ async fn connect_error(client: &TransportLayer, address: Multiaddr) -> Report<Tr
 
 #[track_caller]
 async fn assert_response(
-    stream: impl Stream<Item = error_stack::Result<Response, io::Error>> + Send + Sync,
+    stream: impl Stream<Item = Result<Response, Report<io::Error>>> + Send + Sync,
     expected: impl AsRef<[u8]> + Send,
 ) {
     pin!(stream);

--- a/libs/@local/harpc/net/src/session/test.rs
+++ b/libs/@local/harpc/net/src/session/test.rs
@@ -61,7 +61,7 @@ impl SimpleEchoService {
     async fn handle(
         mut sink: TransactionSink,
         mut stream: TransactionStream,
-    ) -> error_stack::Result<(), PingError> {
+    ) -> Result<(), Report<PingError>> {
         while let Some(received) = stream.next().await {
             sink.send(Ok(received))
                 .await

--- a/libs/@local/harpc/net/src/transport/client.rs
+++ b/libs/@local/harpc/net/src/transport/client.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use bytes::BytesMut;
 use codec::harpc::wire::{RequestCodec, ResponseCodec};
-use error_stack::{Report, Result};
+use error_stack::Report;
 use harpc_wire_protocol::{request::Request, response::Response};
 use tokio_util::codec::{Decoder, Encoder};
 
@@ -24,7 +24,7 @@ impl ClientCodec {
 impl Encoder<Request> for ClientCodec {
     type Error = Report<io::Error>;
 
-    fn encode(&mut self, item: Request, dst: &mut BytesMut) -> Result<(), io::Error> {
+    fn encode(&mut self, item: Request, dst: &mut BytesMut) -> Result<(), Report<io::Error>> {
         self.request.encode(item, dst)
     }
 }
@@ -33,7 +33,7 @@ impl Decoder for ClientCodec {
     type Error = Report<io::Error>;
     type Item = Response;
 
-    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Response>, io::Error> {
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Response>, Report<io::Error>> {
         self.response.decode(src)
     }
 }

--- a/libs/@local/harpc/net/src/transport/ipc.rs
+++ b/libs/@local/harpc/net/src/transport/ipc.rs
@@ -1,4 +1,4 @@
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use libp2p::{Multiaddr, PeerId};
 use libp2p_stream::Control;
 use tokio::sync::{mpsc, oneshot};
@@ -15,7 +15,7 @@ impl TransportLayerIpc {
         Self { tx }
     }
 
-    pub(super) async fn control(&self) -> Result<Control, IpcError> {
+    pub(super) async fn control(&self) -> Result<Control, Report<IpcError>> {
         let (tx, rx) = oneshot::channel();
 
         self.tx
@@ -26,7 +26,7 @@ impl TransportLayerIpc {
         rx.await.change_context(IpcError::NoResponse)
     }
 
-    pub(super) async fn lookup_peer(&self, address: Multiaddr) -> Result<PeerId, IpcError> {
+    pub(super) async fn lookup_peer(&self, address: Multiaddr) -> Result<PeerId, Report<IpcError>> {
         let (tx, rx) = oneshot::channel();
 
         self.tx
@@ -39,7 +39,10 @@ impl TransportLayerIpc {
             .change_context(IpcError::Swarm)
     }
 
-    pub(super) async fn listen_on(&self, address: Multiaddr) -> Result<Multiaddr, IpcError> {
+    pub(super) async fn listen_on(
+        &self,
+        address: Multiaddr,
+    ) -> Result<Multiaddr, Report<IpcError>> {
         let (tx, rx) = oneshot::channel();
 
         self.tx
@@ -59,7 +62,7 @@ impl TransportLayerIpc {
     /// # Errors
     ///
     /// If the transport layer has been shut down, this will return an error.
-    pub async fn external_addresses(&self) -> Result<Vec<Multiaddr>, IpcError> {
+    pub async fn external_addresses(&self) -> Result<Vec<Multiaddr>, Report<IpcError>> {
         let (tx, rx) = oneshot::channel();
 
         self.tx

--- a/libs/@local/harpc/net/src/transport/server.rs
+++ b/libs/@local/harpc/net/src/transport/server.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use bytes::BytesMut;
 use codec::harpc::wire::{RequestCodec, ResponseCodec};
-use error_stack::{Report, Result};
+use error_stack::Report;
 use harpc_wire_protocol::{request::Request, response::Response};
 use tokio_util::codec::{Decoder, Encoder};
 
@@ -24,7 +24,7 @@ impl ServerCodec {
 impl Encoder<Response> for ServerCodec {
     type Error = Report<io::Error>;
 
-    fn encode(&mut self, item: Response, dst: &mut BytesMut) -> Result<(), io::Error> {
+    fn encode(&mut self, item: Response, dst: &mut BytesMut) -> Result<(), Report<io::Error>> {
         self.response.encode(item, dst)
     }
 }
@@ -33,7 +33,7 @@ impl Decoder for ServerCodec {
     type Error = Report<io::Error>;
     type Item = Request;
 
-    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Request>, io::Error> {
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Request>, Report<io::Error>> {
         self.request.decode(src)
     }
 }

--- a/libs/@local/harpc/net/src/transport/task.rs
+++ b/libs/@local/harpc/net/src/transport/task.rs
@@ -5,7 +5,7 @@ use std::{
     io,
 };
 
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use futures::prelude::stream::StreamExt as _;
 use libp2p::{
     Multiaddr, PeerId, SwarmBuilder,
@@ -74,7 +74,7 @@ impl TransportTask {
     pub(crate) fn new(
         config: TransportConfig,
         transport: impl Transport,
-    ) -> Result<Self, TransportError> {
+    ) -> Result<Self, Report<TransportError>> {
         let mut registry = metrics::Registry::default();
 
         let (ipx_tx, rx) = mpsc::channel(config.ipc_buffer_size.get());

--- a/libs/@local/harpc/server/package.json
+++ b/libs/@local/harpc/server/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "license": "AGPL-3",
   "dependencies": {
+    "@rust/error-stack": "0.5.0",
     "@rust/harpc-codec": "0.0.0-private",
     "@rust/harpc-net": "0.0.0-private",
     "@rust/harpc-service": "0.0.0-private",

--- a/libs/@local/harpc/tower/package.json
+++ b/libs/@local/harpc/tower/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "license": "AGPL-3",
   "dependencies": {
+    "@rust/error-stack": "0.5.0",
     "@rust/harpc-codec": "0.0.0-private",
     "@rust/harpc-net": "0.0.0-private",
     "@rust/harpc-types": "0.0.0-private"

--- a/libs/@local/harpc/tower/src/layer/body_report.rs
+++ b/libs/@local/harpc/tower/src/layer/body_report.rs
@@ -47,7 +47,7 @@ where
     // The extra bounds here are not strictly required, but they help to make the error messages
     // more expressive during compilation
     ResBody: Body<Control: AsRef<ResponseKind>, Error = Report<C>>,
-    C: error_stack::Context,
+    C: ::core::error::Error + Send + Sync + 'static,
 {
     type Error = S::Error;
     type Response = Response<EncodeReport<ResBody>>;

--- a/libs/@local/harpc/tower/src/layer/body_report.rs
+++ b/libs/@local/harpc/tower/src/layer/body_report.rs
@@ -1,4 +1,7 @@
-use core::task::{Context, Poll};
+use core::{
+    error::Error,
+    task::{Context, Poll},
+};
 
 use error_stack::Report;
 use futures::TryFutureExt as _;
@@ -47,7 +50,7 @@ where
     // The extra bounds here are not strictly required, but they help to make the error messages
     // more expressive during compilation
     ResBody: Body<Control: AsRef<ResponseKind>, Error = Report<C>>,
-    C: ::core::error::Error + Send + Sync + 'static,
+    C: Error + Send + Sync + 'static,
 {
     type Error = S::Error;
     type Response = Response<EncodeReport<ResBody>>;

--- a/libs/@local/harpc/wire-protocol/package.json
+++ b/libs/@local/harpc/wire-protocol/package.json
@@ -10,6 +10,7 @@
     "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
   },
   "dependencies": {
+    "@rust/error-stack": "0.5.0",
     "@rust/harpc-types": "0.0.0-private"
   }
 }

--- a/libs/@local/harpc/wire-protocol/src/codec/decode.rs
+++ b/libs/@local/harpc/wire-protocol/src/codec/decode.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, Bytes};
-use error_stack::{Context, Report};
+use error_stack::Report;
 
 use super::buffer::{Buffer, BufferError};
 

--- a/libs/@local/harpc/wire-protocol/src/codec/decode.rs
+++ b/libs/@local/harpc/wire-protocol/src/codec/decode.rs
@@ -5,7 +5,7 @@ use super::buffer::{Buffer, BufferError};
 
 pub trait Decode: Sized {
     type Context: Send + Sync;
-    type Error: Context;
+    type Error: ::core::error::Error + Send + Sync + 'static;
 
     /// Decode a value from the buffer.
     ///

--- a/libs/@local/harpc/wire-protocol/src/codec/decode.rs
+++ b/libs/@local/harpc/wire-protocol/src/codec/decode.rs
@@ -1,3 +1,5 @@
+use core::error::Error;
+
 use bytes::{Buf, Bytes};
 use error_stack::Report;
 
@@ -5,7 +7,7 @@ use super::buffer::{Buffer, BufferError};
 
 pub trait Decode: Sized {
     type Context: Send + Sync;
-    type Error: ::core::error::Error + Send + Sync + 'static;
+    type Error: Error + Send + Sync + 'static;
 
     /// Decode a value from the buffer.
     ///

--- a/libs/@local/harpc/wire-protocol/src/codec/decode.rs
+++ b/libs/@local/harpc/wire-protocol/src/codec/decode.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, Bytes};
-use error_stack::{Context, Result};
+use error_stack::{Context, Report};
 
 use super::buffer::{Buffer, BufferError};
 
@@ -12,7 +12,10 @@ pub trait Decode: Sized {
     /// # Errors
     ///
     /// Returns an error if the contained value is invalid, or the buffer is too short.
-    fn decode<B>(buffer: &mut Buffer<B>, context: Self::Context) -> Result<Self, Self::Error>
+    fn decode<B>(
+        buffer: &mut Buffer<B>,
+        context: Self::Context,
+    ) -> Result<Self, Report<Self::Error>>
     where
         B: Buf;
 }
@@ -21,7 +24,7 @@ impl Decode for u8 {
     type Context = ();
     type Error = BufferError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {
@@ -33,7 +36,7 @@ impl Decode for u16 {
     type Context = ();
     type Error = BufferError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {
@@ -45,7 +48,7 @@ impl Decode for u32 {
     type Context = ();
     type Error = BufferError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {
@@ -57,7 +60,7 @@ impl Decode for Bytes {
     type Context = ();
     type Error = BufferError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {

--- a/libs/@local/harpc/wire-protocol/src/codec/encode.rs
+++ b/libs/@local/harpc/wire-protocol/src/codec/encode.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 
 use bytes::{BufMut, Bytes};
-use error_stack::{Context, Report, Result, ResultExt as _};
+use error_stack::{Context, Report, ResultExt as _};
 
 use super::{BufferError, buffer::Buffer};
 
@@ -13,7 +13,7 @@ pub trait Encode {
     /// # Errors
     ///
     /// Returns an error if the buffer is not large enough or if the to be encoded value is invalid.
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut;
 }
@@ -21,7 +21,7 @@ pub trait Encode {
 impl Encode for u8 {
     type Error = BufferError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -32,7 +32,7 @@ impl Encode for u8 {
 impl Encode for u16 {
     type Error = BufferError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -43,7 +43,7 @@ impl Encode for u16 {
 impl Encode for u32 {
     type Error = BufferError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -62,7 +62,7 @@ pub enum BytesEncodeError {
 impl Encode for Bytes {
     type Error = BytesEncodeError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {

--- a/libs/@local/harpc/wire-protocol/src/codec/encode.rs
+++ b/libs/@local/harpc/wire-protocol/src/codec/encode.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 
 use bytes::{BufMut, Bytes};
-use error_stack::{Context, Report, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 
 use super::{BufferError, buffer::Buffer};
 

--- a/libs/@local/harpc/wire-protocol/src/codec/encode.rs
+++ b/libs/@local/harpc/wire-protocol/src/codec/encode.rs
@@ -6,7 +6,7 @@ use error_stack::{Context, Report, ResultExt as _};
 use super::{BufferError, buffer::Buffer};
 
 pub trait Encode {
-    type Error: Context;
+    type Error: ::core::error::Error + Send + Sync + 'static;
 
     /// Encode the value into the buffer.
     ///

--- a/libs/@local/harpc/wire-protocol/src/codec/encode.rs
+++ b/libs/@local/harpc/wire-protocol/src/codec/encode.rs
@@ -1,4 +1,4 @@
-use core::fmt::Debug;
+use core::{error::Error, fmt::Debug};
 
 use bytes::{BufMut, Bytes};
 use error_stack::{Report, ResultExt as _};
@@ -6,7 +6,7 @@ use error_stack::{Report, ResultExt as _};
 use super::{BufferError, buffer::Buffer};
 
 pub trait Encode {
-    type Error: ::core::error::Error + Send + Sync + 'static;
+    type Error: Error + Send + Sync + 'static;
 
     /// Encode the value into the buffer.
     ///

--- a/libs/@local/harpc/wire-protocol/src/codec/types.rs
+++ b/libs/@local/harpc/wire-protocol/src/codec/types.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, BufMut};
-use error_stack::Result;
+use error_stack::Report;
 use harpc_types::{procedure::ProcedureId, service::ServiceId, version::Version};
 
 use super::{Buffer, BufferError, Decode};
@@ -8,7 +8,7 @@ use crate::codec::Encode;
 impl Encode for Version {
     type Error = BufferError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -23,7 +23,7 @@ impl Decode for Version {
     type Context = ();
     type Error = BufferError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {
@@ -37,7 +37,7 @@ impl Decode for Version {
 impl Encode for ProcedureId {
     type Error = BufferError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -49,7 +49,7 @@ impl Decode for ProcedureId {
     type Context = ();
     type Error = BufferError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {
@@ -60,7 +60,7 @@ impl Decode for ProcedureId {
 impl Encode for ServiceId {
     type Error = BufferError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -72,7 +72,7 @@ impl Decode for ServiceId {
     type Context = ();
     type Error = BufferError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {

--- a/libs/@local/harpc/wire-protocol/src/payload.rs
+++ b/libs/@local/harpc/wire-protocol/src/payload.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, BufMut, Bytes};
-use error_stack::Result;
+use error_stack::Report;
 
 use crate::codec::{Buffer, BufferError, BytesEncodeError, Decode, Encode};
 
@@ -50,7 +50,7 @@ impl Payload {
 impl Encode for Payload {
     type Error = BytesEncodeError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -62,7 +62,7 @@ impl Decode for Payload {
     type Context = ();
     type Error = BufferError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {

--- a/libs/@local/harpc/wire-protocol/src/protocol.rs
+++ b/libs/@local/harpc/wire-protocol/src/protocol.rs
@@ -3,7 +3,7 @@
 use core::fmt::Display;
 
 use bytes::{Buf, BufMut};
-use error_stack::{Report, Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 
 use crate::codec::{Buffer, BufferError, Decode, Encode};
 
@@ -40,7 +40,7 @@ impl Display for ProtocolVersion {
 impl Encode for ProtocolVersion {
     type Error = BufferError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -52,7 +52,7 @@ impl Decode for ProtocolVersion {
     type Context = ();
     type Error = ProtocolVersionDecodeError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {
@@ -93,7 +93,7 @@ pub struct Protocol {
 impl Encode for Protocol {
     type Error = BufferError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -107,7 +107,7 @@ impl Decode for Protocol {
     type Context = ();
     type Error = ProtocolDecodeError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {

--- a/libs/@local/harpc/wire-protocol/src/request/begin.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/begin.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, BufMut};
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use harpc_types::{procedure::ProcedureDescriptor, service::ServiceDescriptor};
 
 use crate::{
@@ -23,7 +23,7 @@ pub struct RequestBegin {
 impl Encode for RequestBegin {
     type Error = RequestBeginEncodeError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -50,7 +50,7 @@ impl Decode for RequestBegin {
     type Context = ();
     type Error = BufferError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {

--- a/libs/@local/harpc/wire-protocol/src/request/body.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/body.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, BufMut};
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 
 use super::{
     begin::RequestBegin,
@@ -42,7 +42,7 @@ impl RequestBody {
 impl Encode for RequestBody {
     type Error = RequestBodyEncodeError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -89,7 +89,10 @@ impl Decode for RequestBody {
     type Context = RequestBodyContext;
     type Error = BufferError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, context: Self::Context) -> Result<Self, Self::Error>
+    fn decode<B>(
+        buffer: &mut Buffer<B>,
+        context: Self::Context,
+    ) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {

--- a/libs/@local/harpc/wire-protocol/src/request/flags.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/flags.rs
@@ -1,6 +1,6 @@
 use bytes::{Buf, BufMut};
 use enumflags2::BitFlags;
-use error_stack::Result;
+use error_stack::Report;
 
 use super::body::RequestBody;
 use crate::{
@@ -60,7 +60,7 @@ impl From<RequestFlag> for RequestFlags {
 impl Encode for RequestFlags {
     type Error = BufferError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -74,7 +74,7 @@ impl Decode for RequestFlags {
     type Context = ();
     type Error = BufferError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {

--- a/libs/@local/harpc/wire-protocol/src/request/frame.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/frame.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, BufMut};
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 
 use crate::{
     codec::{Buffer, BufferError, Decode, Encode},
@@ -19,7 +19,7 @@ pub struct RequestFrame {
 impl Encode for RequestFrame {
     type Error = RequestFrameEncodeError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -38,7 +38,7 @@ impl Decode for RequestFrame {
     type Context = ();
     type Error = BufferError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {

--- a/libs/@local/harpc/wire-protocol/src/request/header.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/header.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, BufMut};
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 
 use super::{body::RequestBody, flags::RequestFlags, id::RequestId};
 use crate::{
@@ -36,7 +36,7 @@ impl RequestHeader {
 impl Encode for RequestHeader {
     type Error = BufferError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -52,7 +52,7 @@ impl Decode for RequestHeader {
     type Context = ();
     type Error = RequestHeaderDecodeError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {

--- a/libs/@local/harpc/wire-protocol/src/request/id.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/id.rs
@@ -4,7 +4,7 @@ use core::{
 };
 
 use bytes::{Buf, BufMut};
-use error_stack::Result;
+use error_stack::Report;
 
 use crate::codec::{Buffer, BufferError, Decode, Encode};
 
@@ -21,7 +21,7 @@ impl Display for RequestId {
 impl Encode for RequestId {
     type Error = BufferError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -33,7 +33,7 @@ impl Decode for RequestId {
     type Context = ();
     type Error = BufferError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {

--- a/libs/@local/harpc/wire-protocol/src/request/mod.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/mod.rs
@@ -1,6 +1,6 @@
 pub use bytes::Bytes;
 use bytes::{Buf, BufMut};
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 
 use self::{
     body::{RequestBody, RequestBodyContext},
@@ -101,7 +101,7 @@ pub struct Request {
 impl Encode for Request {
     type Error = RequestEncodeError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -118,7 +118,7 @@ impl Decode for Request {
     type Context = ();
     type Error = RequestDecodeError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {

--- a/libs/@local/harpc/wire-protocol/src/request/procedure.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/procedure.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, BufMut};
-use error_stack::Result;
+use error_stack::Report;
 use harpc_types::procedure::{ProcedureDescriptor, ProcedureId};
 
 use crate::codec::{Buffer, BufferError, Decode, Encode};
@@ -7,7 +7,7 @@ use crate::codec::{Buffer, BufferError, Decode, Encode};
 impl Encode for ProcedureDescriptor {
     type Error = BufferError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -19,7 +19,7 @@ impl Decode for ProcedureDescriptor {
     type Context = ();
     type Error = BufferError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {

--- a/libs/@local/harpc/wire-protocol/src/request/service.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/service.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, BufMut};
-use error_stack::Result;
+use error_stack::Report;
 use harpc_types::{
     service::{ServiceDescriptor, ServiceId},
     version::Version,
@@ -10,7 +10,7 @@ use crate::codec::{Buffer, BufferError, Decode, Encode};
 impl Encode for ServiceDescriptor {
     type Error = BufferError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -25,7 +25,7 @@ impl Decode for ServiceDescriptor {
     type Context = ();
     type Error = BufferError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {

--- a/libs/@local/harpc/wire-protocol/src/response/begin.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/begin.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, BufMut};
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use harpc_types::response_kind::ResponseKind;
 
 use crate::{
@@ -22,7 +22,7 @@ pub struct ResponseBegin {
 impl Encode for ResponseBegin {
     type Error = ResponseBeginEncodeError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -45,7 +45,7 @@ impl Decode for ResponseBegin {
     type Context = ();
     type Error = BufferError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {

--- a/libs/@local/harpc/wire-protocol/src/response/body.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/body.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, BufMut};
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 
 use super::{
     begin::ResponseBegin,
@@ -35,7 +35,7 @@ impl ResponseBody {
 impl Encode for ResponseBody {
     type Error = ResponseBodyEncodeError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -81,7 +81,10 @@ impl Decode for ResponseBody {
     type Context = ResponseBodyContext;
     type Error = BufferError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, context: Self::Context) -> Result<Self, Self::Error>
+    fn decode<B>(
+        buffer: &mut Buffer<B>,
+        context: Self::Context,
+    ) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {

--- a/libs/@local/harpc/wire-protocol/src/response/flags.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/flags.rs
@@ -1,6 +1,6 @@
 use bytes::{Buf, BufMut};
 use enumflags2::BitFlags;
-use error_stack::Result;
+use error_stack::Report;
 
 use super::body::ResponseBody;
 use crate::{
@@ -60,7 +60,7 @@ impl From<ResponseFlag> for ResponseFlags {
 impl Encode for ResponseFlags {
     type Error = BufferError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -74,7 +74,7 @@ impl Decode for ResponseFlags {
     type Context = ();
     type Error = BufferError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {

--- a/libs/@local/harpc/wire-protocol/src/response/frame.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/frame.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, BufMut};
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 
 use crate::{
     codec::{Buffer, BufferError, Decode, Encode},
@@ -19,7 +19,7 @@ pub struct ResponseFrame {
 impl Encode for ResponseFrame {
     type Error = ResponseFrameEncodeError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -38,7 +38,7 @@ impl Decode for ResponseFrame {
     type Context = ();
     type Error = BufferError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {

--- a/libs/@local/harpc/wire-protocol/src/response/header.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/header.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, BufMut};
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 
 use super::{ResponseBody, flags::ResponseFlags};
 use crate::{
@@ -37,7 +37,7 @@ impl ResponseHeader {
 impl Encode for ResponseHeader {
     type Error = BufferError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -53,7 +53,7 @@ impl Decode for ResponseHeader {
     type Context = ();
     type Error = ResponseHeaderDecodeError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {

--- a/libs/@local/harpc/wire-protocol/src/response/kind.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/kind.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, BufMut};
-use error_stack::Result;
+use error_stack::Report;
 use harpc_types::response_kind::ResponseKind;
 
 use crate::codec::{Buffer, BufferError, Decode, Encode};
@@ -7,7 +7,7 @@ use crate::codec::{Buffer, BufferError, Decode, Encode};
 impl Encode for ResponseKind {
     type Error = BufferError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -19,7 +19,7 @@ impl Decode for ResponseKind {
     type Context = ();
     type Error = BufferError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {

--- a/libs/@local/harpc/wire-protocol/src/response/mod.rs
+++ b/libs/@local/harpc/wire-protocol/src/response/mod.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, BufMut};
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 
 use self::{
     body::{ResponseBody, ResponseBodyContext},
@@ -100,7 +100,7 @@ pub struct Response {
 impl Encode for Response {
     type Error = ResponseEncodeError;
 
-    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Self::Error>
+    fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
     where
         B: BufMut,
     {
@@ -120,7 +120,7 @@ impl Decode for Response {
     type Context = ();
     type Error = ResponseDecodeError;
 
-    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Self::Error>
+    fn decode<B>(buffer: &mut Buffer<B>, (): ()) -> Result<Self, Report<Self::Error>>
     where
         B: Buf,
     {

--- a/libs/@local/hash-authorization/package.json
+++ b/libs/@local/hash-authorization/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",
     "@rust/codec": "0.0.0-private",
+    "@rust/error-stack": "0.5.0",
     "@rust/graph-types": "0.0.0-private"
   }
 }

--- a/libs/@local/hash-authorization/src/api.rs
+++ b/libs/@local/hash-authorization/src/api.rs
@@ -520,7 +520,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
 /// Managed pool to keep track about [`AuthorizationApi`]s.
 pub trait AuthorizationApiPool {
     /// The error returned when acquiring an [`AuthorizationApi`].
-    type Error: Context;
+    type Error: ::core::error::Error + Send + Sync + 'static;
 
     /// The [`AuthorizationApi`] returned when acquiring.
     type Api<'pool>: AuthorizationApi;

--- a/libs/@local/hash-authorization/src/api.rs
+++ b/libs/@local/hash-authorization/src/api.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use error_stack::{Context, Result};
+use error_stack::{Context, Report};
 use graph_types::{
     account::{AccountGroupId, AccountId},
     knowledge::entity::{EntityId, EntityUuid},
@@ -22,8 +22,9 @@ use crate::{
 };
 
 pub trait AuthorizationApi: Send + Sync {
-    fn seed(&mut self)
-    -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
+    fn seed(
+        &mut self,
+    ) -> impl Future<Output = Result<Zookie<'static>, Report<ModifyRelationError>>> + Send;
 
     ////////////////////////////////////////////////////////////////////////////
     // Account group authorization
@@ -34,7 +35,7 @@ pub trait AuthorizationApi: Send + Sync {
         permission: AccountGroupPermission,
         account_group: AccountGroupId,
         consistency: Consistency<'_>,
-    ) -> impl Future<Output = Result<CheckResponse, CheckError>> + Send;
+    ) -> impl Future<Output = Result<CheckResponse, Report<CheckError>>> + Send;
 
     fn modify_account_group_relations(
         &mut self,
@@ -46,7 +47,7 @@ pub trait AuthorizationApi: Send + Sync {
             ),
             IntoIter: Send,
         > + Send,
-    ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
+    ) -> impl Future<Output = Result<Zookie<'static>, Report<ModifyRelationError>>> + Send;
 
     ////////////////////////////////////////////////////////////////////////////
     // Web authorization
@@ -57,7 +58,7 @@ pub trait AuthorizationApi: Send + Sync {
         permission: WebPermission,
         web: OwnedById,
         consistency: Consistency<'_>,
-    ) -> impl Future<Output = Result<CheckResponse, CheckError>> + Send;
+    ) -> impl Future<Output = Result<CheckResponse, Report<CheckError>>> + Send;
 
     fn check_webs_permission(
         &self,
@@ -65,8 +66,9 @@ pub trait AuthorizationApi: Send + Sync {
         permission: WebPermission,
         entities: impl IntoIterator<Item = OwnedById, IntoIter: Send> + Send,
         consistency: Consistency<'_>,
-    ) -> impl Future<Output = Result<(HashMap<OwnedById, bool>, Zookie<'static>), CheckError>> + Send
-    {
+    ) -> impl Future<
+        Output = Result<(HashMap<OwnedById, bool>, Zookie<'static>), Report<CheckError>>,
+    > + Send {
         async move {
             let mut zookie = Zookie::empty();
             let mut result = HashMap::new();
@@ -94,13 +96,13 @@ pub trait AuthorizationApi: Send + Sync {
             ),
             IntoIter: Send,
         > + Send,
-    ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
+    ) -> impl Future<Output = Result<Zookie<'static>, Report<ModifyRelationError>>> + Send;
 
     fn get_web_relations(
         &self,
         web: OwnedById,
         consistency: Consistency<'static>,
-    ) -> impl Future<Output = Result<Vec<WebRelationAndSubject>, ReadError>> + Send;
+    ) -> impl Future<Output = Result<Vec<WebRelationAndSubject>, Report<ReadError>>> + Send;
 
     ////////////////////////////////////////////////////////////////////////////
     // Entity authorization
@@ -111,7 +113,7 @@ pub trait AuthorizationApi: Send + Sync {
         permission: EntityPermission,
         entity: EntityId,
         consistency: Consistency<'_>,
-    ) -> impl Future<Output = Result<CheckResponse, CheckError>> + Send;
+    ) -> impl Future<Output = Result<CheckResponse, Report<CheckError>>> + Send;
 
     fn modify_entity_relations(
         &mut self,
@@ -123,7 +125,7 @@ pub trait AuthorizationApi: Send + Sync {
             ),
             IntoIter: Send,
         > + Send,
-    ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
+    ) -> impl Future<Output = Result<Zookie<'static>, Report<ModifyRelationError>>> + Send;
 
     fn check_entities_permission(
         &self,
@@ -131,13 +133,15 @@ pub trait AuthorizationApi: Send + Sync {
         permission: EntityPermission,
         entities: impl IntoIterator<Item = EntityId, IntoIter: Send> + Send,
         consistency: Consistency<'_>,
-    ) -> impl Future<Output = Result<(HashMap<EntityUuid, bool>, Zookie<'static>), CheckError>> + Send;
+    ) -> impl Future<
+        Output = Result<(HashMap<EntityUuid, bool>, Zookie<'static>), Report<CheckError>>,
+    > + Send;
 
     fn get_entity_relations(
         &self,
         entity: EntityId,
         consistency: Consistency<'static>,
-    ) -> impl Future<Output = Result<Vec<EntityRelationAndSubject>, ReadError>> + Send;
+    ) -> impl Future<Output = Result<Vec<EntityRelationAndSubject>, Report<ReadError>>> + Send;
 
     ////////////////////////////////////////////////////////////////////////////
     // Entity type authorization
@@ -148,7 +152,7 @@ pub trait AuthorizationApi: Send + Sync {
         permission: EntityTypePermission,
         entity_type: EntityTypeUuid,
         consistency: Consistency<'_>,
-    ) -> impl Future<Output = Result<CheckResponse, CheckError>> + Send;
+    ) -> impl Future<Output = Result<CheckResponse, Report<CheckError>>> + Send;
 
     fn modify_entity_type_relations(
         &mut self,
@@ -160,7 +164,7 @@ pub trait AuthorizationApi: Send + Sync {
             ),
             IntoIter: Send,
         > + Send,
-    ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
+    ) -> impl Future<Output = Result<Zookie<'static>, Report<ModifyRelationError>>> + Send;
 
     fn check_entity_types_permission(
         &self,
@@ -168,13 +172,15 @@ pub trait AuthorizationApi: Send + Sync {
         permission: EntityTypePermission,
         entity_types: impl IntoIterator<Item = EntityTypeUuid, IntoIter: Send> + Send,
         consistency: Consistency<'_>,
-    ) -> impl Future<Output = Result<(HashMap<EntityTypeUuid, bool>, Zookie<'static>), CheckError>> + Send;
+    ) -> impl Future<
+        Output = Result<(HashMap<EntityTypeUuid, bool>, Zookie<'static>), Report<CheckError>>,
+    > + Send;
 
     fn get_entity_type_relations(
         &self,
         entity_type: EntityTypeUuid,
         consistency: Consistency<'static>,
-    ) -> impl Future<Output = Result<Vec<EntityTypeRelationAndSubject>, ReadError>> + Send;
+    ) -> impl Future<Output = Result<Vec<EntityTypeRelationAndSubject>, Report<ReadError>>> + Send;
 
     ////////////////////////////////////////////////////////////////////////////
     // Property type authorization
@@ -185,7 +191,7 @@ pub trait AuthorizationApi: Send + Sync {
         permission: PropertyTypePermission,
         property_type: PropertyTypeUuid,
         consistency: Consistency<'_>,
-    ) -> impl Future<Output = Result<CheckResponse, CheckError>> + Send;
+    ) -> impl Future<Output = Result<CheckResponse, Report<CheckError>>> + Send;
 
     fn modify_property_type_relations(
         &mut self,
@@ -197,7 +203,7 @@ pub trait AuthorizationApi: Send + Sync {
             ),
             IntoIter: Send,
         > + Send,
-    ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
+    ) -> impl Future<Output = Result<Zookie<'static>, Report<ModifyRelationError>>> + Send;
 
     fn check_property_types_permission(
         &self,
@@ -205,14 +211,15 @@ pub trait AuthorizationApi: Send + Sync {
         permission: PropertyTypePermission,
         property_types: impl IntoIterator<Item = PropertyTypeUuid, IntoIter: Send> + Send,
         consistency: Consistency<'_>,
-    ) -> impl Future<Output = Result<(HashMap<PropertyTypeUuid, bool>, Zookie<'static>), CheckError>>
-    + Send;
+    ) -> impl Future<
+        Output = Result<(HashMap<PropertyTypeUuid, bool>, Zookie<'static>), Report<CheckError>>,
+    > + Send;
 
     fn get_property_type_relations(
         &self,
         property_type: PropertyTypeUuid,
         consistency: Consistency<'static>,
-    ) -> impl Future<Output = Result<Vec<PropertyTypeRelationAndSubject>, ReadError>> + Send;
+    ) -> impl Future<Output = Result<Vec<PropertyTypeRelationAndSubject>, Report<ReadError>>> + Send;
 
     ////////////////////////////////////////////////////////////////////////////
     // Data type authorization
@@ -223,7 +230,7 @@ pub trait AuthorizationApi: Send + Sync {
         permission: DataTypePermission,
         data_type: DataTypeUuid,
         consistency: Consistency<'_>,
-    ) -> impl Future<Output = Result<CheckResponse, CheckError>> + Send;
+    ) -> impl Future<Output = Result<CheckResponse, Report<CheckError>>> + Send;
 
     fn modify_data_type_relations(
         &mut self,
@@ -235,7 +242,7 @@ pub trait AuthorizationApi: Send + Sync {
             ),
             IntoIter: Send,
         > + Send,
-    ) -> impl Future<Output = Result<Zookie<'static>, ModifyRelationError>> + Send;
+    ) -> impl Future<Output = Result<Zookie<'static>, Report<ModifyRelationError>>> + Send;
 
     fn check_data_types_permission(
         &self,
@@ -243,17 +250,19 @@ pub trait AuthorizationApi: Send + Sync {
         permission: DataTypePermission,
         data_types: impl IntoIterator<Item = DataTypeUuid, IntoIter: Send> + Send,
         consistency: Consistency<'_>,
-    ) -> impl Future<Output = Result<(HashMap<DataTypeUuid, bool>, Zookie<'static>), CheckError>> + Send;
+    ) -> impl Future<
+        Output = Result<(HashMap<DataTypeUuid, bool>, Zookie<'static>), Report<CheckError>>,
+    > + Send;
 
     fn get_data_type_relations(
         &self,
         data_type: DataTypeUuid,
         consistency: Consistency<'static>,
-    ) -> impl Future<Output = Result<Vec<DataTypeRelationAndSubject>, ReadError>> + Send;
+    ) -> impl Future<Output = Result<Vec<DataTypeRelationAndSubject>, Report<ReadError>>> + Send;
 }
 
 impl<A: AuthorizationApi> AuthorizationApi for &mut A {
-    async fn seed(&mut self) -> Result<Zookie<'static>, ModifyRelationError> {
+    async fn seed(&mut self) -> Result<Zookie<'static>, Report<ModifyRelationError>> {
         (**self).seed().await
     }
 
@@ -263,7 +272,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
         permission: AccountGroupPermission,
         account_group: AccountGroupId,
         consistency: Consistency<'_>,
-    ) -> Result<CheckResponse, CheckError> {
+    ) -> Result<CheckResponse, Report<CheckError>> {
         (**self)
             .check_account_group_permission(actor, permission, account_group, consistency)
             .await
@@ -279,7 +288,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
             ),
             IntoIter: Send,
         > + Send,
-    ) -> Result<Zookie<'static>, ModifyRelationError> {
+    ) -> Result<Zookie<'static>, Report<ModifyRelationError>> {
         (**self).modify_account_group_relations(relationships).await
     }
 
@@ -289,7 +298,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
         permission: WebPermission,
         web: OwnedById,
         consistency: Consistency<'_>,
-    ) -> Result<CheckResponse, CheckError> {
+    ) -> Result<CheckResponse, Report<CheckError>> {
         (**self)
             .check_web_permission(actor, permission, web, consistency)
             .await
@@ -305,7 +314,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
             ),
             IntoIter: Send,
         > + Send,
-    ) -> Result<Zookie<'static>, ModifyRelationError> {
+    ) -> Result<Zookie<'static>, Report<ModifyRelationError>> {
         (**self).modify_web_relations(relationships).await
     }
 
@@ -313,7 +322,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
         &self,
         web: OwnedById,
         consistency: Consistency<'static>,
-    ) -> Result<Vec<WebRelationAndSubject>, ReadError> {
+    ) -> Result<Vec<WebRelationAndSubject>, Report<ReadError>> {
         (**self).get_web_relations(web, consistency).await
     }
 
@@ -323,7 +332,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
         permission: EntityPermission,
         entity: EntityId,
         consistency: Consistency<'_>,
-    ) -> Result<CheckResponse, CheckError> {
+    ) -> Result<CheckResponse, Report<CheckError>> {
         (**self)
             .check_entity_permission(actor, permission, entity, consistency)
             .await
@@ -339,7 +348,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
             ),
             IntoIter: Send,
         > + Send,
-    ) -> Result<Zookie<'static>, ModifyRelationError> {
+    ) -> Result<Zookie<'static>, Report<ModifyRelationError>> {
         (**self).modify_entity_relations(relationships).await
     }
 
@@ -349,7 +358,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
         permission: EntityPermission,
         entities: impl IntoIterator<Item = EntityId, IntoIter: Send> + Send,
         consistency: Consistency<'_>,
-    ) -> Result<(HashMap<EntityUuid, bool>, Zookie<'static>), CheckError> {
+    ) -> Result<(HashMap<EntityUuid, bool>, Zookie<'static>), Report<CheckError>> {
         (**self)
             .check_entities_permission(actor, permission, entities, consistency)
             .await
@@ -359,7 +368,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
         &self,
         entity: EntityId,
         consistency: Consistency<'static>,
-    ) -> Result<Vec<EntityRelationAndSubject>, ReadError> {
+    ) -> Result<Vec<EntityRelationAndSubject>, Report<ReadError>> {
         (**self).get_entity_relations(entity, consistency).await
     }
 
@@ -369,7 +378,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
         permission: EntityTypePermission,
         entity_type: EntityTypeUuid,
         consistency: Consistency<'_>,
-    ) -> Result<CheckResponse, CheckError> {
+    ) -> Result<CheckResponse, Report<CheckError>> {
         (**self)
             .check_entity_type_permission(actor, permission, entity_type, consistency)
             .await
@@ -385,7 +394,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
             ),
             IntoIter: Send,
         > + Send,
-    ) -> Result<Zookie<'static>, ModifyRelationError> {
+    ) -> Result<Zookie<'static>, Report<ModifyRelationError>> {
         (**self).modify_entity_type_relations(relationships).await
     }
 
@@ -395,7 +404,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
         permission: EntityTypePermission,
         entity_types: impl IntoIterator<Item = EntityTypeUuid, IntoIter: Send> + Send,
         consistency: Consistency<'_>,
-    ) -> Result<(HashMap<EntityTypeUuid, bool>, Zookie<'static>), CheckError> {
+    ) -> Result<(HashMap<EntityTypeUuid, bool>, Zookie<'static>), Report<CheckError>> {
         (**self)
             .check_entity_types_permission(actor, permission, entity_types, consistency)
             .await
@@ -405,7 +414,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
         &self,
         entity_type: EntityTypeUuid,
         consistency: Consistency<'static>,
-    ) -> Result<Vec<EntityTypeRelationAndSubject>, ReadError> {
+    ) -> Result<Vec<EntityTypeRelationAndSubject>, Report<ReadError>> {
         (**self)
             .get_entity_type_relations(entity_type, consistency)
             .await
@@ -417,7 +426,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
         permission: PropertyTypePermission,
         property_type: PropertyTypeUuid,
         consistency: Consistency<'_>,
-    ) -> Result<CheckResponse, CheckError> {
+    ) -> Result<CheckResponse, Report<CheckError>> {
         (**self)
             .check_property_type_permission(actor, permission, property_type, consistency)
             .await
@@ -433,7 +442,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
             ),
             IntoIter: Send,
         > + Send,
-    ) -> Result<Zookie<'static>, ModifyRelationError> {
+    ) -> Result<Zookie<'static>, Report<ModifyRelationError>> {
         (**self).modify_property_type_relations(relationships).await
     }
 
@@ -443,7 +452,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
         permission: PropertyTypePermission,
         property_types: impl IntoIterator<Item = PropertyTypeUuid, IntoIter: Send> + Send,
         consistency: Consistency<'_>,
-    ) -> Result<(HashMap<PropertyTypeUuid, bool>, Zookie<'static>), CheckError> {
+    ) -> Result<(HashMap<PropertyTypeUuid, bool>, Zookie<'static>), Report<CheckError>> {
         (**self)
             .check_property_types_permission(actor, permission, property_types, consistency)
             .await
@@ -453,7 +462,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
         &self,
         property_type: PropertyTypeUuid,
         consistency: Consistency<'static>,
-    ) -> Result<Vec<PropertyTypeRelationAndSubject>, ReadError> {
+    ) -> Result<Vec<PropertyTypeRelationAndSubject>, Report<ReadError>> {
         (**self)
             .get_property_type_relations(property_type, consistency)
             .await
@@ -465,7 +474,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
         permission: DataTypePermission,
         data_type: DataTypeUuid,
         consistency: Consistency<'_>,
-    ) -> Result<CheckResponse, CheckError> {
+    ) -> Result<CheckResponse, Report<CheckError>> {
         (**self)
             .check_data_type_permission(actor, permission, data_type, consistency)
             .await
@@ -481,7 +490,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
             ),
             IntoIter: Send,
         > + Send,
-    ) -> Result<Zookie<'static>, ModifyRelationError> {
+    ) -> Result<Zookie<'static>, Report<ModifyRelationError>> {
         (**self).modify_data_type_relations(relationships).await
     }
 
@@ -491,7 +500,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
         permission: DataTypePermission,
         data_types: impl IntoIterator<Item = DataTypeUuid, IntoIter: Send> + Send,
         consistency: Consistency<'_>,
-    ) -> Result<(HashMap<DataTypeUuid, bool>, Zookie<'static>), CheckError> {
+    ) -> Result<(HashMap<DataTypeUuid, bool>, Zookie<'static>), Report<CheckError>> {
         (**self)
             .check_data_types_permission(actor, permission, data_types, consistency)
             .await
@@ -501,7 +510,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
         &self,
         data_type: DataTypeUuid,
         consistency: Consistency<'static>,
-    ) -> Result<Vec<DataTypeRelationAndSubject>, ReadError> {
+    ) -> Result<Vec<DataTypeRelationAndSubject>, Report<ReadError>> {
         (**self)
             .get_data_type_relations(data_type, consistency)
             .await
@@ -517,7 +526,7 @@ pub trait AuthorizationApiPool {
     type Api<'pool>: AuthorizationApi;
 
     /// Retrieves an [`AuthorizationApi`] from the pool.
-    fn acquire(&self) -> impl Future<Output = Result<Self::Api<'_>, Self::Error>> + Send;
+    fn acquire(&self) -> impl Future<Output = Result<Self::Api<'_>, Report<Self::Error>>> + Send;
 
     /// Retrieves an owned [`AuthorizationApi`] from the pool.
     ///
@@ -526,6 +535,7 @@ pub trait AuthorizationApiPool {
     /// reference to the `AuthorizationApiPool`) should be preferred whenever possible.
     ///
     /// [`acquire`]: Self::acquire
-    fn acquire_owned(&self)
-    -> impl Future<Output = Result<Self::Api<'static>, Self::Error>> + Send;
+    fn acquire_owned(
+        &self,
+    ) -> impl Future<Output = Result<Self::Api<'static>, Report<Self::Error>>> + Send;
 }

--- a/libs/@local/hash-authorization/src/api.rs
+++ b/libs/@local/hash-authorization/src/api.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use error_stack::{Context, Report};
+use error_stack::Report;
 use graph_types::{
     account::{AccountGroupId, AccountId},
     knowledge::entity::{EntityId, EntityUuid},

--- a/libs/@local/hash-authorization/src/api.rs
+++ b/libs/@local/hash-authorization/src/api.rs
@@ -1,3 +1,4 @@
+use core::error::Error;
 use std::collections::HashMap;
 
 use error_stack::Report;
@@ -520,7 +521,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
 /// Managed pool to keep track about [`AuthorizationApi`]s.
 pub trait AuthorizationApiPool {
     /// The error returned when acquiring an [`AuthorizationApi`].
-    type Error: ::core::error::Error + Send + Sync + 'static;
+    type Error: Error + Send + Sync + 'static;
 
     /// The [`AuthorizationApi`] returned when acquiring.
     type Api<'pool>: AuthorizationApi;

--- a/libs/@local/hash-authorization/src/backend/spicedb/mod.rs
+++ b/libs/@local/hash-authorization/src/backend/spicedb/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod serde;
 
 use core::fmt;
 
-use error_stack::Result;
+use error_stack::Report;
 
 pub use self::model::RpcError;
 
@@ -32,7 +32,10 @@ impl SpiceDbOpenApi {
     /// # Errors
     ///
     /// - Errors if the client could not be built
-    pub fn new(base_path: impl Into<String>, key: Option<&str>) -> Result<Self, reqwest::Error> {
+    pub fn new(
+        base_path: impl Into<String>,
+        key: Option<&str>,
+    ) -> Result<Self, Report<reqwest::Error>> {
         Ok(Self {
             base_path: base_path.into(),
             client: reqwest::Client::builder()

--- a/libs/@local/hash-authorization/src/lib.rs
+++ b/libs/@local/hash-authorization/src/lib.rs
@@ -18,7 +18,7 @@ use crate::schema::{
 
 mod api;
 
-use error_stack::Result;
+use error_stack::Report;
 use graph_types::{
     account::{AccountGroupId, AccountId},
     knowledge::entity::{EntityId, EntityUuid},
@@ -38,7 +38,7 @@ use crate::{
 pub struct NoAuthorization;
 
 impl AuthorizationApi for NoAuthorization {
-    async fn seed(&mut self) -> Result<Zookie<'static>, ModifyRelationError> {
+    async fn seed(&mut self) -> Result<Zookie<'static>, Report<ModifyRelationError>> {
         Ok(Zookie::empty())
     }
 
@@ -48,7 +48,7 @@ impl AuthorizationApi for NoAuthorization {
         _: AccountGroupPermission,
         _: AccountGroupId,
         _: Consistency<'_>,
-    ) -> Result<CheckResponse, CheckError> {
+    ) -> Result<CheckResponse, Report<CheckError>> {
         Ok(CheckResponse {
             has_permission: true,
             checked_at: Zookie::empty(),
@@ -65,7 +65,7 @@ impl AuthorizationApi for NoAuthorization {
             ),
             IntoIter: Send,
         > + Send,
-    ) -> Result<Zookie<'static>, ModifyRelationError> {
+    ) -> Result<Zookie<'static>, Report<ModifyRelationError>> {
         Ok(Zookie::empty())
     }
 
@@ -75,7 +75,7 @@ impl AuthorizationApi for NoAuthorization {
         _: WebPermission,
         _: OwnedById,
         _: Consistency<'_>,
-    ) -> Result<CheckResponse, CheckError> {
+    ) -> Result<CheckResponse, Report<CheckError>> {
         Ok(CheckResponse {
             has_permission: true,
             checked_at: Zookie::empty(),
@@ -92,7 +92,7 @@ impl AuthorizationApi for NoAuthorization {
             ),
             IntoIter: Send,
         > + Send,
-    ) -> Result<Zookie<'static>, ModifyRelationError> {
+    ) -> Result<Zookie<'static>, Report<ModifyRelationError>> {
         Ok(Zookie::empty())
     }
 
@@ -100,7 +100,7 @@ impl AuthorizationApi for NoAuthorization {
         &self,
         _: OwnedById,
         _: Consistency<'static>,
-    ) -> Result<Vec<WebRelationAndSubject>, ReadError> {
+    ) -> Result<Vec<WebRelationAndSubject>, Report<ReadError>> {
         Ok(Vec::new())
     }
 
@@ -110,7 +110,7 @@ impl AuthorizationApi for NoAuthorization {
         _: EntityPermission,
         _: EntityId,
         _: Consistency<'_>,
-    ) -> Result<CheckResponse, CheckError> {
+    ) -> Result<CheckResponse, Report<CheckError>> {
         Ok(CheckResponse {
             has_permission: true,
             checked_at: Zookie::empty(),
@@ -123,7 +123,7 @@ impl AuthorizationApi for NoAuthorization {
         _: EntityPermission,
         entities: impl IntoIterator<Item = EntityId, IntoIter: Send> + Send,
         _: Consistency<'_>,
-    ) -> Result<(HashMap<EntityUuid, bool>, Zookie<'static>), CheckError> {
+    ) -> Result<(HashMap<EntityUuid, bool>, Zookie<'static>), Report<CheckError>> {
         Ok((
             entities
                 .into_iter()
@@ -143,7 +143,7 @@ impl AuthorizationApi for NoAuthorization {
             ),
             IntoIter: Send,
         > + Send,
-    ) -> Result<Zookie<'static>, ModifyRelationError> {
+    ) -> Result<Zookie<'static>, Report<ModifyRelationError>> {
         Ok(Zookie::empty())
     }
 
@@ -151,7 +151,7 @@ impl AuthorizationApi for NoAuthorization {
         &self,
         _: EntityId,
         _: Consistency<'static>,
-    ) -> Result<Vec<EntityRelationAndSubject>, ReadError> {
+    ) -> Result<Vec<EntityRelationAndSubject>, Report<ReadError>> {
         Ok(Vec::new())
     }
 
@@ -165,7 +165,7 @@ impl AuthorizationApi for NoAuthorization {
             ),
             IntoIter: Send,
         > + Send,
-    ) -> Result<Zookie<'static>, ModifyRelationError> {
+    ) -> Result<Zookie<'static>, Report<ModifyRelationError>> {
         Ok(Zookie::empty())
     }
 
@@ -175,7 +175,7 @@ impl AuthorizationApi for NoAuthorization {
         _: EntityTypePermission,
         _: EntityTypeUuid,
         _: Consistency<'_>,
-    ) -> Result<CheckResponse, CheckError> {
+    ) -> Result<CheckResponse, Report<CheckError>> {
         Ok(CheckResponse {
             has_permission: true,
             checked_at: Zookie::empty(),
@@ -188,7 +188,7 @@ impl AuthorizationApi for NoAuthorization {
         _: EntityTypePermission,
         entity_types: impl IntoIterator<Item = EntityTypeUuid, IntoIter: Send> + Send,
         _: Consistency<'_>,
-    ) -> Result<(HashMap<EntityTypeUuid, bool>, Zookie<'static>), CheckError> {
+    ) -> Result<(HashMap<EntityTypeUuid, bool>, Zookie<'static>), Report<CheckError>> {
         Ok((
             entity_types
                 .into_iter()
@@ -202,7 +202,7 @@ impl AuthorizationApi for NoAuthorization {
         &self,
         _: EntityTypeUuid,
         _: Consistency<'static>,
-    ) -> Result<Vec<EntityTypeRelationAndSubject>, ReadError> {
+    ) -> Result<Vec<EntityTypeRelationAndSubject>, Report<ReadError>> {
         Ok(Vec::new())
     }
 
@@ -216,7 +216,7 @@ impl AuthorizationApi for NoAuthorization {
             ),
             IntoIter: Send,
         > + Send,
-    ) -> Result<Zookie<'static>, ModifyRelationError> {
+    ) -> Result<Zookie<'static>, Report<ModifyRelationError>> {
         Ok(Zookie::empty())
     }
 
@@ -226,7 +226,7 @@ impl AuthorizationApi for NoAuthorization {
         _: PropertyTypePermission,
         _: PropertyTypeUuid,
         _: Consistency<'_>,
-    ) -> Result<CheckResponse, CheckError> {
+    ) -> Result<CheckResponse, Report<CheckError>> {
         Ok(CheckResponse {
             has_permission: true,
             checked_at: Zookie::empty(),
@@ -239,7 +239,7 @@ impl AuthorizationApi for NoAuthorization {
         _: PropertyTypePermission,
         property_types: impl IntoIterator<Item = PropertyTypeUuid, IntoIter: Send> + Send,
         _: Consistency<'_>,
-    ) -> Result<(HashMap<PropertyTypeUuid, bool>, Zookie<'static>), CheckError> {
+    ) -> Result<(HashMap<PropertyTypeUuid, bool>, Zookie<'static>), Report<CheckError>> {
         Ok((
             property_types
                 .into_iter()
@@ -253,7 +253,7 @@ impl AuthorizationApi for NoAuthorization {
         &self,
         _: PropertyTypeUuid,
         _: Consistency<'static>,
-    ) -> Result<Vec<PropertyTypeRelationAndSubject>, ReadError> {
+    ) -> Result<Vec<PropertyTypeRelationAndSubject>, Report<ReadError>> {
         Ok(Vec::new())
     }
 
@@ -267,7 +267,7 @@ impl AuthorizationApi for NoAuthorization {
             ),
             IntoIter: Send,
         > + Send,
-    ) -> Result<Zookie<'static>, ModifyRelationError> {
+    ) -> Result<Zookie<'static>, Report<ModifyRelationError>> {
         Ok(Zookie::empty())
     }
 
@@ -277,7 +277,7 @@ impl AuthorizationApi for NoAuthorization {
         _: DataTypePermission,
         _: DataTypeUuid,
         _: Consistency<'_>,
-    ) -> Result<CheckResponse, CheckError> {
+    ) -> Result<CheckResponse, Report<CheckError>> {
         Ok(CheckResponse {
             has_permission: true,
             checked_at: Zookie::empty(),
@@ -290,7 +290,7 @@ impl AuthorizationApi for NoAuthorization {
         _: DataTypePermission,
         data_types: impl IntoIterator<Item = DataTypeUuid, IntoIter: Send> + Send,
         _: Consistency<'_>,
-    ) -> Result<(HashMap<DataTypeUuid, bool>, Zookie<'static>), CheckError> {
+    ) -> Result<(HashMap<DataTypeUuid, bool>, Zookie<'static>), Report<CheckError>> {
         Ok((
             data_types
                 .into_iter()
@@ -304,7 +304,7 @@ impl AuthorizationApi for NoAuthorization {
         &self,
         _: DataTypeUuid,
         _: Consistency<'static>,
-    ) -> Result<Vec<DataTypeRelationAndSubject>, ReadError> {
+    ) -> Result<Vec<DataTypeRelationAndSubject>, Report<ReadError>> {
         Ok(Vec::new())
     }
 }
@@ -316,11 +316,11 @@ where
     type Api<'pool> = Self;
     type Error = core::convert::Infallible;
 
-    async fn acquire(&self) -> Result<Self::Api<'_>, Self::Error> {
+    async fn acquire(&self) -> Result<Self::Api<'_>, Report<Self::Error>> {
         Ok(self.clone())
     }
 
-    async fn acquire_owned(&self) -> Result<Self::Api<'static>, Self::Error> {
+    async fn acquire_owned(&self) -> Result<Self::Api<'static>, Report<Self::Error>> {
         Ok(self.clone())
     }
 }

--- a/libs/@local/hash-authorization/src/zanzibar/api.rs
+++ b/libs/@local/hash-authorization/src/zanzibar/api.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use error_stack::{ReportSink, Result, ResultExt as _};
+use error_stack::{Report, ReportSink, ResultExt as _};
 use futures::{Stream, TryStreamExt as _};
 use graph_types::{
     account::{AccountGroupId, AccountId},
@@ -46,7 +46,7 @@ impl<B> AuthorizationApi for ZanzibarClient<B>
 where
     B: ZanzibarBackend + Send + Sync,
 {
-    async fn seed(&mut self) -> Result<Zookie<'static>, ModifyRelationError> {
+    async fn seed(&mut self) -> Result<Zookie<'static>, Report<ModifyRelationError>> {
         Ok(self
             .backend
             .modify_relationships([
@@ -96,7 +96,7 @@ where
         permission: AccountGroupPermission,
         account_group: AccountGroupId,
         consistency: Consistency<'_>,
-    ) -> Result<CheckResponse, CheckError> {
+    ) -> Result<CheckResponse, Report<CheckError>> {
         self.backend
             .check_permission(&account_group, &permission, &actor, consistency)
             .await
@@ -113,7 +113,7 @@ where
             ),
             IntoIter: Send,
         > + Send,
-    ) -> Result<Zookie<'static>, ModifyRelationError> {
+    ) -> Result<Zookie<'static>, Report<ModifyRelationError>> {
         Ok(self
             .backend
             .modify_relationships(relationships.into_iter().map(
@@ -134,7 +134,7 @@ where
         permission: WebPermission,
         web: OwnedById,
         consistency: Consistency<'_>,
-    ) -> Result<CheckResponse, CheckError> {
+    ) -> Result<CheckResponse, Report<CheckError>> {
         self.backend
             .check_permission(&web, &permission, &actor, consistency)
             .await
@@ -151,7 +151,7 @@ where
             ),
             IntoIter: Send,
         > + Send,
-    ) -> Result<Zookie<'static>, ModifyRelationError> {
+    ) -> Result<Zookie<'static>, Report<ModifyRelationError>> {
         Ok(self
             .backend
             .modify_relationships(
@@ -169,7 +169,7 @@ where
         &self,
         web: OwnedById,
         consistency: Consistency<'static>,
-    ) -> Result<Vec<WebRelationAndSubject>, ReadError> {
+    ) -> Result<Vec<WebRelationAndSubject>, Report<ReadError>> {
         self.backend
             .read_relations::<(OwnedById, WebRelationAndSubject)>(
                 RelationshipFilter::from_resource(web),
@@ -193,7 +193,7 @@ where
             ),
             IntoIter: Send,
         > + Send,
-    ) -> Result<Zookie<'static>, ModifyRelationError> {
+    ) -> Result<Zookie<'static>, Report<ModifyRelationError>> {
         Ok(self
             .backend
             .modify_relationships(relationships.into_iter().map(
@@ -211,7 +211,7 @@ where
         permission: EntityPermission,
         entity: EntityId,
         consistency: Consistency<'_>,
-    ) -> Result<CheckResponse, CheckError> {
+    ) -> Result<CheckResponse, Report<CheckError>> {
         self.backend
             .check_permission(&entity.entity_uuid, &permission, &actor, consistency)
             .await
@@ -224,7 +224,7 @@ where
         permission: EntityPermission,
         entities: impl IntoIterator<Item = EntityId, IntoIter: Send> + Send,
         consistency: Consistency<'_>,
-    ) -> Result<(HashMap<EntityUuid, bool>, Zookie<'static>), CheckError> {
+    ) -> Result<(HashMap<EntityUuid, bool>, Zookie<'static>), Report<CheckError>> {
         let response = self
             .backend
             .check_permissions(
@@ -263,7 +263,7 @@ where
         &self,
         entity: EntityId,
         consistency: Consistency<'static>,
-    ) -> Result<Vec<EntityRelationAndSubject>, ReadError> {
+    ) -> Result<Vec<EntityRelationAndSubject>, Report<ReadError>> {
         self.backend
             .read_relations::<(EntityUuid, EntityRelationAndSubject)>(
                 RelationshipFilter::from_resource(entity.entity_uuid),
@@ -287,7 +287,7 @@ where
             ),
             IntoIter: Send,
         > + Send,
-    ) -> Result<Zookie<'static>, ModifyRelationError> {
+    ) -> Result<Zookie<'static>, Report<ModifyRelationError>> {
         Ok(self
             .backend
             .modify_relationships(
@@ -307,7 +307,7 @@ where
         permission: EntityTypePermission,
         entity_type: EntityTypeUuid,
         consistency: Consistency<'_>,
-    ) -> Result<CheckResponse, CheckError> {
+    ) -> Result<CheckResponse, Report<CheckError>> {
         self.backend
             .check_permission(&entity_type, &permission, &actor, consistency)
             .await
@@ -320,7 +320,7 @@ where
         permission: EntityTypePermission,
         entity_types: impl IntoIterator<Item = EntityTypeUuid, IntoIter: Send> + Send,
         consistency: Consistency<'_>,
-    ) -> Result<(HashMap<EntityTypeUuid, bool>, Zookie<'static>), CheckError> {
+    ) -> Result<(HashMap<EntityTypeUuid, bool>, Zookie<'static>), Report<CheckError>> {
         let response = self
             .backend
             .check_permissions(
@@ -359,7 +359,7 @@ where
         &self,
         entity_type: EntityTypeUuid,
         consistency: Consistency<'static>,
-    ) -> Result<Vec<EntityTypeRelationAndSubject>, ReadError> {
+    ) -> Result<Vec<EntityTypeRelationAndSubject>, Report<ReadError>> {
         self.backend
             .read_relations::<(EntityTypeUuid, EntityTypeRelationAndSubject)>(
                 RelationshipFilter::from_resource(entity_type),
@@ -383,7 +383,7 @@ where
             ),
             IntoIter: Send,
         > + Send,
-    ) -> Result<Zookie<'static>, ModifyRelationError> {
+    ) -> Result<Zookie<'static>, Report<ModifyRelationError>> {
         Ok(self
             .backend
             .modify_relationships(
@@ -405,7 +405,7 @@ where
         permission: PropertyTypePermission,
         property_type: PropertyTypeUuid,
         consistency: Consistency<'_>,
-    ) -> Result<CheckResponse, CheckError> {
+    ) -> Result<CheckResponse, Report<CheckError>> {
         self.backend
             .check_permission(&property_type, &permission, &actor, consistency)
             .await
@@ -418,7 +418,7 @@ where
         permission: PropertyTypePermission,
         property_types: impl IntoIterator<Item = PropertyTypeUuid, IntoIter: Send> + Send,
         consistency: Consistency<'_>,
-    ) -> Result<(HashMap<PropertyTypeUuid, bool>, Zookie<'static>), CheckError> {
+    ) -> Result<(HashMap<PropertyTypeUuid, bool>, Zookie<'static>), Report<CheckError>> {
         let response = self
             .backend
             .check_permissions(
@@ -457,7 +457,7 @@ where
         &self,
         property_type: PropertyTypeUuid,
         consistency: Consistency<'static>,
-    ) -> Result<Vec<PropertyTypeRelationAndSubject>, ReadError> {
+    ) -> Result<Vec<PropertyTypeRelationAndSubject>, Report<ReadError>> {
         self.backend
             .read_relations::<(PropertyTypeUuid, PropertyTypeRelationAndSubject)>(
                 RelationshipFilter::from_resource(property_type),
@@ -481,7 +481,7 @@ where
             ),
             IntoIter: Send,
         > + Send,
-    ) -> Result<Zookie<'static>, ModifyRelationError> {
+    ) -> Result<Zookie<'static>, Report<ModifyRelationError>> {
         Ok(self
             .backend
             .modify_relationships(
@@ -501,7 +501,7 @@ where
         permission: DataTypePermission,
         data_type: DataTypeUuid,
         consistency: Consistency<'_>,
-    ) -> Result<CheckResponse, CheckError> {
+    ) -> Result<CheckResponse, Report<CheckError>> {
         self.backend
             .check_permission(&data_type, &permission, &actor, consistency)
             .await
@@ -514,7 +514,7 @@ where
         permission: DataTypePermission,
         data_types: impl IntoIterator<Item = DataTypeUuid, IntoIter: Send> + Send,
         consistency: Consistency<'_>,
-    ) -> Result<(HashMap<DataTypeUuid, bool>, Zookie<'static>), CheckError> {
+    ) -> Result<(HashMap<DataTypeUuid, bool>, Zookie<'static>), Report<CheckError>> {
         let response = self
             .backend
             .check_permissions(
@@ -553,7 +553,7 @@ where
         &self,
         data_type: DataTypeUuid,
         consistency: Consistency<'static>,
-    ) -> Result<Vec<DataTypeRelationAndSubject>, ReadError> {
+    ) -> Result<Vec<DataTypeRelationAndSubject>, Report<ReadError>> {
         self.backend
             .read_relations::<(DataTypeUuid, DataTypeRelationAndSubject)>(
                 RelationshipFilter::from_resource(data_type),
@@ -574,18 +574,18 @@ where
     async fn import_schema(
         &mut self,
         schema: &str,
-    ) -> Result<ImportSchemaResponse, ImportSchemaError> {
+    ) -> Result<ImportSchemaResponse, Report<ImportSchemaError>> {
         self.backend.import_schema(schema).await
     }
 
-    async fn export_schema(&self) -> Result<ExportSchemaResponse, ExportSchemaError> {
+    async fn export_schema(&self) -> Result<ExportSchemaResponse, Report<ExportSchemaError>> {
         self.backend.export_schema().await
     }
 
     async fn modify_relationships<R>(
         &mut self,
         relationships: impl IntoIterator<Item = (ModifyRelationshipOperation, R), IntoIter: Send> + Send,
-    ) -> Result<ModifyRelationshipResponse, ModifyRelationshipError>
+    ) -> Result<ModifyRelationshipResponse, Report<ModifyRelationshipError>>
     where
         R: Relationship<
                 Resource: Resource<Kind: Serialize, Id: Serialize>,
@@ -604,7 +604,7 @@ where
         permission: &R,
         subject: &S,
         consistency: Consistency<'_>,
-    ) -> Result<CheckResponse, CheckError>
+    ) -> Result<CheckResponse, Report<CheckError>>
     where
         O: Resource<Kind: Serialize, Id: Serialize> + Sync,
         R: Serialize + Permission<O> + Sync,
@@ -619,7 +619,10 @@ where
         &self,
         relationships: impl IntoIterator<Item = (O, R, S)> + Send,
         consistency: Consistency<'_>,
-    ) -> Result<BulkCheckResponse<impl IntoIterator<Item = BulkCheckItem<O, R, S>>>, CheckError>
+    ) -> Result<
+        BulkCheckResponse<impl IntoIterator<Item = BulkCheckItem<O, R, S>>>,
+        Report<CheckError>,
+    >
     where
         O: Resource<Kind: Serialize + DeserializeOwned, Id: Serialize + DeserializeOwned>
             + Send
@@ -650,7 +653,7 @@ where
             impl Serialize + Send + Sync,
         >,
         consistency: Consistency<'_>,
-    ) -> Result<impl Stream<Item = Result<R, ReadError>> + Send, ReadError>
+    ) -> Result<impl Stream<Item = Result<R, Report<ReadError>>> + Send, Report<ReadError>>
     where
         for<'de> R: Relationship<
                 Resource: Resource<Kind: Deserialize<'de>, Id: Deserialize<'de>>,
@@ -672,7 +675,7 @@ where
             impl Serialize + Send + Sync,
             impl Serialize + Send + Sync,
         >,
-    ) -> Result<DeleteRelationshipResponse, DeleteRelationshipError> {
+    ) -> Result<DeleteRelationshipResponse, Report<DeleteRelationshipError>> {
         self.backend.delete_relations(filter).await
     }
 }

--- a/libs/@local/hash-graph-types/rust/package.json
+++ b/libs/@local/hash-graph-types/rust/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",
     "@rust/codec": "0.0.0-private",
+    "@rust/error-stack": "0.5.0",
     "@rust/temporal-versioning": "0.0.0-private"
   },
   "devDependencies": {

--- a/libs/@local/hash-graph-types/rust/src/ontology/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/ontology/mod.rs
@@ -5,7 +5,7 @@ mod provenance;
 
 use core::{borrow::Borrow, fmt};
 
-use error_stack::{Context, Report};
+use error_stack::Report;
 use serde::{Deserialize, Serialize};
 use temporal_versioning::{LeftClosedTemporalInterval, TransactionTime};
 use time::OffsetDateTime;
@@ -172,7 +172,9 @@ pub trait OntologyTypeProvider<O> {
     fn provide_type(
         &self,
         type_id: &VersionedUrl,
-    ) -> impl Future<Output = Result<Self::Value, Report<impl ::core::error::Error + Send + Sync + 'static>>> + Send;
+    ) -> impl Future<
+        Output = Result<Self::Value, Report<impl ::core::error::Error + Send + Sync + 'static>>,
+    > + Send;
 }
 
 pub trait DataTypeProvider: OntologyTypeProvider<DataTypeWithMetadata> {
@@ -180,13 +182,20 @@ pub trait DataTypeProvider: OntologyTypeProvider<DataTypeWithMetadata> {
         &self,
         child: &VersionedUrl,
         parent: &BaseUrl,
-    ) -> impl Future<Output = Result<bool, Report<impl ::core::error::Error + Send + Sync + 'static>>> + Send;
+    ) -> impl Future<
+        Output = Result<bool, Report<impl ::core::error::Error + Send + Sync + 'static>>,
+    > + Send;
 
     fn find_conversion(
         &self,
         source_data_type_id: &VersionedUrl,
         target_data_type_id: &VersionedUrl,
-    ) -> impl Future<Output = Result<impl Borrow<Vec<ConversionExpression>>, Report<impl ::core::error::Error + Send + Sync + 'static>>> + Send;
+    ) -> impl Future<
+        Output = Result<
+            impl Borrow<Vec<ConversionExpression>>,
+            Report<impl ::core::error::Error + Send + Sync + 'static>,
+        >,
+    > + Send;
 }
 
 pub trait PropertyTypeProvider: OntologyTypeProvider<PropertyType> {}
@@ -202,10 +211,17 @@ pub trait EntityTypeProvider: OntologyTypeProvider<ClosedEntityType> {
         &self,
         parent: &VersionedUrl,
         child: &VersionedUrl,
-    ) -> impl Future<Output = Result<bool, Report<impl ::core::error::Error + Send + Sync + 'static>>> + Send;
+    ) -> impl Future<
+        Output = Result<bool, Report<impl ::core::error::Error + Send + Sync + 'static>>,
+    > + Send;
 
     fn find_parents(
         &self,
         entity_types: &[VersionedUrl],
-    ) -> impl Future<Output = Result<Vec<VersionedUrl>, Report<impl ::core::error::Error + Send + Sync + 'static>>> + Send;
+    ) -> impl Future<
+        Output = Result<
+            Vec<VersionedUrl>,
+            Report<impl ::core::error::Error + Send + Sync + 'static>,
+        >,
+    > + Send;
 }

--- a/libs/@local/hash-graph-types/rust/src/ontology/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/ontology/mod.rs
@@ -172,7 +172,7 @@ pub trait OntologyTypeProvider<O> {
     fn provide_type(
         &self,
         type_id: &VersionedUrl,
-    ) -> impl Future<Output = Result<Self::Value, Report<impl Context>>> + Send;
+    ) -> impl Future<Output = Result<Self::Value, Report<impl ::core::error::Error + Send + Sync + 'static>>> + Send;
 }
 
 pub trait DataTypeProvider: OntologyTypeProvider<DataTypeWithMetadata> {
@@ -180,13 +180,13 @@ pub trait DataTypeProvider: OntologyTypeProvider<DataTypeWithMetadata> {
         &self,
         child: &VersionedUrl,
         parent: &BaseUrl,
-    ) -> impl Future<Output = Result<bool, Report<impl Context>>> + Send;
+    ) -> impl Future<Output = Result<bool, Report<impl ::core::error::Error + Send + Sync + 'static>>> + Send;
 
     fn find_conversion(
         &self,
         source_data_type_id: &VersionedUrl,
         target_data_type_id: &VersionedUrl,
-    ) -> impl Future<Output = Result<impl Borrow<Vec<ConversionExpression>>, Report<impl Context>>> + Send;
+    ) -> impl Future<Output = Result<impl Borrow<Vec<ConversionExpression>>, Report<impl ::core::error::Error + Send + Sync + 'static>>> + Send;
 }
 
 pub trait PropertyTypeProvider: OntologyTypeProvider<PropertyType> {}
@@ -202,10 +202,10 @@ pub trait EntityTypeProvider: OntologyTypeProvider<ClosedEntityType> {
         &self,
         parent: &VersionedUrl,
         child: &VersionedUrl,
-    ) -> impl Future<Output = Result<bool, Report<impl Context>>> + Send;
+    ) -> impl Future<Output = Result<bool, Report<impl ::core::error::Error + Send + Sync + 'static>>> + Send;
 
     fn find_parents(
         &self,
         entity_types: &[VersionedUrl],
-    ) -> impl Future<Output = Result<Vec<VersionedUrl>, Report<impl Context>>> + Send;
+    ) -> impl Future<Output = Result<Vec<VersionedUrl>, Report<impl ::core::error::Error + Send + Sync + 'static>>> + Send;
 }

--- a/libs/@local/hash-graph-types/rust/src/ontology/mod.rs
+++ b/libs/@local/hash-graph-types/rust/src/ontology/mod.rs
@@ -3,7 +3,7 @@ mod entity_type;
 mod property_type;
 mod provenance;
 
-use core::{borrow::Borrow, fmt};
+use core::{borrow::Borrow, error::Error, fmt};
 
 use error_stack::Report;
 use serde::{Deserialize, Serialize};
@@ -172,9 +172,7 @@ pub trait OntologyTypeProvider<O> {
     fn provide_type(
         &self,
         type_id: &VersionedUrl,
-    ) -> impl Future<
-        Output = Result<Self::Value, Report<impl ::core::error::Error + Send + Sync + 'static>>,
-    > + Send;
+    ) -> impl Future<Output = Result<Self::Value, Report<impl Error + Send + Sync + 'static>>> + Send;
 }
 
 pub trait DataTypeProvider: OntologyTypeProvider<DataTypeWithMetadata> {
@@ -182,9 +180,7 @@ pub trait DataTypeProvider: OntologyTypeProvider<DataTypeWithMetadata> {
         &self,
         child: &VersionedUrl,
         parent: &BaseUrl,
-    ) -> impl Future<
-        Output = Result<bool, Report<impl ::core::error::Error + Send + Sync + 'static>>,
-    > + Send;
+    ) -> impl Future<Output = Result<bool, Report<impl Error + Send + Sync + 'static>>> + Send;
 
     fn find_conversion(
         &self,
@@ -193,7 +189,7 @@ pub trait DataTypeProvider: OntologyTypeProvider<DataTypeWithMetadata> {
     ) -> impl Future<
         Output = Result<
             impl Borrow<Vec<ConversionExpression>>,
-            Report<impl ::core::error::Error + Send + Sync + 'static>,
+            Report<impl Error + Send + Sync + 'static>,
         >,
     > + Send;
 }
@@ -211,17 +207,10 @@ pub trait EntityTypeProvider: OntologyTypeProvider<ClosedEntityType> {
         &self,
         parent: &VersionedUrl,
         child: &VersionedUrl,
-    ) -> impl Future<
-        Output = Result<bool, Report<impl ::core::error::Error + Send + Sync + 'static>>,
-    > + Send;
+    ) -> impl Future<Output = Result<bool, Report<impl Error + Send + Sync + 'static>>> + Send;
 
     fn find_parents(
         &self,
         entity_types: &[VersionedUrl],
-    ) -> impl Future<
-        Output = Result<
-            Vec<VersionedUrl>,
-            Report<impl ::core::error::Error + Send + Sync + 'static>,
-        >,
-    > + Send;
+    ) -> impl Future<Output = Result<Vec<VersionedUrl>, Report<impl Error + Send + Sync + 'static>>> + Send;
 }

--- a/libs/@local/hash-validation/package.json
+++ b/libs/@local/hash-validation/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",
+    "@rust/error-stack": "0.5.0",
     "@rust/graph-types": "0.0.0-private"
   },
   "devDependencies": {

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -10,14 +10,14 @@ mod property;
 mod test_data_type;
 mod test_property_type;
 
-use core::borrow::Borrow;
+use core::{borrow::Borrow, error::Error};
 
 use error_stack::Report;
 use graph_types::knowledge::entity::{Entity, EntityId};
 use serde::Deserialize;
 
 pub trait Schema<V: ?Sized, P: Sync> {
-    type Error: ::core::error::Error + Send + Sync + 'static;
+    type Error: Error + Send + Sync + 'static;
 
     fn validate_value<'a>(
         &'a self,
@@ -73,7 +73,7 @@ impl Default for ValidateEntityComponents {
 }
 
 pub trait Validate<S, C> {
-    type Error: ::core::error::Error + Send + Sync + 'static;
+    type Error: Error + Send + Sync + 'static;
 
     fn validate(
         &self,
@@ -90,7 +90,7 @@ pub trait EntityProvider {
     ) -> impl Future<
         Output = Result<
             impl Borrow<Entity> + Send + Sync,
-            Report<impl ::core::error::Error + Send + Sync + 'static>,
+            Report<impl Error + Send + Sync + 'static>,
         >,
     > + Send;
 }

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -87,7 +87,7 @@ pub trait EntityProvider {
     fn provide_entity(
         &self,
         entity_id: EntityId,
-    ) -> impl Future<Output = Result<impl Borrow<Entity> + Send + Sync, Report<impl Context>>> + Send;
+    ) -> impl Future<Output = Result<impl Borrow<Entity> + Send + Sync, Report<impl ::core::error::Error + Send + Sync + 'static>>> + Send;
 }
 
 #[cfg(test)]

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -12,7 +12,7 @@ mod test_property_type;
 
 use core::borrow::Borrow;
 
-use error_stack::{Context, Report};
+use error_stack::Report;
 use graph_types::knowledge::entity::{Entity, EntityId};
 use serde::Deserialize;
 
@@ -87,7 +87,12 @@ pub trait EntityProvider {
     fn provide_entity(
         &self,
         entity_id: EntityId,
-    ) -> impl Future<Output = Result<impl Borrow<Entity> + Send + Sync, Report<impl ::core::error::Error + Send + Sync + 'static>>> + Send;
+    ) -> impl Future<
+        Output = Result<
+            impl Borrow<Entity> + Send + Sync,
+            Report<impl ::core::error::Error + Send + Sync + 'static>,
+        >,
+    > + Send;
 }
 
 #[cfg(test)]

--- a/libs/@local/hash-validation/src/lib.rs
+++ b/libs/@local/hash-validation/src/lib.rs
@@ -17,7 +17,7 @@ use graph_types::knowledge::entity::{Entity, EntityId};
 use serde::Deserialize;
 
 pub trait Schema<V: ?Sized, P: Sync> {
-    type Error: Context;
+    type Error: ::core::error::Error + Send + Sync + 'static;
 
     fn validate_value<'a>(
         &'a self,
@@ -73,7 +73,7 @@ impl Default for ValidateEntityComponents {
 }
 
 pub trait Validate<S, C> {
-    type Error: Context;
+    type Error: ::core::error::Error + Send + Sync + 'static;
 
     fn validate(
         &self,

--- a/libs/@local/hql/diagnostics/package.json
+++ b/libs/@local/hql/diagnostics/package.json
@@ -9,6 +9,7 @@
     "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
   },
   "dependencies": {
+    "@rust/error-stack": "0.5.0",
     "@rust/hql-span": "0.0.0-private"
   }
 }

--- a/libs/@local/hql/diagnostics/src/diagnostic.rs
+++ b/libs/@local/hql/diagnostics/src/diagnostic.rs
@@ -4,7 +4,7 @@ use core::{
 };
 
 use ariadne::ColorGenerator;
-use error_stack::{Report, Result, TryReportIteratorExt as _, TryReportTupleExt as _};
+use error_stack::{Report, TryReportIteratorExt as _, TryReportTupleExt as _};
 use hql_span::{Span, SpanId, storage::SpanStorage, tree::SpanNode};
 
 use crate::{
@@ -60,7 +60,7 @@ impl<'a> Diagnostic<'a, SpanId> {
     pub fn resolve<S>(
         self,
         storage: &SpanStorage<S>,
-    ) -> Result<Diagnostic<'a, SpanNode<S>>, [ResolveError]>
+    ) -> Result<Diagnostic<'a, SpanNode<S>>, Report<[ResolveError]>>
     where
         S: Span + Clone,
     {

--- a/libs/@local/hql/diagnostics/src/label.rs
+++ b/libs/@local/hql/diagnostics/src/label.rs
@@ -1,6 +1,6 @@
 use anstyle::Color;
 use ariadne::ColorGenerator;
-use error_stack::{Report, Result};
+use error_stack::Report;
 use hql_span::{Span, SpanId, storage::SpanStorage, tree::SpanNode};
 
 use crate::{
@@ -71,7 +71,7 @@ impl Label<SpanId> {
     pub(crate) fn resolve<S>(
         self,
         storage: &SpanStorage<S>,
-    ) -> Result<Label<SpanNode<S>>, ResolveError>
+    ) -> Result<Label<SpanNode<S>>, Report<ResolveError>>
     where
         S: Span + Clone,
     {

--- a/libs/@local/repo-chores/rust/package.json
+++ b/libs/@local/repo-chores/rust/package.json
@@ -9,5 +9,8 @@
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
     "upload-benchmarks": "../../../../target/debug/repo-chores-cli benches upload"
+  },
+  "dependencies": {
+    "@rust/error-stack": "0.5.0"
   }
 }

--- a/libs/@local/repo-chores/rust/src/benches/analyze/tracing.rs
+++ b/libs/@local/repo-chores/rust/src/benches/analyze/tracing.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use error_stack::{Context, Report};
+use error_stack::Report;
 use inferno::flamegraph;
 
 use crate::benches::{generate_path, report::Measurement};

--- a/libs/@local/repo-chores/rust/src/benches/analyze/tracing.rs
+++ b/libs/@local/repo-chores/rust/src/benches/analyze/tracing.rs
@@ -1,3 +1,4 @@
+use core::error::Error;
 use std::{
     fs::File,
     io,
@@ -72,7 +73,7 @@ impl FoldedStacks {
     pub fn create_flame_graph(
         &self,
         mut options: flamegraph::Options,
-    ) -> Result<FlameGraph, Report<impl ::core::error::Error + Send + Sync + 'static>> {
+    ) -> Result<FlameGraph, Report<impl Error + Send + Sync + 'static>> {
         let mut buffer = Vec::new();
         flamegraph::from_lines(
             &mut options,

--- a/libs/@local/repo-chores/rust/src/benches/analyze/tracing.rs
+++ b/libs/@local/repo-chores/rust/src/benches/analyze/tracing.rs
@@ -72,7 +72,7 @@ impl FoldedStacks {
     pub fn create_flame_graph(
         &self,
         mut options: flamegraph::Options,
-    ) -> Result<FlameGraph, Report<impl Context>> {
+    ) -> Result<FlameGraph, Report<impl ::core::error::Error + Send + Sync + 'static>> {
         let mut buffer = Vec::new();
         flamegraph::from_lines(
             &mut options,

--- a/libs/@local/temporal-client/package.json
+++ b/libs/@local/temporal-client/package.json
@@ -8,6 +8,7 @@
     "lint:clippy": "just clippy"
   },
   "dependencies": {
+    "@rust/error-stack": "0.5.0",
     "@rust/graph-types": "0.0.0-private"
   }
 }

--- a/libs/@local/tracing/package.json
+++ b/libs/@local/tracing/package.json
@@ -6,5 +6,8 @@
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy"
+  },
+  "dependencies": {
+    "@rust/error-stack": "0.5.0"
   }
 }

--- a/libs/chonky/package.json
+++ b/libs/chonky/package.json
@@ -6,5 +6,8 @@
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
     "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
+  },
+  "dependencies": {
+    "@rust/error-stack": "0.5.0"
   }
 }

--- a/libs/deer/desert/package.json
+++ b/libs/deer/desert/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-private",
   "private": true,
   "dependencies": {
-    "@rust/deer": "0.0.0-reserved-private"
+    "@rust/deer": "0.0.0-reserved-private",
+    "@rust/error-stack": "0.5.0"
   }
 }

--- a/libs/deer/desert/src/array.rs
+++ b/libs/deer/desert/src/array.rs
@@ -2,7 +2,7 @@ use deer::{
     Context, Deserialize, Deserializer as _,
     error::{ArrayAccessError, ArrayLengthError},
 };
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 
 use crate::{deserializer::Deserializer, skip::skip_tokens, token::Token};
 
@@ -34,7 +34,7 @@ impl<'de> deer::ArrayAccess<'de> for ArrayAccess<'_, '_, 'de> {
         self.deserializer.context()
     }
 
-    fn next<T>(&mut self) -> Option<Result<T, ArrayAccessError>>
+    fn next<T>(&mut self) -> Option<Result<T, Report<ArrayAccessError>>>
     where
         T: Deserialize<'de>,
     {
@@ -54,7 +54,7 @@ impl<'de> deer::ArrayAccess<'de> for ArrayAccess<'_, '_, 'de> {
         self.length
     }
 
-    fn end(self) -> Result<(), ArrayAccessError> {
+    fn end(self) -> Result<(), Report<ArrayAccessError>> {
         // ensure that we consume the last token, if it is the wrong token error out
         let result = if self.deserializer.peek() == Token::ArrayEnd {
             Ok(())

--- a/libs/deer/desert/src/deserializer.rs
+++ b/libs/deer/desert/src/deserializer.rs
@@ -10,7 +10,7 @@ use deer::{
     helpers::EnumObjectVisitor,
     value::NoneDeserializer,
 };
-use error_stack::{Report, Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use num_traits::ToPrimitive as _;
 
 use crate::{
@@ -20,7 +20,7 @@ use crate::{
 macro_rules! forward {
     ($($method:ident),*) => {
         $(
-        fn $method<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+        fn $method<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
         where
             V: Visitor<'de>,
         {
@@ -56,7 +56,7 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
         self.context
     }
 
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: Visitor<'de>,
     {
@@ -84,7 +84,7 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
         .change_context(DeserializerError)
     }
 
-    fn deserialize_optional<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_optional<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: OptionalVisitor<'de>,
     {
@@ -101,7 +101,7 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
         .change_context(DeserializerError)
     }
 
-    fn deserialize_enum<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_enum<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: EnumVisitor<'de>,
     {
@@ -120,7 +120,7 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
         }
     }
 
-    fn deserialize_struct<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_struct<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: StructVisitor<'de>,
     {
@@ -140,13 +140,13 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
         }
     }
 
-    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: IdentifierVisitor<'de>,
     {
         let token = self.next();
 
-        let visit_try = |value: core::result::Result<u64, TryFromIntError>| {
+        let visit_try = |value: Result<u64, TryFromIntError>| {
             value
                 .change_context(ValueError.into_error())
                 .attach(ExpectedType::new(visitor.expecting()))

--- a/libs/deer/desert/src/object.rs
+++ b/libs/deer/desert/src/object.rs
@@ -2,7 +2,7 @@ use deer::{
     Context, Deserializer as _, FieldVisitor,
     error::{ObjectAccessError, ObjectLengthError},
 };
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 
 use crate::{deserializer::Deserializer, skip::skip_tokens, token::Token};
 
@@ -35,10 +35,7 @@ impl<'de> deer::ObjectAccess<'de> for ObjectAccess<'_, '_, 'de> {
         self.deserializer.context()
     }
 
-    fn try_field<F>(
-        &mut self,
-        visitor: F,
-    ) -> core::result::Result<Result<F::Value, ObjectAccessError>, F>
+    fn try_field<F>(&mut self, visitor: F) -> Result<Result<F::Value, Report<ObjectAccessError>>, F>
     where
         F: FieldVisitor<'de>,
     {
@@ -67,7 +64,7 @@ impl<'de> deer::ObjectAccess<'de> for ObjectAccess<'_, '_, 'de> {
         self.length
     }
 
-    fn end(self) -> Result<(), ObjectAccessError> {
+    fn end(self) -> Result<(), Report<ObjectAccessError>> {
         // ensure that we consume the last token, if it is the wrong token error out
         let result = if self.deserializer.peek() == Token::ObjectEnd {
             Ok(())

--- a/libs/deer/json/package.json
+++ b/libs/deer/json/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "license": "MIT OR Apache-2.0",
   "dependencies": {
-    "@rust/deer": "0.0.0-reserved-private"
+    "@rust/deer": "0.0.0-reserved-private",
+    "@rust/error-stack": "0.5.0"
   }
 }

--- a/libs/deer/json/src/array.rs
+++ b/libs/deer/json/src/array.rs
@@ -2,7 +2,7 @@ use deer::{
     Context, Deserialize, Deserializer as _,
     error::{ArrayAccessError, ArrayLengthError, DeserializerError, Error, Variant as _},
 };
-use error_stack::{Report, ReportSink, Result, ResultExt as _};
+use error_stack::{Report, ReportSink, ResultExt as _};
 use justjson::parser::{PeekableTokenKind, Token};
 
 use crate::{
@@ -21,7 +21,7 @@ pub(crate) struct ArrayAccess<'a, 'b, 'de: 'a> {
 impl<'a, 'b, 'de: 'a> ArrayAccess<'a, 'b, 'de> {
     pub(crate) fn new(
         deserializer: &'a mut Deserializer<'b, 'de>,
-    ) -> Result<Self, DeserializerError> {
+    ) -> Result<Self, Report<DeserializerError>> {
         deserializer.try_stack_push(&Token::Array)?;
 
         Ok(Self {
@@ -31,7 +31,7 @@ impl<'a, 'b, 'de: 'a> ArrayAccess<'a, 'b, 'de> {
         })
     }
 
-    fn try_skip_comma(&mut self) -> Result<(), Error> {
+    fn try_skip_comma(&mut self) -> Result<(), Report<Error>> {
         self.deserializer
             .try_skip(PeekableTokenKind::Comma, SyntaxError::ExpectedComma)
     }
@@ -46,7 +46,7 @@ impl<'de> deer::ArrayAccess<'de> for ArrayAccess<'_, '_, 'de> {
         self.deserializer.context()
     }
 
-    fn next<T>(&mut self) -> Option<Result<T, ArrayAccessError>>
+    fn next<T>(&mut self) -> Option<Result<T, Report<ArrayAccessError>>>
     where
         T: Deserialize<'de>,
     {
@@ -89,7 +89,7 @@ impl<'de> deer::ArrayAccess<'de> for ArrayAccess<'_, '_, 'de> {
         None
     }
 
-    fn end(self) -> Result<(), ArrayAccessError> {
+    fn end(self) -> Result<(), Report<ArrayAccessError>> {
         self.deserializer.stack.pop();
 
         let result = match self.deserializer.peek() {

--- a/libs/deer/json/src/deserializer.rs
+++ b/libs/deer/json/src/deserializer.rs
@@ -10,7 +10,7 @@ use deer::{
     schema::Document,
     value::NoneDeserializer,
 };
-use error_stack::{Report, ReportSink, Result, ResultExt as _};
+use error_stack::{Report, ReportSink, ResultExt as _};
 use justjson::{
     AnyStr,
     parser::{PeekableTokenKind, Token, Tokenizer},
@@ -52,7 +52,7 @@ impl Stack {
         Self { limit, depth: 0 }
     }
 
-    pub(crate) fn push(&mut self) -> Result<(), DeserializerError> {
+    pub(crate) fn push(&mut self) -> Result<(), Report<DeserializerError>> {
         self.depth += 1;
 
         if self.depth >= self.limit {
@@ -89,7 +89,7 @@ impl<'a, 'de> Deserializer<'a, 'de> {
         }
     }
 
-    fn next(&mut self) -> Result<Token<'de>, DeserializerError> {
+    fn next(&mut self) -> Result<Token<'de>, Report<DeserializerError>> {
         let offset = self.tokenizer.offset();
         let Some(token) = self.tokenizer.next() else {
             return Err(Report::new(SyntaxError::UnexpectedEof.into_error())
@@ -102,7 +102,7 @@ impl<'a, 'de> Deserializer<'a, 'de> {
             .change_context(DeserializerError)
     }
 
-    fn next_value(&mut self) -> Result<ValueToken<'de>, DeserializerError> {
+    fn next_value(&mut self) -> Result<ValueToken<'de>, Report<DeserializerError>> {
         let token = self.next()?;
 
         ValueToken::try_from(token).change_context(DeserializerError)
@@ -139,7 +139,7 @@ impl<'a, 'de> Deserializer<'a, 'de> {
         &mut self,
         token: PeekableTokenKind,
         error: SyntaxError,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Report<Error>> {
         if self.skip_if(token).is_none() {
             Err(Report::new(error.into_error()).attach(Position::new(self.offset())))
         } else {
@@ -155,7 +155,10 @@ impl<'a, 'de> Deserializer<'a, 'de> {
         self.tokenizer.offset()
     }
 
-    pub(crate) fn try_stack_push(&mut self, token: &Token) -> Result<(), DeserializerError> {
+    pub(crate) fn try_stack_push(
+        &mut self,
+        token: &Token,
+    ) -> Result<(), Report<DeserializerError>> {
         if let Err(error) = self.stack.push() {
             // we can still recover, we pop us again from the stack as we stopped before and do not
             // commit. We still show the error, but we could continue, so we skip all tokens.
@@ -187,7 +190,7 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
         self.context
     }
 
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: Visitor<'de>,
     {
@@ -211,7 +214,7 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
         .change_context(DeserializerError)
     }
 
-    fn deserialize_null<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_null<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: Visitor<'de>,
     {
@@ -223,7 +226,7 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
         }
     }
 
-    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: Visitor<'de>,
     {
@@ -235,7 +238,7 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
         }
     }
 
-    fn deserialize_number<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_number<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: Visitor<'de>,
     {
@@ -249,21 +252,21 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
         }
     }
 
-    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: Visitor<'de>,
     {
         self.deserialize_str(visitor)
     }
 
-    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: Visitor<'de>,
     {
         self.deserialize_str(visitor)
     }
 
-    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: Visitor<'de>,
     {
@@ -279,21 +282,21 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
         }
     }
 
-    fn deserialize_bytes<V>(self, _: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_bytes<V>(self, _: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: Visitor<'de>,
     {
         Err(Report::new(BytesUnsupportedError.into_error()).change_context(DeserializerError))
     }
 
-    fn deserialize_bytes_buffer<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_bytes_buffer<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: Visitor<'de>,
     {
         self.deserialize_bytes(visitor)
     }
 
-    fn deserialize_array<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_array<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: Visitor<'de>,
     {
@@ -307,7 +310,7 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
         }
     }
 
-    fn deserialize_object<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_object<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: Visitor<'de>,
     {
@@ -321,7 +324,7 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
         }
     }
 
-    fn deserialize_optional<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_optional<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: OptionalVisitor<'de>,
     {
@@ -340,7 +343,7 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
         }
     }
 
-    fn deserialize_enum<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_enum<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: EnumVisitor<'de>,
     {
@@ -427,7 +430,7 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
         value.change_context(DeserializerError)
     }
 
-    fn deserialize_struct<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_struct<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: StructVisitor<'de>,
     {
@@ -444,7 +447,7 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
         }
     }
 
-    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: IdentifierVisitor<'de>,
     {

--- a/libs/deer/json/src/lib.rs
+++ b/libs/deer/json/src/lib.rs
@@ -14,11 +14,14 @@ mod token;
 extern crate alloc;
 
 use deer::{Context, Deserialize, error::DeserializeError};
-use error_stack::Result;
+use error_stack::Report;
 
 pub use crate::deserializer::{Deserializer, StackLimit};
 
-pub fn from_slice<'de, T>(slice: &'de [u8], context: &Context) -> Result<T, DeserializeError>
+pub fn from_slice<'de, T>(
+    slice: &'de [u8],
+    context: &Context,
+) -> Result<T, Report<DeserializeError>>
 where
     T: Deserialize<'de>,
 {
@@ -27,7 +30,7 @@ where
     T::deserialize(&mut deserializer)
 }
 
-pub fn from_str<'de, T>(value: &'de str, context: &Context) -> Result<T, DeserializeError>
+pub fn from_str<'de, T>(value: &'de str, context: &Context) -> Result<T, Report<DeserializeError>>
 where
     T: Deserialize<'de>,
 {

--- a/libs/deer/json/src/number.rs
+++ b/libs/deer/json/src/number.rs
@@ -12,7 +12,7 @@ use lexical::{
 use crate::error::NumberError;
 
 #[cfg(not(feature = "arbitrary-precision"))]
-pub(crate) fn try_convert_number(number: &JsonNumber) -> Result<Number, Error> {
+pub(crate) fn try_convert_number(number: &JsonNumber) -> Result<Number, Report<Error>> {
     let number_source = number.source();
     let negative = number_source.as_bytes().first().copied() == Some(b'-');
 

--- a/libs/deer/json/src/number.rs
+++ b/libs/deer/json/src/number.rs
@@ -1,9 +1,7 @@
 #[cfg(not(feature = "arbitrary-precision"))]
 use deer::error::Variant as _;
 use deer::{Number, error::Error};
-#[cfg(not(feature = "arbitrary-precision"))]
 use error_stack::Report;
-use error_stack::Result;
 use justjson::JsonNumber;
 #[cfg(not(feature = "arbitrary-precision"))]
 use lexical::{
@@ -56,7 +54,7 @@ pub(crate) fn try_convert_number(number: &JsonNumber) -> Result<Number, Error> {
 
 #[cfg(feature = "arbitrary-precision")]
 #[expect(clippy::unnecessary_wraps)]
-pub(crate) fn try_convert_number(number: &JsonNumber) -> Result<Number, Error> {
+pub(crate) fn try_convert_number(number: &JsonNumber) -> Result<Number, Report<Error>> {
     #[expect(unsafe_code)]
     // SAFETY: `justjson` ensures that the contained source is a valid JSON number, these are
     // accepted by the parse algorithm of Rust

--- a/libs/deer/json/src/object.rs
+++ b/libs/deer/json/src/object.rs
@@ -2,7 +2,7 @@ use deer::{
     Context, Deserializer as _, FieldVisitor,
     error::{DeserializerError, Error, ObjectAccessError, ObjectLengthError, Variant as _},
 };
-use error_stack::{Report, ReportSink, Result, ResultExt as _};
+use error_stack::{Report, ReportSink, ResultExt as _};
 use justjson::parser::{PeekableTokenKind, Token};
 
 use crate::{
@@ -21,7 +21,7 @@ pub(crate) struct ObjectAccess<'a, 'b, 'de: 'a> {
 impl<'a, 'b, 'de: 'a> ObjectAccess<'a, 'b, 'de> {
     pub(crate) fn new(
         deserializer: &'a mut Deserializer<'b, 'de>,
-    ) -> Result<Self, DeserializerError> {
+    ) -> Result<Self, Report<DeserializerError>> {
         deserializer.try_stack_push(&Token::Object)?;
 
         Ok(Self {
@@ -32,13 +32,13 @@ impl<'a, 'b, 'de: 'a> ObjectAccess<'a, 'b, 'de> {
         })
     }
 
-    pub(crate) fn try_skip_colon(&mut self) -> Result<(), Error> {
+    pub(crate) fn try_skip_colon(&mut self) -> Result<(), Report<Error>> {
         // skip `:`, be tolerant if someone forgot, but still propagate the error
         self.deserializer
             .try_skip(PeekableTokenKind::Colon, SyntaxError::ExpectedColon)
     }
 
-    pub(crate) fn try_skip_comma(&mut self) -> Result<(), Error> {
+    pub(crate) fn try_skip_comma(&mut self) -> Result<(), Report<Error>> {
         self.deserializer
             .try_skip(PeekableTokenKind::Comma, SyntaxError::ExpectedComma)
     }
@@ -56,7 +56,7 @@ impl<'de> deer::ObjectAccess<'de> for ObjectAccess<'_, '_, 'de> {
     fn try_field<F>(
         &mut self,
         visitor: F,
-    ) -> core::result::Result<Result<F::Value, ObjectAccessError>, F>
+    ) -> core::result::Result<Result<F::Value, Report<ObjectAccessError>>, F>
     where
         F: FieldVisitor<'de>,
     {
@@ -151,7 +151,7 @@ impl<'de> deer::ObjectAccess<'de> for ObjectAccess<'_, '_, 'de> {
         None
     }
 
-    fn end(self) -> Result<(), ObjectAccessError> {
+    fn end(self) -> Result<(), Report<ObjectAccessError>> {
         self.deserializer.stack.pop();
 
         let result = match self.deserializer.peek() {

--- a/libs/deer/src/error/mod.rs
+++ b/libs/deer/src/error/mod.rs
@@ -65,7 +65,7 @@ use core::{
 };
 
 pub use duplicate::{DuplicateField, DuplicateFieldError, DuplicateKey, DuplicateKeyError};
-use error_stack::{Context, Frame, Report};
+use error_stack::{Frame, Report};
 pub use extra::{
     ArrayLengthError, ExpectedLength, ObjectItemsExtraError, ObjectLengthError, ReceivedKey,
     ReceivedLength,

--- a/libs/deer/src/error/mod.rs
+++ b/libs/deer/src/error/mod.rs
@@ -463,17 +463,17 @@ error!(
     ArrayAccessError: "array access encountered one or more errors during access"
 );
 
-pub trait ReportExt<C: Context> {
+pub trait ReportExt<C: ::core::error::Error + Send + Sync + 'static> {
     fn export(self) -> Export<C>;
 }
 
-impl<C: Context> ReportExt<C> for Report<C> {
+impl<C: ::core::error::Error + Send + Sync + 'static> ReportExt<C> for Report<C> {
     fn export(self) -> Export<C> {
         Export::new(self.expand())
     }
 }
 
-impl<C: Context> ReportExt<C> for Report<[C]> {
+impl<C: ::core::error::Error + Send + Sync + 'static> ReportExt<C> for Report<[C]> {
     fn export(self) -> Export<C> {
         Export::new(self)
     }

--- a/libs/deer/src/error/mod.rs
+++ b/libs/deer/src/error/mod.rs
@@ -167,7 +167,7 @@ impl SerdeSerializeError {
 impl core::error::Error for SerdeSerializeError {}
 
 #[cfg(all(not(nightly), not(feature = "std")))]
-impl ::core::error::Error for SerdeSerializeError {}
+impl Error for SerdeSerializeError {}
 
 #[cfg(all(not(nightly), feature = "std"))]
 impl std::error::Error for SerdeSerializeError {}
@@ -386,18 +386,12 @@ impl Error {
     }
 }
 
-#[cfg(nightly)]
 impl core::error::Error for Error {
+    #[cfg(nightly)]
     fn provide<'a>(&'a self, request: &mut Request<'a>) {
         (self.provide)(&self.variant, request);
     }
 }
-
-#[cfg(all(not(nightly), not(feature = "std")))]
-impl ::core::error::Error for Error {}
-
-#[cfg(all(not(nightly), feature = "std"))]
-impl std::error::Error for Error {}
 
 /// This macro makes implementation of error structs easier, by implementing all necessary
 /// traits automatically and removing significant boilerplate.
@@ -463,17 +457,17 @@ error!(
     ArrayAccessError: "array access encountered one or more errors during access"
 );
 
-pub trait ReportExt<C: ::core::error::Error + Send + Sync + 'static> {
+pub trait ReportExt<C: core::error::Error + Send + Sync + 'static> {
     fn export(self) -> Export<C>;
 }
 
-impl<C: ::core::error::Error + Send + Sync + 'static> ReportExt<C> for Report<C> {
+impl<C: core::error::Error + Send + Sync + 'static> ReportExt<C> for Report<C> {
     fn export(self) -> Export<C> {
         Export::new(self.expand())
     }
 }
 
-impl<C: ::core::error::Error + Send + Sync + 'static> ReportExt<C> for Report<[C]> {
+impl<C: core::error::Error + Send + Sync + 'static> ReportExt<C> for Report<[C]> {
     fn export(self) -> Export<C> {
         Export::new(self)
     }

--- a/libs/deer/src/error/mod.rs
+++ b/libs/deer/src/error/mod.rs
@@ -65,7 +65,7 @@ use core::{
 };
 
 pub use duplicate::{DuplicateField, DuplicateFieldError, DuplicateKey, DuplicateKeyError};
-use error_stack::{Context, Frame, Report, Result};
+use error_stack::{Context, Frame, Report};
 pub use extra::{
     ArrayLengthError, ExpectedLength, ObjectItemsExtraError, ObjectLengthError, ReceivedKey,
     ReceivedLength,
@@ -203,7 +203,7 @@ pub trait ErrorProperties {
 
     fn value<'a>(stack: &[&'a Frame]) -> Self::Value<'a>;
 
-    fn output<S>(value: Self::Value<'_>, map: &mut S) -> Result<(), [SerdeSerializeError]>
+    fn output<S>(value: Self::Value<'_>, map: &mut S) -> Result<(), Report<[SerdeSerializeError]>>
     where
         S: SerializeMap;
 }
@@ -223,7 +223,7 @@ impl<T: ErrorProperty + 'static> ErrorProperties for T {
         <T as ErrorProperty>::value(stack)
     }
 
-    fn output<S>(value: Self::Value<'_>, map: &mut S) -> Result<(), [SerdeSerializeError]>
+    fn output<S>(value: Self::Value<'_>, map: &mut S) -> Result<(), Report<[SerdeSerializeError]>>
     where
         S: SerializeMap,
     {

--- a/libs/deer/src/error/mod.rs
+++ b/libs/deer/src/error/mod.rs
@@ -167,7 +167,7 @@ impl SerdeSerializeError {
 impl core::error::Error for SerdeSerializeError {}
 
 #[cfg(all(not(nightly), not(feature = "std")))]
-impl error_stack::Context for SerdeSerializeError {}
+impl ::core::error::Error for SerdeSerializeError {}
 
 #[cfg(all(not(nightly), feature = "std"))]
 impl std::error::Error for SerdeSerializeError {}
@@ -394,7 +394,7 @@ impl core::error::Error for Error {
 }
 
 #[cfg(all(not(nightly), not(feature = "std")))]
-impl error_stack::Context for Error {}
+impl ::core::error::Error for Error {}
 
 #[cfg(all(not(nightly), feature = "std"))]
 impl std::error::Error for Error {}

--- a/libs/deer/src/error/serialize.rs
+++ b/libs/deer/src/error/serialize.rs
@@ -7,7 +7,7 @@ use core::{
     iter::once,
 };
 
-use error_stack::{Context, Frame, Report};
+use error_stack::{Frame, Report};
 use serde::{
     Serialize, Serializer,
     ser::{Error as _, SerializeMap as _},
@@ -277,7 +277,7 @@ mod tests {
     use alloc::{format, vec, vec::Vec};
     use core::fmt::{Display, Formatter};
 
-    use error_stack::{AttachmentKind, Context, Frame, FrameKind, Report};
+    use error_stack::{AttachmentKind, Frame, FrameKind, Report};
     use serde_json::{json, to_value};
     use similar_asserts::assert_serde_eq;
 

--- a/libs/deer/src/error/serialize.rs
+++ b/libs/deer/src/error/serialize.rs
@@ -134,7 +134,7 @@ struct FrameSplitIterator<'a> {
 }
 
 impl<'a> FrameSplitIterator<'a> {
-    fn new(report: &'a Report<[impl Context]>) -> Self {
+    fn new(report: &'a Report<[impl ::core::error::Error + Send + Sync + 'static]>) -> Self {
         let stack = report
             .current_frames()
             .iter()
@@ -198,7 +198,7 @@ fn divide_frames<'a>(
 }
 
 fn serialize_report<S: Serializer>(
-    report: &Report<[impl Context]>,
+    report: &Report<[impl ::core::error::Error + Send + Sync + 'static]>,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
     let frames = FrameSplitIterator::new(report);

--- a/libs/deer/src/error/serialize.rs
+++ b/libs/deer/src/error/serialize.rs
@@ -254,15 +254,15 @@ pub(super) fn impl_serialize<'a, E: Variant>(
 ///
 /// These types can then be used to generate a personalized message and will be attached to
 /// `properties` with the predefined key.
-pub struct Export<C: Context>(Report<[C]>);
+pub struct Export<C: ::core::error::Error + Send + Sync + 'static>(Report<[C]>);
 
-impl<C: Context> Export<C> {
+impl<C: ::core::error::Error + Send + Sync + 'static> Export<C> {
     pub(crate) const fn new(report: Report<[C]>) -> Self {
         Self(report)
     }
 }
 
-impl<C: Context> Serialize for Export<C> {
+impl<C: ::core::error::Error + Send + Sync + 'static> Serialize for Export<C> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/libs/deer/src/error/serialize.rs
+++ b/libs/deer/src/error/serialize.rs
@@ -310,7 +310,7 @@ mod tests {
         }
     }
 
-    impl Context for Root {}
+    impl ::core::error::Error for Root {}
 
     fn assert_stack(frames: &[&Frame], expect: &[&'static str]) {
         let frames: Vec<_> = frames
@@ -378,7 +378,7 @@ mod tests {
         }
     }
 
-    impl Context for ErrorY {}
+    impl ::core::error::Error for ErrorY {}
 
     #[derive(Debug)]
     struct ErrorZ;

--- a/libs/deer/src/error/serialize.rs
+++ b/libs/deer/src/error/serialize.rs
@@ -2,6 +2,7 @@
 use alloc::{boxed::Box, format, string::String, vec, vec::Vec};
 use core::{
     cell::Cell,
+    error::Error,
     fmt,
     fmt::{Display, Formatter},
     iter::once,
@@ -134,7 +135,7 @@ struct FrameSplitIterator<'a> {
 }
 
 impl<'a> FrameSplitIterator<'a> {
-    fn new(report: &'a Report<[impl ::core::error::Error + Send + Sync + 'static]>) -> Self {
+    fn new(report: &'a Report<[impl Error + Send + Sync + 'static]>) -> Self {
         let stack = report
             .current_frames()
             .iter()
@@ -198,7 +199,7 @@ fn divide_frames<'a>(
 }
 
 fn serialize_report<S: Serializer>(
-    report: &Report<[impl ::core::error::Error + Send + Sync + 'static]>,
+    report: &Report<[impl Error + Send + Sync + 'static]>,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
     let frames = FrameSplitIterator::new(report);
@@ -254,15 +255,15 @@ pub(super) fn impl_serialize<'a, E: Variant>(
 ///
 /// These types can then be used to generate a personalized message and will be attached to
 /// `properties` with the predefined key.
-pub struct Export<C: ::core::error::Error + Send + Sync + 'static>(Report<[C]>);
+pub struct Export<C: Error + Send + Sync + 'static>(Report<[C]>);
 
-impl<C: ::core::error::Error + Send + Sync + 'static> Export<C> {
+impl<C: Error + Send + Sync + 'static> Export<C> {
     pub(crate) const fn new(report: Report<[C]>) -> Self {
         Self(report)
     }
 }
 
-impl<C: ::core::error::Error + Send + Sync + 'static> Serialize for Export<C> {
+impl<C: Error + Send + Sync + 'static> Serialize for Export<C> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -275,7 +276,10 @@ impl<C: ::core::error::Error + Send + Sync + 'static> Serialize for Export<C> {
 mod tests {
     #[cfg_attr(feature = "std", allow(unused_imports))]
     use alloc::{format, vec, vec::Vec};
-    use core::fmt::{Display, Formatter};
+    use core::{
+        error::Error,
+        fmt::{Display, Formatter},
+    };
 
     use error_stack::{AttachmentKind, Frame, FrameKind, Report};
     use serde_json::{json, to_value};
@@ -310,7 +314,7 @@ mod tests {
         }
     }
 
-    impl ::core::error::Error for Root {}
+    impl Error for Root {}
 
     fn assert_stack(frames: &[&Frame], expect: &[&'static str]) {
         let frames: Vec<_> = frames
@@ -378,7 +382,7 @@ mod tests {
         }
     }
 
-    impl ::core::error::Error for ErrorY {}
+    impl Error for ErrorY {}
 
     #[derive(Debug)]
     struct ErrorZ;

--- a/libs/deer/src/error/serialize.rs
+++ b/libs/deer/src/error/serialize.rs
@@ -2,7 +2,6 @@
 use alloc::{boxed::Box, format, string::String, vec, vec::Vec};
 use core::{
     cell::Cell,
-    error::Error,
     fmt,
     fmt::{Display, Formatter},
     iter::once,
@@ -135,7 +134,7 @@ struct FrameSplitIterator<'a> {
 }
 
 impl<'a> FrameSplitIterator<'a> {
-    fn new(report: &'a Report<[impl Error + Send + Sync + 'static]>) -> Self {
+    fn new(report: &'a Report<[impl core::error::Error + Send + Sync + 'static]>) -> Self {
         let stack = report
             .current_frames()
             .iter()
@@ -199,7 +198,7 @@ fn divide_frames<'a>(
 }
 
 fn serialize_report<S: Serializer>(
-    report: &Report<[impl Error + Send + Sync + 'static]>,
+    report: &Report<[impl core::error::Error + Send + Sync + 'static]>,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
     let frames = FrameSplitIterator::new(report);
@@ -255,15 +254,15 @@ pub(super) fn impl_serialize<'a, E: Variant>(
 ///
 /// These types can then be used to generate a personalized message and will be attached to
 /// `properties` with the predefined key.
-pub struct Export<C: Error + Send + Sync + 'static>(Report<[C]>);
+pub struct Export<C: core::error::Error + Send + Sync + 'static>(Report<[C]>);
 
-impl<C: Error + Send + Sync + 'static> Export<C> {
+impl<C: core::error::Error + Send + Sync + 'static> Export<C> {
     pub(crate) const fn new(report: Report<[C]>) -> Self {
         Self(report)
     }
 }
 
-impl<C: Error + Send + Sync + 'static> Serialize for Export<C> {
+impl<C: core::error::Error + Send + Sync + 'static> Serialize for Export<C> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -276,10 +275,7 @@ impl<C: Error + Send + Sync + 'static> Serialize for Export<C> {
 mod tests {
     #[cfg_attr(feature = "std", allow(unused_imports))]
     use alloc::{format, vec, vec::Vec};
-    use core::{
-        error::Error,
-        fmt::{Display, Formatter},
-    };
+    use core::fmt::{Display, Formatter};
 
     use error_stack::{AttachmentKind, Frame, FrameKind, Report};
     use serde_json::{json, to_value};
@@ -314,7 +310,7 @@ mod tests {
         }
     }
 
-    impl Error for Root {}
+    impl core::error::Error for Root {}
 
     fn assert_stack(frames: &[&Frame], expect: &[&'static str]) {
         let frames: Vec<_> = frames
@@ -382,7 +378,7 @@ mod tests {
         }
     }
 
-    impl Error for ErrorY {}
+    impl core::error::Error for ErrorY {}
 
     #[derive(Debug)]
     struct ErrorZ;

--- a/libs/deer/src/error/tuple.rs
+++ b/libs/deer/src/error/tuple.rs
@@ -81,7 +81,7 @@ macro_rules! properties {
             fn output<S>(
                 value: Self::Value<'_>,
                 map: &mut S,
-            ) -> error_stack::Result<(), [SerdeSerializeError]>
+            ) -> Result<(), Report<[SerdeSerializeError]>>
             where
                 S: SerializeMap,
             {
@@ -112,7 +112,7 @@ impl ErrorProperties for () {
 
     fn value<'a>(_: &[&'a Frame]) -> Self::Value<'a> {}
 
-    fn output<S>((): Self::Value<'_>, _: &mut S) -> error_stack::Result<(), [SerdeSerializeError]>
+    fn output<S>((): Self::Value<'_>, _: &mut S) -> Result<(), Report<[SerdeSerializeError]>>
     where
         S: SerializeMap,
     {

--- a/libs/deer/src/helpers.rs
+++ b/libs/deer/src/helpers.rs
@@ -1,4 +1,4 @@
-use error_stack::{Result, ResultExt as _, TryReportTupleExt as _};
+use error_stack::{Report, ResultExt as _, TryReportTupleExt as _};
 use serde::{Serialize, Serializer, ser::SerializeMap as _};
 
 use crate::{
@@ -19,14 +19,18 @@ where
     type Key = T::Discriminant;
     type Value = T::Value;
 
-    fn visit_key<D>(&self, deserializer: D) -> Result<Self::Key, VisitorError>
+    fn visit_key<D>(&self, deserializer: D) -> Result<Self::Key, Report<VisitorError>>
     where
         D: Deserializer<'de>,
     {
         self.visitor.visit_discriminant(deserializer)
     }
 
-    fn visit_value<D>(self, key: Self::Key, deserializer: D) -> Result<Self::Value, VisitorError>
+    fn visit_value<D>(
+        self,
+        key: Self::Key,
+        deserializer: D,
+    ) -> Result<Self::Value, Report<VisitorError>>
     where
         D: Deserializer<'de>,
     {
@@ -55,7 +59,7 @@ where
         self.visitor.expecting()
     }
 
-    fn visit_object<A>(self, object: A) -> Result<Self::Value, VisitorError>
+    fn visit_object<A>(self, object: A) -> Result<Self::Value, Report<VisitorError>>
     where
         A: ObjectAccess<'de>,
     {
@@ -89,7 +93,7 @@ impl Visitor<'_> for ExpectNoneVisitor {
         Self::Value::reflection()
     }
 
-    fn visit_none(self) -> Result<Self::Value, VisitorError> {
+    fn visit_none(self) -> Result<Self::Value, Report<VisitorError>> {
         Ok(ExpectNone)
     }
 }
@@ -107,7 +111,7 @@ impl Reflection for ExpectNone {
 impl<'de> Deserialize<'de> for ExpectNone {
     type Reflection = Self;
 
-    fn deserialize<D>(deserializer: D) -> Result<Self, DeserializeError>
+    fn deserialize<D>(deserializer: D) -> Result<Self, Report<DeserializeError>>
     where
         D: Deserializer<'de>,
     {

--- a/libs/deer/src/impls/core/array.rs
+++ b/libs/deer/src/impls/core/array.rs
@@ -1,6 +1,6 @@
 use core::{marker::PhantomData, mem, mem::MaybeUninit, ptr};
 
-use error_stack::{Report, ReportSink, Result, ResultExt as _};
+use error_stack::{Report, ReportSink, ResultExt as _};
 
 use crate::{
     ArrayAccess, Deserialize, Deserializer, Document, Reflection, Schema, Visitor,
@@ -19,7 +19,7 @@ impl<'de, T: Deserialize<'de>, const N: usize> Visitor<'de> for ArrayVisitor<'de
         <[T; N]>::reflection()
     }
 
-    fn visit_array<A>(self, array: A) -> Result<Self::Value, VisitorError>
+    fn visit_array<A>(self, array: A) -> Result<Self::Value, Report<VisitorError>>
     where
         A: ArrayAccess<'de>,
     {
@@ -155,7 +155,9 @@ impl<T: Reflection + ?Sized, const N: usize> Reflection for ArrayReflection<T, N
 impl<'de, T: Deserialize<'de>, const N: usize> Deserialize<'de> for [T; N] {
     type Reflection = ArrayReflection<T::Reflection, N>;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_array(ArrayVisitor(PhantomData))
             .change_context(DeserializeError)

--- a/libs/deer/src/impls/core/bool.rs
+++ b/libs/deer/src/impls/core/bool.rs
@@ -1,4 +1,4 @@
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 
 use crate::{
     Deserialize, Deserializer, Document, Reflection, Schema, Visitor,
@@ -14,7 +14,7 @@ impl Visitor<'_> for BoolVisitor {
         bool::document()
     }
 
-    fn visit_bool(self, value: bool) -> Result<Self::Value, VisitorError> {
+    fn visit_bool(self, value: bool) -> Result<Self::Value, Report<VisitorError>> {
         Ok(value)
     }
 }
@@ -28,7 +28,9 @@ impl Reflection for bool {
 impl<'de> Deserialize<'de> for bool {
     type Reflection = Self;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_bool(BoolVisitor)
             .change_context(DeserializeError)

--- a/libs/deer/src/impls/core/bytes.rs
+++ b/libs/deer/src/impls/core/bytes.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use error_stack::ResultExt as _;
+use error_stack::{Report, ResultExt as _};
 
 use crate::{
     Deserialize, Deserializer, Document, Reflection, Schema, Visitor,
@@ -16,10 +16,7 @@ impl<'de> Visitor<'de> for BytesVisitor<'de> {
         Self::Value::reflection()
     }
 
-    fn visit_borrowed_bytes(
-        self,
-        value: &'de [u8],
-    ) -> error_stack::Result<Self::Value, VisitorError> {
+    fn visit_borrowed_bytes(self, value: &'de [u8]) -> Result<Self::Value, Report<VisitorError>> {
         Ok(value)
     }
 }
@@ -37,7 +34,7 @@ impl<'de> Deserialize<'de> for &'de [u8] {
 
     fn deserialize<D: Deserializer<'de>>(
         deserializer: D,
-    ) -> error_stack::Result<Self, DeserializeError> {
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_bytes(BytesVisitor(PhantomData))
             .change_context(DeserializeError)

--- a/libs/deer/src/impls/core/cell.rs
+++ b/libs/deer/src/impls/core/cell.rs
@@ -2,6 +2,8 @@ use core::cell::{Cell, RefCell, UnsafeCell};
 #[cfg(nightly)]
 use core::cell::{OnceCell, SyncUnsafeCell};
 
+use error_stack::Report;
+
 use crate::{Deserialize, Deserializer, Document, Reflection, Schema, error::DeserializeError};
 
 macro_rules! impl_cell {
@@ -25,7 +27,7 @@ macro_rules! impl_cell {
 
             fn deserialize<D: Deserializer<'de>>(
                 deserializer: D,
-            ) -> error_stack::Result<Self, DeserializeError> {
+            ) -> Result<Self, Report<DeserializeError>> {
                 T::deserialize(deserializer).map(Self::from)
             }
         }

--- a/libs/deer/src/impls/core/cmp.rs
+++ b/libs/deer/src/impls/core/cmp.rs
@@ -1,6 +1,6 @@
 use core::cmp::{Ordering, Reverse};
 
-use error_stack::{Report, Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 
 use crate::{
     Deserialize, Deserializer, Document, Reflection, Schema, Visitor,
@@ -13,7 +13,9 @@ use crate::{
 impl<'de, T: Deserialize<'de>> Deserialize<'de> for Reverse<T> {
     type Reflection = T::Reflection;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         T::deserialize(deserializer).map(Reverse)
     }
 }
@@ -27,7 +29,7 @@ impl Visitor<'_> for OrderingVisitor {
         Ordering::reflection()
     }
 
-    fn visit_str(self, value: &str) -> Result<Self::Value, VisitorError> {
+    fn visit_str(self, value: &str) -> Result<Self::Value, Report<VisitorError>> {
         match value {
             "Less" => Ok(Ordering::Less),
             "Equal" => Ok(Ordering::Equal),
@@ -41,7 +43,7 @@ impl Visitor<'_> for OrderingVisitor {
         }
     }
 
-    fn visit_bytes(self, value: &[u8]) -> Result<Self::Value, VisitorError> {
+    fn visit_bytes(self, value: &[u8]) -> Result<Self::Value, Report<VisitorError>> {
         match value {
             b"Less" => Ok(Ordering::Less),
             b"Equal" => Ok(Ordering::Equal),
@@ -72,7 +74,9 @@ impl Reflection for Ordering {
 impl<'de> Deserialize<'de> for Ordering {
     type Reflection = Self;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_str(OrderingVisitor)
             .change_context(DeserializeError)

--- a/libs/deer/src/impls/core/marker.rs
+++ b/libs/deer/src/impls/core/marker.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 
 use crate::{
     Deserialize, Deserializer, Document, Reflection, Schema, Visitor,
@@ -16,11 +16,11 @@ impl<T: ?Sized> Visitor<'_> for PhantomDataVisitor<T> {
         Self::Value::reflection()
     }
 
-    fn visit_none(self) -> Result<Self::Value, VisitorError> {
+    fn visit_none(self) -> Result<Self::Value, Report<VisitorError>> {
         Ok(PhantomData)
     }
 
-    fn visit_null(self) -> Result<Self::Value, VisitorError> {
+    fn visit_null(self) -> Result<Self::Value, Report<VisitorError>> {
         Ok(PhantomData)
     }
 }
@@ -38,7 +38,9 @@ impl Reflection for PhantomDataReflection {
 impl<'de, T: ?Sized> Deserialize<'de> for PhantomData<T> {
     type Reflection = PhantomDataReflection;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_null(PhantomDataVisitor(Self))
             .change_context(DeserializeError)

--- a/libs/deer/src/impls/core/mem.rs
+++ b/libs/deer/src/impls/core/mem.rs
@@ -1,13 +1,15 @@
 use core::mem::ManuallyDrop;
 
-use error_stack::Result;
+use error_stack::Report;
 
 use crate::{Deserialize, Deserializer, error::DeserializeError};
 
 impl<'de, T: Deserialize<'de>> Deserialize<'de> for ManuallyDrop<T> {
     type Reflection = T::Reflection;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         T::deserialize(deserializer).map(Self::new)
     }
 }

--- a/libs/deer/src/impls/core/num/floating.rs
+++ b/libs/deer/src/impls/core/num/floating.rs
@@ -1,4 +1,4 @@
-use error_stack::{Report, Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use num_traits::ToPrimitive as _;
 
 use crate::{

--- a/libs/deer/src/impls/core/num/integral.rs
+++ b/libs/deer/src/impls/core/num/integral.rs
@@ -1,4 +1,4 @@
-use error_stack::{Report, Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use num_traits::ToPrimitive as _;
 
 use crate::{
@@ -132,7 +132,9 @@ impl<'de> Deserialize<'de> for usize {
     }
 
     #[cfg(target_pointer_width = "64")]
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         u64::deserialize(deserializer).map(|value| value as Self)
     }
 }
@@ -161,7 +163,9 @@ impl<'de> Deserialize<'de> for isize {
     }
 
     #[cfg(target_pointer_width = "64")]
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         i64::deserialize(deserializer).map(|value| value as Self)
     }
 }

--- a/libs/deer/src/impls/core/num/mod.rs
+++ b/libs/deer/src/impls/core/num/mod.rs
@@ -37,7 +37,7 @@ macro_rules! impl_nonzero {
         impl<'de> Deserialize<'de> for $typ {
             type Reflection = Self;
 
-            fn deserialize<D: Deserializer<'de>>(deserializer: D) -> error_stack::Result<Self, DeserializeError> {
+            fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, Report<DeserializeError>> {
                 let value = $int::deserialize(deserializer)?;
 
                 Self::new(value)
@@ -77,7 +77,7 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for Wrapping<T> {
 
     fn deserialize<D: Deserializer<'de>>(
         deserializer: D,
-    ) -> error_stack::Result<Self, DeserializeError> {
+    ) -> Result<Self, Report<DeserializeError>> {
         T::deserialize(deserializer).map(Self)
     }
 }
@@ -88,7 +88,7 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for Saturating<T> {
 
     fn deserialize<D: Deserializer<'de>>(
         deserializer: D,
-    ) -> error_stack::Result<Self, DeserializeError> {
+    ) -> Result<Self, Report<DeserializeError>> {
         T::deserialize(deserializer).map(Self)
     }
 }
@@ -104,7 +104,7 @@ macro_rules! impl_num {
         impl<'de> Deserialize<'de> for $primitive {
             type Reflection = Self;
 
-            fn deserialize<D>(deserializer: D) -> Result<Self, DeserializeError>
+            fn deserialize<D>(deserializer: D) -> Result<Self, Report<DeserializeError>>
             where
                 D: Deserializer<'de>,
             {
@@ -128,7 +128,7 @@ macro_rules! impl_num {
 
 macro_rules! num_self {
     ($primitive:ident:: $visit:ident) => {
-        fn $visit(self, value: $primitive) -> Result<Self::Value, VisitorError> {
+        fn $visit(self, value: $primitive) -> Result<Self::Value, Report<VisitorError>> {
             Ok(value)
         }
     };
@@ -136,7 +136,7 @@ macro_rules! num_self {
 
 macro_rules! num_from {
     ($primitive:ident:: $visit:ident) => {
-        fn $visit(self, value: $primitive) -> Result<Self::Value, VisitorError> {
+        fn $visit(self, value: $primitive) -> Result<Self::Value, Report<VisitorError>> {
             Ok(Self::Value::from(value))
         }
     };
@@ -144,7 +144,7 @@ macro_rules! num_from {
 
 macro_rules! num_try_from {
     ($primitive:ident:: $visit:ident) => {
-        fn $visit(self, value: $primitive) -> Result<Self::Value, VisitorError> {
+        fn $visit(self, value: $primitive) -> Result<Self::Value, Report<VisitorError>> {
             Self::Value::try_from(value)
                 .change_context(ValueError.into_error())
                 .attach(ExpectedType::new(self.expecting()))
@@ -156,7 +156,7 @@ macro_rules! num_try_from {
 
 macro_rules! num_as_lossy {
     ($primitive:ident:: $visit:ident) => {
-        fn $visit(self, value: $primitive) -> Result<Self::Value, VisitorError> {
+        fn $visit(self, value: $primitive) -> Result<Self::Value, Report<VisitorError>> {
             Ok(value as Self::Value)
         }
     };
@@ -164,7 +164,7 @@ macro_rules! num_as_lossy {
 
 macro_rules! num_number {
     ($primitive:ident:: $to:ident) => {
-        fn visit_number(self, value: Number) -> Result<Self::Value, VisitorError> {
+        fn visit_number(self, value: Number) -> Result<Self::Value, Report<VisitorError>> {
             value.$to().ok_or_else(|| {
                 Report::new(ValueError.into_error())
                     .attach(ExpectedType::new(self.expecting()))

--- a/libs/deer/src/impls/core/ops.rs
+++ b/libs/deer/src/impls/core/ops.rs
@@ -3,7 +3,7 @@ use core::{
     ops::{Bound, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive},
 };
 
-use error_stack::{Report, ReportSink, Result, ResultExt as _, TryReportTupleExt as _};
+use error_stack::{Report, ReportSink, ResultExt as _, TryReportTupleExt as _};
 
 use crate::{
     ArrayAccess, Deserialize, Deserializer, Document, EnumVisitor, FieldVisitor, ObjectAccess,
@@ -44,7 +44,7 @@ where
         self,
         discriminant: Self::Discriminant,
         deserializer: D,
-    ) -> Result<Self::Value, VisitorError>
+    ) -> Result<Self::Value, Report<VisitorError>>
     where
         D: Deserializer<'de>,
     {
@@ -96,7 +96,9 @@ where
 {
     type Reflection = BoundReflection<T::Reflection>;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_enum(BoundEnumVisitor(PhantomData))
             .change_context(DeserializeError)
@@ -123,7 +125,11 @@ where
     type Key = RangeIdent;
     type Value = ();
 
-    fn visit_value<D>(self, key: Self::Key, deserializer: D) -> Result<Self::Value, VisitorError>
+    fn visit_value<D>(
+        self,
+        key: Self::Key,
+        deserializer: D,
+    ) -> Result<Self::Value, Report<VisitorError>>
     where
         D: Deserializer<'de>,
     {
@@ -179,7 +185,7 @@ where
         R::document()
     }
 
-    fn visit_array<A>(self, array: A) -> Result<Self::Value, VisitorError>
+    fn visit_array<A>(self, array: A) -> Result<Self::Value, Report<VisitorError>>
     where
         A: ArrayAccess<'de>,
     {
@@ -210,7 +216,7 @@ where
         Ok((start, end))
     }
 
-    fn visit_object<A>(self, mut object: A) -> Result<Self::Value, VisitorError>
+    fn visit_object<A>(self, mut object: A) -> Result<Self::Value, Report<VisitorError>>
     where
         A: ObjectAccess<'de>,
     {
@@ -283,7 +289,7 @@ where
 {
     type Reflection = RangeReflection<T::Reflection, T::Reflection>;
 
-    fn deserialize<D>(deserializer: D) -> Result<Self, DeserializeError>
+    fn deserialize<D>(deserializer: D) -> Result<Self, Report<DeserializeError>>
     where
         D: Deserializer<'de>,
     {
@@ -303,7 +309,7 @@ where
 {
     type Reflection = RangeReflection<T::Reflection, T::Reflection>;
 
-    fn deserialize<D>(deserializer: D) -> Result<Self, DeserializeError>
+    fn deserialize<D>(deserializer: D) -> Result<Self, Report<DeserializeError>>
     where
         D: Deserializer<'de>,
     {
@@ -331,7 +337,7 @@ where
 {
     type Reflection = RangeReflection<T::Reflection, <Option<()> as Deserialize<'de>>::Reflection>;
 
-    fn deserialize<D>(deserializer: D) -> Result<Self, DeserializeError>
+    fn deserialize<D>(deserializer: D) -> Result<Self, Report<DeserializeError>>
     where
         D: Deserializer<'de>,
     {
@@ -353,7 +359,7 @@ where
 {
     type Reflection = RangeReflection<<Option<()> as Deserialize<'de>>::Reflection, T::Reflection>;
 
-    fn deserialize<D>(deserializer: D) -> Result<Self, DeserializeError>
+    fn deserialize<D>(deserializer: D) -> Result<Self, Report<DeserializeError>>
     where
         D: Deserializer<'de>,
     {
@@ -373,7 +379,7 @@ where
 {
     type Reflection = RangeReflection<<Option<()> as Deserialize<'de>>::Reflection, T::Reflection>;
 
-    fn deserialize<D>(deserializer: D) -> Result<Self, DeserializeError>
+    fn deserialize<D>(deserializer: D) -> Result<Self, Report<DeserializeError>>
     where
         D: Deserializer<'de>,
     {
@@ -393,7 +399,7 @@ impl<'de> Deserialize<'de> for RangeFull {
         <Option<()> as Deserialize<'de>>::Reflection,
     >;
 
-    fn deserialize<D>(deserializer: D) -> Result<Self, DeserializeError>
+    fn deserialize<D>(deserializer: D) -> Result<Self, Report<DeserializeError>>
     where
         D: Deserializer<'de>,
     {

--- a/libs/deer/src/impls/core/option.rs
+++ b/libs/deer/src/impls/core/option.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use error_stack::{Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 
 use crate::{
     Deserialize, Deserializer, Document, OptionalVisitor, Reflection, Schema,
@@ -16,15 +16,15 @@ impl<'de, T: Deserialize<'de>> OptionalVisitor<'de> for OptionVisitor<T> {
         Self::Value::reflection()
     }
 
-    fn visit_none(self) -> Result<Self::Value, VisitorError> {
+    fn visit_none(self) -> Result<Self::Value, Report<VisitorError>> {
         Ok(None)
     }
 
-    fn visit_null(self) -> Result<Self::Value, VisitorError> {
+    fn visit_null(self) -> Result<Self::Value, Report<VisitorError>> {
         Ok(None)
     }
 
-    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, VisitorError>
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, Report<VisitorError>>
     where
         D: Deserializer<'de>,
     {
@@ -50,7 +50,9 @@ impl<T: Reflection + ?Sized> Reflection for OptionReflection<T> {
 impl<'de, T: Deserialize<'de>> Deserialize<'de> for Option<T> {
     type Reflection = OptionReflection<T::Reflection>;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_optional(OptionVisitor(PhantomData))
             .change_context(DeserializeError)

--- a/libs/deer/src/impls/core/result.rs
+++ b/libs/deer/src/impls/core/result.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use error_stack::{Report, Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 
 use crate::{
     Deserialize, Deserializer, Document, EnumVisitor, Reflection, Schema, Visitor,
@@ -25,7 +25,7 @@ impl Visitor<'_> for ResultDiscriminantVisitor {
         ResultDiscriminant::reflection()
     }
 
-    fn visit_str(self, value: &str) -> Result<Self::Value, VisitorError> {
+    fn visit_str(self, value: &str) -> Result<Self::Value, Report<VisitorError>> {
         match value {
             "Ok" => Ok(ResultDiscriminant::Ok),
             "Err" => Ok(ResultDiscriminant::Err),
@@ -37,7 +37,7 @@ impl Visitor<'_> for ResultDiscriminantVisitor {
         }
     }
 
-    fn visit_bytes(self, value: &[u8]) -> Result<Self::Value, VisitorError> {
+    fn visit_bytes(self, value: &[u8]) -> Result<Self::Value, Report<VisitorError>> {
         match value {
             b"Ok" => Ok(ResultDiscriminant::Ok),
             b"Err" => Ok(ResultDiscriminant::Err),
@@ -65,7 +65,9 @@ impl Reflection for ResultDiscriminant {
 impl<'de> Deserialize<'de> for ResultDiscriminant {
     type Reflection = Self;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_str(ResultDiscriminantVisitor)
             .change_context(DeserializeError)
@@ -90,7 +92,7 @@ where
         self,
         discriminant: Self::Discriminant,
         deserializer: D,
-    ) -> Result<Self::Value, VisitorError>
+    ) -> Result<Self::Value, Report<VisitorError>>
     where
         D: Deserializer<'de>,
     {
@@ -149,7 +151,9 @@ where
 {
     type Reflection = ResultReflection<T::Reflection, E::Reflection>;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_enum(ResultEnumVisitor(PhantomData))
             .change_context(DeserializeError)

--- a/libs/deer/src/impls/core/string.rs
+++ b/libs/deer/src/impls/core/string.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use error_stack::{Report, Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 
 use crate::{
     Deserialize, Deserializer, Document, Reflection, Schema, Visitor,
@@ -16,7 +16,7 @@ impl<'de: 'a, 'a> Visitor<'de> for StrVisitor<'a> {
         <&str>::reflection()
     }
 
-    fn visit_borrowed_str(self, value: &'de str) -> Result<Self::Value, VisitorError> {
+    fn visit_borrowed_str(self, value: &'de str) -> Result<Self::Value, Report<VisitorError>> {
         Ok(value)
     }
 }
@@ -30,7 +30,9 @@ impl Reflection for str {
 impl<'de: 'a, 'a> Deserialize<'de> for &'a str {
     type Reflection = str;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_str(StrVisitor(PhantomData))
             .change_context(DeserializeError)
@@ -46,11 +48,11 @@ impl Visitor<'_> for CharVisitor {
         Document::new::<char>()
     }
 
-    fn visit_char(self, value: char) -> Result<Self::Value, VisitorError> {
+    fn visit_char(self, value: char) -> Result<Self::Value, Report<VisitorError>> {
         Ok(value)
     }
 
-    fn visit_str(self, value: &str) -> Result<Self::Value, VisitorError> {
+    fn visit_str(self, value: &str) -> Result<Self::Value, Report<VisitorError>> {
         let mut chars = value.chars();
 
         let first = chars.next();
@@ -79,7 +81,9 @@ impl Reflection for char {
 impl<'de> Deserialize<'de> for char {
     type Reflection = Self;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_char(CharVisitor)
             .change_context(DeserializeError)

--- a/libs/deer/src/impls/core/sync/atomic.rs
+++ b/libs/deer/src/impls/core/sync/atomic.rs
@@ -12,6 +12,8 @@ use core::sync::atomic::{AtomicI128, AtomicU128};
 #[cfg(target_has_atomic = "ptr")]
 use core::sync::atomic::{AtomicIsize, AtomicUsize};
 
+use error_stack::Report;
+
 use crate::{Deserialize, Deserializer, Document, Reflection, Schema, error::DeserializeError};
 
 macro_rules! impl_atomic {
@@ -29,7 +31,7 @@ macro_rules! impl_atomic {
 
             fn deserialize<D: Deserializer<'de>>(
                 deserializer: D,
-            ) -> error_stack::Result<Self, DeserializeError> {
+            ) -> Result<Self, Report<DeserializeError>> {
                 $int::deserialize(deserializer).map(Self::new)
             }
         }

--- a/libs/deer/src/impls/core/sync/mod.rs
+++ b/libs/deer/src/impls/core/sync/mod.rs
@@ -5,6 +5,7 @@ use core::sync::Exclusive;
 use crate::{Deserialize, Deserializer, error::DeserializeError};
 
 mod atomic;
+use error_stack::Report;
 
 #[cfg(nightly)]
 impl<'de, T> Deserialize<'de> for Exclusive<T>
@@ -15,7 +16,7 @@ where
 
     fn deserialize<D: Deserializer<'de>>(
         deserializer: D,
-    ) -> error_stack::Result<Self, DeserializeError> {
+    ) -> Result<Self, Report<DeserializeError>> {
         T::deserialize(deserializer).map(Self::new)
     }
 }

--- a/libs/deer/src/impls/core/time.rs
+++ b/libs/deer/src/impls/core/time.rs
@@ -1,13 +1,15 @@
 use core::time::Duration;
 
-use error_stack::Result;
+use error_stack::Report;
 
 use crate::{Deserialize, Deserializer, error::DeserializeError};
 
 impl<'de> Deserialize<'de> for Duration {
     type Reflection = <f64 as Deserialize<'de>>::Reflection;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         f64::deserialize(deserializer).map(Self::from_secs_f64)
     }
 }

--- a/libs/deer/src/impls/core/tuples.rs
+++ b/libs/deer/src/impls/core/tuples.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use error_stack::{Report, Result, ResultExt as _, TryReportTupleExt as _};
+use error_stack::{Report, ResultExt as _, TryReportTupleExt as _};
 
 use crate::{
     ArrayAccess, Deserialize, Deserializer, Document, Reflection, Schema, Visitor,
@@ -65,7 +65,7 @@ macro_rules! impl_tuple {
             }
 
             #[expect(non_snake_case)]
-            fn visit_array<A>(self, array: A) -> Result<Self::Value, VisitorError>
+            fn visit_array<A>(self, array: A) -> Result<Self::Value, Report<VisitorError>>
             where
                 A: ArrayAccess<'de>,
             {
@@ -103,7 +103,7 @@ macro_rules! impl_tuple {
         {
             type Reflection = $reflection<$($elem::Reflection),*>;
 
-            fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, DeserializeError> {
+            fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, Report<DeserializeError>> {
                 de.deserialize_array($visitor::<$($elem,)*>(PhantomData))
                             .change_context(DeserializeError)
             }

--- a/libs/deer/src/impls/core/unit.rs
+++ b/libs/deer/src/impls/core/unit.rs
@@ -1,4 +1,4 @@
-use error_stack::ResultExt as _;
+use error_stack::{Report, ResultExt as _};
 
 use crate::{
     Deserialize, Deserializer, Document, Reflection, Schema, Visitor,
@@ -14,7 +14,7 @@ impl Visitor<'_> for UnitVisitor {
         <()>::reflection()
     }
 
-    fn visit_null(self) -> error_stack::Result<Self::Value, VisitorError> {
+    fn visit_null(self) -> Result<Self::Value, Report<VisitorError>> {
         Ok(())
     }
 }
@@ -35,7 +35,7 @@ impl<'de> Deserialize<'de> for () {
 
     fn deserialize<D: Deserializer<'de>>(
         deserializer: D,
-    ) -> error_stack::Result<Self, DeserializeError> {
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_null(UnitVisitor)
             .change_context(DeserializeError)

--- a/libs/deer/src/impls/mod.rs
+++ b/libs/deer/src/impls/mod.rs
@@ -1,4 +1,4 @@
-use error_stack::Result;
+use error_stack::Report;
 
 use crate::{Deserialize, Document, OptionalVisitor, error::VisitorError};
 
@@ -14,11 +14,11 @@ impl OptionalVisitor<'_> for UnitVariantVisitor {
         <() as Deserialize>::reflection()
     }
 
-    fn visit_none(self) -> Result<Self::Value, VisitorError> {
+    fn visit_none(self) -> Result<Self::Value, Report<VisitorError>> {
         Ok(())
     }
 
-    fn visit_null(self) -> Result<Self::Value, VisitorError> {
+    fn visit_null(self) -> Result<Self::Value, Report<VisitorError>> {
         Ok(())
     }
 

--- a/libs/deer/src/lib.rs
+++ b/libs/deer/src/lib.rs
@@ -812,6 +812,7 @@ pub(crate) mod test {
     #[cfg_attr(feature = "std", allow(unused_imports))]
     use alloc::{format, string::String, vec::Vec};
     use core::{
+        error::Error,
         fmt::{Display, Formatter},
         marker::PhantomData,
     };
@@ -844,7 +845,7 @@ pub(crate) mod test {
     }
 
     pub(crate) fn to_json<T: Variant>(
-        report: &Report<impl ::core::error::Error + Send + Sync + 'static>,
+        report: &Report<impl Error + Send + Sync + 'static>,
     ) -> serde_json::Value {
         // we do not need to worry about the tree structure
         let frames: Vec<_> = report.frames().collect();

--- a/libs/deer/src/lib.rs
+++ b/libs/deer/src/lib.rs
@@ -816,7 +816,7 @@ pub(crate) mod test {
         marker::PhantomData,
     };
 
-    use error_stack::{Context, Frame, Report};
+    use error_stack::{Frame, Report};
     use serde::{
         Serialize, Serializer,
         ser::{Error as _, SerializeMap as _},
@@ -843,7 +843,9 @@ pub(crate) mod test {
         }
     }
 
-    pub(crate) fn to_json<T: Variant>(report: &Report<impl ::core::error::Error + Send + Sync + 'static>) -> serde_json::Value {
+    pub(crate) fn to_json<T: Variant>(
+        report: &Report<impl ::core::error::Error + Send + Sync + 'static>,
+    ) -> serde_json::Value {
         // we do not need to worry about the tree structure
         let frames: Vec<_> = report.frames().collect();
 

--- a/libs/deer/src/lib.rs
+++ b/libs/deer/src/lib.rs
@@ -812,7 +812,6 @@ pub(crate) mod test {
     #[cfg_attr(feature = "std", allow(unused_imports))]
     use alloc::{format, string::String, vec::Vec};
     use core::{
-        error::Error,
         fmt::{Display, Formatter},
         marker::PhantomData,
     };
@@ -845,7 +844,7 @@ pub(crate) mod test {
     }
 
     pub(crate) fn to_json<T: Variant>(
-        report: &Report<impl Error + Send + Sync + 'static>,
+        report: &Report<impl core::error::Error + Send + Sync + 'static>,
     ) -> serde_json::Value {
         // we do not need to worry about the tree structure
         let frames: Vec<_> = report.frames().collect();

--- a/libs/deer/src/lib.rs
+++ b/libs/deer/src/lib.rs
@@ -843,7 +843,7 @@ pub(crate) mod test {
         }
     }
 
-    pub(crate) fn to_json<T: Variant>(report: &Report<impl Context>) -> serde_json::Value {
+    pub(crate) fn to_json<T: Variant>(report: &Report<impl ::core::error::Error + Send + Sync + 'static>) -> serde_json::Value {
         // we do not need to worry about the tree structure
         let frames: Vec<_> = report.frames().collect();
 

--- a/libs/deer/src/macros.rs
+++ b/libs/deer/src/macros.rs
@@ -16,7 +16,13 @@ macro_rules! forward_to_deserialize_any {
 macro_rules! forward_to_deserialize_any_method {
     ($func:ident < $l:tt, $v:ident > ()) => {
         #[inline]
-        fn $func<$v>(self, visitor: $v) -> error_stack::Result<$v::Value, $crate::DeserializerError>
+        fn $func<$v>(
+            self,
+            visitor: $v,
+        ) -> ::core::result::Result<
+            $v::Value,
+            $crate::export::error_stack::Report<$crate::DeserializerError>,
+        >
         where
             $v: $crate::Visitor<$l>,
         {
@@ -295,7 +301,7 @@ macro_rules! identifier {
         impl<'de> $crate::Deserialize<'de> for $name {
             type Reflection = Self;
 
-            fn deserialize<D>(deserializer: D) -> $crate::export::error_stack::Result<Self, $crate::error::DeserializeError> where D: $crate::Deserializer<'de> {
+            fn deserialize<D>(deserializer: D) -> ::core::result::Result<Self, $crate::export::error_stack::Report<$crate::error::DeserializeError>> where D: $crate::Deserializer<'de> {
                 struct Visitor;
 
                 impl<'de> $crate::IdentifierVisitor<'de> for Visitor {
@@ -305,7 +311,7 @@ macro_rules! identifier {
                         <Self::Value as $crate::Reflection>::document()
                     }
 
-                    fn visit_str(self, value: &str) -> $crate::export::error_stack::Result<Self::Value, $crate::error::VisitorError> {
+                    fn visit_str(self, value: &str) -> ::core::result::Result<Self::Value, $crate::export::error_stack::Report<$crate::error::VisitorError>> {
                         identifier!(@internal
                             match str, value; $name
                             @($(($variant, $str)),*)
@@ -313,7 +319,7 @@ macro_rules! identifier {
                         )
                     }
 
-                    fn visit_bytes(self, value: &[u8]) -> $crate::export::error_stack::Result<Self::Value, $crate::error::VisitorError> {
+                    fn visit_bytes(self, value: &[u8]) -> ::core::result::Result<Self::Value, $crate::export::error_stack::Report<$crate::error::VisitorError>> {
                         identifier!(@internal
                             match bytes, value; $name
                             @($(($variant, $bytes)),*)
@@ -321,7 +327,7 @@ macro_rules! identifier {
                         )
                     }
 
-                    fn visit_u64(self, value: u64) -> $crate::export::error_stack::Result<Self::Value, $crate::error::VisitorError> {
+                    fn visit_u64(self, value: u64) -> ::core::result::Result<Self::Value, $crate::export::error_stack::Report<$crate::error::VisitorError>> {
                         identifier!(@internal
                             match u64, value; $name
                             @($(($variant, $u64)),*)

--- a/libs/deer/src/number.rs
+++ b/libs/deer/src/number.rs
@@ -4,7 +4,7 @@ use core::fmt::{Display, Formatter};
 #[cfg(not(feature = "arbitrary-precision"))]
 use core::ops::Neg;
 
-use error_stack::ResultExt as _;
+use error_stack::{Report, ResultExt as _};
 use num_traits::{FromPrimitive, ToPrimitive};
 use serde::{Serialize, Serializer};
 
@@ -383,7 +383,7 @@ impl<'de> Deserialize<'de> for Number {
 
     fn deserialize<D: Deserializer<'de>>(
         deserializer: D,
-    ) -> error_stack::Result<Self, DeserializeError> {
+    ) -> Result<Self, Report<DeserializeError>> {
         struct Visitor;
 
         impl crate::Visitor<'_> for Visitor {
@@ -393,7 +393,7 @@ impl<'de> Deserialize<'de> for Number {
                 Number::reflection()
             }
 
-            fn visit_number(self, value: Number) -> error_stack::Result<Self::Value, VisitorError> {
+            fn visit_number(self, value: Number) -> Result<Self::Value, Report<VisitorError>> {
                 Ok(value)
             }
 

--- a/libs/deer/src/value/array.rs
+++ b/libs/deer/src/value/array.rs
@@ -1,4 +1,4 @@
-use error_stack::{Report, Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 
 use crate::{
     ArrayAccess, Context, Deserializer, EnumVisitor, IdentifierVisitor, OptionalVisitor,
@@ -43,7 +43,7 @@ where
         self.context
     }
 
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: Visitor<'de>,
     {
@@ -52,21 +52,21 @@ where
             .change_context(DeserializerError)
     }
 
-    fn deserialize_optional<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_optional<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: OptionalVisitor<'de>,
     {
         visitor.visit_some(self).change_context(DeserializerError)
     }
 
-    fn deserialize_enum<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_enum<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: EnumVisitor<'de>,
     {
         EnumUnitDeserializer::new(self.context, self).deserialize_enum(visitor)
     }
 
-    fn deserialize_struct<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_struct<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: StructVisitor<'de>,
     {
@@ -75,7 +75,7 @@ where
             .change_context(DeserializerError)
     }
 
-    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: IdentifierVisitor<'de>,
     {

--- a/libs/deer/src/value/bytes.rs
+++ b/libs/deer/src/value/bytes.rs
@@ -1,7 +1,7 @@
 #[cfg_attr(feature = "std", allow(unused_imports))]
 use alloc::vec::Vec;
 
-use error_stack::{Report, Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 
 use crate::{
     Context, Deserializer, EnumVisitor, IdentifierVisitor, OptionalVisitor, Reflection as _,

--- a/libs/deer/src/value/mod.rs
+++ b/libs/deer/src/value/mod.rs
@@ -1,4 +1,4 @@
-use error_stack::{Report, Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use num_traits::NumCast;
 
 use crate::{
@@ -36,7 +36,7 @@ impl<'de, D> EnumUnitDeserializer<'_, D>
 where
     D: Deserializer<'de>,
 {
-    fn deserialize_enum<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_enum<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: EnumVisitor<'de>,
     {
@@ -54,7 +54,7 @@ where
 
 macro_rules! deserialize_any {
     ($name:ident, $primitive:ty,as, $cast:ident, $visit:ident) => {
-        fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+        fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
         where
             V: Visitor<'de>,
         {
@@ -65,7 +65,7 @@ macro_rules! deserialize_any {
     };
 
     ($name:ident, $primitive:ty, $visit:ident) => {
-        fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+        fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
         where
             V: Visitor<'de>,
         {
@@ -76,7 +76,7 @@ macro_rules! deserialize_any {
 
 macro_rules! deserialize_optional {
     ($name:ident, $primitive:ty) => {
-        fn deserialize_optional<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+        fn deserialize_optional<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
         where
             V: OptionalVisitor<'de>,
         {
@@ -87,7 +87,7 @@ macro_rules! deserialize_optional {
 
 macro_rules! deserialize_enum {
     ($name:ident, $primitive:ty) => {
-        fn deserialize_enum<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+        fn deserialize_enum<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
         where
             V: EnumVisitor<'de>,
         {
@@ -101,10 +101,7 @@ macro_rules! deserialize_struct {
         deserialize_struct!($name, $primitive, error, <bool as Deserialize>::Reflection);
     };
     ($name:ident, $primitive:ty,error, $expected:ty) => {
-        fn deserialize_struct<V>(
-            self,
-            visitor: V,
-        ) -> error_stack::Result<V::Value, DeserializerError>
+        fn deserialize_struct<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
         where
             V: StructVisitor<'de>,
         {
@@ -129,7 +126,10 @@ macro_rules! deserialize_identifier {
     };
 
     ($name:ident, $primitive:ty,error, $received:ty) => {
-        fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+        fn deserialize_identifier<V>(
+            self,
+            visitor: V,
+        ) -> Result<V::Value, Report<DeserializerError>>
         where
             V: IdentifierVisitor<'de>,
         {
@@ -141,7 +141,10 @@ macro_rules! deserialize_identifier {
     };
 
     ($name:ident, $primitive:ty,visit,deref, $visit:ident) => {
-        fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+        fn deserialize_identifier<V>(
+            self,
+            visitor: V,
+        ) -> Result<V::Value, Report<DeserializerError>>
         where
             V: IdentifierVisitor<'de>,
         {
@@ -152,7 +155,10 @@ macro_rules! deserialize_identifier {
     };
 
     ($name:ident, $primitive:ty,visit,cast, $visit:ident) => {
-        fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+        fn deserialize_identifier<V>(
+            self,
+            visitor: V,
+        ) -> Result<V::Value, Report<DeserializerError>>
         where
             V: IdentifierVisitor<'de>,
         {
@@ -168,7 +174,10 @@ macro_rules! deserialize_identifier {
     };
 
     ($name:ident, $primitive:ty,visit,as, $visit:ident) => {
-        fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+        fn deserialize_identifier<V>(
+            self,
+            visitor: V,
+        ) -> Result<V::Value, Report<DeserializerError>>
         where
             V: IdentifierVisitor<'de>,
         {
@@ -180,7 +189,10 @@ macro_rules! deserialize_identifier {
     };
 
     ($name:ident, $primitive:ty,visit, $visit:ident) => {
-        fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+        fn deserialize_identifier<V>(
+            self,
+            visitor: V,
+        ) -> Result<V::Value, Report<DeserializerError>>
         where
             V: IdentifierVisitor<'de>,
         {
@@ -192,7 +204,10 @@ macro_rules! deserialize_identifier {
 
     ($name:ident, $primitive:ty,try_visit, $visit:ident) => {
         #[cfg(any(nightly, feature = "std"))]
-        fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+        fn deserialize_identifier<V>(
+            self,
+            visitor: V,
+        ) -> Result<V::Value, Report<DeserializerError>>
         where
             V: IdentifierVisitor<'de>,
         {
@@ -207,7 +222,10 @@ macro_rules! deserialize_identifier {
         }
 
         #[cfg(not(any(nightly, feature = "std")))]
-        fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+        fn deserialize_identifier<V>(
+            self,
+            visitor: V,
+        ) -> Result<V::Value, Report<DeserializerError>>
         where
             V: IdentifierVisitor<'de>,
         {
@@ -554,21 +572,21 @@ impl<'de> Deserializer<'de> for NoneDeserializer<'_> {
         self.context
     }
 
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: Visitor<'de>,
     {
         visitor.visit_none().change_context(DeserializerError)
     }
 
-    fn deserialize_optional<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_optional<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: OptionalVisitor<'de>,
     {
         visitor.visit_none().change_context(DeserializerError)
     }
 
-    fn deserialize_enum<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_enum<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: EnumVisitor<'de>,
     {
@@ -581,7 +599,7 @@ impl<'de> Deserializer<'de> for NoneDeserializer<'_> {
             .change_context(DeserializerError)
     }
 
-    fn deserialize_struct<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_struct<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: StructVisitor<'de>,
     {
@@ -590,7 +608,7 @@ impl<'de> Deserializer<'de> for NoneDeserializer<'_> {
             .change_context(DeserializerError))
     }
 
-    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: IdentifierVisitor<'de>,
     {
@@ -629,28 +647,28 @@ impl<'de> Deserializer<'de> for NullDeserializer<'_> {
         self.context
     }
 
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: Visitor<'de>,
     {
         visitor.visit_null().change_context(DeserializerError)
     }
 
-    fn deserialize_optional<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_optional<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: OptionalVisitor<'de>,
     {
         visitor.visit_null().change_context(DeserializerError)
     }
 
-    fn deserialize_enum<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_enum<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: EnumVisitor<'de>,
     {
         EnumUnitDeserializer::new(self.context, self).deserialize_enum(visitor)
     }
 
-    fn deserialize_struct<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_struct<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: StructVisitor<'de>,
     {
@@ -660,7 +678,7 @@ impl<'de> Deserializer<'de> for NullDeserializer<'_> {
             .change_context(DeserializerError))
     }
 
-    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: IdentifierVisitor<'de>,
     {

--- a/libs/deer/src/value/object.rs
+++ b/libs/deer/src/value/object.rs
@@ -1,4 +1,4 @@
-use error_stack::{Report, Result, ResultExt as _, TryReportTupleExt as _};
+use error_stack::{Report, ResultExt as _, TryReportTupleExt as _};
 
 use crate::{
     Context, Deserializer, EnumVisitor, FieldVisitor, IdentifierVisitor, ObjectAccess,
@@ -45,7 +45,7 @@ where
         self.context
     }
 
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: Visitor<'de>,
     {
@@ -54,14 +54,14 @@ where
             .change_context(DeserializerError)
     }
 
-    fn deserialize_optional<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_optional<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: OptionalVisitor<'de>,
     {
         visitor.visit_some(self).change_context(DeserializerError)
     }
 
-    fn deserialize_enum<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_enum<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: EnumVisitor<'de>,
     {
@@ -74,7 +74,7 @@ where
             type Key = T::Discriminant;
             type Value = T::Value;
 
-            fn visit_key<D>(&self, deserializer: D) -> Result<Self::Key, VisitorError>
+            fn visit_key<D>(&self, deserializer: D) -> Result<Self::Key, Report<VisitorError>>
             where
                 D: Deserializer<'de>,
             {
@@ -87,7 +87,7 @@ where
                 self,
                 key: Self::Key,
                 deserializer: D,
-            ) -> Result<Self::Value, VisitorError>
+            ) -> Result<Self::Value, Report<VisitorError>>
             where
                 D: Deserializer<'de>,
             {
@@ -113,7 +113,7 @@ where
         Ok(value)
     }
 
-    fn deserialize_struct<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_struct<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: StructVisitor<'de>,
     {
@@ -122,7 +122,7 @@ where
             .change_context(DeserializerError)
     }
 
-    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Report<DeserializerError>>
     where
         V: IdentifierVisitor<'de>,
     {

--- a/libs/deer/src/value/string.rs
+++ b/libs/deer/src/value/string.rs
@@ -1,7 +1,7 @@
 #[cfg_attr(feature = "std", allow(unused_imports))]
 use alloc::string::String;
 
-use error_stack::{Report, Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 
 use crate::{
     Context, Deserializer, EnumVisitor, IdentifierVisitor, OptionalVisitor, Reflection as _,

--- a/libs/deer/tests/test_bound.rs
+++ b/libs/deer/tests/test_bound.rs
@@ -7,7 +7,7 @@ use deer::{
     schema::Reference,
 };
 use deer_desert::{Token, assert_tokens, assert_tokens_error, error};
-use error_stack::{ReportSink, Result, ResultExt as _};
+use error_stack::{Report, ReportSink, ResultExt as _};
 use serde::{Serialize, Serializer, ser::SerializeMap as _};
 use serde_json::json;
 
@@ -55,7 +55,7 @@ impl<'de> Visitor<'de> for ArrayStatsVisitor {
         Self::Value::document()
     }
 
-    fn visit_array<T>(self, array: T) -> Result<Self::Value, VisitorError>
+    fn visit_array<T>(self, array: T) -> Result<Self::Value, Report<VisitorError>>
     where
         T: ArrayAccess<'de>,
     {
@@ -97,7 +97,9 @@ impl<'de> Visitor<'de> for ArrayStatsVisitor {
 impl<'de> Deserialize<'de> for ArrayStats {
     type Reflection = Self;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_array(ArrayStatsVisitor)
             .change_context(DeserializeError)
@@ -160,7 +162,7 @@ impl<'de> Visitor<'de> for DirtyArrayVisitor {
         <()>::reflection()
     }
 
-    fn visit_array<T>(self, mut array: T) -> Result<Self::Value, VisitorError>
+    fn visit_array<T>(self, mut array: T) -> Result<Self::Value, Report<VisitorError>>
     where
         T: ArrayAccess<'de>,
     {
@@ -176,7 +178,9 @@ impl<'de> Visitor<'de> for DirtyArrayVisitor {
 impl<'de> Deserialize<'de> for DirtyArray {
     type Reflection = <() as Deserialize<'de>>::Reflection;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_array(DirtyArrayVisitor)
             .change_context(DeserializeError)
@@ -254,7 +258,7 @@ impl<'de> Visitor<'de> for ObjectStatsVisitor {
         Self::Value::document()
     }
 
-    fn visit_object<T>(self, object: T) -> Result<Self::Value, VisitorError>
+    fn visit_object<T>(self, object: T) -> Result<Self::Value, Report<VisitorError>>
     where
         T: ObjectAccess<'de>,
     {
@@ -309,7 +313,9 @@ impl<'de> Visitor<'de> for ObjectStatsVisitor {
 impl<'de> Deserialize<'de> for ObjectStats {
     type Reflection = Self;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_object(ObjectStatsVisitor)
             .change_context(DeserializeError)
@@ -405,7 +411,7 @@ impl<'de> Visitor<'de> for DirtyObjectVisitor {
         <()>::reflection()
     }
 
-    fn visit_object<T>(self, mut object: T) -> Result<Self::Value, VisitorError>
+    fn visit_object<T>(self, mut object: T) -> Result<Self::Value, Report<VisitorError>>
     where
         T: ObjectAccess<'de>,
     {
@@ -421,7 +427,9 @@ impl<'de> Visitor<'de> for DirtyObjectVisitor {
 impl<'de> Deserialize<'de> for DirtyObject {
     type Reflection = <() as Deserialize<'de>>::Reflection;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_array(DirtyObjectVisitor)
             .change_context(DeserializeError)

--- a/libs/deer/tests/test_enum_visitor.rs
+++ b/libs/deer/tests/test_enum_visitor.rs
@@ -10,7 +10,7 @@ use deer::{
     schema::Reference,
 };
 use deer_desert::{Token, assert_tokens, assert_tokens_error, error};
-use error_stack::{Report, ReportSink, Result, ResultExt as _};
+use error_stack::{Report, ReportSink, ResultExt as _};
 use serde::{Serializer, ser::SerializeMap as _};
 use serde_json::json;
 
@@ -24,7 +24,7 @@ impl Visitor<'_> for DiscriminantVisitor {
     }
 
     // usually we'd also check for bytes, but meh :shrug:
-    fn visit_str(self, value: &str) -> Result<Self::Value, VisitorError> {
+    fn visit_str(self, value: &str) -> Result<Self::Value, Report<VisitorError>> {
         match value {
             "Variant" => Ok(Discriminant::Variant),
             _ => Err(Report::new(UnknownVariantError.into_error())
@@ -48,7 +48,9 @@ impl Reflection for Discriminant {
 impl<'de> Deserialize<'de> for Discriminant {
     type Reflection = Self;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_str(DiscriminantVisitor)
             .change_context(DeserializeError)
@@ -69,7 +71,7 @@ impl<'de> EnumVisitor<'de> for UnitEnumVisitor {
         self,
         discriminant: Self::Discriminant,
         deserializer: D,
-    ) -> Result<Self::Value, VisitorError>
+    ) -> Result<Self::Value, Report<VisitorError>>
     where
         D: Deserializer<'de>,
     {
@@ -90,7 +92,9 @@ enum UnitEnum {
 impl<'de> Deserialize<'de> for UnitEnum {
     type Reflection = Discriminant;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_enum(UnitEnumVisitor)
             .change_context(DeserializeError)
@@ -136,7 +140,7 @@ impl<'de> EnumVisitor<'de> for NewtypeEnumVisitor {
         self,
         discriminant: Self::Discriminant,
         deserializer: D,
-    ) -> Result<Self::Value, VisitorError>
+    ) -> Result<Self::Value, Report<VisitorError>>
     where
         D: Deserializer<'de>,
     {
@@ -183,7 +187,9 @@ impl<'de> Deserialize<'de> for NewtypeEnum {
     // TODO: this is wrong
     type Reflection = Discriminant;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_enum(NewtypeEnumVisitor)
             .change_context(DeserializeError)
@@ -273,7 +279,7 @@ impl<'de> Visitor<'de> for StructEnumVisitor {
         Self::Value::reflection()
     }
 
-    fn visit_object<A>(self, object: A) -> Result<Self::Value, VisitorError>
+    fn visit_object<A>(self, object: A) -> Result<Self::Value, Report<VisitorError>>
     where
         A: ObjectAccess<'de>,
     {
@@ -302,7 +308,7 @@ impl<'de> Visitor<'de> for StructEnumVisitor {
                         Self::Value::reflection()
                     }
 
-                    fn visit_str(self, value: &str) -> Result<Self::Value, VisitorError> {
+                    fn visit_str(self, value: &str) -> Result<Self::Value, Report<VisitorError>> {
                         match value {
                             "id" => Ok(VariantFieldIdent::Id),
                             _ => Err(Report::new(UnknownVariantError.into_error())
@@ -319,7 +325,7 @@ impl<'de> Visitor<'de> for StructEnumVisitor {
 
                     fn deserialize<D: Deserializer<'de>>(
                         deserializer: D,
-                    ) -> Result<Self, DeserializeError> {
+                    ) -> Result<Self, Report<DeserializeError>> {
                         deserializer
                             .deserialize_str(VariantFieldVisitor)
                             .change_context(DeserializeError)
@@ -336,7 +342,7 @@ impl<'de> Visitor<'de> for StructEnumVisitor {
                         self,
                         key: Self::Key,
                         deserializer: D,
-                    ) -> Result<Self::Value, VisitorError>
+                    ) -> Result<Self::Value, Report<VisitorError>>
                     where
                         D: Deserializer<'de>,
                     {
@@ -403,7 +409,7 @@ impl<'de> EnumVisitor<'de> for StructEnumIdentVisitor {
         self,
         discriminant: Self::Discriminant,
         deserializer: D,
-    ) -> Result<Self::Value, VisitorError>
+    ) -> Result<Self::Value, Report<VisitorError>>
     where
         D: Deserializer<'de>,
     {
@@ -420,7 +426,9 @@ impl<'de> EnumVisitor<'de> for StructEnumIdentVisitor {
 impl<'de> Deserialize<'de> for StructEnum {
     type Reflection = Self;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_enum(StructEnumIdentVisitor)
             .change_context(DeserializeError)

--- a/libs/deer/tests/test_struct_visitor.rs
+++ b/libs/deer/tests/test_struct_visitor.rs
@@ -5,7 +5,7 @@ use deer::{
     Schema, StructVisitor, Visitor,
     error::{ArrayAccessError, DeserializeError, Variant as _, VisitorError},
 };
-use error_stack::{Report, ReportSink, Result, ResultExt as _, TryReportTupleExt as _};
+use error_stack::{Report, ReportSink, ResultExt as _, TryReportTupleExt as _};
 use serde_json::json;
 
 mod common;
@@ -45,7 +45,7 @@ impl Reflection for ExampleFieldDiscriminator {
 impl<'de> Deserialize<'de> for ExampleFieldDiscriminator {
     type Reflection = Self;
 
-    fn deserialize<D>(deserializer: D) -> Result<Self, DeserializeError>
+    fn deserialize<D>(deserializer: D) -> Result<Self, Report<DeserializeError>>
     where
         D: Deserializer<'de>,
     {
@@ -58,7 +58,7 @@ impl<'de> Deserialize<'de> for ExampleFieldDiscriminator {
                 Self::Value::reflection()
             }
 
-            fn visit_str(self, value: &str) -> Result<Self::Value, VisitorError> {
+            fn visit_str(self, value: &str) -> Result<Self::Value, Report<VisitorError>> {
                 match value {
                     "a" => Ok(ExampleFieldDiscriminator::A),
                     "b" => Ok(ExampleFieldDiscriminator::B),
@@ -72,7 +72,7 @@ impl<'de> Deserialize<'de> for ExampleFieldDiscriminator {
                 }
             }
 
-            fn visit_bytes(self, value: &[u8]) -> Result<Self::Value, VisitorError> {
+            fn visit_bytes(self, value: &[u8]) -> Result<Self::Value, Report<VisitorError>> {
                 match value {
                     b"a" => Ok(ExampleFieldDiscriminator::A),
                     b"b" => Ok(ExampleFieldDiscriminator::B),
@@ -92,7 +92,7 @@ impl<'de> Deserialize<'de> for ExampleFieldDiscriminator {
                 }
             }
 
-            fn visit_u64(self, value: u64) -> Result<Self::Value, VisitorError> {
+            fn visit_u64(self, value: u64) -> Result<Self::Value, Report<VisitorError>> {
                 match value {
                     0 => Ok(ExampleFieldDiscriminator::A),
                     1 => Ok(ExampleFieldDiscriminator::B),
@@ -116,7 +116,11 @@ impl<'de> FieldVisitor<'de> for ExampleFieldVisitor<'_> {
     type Key = ExampleFieldDiscriminator;
     type Value = ();
 
-    fn visit_value<D>(self, key: Self::Key, deserializer: D) -> Result<Self::Value, VisitorError>
+    fn visit_value<D>(
+        self,
+        key: Self::Key,
+        deserializer: D,
+    ) -> Result<Self::Value, Report<VisitorError>>
     where
         D: Deserializer<'de>,
     {
@@ -173,7 +177,7 @@ impl<'de> StructVisitor<'de> for ExampleVisitor {
         Example::reflection()
     }
 
-    fn visit_array<A>(self, array: A) -> Result<Self::Value, VisitorError>
+    fn visit_array<A>(self, array: A) -> Result<Self::Value, Report<VisitorError>>
     where
         A: ArrayAccess<'de>,
     {
@@ -219,7 +223,7 @@ impl<'de> StructVisitor<'de> for ExampleVisitor {
         Ok(Example { a, b, c })
     }
 
-    fn visit_object<A>(self, mut object: A) -> Result<Self::Value, VisitorError>
+    fn visit_object<A>(self, mut object: A) -> Result<Self::Value, Report<VisitorError>>
     where
         A: ObjectAccess<'de>,
     {
@@ -293,7 +297,7 @@ impl Reflection for Example {
 impl<'de> Deserialize<'de> for Example {
     type Reflection = Self;
 
-    fn deserialize<D>(deserializer: D) -> Result<Self, DeserializeError>
+    fn deserialize<D>(deserializer: D) -> Result<Self, Report<DeserializeError>>
     where
         D: Deserializer<'de>,
     {

--- a/libs/deer/tests/test_value.rs
+++ b/libs/deer/tests/test_value.rs
@@ -12,7 +12,7 @@ use deer::{
         U64Deserializer, U128Deserializer, UsizeDeserializer,
     },
 };
-use error_stack::{Report, Result, ResultExt as _};
+use error_stack::{Report, ResultExt as _};
 use proptest::prelude::*;
 
 macro_rules! generate_proptest {
@@ -109,7 +109,7 @@ impl Visitor<'_> for ChoiceVisitor {
         Self::Value::document()
     }
 
-    fn visit_str(self, value: &str) -> Result<Self::Value, VisitorError> {
+    fn visit_str(self, value: &str) -> Result<Self::Value, Report<VisitorError>> {
         match value {
             "yes" => Ok(Choice::Yes),
             "no" => Ok(Choice::No),
@@ -124,7 +124,9 @@ impl Visitor<'_> for ChoiceVisitor {
 impl<'de> Deserialize<'de> for Choice {
     type Reflection = Self;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_str(ChoiceVisitor)
             .change_context(DeserializeError)
@@ -148,7 +150,7 @@ impl Visitor<'_> for NullVisitor {
         Self::Value::document()
     }
 
-    fn visit_null(self) -> Result<Self::Value, VisitorError> {
+    fn visit_null(self) -> Result<Self::Value, Report<VisitorError>> {
         Ok(Null)
     }
 }
@@ -156,7 +158,9 @@ impl Visitor<'_> for NullVisitor {
 impl<'de> Deserialize<'de> for Null {
     type Reflection = Self;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_null(NullVisitor)
             .change_context(DeserializeError)
@@ -304,7 +308,7 @@ impl<'de> Visitor<'de> for BytesVisitor {
         Bytes::document()
     }
 
-    fn visit_borrowed_bytes(self, value: &'de [u8]) -> Result<Self::Value, VisitorError> {
+    fn visit_borrowed_bytes(self, value: &'de [u8]) -> Result<Self::Value, Report<VisitorError>> {
         Ok(Bytes(value))
     }
 }
@@ -312,7 +316,9 @@ impl<'de> Visitor<'de> for BytesVisitor {
 impl<'de: 'a, 'a> Deserialize<'de> for Bytes<'a> {
     type Reflection = Bytes<'static>;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_bytes(BytesVisitor)
             .change_context(DeserializeError)
@@ -336,7 +342,7 @@ impl Visitor<'_> for BytesLengthVisitor {
         Self::Value::document()
     }
 
-    fn visit_bytes(self, value: &[u8]) -> Result<Self::Value, VisitorError> {
+    fn visit_bytes(self, value: &[u8]) -> Result<Self::Value, Report<VisitorError>> {
         Ok(BytesLength(value.len()))
     }
 }
@@ -344,7 +350,9 @@ impl Visitor<'_> for BytesLengthVisitor {
 impl<'de> Deserialize<'de> for BytesLength {
     type Reflection = Self;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_bytes(BytesLengthVisitor)
             .change_context(DeserializeError)
@@ -368,7 +376,7 @@ impl Visitor<'_> for ByteBufferVisitor {
         Self::Value::document()
     }
 
-    fn visit_bytes_buffer(self, value: Vec<u8>) -> Result<Self::Value, VisitorError> {
+    fn visit_bytes_buffer(self, value: Vec<u8>) -> Result<Self::Value, Report<VisitorError>> {
         Ok(ByteBuffer(value))
     }
 }
@@ -376,7 +384,9 @@ impl Visitor<'_> for ByteBufferVisitor {
 impl<'de> Deserialize<'de> for ByteBuffer {
     type Reflection = Self;
 
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, DeserializeError> {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, Report<DeserializeError>> {
         deserializer
             .deserialize_bytes_buffer(ByteBufferVisitor)
             .change_context(DeserializeError)

--- a/tests/hash-graph-integration/package.json
+++ b/tests/hash-graph-integration/package.json
@@ -12,6 +12,7 @@
     "@apps/hash-graph": "0.0.0-private",
     "@blockprotocol/type-system-rs": "0.0.0-private",
     "@rust/authorization": "0.0.0-private",
+    "@rust/error-stack": "0.5.0",
     "@rust/graph": "0.0.0-private",
     "@rust/graph-test-data": "0.0.0-private",
     "@rust/graph-types": "0.0.0-private",

--- a/tests/hash-graph-integration/postgres/lib.rs
+++ b/tests/hash-graph-integration/postgres/lib.rs
@@ -37,7 +37,7 @@ use authorization::{
     },
     zanzibar::Consistency,
 };
-use error_stack::Result;
+use error_stack::Report;
 use graph::{
     Environment, load_env,
     store::{
@@ -198,7 +198,7 @@ impl<A: AuthorizationApi> DatabaseTestWrapper<A> {
         data_types: D,
         property_types: P,
         entity_types: E,
-    ) -> Result<DatabaseApi<'_, &mut A>, InsertionError>
+    ) -> Result<DatabaseApi<'_, &mut A>, Report<InsertionError>>
     where
         D: IntoIterator<Item = &'static str, IntoIter: Send> + Send,
         P: IntoIterator<Item = &'static str, IntoIter: Send> + Send,
@@ -290,7 +290,7 @@ impl<A: AuthorizationApi> DataTypeStore for DatabaseApi<'_, A> {
         &mut self,
         actor_id: AccountId,
         params: P,
-    ) -> Result<Vec<DataTypeMetadata>, InsertionError>
+    ) -> Result<Vec<DataTypeMetadata>, Report<InsertionError>>
     where
         P: IntoIterator<Item = CreateDataTypeParams<R>, IntoIter: Send> + Send,
         R: IntoIterator<Item = DataTypeRelationAndSubject> + Send + Sync,
@@ -302,7 +302,7 @@ impl<A: AuthorizationApi> DataTypeStore for DatabaseApi<'_, A> {
         &self,
         actor_id: AccountId,
         params: CountDataTypesParams<'_>,
-    ) -> Result<usize, QueryError> {
+    ) -> Result<usize, Report<QueryError>> {
         self.store.count_data_types(actor_id, params).await
     }
 
@@ -310,7 +310,7 @@ impl<A: AuthorizationApi> DataTypeStore for DatabaseApi<'_, A> {
         &self,
         actor_id: AccountId,
         mut params: GetDataTypesParams<'_>,
-    ) -> Result<GetDataTypesResponse, QueryError> {
+    ) -> Result<GetDataTypesResponse, Report<QueryError>> {
         let include_count = params.include_count;
         let has_limit = params.limit.is_some();
         params.include_count = true;
@@ -342,7 +342,7 @@ impl<A: AuthorizationApi> DataTypeStore for DatabaseApi<'_, A> {
         &self,
         actor_id: AccountId,
         mut params: GetDataTypeSubgraphParams<'_>,
-    ) -> Result<GetDataTypeSubgraphResponse, QueryError> {
+    ) -> Result<GetDataTypeSubgraphResponse, Report<QueryError>> {
         let include_count = params.include_count;
         let has_limit = params.limit.is_some();
         params.include_count = true;
@@ -374,7 +374,7 @@ impl<A: AuthorizationApi> DataTypeStore for DatabaseApi<'_, A> {
         &mut self,
         actor_id: AccountId,
         params: UpdateDataTypesParams<R>,
-    ) -> Result<DataTypeMetadata, UpdateError>
+    ) -> Result<DataTypeMetadata, Report<UpdateError>>
     where
         R: IntoIterator<Item = DataTypeRelationAndSubject> + Send + Sync,
     {
@@ -385,7 +385,7 @@ impl<A: AuthorizationApi> DataTypeStore for DatabaseApi<'_, A> {
         &mut self,
         actor_id: AccountId,
         params: ArchiveDataTypeParams<'_>,
-    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+    ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         self.store.archive_data_type(actor_id, params).await
     }
 
@@ -393,7 +393,7 @@ impl<A: AuthorizationApi> DataTypeStore for DatabaseApi<'_, A> {
         &mut self,
         actor_id: AccountId,
         params: UnarchiveDataTypeParams,
-    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+    ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         self.store.unarchive_data_type(actor_id, params).await
     }
 
@@ -401,13 +401,13 @@ impl<A: AuthorizationApi> DataTypeStore for DatabaseApi<'_, A> {
         &mut self,
         actor_id: AccountId,
         params: UpdateDataTypeEmbeddingParams<'_>,
-    ) -> Result<(), UpdateError> {
+    ) -> Result<(), Report<UpdateError>> {
         self.store
             .update_data_type_embeddings(actor_id, params)
             .await
     }
 
-    async fn reindex_data_type_cache(&mut self) -> Result<(), UpdateError> {
+    async fn reindex_data_type_cache(&mut self) -> Result<(), Report<UpdateError>> {
         self.store.reindex_entity_type_cache().await
     }
 }
@@ -417,7 +417,7 @@ impl<A: AuthorizationApi> PropertyTypeStore for DatabaseApi<'_, A> {
         &mut self,
         actor_id: AccountId,
         params: P,
-    ) -> Result<Vec<PropertyTypeMetadata>, InsertionError>
+    ) -> Result<Vec<PropertyTypeMetadata>, Report<InsertionError>>
     where
         P: IntoIterator<Item = CreatePropertyTypeParams<R>, IntoIter: Send> + Send,
         R: IntoIterator<Item = PropertyTypeRelationAndSubject> + Send + Sync,
@@ -429,7 +429,7 @@ impl<A: AuthorizationApi> PropertyTypeStore for DatabaseApi<'_, A> {
         &self,
         actor_id: AccountId,
         params: CountPropertyTypesParams<'_>,
-    ) -> Result<usize, QueryError> {
+    ) -> Result<usize, Report<QueryError>> {
         self.store.count_property_types(actor_id, params).await
     }
 
@@ -437,7 +437,7 @@ impl<A: AuthorizationApi> PropertyTypeStore for DatabaseApi<'_, A> {
         &self,
         actor_id: AccountId,
         mut params: GetPropertyTypesParams<'_>,
-    ) -> Result<GetPropertyTypesResponse, QueryError> {
+    ) -> Result<GetPropertyTypesResponse, Report<QueryError>> {
         let include_count = params.include_count;
         let has_limit = params.limit.is_some();
         params.include_count = true;
@@ -470,7 +470,7 @@ impl<A: AuthorizationApi> PropertyTypeStore for DatabaseApi<'_, A> {
         &self,
         actor_id: AccountId,
         mut params: GetPropertyTypeSubgraphParams<'_>,
-    ) -> Result<GetPropertyTypeSubgraphResponse, QueryError> {
+    ) -> Result<GetPropertyTypeSubgraphResponse, Report<QueryError>> {
         let include_count = params.include_count;
         let has_limit = params.limit.is_some();
         params.include_count = true;
@@ -507,7 +507,7 @@ impl<A: AuthorizationApi> PropertyTypeStore for DatabaseApi<'_, A> {
         &mut self,
         actor_id: AccountId,
         params: UpdatePropertyTypesParams<R>,
-    ) -> Result<PropertyTypeMetadata, UpdateError>
+    ) -> Result<PropertyTypeMetadata, Report<UpdateError>>
     where
         R: IntoIterator<Item = PropertyTypeRelationAndSubject> + Send + Sync,
     {
@@ -518,7 +518,7 @@ impl<A: AuthorizationApi> PropertyTypeStore for DatabaseApi<'_, A> {
         &mut self,
         actor_id: AccountId,
         params: ArchivePropertyTypeParams<'_>,
-    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+    ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         self.store.archive_property_type(actor_id, params).await
     }
 
@@ -526,7 +526,7 @@ impl<A: AuthorizationApi> PropertyTypeStore for DatabaseApi<'_, A> {
         &mut self,
         actor_id: AccountId,
         params: UnarchivePropertyTypeParams<'_>,
-    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+    ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         self.store.unarchive_property_type(actor_id, params).await
     }
 
@@ -534,7 +534,7 @@ impl<A: AuthorizationApi> PropertyTypeStore for DatabaseApi<'_, A> {
         &mut self,
         actor_id: AccountId,
         params: UpdatePropertyTypeEmbeddingParams<'_>,
-    ) -> Result<(), UpdateError> {
+    ) -> Result<(), Report<UpdateError>> {
         self.store
             .update_property_type_embeddings(actor_id, params)
             .await
@@ -546,7 +546,7 @@ impl<A: AuthorizationApi> EntityTypeStore for DatabaseApi<'_, A> {
         &mut self,
         actor_id: AccountId,
         params: P,
-    ) -> Result<Vec<EntityTypeMetadata>, InsertionError>
+    ) -> Result<Vec<EntityTypeMetadata>, Report<InsertionError>>
     where
         P: IntoIterator<Item = CreateEntityTypeParams<R>, IntoIter: Send> + Send,
         R: IntoIterator<Item = EntityTypeRelationAndSubject> + Send + Sync,
@@ -558,7 +558,7 @@ impl<A: AuthorizationApi> EntityTypeStore for DatabaseApi<'_, A> {
         &self,
         actor_id: AccountId,
         params: CountEntityTypesParams<'_>,
-    ) -> Result<usize, QueryError> {
+    ) -> Result<usize, Report<QueryError>> {
         self.store.count_entity_types(actor_id, params).await
     }
 
@@ -566,7 +566,7 @@ impl<A: AuthorizationApi> EntityTypeStore for DatabaseApi<'_, A> {
         &self,
         actor_id: AccountId,
         mut params: GetEntityTypesParams<'_>,
-    ) -> Result<GetEntityTypesResponse, QueryError> {
+    ) -> Result<GetEntityTypesResponse, Report<QueryError>> {
         let include_count = params.include_count;
         let has_limit = params.limit.is_some();
         params.include_count = true;
@@ -598,7 +598,7 @@ impl<A: AuthorizationApi> EntityTypeStore for DatabaseApi<'_, A> {
         &self,
         actor_id: AccountId,
         params: GetClosedMultiEntityTypeParams,
-    ) -> Result<GetClosedMultiEntityTypeResponse, QueryError> {
+    ) -> Result<GetClosedMultiEntityTypeResponse, Report<QueryError>> {
         self.store
             .get_closed_multi_entity_types(actor_id, params)
             .await
@@ -608,7 +608,7 @@ impl<A: AuthorizationApi> EntityTypeStore for DatabaseApi<'_, A> {
         &self,
         actor_id: AccountId,
         mut params: GetEntityTypeSubgraphParams<'_>,
-    ) -> Result<GetEntityTypeSubgraphResponse, QueryError> {
+    ) -> Result<GetEntityTypeSubgraphResponse, Report<QueryError>> {
         let include_count = params.include_count;
         let has_limit = params.limit.is_some();
         params.include_count = true;
@@ -644,7 +644,7 @@ impl<A: AuthorizationApi> EntityTypeStore for DatabaseApi<'_, A> {
         &mut self,
         actor_id: AccountId,
         params: UpdateEntityTypesParams<R>,
-    ) -> Result<EntityTypeMetadata, UpdateError>
+    ) -> Result<EntityTypeMetadata, Report<UpdateError>>
     where
         R: IntoIterator<Item = EntityTypeRelationAndSubject> + Send + Sync,
     {
@@ -655,7 +655,7 @@ impl<A: AuthorizationApi> EntityTypeStore for DatabaseApi<'_, A> {
         &mut self,
         actor_id: AccountId,
         params: ArchiveEntityTypeParams<'_>,
-    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+    ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         self.store.archive_entity_type(actor_id, params).await
     }
 
@@ -663,7 +663,7 @@ impl<A: AuthorizationApi> EntityTypeStore for DatabaseApi<'_, A> {
         &mut self,
         actor_id: AccountId,
         params: UnarchiveEntityTypeParams<'_>,
-    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+    ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         self.store.unarchive_entity_type(actor_id, params).await
     }
 
@@ -671,13 +671,13 @@ impl<A: AuthorizationApi> EntityTypeStore for DatabaseApi<'_, A> {
         &mut self,
         actor_id: AccountId,
         params: UpdateEntityTypeEmbeddingParams<'_>,
-    ) -> Result<(), UpdateError> {
+    ) -> Result<(), Report<UpdateError>> {
         self.store
             .update_entity_type_embeddings(actor_id, params)
             .await
     }
 
-    async fn reindex_entity_type_cache(&mut self) -> Result<(), UpdateError> {
+    async fn reindex_entity_type_cache(&mut self) -> Result<(), Report<UpdateError>> {
         self.store.reindex_entity_type_cache().await
     }
 }
@@ -690,7 +690,7 @@ where
         &mut self,
         actor_id: AccountId,
         params: Vec<CreateEntityParams<R>>,
-    ) -> Result<Vec<Entity>, InsertionError>
+    ) -> Result<Vec<Entity>, Report<InsertionError>>
     where
         R: IntoIterator<Item = EntityRelationAndSubject> + Send,
     {
@@ -702,7 +702,7 @@ where
         actor_id: AccountId,
         consistency: Consistency<'_>,
         params: Vec<ValidateEntityParams<'_>>,
-    ) -> Result<(), ValidateEntityError> {
+    ) -> Result<(), Report<ValidateEntityError>> {
         self.store
             .validate_entities(actor_id, consistency, params)
             .await
@@ -712,7 +712,7 @@ where
         &self,
         actor_id: AccountId,
         mut params: GetEntitiesParams<'_>,
-    ) -> Result<GetEntitiesResponse<'static>, QueryError> {
+    ) -> Result<GetEntitiesResponse<'static>, Report<QueryError>> {
         let include_count = params.include_count;
         let has_limit = params.limit.is_some();
         params.include_count = true;
@@ -744,7 +744,7 @@ where
         &self,
         actor_id: AccountId,
         mut params: GetEntitySubgraphParams<'_>,
-    ) -> Result<GetEntitySubgraphResponse<'static>, QueryError> {
+    ) -> Result<GetEntitySubgraphResponse<'static>, Report<QueryError>> {
         let include_count = params.include_count;
         let has_limit = params.limit.is_some();
         params.include_count = true;
@@ -775,7 +775,7 @@ where
         &self,
         actor_id: AccountId,
         params: CountEntitiesParams<'_>,
-    ) -> Result<usize, QueryError> {
+    ) -> Result<usize, Report<QueryError>> {
         self.store.count_entities(actor_id, params).await
     }
 
@@ -785,7 +785,7 @@ where
         entity_id: EntityId,
         transaction_time: Option<Timestamp<TransactionTime>>,
         decision_time: Option<Timestamp<DecisionTime>>,
-    ) -> Result<Entity, QueryError> {
+    ) -> Result<Entity, Report<QueryError>> {
         self.store
             .get_entity_by_id(actor_id, entity_id, transaction_time, decision_time)
             .await
@@ -795,7 +795,7 @@ where
         &mut self,
         actor_id: AccountId,
         params: PatchEntityParams,
-    ) -> Result<Entity, UpdateError> {
+    ) -> Result<Entity, Report<UpdateError>> {
         self.store.patch_entity(actor_id, params).await
     }
 
@@ -803,11 +803,11 @@ where
         &mut self,
         actor_id: AccountId,
         params: UpdateEntityEmbeddingsParams<'_>,
-    ) -> Result<(), UpdateError> {
+    ) -> Result<(), Report<UpdateError>> {
         self.store.update_entity_embeddings(actor_id, params).await
     }
 
-    async fn reindex_entity_cache(&mut self) -> Result<(), UpdateError> {
+    async fn reindex_entity_cache(&mut self) -> Result<(), Report<UpdateError>> {
         self.store.reindex_entity_cache().await
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We recently updated the in-tree version of error-stack and added a deprecation to `error_stack::{Result, Context}`. To not need to address these in the whole workspace this has been deferred to this PR.

## 🔍 What does this change?

- Replace `error_stack::Result` with `core::result::Result<_, error_stack::Report<_>>`
- Replace `error_stack::Context` with `core::error::Error`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph