### PR TITLE
H-3570: Provide formatter for `*.toml` files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -273,6 +273,18 @@ jobs:
             exit 1
           fi
 
+      - name: Run yarn lint:taplo
+        if: ${{ success() || failure() }}
+        run: |
+          if ! yarn lint:taplo; then
+            echo ''
+            echo ''
+            echo 'ℹ️ ℹ️ ℹ️'
+            echo 'Try running `yarn fix:taplo` locally to apply autofixes.'
+            echo 'ℹ️ ℹ️ ℹ️'
+            exit 1
+          fi
+
         ## TODO: Replace with `yarn fix:yarn-dedupe` after upgrading to Yarn v3+
         ## https://yarnpkg.com/cli/dedupe
         ## https://github.com/yarnpkg/berry/issues/2297

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,3 +1,4 @@
+exclude = ["node_modules/**"]
 include = ["**/Cargo.toml", ".taplo.toml"]
 
 [formatting]

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,30 @@
+include = ["**/Cargo.toml", ".taplo.toml"]
+
+[formatting]
+align_comments      = false
+array_auto_collapse = false
+array_auto_expand   = false
+indent_string       = "    "
+inline_table_expand = false
+
+[[rule]]
+include = ["**/Cargo.toml"]
+keys    = ["dependencies", "workspace.dependencies"]
+
+[rule.formatting]
+reorder_keys = true
+
+[[rule]]
+include = ["**/Cargo.toml"]
+keys    = ["workspace"]
+
+[rule.formatting]
+reorder_arrays = true
+reorder_keys   = true
+
+[[rule]]
+include = [".taplo.toml"]
+
+[rule.formatting]
+align_entries = true
+reorder_keys  = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,9 @@
 cargo-features = ["edition2024"]
 
 [workspace]
+default-members = [
+    "apps/hash-graph",
+]
 members = [
     "apps/hash-graph",
     "libs/@blockprotocol/type-system/rust",
@@ -41,24 +44,29 @@ members = [
     "tests/graph/integration",
     "tests/graph/test-data/rust",
 ]
-default-members = [
-    "apps/hash-graph",
-]
 resolver = "3"
 
 [workspace.package]
 authors = ["HASH"]
-version = "0.0.0"
 edition = "2024"
 license = "AGPL-3"
 publish = false
+version = "0.0.0"
 
 [workspace.dependencies]
 # Workspace members
 error-stack = { path = "./libs/error-stack", default-features = false }
+harpc-client.path = "libs/@local/harpc/client"
+harpc-codec.path = "libs/@local/harpc/codec"
+harpc-net.path = "libs/@local/harpc/net"
+harpc-server.path = "libs/@local/harpc/server"
+harpc-system.path = "libs/@local/harpc/system"
+harpc-tower.path = "libs/@local/harpc/tower"
+harpc-types.path = "libs/@local/harpc/types"
+harpc-wire-protocol.path = "libs/@local/harpc/wire-protocol"
 hash-codec.path = "libs/@local/codec"
-hash-graph-authorization.path = "libs/@local/graph/authorization"
 hash-graph-api.path = "libs/@local/graph/api"
+hash-graph-authorization.path = "libs/@local/graph/authorization"
 hash-graph-postgres-store.path = "libs/@local/graph/postgres-store"
 hash-graph-store.path = "libs/@local/graph/store"
 hash-graph-temporal-versioning.path = "libs/@local/graph/temporal-versioning"
@@ -69,16 +77,8 @@ hash-graph-type-fetcher.path = "libs/@local/graph/type-fetcher"
 hash-graph-types.path = "libs/@local/graph/types/rust"
 hash-graph-validation.path = "libs/@local/graph/validation"
 hash-repo-chores.path = "libs/@local/repo-chores/rust"
-hash-temporal-client.path = "libs/@local/temporal-client"
-harpc-net.path = "libs/@local/harpc/net"
-harpc-types.path = "libs/@local/harpc/types"
-harpc-wire-protocol.path = "libs/@local/harpc/wire-protocol"
-harpc-tower.path = "libs/@local/harpc/tower"
-harpc-system.path = "libs/@local/harpc/system"
-harpc-codec.path = "libs/@local/harpc/codec"
-harpc-server.path = "libs/@local/harpc/server"
-harpc-client.path = "libs/@local/harpc/client"
 hash-status.path = "libs/@local/status/rust"
+hash-temporal-client.path = "libs/@local/temporal-client"
 hash-tracing.path = "libs/@local/tracing"
 hql-cst.path = "libs/@local/hql/cst"
 hql-diagnostics.path = "libs/@local/hql/diagnostics"
@@ -106,30 +106,33 @@ futures-core = { version = "=0.3.31", default-features = false }
 futures-io = { version = "=0.3.31", default-features = false }
 futures-sink = { version = "=0.3.31", default-features = false }
 futures-util = { version = "=0.3.31", default-features = false }
-hashbrown = { version = "=0.15.1", default-features = false, features = ["nightly", "inline-more"] }
+hashbrown = { version = "=0.15.1", default-features = false, features = ["inline-more", "nightly"] }
 http = { version = "=1.1.0", default-features = false }
 inferno = { version = "=0.11.21", default-features = false }
 iso8601-duration = { version = "=0.2.0", default-features = false }
 json-number = { version = "=0.4.9", default-features = false }
 jsonptr = { version = "=0.6.3", default-features = false }
-multiaddr = { version = "=0.18.2", default-features = false }
-multistream-select = { version = "=0.13.0", default-features = false }
 libp2p-core = { version = "=0.42.0", default-features = false }
 libp2p-identity = { version = "=0.2.9", default-features = false }
 libp2p-ping = { version = "=0.45.0", default-features = false }
 libp2p-swarm = { version = "=0.45.1", default-features = false }
 libp2p-yamux = { version = "=0.46.0", default-features = false }
-prometheus-client = { version = "=0.22.3", default-features = false }
+multiaddr = { version = "=0.18.2", default-features = false }
+multistream-select = { version = "=0.13.0", default-features = false }
 postgres-types = { version = "=0.2.8", default-features = false }
-reqwest = { version = "=0.12.9", default-features = false, features = ["rustls-tls"] }
+prometheus-client = { version = "=0.22.3", default-features = false }
 regex = { version = "=1.11.1", default-features = false, features = ["perf", "unicode"] }
+reqwest = { version = "=0.12.9", default-features = false, features = ["rustls-tls"] }
 semver = { version = "=1.0.23", default-features = false }
 sentry-types = { version = "=0.34.0", default-features = false }
 serde = { version = "=1.0.214", default-features = false }
 serde_json = { version = "=1.0.132" }
 text-size = { version = "=1.1.1", default-features = false }
+time = { version = "=0.3.36", default-features = false }
 tokio = { version = "=1.41.1", default-features = false }
+tokio-postgres = { version = "=0.7.12", default-features = false }
 tokio-util = { version = "=0.7.12", default-features = false }
+tower-http = { version = "=0.6.1", features = ["trace"] }
 tower-layer = { version = "=0.3.3", default-features = false }
 tower-service = { version = "=0.3.3", default-features = false }
 tracing-appender = { version = "=0.2.3", default-features = false }
@@ -138,9 +141,6 @@ tracing-subscriber = { version = "=0.3.18", default-features = false }
 url = { version = "=2.5.3", default-features = false }
 utoipa = { version = "=4.2.3", default-features = false }
 uuid = { version = "=1.11.0", default-features = false }
-time = { version = "=0.3.36", default-features = false }
-tokio-postgres = { version = "=0.7.12", default-features = false }
-tower-http = { version = "=0.6.1", features = ["trace"] }
 
 # Shared third-party dependencies
 ansi-to-html = { version = "=0.2.1", default-features = false }
@@ -153,12 +153,12 @@ aws-config = { version = "=1.5.10" }
 aws-sdk-s3 = { version = "=1.60.0", default-features = false }
 bitvec = { version = "=1.0.1", default-features = false }
 bytes-utils = { version = "=0.1.4", default-features = false }
-clap = { version = "=4.5.20", features = ["std", "color", "help", "usage", "error-context", "suggestions"] }
+clap = { version = "=4.5.20", features = ["color", "error-context", "help", "std", "suggestions", "usage"] }
 clap_complete = { version = "=4.5.37", default-features = false }
 coverage-helper = { version = "=0.2.2", default-features = false }
 criterion-macro = { version = "=0.4.0", default-features = false }
-derive_more = { version = "=1.0.0", default-features = false }
 derive-where = { version = "=1.2.7", default-features = false, features = ["nightly"] }
+derive_more = { version = "=1.0.0", default-features = false }
 dotenv-flow = { version = "=0.16.2", default-features = false }
 expect-test = { version = "=1.5.0", default-features = false }
 futures = { version = "=0.3.31", default-features = false }
@@ -194,7 +194,7 @@ rand = { version = "=0.8.5", default-features = false }
 refinery = { version = "=0.8.14", default-features = false }
 rustc_version = { version = "=0.4.1", default-features = false }
 scc = { version = "=2.2.4", default-features = false }
-sentry = { version = "=0.34.0", default-features = false, features = ["backtrace", "contexts", "debug-images", "panic", "reqwest", "rustls", "tracing", "tower-http"] }
+sentry = { version = "=0.34.0", default-features = false, features = ["backtrace", "contexts", "debug-images", "panic", "reqwest", "rustls", "tower-http", "tracing"] }
 seq-macro = { version = "=0.3.5", default-features = false }
 serde_plain = { version = "=1.0.2", default-features = false }
 serde_with = { version = "=3.11.0", default-features = false }
@@ -213,11 +213,11 @@ tokio-stream = { version = "=0.1.16", default-features = false }
 tokio-test = { version = "=0.4.4", default-features = false }
 tower = { version = "=0.5.1", default-features = false }
 tower-test = { version = "=0.4.0", default-features = false }
-trait-variant = { version = "=0.1.2", default-features = false }
 tracing = { version = "=0.1.40", default-features = false }
 tracing-error = { version = "=0.2.0", default-features = false }
 tracing-flame = { version = "=0.2.0", default-features = false }
 tracing-opentelemetry = { version = "=0.27.0", default-features = false }
+trait-variant = { version = "=0.1.2", default-features = false }
 trybuild = { version = "=1.0.101", default-features = false }
 tsify = { version = "=0.4.5", default-features = false }
 unicode-ident = { version = "=1.0.13", default-features = false }
@@ -241,8 +241,8 @@ codegen-backend = "llvm"
 
 # We use `llvm-cov` which requires LLVM`
 [profile.coverage]
-inherits = "test"
 codegen-backend = "llvm"
+inherits = "test"
 
 [profile.production]
 inherits = "release"
@@ -250,11 +250,11 @@ lto = "fat"
 strip = "none"
 
 [workspace.lints.rust]
-nonstandard_style = { level = "warn", priority = -1 }
 future_incompatible = { level = "warn", priority = -1 }
+nonstandard_style = { level = "warn", priority = -1 }
 
-unsafe_code = "deny"
 unreachable_pub = "warn"
+unsafe_code = "deny"
 
 [workspace.lints.cargo]
 
@@ -307,8 +307,8 @@ module_name_repetitions = "allow"
 pub_use = "allow"
 pub_with_shorthand = "allow" # Opposite of `clippy::pub_without_shorthand`
 question_mark_used = "allow"
-ref_patterns = "allow"
 redundant_pub_crate = "allow" # Opposite of `unreachable_pub`
+ref_patterns = "allow"
 semicolon_outside_block = "allow" # Opposite of `clippy::semicolon_inside_block`
 separated_literal_suffix = "allow" # Opposite of `clippy::unseparated_literal_suffix`
 shadow_reuse = "allow"

--- a/apps/hash-graph/Cargo.toml
+++ b/apps/hash-graph/Cargo.toml
@@ -14,20 +14,20 @@ package-name = "@apps/hash-graph"
 
 [dependencies]
 # Workspace dependencies
-hash-codec = { workspace = true }
 error-stack = { workspace = true }
-hash-graph-postgres-store = { workspace = true, features = ["clap"] }
+harpc-codec = { workspace = true, features = ["json"] }
+harpc-server = { workspace = true }
+hash-codec = { workspace = true }
 hash-graph-api = { workspace = true }
 hash-graph-authorization = { workspace = true }
+hash-graph-postgres-store = { workspace = true, features = ["clap"] }
 hash-graph-store = { workspace = true }
+hash-graph-test-server = { workspace = true, optional = true }
 hash-graph-type-fetcher = { workspace = true }
 hash-graph-types = { workspace = true }
-hash-graph-test-server = { workspace = true, optional = true }
 hash-temporal-client = { workspace = true }
 hash-tracing = { workspace = true, features = ["clap"] }
 type-system = { workspace = true }
-harpc-codec = { workspace = true, features = ["json"] }
-harpc-server = { workspace = true }
 
 # Third party dependencies
 axum = { workspace = true }
@@ -35,6 +35,7 @@ clap = { workspace = true, features = ["cargo", "derive", "env", "wrap_help"] }
 clap_complete = { workspace = true }
 futures = { workspace = true }
 mimalloc = { workspace = true }
+multiaddr = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["rustls-tls"] }
 tarpc = { workspace = true, features = [
@@ -49,7 +50,6 @@ tokio = { workspace = true }
 tokio-postgres = { workspace = true }
 tokio-util = { workspace = true, features = ["codec"] }
 tracing = { workspace = true }
-multiaddr = { workspace = true }
 
 [features]
 test-server = ["dep:hash-graph-test-server"]

--- a/libs/@local/codec/Cargo.toml
+++ b/libs/@local/codec/Cargo.toml
@@ -16,8 +16,8 @@ serde = { workspace = true, public = true, optional = true }
 
 # Public third-party dependencies
 bytes = { workspace = true, public = true }
-tokio-util = { workspace = true, public = true, optional = true, features = ["codec"] }
 regex = { workspace = true, public = true, optional = true }
+tokio-util = { workspace = true, public = true, optional = true, features = ["codec"] }
 
 # Private workspace dependencies
 

--- a/libs/@local/graph/api/Cargo.toml
+++ b/libs/@local/graph/api/Cargo.toml
@@ -15,31 +15,31 @@ path = "src/bin/openapi-spec-generator.rs"
 
 [dependencies]
 # Public workspace dependencies
-hash-graph-postgres-store = { workspace = true, public = true, features = ["utoipa"] }
+harpc-client = { workspace = true, public = true }
+harpc-server = { workspace = true, public = true }
 hash-graph-authorization = { workspace = true, public = true }
+hash-graph-postgres-store = { workspace = true, public = true, features = ["utoipa"] }
 hash-graph-store = { workspace = true, features = ["utoipa"] }
 hash-graph-type-fetcher = { workspace = true, public = true }
 hash-graph-types = { workspace = true, public = true, features = ["utoipa"] }
 hash-temporal-client = { workspace = true, public = true }
-harpc-server = { workspace = true, public = true }
-harpc-client = { workspace = true, public = true }
 
 # Public third-party dependencies
 axum = { workspace = true, public = true }
 axum-core = { workspace = true, public = true }
+error-stack = { workspace = true, features = ["futures", "spantrace", "unstable"] }
 http = { workspace = true, public = true }
 tower-http = { workspace = true, public = true }
 tracing = { workspace = true, public = true }
-error-stack = { workspace = true, features = ["futures", "spantrace", "unstable"] }
 
 # Private workspace dependencies
 harpc-codec = { workspace = true }
 harpc-system = { workspace = true }
 harpc-tower = { workspace = true }
 harpc-types = { workspace = true }
-hash-status = { workspace = true }
 hash-graph-temporal-versioning = { workspace = true }
 hash-graph-type-defs = { workspace = true }
+hash-status = { workspace = true }
 type-system = { workspace = true, features = ["utoipa"] }
 
 # Private third-party dependencies

--- a/libs/@local/graph/authorization/Cargo.toml
+++ b/libs/@local/graph/authorization/Cargo.toml
@@ -16,9 +16,9 @@ hash-graph-types = { workspace = true, public = true }
 futures-core = { workspace = true, public = true }
 
 # Private workspace dependencies
+error-stack = { workspace = true, features = ["unstable"] }
 hash-codec = { workspace = true }
 type-system = { workspace = true }
-error-stack = { workspace = true, features = ["unstable"] }
 
 # Private third-party dependencies
 derive-where = { workspace = true }

--- a/libs/@local/graph/postgres-store/Cargo.toml
+++ b/libs/@local/graph/postgres-store/Cargo.toml
@@ -24,11 +24,11 @@ tokio = { workspace = true, public = true, features = ["macros"] }
 tokio-postgres = { workspace = true, public = true }
 
 # Private workspace dependencies
-hash-codec = { workspace = true }
 error-stack = { workspace = true, features = ["std", "serde", "unstable"] }
-hash-status = { workspace = true }
+hash-codec = { workspace = true }
 hash-graph-temporal-versioning = { workspace = true, features = ["postgres"] }
 hash-graph-types = { workspace = true, features = ["postgres"] }
+hash-status = { workspace = true }
 type-system = { workspace = true, features = ["postgres"] }
 
 # Private third-party dependencies

--- a/libs/@local/graph/store/Cargo.toml
+++ b/libs/@local/graph/store/Cargo.toml
@@ -15,19 +15,19 @@ hash-graph-authorization = { workspace = true, public = true }
 hash-temporal-client = { workspace = true, public = true }
 
 # Public third-party dependencies
-utoipa = { workspace = true, public = true, optional = true }
 postgres-types = { workspace = true, public = true, optional = true, features = ["derive", "with-serde_json-1", "with-uuid-1"] }
-tokio-postgres = { workspace = true, public = true, optional = true}
+tokio-postgres = { workspace = true, public = true, optional = true }
+utoipa = { workspace = true, public = true, optional = true }
 
 # Private workspace dependencies
 hash-graph-temporal-versioning = { workspace = true }
-type-system = { workspace = true }
 hash-graph-types = { workspace = true }
+type-system = { workspace = true }
 
 # Private third-party dependencies
 bytes = { workspace = true, optional = true }
-derive_more = { workspace = true, features = ["display", "error"] }
 derive-where = { workspace = true }
+derive_more = { workspace = true, features = ["display", "error"] }
 futures = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/libs/@local/graph/temporal-versioning/Cargo.toml
+++ b/libs/@local/graph/temporal-versioning/Cargo.toml
@@ -13,8 +13,8 @@ authors.workspace = true
 
 # Public third-party dependencies
 bytes = { workspace = true, public = true, optional = true }
-time = { workspace = true, public = true, features = ["serde", "parsing", "formatting", "macros"] }
 postgres-types = { workspace = true, public = true, features = ["with-time-0_3"], optional = true }
+time = { workspace = true, public = true, features = ["serde", "parsing", "formatting", "macros"] }
 utoipa = { workspace = true, public = true, optional = true }
 
 # Private workspace dependencies

--- a/libs/@local/graph/test-server/Cargo.toml
+++ b/libs/@local/graph/test-server/Cargo.toml
@@ -16,10 +16,10 @@ description = "HASH Graph test server"
 
 # Private workspace dependencies
 error-stack = { workspace = true }
-hash-graph-postgres-store = { workspace = true, features = ["utoipa"] }
 hash-codec = { workspace = true }
-hash-graph-authorization = { workspace = true }
 hash-graph-api = { workspace = true }
+hash-graph-authorization = { workspace = true }
+hash-graph-postgres-store = { workspace = true, features = ["utoipa"] }
 hash-graph-store = { workspace = true }
 hash-graph-type-defs = { workspace = true }
 hash-graph-types = { workspace = true, features = ["utoipa"] }

--- a/libs/@local/graph/type-fetcher/Cargo.toml
+++ b/libs/@local/graph/type-fetcher/Cargo.toml
@@ -11,13 +11,13 @@ description = "RPC service definition to fetch external BP types"
 
 [dependencies]
 # Public workspace dependencies
-type-system = { workspace = true, public = true }
 hash-graph-store = { workspace = true, public = true }
+type-system = { workspace = true, public = true }
 
 # Public third-party dependencies
+serde_json = { workspace = true, public = true }
 tarpc = { workspace = true, public = true, features = ["serde-transport", "serde-transport-json", "tcp", "tokio1"] }
 time = { workspace = true, public = true, features = ["serde", "std"] }
-serde_json = { workspace = true, public = true }
 tokio = { workspace = true, public = true }
 
 # Private workspace dependencies

--- a/libs/@local/graph/types/rust/Cargo.toml
+++ b/libs/@local/graph/types/rust/Cargo.toml
@@ -17,8 +17,8 @@ type-system = { workspace = true, public = true }
 semver = { workspace = true, public = true, features = ["serde"] }
 
 # Private workspace dependencies
-hash-codec = { workspace = true, features = ["bytes"] }
 error-stack = { workspace = true }
+hash-codec = { workspace = true, features = ["bytes"] }
 
 # Private third-party dependencies
 bytes = { workspace = true }
@@ -28,10 +28,10 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true, default-features = false, features = ["serde", "parsing", "formatting", "macros"] }
+trait-variant = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 utoipa = { workspace = true, optional = true }
 uuid = { workspace = true, default-features = false, features = ["serde"] }
-trait-variant = { workspace = true }
 
 [dev-dependencies]
 hash-graph-test-data = { workspace = true }

--- a/libs/@local/graph/validation/Cargo.toml
+++ b/libs/@local/graph/validation/Cargo.toml
@@ -10,8 +10,8 @@ authors.workspace = true
 
 [dependencies]
 # Public workspace dependencies
-hash-graph-types = { workspace = true, public = true }
 hash-graph-store = { workspace = true, public = true }
+hash-graph-types = { workspace = true, public = true }
 
 # Public third-party dependencies
 

--- a/libs/@local/harpc/client/Cargo.toml
+++ b/libs/@local/harpc/client/Cargo.toml
@@ -10,12 +10,12 @@ publish.workspace = true
 
 [dependencies]
 # Public workspace dependencies
-harpc-tower = { workspace = true, public = true }
 harpc-system = { workspace = true, public = true }
+harpc-tower = { workspace = true, public = true }
 
 # Public third-party dependencies
-tower = { workspace = true, public = true }
 serde-value = { version = "0.7.0", public = true }
+tower = { workspace = true, public = true }
 
 # Private workspace dependencies
 error-stack = { workspace = true, features = ["unstable", "futures"] }
@@ -26,12 +26,12 @@ harpc-types = { workspace = true }
 # Private third-party dependencies
 bytes = { workspace = true }
 derive-where = { workspace = true }
+derive_more = { workspace = true, features = ["display"] }
 futures = { workspace = true }
 multiaddr = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tokio-util = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
-derive_more = { workspace = true, features = ["display"] }
 
 [lints]
 workspace = true

--- a/libs/@local/harpc/codec/Cargo.toml
+++ b/libs/@local/harpc/codec/Cargo.toml
@@ -16,15 +16,15 @@ harpc-types = { workspace = true, public = true }
 # Public third-party dependencies
 bytes = { workspace = true, public = true }
 futures-core = { workspace = true, public = true }
-serde = { workspace = true, public = true, features = ["derive"]}
 futures-util = { workspace = true, optional = true, public = true }
+serde = { workspace = true, public = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true, public = true }
 
 # Private workspace dependencies
 
 # Private third-party dependencies
-pin-project-lite = { workspace = true, optional = true }
 memchr = { workspace = true, optional = true }
+pin-project-lite = { workspace = true, optional = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/libs/@local/harpc/net/Cargo.toml
+++ b/libs/@local/harpc/net/Cargo.toml
@@ -23,16 +23,16 @@ libp2p-identity = { workspace = true, public = true }
 libp2p-ping = { workspace = true, public = true }
 libp2p-swarm = { workspace = true, public = true }
 libp2p-yamux = { workspace = true, public = true }
-prometheus-client = { workspace = true, public = true }
 multiaddr = { workspace = true, public = true }
 multistream-select = { workspace = true, public = true }
+prometheus-client = { workspace = true, public = true }
 tokio = { workspace = true, public = true, features = ["io-util", "macros"] }
 
 # Private workspace dependencies
-hash-codec = { workspace = true, features = ["harpc"] }
 error-stack = { workspace = true }
-harpc-wire-protocol = { workspace = true }
 harpc-types = { workspace = true }
+harpc-wire-protocol = { workspace = true }
+hash-codec = { workspace = true, features = ["harpc"] }
 
 # Private third-party dependencies
 bytes = { workspace = true }

--- a/libs/@local/harpc/server/Cargo.toml
+++ b/libs/@local/harpc/server/Cargo.toml
@@ -10,8 +10,8 @@ publish.workspace = true
 
 [dependencies]
 # Public workspace dependencies
-harpc-system = { workspace = true, public = true }
 harpc-net = { workspace = true, public = true }
+harpc-system = { workspace = true, public = true }
 
 # Public third-party dependencies
 frunk_core = { version = "0.4.3", public = true }

--- a/libs/@local/harpc/tower/Cargo.toml
+++ b/libs/@local/harpc/tower/Cargo.toml
@@ -19,8 +19,8 @@ tower-service = { workspace = true, public = true }
 
 # Private workspace dependencies
 error-stack = { workspace = true }
-harpc-types = { workspace = true, features = ["serde"] }
 harpc-codec = { workspace = true }
+harpc-types = { workspace = true, features = ["serde"] }
 
 # Private third-party dependencies
 bytes = { workspace = true }

--- a/libs/@local/hql/cst/Cargo.toml
+++ b/libs/@local/hql/cst/Cargo.toml
@@ -16,8 +16,8 @@ hql-span = { workspace = true, public = true }
 ahash = { workspace = true, public = true }
 bumpalo = { workspace = true, public = true, features = ["allocator_api"] }
 ecow = { workspace = true, public = true }
-hashbrown = { workspace = true, public = true, features = ["default-hasher"] }
 foldhash = { workspace = true, public = true }
+hashbrown = { workspace = true, public = true, features = ["default-hasher"] }
 json-number = { workspace = true, public = true }
 
 # Private workspace dependencies

--- a/libs/@local/hql/diagnostics/Cargo.toml
+++ b/libs/@local/hql/diagnostics/Cargo.toml
@@ -10,8 +10,8 @@ authors.workspace = true
 
 [dependencies]
 # Public workspace dependencies
+error-stack = { workspace = true, public = true, features = ["unstable"] }
 hql-span = { workspace = true, public = true }
-error-stack = { workspace = true, public = true, features = ["unstable"]}
 
 # Public third-party dependencies
 anstyle = { workspace = true, public = true }

--- a/libs/@local/tracing/Cargo.toml
+++ b/libs/@local/tracing/Cargo.toml
@@ -14,11 +14,11 @@ error-stack = { workspace = true, public = true }
 
 # Public third-party dependencies
 clap_builder = { workspace = true, public = true }
+sentry-types = { workspace = true, public = true }
 tokio = { workspace = true, public = true }
 tracing-appender = { workspace = true, public = true }
 tracing-core = { workspace = true, public = true }
 tracing-subscriber = { workspace = true, public = true, features = ["ansi", "env-filter", "json"] }
-sentry-types = { workspace = true, public = true }
 
 # Private workspace dependencies
 

--- a/libs/deer/Cargo.toml
+++ b/libs/deer/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 
 [dependencies]
 # Public workspace dependencies
-error-stack = { workspace = true, public = true, default-features = false, features = ["unstable"]}
+error-stack = { workspace = true, public = true, default-features = false, features = ["unstable"] }
 
 # Public third-party dependencies
 erased-serde = { workspace = true, public = true, features = ['alloc'] }

--- a/libs/deer/json/Cargo.toml
+++ b/libs/deer/json/Cargo.toml
@@ -21,7 +21,7 @@ deer = { path = "..", public = true, default-features = false }
 # Public third-party dependencies
 
 # Private workspace dependencies
-error-stack = { workspace = true, default-features = false, features = ["unstable"]}
+error-stack = { workspace = true, default-features = false, features = ["unstable"] }
 
 # Private third-party dependencies
 justjson = { workspace = true, features = ["alloc"] }

--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -19,16 +19,16 @@ exclude = ["package.json", "macros", "experimental"]
 # Public third-party dependencies
 anyhow = { version = ">=1.0.73", public = true, default-features = false, optional = true }
 eyre = { version = ">=0.6", public = true, default-features = false, optional = true }
-serde = { version = ">=1", default-features = false, public = true, optional = true }
 futures-core = { workspace = true, public = true, optional = true }
+serde = { version = ">=1", default-features = false, public = true, optional = true }
 
 # Private workspace dependencies
 pin-project-lite = { workspace = true, optional = true }
 
 # Private third-party dependencies
 spin = { version = ">=0.9", default-features = false, optional = true, features = ['rwlock', 'once'] }
-tracing-error = { version = ">=0.2", optional = true, default-features = false }
 tracing = { version = ">=0.1", optional = true, default-features = false }
+tracing-error = { version = ">=0.2", optional = true, default-features = false }
 
 [dev-dependencies]
 serde = { workspace = true, features = ["derive"] }
@@ -52,16 +52,16 @@ rustc_version = { workspace = true }
 [features]
 default = ["std", "backtrace"]
 
-std = ["anyhow?/std"]  # Enables support for `Error`
-backtrace = ["std"]  # Enables automatic capturing of `Backtrace`s (requires Rust 1.65+)
+std = ["anyhow?/std"] # Enables support for `Error`
+backtrace = ["std"] # Enables automatic capturing of `Backtrace`s (requires Rust 1.65+)
 
-tracing = ["dep:tracing"]  # Uses the `tracing` library if messages would be printed to the terminal
-spantrace = ["dep:tracing-error", "tracing", "std"]  # Enables automatic capturing of `SpanTrace`s
-serde = ["dep:serde"]  # Enables serialization support
-hooks = ['dep:spin']  # Enables hooks on `no-std` platforms using spin locks
+tracing = ["dep:tracing"] # Uses the `tracing` library if messages would be printed to the terminal
+spantrace = ["dep:tracing-error", "tracing", "std"] # Enables automatic capturing of `SpanTrace`s
+serde = ["dep:serde"] # Enables serialization support
+hooks = ['dep:spin'] # Enables hooks on `no-std` platforms using spin locks
 
-anyhow = ["dep:anyhow"]  # Provides `into_report` to convert `anyhow::Error` to `Report`
-eyre = ["dep:eyre", "std"]  # Provides `into_report` to convert `eyre::Report` to `Report`
+anyhow = ["dep:anyhow"] # Provides `into_report` to convert `anyhow::Error` to `Report`
+eyre = ["dep:eyre", "std"] # Provides `into_report` to convert `eyre::Report` to `Report`
 
 futures = ["dep:futures-core", "dep:pin-project-lite"] # Provides support for `futures` types, such as stream.
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@TODO.1": "Upgrade or remove these blocks and remove the --ignore-package options (also @TODO.2)",
     "fix:dependency-version-consistency": "check-dependency-version-consistency --fix . --ignore-dep=@blockprotocol/graph --ignore-package=@apps/hashdotdev --ignore-package=@blocks/embed --ignore-package=@blocks/person",
     "fix:eslint": "turbo --continue fix:eslint --",
+    "fix:taplo": "taplo fmt",
     "fix:markdownlint": "markdownlint --dot --fix .",
     "fix:prettier": "prettier --write  --ignore-unknown .",
     "fix:yarn-deduplicate": "yarn install && yarn-deduplicate --strategy=fewer && yarn install",
@@ -49,6 +50,7 @@
     "lint:lockfile-lint": "lockfile-lint --path yarn.lock --allowed-hosts registry.yarnpkg.com --allowed-schemes \"https:\"",
     "lint:markdownlint": "markdownlint --dot .",
     "lint:prettier": "prettier --check --ignore-unknown .",
+    "lint:taplo": "taplo fmt --check",
     "lint:tsc": "turbo --continue lint:tsc --",
     "lint:yarn-deduplicate": "yarn-deduplicate --fail --list --strategy=fewer",
     "postinstall": "turbo run postinstall; patch-package --error-on-warn && husky install .config/husky",
@@ -100,6 +102,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "0.4.8",
     "@changesets/cli": "2.26.0",
+    "@taplo/cli": "0.7.0",
     "check-dependency-version-consistency": "3.0.3",
     "concurrently": "7.6.0",
     "cross-env": "7.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10161,6 +10161,11 @@
   resolved "https://registry.yarnpkg.com/@tapjs/worker/-/worker-2.0.8.tgz#6c2420063896594d947748f77698445db0400b65"
   integrity sha512-AySf2kV6OHvwgD3DrLdT2az2g4hRdoRtKsFCLdZo3jOoKte+ft/IQJEnOW7CPT0RYUskS3elv6eabYgSyTH4tg==
 
+"@taplo/cli@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@taplo/cli/-/cli-0.7.0.tgz#f0b2c65a169fc6ae9ebecadc2e09d5c681177731"
+  integrity sha512-Ck3zFhQhIhi02Hl6T4ZmJsXdnJE+wXcJz5f8klxd4keRYgenMnip3JDPMGDRLbnC/2iGd8P0sBIQqI3KxfVjBg==
+
 "@temporalio/activity@1.11.3":
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/@temporalio/activity/-/activity-1.11.3.tgz#9caf9deae425eb8ac0fa5660adb6de47ec7aad33"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

While doing [H-1000](https://linear.app/hash/issue/H-1000/split-the-graph-into-multiple-lib-modules) it happened quite some times that manually reformatting *.toml files would have been needed. I used tuple to format the files, it's easy to add that configuration to the repository.


## 🔍 What does this change?

- Add `taplo` to dev-dependencies
- Add `fix:taplo` and `lint:taplo` scripts
- Add `lint:taplo` in CI
- Add small config for taplo
- Run `fix:taplo` to apply changes

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph