### PR TITLE
H-3815: Reorder Postgres statements to join filter statements first

### DIFF
--- a/libs/@local/graph/postgres-store/src/store/postgres/crud.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/crud.rs
@@ -94,6 +94,8 @@ where
             compiler.set_limit(limit);
         }
 
+        compiler.add_filter(filter);
+
         let cursor_indices = sorting.compile(
             &mut compiler,
             cursor_parameters.as_ref(),
@@ -103,7 +105,6 @@ where
         let record_artifacts = R::parameters();
         let record_indices = R::compile(&mut compiler, &record_artifacts);
 
-        compiler.add_filter(filter);
         let (statement, parameters) = compiler.compile();
         let stream = self
             .as_client()


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Postgres is not able to properly reorder `JOIN` statements. Currently, the entities are selected and later the filtering tables are joined. If the selecting joins are joined on already filtered joins this can speed up querying by a large amount (I noticed an improvement of up to x4)