### PR TITLE
H-3788: Do not force FQDN on DNS lookup

### DIFF
--- a/libs/@local/harpc/client/typescript/src/net/internal/transport.ts
+++ b/libs/@local/harpc/client/typescript/src/net/internal/transport.ts
@@ -98,38 +98,34 @@ const resolveDnsMultiaddrSegment = (code: number, value?: string) =>
       return [[code, value] as const];
     }
 
-    let fqdn = value;
+    let hostname = value;
 
     let family: 0 | 4 | 6;
     if (code === DNS4_PROTOCOL.code) {
       family = 4;
 
-      if (isIPv4(fqdn)) {
-        return [[IPV4_PROTOCOL.code, fqdn] as const];
+      if (isIPv4(hostname)) {
+        return [[IPV4_PROTOCOL.code, hostname] as const];
       }
     } else if (code === DNS6_PROTOCOL.code) {
       family = 6;
 
-      if (isIPv6(fqdn)) {
-        return [[IPV6_PROTOCOL.code, fqdn] as const];
+      if (isIPv6(hostname)) {
+        return [[IPV6_PROTOCOL.code, hostname] as const];
       }
     } else {
       family = 0;
 
-      const fqdnFamily = isIP(fqdn);
-      if (fqdnFamily === 4) {
-        return [[IPV4_PROTOCOL.code, fqdn] as const];
-      } else if (fqdnFamily === 6) {
-        return [[IPV6_PROTOCOL.code, fqdn] as const];
+      const hostnameFamily = isIP(hostname);
+      if (hostnameFamily === 4) {
+        return [[IPV4_PROTOCOL.code, hostname] as const];
+      } else if (hostnameFamily === 6) {
+        return [[IPV6_PROTOCOL.code, hostname] as const];
       }
     }
 
-    if (!fqdn.endsWith(".")) {
-      fqdn += ".";
-    }
-
     const responses = yield* Effect.tryPromise({
-      try: () => dns.lookup(fqdn, { all: true, family }),
+      try: () => dns.lookup(hostname, { all: true, family }),
       catch: (cause) => new DnsError({ cause }),
     }).pipe(Effect.mapError((cause) => new TransportError({ cause })));
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We're currently forcing an FQDN DNS lookup, this was previously needed, but prohibits the use of search domains.

This is usually wanted, as otherwise, `machine` might get coerced into `machine.aws.com` on the local system, but it seems like that the AWS system relies on search domains.

## 🔗 Related links

* [Fully qualified domain name](https://en.wikipedia.org/wiki/Fully_qualified_domain_name)
* [Search domain](https://en.wikipedia.org/wiki/Search_domain)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

