### PR TITLE
H-3833: Fix `Workers` page heading

### DIFF
--- a/apps/hashdotai/guide/05_workers/00_index.mdx
+++ b/apps/hashdotai/guide/05_workers/00_index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Overview"
+title: "Workers"
 description: "Helping you with the hard stuff"
 cover: https://hash.ai/cdn-cgi/imagedelivery/EipKtqu98OotgfhvKf6Eew/f2b4136e-eecb-4427-e19e-1096b370ad00/public
 metaTitle: "AI Workers in HASH"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes an incorrect on-page title.