### PR TITLE
H-3674: Allow skipping link validation

### DIFF
--- a/apps/hash-graph/src/subcommand/reindex_cache.rs
+++ b/apps/hash-graph/src/subcommand/reindex_cache.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use error_stack::{Report, ResultExt as _, ensure};
 use hash_graph_authorization::NoAuthorization;
 use hash_graph_postgres_store::store::{
-    DatabaseConnectionInfo, DatabasePoolConfig, PostgresStorePool,
+    DatabaseConnectionInfo, DatabasePoolConfig, PostgresStorePool, PostgresStoreSettings,
 };
 use hash_graph_store::{
     data_type::DataTypeStore as _, entity::EntityStore as _, entity_type::EntityTypeStore as _,
@@ -40,13 +40,18 @@ pub struct ReindexOperations {
 }
 
 pub async fn reindex_cache(args: ReindexCacheArgs) -> Result<(), Report<GraphError>> {
-    let pool = PostgresStorePool::new(&args.db_info, &args.pool_config, NoTls)
-        .await
-        .change_context(GraphError)
-        .map_err(|report| {
-            tracing::error!(error = ?report, "Failed to connect to database");
-            report
-        })?;
+    let pool = PostgresStorePool::new(
+        &args.db_info,
+        &args.pool_config,
+        NoTls,
+        PostgresStoreSettings::default(),
+    )
+    .await
+    .change_context(GraphError)
+    .map_err(|report| {
+        tracing::error!(error = ?report, "Failed to connect to database");
+        report
+    })?;
 
     let mut store = pool
         .acquire(NoAuthorization, None)

--- a/apps/hash-graph/src/subcommand/test_server.rs
+++ b/apps/hash-graph/src/subcommand/test_server.rs
@@ -9,7 +9,7 @@ use hash_graph_authorization::{
 };
 use hash_graph_postgres_store::{
     snapshot::SnapshotEntry,
-    store::{DatabaseConnectionInfo, DatabasePoolConfig, PostgresStorePool},
+    store::{DatabaseConnectionInfo, DatabasePoolConfig, PostgresStorePool, PostgresStoreSettings},
 };
 use reqwest::Client;
 use tokio::{net::TcpListener, time::timeout};
@@ -71,13 +71,18 @@ pub async fn test_server(args: TestServerArgs) -> Result<(), Report<GraphError>>
         .change_context(GraphError);
     }
 
-    let pool = PostgresStorePool::new(&args.db_info, &args.pool_config, NoTls)
-        .await
-        .change_context(GraphError)
-        .map_err(|report| {
-            tracing::error!(error = ?report, "Failed to connect to database");
-            report
-        })?;
+    let pool = PostgresStorePool::new(
+        &args.db_info,
+        &args.pool_config,
+        NoTls,
+        PostgresStoreSettings::default(),
+    )
+    .await
+    .change_context(GraphError)
+    .map_err(|report| {
+        tracing::error!(error = ?report, "Failed to connect to database");
+        report
+    })?;
 
     let mut spicedb_client = SpiceDbOpenApi::new(
         format!("{}:{}", args.spicedb_host, args.spicedb_http_port),

--- a/libs/@local/graph/api/openapi/openapi.json
+++ b/libs/@local/graph/api/openapi/openapi.json
@@ -8446,6 +8446,9 @@
           "linkData": {
             "type": "boolean"
           },
+          "linkValidation": {
+            "type": "boolean"
+          },
           "numItems": {
             "type": "boolean"
           },

--- a/libs/@local/graph/postgres-store/src/snapshot/entity/batch.rs
+++ b/libs/@local/graph/postgres-store/src/snapshot/entity/batch.rs
@@ -251,7 +251,6 @@ where
     #[expect(clippy::too_many_lines)]
     async fn commit(
         postgres_client: &mut PostgresStore<C, A>,
-        validation: bool,
     ) -> Result<(), Report<InsertionError>> {
         postgres_client
             .as_client()
@@ -291,113 +290,112 @@ where
             .await
             .change_context(InsertionError)?;
 
-        if validation {
-            let entities =
-                Read::<Entity>::read_vec(postgres_client, &Filter::All(Vec::new()), None, true)
-                    .await
-                    .change_context(InsertionError)?;
-
-            let validator_provider = StoreProvider {
-                store: postgres_client,
-                cache: StoreCache::default(),
-                authorization: None,
-            };
-
-            let mut edition_ids_updates = Vec::new();
-            let mut properties_updates = Vec::new();
-            let mut metadata_updates = Vec::new();
-
-            for mut entity in entities {
-                let validation_components =
-                    if entity.metadata.record_id.entity_id.draft_id.is_some() {
-                        ValidateEntityComponents::draft()
-                    } else {
-                        ValidateEntityComponents::full()
-                    };
-                let mut property_with_metadata = PropertyWithMetadataObject::from_parts(
-                    entity.properties.clone(),
-                    Some(entity.metadata.properties.clone()),
-                )
-                .change_context(InsertionError)?;
-
-                let entity_type = ClosedMultiEntityType::from_multi_type_closed_schema(
-                    stream::iter(&entity.metadata.entity_type_ids)
-                        .then(|entity_type_url| async {
-                            OntologyTypeProvider::<ClosedEntityType>::provide_type(
-                                &validator_provider,
-                                entity_type_url,
-                            )
-                            .await
-                            .map(|entity_type| (*entity_type).clone())
-                        })
-                        .try_collect::<Vec<ClosedEntityType>>()
-                        .await
-                        .change_context(InsertionError)?,
-                )
-                .change_context(InsertionError)?;
-
-                EntityPreprocessor {
-                    components: validation_components,
-                }
-                .visit_object(
-                    &entity_type,
-                    &mut property_with_metadata,
-                    &validator_provider,
-                )
+        let entities =
+            Read::<Entity>::read_vec(postgres_client, &Filter::All(Vec::new()), None, true)
                 .await
                 .change_context(InsertionError)?;
 
-                let (properties, metadata) = property_with_metadata.into_parts();
-                let mut changed = false;
+        let validator_provider = StoreProvider {
+            store: postgres_client,
+            cache: StoreCache::default(),
+            authorization: None,
+        };
 
-                // We avoid updating the entity if the properties and metadata are the same
-                if entity.properties != properties || entity.metadata.properties != metadata {
-                    changed = true;
-                    entity.properties = properties;
-                    entity.metadata.properties = metadata;
-                }
+        let mut edition_ids_updates = Vec::new();
+        let mut properties_updates = Vec::new();
+        let mut metadata_updates = Vec::new();
 
-                entity
-                    .validate(
-                        &entity_type,
-                        if entity.metadata.record_id.entity_id.draft_id.is_some() {
-                            ValidateEntityComponents::draft()
-                        } else {
-                            ValidateEntityComponents::full()
-                        },
-                        &validator_provider,
-                    )
+        for mut entity in entities {
+            let validation_components = if entity.metadata.record_id.entity_id.draft_id.is_some() {
+                ValidateEntityComponents::draft()
+            } else {
+                ValidateEntityComponents::full()
+            };
+            let mut property_with_metadata = PropertyWithMetadataObject::from_parts(
+                entity.properties.clone(),
+                Some(entity.metadata.properties.clone()),
+            )
+            .change_context(InsertionError)?;
+
+            let entity_type = ClosedMultiEntityType::from_multi_type_closed_schema(
+                stream::iter(&entity.metadata.entity_type_ids)
+                    .then(|entity_type_url| async {
+                        OntologyTypeProvider::<ClosedEntityType>::provide_type(
+                            &validator_provider,
+                            entity_type_url,
+                        )
+                        .await
+                        .map(|entity_type| (*entity_type).clone())
+                    })
+                    .try_collect::<Vec<ClosedEntityType>>()
                     .await
-                    .change_context(InsertionError)?;
+                    .change_context(InsertionError)?,
+            )
+            .change_context(InsertionError)?;
 
-                if changed {
-                    edition_ids_updates.push(entity.metadata.record_id.edition_id);
-                    properties_updates.push(entity.properties);
-                    metadata_updates.push(entity.metadata.properties);
-                }
+            EntityPreprocessor {
+                components: validation_components,
+            }
+            .visit_object(
+                &entity_type,
+                &mut property_with_metadata,
+                &validator_provider,
+            )
+            .await
+            .change_context(InsertionError)?;
+
+            let (properties, metadata) = property_with_metadata.into_parts();
+            let mut changed = false;
+
+            // We avoid updating the entity if the properties and metadata are the same
+            if entity.properties != properties || entity.metadata.properties != metadata {
+                changed = true;
+                entity.properties = properties;
+                entity.metadata.properties = metadata;
             }
 
-            postgres_client
-                .as_client()
-                .client()
-                .query(
-                    "
-                        UPDATE entity_editions
-                        SET
-                            properties = data_table.properties,
-                            property_metadata = data_table.property_metadata
-                        FROM (
-                            SELECT unnest($1::uuid[]) as edition_id,
-                                   unnest($2::jsonb[]) as properties,
-                                   unnest($3::jsonb[]) as property_metadata
-                           ) as data_table
-                        WHERE entity_editions.entity_edition_id = data_table.edition_id;
-                    ",
-                    &[&edition_ids_updates, &properties_updates, &metadata_updates],
-                )
+            let mut validation_components = ValidateEntityComponents {
+                link_validation: postgres_client.settings.validate_links,
+                ..if entity.metadata.record_id.entity_id.draft_id.is_some() {
+                    ValidateEntityComponents::draft()
+                } else {
+                    ValidateEntityComponents::full()
+                }
+            };
+            validation_components.link_validation = postgres_client.settings.validate_links;
+
+            entity
+                .validate(&entity_type, validation_components, &validator_provider)
                 .await
                 .change_context(InsertionError)?;
+
+            if changed {
+                edition_ids_updates.push(entity.metadata.record_id.edition_id);
+                properties_updates.push(entity.properties);
+                metadata_updates.push(entity.metadata.properties);
+            }
         }
+
+        postgres_client
+            .as_client()
+            .client()
+            .query(
+                "
+                    UPDATE entity_editions
+                    SET
+                        properties = data_table.properties,
+                        property_metadata = data_table.property_metadata
+                    FROM (
+                        SELECT unnest($1::uuid[]) as edition_id,
+                                unnest($2::jsonb[]) as properties,
+                                unnest($3::jsonb[]) as property_metadata
+                        ) as data_table
+                    WHERE entity_editions.entity_edition_id = data_table.edition_id;
+                ",
+                &[&edition_ids_updates, &properties_updates, &metadata_updates],
+            )
+            .await
+            .change_context(InsertionError)?;
 
         Ok(())
     }

--- a/libs/@local/graph/postgres-store/src/snapshot/mod.rs
+++ b/libs/@local/graph/postgres-store/src/snapshot/mod.rs
@@ -244,7 +244,6 @@ trait WriteBatch<C, A> {
     ) -> impl Future<Output = Result<(), Report<InsertionError>>> + Send;
     fn commit(
         postgres_client: &mut PostgresStore<C, A>,
-        validation: bool,
     ) -> impl Future<Output = Result<(), Report<InsertionError>>> + Send;
 }
 
@@ -812,7 +811,6 @@ where
         + Send
         + 'static,
         chunk_size: usize,
-        validation: bool,
     ) -> Result<(), Report<SnapshotRestoreError>> {
         tracing::info!("snapshot restore started");
 
@@ -857,7 +855,7 @@ where
             .await
             .change_context(SnapshotRestoreError::Read)??;
 
-        SnapshotRecordBatch::commit(&mut client, validation)
+        SnapshotRecordBatch::commit(&mut client)
             .await
             .change_context(SnapshotRestoreError::Write)
             .map_err(|report| {

--- a/libs/@local/graph/postgres-store/src/snapshot/ontology/data_type/batch.rs
+++ b/libs/@local/graph/postgres-store/src/snapshot/ontology/data_type/batch.rs
@@ -133,7 +133,6 @@ where
 
     async fn commit(
         postgres_client: &mut PostgresStore<C, A>,
-        _validation: bool,
     ) -> Result<(), Report<InsertionError>> {
         postgres_client
             .as_client()

--- a/libs/@local/graph/postgres-store/src/snapshot/ontology/entity_type/batch.rs
+++ b/libs/@local/graph/postgres-store/src/snapshot/ontology/entity_type/batch.rs
@@ -112,7 +112,6 @@ where
 
     async fn commit(
         postgres_client: &mut PostgresStore<C, A>,
-        _validation: bool,
     ) -> Result<(), Report<InsertionError>> {
         postgres_client
             .as_client()

--- a/libs/@local/graph/postgres-store/src/snapshot/ontology/metadata/batch.rs
+++ b/libs/@local/graph/postgres-store/src/snapshot/ontology/metadata/batch.rs
@@ -135,7 +135,6 @@ where
 
     async fn commit(
         postgres_client: &mut PostgresStore<C, A>,
-        _validation: bool,
     ) -> Result<(), Report<InsertionError>> {
         postgres_client
             .as_client()

--- a/libs/@local/graph/postgres-store/src/snapshot/ontology/property_type/batch.rs
+++ b/libs/@local/graph/postgres-store/src/snapshot/ontology/property_type/batch.rs
@@ -157,7 +157,6 @@ where
 
     async fn commit(
         postgres_client: &mut PostgresStore<C, A>,
-        _validation: bool,
     ) -> Result<(), Report<InsertionError>> {
         postgres_client
             .as_client()

--- a/libs/@local/graph/postgres-store/src/snapshot/owner/batch.rs
+++ b/libs/@local/graph/postgres-store/src/snapshot/owner/batch.rs
@@ -98,7 +98,6 @@ where
 
     async fn commit(
         postgres_client: &mut PostgresStore<C, A>,
-        _validation: bool,
     ) -> Result<(), Report<InsertionError>> {
         postgres_client
             .as_client()

--- a/libs/@local/graph/postgres-store/src/snapshot/restore/batch.rs
+++ b/libs/@local/graph/postgres-store/src/snapshot/restore/batch.rs
@@ -61,15 +61,14 @@ where
 
     async fn commit(
         postgres_client: &mut PostgresStore<C, A>,
-        validation: bool,
     ) -> Result<(), Report<InsertionError>> {
-        AccountRowBatch::commit(postgres_client, validation).await?;
-        WebBatch::commit(postgres_client, validation).await?;
-        OntologyTypeMetadataRowBatch::commit(postgres_client, validation).await?;
-        DataTypeRowBatch::commit(postgres_client, validation).await?;
-        PropertyTypeRowBatch::commit(postgres_client, validation).await?;
-        EntityTypeRowBatch::commit(postgres_client, validation).await?;
-        EntityRowBatch::commit(postgres_client, validation).await?;
+        AccountRowBatch::commit(postgres_client).await?;
+        WebBatch::commit(postgres_client).await?;
+        OntologyTypeMetadataRowBatch::commit(postgres_client).await?;
+        DataTypeRowBatch::commit(postgres_client).await?;
+        PropertyTypeRowBatch::commit(postgres_client).await?;
+        EntityTypeRowBatch::commit(postgres_client).await?;
+        EntityRowBatch::commit(postgres_client).await?;
         Ok(())
     }
 }

--- a/libs/@local/graph/postgres-store/src/snapshot/web/batch.rs
+++ b/libs/@local/graph/postgres-store/src/snapshot/web/batch.rs
@@ -74,7 +74,6 @@ where
 
     async fn commit(
         postgres_client: &mut PostgresStore<C, A>,
-        _validation: bool,
     ) -> Result<(), Report<InsertionError>> {
         postgres_client
             .as_client()

--- a/libs/@local/graph/postgres-store/src/store/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/mod.rs
@@ -7,6 +7,6 @@ pub(crate) mod postgres;
 
 pub use self::{
     config::{DatabaseConnectionInfo, DatabasePoolConfig, DatabaseType},
-    postgres::{AsClient, PostgresStore, PostgresStorePool},
+    postgres::{AsClient, PostgresStore, PostgresStorePool, PostgresStoreSettings},
     validation::{StoreCache, StoreProvider},
 };

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -787,15 +787,12 @@ where
             )
             .change_context(InsertionError)?;
 
-            let validation_components = if params.draft {
-                ValidateEntityComponents {
-                    num_items: false,
-                    required_properties: false,
-                    ..ValidateEntityComponents::full()
-                }
+            let mut validation_components = if params.draft {
+                ValidateEntityComponents::draft()
             } else {
                 ValidateEntityComponents::full()
             };
+            validation_components.link_validation = self.settings.validate_links;
             EntityPreprocessor {
                 components: validation_components,
             }
@@ -1694,11 +1691,12 @@ where
         )
         .change_context(UpdateError)?;
 
-        let validation_components = if draft {
+        let mut validation_components = if draft {
             ValidateEntityComponents::draft()
         } else {
             ValidateEntityComponents::full()
         };
+        validation_components.link_validation = transaction.settings.validate_links;
 
         let (properties, property_metadata) =
             if let PropertyWithMetadata::Object(mut object) = properties_with_metadata {

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -61,11 +61,25 @@ use crate::store::error::{
     StoreError, VersionedUrlAlreadyExists,
 };
 
+#[derive(Debug, Clone)]
+pub struct PostgresStoreSettings {
+    pub validate_links: bool,
+}
+
+impl Default for PostgresStoreSettings {
+    fn default() -> Self {
+        Self {
+            validate_links: true,
+        }
+    }
+}
+
 /// A Postgres-backed store
 pub struct PostgresStore<C, A> {
     client: C,
     pub authorization_api: A,
     pub temporal_client: Option<Arc<TemporalClient>>,
+    pub settings: PostgresStoreSettings,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -122,11 +136,13 @@ where
         client: C,
         authorization_api: A,
         temporal_client: Option<Arc<TemporalClient>>,
+        settings: PostgresStoreSettings,
     ) -> Self {
         Self {
             client,
             authorization_api,
             temporal_client,
+            settings,
         }
     }
 
@@ -818,6 +834,7 @@ where
                 .change_context(StoreError)?,
             &mut self.authorization_api,
             self.temporal_client.clone(),
+            self.settings.clone(),
         ))
     }
 }

--- a/libs/@local/graph/postgres-store/src/store/postgres/pool.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/pool.rs
@@ -15,11 +15,12 @@ use tokio_postgres::{
 use crate::store::{
     config::{DatabaseConnectionInfo, DatabasePoolConfig},
     error::StoreError,
-    postgres::PostgresStore,
+    postgres::{PostgresStore, PostgresStoreSettings},
 };
 
 pub struct PostgresStorePool {
     pool: Pool,
+    pub settings: PostgresStoreSettings,
 }
 
 impl PostgresStorePool {
@@ -33,6 +34,7 @@ impl PostgresStorePool {
         db_info: &DatabaseConnectionInfo,
         pool_config: &DatabasePoolConfig,
         tls: Tls,
+        settings: PostgresStoreSettings,
     ) -> Result<Self, Report<StoreError>>
     where
         Tls: Clone
@@ -78,6 +80,7 @@ impl PostgresStorePool {
                 }))
                 .build()
                 .change_context(StoreError)?,
+            settings,
         })
     }
 }
@@ -103,6 +106,7 @@ impl StorePool for PostgresStorePool {
             self.pool.get().await?,
             authorization_api,
             temporal_client,
+            self.settings.clone(),
         ))
     }
 }

--- a/libs/@local/graph/store/src/entity/store.rs
+++ b/libs/@local/graph/store/src/entity/store.rs
@@ -65,6 +65,10 @@ const fn default_true() -> bool {
 #[derive(Debug, Copy, Clone, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "This is a configuration struct."
+)]
 pub struct ValidateEntityComponents {
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     #[serde(default = "default_true")]
@@ -75,6 +79,9 @@ pub struct ValidateEntityComponents {
     #[cfg_attr(feature = "utoipa", schema(nullable = false))]
     #[serde(default = "default_true")]
     pub num_items: bool,
+    #[cfg_attr(feature = "utoipa", schema(nullable = false))]
+    #[serde(default = "default_true")]
+    pub link_validation: bool,
 }
 
 impl ValidateEntityComponents {
@@ -84,6 +91,7 @@ impl ValidateEntityComponents {
             link_data: true,
             required_properties: true,
             num_items: true,
+            link_validation: true,
         }
     }
 

--- a/libs/@local/graph/test-server/src/lib.rs
+++ b/libs/@local/graph/test-server/src/lib.rs
@@ -112,7 +112,6 @@ where
                 JsonLinesDecoder::default(),
             ),
             10_000,
-            true,
         )
         .await
         .map_err(|report| {

--- a/libs/@local/graph/validation/src/entity_type.rs
+++ b/libs/@local/graph/validation/src/entity_type.rs
@@ -142,14 +142,17 @@ where
             status.capture(EntityValidationError::EmptyEntityTypes);
         }
 
-        if let Err(error) = self
-            .link_data
-            .as_ref()
-            .validate(schema, components, context)
-            .await
-        {
-            status.append(error);
+        if components.link_validation {
+            if let Err(error) = self
+                .link_data
+                .as_ref()
+                .validate(schema, components, context)
+                .await
+            {
+                status.append(error);
+            }
         }
+
         if let Err(error) = self
             .metadata
             .properties

--- a/tests/graph/benches/util.rs
+++ b/tests/graph/benches/util.rs
@@ -13,7 +13,7 @@ use hash_graph_postgres_store::{
     Environment, load_env,
     store::{
         AsClient, DatabaseConnectionInfo, DatabasePoolConfig, DatabaseType, PostgresStore,
-        PostgresStorePool, error::BaseUrlAlreadyExists,
+        PostgresStorePool, PostgresStoreSettings, error::BaseUrlAlreadyExists,
     },
 };
 use hash_graph_store::{
@@ -128,6 +128,7 @@ where
             &source_db_connection_info,
             &DatabasePoolConfig::default(),
             NoTls,
+            PostgresStoreSettings::default(),
         )
         .await
         .expect("could not connect to database");
@@ -201,6 +202,7 @@ where
                 ),
                 &DatabasePoolConfig::default(),
                 NoTls,
+                PostgresStoreSettings::default(),
             )
             .await
             .expect("could not connect to database");
@@ -218,6 +220,7 @@ where
             &bench_db_connection_info,
             &DatabasePoolConfig::default(),
             NoTls,
+            PostgresStoreSettings::default(),
         )
         .await
         .expect("could not connect to database");

--- a/tests/graph/integration/postgres/lib.rs
+++ b/tests/graph/integration/postgres/lib.rs
@@ -41,6 +41,7 @@ use hash_graph_postgres_store::{
     Environment, load_env,
     store::{
         DatabaseConnectionInfo, DatabasePoolConfig, DatabaseType, PostgresStore, PostgresStorePool,
+        PostgresStoreSettings,
     },
 };
 use hash_graph_store::{
@@ -176,9 +177,14 @@ impl DatabaseTestWrapper<NoAuthorization> {
             database,
         );
 
-        let pool = PostgresStorePool::new(&connection_info, &DatabasePoolConfig::default(), NoTls)
-            .await
-            .expect("could not connect to database");
+        let pool = PostgresStorePool::new(
+            &connection_info,
+            &DatabasePoolConfig::default(),
+            NoTls,
+            PostgresStoreSettings::default(),
+        )
+        .await
+        .expect("could not connect to database");
 
         let connection = pool
             .acquire_owned(NoAuthorization, None)


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The link validation is known to be slow currently (see [H-3522](https://linear.app/hash/issue/H-3522/speed-up-link-validation)). Until we sped up link validation we need a way to quickly seed a lot of data. For this, a CLI parameter is desired to skip validation of links.


## 🔍 What does this change?

- Adds a CLI parameter `--skip-link-validation`
- Propagates the settings down do the validation logic by adding a `settings` field to the Postgres store.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change
### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

Run the `hash-graph` binary directly using
```
cargo run --all-features --bin hash-graph --release -- server --skip-link-validation
```

and insert your data.
