### PR TITLE
H-3879: Add protocol dropdown to early access form URL input

### DIFF
--- a/apps/hash-frontend/src/pages/index.page/waitlisted/early-access-modal.tsx
+++ b/apps/hash-frontend/src/pages/index.page/waitlisted/early-access-modal.tsx
@@ -9,6 +9,7 @@ import { Button } from "../../../shared/ui/button";
 import { MenuItem } from "../../../shared/ui/menu-item";
 import { Modal } from "../../../shared/ui/modal";
 import { useAuthenticatedUser } from "../../shared/auth-info-context";
+import { UrlInput } from "../../shared/url-input";
 
 type FormFieldMetadata = {
   label: string;
@@ -93,7 +94,14 @@ const Input = ({
         *
       </Box>
       <Box>
-        {options ? (
+        {url ? (
+          <UrlInput
+            autoFocus
+            onChange={onChange}
+            placeholder={placeholder}
+            value={value}
+          />
+        ) : options ? (
           <Select
             value={value}
             onChange={(event) => onChange(event.target.value)}
@@ -107,12 +115,6 @@ const Input = ({
           </Select>
         ) : (
           <TextField
-            autoFocus={url}
-            inputProps={
-              url
-                ? { pattern: "\\S+\\.\\w+", title: "Please enter a valid URL" }
-                : undefined
-            }
             multiline={multiline}
             onChange={(event) => onChange(event.target.value)}
             placeholder={placeholder}

--- a/apps/hash-frontend/src/pages/shared/url-input.tsx
+++ b/apps/hash-frontend/src/pages/shared/url-input.tsx
@@ -1,0 +1,89 @@
+import { Select, TextField } from "@hashintel/design-system";
+import { Stack } from "@mui/material";
+import debounce from "lodash/debounce";
+import { useEffect, useState } from "react";
+
+import { MenuItem } from "../../shared/ui/menu-item";
+
+const protocols = ["https://", "http://"] as const;
+
+type Protocol = (typeof protocols)[number];
+
+const protocolFromUrl = (url: string): Protocol => {
+  if (!url) {
+    return "https://";
+  }
+
+  try {
+    const urlObject = new URL(url);
+    if (!protocols.includes(urlObject.protocol as Protocol)) {
+      return "https://";
+    }
+
+    return urlObject.protocol as Protocol;
+  } catch {
+    return "https://";
+  }
+};
+
+export const UrlInput = ({
+  autoFocus,
+  onChange,
+  placeholder,
+  value,
+}: {
+  autoFocus: boolean;
+  onChange: (value: string) => void;
+  placeholder: string;
+  value: string;
+}) => {
+  const [protocol, setProtocol] = useState<Protocol>(() => {
+    return protocolFromUrl(value);
+  });
+  const [rest, setRest] = useState(() => value.split("://").at(-1));
+
+  useEffect(() => {
+    setProtocol(protocolFromUrl(value));
+    setRest(value.split("://").at(-1));
+  }, [value]);
+
+  const updateValue = debounce((fullUrl: string) => {
+    onChange(fullUrl);
+  }, 300);
+
+  return (
+    <Stack direction="row" gap={2}>
+      <Select
+        value={protocol}
+        onChange={(event) => {
+          const newProtocol = event.target.value as Protocol;
+          setProtocol(newProtocol);
+          updateValue(newProtocol + rest);
+        }}
+        sx={{ width: 100 }}
+      >
+        {protocols.map((option) => (
+          <MenuItem key={option} value={option}>
+            {option}
+          </MenuItem>
+        ))}
+      </Select>
+      <TextField
+        autoFocus={autoFocus}
+        inputProps={{
+          pattern: "\\S+\\.\\w+",
+          title: "Please enter a valid domain",
+        }}
+        onChange={(event) => {
+          const newRest = event.target.value;
+          setRest(newRest);
+          updateValue(protocol + newRest);
+        }}
+        placeholder={placeholder}
+        sx={{ width: "100%" }}
+        type="text"
+        value={rest}
+      />
+    </Stack>
+  );
+};

--- a/apps/hash-frontend/src/pages/shared/url-input.tsx
+++ b/apps/hash-frontend/src/pages/shared/url-input.tsx
@@ -1,5 +1,5 @@
 import { Select, TextField } from "@hashintel/design-system";
-import { Stack } from "@mui/material";
+import { outlinedInputClasses, Stack } from "@mui/material";
 
 import { MenuItem } from "../../shared/ui/menu-item";
 
@@ -35,7 +35,7 @@ export const UrlInput = ({
   const { protocol, rest } = partsFromUrl(value);
 
   return (
-    <Stack direction="row" gap={2}>
+    <Stack direction="row">
       <Select
         value={protocol}
         onChange={(event) => {
@@ -43,6 +43,13 @@ export const UrlInput = ({
           onChange(`${newProtocol}://${rest}`);
         }}
         sx={{
+          [`& .${outlinedInputClasses.root}`]: {
+            borderTopRightRadius: 0,
+            borderBottomRightRadius: 0,
+          },
+          [`.${outlinedInputClasses.notchedOutline}`]: {
+            borderRight: "none",
+          },
           width: 110,
           "& svg": { color: ({ palette }) => palette.gray[30] },
         }}
@@ -64,7 +71,16 @@ export const UrlInput = ({
           onChange(`${protocol}://${newRest}`);
         }}
         placeholder={placeholder}
-        sx={{ width: "100%" }}
+        sx={{
+          width: "100%",
+          [`.${outlinedInputClasses.notchedOutline}`]: {
+            borderLeftColor: "transparent",
+          },
+          [`& .${outlinedInputClasses.root}`]: {
+            borderTopLeftRadius: 0,
+            borderBottomLeftRadius: 0,
+          },
+        }}
         type="text"
         value={rest}
       />

--- a/apps/hash-frontend/src/pages/shared/url-input.tsx
+++ b/apps/hash-frontend/src/pages/shared/url-input.tsx
@@ -67,8 +67,15 @@ export const UrlInput = ({
           title: "Please enter a valid domain",
         }}
         onChange={(event) => {
-          const newRest = event.target.value;
-          onChange(`${protocol}://${newRest}`);
+          /**
+           * Account for users entering the protocol into the rest field, e.g. by pasting a full URL
+           */
+          const [_, maybeProtocol, maybeRest] =
+            event.target.value.match("^(https?)://(.*)$") ?? [];
+
+          onChange(
+            `${maybeProtocol ?? protocol}://${maybeRest?.replace(/\/$/, "") ?? event.target.value}`,
+          );
         }}
         placeholder={placeholder}
         sx={{

--- a/libs/@hashintel/design-system/src/theme/components/inputs/mui-select-theme-options.tsx
+++ b/libs/@hashintel/design-system/src/theme/components/inputs/mui-select-theme-options.tsx
@@ -70,7 +70,7 @@ export const MuiSelectThemeOptions: Components<Theme>["MuiSelect"] = {
         },
 
       [`&:focus ~ .${outlinedInputClasses.notchedOutline}`]: {
-        border: `1px solid ${theme.palette.blue[60]}`,
+        border: `2px solid ${theme.palette.blue[60]}`,
       },
     }),
     icon: ({ theme }) => ({

--- a/libs/@hashintel/design-system/src/theme/components/navigation/mui-menu-item-theme-options.ts
+++ b/libs/@hashintel/design-system/src/theme/components/navigation/mui-menu-item-theme-options.ts
@@ -85,8 +85,7 @@ export const MuiMenuItemThemeOptions: Components<Theme>["MuiMenuItem"] = {
       },
 
       [`&.${menuItemClasses.focusVisible}, &:focus`]: {
-        boxShadow: `0px 0px 0px 2px ${theme.palette.white}, 0px 0px 0px 4px ${theme.palette.blue[70]}`,
-        backgroundColor: "transparent",
+        backgroundColor: theme.palette.blue[20],
       },
 
       [`&.${menuItemClasses.selected}, &.${menuItemClasses.selected}:hover, &:active`]:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We want to move property types which have URLs as their values to using the `URL` data type. This means values for them must pass URL validation, e.g. include a scheme at the start (`https://`) rather than just be e.g. `example.com`

But we also want users to be able to just type `example.com` into some inputs, e.g. in the early access form.

This PR adds a protocol dropdown to the early access form's website URL input so that we can pass a full URL to the database but users don't have to type it out properly themselves.

It also allows for having a path in the URL (e.g. `example.com/my-page`) which the early access form website URL input was previously not allowing.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

https://github.com/user-attachments/assets/12c790d7-dfff-4606-b046-fe176f1570b8

