### PR TITLE
H-3804: Improve performance observability tooling in the graph

### DIFF
--- a/libs/@local/graph/api/src/rest/account.rs
+++ b/libs/@local/graph/api/src/rest/account.rs
@@ -235,7 +235,7 @@ where
     A: AuthorizationApiPool + Send + Sync,
 {
     if let Some(query_logger) = &mut query_logger {
-        query_logger.capture(OpenApiQuery::CheckAccountGroupPermission {
+        query_logger.capture(actor_id, OpenApiQuery::CheckAccountGroupPermission {
             account_group_id,
             permission,
         });

--- a/libs/@local/graph/api/src/rest/data_type.rs
+++ b/libs/@local/graph/api/src/rest/data_type.rs
@@ -412,7 +412,7 @@ where
     A: AuthorizationApiPool + Send + Sync,
 {
     if let Some(query_logger) = &mut query_logger {
-        query_logger.capture(OpenApiQuery::GetDataTypes(&request));
+        query_logger.capture(actor_id, OpenApiQuery::GetDataTypes(&request));
     }
 
     let authorization_api = authorization_api_pool
@@ -487,7 +487,7 @@ where
     A: AuthorizationApiPool + Send + Sync,
 {
     if let Some(query_logger) = &mut query_logger {
-        query_logger.capture(OpenApiQuery::GetDataTypeSubgraph(&request));
+        query_logger.capture(actor_id, OpenApiQuery::GetDataTypeSubgraph(&request));
     }
 
     let authorization_api = authorization_api_pool
@@ -890,9 +890,12 @@ where
     A: AuthorizationApiPool + Send + Sync,
 {
     if let Some(query_logger) = &mut query_logger {
-        query_logger.capture(OpenApiQuery::GetDataTypeAuthorizationRelationships {
-            data_type_id: &data_type_id,
-        });
+        query_logger.capture(
+            actor_id,
+            OpenApiQuery::GetDataTypeAuthorizationRelationships {
+                data_type_id: &data_type_id,
+            },
+        );
     }
 
     let authorization_api = authorization_api_pool
@@ -939,7 +942,7 @@ where
     A: AuthorizationApiPool + Send + Sync,
 {
     if let Some(query_logger) = &mut query_logger {
-        query_logger.capture(OpenApiQuery::CheckDataTypePermission {
+        query_logger.capture(actor_id, OpenApiQuery::CheckDataTypePermission {
             data_type_id: &data_type_id,
             permission,
         });

--- a/libs/@local/graph/api/src/rest/entity_type.rs
+++ b/libs/@local/graph/api/src/rest/entity_type.rs
@@ -285,9 +285,12 @@ where
     A: AuthorizationApiPool + Send + Sync,
 {
     if let Some(query_logger) = &mut query_logger {
-        query_logger.capture(OpenApiQuery::GetEntityTypeAuthorizationRelationships {
-            entity_type_id: &entity_type_id,
-        });
+        query_logger.capture(
+            actor_id,
+            OpenApiQuery::GetEntityTypeAuthorizationRelationships {
+                entity_type_id: &entity_type_id,
+            },
+        );
     }
 
     let authorization_api = authorization_api_pool
@@ -336,7 +339,7 @@ where
     A: AuthorizationApiPool + Send + Sync,
 {
     if let Some(query_logger) = &mut query_logger {
-        query_logger.capture(OpenApiQuery::CheckEntityTypePermission {
+        query_logger.capture(actor_id, OpenApiQuery::CheckEntityTypePermission {
             entity_type_id: &entity_type_id,
             permission,
         });
@@ -725,7 +728,7 @@ where
     A: AuthorizationApiPool + Send + Sync,
 {
     if let Some(query_logger) = &mut query_logger {
-        query_logger.capture(OpenApiQuery::GetEntityTypes(&request));
+        query_logger.capture(actor_id, OpenApiQuery::GetEntityTypes(&request));
     }
 
     let authorization_api = authorization_api_pool
@@ -793,7 +796,7 @@ where
     A: AuthorizationApiPool + Send + Sync,
 {
     if let Some(query_logger) = &mut query_logger {
-        query_logger.capture(OpenApiQuery::GetClosedMultiEntityTypes(&request));
+        query_logger.capture(actor_id, OpenApiQuery::GetClosedMultiEntityTypes(&request));
     }
 
     let authorization_api = authorization_api_pool
@@ -874,7 +877,7 @@ where
     A: AuthorizationApiPool + Send + Sync,
 {
     if let Some(query_logger) = &mut query_logger {
-        query_logger.capture(OpenApiQuery::GetEntityTypeSubgraph(&request));
+        query_logger.capture(actor_id, OpenApiQuery::GetEntityTypeSubgraph(&request));
     }
 
     let authorization_api = authorization_api_pool

--- a/libs/@local/graph/api/src/rest/property_type.rs
+++ b/libs/@local/graph/api/src/rest/property_type.rs
@@ -401,7 +401,7 @@ where
     A: AuthorizationApiPool + Send + Sync,
 {
     if let Some(query_logger) = &mut query_logger {
-        query_logger.capture(OpenApiQuery::GetPropertyTypes(&request));
+        query_logger.capture(actor_id, OpenApiQuery::GetPropertyTypes(&request));
     }
 
     let authorization_api = authorization_api_pool
@@ -480,7 +480,7 @@ where
     A: AuthorizationApiPool + Send + Sync,
 {
     if let Some(query_logger) = &mut query_logger {
-        query_logger.capture(OpenApiQuery::GetPropertyTypeSubgraph(&request));
+        query_logger.capture(actor_id, OpenApiQuery::GetPropertyTypeSubgraph(&request));
     }
 
     let authorization_api = authorization_api_pool
@@ -878,9 +878,12 @@ where
     A: AuthorizationApiPool + Send + Sync,
 {
     if let Some(query_logger) = &mut query_logger {
-        query_logger.capture(OpenApiQuery::GetPropertyTypeAuthorizationRelationships {
-            property_type_id: &property_type_id,
-        });
+        query_logger.capture(
+            actor_id,
+            OpenApiQuery::GetPropertyTypeAuthorizationRelationships {
+                property_type_id: &property_type_id,
+            },
+        );
     }
 
     let authorization_api = authorization_api_pool
@@ -929,7 +932,7 @@ where
     A: AuthorizationApiPool + Send + Sync,
 {
     if let Some(query_logger) = &mut query_logger {
-        query_logger.capture(OpenApiQuery::CheckPropertyTypePermission {
+        query_logger.capture(actor_id, OpenApiQuery::CheckPropertyTypePermission {
             property_type_id: &property_type_id,
             permission,
         });


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To properly reproduce performance bottleneck based on query logs it's required to include the `AccountId` of the actor.

## 🔍 What does this change?

- Add `actor_id` to the query logger
- drive-by: Emit a warning if `limit` is set to `0` in entity queries. If only the number of entities is required, `countEntities` can be used.