### PR TITLE
H-3703: Remove unused `data_type_constrains_values_on` table

### DIFF
--- a/libs/@local/graph/migrations/graph-migrations/v006__data_types/down.sql
+++ b/libs/@local/graph/migrations/graph-migrations/v006__data_types/down.sql
@@ -1,7 +1,6 @@
 DROP VIEW data_type_conversion_aggregation;
 DROP TABLE data_type_conversions;
 DROP TABLE data_type_embeddings;
-DROP TABLE data_type_constrains_values_on;
 DROP VIEW data_type_inherits_from_aggregation;
 DROP TABLE data_type_inherits_from;
 DROP TABLE data_types;

--- a/libs/@local/graph/migrations/graph-migrations/v006__data_types/up.sql
+++ b/libs/@local/graph/migrations/graph-migrations/v006__data_types/up.sql
@@ -21,12 +21,6 @@ SELECT
 FROM data_type_inherits_from
 GROUP BY data_type_inherits_from.source_data_type_ontology_id;
 
-
-CREATE TABLE data_type_constrains_values_on (
-    source_data_type_ontology_id UUID NOT NULL REFERENCES data_types,
-    target_data_type_ontology_id UUID NOT NULL REFERENCES data_types
-);
-
 CREATE TABLE data_type_embeddings (
     ontology_id UUID PRIMARY KEY REFERENCES data_types,
     embedding VECTOR(3072) NOT NULL,

--- a/libs/@local/graph/postgres-store/postgres_migrations/V35__remove_data_type_constrains_values_on_table.sql
+++ b/libs/@local/graph/postgres-store/postgres_migrations/V35__remove_data_type_constrains_values_on_table.sql
@@ -1,0 +1,1 @@
+DROP TABLE data_type_constrains_values_on;

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
@@ -286,19 +286,13 @@ where
                 }
             }
 
-            for (edge_kind, table) in [
-                (
-                    OntologyEdgeKind::InheritsFrom,
-                    ReferenceTable::DataTypeInheritsFrom {
-                        // TODO: Use the resolve depths passed to the query
-                        inheritance_depth: Some(0),
-                    },
-                ),
-                (
-                    OntologyEdgeKind::ConstrainsValuesOn,
-                    ReferenceTable::DataTypeConstrainsValuesOn,
-                ),
-            ] {
+            for (edge_kind, table) in [(
+                OntologyEdgeKind::InheritsFrom,
+                ReferenceTable::DataTypeInheritsFrom {
+                    // TODO: Use the resolve depths passed to the query
+                    inheritance_depth: Some(0),
+                },
+            )] {
                 if let Some(traversal_data) = edges_to_traverse.get(&edge_kind) {
                     data_type_queue.extend(
                         Self::filter_data_types_by_permission(
@@ -344,7 +338,6 @@ where
                 "
                     DELETE FROM data_type_embeddings;
                     DELETE FROM data_type_inherits_from;
-                    DELETE FROM data_type_constrains_values_on;
                     DELETE FROM data_type_conversions;
                 ",
             )

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
@@ -45,7 +45,6 @@ pub enum Table {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum ReferenceTable {
-    DataTypeConstrainsValuesOn,
     DataTypeInheritsFrom { inheritance_depth: Option<u32> },
     PropertyTypeConstrainsValuesOn,
     PropertyTypeConstrainsPropertiesOn,
@@ -96,13 +95,6 @@ impl ReferenceTable {
 
     pub const fn source_relation(self) -> ForeignKeyReference {
         match self {
-            Self::DataTypeConstrainsValuesOn => ForeignKeyReference::Single {
-                on: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
-                join: Column::DataTypeConstrainsValuesOn(
-                    DataTypeConstrainsValuesOn::SourceDataTypeOntologyId,
-                ),
-                join_type: JoinType::Inner,
-            },
             Self::DataTypeInheritsFrom { inheritance_depth } => ForeignKeyReference::Single {
                 on: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
                 join: Column::DataTypeInheritsFrom(
@@ -195,13 +187,6 @@ impl ReferenceTable {
 
     pub const fn target_relation(self) -> ForeignKeyReference {
         match self {
-            Self::DataTypeConstrainsValuesOn => ForeignKeyReference::Single {
-                on: Column::DataTypeConstrainsValuesOn(
-                    DataTypeConstrainsValuesOn::TargetDataTypeOntologyId,
-                ),
-                join: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
-                join_type: JoinType::Inner,
-            },
             Self::DataTypeInheritsFrom { inheritance_depth } => ForeignKeyReference::Single {
                 on: Column::DataTypeInheritsFrom(
                     DataTypeInheritsFrom::TargetDataTypeOntologyId,
@@ -296,7 +281,6 @@ impl ReferenceTable {
 impl ReferenceTable {
     const fn as_str(self) -> &'static str {
         match self {
-            Self::DataTypeConstrainsValuesOn => "data_type_constrains_values_on",
             Self::DataTypeInheritsFrom {
                 inheritance_depth: _,
             } => "data_type_inherits_from",
@@ -843,31 +827,6 @@ impl DatabaseColumn for DataTypeEmbeddings {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum DataTypeConstrainsValuesOn {
-    SourceDataTypeOntologyId,
-    TargetDataTypeOntologyId,
-}
-
-impl DatabaseColumn for DataTypeConstrainsValuesOn {
-    fn parameter_type(self) -> ParameterType {
-        match self {
-            Self::SourceDataTypeOntologyId | Self::TargetDataTypeOntologyId => ParameterType::Uuid,
-        }
-    }
-
-    fn nullable(self) -> bool {
-        false
-    }
-
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::SourceDataTypeOntologyId => "source_data_type_ontology_id",
-            Self::TargetDataTypeOntologyId => "target_data_type_ontology_id",
-        }
-    }
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum DataTypeInheritsFrom {
     SourceDataTypeOntologyId,
     TargetDataTypeOntologyId,
@@ -1372,7 +1331,6 @@ pub enum Column {
     OntologyAdditionalMetadata(OntologyAdditionalMetadata),
     DataTypes(DataTypes),
     DataTypeEmbeddings(DataTypeEmbeddings),
-    DataTypeConstrainsValuesOn(DataTypeConstrainsValuesOn),
     DataTypeInheritsFrom(DataTypeInheritsFrom, Option<u32>),
     DataTypeConversions(DataTypeConversions),
     DataTypeConversionAggregation(DataTypeConversionAggregation),
@@ -1566,9 +1524,6 @@ impl Column {
             Self::EntityTemporalMetadata(_) => Table::EntityTemporalMetadata,
             Self::EntityEditions(_) => Table::EntityEditions,
             Self::EntityEmbeddings(_) => Table::EntityEmbeddings,
-            Self::DataTypeConstrainsValuesOn(_) => {
-                Table::Reference(ReferenceTable::DataTypeConstrainsValuesOn)
-            }
             Self::DataTypeInheritsFrom(_, inheritance_depth) => {
                 Table::Reference(ReferenceTable::DataTypeInheritsFrom { inheritance_depth })
             }
@@ -1634,7 +1589,6 @@ impl DatabaseColumn for Column {
             Self::DataTypes(column) => column.parameter_type(),
             Self::DataTypeEmbeddings(column) => column.parameter_type(),
             Self::DataTypeInheritsFrom(column, _) => column.parameter_type(),
-            Self::DataTypeConstrainsValuesOn(column) => column.parameter_type(),
             Self::DataTypeConversions(column) => column.parameter_type(),
             Self::DataTypeConversionAggregation(column) => column.parameter_type(),
             Self::PropertyTypes(column) => column.parameter_type(),
@@ -1668,7 +1622,6 @@ impl DatabaseColumn for Column {
             Self::DataTypes(column) => column.nullable(),
             Self::DataTypeEmbeddings(column) => column.nullable(),
             Self::DataTypeInheritsFrom(column, _) => column.nullable(),
-            Self::DataTypeConstrainsValuesOn(column) => column.nullable(),
             Self::DataTypeConversions(column) => column.nullable(),
             Self::DataTypeConversionAggregation(column) => column.nullable(),
             Self::PropertyTypes(column) => column.nullable(),
@@ -1702,7 +1655,6 @@ impl DatabaseColumn for Column {
             Self::DataTypes(column) => column.as_str(),
             Self::DataTypeEmbeddings(column) => column.as_str(),
             Self::DataTypeInheritsFrom(column, _) => column.as_str(),
-            Self::DataTypeConstrainsValuesOn(column) => column.as_str(),
             Self::DataTypeConversions(column) => column.as_str(),
             Self::DataTypeConversionAggregation(column) => column.as_str(),
             Self::PropertyTypes(column) => column.as_str(),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When I added support for Custom Data Types in the graph I added two reference tables:
- `data_type_inherits_from`
- `data_type_constrains_values_on`

The former is used for the `allOf`. The second one I added in advance because I assumed this is what we’re going to use for `anyOf`. However, we chose another route here. If we need it we can easily re-add it.
