### PR TITLE
H-3845: Fix Docker set up for Yarn 4 + Node 22

### DIFF
--- a/.env
+++ b/.env
@@ -110,12 +110,19 @@ HASH_TELEMETRY_DESTINATION=REPLACE_ME.aws.com
 # Is used for differentiating different apps, can be any value
 HASH_TELEMETRY_APP_ID=hash-app
 
+###########################################
 # Disable telemetry from third-party dependencies who transmit IP addresses
-NEXT_TELEMETRY_DISABLED=1 # Vercel Next.js
-TURBO_TELEMETRY_DISABLED=1 # Vercel Turborepo
-YARN_ENABLE_TELEMETRY=0 # Yarn
-ARTILLERY_DISABLE_TELEMETRY=true # Artillery
-CHECKPOINT_DISABLE=1 # Terraform and others
+###########################################
+# Vercel Next.js
+NEXT_TELEMETRY_DISABLED=1
+# Vercel Turborepo
+TURBO_TELEMETRY_DISABLED=1
+# Yarn
+YARN_ENABLE_TELEMETRY=0
+# Artillery
+ARTILLERY_DISABLE_TELEMETRY=true
+# Terraform and others
+CHECKPOINT_DISABLE=1
 
 ###########################################
 ## Aliases for dockerized external services

--- a/apps/hash-ai-worker-ts/docker/Dockerfile
+++ b/apps/hash-ai-worker-ts/docker/Dockerfile
@@ -57,7 +57,16 @@ FROM node:22.12-slim AS runner
 COPY --from=installer /usr/local/src /usr/local/src
 WORKDIR /usr/local/src/apps/hash-ai-worker-ts
 
-ENTRYPOINT [ "yarn", "--cache-folder", "/tmp/yarn-cache", "--global-folder", "/tmp/yarn-global" ]
+RUN groupadd --system --gid 60000 hash && \
+    useradd --system tsworker -G hash
+
+# Set a writable Corepack cache directory
+ENV COREPACK_HOME=/usr/local/src/var/corepack-cache
+RUN mkdir -p $COREPACK_HOME && \
+    chown tsworker:hash $COREPACK_HOME && \
+    corepack enable && corepack prepare --activate
+
+ENTRYPOINT [ "yarn"]
 CMD ["start"]
 
 ARG GOOGLE_CLOUD_WORKLOAD_IDENTITY_FEDERATION_CONFIG_JSON
@@ -74,8 +83,6 @@ RUN if [ -n "$GOOGLE_CLOUD_WORKLOAD_IDENTITY_FEDERATION_CONFIG_JSON" ]; then \
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl && \
     rm -rf /var/lib/apt/lists/* && \
-    groupadd --system --gid 60000 hash && \
-    useradd --system tsworker -G hash && \
     install -d -m 0775 -o tsworker -g hash /log
 
 RUN mkdir -p officeParserTemp/tempfiles && \

--- a/apps/hash-integration-worker/docker/Dockerfile
+++ b/apps/hash-integration-worker/docker/Dockerfile
@@ -57,14 +57,21 @@ FROM node:22.12-slim AS runner
 COPY --from=installer /usr/local/src /usr/local/src
 WORKDIR /usr/local/src/apps/hash-integration-worker
 
-ENTRYPOINT [ "yarn", "--cache-folder", "/tmp/yarn-cache", "--global-folder", "/tmp/yarn-global" ]
+RUN groupadd --system --gid 60000 hash && \
+    useradd --system integrationworker -G hash
+
+# Set a writable Corepack cache directory
+ENV COREPACK_HOME=/usr/local/src/var/corepack-cache
+RUN mkdir -p $COREPACK_HOME && \
+    chown integrationworker:hash $COREPACK_HOME && \
+    corepack enable && corepack prepare --activate
+
+ENTRYPOINT [ "yarn"]
 CMD ["start"]
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl && \
     rm -rf /var/lib/apt/lists/* && \
-    groupadd --system --gid 60000 hash && \
-    useradd --system integrationworker -G hash && \
     install -d -m 0775 -o integrationworker -g hash /log
 
 USER integrationworker:hash

--- a/infra/docker/api/prod/Dockerfile
+++ b/infra/docker/api/prod/Dockerfile
@@ -58,14 +58,21 @@ COPY --from=installer /usr/local/src /usr/local/src
 WORKDIR /usr/local/src/apps/hash-api
 RUN mkdir -p /usr/local/src/var/uploads
 
-ENTRYPOINT [ "yarn", "--cache-folder", "/tmp/yarn-cache", "--global-folder", "/tmp/yarn-global" ]
+RUN groupadd --system --gid 60000 hash && \
+    useradd --system api -G hash
+
+# Set a writable Corepack cache directory
+ENV COREPACK_HOME=/usr/local/src/var/corepack-cache
+RUN mkdir -p $COREPACK_HOME && \
+    chown api:hash $COREPACK_HOME && \
+    corepack enable && corepack prepare --activate
+
+ENTRYPOINT [ "yarn"]
 CMD ["start"]
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl && \
-    rm -rf /var/lib/apt/lists/* && \
-    groupadd --system --gid 60000 hash && \
-    useradd --system api -G hash && \
+    rm -rf /var/lib/apt/lists/*  && \
     install -d -m 0775 -o api -g hash /log
 
 USER api:hash


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Introduces some fixes to Dockerfiles necessary to use Yarn 4 with Node 22 to:
1. enable `corepack`, with a directory that the runner user can write to
2. Move some comments in the `.env` file so that they aren't parsed as values by Yarn can be parsed correctly
