### PR TITLE
H-3557: Introduce `Subsystem` and `SubsystemIdentifier`

### DIFF
--- a/apps/hash-graph/libs/api/src/rpc/account.rs
+++ b/apps/hash-graph/libs/api/src/rpc/account.rs
@@ -103,7 +103,9 @@ pub mod meta {
         metadata::Metadata,
         procedure::{Procedure, ProcedureIdentifier},
     };
-    use harpc_types::{procedure::ProcedureId, subsystem::SubsystemId, version::Version};
+    use harpc_types::{procedure::ProcedureId, version::Version};
+
+    use crate::rpc::GraphSubsystemId;
 
     pub enum AccountProcedureId {
         CreateAccount,
@@ -149,8 +151,9 @@ pub mod meta {
             ProcedureAddAccountGroupMember,
             ProcedureRemoveAccountGroupMember
         ];
+        type SubsystemId = GraphSubsystemId;
 
-        const ID: SubsystemId = SubsystemId::new(0x01);
+        const ID: GraphSubsystemId = GraphSubsystemId::Account;
         const VERSION: Version = Version {
             major: 0x00,
             minor: 0x00,

--- a/apps/hash-graph/libs/api/src/rpc/auth.rs
+++ b/apps/hash-graph/libs/api/src/rpc/auth.rs
@@ -9,7 +9,7 @@ use harpc_server::{
     session::Session,
     utils::{delegate_call_discrete, parse_procedure_id},
 };
-use harpc_service::delegate::ServiceDelegate;
+use harpc_service::delegate::SubsystemDelegate;
 use harpc_tower::{body::Body, request::Request, response::Response};
 use harpc_types::response_kind::ResponseKind;
 
@@ -41,14 +41,14 @@ pub mod meta {
         metadata::Metadata,
         procedure::{Procedure, ProcedureIdentifier},
     };
-    use harpc_types::{procedure::ProcedureId, service::ServiceId, version::Version};
+    use harpc_types::{procedure::ProcedureId, subsystem::SubsystemId, version::Version};
 
     pub enum AuthenticationProcedureId {
         Authenticate,
     }
 
     impl ProcedureIdentifier for AuthenticationProcedureId {
-        type Service = AuthenticationSystem;
+        type Subsystem = AuthenticationSystem;
 
         fn from_id(id: ProcedureId) -> Option<Self> {
             match id.value() {
@@ -70,7 +70,7 @@ pub mod meta {
         type ProcedureId = AuthenticationProcedureId;
         type Procedures = HList![ProcedureAuthenticate];
 
-        const ID: ServiceId = ServiceId::new(0x00);
+        const ID: SubsystemId = SubsystemId::new(0x00);
         const VERSION: Version = Version {
             major: 0x00,
             minor: 0x00,
@@ -132,13 +132,13 @@ pub struct AuthenticationDelegate<T> {
     inner: T,
 }
 
-impl<T, C> ServiceDelegate<Session<Account>, C> for AuthenticationDelegate<T>
+impl<T, C> SubsystemDelegate<Session<Account>, C> for AuthenticationDelegate<T>
 where
     T: AuthenticationSystem<role::Server, authenticate(..): Send> + Send,
     C: Encoder + ReportDecoder + Clone + Send,
 {
     type Error = Report<DelegationError>;
-    type Service = meta::AuthenticationSystem;
+    type Subsystem = meta::AuthenticationSystem;
 
     type Body<Source>
         = impl Body<Control: AsRef<ResponseKind>, Error = <C as Encoder>::Error>

--- a/apps/hash-graph/libs/api/src/rpc/auth.rs
+++ b/apps/hash-graph/libs/api/src/rpc/auth.rs
@@ -41,7 +41,9 @@ pub mod meta {
         metadata::Metadata,
         procedure::{Procedure, ProcedureIdentifier},
     };
-    use harpc_types::{procedure::ProcedureId, subsystem::SubsystemId, version::Version};
+    use harpc_types::{procedure::ProcedureId, version::Version};
+
+    use crate::rpc::GraphSubsystemId;
 
     pub enum AuthenticationProcedureId {
         Authenticate,
@@ -69,8 +71,9 @@ pub mod meta {
     impl Subsystem for AuthenticationSystem {
         type ProcedureId = AuthenticationProcedureId;
         type Procedures = HList![ProcedureAuthenticate];
+        type SubsystemId = GraphSubsystemId;
 
-        const ID: SubsystemId = SubsystemId::new(0x00);
+        const ID: GraphSubsystemId = GraphSubsystemId::Authentication;
         const VERSION: Version = Version {
             major: 0x00,
             minor: 0x00,

--- a/apps/hash-graph/libs/api/src/rpc/echo.rs
+++ b/apps/hash-graph/libs/api/src/rpc/echo.rs
@@ -38,7 +38,9 @@ pub mod meta {
         metadata::Metadata,
         procedure::{Procedure, ProcedureIdentifier},
     };
-    use harpc_types::{procedure::ProcedureId, subsystem::SubsystemId, version::Version};
+    use harpc_types::{procedure::ProcedureId, version::Version};
+
+    use crate::rpc::GraphSubsystemId;
 
     pub enum EchoProcedureId {
         Echo,
@@ -66,8 +68,9 @@ pub mod meta {
     impl Subsystem for EchoSystem {
         type ProcedureId = EchoProcedureId;
         type Procedures = HList![ProcedureEcho];
+        type SubsystemId = GraphSubsystemId;
 
-        const ID: SubsystemId = SubsystemId::new(0x02);
+        const ID: GraphSubsystemId = GraphSubsystemId::Echo;
         const VERSION: Version = Version {
             major: 0x00,
             minor: 0x00,

--- a/apps/hash-graph/libs/api/src/rpc/echo.rs
+++ b/apps/hash-graph/libs/api/src/rpc/echo.rs
@@ -6,7 +6,7 @@ use harpc_server::{
     session::Session,
     utils::{delegate_call_discrete, parse_procedure_id},
 };
-use harpc_service::{delegate::ServiceDelegate, role::Role};
+use harpc_service::{delegate::SubsystemDelegate, role::Role};
 use harpc_tower::{body::Body, request::Request, response::Response};
 use harpc_types::response_kind::ResponseKind;
 
@@ -38,14 +38,14 @@ pub mod meta {
         metadata::Metadata,
         procedure::{Procedure, ProcedureIdentifier},
     };
-    use harpc_types::{procedure::ProcedureId, service::ServiceId, version::Version};
+    use harpc_types::{procedure::ProcedureId, subsystem::SubsystemId, version::Version};
 
     pub enum EchoProcedureId {
         Echo,
     }
 
     impl ProcedureIdentifier for EchoProcedureId {
-        type Service = EchoSystem;
+        type Subsystem = EchoSystem;
 
         fn from_id(id: ProcedureId) -> Option<Self> {
             match id.value() {
@@ -67,7 +67,7 @@ pub mod meta {
         type ProcedureId = EchoProcedureId;
         type Procedures = HList![ProcedureEcho];
 
-        const ID: ServiceId = ServiceId::new(0x02);
+        const ID: SubsystemId = SubsystemId::new(0x02);
         const VERSION: Version = Version {
             major: 0x00,
             minor: 0x00,
@@ -128,13 +128,13 @@ impl<T> EchoDelegate<T> {
     }
 }
 
-impl<T, C> ServiceDelegate<Session<Account>, C> for EchoDelegate<T>
+impl<T, C> SubsystemDelegate<Session<Account>, C> for EchoDelegate<T>
 where
     T: EchoSystem<role::Server, echo(..): Send> + Send,
     C: Encoder + ReportDecoder + Clone + Send,
 {
     type Error = Report<DelegationError>;
-    type Service = meta::EchoSystem;
+    type Subsystem = meta::EchoSystem;
 
     type Body<Source>
         = impl Body<Control: AsRef<ResponseKind>, Error = <C as Encoder>::Error>

--- a/apps/hash-graph/libs/api/src/rpc/mod.rs
+++ b/apps/hash-graph/libs/api/src/rpc/mod.rs
@@ -3,6 +3,9 @@ pub mod auth;
 pub mod echo;
 mod session;
 
+use harpc_service::SubsystemIdentifier;
+use harpc_types::subsystem::SubsystemId;
+
 mod role {
     use harpc_client::connection::Connection;
     use harpc_server::session::Session;
@@ -12,4 +15,33 @@ mod role {
 
     pub(crate) type Server = harpc_service::role::Server<Session<Account>>;
     pub(crate) type Client<Svc, C> = harpc_service::role::Client<Connection<Svc, C>>;
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum GraphSubsystemId {
+    Echo,
+    Authentication,
+    Account,
+}
+
+impl SubsystemIdentifier for GraphSubsystemId {
+    fn from_id(id: SubsystemId) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        match id.value() {
+            0x00 => Some(Self::Echo),
+            0x01 => Some(Self::Authentication),
+            0x02 => Some(Self::Account),
+            _ => None,
+        }
+    }
+
+    fn into_id(self) -> SubsystemId {
+        match self {
+            Self::Echo => SubsystemId::new(0x00),
+            Self::Authentication => SubsystemId::new(0x01),
+            Self::Account => SubsystemId::new(0x02),
+        }
+    }
 }

--- a/libs/@local/harpc/client/src/connection/service.rs
+++ b/libs/@local/harpc/client/src/connection/service.rs
@@ -51,7 +51,7 @@ where
         let connection = Arc::clone(&self.inner);
 
         async move {
-            let service = req.service();
+            let service = req.subsystem();
             let procedure = req.procedure();
             let session = req.session();
 

--- a/libs/@local/harpc/client/src/utils.rs
+++ b/libs/@local/harpc/client/src/utils.rs
@@ -6,7 +6,7 @@ use error_stack::{Report, ResultExt as _, TryReportStreamExt as _};
 use futures::{StreamExt as _, stream};
 use harpc_codec::encode::Encoder;
 use harpc_net::session::server::SessionId;
-use harpc_service::{Service, procedure::ProcedureIdentifier};
+use harpc_service::{Subsystem, procedure::ProcedureIdentifier};
 use harpc_tower::{
     Extensions,
     request::{self, Request},
@@ -38,8 +38,8 @@ where
     Ok(Request::from_parts(
         request::Parts {
             service: ServiceDescriptor {
-                id: <P::Service as Service>::ID,
-                version: <P::Service as Service>::VERSION,
+                id: <P::Service as Subsystem>::ID,
+                version: <P::Service as Subsystem>::VERSION,
             },
             procedure: ProcedureDescriptor {
                 id: procedure.into_id(),

--- a/libs/@local/harpc/client/src/utils.rs
+++ b/libs/@local/harpc/client/src/utils.rs
@@ -11,7 +11,7 @@ use harpc_tower::{
     Extensions,
     request::{self, Request},
 };
-use harpc_types::{procedure::ProcedureDescriptor, subsystem::SubsystemDescriptor};
+use harpc_types::procedure::ProcedureDescriptor;
 use tower::ServiceExt as _;
 
 use crate::{
@@ -37,10 +37,7 @@ where
 
     Ok(Request::from_parts(
         request::Parts {
-            subsystem: SubsystemDescriptor {
-                id: <P::Subsystem as Subsystem>::ID,
-                version: <P::Subsystem as Subsystem>::VERSION,
-            },
+            subsystem: <P::Subsystem as Subsystem>::descriptor(),
             procedure: ProcedureDescriptor {
                 id: procedure.into_id(),
             },

--- a/libs/@local/harpc/client/src/utils.rs
+++ b/libs/@local/harpc/client/src/utils.rs
@@ -11,7 +11,7 @@ use harpc_tower::{
     Extensions,
     request::{self, Request},
 };
-use harpc_types::{procedure::ProcedureDescriptor, service::ServiceDescriptor};
+use harpc_types::{procedure::ProcedureDescriptor, subsystem::SubsystemDescriptor};
 use tower::ServiceExt as _;
 
 use crate::{
@@ -37,9 +37,9 @@ where
 
     Ok(Request::from_parts(
         request::Parts {
-            service: ServiceDescriptor {
-                id: <P::Service as Subsystem>::ID,
-                version: <P::Service as Subsystem>::VERSION,
+            subsystem: SubsystemDescriptor {
+                id: <P::Subsystem as Subsystem>::ID,
+                version: <P::Subsystem as Subsystem>::VERSION,
             },
             procedure: ProcedureDescriptor {
                 id: procedure.into_id(),

--- a/libs/@local/harpc/net/src/session/client/connection/mod.rs
+++ b/libs/@local/harpc/net/src/session/client/connection/mod.rs
@@ -8,7 +8,7 @@ use alloc::sync::Arc;
 use bytes::Bytes;
 use error_stack::Report;
 use futures::{Sink, Stream, StreamExt as _, prelude::future::FutureExt as _};
-use harpc_types::{procedure::ProcedureDescriptor, service::ServiceDescriptor};
+use harpc_types::{procedure::ProcedureDescriptor, subsystem::SubsystemDescriptor};
 use harpc_wire_protocol::{request::Request, response::Response};
 use scc::ebr::Guard;
 use tachyonix::SendTimeoutError;
@@ -335,7 +335,7 @@ impl Connection {
     /// connection is currently in its process of being closed.
     pub async fn call(
         &self,
-        service: ServiceDescriptor,
+        subsystem: SubsystemDescriptor,
         procedure: ProcedureDescriptor,
         payload: impl Stream<Item = Bytes> + Send + 'static,
     ) -> Result<ResponseStream, Report<ConnectionPartiallyClosedError>> {
@@ -362,7 +362,7 @@ impl Connection {
         let task = TransactionTask {
             config: self.config,
             permit,
-            service,
+            subsystem,
             procedure,
             response_rx,
             response_tx: stream_tx,

--- a/libs/@local/harpc/net/src/session/client/transaction/mod.rs
+++ b/libs/@local/harpc/net/src/session/client/transaction/mod.rs
@@ -8,7 +8,7 @@ use core::ops::ControlFlow;
 use bytes::Bytes;
 use futures::{Stream, StreamExt as _, prelude::future::FutureExt as _};
 use harpc_types::{
-    procedure::ProcedureDescriptor, response_kind::ResponseKind, service::ServiceDescriptor,
+    procedure::ProcedureDescriptor, response_kind::ResponseKind, subsystem::SubsystemDescriptor,
 };
 use harpc_wire_protocol::{
     flags::BitFlagsOp as _,
@@ -183,7 +183,7 @@ where
 pub(crate) struct TransactionSendTask<S, P> {
     config: SessionConfig,
 
-    service: ServiceDescriptor,
+    subsystem: SubsystemDescriptor,
     procedure: ProcedureDescriptor,
 
     rx: S,
@@ -209,7 +209,7 @@ where
             },
             RequestContext {
                 id: self.permit.id(),
-                service: self.service,
+                subsystem: self.subsystem,
                 procedure: self.procedure,
             },
             &self.tx,
@@ -250,7 +250,7 @@ pub(crate) struct TransactionTask<S, P> {
     pub config: SessionConfig,
     pub permit: P,
 
-    pub service: ServiceDescriptor,
+    pub subsystem: SubsystemDescriptor,
     pub procedure: ProcedureDescriptor,
 
     pub response_rx: tachyonix::Receiver<Response>,
@@ -282,7 +282,7 @@ where
             TransactionSendTask {
                 config: self.config,
 
-                service: self.service,
+                subsystem: self.subsystem,
                 procedure: self.procedure,
 
                 rx: self.request_rx,

--- a/libs/@local/harpc/net/src/session/client/transaction/test.rs
+++ b/libs/@local/harpc/net/src/session/client/transaction/test.rs
@@ -745,7 +745,7 @@ fn setup_send_mapped<T>(
 
     let task = TransactionSendTask {
         config,
-        service: descriptor.service,
+        subsystem: descriptor.subsystem,
         procedure: descriptor.procedure,
         rx: ReceiverStream::new(bytes_rx),
         tx: request_tx,
@@ -790,10 +790,10 @@ async fn send_drop_sender() {
     assert_matches!(
         request.body,
         RequestBody::Begin(RequestBegin {
-            service,
+            subsystem,
             procedure,
             payload
-        }) if service == descriptor.service
+        }) if subsystem == descriptor.subsystem
             && procedure == descriptor.procedure
             && payload.is_empty()
     );
@@ -879,10 +879,10 @@ async fn send_no_delay() {
     assert_matches!(
         request.body,
         RequestBody::Begin(RequestBegin {
-            service,
+            subsystem,
             procedure,
             payload
-        }) if service == descriptor.service
+        }) if subsystem == descriptor.subsystem
             && procedure == descriptor.procedure
             && *payload.as_bytes() == Bytes::from_static(b"apple")
     );
@@ -922,10 +922,10 @@ async fn send_no_delay_flush_empty() {
     assert_matches!(
         request.body,
         RequestBody::Begin(RequestBegin {
-            service,
+            subsystem,
             procedure,
             payload
-        }) if service == descriptor.service
+        }) if subsystem == descriptor.subsystem
             && procedure == descriptor.procedure
             && payload.is_empty()
     );
@@ -968,10 +968,10 @@ async fn send_delay() {
     assert_matches!(
         request.body,
         RequestBody::Begin(RequestBegin {
-            service,
+            subsystem,
             procedure,
             payload
-        }) if service == descriptor.service
+        }) if subsystem == descriptor.subsystem
             && procedure == descriptor.procedure
             && payload.len() == Payload::MAX_SIZE
     );
@@ -1020,10 +1020,10 @@ async fn send_delay_flush_partial() {
     assert_matches!(
         request.body,
         RequestBody::Begin(RequestBegin {
-            service,
+            subsystem,
             procedure,
             payload
-        }) if service == descriptor.service
+        }) if subsystem == descriptor.subsystem
             && procedure == descriptor.procedure
             && payload.len() == Payload::MAX_SIZE
     );
@@ -1053,10 +1053,10 @@ async fn send_delay_flush_empty() {
     assert_matches!(
         request.body,
         RequestBody::Begin(RequestBegin {
-            service,
+            subsystem,
             procedure,
             payload
-        }) if service == descriptor.service
+        }) if subsystem == descriptor.subsystem
             && procedure == descriptor.procedure
             && payload.is_empty()
     );

--- a/libs/@local/harpc/net/src/session/server/transaction/mod.rs
+++ b/libs/@local/harpc/net/src/session/server/transaction/mod.rs
@@ -11,7 +11,7 @@ use bytes::Bytes;
 use futures::{Sink, Stream, StreamExt as _, stream::FusedStream};
 use harpc_codec::error::NetworkError;
 use harpc_types::{
-    procedure::ProcedureDescriptor, response_kind::ResponseKind, service::ServiceDescriptor,
+    procedure::ProcedureDescriptor, response_kind::ResponseKind, subsystem::SubsystemDescriptor,
 };
 use harpc_wire_protocol::{
     flags::BitFlagsOp as _,
@@ -179,7 +179,7 @@ pub struct TransactionContext {
     peer: Box<PeerId>,
     session: SessionId,
 
-    service: ServiceDescriptor,
+    subsystem: SubsystemDescriptor,
     procedure: ProcedureDescriptor,
 }
 
@@ -200,8 +200,8 @@ impl TransactionContext {
     }
 
     #[must_use]
-    pub const fn service(&self) -> ServiceDescriptor {
-        self.service
+    pub const fn subsystem(&self) -> SubsystemDescriptor {
+        self.subsystem
     }
 
     #[must_use]
@@ -248,7 +248,7 @@ impl Transaction {
                 id: permit.id(),
                 peer: Box::new(peer),
                 session,
-                service: body.service,
+                subsystem: body.subsystem,
                 procedure: body.procedure,
             },
 

--- a/libs/@local/harpc/net/src/session/server/transaction/test.rs
+++ b/libs/@local/harpc/net/src/session/server/transaction/test.rs
@@ -12,7 +12,7 @@ use harpc_types::{
     error_code::ErrorCode,
     procedure::{ProcedureDescriptor, ProcedureId},
     response_kind::ResponseKind,
-    service::{ServiceDescriptor, ServiceId},
+    subsystem::{SubsystemDescriptor, SubsystemId},
     version::Version,
 };
 use harpc_wire_protocol::{
@@ -1271,8 +1271,8 @@ fn make_begin(flags: impl Into<RequestFlags>, payload: impl Into<Bytes>) -> Requ
             request_id: mock_request_id(0x01),
         },
         body: RequestBody::Begin(RequestBegin {
-            service: ServiceDescriptor {
-                id: ServiceId::new(0x00),
+            subsystem: SubsystemDescriptor {
+                id: SubsystemId::new(0x00),
                 version: Version {
                     major: 0x00,
                     minor: 0x00,

--- a/libs/@local/harpc/net/src/session/test.rs
+++ b/libs/@local/harpc/net/src/session/test.rs
@@ -6,7 +6,7 @@ use error_stack::{Report, ResultExt as _};
 use futures::{prelude::stream, sink::SinkExt as _, stream::StreamExt as _};
 use harpc_types::{
     procedure::{ProcedureDescriptor, ProcedureId},
-    service::{ServiceDescriptor, ServiceId},
+    subsystem::{SubsystemDescriptor, SubsystemId},
     version::Version,
 };
 use humansize::ISizeFormatter;
@@ -25,15 +25,15 @@ use crate::transport::{Transport, TransportConfig, TransportLayer, test::memory_
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct Descriptor {
-    pub service: ServiceDescriptor,
+    pub subsystem: SubsystemDescriptor,
     pub procedure: ProcedureDescriptor,
 }
 
 impl Default for Descriptor {
     fn default() -> Self {
         Self {
-            service: ServiceDescriptor {
-                id: ServiceId::new(0x00),
+            subsystem: SubsystemDescriptor {
+                id: SubsystemId::new(0x00),
                 version: Version { major: 1, minor: 1 },
             },
             procedure: ProcedureDescriptor {
@@ -51,13 +51,13 @@ enum PingError {
     Sink,
 }
 
-/// Simple Echo Service
+/// Simple Echo Subsystem
 ///
-/// Unlike the `EchoService` in `server/test.rs` this one doesn't keep track of statistics, to
+/// Unlike the `EchoSystem` in `server/test.rs` this one doesn't keep track of statistics, to
 /// remove as many variables as possible from RTT measurements.
-struct SimpleEchoService;
+struct SimpleEchoSystem;
 
-impl SimpleEchoService {
+impl SimpleEchoSystem {
     async fn handle(
         mut sink: TransactionSink,
         mut stream: TransactionStream,
@@ -152,7 +152,7 @@ where
             .pop()
             .expect("should have at least one external address");
 
-        SimpleEchoService::spawn(server_stream);
+        SimpleEchoSystem::spawn(server_stream);
 
         address
     };
@@ -178,7 +178,7 @@ where
 
     let mut stream = connection
         .call(
-            descriptor.service,
+            descriptor.subsystem,
             descriptor.procedure,
             stream::iter(iter::once(payload)),
         )
@@ -252,7 +252,7 @@ async fn echo_client<const VERIFY: bool>(
 
     let mut stream = connection
         .call(
-            descriptor.service,
+            descriptor.subsystem,
             descriptor.procedure,
             stream::iter(iter::once(payload)),
         )
@@ -311,7 +311,7 @@ async fn echo_concurrent<T>(
             .pop()
             .expect("should have at least one external address");
 
-        SimpleEchoService::spawn(server_stream);
+        SimpleEchoSystem::spawn(server_stream);
 
         address
     };

--- a/libs/@local/harpc/net/src/session/writer/mod.rs
+++ b/libs/@local/harpc/net/src/session/writer/mod.rs
@@ -4,7 +4,7 @@ mod test;
 use bytes::{Buf as _, Bytes};
 use bytes_utils::SegmentedBuf;
 use harpc_types::{
-    procedure::ProcedureDescriptor, response_kind::ResponseKind, service::ServiceDescriptor,
+    procedure::ProcedureDescriptor, response_kind::ResponseKind, subsystem::SubsystemDescriptor,
 };
 use harpc_wire_protocol::{
     flags::BitFlagsOp as _,
@@ -62,7 +62,7 @@ pub(crate) trait NetworkPacket {
 pub(crate) struct RequestContext {
     pub id: RequestId,
 
-    pub service: ServiceDescriptor,
+    pub subsystem: SubsystemDescriptor,
     pub procedure: ProcedureDescriptor,
 }
 
@@ -83,7 +83,7 @@ impl NetworkPacket for Request {
         Self {
             header: new_request_header(*context),
             body: RequestBody::Begin(RequestBegin {
-                service: context.service,
+                subsystem: context.subsystem,
                 procedure: context.procedure,
                 payload: Payload::new(bytes),
             }),

--- a/libs/@local/harpc/server/examples/account.rs
+++ b/libs/@local/harpc/server/examples/account.rs
@@ -22,7 +22,7 @@ use harpc_client::{Client, ClientConfig, connection::Connection};
 use harpc_codec::{decode::Decoder, encode::Encoder, json::JsonCodec};
 use harpc_server::{Server, ServerConfig, router::RouterBuilder, serve::serve, session::SessionId};
 use harpc_service::{
-    Service,
+    Subsystem,
     delegate::ServiceDelegate,
     metadata::Metadata,
     procedure::{Procedure, ProcedureIdentifier},
@@ -70,7 +70,7 @@ impl ProcedureIdentifier for AccountProcedureId {
 
 struct Account;
 
-impl Service for Account {
+impl Subsystem for Account {
     type ProcedureId = AccountProcedureId;
     type Procedures = HList![CreateAccount];
 
@@ -97,9 +97,9 @@ struct CreateAccount {
 }
 
 impl Procedure for CreateAccount {
-    type Service = Account;
+    type Subsystem = Account;
 
-    const ID: <Self::Service as Service>::ProcedureId = AccountProcedureId::CreateAccount;
+    const ID: <Self::Subsystem as Subsystem>::ProcedureId = AccountProcedureId::CreateAccount;
 
     fn metadata() -> Metadata {
         Metadata {

--- a/libs/@local/harpc/server/src/error.rs
+++ b/libs/@local/harpc/server/src/error.rs
@@ -7,25 +7,25 @@ use core::{
 use harpc_types::{
     error_code::ErrorCode,
     procedure::{ProcedureDescriptor, ProcedureId},
-    service::ServiceDescriptor,
+    subsystem::SubsystemDescriptor,
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::Display)]
-#[display("service {service} not found")]
-pub struct ServiceNotFound {
-    pub service: ServiceDescriptor,
+#[display("subsystem {subsystem} not found")]
+pub struct SubsystemNotFound {
+    pub subsystem: SubsystemDescriptor,
 }
 
-impl Error for ServiceNotFound {
+impl Error for SubsystemNotFound {
     fn provide<'a>(&'a self, request: &mut core::error::Request<'a>) {
-        request.provide_value(ErrorCode::SERVICE_NOT_FOUND);
+        request.provide_value(ErrorCode::SUBSYSTEM_NOT_FOUND);
     }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::Display)]
-#[display("procedure {procedure} not found in service {service}")]
+#[display("procedure {procedure} not found in subsystem {subsystem}")]
 pub struct ProcedureNotFound {
-    pub service: ServiceDescriptor,
+    pub subsystem: SubsystemDescriptor,
 
     pub procedure: ProcedureId,
 }
@@ -38,7 +38,7 @@ impl Error for ProcedureNotFound {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Forbidden {
-    pub service: ServiceDescriptor,
+    pub subsystem: SubsystemDescriptor,
     pub procedure: ProcedureDescriptor,
 
     pub reason: Cow<'static, str>,
@@ -49,7 +49,7 @@ impl Display for Forbidden {
         write!(
             fmt,
             "forbidden to call {}::{}",
-            self.service, self.procedure
+            self.subsystem, self.procedure
         )?;
 
         if !self.reason.is_empty() {
@@ -129,5 +129,5 @@ impl Error for RequestExpectedItemCountMismatch {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, derive_more::Display, derive_more::Error)]
-#[display("unable to delegate request to service implementation")]
+#[display("unable to delegate request to subsystem implementation")]
 pub struct DelegationError;

--- a/libs/@local/harpc/server/src/route.rs
+++ b/libs/@local/harpc/server/src/route.rs
@@ -4,32 +4,33 @@ use bytes::Bytes;
 use frunk::{HCons, HNil};
 use futures::FutureExt as _;
 use harpc_codec::error::NetworkError;
+use harpc_service::{RefinedSubsystemIdentifier, SubsystemIdentifier};
 use harpc_tower::{
     body::{Body, controlled::Controlled, full::Full},
     request::Request,
     response::{Parts, Response},
 };
-use harpc_types::{response_kind::ResponseKind, subsystem::SubsystemId, version::Version};
+use harpc_types::{response_kind::ResponseKind, version::Version};
 use tower::{Service, ServiceExt as _, util::Oneshot};
 
 use crate::error::SubsystemNotFound;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct Handler<S> {
-    subsystem: SubsystemId,
+pub struct Handler<S, I> {
+    subsystem: I,
     version: Version,
 
     inner: S,
 }
 
-impl<S> Handler<S> {
-    pub(crate) const fn new<Svc>(inner: S) -> Self
+impl<Svc> Handler<Svc, !> {
+    pub(crate) const fn new<Sys>(inner: Svc) -> Handler<Svc, Sys::SubsystemId>
     where
-        Svc: harpc_service::Subsystem,
+        Sys: harpc_service::Subsystem,
     {
-        Self {
-            subsystem: Svc::ID,
-            version: Svc::VERSION,
+        Handler {
+            subsystem: Sys::ID,
+            version: Sys::VERSION,
 
             inner,
         }
@@ -68,6 +69,7 @@ impl<S> Handler<S> {
 /// [`Router`]: crate::router::Router
 /// [`Steer`]: https://docs.rs/tower/latest/tower/steer/struct.Steer.html
 pub trait Route<ReqBody> {
+    type SubsystemId;
     type ResponseBody: Body<Control: AsRef<ResponseKind>, Error = !>;
     type Future: Future<Output = Response<Self::ResponseBody>>;
 
@@ -78,11 +80,12 @@ pub trait Route<ReqBody> {
 
 // The clone requirement might seem odd here, but is the same as in axum's router implementation.
 // see: https://docs.rs/axum/latest/src/axum/routing/route.rs.html#45
-impl<Svc, Tail, ReqBody, ResBody> Route<ReqBody> for HCons<Handler<Svc>, Tail>
+impl<Svc, Tail, ReqBody, ResBody, Id> Route<ReqBody> for HCons<Handler<Svc, Id>, Tail>
 where
     Svc: Service<Request<ReqBody>, Response = Response<ResBody>, Error = !> + Clone,
-    Tail: Route<ReqBody>,
+    Tail: Route<ReqBody, SubsystemId: RefinedSubsystemIdentifier<Id>>,
     ResBody: Body<Control: AsRef<ResponseKind>, Error = !>,
+    Id: SubsystemIdentifier,
 {
     // cannot use `impl Future` here, as it would require additional constraints on the associated
     // type, that are already present on the `call` method.
@@ -97,6 +100,7 @@ where
         >,
     >;
     type ResponseBody = harpc_tower::either::Either<ResBody, Tail::ResponseBody>;
+    type SubsystemId = Id;
 
     fn call(&self, request: Request<ReqBody>) -> Self::Future
     where
@@ -104,7 +108,7 @@ where
     {
         let requirement = self.head.version.into_requirement();
 
-        if self.head.subsystem == request.subsystem().id
+        if self.head.subsystem.into_id() == request.subsystem().id
             && requirement.compatible(request.subsystem().version)
         {
             let service = self.head.inner.clone();
@@ -127,6 +131,7 @@ where
 impl<ReqBody> Route<ReqBody> for HNil {
     type Future = core::future::Ready<Response<Self::ResponseBody>>;
     type ResponseBody = Controlled<ResponseKind, Full<Bytes>>;
+    type SubsystemId = !;
 
     fn call(&self, request: Request<ReqBody>) -> Self::Future
     where

--- a/libs/@local/harpc/server/src/route.rs
+++ b/libs/@local/harpc/server/src/route.rs
@@ -9,14 +9,14 @@ use harpc_tower::{
     request::Request,
     response::{Parts, Response},
 };
-use harpc_types::{response_kind::ResponseKind, service::ServiceId, version::Version};
+use harpc_types::{response_kind::ResponseKind, subsystem::SubsystemId, version::Version};
 use tower::{Service, ServiceExt as _, util::Oneshot};
 
-use crate::error::ServiceNotFound;
+use crate::error::SubsystemNotFound;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Handler<S> {
-    service: ServiceId,
+    subsystem: SubsystemId,
     version: Version,
 
     inner: S,
@@ -28,7 +28,7 @@ impl<S> Handler<S> {
         Svc: harpc_service::Subsystem,
     {
         Self {
-            service: Svc::ID,
+            subsystem: Svc::ID,
             version: Svc::VERSION,
 
             inner,
@@ -104,8 +104,8 @@ where
     {
         let requirement = self.head.version.into_requirement();
 
-        if self.head.service == request.service().id
-            && requirement.compatible(request.service().version)
+        if self.head.subsystem == request.subsystem().id
+            && requirement.compatible(request.subsystem().version)
         {
             let service = self.head.inner.clone();
 
@@ -132,8 +132,8 @@ impl<ReqBody> Route<ReqBody> for HNil {
     where
         ReqBody: Body<Control = !, Error: Send + Sync> + Send + Sync,
     {
-        let error = ServiceNotFound {
-            service: request.service(),
+        let error = SubsystemNotFound {
+            subsystem: request.subsystem(),
         };
 
         let session = request.session();

--- a/libs/@local/harpc/server/src/route.rs
+++ b/libs/@local/harpc/server/src/route.rs
@@ -25,7 +25,7 @@ pub struct Handler<S> {
 impl<S> Handler<S> {
     pub(crate) const fn new<Svc>(inner: S) -> Self
     where
-        Svc: harpc_service::Service,
+        Svc: harpc_service::Subsystem,
     {
         Self {
             service: Svc::ID,

--- a/libs/@local/harpc/server/src/router.rs
+++ b/libs/@local/harpc/server/src/router.rs
@@ -7,7 +7,7 @@ use core::{
 use frunk::{HCons, HNil};
 use futures::{FutureExt as _, Stream};
 use harpc_net::session::server::SessionEvent;
-use harpc_service::delegate::SubsystemDelegate;
+use harpc_service::{Subsystem, delegate::SubsystemDelegate};
 use harpc_tower::{
     body::Body,
     net::pack::{PackLayer, PackService},
@@ -56,7 +56,10 @@ impl<S, C> RouterBuilder<HNil, Identity, S, C> {
     }
 }
 
-type ServiceHandler<D, L, S, C> = Handler<<L as Layer<SubsystemDelegateService<D, S, C>>>::Service>;
+type ServiceHandler<D, L, S, C> = Handler<
+    <L as Layer<SubsystemDelegateService<D, S, C>>>::Service,
+    <<D as SubsystemDelegate<S, C>>::Subsystem as Subsystem>::SubsystemId,
+>;
 
 impl<R, L, S, C> RouterBuilder<R, L, S, C> {
     pub fn with_builder<L2>(

--- a/libs/@local/harpc/server/src/session.rs
+++ b/libs/@local/harpc/server/src/session.rs
@@ -5,14 +5,14 @@ use std::{collections::HashSet, sync::Mutex};
 use futures::{Stream, StreamExt as _};
 pub use harpc_net::session::server::SessionId;
 use harpc_net::session::server::{SessionEvent, SessionEventError};
-use harpc_types::{procedure::ProcedureDescriptor, service::ServiceDescriptor};
+use harpc_types::{procedure::ProcedureDescriptor, subsystem::SubsystemDescriptor};
 use scc::{ebr::Guard, hash_index::Entry};
 use tokio::pin;
 use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RequestInfo {
-    pub service: ServiceDescriptor,
+    pub subsystem: SubsystemDescriptor,
     pub procedure: ProcedureDescriptor,
 }
 

--- a/libs/@local/harpc/server/src/utils.rs
+++ b/libs/@local/harpc/server/src/utils.rs
@@ -12,7 +12,7 @@ use harpc_tower::{
     response::{self, Response},
 };
 use harpc_types::{
-    procedure::ProcedureDescriptor, response_kind::ResponseKind, service::ServiceDescriptor,
+    procedure::ProcedureDescriptor, response_kind::ResponseKind, subsystem::SubsystemDescriptor,
 };
 
 use crate::error::{DelegationError, ProcedureNotFound, RequestExpectedItemCountMismatch};
@@ -34,9 +34,9 @@ where
 
     P::from_id(id)
         .ok_or(ProcedureNotFound {
-            service: ServiceDescriptor {
-                id: <P::Service as Subsystem>::ID,
-                version: <P::Service as Subsystem>::VERSION,
+            subsystem: SubsystemDescriptor {
+                id: <P::Subsystem as Subsystem>::ID,
+                version: <P::Subsystem as Subsystem>::VERSION,
             },
             procedure: id,
         })

--- a/libs/@local/harpc/server/src/utils.rs
+++ b/libs/@local/harpc/server/src/utils.rs
@@ -11,9 +11,7 @@ use harpc_tower::{
     request::Request,
     response::{self, Response},
 };
-use harpc_types::{
-    procedure::ProcedureDescriptor, response_kind::ResponseKind, subsystem::SubsystemDescriptor,
-};
+use harpc_types::{procedure::ProcedureDescriptor, response_kind::ResponseKind};
 
 use crate::error::{DelegationError, ProcedureNotFound, RequestExpectedItemCountMismatch};
 
@@ -33,11 +31,8 @@ where
     let ProcedureDescriptor { id } = request.procedure();
 
     P::from_id(id)
-        .ok_or(ProcedureNotFound {
-            subsystem: SubsystemDescriptor {
-                id: <P::Subsystem as Subsystem>::ID,
-                version: <P::Subsystem as Subsystem>::VERSION,
-            },
+        .ok_or_else(|| ProcedureNotFound {
+            subsystem: <P::Subsystem as Subsystem>::descriptor(),
             procedure: id,
         })
         .change_context(DelegationError)

--- a/libs/@local/harpc/server/src/utils.rs
+++ b/libs/@local/harpc/server/src/utils.rs
@@ -5,7 +5,7 @@ use core::{array, pin::pin};
 use error_stack::{Report, ResultExt as _};
 use futures::{StreamExt as _, stream};
 use harpc_codec::{decode::ReportDecoder, encode::Encoder};
-use harpc_service::{Service, procedure::ProcedureIdentifier};
+use harpc_service::{Subsystem, procedure::ProcedureIdentifier};
 use harpc_tower::{
     body::{Body, BodyExt as _, Frame, controlled::Controlled, stream::StreamBody},
     request::Request,
@@ -35,8 +35,8 @@ where
     P::from_id(id)
         .ok_or(ProcedureNotFound {
             service: ServiceDescriptor {
-                id: <P::Service as Service>::ID,
-                version: <P::Service as Service>::VERSION,
+                id: <P::Service as Subsystem>::ID,
+                version: <P::Service as Subsystem>::VERSION,
             },
             procedure: id,
         })

--- a/libs/@local/harpc/service/src/delegate.rs
+++ b/libs/@local/harpc/service/src/delegate.rs
@@ -1,7 +1,7 @@
 use harpc_tower::{body::Body, request::Request, response::Response};
 use harpc_types::response_kind::ResponseKind;
 
-use crate::Service;
+use crate::Subsystem;
 
 /// Delegates service calls to an inner typed service.
 ///
@@ -19,7 +19,7 @@ use crate::Service;
 /// [`Self::Service`].
 pub trait ServiceDelegate<S, C> {
     /// The inner service type that this delegate wraps.
-    type Service: Service;
+    type Service: Subsystem;
 
     type Error;
 

--- a/libs/@local/harpc/service/src/delegate.rs
+++ b/libs/@local/harpc/service/src/delegate.rs
@@ -17,9 +17,9 @@ use crate::Subsystem;
 ///
 /// The caller must verify that the version and service of the incoming request match those of
 /// [`Self::Service`].
-pub trait ServiceDelegate<S, C> {
+pub trait SubsystemDelegate<S, C> {
     /// The inner service type that this delegate wraps.
-    type Service: Subsystem;
+    type Subsystem: Subsystem;
 
     type Error;
 

--- a/libs/@local/harpc/service/src/delegate.rs
+++ b/libs/@local/harpc/service/src/delegate.rs
@@ -16,7 +16,7 @@ use crate::Subsystem;
 /// operation will be repeated for each request and add latency.
 ///
 /// The caller must verify that the version and service of the incoming request match those of
-/// [`Self::Service`].
+/// [`Self::Subsystem`].
 pub trait SubsystemDelegate<S, C> {
     /// The inner service type that this delegate wraps.
     type Subsystem: Subsystem;

--- a/libs/@local/harpc/service/src/lib.rs
+++ b/libs/@local/harpc/service/src/lib.rs
@@ -12,21 +12,50 @@ pub mod metadata;
 pub mod procedure;
 pub mod role;
 
-pub trait SubsystemIdentifier {}
+pub trait SubsystemIdentifier: Copy {
+    fn from_id(id: SubsystemId) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn into_id(self) -> SubsystemId;
+}
+
+/// Represents a specialized or refined version of a broader subsystem identifier.
+///
+/// Primarily used for type-level validation in the `harpc-server` crate.
+pub trait RefinedSubsystemIdentifier<Id> {
+    fn broaden(self) -> Id;
+}
+
+impl<Id> RefinedSubsystemIdentifier<Id> for Id
+where
+    Id: SubsystemIdentifier,
+{
+    fn broaden(self) -> Id {
+        self
+    }
+}
+
+impl<Id> RefinedSubsystemIdentifier<Id> for ! {
+    fn broaden(self) -> Id {
+        match self {}
+    }
+}
 
 pub trait Subsystem {
+    type SubsystemId: SubsystemIdentifier;
     type ProcedureId: ProcedureIdentifier<Subsystem = Self>;
     /// Heterogeneous list of procedures that are part of this service, used for type-level
     /// validation.
     type Procedures;
 
-    const ID: SubsystemId;
+    const ID: Self::SubsystemId;
     const VERSION: Version;
 
     #[must_use]
     fn descriptor() -> SubsystemDescriptor {
         SubsystemDescriptor {
-            id: Self::ID,
+            id: Self::ID.into_id(),
             version: Self::VERSION,
         }
     }

--- a/libs/@local/harpc/service/src/lib.rs
+++ b/libs/@local/harpc/service/src/lib.rs
@@ -12,7 +12,7 @@ pub mod metadata;
 pub mod procedure;
 pub mod role;
 
-pub trait Service {
+pub trait Subsystem {
     type ProcedureId: ProcedureIdentifier<Service = Self>;
     /// Heterogeneous list of procedures that are part of this service, used for type-level
     /// validation.

--- a/libs/@local/harpc/service/src/lib.rs
+++ b/libs/@local/harpc/service/src/lib.rs
@@ -1,7 +1,7 @@
 #![feature(never_type, marker_trait_attr)]
 
 use harpc_types::{
-    service::{ServiceDescriptor, ServiceId},
+    subsystem::{SubsystemDescriptor, SubsystemId},
     version::Version,
 };
 
@@ -12,18 +12,20 @@ pub mod metadata;
 pub mod procedure;
 pub mod role;
 
+pub trait SubsystemIdentifier {}
+
 pub trait Subsystem {
-    type ProcedureId: ProcedureIdentifier<Service = Self>;
+    type ProcedureId: ProcedureIdentifier<Subsystem = Self>;
     /// Heterogeneous list of procedures that are part of this service, used for type-level
     /// validation.
     type Procedures;
 
-    const ID: ServiceId;
+    const ID: SubsystemId;
     const VERSION: Version;
 
     #[must_use]
-    fn descriptor() -> ServiceDescriptor {
-        ServiceDescriptor {
+    fn descriptor() -> SubsystemDescriptor {
+        SubsystemDescriptor {
             id: Self::ID,
             version: Self::VERSION,
         }

--- a/libs/@local/harpc/service/src/procedure.rs
+++ b/libs/@local/harpc/service/src/procedure.rs
@@ -14,7 +14,7 @@ impl<Head, Tail> IncludesProcedure<Head> for HCons<Head, Tail> where Head: Proce
 impl<Head, Tail, P> IncludesProcedure<P> for HCons<Head, Tail> where Tail: IncludesProcedure<P> {}
 
 pub trait ProcedureIdentifier: Sized {
-    type Service: Subsystem;
+    type Subsystem: Subsystem;
 
     fn from_id(id: ProcedureId) -> Option<Self>;
     fn into_id(self) -> ProcedureId;

--- a/libs/@local/harpc/service/src/procedure.rs
+++ b/libs/@local/harpc/service/src/procedure.rs
@@ -1,7 +1,7 @@
 use frunk::HCons;
 use harpc_types::procedure::{ProcedureDescriptor, ProcedureId};
 
-use crate::{Service, metadata::Metadata};
+use crate::{Subsystem, metadata::Metadata};
 
 /// A marker trait for procedures that are included in a service.
 ///
@@ -14,16 +14,16 @@ impl<Head, Tail> IncludesProcedure<Head> for HCons<Head, Tail> where Head: Proce
 impl<Head, Tail, P> IncludesProcedure<P> for HCons<Head, Tail> where Tail: IncludesProcedure<P> {}
 
 pub trait ProcedureIdentifier: Sized {
-    type Service: Service;
+    type Service: Subsystem;
 
     fn from_id(id: ProcedureId) -> Option<Self>;
     fn into_id(self) -> ProcedureId;
 }
 
 pub trait Procedure: Sized {
-    type Service: Service<Procedures: IncludesProcedure<Self>>;
+    type Subsystem: Subsystem<Procedures: IncludesProcedure<Self>>;
 
-    const ID: <Self::Service as Service>::ProcedureId;
+    const ID: <Self::Subsystem as Subsystem>::ProcedureId;
 
     #[must_use]
     fn descriptor() -> ProcedureDescriptor {

--- a/libs/@local/harpc/tower/src/layer/error.rs
+++ b/libs/@local/harpc/tower/src/layer/error.rs
@@ -102,7 +102,7 @@ pub(crate) mod test {
         error_code::ErrorCode,
         procedure::{ProcedureDescriptor, ProcedureId},
         response_kind::ResponseKind,
-        service::{ServiceDescriptor, ServiceId},
+        subsystem::{SubsystemDescriptor, SubsystemId},
         version::Version,
     };
     use tokio_test::{assert_pending, assert_ready};
@@ -194,8 +194,8 @@ pub(crate) mod test {
     pub(crate) fn request() -> Request<Full<Bytes>> {
         Request::from_parts(
             request::Parts {
-                service: ServiceDescriptor {
-                    id: ServiceId::new(0x00),
+                subsystem: SubsystemDescriptor {
+                    id: SubsystemId::new(0x00),
                     version: Version {
                         major: 0x00,
                         minor: 0x00,

--- a/libs/@local/harpc/tower/src/request.rs
+++ b/libs/@local/harpc/tower/src/request.rs
@@ -1,12 +1,12 @@
 use harpc_net::session::server::{SessionId, transaction::TransactionContext};
-use harpc_types::{procedure::ProcedureDescriptor, service::ServiceDescriptor};
+use harpc_types::{procedure::ProcedureDescriptor, subsystem::SubsystemDescriptor};
 
 use crate::extensions::Extensions;
 
 /// Component parts of a harpc `Request`.
 #[derive(Debug, Clone)]
 pub struct Parts {
-    pub service: ServiceDescriptor,
+    pub subsystem: SubsystemDescriptor,
     pub procedure: ProcedureDescriptor,
 
     pub session: SessionId,
@@ -18,7 +18,7 @@ impl Parts {
     #[must_use]
     pub fn from_transaction(context: &TransactionContext) -> Self {
         Self {
-            service: context.service(),
+            subsystem: context.subsystem(),
             procedure: context.procedure(),
             session: context.session(),
             extensions: Extensions::new(),
@@ -43,8 +43,8 @@ impl<B> Request<B> {
         (self.head, self.body)
     }
 
-    pub const fn service(&self) -> ServiceDescriptor {
-        self.head.service
+    pub const fn subsystem(&self) -> SubsystemDescriptor {
+        self.head.subsystem
     }
 
     pub const fn procedure(&self) -> ProcedureDescriptor {

--- a/libs/@local/harpc/types/src/error_code.rs
+++ b/libs/@local/harpc/types/src/error_code.rs
@@ -85,7 +85,7 @@ define_error_code_consts! {
         /// The combination of service and version requirement could not be found on the server.
         ///
         /// The HTTP equivalent is 404 Not Found.
-        SERVICE_NOT_FOUND,
+        SUBSYSTEM_NOT_FOUND,
         /// The service was found, but the procedure was not.
         ///
         /// The HTTP equivalent is 404 Not Found.

--- a/libs/@local/harpc/types/src/lib.rs
+++ b/libs/@local/harpc/types/src/lib.rs
@@ -3,5 +3,5 @@
 pub mod error_code;
 pub mod procedure;
 pub mod response_kind;
-pub mod service;
+pub mod subsystem;
 pub mod version;

--- a/libs/@local/harpc/types/src/subsystem.rs
+++ b/libs/@local/harpc/types/src/subsystem.rs
@@ -5,9 +5,9 @@ use crate::version::Version;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
-pub struct ServiceId(u16);
+pub struct SubsystemId(u16);
 
-impl ServiceId {
+impl SubsystemId {
     #[must_use]
     pub const fn new(value: u16) -> Self {
         Self(value)
@@ -25,7 +25,7 @@ impl ServiceId {
     }
 }
 
-impl Display for ServiceId {
+impl Display for SubsystemId {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let Self(value) = self;
 
@@ -36,12 +36,12 @@ impl Display for ServiceId {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
-pub struct ServiceDescriptor {
-    pub id: ServiceId,
+pub struct SubsystemDescriptor {
+    pub id: SubsystemId,
     pub version: Version,
 }
 
-impl Display for ServiceDescriptor {
+impl Display for SubsystemDescriptor {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let &Self { id, version } = self;
 

--- a/libs/@local/harpc/wire-protocol/src/codec/types.rs
+++ b/libs/@local/harpc/wire-protocol/src/codec/types.rs
@@ -1,6 +1,6 @@
 use bytes::{Buf, BufMut};
 use error_stack::Report;
-use harpc_types::{procedure::ProcedureId, service::ServiceId, version::Version};
+use harpc_types::{procedure::ProcedureId, subsystem::SubsystemId, version::Version};
 
 use super::{Buffer, BufferError, Decode};
 use crate::codec::Encode;
@@ -57,7 +57,7 @@ impl Decode for ProcedureId {
     }
 }
 
-impl Encode for ServiceId {
+impl Encode for SubsystemId {
     type Error = BufferError;
 
     fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
@@ -68,7 +68,7 @@ impl Encode for ServiceId {
     }
 }
 
-impl Decode for ServiceId {
+impl Decode for SubsystemId {
     type Context = ();
     type Error = BufferError;
 
@@ -84,7 +84,7 @@ impl Decode for ServiceId {
 mod test {
     #![expect(clippy::needless_raw_strings)]
     use expect_test::expect;
-    use harpc_types::{service::ServiceId, version::Version};
+    use harpc_types::{subsystem::SubsystemId, version::Version};
 
     use crate::codec::test::{assert_codec, assert_decode, assert_encode};
 
@@ -109,20 +109,20 @@ mod test {
     }
 
     #[test]
-    fn encode_service_id() {
-        assert_encode(&ServiceId::new(0x01_02), expect![[r#"
+    fn encode_subsystem_id() {
+        assert_encode(&SubsystemId::new(0x01_02), expect![[r#"
                 0x01 0x02
             "#]]);
     }
 
     #[test]
-    fn decode_service_id() {
-        assert_decode(&[0x12_u8, 0x34] as &[_], &ServiceId::new(0x1234), ());
+    fn decode_subsystem_id() {
+        assert_decode(&[0x12_u8, 0x34] as &[_], &SubsystemId::new(0x1234), ());
     }
 
     #[test_strategy::proptest]
     #[cfg_attr(miri, ignore)]
-    fn codec_service_id(id: ServiceId) {
+    fn codec_subsystem_id(id: SubsystemId) {
         assert_codec(&id, ());
     }
 

--- a/libs/@local/harpc/wire-protocol/src/request/begin.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/begin.rs
@@ -1,6 +1,6 @@
 use bytes::{Buf, BufMut};
 use error_stack::{Report, ResultExt as _};
-use harpc_types::{procedure::ProcedureDescriptor, service::ServiceDescriptor};
+use harpc_types::{procedure::ProcedureDescriptor, subsystem::SubsystemDescriptor};
 
 use crate::{
     codec::{Buffer, BufferError, Decode, Encode},
@@ -14,7 +14,7 @@ pub struct RequestBeginEncodeError;
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub struct RequestBegin {
-    pub service: ServiceDescriptor,
+    pub subsystem: SubsystemDescriptor,
     pub procedure: ProcedureDescriptor,
 
     pub payload: Payload,
@@ -27,7 +27,7 @@ impl Encode for RequestBegin {
     where
         B: BufMut,
     {
-        self.service
+        self.subsystem
             .encode(buffer)
             .change_context(RequestBeginEncodeError)?;
 
@@ -54,7 +54,7 @@ impl Decode for RequestBegin {
     where
         B: Buf,
     {
-        let service = ServiceDescriptor::decode(buffer, ())?;
+        let subsystem = SubsystemDescriptor::decode(buffer, ())?;
         let procedure = ProcedureDescriptor::decode(buffer, ())?;
 
         // skip 13 bytes (reserved for future use)
@@ -63,7 +63,7 @@ impl Decode for RequestBegin {
         let payload = Payload::decode(buffer, ())?;
 
         Ok(Self {
-            service,
+            subsystem,
             procedure,
             payload,
         })
@@ -75,7 +75,7 @@ mod test {
     use expect_test::expect;
     use harpc_types::{
         procedure::{ProcedureDescriptor, ProcedureId},
-        service::{ServiceDescriptor, ServiceId},
+        subsystem::{SubsystemDescriptor, SubsystemId},
         version::Version,
     };
 
@@ -86,8 +86,8 @@ mod test {
     };
 
     static EXAMPLE_REQUEST: RequestBegin = RequestBegin {
-        service: ServiceDescriptor {
-            id: ServiceId::new(0x01_02),
+        subsystem: SubsystemDescriptor {
+            id: SubsystemId::new(0x01_02),
             version: Version {
                 major: 0x03,
                 minor: 0x04,
@@ -100,8 +100,8 @@ mod test {
     };
 
     const EXAMPLE_REQUEST_BYTES: &[u8] = &[
-        0x01, 0x02, // service id
-        0x03, 0x04, // service version
+        0x01, 0x02, // subsystem id
+        0x03, 0x04, // subsystem version
         0x05, 0x06, // procedure id
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, // reserved
@@ -122,8 +122,8 @@ mod test {
         assert_decode(
             EXAMPLE_REQUEST_BYTES,
             &RequestBegin {
-                service: ServiceDescriptor {
-                    id: ServiceId::new(0x01_02),
+                subsystem: SubsystemDescriptor {
+                    id: SubsystemId::new(0x01_02),
                     version: Version {
                         major: 0x03,
                         minor: 0x04,

--- a/libs/@local/harpc/wire-protocol/src/request/body.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/body.rs
@@ -109,7 +109,7 @@ mod test {
     use expect_test::expect;
     use harpc_types::{
         procedure::{ProcedureDescriptor, ProcedureId},
-        service::{ServiceDescriptor, ServiceId},
+        subsystem::{SubsystemDescriptor, SubsystemId},
         version::Version,
     };
 
@@ -121,8 +121,8 @@ mod test {
     };
 
     static EXAMPLE_BEGIN: RequestBegin = RequestBegin {
-        service: ServiceDescriptor {
-            id: ServiceId::new(0x0102),
+        subsystem: SubsystemDescriptor {
+            id: SubsystemId::new(0x0102),
             version: Version {
                 major: 0x03,
                 minor: 0x04,

--- a/libs/@local/harpc/wire-protocol/src/request/mod.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/mod.rs
@@ -14,8 +14,8 @@ pub mod flags;
 pub mod frame;
 pub mod header;
 pub mod id;
-pub mod procedure;
-pub mod service;
+mod procedure;
+mod subsystem;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, thiserror::Error)]
 #[error("unable to encode request")]
@@ -55,8 +55,8 @@ pub struct RequestDecodeError;
 /// * Protocol Version (1 byte)
 /// * Request Id (4 bytes)
 /// * Flags (1 byte)
-/// * Service Id (2 bytes)
-/// * Service Version (2 bytes)
+/// * Subsystem Id (2 bytes)
+/// * Subsystem Version (2 bytes)
 /// * Procedure Id (2 bytes)
 /// * Reserved (13 bytes)
 /// * Payload Length (2 bytes)
@@ -137,7 +137,7 @@ mod test {
     use expect_test::expect;
     use harpc_types::{
         procedure::{ProcedureDescriptor, ProcedureId},
-        service::{ServiceDescriptor, ServiceId},
+        subsystem::{SubsystemDescriptor, SubsystemId},
         version::Version,
     };
 
@@ -170,8 +170,8 @@ mod test {
         b'h', b'a', b'r', b'p', b'c', 0x01, // protocol
         0x89, 0xAB, 0xCD, 0xEF,             // request_id
         0x80,                               // flags
-        0x01, 0x02,                         // service_id
-        0x03, 0x04,                         // service_version
+        0x01, 0x02,                         // subsystem_id
+        0x03, 0x04,                         // subsystem_version
         0x05, 0x06,                         // procedure_id
         // 13 bytes reserved
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -201,8 +201,8 @@ mod test {
                     ..EXAMPLE_HEADER
                 },
                 body: RequestBody::Begin(RequestBegin {
-                    service: ServiceDescriptor {
-                        id: ServiceId::new(0x01_02),
+                    subsystem: SubsystemDescriptor {
+                        id: SubsystemId::new(0x01_02),
                         version: Version {
                             major: 0x03,
                             minor: 0x04,
@@ -230,8 +230,8 @@ mod test {
             &Request {
                 header: EXAMPLE_HEADER,
                 body: RequestBody::Begin(RequestBegin {
-                    service: ServiceDescriptor {
-                        id: ServiceId::new(0x01_02),
+                    subsystem: SubsystemDescriptor {
+                        id: SubsystemId::new(0x01_02),
                         version: Version {
                             major: 0x03,
                             minor: 0x04,
@@ -299,8 +299,8 @@ mod test {
                     ..EXAMPLE_HEADER
                 },
                 body: RequestBody::Begin(RequestBegin {
-                    service: ServiceDescriptor {
-                        id: ServiceId::new(0x01_02),
+                    subsystem: SubsystemDescriptor {
+                        id: SubsystemId::new(0x01_02),
                         version: Version {
                             major: 0x03,
                             minor: 0x04,

--- a/libs/@local/harpc/wire-protocol/src/request/subsystem.rs
+++ b/libs/@local/harpc/wire-protocol/src/request/subsystem.rs
@@ -1,13 +1,13 @@
 use bytes::{Buf, BufMut};
 use error_stack::Report;
 use harpc_types::{
-    service::{ServiceDescriptor, ServiceId},
+    subsystem::{SubsystemDescriptor, SubsystemId},
     version::Version,
 };
 
 use crate::codec::{Buffer, BufferError, Decode, Encode};
 
-impl Encode for ServiceDescriptor {
+impl Encode for SubsystemDescriptor {
     type Error = BufferError;
 
     fn encode<B>(&self, buffer: &mut Buffer<B>) -> Result<(), Report<Self::Error>>
@@ -21,7 +21,7 @@ impl Encode for ServiceDescriptor {
     }
 }
 
-impl Decode for ServiceDescriptor {
+impl Decode for SubsystemDescriptor {
     type Context = ();
     type Error = BufferError;
 
@@ -29,7 +29,7 @@ impl Decode for ServiceDescriptor {
     where
         B: Buf,
     {
-        let id = ServiceId::decode(buffer, ())?;
+        let id = SubsystemId::decode(buffer, ())?;
         let version = Version::decode(buffer, ())?;
 
         Ok(Self { id, version })
@@ -40,24 +40,24 @@ impl Decode for ServiceDescriptor {
 mod test {
     #![expect(clippy::needless_raw_strings)]
     use expect_test::expect;
-    use harpc_types::{service::ServiceId, version::Version};
+    use harpc_types::{subsystem::SubsystemId, version::Version};
 
     use crate::{
         codec::test::{assert_codec, assert_decode, assert_encode},
-        request::service::ServiceDescriptor,
+        request::subsystem::SubsystemDescriptor,
     };
 
     #[test]
     fn encode() {
-        let service = ServiceDescriptor {
-            id: ServiceId::new(0x01_02),
+        let subsystem = SubsystemDescriptor {
+            id: SubsystemId::new(0x01_02),
             version: Version {
                 major: 0x03,
                 minor: 0x04,
             },
         };
 
-        assert_encode(&service, expect![[r#"
+        assert_encode(&subsystem, expect![[r#"
                 0x01 0x02 0x03 0x04
             "#]]);
     }
@@ -66,8 +66,8 @@ mod test {
     fn decode() {
         assert_decode(
             &[0x12_u8, 0x34, 0x56, 0x78] as &[_],
-            &ServiceDescriptor {
-                id: ServiceId::new(0x12_34),
+            &SubsystemDescriptor {
+                id: SubsystemId::new(0x12_34),
                 version: Version {
                     major: 0x56,
                     minor: 0x78,
@@ -79,7 +79,7 @@ mod test {
 
     #[test_strategy::proptest]
     #[cfg_attr(miri, ignore)]
-    fn encode_decode(service: ServiceDescriptor) {
-        assert_codec(&service, ());
+    fn encode_decode(subsystem: SubsystemDescriptor) {
+        assert_codec(&subsystem, ());
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This introduces the `Subsystem` and `SubsystemIdentifier`, by renaming `harpc_service::Service` to `Subsystem`. Additionally the `harpc_server` has been made aware of the `SubsystemIdentifier` and will now only allow routes that have the same subsystem.

The change of term has also been propagated to the underlying layers.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
