### PR TITLE
H-3929: Include data type conversion target title

### DIFF
--- a/apps/hash-api/src/graph/ontology/primitive/data-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/data-type.ts
@@ -1,6 +1,5 @@
 import type {
   BaseUrl,
-  ConversionDefinition,
   Conversions,
   VersionedUrl,
 } from "@blockprotocol/type-system";

--- a/apps/hash-api/src/graph/ontology/primitive/data-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/data-type.ts
@@ -23,6 +23,7 @@ import type {
   OntologyTypeRecordId,
 } from "@local/hash-graph-types/ontology";
 import type { OwnedById } from "@local/hash-graph-types/web";
+import type { DataTypeConversionTargets } from "@local/hash-isomorphic-utils/data-types";
 import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { generateTypeId } from "@local/hash-isomorphic-utils/ontology-types";
 import {
@@ -284,7 +285,7 @@ export const unarchiveDataType: ImpureGraphFunction<
 
 export const getDataTypeConversionTargets: ImpureGraphFunction<
   { dataTypeIds: VersionedUrl[] },
-  Promise<Record<VersionedUrl, Record<VersionedUrl, ConversionDefinition[]>>>
+  Promise<Record<VersionedUrl, Record<VersionedUrl, DataTypeConversionTargets>>>
 > = async ({ graphApi }, { actorId }, params) =>
   graphApi
     .getDataTypeConversionTargets(actorId, params)

--- a/libs/@blockprotocol/type-system/rust/src/url/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/url/mod.rs
@@ -272,6 +272,33 @@ impl<'de> Deserialize<'de> for VersionedUrl {
     }
 }
 
+#[cfg(feature = "postgres")]
+impl ToSql for VersionedUrl {
+    postgres_types::to_sql_checked!();
+
+    fn to_sql(&self, ty: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>>
+    where
+        Self: Sized,
+    {
+        self.to_string().to_sql(ty, out)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <String as ToSql>::accepts(ty)
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> FromSql<'a> for VersionedUrl {
+    fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        Ok(Self::from_str(&<String as FromSql>::from_sql(ty, raw)?)?)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <String as FromSql>::accepts(ty)
+    }
+}
+
 #[cfg(feature = "utoipa")]
 impl ToSchema<'_> for VersionedUrl {
     fn schema() -> (&'static str, openapi::RefOr<openapi::Schema>) {

--- a/libs/@local/graph/api/openapi/openapi.json
+++ b/libs/@local/graph/api/openapi/openapi.json
@@ -3692,6 +3692,24 @@
           "propertyName": "type"
         }
       },
+      "DataTypeConversionTargets": {
+        "type": "object",
+        "required": [
+          "title",
+          "conversions"
+        ],
+        "properties": {
+          "conversions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConversionDefinition"
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      },
       "DataTypeInferenceError": {
         "oneOf": [
           {
@@ -5606,10 +5624,7 @@
             "additionalProperties": {
               "type": "object",
               "additionalProperties": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/ConversionDefinition"
-                }
+                "$ref": "#/components/schemas/DataTypeConversionTargets"
               }
             }
           }

--- a/libs/@local/graph/api/src/rest/data_type.rs
+++ b/libs/@local/graph/api/src/rest/data_type.rs
@@ -25,10 +25,11 @@ use hash_graph_postgres_store::{
 };
 use hash_graph_store::{
     data_type::{
-        ArchiveDataTypeParams, CreateDataTypeParams, DataTypeQueryToken, DataTypeStore as _,
-        GetDataTypeConversionTargetsParams, GetDataTypeConversionTargetsResponse,
-        GetDataTypeSubgraphParams, GetDataTypesParams, GetDataTypesResponse,
-        UnarchiveDataTypeParams, UpdateDataTypeEmbeddingParams, UpdateDataTypesParams,
+        ArchiveDataTypeParams, CreateDataTypeParams, DataTypeConversionTargets, DataTypeQueryToken,
+        DataTypeStore as _, GetDataTypeConversionTargetsParams,
+        GetDataTypeConversionTargetsResponse, GetDataTypeSubgraphParams, GetDataTypesParams,
+        GetDataTypesResponse, UnarchiveDataTypeParams, UpdateDataTypeEmbeddingParams,
+        UpdateDataTypesParams,
     },
     entity_type::ClosedDataTypeDefinition,
     pool::StorePool,
@@ -102,6 +103,7 @@ use crate::rest::{
             GetDataTypeSubgraphResponse,
             GetDataTypeConversionTargetsParams,
             GetDataTypeConversionTargetsResponse,
+            DataTypeConversionTargets,
             ArchiveDataTypeParams,
             UnarchiveDataTypeParams,
             ClosedDataTypeDefinition,

--- a/libs/@local/graph/store/src/data_type/mod.rs
+++ b/libs/@local/graph/store/src/data_type/mod.rs
@@ -2,11 +2,11 @@ pub(crate) use self::query::DataTypeQueryPathVisitor;
 pub use self::{
     query::{DataTypeQueryPath, DataTypeQueryToken},
     store::{
-        ArchiveDataTypeParams, CountDataTypesParams, CreateDataTypeParams, DataTypeStore,
-        GetDataTypeConversionTargetsParams, GetDataTypeConversionTargetsResponse,
-        GetDataTypeSubgraphParams, GetDataTypeSubgraphResponse, GetDataTypesParams,
-        GetDataTypesResponse, UnarchiveDataTypeParams, UpdateDataTypeEmbeddingParams,
-        UpdateDataTypesParams,
+        ArchiveDataTypeParams, CountDataTypesParams, CreateDataTypeParams,
+        DataTypeConversionTargets, DataTypeStore, GetDataTypeConversionTargetsParams,
+        GetDataTypeConversionTargetsResponse, GetDataTypeSubgraphParams,
+        GetDataTypeSubgraphResponse, GetDataTypesParams, GetDataTypesResponse,
+        UnarchiveDataTypeParams, UpdateDataTypeEmbeddingParams, UpdateDataTypesParams,
     },
 };
 

--- a/libs/@local/graph/store/src/data_type/store.rs
+++ b/libs/@local/graph/store/src/data_type/store.rs
@@ -154,8 +154,16 @@ pub struct GetDataTypeConversionTargetsParams {
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
+pub struct DataTypeConversionTargets {
+    pub title: String,
+    pub conversions: Vec<ConversionDefinition>,
+}
+
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct GetDataTypeConversionTargetsResponse {
-    pub conversions: HashMap<VersionedUrl, HashMap<VersionedUrl, Vec<ConversionDefinition>>>,
+    pub conversions: HashMap<VersionedUrl, HashMap<VersionedUrl, DataTypeConversionTargets>>,
 }
 
 /// Describes the API of a store implementation for [`DataType`]s.

--- a/libs/@local/hash-isomorphic-utils/src/data-types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/data-types.ts
@@ -13,6 +13,7 @@ import type {
   VersionedUrl,
 } from "@blockprotocol/type-system";
 import { mustHaveAtLeastOne } from "@blockprotocol/type-system";
+import type { DataTypeConversionTargets as GraphApiDataTypeConversionTargets } from "@local/hash-graph-client";
 import type { ClosedDataTypeDefinition } from "@local/hash-graph-types/ontology";
 
 type MergedNumberSchema = {
@@ -202,6 +203,13 @@ export const createConversionFunction = (
     }
     return evaluatedValue;
   };
+};
+
+export type DataTypeConversionTargets = Omit<
+  GraphApiDataTypeConversionTargets,
+  "conversions"
+> & {
+  conversions: ConversionDefinition[];
 };
 
 const transformConstraint = (

--- a/libs/@local/hash-isomorphic-utils/src/subgraph-mapping.ts
+++ b/libs/@local/hash-isomorphic-utils/src/subgraph-mapping.ts
@@ -1,12 +1,9 @@
-import type {
-  ConversionDefinition,
-  VersionedUrl,
-} from "@blockprotocol/type-system";
+import type { VersionedUrl } from "@blockprotocol/type-system";
 import { typedEntries } from "@local/advanced-types/typed-entries";
 import type {
   ClosedEntityType as GraphApiClosedEntityType,
   ClosedMultiEntityType as GraphApiClosedMultiEntityType,
-  ConversionDefinition as GraphApiConversionDefinition,
+  DataTypeConversionTargets as GraphApiDataTypeConversionTargets,
   DataTypeWithMetadata as GraphApiDataTypeWithMetadata,
   Entity as GraphApiEntity,
   EntityTypeResolveDefinitions as GraphApiEntityTypeResolveDefinitions,
@@ -47,6 +44,7 @@ import {
   isEntityVertex,
 } from "@local/hash-subgraph";
 
+import type { DataTypeConversionTargets } from "./data-types.js";
 import { systemEntityTypes, systemPropertyTypes } from "./ontology-type-ids.js";
 
 const restrictedPropertyBaseUrls: string[] = [
@@ -246,9 +244,12 @@ export const mapGraphApiDataTypesToDataTypes = (
 ) => entityTypes as DataTypeWithMetadata[];
 
 export const mapGraphApiDataTypeConversions = (
-  conversions: Record<string, Record<string, GraphApiConversionDefinition[]>>,
+  conversions: Record<
+    string,
+    Record<string, GraphApiDataTypeConversionTargets>
+  >,
 ) =>
   conversions as Record<
     VersionedUrl,
-    Record<VersionedUrl, ConversionDefinition[]>
+    Record<VersionedUrl, DataTypeConversionTargets>
   >;

--- a/tests/hash-backend-integration/src/tests/graph/ontology/primitive/data-type.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/ontology/primitive/data-type.test.ts
@@ -171,7 +171,10 @@ describe("Data type CRU", () => {
               Object.entries(conversions).map(
                 ([targetDataTypeId, conversion]) => [
                   targetDataTypeId,
-                  createConversionFunction(conversion),
+                  {
+                    convert: createConversionFunction(conversion.conversions),
+                    title: conversion.title,
+                  },
                 ],
               ),
             ),
@@ -183,28 +186,56 @@ describe("Data type CRU", () => {
     expect(
       conversionMap[systemDataTypes.centimeters.dataTypeId]![
         systemDataTypes.millimeters.dataTypeId
-      ]!(100),
+      ]!.convert(100),
     ).toBe(1000);
     expect(
       conversionMap[systemDataTypes.centimeters.dataTypeId]![
+        systemDataTypes.millimeters.dataTypeId
+      ]!.title,
+    ).toBe(systemDataTypes.millimeters.title);
+
+    expect(
+      conversionMap[systemDataTypes.centimeters.dataTypeId]![
         systemDataTypes.meters.dataTypeId
-      ]!(1000),
+      ]!.convert(1000),
     ).toBe(10);
     expect(
       conversionMap[systemDataTypes.centimeters.dataTypeId]![
+        systemDataTypes.millimeters.dataTypeId
+      ]!.title,
+    ).toBe(systemDataTypes.millimeters.title);
+
+    expect(
+      conversionMap[systemDataTypes.centimeters.dataTypeId]![
         systemDataTypes.kilometers.dataTypeId
-      ]!(100000),
+      ]!.convert(100000),
     ).toBe(1);
+    expect(
+      conversionMap[systemDataTypes.centimeters.dataTypeId]![
+        systemDataTypes.kilometers.dataTypeId
+      ]!.title,
+    ).toBe(systemDataTypes.kilometers.title);
 
     expect(
       conversionMap[systemDataTypes.meters.dataTypeId]![
         systemDataTypes.millimeters.dataTypeId
-      ]!(1),
+      ]!.convert(1),
     ).toBe(1000);
+    expect(
+      conversionMap[systemDataTypes.centimeters.dataTypeId]![
+        systemDataTypes.millimeters.dataTypeId
+      ]!.title,
+    ).toBe(systemDataTypes.millimeters.title);
+
     expect(
       conversionMap[systemDataTypes.meters.dataTypeId]![
         systemDataTypes.kilometers.dataTypeId
-      ]!(1000),
+      ]!.convert(1000),
     ).toBe(1);
+    expect(
+      conversionMap[systemDataTypes.centimeters.dataTypeId]![
+        systemDataTypes.kilometers.dataTypeId
+      ]!.title,
+    ).toBe(systemDataTypes.kilometers.title);
   });
 });


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We can query for conversion targets, but another roundtrip to the graph is required to read the title. This can be done at the same time instead.

## 🔍 What does this change?

- Change the return type for `POST /data-types/query/conversions` to include the title