### PR TITLE
H-3733: Experiment with lefthook as a husky/lint-staged replacement

### DIFF
--- a/.config/husky/pre-commit
+++ b/.config/husky/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-yarn lint-staged

--- a/.github/actions/warm-up-repo/action.yml
+++ b/.github/actions/warm-up-repo/action.yml
@@ -24,7 +24,7 @@ runs:
     - name: Install yarn dependencies
       uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
       env:
-        HUSKY: 0
+        LEFTHOOK: 0
       with:
         max_attempts: 3
         timeout_minutes: 10

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -18,7 +18,7 @@ pre-commit:
       stage_fixed: true
     yarn:
       tags: frontend style
-      glob: "**/package.json"
+      glob: "{*/package.json, package.json}"
       run: yarn fix:constraints && yarn fix:yarn-deduplicate
       stage_fixed: true
     sqlfluff:

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -8,12 +8,12 @@ pre-commit:
   commands:
     markdownlint:
       tags: frontend style
-      glob: "**/*.md"
+      glob: "*.md"
       run: yarn run markdownlint --fix {staged_files} || true
       stage_fixed: true
     prettier:
       tags: frontend style
-      glob: "**/*.{cjs,css,js,json,md,mdx,mjs,scss,ts,tsx,yml}"
+      glob: "*.{cjs,css,js,json,md,mdx,mjs,scss,ts,tsx,yml}"
       run: yarn run prettier --write {staged_files} || true
       stage_fixed: true
     yarn:
@@ -23,11 +23,11 @@ pre-commit:
       stage_fixed: true
     sqlfluff:
       tags: backend style
-      glob: "**/*.sql"
+      glob: "*.sql"
       run: sqlfluff fix {staged_files} || true
       stage_fixed: true
     rust:
       tags: backend style
-      glob: "**/*.rs"
+      glob: "*.rs"
       run: cargo fmt -- {staged_files} || true
       stage_fixed: true

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -16,3 +16,13 @@ pre-commit:
       glob: "**/*.{cjs,css,js,json,md,mdx,mjs,scss,ts,tsx,yml}"
       run: yarn run prettier --write {staged_files} || true
       stage_fixed: true
+    sqlfluff:
+      tags: backend style
+      glob: "**/*.sql"
+      run: sqlfluff fix {staged_files} || true
+      stage_fixed: true
+    rust:
+      tags: backend style
+      glob: "**/*.rs"
+      run: cargo fmt -- {staged_files} || true
+      stage_fixed: true

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -31,3 +31,8 @@ pre-commit:
       glob: "*.rs"
       run: cargo fmt -- {staged_files} || true
       stage_fixed: true
+    toml:
+      tags: backend style
+      glob: "*.toml"
+      run: yarn run taplo format {staged_files} || true
+      stage_fixed: true

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -16,6 +16,11 @@ pre-commit:
       glob: "**/*.{cjs,css,js,json,md,mdx,mjs,scss,ts,tsx,yml}"
       run: yarn run prettier --write {staged_files} || true
       stage_fixed: true
+    yarn:
+      tags: frontend style
+      glob: "**/package.json"
+      run: yarn fix:constraints && yarn fix:yarn-deduplicate
+      stage_fixed: true
     sqlfluff:
       tags: backend style
       glob: "**/*.sql"

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -1,0 +1,18 @@
+$schema: https://json.schemastore.org/lefthook.json
+
+pre-commit:
+  parallel: true
+  skip:
+    - merge
+    - rebase
+  commands:
+    markdownlint:
+      tags: frontend style
+      glob: "**/*.md"
+      run: yarn run markdownlint --fix {staged_files} || true
+      stage_fixed: true
+    prettier:
+      tags: frontend style
+      glob: "**/*.{cjs,css,js,json,md,mdx,mjs,scss,ts,tsx,yml}"
+      run: yarn run prettier --write {staged_files} || true
+      stage_fixed: true

--- a/apps/hash-frontend/vercel-install.sh
+++ b/apps/hash-frontend/vercel-install.sh
@@ -53,4 +53,4 @@ for _ in {1..5}; do rustup show && break || sleep 5; done
 # Install the pruned dependencies
 
 echo "Installing yarn dependencies"
-HUSKY=0 yarn install --immutable
+LEFTHOOK=0 yarn install --immutable

--- a/apps/hashdotdesign/vercel-install.sh
+++ b/apps/hashdotdesign/vercel-install.sh
@@ -19,4 +19,4 @@ source "$HOME/.cargo/env"
 for _ in {1..5}; do rustup show && break || sleep 5; done
 
 echo "Installing yarn dependencies"
-HUSKY=0 yarn install --immutable
+LEFTHOOK=0 yarn install --immutable

--- a/apps/hashdotdev/vercel-install.sh
+++ b/apps/hashdotdev/vercel-install.sh
@@ -19,4 +19,4 @@ source "$HOME/.cargo/env"
 for _ in {1..5}; do rustup show && break || sleep 5; done
 
 echo "Installing yarn dependencies"
-HUSKY=0 yarn install --immutable
+LEFTHOOK=0 yarn install --immutable

--- a/package.json
+++ b/package.json
@@ -66,13 +66,6 @@
     "bench:integration": "turbo run bench:integration --env-mode=loose --",
     "prune-node-modules": "find . -type d -name \"node_modules\" -exec rm -rf {} +"
   },
-  "lint-staged": {
-    "**": [
-      "suppress-exit-code markdownlint --fix",
-      "suppress-exit-code prettier --write",
-      "suppress-exit-code yarn constraints --fix"
-    ]
-  },
   "prettier": {
     "plugins": [
       "prettier-plugin-packagejson",
@@ -124,9 +117,7 @@
     "@taplo/cli": "0.7.0",
     "@yarnpkg/types": "^4.0.0",
     "concurrently": "7.6.0",
-    "husky": "8.0.3",
     "lefthook": "1.8.5",
-    "lint-staged": "15.2.10",
     "lockfile-lint": "4.14.0",
     "markdownlint-cli": "0.43.0",
     "npm-run-all2": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "lint:taplo": "taplo fmt --check",
     "lint:tsc": "turbo --continue lint:tsc --",
     "lint:yarn-deduplicate": "yarn dedupe --strategy highest --check",
-    "postinstall": "turbo run postinstall; husky install .config/husky",
+    "postinstall": "turbo run postinstall",
     "seed-data:opensearch": "yarn workspace @apps/hash-search-loader clear-opensearch",
     "seed-data:redis": "yarn workspace @apps/hash-realtime clear-redis",
     "seed-data": "concurrently \"yarn:seed-data:*\"",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "@yarnpkg/types": "^4.0.0",
     "concurrently": "7.6.0",
     "husky": "8.0.3",
+    "lefthook": "1.8.5",
     "lint-staged": "15.2.10",
     "lockfile-lint": "4.14.0",
     "markdownlint-cli": "0.43.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -328,6 +328,7 @@ __metadata:
     ajv-formats: "npm:3.0.1"
     axios: "npm:1.7.8"
     cache-manager: "npm:5.7.6"
+    cross-env: "npm:7.0.3"
     dedent: "npm:0.7.0"
     dotenv-flow: "npm:3.3.0"
     e2b: "npm:0.13.1"
@@ -367,11 +368,11 @@ __metadata:
   resolution: "@apps/hash-api@workspace:apps/hash-api"
   dependencies:
     "@apps/hash-graph": "npm:0.0.0-private"
-    "@aws-sdk/client-s3": "npm:3.703.0"
+    "@aws-sdk/client-s3": "npm:3.701.0"
     "@aws-sdk/client-ses": "npm:3.699.0"
     "@aws-sdk/credential-provider-node": "npm:3.699.0"
-    "@aws-sdk/s3-presigned-post": "npm:3.703.0"
-    "@aws-sdk/s3-request-presigner": "npm:3.703.0"
+    "@aws-sdk/s3-presigned-post": "npm:3.701.0"
+    "@aws-sdk/s3-request-presigner": "npm:3.701.0"
     "@blockprotocol/core": "npm:0.1.3"
     "@blockprotocol/graph": "npm:0.4.0-canary.0"
     "@blockprotocol/type-system": "npm:0.1.2-canary.0"
@@ -607,7 +608,7 @@ __metadata:
     rimraf: "npm:6.0.1"
     rooks: "npm:7.14.1"
     safe-stable-stringify: "npm:2.5.0"
-    sass: "npm:1.81.1"
+    sass: "npm:1.81.0"
     setimmediate: "npm:1.0.5"
     sigma: "npm:3.0.0-beta.38"
     signia: "npm:0.1.5"
@@ -665,6 +666,7 @@ __metadata:
     "@types/dotenv-flow": "npm:3.3.3"
     agentkeepalive: "npm:4.5.0"
     axios: "npm:1.7.8"
+    cross-env: "npm:7.0.3"
     dotenv-flow: "npm:3.3.0"
     eslint: "npm:8.57.0"
     rimraf: "npm:6.0.1"
@@ -683,6 +685,7 @@ __metadata:
     "@local/tsconfig": "npm:0.0.0-private"
     "@types/node": "npm:22.10.0"
     "@types/set-interval-async": "npm:1.0.3"
+    cross-env: "npm:7.0.3"
     eslint: "npm:8.57.0"
     set-interval-async: "npm:2.0.3"
     slonik: "npm:24.2.0"
@@ -701,6 +704,7 @@ __metadata:
     "@local/hash-isomorphic-utils": "npm:0.0.0-private"
     "@local/tsconfig": "npm:0.0.0-private"
     "@types/node": "npm:22.10.0"
+    cross-env: "npm:7.0.3"
     eslint: "npm:8.57.0"
     hot-shots: "npm:8.5.2"
     tsx: "npm:4.19.2"
@@ -861,7 +865,7 @@ __metadata:
     react-refresh: "npm:0.14.0"
     react-refresh-typescript: "npm:2.0.9"
     rimraf: "npm:6.0.1"
-    sass: "npm:1.81.1"
+    sass: "npm:1.81.0"
     sass-loader: "npm:13.3.3"
     source-map-loader: "npm:3.0.2"
     style-loader: "npm:3.3.4"
@@ -1285,9 +1289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-s3@npm:3.703.0":
-  version: 3.703.0
-  resolution: "@aws-sdk/client-s3@npm:3.703.0"
+"@aws-sdk/client-s3@npm:3.701.0":
+  version: 3.701.0
+  resolution: "@aws-sdk/client-s3@npm:3.701.0"
   dependencies:
     "@aws-crypto/sha1-browser": "npm:5.2.0"
     "@aws-crypto/sha256-browser": "npm:5.2.0"
@@ -1347,7 +1351,7 @@ __metadata:
     "@smithy/util-utf8": "npm:^3.0.0"
     "@smithy/util-waiter": "npm:^3.1.9"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/eba492878a32cad0709383af4d56b9df95e8de02d99963cb9e3bdb60ade49c8617c857340bd0348711f2212b9ca6d9f7dc00ea80c001ac31afcdeee6824b702d
+  checksum: 10c0/b7eeb84dddb1c5581de6210ecdfd943a1f94582d30bf58e7ce2ff7ecdbfee68edf01838c0f78f015ebfb134f60cb27d6827f85b78ad8b90cb6516a072425987f
   languageName: node
   linkType: hard
 
@@ -1937,11 +1941,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/s3-presigned-post@npm:3.703.0":
-  version: 3.703.0
-  resolution: "@aws-sdk/s3-presigned-post@npm:3.703.0"
+"@aws-sdk/s3-presigned-post@npm:3.701.0":
+  version: 3.701.0
+  resolution: "@aws-sdk/s3-presigned-post@npm:3.701.0"
   dependencies:
-    "@aws-sdk/client-s3": "npm:3.703.0"
+    "@aws-sdk/client-s3": "npm:3.701.0"
     "@aws-sdk/types": "npm:3.696.0"
     "@aws-sdk/util-format-url": "npm:3.696.0"
     "@smithy/middleware-endpoint": "npm:^3.2.3"
@@ -1950,13 +1954,13 @@ __metadata:
     "@smithy/util-hex-encoding": "npm:^3.0.0"
     "@smithy/util-utf8": "npm:^3.0.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/6c9f72bbf4ba7e269685ec5cade64b8746e21586c5a86b47bd3d2d3a1ca61efaa3620e2c7f4baa3f6e356e443a14bdfbab4422b6b8158cbed237c3d9ec00e5f9
+  checksum: 10c0/6473d4e248e0ad265e6ea4753c5a46be9827e4ac12022780343b0e9a24f33017ce963c337d7a651991780d3fe7b5ff5084eb577b62ab4a917529fb5409494dcd
   languageName: node
   linkType: hard
 
-"@aws-sdk/s3-request-presigner@npm:3.703.0":
-  version: 3.703.0
-  resolution: "@aws-sdk/s3-request-presigner@npm:3.703.0"
+"@aws-sdk/s3-request-presigner@npm:3.701.0":
+  version: 3.701.0
+  resolution: "@aws-sdk/s3-request-presigner@npm:3.701.0"
   dependencies:
     "@aws-sdk/signature-v4-multi-region": "npm:3.696.0"
     "@aws-sdk/types": "npm:3.696.0"
@@ -1966,7 +1970,7 @@ __metadata:
     "@smithy/smithy-client": "npm:^3.4.4"
     "@smithy/types": "npm:^3.7.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/055cf3f6968d30561b5a43edec225fdd8df75138c6f9cee05f94e260c0a760c9c7c888423169ab27eab19068e7f555935dcab26ce9db940e005139f2758a82dd
+  checksum: 10c0/8cda9baeadd20cfc3ea770dca500dc6dab8cb40ac42c7cd0545b72830c3059ba06965546897e2e56e03cc6207681cee655051bb1c71faab285560d96fb795c5b
   languageName: node
   linkType: hard
 
@@ -8476,8 +8480,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@local/hash-backend-utils@workspace:libs/@local/hash-backend-utils"
   dependencies:
-    "@aws-sdk/client-s3": "npm:3.703.0"
-    "@aws-sdk/s3-request-presigner": "npm:3.703.0"
+    "@aws-sdk/client-s3": "npm:3.701.0"
+    "@aws-sdk/s3-request-presigner": "npm:3.701.0"
     "@blockprotocol/core": "npm:0.1.3"
     "@blockprotocol/graph": "npm:0.4.0-canary.0"
     "@blockprotocol/type-system": "npm:0.1.2-canary.0"
@@ -8531,6 +8535,7 @@ __metadata:
     "@rust/hash-graph-api": "npm:0.0.0-private"
     "@types/node": "npm:22.10.0"
     axios: "npm:1.7.8"
+    eslint: "npm:8.57.0"
     fix-esm-import-path: "npm:1.10.1"
     rimraf: "npm:6.0.1"
     typescript: "npm:5.6.3"
@@ -8655,6 +8660,7 @@ __metadata:
     "@openapitools/openapi-generator-cli": "npm:2.15.3"
     "@types/node": "npm:22.10.0"
     axios: "npm:1.7.8"
+    eslint: "npm:8.57.0"
     prettier: "npm:3.4.1"
     rimraf: "npm:6.0.1"
     typescript: "npm:5.6.3"
@@ -18974,7 +18980,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:8.17.1, ajv@npm:^8.0.0, ajv@npm:^8.11.2, ajv@npm:^8.12.0, ajv@npm:^8.9.0":
+"ajv@npm:8.17.1, ajv@npm:^8.0.0, ajv@npm:^8.0.1, ajv@npm:^8.11.2, ajv@npm:^8.12.0, ajv@npm:^8.9.0":
   version: 8.17.1
   resolution: "ajv@npm:8.17.1"
   dependencies:
@@ -19032,15 +19038,6 @@ __metadata:
   version: 6.2.1
   resolution: "ansi-escapes@npm:6.2.1"
   checksum: 10c0/a2c6f58b044be5f69662ee17073229b492daa2425a7fd99a665db6c22eab6e4ab42752807def7281c1c7acfed48f87f2362dda892f08c2c437f1b39c6b033103
-  languageName: node
-  linkType: hard
-
-"ansi-escapes@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "ansi-escapes@npm:7.0.0"
-  dependencies:
-    environment: "npm:^1.0.0"
-  checksum: 10c0/86e51e36fabef18c9c004af0a280573e828900641cea35134a124d2715e0c5a473494ab4ce396614505da77638ae290ff72dd8002d9747d2ee53f5d6bbe336be
   languageName: node
   linkType: hard
 
@@ -21284,7 +21281,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:5.3.0, chalk@npm:^5.2.0, chalk@npm:^5.3.0, chalk@npm:~5.3.0":
+"chalk@npm:5.3.0, chalk@npm:^5.0.1, chalk@npm:^5.2.0, chalk@npm:^5.3.0":
   version: 5.3.0
   resolution: "chalk@npm:5.3.0"
   checksum: 10c0/8297d436b2c0f95801103ff2ef67268d362021b8210daf8ddbe349695333eb3610a71122172ff3b0272f1ef2cf7cc2c41fdaa4715f52e49ffe04c56340feed09
@@ -21425,6 +21422,23 @@ __metadata:
   version: 0.0.2
   resolution: "charenc@npm:0.0.2"
   checksum: 10c0/a45ec39363a16799d0f9365c8dd0c78e711415113c6f14787a22462ef451f5013efae8a28f1c058f81fc01f2a6a16955f7a5fd0cd56247ce94a45349c89877d8
+  languageName: node
+  linkType: hard
+
+"check-dependency-version-consistency@npm:3.0.3":
+  version: 3.0.3
+  resolution: "check-dependency-version-consistency@npm:3.0.3"
+  dependencies:
+    chalk: "npm:^5.0.1"
+    commander: "npm:^9.0.0"
+    edit-json-file: "npm:^1.7.0"
+    globby: "npm:^13.1.1"
+    semver: "npm:^7.3.5"
+    table: "npm:^6.7.1"
+    type-fest: "npm:^2.1.0"
+  bin:
+    check-dependency-version-consistency: dist/bin/check-dependency-version-consistency.js
+  checksum: 10c0/7ff6a2bfd0e3208b095f04788f19b83dc2f8507148047f7f9e8ca7e7cd36ec39e43c4cccd072c1c9b1c05cfd9636a33b37af02f45e560f990f1471a838aadbb7
   languageName: node
   linkType: hard
 
@@ -21678,15 +21692,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-cursor@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "cli-cursor@npm:5.0.0"
-  dependencies:
-    restore-cursor: "npm:^5.0.0"
-  checksum: 10c0/7ec62f69b79f6734ab209a3e4dbdc8af7422d44d360a7cb1efa8a0887bbe466a6e625650c466fe4359aee44dbe2dc0b6994b583d40a05d0808a5cb193641d220
-  languageName: node
-  linkType: hard
-
 "cli-progress@npm:^3.12.0":
   version: 3.12.0
   resolution: "cli-progress@npm:3.12.0"
@@ -21733,16 +21738,6 @@ __metadata:
     slice-ansi: "npm:^5.0.0"
     string-width: "npm:^5.0.0"
   checksum: 10c0/a19088878409ec0e5dc2659a5166929629d93cfba6d68afc9cde2282fd4c751af5b555bf197047e31c87c574396348d011b7aa806fec29c4139ea4f7f00b324c
-  languageName: node
-  linkType: hard
-
-"cli-truncate@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "cli-truncate@npm:4.0.0"
-  dependencies:
-    slice-ansi: "npm:^5.0.0"
-    string-width: "npm:^7.0.0"
-  checksum: 10c0/d7f0b73e3d9b88cb496e6c086df7410b541b56a43d18ade6a573c9c18bd001b1c3fba1ad578f741a4218fdc794d042385f8ac02c25e1c295a2d8b9f3cb86eb4c
   languageName: node
   linkType: hard
 
@@ -22031,7 +22026,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"colorette@npm:^2.0.10, colorette@npm:^2.0.14, colorette@npm:^2.0.16, colorette@npm:^2.0.20":
+"colorette@npm:^2.0.10, colorette@npm:^2.0.14, colorette@npm:^2.0.16":
   version: 2.0.20
   resolution: "colorette@npm:2.0.20"
   checksum: 10c0/e94116ff33b0ff56f3b83b9ace895e5bf87c2a7a47b3401b8c3f3226e050d5ef76cf4072fb3325f9dc24d1698f9b730baf4e05eeaf861d74a1883073f4c98a40
@@ -22135,6 +22130,13 @@ __metadata:
   version: 6.2.1
   resolution: "commander@npm:6.2.1"
   checksum: 10c0/85748abd9d18c8bc88febed58b98f66b7c591d9b5017cad459565761d7b29ca13b7783ea2ee5ce84bf235897333706c4ce29adf1ce15c8252780e7000e2ce9ea
+  languageName: node
+  linkType: hard
+
+"commander@npm:^9.0.0":
+  version: 9.5.0
+  resolution: "commander@npm:9.5.0"
+  checksum: 10c0/5f7784fbda2aaec39e89eb46f06a999e00224b3763dc65976e05929ec486e174fe9aac2655f03ba6a5e83875bd173be5283dc19309b7c65954701c02025b3c1d
   languageName: node
   linkType: hard
 
@@ -23403,7 +23405,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.3.6, debug@npm:^4.3.7, debug@npm:~4.3.1, debug@npm:~4.3.2, debug@npm:~4.3.6":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.3.6, debug@npm:^4.3.7, debug@npm:~4.3.1, debug@npm:~4.3.2":
   version: 4.3.7
   resolution: "debug@npm:4.3.7"
   dependencies:
@@ -24458,6 +24460,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"edit-json-file@npm:^1.7.0":
+  version: 1.8.0
+  resolution: "edit-json-file@npm:1.8.0"
+  dependencies:
+    find-value: "npm:^1.0.12"
+    iterate-object: "npm:^1.3.4"
+    r-json: "npm:^1.2.10"
+    set-value: "npm:^4.1.0"
+    w-json: "npm:^1.3.10"
+  checksum: 10c0/3dc1e7da2245601bd301310d0a3d40123918eb9468268ad4f7b9aeb347fbf10286da026515be870d01b8e4fb5282254650113a6d501e14815663a94cb705e753
+  languageName: node
+  linkType: hard
+
 "ee-first@npm:1.1.1":
   version: 1.1.1
   resolution: "ee-first@npm:1.1.1"
@@ -24512,13 +24527,6 @@ __metadata:
   version: 5.2.1
   resolution: "emoji-mart@npm:5.2.1"
   checksum: 10c0/2701424c834a5d69bb5deb91a1d4eb11276b4b7b1df236a612474d6e757ca8ea0a4e87af00cfab95b6d95250edda79aca127179af56429665017c01c0e6ecf35
-  languageName: node
-  linkType: hard
-
-"emoji-regex@npm:^10.3.0":
-  version: 10.4.0
-  resolution: "emoji-regex@npm:10.4.0"
-  checksum: 10c0/a3fcedfc58bfcce21a05a5f36a529d81e88d602100145fcca3dc6f795e3c8acc4fc18fe773fbf9b6d6e9371205edb3afa2668ec3473fa2aa7fd47d2a9d46482d
   languageName: node
   linkType: hard
 
@@ -24693,13 +24701,6 @@ __metadata:
   bin:
     envinfo: dist/cli.js
   checksum: 10c0/059a031eee101e056bd9cc5cbfe25c2fab433fe1780e86cf0a82d24a000c6931e327da6a8ffb3dce528a24f83f256e7efc0b36813113eff8fdc6839018efe327
-  languageName: node
-  linkType: hard
-
-"environment@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "environment@npm:1.1.0"
-  checksum: 10c0/fb26434b0b581ab397039e51ff3c92b34924a98b2039dcb47e41b7bca577b9dbf134a8eadb364415c74464b682e2d3afe1a4c0eb9873dc44ea814c5d3103331d
   languageName: node
   linkType: hard
 
@@ -25939,24 +25940,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "execa@npm:6.1.0"
-  dependencies:
-    cross-spawn: "npm:^7.0.3"
-    get-stream: "npm:^6.0.1"
-    human-signals: "npm:^3.0.1"
-    is-stream: "npm:^3.0.0"
-    merge-stream: "npm:^2.0.0"
-    npm-run-path: "npm:^5.1.0"
-    onetime: "npm:^6.0.0"
-    signal-exit: "npm:^3.0.7"
-    strip-final-newline: "npm:^3.0.0"
-  checksum: 10c0/004ee32092af745766a1b0352fdba8701a4001bc3fe08e63101c04276d4c860bbe11bb8ab85f37acdff13d3da83d60e044041dcf24bd7e25e645a543828d9c41
-  languageName: node
-  linkType: hard
-
-"execa@npm:^8.0.1, execa@npm:~8.0.1":
+"execa@npm:^8.0.1":
   version: 8.0.1
   resolution: "execa@npm:8.0.1"
   dependencies:
@@ -26721,6 +26705,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"find-value@npm:^1.0.12":
+  version: 1.0.12
+  resolution: "find-value@npm:1.0.12"
+  checksum: 10c0/71fa0c4cd003ca09c3a679c99b899a1d45d60e325f858fd463c484358a3424c7dba9ff965b67764ba3226ffe6642cf458c5be7797fdd68c90fb9c0a9eae4e39c
+  languageName: node
+  linkType: hard
+
 "find-yarn-workspace-root2@npm:1.2.16":
   version: 1.2.16
   resolution: "find-yarn-workspace-root2@npm:1.2.16"
@@ -27349,13 +27340,6 @@ __metadata:
   version: 2.0.5
   resolution: "get-caller-file@npm:2.0.5"
   checksum: 10c0/c6c7b60271931fa752aeb92f2b47e355eac1af3a2673f47c9589e8f8a41adc74d45551c1bc57b5e66a80609f10ffb72b6f575e4370d61cc3f7f3aaff01757cde
-  languageName: node
-  linkType: hard
-
-"get-east-asian-width@npm:^1.0.0":
-  version: 1.3.0
-  resolution: "get-east-asian-width@npm:1.3.0"
-  checksum: 10c0/1a049ba697e0f9a4d5514c4623781c5246982bdb61082da6b5ae6c33d838e52ce6726407df285cdbb27ec1908b333cf2820989bd3e986e37bb20979437fdf34b
   languageName: node
   linkType: hard
 
@@ -28320,18 +28304,20 @@ __metadata:
     "@sentry/cli": "npm:^2.39.1"
     "@taplo/cli": "npm:0.7.0"
     "@yarnpkg/types": "npm:^4.0.0"
+    check-dependency-version-consistency: "npm:3.0.3"
     concurrently: "npm:7.6.0"
-    husky: "npm:8.0.3"
+    cross-env: "npm:7.0.3"
+    dotenv-flow: "npm:3.3.0"
     lefthook: "npm:1.8.5"
-    lint-staged: "npm:15.2.10"
     lockfile-lint: "npm:4.14.0"
     markdownlint-cli: "npm:0.43.0"
     npm-run-all2: "npm:7.0.1"
+    postinstall-postinstall: "npm:2.1.0"
     prettier: "npm:3.4.1"
     prettier-plugin-packagejson: "npm:2.5.6"
     prettier-plugin-sh: "npm:0.14.0"
-    suppress-exit-code: "npm:3.2.0"
     turbo: "npm:2.3.3"
+    wait-on: "npm:8.0.1"
   languageName: unknown
   linkType: soft
 
@@ -29045,13 +29031,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"human-signals@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "human-signals@npm:3.0.1"
-  checksum: 10c0/0bb27e72aea1666322f69ab9816e05df952ef2160346f2293f98f45d472edb1b62d0f1a596697b50d48d8f8222e6db3b9f9dc0b6bf6113866121001f0a8e48e9
-  languageName: node
-  linkType: hard
-
 "human-signals@npm:^4.3.0":
   version: 4.3.1
   resolution: "human-signals@npm:4.3.1"
@@ -29072,15 +29051,6 @@ __metadata:
   dependencies:
     ms: "npm:^2.0.0"
   checksum: 10c0/f34a2c20161d02303c2807badec2f3b49cbfbbb409abd4f95a07377ae01cfe6b59e3d15ac609cffcd8f2521f0eb37b7e1091acf65da99aa2a4f1ad63c21e7e7a
-  languageName: node
-  linkType: hard
-
-"husky@npm:8.0.3":
-  version: 8.0.3
-  resolution: "husky@npm:8.0.3"
-  bin:
-    husky: lib/bin.js
-  checksum: 10c0/6722591771c657b91a1abb082e07f6547eca79144d678e586828ae806499d90dce2a6aee08b66183fd8b085f19d20e0990a2ad396961746b4c8bd5bdb619d668
   languageName: node
   linkType: hard
 
@@ -29882,15 +29852,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-fullwidth-code-point@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "is-fullwidth-code-point@npm:5.0.0"
-  dependencies:
-    get-east-asian-width: "npm:^1.0.0"
-  checksum: 10c0/cd591b27d43d76b05fa65ed03eddce57a16e1eca0b7797ff7255de97019bcaf0219acfc0c4f7af13319e13541f2a53c0ace476f442b13267b9a6a7568f2b65c8
-  languageName: node
-  linkType: hard
-
 "is-generator-function@npm:^1.0.10, is-generator-function@npm:^1.0.7":
   version: 1.0.10
   resolution: "is-generator-function@npm:1.0.10"
@@ -30162,6 +30123,13 @@ __metadata:
   version: 1.0.1
   resolution: "is-potential-custom-element-name@npm:1.0.1"
   checksum: 10c0/b73e2f22bc863b0939941d369486d308b43d7aef1f9439705e3582bfccaa4516406865e32c968a35f97a99396dac84e2624e67b0a16b0a15086a785e16ce7db9
+  languageName: node
+  linkType: hard
+
+"is-primitive@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "is-primitive@npm:3.0.1"
+  checksum: 10c0/2e3b6f029fabbdda467ea51ea4fdd00e6552434108b863a08f296638072c506a7c195089e3e31f83e7fc14bebbd1c5c9f872fe127c9284a7665c8227b47ffdd6
   languageName: node
   linkType: hard
 
@@ -30792,6 +30760,13 @@ __metadata:
   version: 1.2.1
   resolution: "iterare@npm:1.2.1"
   checksum: 10c0/02667d486e3e83ead028ba8484d927498c2ceab7e8c6a69dd881fd02abc4114f00b13abb36b592252fbb578b6e6f99ca1dfc2835408b9158c9a112a9964f453f
+  languageName: node
+  linkType: hard
+
+"iterate-object@npm:^1.3.4":
+  version: 1.3.4
+  resolution: "iterate-object@npm:1.3.4"
+  checksum: 10c0/ff37f08223397ea637af136061ba74590efe5b29be5ca9006ae8168ce2faca67b0b4ebc763317173da65d2ae3ba81c1b51f4ceb80092a7bc668f3798f63db9e2
   languageName: node
   linkType: hard
 
@@ -31877,13 +31852,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lilconfig@npm:~3.1.2":
-  version: 3.1.2
-  resolution: "lilconfig@npm:3.1.2"
-  checksum: 10c0/f059630b1a9bddaeba83059db00c672b64dc14074e9f232adce32b38ca1b5686ab737eb665c5ba3c32f147f0002b4bee7311ad0386a9b98547b5623e87071fbe
-  languageName: node
-  linkType: hard
-
 "lines-and-columns@npm:^1.1.6":
   version: 1.2.4
   resolution: "lines-and-columns@npm:1.2.4"
@@ -31897,26 +31865,6 @@ __metadata:
   dependencies:
     uc.micro: "npm:^2.0.0"
   checksum: 10c0/ff4abbcdfa2003472fc3eb4b8e60905ec97718e11e33cca52059919a4c80cc0e0c2a14d23e23d8c00e5402bc5a885cdba8ca053a11483ab3cc8b3c7a52f88e2d
-  languageName: node
-  linkType: hard
-
-"lint-staged@npm:15.2.10":
-  version: 15.2.10
-  resolution: "lint-staged@npm:15.2.10"
-  dependencies:
-    chalk: "npm:~5.3.0"
-    commander: "npm:~12.1.0"
-    debug: "npm:~4.3.6"
-    execa: "npm:~8.0.1"
-    lilconfig: "npm:~3.1.2"
-    listr2: "npm:~8.2.4"
-    micromatch: "npm:~4.0.8"
-    pidtree: "npm:~0.6.0"
-    string-argv: "npm:~0.3.2"
-    yaml: "npm:~2.5.0"
-  bin:
-    lint-staged: bin/lint-staged.js
-  checksum: 10c0/6ad7b41f5e87a84fa2eb1990080ea3c68a2f2031b4e81edcdc2a458cc878538eedb310e6f98ffd878a1287e1a52ac968e540ee8a0e96c247e04b0cbc36421cdd
   languageName: node
   linkType: hard
 
@@ -31938,20 +31886,6 @@ __metadata:
     enquirer:
       optional: true
   checksum: 10c0/0e64dc5e66fbd4361f6b35c49489ed842a1d7de30cf2b5c06bf4569669449288698b8ea93f7842aaf3c510963a1e554bca31376b9054d1521445d1ce4c917ea1
-  languageName: node
-  linkType: hard
-
-"listr2@npm:~8.2.4":
-  version: 8.2.5
-  resolution: "listr2@npm:8.2.5"
-  dependencies:
-    cli-truncate: "npm:^4.0.0"
-    colorette: "npm:^2.0.20"
-    eventemitter3: "npm:^5.0.1"
-    log-update: "npm:^6.1.0"
-    rfdc: "npm:^1.4.1"
-    wrap-ansi: "npm:^9.0.0"
-  checksum: 10c0/f5a9599514b00c27d7eb32d1117c83c61394b2a985ec20e542c798bf91cf42b19340215701522736f5b7b42f557e544afeadec47866e35e5d4f268f552729671
   languageName: node
   linkType: hard
 
@@ -32362,6 +32296,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.truncate@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "lodash.truncate@npm:4.4.2"
+  checksum: 10c0/4e870d54e8a6c86c8687e057cec4069d2e941446ccab7f40b4d9555fa5872d917d0b6aa73bece7765500a3123f1723bcdba9ae881b679ef120bba9e1a0b0ed70
+  languageName: node
+  linkType: hard
+
 "lodash.union@npm:^4.6.0":
   version: 4.6.0
   resolution: "lodash.union@npm:4.6.0"
@@ -32418,19 +32359,6 @@ __metadata:
     slice-ansi: "npm:^4.0.0"
     wrap-ansi: "npm:^6.2.0"
   checksum: 10c0/18b299e230432a156f2535660776406d15ba8bb7817dd3eaadd58004b363756d4ecaabcd658f9949f90b62ea7d3354423be3fdeb7a201ab951ec0e8d6139af86
-  languageName: node
-  linkType: hard
-
-"log-update@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "log-update@npm:6.1.0"
-  dependencies:
-    ansi-escapes: "npm:^7.0.0"
-    cli-cursor: "npm:^5.0.0"
-    slice-ansi: "npm:^7.1.0"
-    strip-ansi: "npm:^7.1.0"
-    wrap-ansi: "npm:^9.0.0"
-  checksum: 10c0/4b350c0a83d7753fea34dcac6cd797d1dc9603291565de009baa4aa91c0447eab0d3815a05c8ec9ac04fdfffb43c82adcdb03ec1fceafd8518e1a8c1cff4ff89
   languageName: node
   linkType: hard
 
@@ -34387,7 +34315,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.0, micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.5, micromatch@npm:^4.0.8, micromatch@npm:~4.0.8":
+"micromatch@npm:^4.0.0, micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.5, micromatch@npm:^4.0.8":
   version: 4.0.8
   resolution: "micromatch@npm:4.0.8"
   dependencies:
@@ -34485,13 +34413,6 @@ __metadata:
   version: 4.0.0
   resolution: "mimic-fn@npm:4.0.0"
   checksum: 10c0/de9cc32be9996fd941e512248338e43407f63f6d497abe8441fa33447d922e927de54d4cc3c1a3c6d652857acd770389d5a3823f311a744132760ce2be15ccbf
-  languageName: node
-  linkType: hard
-
-"mimic-function@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "mimic-function@npm:5.0.1"
-  checksum: 10c0/f3d9464dd1816ecf6bdf2aec6ba32c0728022039d992f178237d8e289b48764fee4131319e72eedd4f7f094e22ded0af836c3187a7edc4595d28dd74368fd81d
   languageName: node
   linkType: hard
 
@@ -36365,15 +36286,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"onetime@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "onetime@npm:7.0.0"
-  dependencies:
-    mimic-function: "npm:^5.0.0"
-  checksum: 10c0/5cb9179d74b63f52a196a2e7037ba2b9a893245a5532d3f44360012005c9cadb60851d56716ebff18a6f47129dab7168022445df47c2aff3b276d92585ed1221
-  languageName: node
-  linkType: hard
-
 "onnx-proto@npm:^4.0.4":
   version: 4.0.4
   resolution: "onnx-proto@npm:4.0.4"
@@ -37509,7 +37421,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pidtree@npm:^0.6.0, pidtree@npm:~0.6.0":
+"pidtree@npm:^0.6.0":
   version: 0.6.0
   resolution: "pidtree@npm:0.6.0"
   bin:
@@ -37924,6 +37836,13 @@ __metadata:
   dependencies:
     axios: "npm:^0.27.0"
   checksum: 10c0/5df24696dc8047def4a001cf9137c31ac32f46e9ba6a906fe3908641b9b468578af9d36c720b9f18c02981d2bb8137a85b35693d406e7955ac0d57aba9f9447e
+  languageName: node
+  linkType: hard
+
+"postinstall-postinstall@npm:2.1.0":
+  version: 2.1.0
+  resolution: "postinstall-postinstall@npm:2.1.0"
+  checksum: 10c0/70488447292c712afa7806126824d6fe93362392cbe261ae60166d9119a350713e0dbf4deb2ca91637c1037bc030ed1de78d61d9041bf2504513070f1caacdfd
   languageName: node
   linkType: hard
 
@@ -38885,6 +38804,15 @@ __metadata:
   version: 1.0.0
   resolution: "quote-unquote@npm:1.0.0"
   checksum: 10c0/eba86bb7f68ada486f5608c5c71cc155235f0408b8a0a180436cdf2457ae86f56a17de6b0bc5a1b7ae5f27735b3b789662cdf7f3b8195ac816cd0289085129ec
+  languageName: node
+  linkType: hard
+
+"r-json@npm:^1.2.10":
+  version: 1.3.0
+  resolution: "r-json@npm:1.3.0"
+  dependencies:
+    w-json: "npm:1.3.10"
+  checksum: 10c0/de54df28ee2642767c821818257da87d68d72f443cdb1db2256afc1dba9701acdebb0afbea9017680daff483464dfe02ba9692a9b1dfea29a14ba3ce0a9e9fcb
   languageName: node
   linkType: hard
 
@@ -40624,16 +40552,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"restore-cursor@npm:^5.0.0":
-  version: 5.1.0
-  resolution: "restore-cursor@npm:5.1.0"
-  dependencies:
-    onetime: "npm:^7.0.0"
-    signal-exit: "npm:^4.1.0"
-  checksum: 10c0/c2ba89131eea791d1b25205bdfdc86699767e2b88dee2a590b1a6caa51737deac8bad0260a5ded2f7c074b7db2f3a626bcf1fcf3cdf35974cbeea5e2e6764f60
-  languageName: node
-  linkType: hard
-
 "ret@npm:~0.1.10":
   version: 0.1.15
   resolution: "ret@npm:0.1.15"
@@ -40673,7 +40591,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rfdc@npm:^1.3.0, rfdc@npm:^1.3.1, rfdc@npm:^1.4.1":
+"rfdc@npm:^1.3.0, rfdc@npm:^1.3.1":
   version: 1.4.1
   resolution: "rfdc@npm:1.4.1"
   checksum: 10c0/4614e4292356cafade0b6031527eea9bc90f2372a22c012313be1dcc69a3b90c7338158b414539be863fa95bfcb2ddcd0587be696841af4e6679d85e62c060c7
@@ -41055,9 +40973,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass@npm:1.81.1, sass@npm:^1.52.3":
-  version: 1.81.1
-  resolution: "sass@npm:1.81.1"
+"sass@npm:1.81.0, sass@npm:^1.52.3":
+  version: 1.81.0
+  resolution: "sass@npm:1.81.0"
   dependencies:
     "@parcel/watcher": "npm:^2.4.1"
     chokidar: "npm:^4.0.0"
@@ -41068,7 +40986,7 @@ __metadata:
       optional: true
   bin:
     sass: sass.js
-  checksum: 10c0/be30371b1706ae84ca39fc724368deae5fd9cf94f4737fb0120f166e81545d113d1aa9abd3d797cf66f1d48625ab20ec838509f157d23e3e1e57c6a7e5e78cda
+  checksum: 10c0/9c59b3c9b4231c18fcb4583cc232dbc4de501ddc11101b7a025e44833e3f3ce6031546dc1cd109ee9f04ebcfb1fe30ff870810af33b8feb9aa9e36dfba9ec1ef
   languageName: node
   linkType: hard
 
@@ -41406,6 +41324,16 @@ __metadata:
   dependencies:
     "@babel/runtime": "npm:7.5.0"
   checksum: 10c0/453265515bbab66342012cf83ae8150c096c9ffe739a302e5489ad5ca518a206de7b75b69fe160071ebe220b74f6376e4bd7c9c3a382da1f2a1f92bbd065d10b
+  languageName: node
+  linkType: hard
+
+"set-value@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "set-value@npm:4.1.0"
+  dependencies:
+    is-plain-object: "npm:^2.0.4"
+    is-primitive: "npm:^3.0.1"
+  checksum: 10c0/dc186676b6cc0cfcf1656b8acdfe7a68591f0645dd2872250100817fb53e5e9298dc1727a95605ac03f82110e9b3820c90a0a02d84e0fb89f210922b08b37e02
   languageName: node
   linkType: hard
 
@@ -41927,16 +41855,6 @@ __metadata:
     ansi-styles: "npm:^6.2.1"
     is-fullwidth-code-point: "npm:^4.0.0"
   checksum: 10c0/d105f1296c2c5744a1fb5bedd69ad55596fabe95b0b3533c046969dd34d928b4794ff46ef18054d8f5786d6fbc7d8b94937391c10f8db89d8c236e47403223b8
-  languageName: node
-  linkType: hard
-
-"slice-ansi@npm:^7.1.0":
-  version: 7.1.0
-  resolution: "slice-ansi@npm:7.1.0"
-  dependencies:
-    ansi-styles: "npm:^6.2.1"
-    is-fullwidth-code-point: "npm:^5.0.0"
-  checksum: 10c0/631c971d4abf56cf880f034d43fcc44ff883624867bf11ecbd538c47343911d734a4656d7bc02362b40b89d765652a7f935595441e519b59e2ad3f4d5d6fe7ca
   languageName: node
   linkType: hard
 
@@ -42559,13 +42477,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-argv@npm:~0.3.2":
-  version: 0.3.2
-  resolution: "string-argv@npm:0.3.2"
-  checksum: 10c0/75c02a83759ad1722e040b86823909d9a2fc75d15dd71ec4b537c3560746e33b5f5a07f7332d1e3f88319909f82190843aa2f0a0d8c8d591ec08e93d5b8dec82
-  languageName: node
-  linkType: hard
-
 "string-collapse-leading-whitespace@npm:^7.0.7":
   version: 7.0.7
   resolution: "string-collapse-leading-whitespace@npm:7.0.7"
@@ -42671,17 +42582,6 @@ __metadata:
     emoji-regex: "npm:^9.2.2"
     strip-ansi: "npm:^7.0.1"
   checksum: 10c0/ab9c4264443d35b8b923cbdd513a089a60de339216d3b0ed3be3ba57d6880e1a192b70ae17225f764d7adbf5994e9bb8df253a944736c15a0240eff553c678ca
-  languageName: node
-  linkType: hard
-
-"string-width@npm:^7.0.0":
-  version: 7.2.0
-  resolution: "string-width@npm:7.2.0"
-  dependencies:
-    emoji-regex: "npm:^10.3.0"
-    get-east-asian-width: "npm:^1.0.0"
-    strip-ansi: "npm:^7.1.0"
-  checksum: 10c0/eb0430dd43f3199c7a46dcbf7a0b34539c76fe3aa62763d0b0655acdcbdf360b3f66f3d58ca25ba0205f42ea3491fa00f09426d3b7d3040e506878fc7664c9b9
   languageName: node
   linkType: hard
 
@@ -43145,17 +43045,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"suppress-exit-code@npm:3.2.0":
-  version: 3.2.0
-  resolution: "suppress-exit-code@npm:3.2.0"
-  dependencies:
-    execa: "npm:^6.1.0"
-  bin:
-    suppress-exit-code: main.js
-  checksum: 10c0/173508a1472e2c7e63ad71c283e9744f58c3c38021bc1641e33ceaa662a63ed28db6c7fe9cce5c4152eb1fc9667a74a6bf37ce0eecc612e8eb9ee597a5e2a85c
-  languageName: node
-  linkType: hard
-
 "svg-parser@npm:^2.0.4":
   version: 2.0.4
   resolution: "svg-parser@npm:2.0.4"
@@ -43286,6 +43175,19 @@ __metadata:
     typical: "npm:^2.6.1"
     wordwrapjs: "npm:^3.0.0"
   checksum: 10c0/0abe0256d6f588998f42e3ad9e54625d2c5a7ab60a21f600bd8d811af95d11a39a0c113fe74f6bbc0e8523d64251fb7ecb6aef73d1a04f90889b1d449592d55a
+  languageName: node
+  linkType: hard
+
+"table@npm:^6.7.1":
+  version: 6.8.2
+  resolution: "table@npm:6.8.2"
+  dependencies:
+    ajv: "npm:^8.0.1"
+    lodash.truncate: "npm:^4.4.2"
+    slice-ansi: "npm:^4.0.0"
+    string-width: "npm:^4.2.3"
+    strip-ansi: "npm:^6.0.1"
+  checksum: 10c0/f8b348af38ee34e419d8ce7306ba00671ce6f20e861ccff22555f491ba264e8416086063ce278a8d81abfa8d23b736ec2cca7ac4029b5472f63daa4b4688b803
   languageName: node
   linkType: hard
 
@@ -44537,7 +44439,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^2.12.2, type-fest@npm:^2.19.0, type-fest@npm:^2.3.3, type-fest@npm:~2.19":
+"type-fest@npm:^2.1.0, type-fest@npm:^2.12.2, type-fest@npm:^2.19.0, type-fest@npm:^2.3.3, type-fest@npm:~2.19":
   version: 2.19.0
   resolution: "type-fest@npm:2.19.0"
   checksum: 10c0/a5a7ecf2e654251613218c215c7493574594951c08e52ab9881c9df6a6da0aeca7528c213c622bc374b4e0cb5c443aa3ab758da4e3c959783ce884c3194e12cb
@@ -45993,6 +45895,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"w-json@npm:1.3.10, w-json@npm:^1.3.10":
+  version: 1.3.10
+  resolution: "w-json@npm:1.3.10"
+  checksum: 10c0/441bf7685d8c8d9ff787066d75c66f7a66794a90ea7577d9e94103089427f04117176b40bdf4def505c5f90ee3e65a4f569765754e866f688d68e4521da1fa94
+  languageName: node
+  linkType: hard
+
 "w3c-keyname@npm:^2.2.0":
   version: 2.2.8
   resolution: "w3c-keyname@npm:2.2.8"
@@ -46822,17 +46731,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrap-ansi@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "wrap-ansi@npm:9.0.0"
-  dependencies:
-    ansi-styles: "npm:^6.2.1"
-    string-width: "npm:^7.0.0"
-    strip-ansi: "npm:^7.1.0"
-  checksum: 10c0/a139b818da9573677548dd463bd626a5a5286271211eb6e4e82f34a4f643191d74e6d4a9bb0a3c26ec90e6f904f679e0569674ac099ea12378a8b98e20706066
-  languageName: node
-  linkType: hard
-
 "wrappy@npm:1":
   version: 1.0.2
   resolution: "wrappy@npm:1.0.2"
@@ -47104,15 +47002,6 @@ __metadata:
   bin:
     yaml: bin.mjs
   checksum: 10c0/aebf07f61c72b38c74d2b60c3a3ccf89ee4da45bcd94b2bfb7899ba07a5257625a7c9f717c65a6fc511563d48001e01deb1d9e55f0133f3e2edf86039c8c1be7
-  languageName: node
-  linkType: hard
-
-"yaml@npm:~2.5.0":
-  version: 2.5.1
-  resolution: "yaml@npm:2.5.1"
-  bin:
-    yaml: bin.mjs
-  checksum: 10c0/40fba5682898dbeeb3319e358a968fe886509fab6f58725732a15f8dda3abac509f91e76817c708c9959a15f786f38ff863c1b88062d7c1162c5334a7d09cb4a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -40906,7 +40906,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass@npm:1.81.1":
+"sass@npm:1.81.1, sass@npm:^1.52.3":
   version: 1.81.1
   resolution: "sass@npm:1.81.1"
   dependencies:
@@ -40920,23 +40920,6 @@ __metadata:
   bin:
     sass: sass.js
   checksum: 10c0/be30371b1706ae84ca39fc724368deae5fd9cf94f4737fb0120f166e81545d113d1aa9abd3d797cf66f1d48625ab20ec838509f157d23e3e1e57c6a7e5e78cda
-  languageName: node
-  linkType: hard
-
-"sass@npm:^1.52.3":
-  version: 1.81.0
-  resolution: "sass@npm:1.81.0"
-  dependencies:
-    "@parcel/watcher": "npm:^2.4.1"
-    chokidar: "npm:^4.0.0"
-    immutable: "npm:^5.0.2"
-    source-map-js: "npm:>=0.6.2 <2.0.0"
-  dependenciesMeta:
-    "@parcel/watcher":
-      optional: true
-  bin:
-    sass: sass.js
-  checksum: 10c0/9c59b3c9b4231c18fcb4583cc232dbc4de501ddc11101b7a025e44833e3f3ce6031546dc1cd109ee9f04ebcfb1fe30ff870810af33b8feb9aa9e36dfba9ec1ef
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -328,7 +328,6 @@ __metadata:
     ajv-formats: "npm:3.0.1"
     axios: "npm:1.7.8"
     cache-manager: "npm:5.7.6"
-    cross-env: "npm:7.0.3"
     dedent: "npm:0.7.0"
     dotenv-flow: "npm:3.3.0"
     e2b: "npm:0.13.1"
@@ -368,11 +367,11 @@ __metadata:
   resolution: "@apps/hash-api@workspace:apps/hash-api"
   dependencies:
     "@apps/hash-graph": "npm:0.0.0-private"
-    "@aws-sdk/client-s3": "npm:3.701.0"
+    "@aws-sdk/client-s3": "npm:3.703.0"
     "@aws-sdk/client-ses": "npm:3.699.0"
     "@aws-sdk/credential-provider-node": "npm:3.699.0"
-    "@aws-sdk/s3-presigned-post": "npm:3.701.0"
-    "@aws-sdk/s3-request-presigner": "npm:3.701.0"
+    "@aws-sdk/s3-presigned-post": "npm:3.703.0"
+    "@aws-sdk/s3-request-presigner": "npm:3.703.0"
     "@blockprotocol/core": "npm:0.1.3"
     "@blockprotocol/graph": "npm:0.4.0-canary.0"
     "@blockprotocol/type-system": "npm:0.1.2-canary.0"
@@ -608,7 +607,7 @@ __metadata:
     rimraf: "npm:6.0.1"
     rooks: "npm:7.14.1"
     safe-stable-stringify: "npm:2.5.0"
-    sass: "npm:1.81.0"
+    sass: "npm:1.81.1"
     setimmediate: "npm:1.0.5"
     sigma: "npm:3.0.0-beta.38"
     signia: "npm:0.1.5"
@@ -666,7 +665,6 @@ __metadata:
     "@types/dotenv-flow": "npm:3.3.3"
     agentkeepalive: "npm:4.5.0"
     axios: "npm:1.7.8"
-    cross-env: "npm:7.0.3"
     dotenv-flow: "npm:3.3.0"
     eslint: "npm:8.57.0"
     rimraf: "npm:6.0.1"
@@ -685,7 +683,6 @@ __metadata:
     "@local/tsconfig": "npm:0.0.0-private"
     "@types/node": "npm:22.10.0"
     "@types/set-interval-async": "npm:1.0.3"
-    cross-env: "npm:7.0.3"
     eslint: "npm:8.57.0"
     set-interval-async: "npm:2.0.3"
     slonik: "npm:24.2.0"
@@ -704,7 +701,6 @@ __metadata:
     "@local/hash-isomorphic-utils": "npm:0.0.0-private"
     "@local/tsconfig": "npm:0.0.0-private"
     "@types/node": "npm:22.10.0"
-    cross-env: "npm:7.0.3"
     eslint: "npm:8.57.0"
     hot-shots: "npm:8.5.2"
     tsx: "npm:4.19.2"
@@ -865,7 +861,7 @@ __metadata:
     react-refresh: "npm:0.14.0"
     react-refresh-typescript: "npm:2.0.9"
     rimraf: "npm:6.0.1"
-    sass: "npm:1.81.0"
+    sass: "npm:1.81.1"
     sass-loader: "npm:13.3.3"
     source-map-loader: "npm:3.0.2"
     style-loader: "npm:3.3.4"
@@ -1289,9 +1285,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-s3@npm:3.701.0":
-  version: 3.701.0
-  resolution: "@aws-sdk/client-s3@npm:3.701.0"
+"@aws-sdk/client-s3@npm:3.703.0":
+  version: 3.703.0
+  resolution: "@aws-sdk/client-s3@npm:3.703.0"
   dependencies:
     "@aws-crypto/sha1-browser": "npm:5.2.0"
     "@aws-crypto/sha256-browser": "npm:5.2.0"
@@ -1351,7 +1347,7 @@ __metadata:
     "@smithy/util-utf8": "npm:^3.0.0"
     "@smithy/util-waiter": "npm:^3.1.9"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/b7eeb84dddb1c5581de6210ecdfd943a1f94582d30bf58e7ce2ff7ecdbfee68edf01838c0f78f015ebfb134f60cb27d6827f85b78ad8b90cb6516a072425987f
+  checksum: 10c0/eba492878a32cad0709383af4d56b9df95e8de02d99963cb9e3bdb60ade49c8617c857340bd0348711f2212b9ca6d9f7dc00ea80c001ac31afcdeee6824b702d
   languageName: node
   linkType: hard
 
@@ -1941,11 +1937,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/s3-presigned-post@npm:3.701.0":
-  version: 3.701.0
-  resolution: "@aws-sdk/s3-presigned-post@npm:3.701.0"
+"@aws-sdk/s3-presigned-post@npm:3.703.0":
+  version: 3.703.0
+  resolution: "@aws-sdk/s3-presigned-post@npm:3.703.0"
   dependencies:
-    "@aws-sdk/client-s3": "npm:3.701.0"
+    "@aws-sdk/client-s3": "npm:3.703.0"
     "@aws-sdk/types": "npm:3.696.0"
     "@aws-sdk/util-format-url": "npm:3.696.0"
     "@smithy/middleware-endpoint": "npm:^3.2.3"
@@ -1954,13 +1950,13 @@ __metadata:
     "@smithy/util-hex-encoding": "npm:^3.0.0"
     "@smithy/util-utf8": "npm:^3.0.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/6473d4e248e0ad265e6ea4753c5a46be9827e4ac12022780343b0e9a24f33017ce963c337d7a651991780d3fe7b5ff5084eb577b62ab4a917529fb5409494dcd
+  checksum: 10c0/6c9f72bbf4ba7e269685ec5cade64b8746e21586c5a86b47bd3d2d3a1ca61efaa3620e2c7f4baa3f6e356e443a14bdfbab4422b6b8158cbed237c3d9ec00e5f9
   languageName: node
   linkType: hard
 
-"@aws-sdk/s3-request-presigner@npm:3.701.0":
-  version: 3.701.0
-  resolution: "@aws-sdk/s3-request-presigner@npm:3.701.0"
+"@aws-sdk/s3-request-presigner@npm:3.703.0":
+  version: 3.703.0
+  resolution: "@aws-sdk/s3-request-presigner@npm:3.703.0"
   dependencies:
     "@aws-sdk/signature-v4-multi-region": "npm:3.696.0"
     "@aws-sdk/types": "npm:3.696.0"
@@ -1970,7 +1966,7 @@ __metadata:
     "@smithy/smithy-client": "npm:^3.4.4"
     "@smithy/types": "npm:^3.7.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/8cda9baeadd20cfc3ea770dca500dc6dab8cb40ac42c7cd0545b72830c3059ba06965546897e2e56e03cc6207681cee655051bb1c71faab285560d96fb795c5b
+  checksum: 10c0/055cf3f6968d30561b5a43edec225fdd8df75138c6f9cee05f94e260c0a760c9c7c888423169ab27eab19068e7f555935dcab26ce9db940e005139f2758a82dd
   languageName: node
   linkType: hard
 
@@ -8480,8 +8476,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@local/hash-backend-utils@workspace:libs/@local/hash-backend-utils"
   dependencies:
-    "@aws-sdk/client-s3": "npm:3.701.0"
-    "@aws-sdk/s3-request-presigner": "npm:3.701.0"
+    "@aws-sdk/client-s3": "npm:3.703.0"
+    "@aws-sdk/s3-request-presigner": "npm:3.703.0"
     "@blockprotocol/core": "npm:0.1.3"
     "@blockprotocol/graph": "npm:0.4.0-canary.0"
     "@blockprotocol/type-system": "npm:0.1.2-canary.0"
@@ -8535,7 +8531,6 @@ __metadata:
     "@rust/hash-graph-api": "npm:0.0.0-private"
     "@types/node": "npm:22.10.0"
     axios: "npm:1.7.8"
-    eslint: "npm:8.57.0"
     fix-esm-import-path: "npm:1.10.1"
     rimraf: "npm:6.0.1"
     typescript: "npm:5.6.3"
@@ -8660,7 +8655,6 @@ __metadata:
     "@openapitools/openapi-generator-cli": "npm:2.15.3"
     "@types/node": "npm:22.10.0"
     axios: "npm:1.7.8"
-    eslint: "npm:8.57.0"
     prettier: "npm:3.4.1"
     rimraf: "npm:6.0.1"
     typescript: "npm:5.6.3"
@@ -18980,7 +18974,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:8.17.1, ajv@npm:^8.0.0, ajv@npm:^8.0.1, ajv@npm:^8.11.2, ajv@npm:^8.12.0, ajv@npm:^8.9.0":
+"ajv@npm:8.17.1, ajv@npm:^8.0.0, ajv@npm:^8.11.2, ajv@npm:^8.12.0, ajv@npm:^8.9.0":
   version: 8.17.1
   resolution: "ajv@npm:8.17.1"
   dependencies:
@@ -21281,7 +21275,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:5.3.0, chalk@npm:^5.0.1, chalk@npm:^5.2.0, chalk@npm:^5.3.0":
+"chalk@npm:5.3.0, chalk@npm:^5.2.0, chalk@npm:^5.3.0":
   version: 5.3.0
   resolution: "chalk@npm:5.3.0"
   checksum: 10c0/8297d436b2c0f95801103ff2ef67268d362021b8210daf8ddbe349695333eb3610a71122172ff3b0272f1ef2cf7cc2c41fdaa4715f52e49ffe04c56340feed09
@@ -21422,23 +21416,6 @@ __metadata:
   version: 0.0.2
   resolution: "charenc@npm:0.0.2"
   checksum: 10c0/a45ec39363a16799d0f9365c8dd0c78e711415113c6f14787a22462ef451f5013efae8a28f1c058f81fc01f2a6a16955f7a5fd0cd56247ce94a45349c89877d8
-  languageName: node
-  linkType: hard
-
-"check-dependency-version-consistency@npm:3.0.3":
-  version: 3.0.3
-  resolution: "check-dependency-version-consistency@npm:3.0.3"
-  dependencies:
-    chalk: "npm:^5.0.1"
-    commander: "npm:^9.0.0"
-    edit-json-file: "npm:^1.7.0"
-    globby: "npm:^13.1.1"
-    semver: "npm:^7.3.5"
-    table: "npm:^6.7.1"
-    type-fest: "npm:^2.1.0"
-  bin:
-    check-dependency-version-consistency: dist/bin/check-dependency-version-consistency.js
-  checksum: 10c0/7ff6a2bfd0e3208b095f04788f19b83dc2f8507148047f7f9e8ca7e7cd36ec39e43c4cccd072c1c9b1c05cfd9636a33b37af02f45e560f990f1471a838aadbb7
   languageName: node
   linkType: hard
 
@@ -22130,13 +22107,6 @@ __metadata:
   version: 6.2.1
   resolution: "commander@npm:6.2.1"
   checksum: 10c0/85748abd9d18c8bc88febed58b98f66b7c591d9b5017cad459565761d7b29ca13b7783ea2ee5ce84bf235897333706c4ce29adf1ce15c8252780e7000e2ce9ea
-  languageName: node
-  linkType: hard
-
-"commander@npm:^9.0.0":
-  version: 9.5.0
-  resolution: "commander@npm:9.5.0"
-  checksum: 10c0/5f7784fbda2aaec39e89eb46f06a999e00224b3763dc65976e05929ec486e174fe9aac2655f03ba6a5e83875bd173be5283dc19309b7c65954701c02025b3c1d
   languageName: node
   linkType: hard
 
@@ -24460,19 +24430,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"edit-json-file@npm:^1.7.0":
-  version: 1.8.0
-  resolution: "edit-json-file@npm:1.8.0"
-  dependencies:
-    find-value: "npm:^1.0.12"
-    iterate-object: "npm:^1.3.4"
-    r-json: "npm:^1.2.10"
-    set-value: "npm:^4.1.0"
-    w-json: "npm:^1.3.10"
-  checksum: 10c0/3dc1e7da2245601bd301310d0a3d40123918eb9468268ad4f7b9aeb347fbf10286da026515be870d01b8e4fb5282254650113a6d501e14815663a94cb705e753
-  languageName: node
-  linkType: hard
-
 "ee-first@npm:1.1.1":
   version: 1.1.1
   resolution: "ee-first@npm:1.1.1"
@@ -25940,6 +25897,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"execa@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "execa@npm:6.1.0"
+  dependencies:
+    cross-spawn: "npm:^7.0.3"
+    get-stream: "npm:^6.0.1"
+    human-signals: "npm:^3.0.1"
+    is-stream: "npm:^3.0.0"
+    merge-stream: "npm:^2.0.0"
+    npm-run-path: "npm:^5.1.0"
+    onetime: "npm:^6.0.0"
+    signal-exit: "npm:^3.0.7"
+    strip-final-newline: "npm:^3.0.0"
+  checksum: 10c0/004ee32092af745766a1b0352fdba8701a4001bc3fe08e63101c04276d4c860bbe11bb8ab85f37acdff13d3da83d60e044041dcf24bd7e25e645a543828d9c41
+  languageName: node
+  linkType: hard
+
 "execa@npm:^8.0.1":
   version: 8.0.1
   resolution: "execa@npm:8.0.1"
@@ -26702,13 +26676,6 @@ __metadata:
     locate-path: "npm:^7.1.0"
     path-exists: "npm:^5.0.0"
   checksum: 10c0/07e0314362d316b2b13f7f11ea4692d5191e718ca3f7264110127520f3347996349bf9e16805abae3e196805814bc66ef4bff2b8904dc4a6476085fc9b0eba07
-  languageName: node
-  linkType: hard
-
-"find-value@npm:^1.0.12":
-  version: 1.0.12
-  resolution: "find-value@npm:1.0.12"
-  checksum: 10c0/71fa0c4cd003ca09c3a679c99b899a1d45d60e325f858fd463c484358a3424c7dba9ff965b67764ba3226ffe6642cf458c5be7797fdd68c90fb9c0a9eae4e39c
   languageName: node
   linkType: hard
 
@@ -28304,20 +28271,16 @@ __metadata:
     "@sentry/cli": "npm:^2.39.1"
     "@taplo/cli": "npm:0.7.0"
     "@yarnpkg/types": "npm:^4.0.0"
-    check-dependency-version-consistency: "npm:3.0.3"
     concurrently: "npm:7.6.0"
-    cross-env: "npm:7.0.3"
-    dotenv-flow: "npm:3.3.0"
     lefthook: "npm:1.8.5"
     lockfile-lint: "npm:4.14.0"
     markdownlint-cli: "npm:0.43.0"
     npm-run-all2: "npm:7.0.1"
-    postinstall-postinstall: "npm:2.1.0"
     prettier: "npm:3.4.1"
     prettier-plugin-packagejson: "npm:2.5.6"
     prettier-plugin-sh: "npm:0.14.0"
+    suppress-exit-code: "npm:3.2.0"
     turbo: "npm:2.3.3"
-    wait-on: "npm:8.0.1"
   languageName: unknown
   linkType: soft
 
@@ -29028,6 +28991,13 @@ __metadata:
   version: 2.1.0
   resolution: "human-signals@npm:2.1.0"
   checksum: 10c0/695edb3edfcfe9c8b52a76926cd31b36978782062c0ed9b1192b36bebc75c4c87c82e178dfcb0ed0fc27ca59d434198aac0bd0be18f5781ded775604db22304a
+  languageName: node
+  linkType: hard
+
+"human-signals@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "human-signals@npm:3.0.1"
+  checksum: 10c0/0bb27e72aea1666322f69ab9816e05df952ef2160346f2293f98f45d472edb1b62d0f1a596697b50d48d8f8222e6db3b9f9dc0b6bf6113866121001f0a8e48e9
   languageName: node
   linkType: hard
 
@@ -30126,13 +30096,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-primitive@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "is-primitive@npm:3.0.1"
-  checksum: 10c0/2e3b6f029fabbdda467ea51ea4fdd00e6552434108b863a08f296638072c506a7c195089e3e31f83e7fc14bebbd1c5c9f872fe127c9284a7665c8227b47ffdd6
-  languageName: node
-  linkType: hard
-
 "is-promise@npm:^2.2.2":
   version: 2.2.2
   resolution: "is-promise@npm:2.2.2"
@@ -30760,13 +30723,6 @@ __metadata:
   version: 1.2.1
   resolution: "iterare@npm:1.2.1"
   checksum: 10c0/02667d486e3e83ead028ba8484d927498c2ceab7e8c6a69dd881fd02abc4114f00b13abb36b592252fbb578b6e6f99ca1dfc2835408b9158c9a112a9964f453f
-  languageName: node
-  linkType: hard
-
-"iterate-object@npm:^1.3.4":
-  version: 1.3.4
-  resolution: "iterate-object@npm:1.3.4"
-  checksum: 10c0/ff37f08223397ea637af136061ba74590efe5b29be5ca9006ae8168ce2faca67b0b4ebc763317173da65d2ae3ba81c1b51f4ceb80092a7bc668f3798f63db9e2
   languageName: node
   linkType: hard
 
@@ -32293,13 +32249,6 @@ __metadata:
   version: 4.1.1
   resolution: "lodash.throttle@npm:4.1.1"
   checksum: 10c0/14628013e9e7f65ac904fc82fd8ecb0e55a9c4c2416434b1dd9cf64ae70a8937f0b15376a39a68248530adc64887ed0fe2b75204b2c9ec3eea1cb2d66ddd125d
-  languageName: node
-  linkType: hard
-
-"lodash.truncate@npm:^4.4.2":
-  version: 4.4.2
-  resolution: "lodash.truncate@npm:4.4.2"
-  checksum: 10c0/4e870d54e8a6c86c8687e057cec4069d2e941446ccab7f40b4d9555fa5872d917d0b6aa73bece7765500a3123f1723bcdba9ae881b679ef120bba9e1a0b0ed70
   languageName: node
   linkType: hard
 
@@ -37839,13 +37788,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postinstall-postinstall@npm:2.1.0":
-  version: 2.1.0
-  resolution: "postinstall-postinstall@npm:2.1.0"
-  checksum: 10c0/70488447292c712afa7806126824d6fe93362392cbe261ae60166d9119a350713e0dbf4deb2ca91637c1037bc030ed1de78d61d9041bf2504513070f1caacdfd
-  languageName: node
-  linkType: hard
-
 "prebuild-install@npm:^7.1.1":
   version: 7.1.2
   resolution: "prebuild-install@npm:7.1.2"
@@ -38804,15 +38746,6 @@ __metadata:
   version: 1.0.0
   resolution: "quote-unquote@npm:1.0.0"
   checksum: 10c0/eba86bb7f68ada486f5608c5c71cc155235f0408b8a0a180436cdf2457ae86f56a17de6b0bc5a1b7ae5f27735b3b789662cdf7f3b8195ac816cd0289085129ec
-  languageName: node
-  linkType: hard
-
-"r-json@npm:^1.2.10":
-  version: 1.3.0
-  resolution: "r-json@npm:1.3.0"
-  dependencies:
-    w-json: "npm:1.3.10"
-  checksum: 10c0/de54df28ee2642767c821818257da87d68d72f443cdb1db2256afc1dba9701acdebb0afbea9017680daff483464dfe02ba9692a9b1dfea29a14ba3ce0a9e9fcb
   languageName: node
   linkType: hard
 
@@ -40973,7 +40906,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass@npm:1.81.0, sass@npm:^1.52.3":
+"sass@npm:1.81.1":
+  version: 1.81.1
+  resolution: "sass@npm:1.81.1"
+  dependencies:
+    "@parcel/watcher": "npm:^2.4.1"
+    chokidar: "npm:^4.0.0"
+    immutable: "npm:^5.0.2"
+    source-map-js: "npm:>=0.6.2 <2.0.0"
+  dependenciesMeta:
+    "@parcel/watcher":
+      optional: true
+  bin:
+    sass: sass.js
+  checksum: 10c0/be30371b1706ae84ca39fc724368deae5fd9cf94f4737fb0120f166e81545d113d1aa9abd3d797cf66f1d48625ab20ec838509f157d23e3e1e57c6a7e5e78cda
+  languageName: node
+  linkType: hard
+
+"sass@npm:^1.52.3":
   version: 1.81.0
   resolution: "sass@npm:1.81.0"
   dependencies:
@@ -41324,16 +41274,6 @@ __metadata:
   dependencies:
     "@babel/runtime": "npm:7.5.0"
   checksum: 10c0/453265515bbab66342012cf83ae8150c096c9ffe739a302e5489ad5ca518a206de7b75b69fe160071ebe220b74f6376e4bd7c9c3a382da1f2a1f92bbd065d10b
-  languageName: node
-  linkType: hard
-
-"set-value@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "set-value@npm:4.1.0"
-  dependencies:
-    is-plain-object: "npm:^2.0.4"
-    is-primitive: "npm:^3.0.1"
-  checksum: 10c0/dc186676b6cc0cfcf1656b8acdfe7a68591f0645dd2872250100817fb53e5e9298dc1727a95605ac03f82110e9b3820c90a0a02d84e0fb89f210922b08b37e02
   languageName: node
   linkType: hard
 
@@ -43045,6 +42985,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"suppress-exit-code@npm:3.2.0":
+  version: 3.2.0
+  resolution: "suppress-exit-code@npm:3.2.0"
+  dependencies:
+    execa: "npm:^6.1.0"
+  bin:
+    suppress-exit-code: main.js
+  checksum: 10c0/173508a1472e2c7e63ad71c283e9744f58c3c38021bc1641e33ceaa662a63ed28db6c7fe9cce5c4152eb1fc9667a74a6bf37ce0eecc612e8eb9ee597a5e2a85c
+  languageName: node
+  linkType: hard
+
 "svg-parser@npm:^2.0.4":
   version: 2.0.4
   resolution: "svg-parser@npm:2.0.4"
@@ -43175,19 +43126,6 @@ __metadata:
     typical: "npm:^2.6.1"
     wordwrapjs: "npm:^3.0.0"
   checksum: 10c0/0abe0256d6f588998f42e3ad9e54625d2c5a7ab60a21f600bd8d811af95d11a39a0c113fe74f6bbc0e8523d64251fb7ecb6aef73d1a04f90889b1d449592d55a
-  languageName: node
-  linkType: hard
-
-"table@npm:^6.7.1":
-  version: 6.8.2
-  resolution: "table@npm:6.8.2"
-  dependencies:
-    ajv: "npm:^8.0.1"
-    lodash.truncate: "npm:^4.4.2"
-    slice-ansi: "npm:^4.0.0"
-    string-width: "npm:^4.2.3"
-    strip-ansi: "npm:^6.0.1"
-  checksum: 10c0/f8b348af38ee34e419d8ce7306ba00671ce6f20e861ccff22555f491ba264e8416086063ce278a8d81abfa8d23b736ec2cca7ac4029b5472f63daa4b4688b803
   languageName: node
   linkType: hard
 
@@ -44439,7 +44377,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^2.1.0, type-fest@npm:^2.12.2, type-fest@npm:^2.19.0, type-fest@npm:^2.3.3, type-fest@npm:~2.19":
+"type-fest@npm:^2.12.2, type-fest@npm:^2.19.0, type-fest@npm:^2.3.3, type-fest@npm:~2.19":
   version: 2.19.0
   resolution: "type-fest@npm:2.19.0"
   checksum: 10c0/a5a7ecf2e654251613218c215c7493574594951c08e52ab9881c9df6a6da0aeca7528c213c622bc374b4e0cb5c443aa3ab758da4e3c959783ce884c3194e12cb
@@ -45892,13 +45830,6 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/4bbb5caf3f04fed933b01c100804f3693ff902984a3152ea1359a972264fa3240f6551d32f0163a79c64df3715b4d6691818c9f652cdd41b2473c69e2b0a373d
-  languageName: node
-  linkType: hard
-
-"w-json@npm:1.3.10, w-json@npm:^1.3.10":
-  version: 1.3.10
-  resolution: "w-json@npm:1.3.10"
-  checksum: 10c0/441bf7685d8c8d9ff787066d75c66f7a66794a90ea7577d9e94103089427f04117176b40bdf4def505c5f90ee3e65a4f569765754e866f688d68e4521da1fa94
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -28322,6 +28322,7 @@ __metadata:
     "@yarnpkg/types": "npm:^4.0.0"
     concurrently: "npm:7.6.0"
     husky: "npm:8.0.3"
+    lefthook: "npm:1.8.5"
     lint-staged: "npm:15.2.10"
     lockfile-lint: "npm:4.14.0"
     markdownlint-cli: "npm:0.43.0"
@@ -31668,6 +31669,117 @@ __metadata:
   version: 0.6.0
   resolution: "leac@npm:0.6.0"
   checksum: 10c0/5257781e10791ef8462eb1cbe5e48e3cda7692486f2a775265d6f5216cc088960c62f138163b8df0dcf2119d18673bfe7b050d6b41543d92a7b7ac90e4eb1e8b
+  languageName: node
+  linkType: hard
+
+"lefthook-darwin-arm64@npm:1.8.5":
+  version: 1.8.5
+  resolution: "lefthook-darwin-arm64@npm:1.8.5"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-darwin-x64@npm:1.8.5":
+  version: 1.8.5
+  resolution: "lefthook-darwin-x64@npm:1.8.5"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-freebsd-arm64@npm:1.8.5":
+  version: 1.8.5
+  resolution: "lefthook-freebsd-arm64@npm:1.8.5"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-freebsd-x64@npm:1.8.5":
+  version: 1.8.5
+  resolution: "lefthook-freebsd-x64@npm:1.8.5"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-linux-arm64@npm:1.8.5":
+  version: 1.8.5
+  resolution: "lefthook-linux-arm64@npm:1.8.5"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-linux-x64@npm:1.8.5":
+  version: 1.8.5
+  resolution: "lefthook-linux-x64@npm:1.8.5"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-openbsd-arm64@npm:1.8.5":
+  version: 1.8.5
+  resolution: "lefthook-openbsd-arm64@npm:1.8.5"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-openbsd-x64@npm:1.8.5":
+  version: 1.8.5
+  resolution: "lefthook-openbsd-x64@npm:1.8.5"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-windows-arm64@npm:1.8.5":
+  version: 1.8.5
+  resolution: "lefthook-windows-arm64@npm:1.8.5"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-windows-x64@npm:1.8.5":
+  version: 1.8.5
+  resolution: "lefthook-windows-x64@npm:1.8.5"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook@npm:1.8.5":
+  version: 1.8.5
+  resolution: "lefthook@npm:1.8.5"
+  dependencies:
+    lefthook-darwin-arm64: "npm:1.8.5"
+    lefthook-darwin-x64: "npm:1.8.5"
+    lefthook-freebsd-arm64: "npm:1.8.5"
+    lefthook-freebsd-x64: "npm:1.8.5"
+    lefthook-linux-arm64: "npm:1.8.5"
+    lefthook-linux-x64: "npm:1.8.5"
+    lefthook-openbsd-arm64: "npm:1.8.5"
+    lefthook-openbsd-x64: "npm:1.8.5"
+    lefthook-windows-arm64: "npm:1.8.5"
+    lefthook-windows-x64: "npm:1.8.5"
+  dependenciesMeta:
+    lefthook-darwin-arm64:
+      optional: true
+    lefthook-darwin-x64:
+      optional: true
+    lefthook-freebsd-arm64:
+      optional: true
+    lefthook-freebsd-x64:
+      optional: true
+    lefthook-linux-arm64:
+      optional: true
+    lefthook-linux-x64:
+      optional: true
+    lefthook-openbsd-arm64:
+      optional: true
+    lefthook-openbsd-x64:
+      optional: true
+    lefthook-windows-arm64:
+      optional: true
+    lefthook-windows-x64:
+      optional: true
+  bin:
+    lefthook: bin/index.js
+  checksum: 10c0/71f16a752c38f732b9bf1163dd552c9e92231df173c4ebb908f7ab634c5c01a813f6b3b325f1e749bc92c07c0cacf44613bb1251f97cd49d160c360344c3aa48
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

husky and lint-staged are both dependency heavy and there have been challenges in trying to make external tools work (tools that cannot be installed with yarn).

The goal of this is to try to see if lefthook can be a minimally invasive alternative that allows for sqlfluff (and other packages) to be used.

> Personally I've also seen instances where husky/lint-staged just doesn't work because because e.g. it picked up the wrong node version from my system (I use mise to configure those) which has been very annoying in the past.

**husky doesn't clean up correctly**, while it works fine without doing it, keeping your hook location to the one of husky will mean you have a permanent stage file that shouldn't be committed, unset the git change that husky applied via: `git config --unset core.hooksPath`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
