### PR TITLE
H-3723: Add link table indices

### DIFF
--- a/libs/@local/graph/migrations/graph-migrations/v009__entities/up.sql
+++ b/libs/@local/graph/migrations/graph-migrations/v009__entities/up.sql
@@ -76,6 +76,8 @@ CREATE TABLE entity_has_left_entity (
     FOREIGN KEY (web_id, entity_uuid) REFERENCES entity_ids,
     FOREIGN KEY (left_web_id, left_entity_uuid) REFERENCES entity_ids
 );
+CREATE INDEX entity_has_left_entity_source_idx
+    ON entity_has_left_entity(web_id, entity_uuid);
 
 CREATE TABLE entity_has_right_entity (
     web_id UUID NOT NULL,
@@ -87,6 +89,8 @@ CREATE TABLE entity_has_right_entity (
     FOREIGN KEY (web_id, entity_uuid) REFERENCES entity_ids,
     FOREIGN KEY (right_web_id, right_entity_uuid) REFERENCES entity_ids
 );
+CREATE INDEX entity_has_right_entity_source_idx
+    ON entity_has_right_entity(web_id, entity_uuid);
 
 CREATE TABLE entity_embeddings (
     web_id UUID NOT NULL,

--- a/libs/@local/graph/postgres-store/postgres_migrations/V36__link_table_indices.sql
+++ b/libs/@local/graph/postgres-store/postgres_migrations/V36__link_table_indices.sql
@@ -1,0 +1,4 @@
+CREATE INDEX entity_has_left_entity_source_idx
+    ON entity_has_left_entity(web_id, entity_uuid);
+CREATE INDEX entity_has_right_entity_source_idx
+    ON entity_has_right_entity(web_id, entity_uuid);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

I further tested out on adding more indices. A direct improvement gave the `link-entity` indices (uni-directional). All other indices did not show a noticeable change or even decreased performance. I don’t think there is any point in poking around in indices even more if we don’t have more benchmark coverage in place or a query in mind in particular which is slow.

## 🔍 What does this change?

Add the two link-indices