### PR TITLE
H-3558: `harpc`: rename `Metadata` to `SubsystemInformation` and `ProcedureInformation`

### DIFF
--- a/apps/hash-graph/libs/api/src/rpc/account.rs
+++ b/apps/hash-graph/libs/api/src/rpc/account.rs
@@ -100,7 +100,6 @@ pub mod meta {
     use frunk::HList;
     use harpc_service::{
         Subsystem,
-        metadata::Metadata,
         procedure::{Procedure, ProcedureIdentifier},
     };
     use harpc_types::{procedure::ProcedureId, version::Version};
@@ -158,16 +157,6 @@ pub mod meta {
             major: 0x00,
             minor: 0x00,
         };
-
-        fn metadata() -> Metadata {
-            Metadata {
-                since: Version {
-                    major: 0x00,
-                    minor: 0x00,
-                },
-                deprecation: None,
-            }
-        }
     }
 
     pub struct ProcedureCreateAccount;
@@ -176,16 +165,6 @@ pub mod meta {
         type Subsystem = AccountSystem;
 
         const ID: <Self::Subsystem as Subsystem>::ProcedureId = AccountProcedureId::CreateAccount;
-
-        fn metadata() -> Metadata {
-            Metadata {
-                since: Version {
-                    major: 0x00,
-                    minor: 0x00,
-                },
-                deprecation: None,
-            }
-        }
     }
 
     pub struct ProcedureCreateAccountGroup;
@@ -195,16 +174,6 @@ pub mod meta {
 
         const ID: <Self::Subsystem as Subsystem>::ProcedureId =
             AccountProcedureId::CreateAccountGroup;
-
-        fn metadata() -> Metadata {
-            Metadata {
-                since: Version {
-                    major: 0x00,
-                    minor: 0x00,
-                },
-                deprecation: None,
-            }
-        }
     }
 
     pub struct ProcedureCheckAccountGroupPermission;
@@ -214,16 +183,6 @@ pub mod meta {
 
         const ID: <Self::Subsystem as Subsystem>::ProcedureId =
             AccountProcedureId::CheckAccountGroupPermission;
-
-        fn metadata() -> Metadata {
-            Metadata {
-                since: Version {
-                    major: 0x00,
-                    minor: 0x00,
-                },
-                deprecation: None,
-            }
-        }
     }
 
     pub struct ProcedureAddAccountGroupMember;
@@ -233,16 +192,6 @@ pub mod meta {
 
         const ID: <Self::Subsystem as Subsystem>::ProcedureId =
             AccountProcedureId::AddAccountGroupMember;
-
-        fn metadata() -> Metadata {
-            Metadata {
-                since: Version {
-                    major: 0x00,
-                    minor: 0x00,
-                },
-                deprecation: None,
-            }
-        }
     }
 
     pub struct ProcedureRemoveAccountGroupMember;
@@ -252,16 +201,6 @@ pub mod meta {
 
         const ID: <Self::Subsystem as Subsystem>::ProcedureId =
             AccountProcedureId::RemoveAccountGroupMember;
-
-        fn metadata() -> Metadata {
-            Metadata {
-                since: Version {
-                    major: 0x00,
-                    minor: 0x00,
-                },
-                deprecation: None,
-            }
-        }
     }
 }
 

--- a/apps/hash-graph/libs/api/src/rpc/auth.rs
+++ b/apps/hash-graph/libs/api/src/rpc/auth.rs
@@ -38,7 +38,6 @@ pub mod meta {
     use frunk::HList;
     use harpc_service::{
         Subsystem,
-        metadata::Metadata,
         procedure::{Procedure, ProcedureIdentifier},
     };
     use harpc_types::{procedure::ProcedureId, version::Version};
@@ -78,16 +77,6 @@ pub mod meta {
             major: 0x00,
             minor: 0x00,
         };
-
-        fn metadata() -> Metadata {
-            Metadata {
-                since: Version {
-                    major: 0x00,
-                    minor: 0x00,
-                },
-                deprecation: None,
-            }
-        }
     }
 
     pub struct ProcedureAuthenticate;
@@ -97,16 +86,6 @@ pub mod meta {
 
         const ID: <Self::Subsystem as Subsystem>::ProcedureId =
             AuthenticationProcedureId::Authenticate;
-
-        fn metadata() -> Metadata {
-            Metadata {
-                since: Version {
-                    major: 0x00,
-                    minor: 0x00,
-                },
-                deprecation: None,
-            }
-        }
     }
 }
 

--- a/apps/hash-graph/libs/api/src/rpc/echo.rs
+++ b/apps/hash-graph/libs/api/src/rpc/echo.rs
@@ -35,7 +35,6 @@ pub mod meta {
     use frunk::HList;
     use harpc_service::{
         Subsystem,
-        metadata::Metadata,
         procedure::{Procedure, ProcedureIdentifier},
     };
     use harpc_types::{procedure::ProcedureId, version::Version};
@@ -75,16 +74,6 @@ pub mod meta {
             major: 0x00,
             minor: 0x00,
         };
-
-        fn metadata() -> Metadata {
-            Metadata {
-                since: Version {
-                    major: 0x00,
-                    minor: 0x00,
-                },
-                deprecation: None,
-            }
-        }
     }
 
     pub struct ProcedureEcho;
@@ -93,16 +82,6 @@ pub mod meta {
         type Subsystem = EchoSystem;
 
         const ID: <Self::Subsystem as Subsystem>::ProcedureId = EchoProcedureId::Echo;
-
-        fn metadata() -> Metadata {
-            Metadata {
-                since: Version {
-                    major: 0x00,
-                    minor: 0x00,
-                },
-                deprecation: None,
-            }
-        }
     }
 }
 

--- a/libs/@local/harpc/server/examples/account.rs
+++ b/libs/@local/harpc/server/examples/account.rs
@@ -24,7 +24,6 @@ use harpc_server::{Server, ServerConfig, router::RouterBuilder, serve::serve, se
 use harpc_service::{
     Subsystem, SubsystemIdentifier,
     delegate::SubsystemDelegate,
-    metadata::Metadata,
     procedure::{Procedure, ProcedureIdentifier},
     role,
 };
@@ -103,16 +102,6 @@ impl Subsystem for Account {
         major: 0x00,
         minor: 0x00,
     };
-
-    fn metadata() -> Metadata {
-        Metadata {
-            since: Version {
-                major: 0x00,
-                minor: 0x00,
-            },
-            deprecation: None,
-        }
-    }
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -124,16 +113,6 @@ impl Procedure for CreateAccount {
     type Subsystem = Account;
 
     const ID: <Self::Subsystem as Subsystem>::ProcedureId = AccountProcedureId::CreateAccount;
-
-    fn metadata() -> Metadata {
-        Metadata {
-            since: Version {
-                major: 0x00,
-                minor: 0x00,
-            },
-            deprecation: None,
-        }
-    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, thiserror::Error)]

--- a/libs/@local/harpc/service/src/lib.rs
+++ b/libs/@local/harpc/service/src/lib.rs
@@ -5,7 +5,7 @@ use harpc_types::{
     version::Version,
 };
 
-use self::{metadata::Metadata, procedure::ProcedureIdentifier};
+use self::{metadata::Deprecation, procedure::ProcedureIdentifier};
 
 pub mod delegate;
 pub mod metadata;
@@ -42,6 +42,15 @@ impl<Id> RefinedSubsystemIdentifier<Id> for ! {
     }
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct SubsystemInformation {
+    pub descriptor: SubsystemDescriptor,
+    /// The deprecation information for subsystem.
+    pub deprecation: Option<Deprecation>,
+    /// The initial version this subsystem was introduced in.
+    pub initial_version: Version,
+}
+
 pub trait Subsystem {
     type SubsystemId: SubsystemIdentifier;
     type ProcedureId: ProcedureIdentifier<Subsystem = Self>;
@@ -52,6 +61,7 @@ pub trait Subsystem {
     const ID: Self::SubsystemId;
     const VERSION: Version;
 
+    /// Returns the descriptor for this subsystem.
     #[must_use]
     fn descriptor() -> SubsystemDescriptor {
         SubsystemDescriptor {
@@ -60,5 +70,38 @@ pub trait Subsystem {
         }
     }
 
-    fn metadata() -> Metadata;
+    /// Returns the initial version in which this subsystem was introduced.
+    ///
+    /// This version represents the first release where the subsystem became available.
+    ///
+    /// By default, this returns the initial version of `0.0`.
+    #[must_use]
+    fn initial_version() -> Version {
+        Version {
+            major: 0x00,
+            minor: 0x00,
+        }
+    }
+
+    /// Returns the deprecation information for this subsystem, if any.
+    ///
+    /// By default, this returns `None`, indicating that the procedure is not deprecated.
+    /// Override this method to specify deprecation information.
+    #[must_use]
+    fn deprecation() -> Option<Deprecation> {
+        None
+    }
+
+    /// Returns comprehensive information about the subsystem.
+    ///
+    /// This method aggregates various details about the subsystem, including its
+    /// descriptor, initial version, and deprecation status.
+    #[must_use]
+    fn information() -> SubsystemInformation {
+        SubsystemInformation {
+            descriptor: Self::descriptor(),
+            initial_version: Self::initial_version(),
+            deprecation: Self::deprecation(),
+        }
+    }
 }

--- a/libs/@local/harpc/service/src/metadata.rs
+++ b/libs/@local/harpc/service/src/metadata.rs
@@ -10,13 +10,3 @@ pub struct Deprecation {
     /// The reason for deprecation.
     pub reason: Option<&'static str>,
 }
-
-/// Metadata containing version information for procedures and services.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct Metadata {
-    /// The version at which the procedure/service was introduced.
-    pub since: Version,
-
-    /// The deprecation information for the procedure/service.
-    pub deprecation: Option<Deprecation>,
-}

--- a/libs/@local/harpc/service/src/procedure.rs
+++ b/libs/@local/harpc/service/src/procedure.rs
@@ -1,7 +1,10 @@
 use frunk::HCons;
-use harpc_types::procedure::{ProcedureDescriptor, ProcedureId};
+use harpc_types::{
+    procedure::{ProcedureDescriptor, ProcedureId},
+    version::Version,
+};
 
-use crate::{Subsystem, metadata::Metadata};
+use crate::{Subsystem, metadata::Deprecation};
 
 /// A marker trait for procedures that are included in a service.
 ///
@@ -20,11 +23,23 @@ pub trait ProcedureIdentifier: Sized {
     fn into_id(self) -> ProcedureId;
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct ProcedureInformation {
+    pub descriptor: ProcedureDescriptor,
+
+    /// The version at which the procedure was introduced.
+    pub since: Version,
+
+    /// The deprecation information for the procedure.
+    pub deprecation: Option<Deprecation>,
+}
+
 pub trait Procedure: Sized {
     type Subsystem: Subsystem<Procedures: IncludesProcedure<Self>>;
 
     const ID: <Self::Subsystem as Subsystem>::ProcedureId;
 
+    /// Returns the descriptor for this procedure.
     #[must_use]
     fn descriptor() -> ProcedureDescriptor {
         ProcedureDescriptor {
@@ -32,5 +47,34 @@ pub trait Procedure: Sized {
         }
     }
 
-    fn metadata() -> Metadata;
+    /// Returns the version at which this procedure was introduced.
+    ///
+    /// By default, this returns the initial version of the subsystem.
+    /// Override this method to specify a different introduction version.
+    #[must_use]
+    fn since() -> Version {
+        Self::Subsystem::initial_version()
+    }
+
+    /// Returns the deprecation information for this procedure.
+    ///
+    /// By default, this returns `None`, indicating that the procedure is not deprecated.
+    /// Override this method to specify deprecation information.
+    #[must_use]
+    fn deprecation() -> Option<Deprecation> {
+        None
+    }
+
+    /// Returns comprehensive information about the procedure.
+    ///
+    /// This method aggregates the descriptor, introduction version, and deprecation status
+    /// of the procedure into a single `ProcedureInformation` struct.
+    #[must_use]
+    fn information() -> ProcedureInformation {
+        ProcedureInformation {
+            descriptor: Self::descriptor(),
+            since: Self::since(),
+            deprecation: Self::deprecation(),
+        }
+    }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Splits `Metadata` into `SubsystemInformation` and `ProcedureInformation`, additionally they are altered slightly as well as how they're constructed, to make overwriting them in the future easier and more consistent.


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
