### PR TITLE
H-3745: Upgrade recursive dependencies and TemporalIO dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,40 +797,12 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 0.1.2",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core 0.4.5",
+ "axum-core",
  "bytes",
  "futures-util",
  "http 1.2.0",
@@ -849,29 +821,12 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.1",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower 0.5.1",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "mime",
- "rustversion",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -889,7 +844,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.1",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1155,9 +1110,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.28"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
  "jobserver",
  "libc",
@@ -1217,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1227,7 +1182,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1287,7 +1242,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
  "terminal_size",
 ]
 
@@ -1376,12 +1331,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "convert_case"
@@ -1581,36 +1530,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
- "darling_core 0.20.10",
- "darling_macro 0.20.10",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1623,19 +1548,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.90",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core 0.14.4",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1644,7 +1558,7 @@ version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
- "darling_core 0.20.10",
+ "darling_core",
  "quote",
  "syn 2.0.90",
 ]
@@ -1810,45 +1724,32 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.12.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
 dependencies = [
  "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.12.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling 0.14.4",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.12.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
-dependencies = [
- "convert_case 0.4.0",
- "proc-macro2",
- "quote",
- "rustc_version",
  "syn 2.0.90",
 ]
 
@@ -2602,7 +2503,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "derive-where",
- "derive_more 1.0.0",
+ "derive_more",
  "error-stack",
  "futures",
  "harpc-codec",
@@ -2641,7 +2542,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "bytes-utils",
- "derive_more 1.0.0",
+ "derive_more",
  "error-stack",
  "futures",
  "futures-core",
@@ -2682,7 +2583,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "derive-where",
- "derive_more 1.0.0",
+ "derive_more",
  "error-stack",
  "frunk",
  "frunk_core",
@@ -2719,7 +2620,7 @@ name = "harpc-tower"
 version = "0.0.0"
 dependencies = [
  "bytes",
- "derive_more 1.0.0",
+ "derive_more",
  "error-stack",
  "futures",
  "futures-core",
@@ -2786,7 +2687,7 @@ dependencies = [
 name = "hash-graph"
 version = "0.0.0"
 dependencies = [
- "axum 0.7.9",
+ "axum",
  "clap",
  "clap_complete",
  "error-stack",
@@ -2821,11 +2722,11 @@ name = "hash-graph-api"
 version = "0.0.0"
 dependencies = [
  "async-trait",
- "axum 0.7.9",
- "axum-core 0.4.5",
+ "axum",
+ "axum-core",
  "bytes",
  "derive-where",
- "derive_more 1.0.0",
+ "derive_more",
  "error-stack",
  "frunk",
  "futures",
@@ -2939,7 +2840,7 @@ dependencies = [
  "bytes",
  "clap",
  "clap_complete",
- "derive_more 1.0.0",
+ "derive_more",
  "error-stack",
  "futures",
  "hash-graph-migrations-macros",
@@ -2957,8 +2858,8 @@ dependencies = [
 name = "hash-graph-migrations-macros"
 version = "0.0.0"
 dependencies = [
- "convert_case 0.6.0",
- "derive_more 1.0.0",
+ "convert_case",
+ "derive_more",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -3011,7 +2912,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "derive-where",
- "derive_more 1.0.0",
+ "derive_more",
  "error-stack",
  "futures",
  "hash-graph-authorization",
@@ -3053,7 +2954,7 @@ version = "0.0.0"
 name = "hash-graph-test-server"
 version = "0.0.0"
 dependencies = [
- "axum 0.7.9",
+ "axum",
  "error-stack",
  "futures",
  "hash-codec",
@@ -3083,7 +2984,7 @@ dependencies = [
 name = "hash-graph-type-fetcher"
 version = "0.0.0"
 dependencies = [
- "derive_more 1.0.0",
+ "derive_more",
  "error-stack",
  "futures",
  "hash-graph-authorization",
@@ -3130,7 +3031,7 @@ dependencies = [
 name = "hash-graph-validation"
 version = "0.0.0"
 dependencies = [
- "derive_more 1.0.0",
+ "derive_more",
  "error-stack",
  "futures",
  "hash-graph-store",
@@ -3196,7 +3097,7 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "clap_builder",
- "derive_more 1.0.0",
+ "derive_more",
  "error-stack",
  "opentelemetry 0.27.1",
  "opentelemetry-otlp",
@@ -3333,15 +3234,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
-]
-
-[[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3566,7 +3458,7 @@ dependencies = [
  "hyper 0.14.30",
  "log",
  "rustls 0.21.12",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -3587,18 +3479,6 @@ dependencies = [
  "tokio-rustls 0.26.0",
  "tower-service",
  "webpki-roots",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper 0.14.30",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
 ]
 
 [[package]]
@@ -3644,7 +3524,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core 0.51.1",
 ]
 
 [[package]]
@@ -3982,9 +3862,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jobserver"
@@ -4003,9 +3883,9 @@ checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -4147,9 +4027,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -5096,22 +4976,6 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
-dependencies = [
- "futures-core",
- "futures-sink",
- "indexmap 2.6.0",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror 1.0.69",
- "urlencoding",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "570074cc999d1a58184080966e5bd3bf3a9a4af650c3b05047c2621e7405cd17"
@@ -5150,10 +5014,10 @@ dependencies = [
  "opentelemetry 0.27.1",
  "opentelemetry-proto",
  "opentelemetry_sdk 0.27.1",
- "prost 0.13.3",
+ "prost",
  "thiserror 1.0.69",
  "tokio",
- "tonic 0.12.3",
+ "tonic",
 ]
 
 [[package]]
@@ -5164,8 +5028,8 @@ checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
 dependencies = [
  "opentelemetry 0.27.1",
  "opentelemetry_sdk 0.27.1",
- "prost 0.13.3",
- "tonic 0.12.3",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -5361,7 +5225,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "image",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "js-sys",
  "libloading",
  "log",
@@ -5624,16 +5488,6 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "prettyplease"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
@@ -5756,57 +5610,33 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
-dependencies = [
- "bytes",
- "prost-derive 0.11.9",
-]
-
-[[package]]
-name = "prost"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
 dependencies = [
  "bytes",
- "prost-derive 0.13.3",
+ "prost-derive",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.11.9"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
  "heck 0.4.1",
  "itertools 0.10.5",
- "lazy_static",
  "log",
  "multimap",
+ "once_cell",
  "petgraph",
- "prettyplease 0.1.25",
- "prost 0.11.9",
+ "prettyplease",
+ "prost",
  "prost-types",
  "regex",
- "syn 1.0.109",
+ "syn 2.0.90",
  "tempfile",
- "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -5816,7 +5646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -5824,22 +5654,22 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.9"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
 dependencies = [
- "prost 0.11.9",
+ "prost",
 ]
 
 [[package]]
 name = "prost-wkt"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562788060bcf2bfabe055194bd991ed2442457661744c88e0a0828ff9a08c08b"
+checksum = "a8d84e2bee181b04c2bac339f2bfe818c46a99750488cc6728ce4181d5aa8299"
 dependencies = [
  "chrono",
  "inventory",
- "prost 0.11.9",
+ "prost",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5848,12 +5678,12 @@ dependencies = [
 
 [[package]]
 name = "prost-wkt-build"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4dca8bcead3b728a6a7da017cc95e7f4cb2320ec4f6896bc593a1c4700f7328"
+checksum = "8a669d5acbe719010c6f62a64e6d7d88fdedc1fe46e419747949ecb6312e9b14"
 dependencies = [
  "heck 0.4.1",
- "prost 0.11.9",
+ "prost",
  "prost-build",
  "prost-types",
  "quote",
@@ -5861,12 +5691,12 @@ dependencies = [
 
 [[package]]
 name = "prost-wkt-types"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2377c5680f2342871823045052e791b4487f7c90aae17e0feaee24cf59578a34"
+checksum = "01ef068e9b82e654614b22e6b13699bd545b6c0e2e721736008b00b38aeb4f64"
 dependencies = [
  "chrono",
- "prost 0.11.9",
+ "prost",
  "prost-build",
  "prost-types",
  "prost-wkt",
@@ -6280,7 +6110,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.1",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.0",
  "tokio-util",
@@ -6452,6 +6282,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6498,9 +6341,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "rw-stream-sink"
@@ -6865,7 +6708,7 @@ version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
 dependencies = [
- "darling 0.20.10",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -7074,12 +6917,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -7158,9 +6995,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
  "futures-core",
 ]
@@ -7293,27 +7130,29 @@ dependencies = [
 [[package]]
 name = "temporal-client"
 version = "0.1.0"
-source = "git+https://github.com/temporalio/sdk-core?rev=7e3c23f#7e3c23fd90daae19c8d8305f20b3530d6d2cd252"
+source = "git+https://github.com/temporalio/sdk-core?rev=4a2368d#4a2368d19f57e971ca9b2465f1dbeede7a861c34"
 dependencies = [
  "anyhow",
  "async-trait",
  "backoff",
+ "base64 0.22.1",
  "derive_builder",
- "derive_more 0.99.18",
- "futures",
+ "derive_more",
  "futures-retry",
- "http 0.2.12",
- "once_cell",
- "opentelemetry 0.21.0",
+ "futures-util",
+ "http 1.2.0",
+ "http-body-util",
+ "hyper 1.5.1",
+ "hyper-util",
  "parking_lot",
  "prost-types",
  "slotmap",
  "temporal-sdk-core-api",
  "temporal-sdk-core-protos",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tokio",
- "tonic 0.9.2",
- "tower 0.4.13",
+ "tonic",
+ "tower 0.5.1",
  "tracing",
  "url",
  "uuid",
@@ -7322,18 +7161,17 @@ dependencies = [
 [[package]]
 name = "temporal-sdk-core-api"
 version = "0.1.0"
-source = "git+https://github.com/temporalio/sdk-core?rev=7e3c23f#7e3c23fd90daae19c8d8305f20b3530d6d2cd252"
+source = "git+https://github.com/temporalio/sdk-core?rev=4a2368d#4a2368d19f57e971ca9b2465f1dbeede7a861c34"
 dependencies = [
  "async-trait",
  "derive_builder",
- "derive_more 0.99.18",
+ "derive_more",
+ "prost",
  "prost-types",
- "serde",
  "serde_json",
  "temporal-sdk-core-protos",
- "thiserror 1.0.69",
- "tokio",
- "tonic 0.9.2",
+ "thiserror 2.0.4",
+ "tonic",
  "tracing-core",
  "url",
 ]
@@ -7341,19 +7179,21 @@ dependencies = [
 [[package]]
 name = "temporal-sdk-core-protos"
 version = "0.1.0"
-source = "git+https://github.com/temporalio/sdk-core?rev=7e3c23f#7e3c23fd90daae19c8d8305f20b3530d6d2cd252"
+source = "git+https://github.com/temporalio/sdk-core?rev=4a2368d#4a2368d19f57e971ca9b2465f1dbeede7a861c34"
 dependencies = [
  "anyhow",
- "base64 0.21.7",
- "derive_more 0.99.18",
- "prost 0.11.9",
+ "base64 0.22.1",
+ "derive_more",
+ "prost",
+ "prost-build",
+ "prost-types",
  "prost-wkt",
  "prost-wkt-build",
  "prost-wkt-types",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
- "tonic 0.9.2",
+ "thiserror 2.0.4",
+ "tonic",
  "tonic-build",
 ]
 
@@ -7405,11 +7245,11 @@ version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d547323725fa9910b0b3146eeaedd471c000dd75eb107c350aa8e1aebef2d7a"
 dependencies = [
- "darling 0.20.10",
+ "darling",
  "heck 0.5.0",
  "itertools 0.13.0",
  "once_cell",
- "prettyplease 0.2.22",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -7605,16 +7445,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7766,45 +7596,13 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.6.20",
- "base64 0.21.7",
- "bytes",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
- "hyper-timeout 0.4.1",
- "percent-encoding",
- "pin-project",
- "prost 0.11.9",
- "rustls-native-certs",
- "rustls-pemfile 1.0.4",
- "tokio",
- "tokio-rustls 0.24.1",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.7.9",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "h2 0.4.6",
@@ -7812,13 +7610,16 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.5.1",
- "hyper-timeout 0.5.1",
+ "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.13.3",
+ "prost",
+ "rustls-native-certs 0.8.0",
+ "rustls-pemfile 2.2.0",
  "socket2",
  "tokio",
+ "tokio-rustls 0.26.0",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
@@ -7828,15 +7629,16 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.9.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
 dependencies = [
- "prettyplease 0.1.25",
+ "prettyplease",
  "proc-macro2",
  "prost-build",
+ "prost-types",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -8120,7 +7922,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "console_error_panic_hook",
- "derive_more 1.0.0",
+ "derive_more",
  "email_address",
  "error-stack",
  "futures",
@@ -8470,9 +8272,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8483,13 +8285,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -8498,9 +8299,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.47"
+version = "0.4.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
+checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -8511,9 +8312,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8521,9 +8322,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8534,19 +8335,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d919bb60ebcecb9160afee6c71b43a58a4f0517a2de0054cd050d02cec08201"
+checksum = "c61d44563646eb934577f2772656c7ad5e9c90fac78aa8013d776fcdaf24625d"
 dependencies = [
  "js-sys",
  "minicov",
- "once_cell",
  "scoped-tls",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -8555,9 +8355,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222ebde6ea87fbfa6bdd2e9f1fd8a91d60aee5db68792632176c4e16a74fc7d8"
+checksum = "54171416ce73aa0b9c377b51cc3cb542becee1cd678204812e8392e5b0e4a031"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8579,9 +8379,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8611,18 +8411,6 @@ name = "weezl"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
-]
 
 [[package]]
 name = "whoami"
@@ -8663,7 +8451,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,93 +148,93 @@ utoipa             = { version = "=4.2.3", default-features = false }
 uuid               = { version = "=1.11.0", default-features = false }
 
 # Shared third-party dependencies
-ansi-to-html                = { version = "=0.2.2", default-features = false }
-anstyle                     = { version = "=1.0.10", default-features = false }
-anstyle-yansi               = { version = "=2.0.2", default-features = false }
-approx                      = { version = "=0.5.1", default-features = false }
-async-scoped                = { version = "=0.9.0", default-features = false }
-async-trait                 = { version = "=0.1.83", default-features = false }
-aws-config                  = { version = "=1.5.10" }
-aws-sdk-s3                  = { version = "=1.65.0", default-features = false }
-bitvec                      = { version = "=1.0.1", default-features = false }
-bytes-utils                 = { version = "=0.1.4", default-features = false }
-clap                        = { version = "=4.5.23", features = ["color", "error-context", "help", "std", "suggestions", "usage"] }
-clap_complete               = { version = "=4.5.38", default-features = false }
-convert_case                = { version = "=0.6.0", default-features = false }
-criterion-macro             = { version = "=0.4.0", default-features = false }
-derive-where                = { version = "=1.2.7", default-features = false, features = ["nightly"] }
-derive_more                 = { version = "=1.0.0", default-features = false }
-dotenv-flow                 = { version = "=0.16.2", default-features = false }
-expect-test                 = { version = "=1.5.0", default-features = false }
-frunk_core                  = { version = "0.4.3", default-features = false }
-futures                     = { version = "=0.3.31", default-features = false }
-hifijson                    = { version = "=0.2.2", default-features = false }
-humansize                   = { version = "=2.1.3", default-features = false }
-hyper                       = { version = "=1.5.1", default-features = false }
-include_dir                 = { version = "=0.7.4", default-features = false }
-insta                       = { version = "=1.41.1", default-features = false }
-itertools                   = { version = "0.13.0", default-features = false }
-jsonschema                  = { version = "=0.26.1", default-features = false }
-justjson                    = { version = "=0.3.0", default-features = false }
-lexical                     = { version = "=7.0.3", default-features = false }
-libp2p                      = { version = "=0.54.1", default-features = false }
-libp2p-stream               = { version = "=0.2.0-alpha", default-features = false }
-logos                       = { version = "=0.15.0", default-features = false }
-memchr                      = { version = "=2.7.4", default-features = false }
-mimalloc                    = { version = "=0.1.43", default-features = false }
-mime                        = { version = "=0.3.17", default-features = false }
-num-traits                  = { version = "=0.2.19", default-features = false }
-once_cell                   = { version = "=1.20.2", default-features = false }
-opentelemetry               = { version = "=0.27.1", default-features = false }
-opentelemetry-otlp          = { version = "=0.27.0", default-features = false }
-opentelemetry_sdk           = { version = "=0.27.1", default-features = false }
-orx-concurrent-vec          = { version = "=3.0.2", default-features = false }
-owo-colors                  = { version = "=4.1.0", default-features = false }
-paste                       = { version = "=1.0.15", default-features = false }
-pin-project                 = { version = "=1.1.7", default-features = false }
-pin-project-lite            = { version = "=0.2.15", default-features = false }
-postgres-protocol           = { version = "=0.6.7", default-features = false }
-pretty_assertions           = { version = "=1.4.1", default-features = false, features = ["alloc"] }
-proc-macro-error2           = { version = "=2.0.1", default-features = false }
-proc-macro2                 = { version = "=1.0.92", default-features = false }
-proptest                    = { version = "=1.5.0", default-features = false, features = ["alloc"] }
-quote                       = { version = "=1.0.37", default-features = false }
-rand                        = { version = "=0.8.5", default-features = false }
-refinery                    = { version = "=0.8.14", default-features = false }
-rustc_version               = { version = "=0.4.1", default-features = false }
-scc                         = { version = "=2.2.5", default-features = false }
-sentry                      = { version = "=0.35.0", default-features = false, features = ["backtrace", "contexts", "debug-images", "panic", "reqwest", "rustls", "tower-http", "tracing"] }
-seq-macro                   = { version = "=0.3.5", default-features = false }
-serde_plain                 = { version = "=1.0.2", default-features = false }
-serde_with                  = { version = "=3.11.0", default-features = false }
-sha2                        = { version = "=0.10.8", default-features = false }
-similar-asserts             = { version = "=1.6.0", default-features = false }
-supports-color              = { version = "=3.0.2", default-features = false }
-supports-unicode            = { version = "=3.0.0", default-features = false }
-syn                         = { version = "=2.0.90", default-features = false }
-tachyonix                   = { version = "=0.3.1", default-features = false }
-tarpc                       = { version = "=0.35.0", default-features = false }
-temporal-io-client          = { package = "temporal-client", git = "https://github.com/temporalio/sdk-core", rev = "4a2368d" }
-temporal-io-sdk-core-protos = { package = "temporal-sdk-core-protos", git = "https://github.com/temporalio/sdk-core", rev = "4a2368d" }
-test-fuzz                   = { version = "=7.0.1", default-features = false }
-test-log                    = { version = "=0.2.16", default-features = false }
-test-strategy               = { version = "=0.4.0", default-features = false }
-thiserror                   = { version = "=2.0.4", default-features = false }
-tokio-stream                = { version = "=0.1.17", default-features = false }
-tokio-test                  = { version = "=0.4.4", default-features = false }
-tower                       = { version = "=0.5.1", default-features = false }
-tower-test                  = { version = "=0.4.0", default-features = false }
-tracing                     = { version = "=0.1.41", default-features = false }
-tracing-error               = { version = "=0.2.1", default-features = false }
-tracing-flame               = { version = "=0.2.0", default-features = false }
-tracing-opentelemetry       = { version = "=0.28.0", default-features = false }
-trait-variant               = { version = "=0.1.2", default-features = false }
-trybuild                    = { version = "=1.0.101", default-features = false }
-tsify                       = { version = "=0.4.5", default-features = false }
-unicode-ident               = { version = "=1.0.14", default-features = false }
-virtue                      = { version = "=0.0.18", default-features = false }
-walkdir                     = { version = "=2.5.0", default-features = false }
-winnow                      = { version = "=0.6.20", default-features = false }
+ansi-to-html             = { version = "=0.2.2", default-features = false }
+anstyle                  = { version = "=1.0.10", default-features = false }
+anstyle-yansi            = { version = "=2.0.2", default-features = false }
+approx                   = { version = "=0.5.1", default-features = false }
+async-scoped             = { version = "=0.9.0", default-features = false }
+async-trait              = { version = "=0.1.83", default-features = false }
+aws-config               = { version = "=1.5.10" }
+aws-sdk-s3               = { version = "=1.65.0", default-features = false }
+bitvec                   = { version = "=1.0.1", default-features = false }
+bytes-utils              = { version = "=0.1.4", default-features = false }
+clap                     = { version = "=4.5.23", features = ["color", "error-context", "help", "std", "suggestions", "usage"] }
+clap_complete            = { version = "=4.5.38", default-features = false }
+convert_case             = { version = "=0.6.0", default-features = false }
+criterion-macro          = { version = "=0.4.0", default-features = false }
+derive-where             = { version = "=1.2.7", default-features = false, features = ["nightly"] }
+derive_more              = { version = "=1.0.0", default-features = false }
+dotenv-flow              = { version = "=0.16.2", default-features = false }
+expect-test              = { version = "=1.5.0", default-features = false }
+frunk_core               = { version = "0.4.3", default-features = false }
+futures                  = { version = "=0.3.31", default-features = false }
+hifijson                 = { version = "=0.2.2", default-features = false }
+humansize                = { version = "=2.1.3", default-features = false }
+hyper                    = { version = "=1.5.1", default-features = false }
+include_dir              = { version = "=0.7.4", default-features = false }
+insta                    = { version = "=1.41.1", default-features = false }
+itertools                = { version = "0.13.0", default-features = false }
+jsonschema               = { version = "=0.26.1", default-features = false }
+justjson                 = { version = "=0.3.0", default-features = false }
+lexical                  = { version = "=7.0.3", default-features = false }
+libp2p                   = { version = "=0.54.1", default-features = false }
+libp2p-stream            = { version = "=0.2.0-alpha", default-features = false }
+logos                    = { version = "=0.15.0", default-features = false }
+memchr                   = { version = "=2.7.4", default-features = false }
+mimalloc                 = { version = "=0.1.43", default-features = false }
+mime                     = { version = "=0.3.17", default-features = false }
+num-traits               = { version = "=0.2.19", default-features = false }
+once_cell                = { version = "=1.20.2", default-features = false }
+opentelemetry            = { version = "=0.27.1", default-features = false }
+opentelemetry-otlp       = { version = "=0.27.0", default-features = false }
+opentelemetry_sdk        = { version = "=0.27.1", default-features = false }
+orx-concurrent-vec       = { version = "=3.0.2", default-features = false }
+owo-colors               = { version = "=4.1.0", default-features = false }
+paste                    = { version = "=1.0.15", default-features = false }
+pin-project              = { version = "=1.1.7", default-features = false }
+pin-project-lite         = { version = "=0.2.15", default-features = false }
+postgres-protocol        = { version = "=0.6.7", default-features = false }
+pretty_assertions        = { version = "=1.4.1", default-features = false, features = ["alloc"] }
+proc-macro-error2        = { version = "=2.0.1", default-features = false }
+proc-macro2              = { version = "=1.0.92", default-features = false }
+proptest                 = { version = "=1.5.0", default-features = false, features = ["alloc"] }
+quote                    = { version = "=1.0.37", default-features = false }
+rand                     = { version = "=0.8.5", default-features = false }
+refinery                 = { version = "=0.8.14", default-features = false }
+rustc_version            = { version = "=0.4.1", default-features = false }
+scc                      = { version = "=2.2.5", default-features = false }
+sentry                   = { version = "=0.35.0", default-features = false, features = ["backtrace", "contexts", "debug-images", "panic", "reqwest", "rustls", "tower-http", "tracing"] }
+seq-macro                = { version = "=0.3.5", default-features = false }
+serde_plain              = { version = "=1.0.2", default-features = false }
+serde_with               = { version = "=3.11.0", default-features = false }
+sha2                     = { version = "=0.10.8", default-features = false }
+similar-asserts          = { version = "=1.6.0", default-features = false }
+supports-color           = { version = "=3.0.2", default-features = false }
+supports-unicode         = { version = "=3.0.0", default-features = false }
+syn                      = { version = "=2.0.90", default-features = false }
+tachyonix                = { version = "=0.3.1", default-features = false }
+tarpc                    = { version = "=0.35.0", default-features = false }
+temporal-client          = { git = "https://github.com/temporalio/sdk-core", rev = "4a2368d" }
+temporal-sdk-core-protos = { git = "https://github.com/temporalio/sdk-core", rev = "4a2368d" }
+test-fuzz                = { version = "=7.0.1", default-features = false }
+test-log                 = { version = "=0.2.16", default-features = false }
+test-strategy            = { version = "=0.4.0", default-features = false }
+thiserror                = { version = "=2.0.4", default-features = false }
+tokio-stream             = { version = "=0.1.17", default-features = false }
+tokio-test               = { version = "=0.4.4", default-features = false }
+tower                    = { version = "=0.5.1", default-features = false }
+tower-test               = { version = "=0.4.0", default-features = false }
+tracing                  = { version = "=0.1.41", default-features = false }
+tracing-error            = { version = "=0.2.1", default-features = false }
+tracing-flame            = { version = "=0.2.0", default-features = false }
+tracing-opentelemetry    = { version = "=0.28.0", default-features = false }
+trait-variant            = { version = "=0.1.2", default-features = false }
+trybuild                 = { version = "=1.0.101", default-features = false }
+tsify                    = { version = "=0.4.5", default-features = false }
+unicode-ident            = { version = "=1.0.14", default-features = false }
+virtue                   = { version = "=0.0.18", default-features = false }
+walkdir                  = { version = "=2.5.0", default-features = false }
+winnow                   = { version = "=0.6.20", default-features = false }
 
 [profile.dev]
 codegen-backend = "cranelift"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,9 +92,9 @@ ahash              = { version = "=0.8.11", default-features = false }
 ariadne            = { version = "=0.5.0", default-features = false }
 aws-types          = { version = "=1.3.3", default-features = false }
 axum               = { version = "0.7.5" }
-axum-core          = { version = "0.4.3" }
+axum-core          = { version = "0.4.5" }
 bumpalo            = { version = "=3.16.0", default-features = false }
-bytes              = { version = "1.6.0" }
+bytes              = { version = "1.9.0" }
 clap_builder       = { version = "=4.5.23", default-features = false, features = ["std"] }
 criterion          = { version = "=0.5.1" }
 deadpool           = { version = "=0.12.1", default-features = false }
@@ -214,8 +214,8 @@ supports-unicode            = { version = "=3.0.0", default-features = false }
 syn                         = { version = "=2.0.90", default-features = false }
 tachyonix                   = { version = "=0.3.1", default-features = false }
 tarpc                       = { version = "=0.35.0", default-features = false }
-temporal-io-client          = { package = "temporal-client", git = "https://github.com/temporalio/sdk-core", rev = "7e3c23f" }
-temporal-io-sdk-core-protos = { package = "temporal-sdk-core-protos", git = "https://github.com/temporalio/sdk-core", rev = "7e3c23f" }
+temporal-io-client          = { package = "temporal-client", git = "https://github.com/temporalio/sdk-core", rev = "4a2368d" }
+temporal-io-sdk-core-protos = { package = "temporal-sdk-core-protos", git = "https://github.com/temporalio/sdk-core", rev = "4a2368d" }
 test-fuzz                   = { version = "=7.0.1", default-features = false }
 test-log                    = { version = "=0.2.16", default-features = false }
 test-strategy               = { version = "=0.4.0", default-features = false }

--- a/libs/@blockprotocol/type-system/rust/Cargo.toml
+++ b/libs/@blockprotocol/type-system/rust/Cargo.toml
@@ -51,7 +51,7 @@ utoipa   = ["dep:utoipa"]
 workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = { version = "0.2.92", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2.99", features = ["serde-serialize"] }
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
@@ -59,4 +59,4 @@ wasm-bindgen = { version = "0.2.92", features = ["serde-serialize"] }
 console_error_panic_hook = { version = "0.1.7" }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = "0.3.42"
+wasm-bindgen-test = "0.3.49"

--- a/libs/@local/hql/diagnostics/Cargo.toml
+++ b/libs/@local/hql/diagnostics/Cargo.toml
@@ -25,7 +25,7 @@ serde_with    = { workspace = true, optional = true, features = ["std", "macros"
 thiserror     = { workspace = true }
 
 [dev-dependencies]
-jsonptr    = "0.6.0"
+jsonptr    = "0.6.3"
 serde_json = { workspace = true }
 
 [features]

--- a/libs/@local/temporal-client/Cargo.toml
+++ b/libs/@local/temporal-client/Cargo.toml
@@ -16,13 +16,13 @@ hash-graph-types = { workspace = true, public = true }
 error-stack = { workspace = true }
 
 # Private third-party dependencies
-serde                       = { workspace = true }
-serde_json                  = { workspace = true }
-temporal-io-client          = { workspace = true }
-temporal-io-sdk-core-protos = { workspace = true }
-thiserror                   = { workspace = true }
-url                         = { workspace = true }
-uuid                        = { workspace = true, features = ["v4"] }
+serde                    = { workspace = true }
+serde_json               = { workspace = true }
+temporal-client          = { workspace = true }
+temporal-sdk-core-protos = { workspace = true }
+thiserror                = { workspace = true }
+url                      = { workspace = true }
+uuid                     = { workspace = true, features = ["v4"] }
 
 [lints]
 workspace = true

--- a/libs/@local/temporal-client/src/ai.rs
+++ b/libs/@local/temporal-client/src/ai.rs
@@ -7,8 +7,8 @@ use hash_graph_types::{
     ontology::{DataTypeWithMetadata, EntityTypeWithMetadata, PropertyTypeWithMetadata},
 };
 use serde::Serialize;
-use temporal_io_client::{WorkflowClientTrait as _, WorkflowOptions};
-use temporal_io_sdk_core_protos::{
+use temporal_client::{WorkflowClientTrait as _, WorkflowOptions};
+use temporal_sdk_core_protos::{
     ENCODING_PAYLOAD_KEY, JSON_ENCODING_VAL, temporal::api::common::v1::Payload,
 };
 use uuid::Uuid;

--- a/libs/@local/temporal-client/src/lib.rs
+++ b/libs/@local/temporal-client/src/lib.rs
@@ -6,7 +6,7 @@ mod ai;
 mod error;
 
 use error_stack::{Report, ResultExt as _};
-use temporal_io_client::{Client, ClientOptions, ClientOptionsBuilder, RetryClient};
+use temporal_client::{Client, ClientOptions, ClientOptionsBuilder, RetryClient};
 use url::Url;
 
 #[derive(Debug)]

--- a/libs/@local/temporal-client/src/lib.rs
+++ b/libs/@local/temporal-client/src/lib.rs
@@ -28,7 +28,7 @@ impl IntoFuture for TemporalClientConfig {
             Ok(TemporalClient {
                 client: self
                     .options
-                    .connect("HASH", None, None)
+                    .connect("HASH", None)
                     .await
                     .change_context(ConnectionError)?,
             })


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We did not upgrade the Temporal dependency in a while. This also required some recursive dependencies to be upgraded (most importantly `chromo`) which is a feature which is sadly missing from Renovate. 


## 🔍 What does this change?

- Upgrade to latest Temporal version
- Adjust and test new Temporal client code (minimal changes required)
- Avoid the renaming of the temporal packages
- Run `cargo upgrade`