### PR TITLE
H-3535: Paginate big requests to SpiceDB

### DIFF
--- a/libs/@local/graph/api/src/rest/entity.rs
+++ b/libs/@local/graph/api/src/rest/entity.rs
@@ -297,10 +297,7 @@ where
         (status = 500, description = "Store error occurred"),
     ),
 )]
-#[tracing::instrument(
-    level = "info",
-    skip(store_pool, authorization_api_pool, temporal_client)
-)]
+#[tracing::instrument(level = "info", skip_all)]
 async fn create_entities<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,

--- a/libs/@local/graph/authorization/src/api.rs
+++ b/libs/@local/graph/authorization/src/api.rs
@@ -132,7 +132,7 @@ pub trait AuthorizationApi: Send + Sync {
         &self,
         actor: AccountId,
         permission: EntityPermission,
-        entities: impl IntoIterator<Item = EntityId, IntoIter: Send> + Send,
+        entities: impl IntoIterator<Item = EntityId, IntoIter: Send + Sync> + Send,
         consistency: Consistency<'_>,
     ) -> impl Future<
         Output = Result<(HashMap<EntityUuid, bool>, Zookie<'static>), Report<CheckError>>,
@@ -171,7 +171,7 @@ pub trait AuthorizationApi: Send + Sync {
         &self,
         actor: AccountId,
         permission: EntityTypePermission,
-        entity_types: impl IntoIterator<Item = EntityTypeUuid, IntoIter: Send> + Send,
+        entity_types: impl IntoIterator<Item = EntityTypeUuid, IntoIter: Send + Sync> + Send,
         consistency: Consistency<'_>,
     ) -> impl Future<
         Output = Result<(HashMap<EntityTypeUuid, bool>, Zookie<'static>), Report<CheckError>>,
@@ -210,7 +210,7 @@ pub trait AuthorizationApi: Send + Sync {
         &self,
         actor: AccountId,
         permission: PropertyTypePermission,
-        property_types: impl IntoIterator<Item = PropertyTypeUuid, IntoIter: Send> + Send,
+        property_types: impl IntoIterator<Item = PropertyTypeUuid, IntoIter: Send + Sync> + Send,
         consistency: Consistency<'_>,
     ) -> impl Future<
         Output = Result<(HashMap<PropertyTypeUuid, bool>, Zookie<'static>), Report<CheckError>>,
@@ -249,7 +249,7 @@ pub trait AuthorizationApi: Send + Sync {
         &self,
         actor: AccountId,
         permission: DataTypePermission,
-        data_types: impl IntoIterator<Item = DataTypeUuid, IntoIter: Send> + Send,
+        data_types: impl IntoIterator<Item = DataTypeUuid, IntoIter: Send + Sync> + Send,
         consistency: Consistency<'_>,
     ) -> impl Future<
         Output = Result<(HashMap<DataTypeUuid, bool>, Zookie<'static>), Report<CheckError>>,
@@ -357,7 +357,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
         &self,
         actor: AccountId,
         permission: EntityPermission,
-        entities: impl IntoIterator<Item = EntityId, IntoIter: Send> + Send,
+        entities: impl IntoIterator<Item = EntityId, IntoIter: Send + Sync> + Send,
         consistency: Consistency<'_>,
     ) -> Result<(HashMap<EntityUuid, bool>, Zookie<'static>), Report<CheckError>> {
         (**self)
@@ -403,7 +403,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
         &self,
         actor: AccountId,
         permission: EntityTypePermission,
-        entity_types: impl IntoIterator<Item = EntityTypeUuid, IntoIter: Send> + Send,
+        entity_types: impl IntoIterator<Item = EntityTypeUuid, IntoIter: Send + Sync> + Send,
         consistency: Consistency<'_>,
     ) -> Result<(HashMap<EntityTypeUuid, bool>, Zookie<'static>), Report<CheckError>> {
         (**self)
@@ -451,7 +451,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
         &self,
         actor: AccountId,
         permission: PropertyTypePermission,
-        property_types: impl IntoIterator<Item = PropertyTypeUuid, IntoIter: Send> + Send,
+        property_types: impl IntoIterator<Item = PropertyTypeUuid, IntoIter: Send + Sync> + Send,
         consistency: Consistency<'_>,
     ) -> Result<(HashMap<PropertyTypeUuid, bool>, Zookie<'static>), Report<CheckError>> {
         (**self)
@@ -499,7 +499,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
         &self,
         actor: AccountId,
         permission: DataTypePermission,
-        data_types: impl IntoIterator<Item = DataTypeUuid, IntoIter: Send> + Send,
+        data_types: impl IntoIterator<Item = DataTypeUuid, IntoIter: Send + Sync> + Send,
         consistency: Consistency<'_>,
     ) -> Result<(HashMap<DataTypeUuid, bool>, Zookie<'static>), Report<CheckError>> {
         (**self)

--- a/libs/@local/graph/authorization/src/backend/mod.rs
+++ b/libs/@local/graph/authorization/src/backend/mod.rs
@@ -173,7 +173,7 @@ pub trait ZanzibarBackend {
     /// set to `false`.
     fn check_permissions<O, R, S>(
         &self,
-        relationships: impl IntoIterator<Item = (O, R, S)> + Send,
+        relationships: impl IntoIterator<Item = (O, R, S), IntoIter: Send + Sync> + Send,
         consistency: Consistency<'_>,
     ) -> impl Future<
         Output = Result<
@@ -285,7 +285,7 @@ impl<Z: ZanzibarBackend + Send + Sync> ZanzibarBackend for &mut Z {
 
     async fn check_permissions<O, R, S>(
         &self,
-        relationships: impl IntoIterator<Item = (O, R, S)> + Send,
+        relationships: impl IntoIterator<Item = (O, R, S), IntoIter: Send + Sync> + Send,
         consistency: Consistency<'_>,
     ) -> Result<
         BulkCheckResponse<impl IntoIterator<Item = BulkCheckItem<O, R, S>>>,

--- a/libs/@local/graph/authorization/src/backend/spicedb/api.rs
+++ b/libs/@local/graph/authorization/src/backend/spicedb/api.rs
@@ -490,14 +490,13 @@ impl ZanzibarBackend for SpiceDbOpenApi {
 
             if relationships.peek().is_none() {
                 break response.checked_at.token;
-            } else {
-                current_token = Some(response.checked_at.token);
             }
+            current_token = Some(response.checked_at.token);
         };
 
         Ok(BulkCheckResponse {
-            checked_at,
             permissions,
+            checked_at,
         })
     }
 

--- a/libs/@local/graph/authorization/src/backend/spicedb/api.rs
+++ b/libs/@local/graph/authorization/src/backend/spicedb/api.rs
@@ -351,7 +351,7 @@ impl ZanzibarBackend for SpiceDbOpenApi {
     #[expect(clippy::too_many_lines)]
     async fn check_permissions<O, R, S>(
         &self,
-        relationships: impl IntoIterator<Item = (O, R, S)> + Send,
+        relationships: impl IntoIterator<Item = (O, R, S), IntoIter: Send + Sync> + Send,
         consistency: Consistency<'_>,
     ) -> Result<
         BulkCheckResponse<impl IntoIterator<Item = BulkCheckItem<O, R, S>>>,
@@ -451,28 +451,34 @@ impl ZanzibarBackend for SpiceDbOpenApi {
             response: Response,
         }
 
-        let request = BulkCheckPermissionRequest::<O, R, S> {
-            consistency: consistency.into(),
-            items: relationships
-                .into_iter()
-                .map(
-                    |(resource, permission, subject)| BulkCheckPermissionRequestItem {
-                        resource,
-                        permission,
-                        subject,
-                    },
-                )
-                .collect(),
-        };
+        let mut current_token = None;
+        let mut relationships = relationships.into_iter().peekable();
+        let mut permissions = Vec::with_capacity(relationships.size_hint().0);
+        let checked_at = loop {
+            let request = BulkCheckPermissionRequest::<O, R, S> {
+                consistency: current_token
+                    .as_ref()
+                    .map_or(consistency, Consistency::AtLeastAsFresh)
+                    .into(),
+                items: relationships
+                    .by_ref()
+                    .take(10000)
+                    .map(
+                        |(resource, permission, subject)| BulkCheckPermissionRequestItem {
+                            resource,
+                            permission,
+                            subject,
+                        },
+                    )
+                    .collect(),
+            };
 
-        let response: BulkCheckPermissionResponse<O, R, S> = self
-            .call("/v1/experimental/permissions/bulkcheckpermission", &request)
-            .await
-            .change_context(CheckError)?;
+            let response: BulkCheckPermissionResponse<O, R, S> = self
+                .call("/v1/experimental/permissions/bulkcheckpermission", &request)
+                .await
+                .change_context(CheckError)?;
 
-        Ok(BulkCheckResponse {
-            checked_at: response.checked_at.token,
-            permissions: response.pairs.into_iter().map(|pair| BulkCheckItem {
+            permissions.extend(response.pairs.into_iter().map(|pair| BulkCheckItem {
                 subject: pair.request.subject,
                 permission: pair.request.permission,
                 resource: pair.request.resource,
@@ -480,7 +486,18 @@ impl ZanzibarBackend for SpiceDbOpenApi {
                     Response::Item(item) => Ok(item.permissionship.into()),
                     Response::Error(error) => Err(error),
                 },
-            }),
+            }));
+
+            if relationships.peek().is_none() {
+                break response.checked_at.token;
+            } else {
+                current_token = Some(response.checked_at.token);
+            }
+        };
+
+        Ok(BulkCheckResponse {
+            checked_at,
+            permissions,
         })
     }
 

--- a/libs/@local/graph/authorization/src/zanzibar/api.rs
+++ b/libs/@local/graph/authorization/src/zanzibar/api.rs
@@ -222,7 +222,7 @@ where
         &self,
         actor: AccountId,
         permission: EntityPermission,
-        entities: impl IntoIterator<Item = EntityId, IntoIter: Send> + Send,
+        entities: impl IntoIterator<Item = EntityId, IntoIter: Send + Sync> + Send,
         consistency: Consistency<'_>,
     ) -> Result<(HashMap<EntityUuid, bool>, Zookie<'static>), Report<CheckError>> {
         let response = self
@@ -318,7 +318,7 @@ where
         &self,
         actor: AccountId,
         permission: EntityTypePermission,
-        entity_types: impl IntoIterator<Item = EntityTypeUuid, IntoIter: Send> + Send,
+        entity_types: impl IntoIterator<Item = EntityTypeUuid, IntoIter: Send + Sync> + Send,
         consistency: Consistency<'_>,
     ) -> Result<(HashMap<EntityTypeUuid, bool>, Zookie<'static>), Report<CheckError>> {
         let response = self
@@ -416,7 +416,7 @@ where
         &self,
         actor: AccountId,
         permission: PropertyTypePermission,
-        property_types: impl IntoIterator<Item = PropertyTypeUuid, IntoIter: Send> + Send,
+        property_types: impl IntoIterator<Item = PropertyTypeUuid, IntoIter: Send + Sync> + Send,
         consistency: Consistency<'_>,
     ) -> Result<(HashMap<PropertyTypeUuid, bool>, Zookie<'static>), Report<CheckError>> {
         let response = self
@@ -512,7 +512,7 @@ where
         &self,
         actor: AccountId,
         permission: DataTypePermission,
-        data_types: impl IntoIterator<Item = DataTypeUuid, IntoIter: Send> + Send,
+        data_types: impl IntoIterator<Item = DataTypeUuid, IntoIter: Send + Sync> + Send,
         consistency: Consistency<'_>,
     ) -> Result<(HashMap<DataTypeUuid, bool>, Zookie<'static>), Report<CheckError>> {
         let response = self
@@ -617,7 +617,7 @@ where
 
     async fn check_permissions<O, R, S>(
         &self,
-        relationships: impl IntoIterator<Item = (O, R, S)> + Send,
+        relationships: impl IntoIterator<Item = (O, R, S), IntoIter: Send + Sync> + Send,
         consistency: Consistency<'_>,
     ) -> Result<
         BulkCheckResponse<impl IntoIterator<Item = BulkCheckItem<O, R, S>>>,

--- a/libs/@local/temporal-client/src/ai.rs
+++ b/libs/@local/temporal-client/src/ai.rs
@@ -158,6 +158,11 @@ impl TemporalClient {
         // we need to split the entities into chunks.
         const CHUNK_SIZE: usize = 100;
 
+        #[expect(
+            clippy::integer_division,
+            clippy::integer_division_remainder_used,
+            reason = "The devision is only used to calculate vector capacity and is rounded up."
+        )]
         let mut workflow_ids = Vec::with_capacity(entities.len() / CHUNK_SIZE + 1);
         for partial_entities in entities.chunks(CHUNK_SIZE) {
             workflow_ids.push(

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "start:graph:test-server": "turbo run start start:healthcheck --filter @rust/test-server",
     "start:worker": "turbo run start start:healthcheck --filter '@apps/hash-*-worker*' --env-mode=loose",
     "start:test": "turbo run start:test start:test:healthcheck --env-mode=loose",
-    "graph:reset-database": "yarn workspace @rust/graph-http-tests reset-database",
+    "graph:reset-database": "yarn workspace @rust/hash-graph-http-tests reset-database",
     "external-services": "turbo deploy --filter '@apps/hash-external-services' --",
     "external-services:offline": "turbo deploy:offline --filter '@apps/hash-external-services' --",
     "external-services:test": "turbo deploy:test --filter '@apps/hash-external-services' --",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Big requests to SpiceDB exceed the limit of gRPC and also results in not enough shared memory for Postgres. Also, a few minor things were addressed.

## 🔍 What does this change?

- Paginate (all) permission-requests to SpiceDB. Only 10 000 permissions are now checked per request.
- drive-by: Also batch embedding creation requests for entities to Temporal.io
- drive-by: Don't add whole body to span when creating entities
- drive-by: Fix package name in `package.json` script to reset database

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph