### PR TITLE
H-3789: Detect queries to the graph and record times

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2730,6 +2730,7 @@ dependencies = [
  "error-stack",
  "frunk",
  "futures",
+ "futures-channel",
  "harpc-client",
  "harpc-codec",
  "harpc-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ enumflags2         = { version = "=0.7.10", default-features = false }
 erased-serde       = { version = "=0.4.5", default-features = false }
 foldhash           = { version = "=0.1.3", default-features = false }
 frunk              = { version = "0.4.3", default-features = false }
+futures-channel    = { version = "=0.3.31", default-features = false }
 futures-core       = { version = "=0.3.31", default-features = false }
 futures-io         = { version = "=0.3.31", default-features = false }
 futures-sink       = { version = "=0.3.31", default-features = false }

--- a/libs/@local/graph/api/Cargo.toml
+++ b/libs/@local/graph/api/Cargo.toml
@@ -22,11 +22,12 @@ hash-graph-types          = { workspace = true, public = true, features = ["utoi
 hash-temporal-client      = { workspace = true, public = true }
 
 # Public third-party dependencies
-axum       = { workspace = true, public = true }
-axum-core  = { workspace = true, public = true }
-http       = { workspace = true, public = true }
-tower-http = { workspace = true, public = true }
-tracing    = { workspace = true, public = true }
+axum            = { workspace = true, public = true }
+axum-core       = { workspace = true, public = true }
+futures-channel = { workspace = true, public = true }
+http            = { workspace = true, public = true }
+tower-http      = { workspace = true, public = true }
+tracing         = { workspace = true, public = true }
 
 # Private workspace dependencies
 harpc-codec                    = { workspace = true }

--- a/libs/@local/graph/api/src/rest/data_type.rs
+++ b/libs/@local/graph/api/src/rest/data_type.rs
@@ -57,7 +57,7 @@ use utoipa::{OpenApi, ToSchema};
 
 use super::api_resource::RoutedResource;
 use crate::rest::{
-    AuthenticatedUserHeader, PermissionResponse, RestApiStore,
+    AuthenticatedUserHeader, OpenApiQuery, PermissionResponse, QueryLogger, RestApiStore,
     json::Json,
     status::{report_to_response, status_to_response},
     utoipa_typedef::{ListOrValue, MaybeListOfDataType, subgraph::Subgraph},
@@ -404,12 +404,17 @@ async fn get_data_types<S, A>(
     store_pool: Extension<Arc<S>>,
     authorization_api_pool: Extension<Arc<A>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
+    mut query_logger: Option<Extension<QueryLogger>>,
     Json(request): Json<serde_json::Value>,
 ) -> Result<Json<GetDataTypesResponse>, Response>
 where
     S: StorePool + Send + Sync,
     A: AuthorizationApiPool + Send + Sync,
 {
+    if let Some(query_logger) = &mut query_logger {
+        query_logger.capture(OpenApiQuery::GetDataTypes(&request));
+    }
+
     let authorization_api = authorization_api_pool
         .acquire()
         .await
@@ -420,7 +425,7 @@ where
         .await
         .map_err(report_to_response)?;
 
-    store
+    let response = store
         .get_data_types(
             actor_id,
             // Manually deserialize the query from a JSON value to allow borrowed deserialization
@@ -431,7 +436,11 @@ where
         )
         .await
         .map_err(report_to_response)
-        .map(Json)
+        .map(Json);
+    if let Some(query_logger) = &mut query_logger {
+        query_logger.send().await.map_err(report_to_response)?;
+    }
+    response
 }
 
 #[derive(Serialize, ToSchema)]
@@ -470,12 +479,17 @@ async fn get_data_type_subgraph<S, A>(
     store_pool: Extension<Arc<S>>,
     authorization_api_pool: Extension<Arc<A>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
+    mut query_logger: Option<Extension<QueryLogger>>,
     Json(request): Json<serde_json::Value>,
 ) -> Result<Json<GetDataTypeSubgraphResponse>, Response>
 where
     S: StorePool + Send + Sync,
     A: AuthorizationApiPool + Send + Sync,
 {
+    if let Some(query_logger) = &mut query_logger {
+        query_logger.capture(OpenApiQuery::GetDataTypeSubgraph(&request));
+    }
+
     let authorization_api = authorization_api_pool
         .acquire()
         .await
@@ -486,7 +500,7 @@ where
         .await
         .map_err(report_to_response)?;
 
-    store
+    let response = store
         .get_data_type_subgraph(
             actor_id,
             // Manually deserialize the query from a JSON value to allow borrowed deserialization
@@ -502,7 +516,11 @@ where
                 subgraph: Subgraph::from(response.subgraph),
                 cursor: response.cursor,
             })
-        })
+        });
+    if let Some(query_logger) = &mut query_logger {
+        query_logger.send().await.map_err(report_to_response)?;
+    }
+    response
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -866,24 +884,33 @@ async fn get_data_type_authorization_relationships<A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     Path(data_type_id): Path<VersionedUrl>,
     authorization_api_pool: Extension<Arc<A>>,
+    mut query_logger: Option<Extension<QueryLogger>>,
 ) -> Result<Json<Vec<DataTypeRelationAndSubject>>, Response>
 where
     A: AuthorizationApiPool + Send + Sync,
 {
+    if let Some(query_logger) = &mut query_logger {
+        query_logger.capture(OpenApiQuery::GetDataTypeAuthorizationRelationships {
+            data_type_id: &data_type_id,
+        });
+    }
+
     let authorization_api = authorization_api_pool
         .acquire()
         .await
         .map_err(report_to_response)?;
 
-    Ok(Json(
-        authorization_api
-            .get_data_type_relations(
-                DataTypeUuid::from_url(&data_type_id),
-                Consistency::FullyConsistent,
-            )
-            .await
-            .map_err(report_to_response)?,
-    ))
+    let response = authorization_api
+        .get_data_type_relations(
+            DataTypeUuid::from_url(&data_type_id),
+            Consistency::FullyConsistent,
+        )
+        .await
+        .map_err(report_to_response)?;
+    if let Some(query_logger) = &mut query_logger {
+        query_logger.send().await.map_err(report_to_response)?;
+    }
+    Ok(Json(response))
 }
 
 #[utoipa::path(
@@ -904,13 +931,21 @@ where
 #[tracing::instrument(level = "info", skip(authorization_api_pool))]
 async fn check_data_type_permission<A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    mut query_logger: Option<Extension<QueryLogger>>,
     Path((data_type_id, permission)): Path<(VersionedUrl, DataTypePermission)>,
     authorization_api_pool: Extension<Arc<A>>,
 ) -> Result<Json<PermissionResponse>, Response>
 where
     A: AuthorizationApiPool + Send + Sync,
 {
-    Ok(Json(PermissionResponse {
+    if let Some(query_logger) = &mut query_logger {
+        query_logger.capture(OpenApiQuery::CheckDataTypePermission {
+            data_type_id: &data_type_id,
+            permission,
+        });
+    }
+
+    let response = Ok(Json(PermissionResponse {
         has_permission: authorization_api_pool
             .acquire()
             .await
@@ -924,5 +959,9 @@ where
             .await
             .map_err(report_to_response)?
             .has_permission,
-    }))
+    }));
+    if let Some(query_logger) = &mut query_logger {
+        query_logger.send().await.map_err(report_to_response)?;
+    }
+    response
 }

--- a/libs/@local/graph/api/src/rest/entity_type.rs
+++ b/libs/@local/graph/api/src/rest/entity_type.rs
@@ -57,7 +57,7 @@ use type_system::{
 use utoipa::{OpenApi, ToSchema};
 
 use crate::rest::{
-    AuthenticatedUserHeader, PermissionResponse, RestApiStore,
+    AuthenticatedUserHeader, OpenApiQuery, PermissionResponse, QueryLogger, RestApiStore,
     api_resource::RoutedResource,
     json::Json,
     status::{report_to_response, status_to_response},
@@ -279,16 +279,23 @@ async fn get_entity_type_authorization_relationships<A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     Path(entity_type_id): Path<VersionedUrl>,
     authorization_api_pool: Extension<Arc<A>>,
+    mut query_logger: Option<Extension<QueryLogger>>,
 ) -> Result<Json<Vec<EntityTypeRelationAndSubject>>, Response>
 where
     A: AuthorizationApiPool + Send + Sync,
 {
+    if let Some(query_logger) = &mut query_logger {
+        query_logger.capture(OpenApiQuery::GetEntityTypeAuthorizationRelationships {
+            entity_type_id: &entity_type_id,
+        });
+    }
+
     let authorization_api = authorization_api_pool
         .acquire()
         .await
         .map_err(report_to_response)?;
 
-    Ok(Json(
+    let response = Ok(Json(
         authorization_api
             .get_entity_type_relations(
                 EntityTypeUuid::from_url(&entity_type_id),
@@ -296,7 +303,11 @@ where
             )
             .await
             .map_err(report_to_response)?,
-    ))
+    ));
+    if let Some(query_logger) = &mut query_logger {
+        query_logger.send().await.map_err(report_to_response)?;
+    }
+    response
 }
 
 #[utoipa::path(
@@ -319,11 +330,19 @@ async fn check_entity_type_permission<A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     Path((entity_type_id, permission)): Path<(VersionedUrl, EntityTypePermission)>,
     authorization_api_pool: Extension<Arc<A>>,
+    mut query_logger: Option<Extension<QueryLogger>>,
 ) -> Result<Json<PermissionResponse>, Response>
 where
     A: AuthorizationApiPool + Send + Sync,
 {
-    Ok(Json(PermissionResponse {
+    if let Some(query_logger) = &mut query_logger {
+        query_logger.capture(OpenApiQuery::CheckEntityTypePermission {
+            entity_type_id: &entity_type_id,
+            permission,
+        });
+    }
+
+    let response = Ok(Json(PermissionResponse {
         has_permission: authorization_api_pool
             .acquire()
             .await
@@ -337,7 +356,11 @@ where
             .await
             .map_err(report_to_response)?
             .has_permission,
-    }))
+    }));
+    if let Some(query_logger) = &mut query_logger {
+        query_logger.send().await.map_err(report_to_response)?;
+    }
+    response
 }
 
 #[utoipa::path(
@@ -694,12 +717,17 @@ async fn get_entity_types<S, A>(
     store_pool: Extension<Arc<S>>,
     authorization_api_pool: Extension<Arc<A>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
+    mut query_logger: Option<Extension<QueryLogger>>,
     Json(request): Json<serde_json::Value>,
 ) -> Result<Json<GetEntityTypesResponse>, Response>
 where
     S: StorePool + Send + Sync,
     A: AuthorizationApiPool + Send + Sync,
 {
+    if let Some(query_logger) = &mut query_logger {
+        query_logger.capture(OpenApiQuery::GetEntityTypes(&request));
+    }
+
     let authorization_api = authorization_api_pool
         .acquire()
         .await
@@ -710,7 +738,7 @@ where
         .await
         .map_err(report_to_response)?;
 
-    store
+    let response = store
         .get_entity_types(
             actor_id,
             // Manually deserialize the query from a JSON value to allow borrowed deserialization
@@ -721,7 +749,11 @@ where
         )
         .await
         .map_err(report_to_response)
-        .map(Json)
+        .map(Json);
+    if let Some(query_logger) = &mut query_logger {
+        query_logger.send().await.map_err(report_to_response)?;
+    }
+    response
 }
 
 #[utoipa::path(
@@ -753,12 +785,17 @@ async fn get_closed_multi_entity_type<S, A>(
     store_pool: Extension<Arc<S>>,
     authorization_api_pool: Extension<Arc<A>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
+    mut query_logger: Option<Extension<QueryLogger>>,
     Json(request): Json<serde_json::Value>,
 ) -> Result<Json<GetClosedMultiEntityTypeResponse>, Response>
 where
     S: StorePool + Send + Sync,
     A: AuthorizationApiPool + Send + Sync,
 {
+    if let Some(query_logger) = &mut query_logger {
+        query_logger.capture(OpenApiQuery::GetClosedMultiEntityTypes(&request));
+    }
+
     let authorization_api = authorization_api_pool
         .acquire()
         .await
@@ -769,7 +806,7 @@ where
         .await
         .map_err(report_to_response)?;
 
-    store
+    let response = store
         .get_closed_multi_entity_types(
             actor_id,
             // Manually deserialize the query from a JSON value to allow borrowed deserialization
@@ -780,7 +817,11 @@ where
         )
         .await
         .map_err(report_to_response)
-        .map(Json)
+        .map(Json);
+    if let Some(query_logger) = &mut query_logger {
+        query_logger.send().await.map_err(report_to_response)?;
+    }
+    response
 }
 
 #[derive(Serialize, ToSchema)]
@@ -825,12 +866,17 @@ async fn get_entity_type_subgraph<S, A>(
     store_pool: Extension<Arc<S>>,
     authorization_api_pool: Extension<Arc<A>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
+    mut query_logger: Option<Extension<QueryLogger>>,
     Json(request): Json<serde_json::Value>,
 ) -> Result<Json<GetEntityTypeSubgraphResponse>, Response>
 where
     S: StorePool + Send + Sync,
     A: AuthorizationApiPool + Send + Sync,
 {
+    if let Some(query_logger) = &mut query_logger {
+        query_logger.capture(OpenApiQuery::GetEntityTypeSubgraph(&request));
+    }
+
     let authorization_api = authorization_api_pool
         .acquire()
         .await
@@ -841,7 +887,7 @@ where
         .await
         .map_err(report_to_response)?;
 
-    store
+    let response = store
         .get_entity_type_subgraph(
             actor_id,
             GetEntityTypeSubgraphParams::deserialize(&request)
@@ -858,7 +904,11 @@ where
                 web_ids: response.web_ids,
                 edition_created_by_ids: response.edition_created_by_ids,
             })
-        })
+        });
+    if let Some(query_logger) = &mut query_logger {
+        query_logger.send().await.map_err(report_to_response)?;
+    }
+    response
 }
 
 #[derive(Debug, Deserialize, ToSchema)]

--- a/libs/@local/graph/api/src/rest/mod.rs
+++ b/libs/@local/graph/api/src/rest/mod.rs
@@ -239,6 +239,7 @@ impl QueryLogger {
 
     #[expect(clippy::missing_panics_doc)]
     pub fn capture(&mut self, query: OpenApiQuery<'_>) {
+        self.created_at = Instant::now();
         self.value = Some(
             serde_json::to_value(query)
                 .change_context(QueryLoggingError)
@@ -246,9 +247,7 @@ impl QueryLogger {
         );
     }
 
-    /// Sends a query to the query logger.
-    ///
-    /// If the sender is `None`, nothing happens.
+    /// Sends the captured query to the query logger.
     ///
     /// # Errors
     ///

--- a/libs/@local/graph/store/src/entity/store.rs
+++ b/libs/@local/graph/store/src/entity/store.rs
@@ -300,7 +300,7 @@ pub struct UpdateEntityEmbeddingsParams<'e> {
     pub reset: bool,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DiffEntityParams {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In order to find slow queries the simplest way is to log the query times in question and capture the time spent on them.
This might be extended to other queries in the future, but for now we only need the actual read queries.


## 🔍 What does this change?

Adds a `--log-queries <PATH>` argument to the `server` subcommand to log queries at the specified path in JSON-lines format.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

The code is quite repetitive as I really wanted full control what exactly goes to the logger. It might be possible to encapsulate this in a new service, but this probably would have token more time than just implementing it as it is.