### PR TITLE
H-3771: Fix `includeCount` not working in entity subgraph queries

### DIFF
--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -1337,7 +1337,7 @@ where
                     sorting: params.sorting,
                     limit: params.limit,
                     include_drafts: params.include_drafts,
-                    include_count: false,
+                    include_count: params.include_count,
                     include_entity_types: None,
                     include_web_ids: params.include_web_ids,
                     include_created_by_ids: params.include_created_by_ids,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The parameter was wrongly set to `false` (as previously `count` was gotten from somewhere else).