### PR TITLE
H-3694: Add output when resolving a type

### DIFF
--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
@@ -1131,7 +1131,9 @@ where
         .collect::<Vec<_>>();
 
         let data_type_validator = DataTypeValidator;
-        for (data_type_id, schema) in data_types {
+        let num_data_types = data_types.len();
+        for (idx, (data_type_id, schema)) in data_types.into_iter().enumerate() {
+            tracing::debug!(data_type_id=%schema.id, "Reindexing schema {}/{}", idx + 1, num_data_types);
             let schema_metadata = ontology_type_resolver
                 .resolve_data_type_metadata(data_type_id)
                 .change_context(UpdateError)?;

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
@@ -1491,7 +1491,9 @@ where
         .collect::<Vec<_>>();
 
         let entity_type_validator = EntityTypeValidator;
-        for (entity_type_id, schema) in entity_types {
+        let num_entity_types = entity_types.len();
+        for (idx, (entity_type_id, schema)) in entity_types.into_iter().enumerate() {
+            tracing::debug!(entity_type_id=%schema.id, "Reindexing schema {}/{}", idx + 1, num_entity_types);
             let schema_metadata = ontology_type_resolver
                 .resolve_entity_type_metadata(entity_type_id)
                 .change_context(UpdateError)?;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When running `hash-graph reindex-cache` with `--data-types` or `--entity-types` there is now way to see the progress.


## 🔍 What does this change?

- Add a simple output to show the progress