### PR TITLE
H-3770: Group `libp2p` Renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -105,7 +105,7 @@
       "matchPackageNames": ["/^@openai//", "/^@anthropic-ai//", "/groq-sdk/"]
     },
     {
-      "groupName": "katex npm packages",
+      "groupName": "`katex` npm packages",
       "matchManagers": ["npm"],
       "matchPackageNames": ["/@matejmazur/react-katex/", "/^katex/"]
     },
@@ -115,22 +115,26 @@
       "matchPackageNames": ["/^@ory//"]
     },
     {
-      "groupName": "rollup npm packages",
+      "groupName": "`rollup` npm packages",
       "matchManagers": ["npm"],
       "matchPackageNames": ["/^@rollup//", "/^rollup$/"],
       "dependencyDashboardApproval": false
     },
     {
-      "groupName": "sigma npm packages",
+      "groupName": "`sigma` npm packages",
       "matchManagers": ["npm"],
       "matchPackageNames": ["/^@sigma/", "/sigma$/"]
     },
     {
-      "groupName": "signia npm packages",
+      "groupName": "`libp2p` npm packages",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["/^@libp2p/", "/libp2p$/"]
+    },
+    {
+      "groupName": "`signia` npm packages",
       "matchManagers": ["npm"],
       "matchPackageNames": ["/^signia/", "/signia$/"]
     },
-
     {
       "groupName": "Block Protocol npm packages",
       "matchManagers": ["npm"],
@@ -154,7 +158,7 @@
       ]
     },
     {
-      "groupName": "effect npm packages",
+      "groupName": "`effect` npm packages",
       "matchManagers": ["npm"],
       "matchPackageNames": ["/^@effect//", "/^effect-/", "/effect$/"]
     },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Groups `libp2p` updates in Renovate, for synchronous updating. Also improves the name formatting of other grouped `npm` package collections updated by Renovate.