### PR TITLE
H-3544: Fix spans occurring in unrelated queries

### DIFF
--- a/libs/@local/graph/type-fetcher/src/store.rs
+++ b/libs/@local/graph/type-fetcher/src/store.rs
@@ -66,6 +66,7 @@ use hash_graph_types::{
 use hash_temporal_client::TemporalClient;
 use tarpc::context;
 use tokio::net::ToSocketAddrs;
+use tracing::Instrument as _;
 use type_system::{
     schema::{DataType, DomainValidator, EntityType, EntityTypeReference, PropertyType},
     url::VersionedUrl,
@@ -381,9 +382,9 @@ where
                     "fetching ontology types from type fetcher",
                     urls=?ontology_urls
                 );
-                let _enter = span.enter();
                 fetcher
                     .fetch_ontology_types(context::current(), ontology_urls)
+                    .instrument(span)
                     .await
                     .change_context(QueryError)?
                     .change_context(QueryError)?


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We have an issue that tracing spans from previous queries occurring in new queries.

## 🔍 What does this change?

When `Span::enter()` is called and the returned `Drop`-guard is kept over an `.await` point it's possible that this results in wrong traces. For more information see the [`Span::enter()` documentation](https://docs.rs/tracing/latest/tracing/struct.Span.html#method.enter). This PR avoids calling `.enter()` in `async` context and uses the `Instrument` trait instead.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph