### PR TITLE
Enable verbose logging for HaRPC

### DIFF
--- a/apps/hash-api/src/index.ts
+++ b/apps/hash-api/src/index.ts
@@ -560,10 +560,10 @@ const main = async () => {
       }).pipe(
         Effect.provide(
           RpcClient.connectLayer(
-            Transport.multiaddr(`/dns/${rpcHost}/tcp/${rpcPort}`),
+            Transport.multiaddr(`/dns4/${rpcHost}/tcp/${rpcPort}`),
           ),
         ),
-        Logger.withMinimumLogLevel(LogLevel.Info),
+        Logger.withMinimumLogLevel(LogLevel.Trace),
       );
 
       runtime.runCallback(effect, {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To track down an error in production we need to enable logging. Also, we only use IPv4, so we can restrict the DNS lookup to `dns4` for now.