### PR TITLE
H-1628: Write a benchmark which runs queries as specified in a JSON file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,6 +2794,8 @@ version = "0.0.0"
 dependencies = [
  "criterion",
  "criterion-macro",
+ "error-stack",
+ "hash-graph-api",
  "hash-graph-authorization",
  "hash-graph-postgres-store",
  "hash-graph-store",
@@ -2802,6 +2804,7 @@ dependencies = [
  "hash-graph-types",
  "hash-repo-chores",
  "rand",
+ "serde",
  "serde_json",
  "tokio",
  "tokio-postgres",
@@ -2810,6 +2813,7 @@ dependencies = [
  "tracing-subscriber",
  "type-system",
  "uuid",
+ "walkdir",
 ]
 
 [[package]]

--- a/libs/@local/graph/api/src/rest/entity.rs
+++ b/libs/@local/graph/api/src/rest/entity.rs
@@ -578,13 +578,13 @@ fn generate_sorting_paths(
     }
 }
 
-#[derive(Debug, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[expect(
     clippy::struct_excessive_bools,
     reason = "Parameter struct deserialized from JSON"
 )]
-struct GetEntitiesRequest<'q, 's, 'p> {
+pub struct GetEntitiesRequest<'q, 's, 'p> {
     #[serde(borrow)]
     filter: Filter<'q, Entity>,
     temporal_axes: QueryTemporalAxesUnresolved,
@@ -608,6 +608,30 @@ struct GetEntitiesRequest<'q, 's, 'p> {
     include_edition_created_by_ids: bool,
     #[serde(default)]
     include_type_ids: bool,
+}
+
+impl<'q, 's, 'p: 'q> From<GetEntitiesRequest<'q, 's, 'p>> for GetEntitiesParams<'q> {
+    fn from(request: GetEntitiesRequest<'q, 's, 'p>) -> Self {
+        Self {
+            filter: request.filter,
+            sorting: generate_sorting_paths(
+                request.sorting_paths,
+                request.limit,
+                request.cursor,
+                &request.temporal_axes,
+            ),
+            limit: request.limit,
+            conversions: request.conversions,
+            include_drafts: request.include_drafts,
+            include_count: request.include_count,
+            include_entity_types: request.include_entity_types,
+            temporal_axes: request.temporal_axes,
+            include_web_ids: request.include_web_ids,
+            include_created_by_ids: request.include_created_by_ids,
+            include_edition_created_by_ids: request.include_edition_created_by_ids,
+            include_type_ids: request.include_type_ids,
+        }
+    }
 }
 
 #[utoipa::path(
@@ -665,25 +689,7 @@ where
         .map_err(Report::from)
         .map_err(report_to_response)?;
     let response = store
-        .get_entities(actor_id, GetEntitiesParams {
-            filter: request.filter,
-            sorting: generate_sorting_paths(
-                request.sorting_paths,
-                request.limit,
-                request.cursor,
-                &request.temporal_axes,
-            ),
-            limit: request.limit,
-            conversions: request.conversions,
-            include_drafts: request.include_drafts,
-            include_count: request.include_count,
-            include_entity_types: request.include_entity_types,
-            temporal_axes: request.temporal_axes,
-            include_web_ids: request.include_web_ids,
-            include_created_by_ids: request.include_created_by_ids,
-            include_edition_created_by_ids: request.include_edition_created_by_ids,
-            include_type_ids: request.include_type_ids,
-        })
+        .get_entities(actor_id, request.into())
         .await
         .map(|response| {
             Json(GetEntitiesResponse {
@@ -705,13 +711,13 @@ where
     response
 }
 
-#[derive(Debug, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[expect(
     clippy::struct_excessive_bools,
     reason = "Parameter struct deserialized from JSON"
 )]
-struct GetEntitySubgraphRequest<'q, 's, 'p> {
+pub struct GetEntitySubgraphRequest<'q, 's, 'p> {
     #[serde(borrow)]
     filter: Filter<'q, Entity>,
     graph_resolve_depths: GraphResolveDepths,
@@ -736,6 +742,31 @@ struct GetEntitySubgraphRequest<'q, 's, 'p> {
     include_edition_created_by_ids: bool,
     #[serde(default)]
     include_type_ids: bool,
+}
+
+impl<'q, 's, 'p: 'q> From<GetEntitySubgraphRequest<'q, 's, 'p>> for GetEntitySubgraphParams<'q> {
+    fn from(request: GetEntitySubgraphRequest<'q, 's, 'p>) -> Self {
+        Self {
+            filter: request.filter,
+            sorting: generate_sorting_paths(
+                request.sorting_paths,
+                request.limit,
+                request.cursor,
+                &request.temporal_axes,
+            ),
+            limit: request.limit,
+            conversions: request.conversions,
+            graph_resolve_depths: request.graph_resolve_depths,
+            include_drafts: request.include_drafts,
+            include_count: request.include_count,
+            include_entity_types: request.include_entity_types,
+            temporal_axes: request.temporal_axes,
+            include_web_ids: request.include_web_ids,
+            include_created_by_ids: request.include_created_by_ids,
+            include_edition_created_by_ids: request.include_edition_created_by_ids,
+            include_type_ids: request.include_type_ids,
+        }
+    }
 }
 
 #[derive(Serialize, ToSchema)]
@@ -820,26 +851,7 @@ where
         .map_err(Report::from)
         .map_err(report_to_response)?;
     let response = store
-        .get_entity_subgraph(actor_id, GetEntitySubgraphParams {
-            filter: request.filter,
-            sorting: generate_sorting_paths(
-                request.sorting_paths,
-                request.limit,
-                request.cursor,
-                &request.temporal_axes,
-            ),
-            limit: request.limit,
-            conversions: request.conversions,
-            graph_resolve_depths: request.graph_resolve_depths,
-            include_drafts: request.include_drafts,
-            include_count: request.include_count,
-            include_entity_types: request.include_entity_types,
-            temporal_axes: request.temporal_axes,
-            include_web_ids: request.include_web_ids,
-            include_created_by_ids: request.include_created_by_ids,
-            include_edition_created_by_ids: request.include_edition_created_by_ids,
-            include_type_ids: request.include_type_ids,
-        })
+        .get_entity_subgraph(actor_id, request.into())
         .await
         .map(|response| {
             Json(GetEntitySubgraphResponse {

--- a/libs/@local/graph/api/src/rest/mod.rs
+++ b/libs/@local/graph/api/src/rest/mod.rs
@@ -2,18 +2,19 @@
 //!
 //! Handler methods are grouped by routes that make up the REST API.
 
+pub mod account;
+pub mod data_type;
+pub mod entity;
+pub mod entity_type;
+pub mod middleware;
+pub mod property_type;
+pub mod status;
+pub mod web;
+
 mod api_resource;
 mod json;
-pub mod middleware;
-pub mod status;
 mod utoipa_typedef;
 
-mod account;
-mod data_type;
-mod entity;
-mod entity_type;
-mod property_type;
-mod web;
 use alloc::{borrow::Cow, sync::Arc};
 use core::str::FromStr as _;
 use std::{fs, io, time::Instant};

--- a/libs/@local/graph/store/src/entity/store.rs
+++ b/libs/@local/graph/store/src/entity/store.rs
@@ -161,7 +161,7 @@ pub struct ValidateEntityParams<'a> {
     pub components: ValidateEntityComponents,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct QueryConversion<'a> {

--- a/tests/graph/benches/Cargo.toml
+++ b/tests/graph/benches/Cargo.toml
@@ -14,6 +14,8 @@ autobenches = false
 
 [dev-dependencies]
 # Private workspace dependencies
+error-stack                    = { workspace = true }
+hash-graph-api                 = { workspace = true }
 hash-graph-authorization       = { workspace = true }
 hash-graph-postgres-store      = { workspace = true }
 hash-graph-store               = { workspace = true }
@@ -27,6 +29,7 @@ type-system                    = { workspace = true }
 criterion          = { workspace = true, features = ["async_tokio", "html_reports"] }
 criterion-macro    = { workspace = true }
 rand               = { workspace = true }
+serde              = { workspace = true, features = ["derive"] }
 serde_json         = { workspace = true }
 tokio              = { workspace = true, features = ["macros"] }
 tokio-postgres     = { workspace = true, default-features = false }
@@ -34,17 +37,22 @@ tracing            = { workspace = true }
 tracing-flame      = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid               = { workspace = true, features = ["v4", "serde"] }
+walkdir            = { workspace = true }
 
 [lints]
 workspace = true
 
 [[bench]]
-name = "read_scaling"
+name = "read-scaling"
 path = "read_scaling/lib.rs"
 
 [[bench]]
-name = "representative_read"
+name = "representative-read"
 path = "representative_read/lib.rs"
+
+[[bench]]
+name = "manual-queries"
+path = "manual_queries/lib.rs"
 
 [package.metadata.cargo-shear]
 # Cargo shear does not detect these dependencies

--- a/tests/graph/benches/manual_queries/entity_queries/all-public.json
+++ b/tests/graph/benches/manual_queries/entity_queries/all-public.json
@@ -1,0 +1,23 @@
+{
+  "type": "getEntities",
+  "actorId": "00000000-0000-0000-0000-000000000000",
+  "request": {
+    "filter": {
+      "all": []
+    },
+    "temporalAxes": {
+      "pinned": {
+        "axis": "transactionTime",
+        "timestamp": null
+      },
+      "variable": {
+        "axis": "decisionTime",
+        "interval": {
+          "start": null,
+          "end": null
+        }
+      }
+    },
+    "includeDrafts": false
+  }
+}

--- a/tests/graph/benches/manual_queries/entity_queries/mod.rs
+++ b/tests/graph/benches/manual_queries/entity_queries/mod.rs
@@ -1,0 +1,196 @@
+use core::fmt;
+use std::{collections::HashMap, env, ffi::OsStr, fs::File, io, path::Path};
+
+use criterion::{BenchmarkId, Criterion};
+use criterion_macro::criterion;
+use error_stack::Report;
+use hash_graph_api::rest::entity::{GetEntitiesRequest, GetEntitySubgraphRequest};
+use hash_graph_authorization::{backend::SpiceDbOpenApi, zanzibar::ZanzibarClient};
+use hash_graph_postgres_store::{
+    Environment, load_env,
+    store::{
+        DatabaseConnectionInfo, DatabasePoolConfig, DatabaseType, PostgresStorePool,
+        PostgresStoreSettings,
+    },
+};
+use hash_graph_store::{entity::EntityStore, pool::StorePool as _};
+use hash_graph_types::account::AccountId;
+use serde::{Deserialize as _, Serialize as _};
+use serde_json::Value as JsonValue;
+use tokio::runtime::Runtime;
+use tokio_postgres::NoTls;
+use walkdir::WalkDir;
+
+use crate::util::setup_subscriber;
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+enum GraphQuery<'q, 's, 'p> {
+    #[serde(borrow)]
+    GetEntities(GetEntitiesQuery<'q, 's, 'p>),
+    #[serde(borrow)]
+    GetEntitySubgraph(GetEntitySubgraphQuery<'q, 's, 'p>),
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum GraphQueryType {
+    GetEntities,
+    GetEntitySubgraph,
+}
+
+impl fmt::Display for GraphQueryType {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.serialize(fmt)
+    }
+}
+
+impl GraphQuery<'_, '_, '_> {
+    const fn query_type(&self) -> GraphQueryType {
+        match self {
+            Self::GetEntities(_) => GraphQueryType::GetEntities,
+            Self::GetEntitySubgraph(_) => GraphQueryType::GetEntitySubgraph,
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct GetEntitiesQuery<'q, 's, 'p> {
+    actor_id: AccountId,
+    #[serde(borrow)]
+    request: GetEntitiesRequest<'q, 's, 'p>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct GetEntitySubgraphQuery<'q, 's, 'p> {
+    actor_id: AccountId,
+    #[serde(borrow)]
+    request: GetEntitySubgraphRequest<'q, 's, 'p>,
+}
+
+fn read_groups(path: impl AsRef<Path>) -> Result<Vec<(String, JsonValue)>, Report<io::Error>> {
+    WalkDir::new(path)
+        .sort_by_file_name()
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            !entry.file_type().is_dir() && entry.path().extension() == Some(OsStr::new("json"))
+        })
+        .map(|entry| {
+            Ok((
+                entry
+                    .path()
+                    .file_stem()
+                    .ok_or_else(|| {
+                        io::Error::new(io::ErrorKind::Other, "File does not have a valid file name")
+                    })?
+                    .to_string_lossy()
+                    .into_owned(),
+                serde_json::from_reader(File::open(entry.path())?).map_err(io::Error::from)?,
+            ))
+        })
+        .collect()
+}
+
+async fn run_benchmark<'q, 's, 'p: 'q, S>(store: &S, request: GraphQuery<'q, 's, 'p>)
+where
+    S: EntityStore + Sync,
+{
+    match request {
+        GraphQuery::GetEntities(request) => {
+            let _response = store
+                .get_entities(request.actor_id, request.request.into())
+                .await
+                .expect("failed to read entities from store");
+        }
+        GraphQuery::GetEntitySubgraph(request) => {
+            let _response = store
+                .get_entity_subgraph(request.actor_id, request.request.into())
+                .await
+                .expect("failed to read entity subgraph from store");
+        }
+    }
+}
+
+#[criterion]
+fn bench_json_queries(crit: &mut Criterion) {
+    load_env(Environment::Test);
+
+    let groups = read_groups("manual_queries/entity_queries").expect("groups should be readable");
+    let groups = groups
+        .iter()
+        .try_fold(
+            HashMap::<GraphQueryType, Vec<(&str, GraphQuery)>>::new(),
+            |mut map, (name, request)| {
+                GraphQuery::deserialize(request).map(|request| {
+                    map.entry(request.query_type())
+                        .or_default()
+                        .push((name, request));
+                    map
+                })
+            },
+        )
+        .expect("benchmark definitions should be valid");
+
+    let runtime = Runtime::new().expect("runtime should be creatable");
+
+    let pool = runtime
+        .block_on(PostgresStorePool::new(
+            &DatabaseConnectionInfo::new(
+                DatabaseType::Postgres,
+                env::var("HASH_GRAPH_PG_USER").unwrap_or_else(|_| "graph".to_owned()),
+                env::var("HASH_GRAPH_PG_PASSWORD").unwrap_or_else(|_| "graph".to_owned()),
+                env::var("HASH_GRAPH_PG_HOST").unwrap_or_else(|_| "localhost".to_owned()),
+                env::var("HASH_GRAPH_PG_PORT")
+                    .map(|port| {
+                        port.parse::<u16>()
+                            .unwrap_or_else(|_| panic!("{port} is not a valid port"))
+                    })
+                    .unwrap_or(5432),
+                env::var("HASH_GRAPH_PG_DATABASE").unwrap_or_else(|_| "graph".to_owned()),
+            ),
+            &DatabasePoolConfig::default(),
+            NoTls,
+            PostgresStoreSettings::default(),
+        ))
+        .expect("pool should be able to be created");
+
+    let spicedb_client = SpiceDbOpenApi::new(
+        format!(
+            "{}:{}",
+            env::var("HASH_SPICEDB_HOST").unwrap_or_else(|_| "localhost".to_owned()),
+            env::var("HASH_SPICEDB_HTTP_PORT")
+                .map(|port| {
+                    port.parse::<u16>()
+                        .unwrap_or_else(|_| panic!("{port} is not a valid port"))
+                })
+                .unwrap_or(8443)
+        ),
+        Some(&env::var("HASH_SPICEDB_GRPC_PRESHARED_KEY").unwrap_or_else(|_| "secret".to_owned())),
+    )
+    .expect("SpiceDB client should be able to be instantiated");
+
+    let store = runtime
+        .block_on(pool.acquire(ZanzibarClient::new(spicedb_client), None))
+        .expect("pool should be able to acquire store");
+
+    for (query_type, requests) in groups {
+        let group_id = query_type.to_string();
+        let mut group = crit.benchmark_group(&group_id);
+
+        for (name, request) in requests {
+            let parameter = "";
+            group.bench_function(BenchmarkId::new(name, parameter), |bencher| {
+                let _guard = setup_subscriber(&group_id, Some(name), Some(parameter));
+
+                bencher.to_async(&runtime).iter_batched(
+                    || request.clone(),
+                    |request| run_benchmark(&store, request),
+                    criterion::BatchSize::SmallInput,
+                );
+            });
+        }
+    }
+}

--- a/tests/graph/benches/manual_queries/lib.rs
+++ b/tests/graph/benches/manual_queries/lib.rs
@@ -1,0 +1,12 @@
+#![feature(custom_test_frameworks)]
+#![test_runner(criterion::runner)]
+
+#[path = "../util.rs"]
+#[expect(
+    dead_code,
+    unreachable_pub,
+    reason = "this module is shared between benches"
+)]
+mod util;
+
+mod entity_queries;

--- a/tests/graph/benches/package.json
+++ b/tests/graph/benches/package.json
@@ -4,11 +4,14 @@
   "private": true,
   "license": "AGPL-3",
   "scripts": {
-    "bench:integration": "cargo bench",
+    "bench:integration": "cargo bench --bench read-scaling --bench representative-read",
+    "bench:integration:manual": "cargo bench --bench manual-queries",
     "test:integration": "cargo hack test --feature-powerset --all-targets"
   },
   "devDependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",
+    "@rust/error-stack": "0.5.0",
+    "@rust/hash-graph-api": "0.0.0-private",
     "@rust/hash-graph-authorization": "0.0.0-private",
     "@rust/hash-graph-postgres-store": "0.0.0-private",
     "@rust/hash-graph-store": "0.0.0-private",

--- a/tests/graph/benches/package.json
+++ b/tests/graph/benches/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "bench:integration": "cargo bench --bench read-scaling --bench representative-read",
     "bench:integration:manual": "cargo bench --bench manual-queries",
-    "test:integration": "cargo hack test --feature-powerset --all-targets"
+    "test:integration": "cargo test --bench read-scaling --bench representative-read",
+    "test:integration:manual": "cargo test --bench manual-queries"
   },
   "devDependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13140,6 +13140,8 @@ __metadata:
   resolution: "@rust/hash-graph-benches@workspace:tests/graph/benches"
   dependencies:
     "@blockprotocol/type-system-rs": "npm:0.0.0-private"
+    "@rust/error-stack": "npm:0.5.0"
+    "@rust/hash-graph-api": "npm:0.0.0-private"
     "@rust/hash-graph-authorization": "npm:0.0.0-private"
     "@rust/hash-graph-postgres-store": "npm:0.0.0-private"
     "@rust/hash-graph-store": "npm:0.0.0-private"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Dynamically measure the performance for a specific query currently is quite hard. This adds a new benchmark to `tests/graph/benches` which can be run by `yarn bench:integration:manual`.
The queries will be read from the `manual_queries` directory and are in this shape:
- `type: "getEntities" | "getEntitySubgraph"`
- `actorId: Uuid`
- `request`  depending on type the exact same input as you’d pass to the graphApi functions

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

- It would be good to add more dynamic behavior by allowing certain parameters to be dynamic such as the ActorID or the graph resolve depths. This will be done later.