### PR TITLE
H-3705, H-3706: Fix codegen for data type constraints and prohibit multiple formats in constraints

### DIFF
--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/closed.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/closed.rs
@@ -72,6 +72,8 @@ pub enum ResolveClosedDataTypeError {
     ConflictingConstEnumValue(JsonValue, Vec<JsonValue>),
     #[error("The constraint is unsatisfiable: {}", json!(.0))]
     UnsatisfiableConstraint(ValueConstraints),
+    #[error("The constraints are incompatible: {} <=> {}", json!(.0), json!(.1))]
+    IncompatibleConstraints(ValueConstraints, ValueConstraints),
     #[error("The combined constraints results in an empty `anyOf`")]
     EmptyAnyOf,
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
@@ -44,7 +44,7 @@ pub enum ArrayTypeTag {
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum ArrayItemConstraints {
-    Boolean(BooleanSchema),
+    Boolean,
     Number(NumberSchema),
     String(StringSchema),
 }
@@ -55,9 +55,7 @@ impl Constraint for ArrayItemConstraints {
         other: Self,
     ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {
         match (self, other) {
-            (Self::Boolean(lhs), Self::Boolean(rhs)) => lhs
-                .intersection(rhs)
-                .map(|(lhs, rhs)| (Self::Boolean(lhs), rhs.map(Self::Boolean))),
+            (Self::Boolean, Self::Boolean) => Ok((Self::Boolean, None)),
             (Self::Number(lhs), Self::Number(rhs)) => lhs
                 .intersection(rhs)
                 .map(|(lhs, rhs)| (Self::Number(lhs), rhs.map(Self::Number))),
@@ -74,7 +72,7 @@ impl ConstraintValidator<JsonValue> for ArrayItemConstraints {
 
     fn is_valid(&self, value: &JsonValue) -> bool {
         match self {
-            Self::Boolean(schema) => schema.is_valid(value),
+            Self::Boolean => BooleanSchema.is_valid(value),
             Self::Number(schema) => schema.is_valid(value),
             Self::String(schema) => schema.is_valid(value),
         }
@@ -82,7 +80,7 @@ impl ConstraintValidator<JsonValue> for ArrayItemConstraints {
 
     fn validate_value(&self, value: &JsonValue) -> Result<(), Report<ConstraintError>> {
         match self {
-            Self::Boolean(schema) => schema.validate_value(value),
+            Self::Boolean => BooleanSchema.validate_value(value),
             Self::Number(schema) => schema.validate_value(value),
             Self::String(schema) => schema.validate_value(value),
         }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/boolean.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/boolean.rs
@@ -8,14 +8,12 @@ use crate::schema::{
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum BooleanTypeTag {
     Boolean,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct BooleanSchema;
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/null.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/null.rs
@@ -8,14 +8,12 @@ use crate::schema::{
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum NullTypeTag {
     Null,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct NullSchema;
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/object.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/object.rs
@@ -21,7 +21,6 @@ pub enum ObjectTypeTag {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(untagged, rename_all = "camelCase", deny_unknown_fields)]
 pub enum ObjectSchema {
     Constrained(ObjectConstraints),
@@ -87,13 +86,8 @@ impl ConstraintValidator<JsonObject> for ObjectSchema {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[expect(
-    clippy::empty_structs_with_brackets,
-    reason = "This struct is a placeholder for future functionality."
-)]
-pub struct ObjectConstraints {}
+pub struct ObjectConstraints;
 
 impl Constraint for ObjectConstraints {
     fn intersection(

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -119,12 +119,12 @@ mod raw {
     use super::{DataTypeSchemaTag, DataTypeTag, ValueSchemaMetadata};
     use crate::{
         schema::{
-            ArrayTypeTag, BooleanTypeTag, DataTypeReference, NullSchema, NullTypeTag,
-            NumberTypeTag, ObjectTypeTag, StringTypeTag,
+            ArrayTypeTag, BooleanTypeTag, DataTypeReference, NullTypeTag, NumberTypeTag,
+            ObjectTypeTag, StringTypeTag,
             data_type::constraint::{
-                AnyOfConstraints, ArrayConstraints, ArraySchema, BooleanSchema, NumberConstraints,
-                NumberSchema, ObjectConstraints, ObjectSchema, SingleValueConstraints,
-                StringConstraints, StringSchema, TupleConstraints, ValueConstraints,
+                AnyOfConstraints, ArrayConstraints, ArraySchema, NumberConstraints, NumberSchema,
+                SingleValueConstraints, StringConstraints, StringSchema, TupleConstraints,
+                ValueConstraints,
             },
         },
         url::VersionedUrl,
@@ -222,8 +222,6 @@ mod raw {
             base: DataTypeBase,
             #[serde(flatten)]
             metadata: ValueSchemaMetadata,
-            #[serde(flatten)]
-            constraints: ObjectConstraints,
         },
         Array {
             r#type: ArrayTypeTag,
@@ -292,7 +290,7 @@ mod raw {
                 } => (
                     base,
                     metadata,
-                    ValueConstraints::Typed(SingleValueConstraints::Null(NullSchema)),
+                    ValueConstraints::Typed(SingleValueConstraints::Null),
                 ),
                 DataType::Boolean {
                     r#type: _,
@@ -301,7 +299,7 @@ mod raw {
                 } => (
                     base,
                     metadata,
-                    ValueConstraints::Typed(SingleValueConstraints::Boolean(BooleanSchema)),
+                    ValueConstraints::Typed(SingleValueConstraints::Boolean),
                 ),
                 DataType::Number {
                     r#type: _,
@@ -379,13 +377,10 @@ mod raw {
                     r#type: _,
                     base,
                     metadata,
-                    constraints,
                 } => (
                     base,
                     metadata,
-                    ValueConstraints::Typed(SingleValueConstraints::Object(
-                        ObjectSchema::Constrained(constraints),
-                    )),
+                    ValueConstraints::Typed(SingleValueConstraints::Object),
                 ),
                 DataType::Array {
                     r#type: _,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The current type constraints are defined for example like `{ type: "null" } & null`. We need to omit the unneeded part, so only `{ type: "null" }` remains. Also applies for `boolean` and `object`. Also, at the moment in theory it's possible to create conflicting format constraints. Until we actually find a use for this feature we avoid it.

## 🔍 What does this change?

- Change `SingleValueConstraint` to:
	```ts
	export type SingleValueConstraints =
	  | { type: "null" }
	  | { type: "boolean" }
	  | ({ type: "number" } & NumberSchema)
	  | ({ type: "string" } & StringSchema)
	  | ({ type: "array" } & ArraySchema)
	  | { type: "object" };
	```
- Return an error if two different formats are used in value constraints

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph