### PR TITLE
H-3677: Include entity type in closed entity type's `allOf`

### DIFF
--- a/libs/@blockprotocol/type-system/rust/src/schema/entity_type/closed.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/entity_type/closed.rs
@@ -26,7 +26,6 @@ pub struct ClosedEntityTypeMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title_plural: Option<String>,
     pub description: String,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[cfg_attr(
         target_arch = "wasm32",
         tsify(type = "[EntityTypeDisplayMetadata, ...EntityTypeDisplayMetadata[]]")
@@ -46,7 +45,6 @@ pub struct ClosedEntityType {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title_plural: Option<String>,
     pub description: String,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[cfg_attr(
         target_arch = "wasm32",
         tsify(type = "[EntityTypeDisplayMetadata, ...EntityTypeDisplayMetadata[]]")

--- a/libs/@blockprotocol/type-system/rust/src/schema/entity_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/entity_type/mod.rs
@@ -74,6 +74,7 @@ pub struct EntityTypeSchemaMetadata {
 pub struct EntityTypeDisplayMetadata {
     #[serde(rename = "$id")]
     pub id: VersionedUrl,
+    pub depth: u16,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label_property: Option<BaseUrl>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/tests/hash-backend-integration/src/tests/graph/ontology/primitive/entity-type.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/ontology/primitive/entity-type.test.ts
@@ -339,6 +339,16 @@ describe("Entity type CRU", () => {
             ...(userType.schema.links ?? {}),
             ...(userType.schema.links ?? {}),
           },
+          allOf: [
+            {
+              depth: 0,
+              $id: systemEntityTypes.user.entityTypeId,
+            },
+            {
+              depth: 1,
+              $id: systemEntityTypes.actor.entityTypeId,
+            },
+          ],
         } satisfies ClosedEntityType,
       },
     ]);
@@ -394,6 +404,7 @@ describe("Entity type CRU", () => {
             $id: closedEntityType.schema.$id,
             title: closedEntityType.schema.title,
             description: closedEntityType.schema.description,
+            allOf: closedEntityType.schema.allOf,
           }) as ClosedMultiEntityType["allOf"][0],
       ),
     );


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The open entity type should be contained in the `allOf` of the closed entity type provide a unified interface to all `icon`s and `labelProperty`s. In addition, the depth should be included.

## 🔍 What does this change?

- Add all parents to the `allOf`
- Add the schema itself as well
