### PR TITLE
H-3650: Add `allOf` and `abstract` to `ClosedDataType`

### DIFF
--- a/libs/@local/graph/api/openapi/models/closed_data_type.json
+++ b/libs/@local/graph/api/openapi/models/closed_data_type.json
@@ -25,8 +25,16 @@
           "minItems": 1
         }
       ]
+    },
+    "allOf": {
+      "type": "array",
+      "items": {},
+      "minItems": 1
+    },
+    "abstract": {
+      "type": "boolean"
     }
   },
-  "required": ["$id", "title", "description"],
+  "required": ["$id", "title", "description", "allOf", "abstract"],
   "additionalProperties": true
 }

--- a/libs/@local/graph/api/src/rest/json_schemas/closed_data_type.json
+++ b/libs/@local/graph/api/src/rest/json_schemas/closed_data_type.json
@@ -25,8 +25,16 @@
           "minItems": 1
         }
       ]
+    },
+    "allOf": {
+      "type": "array",
+      "items": {},
+      "minItems": 1
+    },
+    "abstract": {
+      "type": "boolean"
     }
   },
-  "required": ["$id", "title", "description"],
+  "required": ["$id", "title", "description", "allOf", "abstract"],
   "additionalProperties": true
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The OpenAPI specs are missing `allOf` and `abstract` from the `ClosedDataType` type and typescript is complaining when converting them to the type-system variants. This adds the definitions.