### PR TITLE
H-3919: Return error instead of `panic` in `SelectCompiler`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2907,6 +2907,7 @@ dependencies = [
  "deadpool",
  "deadpool-postgres",
  "derive-where",
+ "derive_more",
  "dotenv-flow",
  "error-stack",
  "futures",

--- a/apps/hash-graph/src/subcommand/server.rs
+++ b/apps/hash-graph/src/subcommand/server.rs
@@ -294,7 +294,7 @@ pub async fn server(args: ServerArgs) -> Result<(), Report<GraphError>> {
     let mut zanzibar_client = ZanzibarClient::new(spicedb_client);
     zanzibar_client.seed().await.change_context(GraphError)?;
 
-    let temporal_client_fn = async |host: Option<String>, port: u16| {
+    let temporal_client_fn = |host: Option<String>, port: u16| async move {
         if let Some(host) = host {
             TemporalClientConfig::new(
                 Url::from_str(&format!("{host}:{port}")).change_context(GraphError)?,

--- a/libs/@local/graph/api/src/rest/entity.rs
+++ b/libs/@local/graph/api/src/rest/entity.rs
@@ -661,7 +661,7 @@ impl<'q, 's, 'p: 'q> From<GetEntitiesRequest<'q, 's, 'p>> for GetEntitiesParams<
 #[tracing::instrument(
     level = "info",
     skip_all,
-    fields(actor=%actor_id, %request)
+    fields(actor=%actor_id)
 )]
 async fn get_entities<S, A>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,

--- a/libs/@local/graph/postgres-store/Cargo.toml
+++ b/libs/@local/graph/postgres-store/Cargo.toml
@@ -34,6 +34,7 @@ async-scoped   = { workspace = true, features = ["use-tokio"] }
 bytes          = { workspace = true }
 clap           = { workspace = true, optional = true, features = ["derive", "env"] }
 derive-where   = { workspace = true }
+derive_more    = { workspace = true }
 dotenv-flow    = { workspace = true }
 futures        = { workspace = true }
 postgres-types = { workspace = true, features = ["derive", "with-serde_json-1"] }

--- a/libs/@local/graph/postgres-store/src/store/postgres/crud.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/crud.rs
@@ -94,13 +94,15 @@ where
             compiler.set_limit(limit);
         }
 
-        compiler.add_filter(filter);
+        compiler.add_filter(filter).change_context(QueryError)?;
 
-        let cursor_indices = sorting.compile(
-            &mut compiler,
-            cursor_parameters.as_ref(),
-            temporal_axes.expect("To use a cursor, temporal axes has to be specified"),
-        );
+        let cursor_indices = sorting
+            .compile(
+                &mut compiler,
+                cursor_parameters.as_ref(),
+                temporal_axes.expect("To use a cursor, temporal axes has to be specified"),
+            )
+            .change_context(QueryError)?;
 
         let record_artifacts = R::parameters();
         let record_indices = R::compile(&mut compiler, &record_artifacts);
@@ -145,7 +147,7 @@ where
         let record_artifacts = R::parameters();
         let record_indices = R::compile(&mut compiler, &record_artifacts);
 
-        compiler.add_filter(filter);
+        compiler.add_filter(filter).change_context(QueryError)?;
         let (statement, parameters) = compiler.compile();
 
         Ok(self
@@ -170,7 +172,7 @@ where
         let record_artifacts = R::parameters();
         let record_indices = R::compile(&mut compiler, &record_artifacts);
 
-        compiler.add_filter(filter);
+        compiler.add_filter(filter).change_context(QueryError)?;
         let (statement, parameters) = compiler.compile();
 
         let rows = self

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -622,7 +622,6 @@ where
                 .count();
             let type_ids = type_ids.map(HashMap::from);
 
-            #[expect(clippy::if_then_some_else_none)]
             let type_titles = if params.include_type_titles {
                 let type_uuids = type_ids
                     .as_ref()

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -532,7 +532,9 @@ where
                 )
             });
 
-            compiler.add_filter(&params.filter);
+            compiler
+                .add_filter(&params.filter)
+                .change_context(QueryError)?;
 
             let (statement, parameters) = compiler.compile();
 
@@ -643,7 +645,9 @@ where
                     },
                     ParameterList::EntityTypeIds(&type_uuids),
                 );
-                type_compiler.add_filter(&filter);
+                type_compiler
+                    .add_filter(&filter)
+                    .change_context(QueryError)?;
 
                 let (statement, parameters) = type_compiler.compile();
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
@@ -387,7 +387,9 @@ where
                 compiler.add_selection_path(&EntityTypeQueryPath::EditionProvenance(None))
             });
 
-            compiler.add_filter(&params.filter);
+            compiler
+                .add_filter(&params.filter)
+                .change_context(QueryError)?;
 
             let (statement, parameters) = compiler.compile();
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/read.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/read.rs
@@ -76,7 +76,7 @@ impl<C: AsClient, A: Send + Sync> PostgresStore<C, A> {
         let closed_schema_index =
             compiler.add_selection_path(&EntityTypeQueryPath::ClosedSchema(None));
 
-        compiler.add_filter(filter);
+        compiler.add_filter(filter).change_context(QueryError)?;
         let (statement, parameters) = compiler.compile();
 
         Ok(self

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/condition.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/condition.rs
@@ -164,7 +164,9 @@ mod tests {
         parameters: &[&'p dyn ToSql],
     ) {
         let mut compiler = SelectCompiler::new(None, false);
-        let condition = compiler.compile_filter(filter);
+        let condition = compiler
+            .compile_filter(filter)
+            .expect("failed to compile filter");
 
         assert_eq!(condition.transpile_to_string(), rendered);
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/expression/where_clause.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/expression/where_clause.rs
@@ -150,7 +150,11 @@ mod tests {
                 convert: None,
             }),
         );
-        where_clause.add_condition(compiler.compile_filter(&filter_a));
+        where_clause.add_condition(
+            compiler
+                .compile_filter(&filter_a)
+                .expect("Failed to compile filter"),
+        );
 
         assert_eq!(
             where_clause.transpile_to_string(),
@@ -179,7 +183,11 @@ mod tests {
                 }),
             ),
         ]);
-        where_clause.add_condition(compiler.compile_filter(&filter_b));
+        where_clause.add_condition(
+            compiler
+                .compile_filter(&filter_b)
+                .expect("Failed to compile filter"),
+        );
 
         assert_eq!(
             trim_whitespace(&where_clause.transpile_to_string()),
@@ -196,7 +204,11 @@ mod tests {
             }),
             None,
         );
-        where_clause.add_condition(compiler.compile_filter(&filter_c));
+        where_clause.add_condition(
+            compiler
+                .compile_filter(&filter_c)
+                .expect("Failed to compile filter"),
+        );
 
         assert_eq!(
             trim_whitespace(&where_clause.transpile_to_string()),
@@ -228,7 +240,11 @@ mod tests {
                 }),
             ),
         ]);
-        where_clause.add_condition(compiler.compile_filter(&filter_d));
+        where_clause.add_condition(
+            compiler
+                .compile_filter(&filter_d)
+                .expect("Failed to compile filter"),
+        );
 
         assert_eq!(
             trim_whitespace(&where_clause.transpile_to_string()),

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/mod.rs
@@ -19,6 +19,7 @@ use core::{
     fmt::{self, Display, Formatter},
 };
 
+use error_stack::Report;
 use hash_graph_store::{
     entity::{EntityQueryCursor, EntityQuerySorting},
     filter::{ParameterConversionError, QueryRecord},
@@ -30,7 +31,7 @@ use serde_json::Value;
 use tokio_postgres::Row;
 
 pub use self::{
-    compile::SelectCompiler,
+    compile::{SelectCompiler, SelectCompilerError},
     condition::{Condition, EqualityOperator},
     expression::{
         Constant, Expression, Function, JoinExpression, OrderByExpression, SelectExpression,
@@ -105,7 +106,7 @@ pub trait PostgresSorting<'s, R: QueryRecord>:
         compiler: &mut SelectCompiler<'p, 'q, R>,
         parameters: Option<&'p Self::CompilationParameters>,
         temporal_axes: &QueryTemporalAxes,
-    ) -> Self::Indices
+    ) -> Result<Self::Indices, Report<SelectCompilerError>>
     where
         's: 'q;
 }
@@ -137,7 +138,7 @@ where
         compiler: &mut SelectCompiler<'p, 'q, Entity>,
         _: Option<&'p Self::CompilationParameters>,
         _: &QueryTemporalAxes,
-    ) -> Self::Indices
+    ) -> Result<Self::Indices, Report<SelectCompilerError>>
     where
         's: 'q,
     {
@@ -158,7 +159,8 @@ where
                 })
                 .collect()
         } else {
-            self.paths
+            Ok(self
+                .paths
                 .iter()
                 .map(|sorting_record| {
                     compiler.add_distinct_selection_with_ordering(
@@ -167,7 +169,7 @@ where
                         Some((sorting_record.ordering, sorting_record.nulls)),
                     )
                 })
-                .collect()
+                .collect())
         }
     }
 }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/statement/select.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/statement/select.rs
@@ -180,17 +180,19 @@ mod tests {
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler =
             SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
-        compiler.add_filter(&Filter::Equal(
-            Some(FilterExpression::Path {
-                path: DataTypeQueryPath::VersionedUrl,
-            }),
-            Some(FilterExpression::Parameter {
-                parameter: Parameter::Text(Cow::Borrowed(
-                    "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
-                )),
-                convert: None,
-            }),
-        ));
+        compiler
+            .add_filter(&Filter::Equal(
+                Some(FilterExpression::Path {
+                    path: DataTypeQueryPath::VersionedUrl,
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::Text(Cow::Borrowed(
+                        "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
+                    )),
+                    convert: None,
+                }),
+            ))
+            .expect("Failed to add filter");
         test_compilation(
             &compiler,
             r#"
@@ -221,7 +223,7 @@ mod tests {
                 convert: None,
             }),
         );
-        compiler.add_filter(&filter);
+        compiler.add_filter(&filter).expect("Failed to add filter");
         test_compilation(
             &compiler,
             r#"
@@ -252,7 +254,7 @@ mod tests {
                 convert: None,
             }),
         );
-        compiler.add_filter(&filter);
+        compiler.add_filter(&filter).expect("Failed to add filter");
         test_compilation(
             &compiler,
             r#"
@@ -294,7 +296,7 @@ mod tests {
                 }),
             ),
         ]);
-        compiler.add_filter(&filter);
+        compiler.add_filter(&filter).expect("Failed to add filter");
 
         test_compilation(
             &compiler,
@@ -321,15 +323,17 @@ mod tests {
         let mut compiler =
             SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
 
-        compiler.add_filter(&Filter::Equal(
-            Some(FilterExpression::Path {
-                path: DataTypeQueryPath::Version,
-            }),
-            Some(FilterExpression::Parameter {
-                parameter: Parameter::Text(Cow::Borrowed("latest")),
-                convert: None,
-            }),
-        ));
+        compiler
+            .add_filter(&Filter::Equal(
+                Some(FilterExpression::Path {
+                    path: DataTypeQueryPath::Version,
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::Text(Cow::Borrowed("latest")),
+                    convert: None,
+                }),
+            ))
+            .expect("Failed to add filter");
 
         test_compilation(
             &compiler,
@@ -353,15 +357,17 @@ mod tests {
         let mut compiler =
             SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
 
-        compiler.add_filter(&Filter::NotEqual(
-            Some(FilterExpression::Path {
-                path: DataTypeQueryPath::Version,
-            }),
-            Some(FilterExpression::Parameter {
-                parameter: Parameter::Text(Cow::Borrowed("latest")),
-                convert: None,
-            }),
-        ));
+        compiler
+            .add_filter(&Filter::NotEqual(
+                Some(FilterExpression::Path {
+                    path: DataTypeQueryPath::Version,
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::Text(Cow::Borrowed("latest")),
+                    convert: None,
+                }),
+            ))
+            .expect("Failed to add filter");
 
         test_compilation(
             &compiler,
@@ -385,18 +391,20 @@ mod tests {
         let mut compiler =
             SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
 
-        compiler.add_filter(&Filter::Equal(
-            Some(FilterExpression::Path {
-                path: PropertyTypeQueryPath::DataTypeEdge {
-                    edge_kind: OntologyEdgeKind::ConstrainsValuesOn,
-                    path: DataTypeQueryPath::Title,
-                },
-            }),
-            Some(FilterExpression::Parameter {
-                parameter: Parameter::Text(Cow::Borrowed("Text")),
-                convert: None,
-            }),
-        ));
+        compiler
+            .add_filter(&Filter::Equal(
+                Some(FilterExpression::Path {
+                    path: PropertyTypeQueryPath::DataTypeEdge {
+                        edge_kind: OntologyEdgeKind::ConstrainsValuesOn,
+                        path: DataTypeQueryPath::Title,
+                    },
+                }),
+                Some(FilterExpression::Parameter {
+                    parameter: Parameter::Text(Cow::Borrowed("Text")),
+                    convert: None,
+                }),
+            ))
+            .expect("Failed to add filter");
 
         test_compilation(
             &compiler,
@@ -444,7 +452,7 @@ mod tests {
                 }),
             ),
         ]);
-        compiler.add_filter(&filter);
+        compiler.add_filter(&filter).expect("Failed to add filter");
 
         test_compilation(
             &compiler,
@@ -498,7 +506,7 @@ mod tests {
                 convert: None,
             }),
         );
-        compiler.add_filter(&filter);
+        compiler.add_filter(&filter).expect("Failed to add filter");
 
         test_compilation(
             &compiler,
@@ -539,7 +547,7 @@ mod tests {
                 convert: None,
             }),
         );
-        compiler.add_filter(&filter);
+        compiler.add_filter(&filter).expect("Failed to add filter");
 
         test_compilation(
             &compiler,
@@ -587,7 +595,7 @@ mod tests {
                 convert: None,
             }),
         );
-        compiler.add_filter(&filter);
+        compiler.add_filter(&filter).expect("Failed to add filter");
 
         test_compilation(
             &compiler,
@@ -639,7 +647,7 @@ mod tests {
                 convert: None,
             }),
         );
-        compiler.add_filter(&filter);
+        compiler.add_filter(&filter).expect("Failed to add filter");
 
         test_compilation(
             &compiler,
@@ -679,7 +687,7 @@ mod tests {
                 convert: None,
             }),
         );
-        compiler.add_filter(&filter);
+        compiler.add_filter(&filter).expect("Failed to add filter");
 
         test_compilation(
             &compiler,
@@ -725,7 +733,7 @@ mod tests {
                 convert: None,
             }),
         );
-        compiler.add_filter(&filter);
+        compiler.add_filter(&filter).expect("Failed to add filter");
 
         test_compilation(
             &compiler,
@@ -770,7 +778,7 @@ mod tests {
                 convert: None,
             }),
         );
-        compiler.add_filter(&filter);
+        compiler.add_filter(&filter).expect("Failed to add filter");
 
         test_compilation(
             &compiler,
@@ -808,7 +816,7 @@ mod tests {
             }),
             None,
         );
-        compiler.add_filter(&filter);
+        compiler.add_filter(&filter).expect("Failed to add filter");
 
         test_compilation(
             &compiler,
@@ -853,7 +861,7 @@ mod tests {
                 convert: None,
             }),
         );
-        compiler.add_filter(&filter);
+        compiler.add_filter(&filter).expect("Failed to add filter");
 
         test_compilation(
             &compiler,
@@ -914,7 +922,7 @@ mod tests {
                 convert: None,
             }),
         );
-        compiler.add_filter(&filter);
+        compiler.add_filter(&filter).expect("Failed to add filter");
 
         test_compilation(
             &compiler,
@@ -1012,7 +1020,7 @@ mod tests {
                 }),
             ),
         ]);
-        compiler.add_filter(&filter);
+        compiler.add_filter(&filter).expect("Failed to add filter");
 
         test_compilation(
             &compiler,
@@ -1090,7 +1098,7 @@ mod tests {
                 }),
             ),
         ]);
-        compiler.add_filter(&filter);
+        compiler.add_filter(&filter).expect("Failed to add filter");
 
         test_compilation(
             &compiler,
@@ -1163,7 +1171,7 @@ mod tests {
                 convert: None,
             },
         );
-        compiler.add_filter(&filter);
+        compiler.add_filter(&filter).expect("Failed to add filter");
 
         test_compilation(
             &compiler,
@@ -1215,7 +1223,7 @@ mod tests {
                 SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
 
             let filter = Filter::for_versioned_url(&url);
-            compiler.add_filter(&filter);
+            compiler.add_filter(&filter).expect("Failed to add filter");
 
             test_compilation(
                 &compiler,
@@ -1244,7 +1252,7 @@ mod tests {
             let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
 
             let filter = Filter::for_entity_by_entity_id(entity_id);
-            compiler.add_filter(&filter);
+            compiler.add_filter(&filter).expect("Failed to add filter");
 
             test_compilation(
                 &compiler,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In some very special cases the `SelectCompiler` panics. To avoid crashing the graph if this happens, this is changed to errors instead.

## 🔍 What does this change?

- Expose a `SelectComilerError` instead of panics
- Drive-by: Allow `limit` in more locations
- Drive-by: Make sure the compiler correctly errors when a cursor is passed

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph