### PR TITLE
H-3787: Reduce logging level for Node API in AWS

### DIFF
--- a/infra/terraform/hash/prod-usea1.tfvars
+++ b/infra/terraform/hash/prod-usea1.tfvars
@@ -71,7 +71,7 @@ hash_api_env_vars = [
   { name = "FRONTEND_URL", secret = false, value = "https://app.hash.ai" },
   { name = "API_ORIGIN", secret = false, value = "https://app-api.hash.ai" },
 
-  { name = "LOG_LEVEL", secret = false, value = "debug" },
+  { name = "LOG_LEVEL", secret = false, value = "warn" },
 
   { name = "FILE_UPLOAD_PROVIDER", secret = false, value = "AWS_S3" },
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The current logging level is quite verbose, we set this to warn instead.