### PR TITLE
H-3913, H-3828: Improve entity table loading, reduce sidebar data usage

### DIFF
--- a/apps/hash-frontend/src/pages/shared/entities-visualizer/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-visualizer/entities-table.tsx
@@ -104,6 +104,7 @@ export const EntitiesTable: FunctionComponent<
     readonly?: boolean;
     selectedRows: EntitiesTableRow[];
     setLimit: (limit: number) => void;
+    setLoading: (loading: boolean) => void;
     setSelectedRows: (rows: EntitiesTableRow[]) => void;
     setSelectedEntityType: (params: { entityTypeId: VersionedUrl }) => void;
     setShowSearch: (showSearch: boolean) => void;
@@ -134,6 +135,7 @@ export const EntitiesTable: FunctionComponent<
   readonly,
   setLimit: _setLimit,
   selectedRows,
+  setLoading,
   setSelectedRows,
   showSearch,
   setShowSearch,
@@ -160,6 +162,10 @@ export const EntitiesTable: FunctionComponent<
     typeIds,
     webIds,
   });
+
+  useEffect(() => {
+    setLoading(tableDataCalculating);
+  }, [tableDataCalculating, setLoading]);
 
   const {
     columns,
@@ -615,7 +621,7 @@ export const EntitiesTable: FunctionComponent<
     ];
   }, [columns]);
 
-  if (!entities && (entityDataLoading || tableDataCalculating)) {
+  if (!tableData && (entityDataLoading || tableDataCalculating)) {
     return (
       <Stack
         alignItems="center"
@@ -645,7 +651,7 @@ export const EntitiesTable: FunctionComponent<
           createRenderUrlCell({ firstColumnLeftPadding }),
           createRenderChipCell({ firstColumnLeftPadding }),
         ]}
-        dataLoading={entityDataLoading || tableDataCalculating}
+        dataLoading={false}
         enableCheckboxSelection={!readonly}
         firstColumnLeftPadding={firstColumnLeftPadding}
         freezeColumns={1}

--- a/apps/hash-frontend/src/pages/shared/entities-visualizer/entities-table/use-entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-visualizer/entities-table/use-entities-table.tsx
@@ -327,7 +327,6 @@ export const useEntitiesTable = (
         throw new Error("No worker available");
       }
 
-      setTableData(null);
       setWaitingTableData(true);
 
       worker.postMessage({

--- a/apps/hash-frontend/src/pages/shared/entities-visualizer/use-entities-visualizer-data.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-visualizer/use-entities-visualizer-data.tsx
@@ -72,11 +72,11 @@ export const useEntitiesVisualizerData = (params: {
     createdByIds,
     cursor: nextCursor,
     editionCreatedByIds,
-    subgraph,
     entities,
     hadCachedContent,
     loading,
     refetch,
+    subgraph,
     typeIds,
     webIds,
   } = useEntityTypeEntities({
@@ -138,19 +138,36 @@ export const useEntitiesVisualizerData = (params: {
     return [relevantTypes, relevantProperties];
   }, [subgraph, entities]);
 
-  return {
-    count,
-    createdByIds,
-    cursor: nextCursor,
-    editionCreatedByIds,
-    entities,
-    entityTypes,
-    hadCachedContent,
-    loading,
-    propertyTypes,
-    refetch,
-    subgraph,
-    typeIds,
-    webIds,
-  };
+  return useMemo(
+    () => ({
+      count,
+      createdByIds,
+      cursor: nextCursor,
+      editionCreatedByIds,
+      entities,
+      entityTypes,
+      hadCachedContent,
+      loading,
+      propertyTypes,
+      refetch,
+      subgraph,
+      typeIds,
+      webIds,
+    }),
+    [
+      count,
+      createdByIds,
+      nextCursor,
+      editionCreatedByIds,
+      entities,
+      entityTypes,
+      hadCachedContent,
+      loading,
+      propertyTypes,
+      refetch,
+      subgraph,
+      typeIds,
+      webIds,
+    ],
+  );
 };

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/account-entities-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/account-entities-list.tsx
@@ -1,10 +1,15 @@
+import { useQuery } from "@apollo/client";
 import { IconButton } from "@hashintel/design-system";
 import type { OwnedById } from "@local/hash-graph-types/web";
 import { blockProtocolHubOrigin } from "@local/hash-isomorphic-utils/blocks";
+import {
+  currentTimeInstantTemporalAxes,
+  zeroedGraphResolveDepths,
+} from "@local/hash-isomorphic-utils/graph-queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { isOwnedOntologyElementMetadata } from "@local/hash-subgraph";
 import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
-import { Box, Collapse, Fade, Tooltip } from "@mui/material";
+import { Box, Collapse, Fade, Tooltip, Typography } from "@mui/material";
 import { orderBy } from "lodash";
 import { bindTrigger, usePopupState } from "material-ui-popup-state/hooks";
 import type { FunctionComponent } from "react";
@@ -12,6 +17,11 @@ import { useMemo, useState } from "react";
 import { TransitionGroup } from "react-transition-group";
 
 import { useUpdateAuthenticatedUser } from "../../../../components/hooks/use-update-authenticated-user";
+import type {
+  GetEntitySubgraphQuery,
+  GetEntitySubgraphQueryVariables,
+} from "../../../../graphql/api-types.gen";
+import { getEntitySubgraphQuery } from "../../../../graphql/queries/knowledge/entity.queries";
 import { hiddenEntityTypeIds } from "../../../../pages/shared/hidden-types";
 import { useActiveWorkspace } from "../../../../pages/shared/workspace-context";
 import { useLatestEntityTypesOptional } from "../../../entity-types-context/hooks";
@@ -19,7 +29,7 @@ import { ArrowDownAZRegularIcon } from "../../../icons/arrow-down-a-z-regular-ic
 import { ArrowUpZARegularIcon } from "../../../icons/arrow-up-a-z-regular-icon";
 import { PlusRegularIcon } from "../../../icons/plus-regular";
 import { Link } from "../../../ui";
-import { useEntityTypeEntities } from "../../../use-entity-type-entities";
+import { generateUseEntityTypeEntitiesFilter } from "../../../use-entity-type-entities";
 import { useUserPreferences } from "../../../use-user-preferences";
 import { LoadingSkeleton } from "../shared/loading-skeleton";
 import { EntityOrTypeSidebarItem } from "./shared/entity-or-type-sidebar-item";
@@ -74,10 +84,35 @@ export const AccountEntitiesList: FunctionComponent<
     isSpecialEntityTypeLookup,
   } = useLatestEntityTypesOptional();
 
-  const { entities: userEntities, loading: entityTypeEntitiesLoading } =
-    useEntityTypeEntities({ ownedByIds: [ownedById] });
+  const { data: userEntitiesData, loading: userEntitiesLoading } = useQuery<
+    GetEntitySubgraphQuery,
+    GetEntitySubgraphQueryVariables
+  >(getEntitySubgraphQuery, {
+    variables: {
+      request: {
+        /**
+         * We only make this request to get the count of entities by typeId to filter types in the sidebar,
+         * to only those for which the active workspace has at least one entity.
+         *
+         * We don't actually need a single entity but the Graph rejects requests with a limit of 0.
+         * We currently can't use countEntities as it just returns a total number, with no count by typeId.
+         */
+        limit: 1,
+        includeTypeIds: true,
+        filter: generateUseEntityTypeEntitiesFilter({
+          ownedByIds: [ownedById],
+          includeArchived: false,
+        }),
+        graphResolveDepths: zeroedGraphResolveDepths,
+        includeDrafts: false,
+        temporalAxes: currentTimeInstantTemporalAxes,
+      },
+      includePermissions: false,
+    },
+    fetchPolicy: "network-only",
+  });
 
-  const loading = entityTypesLoading || entityTypeEntitiesLoading;
+  const loading = entityTypesLoading || userEntitiesLoading;
 
   const pinnedEntityTypes = useMemo(() => {
     const { pinnedEntityTypeBaseUrls } = activeWorkspace ?? {};
@@ -95,9 +130,9 @@ export const AccountEntitiesList: FunctionComponent<
         (root) =>
           ((isOwnedOntologyElementMetadata(root.metadata) &&
             root.metadata.ownedById === ownedById) ||
-            userEntities?.find((entity) =>
-              entity.metadata.entityTypeIds.includes(root.schema.$id),
-            )) &&
+            Object.keys(
+              userEntitiesData?.getEntitySubgraph.typeIds ?? {},
+            ).includes(root.schema.$id)) &&
           // Filter out external types from blockprotocol.org, except the Address type.
           (!root.schema.$id.startsWith(blockProtocolHubOrigin) ||
             root.schema.$id.includes("/address/")) &&
@@ -109,7 +144,12 @@ export const AccountEntitiesList: FunctionComponent<
     }
 
     return null;
-  }, [latestEntityTypes, ownedById, userEntities, isSpecialEntityTypeLookup]);
+  }, [
+    latestEntityTypes,
+    ownedById,
+    userEntitiesData,
+    isSpecialEntityTypeLookup,
+  ]);
 
   const sidebarEntityTypes = useMemo(
     () => [...(pinnedEntityTypes ?? []), ...(accountEntityTypes ?? [])],
@@ -184,7 +224,7 @@ export const AccountEntitiesList: FunctionComponent<
         <Box component="ul">
           {loading && sortedEntityTypes.length === 0 ? (
             <LoadingSkeleton />
-          ) : (
+          ) : sortedEntityTypes.length > 0 ? (
             <TransitionGroup>
               {sortedEntityTypes.map((root) => (
                 <Collapse key={root.schema.$id}>
@@ -198,6 +238,17 @@ export const AccountEntitiesList: FunctionComponent<
                 </Collapse>
               ))}
             </TransitionGroup>
+          ) : (
+            <Typography
+              component="li"
+              sx={{
+                pl: 2.5,
+                color: ({ palette }) => palette.gray[50],
+                fontSize: 13,
+              }}
+            >
+              No entities in this workspace
+            </Typography>
           )}
 
           <Box marginLeft={1} marginTop={0.5}>

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/account-entity-type-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/account-entity-type-list.tsx
@@ -1,6 +1,6 @@
 import { IconButton } from "@hashintel/design-system";
 import { isOwnedOntologyElementMetadata } from "@local/hash-subgraph";
-import { Box, Collapse, Fade, Tooltip } from "@mui/material";
+import { Box, Collapse, Fade, Tooltip, Typography } from "@mui/material";
 import { orderBy } from "lodash";
 import { bindTrigger, usePopupState } from "material-ui-popup-state/hooks";
 import type { FunctionComponent } from "react";
@@ -156,7 +156,7 @@ export const AccountEntityTypeList: FunctionComponent<
         <Box component="ul">
           {loading && filteredEntityTypes.length === 0 ? (
             <LoadingSkeleton />
-          ) : (
+          ) : filteredEntityTypes.length > 0 ? (
             <TransitionGroup>
               {filteredEntityTypes.map((root) => (
                 <Collapse key={root.schema.$id}>
@@ -167,6 +167,17 @@ export const AccountEntityTypeList: FunctionComponent<
                 </Collapse>
               ))}
             </TransitionGroup>
+          ) : (
+            <Typography
+              component="li"
+              sx={{
+                pl: 2.5,
+                color: ({ palette }) => palette.gray[50],
+                fontSize: 13,
+              }}
+            >
+              No types in this workspace
+            </Typography>
           )}
           <Box
             tabIndex={0}

--- a/apps/hash-frontend/src/shared/table-header.tsx
+++ b/apps/hash-frontend/src/shared/table-header.tsx
@@ -5,6 +5,7 @@ import {
   EyeRegularIcon,
   EyeSlashRegularIcon,
   IconButton,
+  LoadingSpinner,
 } from "@hashintel/design-system";
 import type { Entity } from "@local/hash-graph-sdk/entity";
 import type {
@@ -23,6 +24,7 @@ import {
   styled,
   Tooltip,
   tooltipClasses,
+  useTheme,
 } from "@mui/material";
 import type {
   Dispatch,
@@ -112,6 +114,7 @@ type TableHeaderProps<R extends GridRow> = {
   hideExportToCsv?: boolean;
   hideFilters?: boolean;
   itemLabelPlural: "entities" | "pages" | "types";
+  loading: boolean;
   numberOfExternalItems?: number;
   numberOfUserWebItems?: number;
   onBulkActionCompleted?: () => void;
@@ -140,6 +143,7 @@ export const TableHeader = <R extends GridRow>({
   hideExportToCsv,
   hideFilters,
   itemLabelPlural,
+  loading,
   numberOfExternalItems,
   numberOfUserWebItems,
   onBulkActionCompleted,
@@ -151,6 +155,8 @@ export const TableHeader = <R extends GridRow>({
   const [displayFilters, setDisplayFilters] = useState<boolean>(false);
   const [publicFilterHovered, setPublicFilterHovered] =
     useState<boolean>(false);
+
+  const theme = useTheme();
 
   const generateCsvFile = useCallback<GenerateCsvFileFunction>(() => {
     const currentlyDisplayedRows = currentlyDisplayedRowsRef.current;
@@ -308,6 +314,7 @@ export const TableHeader = <R extends GridRow>({
             </NoMaxWidthTooltip>
           </>
         )}
+        {loading && <LoadingSpinner size={16} color={theme.palette.blue[70]} />}
       </Box>
       <Box display="flex" alignItems="center" columnGap={1}>
         {!hideFilters && (


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A couple of smaller improvements to the frontend:

1. In the entities table, instead of wiping the table when a new request is made (e.g. new sort, change filter), show a loading indicator in the table header
2. In the sidebar, instead of requesting all the active workspace's entity data in order to determine which types to show in the 'Entities' list, just get the list of number of entities by type (this is only visible if the user has switched from the simple 'Entities' link to the full toggle list)
3. If the user has no entities or types in the toggleable sidebar lists, show a message (instead of nothing)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- Some existing basic tests on the entities table.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Compare loading behavior of preview deployment to production

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

https://github.com/user-attachments/assets/fab3b0c7-757a-43ab-aea9-b2bebd3508ed

---

<img width="1213" alt="Screenshot 2025-01-21 at 19 06 27" src="https://github.com/user-attachments/assets/212f55d7-eb86-44eb-86a6-62b3a6c4b8f2" />

