### PR TITLE
H-3791: Log discovered `PeerId`s in HaRPC

### DIFF
--- a/apps/hash-api/src/index.ts
+++ b/apps/hash-api/src/index.ts
@@ -537,6 +537,7 @@ const main = async () => {
         RequestIdProducer.layer,
         JsonDecoder.layer,
         JsonEncoder.layer,
+        Logger.pretty,
       ),
     );
 
@@ -560,7 +561,7 @@ const main = async () => {
       }).pipe(
         Effect.provide(
           RpcClient.connectLayer(
-            Transport.multiaddr(`/dns4/${rpcHost}/tcp/${rpcPort}`),
+            Transport.multiaddr(`/dns/${rpcHost}/tcp/${rpcPort}`),
           ),
         ),
         Logger.withMinimumLogLevel(LogLevel.Trace),

--- a/libs/@local/harpc/client/typescript/src/net/internal/transport.ts
+++ b/libs/@local/harpc/client/typescript/src/net/internal/transport.ts
@@ -30,7 +30,10 @@ import {
   Option,
   pipe,
   Predicate,
+  Record,
   Stream,
+  Struct,
+  Tuple,
 } from "effect";
 import type { Libp2p } from "libp2p";
 import { createLibp2p } from "libp2p";
@@ -250,22 +253,42 @@ const lookupPeer = (transport: Transport, address: Multiaddr) =>
     );
 
     const peers = yield* Effect.tryPromise({
-      try: () =>
-        transport.peerStore.all({
-          filters: [
-            (peer) =>
-              peer.addresses.some((peerAddress) =>
-                resolved.some((resolvedAddress) =>
-                  resolvedAddress.equals(peerAddress.multiaddr),
-                ),
-              ),
-          ],
-          limit: 1,
-        }),
+      try: () => transport.peerStore.all(),
       catch: (cause) => new TransportError({ cause }),
     });
 
-    return Array.head(peers).pipe(Option.map((peer) => peer.id));
+    const addressesByPeer = pipe(
+      peers,
+      Array.map((peer) => ({
+        id: peer.id,
+        addresses: peer.addresses.map(Struct.get("multiaddr")),
+      })),
+    );
+
+    const matchingPeers = pipe(
+      addressesByPeer,
+      Array.filter(
+        flow(
+          Struct.get("addresses"),
+          Array.unionWith(resolved, (a, b) => a.equals(b)),
+          Array.isNonEmptyArray,
+        ),
+      ),
+    );
+
+    yield* Effect.logTrace("discovered peers").pipe(
+      Effect.annotateLogs({
+        known: addressesByPeer,
+        match: matchingPeers,
+        resolved: resolved.map((resolvedAddress) => resolvedAddress.toString()),
+      }),
+    );
+
+    return pipe(
+      matchingPeers, //
+      Array.map(Struct.get("id")),
+      Array.head,
+    );
   });
 
 const resolvePeer = (
@@ -284,16 +307,14 @@ const resolvePeer = (
     const key = HashableMultiaddr.make(address);
     const peerIdEither = yield* cache.getEither(key);
     if (Either.isLeft(peerIdEither)) {
-      yield* Effect.logTrace("resolved peerID from cache");
+      yield* Effect.logTrace("retrieved PeerID from cache");
     } else {
-      yield* Effect.logTrace("computed peerID");
+      yield* Effect.logTrace("resolved and matched multiaddr to PeerID");
     }
 
     const peerId = Either.merge(peerIdEither);
     if (Option.isNone(peerId)) {
-      yield* Effect.logDebug(
-        "unable to resolve peer to a known peer ID, invalidating cache to retry next time",
-      );
+      yield* Effect.logDebug("PeerID lookup failed, invalidating cache entry");
 
       yield* cache.invalidate(key);
     }

--- a/libs/@local/harpc/client/typescript/src/net/internal/transport.ts
+++ b/libs/@local/harpc/client/typescript/src/net/internal/transport.ts
@@ -30,10 +30,8 @@ import {
   Option,
   pipe,
   Predicate,
-  Record,
   Stream,
   Struct,
-  Tuple,
 } from "effect";
 import type { Libp2p } from "libp2p";
 import { createLibp2p } from "libp2p";


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We're experiencing an issue in the harpc client implementation, where the resolved DNS entry seems to be out of sync with the one libp2p is using.


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

