### PR TITLE
H-3784: Correctly resolve multiple DNS entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,7 +3008,7 @@ name = "hash-graph-types"
 version = "0.0.0"
 dependencies = [
  "bytes",
- "derive_more 1.0.0",
+ "derive_more",
  "error-stack",
  "futures",
  "hash-codec",

--- a/libs/@local/harpc/client/typescript/package.json
+++ b/libs/@local/harpc/client/typescript/package.json
@@ -23,7 +23,6 @@
     "test:unit": "vitest --run"
   },
   "dependencies": {
-    "@chainsafe/is-ip": "2.0.2",
     "@chainsafe/libp2p-noise": "16.0.0",
     "@chainsafe/libp2p-yamux": "7.0.1",
     "@libp2p/crypto": "5.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5236,7 +5236,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chainsafe/is-ip@npm:2.0.2, @chainsafe/is-ip@npm:^2.0.1, @chainsafe/is-ip@npm:^2.0.2":
+"@chainsafe/is-ip@npm:^2.0.1, @chainsafe/is-ip@npm:^2.0.2":
   version: 2.0.2
   resolution: "@chainsafe/is-ip@npm:2.0.2"
   checksum: 10c0/0bb8b9d0babe583642d31ffafad603ac5e5dc48884266feae57479d81f4e81ef903628527d81b39d5305657a957bf435bd2ef38b98a4526a7aab366febf793ad
@@ -9104,7 +9104,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@local/harpc-client@workspace:libs/@local/harpc/client/typescript"
   dependencies:
-    "@chainsafe/is-ip": "npm:2.0.2"
     "@chainsafe/libp2p-noise": "npm:16.0.0"
     "@chainsafe/libp2p-yamux": "npm:7.0.1"
     "@effect/platform": "npm:0.70.6"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The current harpc TypeScript DNS resolution has a bug, where multiple DNS entries lead to a relay address, instead of multiple possible addresses.

For example, `localhost` might resolve to both: `127.0.0.1` *and* `192.168.178.24`, this means that `/dns/localhost/tcp/4002` should resolve to: `/ip4/127.0.0.1/tcp/4002` **and** `/ip4/192.168.178.24/tcp/4002`, instead it will resolve to `/ip4/127.0.0.1/ip4/192.168.178.24/tcp/4002` which is a valid multiaddr but means: connect to `127.0.0.1` **over** `192.168.178.24` as a relay (which is obviously incorrect).

The fix is very straightforward and "just" a logic bug in the use of `flatMap` instead of `reduce`.

As a drive-by it also switches from `dns.resolve` to `dns.lookup`, to see if this changes the DNS resolution enough to work on AWS.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
