### PR TITLE
H-3811: Exclude `@effect/vitest` from Vitest upgrade group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -82,7 +82,8 @@
         "/rimraf/",
         "/turbo/",
         "/yarn-deduplicate/",
-        "/@redocly/cli/"
+        "/@redocly/cli/",
+        "!/@effect/vitest/"
       ]
     },
     {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

At the moment, `@effect/vitest` matches the `vitest` pattern we use in Renovate, and thus is excluded from the `effect` group (with which it should belong).

This PR adds a negative match for the `@effect/vitest` package in the `vitest` group, in the hopes that it is then correctly picked up as part of the `effect` group.

## Links

- [Negative matching syntax](https://docs.renovatebot.com/string-pattern-matching/#negative-matching) in the Renovate docs