### PR TITLE
H-3818: Switch to stricter ESLint configuration for `@local/harpc-client`

### DIFF
--- a/libs/@local/eslint/src/builtIn.ts
+++ b/libs/@local/eslint/src/builtIn.ts
@@ -1,5 +1,6 @@
 import { Array as ReadonlyArray, Option, pipe, Predicate } from "effect";
 import type { PartialDeep } from "type-fest";
+import { baseNoRestrictedSyntaxRules } from "eslint-config-sheriff";
 
 import type { NoRestrictedImportsRule } from "./types.js";
 import { defineConfig, type ESConfig } from "./utils.js";
@@ -88,6 +89,18 @@ export const builtIn =
             {
               allowAsStatement: true,
             },
+          ],
+          "no-restricted-syntax": [
+            "error",
+            ...baseNoRestrictedSyntaxRules.map((rule) =>
+              // remap the `ClassDeclaration` rule to exclude `Error` classes
+              rule.selector === "ClassDeclaration"
+                ? {
+                    selector: "ClassDeclaration[id.name!=/Error$/]",
+                    message: rule.message,
+                  }
+                : rule,
+            ),
           ],
         },
       },

--- a/libs/@local/eslint/src/builtIn.ts
+++ b/libs/@local/eslint/src/builtIn.ts
@@ -90,10 +90,10 @@ export const builtIn =
               allowAsStatement: true,
             },
           ],
+          // remap the `ClassDeclaration` rule to exclude `Error` classes
           "no-restricted-syntax": [
             "error",
             ...baseNoRestrictedSyntaxRules.map((rule) =>
-              // remap the `ClassDeclaration` rule to exclude `Error` classes
               rule.selector === "ClassDeclaration"
                 ? {
                     selector: "ClassDeclaration[id.name!=/Error$/]",
@@ -102,6 +102,8 @@ export const builtIn =
                 : rule,
             ),
           ],
+          // exclude forEach from `array-callback-return`, as it only checks by name, not by type and clashes with effect.
+          "array-callback-return": ["error", { allowImplicit: true }],
         },
       },
       ...noRestrictedImports(config, options.noRestrictedImports ?? (() => [])),

--- a/libs/@local/eslint/src/index.ts
+++ b/libs/@local/eslint/src/index.ts
@@ -9,7 +9,9 @@ import { react } from "./react.js";
 import { stylistic } from "./stylistic.js";
 import type { NoRestrictedImportsRule } from "./types.js";
 import { typescript } from "./typescript.js";
+import { jsdoc } from "./jsdoc.js";
 import { unicorn } from "./unicorn.js";
+import { vitest } from "./vitest.js";
 import { projectIgnoreFiles, type ESConfig } from "./utils.js";
 
 export type * from "./types.js";
@@ -60,5 +62,7 @@ export const create = (
     react(options ?? {}),
     typescript,
     stylistic,
+    jsdoc,
+    vitest(options ?? {}),
   );
 };

--- a/libs/@local/eslint/src/jsdoc.ts
+++ b/libs/@local/eslint/src/jsdoc.ts
@@ -10,6 +10,8 @@ export const jsdoc = (config: readonly ESConfig[]): readonly ESConfig[] =>
           "error",
           { exemptedBy: ["inheritdoc", "internal"] },
         ],
+        // conflicts with tsdoc
+        "jsdoc/check-tag-names": "off",
       },
     },
   ]);

--- a/libs/@local/eslint/src/jsdoc.ts
+++ b/libs/@local/eslint/src/jsdoc.ts
@@ -1,0 +1,15 @@
+import { Array } from "effect";
+
+import type { ESConfig } from "./utils.js";
+
+export const jsdoc = (config: readonly ESConfig[]): readonly ESConfig[] =>
+  Array.appendAll(config, [
+    {
+      rules: {
+        "jsdoc/require-description": [
+          "error",
+          { exemptedBy: ["inheritdoc", "internal"] },
+        ],
+      },
+    },
+  ]);

--- a/libs/@local/eslint/src/unicorn.ts
+++ b/libs/@local/eslint/src/unicorn.ts
@@ -154,6 +154,8 @@ export const unicorn = (config: readonly ESConfig[]): readonly ESConfig[] =>
         // spread operator. It's also a very common pattern in functional
         // programming.
         "unicorn/no-array-reduce": "off",
+        // This doesn't work well with `effect/Data/TaggedError`.
+        "unicorn/throw-new-error": "off",
       },
     },
     preventAbbreviations(),

--- a/libs/@local/eslint/src/vitest.ts
+++ b/libs/@local/eslint/src/vitest.ts
@@ -1,11 +1,13 @@
-import type { Options } from "./index.js";
 import type { PartialDeep } from "type-fest";
-import { ESConfig } from "./utils.js";
 import { Array } from "effect";
 import { testsFilePatterns } from "eslint-config-sheriff";
 
+import type { ESConfig } from "./utils.js";
+
+import type { Options } from "./index.js";
+
 export const vitest =
-  (options: PartialDeep<Options> = {}) =>
+  (options: PartialDeep<Options>) =>
   (config: readonly ESConfig[]): readonly ESConfig[] => {
     if (!options.enabled?.tests) {
       return config;

--- a/libs/@local/eslint/src/vitest.ts
+++ b/libs/@local/eslint/src/vitest.ts
@@ -1,0 +1,25 @@
+import type { Options } from "./index.js";
+import type { PartialDeep } from "type-fest";
+import { ESConfig } from "./utils.js";
+import { Array } from "effect";
+import { testsFilePatterns } from "eslint-config-sheriff";
+
+export const vitest =
+  (options: PartialDeep<Options> = {}) =>
+  (config: readonly ESConfig[]): readonly ESConfig[] => {
+    if (!options.enabled?.tests) {
+      return config;
+    }
+
+    return Array.appendAll(config, [
+      {
+        files: [...testsFilePatterns],
+        rules: {
+          // this rule is too buggy
+          "vitest/require-hook": "off",
+          // in tests non-null assertions are fine
+          "@typescript-eslint/no-non-null-assertion": "off",
+        },
+      },
+    ]);
+  };

--- a/libs/@local/harpc/client/typescript/eslint.config.js
+++ b/libs/@local/harpc/client/typescript/eslint.config.js
@@ -9,16 +9,9 @@ export default [
       storybook: false,
     },
   }),
-  // {
-  //   rules: {
-  //     "@typescript-eslint/no-redeclare": "off",
-  //     "unicorn/filename-case": "off",
-  //     "func-names": "off",
-  //     "canonical/filename-no-index": "off",
-  //     "@typescript-eslint/no-empty-object-type": [
-  //       "error",
-  //       { allowInterfaces: "with-single-extends" },
-  //     ],
-  //   },
-  // },
+  {
+    rules: {
+      "fsecond/prefer-destructured-optionals": "off",
+    },
+  },
 ];

--- a/libs/@local/harpc/client/typescript/eslint.config.js
+++ b/libs/@local/harpc/client/typescript/eslint.config.js
@@ -1,17 +1,24 @@
-import { createBase } from "@local/eslint/deprecated";
+import { create } from "@local/eslint";
 
 export default [
-  ...createBase(import.meta.dirname),
-  {
-    rules: {
-      "@typescript-eslint/no-redeclare": "off",
-      "unicorn/filename-case": "off",
-      "func-names": "off",
-      "canonical/filename-no-index": "off",
-      "@typescript-eslint/no-empty-object-type": [
-        "error",
-        { allowInterfaces: "with-single-extends" },
-      ],
+  ...create(import.meta.dirname, {
+    enabled: {
+      frontend: false,
+      playwright: false,
+      tests: true,
+      storybook: false,
     },
-  },
+  }),
+  // {
+  //   rules: {
+  //     "@typescript-eslint/no-redeclare": "off",
+  //     "unicorn/filename-case": "off",
+  //     "func-names": "off",
+  //     "canonical/filename-no-index": "off",
+  //     "@typescript-eslint/no-empty-object-type": [
+  //       "error",
+  //       { allowInterfaces: "with-single-extends" },
+  //     ],
+  //   },
+  // },
 ];

--- a/libs/@local/harpc/client/typescript/src/binary/MutableBytes.ts
+++ b/libs/@local/harpc/client/typescript/src/binary/MutableBytes.ts
@@ -39,13 +39,13 @@ export const make = (options?: {
   /**
    * The initial capacity of the buffer.
    *
-   * @default 1024
+   * @defaultValue 1024
    */
   readonly initialCapacity?: number;
   /**
    * The strategy for growing the buffer when more space is needed.
    *
-   * @default "doubling"
+   * @defaultValue "doubling"
    */
   readonly growthStrategy?: GrowthStrategy;
 }): MutableBytes =>

--- a/libs/@local/harpc/client/typescript/src/binary/MutableBytes.ts
+++ b/libs/@local/harpc/client/typescript/src/binary/MutableBytes.ts
@@ -3,6 +3,7 @@ import { Match, Option, Pipeable, Predicate } from "effect";
 import { createProto } from "../utils.js";
 
 const TypeId: unique symbol = Symbol("@local/harpc-client/binary/Bytes");
+
 export type TypeId = typeof TypeId;
 
 export type GrowthStrategy = "doubling" | "linear" | "exponential";
@@ -74,8 +75,10 @@ const allocate = (self: MutableBytes, newCapacity: number) => {
   const impl = self as MutableBytesImpl;
 
   const newBuffer = new ArrayBuffer(newCapacity);
+
   new Uint8Array(newBuffer).set(new Uint8Array(impl.inner));
   impl.inner = newBuffer;
+
   return self;
 };
 
@@ -86,11 +89,10 @@ const requiredCapacity = (self: MutableBytes, minimum: number) => {
 
   while (next < minimum) {
     next = Match.value(impl.growthStrategy).pipe(
-      // eslint-disable-next-line no-loop-func
       Match.when(Match.is("doubling"), () => next * 2),
       Match.when(
         Match.is("linear"),
-        // eslint-disable-next-line no-loop-func
+
         () =>
           next +
           // if the initialCapacity is 0 we should use the default, otherwise this turns into an infinite loop
@@ -98,7 +100,7 @@ const requiredCapacity = (self: MutableBytes, minimum: number) => {
             ? DEFAULT_INITIAL_CAPACITY
             : impl.initialCapacity),
       ),
-      // eslint-disable-next-line no-loop-func
+
       Match.when(Match.is("exponential"), () => next ** 2),
       Match.exhaustive,
     );
@@ -133,13 +135,16 @@ export const appendArray = (
     return self;
   }
 
-  const totalLength = bytes.reduce((acc, b) => acc + b.byteLength, 0);
+  const totalLength = bytes.reduce(
+    (accumulator, b) => accumulator + b.byteLength,
+    0,
+  );
 
   reserve(self, totalLength);
 
   for (const array of bytes) {
     new Uint8Array(impl.inner).set(array, impl.length);
-    impl.length += array.byteLength;
+    impl.length = impl.length + array.byteLength;
   }
 
   return self;
@@ -160,20 +165,23 @@ export const append = (
     return self;
   }
 
-  const totalLength = other.reduce((acc, b) => acc + length(b), 0);
+  const totalLength = other.reduce(
+    (accumulator, b) => accumulator + length(b),
+    0,
+  );
 
   reserve(self, totalLength);
 
   for (const array of other) {
     new Uint8Array(impl.inner).set(asArray(array), impl.length);
-    impl.length += length(array);
+    impl.length = impl.length + length(array);
   }
 
   return self;
 };
 
 /**
- * Split the bytes object, so that bytes object contains `[at,length)` and the rest is returned as a new bytes object
+ * Split the bytes object, so that bytes object contains `[at,length)` and the rest is returned as a new bytes object.
  */
 export const splitTo = (self: MutableBytes, at: number) => {
   if (at > length(self)) {
@@ -186,10 +194,11 @@ export const splitTo = (self: MutableBytes, at: number) => {
     initialCapacity: at,
     growthStrategy: impl.growthStrategy,
   });
+
   appendBuffer(destination, impl.inner.slice(0, at));
 
   impl.inner = impl.inner.slice(at);
-  impl.length -= at;
+  impl.length = impl.length - at;
 
   return Option.some(destination);
 };

--- a/libs/@local/harpc/client/typescript/src/binary/MutableBytes.ts
+++ b/libs/@local/harpc/client/typescript/src/binary/MutableBytes.ts
@@ -89,10 +89,12 @@ const requiredCapacity = (self: MutableBytes, minimum: number) => {
 
   while (next < minimum) {
     next = Match.value(impl.growthStrategy).pipe(
+      // eslint-disable-next-line @typescript-eslint/no-loop-func
       Match.when(Match.is("doubling"), () => next * 2),
       Match.when(
         Match.is("linear"),
 
+        // eslint-disable-next-line @typescript-eslint/no-loop-func
         () =>
           next +
           // if the initialCapacity is 0 we should use the default, otherwise this turns into an infinite loop
@@ -100,7 +102,7 @@ const requiredCapacity = (self: MutableBytes, minimum: number) => {
             ? DEFAULT_INITIAL_CAPACITY
             : impl.initialCapacity),
       ),
-
+      // eslint-disable-next-line @typescript-eslint/no-loop-func
       Match.when(Match.is("exponential"), () => next ** 2),
       Match.exhaustive,
     );

--- a/libs/@local/harpc/client/typescript/src/codec/Decoder.ts
+++ b/libs/@local/harpc/client/typescript/src/codec/Decoder.ts
@@ -75,6 +75,7 @@ const DecoderProto: Omit<DecoderImpl, "decode"> = {
   },
 };
 
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- description is defined
 export const Decoder = GenericTag<Decoder>(TypeId.description!);
 
 export const make = <E = DecodingError, R = never>(

--- a/libs/@local/harpc/client/typescript/src/codec/Decoder.ts
+++ b/libs/@local/harpc/client/typescript/src/codec/Decoder.ts
@@ -1,10 +1,18 @@
-import type { ParseResult, Schema, Stream } from "effect";
-import { Data, Function, Inspectable, Pipeable } from "effect";
+import {
+  type ParseResult,
+  type Schema,
+  type Stream,
+  Data,
+  Function,
+  Inspectable,
+  Pipeable,
+} from "effect";
 import { GenericTag } from "effect/Context";
 
 import { createProto } from "../utils.js";
 
 const TypeId: unique symbol = Symbol("@local/harpc-client/codec/Decoder");
+
 export type TypeId = typeof TypeId;
 
 export class DecodingError extends Data.TaggedError("DecodingError")<{

--- a/libs/@local/harpc/client/typescript/src/codec/Encoder.ts
+++ b/libs/@local/harpc/client/typescript/src/codec/Encoder.ts
@@ -75,6 +75,7 @@ const EncoderProto: Omit<EncoderImpl, "encode"> = {
   },
 };
 
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- description is defined
 export const Encoder = GenericTag<Encoder>(TypeId.description!);
 
 export const make = <E = EncodingError, R = never>(

--- a/libs/@local/harpc/client/typescript/src/codec/Encoder.ts
+++ b/libs/@local/harpc/client/typescript/src/codec/Encoder.ts
@@ -1,10 +1,18 @@
-import type { ParseResult, Schema, Stream } from "effect";
-import { Data, Function, Inspectable, Pipeable } from "effect";
+import {
+  type ParseResult,
+  type Schema,
+  type Stream,
+  Data,
+  Function,
+  Inspectable,
+  Pipeable,
+} from "effect";
 import { GenericTag } from "effect/Context";
 
 import { createProto } from "../utils.js";
 
 const TypeId: unique symbol = Symbol("@local/harpc-client/codec/Encoder");
+
 export type TypeId = typeof TypeId;
 
 export class EncodingError extends Data.TaggedError("EncodingError")<{

--- a/libs/@local/harpc/client/typescript/src/codec/JsonDecoder.ts
+++ b/libs/@local/harpc/client/typescript/src/codec/JsonDecoder.ts
@@ -84,7 +84,7 @@ interface Options {
   schema: boolean;
 }
 
-const decoder = (options: Options) =>
+const make = (options: Options) =>
   Decoder.make((input, schema) => {
     const useSchema = options.schema;
 
@@ -109,6 +109,7 @@ const decoder = (options: Options) =>
             useSchema ? Option.some(decodeJson) : Option.none(),
           );
 
+          // eslint-disable-next-line require-atomic-updates -- this is correct, as the stream runs sequentially
           fragment = nextFragment;
 
           return items;
@@ -117,7 +118,7 @@ const decoder = (options: Options) =>
     );
   });
 
-export const layer = Layer.succeed(Decoder.Decoder, decoder({ schema: true }));
+export const layer = Layer.succeed(Decoder.Decoder, make({ schema: true }));
 
 /**
  * Like `layer`, but won't invoke the schema decoder, therefore neither transforming or validating the input.
@@ -125,5 +126,5 @@ export const layer = Layer.succeed(Decoder.Decoder, decoder({ schema: true }));
  */
 export const layerUnchecked = Layer.succeed(
   Decoder.Decoder,
-  decoder({ schema: false }),
+  make({ schema: false }),
 );

--- a/libs/@local/harpc/client/typescript/src/net/Client.ts
+++ b/libs/@local/harpc/client/typescript/src/net/Client.ts
@@ -29,6 +29,7 @@ const ClientProto: Omit<ClientImpl, "client" | "config"> = {
   [TypeId]: TypeId,
 };
 
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- TypeId is defined
 export const Client = GenericTag<Client>(TypeId.description!);
 
 // TODO: add a metrics compatability layer

--- a/libs/@local/harpc/client/typescript/src/net/Client.ts
+++ b/libs/@local/harpc/client/typescript/src/net/Client.ts
@@ -2,11 +2,13 @@ import { Effect, Function, Layer, type Scope } from "effect";
 import { GenericTag } from "effect/Context";
 
 import { createProto } from "../utils.js";
+
 import * as Connection from "./Connection.js";
 import * as internalTransport from "./internal/transport.js";
 import type * as Transport from "./Transport.js";
 
 const TypeId: unique symbol = Symbol("@local/harpc-client/net/Client");
+
 export type TypeId = typeof TypeId;
 
 export interface ClientConfig {
@@ -31,6 +33,7 @@ export const Client = GenericTag<Client>(TypeId.description!);
 
 // TODO: add a metrics compatability layer
 //  see: https://linear.app/hash/issue/H-3712/libp2p-metrics-compatibility-layer
+
 export const make = (config?: ClientConfig) =>
   Effect.gen(function* () {
     const client = yield* internalTransport.make(config?.transport);

--- a/libs/@local/harpc/client/typescript/src/net/Config.ts
+++ b/libs/@local/harpc/client/typescript/src/net/Config.ts
@@ -14,33 +14,33 @@ export interface KeyPair {
 }
 
 export interface ICryptoInterface {
-  hashSHA256(data: Uint8Array | Uint8ArrayList): Uint8Array;
+  hashSHA256: (data: Uint8Array | Uint8ArrayList) => Uint8Array;
 
-  getHKDF(
+  getHKDF: (
     ck: Uint8Array,
     ikm: Uint8Array,
-  ): [Uint8Array, Uint8Array, Uint8Array];
+  ) => [Uint8Array, Uint8Array, Uint8Array];
 
-  generateX25519KeyPair(): KeyPair;
-  generateX25519KeyPairFromSeed(seed: Uint8Array): KeyPair;
-  generateX25519SharedKey(
+  generateX25519KeyPair: () => KeyPair;
+  generateX25519KeyPairFromSeed: (seed: Uint8Array) => KeyPair;
+  generateX25519SharedKey: (
     privateKey: Uint8Array | Uint8ArrayList,
     publicKey: Uint8Array | Uint8ArrayList,
-  ): Uint8Array;
+  ) => Uint8Array;
 
-  chaCha20Poly1305Encrypt(
+  chaCha20Poly1305Encrypt: (
     plaintext: Uint8Array | Uint8ArrayList,
     nonce: Uint8Array,
     ad: Uint8Array,
     k: Uint8Array,
-  ): Uint8ArrayList | Uint8Array;
-  chaCha20Poly1305Decrypt(
+  ) => Uint8ArrayList | Uint8Array;
+  chaCha20Poly1305Decrypt: (
     ciphertext: Uint8Array | Uint8ArrayList,
     nonce: Uint8Array,
     ad: Uint8Array,
     k: Uint8Array,
     dst?: Uint8Array,
-  ): Uint8ArrayList | Uint8Array;
+  ) => Uint8ArrayList | Uint8Array;
 }
 
 export interface NoiseConfig {

--- a/libs/@local/harpc/client/typescript/src/net/Config.ts
+++ b/libs/@local/harpc/client/typescript/src/net/Config.ts
@@ -13,7 +13,7 @@ export interface KeyPair {
   privateKey: Uint8Array;
 }
 
-export interface ICryptoInterface {
+export interface CryptoInterface {
   hashSHA256: (data: Uint8Array | Uint8ArrayList) => Uint8Array;
 
   getHKDF: (
@@ -39,13 +39,13 @@ export interface ICryptoInterface {
     nonce: Uint8Array,
     ad: Uint8Array,
     k: Uint8Array,
-    dst?: Uint8Array,
+    destination?: Uint8Array,
   ) => Uint8ArrayList | Uint8Array;
 }
 
 export interface NoiseConfig {
   staticNoiseKey?: Uint8Array;
   extensions?: NoiseExtensions;
-  crypto?: ICryptoInterface;
+  crypto?: CryptoInterface;
   prologueBytes?: Uint8Array;
 }

--- a/libs/@local/harpc/client/typescript/src/net/Connection.ts
+++ b/libs/@local/harpc/client/typescript/src/net/Connection.ts
@@ -1,5 +1,6 @@
-import type { Chunk, Scope } from "effect";
 import {
+  type Chunk,
+  type Scope,
   Deferred,
   Duration,
   Effect,
@@ -15,18 +16,24 @@ import { GenericTag } from "effect/Context";
 
 import { createProto } from "../utils.js";
 import { Buffer } from "../wire-protocol/index.js";
-import type { RequestId } from "../wire-protocol/models/request/index.js";
-import { Request as WireRequest } from "../wire-protocol/models/request/index.js";
-import type { Response as WireResponse } from "../wire-protocol/models/response/index.js";
-import { ResponseFlags } from "../wire-protocol/models/response/index.js";
+import {
+  type RequestId,
+  Request as WireRequest,
+} from "../wire-protocol/models/request/index.js";
+import {
+  type Response as WireResponse,
+  ResponseFlags,
+} from "../wire-protocol/models/response/index.js";
 import { ResponseFromBytesStream } from "../wire-protocol/stream/index.js";
 import type { IncompleteResponseError } from "../wire-protocol/stream/ResponseFromBytesStream.js";
+
 import * as internalTransport from "./internal/transport.js";
 import * as Request from "./Request.js";
 import * as Transaction from "./Transaction.js";
 import * as Transport from "./Transport.js";
 
 const TypeId: unique symbol = Symbol("@local/harpc-client/net/Connection");
+
 export type TypeId = typeof TypeId;
 
 interface ConnectionDuplex {
@@ -57,7 +64,7 @@ export interface ConnectionConfig {
   /**
    * The size of the number of buffered responses to keep in memory.
    * A larger buffer can improve performance and allows for more lenient timeouts,
-   * but consumes more memory. (a single response is a maximum of 64KiB)
+   * but consumes more memory. (a single response is a maximum of 64KiB).
    *
    * @default 16
    */
@@ -113,12 +120,12 @@ const ConnectionProto: Omit<
 export const Connection = GenericTag<Connection>(TypeId.description!);
 
 const makeSink = (connection: ConnectionImpl) =>
-  // eslint-disable-next-line unicorn/no-array-for-each
   Sink.forEach((response: WireResponse.Response) =>
     Effect.gen(function* () {
       const id = response.header.requestId;
 
       const transaction = MutableHashMap.get(connection.transactions, id);
+
       if (Option.isNone(transaction)) {
         yield* Effect.logWarning("response without a transaction found");
 
@@ -163,6 +170,7 @@ const wrapDrop = (
 ) =>
   Effect.gen(function* () {
     const transaction = MutableHashMap.get(connection.transactions, id);
+
     if (Option.isNone(transaction)) {
       yield* Effect.logWarning("transaction has been dropped multiple times");
 
@@ -174,6 +182,7 @@ const wrapDrop = (
 
     // call user defined drop function
     const dropImpl = yield* Deferred.poll(drop);
+
     if (Option.isSome(dropImpl)) {
       yield* dropImpl.value;
     }
@@ -233,6 +242,7 @@ export const makeUnchecked = (
           yield* WireRequest.encode(buffer, request);
 
           const array = yield* Buffer.take(buffer);
+
           return new Uint8Array(array);
         }),
       ),

--- a/libs/@local/harpc/client/typescript/src/net/Connection.ts
+++ b/libs/@local/harpc/client/typescript/src/net/Connection.ts
@@ -285,6 +285,7 @@ export const send: {
     request: Request.Request<never, R>,
   ): Effect.Effect<Transaction.Transaction, never, Exclude<R, Scope.Scope>> =>
     Effect.gen(function* () {
+      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type -- it's indeed correct here
       const deferredDrop = yield* Deferred.make<void>();
       const drop = wrapDrop(self, request.id, deferredDrop);
 

--- a/libs/@local/harpc/client/typescript/src/net/Connection.ts
+++ b/libs/@local/harpc/client/typescript/src/net/Connection.ts
@@ -57,7 +57,7 @@ export interface ConnectionConfig {
    * The maximum duration to wait for a response before considering the transaction lagged.
    * If a response is not received within this timeout, the transaction will be dropped.
    *
-   * @default 200ms
+   * @defaultValue 200ms
    */
   lagTimeout?: Duration.DurationInput;
 
@@ -66,7 +66,7 @@ export interface ConnectionConfig {
    * A larger buffer can improve performance and allows for more lenient timeouts,
    * but consumes more memory. (a single response is a maximum of 64KiB).
    *
-   * @default 16
+   * @defaultValue 16
    */
   responseBufferSize?: number;
 
@@ -85,7 +85,7 @@ export interface ConnectionConfig {
    * will be transferring a lot of data or the stream will be open for a long time
    * consider upgrading to a direct connection before opening the stream.
    *
-   * @default false
+   * @defaultValue false
    */
   runOnLimitedConnection?: boolean;
 }
@@ -117,6 +117,7 @@ const ConnectionProto: Omit<
   [TypeId]: TypeId,
 };
 
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- always defined
 export const Connection = GenericTag<Connection>(TypeId.description!);
 
 const makeSink = (connection: ConnectionImpl) =>

--- a/libs/@local/harpc/client/typescript/src/net/NetworkLogger.ts
+++ b/libs/@local/harpc/client/typescript/src/net/NetworkLogger.ts
@@ -2,9 +2,11 @@ import type { ComponentLogger, Logger } from "@libp2p/interface";
 import { Effect, LogLevel, Runtime } from "effect";
 
 import { createProto } from "../utils.js";
+
 import * as internal from "./internal/networkLogger.js";
 
 const TypeId: unique symbol = Symbol("@local/harpc-client/net/Logger");
+
 export type TypeId = typeof TypeId;
 
 export type Formatter = internal.Formatter;
@@ -20,10 +22,10 @@ interface NetworkLoggerImpl extends NetworkLogger {
 
   readonly runtime: Runtime.Runtime<never>;
 
-  logger(
+  logger: (
     name: string,
     level: LogLevel.LogLevel,
-  ): (formatter: unknown, ...args: ReadonlyArray<unknown>) => void;
+  ) => (formatter: unknown, ...args: readonly unknown[]) => void;
 }
 
 const NetworkLoggerProto: Omit<NetworkLoggerImpl, "formatters" | "runtime"> = {
@@ -32,7 +34,7 @@ const NetworkLoggerProto: Omit<NetworkLoggerImpl, "formatters" | "runtime"> = {
   logger(this: NetworkLoggerImpl, name: string, level: LogLevel.LogLevel) {
     const fork = Runtime.runFork(this.runtime);
 
-    return (formatter: unknown, ...args: ReadonlyArray<unknown>) => {
+    return (formatter: unknown, ...args: readonly unknown[]) => {
       const effect = internal
         .format(this.formatters, level, formatter, args)
         .pipe(Effect.withSpan(name));

--- a/libs/@local/harpc/client/typescript/src/net/Request.ts
+++ b/libs/@local/harpc/client/typescript/src/net/Request.ts
@@ -10,8 +10,8 @@ import {
   Protocol,
   ProtocolVersion,
 } from "../wire-protocol/models/index.js";
-import type { RequestId } from "../wire-protocol/models/request/index.js";
 import {
+  type RequestId,
   Request,
   RequestBegin,
   RequestBody,
@@ -22,6 +22,7 @@ import {
 import * as RequestIdProducer from "../wire-protocol/RequestIdProducer.js";
 
 const TypeId: unique symbol = Symbol("@local/harpc-client/net/Request");
+
 export type TypeId = typeof TypeId;
 
 export interface Request<E, R> {
@@ -80,6 +81,7 @@ const splitBuffer = (scratch: Scratch, that: ArrayBuffer) => {
     const available = Payload.MAX_SIZE - self.length;
 
     const selfView = new Uint8Array(self.buffer);
+
     selfView.set(new Uint8Array(buffer, 0, available), self.length);
 
     output.push(self.buffer);
@@ -92,9 +94,10 @@ const splitBuffer = (scratch: Scratch, that: ArrayBuffer) => {
   // we can just copy the buffer into the scratch buffer.
   if (buffer.byteLength > 0) {
     const view = new Uint8Array(self.buffer);
+
     view.set(new Uint8Array(buffer), self.length);
 
-    self.length += buffer.byteLength;
+    self.length = self.length + buffer.byteLength;
   }
 
   return [self, output] as const;
@@ -246,7 +249,9 @@ export const encode: {
     options?: EncodeOptions,
   ): <E, R>(self: Request<E, R>) => Stream.Stream<Request.Request, E, R>;
 } = Function.dual(
-  // function is `DataFirst` (will be executed immediately), if:
+  /**
+   * Function is `DataFirst` (will be executed immediately), if:
+   */
   (args) => isRequest(args[0]),
   encodeImpl,
 );

--- a/libs/@local/harpc/client/typescript/src/net/Request.ts
+++ b/libs/@local/harpc/client/typescript/src/net/Request.ts
@@ -118,9 +118,9 @@ const pack = <E, R>(
       return pipe(
         stream,
         Stream.mapConcat((buffer) => {
-          const [scratch, output] = splitBuffer(makeScratch(), buffer);
+          const [remaining, output] = splitBuffer(makeScratch(), buffer);
 
-          output.push(scratch.buffer.slice(0, scratch.length));
+          output.push(remaining.buffer.slice(0, remaining.length));
 
           return output;
         }),
@@ -250,7 +250,7 @@ export const encode: {
   ): <E, R>(self: Request<E, R>) => Stream.Stream<Request.Request, E, R>;
 } = Function.dual(
   /**
-   * Function is `DataFirst` (will be executed immediately), if:
+   * Function is `DataFirst` (will be executed immediately), if...
    */
   (args) => isRequest(args[0]),
   encodeImpl,

--- a/libs/@local/harpc/client/typescript/src/net/Response.ts
+++ b/libs/@local/harpc/client/typescript/src/net/Response.ts
@@ -108,6 +108,7 @@ const processResponseStream = <E, R>(
     stream,
     Stream.mapConcatEffect((segment) => {
       return ResponseSegment.$match(segment, {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         ControlFlow: ({ code }) => {
           // replace the existing error with a new one if we have an error
           const error = partialError;
@@ -122,6 +123,7 @@ const processResponseStream = <E, R>(
             onSome: Effect.fail,
           });
         },
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         Body: ({ data }) => {
           if (Option.isNone(partialError)) {
             return Effect.succeed([data]);

--- a/libs/@local/harpc/client/typescript/src/net/Response.ts
+++ b/libs/@local/harpc/client/typescript/src/net/Response.ts
@@ -4,13 +4,14 @@ import { MutableBytes } from "../binary/index.js";
 import { InvalidUtf8Error } from "../ClientError.js";
 import { type ErrorCode, ResponseKind } from "../types/index.js";
 import { createProto } from "../utils.js";
-import type { Response } from "../wire-protocol/models/response/index.js";
 import {
+  type Response,
   ResponseBody,
   ResponseFlags,
 } from "../wire-protocol/models/response/index.js";
 
 const TypeId = Symbol("@local/harpc-client/net/Response");
+
 export type TypeId = typeof TypeId;
 
 export class UnexpectedResponseTypeError extends Data.TaggedError(
@@ -79,8 +80,9 @@ const flattenResponseStream = <E, R>(
       const output: ResponseSegment[] = [];
 
       const begin = ResponseBody.getBegin(response.body);
+
       if (Option.isSome(begin)) {
-        const kind = begin.value.kind;
+        const { kind } = begin.value;
         const code = ResponseKind.getErr(kind);
 
         output.push(ResponseSegment.ControlFlow({ code }));
@@ -92,6 +94,7 @@ const flattenResponseStream = <E, R>(
       );
 
       output.push(ResponseSegment.Body({ data: payload }));
+
       return output;
     }),
   );
@@ -108,6 +111,7 @@ const processResponseStream = <E, R>(
         ControlFlow: ({ code }) => {
           // replace the existing error with a new one if we have an error
           const error = partialError;
+
           partialError = Option.map(
             code,
             (_) => new NetworkError({ code: _, bytes: MutableBytes.make() }),
@@ -124,6 +128,7 @@ const processResponseStream = <E, R>(
           }
 
           MutableBytes.appendBuffer(partialError.value.bytes, data);
+
           return Effect.succeed([]);
         },
       });

--- a/libs/@local/harpc/client/typescript/src/net/Transaction.ts
+++ b/libs/@local/harpc/client/typescript/src/net/Transaction.ts
@@ -1,12 +1,13 @@
-import type { Effect, Queue } from "effect";
-import { Deferred, Function } from "effect";
+import { type Effect, type Queue, Deferred, Function } from "effect";
 
 import { createProto } from "../utils.js";
 import type { RequestId } from "../wire-protocol/models/request/index.js";
 import type { Response as WireResponse } from "../wire-protocol/models/response/index.js";
+
 import * as Response from "./Response.js";
 
 const TypeId: unique symbol = Symbol("@local/harpc-client/net/Transaction");
+
 export type TypeId = typeof TypeId;
 
 export interface Transaction {

--- a/libs/@local/harpc/client/typescript/src/net/Transaction.ts
+++ b/libs/@local/harpc/client/typescript/src/net/Transaction.ts
@@ -29,10 +29,10 @@ const TransactionProto: Omit<TransactionImpl, "id" | "read" | "drop"> = {
 /** @internal */
 export const makeUnchecked = (
   id: RequestId.RequestId,
-  read: Queue.Dequeue<WireResponse.Response>,
+  readQueue: Queue.Dequeue<WireResponse.Response>,
   drop: Deferred.Deferred<void>,
 ): Transaction =>
-  createProto(TransactionProto, { id, read, drop }) as Transaction;
+  createProto(TransactionProto, { id, read: readQueue, drop }) as Transaction;
 
 export const registerDestructor: {
   (

--- a/libs/@local/harpc/client/typescript/src/net/Transport.ts
+++ b/libs/@local/harpc/client/typescript/src/net/Transport.ts
@@ -1,19 +1,10 @@
 import type { DNS } from "@multiformats/dns";
-import { Data } from "effect";
 
 import type { NoiseConfig, TCPConfig, YamuxConfig } from "./Config.js";
 import type * as internal from "./internal/transport.js";
 
-export { TransportError } from "./internal/transport.js";
+export { InitializationError, TransportError } from "./internal/transport.js";
 export { type Multiaddr, multiaddr } from "@multiformats/multiaddr";
-
-export class InitializationError extends Data.TaggedError(
-  "InitializationError",
-)<{ cause: unknown }> {
-  get message() {
-    return "Failed to initialize client";
-  }
-}
 
 export type Address = internal.Address;
 

--- a/libs/@local/harpc/client/typescript/src/net/Transport.ts
+++ b/libs/@local/harpc/client/typescript/src/net/Transport.ts
@@ -27,21 +27,21 @@ export interface DNSConfig {
    * When resolving DNSADDR Multiaddrs that resolve to other DNSADDR Multiaddrs,
    * limit how many times we will recursively resolve them.
    *
-   * @default 32
+   * @defaultValue 32
    */
   maxRecursiveDepth?: number;
 
   /**
    * Amount of cached resolved multiaddrs to keep in memory.
    *
-   * @default 32
+   * @defaultValue 32
    */
   cacheCapacity?: number;
 
   /**
    * Time in milliseconds until a cached resolved multiaddr is considered stale.
    *
-   * @default 5 minutes
+   * @defaultValue 5 minutes
    */
   cacheTimeToLive?: number;
 }

--- a/libs/@local/harpc/client/typescript/src/net/index.ts
+++ b/libs/@local/harpc/client/typescript/src/net/index.ts
@@ -1,5 +1,5 @@
 export * as Client from "./Client.js";
-export * as Config from "./Config.js";
+export type * as Config from "./Config.js";
 export * as Connection from "./Connection.js";
 export * as NetworkLogger from "./NetworkLogger.js";
 export * as Request from "./Request.js";

--- a/libs/@local/harpc/client/typescript/src/net/internal/multiaddr.ts
+++ b/libs/@local/harpc/client/typescript/src/net/internal/multiaddr.ts
@@ -9,11 +9,13 @@ import { Equal, Hash, pipe, Predicate } from "effect";
 import { createProto, hashUint8Array } from "../../utils.js";
 
 const MultiaddrSymbol = Symbol.for("@multiformats/js-multiaddr/multiaddr");
+
 type MultiaddrSymbol = typeof MultiaddrSymbol;
 
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/net/internal/HashableMultiaddr",
 );
+
 type TypeId = typeof TypeId;
 
 /** @internal */

--- a/libs/@local/harpc/client/typescript/src/net/internal/networkLogger.ts
+++ b/libs/@local/harpc/client/typescript/src/net/internal/networkLogger.ts
@@ -68,10 +68,10 @@ interface Literal {
 
 type Token = Format | Literal;
 
-const tokenize = (format: string) => {
+const tokenize = (spec: string) => {
   const tokens: Token[] = [];
 
-  let rest = format;
+  let rest = spec;
 
   while (rest.length > 0) {
     const nextToken = rest.search(/%[a-z%]/i);
@@ -83,6 +83,7 @@ const tokenize = (format: string) => {
 
     tokens.push({ value: rest.slice(0, nextToken) });
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guaranteed by regex
     const type = rest[nextToken + 1]!;
 
     if (type === "%") {
@@ -110,6 +111,7 @@ const enrichContext = (
     Option.getOrElse(() => `unknown${index}`),
   );
 
+  // eslint-disable-next-line no-param-reassign
   context[name] = value;
 };
 
@@ -123,7 +125,7 @@ export const format = (
   const inputArguments = [...args];
   const context: Record<string, unknown> = {};
 
-  let formatString = "";
+  let formatString;
 
   // special casing of some arguments
   if (Predicate.isError(input)) {
@@ -174,7 +176,7 @@ export const format = (
   }
 
   // add any arguments to the context that were not used
-  for (let i = argumentIndex; i < inputArguments.length; i++) {
+  for (let i = argumentIndex; i < inputArguments.length; i = i + 1) {
     enrichContext(context, i, inputArguments[i]);
   }
 
@@ -197,7 +199,9 @@ const debugJsFormatters: FormatterCollection = {
       Option.liftPredicate(value, Predicate.isNumber), //
       Option.map((number) => number.toString()),
     ),
+  // eslint-disable-next-line unicorn/prevent-abbreviations
   j: (value: unknown) => Option.some(JSON.stringify(value)),
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   O: (value: unknown) => Option.some(Inspectable.toStringUnknown(value)),
   o: (value: unknown) =>
     Option.some(Inspectable.toStringUnknown(value, "").replaceAll("\n", " ")),
@@ -208,6 +212,7 @@ const libp2pFormatters: FormatterCollection = {
   /**
    * Custom (more sane) UTF-8 first formatter.
    */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   B: (value: unknown) =>
     pipe(
       Option.liftPredicate(value, Predicate.isUint8Array),
@@ -221,8 +226,8 @@ const libp2pFormatters: FormatterCollection = {
           Option.getOrElse(() =>
             // see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/toHex
             array.reduce(
-              (accumulator, value_) =>
-                accumulator + value_.toString(16).padStart(2, "0"),
+              (accumulator, byte) =>
+                accumulator + byte.toString(16).padStart(2, "0"),
               "",
             ),
           ),
@@ -230,7 +235,7 @@ const libp2pFormatters: FormatterCollection = {
       ),
     ),
   /**
-   * Uint8Array -> Base58.
+   * Uint8Array as Base58.
    */
   b: (value: unknown) =>
     pipe(
@@ -238,7 +243,7 @@ const libp2pFormatters: FormatterCollection = {
       Option.map(base58btc.baseEncode),
     ),
   /**
-   * Uint8Array -> Base32.
+   * Uint8Array as Base32.
    */
   t: (value: unknown) =>
     pipe(
@@ -246,7 +251,7 @@ const libp2pFormatters: FormatterCollection = {
       Option.map(base32.baseEncode),
     ),
   /**
-   * Uint8Array -> Base64.
+   * Uint8Array as Base64.
    */
   m: (value: unknown) =>
     pipe(
@@ -281,6 +286,7 @@ const libp2pFormatters: FormatterCollection = {
   /**
    * Error.
    */
+  // eslint-disable-next-line unicorn/prevent-abbreviations
   e: (value: unknown) =>
     pipe(
       Option.liftPredicate(value, Predicate.isError),

--- a/libs/@local/harpc/client/typescript/src/net/internal/transport.ts
+++ b/libs/@local/harpc/client/typescript/src/net/internal/transport.ts
@@ -31,12 +31,7 @@ import type { NonEmptyArray } from "effect/Array";
 import { type Libp2p, createLibp2p } from "libp2p";
 
 import * as NetworkLogger from "../NetworkLogger.js";
-import {
-  type DNSConfig,
-  type Multiaddr,
-  type TransportConfig,
-  InitializationError,
-} from "../Transport.js";
+import type { DNSConfig, Multiaddr, TransportConfig } from "../Transport.js";
 
 import * as Dns from "./dns.js";
 import * as HashableMultiaddr from "./multiaddr.js";
@@ -65,6 +60,15 @@ export class TransportError extends Data.TaggedError("TransportError")<{
 }> {
   get message() {
     return "Underlying transport stream experienced an error";
+  }
+}
+
+/** @internal */
+export class InitializationError extends Data.TaggedError(
+  "InitializationError",
+)<{ cause: unknown }> {
+  get message() {
+    return "Failed to initialize client";
   }
 }
 

--- a/libs/@local/harpc/client/typescript/src/types/ErrorCode.ts
+++ b/libs/@local/harpc/client/typescript/src/types/ErrorCode.ts
@@ -18,7 +18,9 @@ const TypeId = Symbol("@local/harpc-client/wire-protocol/types/ErrorCode");
 
 export type TypeId = typeof TypeId;
 
-export class ErrorCodeTooLarge extends Data.TaggedError("ErrorCodeTooLarge")<{
+export class ErrorCodeTooLargeError extends Data.TaggedError(
+  "ErrorCodeTooLargeError",
+)<{
   received: number;
 }> {
   get message() {
@@ -26,8 +28,8 @@ export class ErrorCodeTooLarge extends Data.TaggedError("ErrorCodeTooLarge")<{
   }
 }
 
-export class ErrorCodeTooSmall extends Data.TaggedError(
-  "ErrorCodeNotPositive",
+export class ErrorCodeTooSmallError extends Data.TaggedError(
+  "ErrorCodeNotPositiveError",
 )<{ received: number }> {
   get message() {
     return `error code mut be a positive number, got ${this.received}`;
@@ -86,12 +88,15 @@ export const makeUnchecked = (value: number): ErrorCode =>
 
 export const make = (
   value: number,
-): Effect.Effect<ErrorCode, ErrorCodeTooLarge | ErrorCodeTooSmall> => {
+): Effect.Effect<
+  ErrorCode,
+  ErrorCodeTooLargeError | ErrorCodeTooSmallError
+> => {
   if (value < 1) {
-    return Effect.fail(new ErrorCodeTooSmall({ received: value }));
+    return Effect.fail(new ErrorCodeTooSmallError({ received: value }));
   }
   if (value > U16_MAX) {
-    return Effect.fail(new ErrorCodeTooLarge({ received: value }));
+    return Effect.fail(new ErrorCodeTooLargeError({ received: value }));
   }
 
   return Effect.succeed(makeUnchecked(value));

--- a/libs/@local/harpc/client/typescript/src/types/ErrorCode.ts
+++ b/libs/@local/harpc/client/typescript/src/types/ErrorCode.ts
@@ -1,5 +1,5 @@
-import type { FastCheck } from "effect";
 import {
+  type FastCheck,
   Data,
   Effect,
   Equal,
@@ -15,6 +15,7 @@ import { createProto, encodeDual } from "../utils.js";
 import * as Buffer from "../wire-protocol/Buffer.js";
 
 const TypeId = Symbol("@local/harpc-client/wire-protocol/types/ErrorCode");
+
 export type TypeId = typeof TypeId;
 
 export class ErrorCodeTooLarge extends Data.TaggedError("ErrorCodeTooLarge")<{
@@ -88,11 +89,12 @@ export const make = (
 ): Effect.Effect<ErrorCode, ErrorCodeTooLarge | ErrorCodeTooSmall> => {
   if (value < 1) {
     return Effect.fail(new ErrorCodeTooSmall({ received: value }));
-  } else if (value > U16_MAX) {
-    return Effect.fail(new ErrorCodeTooLarge({ received: value }));
-  } else {
-    return Effect.succeed(makeUnchecked(value));
   }
+  if (value > U16_MAX) {
+    return Effect.fail(new ErrorCodeTooLarge({ received: value }));
+  }
+
+  return Effect.succeed(makeUnchecked(value));
 };
 
 export type EncodeError = Effect.Effect.Error<ReturnType<typeof encode>>;

--- a/libs/@local/harpc/client/typescript/src/types/ProcedureDescriptor.ts
+++ b/libs/@local/harpc/client/typescript/src/types/ProcedureDescriptor.ts
@@ -1,5 +1,5 @@
-import type { FastCheck } from "effect";
 import {
+  type FastCheck,
   Effect,
   Equal,
   Hash,
@@ -11,11 +11,13 @@ import {
 
 import { createProto, encodeDual } from "../utils.js";
 import type * as Buffer from "../wire-protocol/Buffer.js";
+
 import * as ProcedureId from "./ProcedureId.js";
 
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/types/ProcedureDescriptor",
 );
+
 export type TypeId = typeof TypeId;
 
 export interface ProcedureDescriptor

--- a/libs/@local/harpc/client/typescript/src/types/ProcedureId.ts
+++ b/libs/@local/harpc/client/typescript/src/types/ProcedureId.ts
@@ -20,16 +20,16 @@ const TypeId: unique symbol = Symbol(
 
 export type TypeId = typeof TypeId;
 
-export class ProcedureIdTooLarge extends Data.TaggedError(
-  "ProcedureIdTooLarge",
+export class ProcedureIdTooLargeError extends Data.TaggedError(
+  "ProcedureIdTooLargeError",
 )<{ received: number }> {
   get message() {
     return `Procedure ID too large: ${this.received}, expected between ${U16_MIN} and ${U16_MAX}`;
   }
 }
 
-export class ProcedureIdTooSmall extends Data.TaggedError(
-  "ProcedureIdTooSmall",
+export class ProcedureIdTooSmallError extends Data.TaggedError(
+  "ProcedureIdTooSmallError",
 )<{ received: number }> {
   get message() {
     return `Procedure ID too small: ${this.received}, expected between ${U16_MIN} and ${U16_MAX}`;
@@ -90,12 +90,15 @@ export const makeUnchecked = (value: number): ProcedureId =>
 
 export const make = (
   id: number,
-): Effect.Effect<ProcedureId, ProcedureIdTooSmall | ProcedureIdTooLarge> => {
+): Effect.Effect<
+  ProcedureId,
+  ProcedureIdTooSmallError | ProcedureIdTooLargeError
+> => {
   if (id < U16_MIN) {
-    return Effect.fail(new ProcedureIdTooSmall({ received: id }));
+    return Effect.fail(new ProcedureIdTooSmallError({ received: id }));
   }
   if (id > U16_MAX) {
-    return Effect.fail(new ProcedureIdTooLarge({ received: id }));
+    return Effect.fail(new ProcedureIdTooLargeError({ received: id }));
   }
 
   return Effect.succeed(makeUnchecked(id));

--- a/libs/@local/harpc/client/typescript/src/types/ProcedureId.ts
+++ b/libs/@local/harpc/client/typescript/src/types/ProcedureId.ts
@@ -1,5 +1,5 @@
-import type { FastCheck } from "effect";
 import {
+  type FastCheck,
   Data,
   Effect,
   Equal,
@@ -17,6 +17,7 @@ import * as Buffer from "../wire-protocol/Buffer.js";
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/types/ProcedureId",
 );
+
 export type TypeId = typeof TypeId;
 
 export class ProcedureIdTooLarge extends Data.TaggedError(
@@ -116,7 +117,6 @@ export const isProcedureId = (value: unknown): value is ProcedureId =>
   Predicate.hasProperty(value, TypeId);
 
 export const isReserved = (value: ProcedureId) =>
-  // eslint-disable-next-line no-bitwise
   (value.value & 0xf0_00) === 0xf0_00;
 
 export const arbitrary = (fc: typeof FastCheck) =>

--- a/libs/@local/harpc/client/typescript/src/types/ResponseKind.ts
+++ b/libs/@local/harpc/client/typescript/src/types/ResponseKind.ts
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/prevent-abbreviations -- same name as Rust reference implementation */
 import {
   Effect,
   Equal,
@@ -69,7 +70,6 @@ const OkProto: Ok = {
 
 export const ok = (): Ok => createProto(OkProto, {});
 
-// eslint-disable-next-line unicorn/prevent-abbreviations -- same name as Rust implementation
 export interface Err
   extends Equal.Equal,
     Inspectable.Inspectable,
@@ -80,7 +80,6 @@ export interface Err
   readonly code: ErrorCode.ErrorCode;
 }
 
-// eslint-disable-next-line unicorn/prevent-abbreviations
 const ErrProto: Omit<Err, "code"> = {
   [TypeId]: TypeId,
   _tag: "Err",

--- a/libs/@local/harpc/client/typescript/src/types/ResponseKind.ts
+++ b/libs/@local/harpc/client/typescript/src/types/ResponseKind.ts
@@ -13,6 +13,7 @@ import {
 
 import { createProto, encodeDual } from "../utils.js";
 import * as Buffer from "../wire-protocol/Buffer.js";
+
 import * as ErrorCode from "./ErrorCode.js";
 
 const TypeId: unique symbol = Symbol(
@@ -68,6 +69,7 @@ const OkProto: Ok = {
 
 export const ok = (): Ok => createProto(OkProto, {});
 
+// eslint-disable-next-line unicorn/prevent-abbreviations -- same name as Rust implementation
 export interface Err
   extends Equal.Equal,
     Inspectable.Inspectable,
@@ -78,6 +80,7 @@ export interface Err
   readonly code: ErrorCode.ErrorCode;
 }
 
+// eslint-disable-next-line unicorn/prevent-abbreviations
 const ErrProto: Omit<Err, "code"> = {
   [TypeId]: TypeId,
   _tag: "Err",
@@ -130,9 +133,9 @@ export const encode = encodeDual(
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
       if (isOk(kind)) {
         return yield* Buffer.putU16(buffer, 0);
-      } else {
-        return yield* ErrorCode.encode(buffer, kind.code);
       }
+
+      return yield* ErrorCode.encode(buffer, kind.code);
     }),
 );
 
@@ -141,12 +144,13 @@ export type DecodeError = Effect.Effect.Error<ReturnType<typeof decode>>;
 export const decode = (buffer: Buffer.ReadBuffer) =>
   Effect.gen(function* () {
     const value = yield* Buffer.getU16(buffer);
+
     if (value === 0) {
       return ok();
-    } else {
-      const code = ErrorCode.makeUnchecked(value);
-      return err(code);
     }
+    const code = ErrorCode.makeUnchecked(value);
+
+    return err(code);
   });
 
 export const isResponseKind = (value: unknown): value is ResponseKind =>
@@ -181,9 +185,9 @@ export const match: {
   ) => {
     if (isOk(self)) {
       return options.onOk();
-    } else {
-      return options.onErr(self.code);
     }
+
+    return options.onErr(self.code);
   },
 );
 

--- a/libs/@local/harpc/client/typescript/src/types/SubsystemDescriptor.ts
+++ b/libs/@local/harpc/client/typescript/src/types/SubsystemDescriptor.ts
@@ -1,5 +1,5 @@
-import type { FastCheck } from "effect";
 import {
+  type FastCheck,
   Effect,
   Equal,
   Function,
@@ -12,12 +12,14 @@ import {
 
 import { createProto, encodeDual } from "../utils.js";
 import type * as Buffer from "../wire-protocol/Buffer.js";
+
 import * as SubsystemId from "./SubsystemId.js";
 import * as Version from "./Version.js";
 
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/types/SubsystemDescriptor",
 );
+
 export type TypeId = typeof TypeId;
 
 export interface SubsystemDescriptor

--- a/libs/@local/harpc/client/typescript/src/types/SubsystemId.ts
+++ b/libs/@local/harpc/client/typescript/src/types/SubsystemId.ts
@@ -20,16 +20,16 @@ const TypeId: unique symbol = Symbol(
 
 export type TypeId = typeof TypeId;
 
-export class SubsystemIdTooLarge extends Data.TaggedError(
-  "SubsystemIdTooLarge",
+export class SubsystemIdTooLargeError extends Data.TaggedError(
+  "SubsystemIdTooLargeError",
 )<{ received: number }> {
   get message() {
     return `Procedure ID too large: ${this.received}, expected between ${U16_MIN} and ${U16_MAX}`;
   }
 }
 
-export class SubsystemIdTooSmall extends Data.TaggedError(
-  "SubsystemIdTooSmall",
+export class SubsystemIdTooSmallError extends Data.TaggedError(
+  "SubsystemIdTooSmallError",
 )<{ received: number }> {
   get message() {
     return `Procedure ID too small: ${this.received}, expected between ${U16_MIN} and ${U16_MAX}`;
@@ -90,13 +90,16 @@ export const makeUnchecked = (value: number): SubsystemId =>
 
 export const make = (
   id: number,
-): Effect.Effect<SubsystemId, SubsystemIdTooLarge | SubsystemIdTooSmall> => {
+): Effect.Effect<
+  SubsystemId,
+  SubsystemIdTooLargeError | SubsystemIdTooSmallError
+> => {
   if (id < U16_MIN) {
-    return Effect.fail(new SubsystemIdTooSmall({ received: id }));
+    return Effect.fail(new SubsystemIdTooSmallError({ received: id }));
   }
 
   if (id > U16_MAX) {
-    return Effect.fail(new SubsystemIdTooLarge({ received: id }));
+    return Effect.fail(new SubsystemIdTooLargeError({ received: id }));
   }
 
   return Effect.succeed(makeUnchecked(id));

--- a/libs/@local/harpc/client/typescript/src/types/SubsystemId.ts
+++ b/libs/@local/harpc/client/typescript/src/types/SubsystemId.ts
@@ -1,5 +1,5 @@
-import type { FastCheck } from "effect";
 import {
+  type FastCheck,
   Data,
   Effect,
   Equal,
@@ -17,6 +17,7 @@ import * as Buffer from "../wire-protocol/Buffer.js";
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/types/SubsystemId",
 );
+
 export type TypeId = typeof TypeId;
 
 export class SubsystemIdTooLarge extends Data.TaggedError(
@@ -117,7 +118,6 @@ export const isSubsystemId = (value: unknown): value is SubsystemId =>
   Predicate.hasProperty(value, TypeId);
 
 export const isReserved = (value: SubsystemId) =>
-  // eslint-disable-next-line no-bitwise
   (value.value & 0xf0_00) === 0xf0_00;
 
 export const arbitrary = (fc: typeof FastCheck) =>

--- a/libs/@local/harpc/client/typescript/src/types/Version.ts
+++ b/libs/@local/harpc/client/typescript/src/types/Version.ts
@@ -1,5 +1,5 @@
-import type { FastCheck } from "effect";
 import {
+  type FastCheck,
   Effect,
   Equal,
   Function,
@@ -17,6 +17,7 @@ import * as Buffer from "../wire-protocol/Buffer.js";
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/types/Version",
 );
+
 export type TypeId = typeof TypeId;
 
 export interface Version

--- a/libs/@local/harpc/client/typescript/src/utils.ts
+++ b/libs/@local/harpc/client/typescript/src/utils.ts
@@ -10,7 +10,7 @@ export const createProto = <
   proto: T,
   readableProperties: ReadableProperties,
   writeableProperties?: WriteableProperties,
-): T & ReadableProperties & WriteableProperties => {
+): T & Readonly<ReadableProperties> & WriteableProperties => {
   const readablePropertyDescriptors = Record.map(
     readableProperties,
     (value): PropertyDescriptor => ({
@@ -38,7 +38,7 @@ export const createProto = <
       writeablePropertyDescriptors,
       Function.untupled(Tuple.getFirst),
     ),
-  ) as T & ReadableProperties & WriteableProperties;
+  ) as T & Readonly<ReadableProperties> & WriteableProperties;
 };
 
 /**
@@ -71,7 +71,7 @@ export const hashUint8Array = (array: Uint8Array) => {
   }
 
   // if there are any remaining bytes, we hash them as well
-  for (let i = array.length - remainder; i < array.length; i++) {
+  for (let i = array.length - remainder; i < array.length; i = i + 1) {
     state = Hash.combine(array[i]!)(state);
   }
 

--- a/libs/@local/harpc/client/typescript/src/utils.ts
+++ b/libs/@local/harpc/client/typescript/src/utils.ts
@@ -62,9 +62,13 @@ export const hashUint8Array = (array: Uint8Array) => {
   // we can just take it in 32 bit chunks, which means we need to do less overall.
   for (let i = 0; i < array.length - remainder; i = i + 4) {
     const value =
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       array[i]! |
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       (array[i + 1]! << 8) |
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       (array[i + 2]! << 16) |
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       (array[i + 3]! << 24);
 
     state = Hash.combine(value)(state);
@@ -72,6 +76,7 @@ export const hashUint8Array = (array: Uint8Array) => {
 
   // if there are any remaining bytes, we hash them as well
   for (let i = array.length - remainder; i < array.length; i = i + 1) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     state = Hash.combine(array[i]!)(state);
   }
 

--- a/libs/@local/harpc/client/typescript/src/utils.ts
+++ b/libs/@local/harpc/client/typescript/src/utils.ts
@@ -41,7 +41,9 @@ export const createProto = <
   ) as T & ReadableProperties & WriteableProperties;
 };
 
-// This is more strictly typed than necessary, but this allows us to give better type hints
+/**
+ * This is more strictly typed than necessary, but this allows us to give better type hints.
+ */
 export const encodeDual: <U, E extends Buffer.UnexpectedEndOfBufferError>(
   closure: (buffer: Buffer.WriteBuffer, self: U) => Buffer.WriteResult<E>,
 ) => {
@@ -58,15 +60,11 @@ export const hashUint8Array = (array: Uint8Array) => {
 
   // because they're just numbers and the safe integer range is 2^53 - 1,
   // we can just take it in 32 bit chunks, which means we need to do less overall.
-  for (let i = 0; i < array.length - remainder; i += 4) {
+  for (let i = 0; i < array.length - remainder; i = i + 4) {
     const value =
-      // eslint-disable-next-line no-bitwise
       array[i]! |
-      // eslint-disable-next-line no-bitwise
       (array[i + 1]! << 8) |
-      // eslint-disable-next-line no-bitwise
       (array[i + 2]! << 16) |
-      // eslint-disable-next-line no-bitwise
       (array[i + 3]! << 24);
 
     state = Hash.combine(value)(state);

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/Buffer.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/Buffer.ts
@@ -213,7 +213,7 @@ export const putSlice: {
 
 export const getSlice = (
   buffer: Buffer<Read>,
-  length: number,
+  byteLength: number,
 ): ReadResult<Uint8Array> =>
   SubscriptionRef.modifyEffect(
     (buffer as unknown as BufferImpl<Read>).index,
@@ -221,29 +221,29 @@ export const getSlice = (
       Effect.gen(function* () {
         const impl = buffer as unknown as BufferImpl<Read>;
 
-        yield* validateBounds(impl, index, length);
+        yield* validateBounds(impl, index, byteLength);
 
         // clone the buffer
-        const clone = new ArrayBuffer(length);
+        const clone = new ArrayBuffer(byteLength);
         const value = new Uint8Array(clone);
 
-        value.set(new Uint8Array(impl.value.buffer, index, length));
+        value.set(new Uint8Array(impl.value.buffer, index, byteLength));
 
-        return [value, index + length] as const;
+        return [value, index + byteLength] as const;
       }),
   );
 
 export const advance: {
   (length: number): <T>(buffer: Buffer<T>) => WriteResult;
   <T>(buffer: Buffer<T>, length: number): WriteResult;
-} = Function.dual(2, <T>(buffer: Buffer<T>, length: number) =>
+} = Function.dual(2, <T>(buffer: Buffer<T>, byteLength: number) =>
   SubscriptionRef.modifyEffect(
     (buffer as unknown as BufferImpl<T>).index,
     (index) =>
       Effect.gen(function* () {
-        yield* validateBounds(buffer as BufferImpl<T>, index, length);
+        yield* validateBounds(buffer as BufferImpl<T>, index, byteLength);
 
-        return [buffer, index + length] as const;
+        return [buffer, index + byteLength] as const;
       }),
   ),
 );

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/Buffer.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/Buffer.ts
@@ -3,16 +3,19 @@ import { Data, Effect, Function, SubscriptionRef } from "effect";
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/Buffer",
 );
+
 export type TypeId = typeof TypeId;
 
 const Read: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/Buffer/Read",
 );
+
 export type Read = typeof Read;
 
 const Write: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/Buffer/Write",
 );
+
 export type Write = typeof Write;
 
 export class UnexpectedEndOfBufferError extends Data.TaggedError(
@@ -57,7 +60,7 @@ const validateBounds = <T>(
 const makeUnchecked = <T>(view: DataView, mode: T) =>
   Effect.gen(function* () {
     // the buffer we write to is always a single page of 64KiB
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+
     const object = Object.create(BufferProto);
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -72,7 +75,9 @@ const makeUnchecked = <T>(view: DataView, mode: T) =>
 
 export const makeRead = (view: DataView) => makeUnchecked(view, Read);
 
-// the buffer we write to is always a single page of 64KiB
+/**
+ * The buffer we write to is always a single page of 64KiB.
+ */
 export const makeWrite = () =>
   makeUnchecked(new DataView(new ArrayBuffer(64 * 1024)), Write);
 
@@ -147,23 +152,25 @@ export type ReadResult<T = number> = Effect.Effect<
   UnexpectedEndOfBufferError
 >;
 
-type WriteSignature = {
+interface WriteSignature {
   (value: number): (buffer: Buffer<Write>) => WriteResult;
   (buffer: Buffer<Write>, value: number): WriteResult;
-};
+}
 
 export const putU8: WriteSignature = Function.dual(
   2,
-  putInt(1, (view, byteOffset, value) => view.setUint8(byteOffset, value)),
+  putInt(1, (view, byteOffset, value) => {
+    view.setUint8(byteOffset, value);
+  }),
 );
 
 export const getU8 = getInt(1, (view, byteOffset) => view.getUint8(byteOffset));
 
 export const putU16: WriteSignature = Function.dual(
   2,
-  putInt(2, (view, byteOffset, value) =>
-    view.setUint16(byteOffset, value, false),
-  ),
+  putInt(2, (view, byteOffset, value) => {
+    view.setUint16(byteOffset, value, false);
+  }),
 );
 
 export const getU16 = getInt(2, (view, byteOffset) =>
@@ -172,9 +179,9 @@ export const getU16 = getInt(2, (view, byteOffset) =>
 
 export const putU32: WriteSignature = Function.dual(
   2,
-  putInt(4, (view, byteOffset, value) =>
-    view.setUint32(byteOffset, value, false),
-  ),
+  putInt(4, (view, byteOffset, value) => {
+    view.setUint32(byteOffset, value, false);
+  }),
 );
 
 export const getU32 = getInt(4, (view, byteOffset) =>
@@ -196,6 +203,7 @@ export const putSlice: {
           index,
           value.length,
         );
+
         uint8Array.set(value);
 
         return [buffer, index + value.length] as const;
@@ -218,6 +226,7 @@ export const getSlice = (
         // clone the buffer
         const clone = new ArrayBuffer(length);
         const value = new Uint8Array(clone);
+
         value.set(new Uint8Array(impl.value.buffer, index, length));
 
         return [value, index + length] as const;
@@ -264,5 +273,6 @@ export const take = (buffer: Buffer<Write>) =>
     const impl = buffer as unknown as BufferImpl<Write>;
 
     const inner = impl.value.buffer.slice(0, currentLength);
+
     return inner;
   });

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/RequestIdProducer.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/RequestIdProducer.ts
@@ -2,11 +2,13 @@ import { Effect, Layer, Ref } from "effect";
 import { GenericTag } from "effect/Context";
 
 import { createProto } from "../utils.js";
+
 import * as RequestId from "./models/request/RequestId.js";
 
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/RequestIdProducer",
 );
+
 export type TypeId = typeof TypeId;
 
 export interface RequestIdProducer {

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/RequestIdProducer.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/RequestIdProducer.ts
@@ -24,6 +24,7 @@ const RequestIdProducerProto: Omit<RequestIdProducer, "value"> = {
 };
 
 export const RequestIdProducer = GenericTag<RequestIdProducer>(
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- always defined
   TypeId.description!,
 );
 

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/models/Payload.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/models/Payload.ts
@@ -1,5 +1,5 @@
-import type { FastCheck } from "effect";
 import {
+  type FastCheck,
   Data,
   Effect,
   Equal,
@@ -17,6 +17,7 @@ import * as Buffer from "../Buffer.js";
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/Payload",
 );
+
 export type TypeId = typeof TypeId;
 
 export const MAX_SIZE = U16_MAX - 32;
@@ -67,7 +68,7 @@ const PayloadProto: Omit<Payload, "buffer"> = {
   toJSON(this: Payload) {
     return {
       _id: "Payload",
-      buffer: Array.from(this.buffer),
+      buffer: [...this.buffer],
     };
   },
 

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/models/Protocol.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/models/Protocol.ts
@@ -1,5 +1,5 @@
-import type { FastCheck } from "effect";
 import {
+  type FastCheck,
   Data,
   Effect,
   Equal,
@@ -12,11 +12,13 @@ import {
 
 import { createProto, encodeDual } from "../../utils.js";
 import * as Buffer from "../Buffer.js";
+
 import * as ProtocolVersion from "./ProtocolVersion.js";
 
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/models/Protocol",
 );
+
 export type TypeId = typeof TypeId;
 
 export class InvalidMagicError extends Data.TaggedError("InvalidMagicError")<{
@@ -24,6 +26,7 @@ export class InvalidMagicError extends Data.TaggedError("InvalidMagicError")<{
 }> {
   get message(): string {
     const receivedString = new TextDecoder().decode(this.received);
+
     return `Invalid magic received: ${receivedString}`;
   }
 }

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/models/ProtocolVersion.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/models/ProtocolVersion.ts
@@ -1,5 +1,5 @@
-import type { FastCheck } from "effect";
 import {
+  type FastCheck,
   Data,
   Effect,
   Equal,
@@ -16,6 +16,7 @@ import * as Buffer from "../Buffer.js";
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/models/ProtocolVersion",
 );
+
 export type TypeId = typeof TypeId;
 
 export class InvalidProtocolVersionError extends Data.TaggedError(

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/models/request/Request.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/models/request/Request.ts
@@ -1,5 +1,5 @@
-import type { FastCheck } from "effect";
 import {
+  type FastCheck,
   Effect,
   Equal,
   Function,
@@ -12,6 +12,7 @@ import {
 
 import { createProto, encodeDual } from "../../../utils.js";
 import type * as Buffer from "../../Buffer.js";
+
 import * as RequestBody from "./RequestBody.js";
 import * as RequestFlags from "./RequestFlags.js";
 import * as RequestHeader from "./RequestHeader.js";
@@ -19,6 +20,7 @@ import * as RequestHeader from "./RequestHeader.js";
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/models/request/Request",
 );
+
 export type TypeId = typeof TypeId;
 
 export interface Request
@@ -79,7 +81,8 @@ export const make = (
   body: RequestBody.RequestBody,
 ): Request => createProto(RequestProto, { header, body });
 
-/*
+/**
+ *
  * Prepare a request for encoding, this will ensure that the header has all computed flags set.
  *
  * This step is automatically done during encoding, but can be useful to call manually if you want to inspect the

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/models/request/RequestBegin.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/models/request/RequestBegin.ts
@@ -1,5 +1,5 @@
-import type { FastCheck } from "effect";
 import {
+  type FastCheck,
   Effect,
   Equal,
   Function,
@@ -19,6 +19,7 @@ import * as Payload from "../Payload.js";
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/models/request/RequestBegin",
 );
+
 export type TypeId = typeof TypeId;
 
 export interface RequestBegin
@@ -108,6 +109,7 @@ export const decode = (buffer: Buffer.ReadBuffer) =>
   Effect.gen(function* () {
     const subsystem = yield* SubsystemDescriptor.decode(buffer);
     const procedure = yield* ProcedureDescriptor.decode(buffer);
+
     yield* Buffer.advance(buffer, 13);
     const payload = yield* Payload.decode(buffer);
 

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/models/request/RequestBody.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/models/request/RequestBody.ts
@@ -154,9 +154,9 @@ export type DecodeError = Effect.Effect.Error<ReturnType<typeof decode>>;
 
 export const decode = (
   buffer: Buffer.ReadBuffer,
-  variant: RequestBodyVariant,
+  variantHint: RequestBodyVariant,
 ) => {
-  switch (variant) {
+  switch (variantHint) {
     case "RequestBegin": {
       return pipe(
         buffer,

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/models/request/RequestBody.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/models/request/RequestBody.ts
@@ -1,5 +1,6 @@
-import type { FastCheck, Option } from "effect";
 import {
+  type FastCheck,
+  type Option,
   Effect,
   Either,
   Equal,
@@ -13,12 +14,14 @@ import {
 
 import { createProto, encodeDual } from "../../../utils.js";
 import type * as Buffer from "../../Buffer.js";
+
 import * as RequestBegin from "./RequestBegin.js";
 import * as RequestFrame from "./RequestFrame.js";
 
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/models/request/RequestBody",
 );
+
 export type TypeId = typeof TypeId;
 
 export type RequestBodyVariant = "RequestBegin" | "RequestFrame";
@@ -154,18 +157,20 @@ export const decode = (
   variant: RequestBodyVariant,
 ) => {
   switch (variant) {
-    case "RequestBegin":
+    case "RequestBegin": {
       return pipe(
         buffer,
         RequestBegin.decode,
         Effect.andThen((begin) => make(Either.right(begin))),
       );
-    case "RequestFrame":
+    }
+    case "RequestFrame": {
       return pipe(
         buffer,
         RequestFrame.decode,
         Effect.andThen((frame) => make(Either.left(frame))),
       );
+    }
   }
 };
 

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/models/request/RequestFlags.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/models/request/RequestFlags.ts
@@ -1,5 +1,5 @@
-import type { FastCheck } from "effect";
 import {
+  type FastCheck,
   Effect,
   Equal,
   Hash,
@@ -12,11 +12,13 @@ import {
 
 import { createProto, encodeDual } from "../../../utils.js";
 import * as Buffer from "../../Buffer.js";
+
 import type * as RequestBody from "./RequestBody.js";
 
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/models/request/RequestFlags",
 );
+
 export type TypeId = typeof TypeId;
 
 export type Flag =
@@ -81,10 +83,12 @@ export const applyBodyVariant = (
   variant: RequestBody.RequestBodyVariant,
 ) => {
   switch (variant) {
-    case "RequestBegin":
+    case "RequestBegin": {
       return HashSet.add(flags.flags, "beginOfRequest").pipe(makeUnchecked);
-    case "RequestFrame":
+    }
+    case "RequestFrame": {
       return HashSet.remove(flags.flags, "beginOfRequest").pipe(makeUnchecked);
+    }
   }
 };
 
@@ -92,13 +96,11 @@ export const repr = (flags: RequestFlags) => {
   let value = 0x00;
 
   if (HashSet.has(flags.flags, "beginOfRequest")) {
-    // eslint-disable-next-line no-bitwise
-    value |= 0b1000_0000;
+    value = value | 0b1000_0000;
   }
 
   if (HashSet.has(flags.flags, "endOfRequest")) {
-    // eslint-disable-next-line no-bitwise
-    value |= 0b0000_0001;
+    value = value | 0b0000_0001;
   }
 
   return value;
@@ -123,12 +125,10 @@ export const decode = (buffer: Buffer.ReadBuffer) =>
 
     const flags = HashSet.empty<Flag>().pipe(HashSet.beginMutation);
 
-    // eslint-disable-next-line no-bitwise
     if ((value & 0b1000_0000) === 0b1000_0000) {
       HashSet.add(flags, "beginOfRequest");
     }
 
-    // eslint-disable-next-line no-bitwise
     if ((value & 0b0000_0001) === 0b0000_0001) {
       HashSet.add(flags, "endOfRequest");
     }

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/models/request/RequestFrame.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/models/request/RequestFrame.ts
@@ -1,5 +1,5 @@
-import type { FastCheck } from "effect";
 import {
+  type FastCheck,
   Effect,
   Equal,
   Hash,
@@ -16,6 +16,7 @@ import * as Payload from "../Payload.js";
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/models/request/RequestFrame",
 );
+
 export type TypeId = typeof TypeId;
 
 export interface RequestFrame

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/models/request/RequestHeader.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/models/request/RequestHeader.ts
@@ -1,5 +1,5 @@
-import type { FastCheck } from "effect";
 import {
+  type FastCheck,
   Effect,
   Equal,
   Function,
@@ -13,6 +13,7 @@ import {
 import { createProto, encodeDual } from "../../../utils.js";
 import type * as Buffer from "../../Buffer.js";
 import * as Protocol from "../Protocol.js";
+
 import type * as RequestBody from "./RequestBody.js";
 import * as RequestFlags from "./RequestFlags.js";
 import * as RequestId from "./RequestId.js";

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/models/request/RequestId.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/models/request/RequestId.ts
@@ -1,5 +1,5 @@
-import type { FastCheck } from "effect";
 import {
+  type FastCheck,
   Effect,
   Equal,
   Hash,
@@ -16,6 +16,7 @@ import * as Buffer from "../../Buffer.js";
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/models/request/RequestId",
 );
+
 export type TypeId = typeof TypeId;
 
 export const MIN_VALUE = U32_MIN;

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/models/response/Response.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/models/response/Response.ts
@@ -1,5 +1,5 @@
-import type { FastCheck } from "effect";
 import {
+  type FastCheck,
   Effect,
   Equal,
   Function,
@@ -12,6 +12,7 @@ import {
 
 import { createProto, encodeDual } from "../../../utils.js";
 import type * as Buffer from "../../Buffer.js";
+
 import * as ResponseBody from "./ResponseBody.js";
 import * as ResponseFlags from "./ResponseFlags.js";
 import * as ResponseHeader from "./ResponseHeader.js";
@@ -19,6 +20,7 @@ import * as ResponseHeader from "./ResponseHeader.js";
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/models/response/Response",
 );
+
 export type TypeId = typeof TypeId;
 
 export interface Response
@@ -79,7 +81,8 @@ export const make = (
   body: ResponseBody.ResponseBody,
 ): Response => createProto(ResponseProto, { header, body });
 
-/*
+/**
+ *
  * Prepare a response for encoding, this will ensure that the header has all computed flags set.
  *
  * This step is automatically done during encoding, but can be useful to call manually if you want to inspect the

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/models/response/ResponseBegin.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/models/response/ResponseBegin.ts
@@ -1,5 +1,5 @@
-import type { FastCheck } from "effect";
 import {
+  type FastCheck,
   Effect,
   Equal,
   Function,
@@ -18,6 +18,7 @@ import * as Payload from "../Payload.js";
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/models/response/ResponseBegin",
 );
+
 export type TypeId = typeof TypeId;
 
 export interface ResponseBegin

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/models/response/ResponseBody.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/models/response/ResponseBody.ts
@@ -1,5 +1,6 @@
-import type { FastCheck, Option } from "effect";
 import {
+  type FastCheck,
+  type Option,
   Effect,
   Either,
   Equal,
@@ -13,12 +14,14 @@ import {
 
 import { createProto, encodeDual } from "../../../utils.js";
 import type * as Buffer from "../../Buffer.js";
+
 import * as ResponseBegin from "./ResponseBegin.js";
 import * as ResponseFrame from "./ResponseFrame.js";
 
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/models/response/ResponseBody",
 );
+
 export type TypeId = typeof TypeId;
 
 export type ResponseBodyVariant = "ResponseBegin" | "ResponseFrame";
@@ -148,18 +151,20 @@ export const decode = (
   variant: ResponseBodyVariant,
 ) => {
   switch (variant) {
-    case "ResponseBegin":
+    case "ResponseBegin": {
       return pipe(
         buffer,
         ResponseBegin.decode,
         Effect.andThen((begin) => make(Either.right(begin))),
       );
-    case "ResponseFrame":
+    }
+    case "ResponseFrame": {
       return pipe(
         buffer,
         ResponseFrame.decode,
         Effect.andThen((frame) => make(Either.left(frame))),
       );
+    }
   }
 };
 

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/models/response/ResponseBody.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/models/response/ResponseBody.ts
@@ -148,9 +148,9 @@ export type DecodeError = Effect.Effect.Error<ReturnType<typeof decode>>;
 
 export const decode = (
   buffer: Buffer.ReadBuffer,
-  variant: ResponseBodyVariant,
+  variantHint: ResponseBodyVariant,
 ) => {
-  switch (variant) {
+  switch (variantHint) {
     case "ResponseBegin": {
       return pipe(
         buffer,

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/models/response/ResponseFlags.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/models/response/ResponseFlags.ts
@@ -1,5 +1,5 @@
-import type { FastCheck } from "effect";
 import {
+  type FastCheck,
   Effect,
   Equal,
   Hash,
@@ -12,11 +12,13 @@ import {
 
 import { createProto, encodeDual } from "../../../utils.js";
 import * as Buffer from "../../Buffer.js";
+
 import type * as ResponseBody from "./ResponseBody.js";
 
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/models/response/ResponseFlags",
 );
+
 export type TypeId = typeof TypeId;
 
 export type Flag =
@@ -78,10 +80,12 @@ export const applyBodyVariant = (
   variant: ResponseBody.ResponseBodyVariant,
 ) => {
   switch (variant) {
-    case "ResponseBegin":
+    case "ResponseBegin": {
       return HashSet.add(flags.flags, "beginOfResponse").pipe(make);
-    case "ResponseFrame":
+    }
+    case "ResponseFrame": {
       return HashSet.remove(flags.flags, "beginOfResponse").pipe(make);
+    }
   }
 };
 
@@ -89,13 +93,11 @@ export const repr = (flags: ResponseFlags) => {
   let value = 0x00;
 
   if (HashSet.has(flags.flags, "beginOfResponse")) {
-    // eslint-disable-next-line no-bitwise
-    value |= 0b1000_0000;
+    value = value | 0b1000_0000;
   }
 
   if (HashSet.has(flags.flags, "endOfResponse")) {
-    // eslint-disable-next-line no-bitwise
-    value |= 0b0000_0001;
+    value = value | 0b0000_0001;
   }
 
   return value;
@@ -120,12 +122,10 @@ export const decode = (buffer: Buffer.ReadBuffer) =>
 
     const flags = HashSet.empty<Flag>().pipe(HashSet.beginMutation);
 
-    // eslint-disable-next-line no-bitwise
     if ((value & 0b1000_0000) === 0b1000_0000) {
       HashSet.add(flags, "beginOfResponse");
     }
 
-    // eslint-disable-next-line no-bitwise
     if ((value & 0b0000_0001) === 0b0000_0001) {
       HashSet.add(flags, "endOfResponse");
     }

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/models/response/ResponseFrame.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/models/response/ResponseFrame.ts
@@ -1,5 +1,5 @@
-import type { FastCheck } from "effect";
 import {
+  type FastCheck,
   Effect,
   Equal,
   Hash,
@@ -16,6 +16,7 @@ import * as Payload from "../Payload.js";
 const TypeId: unique symbol = Symbol(
   "@local/harpc-client/wire-protocol/models/response/ResponseFrame",
 );
+
 export type TypeId = typeof TypeId;
 
 export interface ResponseFrame

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/models/response/ResponseHeader.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/models/response/ResponseHeader.ts
@@ -1,5 +1,5 @@
-import type { FastCheck } from "effect";
 import {
+  type FastCheck,
   Effect,
   Equal,
   Function,
@@ -14,6 +14,7 @@ import { createProto, encodeDual } from "../../../utils.js";
 import type * as Buffer from "../../Buffer.js";
 import * as Protocol from "../Protocol.js";
 import { RequestId } from "../request/index.js";
+
 import type * as ResponseBody from "./ResponseBody.js";
 import * as ResponseFlags from "./ResponseFlags.js";
 

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/stream/RequestToBytesStream.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/stream/RequestToBytesStream.ts
@@ -1,36 +1,20 @@
-import { Effect, pipe, Stream, Streamable } from "effect";
+import { Effect, pipe, Stream } from "effect";
 
 import * as Buffer from "../Buffer.js";
 import { Request } from "../models/request/index.js";
 
-export class RequestToBytesStream<E, R> extends Streamable.Class<
-  ArrayBuffer,
-  E | Request.EncodeError,
-  R
-> {
-  readonly #stream: Stream.Stream<Request.Request, E, R>;
+export const make = <E, R>(
+  stream: Stream.Stream<Request.Request, E, R>,
+): Stream.Stream<ArrayBuffer, E | Request.EncodeError, R> =>
+  pipe(
+    stream,
+    Stream.mapEffect((request) =>
+      Effect.gen(function* () {
+        const buffer = yield* Buffer.makeWrite();
 
-  constructor(stream: Stream.Stream<Request.Request, E, R>) {
-    super();
+        yield* Request.encode(buffer, request);
 
-    this.#stream = stream;
-  }
-
-  toStream(): Stream.Stream<ArrayBuffer, E | Request.EncodeError, R> {
-    return pipe(
-      this.#stream,
-      Stream.mapEffect((request) =>
-        Effect.gen(function* () {
-          const buffer = yield* Buffer.makeWrite();
-
-          yield* Request.encode(buffer, request);
-
-          return yield* Buffer.take(buffer);
-        }),
-      ),
-    );
-  }
-}
-
-export const make = <E, R>(stream: Stream.Stream<Request.Request, E, R>) =>
-  new RequestToBytesStream(stream);
+        return yield* Buffer.take(buffer);
+      }),
+    ),
+  );

--- a/libs/@local/harpc/client/typescript/src/wire-protocol/stream/ResponseFromBytesStream.ts
+++ b/libs/@local/harpc/client/typescript/src/wire-protocol/stream/ResponseFromBytesStream.ts
@@ -14,7 +14,9 @@ export class IncompleteResponseError extends Data.TaggedError(
   }
 }
 
-// initial scratch buffer is 2x size of the largest possible packet
+/**
+ * Initial scratch buffer is 2x size of the largest possible packet.
+ */
 const makeScratch = () =>
   MutableBytes.make({
     initialCapacity: 2 * 1024 * 64,
@@ -33,6 +35,7 @@ const tryDecodePacket = (scratch: MutableBytes.MutableBytes) =>
     const packetLength = bufferView.getUint16(0, false);
 
     const split = MutableBytes.splitTo(scratch, packetLength + 32);
+
     if (Option.isNone(split)) {
       // we cannot yet read the full message
       return Option.none();
@@ -45,6 +48,7 @@ const tryDecodePacket = (scratch: MutableBytes.MutableBytes) =>
       new DataView(MutableBytes.asBuffer(packet)),
     );
     const response = yield* Response.decode(reader);
+
     return Option.some(response);
   });
 

--- a/libs/@local/harpc/client/typescript/tests/codec/JsonDecoder.test.ts
+++ b/libs/@local/harpc/client/typescript/tests/codec/JsonDecoder.test.ts
@@ -32,6 +32,7 @@ describe.concurrent("JsonDecoder", () => {
       const textPayload = '{"key": "value"}\x1E';
 
       const items = yield* decode([textPayload]);
+
       cx.expect(items).toMatchObject([{ key: "value" }]);
     }).pipe(Effect.provide(JsonDecoder.layer)),
   );
@@ -41,6 +42,7 @@ describe.concurrent("JsonDecoder", () => {
       const textPayload = '{"key": "value1"}\x1E{"key": "value2"}\x1E';
 
       const items = yield* decode([textPayload]);
+
       cx.expect(items).toMatchObject([{ key: "value1" }, { key: "value2" }]);
     }).pipe(Effect.provide(JsonDecoder.layer)),
   );
@@ -50,6 +52,7 @@ describe.concurrent("JsonDecoder", () => {
       const textPayload = '{"key": "value1"}\x1E{"key": "value2';
 
       const items = yield* decode([textPayload]);
+
       cx.expect(items).toMatchObject([{ key: "value1" }]);
     }).pipe(Effect.provide(JsonDecoder.layer)),
   );
@@ -59,6 +62,7 @@ describe.concurrent("JsonDecoder", () => {
       const textPayload = ['{"key": "val', 'ue1"}\x1E'];
 
       const items = yield* decode(textPayload);
+
       cx.expect(items).toMatchObject([{ key: "value1" }]);
     }).pipe(Effect.provide(JsonDecoder.layer)),
   );
@@ -70,6 +74,7 @@ describe.concurrent("JsonDecoder", () => {
         const textPayload = ['{"key": "val', 'ue1"}\x1E{"key": "value2"}\x1E'];
 
         const items = yield* decode(textPayload);
+
         cx.expect(items).toMatchObject([{ key: "value1" }, { key: "value2" }]);
       }).pipe(Effect.provide(JsonDecoder.layer)),
   );

--- a/libs/@local/harpc/client/typescript/tests/codec/JsonEncoder.test.ts
+++ b/libs/@local/harpc/client/typescript/tests/codec/JsonEncoder.test.ts
@@ -26,6 +26,7 @@ describe.concurrent("JsonEncoder", () => {
       const payload = [{ key: "value" }];
 
       const items = yield* encode(payload);
+
       cx.expect(items).toMatchObject(['{"key":"value"}\x1E']);
     }).pipe(Effect.provide(JsonEncoder.layer)),
   );
@@ -35,6 +36,7 @@ describe.concurrent("JsonEncoder", () => {
       const payload = [{ key: "value1" }, { key: "value2" }];
 
       const items = yield* encode(payload);
+
       cx.expect(items).toMatchObject([
         '{"key":"value1"}\x1E',
         '{"key":"value2"}\x1E',

--- a/libs/@local/harpc/client/typescript/tests/net/Request.test.ts
+++ b/libs/@local/harpc/client/typescript/tests/net/Request.test.ts
@@ -12,8 +12,8 @@ import {
 } from "../../src/types/index.js";
 import { RequestIdProducer } from "../../src/wire-protocol/index.js";
 import { Payload } from "../../src/wire-protocol/models/index.js";
-import type { Request as WireRequest } from "../../src/wire-protocol/models/request/index.js";
 import {
+  type Request as WireRequest,
   RequestBody,
   RequestFlags,
 } from "../../src/wire-protocol/models/request/index.js";
@@ -31,7 +31,7 @@ const makeRequest = <E, R>(stream: Stream.Stream<ArrayBuffer, E, R>) =>
   });
 
 const assertBody = (
-  cx: vitest.TaskContext<vitest.RunnerTestCase<object>> & vitest.TestContext,
+  cx: vitest.TaskContext<vitest.RunnerTestCase> & vitest.TestContext,
   request: WireRequest.Request,
   bodyIs: (request: RequestBody.RequestBody) => boolean,
   body: string | number,
@@ -45,6 +45,7 @@ const assertBody = (
 
   if (Predicate.isString(body)) {
     const text = new TextDecoder().decode(buffer);
+
     cx.expect(text).toBe(body);
   } else if (Predicate.isNumber(body)) {
     cx.expect(buffer.byteLength).toBe(body);

--- a/libs/@local/harpc/client/typescript/tests/wire-protocol/decode.test.ts
+++ b/libs/@local/harpc/client/typescript/tests/wire-protocol/decode.test.ts
@@ -51,6 +51,7 @@ const convertResponseBegin = (
 ): ResponseBeginData => ({
   kind: ResponseKind.match(begin.kind, {
     onOk: () => "Ok",
+    // eslint-disable-next-line unicorn/prevent-abbreviations
     onErr: (code) => ({ Err: code.value }),
   }),
   payload: [...begin.payload.buffer],

--- a/libs/@local/harpc/client/typescript/tests/wire-protocol/decode.test.ts
+++ b/libs/@local/harpc/client/typescript/tests/wire-protocol/decode.test.ts
@@ -12,6 +12,7 @@ import {
   ResponseFrame,
   ResponseHeader,
 } from "../../src/wire-protocol/models/response/index.js";
+
 import { callDecode } from "./utils.js";
 
 const ResponseHeaderFromSelf = Schema.declare(ResponseHeader.isResponseHeader, {
@@ -52,7 +53,7 @@ const convertResponseBegin = (
     onOk: () => "Ok",
     onErr: (code) => ({ Err: code.value }),
   }),
-  payload: Array.from(begin.payload.buffer),
+  payload: [...begin.payload.buffer],
 });
 
 const ResponseFrameFromSelf = Schema.declare(ResponseFrame.isResponseFrame, {
@@ -66,7 +67,7 @@ interface ResponseFrameData {
 const convertResponseFrame = (
   frame: ResponseFrame.ResponseFrame,
 ): ResponseFrameData => ({
-  payload: Array.from(frame.payload.buffer),
+  payload: [...frame.payload.buffer],
 });
 
 const ResponseFromSelf = Schema.declare(Response.isResponse, {

--- a/libs/@local/harpc/client/typescript/tests/wire-protocol/encode.test.ts
+++ b/libs/@local/harpc/client/typescript/tests/wire-protocol/encode.test.ts
@@ -1,6 +1,5 @@
 import { NodeContext } from "@effect/platform-node";
-import type { TestContext } from "@effect/vitest";
-import { describe, it } from "@effect/vitest";
+import { type TestContext, describe, it } from "@effect/vitest";
 import { Effect, Option, Predicate, Schema } from "effect";
 
 import { Buffer } from "../../src/wire-protocol/index.js";
@@ -12,6 +11,7 @@ import {
   RequestFrame,
   RequestHeader,
 } from "../../src/wire-protocol/models/request/index.js";
+
 import { callEncode } from "./utils.js";
 
 const RequestHeaderFromSelf = Schema.declare(RequestHeader.isRequestHeader, {
@@ -63,7 +63,7 @@ const assertRequestBegin = (
   cx.expect(a.subsystem.version.major).toBe(b.subsystem.version.major);
   cx.expect(a.subsystem.version.minor).toBe(b.subsystem.version.minor);
   cx.expect(a.procedure.id.value).toBe(b.procedure.id);
-  cx.expect(Array.from(a.payload.buffer)).toEqual(b.payload);
+  cx.expect([...a.payload.buffer]).toEqual(b.payload);
 };
 
 const RequestFrameFromSelf = Schema.declare(RequestFrame.isRequestFrame, {
@@ -79,7 +79,7 @@ const assertRequestFrame = (
   a: RequestFrame.RequestFrame,
   b: RequestFrameData,
 ) => {
-  cx.expect(Array.from(a.payload.buffer)).toEqual(b.payload);
+  cx.expect([...a.payload.buffer]).toEqual(b.payload);
 };
 
 const RequestFromSelf = Schema.declare(Request.isRequest, {
@@ -121,6 +121,7 @@ describe.concurrent("encode", () => {
     ({ header }, cx) =>
       Effect.gen(function* () {
         const buffer = yield* Buffer.makeWrite();
+
         yield* RequestHeader.encode(buffer, header);
 
         const array = yield* Buffer.take(buffer);
@@ -139,6 +140,7 @@ describe.concurrent("encode", () => {
     ({ begin }, cx) =>
       Effect.gen(function* () {
         const buffer = yield* Buffer.makeWrite();
+
         yield* RequestBegin.encode(buffer, begin);
 
         const array = yield* Buffer.take(buffer);
@@ -146,6 +148,7 @@ describe.concurrent("encode", () => {
           "request-begin",
           new Uint8Array(array),
         );
+
         assertRequestBegin(cx, begin, received as RequestBeginData);
       }).pipe(Effect.provide(NodeContext.layer)),
   );
@@ -156,6 +159,7 @@ describe.concurrent("encode", () => {
     ({ frame }, cx) =>
       Effect.gen(function* () {
         const buffer = yield* Buffer.makeWrite();
+
         yield* RequestFrame.encode(buffer, frame);
 
         const array = yield* Buffer.take(buffer);
@@ -174,6 +178,7 @@ describe.concurrent("encode", () => {
     ({ request }, cx) =>
       Effect.gen(function* () {
         const buffer = yield* Buffer.makeWrite();
+
         yield* Request.encode(buffer, request);
 
         const array = yield* Buffer.take(buffer);

--- a/libs/@local/harpc/client/typescript/tests/wire-protocol/utils.ts
+++ b/libs/@local/harpc/client/typescript/tests/wire-protocol/utils.ts
@@ -57,5 +57,6 @@ export const callDecode = <T>(
 
     // convert base64 to Uint8Array
     const buffer = Buffer.from(output, "base64");
+
     return Uint8Array.from(buffer);
   });

--- a/libs/@local/harpc/client/typescript/tests/wire-protocol/utils.ts
+++ b/libs/@local/harpc/client/typescript/tests/wire-protocol/utils.ts
@@ -43,9 +43,9 @@ export const callEncode = (
     return received;
   });
 
-export const callDecode = <T>(
+export const callDecode = (
   mode: "response-header" | "response-begin" | "response-frame" | "response",
-  payload: T,
+  payload: unknown,
 ) =>
   Effect.gen(function* () {
     const binary = yield* executablePath();

--- a/libs/@local/harpc/client/typescript/vitest.config.ts
+++ b/libs/@local/harpc/client/typescript/vitest.config.ts
@@ -12,7 +12,6 @@ export default defineConfig({
       provider: "istanbul",
       reporter: ["lcov", "text"],
       include: ["**/*.{c,m,}{j,t}s{x,}"],
-      exclude: ["**/node_modules/**", "**/dist/**"],
     },
     environment: "node",
     testTimeout: 30000,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Switch from the old ESLint configuration to the new, stricter configuration for `@local/harpc-client`

> This also added some additional configuration to eslint as I discovered some rough edges.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
