### PR TITLE
H-3590: Allow all CI to pass when opening PRs from a fork

### DIFF
--- a/.github/actions/build-docker-images/action.yml
+++ b/.github/actions/build-docker-images/action.yml
@@ -40,6 +40,9 @@ runs:
           IMAGE_TAG=":$(echo ${{ github.ref_name }} | sed 's|/|-|g')"
         fi
 
+        # `dev` is large (~400 MB), slow, and fast to build
+        # `production` is small (~10 MB), fast, and slow to build (a few minutes linking time due to LTO)
+        # `release` is a compromise between the two (~30 MB, no LTO)
         GRAPH_PROFILE="$([ "${{ github.ref_name }}" == "main" ] && echo "release" || echo "dev")"
 
         set -x
@@ -57,7 +60,7 @@ runs:
         password: ${{ inputs.repo-token }}
 
     - name: Build hash-graph image
-      if: inputs.hash-graph == 'true'
+      if: inputs.hash-graph == 'true' && github.event.pull_request.head.repo.full_name == github.repository
       uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
       with:
         context: .
@@ -70,28 +73,33 @@ runs:
           type=registry,ref=ghcr.io/hashintel/hash-graph
         cache-to: |
           type=registry,ref=ghcr.io/hashintel/hash-graph${{ env.IMAGE_TAG }},mode=max
-        outputs: type=docker,dest=/tmp/hash-graph.tar
         labels: |
           org.opencontainers.image.source="https://github.com/hashintel/hash"
           org.opencontainers.image.licenses="AGPL-3.0-only,"
           org.opencontainers.image.description="The entity-graph query-layer for the HASH datastore"
-        # `dev` is large (~400 MB), slow, and fast to build
-        # `production` is small (~10 MB), fast, and slow to build (a few minutes linking time due to LTO)
-        # `release` is a compromise between the two (~30 MB, no LTO)
         build-args: |
           PROFILE=${{ env.GRAPH_PROFILE }}
           ENABLE_TYPE_FETCHER=yes
           ENABLE_TEST_SERVER=yes
 
-    - name: Upload artifact
-      if: ${{ (success() || failure()) && inputs.hash-graph == 'true' }}
-      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+    - name: Build hash-graph image (fork)
+      if: inputs.hash-graph == 'true' && github.event.pull_request.head.repo.full_name != github.repository
+      uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
       with:
-        name: hash-graph
-        path: /tmp/hash-graph.tar
+        context: .
+        file: apps/hash-graph/docker/Dockerfile
+        tags: |
+          hash-graph
+          hash-graph:test
+        cache-from: |
+          type=registry,ref=ghcr.io/hashintel/hash-graph
+        build-args: |
+          PROFILE=${{ env.GRAPH_PROFILE }}
+          ENABLE_TYPE_FETCHER=yes
+          ENABLE_TEST_SERVER=yes
 
     - name: Build hash-ai-worker-ts image
-      if: inputs.hash-ai-worker-ts == 'true'
+      if: inputs.hash-ai-worker-ts == 'true' && github.event.pull_request.head.repo.full_name == github.repository
       uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
       with:
         context: .
@@ -102,21 +110,23 @@ runs:
           type=registry,ref=ghcr.io/hashintel/hash-ai-worker-ts
         cache-to: |
           type=registry,ref=ghcr.io/hashintel/hash-ai-worker-ts${{ env.IMAGE_TAG }},mode=max
-        outputs: type=docker,dest=/tmp/hash-ai-worker-ts.tar
         labels: |
           org.opencontainers.image.source="https://github.com/hashintel/hash"
           org.opencontainers.image.licenses="AGPL-3.0-only,"
           org.opencontainers.image.description="A TypeScript 'AI' worker for HASH"
 
-    - name: Upload artifact
-      if: ${{ (success() || failure()) && inputs.hash-ai-worker-ts == 'true' }}
-      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+    - name: Build hash-ai-worker-ts image (fork)
+      if: inputs.hash-ai-worker-ts == 'true' && github.event.pull_request.head.repo.full_name != github.repository
+      uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
       with:
-        name: hash-ai-worker-ts
-        path: /tmp/hash-ai-worker-ts.tar
+        context: .
+        file: apps/hash-ai-worker-ts/docker/Dockerfile
+        tags: hash-ai-worker-ts
+        cache-from: |
+          type=registry,ref=ghcr.io/hashintel/hash-ai-worker-ts
 
     - name: Build hash-integration-worker image
-      if: inputs.hash-integration-worker == 'true'
+      if: inputs.hash-integration-worker == 'true' && github.event.pull_request.head.repo.full_name == github.repository
       uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
       with:
         context: .
@@ -127,21 +137,23 @@ runs:
           type=registry,ref=ghcr.io/hashintel/hash-integration-worker
         cache-to: |
           type=registry,ref=ghcr.io/hashintel/hash-integration-worker${{ env.IMAGE_TAG }},mode=max
-        outputs: type=docker,dest=/tmp/hash-integration-worker.tar
         labels: |
           org.opencontainers.image.source="https://github.com/hashintel/hash"
           org.opencontainers.image.licenses="AGPL-3.0-only,"
           org.opencontainers.image.description="A TypeScript worker for HASH for data integration"
 
-    - name: Upload artifact
-      if: ${{ (success() || failure()) && inputs.hash-integration-worker == 'true' }}
-      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+    - name: Build hash-integration-worker image (fork)
+      if: inputs.hash-integration-worker == 'true' && github.event.pull_request.head.repo.full_name != github.repository
+      uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
       with:
-        name: hash-integration-worker
-        path: /tmp/hash-integration-worker.tar
+        context: .
+        file: apps/hash-integration-worker/docker/Dockerfile
+        tags: hash-integration-worker
+        cache-from: |
+          type=registry,ref=ghcr.io/hashintel/hash-integration-worker
 
     - name: Build hash-api image
-      if: inputs.hash-api == 'true'
+      if: inputs.hash-api == 'true' && github.event.pull_request.head.repo.full_name == github.repository
       uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
       with:
         context: .
@@ -152,15 +164,17 @@ runs:
           type=registry,ref=ghcr.io/hashintel/hash-api
         cache-to: |
           type=registry,ref=ghcr.io/hashintel/hash-api${{ env.IMAGE_TAG }},mode=max
-        outputs: type=docker,dest=/tmp/hash-api.tar
         labels: |
           org.opencontainers.image.source="https://github.com/hashintel/hash"
           org.opencontainers.image.licenses="AGPL-3.0-only,"
-          org.opencontainers.image.description="API and data store for HAS"
+          org.opencontainers.image.description="API and data store for HASH"
 
-    - name: Upload artifact
-      if: ${{ (success() || failure()) && inputs.hash-api == 'true' }}
-      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+    - name: Build hash-api image (fork)
+      if: inputs.hash-api == 'true' && github.event.pull_request.head.repo.full_name != github.repository
+      uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
       with:
-        name: hash-api
-        path: /tmp/hash-api.tar
+        context: .
+        file: infra/docker/api/prod/Dockerfile
+        tags: hash-api
+        cache-from: |
+          type=registry,ref=ghcr.io/hashintel/hash-api

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -352,6 +352,7 @@ jobs:
 
       - name: Authenticate Vault
         id: secrets
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c # v3.0.0
         with:
           exportToken: true
@@ -364,6 +365,7 @@ jobs:
             aws/creds/dev-deploy security_token | AWS_SESSION_TOKEN;
 
       - name: Upload benchmark results
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: turbo run upload-benchmarks --env-mode=loose -- --artifacts-path "$(pwd)/${{ matrix.directory }}/out" --enforce-flame-graph
 
       - name: Upload benchmark summary

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -103,9 +103,10 @@ jobs:
 
       - name: Checkout base branch
         if: steps.benches.outputs.create-baseline == 'true'
-        run: |
-          git fetch origin "$GITHUB_BASE_REF"
-          git checkout FETCH_HEAD
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          clean: false
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Install Rust toolchain
         if: steps.benches.outputs.has-rust == 'true' && steps.benches.outputs.create-baseline == 'true'
@@ -140,9 +141,9 @@ jobs:
 
       - name: Checkout head branch
         if: steps.benches.outputs.create-baseline == 'true'
-        run: |
-          git fetch origin "$GITHUB_HEAD_REF"
-          git reset --hard FETCH_HEAD
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install Rust toolchain
         if: steps.benches.outputs.has-rust == 'true'
@@ -251,9 +252,10 @@ jobs:
 
       - name: Checkout base branch
         if: steps.benches.outputs.create-baseline == 'true'
-        run: |
-          git fetch origin "$GITHUB_BASE_REF"
-          git checkout FETCH_HEAD
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          clean: false
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Install Rust toolchain
         if: steps.benches.outputs.has-rust == 'true' && steps.benches.outputs.create-baseline == 'true'
@@ -302,9 +304,10 @@ jobs:
 
       - name: Checkout head branch
         if: steps.benches.outputs.create-baseline == 'true'
-        run: |
-          git fetch origin "$GITHUB_HEAD_REF"
-          git reset --hard FETCH_HEAD
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          clean: false
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install Rust toolchain
         if: steps.benches.outputs.has-rust == 'true'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -424,10 +424,11 @@ jobs:
         run: |
           echo "## Benchmark results" > /tmp/summary.md
           cat downloads/*/*.md >> /tmp/summary.md
+          cat /tmp/summary.md
 
       - name: Post comment
         uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
-        if: github.event_name == 'pull_request' && needs.integration-benches.result == 'success'
+        if: github.event_name == 'pull_request' && needs.integration-benches.result == 'success' && github.event.pull_request.head.repo.full_name == github.repository
         with:
           message-path: /tmp/summary.md
           message-id: benchmark-results

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.sourcemaps) }}
       fail-fast: false
-    if: needs.setup.outputs.sourcemaps != '{"package":[],"include":[]}'
+    if: needs.setup.outputs.sourcemaps != '{"package":[],"include":[]}' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     permissions:
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.repository == 'hashintel/hash'
+    if: github.repository == github.repository
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.repository == github.repository
+    if: github.repository == 'hashintel/hash'
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/tf-plan-hash.yml
+++ b/.github/workflows/tf-plan-hash.yml
@@ -44,6 +44,7 @@ jobs:
     strategy:
       matrix:
         env: ${{ fromJson(needs.matrix-eval.outputs.matrix) }}
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When opening PRs from a fork some CI cannot pass because they require authentication. To avoid this issue, this PR disables these steps (they will still be checked when running the merge-queue)

## 🔍 What does this change?

- Avoid uploading the cache for Build steps
- drive-by: Don't upload the Build results as artifact anymore, it's not used
- Use `checkout` action for Benchmark CI instead of manual commands
- Don't post the Benchmark-result as comment (the action runs from a fork so we cannot use `GH_TOKEN` here) - this can possibly be avoided by adding a `pull_request_target` run but that requires another CI workflow as we must not run the benchmarks using `pull_request_target`.
- Don't upload source maps to Sentry
- Don't attempt to plan a Terraform run

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph