### PR TITLE
H-3926: Filter out blocks from repo workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "workspaces": {
     "packages": [
       "apps/**",
-      "blocks/*",
       "libs/**",
       "tests/**"
     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3063,33 +3063,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/cli@npm:^7.17.6":
-  version: 7.25.9
-  resolution: "@babel/cli@npm:7.25.9"
-  dependencies:
-    "@jridgewell/trace-mapping": "npm:^0.3.25"
-    "@nicolo-ribaudo/chokidar-2": "npm:2.1.8-no-fsevents.3"
-    chokidar: "npm:^3.6.0"
-    commander: "npm:^6.2.0"
-    convert-source-map: "npm:^2.0.0"
-    fs-readdir-recursive: "npm:^1.1.0"
-    glob: "npm:^7.2.0"
-    make-dir: "npm:^2.1.0"
-    slash: "npm:^2.0.0"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  dependenciesMeta:
-    "@nicolo-ribaudo/chokidar-2":
-      optional: true
-    chokidar:
-      optional: true
-  bin:
-    babel: ./bin/babel.js
-    babel-external-helpers: ./bin/babel-external-helpers.js
-  checksum: 10c0/2e8228c3715e220fa902888c643ce1a89c4ee90be3d9f7a31218d5bb2500456e0cef12cb90fd5877ab3e5a4498df8f27670425d346422a3eb52052fd3184d520
-  languageName: node
-  linkType: hard
-
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.16.7, @babel/code-frame@npm:^7.22.13, @babel/code-frame@npm:^7.25.9, @babel/code-frame@npm:^7.26.0":
   version: 7.26.2
   resolution: "@babel/code-frame@npm:7.26.2"
@@ -3108,7 +3081,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:7.26.0, @babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.14.0, @babel/core@npm:^7.16.0, @babel/core@npm:^7.17.9, @babel/core@npm:^7.18.5, @babel/core@npm:^7.18.9, @babel/core@npm:^7.21.0, @babel/core@npm:^7.21.3, @babel/core@npm:^7.22.9, @babel/core@npm:^7.23.0, @babel/core@npm:^7.23.2, @babel/core@npm:^7.23.9":
+"@babel/core@npm:7.26.0, @babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.14.0, @babel/core@npm:^7.16.0, @babel/core@npm:^7.18.5, @babel/core@npm:^7.18.9, @babel/core@npm:^7.21.3, @babel/core@npm:^7.22.9, @babel/core@npm:^7.23.0, @babel/core@npm:^7.23.2, @babel/core@npm:^7.23.9":
   version: 7.26.0
   resolution: "@babel/core@npm:7.26.0"
   dependencies:
@@ -3277,7 +3250,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.16.7, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.18.9, @babel/helper-plugin-utils@npm:^7.20.2, @babel/helper-plugin-utils@npm:^7.22.5, @babel/helper-plugin-utils@npm:^7.25.9, @babel/helper-plugin-utils@npm:^7.8.0, @babel/helper-plugin-utils@npm:^7.8.3":
+"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.18.9, @babel/helper-plugin-utils@npm:^7.20.2, @babel/helper-plugin-utils@npm:^7.22.5, @babel/helper-plugin-utils@npm:^7.25.9, @babel/helper-plugin-utils@npm:^7.8.0, @babel/helper-plugin-utils@npm:^7.8.3":
   version: 7.25.9
   resolution: "@babel/helper-plugin-utils@npm:7.25.9"
   checksum: 10c0/483066a1ba36ff16c0116cd24f93de05de746a603a777cd695ac7a1b034928a65a4ecb35f255761ca56626435d7abdb73219eba196f9aa83b6c3c3169325599d
@@ -3344,7 +3317,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-option@npm:^7.16.7, @babel/helper-validator-option@npm:^7.25.9":
+"@babel/helper-validator-option@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-validator-option@npm:7.25.9"
   checksum: 10c0/27fb195d14c7dcb07f14e58fe77c44eea19a6a40a74472ec05c441478fa0bb49fa1c32b2d64be7a38870ee48ef6601bdebe98d512f0253aea0b39756c4014f3e
@@ -3372,7 +3345,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.16.8, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.21.8, @babel/parser@npm:^7.23.0, @babel/parser@npm:^7.23.9, @babel/parser@npm:^7.25.3, @babel/parser@npm:^7.25.4, @babel/parser@npm:^7.25.9, @babel/parser@npm:^7.26.0, @babel/parser@npm:^7.26.2":
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.16.8, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.21.8, @babel/parser@npm:^7.23.0, @babel/parser@npm:^7.23.9, @babel/parser@npm:^7.25.4, @babel/parser@npm:^7.25.9, @babel/parser@npm:^7.26.0, @babel/parser@npm:^7.26.2":
   version: 7.26.2
   resolution: "@babel/parser@npm:7.26.2"
   dependencies:
@@ -3442,7 +3415,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-class-properties@npm:7.18.6, @babel/plugin-proposal-class-properties@npm:^7.0.0, @babel/plugin-proposal-class-properties@npm:^7.16.0, @babel/plugin-proposal-class-properties@npm:^7.16.7, @babel/plugin-proposal-class-properties@npm:^7.18.6":
+"@babel/plugin-proposal-class-properties@npm:7.18.6, @babel/plugin-proposal-class-properties@npm:^7.0.0, @babel/plugin-proposal-class-properties@npm:^7.16.0":
   version: 7.18.6
   resolution: "@babel/plugin-proposal-class-properties@npm:7.18.6"
   dependencies:
@@ -3454,7 +3427,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-decorators@npm:^7.16.4, @babel/plugin-proposal-decorators@npm:^7.18.2, @babel/plugin-proposal-decorators@npm:^7.21.0":
+"@babel/plugin-proposal-decorators@npm:^7.16.4":
   version: 7.25.9
   resolution: "@babel/plugin-proposal-decorators@npm:7.25.9"
   dependencies:
@@ -3531,7 +3504,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-private-methods@npm:7.18.6, @babel/plugin-proposal-private-methods@npm:^7.16.0":
+"@babel/plugin-proposal-private-methods@npm:^7.16.0":
   version: 7.18.6
   resolution: "@babel/plugin-proposal-private-methods@npm:7.18.6"
   dependencies:
@@ -3540,20 +3513,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/1c273d0ec3d49d0fe80bd754ec0191016e5b3ab4fb1e162ac0c014e9d3c1517a5d973afbf8b6dc9f9c98a8605c79e5f9e8b5ee158a4313fa68d1ff7b02084b6a
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-proposal-private-property-in-object@npm:7.21.0":
-  version: 7.21.0
-  resolution: "@babel/plugin-proposal-private-property-in-object@npm:7.21.0"
-  dependencies:
-    "@babel/helper-annotate-as-pure": "npm:^7.18.6"
-    "@babel/helper-create-class-features-plugin": "npm:^7.21.0"
-    "@babel/helper-plugin-utils": "npm:^7.20.2"
-    "@babel/plugin-syntax-private-property-in-object": "npm:^7.14.5"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/576ec99964c50435a81dfe4178d064df9aa86628090d69bae8759332b9a2b5a0a8575a6f51db915c3751949cd29990b8b3a80c6afc228a0664f4237b7b60d667
   languageName: node
   linkType: hard
 
@@ -4304,7 +4263,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-runtime@npm:^7.16.4, @babel/plugin-transform-runtime@npm:^7.17.0, @babel/plugin-transform-runtime@npm:^7.21.0":
+"@babel/plugin-transform-runtime@npm:^7.16.4":
   version: 7.25.9
   resolution: "@babel/plugin-transform-runtime@npm:7.25.9"
   dependencies:
@@ -4376,7 +4335,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-typescript@npm:^7.16.7, @babel/plugin-transform-typescript@npm:^7.25.9":
+"@babel/plugin-transform-typescript@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-typescript@npm:7.25.9"
   dependencies:
@@ -4438,7 +4397,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-env@npm:7.26.0, @babel/preset-env@npm:^7.16.11, @babel/preset-env@npm:^7.16.4, @babel/preset-env@npm:^7.20.2, @babel/preset-env@npm:^7.23.2":
+"@babel/preset-env@npm:7.26.0, @babel/preset-env@npm:^7.16.4, @babel/preset-env@npm:^7.20.2, @babel/preset-env@npm:^7.23.2":
   version: 7.26.0
   resolution: "@babel/preset-env@npm:7.26.0"
   dependencies:
@@ -4543,7 +4502,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-react@npm:7.26.3, @babel/preset-react@npm:^7.16.0, @babel/preset-react@npm:^7.16.7, @babel/preset-react@npm:^7.18.6, @babel/preset-react@npm:^7.22.15":
+"@babel/preset-react@npm:7.26.3, @babel/preset-react@npm:^7.16.0, @babel/preset-react@npm:^7.18.6, @babel/preset-react@npm:^7.22.15":
   version: 7.26.3
   resolution: "@babel/preset-react@npm:7.26.3"
   dependencies:
@@ -4556,19 +4515,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/b470dcba11032ef6c832066f4af5c75052eaed49feb0f445227231ef1b5c42aacd6e216988c0bd469fd5728cd27b6b059ca307c9ecaa80c6bb5da4bf1c833e12
-  languageName: node
-  linkType: hard
-
-"@babel/preset-typescript@npm:7.16.7":
-  version: 7.16.7
-  resolution: "@babel/preset-typescript@npm:7.16.7"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.16.7"
-    "@babel/helper-validator-option": "npm:^7.16.7"
-    "@babel/plugin-transform-typescript": "npm:^7.16.7"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/90444b3778fed5a961bf3ed9d4a56a963286de52bc7925aa88e27aa9df3e3e306755e290c5e92eaf9088a41321ddaae1fe4cec7e5eea9fb57236c180d3e82044
   languageName: node
   linkType: hard
 
@@ -4621,7 +4567,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.17.9, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.1, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.8, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.24.5, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.1, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.8, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.24.5, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.26.0
   resolution: "@babel/runtime@npm:7.26.0"
   dependencies:
@@ -4692,16 +4638,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@blockprotocol/core@npm:0.0.12":
-  version: 0.0.12
-  resolution: "@blockprotocol/core@npm:0.0.12"
-  dependencies:
-    es-module-lexer: "npm:^0.10.5"
-    uuid: "npm:^8.3.2"
-  checksum: 10c0/961954b17fe06e41cb60043eb0c0fcacf63e5bb86a54441dbf3aa563a8d1e64000ef44cae6b8525d0d7c1ba4670c9812e1f028d97a533603281f94a813af7dd9
-  languageName: node
-  linkType: hard
-
 "@blockprotocol/core@npm:0.0.2":
   version: 0.0.2
   resolution: "@blockprotocol/core@npm:0.0.2"
@@ -4769,18 +4705,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@blockprotocol/graph@npm:0.0.18":
-  version: 0.0.18
-  resolution: "@blockprotocol/graph@npm:0.0.18"
-  dependencies:
-    "@blockprotocol/core": "npm:0.0.12"
-    lit: "npm:^2.2.5"
-  peerDependencies:
-    react: ^18.0.0
-  checksum: 10c0/d62534f360a987a182add66c73a00fd0dc0f0ddc90fc3e1a076a587dcdeffff500e2eaee155c65a84d9217e018036063dd1003e8c4060a4ba8ac14be4eaff780
-  languageName: node
-  linkType: hard
-
 "@blockprotocol/graph@npm:0.2.2":
   version: 0.2.2
   resolution: "@blockprotocol/graph@npm:0.2.2"
@@ -4796,40 +4720,6 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
   checksum: 10c0/4d36843e199ce007515db36793d4928a4a2c7047d5289a14dd7f55b8a1a83f425362759c8a5bf066647971135dd62e0798f68e8c361e2e94619e5ef49919ec05
-  languageName: node
-  linkType: hard
-
-"@blockprotocol/graph@npm:0.3.3":
-  version: 0.3.3
-  resolution: "@blockprotocol/graph@npm:0.3.3"
-  dependencies:
-    "@blockprotocol/core": "npm:0.1.2"
-    "@blockprotocol/type-system": "npm:0.1.1"
-    ajv: "npm:^8.11.2"
-    ajv-formats: "npm:^2.1.1"
-    json-schema-to-typescript: "npm:^11.0.2"
-    lit: "npm:^2.4.1"
-    typescript: "npm:4.9.4"
-  peerDependencies:
-    react: ^18.0.0
-  checksum: 10c0/d01332d35ae0b46ea05129bdcc25cf29a4654f53d593172bfb14b684127c75afd2716e08a45c29867e73118deca0dac779b3aa1e235994572024be739451d426
-  languageName: node
-  linkType: hard
-
-"@blockprotocol/graph@npm:0.3.4":
-  version: 0.3.4
-  resolution: "@blockprotocol/graph@npm:0.3.4"
-  dependencies:
-    "@blockprotocol/core": "npm:0.1.3"
-    "@blockprotocol/type-system": "npm:0.1.1"
-    ajv: "npm:^8.11.2"
-    ajv-formats: "npm:^2.1.1"
-    json-schema-to-typescript: "npm:^11.0.2"
-    lit: "npm:^2.4.1"
-    typescript: "npm:4.9.4"
-  peerDependencies:
-    react: ^18.0.0
-  checksum: 10c0/e10d460158268f5c209f7eeb69a25bb71b888546c102315fe887ddfb5e7dcb1a02ddb5e1769c621fc3925069ba06a1953e79879f25d46caafe2dbfb3a0ffbc46
   languageName: node
   linkType: hard
 
@@ -4858,17 +4748,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@blockprotocol/hook@npm:0.0.8":
-  version: 0.0.8
-  resolution: "@blockprotocol/hook@npm:0.0.8"
-  dependencies:
-    "@blockprotocol/core": "npm:0.0.12"
-  peerDependencies:
-    react: ^18.0.0
-  checksum: 10c0/4a54bc160dadf85bd40b6bf31e9acf66a3fcd83bcd8959b98db487c3f6ce12f79c1de545a78c90c26ba5f2514b25b6b243250ec5841895e87e041f1a6891aa5d
-  languageName: node
-  linkType: hard
-
 "@blockprotocol/hook@npm:0.1.3":
   version: 0.1.3
   resolution: "@blockprotocol/hook@npm:0.1.3"
@@ -4878,18 +4757,6 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
   checksum: 10c0/65b0f13087f5f683fc66d85143b89db7ad3b3d470d91a1bc34cd9c7dcc6ac0f0cc5368810275153db2a0ff6be3e967afa3a7a35b0aa35ab190a92e36ca05ccce
-  languageName: node
-  linkType: hard
-
-"@blockprotocol/hook@npm:0.1.7":
-  version: 0.1.7
-  resolution: "@blockprotocol/hook@npm:0.1.7"
-  dependencies:
-    "@blockprotocol/core": "npm:0.1.2"
-    "@blockprotocol/graph": "npm:0.3.3"
-  peerDependencies:
-    react: ^18.0.0
-  checksum: 10c0/4c8ad38572e50fe8575e716eaf15246f815a31b65ea31a5794a72626676c9b7f0765965bae069667488270da567025c77d86a6d267d662393a8e70b57d6f1943
   languageName: node
   linkType: hard
 
@@ -4943,572 +4810,6 @@ __metadata:
     typescript: "npm:5.7.3"
     vite-plugin-wasm-pack: "npm:0.1.12"
     vitest: "npm:2.1.8"
-  languageName: unknown
-  linkType: soft
-
-"@blocks/address@workspace:blocks/address":
-  version: 0.0.0-use.local
-  resolution: "@blocks/address@workspace:blocks/address"
-  dependencies:
-    "@blockprotocol/graph": "npm:0.3.4"
-    "@blockprotocol/service": "npm:0.1.4"
-    "@fortawesome/free-regular-svg-icons": "npm:6.7.2"
-    "@fortawesome/free-solid-svg-icons": "npm:6.7.2"
-    "@hashintel/block-design-system": "npm:0.0.2"
-    "@hashintel/design-system": "npm:0.0.8"
-    "@local/eslint": "npm:0.0.0-private"
-    "@mui/material": "npm:5.16.14"
-    "@types/lodash.debounce": "npm:4.0.9"
-    "@types/react-dom": "npm:19.0.2"
-    block-scripts: "npm:0.3.4"
-    eslint: "npm:9.17.0"
-    lodash.debounce: "npm:4.0.8"
-    mock-block-dock: "npm:0.1.9"
-    prettier: "npm:3.4.2"
-    react: "npm:19.0.0"
-    react-dom: "npm:19.0.0"
-    react-sizeme: "npm:3.0.2"
-    rooks: "npm:7.14.1"
-    typescript: "npm:5.7.3"
-    uuid: "npm:11.0.5"
-  peerDependencies:
-    react: ^19.0.0
-    react-dom: ^19.0.0
-  languageName: unknown
-  linkType: soft
-
-"@blocks/ai-chat@workspace:blocks/ai-chat":
-  version: 0.0.0-use.local
-  resolution: "@blocks/ai-chat@workspace:blocks/ai-chat"
-  dependencies:
-    "@blockprotocol/graph": "npm:0.3.4"
-    "@blockprotocol/hook": "npm:0.1.3"
-    "@blockprotocol/service": "npm:0.1.4"
-    "@hashintel/block-design-system": "npm:0.0.2"
-    "@hashintel/design-system": "npm:0.0.8"
-    "@local/eslint": "npm:0.0.0-private"
-    "@local/tsconfig": "npm:0.0.0-private"
-    "@mui/material": "npm:5.16.14"
-    "@types/react-dom": "npm:19.0.2"
-    block-scripts: "npm:0.3.4"
-    eslint: "npm:9.17.0"
-    mock-block-dock: "npm:0.1.9"
-    prettier: "npm:3.4.2"
-    react: "npm:19.0.0"
-    react-dom: "npm:19.0.0"
-    react-sizeme: "npm:3.0.2"
-    react-transition-group: "npm:4.4.5"
-    react-type-animation: "npm:3.2.0"
-    typescript: "npm:5.7.3"
-    uuid: "npm:11.0.5"
-  peerDependencies:
-    react: ^19.0.0
-    react-dom: ^19.0.0
-  languageName: unknown
-  linkType: soft
-
-"@blocks/ai-image@workspace:blocks/ai-image":
-  version: 0.0.0-use.local
-  resolution: "@blocks/ai-image@workspace:blocks/ai-image"
-  dependencies:
-    "@blockprotocol/graph": "npm:0.3.4"
-    "@blockprotocol/service": "npm:0.1.4"
-    "@hashintel/block-design-system": "npm:0.0.2"
-    "@hashintel/design-system": "npm:0.0.8"
-    "@local/eslint": "npm:0.0.0-private"
-    "@local/tsconfig": "npm:0.0.0-private"
-    "@mui/material": "npm:5.16.14"
-    "@types/react-dom": "npm:19.0.2"
-    block-scripts: "npm:0.3.4"
-    eslint: "npm:9.17.0"
-    mock-block-dock: "npm:0.1.9"
-    prettier: "npm:3.4.2"
-    react: "npm:19.0.0"
-    react-dom: "npm:19.0.0"
-    react-sizeme: "npm:3.0.2"
-    typescript: "npm:5.7.3"
-    uuid: "npm:11.0.5"
-  peerDependencies:
-    react: ^19.0.0
-    react-dom: ^19.0.0
-  languageName: unknown
-  linkType: soft
-
-"@blocks/ai-text@workspace:blocks/ai-text":
-  version: 0.0.0-use.local
-  resolution: "@blocks/ai-text@workspace:blocks/ai-text"
-  dependencies:
-    "@blockprotocol/graph": "npm:0.3.4"
-    "@blockprotocol/service": "npm:0.1.4"
-    "@hashintel/block-design-system": "npm:0.0.2"
-    "@hashintel/design-system": "npm:0.0.8"
-    "@local/eslint": "npm:0.0.0-private"
-    "@local/tsconfig": "npm:0.0.0-private"
-    "@mui/material": "npm:5.16.14"
-    "@types/react-dom": "npm:19.0.2"
-    block-scripts: "npm:0.3.4"
-    eslint: "npm:9.17.0"
-    mock-block-dock: "npm:0.1.9"
-    prettier: "npm:3.4.2"
-    react: "npm:19.0.0"
-    react-dom: "npm:19.0.0"
-    typescript: "npm:5.7.3"
-  peerDependencies:
-    react: ^19.0.0
-    react-dom: ^19.0.0
-  languageName: unknown
-  linkType: soft
-
-"@blocks/callout@workspace:blocks/callout":
-  version: 0.0.0-use.local
-  resolution: "@blocks/callout@workspace:blocks/callout"
-  dependencies:
-    "@blockprotocol/graph": "npm:0.3.4"
-    "@blockprotocol/hook": "npm:0.1.3"
-    "@local/eslint": "npm:0.0.0-private"
-    "@local/tsconfig": "npm:0.0.0-private"
-    "@types/react-dom": "npm:19.0.2"
-    block-scripts: "npm:0.3.4"
-    eslint: "npm:9.17.0"
-    mock-block-dock: "npm:0.1.9"
-    prettier: "npm:3.4.2"
-    react: "npm:19.0.0"
-    react-dom: "npm:19.0.0"
-    typescript: "npm:5.7.3"
-  peerDependencies:
-    react: ^19.0.0
-    react-dom: ^19.0.0
-  languageName: unknown
-  linkType: soft
-
-"@blocks/chart@workspace:blocks/chart":
-  version: 0.0.0-use.local
-  resolution: "@blocks/chart@workspace:blocks/chart"
-  dependencies:
-    "@blockprotocol/graph": "npm:0.3.4"
-    "@emotion/react": "npm:11.14.0"
-    "@emotion/styled": "npm:11.14.0"
-    "@hashintel/block-design-system": "npm:0.0.2"
-    "@hashintel/design-system": "npm:0.0.8"
-    "@local/eslint": "npm:0.0.0-private"
-    "@local/hash-isomorphic-utils": "npm:0.0.0-private"
-    "@local/tsconfig": "npm:0.0.0-private"
-    "@mui/material": "npm:5.16.14"
-    "@types/lodash.debounce": "npm:4.0.9"
-    "@types/react-dom": "npm:19.0.2"
-    "@types/react-is": "npm:19.0.0"
-    block-scripts: "npm:0.3.4"
-    echarts: "npm:5.6.0"
-    eslint: "npm:9.17.0"
-    lodash.debounce: "npm:4.0.8"
-    mock-block-dock: "npm:0.1.9"
-    prettier: "npm:3.4.2"
-    react: "npm:19.0.0"
-    react-dom: "npm:19.0.0"
-    react-hook-form: "npm:7.54.2"
-    typescript: "npm:5.7.3"
-  peerDependencies:
-    react: ^19.0.0
-    react-dom: ^19.0.0
-  languageName: unknown
-  linkType: soft
-
-"@blocks/code@workspace:blocks/code":
-  version: 0.0.0-use.local
-  resolution: "@blocks/code@workspace:blocks/code"
-  dependencies:
-    "@blockprotocol/graph": "npm:0.3.4"
-    "@local/eslint": "npm:0.0.0-private"
-    "@local/tsconfig": "npm:0.0.0-private"
-    "@types/prismjs": "npm:1.26.5"
-    "@types/react-dom": "npm:19.0.2"
-    block-scripts: "npm:0.3.4"
-    eslint: "npm:9.17.0"
-    mock-block-dock: "npm:0.1.9"
-    prettier: "npm:3.4.2"
-    prismjs: "npm:1.29.0"
-    react: "npm:19.0.0"
-    react-dom: "npm:19.0.0"
-    typescript: "npm:5.7.3"
-  peerDependencies:
-    react: ^19.0.0
-    react-dom: ^19.0.0
-  languageName: unknown
-  linkType: soft
-
-"@blocks/countdown@workspace:blocks/countdown":
-  version: 0.0.0-use.local
-  resolution: "@blocks/countdown@workspace:blocks/countdown"
-  dependencies:
-    "@blockprotocol/graph": "npm:0.3.4"
-    "@local/eslint": "npm:0.0.0-private"
-    "@local/tsconfig": "npm:0.0.0-private"
-    "@types/react-datepicker": "npm:4.19.6"
-    "@types/react-dom": "npm:19.0.2"
-    block-scripts: "npm:0.3.4"
-    date-fns: "npm:4.1.0"
-    eslint: "npm:9.17.0"
-    mock-block-dock: "npm:0.1.9"
-    prettier: "npm:3.4.2"
-    react: "npm:19.0.0"
-    react-datepicker: "npm:4.25.0"
-    react-dom: "npm:19.0.0"
-    typescript: "npm:5.7.3"
-  peerDependencies:
-    react: ^19.0.0
-    react-dom: ^19.0.0
-  languageName: unknown
-  linkType: soft
-
-"@blocks/divider@workspace:blocks/divider":
-  version: 0.0.0-use.local
-  resolution: "@blocks/divider@workspace:blocks/divider"
-  dependencies:
-    "@blockprotocol/core": "patch:@blockprotocol/core@npm%3A0.1.3#~/.yarn/patches/@blockprotocol-core-npm-0.1.3-7c4f062e15.patch"
-    "@blockprotocol/graph": "npm:0.3.4"
-    "@local/eslint": "npm:0.0.0-private"
-    "@local/tsconfig": "npm:0.0.0-private"
-    "@types/react-dom": "npm:19.0.2"
-    block-scripts: "npm:0.3.4"
-    eslint: "npm:9.17.0"
-    mock-block-dock: "npm:0.1.9"
-    prettier: "npm:3.4.2"
-    react: "npm:19.0.0"
-    react-dom: "npm:19.0.0"
-    typescript: "npm:5.7.3"
-  peerDependencies:
-    react: ^19.0.0
-    react-dom: ^19.0.0
-  languageName: unknown
-  linkType: soft
-
-"@blocks/embed@workspace:blocks/embed":
-  version: 0.0.0-use.local
-  resolution: "@blocks/embed@workspace:blocks/embed"
-  dependencies:
-    "@local/eslint": "npm:0.0.0-private"
-    "@local/tsconfig": "npm:0.0.0-private"
-    "@types/lodash": "npm:4.17.14"
-    "@types/react-dom": "npm:19.0.2"
-    block-scripts: "npm:0.0.14"
-    blockprotocol: "patch:blockprotocol@npm%3A0.0.12#~/.yarn/patches/blockprotocol-npm-0.0.12-2558a31f0a.patch"
-    eslint: "npm:9.17.0"
-    lodash: "npm:4.17.21"
-    mock-block-dock: "npm:0.0.10"
-    react: "npm:19.0.0"
-    react-dom: "npm:19.0.0"
-    twind: "npm:0.16.19"
-    typescript: "npm:5.7.3"
-  peerDependencies:
-    lodash: 4.17.21
-    react: ^19.0.0
-    react-dom: ^19.0.0
-  languageName: unknown
-  linkType: soft
-
-"@blocks/faq@workspace:blocks/faq":
-  version: 0.0.0-use.local
-  resolution: "@blocks/faq@workspace:blocks/faq"
-  dependencies:
-    "@blockprotocol/graph": "npm:0.3.4"
-    "@hashintel/block-design-system": "npm:0.0.2"
-    "@hashintel/design-system": "npm:0.0.8"
-    "@local/eslint": "npm:0.0.0-private"
-    "@mui/material": "npm:5.16.14"
-    "@types/react-dom": "npm:19.0.2"
-    block-scripts: "npm:0.3.4"
-    eslint: "npm:9.17.0"
-    mock-block-dock: "npm:0.1.9"
-    prettier: "npm:3.4.2"
-    react: "npm:19.0.0"
-    react-dom: "npm:19.0.0"
-    typescript: "npm:5.7.3"
-    uuid: "npm:11.0.5"
-  peerDependencies:
-    react: ^19.0.0
-    react-dom: ^19.0.0
-  languageName: unknown
-  linkType: soft
-
-"@blocks/heading@workspace:blocks/heading":
-  version: 0.0.0-use.local
-  resolution: "@blocks/heading@workspace:blocks/heading"
-  dependencies:
-    "@blockprotocol/graph": "npm:0.3.4"
-    "@blockprotocol/hook": "npm:0.1.3"
-    "@local/eslint": "npm:0.0.0-private"
-    "@local/tsconfig": "npm:0.0.0-private"
-    "@types/react-dom": "npm:19.0.2"
-    block-scripts: "npm:0.3.4"
-    eslint: "npm:9.17.0"
-    mock-block-dock: "npm:0.1.9"
-    prettier: "npm:3.4.2"
-    react: "npm:19.0.0"
-    react-dom: "npm:19.0.0"
-    typescript: "npm:5.7.3"
-  peerDependencies:
-    react: ^19.0.0
-    react-dom: ^19.0.0
-  languageName: unknown
-  linkType: soft
-
-"@blocks/how-to@workspace:blocks/how-to":
-  version: 0.0.0-use.local
-  resolution: "@blocks/how-to@workspace:blocks/how-to"
-  dependencies:
-    "@blockprotocol/graph": "npm:0.3.4"
-    "@hashintel/block-design-system": "npm:0.0.2"
-    "@hashintel/design-system": "npm:0.0.8"
-    "@local/eslint": "npm:0.0.0-private"
-    "@mui/material": "npm:5.16.14"
-    "@types/react-dom": "npm:19.0.2"
-    block-scripts: "npm:0.3.4"
-    eslint: "npm:9.17.0"
-    mock-block-dock: "npm:0.1.9"
-    prettier: "npm:3.4.2"
-    react: "npm:19.0.0"
-    react-dom: "npm:19.0.0"
-    react-sizeme: "npm:3.0.2"
-    typescript: "npm:5.7.3"
-    uuid: "npm:11.0.5"
-  peerDependencies:
-    react: ^19.0.0
-    react-dom: ^19.0.0
-  languageName: unknown
-  linkType: soft
-
-"@blocks/image@workspace:blocks/image":
-  version: 0.0.0-use.local
-  resolution: "@blocks/image@workspace:blocks/image"
-  dependencies:
-    "@blockprotocol/graph": "npm:0.3.4"
-    "@blockprotocol/hook": "npm:0.1.3"
-    "@local/eslint": "npm:0.0.0-private"
-    "@local/tsconfig": "npm:0.0.0-private"
-    "@types/react-dom": "npm:19.0.2"
-    block-scripts: "npm:0.3.4"
-    eslint: "npm:9.17.0"
-    mock-block-dock: "npm:0.1.9"
-    prettier: "npm:3.4.2"
-    react: "npm:19.0.0"
-    react-dom: "npm:19.0.0"
-    twind: "npm:0.16.19"
-    typescript: "npm:5.7.3"
-  peerDependencies:
-    react: ^19.0.0
-    react-dom: ^19.0.0
-  languageName: unknown
-  linkType: soft
-
-"@blocks/kanban-board@workspace:blocks/kanban-board":
-  version: 0.0.0-use.local
-  resolution: "@blocks/kanban-board@workspace:blocks/kanban-board"
-  dependencies:
-    "@blockprotocol/graph": "npm:0.3.4"
-    "@dnd-kit/core": "npm:6.3.1"
-    "@dnd-kit/sortable": "npm:7.0.2"
-    "@dnd-kit/utilities": "npm:3.2.2"
-    "@hashintel/block-design-system": "npm:0.0.2"
-    "@hashintel/design-system": "npm:0.0.8"
-    "@local/eslint": "npm:0.0.0-private"
-    "@local/tsconfig": "npm:0.0.0-private"
-    "@mui/material": "npm:5.16.14"
-    "@types/lodash.clonedeep": "npm:4.5.9"
-    "@types/lodash.debounce": "npm:4.0.9"
-    "@types/lodash.isequal": "npm:4.5.8"
-    "@types/react-dom": "npm:19.0.2"
-    block-scripts: "npm:0.3.4"
-    clsx: "npm:1.2.1"
-    eslint: "npm:9.17.0"
-    lodash.clonedeep: "npm:4.5.0"
-    lodash.debounce: "npm:4.0.8"
-    lodash.isequal: "npm:4.5.0"
-    mock-block-dock: "npm:0.1.9"
-    prettier: "npm:3.4.2"
-    react: "npm:19.0.0"
-    react-dom: "npm:19.0.0"
-    react-textarea-autosize: "npm:8.5.7"
-    typescript: "npm:5.7.3"
-  peerDependencies:
-    react: ^19.0.0
-    react-dom: ^19.0.0
-  languageName: unknown
-  linkType: soft
-
-"@blocks/minesweeper@workspace:blocks/minesweeper":
-  version: 0.0.0-use.local
-  resolution: "@blocks/minesweeper@workspace:blocks/minesweeper"
-  dependencies:
-    "@blockprotocol/graph": "npm:0.3.4"
-    "@local/eslint": "npm:0.0.0-private"
-    "@local/tsconfig": "npm:0.0.0-private"
-    "@types/react-dom": "npm:19.0.2"
-    block-scripts: "npm:0.3.4"
-    eslint: "npm:9.17.0"
-    lit: "npm:2.8.0"
-    mine-sweeper-tag: "npm:1.0.6"
-    mock-block-dock: "npm:0.1.9"
-    prettier: "npm:3.4.2"
-    react: "npm:19.0.0"
-    react-dom: "npm:19.0.0"
-    typescript: "npm:5.7.3"
-  languageName: unknown
-  linkType: soft
-
-"@blocks/paragraph@workspace:blocks/paragraph":
-  version: 0.0.0-use.local
-  resolution: "@blocks/paragraph@workspace:blocks/paragraph"
-  dependencies:
-    "@blockprotocol/graph": "npm:0.3.4"
-    "@blockprotocol/hook": "npm:0.1.3"
-    "@local/eslint": "npm:0.0.0-private"
-    "@local/tsconfig": "npm:0.0.0-private"
-    "@types/react-dom": "npm:19.0.2"
-    block-scripts: "npm:0.3.4"
-    eslint: "npm:9.17.0"
-    mock-block-dock: "npm:0.1.9"
-    prettier: "npm:3.4.2"
-    react: "npm:19.0.0"
-    react-dom: "npm:19.0.0"
-    typescript: "npm:5.7.3"
-  peerDependencies:
-    react: ^19.0.0
-    react-dom: ^19.0.0
-  languageName: unknown
-  linkType: soft
-
-"@blocks/person@workspace:blocks/person":
-  version: 0.0.0-use.local
-  resolution: "@blocks/person@workspace:blocks/person"
-  dependencies:
-    "@blockprotocol/graph": "npm:0.0.18"
-    "@local/eslint": "npm:0.0.0-private"
-    "@local/tsconfig": "npm:0.0.0-private"
-    "@types/dompurify": "npm:2.4.0"
-    "@types/react-dom": "npm:19.0.2"
-    block-scripts: "npm:0.0.14"
-    dompurify: "npm:2.5.8"
-    eslint: "npm:9.17.0"
-    mock-block-dock: "npm:0.0.38"
-    react: "npm:19.0.0"
-    react-dom: "npm:19.0.0"
-    typescript: "npm:5.7.3"
-  peerDependencies:
-    react: ^19.0.0
-    react-dom: ^19.0.0
-  languageName: unknown
-  linkType: soft
-
-"@blocks/shuffle@workspace:blocks/shuffle":
-  version: 0.0.0-use.local
-  resolution: "@blocks/shuffle@workspace:blocks/shuffle"
-  dependencies:
-    "@blockprotocol/graph": "npm:0.3.4"
-    "@dnd-kit/core": "npm:6.3.1"
-    "@dnd-kit/sortable": "npm:7.0.2"
-    "@dnd-kit/utilities": "npm:3.2.2"
-    "@hashintel/design-system": "npm:0.0.8"
-    "@local/eslint": "npm:0.0.0-private"
-    "@local/tsconfig": "npm:0.0.0-private"
-    "@mui/icons-material": "npm:5.16.14"
-    "@mui/material": "npm:5.16.14"
-    "@types/lodash.isequal": "npm:4.5.8"
-    block-scripts: "npm:0.3.4"
-    eslint: "npm:9.17.0"
-    immer: "npm:9.0.21"
-    lodash.isequal: "npm:4.5.0"
-    mock-block-dock: "npm:0.1.9"
-    prettier: "npm:3.4.2"
-    react: "npm:19.0.0"
-    react-dom: "npm:19.0.0"
-    typescript: "npm:5.7.3"
-    uuid: "npm:11.0.5"
-  peerDependencies:
-    react: ^19.0.0
-    react-dom: ^19.0.0
-  languageName: unknown
-  linkType: soft
-
-"@blocks/table@workspace:blocks/table":
-  version: 0.0.0-use.local
-  resolution: "@blocks/table@workspace:blocks/table"
-  dependencies:
-    "@blockprotocol/graph": "npm:0.3.4"
-    "@glideapps/glide-data-grid": "patch:@glideapps/glide-data-grid@npm%3A6.0.3#~/.yarn/patches/@glideapps-glide-data-grid-npm-6.0.3-f71d586425.patch"
-    "@hashintel/block-design-system": "npm:0.0.2"
-    "@hashintel/design-system": "npm:0.0.8"
-    "@local/eslint": "npm:0.0.0-private"
-    "@local/hash-isomorphic-utils": "npm:0.0.0-private"
-    "@local/tsconfig": "npm:0.0.0-private"
-    "@mui/material": "npm:5.16.14"
-    "@types/lodash.debounce": "npm:4.0.9"
-    "@types/lodash.isequal": "npm:4.5.8"
-    "@types/lodash.uniqueid": "npm:4.0.9"
-    "@types/react-dom": "npm:19.0.2"
-    block-scripts: "npm:0.3.4"
-    clsx: "npm:1.2.1"
-    eslint: "npm:9.17.0"
-    immer: "npm:9.0.21"
-    lodash.debounce: "npm:4.0.8"
-    lodash.isequal: "npm:4.5.0"
-    lodash.uniqueid: "npm:4.0.1"
-    mock-block-dock: "npm:0.1.9"
-    prettier: "npm:3.4.2"
-    react: "npm:19.0.0"
-    react-device-detect: "npm:2.2.3"
-    react-dom: "npm:19.0.0"
-    react-laag: "npm:2.0.5"
-    react-sizeme: "npm:3.0.2"
-    rooks: "npm:7.14.1"
-    typescript: "npm:5.7.3"
-  peerDependencies:
-    react: ^19.0.0
-    react-dom: ^19.0.0
-  languageName: unknown
-  linkType: soft
-
-"@blocks/timer@workspace:blocks/timer":
-  version: 0.0.0-use.local
-  resolution: "@blocks/timer@workspace:blocks/timer"
-  dependencies:
-    "@blockprotocol/graph": "npm:0.3.4"
-    "@local/eslint": "npm:0.0.0-private"
-    "@local/tsconfig": "npm:0.0.0-private"
-    "@types/react-dom": "npm:19.0.2"
-    block-scripts: "npm:0.3.4"
-    date-fns: "npm:4.1.0"
-    duration-fns: "npm:3.0.2"
-    eslint: "npm:9.17.0"
-    mock-block-dock: "npm:0.1.9"
-    prettier: "npm:3.4.2"
-    react: "npm:19.0.0"
-    react-dom: "npm:19.0.0"
-    typescript: "npm:5.7.3"
-  peerDependencies:
-    react: ^19.0.0
-    react-dom: ^19.0.0
-  languageName: unknown
-  linkType: soft
-
-"@blocks/video@workspace:blocks/video":
-  version: 0.0.0-use.local
-  resolution: "@blocks/video@workspace:blocks/video"
-  dependencies:
-    "@blockprotocol/graph": "npm:0.3.4"
-    "@local/eslint": "npm:0.0.0-private"
-    "@local/tsconfig": "npm:0.0.0-private"
-    "@types/react-dom": "npm:19.0.2"
-    block-scripts: "npm:0.3.4"
-    eslint: "npm:9.17.0"
-    mock-block-dock: "npm:0.1.9"
-    prettier: "npm:3.4.2"
-    react: "npm:19.0.0"
-    react-dom: "npm:19.0.0"
-    twind: "npm:0.16.19"
-    typescript: "npm:5.7.3"
-  peerDependencies:
-    react: ^19.0.0
-    react-dom: ^19.0.0
   languageName: unknown
   linkType: soft
 
@@ -6248,7 +5549,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/react@npm:11.14.0, @emotion/react@npm:^11.10.0, @emotion/react@npm:^11.4.0":
+"@emotion/react@npm:11.14.0, @emotion/react@npm:^11.4.0":
   version: 11.14.0
   resolution: "@emotion/react@npm:11.14.0"
   dependencies:
@@ -6306,7 +5607,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/styled@npm:11.14.0, @emotion/styled@npm:^11.10.0, @emotion/styled@npm:^11.3.0":
+"@emotion/styled@npm:11.14.0, @emotion/styled@npm:^11.3.0":
   version: 11.14.0
   resolution: "@emotion/styled@npm:11.14.0"
   dependencies:
@@ -9368,13 +8669,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lit-labs/react@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@lit-labs/react@npm:1.1.1"
-  checksum: 10c0/b4972906248d77bb49704f9d44f469957d4d39fba2d23418875a91997fd4abd0757091d9f43e92c3c953f6e239bae826318eb2ff8c11371872a0e0bcca2ddfc2
-  languageName: node
-  linkType: hard
-
 "@lit-labs/react@npm:1.2.1, @lit-labs/react@npm:^1.0.4":
   version: 1.2.1
   resolution: "@lit-labs/react@npm:1.2.1"
@@ -10128,30 +9422,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/base@npm:5.0.0-alpha.117":
-  version: 5.0.0-alpha.117
-  resolution: "@mui/base@npm:5.0.0-alpha.117"
-  dependencies:
-    "@babel/runtime": "npm:^7.20.7"
-    "@emotion/is-prop-valid": "npm:^1.2.0"
-    "@mui/types": "npm:^7.2.3"
-    "@mui/utils": "npm:^5.11.7"
-    "@popperjs/core": "npm:^2.11.6"
-    clsx: "npm:^1.2.1"
-    prop-types: "npm:^15.8.1"
-    react-is: "npm:^18.2.0"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/c0c69ebcb6f9765772ac3d76b921a0e75140bfdae8235ecb08f31f38f3bd155fc34b4def6be6b5dcf3dbff3039da3ed46773030cbbdadb7913201190005852a7
-  languageName: node
-  linkType: hard
-
-"@mui/core-downloads-tracker@npm:^5.11.8, @mui/core-downloads-tracker@npm:^5.16.14":
+"@mui/core-downloads-tracker@npm:^5.16.14":
   version: 5.16.14
   resolution: "@mui/core-downloads-tracker@npm:5.16.14"
   checksum: 10c0/eb866003ee4564c40423aadc4513b4c7d72c69723fe7dee4697ac70c19951e6e11093bb190761dc51a8f4d2731e562034ecb284930eec931bae1a56b8e18ca60
@@ -10174,40 +9445,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/material@npm:5.11.8":
-  version: 5.11.8
-  resolution: "@mui/material@npm:5.11.8"
-  dependencies:
-    "@babel/runtime": "npm:^7.20.7"
-    "@mui/base": "npm:5.0.0-alpha.117"
-    "@mui/core-downloads-tracker": "npm:^5.11.8"
-    "@mui/system": "npm:^5.11.8"
-    "@mui/types": "npm:^7.2.3"
-    "@mui/utils": "npm:^5.11.7"
-    "@types/react-transition-group": "npm:^4.4.5"
-    clsx: "npm:^1.2.1"
-    csstype: "npm:^3.1.1"
-    prop-types: "npm:^15.8.1"
-    react-is: "npm:^18.2.0"
-    react-transition-group: "npm:^4.4.5"
-  peerDependencies:
-    "@emotion/react": ^11.5.0
-    "@emotion/styled": ^11.3.0
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-  peerDependenciesMeta:
-    "@emotion/react":
-      optional: true
-    "@emotion/styled":
-      optional: true
-    "@types/react":
-      optional: true
-  checksum: 10c0/ebda2e45c119816b08b698a65873c17d6aec12986af4846c541801208449dfdfb442d8c742b7ab68673c1561f26f84b474a753714cd671ba5d04639874876e6f
-  languageName: node
-  linkType: hard
-
-"@mui/material@npm:5.16.14, @mui/material@npm:^5.0.0, @mui/material@npm:^5.10.4":
+"@mui/material@npm:5.16.14, @mui/material@npm:^5.0.0":
   version: 5.16.14
   resolution: "@mui/material@npm:5.16.14"
   dependencies:
@@ -10278,7 +9516,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/system@npm:5.16.14, @mui/system@npm:^5.11.8, @mui/system@npm:^5.16.14":
+"@mui/system@npm:5.16.14, @mui/system@npm:^5.16.14":
   version: 5.16.14
   resolution: "@mui/system@npm:5.16.14"
   dependencies:
@@ -10306,7 +9544,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/types@npm:^7.2.15, @mui/types@npm:^7.2.3":
+"@mui/types@npm:^7.2.15":
   version: 7.2.19
   resolution: "@mui/types@npm:7.2.19"
   peerDependencies:
@@ -10318,7 +9556,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/utils@npm:^5.11.7, @mui/utils@npm:^5.16.14":
+"@mui/utils@npm:^5.16.14":
   version: 5.16.14
   resolution: "@mui/utils@npm:5.16.14"
   dependencies:
@@ -10546,13 +9784,6 @@ __metadata:
     seedrandom: "npm:3.0.5"
     uuid: "npm:8.3.2"
   checksum: 10c0/5a0a3bd3d76837ced616dba471319ebc267ef9da2a7526c4b8afd1685f340c0897f3db96cb60c415d48a3c5e9484067734df3ba89863ef967960bc91485c35d2
-  languageName: node
-  linkType: hard
-
-"@nicolo-ribaudo/chokidar-2@npm:2.1.8-no-fsevents.3":
-  version: 2.1.8-no-fsevents.3
-  resolution: "@nicolo-ribaudo/chokidar-2@npm:2.1.8-no-fsevents.3"
-  checksum: 10c0/27dcabaa0c9a29b3a60217bd3fff87a22cb43ed77863da570c6828e4d0b8f1c6ee52582cd3d439275a2b1f2051005e648ed866b981f2a03b61c645b7e4806ba7
   languageName: node
   linkType: hard
 
@@ -11556,7 +10787,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@popperjs/core@npm:2.11.8, @popperjs/core@npm:^2.11.6, @popperjs/core@npm:^2.11.8, @popperjs/core@npm:^2.9.2":
+"@popperjs/core@npm:2.11.8, @popperjs/core@npm:^2.11.8":
   version: 2.11.8
   resolution: "@popperjs/core@npm:2.11.8"
   checksum: 10c0/4681e682abc006d25eb380d0cf3efc7557043f53b6aea7a5057d0d1e7df849a00e281cd8ea79c902a35a414d7919621fc2ba293ecec05f413598e0b23d5a1e63
@@ -17898,20 +17129,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node10@npm:^1.0.7":
-  version: 1.0.11
-  resolution: "@tsconfig/node10@npm:1.0.11"
-  checksum: 10c0/28a0710e5d039e0de484bdf85fee883bfd3f6a8980601f4d44066b0a6bcd821d31c4e231d1117731c4e24268bd4cf2a788a6787c12fc7f8d11014c07d582783c
-  languageName: node
-  linkType: hard
-
-"@tsconfig/node12@npm:^1.0.7":
-  version: 1.0.11
-  resolution: "@tsconfig/node12@npm:1.0.11"
-  checksum: 10c0/dddca2b553e2bee1308a056705103fc8304e42bb2d2cbd797b84403a223b25c78f2c683ec3e24a095e82cd435387c877239bffcb15a590ba817cd3f6b9a99fd9
-  languageName: node
-  linkType: hard
-
 "@tsconfig/node14@npm:*":
   version: 14.1.2
   resolution: "@tsconfig/node14@npm:14.1.2"
@@ -17919,24 +17136,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node14@npm:^1.0.0":
-  version: 1.0.3
-  resolution: "@tsconfig/node14@npm:1.0.3"
-  checksum: 10c0/67c1316d065fdaa32525bc9449ff82c197c4c19092b9663b23213c8cbbf8d88b6ed6a17898e0cbc2711950fbfaf40388938c1c748a2ee89f7234fc9e7fe2bf44
-  languageName: node
-  linkType: hard
-
 "@tsconfig/node16@npm:*":
   version: 16.1.3
   resolution: "@tsconfig/node16@npm:16.1.3"
   checksum: 10c0/4349c513719c5e1ef1995cc0c09d6099761ec0f3814a7165bf0622dfa76b2cc8580fac022bf1863f7eb6e34ced280c6d2dfb3750b6e1e2c5b96cb4e7e4004f04
-  languageName: node
-  linkType: hard
-
-"@tsconfig/node16@npm:^1.0.2":
-  version: 1.0.4
-  resolution: "@tsconfig/node16@npm:1.0.4"
-  checksum: 10c0/05f8f2734e266fb1839eb1d57290df1664fe2aa3b0fdd685a9035806daa635f7519bf6d5d9b33f6e69dd545b8c46bd6e2b5c79acb2b1f146e885f7f11a42a5bb
   languageName: node
   linkType: hard
 
@@ -18452,15 +17655,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/dompurify@npm:2.4.0":
-  version: 2.4.0
-  resolution: "@types/dompurify@npm:2.4.0"
-  dependencies:
-    "@types/trusted-types": "npm:*"
-  checksum: 10c0/a20c4288a067811e097f0b92a0cae927a9c49c0d5de36fea66b85fcc5c8db63a22ac47df37f324e426a01e8ab99ae28ea04260301350bda194850617a26931d6
-  languageName: node
-  linkType: hard
-
 "@types/domutils@npm:*":
   version: 1.7.8
   resolution: "@types/domutils@npm:1.7.8"
@@ -18777,13 +17971,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/is-hotkey@npm:^0.1.1":
-  version: 0.1.10
-  resolution: "@types/is-hotkey@npm:0.1.10"
-  checksum: 10c0/8ce7cc70a42e4191ba9871905a68fa6586a9da0bfa9940e20fe67e573b34bc79bfc23158e842c7bd3288ebf9c82ee5cce0c7fa1fe8245f6845c2f9b9f3afc536
-  languageName: node
-  linkType: hard
-
 "@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0, @types/istanbul-lib-coverage@npm:^2.0.1":
   version: 2.0.6
   resolution: "@types/istanbul-lib-coverage@npm:2.0.6"
@@ -18827,7 +18014,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.11, @types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.15, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.6, @types/json-schema@npm:^7.0.7, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
+"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.11, @types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.15, @types/json-schema@npm:^7.0.6, @types/json-schema@npm:^7.0.7, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
@@ -18879,15 +18066,6 @@ __metadata:
   dependencies:
     "@types/lodash": "npm:*"
   checksum: 10c0/5d12d2cede07f07ab067541371ed1b838a33edb3c35cb81b73284e93c6fd0c4bbeaefee984e69294bffb53f62d7272c5d679fdba8e595ff71e11d00f2601dde0
-  languageName: node
-  linkType: hard
-
-"@types/lodash.clonedeep@npm:4.5.9":
-  version: 4.5.9
-  resolution: "@types/lodash.clonedeep@npm:4.5.9"
-  dependencies:
-    "@types/lodash": "npm:*"
-  checksum: 10c0/2f224ce9578046bccd1cd9594fb73540600ebd3d59a45695166a6123e2c376b84ab106b005a00453f357907f25bc8bfd2271b822be76e8f5527eadb4690b5e96
   languageName: node
   linkType: hard
 
@@ -18945,7 +18123,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:*, @types/lodash@npm:4.17.14, @types/lodash@npm:^4.14.149, @types/lodash@npm:^4.14.167, @types/lodash@npm:^4.14.182, @types/lodash@npm:^4.17.13, @types/lodash@npm:^4.17.7":
+"@types/lodash@npm:*, @types/lodash@npm:4.17.14, @types/lodash@npm:^4.14.167, @types/lodash@npm:^4.14.182, @types/lodash@npm:^4.17.13, @types/lodash@npm:^4.17.7":
   version: 4.17.14
   resolution: "@types/lodash@npm:4.17.14"
   checksum: 10c0/343c6f722e0b39969036a885ad5aad6578479ead83987128c9b994e6b7f2fb9808244d802d4d332396bb09096f720a6c7060de16a492f5460e06a44560360322
@@ -19082,13 +18260,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^16.9.2":
-  version: 16.18.120
-  resolution: "@types/node@npm:16.18.120"
-  checksum: 10c0/933bb512cd4513da249c7b83227185ecd2b54819f7919cf3ecf60b3a6704fa2a9977f32b99be91b20bd5e0a66529112acdeb0851cbb11587fb84998afb5da7d5
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:^18.0.0, @types/node@npm:^18.11.18":
   version: 18.19.66
   resolution: "@types/node@npm:18.19.66"
@@ -19215,18 +18386,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-datepicker@npm:4.19.6":
-  version: 4.19.6
-  resolution: "@types/react-datepicker@npm:4.19.6"
-  dependencies:
-    "@popperjs/core": "npm:^2.9.2"
-    "@types/react": "npm:*"
-    date-fns: "npm:^2.0.1"
-    react-popper: "npm:^2.2.5"
-  checksum: 10c0/bd3f8266fb8b2f03e361857bc17c789083791ee4c79a812476d0f021d3551236d6581d48b9acd0063571835537eb3465f4029728446dd0b98ff7c1ad4395b628
-  languageName: node
-  linkType: hard
-
 "@types/react-dom@npm:19.0.2":
   version: 19.0.2
   resolution: "@types/react-dom@npm:19.0.2"
@@ -19243,15 +18402,6 @@ __metadata:
     "@types/htmlparser2": "npm:*"
     "@types/react": "npm:*"
   checksum: 10c0/c736d07f5ecbcd1144b920af03e988621215cb7b031d6c7d60832d494d4d79d0af3f522c7abec2dd29d0dbecbc924f6bd261d07c645799d2c2a158ad1e4e2ae6
-  languageName: node
-  linkType: hard
-
-"@types/react-is@npm:19.0.0":
-  version: 19.0.0
-  resolution: "@types/react-is@npm:19.0.0"
-  dependencies:
-    "@types/react": "npm:*"
-  checksum: 10c0/d5fa0294f95cf301540f3e28fb44c00524c74a7de3ef9757703d76067206f3ecc002da6486e1581f23b54173b6449db8631acc3088009116e4569ff216df3ecc
   languageName: node
   linkType: hard
 
@@ -19276,7 +18426,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-transition-group@npm:^4.4.10, @types/react-transition-group@npm:^4.4.5":
+"@types/react-transition-group@npm:^4.4.10":
   version: 4.4.11
   resolution: "@types/react-transition-group@npm:4.4.11"
   dependencies:
@@ -19482,7 +18632,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/trusted-types@npm:*, @types/trusted-types@npm:^2.0.2, @types/trusted-types@npm:^2.0.7":
+"@types/trusted-types@npm:^2.0.2, @types/trusted-types@npm:^2.0.7":
   version: 2.0.7
   resolution: "@types/trusted-types@npm:2.0.7"
   checksum: 10c0/4c4855f10de7c6c135e0d32ce462419d8abbbc33713b31d294596c0cc34ae1fa6112a2f9da729c8f7a20707782b0d69da3b1f8df6645b0366d08825ca1522e0c
@@ -20110,106 +19260,6 @@ __metadata:
   version: 2.4.6
   resolution: "@vladfrangu/async_event_emitter@npm:2.4.6"
   checksum: 10c0/1fe634878902da584493ecb8e81c855436c002b215dd7c25c21780930fc5621ebe8eb79d5b899a56af0d1ea9ea9171e35175221e4438e2f56c67ce64d4b8a373
-  languageName: node
-  linkType: hard
-
-"@vue/compiler-core@npm:3.5.13":
-  version: 3.5.13
-  resolution: "@vue/compiler-core@npm:3.5.13"
-  dependencies:
-    "@babel/parser": "npm:^7.25.3"
-    "@vue/shared": "npm:3.5.13"
-    entities: "npm:^4.5.0"
-    estree-walker: "npm:^2.0.2"
-    source-map-js: "npm:^1.2.0"
-  checksum: 10c0/b89f3e3ca92c3177ae449ada1480df13d99b5b3b2cdcf3202fd37dc30f294a1db1f473209f8bae9233e2d338632219d39b2bfa6941d158cea55255e4b0b30f90
-  languageName: node
-  linkType: hard
-
-"@vue/compiler-dom@npm:3.5.13":
-  version: 3.5.13
-  resolution: "@vue/compiler-dom@npm:3.5.13"
-  dependencies:
-    "@vue/compiler-core": "npm:3.5.13"
-    "@vue/shared": "npm:3.5.13"
-  checksum: 10c0/8f424a71883c9ef4abdd125d2be8d12dd8cf94ba56089245c88734b1f87c65e10597816070ba2ea0a297a2f66dc579f39275a9a53ef5664c143a12409612cd72
-  languageName: node
-  linkType: hard
-
-"@vue/compiler-sfc@npm:3.5.13":
-  version: 3.5.13
-  resolution: "@vue/compiler-sfc@npm:3.5.13"
-  dependencies:
-    "@babel/parser": "npm:^7.25.3"
-    "@vue/compiler-core": "npm:3.5.13"
-    "@vue/compiler-dom": "npm:3.5.13"
-    "@vue/compiler-ssr": "npm:3.5.13"
-    "@vue/shared": "npm:3.5.13"
-    estree-walker: "npm:^2.0.2"
-    magic-string: "npm:^0.30.11"
-    postcss: "npm:^8.4.48"
-    source-map-js: "npm:^1.2.0"
-  checksum: 10c0/5fd57895ce2801e480c08f31f91f0d1746ed08a9c1973895fd7269615f5bcdf75497978fb358bda738938d9844dea2404064c53b2cdda991014225297acce19e
-  languageName: node
-  linkType: hard
-
-"@vue/compiler-ssr@npm:3.5.13":
-  version: 3.5.13
-  resolution: "@vue/compiler-ssr@npm:3.5.13"
-  dependencies:
-    "@vue/compiler-dom": "npm:3.5.13"
-    "@vue/shared": "npm:3.5.13"
-  checksum: 10c0/67621337b12fc414fcf9f16578961850724713a9fb64501136e432c2dfe95de99932c46fa24be9820f8bcdf8e7281f815f585b519a95ea979753bafd637dde1b
-  languageName: node
-  linkType: hard
-
-"@vue/reactivity@npm:3.5.13":
-  version: 3.5.13
-  resolution: "@vue/reactivity@npm:3.5.13"
-  dependencies:
-    "@vue/shared": "npm:3.5.13"
-  checksum: 10c0/4bf2754a4b8cc31afc8da5bdfd12bba6be67b2963a65f7c9e2b59810883c58128dfc58cce6d1e479c4f666190bc0794f17208d9efd3fc909a2e4843d2cc0e69e
-  languageName: node
-  linkType: hard
-
-"@vue/runtime-core@npm:3.5.13":
-  version: 3.5.13
-  resolution: "@vue/runtime-core@npm:3.5.13"
-  dependencies:
-    "@vue/reactivity": "npm:3.5.13"
-    "@vue/shared": "npm:3.5.13"
-  checksum: 10c0/b6be854bf082a224222614a334fbeac0e7b6445f3cf4ea45cbd49ae4bb1551200c461c14c7a452d748f2459f7402ad4dee5522d51be5a28ea4ae1f699a7c016f
-  languageName: node
-  linkType: hard
-
-"@vue/runtime-dom@npm:3.5.13":
-  version: 3.5.13
-  resolution: "@vue/runtime-dom@npm:3.5.13"
-  dependencies:
-    "@vue/reactivity": "npm:3.5.13"
-    "@vue/runtime-core": "npm:3.5.13"
-    "@vue/shared": "npm:3.5.13"
-    csstype: "npm:^3.1.3"
-  checksum: 10c0/8ee7f3980d19f77f8e7ae854e3ff1f7ee9a9b8b4e214c8d0492e1180ae818e33c04803b3d094503524d557431a30728b78cf15c3683d8abbbbd1b263a299d62a
-  languageName: node
-  linkType: hard
-
-"@vue/server-renderer@npm:3.5.13":
-  version: 3.5.13
-  resolution: "@vue/server-renderer@npm:3.5.13"
-  dependencies:
-    "@vue/compiler-ssr": "npm:3.5.13"
-    "@vue/shared": "npm:3.5.13"
-  peerDependencies:
-    vue: 3.5.13
-  checksum: 10c0/f500bdabc199abf41f1d84defd2a365a47afce1f2223a34c32fada84f6193b39ec2ce50636483409eec81b788b8ef0fa1ff59c63ca0c74764d738c24409eef8f
-  languageName: node
-  linkType: hard
-
-"@vue/shared@npm:3.5.13":
-  version: 3.5.13
-  resolution: "@vue/shared@npm:3.5.13"
-  checksum: 10c0/2c940ef907116f1c2583ca1d7733984e5705983ab07054c4e72f1d95eb0f7bdf4d01efbdaee1776c2008f79595963f44e98fced057f5957d86d57b70028f5025
   languageName: node
   linkType: hard
 
@@ -21355,13 +20405,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-union@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "array-union@npm:3.0.1"
-  checksum: 10c0/b5271d7e5688d2d1932928b271796dbbddc422448557ab05ef6f34a9f84fb645eb855384feec6234bf59c226053a0e21b8a00b0e6cd588874b90a5c13dbeb64e
-  languageName: node
-  linkType: hard
-
 "array-uniq@npm:^1.0.1":
   version: 1.0.3
   resolution: "array-uniq@npm:1.0.3"
@@ -21926,7 +20969,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.7.9, axios@npm:^1.4.0, axios@npm:^1.6.0, axios@npm:^1.6.1, axios@npm:^1.7.4, axios@npm:^1.7.9":
+"axios@npm:1.7.9, axios@npm:^1.4.0, axios@npm:^1.6.1, axios@npm:^1.7.4, axios@npm:^1.7.9":
   version: 1.7.9
   resolution: "axios@npm:1.7.9"
   dependencies:
@@ -21978,7 +21021,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-loader@npm:9.2.1, babel-loader@npm:^9.0.0, babel-loader@npm:^9.1.2":
+"babel-loader@npm:9.2.1, babel-loader@npm:^9.0.0":
   version: 9.2.1
   resolution: "babel-loader@npm:9.2.1"
   dependencies:
@@ -21988,21 +21031,6 @@ __metadata:
     "@babel/core": ^7.12.0
     webpack: ">=5"
   checksum: 10c0/efb82faff4c7c27e9c15bb28bf11c73200e61cf365118a9514e8d74dd489d0afc2a0d5aaa62cb4254eefc2ab631579224d95a03fd245410f28ea75e24de54ba4
-  languageName: node
-  linkType: hard
-
-"babel-loader@npm:^8.2.4":
-  version: 8.4.1
-  resolution: "babel-loader@npm:8.4.1"
-  dependencies:
-    find-cache-dir: "npm:^3.3.1"
-    loader-utils: "npm:^2.0.4"
-    make-dir: "npm:^3.1.0"
-    schema-utils: "npm:^2.6.5"
-  peerDependencies:
-    "@babel/core": ^7.0.0
-    webpack: ">=2"
-  checksum: 10c0/efdca9c3ef502af58b923a32123d660c54fd0be125b7b64562c8a43bda0a3a55dac0db32331674104e7e5184061b75c3a0e395b2c5ccdc7cb2125dd9ec7108d2
   languageName: node
   linkType: hard
 
@@ -22248,13 +21276,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"batch-processor@npm:1.0.0":
-  version: 1.0.0
-  resolution: "batch-processor@npm:1.0.0"
-  checksum: 10c0/048b868811bed4cd03a0eec35264055f0f3fe4ab62f501809dce4a8a7b845d905fa5051b4af8b3c5123181116b1e2b6dfabf608829043b60cf61f4da3a359b60
-  languageName: node
-  linkType: hard
-
 "batch@npm:0.6.1":
   version: 0.6.1
   resolution: "batch@npm:0.6.1"
@@ -22388,107 +21409,6 @@ __metadata:
     inherits: "npm:^2.0.4"
     readable-stream: "npm:^4.2.0"
   checksum: 10c0/b509bfa5dfd73a7bf538cdce85ad74248990f71ec434c6e6b4e403c42a52670bd8faae73201a7021a392a172f7c4b2aa7caec9fb71fa1046266062aff6af6c65
-  languageName: node
-  linkType: hard
-
-"block-scripts@npm:0.0.14":
-  version: 0.0.14
-  resolution: "block-scripts@npm:0.0.14"
-  dependencies:
-    "@babel/cli": "npm:^7.17.6"
-    "@babel/core": "npm:^7.17.9"
-    "@babel/plugin-proposal-class-properties": "npm:^7.16.7"
-    "@babel/plugin-proposal-decorators": "npm:^7.18.2"
-    "@babel/plugin-transform-runtime": "npm:^7.17.0"
-    "@babel/preset-env": "npm:^7.16.11"
-    "@babel/preset-react": "npm:^7.16.7"
-    "@babel/preset-typescript": "npm:7.16.7"
-    "@babel/runtime": "npm:^7.17.9"
-    babel-loader: "npm:^8.2.4"
-    chalk: "npm:5.0.1"
-    copy-webpack-plugin: "npm:10.2.4"
-    core-js: "npm:^3.21.1"
-    cross-env: "npm:^7.0.3"
-    css-loader: "npm:^6.7.1"
-    fs-extra: "npm:^10.1.0"
-    html-webpack-plugin: "npm:^5.5.0"
-    lodash: "npm:^4.17.21"
-    regenerator-runtime: "npm:^0.13.9"
-    sass: "npm:^1.52.3"
-    sass-loader: "npm:^12.6.0"
-    serve-handler: "npm:^6.1.3"
-    style-loader: "npm:^3.3.1"
-    typescript: "npm:4.7.2"
-    typescript-json-schema: "npm:^0.53.0"
-    uuid: "npm:^8.3.2"
-    webpack: "npm:^5.72.0"
-    webpack-assets-manifest: "npm:^5.1.0"
-    webpack-bundle-analyzer: "npm:^4.5.0"
-    webpack-cli: "npm:^4.9.2"
-    webpack-dev-server: "npm:^4.8.1"
-    yargs-parser: "npm:21.0.1"
-  bin:
-    block-scripts: bin.js
-  checksum: 10c0/a0837aa876c7dd071ba03a9f1f185d57b02020a6a4869e94ba5096baede06dedaf9f399916fd1a92561b3a84b71129d8ac22833b48cdf26f7407dc18f18eeacb
-  languageName: node
-  linkType: hard
-
-"block-scripts@npm:0.3.4":
-  version: 0.3.4
-  resolution: "block-scripts@npm:0.3.4"
-  dependencies:
-    "@babel/core": "npm:^7.21.0"
-    "@babel/plugin-proposal-class-properties": "npm:^7.18.6"
-    "@babel/plugin-proposal-decorators": "npm:^7.21.0"
-    "@babel/plugin-proposal-private-methods": "npm:7.18.6"
-    "@babel/plugin-proposal-private-property-in-object": "npm:7.21.0"
-    "@babel/plugin-transform-runtime": "npm:^7.21.0"
-    "@babel/preset-env": "npm:^7.20.2"
-    "@babel/preset-react": "npm:^7.18.6"
-    "@babel/preset-typescript": "npm:^7.21.0"
-    "@babel/runtime": "npm:^7.21.0"
-    "@blockprotocol/graph": "npm:0.3.3"
-    "@blockprotocol/type-system": "npm:0.1.1"
-    babel-loader: "npm:^9.1.2"
-    chalk: "npm:5.2.0"
-    copy-webpack-plugin: "npm:10.2.4"
-    core-js: "npm:^3.26.1"
-    css-loader: "npm:^6.7.1"
-    dotenv-webpack: "npm:^8.0.1"
-    fs-extra: "npm:^10.1.0"
-    html-webpack-plugin: "npm:^5.5.0"
-    sass: "npm:^1.52.3"
-    sass-loader: "npm:^12.6.0"
-    serve-handler: "npm:^6.1.3"
-    style-loader: "npm:^3.3.1"
-    typescript: "npm:4.9.4"
-    typescript-json-schema: "npm:^0.55.0"
-    webpack: "npm:^5.76.0"
-    webpack-assets-manifest: "npm:^5.1.0"
-    webpack-bundle-analyzer: "npm:^4.8.0"
-    webpack-dev-server: "npm:^4.11.1"
-    yargs-parser: "npm:21.1.1"
-  bin:
-    block-scripts: bin.js
-  checksum: 10c0/6fb5482d552a8083588738639ca04d55f5f163737988d5e409e83ca59c2724d28d3b58c114e0f684a2586618796b6e2d76154f6b90ecbac8eee9aa61da1d50e0
-  languageName: node
-  linkType: hard
-
-"blockprotocol@npm:0.0.12":
-  version: 0.0.12
-  resolution: "blockprotocol@npm:0.0.12"
-  dependencies:
-    "@types/react": "npm:^18.0.15"
-  checksum: 10c0/81cbf474de1ed8e3ce7ad8b955a83e854e26fd4290a21cfd5742f72b624b5edc90059c6cf65bf3422f9da071b5fd481298e7f2635d3625f1ab41454ea2bb29c7
-  languageName: node
-  linkType: hard
-
-"blockprotocol@patch:blockprotocol@npm%3A0.0.12#~/.yarn/patches/blockprotocol-npm-0.0.12-2558a31f0a.patch":
-  version: 0.0.12
-  resolution: "blockprotocol@patch:blockprotocol@npm%3A0.0.12#~/.yarn/patches/blockprotocol-npm-0.0.12-2558a31f0a.patch::version=0.0.12&hash=da1dbe"
-  dependencies:
-    "@types/react": "npm:^18.0.15"
-  checksum: 10c0/c56e7ee6913a27fdb919ed9c3273e4e5e25efb6829dbcd7c7f28787d60445b5045b162b94c4460083da84c26ce94928ca0c2b540321b8ff53eb0773946c33778
   languageName: node
   linkType: hard
 
@@ -22822,13 +21742,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bytes@npm:3.0.0":
-  version: 3.0.0
-  resolution: "bytes@npm:3.0.0"
-  checksum: 10c0/91d42c38601c76460519ffef88371caacaea483a354c8e4b8808e7b027574436a5713337c003ea3de63ee4991c2a9a637884fdfe7f761760d746929d9e8fec60
-  languageName: node
-  linkType: hard
-
 "bytes@npm:3.1.2":
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
@@ -23126,20 +22039,6 @@ __metadata:
     ansi-styles: "npm:^4.1.0"
     supports-color: "npm:^7.1.0"
   checksum: 10c0/4a3fef5cc34975c898ffe77141450f679721df9dde00f6c304353fa9c8b571929123b26a0e4617bde5018977eb655b31970c297b91b63ee83bb82aeb04666880
-  languageName: node
-  linkType: hard
-
-"chalk@npm:5.0.1":
-  version: 5.0.1
-  resolution: "chalk@npm:5.0.1"
-  checksum: 10c0/97898611ae40cfdeda9778901731df1404ea49fac0eb8253804e8d21b8064917df9823e29c0c9d766aab623da1a0b43d0e072d19a73d4f62d0d9115aef4c64e6
-  languageName: node
-  linkType: hard
-
-"chalk@npm:5.2.0":
-  version: 5.2.0
-  resolution: "chalk@npm:5.2.0"
-  checksum: 10c0/8a519b35c239f96e041b7f1ed8fdd79d3ca2332a8366cb957378b8a1b8a4cdfb740d19628e8bf74654d4c0917aa10cf39c20752e177a1304eac29a1168a740e9
   languageName: node
   linkType: hard
 
@@ -23742,7 +22641,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:1.2.1, clsx@npm:^1.1.0, clsx@npm:^1.1.1, clsx@npm:^1.2.1":
+"clsx@npm:1.2.1, clsx@npm:^1.1.0":
   version: 1.2.1
   resolution: "clsx@npm:1.2.1"
   checksum: 10c0/34dead8bee24f5e96f6e7937d711978380647e936a22e76380290e35486afd8634966ce300fc4b74a32f3762c7d4c0303f442c3e259f4ce02374eb0c82834f27
@@ -23984,7 +22883,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^6.2.0, commander@npm:^6.2.1":
+"commander@npm:^6.2.1":
   version: 6.2.1
   resolution: "commander@npm:6.2.1"
   checksum: 10c0/85748abd9d18c8bc88febed58b98f66b7c591d9b5017cad459565761d7b29ca13b7783ea2ee5ce84bf235897333706c4ce29adf1ce15c8252780e7000e2ce9ea
@@ -24087,13 +22986,6 @@ __metadata:
     safe-buffer: "npm:5.2.1"
     vary: "npm:~1.1.2"
   checksum: 10c0/35c9d2d57c86d8107eab5e637f2146fcefec8475a2ff3e162f5eb0982ff856d385fb5d8c9823c3d50e075f2d9304bc622dac3df27bfef0355309c0a5307861c5
-  languageName: node
-  linkType: hard
-
-"compute-scroll-into-view@npm:^1.0.20":
-  version: 1.0.20
-  resolution: "compute-scroll-into-view@npm:1.0.20"
-  checksum: 10c0/19034322590bfce59cb6939b3603e7aaf6f0d4128b8627bbc136e71c8714905e2f8bf2ba0cb7f153c6e8cdb8ad907ffd6d0188ccc7625dc05790a59ae6a81f01
   languageName: node
   linkType: hard
 
@@ -24215,13 +23107,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-disposition@npm:0.5.2":
-  version: 0.5.2
-  resolution: "content-disposition@npm:0.5.2"
-  checksum: 10c0/49eebaa0da1f9609b192e99d7fec31d1178cb57baa9d01f5b63b29787ac31e9d18b5a1033e854c68c9b6cce790e700a6f7fa60e43f95e2e416404e114a8f2f49
-  languageName: node
-  linkType: hard
-
 "content-disposition@npm:0.5.4":
   version: 0.5.4
   resolution: "content-disposition@npm:0.5.4"
@@ -24321,22 +23206,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"copy-webpack-plugin@npm:10.2.4":
-  version: 10.2.4
-  resolution: "copy-webpack-plugin@npm:10.2.4"
-  dependencies:
-    fast-glob: "npm:^3.2.7"
-    glob-parent: "npm:^6.0.1"
-    globby: "npm:^12.0.2"
-    normalize-path: "npm:^3.0.0"
-    schema-utils: "npm:^4.0.0"
-    serialize-javascript: "npm:^6.0.0"
-  peerDependencies:
-    webpack: ^5.1.0
-  checksum: 10c0/d4501aa2d813eadc906318ed301707240fc7bfeb250813e2e4d93e95bc9896822c136e49de01dfe612ea5334a1f04cb8fbed4412b91117666a92607c0deba624
-  languageName: node
-  linkType: hard
-
 "copy-webpack-plugin@npm:11.0.0":
   version: 11.0.0
   resolution: "copy-webpack-plugin@npm:11.0.0"
@@ -24376,7 +23245,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:^3.21.1, core-js@npm:^3.26.1, core-js@npm:^3.27.2, core-js@npm:^3.32.1":
+"core-js@npm:^3.27.2, core-js@npm:^3.32.1":
   version: 3.39.0
   resolution: "core-js@npm:3.39.0"
   checksum: 10c0/f7602069b6afb2e3298eec612a5c1e0c3e6a458930fbfc7a4c5f9ac03426507f49ce395eecdd2d9bae9024f820e44582b67ffe16f2272395af26964f174eeb6b
@@ -24483,13 +23352,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"create-require@npm:^1.1.0":
-  version: 1.1.1
-  resolution: "create-require@npm:1.1.1"
-  checksum: 10c0/157cbc59b2430ae9a90034a5f3a1b398b6738bf510f713edc4d4e45e169bc514d3d99dd34d8d01ca7ae7830b5b8b537e46ae8f3c8f932371b0875c0151d7ec91
-  languageName: node
-  linkType: hard
-
 "cron-parser@npm:^4.2.1":
   version: 4.9.0
   resolution: "cron-parser@npm:4.9.0"
@@ -24499,7 +23361,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-env@npm:7.0.3, cross-env@npm:^7.0.3":
+"cross-env@npm:7.0.3":
   version: 7.0.3
   resolution: "cross-env@npm:7.0.3"
   dependencies:
@@ -24732,7 +23594,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:3.1.3, csstype@npm:^3.0.2, csstype@npm:^3.0.5, csstype@npm:^3.1.1, csstype@npm:^3.1.3":
+"csstype@npm:3.1.3, csstype@npm:^3.0.2, csstype@npm:^3.1.3":
   version: 3.1.3
   resolution: "csstype@npm:3.1.3"
   checksum: 10c0/80c089d6f7e0c5b2bd83cf0539ab41474198579584fa10d86d0cafe0642202343cbc119e076a0b1aece191989477081415d66c9fefbf3c957fc2fc4b7009f248
@@ -25242,7 +24104,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:^2.0.1, date-fns@npm:^2.16.1, date-fns@npm:^2.30.0":
+"date-fns@npm:^2.16.1":
   version: 2.30.0
   resolution: "date-fns@npm:2.30.0"
   dependencies:
@@ -25947,15 +24809,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"direction@npm:^1.0.3":
-  version: 1.0.4
-  resolution: "direction@npm:1.0.4"
-  bin:
-    direction: cli.js
-  checksum: 10c0/2257006edba01b3294322311a212a3f0e7c656d710ab164fd95123a2a9daaec536252c60da6a9df5be2bb89e9030684e9d1c7804fe82c9b3f510c2f737adeada
-  languageName: node
-  linkType: hard
-
 "discontinuous-range@npm:1.0.0":
   version: 1.0.0
   resolution: "discontinuous-range@npm:1.0.0"
@@ -26118,13 +24971,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:2.5.8":
-  version: 2.5.8
-  resolution: "dompurify@npm:2.5.8"
-  checksum: 10c0/4101708d190b67be00350369d72619266a2e0ebb7dcab12628cf07711329b1df12239baea613df41b65cba571128e8ea4c29c442f4e2c98670a9bb5563521f03
-  languageName: node
-  linkType: hard
-
 "dompurify@npm:^3.0.6":
   version: 3.2.1
   resolution: "dompurify@npm:3.2.1"
@@ -26179,15 +25025,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv-defaults@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "dotenv-defaults@npm:2.0.2"
-  dependencies:
-    dotenv: "npm:^8.2.0"
-  checksum: 10c0/14b7b8f6c21a30404106384398728746e63405bfeabe47ef7aadd0e81de49986d5896a612e5b1acddf655af6472a24947b7b113aa3ef3270a2877afa9c5bd287
-  languageName: node
-  linkType: hard
-
 "dotenv-expand@npm:^10.0.0":
   version: 10.0.0
   resolution: "dotenv-expand@npm:10.0.0"
@@ -26201,17 +25038,6 @@ __metadata:
   dependencies:
     dotenv: "npm:^8.6.0"
   checksum: 10c0/64f367f66532bdd2abad84360ff37668d8718e9362b442ba293ed518b573449c6e8d15e3e50001f7bac4f2c932287a5c8c5e98435b252f230f67bcc30cd27b87
-  languageName: node
-  linkType: hard
-
-"dotenv-webpack@npm:^8.0.1":
-  version: 8.1.0
-  resolution: "dotenv-webpack@npm:8.1.0"
-  dependencies:
-    dotenv-defaults: "npm:^2.0.2"
-  peerDependencies:
-    webpack: ^4 || ^5
-  checksum: 10c0/7a64587fc96eba8e4ffccf56d6af09606611a32bc5cf04a37057b8c2881bcd11bf43c3395404581be734ae7fd2788471ceac76cb3d0ba1283e675223f98e5816
   languageName: node
   linkType: hard
 
@@ -26294,13 +25120,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"duration-fns@npm:3.0.2":
-  version: 3.0.2
-  resolution: "duration-fns@npm:3.0.2"
-  checksum: 10c0/9488be20171815b7614b28bd6e3babc0ee169d2ec100d9816dd8fd61db04d32c9f09a3efc9ee4ffb116899db160679a248546b9c121403ea9f08e136f2b026de
-  languageName: node
-  linkType: hard
-
 "e2b@npm:0.13.1":
   version: 0.13.1
   resolution: "e2b@npm:0.13.1"
@@ -26362,17 +25181,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"echarts@npm:5.4.1":
-  version: 5.4.1
-  resolution: "echarts@npm:5.4.1"
-  dependencies:
-    tslib: "npm:2.3.0"
-    zrender: "npm:5.4.1"
-  checksum: 10c0/dfbe35fce9b64de5e897b8dae7e9b2a1d089d6ab71ca27f1ed0a0b4ba7973088513dac88cbef9cc54aaf5606f2076b3eb48555aa44352a8b676a556efb29017c
-  languageName: node
-  linkType: hard
-
-"echarts@npm:5.6.0, echarts@npm:^5.3.3":
+"echarts@npm:5.6.0":
   version: 5.6.0
   resolution: "echarts@npm:5.6.0"
   dependencies:
@@ -26413,15 +25222,6 @@ __metadata:
   version: 1.5.65
   resolution: "electron-to-chromium@npm:1.5.65"
   checksum: 10c0/4d2db76ca63d34aad9d5392d850a89fecb4d740a3f0e3ab945f23850ed99789df4e09dd36a28cedcf3b4757dd7c82d5d159bfdf1d29f815d172a9132b4ba3bb9
-  languageName: node
-  linkType: hard
-
-"element-resize-detector@npm:^1.2.2":
-  version: 1.2.4
-  resolution: "element-resize-detector@npm:1.2.4"
-  dependencies:
-    batch-processor: "npm:1.0.0"
-  checksum: 10c0/8c180c8c2a6d5b83678f994e937890f06db6355009cce2bde3c690a45510c92f53f927431926b27db416739aa7b661c7d3afe237d17cd16491ecccfa740cda08
   languageName: node
   linkType: hard
 
@@ -28547,7 +27347,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.7, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.0, fast-glob@npm:^3.3.2":
+"fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.0, fast-glob@npm:^3.3.2":
   version: 3.3.2
   resolution: "fast-glob@npm:3.3.2"
   dependencies:
@@ -29542,13 +28342,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-readdir-recursive@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "fs-readdir-recursive@npm:1.1.0"
-  checksum: 10c0/7e190393952143e674b6d1ad4abcafa1b5d3e337fcc21b0cb051079a7140a54617a7df193d562ef9faf21bd7b2148a38601b3d5c16261fa76f278d88dc69989c
-  languageName: node
-  linkType: hard
-
 "fs.realpath@npm:^1.0.0":
   version: 1.0.0
   resolution: "fs.realpath@npm:1.0.0"
@@ -30079,7 +28872,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.0.3, glob@npm:^7.1.1, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:^7.1.7, glob@npm:^7.2.0, glob@npm:^7.2.3":
+"glob@npm:^7.0.3, glob@npm:^7.1.1, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:^7.2.3":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:
@@ -30171,20 +28964,6 @@ __metadata:
     slash: "npm:^5.1.0"
     unicorn-magic: "npm:^0.1.0"
   checksum: 10c0/3f771cd683b8794db1e7ebc8b6b888d43496d93a82aad4e9d974620f578581210b6c5a6e75ea29573ed16a1345222fab6e9b877a8d1ed56eeb147e09f69c6f78
-  languageName: node
-  linkType: hard
-
-"globby@npm:^12.0.2":
-  version: 12.2.0
-  resolution: "globby@npm:12.2.0"
-  dependencies:
-    array-union: "npm:^3.0.1"
-    dir-glob: "npm:^3.0.1"
-    fast-glob: "npm:^3.2.7"
-    ignore: "npm:^5.1.9"
-    merge2: "npm:^1.4.1"
-    slash: "npm:^4.0.0"
-  checksum: 10c0/121fee62bb9a43a35a32731cda9540241003ef578f9cee5ad87b27d3020b94857ff62f8d82cb99dbeedf6f26981c9fa62509d873392642ceb37674f3d6ec4e52
   languageName: node
   linkType: hard
 
@@ -31204,7 +29983,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"htmlparser2@npm:^6.0.0, htmlparser2@npm:^6.1.0":
+"htmlparser2@npm:^6.1.0":
   version: 6.1.0
   resolution: "htmlparser2@npm:6.1.0"
   dependencies:
@@ -31576,7 +30355,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.1.9, ignore@npm:^5.2.0, ignore@npm:^5.2.4, ignore@npm:^5.3.1":
+"ignore@npm:^5.2.0, ignore@npm:^5.2.4, ignore@npm:^5.3.1":
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
   checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
@@ -31612,7 +30391,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immer@npm:9.0.21, immer@npm:^9.0.6":
+"immer@npm:9.0.21":
   version: 9.0.21
   resolution: "immer@npm:9.0.21"
   checksum: 10c0/03ea3ed5d4d72e8bd428df4a38ad7e483ea8308e9a113d3b42e0ea2cc0cc38340eb0a6aca69592abbbf047c685dbda04e3d34bf2ff438ab57339ed0a34cc0a05
@@ -32325,13 +31104,6 @@ __metadata:
   version: 2.0.1
   resolution: "is-hexadecimal@npm:2.0.1"
   checksum: 10c0/3eb60fe2f1e2bbc760b927dcad4d51eaa0c60138cf7fc671803f66353ad90c301605b502c7ea4c6bb0548e1c7e79dfd37b73b632652e3b76030bba603a7e9626
-  languageName: node
-  linkType: hard
-
-"is-hotkey@npm:^0.1.6":
-  version: 0.1.8
-  resolution: "is-hotkey@npm:0.1.8"
-  checksum: 10c0/5aca28f98b9ffff45d9141d26024ffbc33d2d7c8163144d4bd8eccc9330e3299fb7761e962517b7729f6bf9e95f248654aa8b0fccf16478baecddb428a5923fd
   languageName: node
   linkType: hard
 
@@ -34048,13 +32820,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"klona@npm:^2.0.4":
-  version: 2.0.6
-  resolution: "klona@npm:2.0.6"
-  checksum: 10c0/94eed2c6c2ce99f409df9186a96340558897b3e62a85afdc1ee39103954d2ebe1c1c4e9fe2b0952771771fa96d70055ede8b27962a7021406374fdb695fd4d01
-  languageName: node
-  linkType: hard
-
 "kuler@npm:^2.0.0":
   version: 2.0.0
   resolution: "kuler@npm:2.0.0"
@@ -34575,15 +33340,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lockfile@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "lockfile@npm:1.0.4"
-  dependencies:
-    signal-exit: "npm:^3.0.2"
-  checksum: 10c0/80b7777ceb43105d9e588733c3efc2514653a5e3a0dae3e61347a1f5381da34dcaa2caaa60c39ed5d4ad31c1735a4831e5639a0ba1c508bfea8dbc9c89777b37
-  languageName: node
-  linkType: hard
-
 "lodash-es@npm:4.17.21, lodash-es@npm:^4.17.21":
   version: 4.17.21
   resolution: "lodash-es@npm:4.17.21"
@@ -34667,20 +33423,6 @@ __metadata:
   version: 3.5.0
   resolution: "lodash.flow@npm:3.5.0"
   checksum: 10c0/b3202ddbb79e5aab41719806d0d5ae969f64ae6b59e6bdaaecaa96ec68d6ba429e544017fe0e71ecf5b7ee3cea7b45d43c46b7d67ca159d6cca86fca76c61a31
-  languageName: node
-  linkType: hard
-
-"lodash.get@npm:^4.4.2":
-  version: 4.4.2
-  resolution: "lodash.get@npm:4.4.2"
-  checksum: 10c0/48f40d471a1654397ed41685495acb31498d5ed696185ac8973daef424a749ca0c7871bf7b665d5c14f5cc479394479e0307e781f61d5573831769593411be6e
-  languageName: node
-  linkType: hard
-
-"lodash.has@npm:^4.5.2":
-  version: 4.5.2
-  resolution: "lodash.has@npm:4.5.2"
-  checksum: 10c0/3ffa9e549f321996a5fdf6204494c035ff550b2df703f936a448c553131bbb55492b4e7995bb13500648b50b268ed8afc974a7a0c0a43744d28d61cc95cb1ffe
   languageName: node
   linkType: hard
 
@@ -35106,7 +33848,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.30.11, magic-string@npm:^0.30.12, magic-string@npm:^0.30.3, magic-string@npm:^0.30.5":
+"magic-string@npm:^0.30.12, magic-string@npm:^0.30.3, magic-string@npm:^0.30.5":
   version: 0.30.14
   resolution: "magic-string@npm:0.30.14"
   dependencies:
@@ -36904,22 +35646,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-db@npm:~1.33.0":
-  version: 1.33.0
-  resolution: "mime-db@npm:1.33.0"
-  checksum: 10c0/79172ce5468c8503b49dddfdddc18d3f5fe2599f9b5fe1bc321a8cbee14c96730fc6db22f907b23701b05b2936f865795f62ec3a78a7f3c8cb2450bb68c6763e
-  languageName: node
-  linkType: hard
-
-"mime-types@npm:2.1.18":
-  version: 2.1.18
-  resolution: "mime-types@npm:2.1.18"
-  dependencies:
-    mime-db: "npm:~1.33.0"
-  checksum: 10c0/a96a8d12f4bb98bc7bfac6a8ccbd045f40368fc1030d9366050c3613825d3715d1c1f393e10a75a885d2cdc1a26cd6d5e11f3a2a0d5c4d361f00242139430a0f
-  languageName: node
-  linkType: hard
-
 "mime-types@npm:2.1.35, mime-types@npm:^2.1.12, mime-types@npm:^2.1.25, mime-types@npm:^2.1.27, mime-types@npm:^2.1.31, mime-types@npm:~2.1.17, mime-types@npm:~2.1.19, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
@@ -36998,28 +35724,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mine-sweeper-tag@npm:1.0.6":
-  version: 1.0.6
-  resolution: "mine-sweeper-tag@npm:1.0.6"
-  dependencies:
-    vue: "npm:^3.2.45"
-  checksum: 10c0/7ce5079e039680d5f9feb2879f8380684b0ab3ae748873fdfc6060d8b77f45f66054688fb3a79135b4f49c50a5c350203f29c58b6b9a571a957564fe49445d71
-  languageName: node
-  linkType: hard
-
 "minimalistic-assert@npm:^1.0.0":
   version: 1.0.1
   resolution: "minimalistic-assert@npm:1.0.1"
   checksum: 10c0/96730e5601cd31457f81a296f521eb56036e6f69133c0b18c13fe941109d53ad23a4204d946a0d638d7f3099482a0cec8c9bb6d642604612ce43ee536be3dddd
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:3.1.2, minimatch@npm:^3.0.2, minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "minimatch@npm:3.1.2"
-  dependencies:
-    brace-expansion: "npm:^1.1.7"
-  checksum: 10c0/0262810a8fc2e72cca45d6fd86bd349eee435eb95ac6aa45c9ea2180e7ee875ef44c32b55b5973ceabe95ea12682f6e3725cbb63d7a2d1da3ae1163c8b210311
   languageName: node
   linkType: hard
 
@@ -37038,6 +35746,15 @@ __metadata:
   dependencies:
     brace-expansion: "npm:^2.0.1"
   checksum: 10c0/e6c29a81fe83e1877ad51348306be2e8aeca18c88fdee7a99df44322314279e15799e41d7cb274e4e8bb0b451a3bc622d6182e157dfa1717d6cda75e9cd8cd5d
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^3.0.2, minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "minimatch@npm:3.1.2"
+  dependencies:
+    brace-expansion: "npm:^1.1.7"
+  checksum: 10c0/0262810a8fc2e72cca45d6fd86bd349eee435eb95ac6aa45c9ea2180e7ee875ef44c32b55b5973ceabe95ea12682f6e3725cbb63d7a2d1da3ae1163c8b210311
   languageName: node
   linkType: hard
 
@@ -37328,20 +36045,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mock-block-dock@npm:0.0.10":
-  version: 0.0.10
-  resolution: "mock-block-dock@npm:0.0.10"
-  dependencies:
-    blockprotocol: "npm:0.0.10"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    react: ^17.0.2
-    react-dom: ^17.0.2
-  checksum: 10c0/e8028a4ec1aa1843d425516664d7c020a4b84620f04c33c3a0cb19a1c91ea8a8b0b35200865f3a4e3009e188517cf50e8d33c91c3d908538a31369da1fc4a54b
-  languageName: node
-  linkType: hard
-
 "mock-block-dock@npm:0.0.21":
   version: 0.0.21
   resolution: "mock-block-dock@npm:0.0.21"
@@ -37356,64 +36059,6 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
   checksum: 10c0/c7887ead06cc5e55cc303414b9ddd407da851d30b310cfd1ed798afc1c7cce624e944b257b3943a8a70ecfaa5c785f49b4cb62b4cfd3c6213085ec0142cb6382
-  languageName: node
-  linkType: hard
-
-"mock-block-dock@npm:0.0.38":
-  version: 0.0.38
-  resolution: "mock-block-dock@npm:0.0.38"
-  dependencies:
-    "@blockprotocol/core": "npm:0.0.12"
-    "@blockprotocol/graph": "npm:0.0.18"
-    "@blockprotocol/hook": "npm:0.0.8"
-    "@emotion/react": "npm:^11.10.0"
-    "@emotion/styled": "npm:^11.10.0"
-    "@lit-labs/react": "npm:^1.0.4"
-    "@mui/material": "npm:^5.10.4"
-    ajv: "npm:^8.9.0"
-    echarts: "npm:^5.3.3"
-    react-json-view: "npm:^1.21.3"
-    react-resizable: "npm:^3.0.4"
-    slate: "npm:^0.82.1"
-    slate-react: "npm:^0.83.1"
-    styled-jsx: "npm:5.0.7"
-    use-local-storage-state: "npm:^18.1.1"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  checksum: 10c0/e4c2d8385f5f45aeda11e029d6e9bb0d00fcb55191ffe77b3c34eac983c6bb646fca9f5f8b311f4b177b7b5b76c57590e46f923dc3016fd3f9114ee046aa2a02
-  languageName: node
-  linkType: hard
-
-"mock-block-dock@npm:0.1.9":
-  version: 0.1.9
-  resolution: "mock-block-dock@npm:0.1.9"
-  dependencies:
-    "@blockprotocol/core": "npm:0.1.2"
-    "@blockprotocol/graph": "npm:0.3.3"
-    "@blockprotocol/hook": "npm:0.1.7"
-    "@blockprotocol/service": "npm:0.1.4"
-    "@emotion/react": "npm:^11.10.0"
-    "@emotion/styled": "npm:^11.10.0"
-    "@lit-labs/react": "npm:1.1.1"
-    "@mui/material": "npm:5.11.8"
-    ajv: "npm:^8.11.2"
-    axios: "npm:^1.6.0"
-    dotenv-webpack: "npm:^8.0.1"
-    echarts: "npm:5.4.1"
-    mime: "npm:^3.0.0"
-    react-json-view: "npm:^1.21.3"
-    react-resizable: "npm:^3.0.4"
-    slate: "npm:^0.82.1"
-    slate-react: "npm:^0.83.1"
-    styled-jsx: "npm:^5.1.0"
-    use-local-storage-state: "npm:^18.1.1"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  checksum: 10c0/6f3dfcce0595e33101b52dca42b13a4643e343f967e541e01de25fbbdcc0cd51fa2f4997938b2d8b8ac691bd80aa79977e9285d1f421a4581bdb1f0effc98af1
   languageName: node
   linkType: hard
 
@@ -39567,20 +38212,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-equal@npm:1.1.2":
-  version: 1.1.2
-  resolution: "path-equal@npm:1.1.2"
-  checksum: 10c0/5e38ddedecb14104f039105275e594cced89399807a0986fb6b5654f1f7b4407cd56720aaec7b51d80773380d68af7348dc8b7eea1dbc1747f2c74a8425244b5
-  languageName: node
-  linkType: hard
-
-"path-equal@npm:^1.1.2":
-  version: 1.2.5
-  resolution: "path-equal@npm:1.2.5"
-  checksum: 10c0/c589767af1c9021dda41f3431ee52f5779ebba6cb10c9c00f7fb71f78af8454273680007b07654a7e8322f91a649c4b5727bfb88cf31565d738bdd0cf913ec25
-  languageName: node
-  linkType: hard
-
 "path-exists@npm:^3.0.0":
   version: 3.0.0
   resolution: "path-exists@npm:3.0.0"
@@ -39609,7 +38240,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-is-inside@npm:1.0.2, path-is-inside@npm:^1.0.2":
+"path-is-inside@npm:^1.0.2":
   version: 1.0.2
   resolution: "path-is-inside@npm:1.0.2"
   checksum: 10c0/7fdd4b41672c70461cce734fc222b33e7b447fa489c7c4377c95e7e6852d83d69741f307d88ec0cc3b385b41cb4accc6efac3c7c511cd18512e95424f5fa980c
@@ -40270,7 +38901,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.3.11, postcss@npm:^8.4.14, postcss@npm:^8.4.23, postcss@npm:^8.4.33, postcss@npm:^8.4.43, postcss@npm:^8.4.48":
+"postcss@npm:^8.3.11, postcss@npm:^8.4.14, postcss@npm:^8.4.23, postcss@npm:^8.4.33, postcss@npm:^8.4.43":
   version: 8.4.49
   resolution: "postcss@npm:8.4.49"
   dependencies:
@@ -40648,7 +39279,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:15.x, prop-types@npm:^15.5.0, prop-types@npm:^15.5.8, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.5.0, prop-types@npm:^15.5.8, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -41393,13 +40024,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"range-parser@npm:1.2.0":
-  version: 1.2.0
-  resolution: "range-parser@npm:1.2.0"
-  checksum: 10c0/c7aef4f6588eb974c475649c157f197d07437d8c6c8ff7e36280a141463fb5ab7a45918417334ebd7b665c6b8321cf31c763f7631dd5f5db9372249261b8b02a
-  languageName: node
-  linkType: hard
-
 "range-parser@npm:^1.2.1, range-parser@npm:~1.2.1":
   version: 1.2.1
   resolution: "range-parser@npm:1.2.1"
@@ -41485,35 +40109,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-datepicker@npm:4.25.0":
-  version: 4.25.0
-  resolution: "react-datepicker@npm:4.25.0"
-  dependencies:
-    "@popperjs/core": "npm:^2.11.8"
-    classnames: "npm:^2.2.6"
-    date-fns: "npm:^2.30.0"
-    prop-types: "npm:^15.7.2"
-    react-onclickoutside: "npm:^6.13.0"
-    react-popper: "npm:^2.3.0"
-  peerDependencies:
-    react: ^16.9.0 || ^17 || ^18
-    react-dom: ^16.9.0 || ^17 || ^18
-  checksum: 10c0/714fc6cffdf9fa76d1a74581375acb4c86ac81e6c2cde372448ab447370b7e9ffb1840cf388020485028e7b0f43edf82c1cfd2dab7d2c6b964cdd6f4dd560e92
-  languageName: node
-  linkType: hard
-
-"react-device-detect@npm:2.2.3":
-  version: 2.2.3
-  resolution: "react-device-detect@npm:2.2.3"
-  dependencies:
-    ua-parser-js: "npm:^1.0.33"
-  peerDependencies:
-    react: ">= 0.14.0"
-    react-dom: ">= 0.14.0"
-  checksum: 10c0/396bbeeab0cb21da084c67434d204c9cf502fad6c683903313084d3f6487950a36a34f9bf67ccf5c1772a1bb5b79a2a4403fcfe6b51d93877db4c2d9f3a3a925
-  languageName: node
-  linkType: hard
-
 "react-docgen-typescript@npm:^2.2.2":
   version: 2.2.2
   resolution: "react-docgen-typescript@npm:2.2.2"
@@ -41565,19 +40160,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-draggable@npm:^4.0.3":
-  version: 4.4.6
-  resolution: "react-draggable@npm:4.4.6"
-  dependencies:
-    clsx: "npm:^1.1.1"
-    prop-types: "npm:^15.8.1"
-  peerDependencies:
-    react: ">= 16.3.0"
-    react-dom: ">= 16.3.0"
-  checksum: 10c0/1e8cf47414a8554caa68447e5f27749bc40e1eabb4806e2dadcb39ab081d263f517d6aaec5231677e6b425603037c7e3386d1549898f9ffcc98a86cabafb2b9a
-  languageName: node
-  linkType: hard
-
 "react-dropzone@npm:14.3.5":
   version: 14.3.5
   resolution: "react-dropzone@npm:14.3.5"
@@ -41611,13 +40193,6 @@ __metadata:
     react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
     react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
   checksum: 10c0/0d60a0ea758529c32a706d0c69d70b69fb94de3c46442fffdee34f08f51ffceddbb5395b41dfd1565895653e9f60f98ca525835be9d5db1f16d6b22be12f4cd4
-  languageName: node
-  linkType: hard
-
-"react-fast-compare@npm:^3.0.1":
-  version: 3.2.2
-  resolution: "react-fast-compare@npm:3.2.2"
-  checksum: 10c0/0bbd2f3eb41ab2ff7380daaa55105db698d965c396df73e6874831dbafec8c4b5b08ba36ff09df01526caa3c61595247e3269558c284e37646241cba2b90a367
   languageName: node
   linkType: hard
 
@@ -41725,18 +40300,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-laag@npm:2.0.5":
-  version: 2.0.5
-  resolution: "react-laag@npm:2.0.5"
-  dependencies:
-    tiny-warning: "npm:^1.0.3"
-  peerDependencies:
-    react: ^16.0.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/b12b112e30a4767da60466c37ed318782cbba35822294f592adb9adbe5deeea0302325ec78087376ba9add570d354f619601b77a5786460c94416385737b9bf3
-  languageName: node
-  linkType: hard
-
 "react-lifecycles-compat@npm:^3.0.4":
   version: 3.0.4
   resolution: "react-lifecycles-compat@npm:3.0.4"
@@ -41784,16 +40347,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-onclickoutside@npm:^6.13.0":
-  version: 6.13.1
-  resolution: "react-onclickoutside@npm:6.13.1"
-  peerDependencies:
-    react: ^15.5.x || ^16.x || ^17.x || ^18.x
-    react-dom: ^15.5.x || ^16.x || ^17.x || ^18.x
-  checksum: 10c0/93b02c493332ca7f8b480a1e185386c4af55d1daf33af2f68ddf440e4fc9b22ad13f59d7e204694aa31c1c2e332f0766c7ee302fe3b0cecbd0e0b45d55905c96
-  languageName: node
-  linkType: hard
-
 "react-pdf@npm:9.2.1":
   version: 9.2.1
   resolution: "react-pdf@npm:9.2.1"
@@ -41814,20 +40367,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/69b5456b3941ea08f03319a94b155db782232dee4b3e03513c4a4c10cc3d81d129fc3284136990b51d5dcf766192abc64d71e1d258ca7e0eb4e6592343fea6a4
-  languageName: node
-  linkType: hard
-
-"react-popper@npm:^2.2.5, react-popper@npm:^2.3.0":
-  version: 2.3.0
-  resolution: "react-popper@npm:2.3.0"
-  dependencies:
-    react-fast-compare: "npm:^3.0.1"
-    warning: "npm:^4.0.2"
-  peerDependencies:
-    "@popperjs/core": ^2.0.0
-    react: ^16.8.0 || ^17 || ^18
-    react-dom: ^16.8.0 || ^17 || ^18
-  checksum: 10c0/23f93540537ca4c035425bb8d5e51b11131fbc921d7ac1d041d0ae557feac8c877f3a012d36b94df8787803f52ed81e6df9257ac9e58719875f7805518d6db3f
   languageName: node
   linkType: hard
 
@@ -41942,18 +40481,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-resizable@npm:^3.0.4":
-  version: 3.0.5
-  resolution: "react-resizable@npm:3.0.5"
-  dependencies:
-    prop-types: "npm:15.x"
-    react-draggable: "npm:^4.0.3"
-  peerDependencies:
-    react: ">= 16.3"
-  checksum: 10c0/cfe50aa6efb79e0aa09bd681a5beab2fcd1186737c4952eb4c3974ed9395d5d263ccd1130961d06b8f5e24c8f544dd2967b5c740ce68719962d1771de7bdb350
-  languageName: node
-  linkType: hard
-
 "react-responsive-carousel@npm:3.2.23":
   version: 3.2.23
   resolution: "react-responsive-carousel@npm:3.2.23"
@@ -41974,18 +40501,6 @@ __metadata:
   peerDependencies:
     react: ^16.0.0 || ^17.0.0 || ^18.0.0
   checksum: 10c0/c194d741792e86043a4ae272f7353c1cb9412bc649945c4220c6a101a6ea5410cceb3d65d5a4d750f11a24f7426e8eec7977e8a4e3ad5d3ee235ca2b18166fa8
-  languageName: node
-  linkType: hard
-
-"react-sizeme@npm:3.0.2":
-  version: 3.0.2
-  resolution: "react-sizeme@npm:3.0.2"
-  dependencies:
-    element-resize-detector: "npm:^1.2.2"
-    invariant: "npm:^2.2.4"
-    shallowequal: "npm:^1.1.0"
-    throttle-debounce: "npm:^3.0.1"
-  checksum: 10c0/e6b336bbc1e9de78de5c7177afd398f6ea14c4284af698475f08d34389e9307cbc36c0125a61b158e026f182ae4dd17b13c28683bbc1a371792bccd1e51cccff
   languageName: node
   linkType: hard
 
@@ -42034,7 +40549,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-textarea-autosize@npm:8.5.7, react-textarea-autosize@npm:^8.3.2":
+"react-textarea-autosize@npm:^8.3.2":
   version: 8.5.7
   resolution: "react-textarea-autosize@npm:8.5.7"
   dependencies:
@@ -42497,7 +41012,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regenerator-runtime@npm:^0.13.2, regenerator-runtime@npm:^0.13.9":
+"regenerator-runtime@npm:^0.13.2":
   version: 0.13.11
   resolution: "regenerator-runtime@npm:0.13.11"
   checksum: 10c0/12b069dc774001fbb0014f6a28f11c09ebfe3c0d984d88c9bced77fdb6fedbacbca434d24da9ae9371bfbf23f754869307fb51a4c98a8b8b18e5ef748677ca24
@@ -43411,7 +41926,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-stable-stringify@npm:2.5.0, safe-stable-stringify@npm:^2.2.0, safe-stable-stringify@npm:^2.3.1, safe-stable-stringify@npm:^2.4.3":
+"safe-stable-stringify@npm:2.5.0, safe-stable-stringify@npm:^2.3.1, safe-stable-stringify@npm:^2.4.3":
   version: 2.5.0
   resolution: "safe-stable-stringify@npm:2.5.0"
   checksum: 10c0/baea14971858cadd65df23894a40588ed791769db21bafb7fd7608397dbdce9c5aac60748abae9995e0fc37e15f2061980501e012cd48859740796bea2987f49
@@ -43463,31 +41978,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass-loader@npm:^12.6.0":
-  version: 12.6.0
-  resolution: "sass-loader@npm:12.6.0"
-  dependencies:
-    klona: "npm:^2.0.4"
-    neo-async: "npm:^2.6.2"
-  peerDependencies:
-    fibers: ">= 3.1.0"
-    node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
-    sass: ^1.3.0
-    sass-embedded: "*"
-    webpack: ^5.0.0
-  peerDependenciesMeta:
-    fibers:
-      optional: true
-    node-sass:
-      optional: true
-    sass:
-      optional: true
-    sass-embedded:
-      optional: true
-  checksum: 10c0/e1ef655f3898cc4c45f02b3c627f8baf998139993a9a79c524153a80814282bfe20d8d8d703b8cf1d05457c1930940b65e2156d11285ed0861f9a1016f993e53
-  languageName: node
-  linkType: hard
-
 "sass-lookup@npm:^5.0.1":
   version: 5.0.1
   resolution: "sass-lookup@npm:5.0.1"
@@ -43499,7 +41989,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass@npm:1.83.4, sass@npm:^1.52.3":
+"sass@npm:1.83.4":
   version: 1.83.4
   resolution: "sass@npm:1.83.4"
   dependencies:
@@ -43555,18 +42045,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"schema-utils@npm:^2.6.5":
-  version: 2.7.1
-  resolution: "schema-utils@npm:2.7.1"
-  dependencies:
-    "@types/json-schema": "npm:^7.0.5"
-    ajv: "npm:^6.12.4"
-    ajv-keywords: "npm:^3.5.2"
-  checksum: 10c0/f484f34464edd8758712d5d3ba25a306e367dac988aecaf4ce112e99baae73f33a807b5cf869240bb6648c80720b36af2d7d72be3a27faa49a2d4fc63fa3f85f
-  languageName: node
-  linkType: hard
-
-"schema-utils@npm:^3.0.0, schema-utils@npm:^3.1.1, schema-utils@npm:^3.2.0, schema-utils@npm:^3.3.0":
+"schema-utils@npm:^3.0.0, schema-utils@npm:^3.1.1, schema-utils@npm:^3.2.0":
   version: 3.3.0
   resolution: "schema-utils@npm:3.3.0"
   dependencies:
@@ -43586,15 +42065,6 @@ __metadata:
     ajv-formats: "npm:^2.1.1"
     ajv-keywords: "npm:^5.1.0"
   checksum: 10c0/c23f0fa73ef71a01d4a2bb7af4c91e0d356ec640e071aa2d06ea5e67f042962bb7ac7c29a60a295bb0125878801bc3209197a2b8a833dd25bd38e37c3ed21427
-  languageName: node
-  linkType: hard
-
-"scroll-into-view-if-needed@npm:^2.2.20":
-  version: 2.2.31
-  resolution: "scroll-into-view-if-needed@npm:2.2.31"
-  dependencies:
-    compute-scroll-into-view: "npm:^1.0.20"
-  checksum: 10c0/d44c518479505e37ab5b8b4a5aef9130edd8745f8ba9ca291ff0d8358bc89b63da8c30434f35c097384e455702bfe4acbe8b82dfb8b860a971adcae084c5b2f7
   languageName: node
   linkType: hard
 
@@ -43794,21 +42264,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serve-handler@npm:^6.1.3":
-  version: 6.1.6
-  resolution: "serve-handler@npm:6.1.6"
-  dependencies:
-    bytes: "npm:3.0.0"
-    content-disposition: "npm:0.5.2"
-    mime-types: "npm:2.1.18"
-    minimatch: "npm:3.1.2"
-    path-is-inside: "npm:1.0.2"
-    path-to-regexp: "npm:3.3.0"
-    range-parser: "npm:1.2.0"
-  checksum: 10c0/1e1cb6bbc51ee32bc1505f2e0605bdc2e96605c522277c977b67f83be9d66bd1eec8604388714a4d728e036d86b629bc9aec02120ea030d3d2c3899d44696503
-  languageName: node
-  linkType: hard
-
 "serve-index@npm:^1.9.1":
   version: 1.9.1
   resolution: "serve-index@npm:1.9.1"
@@ -43939,7 +42394,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shallowequal@npm:1.1.0, shallowequal@npm:^1.1.0":
+"shallowequal@npm:1.1.0":
   version: 1.1.0
   resolution: "shallowequal@npm:1.1.0"
   checksum: 10c0/b926efb51cd0f47aa9bc061add788a4a650550bbe50647962113a4579b60af2abe7b62f9b02314acc6f97151d4cf87033a2b15fc20852fae306d1a095215396c
@@ -44302,13 +42757,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"slash@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "slash@npm:2.0.0"
-  checksum: 10c0/f83dbd3cb62c41bb8fcbbc6bf5473f3234b97fa1d008f571710a9d3757a28c7169e1811cad1554ccb1cc531460b3d221c9a7b37f549398d9a30707f0a5af9193
-  languageName: node
-  linkType: hard
-
 "slash@npm:^3.0.0":
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
@@ -44334,37 +42782,6 @@ __metadata:
   version: 3.0.12
   resolution: "slashes@npm:3.0.12"
   checksum: 10c0/71ca2a1fcd1ab6814b0fdb8cf9c33a3d54321deec2aa8d173510f0086880201446021a9b9e6a18561f7c472b69a2145977c6a8fb9c53a8ff7be31778f203d175
-  languageName: node
-  linkType: hard
-
-"slate-react@npm:^0.83.1":
-  version: 0.83.2
-  resolution: "slate-react@npm:0.83.2"
-  dependencies:
-    "@types/is-hotkey": "npm:^0.1.1"
-    "@types/lodash": "npm:^4.14.149"
-    direction: "npm:^1.0.3"
-    is-hotkey: "npm:^0.1.6"
-    is-plain-object: "npm:^5.0.0"
-    lodash: "npm:^4.17.4"
-    scroll-into-view-if-needed: "npm:^2.2.20"
-    tiny-invariant: "npm:1.0.6"
-  peerDependencies:
-    react: ">=16.8.0"
-    react-dom: ">=16.8.0"
-    slate: ">=0.65.3"
-  checksum: 10c0/622902c3b2f7acda423044fdb5558851bd694c36e9cb938223dcda7a220df99a03c381f26db0044cc6b885009a528f4f597290d1e00258c4368ab9ab73eb227f
-  languageName: node
-  linkType: hard
-
-"slate@npm:^0.82.1":
-  version: 0.82.1
-  resolution: "slate@npm:0.82.1"
-  dependencies:
-    immer: "npm:^9.0.6"
-    is-plain-object: "npm:^5.0.0"
-    tiny-warning: "npm:^1.0.3"
-  checksum: 10c0/f0d64467c66f4399de147c16c6232ea4e4defea1f9ae0e0e6adedb910fa3af5005af94f1f852a68cefc3145651e1c1227dd455ca81b00b8681188fcba18216b6
   languageName: node
   linkType: hard
 
@@ -45419,13 +43836,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"style-vendorizer@npm:^2.0.0":
-  version: 2.2.3
-  resolution: "style-vendorizer@npm:2.2.3"
-  checksum: 10c0/62892cbfe9a1ccb23ef096c320d0c59e01a93d8999c7286db4a2051ee9296210f8d982af5aeb7b6a1e4d6f5bce80036f479a570b407fe5a4174580026fc11fe7
-  languageName: node
-  linkType: hard
-
 "styled-components@npm:^6.0.7":
   version: 6.1.13
   resolution: "styled-components@npm:6.1.13"
@@ -45446,21 +43856,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"styled-jsx@npm:5.0.7":
-  version: 5.0.7
-  resolution: "styled-jsx@npm:5.0.7"
-  peerDependencies:
-    react: ">= 16.8.0 || 17.x.x || ^18.0.0-0"
-  peerDependenciesMeta:
-    "@babel/core":
-      optional: true
-    babel-plugin-macros:
-      optional: true
-  checksum: 10c0/eb6f388c7611468bb0ba48ecb0d0b269de4a0079ebeea56c5157552a414f00d575bfa1c37dd07eed5bff6547462b496f12b448dedeca386f778f1ccb2cf8b4ef
-  languageName: node
-  linkType: hard
-
-"styled-jsx@npm:5.1.6, styled-jsx@npm:^5.1.0":
+"styled-jsx@npm:5.1.6":
   version: 5.1.6
   resolution: "styled-jsx@npm:5.1.6"
   dependencies:
@@ -46075,13 +44471,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"throttle-debounce@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "throttle-debounce@npm:3.0.1"
-  checksum: 10c0/c8e558479463b7ed8bac30d6b10cc87abd1c9fc64edfce2db4109be1a04acaef5d2d0557f49c1a3845ea07d9f79e6e0389b1b60db0a77c44e5b7a1216596f285
-  languageName: node
-  linkType: hard
-
 "through2@npm:^2.0.3":
   version: 2.0.5
   resolution: "through2@npm:2.0.5"
@@ -46161,24 +44550,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-invariant@npm:1.0.6":
-  version: 1.0.6
-  resolution: "tiny-invariant@npm:1.0.6"
-  checksum: 10c0/37ca64a84b71ff34545466dfb511d206f329a262d3dd1e3ac93db485c23e06c685670437e24c07cb06bba4cf1f75e44ae6cd8f2f30502556b33a71ef2762aeb5
-  languageName: node
-  linkType: hard
-
 "tiny-invariant@npm:^1.0.0, tiny-invariant@npm:^1.0.6, tiny-invariant@npm:^1.3.1, tiny-invariant@npm:^1.3.3":
   version: 1.3.3
   resolution: "tiny-invariant@npm:1.3.3"
   checksum: 10c0/65af4a07324b591a059b35269cd696aba21bef2107f29b9f5894d83cc143159a204b299553435b03874ebb5b94d019afa8b8eff241c8a4cfee95872c2e1c1c4a
-  languageName: node
-  linkType: hard
-
-"tiny-warning@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "tiny-warning@npm:1.0.3"
-  checksum: 10c0/ef8531f581b30342f29670cb41ca248001c6fd7975ce22122bd59b8d62b4fc84ad4207ee7faa95cde982fa3357cd8f4be650142abc22805538c3b1392d7084fa
   languageName: node
   linkType: hard
 
@@ -46552,44 +44927,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-node@npm:^10.2.1, ts-node@npm:^10.9.1":
-  version: 10.9.2
-  resolution: "ts-node@npm:10.9.2"
-  dependencies:
-    "@cspotcode/source-map-support": "npm:^0.8.0"
-    "@tsconfig/node10": "npm:^1.0.7"
-    "@tsconfig/node12": "npm:^1.0.7"
-    "@tsconfig/node14": "npm:^1.0.0"
-    "@tsconfig/node16": "npm:^1.0.2"
-    acorn: "npm:^8.4.1"
-    acorn-walk: "npm:^8.1.1"
-    arg: "npm:^4.1.0"
-    create-require: "npm:^1.1.0"
-    diff: "npm:^4.0.1"
-    make-error: "npm:^1.1.1"
-    v8-compile-cache-lib: "npm:^3.0.1"
-    yn: "npm:3.1.1"
-  peerDependencies:
-    "@swc/core": ">=1.2.50"
-    "@swc/wasm": ">=1.2.50"
-    "@types/node": "*"
-    typescript: ">=2.7"
-  peerDependenciesMeta:
-    "@swc/core":
-      optional: true
-    "@swc/wasm":
-      optional: true
-  bin:
-    ts-node: dist/bin.js
-    ts-node-cwd: dist/bin-cwd.js
-    ts-node-esm: dist/bin-esm.js
-    ts-node-script: dist/bin-script.js
-    ts-node-transpile-only: dist/bin-transpile.js
-    ts-script: dist/bin-script-deprecated.js
-  checksum: 10c0/5f29938489f96982a25ba650b64218e83a3357d76f7bede80195c65ab44ad279c8357264639b7abdd5d7e75fc269a83daa0e9c62fd8637a3def67254ecc9ddc2
-  languageName: node
-  linkType: hard
-
 "ts-pattern@npm:^5.5.0":
   version: 5.5.0
   resolution: "ts-pattern@npm:5.5.0"
@@ -46865,22 +45202,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"twind@npm:0.16.19":
-  version: 0.16.19
-  resolution: "twind@npm:0.16.19"
-  dependencies:
-    csstype: "npm:^3.0.5"
-    htmlparser2: "npm:^6.0.0"
-    style-vendorizer: "npm:^2.0.0"
-  peerDependencies:
-    typescript: ^4.1.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10c0/37bc5a514f8a777b2f01b46e273aa08df5f40910445a6656addda2d33264da61cecb87f6835a2e5b706ca5caa7f370a3def841562469f3f247ea9c08b2a7d632
-  languageName: node
-  linkType: hard
-
 "type-check@npm:^0.4.0, type-check@npm:~0.4.0":
   version: 0.4.0
   resolution: "type-check@npm:0.4.0"
@@ -47081,52 +45402,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-json-schema@npm:^0.53.0":
-  version: 0.53.1
-  resolution: "typescript-json-schema@npm:0.53.1"
-  dependencies:
-    "@types/json-schema": "npm:^7.0.9"
-    "@types/node": "npm:^16.9.2"
-    glob: "npm:^7.1.7"
-    path-equal: "npm:1.1.2"
-    safe-stable-stringify: "npm:^2.2.0"
-    ts-node: "npm:^10.2.1"
-    typescript: "npm:~4.6.0"
-    yargs: "npm:^17.1.1"
-  bin:
-    typescript-json-schema: bin/typescript-json-schema
-  checksum: 10c0/28eb19d030cb99dfb02b532ed21723998887c0e9d7235fb7dc60d4ee1071e66c4919f7bed256be232d126361a2ee12bc44de5068cb37b88a3062b61f50054033
-  languageName: node
-  linkType: hard
-
-"typescript-json-schema@npm:^0.55.0":
-  version: 0.55.0
-  resolution: "typescript-json-schema@npm:0.55.0"
-  dependencies:
-    "@types/json-schema": "npm:^7.0.9"
-    "@types/node": "npm:^16.9.2"
-    glob: "npm:^7.1.7"
-    path-equal: "npm:^1.1.2"
-    safe-stable-stringify: "npm:^2.2.0"
-    ts-node: "npm:^10.9.1"
-    typescript: "npm:~4.8.2"
-    yargs: "npm:^17.1.1"
-  bin:
-    typescript-json-schema: bin/typescript-json-schema
-  checksum: 10c0/15e40dc8d3e8d4ad179297565a054f766ceb857a4ee948ad83354aa682731016dc94f0e57adbb1c6fb302f55af58162f5bbad84a856dec90052524f9ee876b4c
-  languageName: node
-  linkType: hard
-
-"typescript@npm:4.7.2":
-  version: 4.7.2
-  resolution: "typescript@npm:4.7.2"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/c458df58a52f1cb1c954109dbc3477abfeb632644bc6552a9ac2152bce86e377afe11bf661466926bc4dcdc945f1e053d492c347ae377f1cba7051226b930ea3
-  languageName: node
-  linkType: hard
-
 "typescript@npm:4.9.4":
   version: 4.9.4
   resolution: "typescript@npm:4.9.4"
@@ -47164,36 +45439,6 @@ __metadata:
     tsc: ./bin/tsc
     tsserver: ./bin/tsserver
   checksum: 10c0/fae6b38fae5d619b9252fcd134c54c369b67f70603c8b045dd7e61cdbe0ad9357730529c532849e9b1cacb19296f1a9281b85bbf9c06c35d7db9769015556c66
-  languageName: node
-  linkType: hard
-
-"typescript@npm:~4.6.0":
-  version: 4.6.4
-  resolution: "typescript@npm:4.6.4"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/92e2c0328485a4f7bd7435f5b105f03addff32f867e241dc3be8c372ed801a138c732d9a55697696d2f82a80dd6ad4bddff1ad6b0d1884bf4a24b92e71094c44
-  languageName: node
-  linkType: hard
-
-"typescript@npm:~4.8.2":
-  version: 4.8.4
-  resolution: "typescript@npm:4.8.4"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/663bf455b21ac024e719bb8c6a07bcaaa027a9943abfb58a694b59789e7d08578badb5556170267ad480e31786b8b4c8ab3c9c0e597d3b8df39af800e43c6ed5
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A4.7.2#optional!builtin<compat/typescript>":
-  version: 4.7.2
-  resolution: "typescript@patch:typescript@npm%3A4.7.2#optional!builtin<compat/typescript>::version=4.7.2&hash=65a307"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/f454730aef4a8cef2ad5650ce769f38ed4460583fe5867d4f93592282afdbd9b5142b75d448b647e4984edf23575ac1f2adafb2db8614f253f700721d3eb439a
   languageName: node
   linkType: hard
 
@@ -47237,26 +45482,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~4.6.0#optional!builtin<compat/typescript>":
-  version: 4.6.4
-  resolution: "typescript@patch:typescript@npm%3A4.6.4#optional!builtin<compat/typescript>::version=4.6.4&hash=5d3a66"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/0e3fa814d454942a689daf4c00f82328d323e7ecd4077e3265d45375e64642611631f4c882a71be87774468ba03793e9b8ff4bccfac3018194a9e36d8f72c251
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A~4.8.2#optional!builtin<compat/typescript>":
-  version: 4.8.4
-  resolution: "typescript@patch:typescript@npm%3A4.8.4#optional!builtin<compat/typescript>::version=4.8.4&hash=1a91c8"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/eecab597a5a8c6e7f14804f1447cfce02e214e32c02efcfe5219c94290e3d572490e8a0d8033fd075ac429d35babf85182541a50c50bfb0c21df33c59fb9bf82
-  languageName: node
-  linkType: hard
-
 "typical@npm:^2.6.0, typical@npm:^2.6.1":
   version: 2.6.1
   resolution: "typical@npm:2.6.1"
@@ -47264,7 +45489,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ua-parser-js@npm:^1.0.33, ua-parser-js@npm:^1.0.35":
+"ua-parser-js@npm:^1.0.35":
   version: 1.0.39
   resolution: "ua-parser-js@npm:1.0.39"
   bin:
@@ -47990,16 +46215,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-local-storage-state@npm:^18.1.1":
-  version: 18.3.3
-  resolution: "use-local-storage-state@npm:18.3.3"
-  peerDependencies:
-    react: ">=18"
-    react-dom: ">=18"
-  checksum: 10c0/d62ece98bd8b066c891d13f87954dfd532dea9594a4a0355a0b8e41ee0e81c334ab747e6e0c27bd4dbdd37a22e3a7cf004853a49a3b694461ab23d9cd1de7294
-  languageName: node
-  linkType: hard
-
 "use-memo-one@npm:^1.1.1":
   version: 1.1.3
   resolution: "use-memo-one@npm:1.1.3"
@@ -48429,24 +46644,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue@npm:^3.2.45":
-  version: 3.5.13
-  resolution: "vue@npm:3.5.13"
-  dependencies:
-    "@vue/compiler-dom": "npm:3.5.13"
-    "@vue/compiler-sfc": "npm:3.5.13"
-    "@vue/runtime-dom": "npm:3.5.13"
-    "@vue/server-renderer": "npm:3.5.13"
-    "@vue/shared": "npm:3.5.13"
-  peerDependencies:
-    typescript: "*"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10c0/4bbb5caf3f04fed933b01c100804f3693ff902984a3152ea1359a972264fa3240f6551d32f0163a79c64df3715b4d6691818c9f652cdd41b2473c69e2b0a373d
-  languageName: node
-  linkType: hard
-
 "w3c-keyname@npm:^2.2.0":
   version: 2.2.8
   resolution: "w3c-keyname@npm:2.2.8"
@@ -48504,7 +46701,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"warning@npm:^4.0.0, warning@npm:^4.0.2":
+"warning@npm:^4.0.0":
   version: 4.0.3
   resolution: "warning@npm:4.0.3"
   dependencies:
@@ -48620,23 +46817,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-assets-manifest@npm:^5.1.0":
-  version: 5.2.1
-  resolution: "webpack-assets-manifest@npm:5.2.1"
-  dependencies:
-    chalk: "npm:^4.1.2"
-    deepmerge: "npm:^4.3.1"
-    lockfile: "npm:^1.0.4"
-    lodash.get: "npm:^4.4.2"
-    lodash.has: "npm:^4.5.2"
-    schema-utils: "npm:^3.3.0"
-    tapable: "npm:^2.2.1"
-  peerDependencies:
-    webpack: ^5.2.0
-  checksum: 10c0/3ee9380d5d5efca3c3a3dd8c98dc06eeddddfb797d3e6714e1cef1bbdf4db10191ec9c6c6cca96ff698851336d5f64aa83a4fd64bc6530afc38fc27cf166cbdc
-  languageName: node
-  linkType: hard
-
 "webpack-bundle-analyzer@npm:4.10.1":
   version: 4.10.1
   resolution: "webpack-bundle-analyzer@npm:4.10.1"
@@ -48660,29 +46840,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-bundle-analyzer@npm:^4.5.0, webpack-bundle-analyzer@npm:^4.8.0":
-  version: 4.10.2
-  resolution: "webpack-bundle-analyzer@npm:4.10.2"
-  dependencies:
-    "@discoveryjs/json-ext": "npm:0.5.7"
-    acorn: "npm:^8.0.4"
-    acorn-walk: "npm:^8.0.0"
-    commander: "npm:^7.2.0"
-    debounce: "npm:^1.2.1"
-    escape-string-regexp: "npm:^4.0.0"
-    gzip-size: "npm:^6.0.0"
-    html-escaper: "npm:^2.0.2"
-    opener: "npm:^1.5.2"
-    picocolors: "npm:^1.0.0"
-    sirv: "npm:^2.0.3"
-    ws: "npm:^7.3.1"
-  bin:
-    webpack-bundle-analyzer: lib/bin/analyzer.js
-  checksum: 10c0/00603040e244ead15b2d92981f0559fa14216381349412a30070a7358eb3994cd61a8221d34a3b3fb8202dc3d1c5ee1fbbe94c5c52da536e5b410aa1cf279a48
-  languageName: node
-  linkType: hard
-
-"webpack-cli@npm:4.10.0, webpack-cli@npm:^4.9.2":
+"webpack-cli@npm:4.10.0":
   version: 4.10.0
   resolution: "webpack-cli@npm:4.10.0"
   dependencies:
@@ -48748,7 +46906,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-dev-server@npm:4.15.2, webpack-dev-server@npm:^4.11.1, webpack-dev-server@npm:^4.8.1":
+"webpack-dev-server@npm:4.15.2":
   version: 4.15.2
   resolution: "webpack-dev-server@npm:4.15.2"
   dependencies:
@@ -48838,7 +46996,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:5, webpack@npm:5.97.1, webpack@npm:^5.72.0, webpack@npm:^5.76.0, webpack@npm:^5.94.0":
+"webpack@npm:5, webpack@npm:5.97.1, webpack@npm:^5.94.0":
   version: 5.97.1
   resolution: "webpack@npm:5.97.1"
   dependencies:
@@ -49590,20 +47748,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:21.0.1":
-  version: 21.0.1
-  resolution: "yargs-parser@npm:21.0.1"
-  checksum: 10c0/384ca19e113a053bb7858cf47f891e630c10ea6ad91f9ad7cae84ea1cdfb09b155a2d0fa97b51116ee6f01e038faaa6c46964953afecd453fa64a761bb87475f
-  languageName: node
-  linkType: hard
-
-"yargs-parser@npm:21.1.1, yargs-parser@npm:^21.1.1":
-  version: 21.1.1
-  resolution: "yargs-parser@npm:21.1.1"
-  checksum: 10c0/f84b5e48169479d2f402239c59f084cfd1c3acc197a05c59b98bab067452e6b3ea46d4dd8ba2985ba7b3d32a343d77df0debd6b343e5dae3da2aab2cdf5886b2
-  languageName: node
-  linkType: hard
-
 "yargs-parser@npm:^11.1.1":
   version: 11.1.1
   resolution: "yargs-parser@npm:11.1.1"
@@ -49631,6 +47775,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yargs-parser@npm:^21.1.1":
+  version: 21.1.1
+  resolution: "yargs-parser@npm:21.1.1"
+  checksum: 10c0/f84b5e48169479d2f402239c59f084cfd1c3acc197a05c59b98bab067452e6b3ea46d4dd8ba2985ba7b3d32a343d77df0debd6b343e5dae3da2aab2cdf5886b2
+  languageName: node
+  linkType: hard
+
 "yargs@npm:17.0.1":
   version: 17.0.1
   resolution: "yargs@npm:17.0.1"
@@ -49646,7 +47797,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:17.7.2, yargs@npm:^17.0.0, yargs@npm:^17.0.1, yargs@npm:^17.1.1, yargs@npm:^17.7.1, yargs@npm:^17.7.2":
+"yargs@npm:17.7.2, yargs@npm:^17.0.0, yargs@npm:^17.0.1, yargs@npm:^17.7.1, yargs@npm:^17.7.2":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:
@@ -49731,13 +47882,6 @@ __metadata:
   dependencies:
     buffer-crc32: "npm:~0.2.3"
   checksum: 10c0/61a14fcf47246f1a667509809e1034d9548ef7a57cec94bc0395fa0ba74beaa6a412783b99ae59ee33e26e611929b909734f0aa5d1b32f811b206917f85fe87a
-  languageName: node
-  linkType: hard
-
-"yn@npm:3.1.1":
-  version: 3.1.1
-  resolution: "yn@npm:3.1.1"
-  checksum: 10c0/0732468dd7622ed8a274f640f191f3eaf1f39d5349a1b72836df484998d7d9807fbea094e2f5486d6b0cd2414aad5775972df0e68f8604db89a239f0f4bf7443
   languageName: node
   linkType: hard
 
@@ -49828,15 +47972,6 @@ __metadata:
   version: 3.24.1
   resolution: "zod@npm:3.24.1"
   checksum: 10c0/0223d21dbaa15d8928fe0da3b54696391d8e3e1e2d0283a1a070b5980a1dbba945ce631c2d1eccc088fdbad0f2dfa40155590bf83732d3ac4fcca2cc9237591b
-  languageName: node
-  linkType: hard
-
-"zrender@npm:5.4.1":
-  version: 5.4.1
-  resolution: "zrender@npm:5.4.1"
-  dependencies:
-    tslib: "npm:2.3.0"
-  checksum: 10c0/61d4e451c4a54637f5854e26b77a215dd4969e55e5f3c80836072ddf6651ae5b926d5ce73c4deaa326ec0a4bf0ec47e4d8184740fc01c8f8fea0f6d8f120c5d6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
 
We're doing a migration that involves renaming types and updating some of them to refer to more appropriate data types.

This means block codegen currently fails, because some types in Block Protocol refer to types in HASH that don't yet exist.

This PR excludes blocks from workspaces and therefore CI until the migration is complete.