### PR TITLE
H-3812: enable DNS logging during `hash-api` start

### DIFF
--- a/apps/hash-api/src/index.ts
+++ b/apps/hash-api/src/index.ts
@@ -547,6 +547,7 @@ const main = async () => {
     const rpcPort = parseInt(process.env.HASH_GRAPH_RPC_PORT ?? "4002", 10);
 
     // print out (temporary) DNS diagnostics
+    // see: https://linear.app/hash/issue/H-3813/remove-dns-logging-durring-hash-api-start
     void (async () => {
       const { default: dns } = await import("node:dns/promises");
       const { default: fs } = await import("node:fs/promises");

--- a/apps/hash-api/src/index.ts
+++ b/apps/hash-api/src/index.ts
@@ -546,6 +546,30 @@ const main = async () => {
     const rpcHost = getRequiredEnv("HASH_GRAPH_RPC_HOST");
     const rpcPort = parseInt(process.env.HASH_GRAPH_RPC_PORT ?? "4002", 10);
 
+    // print out (temporary) DNS diagnostics
+    void (async () => {
+      const { default: dns } = await import("node:dns/promises");
+      const { default: fs } = await import("node:fs/promises");
+
+      const servers = dns.getServers();
+      logger.info(`DNS servers: ${servers}`);
+
+      try {
+        const resolveAny = await dns.resolveAny(rpcHost);
+        logger.info(`DNS resolution for ${rpcHost}`, { resolveAny });
+      } catch (error) {
+        logger.error(`DNS resolution for ${rpcHost} failed`, { error });
+      }
+
+      // log out /etc/hosts, if it exists
+      try {
+        const hosts = await fs.readFile("/etc/hosts", "utf8");
+        logger.info(`Contents of /etc/hosts`, { hosts });
+      } catch (error) {
+        logger.error(`Could not read /etc/hosts`, { error });
+      }
+    })();
+
     app.get("/rpc/echo", (req, res) => {
       // eslint-disable-next-line func-names
       const effect = Effect.gen(function* () {

--- a/libs/@local/harpc/client/typescript/src/net/internal/dns.ts
+++ b/libs/@local/harpc/client/typescript/src/net/internal/dns.ts
@@ -81,7 +81,9 @@ const resolveAAAA = (hostname: string) =>
 const logEnvironment = (hostname: string) =>
   Effect.gen(function* () {
     const servers = dns.getServers();
-    const records = yield* Effect.tryPromise(() => dns.resolveAny(hostname));
+    const records = yield* Effect.tryPromise(() =>
+      dns.resolveAny(hostname),
+    ).pipe(Effect.merge);
 
     yield* Effect.logTrace("resolved DNS environment").pipe(
       Effect.annotateLogs({ hostname, servers, records }),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

During startup of the API, whenever RPC is enabled, print out useful DNS diagnostics.

This is primarily intended for AWS debugging purposes.

## 🔗 Related links
* removal of debugging information: [H-3813](https://linear.app/hash/issue/H-3813/remove-dns-logging-durring-hash-api-start)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
