### PR TITLE
H-3786: Rename `properties` to `items` in `ArrayValidationReport`

### DIFF
--- a/libs/@local/graph/api/openapi/openapi.json
+++ b/libs/@local/graph/api/openapi/openapi.json
@@ -3168,6 +3168,12 @@
       "ArrayValidationReport": {
         "type": "object",
         "properties": {
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/PropertyValidationReport"
+            }
+          },
           "numItems": {
             "allOf": [
               {
@@ -3175,12 +3181,6 @@
               }
             ],
             "nullable": true
-          },
-          "properties": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/PropertyValidationReport"
-            }
           }
         }
       },

--- a/libs/@local/graph/types/rust/src/knowledge/property/visitor.rs
+++ b/libs/@local/graph/types/rust/src/knowledge/property/visitor.rs
@@ -220,7 +220,7 @@ pub enum ArrayItemNumberMismatch {
 #[must_use]
 pub struct ArrayValidationReport {
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub properties: HashMap<usize, PropertyValidationReport>,
+    pub items: HashMap<usize, PropertyValidationReport>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub num_items: Option<ArrayItemNumberMismatch>,
 }
@@ -228,7 +228,7 @@ pub struct ArrayValidationReport {
 impl ArrayValidationReport {
     #[must_use]
     pub fn is_valid(&self) -> bool {
-        self.properties.is_empty() && self.num_items.is_none()
+        self.items.is_empty() && self.num_items.is_none()
     }
 }
 
@@ -325,7 +325,7 @@ pub trait EntityVisitor: Sized + Send + Sync {
                 Ok(())
             } else {
                 Err(ArrayValidationReport {
-                    properties,
+                    items: properties,
                     ..ArrayValidationReport::default()
                 })
             }

--- a/libs/@local/graph/types/typescript/src/validation.ts
+++ b/libs/@local/graph/types/typescript/src/validation.ts
@@ -158,10 +158,10 @@ export type PropertyArrayValidationReport = Subtype<
 
 export type ArrayValidationReport = Omit<
   ArrayValidationReportGraphApi,
-  "numItems" | "properties"
+  "numItems" | "items"
 > & {
   numItems?: ArrayItemNumberMismatchGraphApi;
-  properties?: { [arrayIndex: string]: PropertyValidationReport };
+  items?: { [index: string]: PropertyValidationReport };
 };
 
 export type PropertyObjectValidationReport = Subtype<

--- a/libs/@local/graph/validation/src/entity_type.rs
+++ b/libs/@local/graph/validation/src/entity_type.rs
@@ -611,7 +611,7 @@ impl EntityVisitor for EntityPreprocessor {
         P: DataTypeLookup + OntologyTypeProvider<PropertyType> + Sync,
     {
         let mut array_validation = ArrayValidationReport {
-            properties: walk_array(self, schema, array, type_provider).await,
+            items: walk_array(self, schema, array, type_provider).await,
             ..ArrayValidationReport::default()
         };
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`properties` is confusing in this context