### PR TITLE
H-2700, H-3556: Claims table in entity editor, AI research worker improvements

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/persist-entity-action.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/persist-entity-action.ts
@@ -318,7 +318,7 @@ export const persistEntityAction: FlowActionActivity = async ({ inputs }) => {
         entityTypeIds: [entityTypeId],
         ownedById: webId,
         provenance: {
-          ...claim.metadata.provenance,
+          sources: claim.metadata.provenance.edition.sources,
           actorType: "ai",
           origin: {
             type: "flow",

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/coordinating-agent.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/coordinating-agent.ts
@@ -36,7 +36,10 @@ import { requestCoordinatorActions } from "./coordinating-agent/request-coordina
 import type { ExistingEntitySummary } from "./coordinating-agent/summarize-existing-entities.js";
 import { summarizeExistingEntities } from "./coordinating-agent/summarize-existing-entities.js";
 import { updateStateFromInferredClaims } from "./coordinating-agent/update-state-from-inferred-claims.js";
-import type { ParsedCoordinatorToolCall } from "./shared/coordinator-tools.js";
+import type {
+  ParsedCoordinatorToolCall,
+  ParsedCoordinatorToolCallMap,
+} from "./shared/coordinator-tools.js";
 import {
   getSomeToolCallResults,
   handleStopTasksRequests,
@@ -248,7 +251,7 @@ export const runCoordinatingAgent: FlowActionActivity<{
       return;
     }
 
-    await handleStopTasksRequests({ state, toolCalls });
+    await handleStopTasksRequests({ toolCalls });
 
     const requestMakingToolCalls = toolCalls.filter(
       (toolCall) =>
@@ -258,9 +261,14 @@ export const runCoordinatingAgent: FlowActionActivity<{
         toolCall.name !== "waitForOutstandingTasks",
     );
 
+    const completeToolCall = toolCalls.find(
+      (toolCall) => toolCall.name === "complete",
+    );
+
     const waitForTasksToolCall = toolCalls.find(
       (toolCall) => toolCall.name === "waitForOutstandingTasks",
     );
+
     if (waitForTasksToolCall && !requestMakingToolCalls.length) {
       /**
        * If the coordinator has decided to wait for outstanding tasks, notify the user of this.
@@ -281,18 +289,47 @@ export const runCoordinatingAgent: FlowActionActivity<{
       ]);
     }
 
-    state.outstandingTasks.push(
-      ...triggerToolCallsRequests({
-        agentType: "coordinator",
-        input,
-        state,
-        toolCalls: requestMakingToolCalls,
-        workerIdentifiers,
-      }),
-    );
+    if (
+      completeToolCall &&
+      state.outstandingTasks.length > 0 &&
+      !requestMakingToolCalls.length
+    ) {
+      /**
+       * If the coordinator has called complete but there are still outstanding tasks,
+       * we let them wrap up so that any claims and entities they've proposed to date are captured.
+       * Otherwise, we'll have 'orphaned' claims which have been created but not attached to any entity.
+       */
+      const stopTasksToolCall = {
+        id: generateUuid(),
+        name: "stopTasks",
+        input: {
+          tasksToStop: state.outstandingTasks.map((task) => ({
+            toolCallId: task.toolCall.id,
+            explanation: "Coordinator decided to complete the research task",
+          })),
+        },
+      } satisfies ParsedCoordinatorToolCallMap["stopTasks"];
+
+      await handleStopTasksRequests({ toolCalls: [stopTasksToolCall] });
+    } else if (requestMakingToolCalls.length) {
+      state.outstandingTasks.push(
+        ...triggerToolCallsRequests({
+          agentType: "coordinator",
+          input,
+          state,
+          toolCalls: requestMakingToolCalls,
+          workerIdentifiers,
+        }),
+      );
+    }
 
     const toolCallResults = await getSomeToolCallResults({
       state,
+      /**
+       * If the worker has called 'complete', we will have issued stop requests to all outstanding tasks.
+       * We wait for them to have finished cleaning up so we can capture whatever they had inferred to this point.
+       */
+      waitForAll: !!completeToolCall,
     });
 
     processCommonStateMutationsFromToolResults({
@@ -349,10 +386,6 @@ export const runCoordinatingAgent: FlowActionActivity<{
       newEntitySummaries,
       workerIdentifiers,
     });
-
-    const completeToolCall = toolCalls.find(
-      (toolCall) => toolCall.name === "complete",
-    );
 
     /**
      * Check whether the research task has completed after processing the other tool calls,

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/coordinating-agent/generate-messages.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/coordinating-agent/generate-messages.ts
@@ -166,7 +166,7 @@ export const generateSystemPromptPrefix = (params: {
     params.input;
 
   return dedent(`
-    You are a coordinating agent for a research task.
+    You are a coordinating agent for a research task. The date is ${new Date().toUTCString()}.
     The user provides you with a research brief, and the types of entities that are relevant.
     Your job is to do research to gather claims about those types of entities, consistent with the research brief,
     as well as relevant entities that they link to – forming a graph.
@@ -211,6 +211,11 @@ export const generateSystemPromptPrefix = (params: {
     If it would be useful to split up the task into sub-tasks to find detailed information on specific entities, do so. 
     Don't start sub-tasks in parallel which duplicate or overlap, or where one will depend on the result of another (do it in sequence).
     For simpler research tasks you might not need sub-tasks.
+    
+    Ask the user questions if necessary to clarify the scope of the research task.
+    The user may want something brief and quick rather than a comprehensive report.
+    
+    Don't explore multiple URLs at once with identical goals. Wait to see if the first URL returns what you need before exploring another.
 
     The "complete" tool for completing the research task will only be available once entities have been discovered.
     When declaring the job complete, you specify which of the proposed entities should be included in the final return to the user.

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/coordinating-agent/update-state-from-inferred-claims.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/coordinating-agent/update-state-from-inferred-claims.ts
@@ -157,10 +157,10 @@ export const updateStateFromInferredClaims = async (params: {
   /**
    * Step 2: Deduplicate claims and update state
    */
-  state.inferredClaims = await deduplicateClaims([
-    ...state.inferredClaims,
-    ...newClaims,
-  ]);
+  state.inferredClaims = await deduplicateClaims(
+    [...state.inferredClaims, ...newClaims],
+    state.proposedEntities,
+  );
 
   /**
    * Step 3: Create or update proposals for new entities and existing entities with new claims

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/sub-coordinating-agent.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/sub-coordinating-agent.ts
@@ -294,7 +294,7 @@ export const runSubCoordinatingAgent = async (params: {
 
       state.inferredClaims.push(...inferredClaimsWithDeduplicatedEntities);
 
-      state.inferredClaims = await deduplicateClaims(state.inferredClaims);
+      state.inferredClaims = await deduplicateClaims(state.inferredClaims, []);
 
       state.entitySummaries = [
         ...state.entitySummaries,

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/sub-coordinating-agent.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/sub-coordinating-agent.ts
@@ -345,6 +345,13 @@ export const runSubCoordinatingAgent = async (params: {
       return { status: "ok", explanation };
     }
 
+    if (isCleanupIteration) {
+      /**
+       * This is an iteration after a stop signal was received, we shouldn't make any more requests.
+       */
+      return { status: "ok", explanation: "Early stopping requesting" };
+    }
+
     /**
      * Prior to asking the coordinator to decide on its next actions, check if we should stop.
      * We checked before waiting for outstanding tasks, but we may have received a stop signal from the coordinator since.
@@ -370,13 +377,6 @@ export const runSubCoordinatingAgent = async (params: {
        * to allow any child tasks to pass whatever results they hold now back here.
        */
       return processToolCalls({ toolCalls: [], isCleanupIteration: true });
-    }
-
-    if (isCleanupIteration) {
-      /**
-       * This is an iteration after a stop signal was received, we shouldn't make any more requests.
-       */
-      return { status: "ok", explanation: "Early stopping requesting" };
     }
 
     const { toolCalls: nextToolCalls } = await requestSubCoordinatorActions({

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/propose-entities-from-claims/propose-entity-from-claims-agent.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/propose-entities-from-claims/propose-entity-from-claims-agent.ts
@@ -447,13 +447,27 @@ export const proposeEntityFromClaimsAgent = async (params: {
   if (proposeEntityToolCall) {
     const { properties: inputProperties, outgoingLinks } =
       proposeEntityToolCall.input as {
-        properties: InputPropertiesObject;
+        properties?: InputPropertiesObject;
         outgoingLinks?: {
           entityTypeId: string;
           targetEntityId: string;
           properties: InputPropertiesObject;
         }[];
       };
+
+    if (!inputProperties) {
+      return retry({
+        retryMessage: {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: `You must provide an object with 'properties' at the root to propose an entity – you provided ${JSON.stringify(proposeEntityToolCall.input)}.`,
+            },
+          ],
+        },
+      });
+    }
 
     const simplifiedProperties = mapInputPropertiesToPropertiesObject({
       inputProperties,

--- a/apps/hash-ai-worker-ts/src/activities/shared/dereference-entity-type.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/dereference-entity-type.ts
@@ -209,6 +209,7 @@ const dereferencePropertyTypeValue = (params: {
     $id: _$id,
     $schema: _$schema,
     kind: _kind,
+    allOf: _allOf,
     ...minimalDataType
   } = dataType.schema;
 

--- a/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response/validation.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response/validation.ts
@@ -58,6 +58,10 @@ const getValidator = () => {
   if (!_ajv) {
     _ajv = new Ajv();
     _ajv.addKeyword("label");
+    _ajv.addKeyword("labelProperty");
+    _ajv.addKeyword("abstract");
+    _ajv.addKeyword("titlePlural");
+    _ajv.addKeyword("inverse");
     addFormats(_ajv);
   }
 
@@ -130,20 +134,26 @@ export const getInputValidationErrors = (params: {
 
   const validator = getValidator();
 
-  const validate = validator.compile(
-    applyAdditionalPropertiesFalseToSchema({
-      schema: toolDefinition.inputSchema,
-    }),
-  );
-
-  const inputIsValid = validate(input);
-
-  if (!inputIsValid) {
-    logger.error(
-      `Input did not match schema for requestId ${requestId}: ${stringify(validate.errors)} for tool: ${toolDefinition.name}`,
+  try {
+    const validate = validator.compile(
+      applyAdditionalPropertiesFalseToSchema({
+        schema: toolDefinition.inputSchema,
+      }),
     );
 
-    return validate.errors ?? [];
+    const inputIsValid = validate(input);
+
+    if (!inputIsValid) {
+      logger.error(
+        `Input did not match schema for requestId ${requestId}: ${stringify(validate.errors)} for tool: ${toolDefinition.name}`,
+      );
+
+      return validate.errors ?? [];
+    }
+  } catch (error) {
+    logger.error(
+      `Error validating input for requestId ${requestId}: ${(error as Error).message} for tool: ${toolDefinition.name}`,
+    );
   }
 
   return null;

--- a/apps/hash-ai-worker-ts/src/workflows/run-flow-workflow.ts
+++ b/apps/hash-ai-worker-ts/src/workflows/run-flow-workflow.ts
@@ -614,7 +614,10 @@ export const runFlowWorkflow = async (
      * Steps may error and be retried, or the whole workflow retried, while still producing the required outputs
      * – start with an initial status of OK if the outputs are present, to be adjusted if necessary.
      */
-    code: outputs.length ? StatusCode.Ok : StatusCode.Internal,
+    code:
+      outputs.length === flowDefinition.outputs.length
+        ? StatusCode.Ok
+        : StatusCode.Internal,
     contents: [{ outputs, stepErrors }],
   };
 };

--- a/apps/hash-external-services/docker-compose.yml
+++ b/apps/hash-external-services/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - hash-postgres-data:/var/lib/postgresql/data
       - ./postgres/postgresql.conf:/etc/postgresql/postgresql.conf:ro
       - ./postgres/init-user-db.sh:/docker-entrypoint-initdb.d/init-user-db.sh:ro
-    shm_size: 256MB
+    shm_size: 1GB
     healthcheck:
       test:
         ["CMD", "pg_isready", "-q", "-h", "postgres", "-U", "${POSTGRES_USER}"]

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor.tsx
@@ -6,6 +6,7 @@ import { Box } from "@mui/material";
 import type { RefObject } from "react";
 import { useMemo } from "react";
 
+import { ClaimsSection } from "./entity-editor/claims-section";
 import { EntityEditorContextProvider } from "./entity-editor/entity-editor-context";
 import { FilePreviewSection } from "./entity-editor/file-preview-section";
 import { HistorySection } from "./entity-editor/history-section";
@@ -17,7 +18,6 @@ import type { CustomColumn } from "./entity-editor/shared/types";
 import { TypesSection } from "./entity-editor/types-section";
 import { useEntityEditorTab } from "./shared/entity-editor-tabs";
 import type { DraftLinkState } from "./shared/use-draft-link-state";
-import { ClaimsSection } from "./entity-editor/claims-section";
 
 export type { CustomColumn };
 

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor.tsx
@@ -17,6 +17,7 @@ import type { CustomColumn } from "./entity-editor/shared/types";
 import { TypesSection } from "./entity-editor/types-section";
 import { useEntityEditorTab } from "./shared/entity-editor-tabs";
 import type { DraftLinkState } from "./shared/use-draft-link-state";
+import { ClaimsSection } from "./entity-editor/claims-section";
 
 export type { CustomColumn };
 
@@ -88,6 +89,8 @@ export const EntityEditor = (props: EntityEditorProps) => {
           <PropertiesSection />
 
           <LinksSection isLinkEntity={isLinkEntity} />
+
+          <ClaimsSection />
 
           {/* <PeersSection /> */}
         </Box>

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/claims-section.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/claims-section.tsx
@@ -1,0 +1,142 @@
+import { useQuery } from "@apollo/client";
+import { Chip, Skeleton } from "@hashintel/design-system";
+import {
+  currentTimeInstantTemporalAxes,
+  generateVersionedUrlMatchingFilter,
+  zeroedGraphResolveDepths,
+} from "@local/hash-isomorphic-utils/graph-queries";
+import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
+import { deserializeSubgraph } from "@local/hash-isomorphic-utils/subgraph-mapping";
+import type { Claim } from "@local/hash-isomorphic-utils/system-types/claim";
+import {
+  type EntityRootType,
+  extractEntityUuidFromEntityId,
+} from "@local/hash-subgraph";
+import { getRoots } from "@local/hash-subgraph/stdlib/subgraph/roots";
+import { Box } from "@mui/material";
+import { useMemo } from "react";
+
+import type {
+  GetEntitySubgraphQuery,
+  GetEntitySubgraphQueryVariables,
+} from "../../../../../graphql/api-types.gen";
+import { getEntitySubgraphQuery } from "../../../../../graphql/queries/knowledge/entity.queries";
+import { LinksIcon } from "../../../../../shared/icons/svg";
+import { ClaimsTable } from "../../../../shared/claims-table";
+import { SectionWrapper } from "../../../../shared/section-wrapper";
+import { virtualizedTableHeaderHeight } from "../../../../shared/virtualized-table/header";
+import { SectionEmptyState } from "../../../shared/section-empty-state";
+import { useEntityEditor } from "./entity-editor-context";
+import {
+  linksTableRowHeight,
+  maxLinksTableHeight,
+} from "./links-section/shared/table-styling";
+
+export const ClaimsSection = () => {
+  const { entitySubgraph, onEntityClick } = useEntityEditor();
+
+  const entityUuid = useMemo(() => {
+    return extractEntityUuidFromEntityId(
+      getRoots(entitySubgraph)[0]!.metadata.recordId.entityId,
+    );
+  }, [entitySubgraph]);
+
+  const { data: claimsData } = useQuery<
+    GetEntitySubgraphQuery,
+    GetEntitySubgraphQueryVariables
+  >(getEntitySubgraphQuery, {
+    variables: {
+      includePermissions: false,
+      request: {
+        filter: {
+          all: [
+            generateVersionedUrlMatchingFilter(
+              systemEntityTypes.claim.entityTypeId,
+              {
+                ignoreParents: true,
+              },
+            ),
+            {
+              equal: [
+                { path: ["outgoingLinks", "rightEntity", "uuid"] },
+                {
+                  parameter: entityUuid,
+                },
+              ],
+            },
+          ],
+        },
+        graphResolveDepths: {
+          ...zeroedGraphResolveDepths,
+          hasLeftEntity: { incoming: 1, outgoing: 1 },
+          hasRightEntity: { outgoing: 1, incoming: 1 },
+        },
+        temporalAxes: currentTimeInstantTemporalAxes,
+        includeDrafts: true,
+      },
+    },
+    skip: !entityUuid,
+    fetchPolicy: "cache-and-network",
+  });
+
+  const { claimsSubgraph, numberOfClaims } = useMemo(() => {
+    if (claimsData) {
+      const subgraph = deserializeSubgraph<EntityRootType<Claim>>(
+        claimsData.getEntitySubgraph.subgraph,
+      );
+
+      const roots = getRoots(subgraph);
+
+      return {
+        claimsSubgraph: subgraph,
+        numberOfClaims: roots.length,
+      };
+    }
+
+    return {
+      claimsSubgraph: undefined,
+      numberOfClaims: 0,
+    };
+  }, [claimsData]);
+
+  const height = Math.min(
+    maxLinksTableHeight,
+    numberOfClaims * linksTableRowHeight +
+      virtualizedTableHeaderHeight +
+      /** borders */
+      2 +
+      /** scrollbar */
+      16,
+  );
+
+  return (
+    <SectionWrapper
+      title="Claims"
+      titleTooltip="Claims are statements made about entities, inferred from public or private data sources."
+      titleStartContent={
+        <Chip
+          size="xs"
+          label={`${numberOfClaims} ${numberOfClaims === 1 ? "claim" : "claims"}`}
+        />
+      }
+    >
+      {!claimsSubgraph ? (
+        <Skeleton height={200} />
+      ) : !numberOfClaims ? (
+        <SectionEmptyState
+          title="This entity currently has no claims linked to it"
+          titleIcon={<LinksIcon />}
+          description="Claims are statements made about entities, inferred from public or private data sources"
+        />
+      ) : (
+        <Box sx={{ height }}>
+          <ClaimsTable
+            claimsSubgraph={claimsSubgraph}
+            includeStatusColumn={false}
+            onEntityClick={onEntityClick}
+          />
+        </Box>
+      )}
+    </SectionWrapper>
+  );
+};

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/history-table/provenance/sources-slideover.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/history-section/history-table/provenance/sources-slideover.tsx
@@ -52,15 +52,18 @@ const SourceRow = ({ source }: { source: SourceProvenance }) => {
   return (
     <TableRow>
       <TableCell>
-        <ValueChip type sx={{ py: 0.2 }}>
-          <FontAwesomeIcon
-            icon={faFile}
-            sx={(theme) => ({
-              fontSize: 12,
-              color: theme.palette.blue[70],
-              mr: 0.6,
-            })}
-          />
+        <ValueChip
+          icon={
+            <FontAwesomeIcon
+              icon={faFile}
+              sx={(theme) => ({
+                color: theme.palette.blue[70],
+                fontSize: 13,
+              })}
+            />
+          }
+          type
+        >
           <Box
             component="span"
             sx={{

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section.tsx
@@ -1,3 +1,6 @@
+import type { NoisySystemTypeId } from "@local/hash-isomorphic-utils/graph-queries";
+import { noisySystemTypeIds } from "@local/hash-isomorphic-utils/graph-queries";
+import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import {
   getIncomingLinkAndSourceEntities,
   getOutgoingLinksForEntity,
@@ -28,7 +31,18 @@ export const LinksSection = ({ isLinkEntity }: { isLinkEntity: boolean }) => {
     entity.metadata.temporalVersioning[
       entitySubgraph.temporalAxes.resolved.variable.axis
     ],
-  );
+  ).filter((incomingLinkAndSource) => {
+    return (
+      incomingLinkAndSource.linkEntity[0] &&
+      !incomingLinkAndSource.linkEntity[0].metadata.entityTypeIds.some(
+        (typeId) => noisySystemTypeIds.includes(typeId as NoisySystemTypeId),
+      ) &&
+      incomingLinkAndSource.leftEntity[0] &&
+      !incomingLinkAndSource.leftEntity[0].metadata.entityTypeIds.includes(
+        systemEntityTypes.claim.entityTypeId,
+      )
+    );
+  });
 
   return (
     <Stack gap={6}>

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/incoming-links-section.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/incoming-links-section.tsx
@@ -15,16 +15,13 @@ export const IncomingLinksSection = ({
   incomingLinksAndSources,
   isLinkEntity,
 }: IncomingLinksSectionProps) => {
-  if (incomingLinksAndSources.length === 0) {
-    if (isLinkEntity) {
-      /**
-       * We don't show the links tables for link entities unless they have some links already set,
-       * because we don't yet fully support linking to/from links in the UI.
-       * If they happen to have ended up with some via a different client / process, we show them.
-       */
-      return null;
-    }
-    return <LinksSectionEmptyState direction="Incoming" />;
+  if (incomingLinksAndSources.length === 0 && isLinkEntity) {
+    /**
+     * We don't show the links tables for link entities unless they have some links already set,
+     * because we don't yet fully support linking to/from links in the UI.
+     * If they happen to have ended up with some via a different client / process, we show them.
+     */
+    return null;
   }
 
   return (
@@ -40,7 +37,11 @@ export const IncomingLinksSection = ({
         </Stack>
       }
     >
-      <IncomingLinksTable incomingLinksAndSources={incomingLinksAndSources} />
+      {incomingLinksAndSources.length ? (
+        <IncomingLinksTable incomingLinksAndSources={incomingLinksAndSources} />
+      ) : (
+        <LinksSectionEmptyState direction="Incoming" />
+      )}
     </SectionWrapper>
   );
 };

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/outgoing-links-section.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/outgoing-links-section.tsx
@@ -83,31 +83,27 @@ export const OutgoingLinksSection = ({
         </Stack>
       }
     >
-      {outgoingLinksAndTargets?.length ? (
-        readonly ? (
-          <OutgoingLinksTable
-            outgoingLinksAndTargets={outgoingLinksAndTargets}
+      {rows.length && !readonly ? (
+        <Paper sx={{ overflow: "hidden" }}>
+          <Grid
+            columns={linkGridColumns}
+            rows={rows}
+            createGetCellContent={createGetCellContent}
+            dataLoading={false}
+            showSearch={showSearch}
+            onSearchClose={() => setShowSearch(false)}
+            // define max height if there are lots of rows
+            height={rows.length > 10 ? 500 : undefined}
+            customRenderers={[
+              renderLinkCell,
+              renderLinkedWithCell,
+              renderSummaryChipCell,
+              createRenderChipCell(),
+            ]}
           />
-        ) : (
-          <Paper sx={{ overflow: "hidden" }}>
-            <Grid
-              columns={linkGridColumns}
-              rows={rows}
-              createGetCellContent={createGetCellContent}
-              dataLoading={false}
-              showSearch={showSearch}
-              onSearchClose={() => setShowSearch(false)}
-              // define max height if there are lots of rows
-              height={rows.length > 10 ? 500 : undefined}
-              customRenderers={[
-                renderLinkCell,
-                renderLinkedWithCell,
-                renderSummaryChipCell,
-                createRenderChipCell(),
-              ]}
-            />
-          </Paper>
-        )
+        </Paper>
+      ) : outgoingLinksAndTargets?.length ? (
+        <OutgoingLinksTable outgoingLinksAndTargets={outgoingLinksAndTargets} />
       ) : (
         <LinksSectionEmptyState direction="Outgoing" />
       )}

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/outgoing-links-section.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/outgoing-links-section.tsx
@@ -59,13 +59,6 @@ export const OutgoingLinksSection = ({
       )
     : null;
 
-  if (
-    rows.length === 0 ||
-    (readonly && outgoingLinksAndTargets?.length === 0)
-  ) {
-    return <LinksSectionEmptyState direction="Outgoing" />;
-  }
-
   return (
     <SectionWrapper
       title="Outgoing Links"
@@ -76,22 +69,24 @@ export const OutgoingLinksSection = ({
             size="xs"
             label={`${outgoingLinks.length} ${outgoingLinks.length === 1 ? "link" : "links"}`}
           />
-          <Stack direction="row" spacing={0.5}>
-            <IconButton
-              rounded
-              onClick={() => setShowSearch(true)}
-              sx={{ color: ({ palette }) => palette.gray[60] }}
-            >
-              <FontAwesomeIcon icon={faMagnifyingGlass} />
-            </IconButton>
-          </Stack>
+          {!!rows.length && (
+            <Stack direction="row" spacing={0.5}>
+              <IconButton
+                rounded
+                onClick={() => setShowSearch(true)}
+                sx={{ color: ({ palette }) => palette.gray[60] }}
+              >
+                <FontAwesomeIcon icon={faMagnifyingGlass} />
+              </IconButton>
+            </Stack>
+          )}
         </Stack>
       }
     >
-      {readonly ? (
-        <OutgoingLinksTable
-          outgoingLinksAndTargets={outgoingLinksAndTargets!}
-        />
+      {rows.length === 0 || !outgoingLinksAndTargets?.length ? (
+        <LinksSectionEmptyState direction="Outgoing" />
+      ) : readonly ? (
+        <OutgoingLinksTable outgoingLinksAndTargets={outgoingLinksAndTargets} />
       ) : (
         <Paper sx={{ overflow: "hidden" }}>
           <Grid

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/outgoing-links-section.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/outgoing-links-section.tsx
@@ -83,29 +83,33 @@ export const OutgoingLinksSection = ({
         </Stack>
       }
     >
-      {rows.length === 0 || !outgoingLinksAndTargets?.length ? (
-        <LinksSectionEmptyState direction="Outgoing" />
-      ) : readonly ? (
-        <OutgoingLinksTable outgoingLinksAndTargets={outgoingLinksAndTargets} />
-      ) : (
-        <Paper sx={{ overflow: "hidden" }}>
-          <Grid
-            columns={linkGridColumns}
-            rows={rows}
-            createGetCellContent={createGetCellContent}
-            dataLoading={false}
-            showSearch={showSearch}
-            onSearchClose={() => setShowSearch(false)}
-            // define max height if there are lots of rows
-            height={rows.length > 10 ? 500 : undefined}
-            customRenderers={[
-              renderLinkCell,
-              renderLinkedWithCell,
-              renderSummaryChipCell,
-              createRenderChipCell(),
-            ]}
+      {outgoingLinksAndTargets?.length ? (
+        readonly ? (
+          <OutgoingLinksTable
+            outgoingLinksAndTargets={outgoingLinksAndTargets}
           />
-        </Paper>
+        ) : (
+          <Paper sx={{ overflow: "hidden" }}>
+            <Grid
+              columns={linkGridColumns}
+              rows={rows}
+              createGetCellContent={createGetCellContent}
+              dataLoading={false}
+              showSearch={showSearch}
+              onSearchClose={() => setShowSearch(false)}
+              // define max height if there are lots of rows
+              height={rows.length > 10 ? 500 : undefined}
+              customRenderers={[
+                renderLinkCell,
+                renderLinkedWithCell,
+                renderSummaryChipCell,
+                createRenderChipCell(),
+              ]}
+            />
+          </Paper>
+        )
+      ) : (
+        <LinksSectionEmptyState direction="Outgoing" />
       )}
     </SectionWrapper>
   );

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/shared/links-section-empty-state.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/shared/links-section-empty-state.tsx
@@ -1,7 +1,4 @@
-import { Chip } from "@hashintel/design-system";
-
 import { LinksIcon } from "../../../../../shared/icons";
-import { SectionWrapper } from "../../../../shared/section-wrapper";
 import { SectionEmptyState } from "../../../shared/section-empty-state";
 
 export const LinksSectionEmptyState = ({
@@ -10,15 +7,10 @@ export const LinksSectionEmptyState = ({
   direction: "Incoming" | "Outgoing";
 }) => {
   return (
-    <SectionWrapper
-      title={`${direction} Links`}
-      titleStartContent={<Chip label="No links" />}
-    >
-      <SectionEmptyState
-        title={`This entity currently has no ${direction.toLowerCase()} links`}
-        titleIcon={<LinksIcon />}
-        description="Links contain information about connections or relationships between different entities"
-      />
-    </SectionWrapper>
+    <SectionEmptyState
+      title={`This entity currently has no ${direction.toLowerCase()} links`}
+      titleIcon={<LinksIcon />}
+      description="Links contain information about connections or relationships between different entities"
+    />
   );
 };

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs.tsx
@@ -46,7 +46,7 @@ import { TypeSlideOverStack } from "../../../shared/entity-type-page/type-slide-
 import { useFlowRunsContext } from "../../../shared/flow-runs-context";
 import { getFileProperties } from "../../../shared/get-file-properties";
 import { generateEntityRootedSubgraph } from "../../../shared/subgraphs";
-import { ClaimsTable } from "./outputs/claims-table";
+import { ClaimsOutput } from "./outputs/claims-output";
 import { Deliverables } from "./outputs/deliverables";
 import type { DeliverableData } from "./outputs/deliverables/shared/types";
 import { EntityResultGraph } from "./outputs/entity-result-graph";
@@ -458,12 +458,12 @@ export const Outputs = ({
         {
           ...fullOntologyResolveDepths,
           hasLeftEntity: {
-            outgoing: 0,
+            outgoing: 1,
             incoming: 1,
           },
           hasRightEntity: {
             outgoing: 1,
-            incoming: 0,
+            incoming: 1,
           },
         },
         {
@@ -676,7 +676,7 @@ export const Outputs = ({
             />
           ))}
         {visibleSection === "claims" && (
-          <ClaimsTable
+          <ClaimsOutput
             onEntityClick={onEntityClick}
             proposedEntities={proposedEntities}
           />

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/claims-output.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/claims-output.tsx
@@ -1,0 +1,145 @@
+import { useQuery } from "@apollo/client";
+import type { EntityId } from "@local/hash-graph-types/entity";
+import type { ProposedEntity } from "@local/hash-isomorphic-utils/flows/types";
+import {
+  currentTimeInstantTemporalAxes,
+  generateVersionedUrlMatchingFilter,
+  zeroedGraphResolveDepths,
+} from "@local/hash-isomorphic-utils/graph-queries";
+import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
+import { deserializeSubgraph } from "@local/hash-isomorphic-utils/subgraph-mapping";
+import type { Claim } from "@local/hash-isomorphic-utils/system-types/claim";
+import type { EntityRootType } from "@local/hash-subgraph";
+import { entityIdFromComponents } from "@local/hash-subgraph";
+import { getRoots } from "@local/hash-subgraph/stdlib";
+import { memo, useLayoutEffect, useMemo, useRef, useState } from "react";
+
+import type {
+  GetEntitySubgraphQuery,
+  GetEntitySubgraphQueryVariables,
+} from "../../../../../graphql/api-types.gen";
+import { getEntitySubgraphQuery } from "../../../../../graphql/queries/knowledge/entity.queries";
+import { ClaimsTable } from "../../../../shared/claims-table";
+import { useFlowRunsContext } from "../../../../shared/flow-runs-context";
+import { EmptyOutputBox } from "./shared/empty-output-box";
+import { outputIcons } from "./shared/icons";
+import { OutputContainer } from "./shared/output-container";
+import { TableSkeleton } from "./shared/table-skeleton";
+
+type ClaimsTableProps = {
+  onEntityClick: (entityId: EntityId) => void;
+  proposedEntities: Pick<ProposedEntity, "claims" | "localEntityId">[];
+};
+
+export const ClaimsOutput = memo(
+  ({ onEntityClick, proposedEntities }: ClaimsTableProps) => {
+    const { selectedFlowRun } = useFlowRunsContext();
+
+    const { data: claimsData, loading: claimsDataLoading } = useQuery<
+      GetEntitySubgraphQuery,
+      GetEntitySubgraphQueryVariables
+    >(getEntitySubgraphQuery, {
+      variables: {
+        includePermissions: false,
+        request: {
+          filter: {
+            all: [
+              generateVersionedUrlMatchingFilter(
+                systemEntityTypes.claim.entityTypeId,
+                {
+                  ignoreParents: true,
+                },
+              ),
+              {
+                equal: [
+                  {
+                    path: ["editionProvenance", "origin", "id"],
+                  },
+                  {
+                    parameter: selectedFlowRun
+                      ? entityIdFromComponents(
+                          selectedFlowRun.webId,
+                          selectedFlowRun.flowRunId,
+                        )
+                      : "never",
+                  },
+                ],
+              },
+            ],
+          },
+          graphResolveDepths: {
+            ...zeroedGraphResolveDepths,
+            hasLeftEntity: { incoming: 1, outgoing: 1 },
+            hasRightEntity: { outgoing: 1, incoming: 1 },
+          },
+          temporalAxes: currentTimeInstantTemporalAxes,
+          includeDrafts: true,
+        },
+      },
+      pollInterval: selectedFlowRun?.closedAt ? 0 : 2_000,
+      skip: !selectedFlowRun,
+      fetchPolicy: "cache-and-network",
+    });
+
+    const outputContainerRef = useRef<HTMLDivElement>(null);
+    const [outputContainerHeight, setOutputContainerHeight] = useState(400);
+    useLayoutEffect(() => {
+      if (
+        outputContainerRef.current &&
+        outputContainerRef.current.clientHeight !== outputContainerHeight
+      ) {
+        setOutputContainerHeight(outputContainerRef.current.clientHeight);
+      }
+    }, [outputContainerHeight]);
+
+    const { claimsSubgraph, hasClaims } = useMemo(() => {
+      if (claimsData) {
+        const subgraph = deserializeSubgraph<EntityRootType<Claim>>(
+          claimsData.getEntitySubgraph.subgraph,
+        );
+
+        const roots = getRoots(subgraph);
+
+        return {
+          claimsSubgraph: subgraph,
+          hasClaims: roots.length > 0,
+        };
+      }
+
+      return {
+        claimsSubgraph: undefined,
+        hasClaims: false,
+      };
+    }, [claimsData]);
+
+    return (
+      <OutputContainer
+        noBorder={hasClaims}
+        ref={outputContainerRef}
+        sx={{
+          flex: 1,
+          minWidth: 400,
+          "& th:not(:last-child)": {
+            borderRight: ({ palette }) => `1px solid ${palette.gray[20]}`,
+          },
+        }}
+      >
+        {hasClaims && claimsSubgraph ? (
+          <ClaimsTable
+            claimsSubgraph={claimsSubgraph}
+            includeStatusColumn
+            onEntityClick={onEntityClick}
+            proposedEntities={proposedEntities}
+          />
+        ) : claimsDataLoading ? (
+          <TableSkeleton cellHeight={43} tableHeight={outputContainerHeight} />
+        ) : (
+          <EmptyOutputBox
+            Icon={outputIcons.table}
+            label="Claims about entities discovered by this flow will appear in a table here"
+          />
+        )}
+      </OutputContainer>
+    );
+  },
+);

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/entity-result-table.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/entity-result-table.tsx
@@ -698,6 +698,30 @@ export const EntityResultTable = memo(
           staticFilterDefs.entityTypeIds.options[entityTypeId].count++;
           staticFilterDefs.entityTypeIds.initialValue.add(entityTypeId);
 
+          const outgoingLinks = outgoingLinksBySourceEntityId[entityId];
+          if (outgoingLinks) {
+            for (const [linkEntityTypeId, linksAndTargets] of typedEntries(
+              outgoingLinks,
+            )) {
+              outgoingLinksByLinkTypeId[linkEntityTypeId] = [];
+
+              for (const { targetEntityId, linkEntityId } of linksAndTargets) {
+                const linkedEntityRecord = entitiesByEntityId[targetEntityId];
+                if (!linkedEntityRecord) {
+                  throw new Error(
+                    `Could not find entity with id ${targetEntityId} linked from entity with id ${entityId}`,
+                  );
+                }
+
+                outgoingLinksByLinkTypeId[linkEntityTypeId].push({
+                  targetEntityId,
+                  targetEntityLabel: linkedEntityRecord.entityLabel,
+                  linkEntityId,
+                });
+              }
+            }
+          }
+
           for (const linkType of entityTypesRecord[entityTypeId]!.linkTypes) {
             const linkTypeId = linkType.schema.$id;
 
@@ -789,31 +813,11 @@ export const EntityResultTable = memo(
             ? "Updated"
             : "Created";
 
-        const outgoingLinks = outgoingLinksBySourceEntityId[entityId];
-        if (outgoingLinks) {
-          for (const [linkEntityTypeId, linksAndTargets] of typedEntries(
-            outgoingLinks,
-          )) {
-            outgoingLinksByLinkTypeId[linkEntityTypeId] = [];
-
-            for (const { targetEntityId, linkEntityId } of linksAndTargets) {
-              const linkedEntityRecord = entitiesByEntityId[targetEntityId];
-              if (!linkedEntityRecord) {
-                throw new Error(
-                  `Could not find entity with id ${targetEntityId} linked from entity with id ${entityId}`,
-                );
-              }
-
-              outgoingLinksByLinkTypeId[linkEntityTypeId].push({
-                targetEntityId,
-                targetEntityLabel: linkedEntityRecord.entityLabel,
-                linkEntityId,
-              });
-            }
-          }
-        }
-
-        const relevance = relevantEntityIds.includes(entityId) ? "Yes" : "No";
+        const relevance = relevantEntityIds.find((relevantEntityId) =>
+          entityId.startsWith(relevantEntityId),
+        )
+          ? "Yes"
+          : "No";
 
         /**
          * Account for the entity's values in the filters, other than types which are handled above when processing the entity's types.

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/entity-result-table/cells.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/entity-result-table/cells.tsx
@@ -16,7 +16,7 @@ import { useRef, useState } from "react";
 import { CircleInfoIcon } from "../../../../../../shared/icons/circle-info-icon";
 import { ValueChip } from "../../../../../shared/value-chip";
 import { defaultCellSx } from "../../../../../shared/virtualized-table";
-import { SourcesPopover } from "../shared/sources-popover";
+import { SourcesPopover } from "../../../../../shared/sources-popover";
 
 export const typographySx = {
   color: ({ palette }) => palette.common.black,

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/entity-result-table/cells.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/outputs/entity-result-table/cells.tsx
@@ -14,9 +14,9 @@ import {
 import { useRef, useState } from "react";
 
 import { CircleInfoIcon } from "../../../../../../shared/icons/circle-info-icon";
+import { SourcesPopover } from "../../../../../shared/sources-popover";
 import { ValueChip } from "../../../../../shared/value-chip";
 import { defaultCellSx } from "../../../../../shared/virtualized-table";
-import { SourcesPopover } from "../../../../../shared/sources-popover";
 
 export const typographySx = {
   color: ({ palette }) => palette.common.black,

--- a/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/shared/format-time-taken.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/shared/flow-visualizer/shared/format-time-taken.tsx
@@ -14,7 +14,7 @@ export const formatTimeTaken = (scheduledAt: string, closedAt?: string) => {
 
   const duration = intervalToDuration({ start: 0, end: elapsed });
 
-  return [duration.hours, duration.minutes, duration.seconds]
+  return [duration.hours, duration.minutes ?? 0, duration.seconds ?? 0]
     .filter(isNonNullable)
     .map(pad)
     .join(":");

--- a/apps/hash-frontend/src/pages/goals/new.page.tsx
+++ b/apps/hash-frontend/src/pages/goals/new.page.tsx
@@ -386,6 +386,7 @@ const NewGoalPageContent = () => {
             title: "New",
           },
         ]}
+        hideDivider
         sideTitle="New research goal"
         title={{
           text: "Goals",

--- a/apps/hash-frontend/src/pages/shared/claims-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/claims-table.tsx
@@ -584,7 +584,11 @@ export const ClaimsTable = memo(
                 return 1;
               }
 
-              return -1;
+              if (!targetStatus) {
+                return -1;
+              }
+
+              return baseStatus.localeCompare(targetStatus);
             }
 
             if (fieldId === "createdAt") {

--- a/apps/hash-frontend/src/pages/shared/entities-table/use-entities-table/worker.ts
+++ b/apps/hash-frontend/src/pages/shared/entities-table/use-entities-table/worker.ts
@@ -435,10 +435,7 @@ self.onmessage = async ({ data }) => {
         } satisfies GenerateEntitiesTableDataResultMessage);
       }
     } else {
-      // eslint-disable-next-line no-console
-      console.info(
-        `Table data generation request ${requestId} cancelled, superseded by a subsequent request`,
-      );
+      // Cancelled
     }
   }
 };

--- a/apps/hash-frontend/src/pages/shared/flow-tables.tsx
+++ b/apps/hash-frontend/src/pages/shared/flow-tables.tsx
@@ -60,7 +60,14 @@ export const FlowTableWebChip = ({
       })}
     >
       <Avatar src={avatarUrl} title={name} size={14} />
-      <Typography component="span" sx={{ fontSize: 12, fontWeight: 500 }}>
+      <Typography
+        component="span"
+        sx={{
+          display: "block",
+          fontSize: 12,
+          fontWeight: 500,
+        }}
+      >
         {name}
       </Typography>
     </Stack>

--- a/apps/hash-frontend/src/pages/shared/sources-popover.tsx
+++ b/apps/hash-frontend/src/pages/shared/sources-popover.tsx
@@ -2,7 +2,7 @@ import type { SourceProvenance } from "@local/hash-graph-client/api";
 import { Box, Popover, Stack, Typography } from "@mui/material";
 import type { RefObject } from "react";
 
-import { Link } from "../../../../../../shared/ui/link";
+import { Link } from "../../shared/ui/link";
 
 const SourcesList = ({ sources }: { sources: SourceProvenance[] }) => {
   return (

--- a/apps/hash-frontend/src/pages/shared/value-chip.tsx
+++ b/apps/hash-frontend/src/pages/shared/value-chip.tsx
@@ -33,6 +33,13 @@ export const ValueChip = ({
           px: 1.2,
           py: 0.8,
           whiteSpace: "nowrap",
+          ...(showInFull
+            ? {}
+            : {
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                width: "fit-content",
+              }),
         }),
         ...(Array.isArray(sx) ? sx : [sx]),
       ]}

--- a/apps/hash-frontend/src/pages/workers.page.tsx
+++ b/apps/hash-frontend/src/pages/workers.page.tsx
@@ -73,7 +73,7 @@ const createColumns: (
     id: "web",
     label: "Web",
     sortable: true,
-    width: 120,
+    width: 150,
   },
   {
     id: "type",
@@ -111,7 +111,7 @@ const createColumns: (
           id: "cost" as const,
           label: "Cost",
           sortable: true,
-          width: 120,
+          width: 80,
         },
       ]
     : []),
@@ -153,7 +153,9 @@ const TableRow = memo(({ workerSummary }: { workerSummary: WorkerSummary }) => {
 
   return (
     <>
-      <MuiTableCell sx={{ ...flowTableCellSx, fontSize: 13 }}>
+      <MuiTableCell
+        sx={{ ...flowTableCellSx, fontSize: 13, overflowX: "hidden" }}
+      >
         <FlowTableWebChip {...web} />
       </MuiTableCell>
       <MuiTableCell sx={flowTableCellSx}>

--- a/apps/hash-frontend/src/shared/use-entity-type-entities.tsx
+++ b/apps/hash-frontend/src/shared/use-entity-type-entities.tsx
@@ -4,6 +4,7 @@ import type { BaseUrl } from "@local/hash-graph-types/ontology";
 import type { OwnedById } from "@local/hash-graph-types/web";
 import {
   currentTimeInstantTemporalAxes,
+  ignoreNoisySystemTypesFilter,
   mapGqlSubgraphFieldsFragmentToSubgraph,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
@@ -107,6 +108,9 @@ export const useEntityTypeEntities = (params: {
                     },
                   ]
                 : []),
+            ...(!entityTypeId && !entityTypeBaseUrl
+              ? [ignoreNoisySystemTypesFilter]
+              : []),
           ],
         },
         graphResolveDepths: {

--- a/apps/hash-frontend/src/shared/workers-header.tsx
+++ b/apps/hash-frontend/src/shared/workers-header.tsx
@@ -60,7 +60,6 @@ export const WorkersHeader = ({
               alignItems="center"
               direction="row"
               justifyContent="space-between"
-              sx={{ mb: 1.5 }}
             >
               <Stack alignItems="center" direction="row" gap={1.5}>
                 <title.Icon
@@ -107,7 +106,7 @@ export const WorkersHeader = ({
               <Typography
                 component="p"
                 variant="largeTextLabels"
-                sx={{ mt: 1, color: ({ palette }) => palette.gray[80] }}
+                sx={{ mt: 2.5, color: ({ palette }) => palette.gray[80] }}
               >
                 {subtitle}
               </Typography>

--- a/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
@@ -22,7 +22,11 @@ import { splitEntityId } from "@local/hash-subgraph";
 import { componentsFromVersionedUrl } from "@local/hash-subgraph/type-system-patch";
 
 import type { SubgraphFieldsFragment } from "./graphql/api-types.gen.js";
-import { systemPropertyTypes } from "./ontology-type-ids.js";
+import {
+  systemEntityTypes,
+  systemLinkEntityTypes,
+  systemPropertyTypes,
+} from "./ontology-type-ids.js";
 import { deserializeSubgraph } from "./subgraph-mapping.js";
 
 export const zeroedGraphResolveDepths: GraphResolveDepths = {
@@ -375,3 +379,39 @@ export const defaultEntityTypeAuthorizationRelationships: EntityTypeRelationAndS
       },
     },
   ];
+
+export const notificationTypesToIgnore = [
+  systemEntityTypes.notification.entityTypeId,
+  systemEntityTypes.graphChangeNotification.entityTypeId,
+];
+
+export const usageRecordTypesToIgnore = [
+  systemEntityTypes.usageRecord.entityTypeId,
+  systemLinkEntityTypes.recordsUsageOf.linkEntityTypeId,
+  systemLinkEntityTypes.created.linkEntityTypeId,
+  systemLinkEntityTypes.updated.linkEntityTypeId,
+  systemLinkEntityTypes.incurredIn.linkEntityTypeId,
+];
+
+const pageNotificationTypesToIgnore = [
+  systemEntityTypes.mentionNotification.entityTypeId,
+  systemEntityTypes.commentNotification.entityTypeId,
+  systemLinkEntityTypes.occurredInEntity.linkEntityTypeId,
+];
+
+export const noisySystemTypeIds = [
+  ...notificationTypesToIgnore,
+  ...usageRecordTypesToIgnore,
+  ...pageNotificationTypesToIgnore,
+] as const;
+
+export type NoisySystemTypeId = (typeof noisySystemTypeIds)[number];
+
+export const ignoreNoisySystemTypesFilter: Filter = {
+  all: noisySystemTypeIds.map((versionedUrl) => ({
+    notEqual: [
+      { path: ["type(inheritanceDepth = 0)", "versionedUrl"] },
+      { parameter: versionedUrl },
+    ],
+  })),
+};

--- a/libs/@local/hash-subgraph/src/stdlib/subgraph/edge/link-entity.ts
+++ b/libs/@local/hash-subgraph/src/stdlib/subgraph/edge/link-entity.ts
@@ -211,7 +211,9 @@ export const getLeftEntityForLinkEntity = (
       subgraph.temporalAxes.resolved.variable.interval.end.limit,
     );
 
-  const outwardEdge = Object.values(subgraph.edges[entityId] ?? {})
+  const outwardEdge = Object.values(
+    subgraph.edges[stripDraftIdFromEntityId(entityId)] ?? {},
+  )
     .flat()
     .find(isHasLeftEntityEdge);
 
@@ -263,7 +265,9 @@ export const getRightEntityForLinkEntity = (
       subgraph.temporalAxes.resolved.variable.interval.end.limit,
     );
 
-  const outwardEdge = Object.values(subgraph.edges[entityId] ?? {})
+  const outwardEdge = Object.values(
+    subgraph.edges[stripDraftIdFromEntityId(entityId)] ?? {},
+  )
     .flat()
     .find(isHasRightEntityEdge);
 

--- a/tests/hash-playwright/tests/entity-editing.spec.ts
+++ b/tests/hash-playwright/tests/entity-editing.spec.ts
@@ -178,6 +178,8 @@ test("both the link and properties tables renders some content", async ({
 
   await page.getByTestId("selector-autocomplete-option").first().click();
 
+  await sleep(200);
+
   const linkTableCanvas = page
     .locator(".dvn-underlay > canvas:first-of-type")
     .nth(1);

--- a/tests/hash-playwright/tests/entity-editing.spec.ts
+++ b/tests/hash-playwright/tests/entity-editing.spec.ts
@@ -178,7 +178,7 @@ test("both the link and properties tables renders some content", async ({
 
   await page.getByTestId("selector-autocomplete-option").first().click();
 
-  await sleep(200);
+  await sleep(500);
 
   const linkTableCanvas = page
     .locator(".dvn-underlay > canvas:first-of-type")

--- a/tests/hash-playwright/tests/entity-editing.spec.ts
+++ b/tests/hash-playwright/tests/entity-editing.spec.ts
@@ -178,8 +178,6 @@ test("both the link and properties tables renders some content", async ({
 
   await page.getByTestId("selector-autocomplete-option").first().click();
 
-  await sleep(500);
-
   const linkTableCanvas = page
     .locator(".dvn-underlay > canvas:first-of-type")
     .nth(1);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR:
1. Exposes claims related to an entity in a new table when viewing it (whether on its page, or in a slideover) – see demo
2. Makes the following improvements to the AI research worker:
    - when a coordinator decides to stop an outstanding task, allow its child tasks to return whatever they have gathered to that point, so that claims are not left in a state where they have been created but not attached to an entity
    - bug fixes related to entity deduplication
    - prompt tweaks
3. Limits the number of requests for webpage content that the browser plugin will process at a single time, to avoid opening lots of tabs if many requests come in from the AI worker at once. Also improves websocket reconnection handling

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- None yet

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Not possible from preview deployment as the bug fixes in the AI worker need to be deployed first

## 📹 Demo

<img width="1556" alt="Screenshot 2024-11-20 at 20 04 46" src="https://github.com/user-attachments/assets/53a95e37-e60a-4798-aec1-d7dc61fe3a94">

<!-- Add a screenshot or video showcasing your work -->
