### PR TITLE
H-3833: Fix typo on intro use cases page

### DIFF
--- a/apps/hashdotai/guide/01_introduction/01_use-cases.mdx
+++ b/apps/hashdotai/guide/01_introduction/01_use-cases.mdx
@@ -13,7 +13,7 @@ sidebarIcon: https://app.hash.ai/icons/docs/introduction-usecases.svg
 
 ### Knowledge graph generation
 
-Quickly create a trustworthy, comprehensive, and useful knowledge graph (or ["web"](/guide/webs)), capturing information about your business, industy or any area of interest in a strongly-typed, semantic graph.
+Quickly create a trustworthy, comprehensive, and useful knowledge graph (or ["web"](/guide/webs)), capturing information about your business, industry or any area of interest in a strongly-typed, semantic graph.
 
 ### Deep research
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes a typo on the `Intro > Use Cases` page of the HASH user guide.
