### PR TITLE
H-3776: Enable HaRPC in AWS

### DIFF
--- a/infra/terraform/hash/hash_application/graph.tf
+++ b/infra/terraform/hash/hash_application/graph.tf
@@ -206,7 +206,6 @@ locals {
       },
       {
         name          = local.graph_rpc_container_port_name
-        appProtocol   = "http2"
         containerPort = local.graph_rpc_container_port
         protocol      = "tcp"
       }

--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -257,7 +257,7 @@ module "application" {
     { name = "HASH_GRAPH_PG_HOST", secret = false, value = module.postgres.pg_host },
     { name = "HASH_GRAPH_PG_PORT", secret = false, value = module.postgres.pg_port },
     { name = "HASH_GRAPH_PG_DATABASE", secret = false, value = "graph" },
-    # { name = "HASH_GRAPH_RPC_ENABLED", secret = false, value = "true" },
+    { name = "HASH_GRAPH_RPC_ENABLED", secret = false, value = "true" },
     {
       name  = "HASH_SPICEDB_GRPC_PRESHARED_KEY", secret = true,
       value = sensitive(data.vault_kv_secret_v2.secrets.data["spicedb_grpc_preshared_key"])
@@ -358,7 +358,7 @@ module "application" {
     { name = "HASH_REDIS_PORT", secret = false, value = module.redis.node.port },
     { name = "HASH_REDIS_ENCRYPTED_TRANSIT", secret = false, value = "true" },
     { name = "HASH_INTEGRATION_QUEUE_NAME", secret = false, value = "integration" },
-    # { name = "HASH_RPC_ENABLED", secret = false, value = "true" },
+    { name = "HASH_RPC_ENABLED", secret = false, value = "true" },
     {
       name  = "HASH_VAULT_HOST", secret = true,
       value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_vault_host"])


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Turn the switch, enable HaRPC 🚀 

## 🔍 What does this change?

- Pass the `HASH_RPC_ENABLED` and `HASH_GRAPH_RPC_ENABLED` environment variables
- Change the app protocol to TCP