### PR TITLE
H-3553, H-3695, H-3805: Entities table and slideover fixes

### DIFF
--- a/apps/hash-api/src/util.ts
+++ b/apps/hash-api/src/util.ts
@@ -10,19 +10,6 @@ export const exactlyOne = (...items: unknown[]): boolean =>
     .map((val) => val !== null && val !== undefined)
     .reduce((acc, val) => (val ? 1 : 0) + acc, 0) === 1;
 
-export const isRecord = (thing: unknown): thing is Record<string, unknown> => {
-  if (typeof thing !== "object") {
-    return false;
-  }
-  if (thing == null) {
-    return false;
-  }
-  if (thing instanceof Array) {
-    return false;
-  }
-  return true;
-};
-
 /** Returns the set intersection of `left` and `right`. */
 export const intersection = <T>(left: Set<T>, right: Set<T>): Set<T> => {
   const result = new Set<T>();
@@ -32,31 +19,6 @@ export const intersection = <T>(left: Set<T>, right: Set<T>): Set<T> => {
     }
   }
   return result;
-};
-
-/**
- * @todo this assumption of the slug might be brittle,
- */
-export const capitalizeComponentName = (cId: string) => {
-  let componentId = cId;
-
-  // If there's a trailing slash, remove it
-  const indexLastSlash = componentId.lastIndexOf("/");
-  if (indexLastSlash === componentId.length - 1) {
-    componentId = componentId.slice(0, -1);
-  }
-
-  //                      *
-  // "https://example.org/value"
-  const indexAfterLastSlash = componentId.lastIndexOf("/") + 1;
-  return (
-    //                      * and uppercase it
-    // "https://example.org/value"
-    componentId.charAt(indexAfterLastSlash).toUpperCase() +
-    //                       ****
-    // "https://example.org/value"
-    componentId.substring(indexAfterLastSlash + 1)
-  );
 };
 
 /**

--- a/apps/hash-frontend/src/components/grid/grid.tsx
+++ b/apps/hash-frontend/src/components/grid/grid.tsx
@@ -580,7 +580,7 @@ export const Grid = <T extends GridRow>({
           if (onSelectedRowsChange && sortedAndFilteredRows) {
             newSelection.rows.toArray();
             const updatedSelectedRows = sortedAndFilteredRows.filter(
-              (_, rowIndex) => selection.rows.hasIndex(rowIndex),
+              (_, rowIndex) => newSelection.rows.hasIndex(rowIndex),
             );
 
             onSelectedRowsChange(updatedSelectedRows);

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/edit-entity-slide-over.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/edit-entity-slide-over.tsx
@@ -5,6 +5,7 @@ import {
   Skeleton,
 } from "@hashintel/design-system";
 import {
+  type Entity,
   getClosedMultiEntityTypeFromMap,
   getDisplayFieldsForClosedEntityType,
   isClosedMultiEntityTypeForEntityTypeIds,
@@ -46,6 +47,9 @@ import {
 } from "../../../../graphql/queries/knowledge/entity.queries";
 import { Button, Link } from "../../../../shared/ui";
 import { SlideBackForwardCloseBar } from "../../../shared/shared/slide-back-forward-close-bar";
+import { ArchivedItemBanner } from "../../../shared/top-context-bar/archived-item-banner";
+import type { MinimalEntityValidationReport } from "../../../shared/use-validate-entity";
+import { useValidateEntity } from "../../../shared/use-validate-entity";
 import type { EntityEditorProps } from "./entity-editor";
 import { EntityEditor } from "./entity-editor";
 import { createDraftEntitySubgraph } from "./shared/create-draft-entity-subgraph";
@@ -261,7 +265,7 @@ const EditEntitySlideOver = memo(
      * we need to fetch it and set it in the local state (from where it will be updated if the user uses the editor
      * form).
      */
-    const { data: fetchedEntityData } = useQuery<
+    const { data: fetchedEntityData, refetch } = useQuery<
       GetEntitySubgraphQuery,
       GetEntitySubgraphQueryVariables
     >(getEntitySubgraphQuery, {
@@ -467,8 +471,26 @@ const EditEntitySlideOver = memo(
       updateEntity,
     ]);
 
+    const [validationReport, setValidationReport] =
+      useState<MinimalEntityValidationReport | null>(null);
+
+    const { validateEntity: validateFn } = useValidateEntity();
+
+    const validateEntity = useCallback(
+      async (entityToValidate: Entity) => {
+        const report = await validateFn({
+          properties: entityToValidate.propertiesWithMetadata,
+          entityTypeIds: entityToValidate.metadata.entityTypeIds,
+        });
+
+        setValidationReport(report);
+      },
+      [validateFn],
+    );
+
     const submitDisabled =
-      !isDirty && !draftLinksToCreate.length && !draftLinksToArchive.length;
+      !!validationReport ||
+      (!isDirty && !draftLinksToCreate.length && !draftLinksToArchive.length);
 
     const onEntityClick = useCallback(
       (entityId: EntityId) =>
@@ -525,31 +547,32 @@ const EditEntitySlideOver = memo(
               onForward={onForward}
               onClose={onClose}
             />
+            {entity.metadata.archived && (
+              <Box mb={1}>
+                <ArchivedItemBanner item={entity} onUnarchived={refetch} />
+              </Box>
+            )}
             <Stack gap={5} px={6} pb={5} pt={1}>
-              <Stack alignItems="center" direction="row">
-                <Box sx={{ minWidth: 40 }}>
-                  <EntityOrTypeIcon
-                    entity={entity}
-                    icon={icon}
-                    isLink={isLink}
-                    fill={({ palette }) => palette.gray[50]}
-                    fontSize={40}
-                  />
-                </Box>
-                <Typography
-                  variant="h2"
-                  color="gray.90"
-                  fontWeight="bold"
-                  ml={2}
-                  sx={{
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                    overflow: "hidden",
-                    maxWidth: "100%",
-                  }}
-                >
-                  {entityLabel}
-                </Typography>
+              <Stack alignItems="flex-start" direction="row">
+                <Stack alignItems="center" direction="row">
+                  <Box sx={{ minWidth: 40 }}>
+                    <EntityOrTypeIcon
+                      entity={entity}
+                      icon={icon}
+                      isLink={isLink}
+                      fill={({ palette }) => palette.gray[50]}
+                      fontSize={40}
+                    />
+                  </Box>
+                  <Typography
+                    variant="h2"
+                    color="gray.90"
+                    fontWeight="bold"
+                    ml={2}
+                  >
+                    {entityLabel}
+                  </Typography>
+                </Stack>
                 {entityOwningShortname && !hideOpenInNew && (
                   <Link
                     href={generateEntityPath({
@@ -585,7 +608,7 @@ const EditEntitySlideOver = memo(
                 entityLabel={entityLabel}
                 entitySubgraph={localEntitySubgraph}
                 handleTypesChange={async (change) => {
-                  await handleTypeChanges(change);
+                  const newEntity = await handleTypeChanges(change);
 
                   const originalEntity = originalEntitySubgraph
                     ? getRoots(originalEntitySubgraph)[0]
@@ -597,8 +620,10 @@ const EditEntitySlideOver = memo(
                         originalEntity?.metadata.entityTypeIds.toSorted(),
                       ),
                   );
+
+                  await validateEntity(newEntity);
                 }}
-                setEntity={(changedEntity) => {
+                setEntity={async (changedEntity) => {
                   setLocalEntitySubgraph((prev) =>
                     createDraftEntitySubgraph({
                       entity: changedEntity,
@@ -607,6 +632,9 @@ const EditEntitySlideOver = memo(
                       omitProperties: [],
                     }),
                   );
+
+                  await validateEntity(changedEntity);
+
                   setIsDirty(true);
                 }}
                 isDirty={isDirty}

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/edit-entity-slide-over.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/edit-entity-slide-over.tsx
@@ -541,6 +541,12 @@ const EditEntitySlideOver = memo(
                   color="gray.90"
                   fontWeight="bold"
                   ml={2}
+                  sx={{
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    maxWidth: "100%",
+                  }}
                 >
                   {entityLabel}
                 </Typography>

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-page-wrapper/entity-page-header.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-page-wrapper/entity-page-header.tsx
@@ -118,7 +118,13 @@ export const EntityPageHeader = ({
               isLink={!!entity?.linkData}
               fontSize={40}
             />
-            <Typography variant="h1" fontWeight="bold" sx={{ lineHeight: 1 }}>
+            <Typography
+              variant="h1"
+              fontWeight="bold"
+              sx={{
+                lineHeight: 1.2,
+              }}
+            >
               {entityLabel}
             </Typography>
           </Stack>

--- a/apps/hash-frontend/src/pages/shared/entities-visualizer.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-visualizer.tsx
@@ -127,6 +127,7 @@ export const EntitiesVisualizer: FunctionComponent<{
     hadCachedContent,
     loading,
     propertyTypes,
+    refetch: refetchWithoutLinks,
     subgraph: subgraphPossiblyWithoutLinks,
   } = useEntityTypeEntitiesContext();
 
@@ -166,20 +167,21 @@ export const EntitiesVisualizer: FunctionComponent<{
     }
   }, [defaultView, isDisplayingFilesOnly]);
 
-  const { subgraph: subgraphWithLinkedEntities } = useEntityTypeEntities({
-    entityTypeBaseUrl,
-    entityTypeId,
-    graphResolveDepths: {
-      constrainsLinksOn: { outgoing: 255 },
-      constrainsLinkDestinationsOn: { outgoing: 255 },
-      constrainsPropertiesOn: { outgoing: 255 },
-      constrainsValuesOn: { outgoing: 255 },
-      inheritsFrom: { outgoing: 255 },
-      isOfType: { outgoing: 1 },
-      hasLeftEntity: { outgoing: 1, incoming: 1 },
-      hasRightEntity: { outgoing: 1, incoming: 1 },
-    },
-  });
+  const { subgraph: subgraphWithLinkedEntities, refetch: refetchWithLinks } =
+    useEntityTypeEntities({
+      entityTypeBaseUrl,
+      entityTypeId,
+      graphResolveDepths: {
+        constrainsLinksOn: { outgoing: 255 },
+        constrainsLinkDestinationsOn: { outgoing: 255 },
+        constrainsPropertiesOn: { outgoing: 255 },
+        constrainsValuesOn: { outgoing: 255 },
+        inheritsFrom: { outgoing: 255 },
+        isOfType: { outgoing: 1 },
+        hasLeftEntity: { outgoing: 1, incoming: 1 },
+        hasRightEntity: { outgoing: 1, incoming: 1 },
+      },
+    });
 
   /**
    The subgraphWithLinkedEntities can take a long time to load with many entities.
@@ -395,7 +397,10 @@ export const EntitiesVisualizer: FunctionComponent<{
           toggleSearch={
             view === "Table" ? () => setShowTableSearch(true) : undefined
           }
-          onBulkActionCompleted={() => null}
+          onBulkActionCompleted={() => {
+            void refetchWithoutLinks();
+            void refetchWithLinks();
+          }}
         />
         {!subgraph ? (
           <Stack

--- a/apps/hash-frontend/src/pages/shared/entity-type-page/type-slide-over-stack.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-page/type-slide-over-stack.tsx
@@ -3,8 +3,8 @@ import { Backdrop } from "@mui/material";
 import type { FunctionComponent, RefObject } from "react";
 import { useCallback, useState } from "react";
 
-import { TypeSlideOverSlide } from "./type-slide-over-stack/type-slide-over-slide";
 import { useScrollLock } from "../../../shared/use-scroll-lock";
+import { TypeSlideOverSlide } from "./type-slide-over-stack/type-slide-over-slide";
 
 export const TypeSlideOverStack: FunctionComponent<{
   rootTypeId: VersionedUrl;

--- a/apps/hash-frontend/src/pages/shared/entity-type-page/type-slide-over-stack.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-page/type-slide-over-stack.tsx
@@ -4,6 +4,7 @@ import type { FunctionComponent, RefObject } from "react";
 import { useCallback, useState } from "react";
 
 import { TypeSlideOverSlide } from "./type-slide-over-stack/type-slide-over-slide";
+import { useScrollLock } from "../../../shared/use-scroll-lock";
 
 export const TypeSlideOverStack: FunctionComponent<{
   rootTypeId: VersionedUrl;
@@ -16,6 +17,8 @@ export const TypeSlideOverStack: FunctionComponent<{
   const [animateOut, setAnimateOut] = useState(false);
   const [items, setItems] = useState<VersionedUrl[]>([rootTypeId]);
   const [currentIndex, setCurrentIndex] = useState<number>(0);
+
+  useScrollLock(true);
 
   if (rootTypeId !== items[0]) {
     setCurrentIndex(0);

--- a/apps/hash-frontend/src/shared/is-of-type.ts
+++ b/apps/hash-frontend/src/shared/is-of-type.ts
@@ -31,5 +31,12 @@ export const isTypePropertyType = (
     | DataTypeWithMetadata,
 ) => type.schema.kind === "propertyType";
 
+export const isTypeDataType = (
+  type:
+    | EntityTypeWithMetadata
+    | PropertyTypeWithMetadata
+    | DataTypeWithMetadata,
+) => type.schema.kind === "dataType";
+
 export const isEntityPageEntity = (item: Entity) =>
   includesPageEntityTypeId(item.metadata.entityTypeIds);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A few small fixes in the frontend:
1. Fix selecting via checkbox in the entities table
2. Support archiving selected entities in the entities table
3. Add an 'archived' banner to the entity slideover, indicating an entity is archived
4. Add validation to the slideover if not in readonly mode
5. Fix locking body scroll when the type slideover is open

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Try the functionality described above


