### PR TITLE
H-3906: Add query endpoint for data type conversion targets

### DIFF
--- a/apps/hash-api/src/graph/ontology/primitive/data-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/data-type.ts
@@ -1,5 +1,6 @@
 import type {
   BaseUrl,
+  ConversionDefinition,
   Conversions,
   VersionedUrl,
 } from "@blockprotocol/type-system";
@@ -25,6 +26,7 @@ import type { OwnedById } from "@local/hash-graph-types/web";
 import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { generateTypeId } from "@local/hash-isomorphic-utils/ontology-types";
 import {
+  mapGraphApiDataTypeConversions,
   mapGraphApiDataTypesToDataTypes,
   mapGraphApiSubgraphToSubgraph,
 } from "@local/hash-isomorphic-utils/subgraph-mapping";
@@ -279,6 +281,19 @@ export const unarchiveDataType: ImpureGraphFunction<
 
   return temporalMetadata;
 };
+
+export const getDataTypeConversionTargets: ImpureGraphFunction<
+  { dataTypeId: VersionedUrl },
+  Promise<
+    Record<
+      VersionedUrl,
+      [ConversionDefinition] | [ConversionDefinition, ConversionDefinition]
+    >
+  >
+> = async ({ graphApi }, { actorId }, params) =>
+  graphApi
+    .getDataTypeConversionTargets(actorId, params)
+    .then(({ data }) => mapGraphApiDataTypeConversions(data.conversions));
 
 export const getDataTypeAuthorizationRelationships: ImpureGraphFunction<
   { dataTypeId: VersionedUrl },

--- a/libs/@local/graph/api/openapi/openapi.json
+++ b/libs/@local/graph/api/openapi/openapi.json
@@ -566,6 +566,51 @@
         }
       }
     },
+    "/data-types/query/conversions": {
+      "post": {
+        "tags": [
+          "Graph",
+          "DataType"
+        ],
+        "operationId": "get_data_type_conversion_targets",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccountId"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetDataTypeConversionTargetsParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetDataTypeConversionTargetsResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Store error occurred"
+          }
+        }
+      }
+    },
     "/data-types/query/subgraph": {
       "post": {
         "tags": [
@@ -5532,6 +5577,35 @@
           },
           "entityType": {
             "$ref": "#/components/schemas/ClosedMultiEntityType"
+          }
+        }
+      },
+      "GetDataTypeConversionTargetsParams": {
+        "type": "object",
+        "required": [
+          "dataTypeId"
+        ],
+        "properties": {
+          "dataTypeId": {
+            "$ref": "#/components/schemas/VersionedUrl"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetDataTypeConversionTargetsResponse": {
+        "type": "object",
+        "required": [
+          "conversions"
+        ],
+        "properties": {
+          "conversions": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ConversionDefinition"
+              }
+            }
           }
         }
       },

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
@@ -13,7 +13,8 @@ use hash_graph_authorization::{
 use hash_graph_store::{
     data_type::{
         ArchiveDataTypeParams, CountDataTypesParams, CreateDataTypeParams, DataTypeQueryPath,
-        DataTypeStore, GetDataTypeSubgraphParams, GetDataTypeSubgraphResponse, GetDataTypesParams,
+        DataTypeStore, GetDataTypeConversionTargetsParams, GetDataTypeConversionTargetsResponse,
+        GetDataTypeSubgraphParams, GetDataTypeSubgraphResponse, GetDataTypesParams,
         GetDataTypesResponse, UnarchiveDataTypeParams, UpdateDataTypeEmbeddingParams,
         UpdateDataTypesParams,
     },
@@ -1086,6 +1087,105 @@ where
             .change_context(UpdateError)?;
 
         Ok(())
+    }
+
+    #[tracing::instrument(level = "info", skip(self))]
+    async fn get_data_type_conversion_targets(
+        &self,
+        actor_id: AccountId,
+        params: GetDataTypeConversionTargetsParams<'_>,
+    ) -> Result<GetDataTypeConversionTargetsResponse, Report<QueryError>> {
+        let mut response = GetDataTypeConversionTargetsResponse {
+            conversions: HashMap::new(),
+        };
+
+        let data_type_uuid = DataTypeUuid::from_url(&params.data_type_id);
+
+        self.authorization_api
+            .check_data_type_permission(
+                actor_id,
+                DataTypePermission::View,
+                data_type_uuid,
+                Consistency::FullyConsistent,
+            )
+            .await
+            .change_context(QueryError)?
+            .assert_permission()
+            .change_context(QueryError)?;
+
+        // Get the conversions between non-canonical data types to other non-canonical data types
+        response.conversions.extend(self.as_client()
+            .query(
+                r#"
+                    SELECT target_ids.base_url, target_ids.version, conversion_a."into", conversion_b."from"
+                    FROM data_type_conversions AS conversion_a
+                    JOIN data_type_conversions AS conversion_b ON conversion_a.target_data_type_base_url = conversion_b.target_data_type_base_url AND conversion_a.source_data_type_ontology_id != conversion_b.source_data_type_ontology_id
+                    JOIN ontology_ids AS target_ids ON target_ids.ontology_id = conversion_b.source_data_type_ontology_id
+                    WHERE conversion_a.source_data_type_ontology_id = $1;
+                "#,
+                &[&data_type_uuid],
+            )
+            .await
+            .change_context(QueryError)?.into_iter().map(|row| {
+                (VersionedUrl {
+                    base_url: row.get(0),
+                    version: row.get(1),
+                }, vec![row.get(2), row.get(3)])
+            }));
+
+        // Get the conversions between non-canonical data types to canonical data types
+        response.conversions.extend(
+            self.as_client()
+                .query(
+                    r#"
+                        SELECT base_url, version, "into"
+                        FROM data_type_conversions
+                        JOIN ontology_ids ON ontology_ids.base_url = target_data_type_base_url
+                        WHERE source_data_type_ontology_id = $1;
+                    "#,
+                    &[&data_type_uuid],
+                )
+                .await
+                .change_context(QueryError)?
+                .into_iter()
+                .map(|row| {
+                    (
+                        VersionedUrl {
+                            base_url: row.get(0),
+                            version: row.get(1),
+                        },
+                        vec![row.get(2)],
+                    )
+                }),
+        );
+
+        // Get the conversions between canonical data types to non-canonical data types
+        response.conversions.extend(
+            self.as_client()
+                .query(
+                    r#"
+                        SELECT base_url, version, "from"
+                        FROM data_type_conversions
+                        JOIN ontology_ids ON ontology_id = source_data_type_ontology_id
+                        WHERE target_data_type_base_url = $1;
+                    "#,
+                    &[&params.data_type_id.base_url],
+                )
+                .await
+                .change_context(QueryError)?
+                .into_iter()
+                .map(|row| {
+                    (
+                        VersionedUrl {
+                            base_url: row.get(0),
+                            version: row.get(1),
+                        },
+                        vec![row.get(2)],
+                    )
+                }),
+        );
+
+        Ok(response)
     }
 
     #[tracing::instrument(level = "info", skip(self))]

--- a/libs/@local/graph/store/src/data_type/mod.rs
+++ b/libs/@local/graph/store/src/data_type/mod.rs
@@ -3,6 +3,7 @@ pub use self::{
     query::{DataTypeQueryPath, DataTypeQueryToken},
     store::{
         ArchiveDataTypeParams, CountDataTypesParams, CreateDataTypeParams, DataTypeStore,
+        GetDataTypeConversionTargetsParams, GetDataTypeConversionTargetsResponse,
         GetDataTypeSubgraphParams, GetDataTypeSubgraphResponse, GetDataTypesParams,
         GetDataTypesResponse, UnarchiveDataTypeParams, UpdateDataTypeEmbeddingParams,
         UpdateDataTypesParams,

--- a/libs/@local/graph/store/src/data_type/store.rs
+++ b/libs/@local/graph/store/src/data_type/store.rs
@@ -15,7 +15,7 @@ use hash_graph_types::{
 };
 use serde::{Deserialize, Serialize};
 use type_system::{
-    schema::{Conversions, DataType},
+    schema::{ConversionDefinition, Conversions, DataType},
     url::{BaseUrl, VersionedUrl},
 };
 
@@ -144,6 +144,21 @@ pub struct UpdateDataTypeEmbeddingParams<'a> {
     pub reset: bool,
 }
 
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GetDataTypeConversionTargetsParams<'a> {
+    #[serde(borrow)]
+    pub data_type_id: Cow<'a, VersionedUrl>,
+}
+
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct GetDataTypeConversionTargetsResponse {
+    pub conversions: HashMap<VersionedUrl, Vec<ConversionDefinition>>,
+}
+
 /// Describes the API of a store implementation for [`DataType`]s.
 pub trait DataTypeStore {
     /// Creates a new [`DataType`].
@@ -254,16 +269,20 @@ pub trait DataTypeStore {
     fn unarchive_data_type(
         &mut self,
         actor_id: AccountId,
-
         params: UnarchiveDataTypeParams,
     ) -> impl Future<Output = Result<OntologyTemporalMetadata, Report<UpdateError>>> + Send;
 
     fn update_data_type_embeddings(
         &mut self,
         actor_id: AccountId,
-
         params: UpdateDataTypeEmbeddingParams<'_>,
     ) -> impl Future<Output = Result<(), Report<UpdateError>>> + Send;
+
+    fn get_data_type_conversion_targets(
+        &self,
+        actor_id: AccountId,
+        params: GetDataTypeConversionTargetsParams<'_>,
+    ) -> impl Future<Output = Result<GetDataTypeConversionTargetsResponse, Report<QueryError>>> + Send;
 
     /// Re-indexes the cache for data types.
     ///

--- a/libs/@local/graph/type-fetcher/src/store.rs
+++ b/libs/@local/graph/type-fetcher/src/store.rs
@@ -20,6 +20,7 @@ use hash_graph_store::{
     },
     data_type::{
         ArchiveDataTypeParams, CountDataTypesParams, CreateDataTypeParams, DataTypeStore,
+        GetDataTypeConversionTargetsParams, GetDataTypeConversionTargetsResponse,
         GetDataTypeSubgraphParams, GetDataTypeSubgraphResponse, GetDataTypesParams,
         GetDataTypesResponse, UnarchiveDataTypeParams, UpdateDataTypeEmbeddingParams,
         UpdateDataTypesParams,
@@ -910,6 +911,16 @@ where
     ) -> Result<(), Report<UpdateError>> {
         self.store
             .update_data_type_embeddings(actor_id, params)
+            .await
+    }
+
+    async fn get_data_type_conversion_targets(
+        &self,
+        actor_id: AccountId,
+        params: GetDataTypeConversionTargetsParams<'_>,
+    ) -> Result<GetDataTypeConversionTargetsResponse, Report<QueryError>> {
+        self.store
+            .get_data_type_conversion_targets(actor_id, params)
             .await
     }
 

--- a/libs/@local/hash-isomorphic-utils/src/subgraph-mapping.ts
+++ b/libs/@local/hash-isomorphic-utils/src/subgraph-mapping.ts
@@ -1,7 +1,12 @@
+import type {
+  ConversionDefinition,
+  VersionedUrl,
+} from "@blockprotocol/type-system";
 import { typedEntries } from "@local/advanced-types/typed-entries";
 import type {
   ClosedEntityType as GraphApiClosedEntityType,
   ClosedMultiEntityType as GraphApiClosedMultiEntityType,
+  ConversionDefinition as GraphApiConversionDefinition,
   DataTypeWithMetadata as GraphApiDataTypeWithMetadata,
   Entity as GraphApiEntity,
   EntityTypeResolveDefinitions as GraphApiEntityTypeResolveDefinitions,
@@ -239,3 +244,11 @@ export const mapGraphApiPropertyTypesToPropertyTypes = (
 export const mapGraphApiDataTypesToDataTypes = (
   entityTypes: GraphApiDataTypeWithMetadata[],
 ) => entityTypes as DataTypeWithMetadata[];
+
+export const mapGraphApiDataTypeConversions = (
+  conversions: Record<string, GraphApiConversionDefinition[]>,
+) =>
+  conversions as Record<
+    VersionedUrl,
+    [ConversionDefinition] | [ConversionDefinition, ConversionDefinition]
+  >;

--- a/tests/graph/integration/postgres/lib.rs
+++ b/tests/graph/integration/postgres/lib.rs
@@ -49,6 +49,7 @@ use hash_graph_store::{
     account::{AccountStore as _, InsertAccountIdParams, InsertWebIdParams},
     data_type::{
         ArchiveDataTypeParams, CountDataTypesParams, CreateDataTypeParams, DataTypeStore,
+        GetDataTypeConversionTargetsParams, GetDataTypeConversionTargetsResponse,
         GetDataTypeSubgraphParams, GetDataTypeSubgraphResponse, GetDataTypesParams,
         GetDataTypesResponse, UnarchiveDataTypeParams, UpdateDataTypeEmbeddingParams,
         UpdateDataTypesParams,
@@ -412,6 +413,16 @@ impl<A: AuthorizationApi> DataTypeStore for DatabaseApi<'_, A> {
     ) -> Result<(), Report<UpdateError>> {
         self.store
             .update_data_type_embeddings(actor_id, params)
+            .await
+    }
+
+    async fn get_data_type_conversion_targets(
+        &self,
+        actor_id: AccountId,
+        params: GetDataTypeConversionTargetsParams<'_>,
+    ) -> Result<GetDataTypeConversionTargetsResponse, Report<QueryError>> {
+        self.store
+            .get_data_type_conversion_targets(actor_id, params)
             .await
     }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We want to convert data on the fly in the frontend. This requires the potential targets and the conversion ratio.

## 🔍 What does this change?

- Adds `POST /data-types/query/conversions` endpoint which expects a `dataTypeId` as input and returns the possible targets and the corresponding conversion
- Adds wrapper in `@apps/hash-api` which uses the `type-system` types instead
- Add a `createConversionFunction` function to create a TS function from the conversion struct

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

A test was added to test the conversions between different data types using the provided endpoint and the newly added function