### PR TITLE
H-3599, H-3600: Implement failing on divergent or missing files

### DIFF
--- a/libs/@local/graph/migrations/src/bin/cli/subcommand/run.rs
+++ b/libs/@local/graph/migrations/src/bin/cli/subcommand/run.rs
@@ -7,12 +7,33 @@ use crate::{Command, subcommand::DatabaseConnectionInfo};
 
 #[derive(Debug, Parser)]
 #[clap(version, author, about, long_about = None)]
+#[expect(clippy::struct_excessive_bools, reason = "This is a CLI command")]
 pub struct RunCommand {
     #[clap(flatten)]
     pub db_info: DatabaseConnectionInfo,
 
+    /// Run the migration up to the specified target.
+    ///
+    /// If the target is not specified, all migrations will be run. If the target is lower than the
+    /// current migration, the migrations will be run in the down direction.
     #[clap(long)]
     pub target: Option<u32>,
+
+    /// Allows the migration to run even if the files are divergent from the database.
+    #[clap(long)]
+    pub allow_divergent: bool,
+
+    /// Divergent migrations will be updated in the database.
+    #[clap(long, requires("allow_divergent"))]
+    pub update_divergent: bool,
+
+    /// Allows the migration to run even if the files are missing from the file system.
+    #[clap(long)]
+    pub allow_missing: bool,
+
+    /// Missing migrations will be removed from the database.
+    #[clap(long, requires("allow_missing"))]
+    pub remove_missing: bool,
 }
 
 hash_graph_migrations::embed_migrations!("graph-migrations");
@@ -29,7 +50,11 @@ impl Command for RunCommand {
 
         let mut builder = MigrationPlanBuilder::new()
             .state(client)
-            .migrations(self::migrations());
+            .migrations(self::migrations())
+            .allow_divergent(self.allow_divergent)
+            .update_divergent(self.update_divergent)
+            .allow_missing(self.allow_missing)
+            .remove_missing(self.remove_missing);
 
         if let Some(target) = self.target {
             builder = builder.target(target);

--- a/libs/@local/graph/migrations/src/info.rs
+++ b/libs/@local/graph/migrations/src/info.rs
@@ -18,8 +18,9 @@ pub enum InvalidMigrationFile {
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Digest([u8; 32]);
 
-impl From<[u8; 32]> for Digest {
-    fn from(bytes: [u8; 32]) -> Self {
+impl Digest {
+    #[must_use]
+    pub const fn new(bytes: [u8; 32]) -> Self {
         Self(bytes)
     }
 }

--- a/libs/@local/graph/migrations/src/lib.rs
+++ b/libs/@local/graph/migrations/src/lib.rs
@@ -26,6 +26,7 @@ mod state;
 #[cfg(feature = "macros")]
 #[doc(hidden)]
 pub mod __export {
+    pub extern crate alloc;
     // `Error-stack` is required for the return value of the `up` and `down` methods in the
     // `Migration` trait.
     pub use error_stack::Report;

--- a/libs/@local/graph/migrations/src/list.rs
+++ b/libs/@local/graph/migrations/src/list.rs
@@ -13,6 +13,9 @@ impl MigrationError {
 }
 
 pub trait MigrationList<C> {
+    /// Returns an iterator over the migration infos in this list.
+    fn infos(&self) -> impl Iterator<Item = &MigrationInfo>;
+
     /// Runs this list in the provided plan and context.
     ///
     /// This will only forward the [`Migration`] to the [`MigrationRunner`].

--- a/libs/@local/graph/migrations/src/state.rs
+++ b/libs/@local/graph/migrations/src/state.rs
@@ -18,6 +18,8 @@ pub trait StateStore {
 
     async fn add(&self, info: MigrationInfo) -> Result<(), Report<Self::Error>>;
 
+    async fn update(&self, info: MigrationInfo) -> Result<(), Report<Self::Error>>;
+
     async fn get_all(&self) -> Result<Vec<(MigrationInfo, MigrationState)>, Report<Self::Error>>;
 
     async fn remove(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When migration files changed and the database was already migrated this should error on migration attempt. Also, if a file was removed form the file system but is stored in the database.

## 🔍 What does this change?

- Implement failing on divergent or missing 
- Add four new parameters (CLI) parameters to the plan builder:
	- `--allow-divergent`: Ignores if a file changed on the file system
	- `--update-divergent`: Update migration info in the database if a file diverged (requires `--allow-divergent`)
	- `--allow-missing`: Ignores if a file is missing in the file system
	- `--remove-missing`: Removes migration info from the database if a file is missing (requires `--allow-missing`)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

TBD