### PR TITLE
H-2976: Improve validation for ontology types

### DIFF
--- a/libs/@blockprotocol/type-system/rust/src/schema/array/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/array/mod.rs
@@ -1,7 +1,9 @@
 mod raw;
+mod validation;
 
 use serde::{Deserialize, Serialize, Serializer};
 
+pub use self::validation::{ArraySchemaValidationError, ArraySchemaValidator};
 use crate::schema::{OneOfSchema, PropertyType, PropertyValues};
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]

--- a/libs/@blockprotocol/type-system/rust/src/schema/array/validation.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/array/validation.rs
@@ -5,8 +5,8 @@ use crate::{Valid, Validator, schema::PropertyValueArray};
 #[derive(Debug, Error)]
 pub enum ArraySchemaValidationError {
     #[error(
-        "Unsatisfiable item number constraints, expected minimum of {min} and maximum of {max} \
-         items"
+        "Unsatisfiable item number constraints, expected minimum amount of items ({min}) to be \
+         less than or equal to the maximum amount of items ({max})"
     )]
     IncompatibleItemNumberConstraints { min: usize, max: usize },
 }
@@ -21,7 +21,11 @@ impl<T: Sync> Validator<PropertyValueArray<T>> for ArraySchemaValidator {
         value: &'v PropertyValueArray<T>,
     ) -> Result<&'v Valid<PropertyValueArray<T>>, Self::Error> {
         if let Some((min, max)) = value.min_items.zip(value.max_items) {
-            return Err(ArraySchemaValidationError::IncompatibleItemNumberConstraints { min, max });
+            if min > max {
+                return Err(
+                    ArraySchemaValidationError::IncompatibleItemNumberConstraints { min, max },
+                );
+            }
         }
 
         Ok(Valid::new_ref_unchecked(value))

--- a/libs/@blockprotocol/type-system/rust/src/schema/array/validation.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/array/validation.rs
@@ -1,0 +1,29 @@
+use thiserror::Error;
+
+use crate::{Valid, Validator, schema::PropertyValueArray};
+
+#[derive(Debug, Error)]
+pub enum ArraySchemaValidationError {
+    #[error(
+        "Unsatisfiable item number constraints, expected minimum of {min} and maximum of {max} \
+         items"
+    )]
+    IncompatibleItemNumberConstraints { min: usize, max: usize },
+}
+
+pub struct ArraySchemaValidator;
+
+impl<T: Sync> Validator<PropertyValueArray<T>> for ArraySchemaValidator {
+    type Error = ArraySchemaValidationError;
+
+    fn validate_ref<'v>(
+        &self,
+        value: &'v PropertyValueArray<T>,
+    ) -> Result<&'v Valid<PropertyValueArray<T>>, Self::Error> {
+        if let Some((min, max)) = value.min_items.zip(value.max_items) {
+            return Err(ArraySchemaValidationError::IncompatibleItemNumberConstraints { min, max });
+        }
+
+        Ok(Valid::new_ref_unchecked(value))
+    }
+}

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/closed.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/closed.rs
@@ -9,22 +9,12 @@ use serde_json::{Value as JsonValue, json};
 use thiserror::Error;
 
 use crate::{
-    Valid,
     schema::{
         DataType, DataTypeUuid, InheritanceDepth, ValueLabel,
         data_type::{DataTypeEdge, constraint::ValueConstraints},
     },
     url::VersionedUrl,
 };
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-// #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
-pub struct ResolvedDataType {
-    #[serde(flatten)]
-    pub schema: Arc<DataType>,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty", rename = "$defs")]
-    pub definitions: HashMap<VersionedUrl, Arc<DataType>>,
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
@@ -111,14 +101,6 @@ impl ClosedDataType {
             )?,
             r#abstract: data_type.r#abstract,
         })
-    }
-}
-
-impl ResolvedDataType {
-    #[must_use]
-    pub fn data_type(&self) -> &Valid<DataType> {
-        // Valid closed schemas imply that the schema is valid
-        Valid::new_ref_unchecked(&self.schema)
     }
 }
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -2,7 +2,7 @@ mod constraint;
 mod conversion;
 
 pub use self::{
-    closed::{ClosedDataType, DataTypeResolveData, ResolvedDataType},
+    closed::{ClosedDataType, DataTypeResolveData},
     constraint::{
         AnyOfConstraints, ArrayConstraints, ArraySchema, ArrayTypeTag, ArrayValidationError,
         BooleanSchema, BooleanTypeTag, ConstraintError, ConstraintValidator, NullSchema,

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/validation.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/validation.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 use crate::{
     Valid, Validator,
-    schema::{ClosedDataType, DataType, DataTypeReference, ResolvedDataType},
+    schema::{ClosedDataType, DataType, DataTypeReference},
     url::VersionedUrl,
 };
 
@@ -72,44 +72,8 @@ impl Validator<DataType> for DataTypeValidator {
             return Err(ValidateDataTypeError::NonPrimitiveValueInheritance);
         }
 
-        // TODO: Implement validation for data types
-        //   see https://linear.app/hash/issue/H-2976/validate-ontology-types-on-creation
-        Ok(Valid::new_ref_unchecked(value))
-    }
-}
-
-impl Validator<ResolvedDataType> for DataTypeValidator {
-    type Error = ValidateDataTypeError;
-
-    fn validate_ref<'v>(
-        &self,
-        value: &'v ResolvedDataType,
-    ) -> Result<&'v Valid<ResolvedDataType>, Self::Error> {
-        let mut checked_types = HashSet::new();
-        let mut types_to_check = value
-            .schema
-            .data_type_references()
-            .map(|(reference, _)| reference)
-            .collect::<Vec<_>>();
-        while let Some(reference) = types_to_check.pop() {
-            if !checked_types.insert(reference) || reference.url == value.schema.id {
-                continue;
-            }
-
-            let data_type = value.definitions.get(&reference.url).ok_or_else(|| {
-                ValidateDataTypeError::MissingDataType {
-                    data_type_id: reference.url.clone(),
-                }
-            })?;
-            types_to_check.extend(
-                data_type
-                    .data_type_references()
-                    .map(|(reference, _)| reference),
-            );
-        }
-
-        // TODO: Implement validation for data types
-        //   see https://linear.app/hash/issue/H-2976/validate-ontology-types-on-creation
+        // Unsatisfiable constraints will automatically be checked when attempting to close the
+        // schema so it's not needed to check constraints here.
         Ok(Valid::new_ref_unchecked(value))
     }
 }
@@ -121,8 +85,7 @@ impl Validator<ClosedDataType> for DataTypeValidator {
         &self,
         value: &'v ClosedDataType,
     ) -> Result<&'v Valid<ClosedDataType>, Self::Error> {
-        // TODO: Validate ontology types on creation
-        //   see https://linear.app/hash/issue/H-2976/validate-ontology-types-on-creation
+        // Closed data types are validated on creation
         Ok(Valid::new_ref_unchecked(value))
     }
 }

--- a/libs/@blockprotocol/type-system/rust/src/schema/entity_type/validation.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/entity_type/validation.rs
@@ -17,6 +17,11 @@ pub enum EntityTypeValidationError {
     #[display("Property object validation failed: {_0}")]
     #[from]
     ObjectValidationFailed(ObjectSchemaValidationError),
+    #[display(
+        "Unsatisfiable link number constraints, expected minimum amount of items ({min}) to be \
+         less than or equal to the maximum amount of items ({max})"
+    )]
+    IncompatibleLinkNumberConstraints { min: usize, max: usize },
 }
 
 #[derive(Debug)]
@@ -39,6 +44,16 @@ impl Validator<EntityType> for EntityTypeValidator {
                     base_url: property.clone(),
                     reference: reference.clone(),
                 });
+            }
+        }
+
+        for links in value.constraints.links.values() {
+            if let Some((min, max)) = links.min_items.zip(links.max_items) {
+                if min > max {
+                    return Err(
+                        EntityTypeValidationError::IncompatibleLinkNumberConstraints { min, max },
+                    );
+                }
             }
         }
 
@@ -65,6 +80,16 @@ impl Validator<ClosedEntityType> for EntityTypeValidator {
                     base_url: property.clone(),
                     reference: reference.clone(),
                 });
+            }
+        }
+
+        for links in value.constraints.links.values() {
+            if let Some((min, max)) = links.min_items.zip(links.max_items) {
+                if min > max {
+                    return Err(
+                        EntityTypeValidationError::IncompatibleLinkNumberConstraints { min, max },
+                    );
+                }
             }
         }
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/entity_type/validation.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/entity_type/validation.rs
@@ -29,8 +29,6 @@ impl Validator<EntityType> for EntityTypeValidator {
         &self,
         value: &'v EntityType,
     ) -> Result<&'v Valid<EntityType>, Self::Error> {
-        ObjectSchemaValidator.validate_ref(value)?;
-
         for (property, value) in &value.constraints.properties {
             let reference = match value {
                 ValueOrArray::Value(value) => value,
@@ -42,8 +40,6 @@ impl Validator<EntityType> for EntityTypeValidator {
                     reference: reference.clone(),
                 });
             }
-            // TODO: Validate reference
-            //   see https://linear.app/hash/issue/H-3046
         }
 
         Ok(Valid::new_ref_unchecked(value))
@@ -70,8 +66,6 @@ impl Validator<ClosedEntityType> for EntityTypeValidator {
                     reference: reference.clone(),
                 });
             }
-            // TODO: Validate reference
-            //   see https://linear.app/hash/issue/H-3046
         }
 
         Ok(Valid::new_ref_unchecked(value))

--- a/libs/@blockprotocol/type-system/rust/src/schema/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/mod.rs
@@ -18,7 +18,10 @@ mod one_of;
 mod identifier;
 
 pub use self::{
-    array::{PropertyArraySchema, PropertyValueArray, ValueOrArray},
+    array::{
+        ArraySchemaValidationError, ArraySchemaValidator, PropertyArraySchema, PropertyValueArray,
+        ValueOrArray,
+    },
     closed_resolver::{InheritanceDepth, OntologyTypeResolver},
     data_type::{
         AnyOfConstraints, ArrayConstraints, ArraySchema, ArrayTypeTag, ArrayValidationError,
@@ -27,9 +30,9 @@ pub use self::{
         DataTypeEdge, DataTypeReference, DataTypeResolveData, DataTypeValidator,
         JsonSchemaValueType, NullSchema, NullTypeTag, NumberConstraints, NumberSchema,
         NumberTypeTag, NumberValidationError, ObjectConstraints, ObjectSchema, ObjectTypeTag,
-        ObjectValidationError, Operator, ResolvedDataType, SingleValueConstraints,
-        SingleValueSchema, StringConstraints, StringFormat, StringFormatError, StringSchema,
-        StringTypeTag, StringValidationError, TupleConstraints, ValidateDataTypeError, ValueLabel,
+        ObjectValidationError, Operator, SingleValueConstraints, SingleValueSchema,
+        StringConstraints, StringFormat, StringFormatError, StringSchema, StringTypeTag,
+        StringValidationError, TupleConstraints, ValidateDataTypeError, ValueLabel,
         ValueSchemaMetadata, Variable,
     },
     domain_validator::{DomainValidationError, DomainValidator, ValidateOntologyType},


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Some ontology types don't make sense, e.g. having a minimum higher than the maximum or an `allOf: [number, string]`. An error should be emitted in this case.

Entity/property types should be validated: e.g. required only specifies actual properties.

The references don't need to be validated up-front as they will be checked when inserted into the graph anyway.

## 🔍 What does this change?

By now, most of the schemas are either validated when created or when creating the closed variant of it.
This PR adds a validation for array property types to ensure that `minItems` must be less than or equal to `maxItems`.
Further, it allows `required` to point to a property which is specified in a parent entity type (by removing this constraint on the `EntityType` but keep it in `ClosedEntityType`).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph