### PR TITLE
H-3843: Change Renovate `postUpdateOptions` strategy

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -56,7 +56,7 @@
       "matchManagers": ["npm"],
       "commitMessageTopic": "npm package `{{depName}}`",
       "additionalBranchPrefix": "js/",
-      "assignees": ["CiaranMn"],
+      "assignees": ["CiaranMn"]
     },
     {
       "matchManagers": ["cargo"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,7 +24,7 @@
   "npm": {
     "minimumReleaseAge": "3 days"
   },
-  "postUpdateOptions": ["yarnDedupeFewer"],
+  "postUpdateOptions": ["yarnDedupeHighest"],
   "rebaseWhen": "conflicted",
   "semanticCommits": "disabled",
   "schedule": ["before 4am every weekday", "every weekend"],
@@ -56,7 +56,7 @@
       "matchManagers": ["npm"],
       "commitMessageTopic": "npm package `{{depName}}`",
       "additionalBranchPrefix": "js/",
-      "assignees": ["CiaranMn"]
+      "assignees": ["CiaranMn"],
     },
     {
       "matchManagers": ["cargo"],


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Switches us from `yarnDedupeFewer` to `yarnDedupeHighest`.

Let's see if this makes a difference, and saves us from the never-ending need to run `yarn fix:yarn-deduplicate` on Renovate `npm` PRs.