### PR TITLE
H-3852: Don't crash entities table if an entity's owner is missing

### DIFF
--- a/apps/hash-frontend/src/components/hooks/use-get-owner-for-entity.ts
+++ b/apps/hash-frontend/src/components/hooks/use-get-owner-for-entity.ts
@@ -1,6 +1,7 @@
 import type { EntityId } from "@local/hash-graph-types/entity";
 import type { OwnedById } from "@local/hash-graph-types/web";
 import { extractOwnedByIdFromEntityId } from "@local/hash-subgraph";
+import * as Sentry from "@sentry/nextjs";
 import { useCallback } from "react";
 
 import { useOrgs } from "./use-orgs";
@@ -37,9 +38,15 @@ export const useGetOwnerForEntity = () => {
         orgs.find((org) => ownedById === org.accountGroupId);
 
       if (!owner) {
-        throw new Error(
-          `Owner with accountId ${ownedById} not found – possibly a caching issue if it has been created mid-session`,
+        Sentry.captureException(
+          new Error(
+            `Owner with accountId ${ownedById} not found in entities table – possibly a caching issue if it has been created mid-session`,
+          ),
         );
+        return {
+          ownedById,
+          shortname: "unknown",
+        };
       }
 
       return {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The entities table currently crashes if it loads an entity where the User or Org owner can't be found. It shouldn't be the case that the User/Org can't be found, but if it does (as has happened due to a past issue when creating a user), we shouldn't crash the page, but instead have some fallback.

This PR does that.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

H-3851: We should make the user (and org) creation process better in rolling back things it has done if some subsequent step changes.

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. View `/entities` in the preview deployment, switch to viewing all global entities. It should not crash (check against prod) – https://hash-bhur9o6re.stage.hash.ai/entities

