### PR TITLE
H-3942: Run Graph on ARM in AWS

### DIFF
--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -48,7 +48,7 @@ name: HASH backend deployment
 jobs:
   build-graph:
     name: Build and push HASH graph image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-arm
     permissions:
       id-token: write
       contents: read
@@ -84,454 +84,454 @@ jobs:
           AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
           IMAGE_NAME: ${{ env.HASH_GRAPH_RESOURCE_NAME }}
 
-  build-api:
-    name: Build and push HASH api image
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  # build-api:
+  #   name: Build and push HASH api image
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-        with:
-          exportToken: true
-          url: ${{ env.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+  #     - name: Authenticate Vault
+  #       id: secrets
+  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+  #       with:
+  #         exportToken: true
+  #         url: ${{ env.VAULT_ADDR }}
+  #         method: jwt
+  #         role: prod
+  #         # Even though it could look like separate calls to fetch the secrets
+  #         # the responses here are cached, so we're only issuing a single set of credentials
+  #         secrets: |
+  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-      - name: Docker image build through docker-build-push
-        uses: ./.github/actions/docker-build-push
-        id: build
-        with:
-          SHORTNAME: "api"
-          CONTEXT_PATH: ${{ github.workspace }}
-          DOCKERFILE_LOCATION: ${{ github.workspace }}/infra/docker/api/prod/Dockerfile
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
-          AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
-          IMAGE_NAME: ${{ env.HASH_API_RESOURCE_NAME }}
+  #     - name: Docker image build through docker-build-push
+  #       uses: ./.github/actions/docker-build-push
+  #       id: build
+  #       with:
+  #         SHORTNAME: "api"
+  #         CONTEXT_PATH: ${{ github.workspace }}
+  #         DOCKERFILE_LOCATION: ${{ github.workspace }}/infra/docker/api/prod/Dockerfile
+  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+  #         AWS_REGION: ${{ env.AWS_REGION }}
+  #         AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
+  #         IMAGE_NAME: ${{ env.HASH_API_RESOURCE_NAME }}
 
-  build-kratos:
-    name: Build and push Kratos image
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  # build-kratos:
+  #   name: Build and push Kratos image
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-        with:
-          exportToken: true
-          url: ${{ env.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+  #     - name: Authenticate Vault
+  #       id: secrets
+  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+  #       with:
+  #         exportToken: true
+  #         url: ${{ env.VAULT_ADDR }}
+  #         method: jwt
+  #         role: prod
+  #         # Even though it could look like separate calls to fetch the secrets
+  #         # the responses here are cached, so we're only issuing a single set of credentials
+  #         secrets: |
+  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-      - name: Docker image build through docker-build-push
-        uses: ./.github/actions/docker-build-push
-        id: build
-        with:
-          SHORTNAME: "kratos"
-          CONTEXT_PATH: ${{ github.workspace }}/apps/hash-external-services/kratos
-          DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/kratos/Dockerfile
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
-          AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
-          IMAGE_NAME: ${{ env.HASH_KRATOS_RESOURCE_NAME }}
-          BUILD_ARGS: |
-            ENV=prod
-            API_SECRET=${{ secrets.HASH_KRATOS_API_SECRET }}
+  #     - name: Docker image build through docker-build-push
+  #       uses: ./.github/actions/docker-build-push
+  #       id: build
+  #       with:
+  #         SHORTNAME: "kratos"
+  #         CONTEXT_PATH: ${{ github.workspace }}/apps/hash-external-services/kratos
+  #         DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/kratos/Dockerfile
+  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+  #         AWS_REGION: ${{ env.AWS_REGION }}
+  #         AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
+  #         IMAGE_NAME: ${{ env.HASH_KRATOS_RESOURCE_NAME }}
+  #         BUILD_ARGS: |
+  #           ENV=prod
+  #           API_SECRET=${{ secrets.HASH_KRATOS_API_SECRET }}
 
-  build-hydra:
-    name: Build and push Hydra image
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  # build-hydra:
+  #   name: Build and push Hydra image
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-        with:
-          exportToken: true
-          url: ${{ env.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+  #     - name: Authenticate Vault
+  #       id: secrets
+  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+  #       with:
+  #         exportToken: true
+  #         url: ${{ env.VAULT_ADDR }}
+  #         method: jwt
+  #         role: prod
+  #         # Even though it could look like separate calls to fetch the secrets
+  #         # the responses here are cached, so we're only issuing a single set of credentials
+  #         secrets: |
+  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-      - name: Docker image build through docker-build-push
-        uses: ./.github/actions/docker-build-push
-        id: build
-        with:
-          SHORTNAME: "hydra"
-          CONTEXT_PATH: ${{ github.workspace }}/apps/hash-external-services/hydra
-          DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/hydra/Dockerfile
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
-          AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
-          IMAGE_NAME: ${{ env.HASH_HYDRA_RESOURCE_NAME }}
-          BUILD_ARGS: |
-            ENV=prod
+  #     - name: Docker image build through docker-build-push
+  #       uses: ./.github/actions/docker-build-push
+  #       id: build
+  #       with:
+  #         SHORTNAME: "hydra"
+  #         CONTEXT_PATH: ${{ github.workspace }}/apps/hash-external-services/hydra
+  #         DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/hydra/Dockerfile
+  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+  #         AWS_REGION: ${{ env.AWS_REGION }}
+  #         AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
+  #         IMAGE_NAME: ${{ env.HASH_HYDRA_RESOURCE_NAME }}
+  #         BUILD_ARGS: |
+  #           ENV=prod
 
-  build-ts-worker:
-    name: Build and push Temporal TS AI Worker
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  # build-ts-worker:
+  #   name: Build and push Temporal TS AI Worker
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-        with:
-          exportToken: true
-          url: ${{ env.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+  #     - name: Authenticate Vault
+  #       id: secrets
+  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+  #       with:
+  #         exportToken: true
+  #         url: ${{ env.VAULT_ADDR }}
+  #         method: jwt
+  #         role: prod
+  #         # Even though it could look like separate calls to fetch the secrets
+  #         # the responses here are cached, so we're only issuing a single set of credentials
+  #         secrets: |
+  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-      - name: Docker image build through docker-build-push
-        uses: ./.github/actions/docker-build-push
-        id: build
-        with:
-          SHORTNAME: "temporal-worker-ai-ts"
-          CONTEXT_PATH: ${{ github.workspace }}
-          DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-ai-worker-ts/docker/Dockerfile
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
-          AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
-          IMAGE_NAME: ${{ env.HASH_TEMPORAL_AI_TS_WORKER_RESOURCE_NAME }}
-          BUILD_ARGS: |
-            GOOGLE_CLOUD_WORKLOAD_IDENTITY_FEDERATION_CONFIG_JSON: ${{ secrets.GOOGLE_CLOUD_WORKLOAD_IDENTITY_FEDERATION_CONFIG_JSON }}
+  #     - name: Docker image build through docker-build-push
+  #       uses: ./.github/actions/docker-build-push
+  #       id: build
+  #       with:
+  #         SHORTNAME: "temporal-worker-ai-ts"
+  #         CONTEXT_PATH: ${{ github.workspace }}
+  #         DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-ai-worker-ts/docker/Dockerfile
+  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+  #         AWS_REGION: ${{ env.AWS_REGION }}
+  #         AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
+  #         IMAGE_NAME: ${{ env.HASH_TEMPORAL_AI_TS_WORKER_RESOURCE_NAME }}
+  #         BUILD_ARGS: |
+  #           GOOGLE_CLOUD_WORKLOAD_IDENTITY_FEDERATION_CONFIG_JSON: ${{ secrets.GOOGLE_CLOUD_WORKLOAD_IDENTITY_FEDERATION_CONFIG_JSON }}
 
-  build-integration-worker:
-    name: Build and push Temporal integration Worker
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  # build-integration-worker:
+  #   name: Build and push Temporal integration Worker
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-        with:
-          exportToken: true
-          url: ${{ env.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+  #     - name: Authenticate Vault
+  #       id: secrets
+  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+  #       with:
+  #         exportToken: true
+  #         url: ${{ env.VAULT_ADDR }}
+  #         method: jwt
+  #         role: prod
+  #         # Even though it could look like separate calls to fetch the secrets
+  #         # the responses here are cached, so we're only issuing a single set of credentials
+  #         secrets: |
+  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-      - name: Docker image build through docker-build-push
-        uses: ./.github/actions/docker-build-push
-        id: build
-        with:
-          SHORTNAME: "temporal-integration-worker"
-          CONTEXT_PATH: ${{ github.workspace }}
-          DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-integration-worker/docker/Dockerfile
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
-          AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
-          IMAGE_NAME: ${{ env.HASH_TEMPORAL_INTEGRATION_WORKER_RESOURCE_NAME }}
+  #     - name: Docker image build through docker-build-push
+  #       uses: ./.github/actions/docker-build-push
+  #       id: build
+  #       with:
+  #         SHORTNAME: "temporal-integration-worker"
+  #         CONTEXT_PATH: ${{ github.workspace }}
+  #         DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-integration-worker/docker/Dockerfile
+  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+  #         AWS_REGION: ${{ env.AWS_REGION }}
+  #         AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
+  #         IMAGE_NAME: ${{ env.HASH_TEMPORAL_INTEGRATION_WORKER_RESOURCE_NAME }}
 
-  build-temporal-migrate:
-    name: Build and push Temporal Migrate image
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  # build-temporal-migrate:
+  #   name: Build and push Temporal Migrate image
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-        with:
-          exportToken: true
-          url: ${{ env.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+  #     - name: Authenticate Vault
+  #       id: secrets
+  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+  #       with:
+  #         exportToken: true
+  #         url: ${{ env.VAULT_ADDR }}
+  #         method: jwt
+  #         role: prod
+  #         # Even though it could look like separate calls to fetch the secrets
+  #         # the responses here are cached, so we're only issuing a single set of credentials
+  #         secrets: |
+  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-      - name: Docker image build through docker-build-push
-        uses: ./.github/actions/docker-build-push
-        id: build
-        with:
-          SHORTNAME: "temporal-migrate"
-          CONTEXT_PATH: ${{ github.workspace }}//apps/hash-external-services/temporal
-          DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/temporal/migrate.Dockerfile
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
-          AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
-          IMAGE_NAME: ${{ env.HASH_TEMPORAL_MIGRATE_RESOURCE_NAME }}
-          IMAGE_TAG: ${{ env.HASH_TEMPORAL_VERSION }}
-          BUILD_ARGS: |
-            TEMPORAL_VERSION=${{ env.HASH_TEMPORAL_VERSION }}
+  #     - name: Docker image build through docker-build-push
+  #       uses: ./.github/actions/docker-build-push
+  #       id: build
+  #       with:
+  #         SHORTNAME: "temporal-migrate"
+  #         CONTEXT_PATH: ${{ github.workspace }}//apps/hash-external-services/temporal
+  #         DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/temporal/migrate.Dockerfile
+  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+  #         AWS_REGION: ${{ env.AWS_REGION }}
+  #         AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
+  #         IMAGE_NAME: ${{ env.HASH_TEMPORAL_MIGRATE_RESOURCE_NAME }}
+  #         IMAGE_TAG: ${{ env.HASH_TEMPORAL_VERSION }}
+  #         BUILD_ARGS: |
+  #           TEMPORAL_VERSION=${{ env.HASH_TEMPORAL_VERSION }}
 
-  build-temporal-setup:
-    name: Build and push Temporal Setup image
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  # build-temporal-setup:
+  #   name: Build and push Temporal Setup image
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-        with:
-          exportToken: true
-          url: ${{ env.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+  #     - name: Authenticate Vault
+  #       id: secrets
+  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+  #       with:
+  #         exportToken: true
+  #         url: ${{ env.VAULT_ADDR }}
+  #         method: jwt
+  #         role: prod
+  #         # Even though it could look like separate calls to fetch the secrets
+  #         # the responses here are cached, so we're only issuing a single set of credentials
+  #         secrets: |
+  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-      - name: Docker image build through docker-build-push
-        uses: ./.github/actions/docker-build-push
-        id: build
-        with:
-          SHORTNAME: "temporal-setup"
-          CONTEXT_PATH: ${{ github.workspace }}//apps/hash-external-services/temporal
-          DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/temporal/setup.Dockerfile
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
-          AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
-          IMAGE_NAME: ${{ env.HASH_TEMPORAL_SETUP_RESOURCE_NAME }}
-          IMAGE_TAG: ${{ env.HASH_TEMPORAL_VERSION }}
-          BUILD_ARGS: |
-            TEMPORAL_VERSION=${{ env.HASH_TEMPORAL_VERSION }}
+  #     - name: Docker image build through docker-build-push
+  #       uses: ./.github/actions/docker-build-push
+  #       id: build
+  #       with:
+  #         SHORTNAME: "temporal-setup"
+  #         CONTEXT_PATH: ${{ github.workspace }}//apps/hash-external-services/temporal
+  #         DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/temporal/setup.Dockerfile
+  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+  #         AWS_REGION: ${{ env.AWS_REGION }}
+  #         AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
+  #         IMAGE_NAME: ${{ env.HASH_TEMPORAL_SETUP_RESOURCE_NAME }}
+  #         IMAGE_TAG: ${{ env.HASH_TEMPORAL_VERSION }}
+  #         BUILD_ARGS: |
+  #           TEMPORAL_VERSION=${{ env.HASH_TEMPORAL_VERSION }}
 
-  deploy-app:
-    name: Deploy HASH app images
-    runs-on: ubuntu-latest
-    needs:
-      - build-ts-worker
-      - build-api
-      - build-kratos
-      - build-hydra
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  # deploy-app:
+  #   name: Deploy HASH app images
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - build-ts-worker
+  #     - build-api
+  #     - build-kratos
+  #     - build-hydra
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-        with:
-          exportToken: true
-          url: ${{ env.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+  #     - name: Authenticate Vault
+  #       id: secrets
+  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+  #       with:
+  #         exportToken: true
+  #         url: ${{ env.VAULT_ADDR }}
+  #         method: jwt
+  #         role: prod
+  #         # Even though it could look like separate calls to fetch the secrets
+  #         # the responses here are cached, so we're only issuing a single set of credentials
+  #         secrets: |
+  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-      - uses: ./.github/actions/docker-ecr-login
-        with:
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
+  #     - uses: ./.github/actions/docker-ecr-login
+  #       with:
+  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+  #         AWS_REGION: ${{ env.AWS_REGION }}
 
-      - name: Redeploy HASH backend service
-        run: |
-          aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_APP_SERVICE_NAME }} --force-new-deployment 1> /dev/null
+  #     - name: Redeploy HASH backend service
+  #       run: |
+  #         aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_APP_SERVICE_NAME }} --force-new-deployment 1> /dev/null
 
-  deploy-graph:
-    name: Deploy HASH graph images
-    runs-on: ubuntu-latest
-    needs:
-      - build-graph
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  # deploy-graph:
+  #   name: Deploy HASH graph images
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - build-graph
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-        with:
-          exportToken: true
-          url: ${{ env.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+  #     - name: Authenticate Vault
+  #       id: secrets
+  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+  #       with:
+  #         exportToken: true
+  #         url: ${{ env.VAULT_ADDR }}
+  #         method: jwt
+  #         role: prod
+  #         # Even though it could look like separate calls to fetch the secrets
+  #         # the responses here are cached, so we're only issuing a single set of credentials
+  #         secrets: |
+  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-      - uses: ./.github/actions/docker-ecr-login
-        with:
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
+  #     - uses: ./.github/actions/docker-ecr-login
+  #       with:
+  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+  #         AWS_REGION: ${{ env.AWS_REGION }}
 
-      - name: Redeploy HASH graph service
-        run: |
-          aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_GRAPH_SERVICE_NAME }} --force-new-deployment 1> /dev/null
+  #     - name: Redeploy HASH graph service
+  #       run: |
+  #         aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_GRAPH_SERVICE_NAME }} --force-new-deployment 1> /dev/null
 
-  deploy-workers:
-    name: Deploy HASH worker images
-    runs-on: ubuntu-latest
-    needs:
-      - build-integration-worker
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  # deploy-workers:
+  #   name: Deploy HASH worker images
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - build-integration-worker
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-        with:
-          exportToken: true
-          url: ${{ env.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+  #     - name: Authenticate Vault
+  #       id: secrets
+  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+  #       with:
+  #         exportToken: true
+  #         url: ${{ env.VAULT_ADDR }}
+  #         method: jwt
+  #         role: prod
+  #         # Even though it could look like separate calls to fetch the secrets
+  #         # the responses here are cached, so we're only issuing a single set of credentials
+  #         secrets: |
+  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-      - uses: ./.github/actions/docker-ecr-login
-        with:
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
+  #     - uses: ./.github/actions/docker-ecr-login
+  #       with:
+  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+  #         AWS_REGION: ${{ env.AWS_REGION }}
 
-      - name: Redeploy HASH worker service
-        run: |
-          aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_WORKER_SERVICE_NAME }} --force-new-deployment 1> /dev/null
+  #     - name: Redeploy HASH worker service
+  #       run: |
+  #         aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_WORKER_SERVICE_NAME }} --force-new-deployment 1> /dev/null
 
-  deploy-temporal:
-    name: Deploy Temporal images
-    runs-on: ubuntu-latest
-    needs:
-      - build-temporal-migrate
-      - build-temporal-setup
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  # deploy-temporal:
+  #   name: Deploy Temporal images
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - build-temporal-migrate
+  #     - build-temporal-setup
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-        with:
-          exportToken: true
-          url: ${{ env.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+  #     - name: Authenticate Vault
+  #       id: secrets
+  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+  #       with:
+  #         exportToken: true
+  #         url: ${{ env.VAULT_ADDR }}
+  #         method: jwt
+  #         role: prod
+  #         # Even though it could look like separate calls to fetch the secrets
+  #         # the responses here are cached, so we're only issuing a single set of credentials
+  #         secrets: |
+  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-      - uses: ./.github/actions/docker-ecr-login
-        with:
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
+  #     - uses: ./.github/actions/docker-ecr-login
+  #       with:
+  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+  #         AWS_REGION: ${{ env.AWS_REGION }}
 
-      - name: Redeploy Temporal service
-        run: |
-          aws ecs update-service --cluster ${{ env.HASH_TEMPORAL_ECS_CLUSTER_NAME }} --service ${{ env.HASH_TEMPORAL_SERVICE_NAME }} --force-new-deployment 1> /dev/null
+  #     - name: Redeploy Temporal service
+  #       run: |
+  #         aws ecs update-service --cluster ${{ env.HASH_TEMPORAL_ECS_CLUSTER_NAME }} --service ${{ env.HASH_TEMPORAL_SERVICE_NAME }} --force-new-deployment 1> /dev/null
 
-  notify-slack:
-    name: Notify Slack on failure
-    needs:
-      - deploy-app
-      - deploy-graph
-      - deploy-workers
-      - deploy-temporal
-    runs-on: ubuntu-latest
-    if: ${{ failure() }}
-    steps:
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@c33737706dea87cd7784c687dadc9adf1be59990
-        env:
-          SLACK_LINK_NAMES: true
-          SLACK_MESSAGE: "Error deploying the HASH backend <@U0143NL4GMP> <@U02NLJY0FGX>" # Notifies C & T
-          SLACK_TITLE: Backend deployment failed
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_USERNAME: GitHub
-          VAULT_ADDR: ""
-          VAULT_TOKEN: ""
+  # notify-slack:
+  #   name: Notify Slack on failure
+  #   needs:
+  #     - deploy-app
+  #     - deploy-graph
+  #     - deploy-workers
+  #     - deploy-temporal
+  #   runs-on: ubuntu-latest
+  #   if: ${{ failure() }}
+  #   steps:
+  #     - name: Slack Notification
+  #       uses: rtCamp/action-slack-notify@c33737706dea87cd7784c687dadc9adf1be59990
+  #       env:
+  #         SLACK_LINK_NAMES: true
+  #         SLACK_MESSAGE: "Error deploying the HASH backend <@U0143NL4GMP> <@U02NLJY0FGX>" # Notifies C & T
+  #         SLACK_TITLE: Backend deployment failed
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+  #         SLACK_USERNAME: GitHub
+  #         VAULT_ADDR: ""
+  #         VAULT_TOKEN: ""

--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -84,454 +84,454 @@ jobs:
           AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
           IMAGE_NAME: ${{ env.HASH_GRAPH_RESOURCE_NAME }}
 
-  # build-api:
-  #   name: Build and push HASH api image
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  build-api:
+    name: Build and push HASH api image
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-  #     - name: Authenticate Vault
-  #       id: secrets
-  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-  #       with:
-  #         exportToken: true
-  #         url: ${{ env.VAULT_ADDR }}
-  #         method: jwt
-  #         role: prod
-  #         # Even though it could look like separate calls to fetch the secrets
-  #         # the responses here are cached, so we're only issuing a single set of credentials
-  #         secrets: |
-  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+      - name: Authenticate Vault
+        id: secrets
+        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+        with:
+          exportToken: true
+          url: ${{ env.VAULT_ADDR }}
+          method: jwt
+          role: prod
+          # Even though it could look like separate calls to fetch the secrets
+          # the responses here are cached, so we're only issuing a single set of credentials
+          secrets: |
+            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-  #     - name: Docker image build through docker-build-push
-  #       uses: ./.github/actions/docker-build-push
-  #       id: build
-  #       with:
-  #         SHORTNAME: "api"
-  #         CONTEXT_PATH: ${{ github.workspace }}
-  #         DOCKERFILE_LOCATION: ${{ github.workspace }}/infra/docker/api/prod/Dockerfile
-  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-  #         AWS_REGION: ${{ env.AWS_REGION }}
-  #         AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
-  #         IMAGE_NAME: ${{ env.HASH_API_RESOURCE_NAME }}
+      - name: Docker image build through docker-build-push
+        uses: ./.github/actions/docker-build-push
+        id: build
+        with:
+          SHORTNAME: "api"
+          CONTEXT_PATH: ${{ github.workspace }}
+          DOCKERFILE_LOCATION: ${{ github.workspace }}/infra/docker/api/prod/Dockerfile
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+          AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
+          IMAGE_NAME: ${{ env.HASH_API_RESOURCE_NAME }}
 
-  # build-kratos:
-  #   name: Build and push Kratos image
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  build-kratos:
+    name: Build and push Kratos image
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-  #     - name: Authenticate Vault
-  #       id: secrets
-  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-  #       with:
-  #         exportToken: true
-  #         url: ${{ env.VAULT_ADDR }}
-  #         method: jwt
-  #         role: prod
-  #         # Even though it could look like separate calls to fetch the secrets
-  #         # the responses here are cached, so we're only issuing a single set of credentials
-  #         secrets: |
-  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+      - name: Authenticate Vault
+        id: secrets
+        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+        with:
+          exportToken: true
+          url: ${{ env.VAULT_ADDR }}
+          method: jwt
+          role: prod
+          # Even though it could look like separate calls to fetch the secrets
+          # the responses here are cached, so we're only issuing a single set of credentials
+          secrets: |
+            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-  #     - name: Docker image build through docker-build-push
-  #       uses: ./.github/actions/docker-build-push
-  #       id: build
-  #       with:
-  #         SHORTNAME: "kratos"
-  #         CONTEXT_PATH: ${{ github.workspace }}/apps/hash-external-services/kratos
-  #         DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/kratos/Dockerfile
-  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-  #         AWS_REGION: ${{ env.AWS_REGION }}
-  #         AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
-  #         IMAGE_NAME: ${{ env.HASH_KRATOS_RESOURCE_NAME }}
-  #         BUILD_ARGS: |
-  #           ENV=prod
-  #           API_SECRET=${{ secrets.HASH_KRATOS_API_SECRET }}
+      - name: Docker image build through docker-build-push
+        uses: ./.github/actions/docker-build-push
+        id: build
+        with:
+          SHORTNAME: "kratos"
+          CONTEXT_PATH: ${{ github.workspace }}/apps/hash-external-services/kratos
+          DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/kratos/Dockerfile
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+          AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
+          IMAGE_NAME: ${{ env.HASH_KRATOS_RESOURCE_NAME }}
+          BUILD_ARGS: |
+            ENV=prod
+            API_SECRET=${{ secrets.HASH_KRATOS_API_SECRET }}
 
-  # build-hydra:
-  #   name: Build and push Hydra image
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  build-hydra:
+    name: Build and push Hydra image
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-  #     - name: Authenticate Vault
-  #       id: secrets
-  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-  #       with:
-  #         exportToken: true
-  #         url: ${{ env.VAULT_ADDR }}
-  #         method: jwt
-  #         role: prod
-  #         # Even though it could look like separate calls to fetch the secrets
-  #         # the responses here are cached, so we're only issuing a single set of credentials
-  #         secrets: |
-  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+      - name: Authenticate Vault
+        id: secrets
+        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+        with:
+          exportToken: true
+          url: ${{ env.VAULT_ADDR }}
+          method: jwt
+          role: prod
+          # Even though it could look like separate calls to fetch the secrets
+          # the responses here are cached, so we're only issuing a single set of credentials
+          secrets: |
+            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-  #     - name: Docker image build through docker-build-push
-  #       uses: ./.github/actions/docker-build-push
-  #       id: build
-  #       with:
-  #         SHORTNAME: "hydra"
-  #         CONTEXT_PATH: ${{ github.workspace }}/apps/hash-external-services/hydra
-  #         DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/hydra/Dockerfile
-  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-  #         AWS_REGION: ${{ env.AWS_REGION }}
-  #         AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
-  #         IMAGE_NAME: ${{ env.HASH_HYDRA_RESOURCE_NAME }}
-  #         BUILD_ARGS: |
-  #           ENV=prod
+      - name: Docker image build through docker-build-push
+        uses: ./.github/actions/docker-build-push
+        id: build
+        with:
+          SHORTNAME: "hydra"
+          CONTEXT_PATH: ${{ github.workspace }}/apps/hash-external-services/hydra
+          DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/hydra/Dockerfile
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+          AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
+          IMAGE_NAME: ${{ env.HASH_HYDRA_RESOURCE_NAME }}
+          BUILD_ARGS: |
+            ENV=prod
 
-  # build-ts-worker:
-  #   name: Build and push Temporal TS AI Worker
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  build-ts-worker:
+    name: Build and push Temporal TS AI Worker
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-  #     - name: Authenticate Vault
-  #       id: secrets
-  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-  #       with:
-  #         exportToken: true
-  #         url: ${{ env.VAULT_ADDR }}
-  #         method: jwt
-  #         role: prod
-  #         # Even though it could look like separate calls to fetch the secrets
-  #         # the responses here are cached, so we're only issuing a single set of credentials
-  #         secrets: |
-  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+      - name: Authenticate Vault
+        id: secrets
+        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+        with:
+          exportToken: true
+          url: ${{ env.VAULT_ADDR }}
+          method: jwt
+          role: prod
+          # Even though it could look like separate calls to fetch the secrets
+          # the responses here are cached, so we're only issuing a single set of credentials
+          secrets: |
+            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-  #     - name: Docker image build through docker-build-push
-  #       uses: ./.github/actions/docker-build-push
-  #       id: build
-  #       with:
-  #         SHORTNAME: "temporal-worker-ai-ts"
-  #         CONTEXT_PATH: ${{ github.workspace }}
-  #         DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-ai-worker-ts/docker/Dockerfile
-  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-  #         AWS_REGION: ${{ env.AWS_REGION }}
-  #         AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
-  #         IMAGE_NAME: ${{ env.HASH_TEMPORAL_AI_TS_WORKER_RESOURCE_NAME }}
-  #         BUILD_ARGS: |
-  #           GOOGLE_CLOUD_WORKLOAD_IDENTITY_FEDERATION_CONFIG_JSON: ${{ secrets.GOOGLE_CLOUD_WORKLOAD_IDENTITY_FEDERATION_CONFIG_JSON }}
+      - name: Docker image build through docker-build-push
+        uses: ./.github/actions/docker-build-push
+        id: build
+        with:
+          SHORTNAME: "temporal-worker-ai-ts"
+          CONTEXT_PATH: ${{ github.workspace }}
+          DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-ai-worker-ts/docker/Dockerfile
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+          AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
+          IMAGE_NAME: ${{ env.HASH_TEMPORAL_AI_TS_WORKER_RESOURCE_NAME }}
+          BUILD_ARGS: |
+            GOOGLE_CLOUD_WORKLOAD_IDENTITY_FEDERATION_CONFIG_JSON: ${{ secrets.GOOGLE_CLOUD_WORKLOAD_IDENTITY_FEDERATION_CONFIG_JSON }}
 
-  # build-integration-worker:
-  #   name: Build and push Temporal integration Worker
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  build-integration-worker:
+    name: Build and push Temporal integration Worker
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-  #     - name: Authenticate Vault
-  #       id: secrets
-  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-  #       with:
-  #         exportToken: true
-  #         url: ${{ env.VAULT_ADDR }}
-  #         method: jwt
-  #         role: prod
-  #         # Even though it could look like separate calls to fetch the secrets
-  #         # the responses here are cached, so we're only issuing a single set of credentials
-  #         secrets: |
-  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+      - name: Authenticate Vault
+        id: secrets
+        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+        with:
+          exportToken: true
+          url: ${{ env.VAULT_ADDR }}
+          method: jwt
+          role: prod
+          # Even though it could look like separate calls to fetch the secrets
+          # the responses here are cached, so we're only issuing a single set of credentials
+          secrets: |
+            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-  #     - name: Docker image build through docker-build-push
-  #       uses: ./.github/actions/docker-build-push
-  #       id: build
-  #       with:
-  #         SHORTNAME: "temporal-integration-worker"
-  #         CONTEXT_PATH: ${{ github.workspace }}
-  #         DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-integration-worker/docker/Dockerfile
-  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-  #         AWS_REGION: ${{ env.AWS_REGION }}
-  #         AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
-  #         IMAGE_NAME: ${{ env.HASH_TEMPORAL_INTEGRATION_WORKER_RESOURCE_NAME }}
+      - name: Docker image build through docker-build-push
+        uses: ./.github/actions/docker-build-push
+        id: build
+        with:
+          SHORTNAME: "temporal-integration-worker"
+          CONTEXT_PATH: ${{ github.workspace }}
+          DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-integration-worker/docker/Dockerfile
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+          AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
+          IMAGE_NAME: ${{ env.HASH_TEMPORAL_INTEGRATION_WORKER_RESOURCE_NAME }}
 
-  # build-temporal-migrate:
-  #   name: Build and push Temporal Migrate image
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  build-temporal-migrate:
+    name: Build and push Temporal Migrate image
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-  #     - name: Authenticate Vault
-  #       id: secrets
-  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-  #       with:
-  #         exportToken: true
-  #         url: ${{ env.VAULT_ADDR }}
-  #         method: jwt
-  #         role: prod
-  #         # Even though it could look like separate calls to fetch the secrets
-  #         # the responses here are cached, so we're only issuing a single set of credentials
-  #         secrets: |
-  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+      - name: Authenticate Vault
+        id: secrets
+        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+        with:
+          exportToken: true
+          url: ${{ env.VAULT_ADDR }}
+          method: jwt
+          role: prod
+          # Even though it could look like separate calls to fetch the secrets
+          # the responses here are cached, so we're only issuing a single set of credentials
+          secrets: |
+            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-  #     - name: Docker image build through docker-build-push
-  #       uses: ./.github/actions/docker-build-push
-  #       id: build
-  #       with:
-  #         SHORTNAME: "temporal-migrate"
-  #         CONTEXT_PATH: ${{ github.workspace }}//apps/hash-external-services/temporal
-  #         DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/temporal/migrate.Dockerfile
-  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-  #         AWS_REGION: ${{ env.AWS_REGION }}
-  #         AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
-  #         IMAGE_NAME: ${{ env.HASH_TEMPORAL_MIGRATE_RESOURCE_NAME }}
-  #         IMAGE_TAG: ${{ env.HASH_TEMPORAL_VERSION }}
-  #         BUILD_ARGS: |
-  #           TEMPORAL_VERSION=${{ env.HASH_TEMPORAL_VERSION }}
+      - name: Docker image build through docker-build-push
+        uses: ./.github/actions/docker-build-push
+        id: build
+        with:
+          SHORTNAME: "temporal-migrate"
+          CONTEXT_PATH: ${{ github.workspace }}//apps/hash-external-services/temporal
+          DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/temporal/migrate.Dockerfile
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+          AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
+          IMAGE_NAME: ${{ env.HASH_TEMPORAL_MIGRATE_RESOURCE_NAME }}
+          IMAGE_TAG: ${{ env.HASH_TEMPORAL_VERSION }}
+          BUILD_ARGS: |
+            TEMPORAL_VERSION=${{ env.HASH_TEMPORAL_VERSION }}
 
-  # build-temporal-setup:
-  #   name: Build and push Temporal Setup image
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  build-temporal-setup:
+    name: Build and push Temporal Setup image
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-  #     - name: Authenticate Vault
-  #       id: secrets
-  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-  #       with:
-  #         exportToken: true
-  #         url: ${{ env.VAULT_ADDR }}
-  #         method: jwt
-  #         role: prod
-  #         # Even though it could look like separate calls to fetch the secrets
-  #         # the responses here are cached, so we're only issuing a single set of credentials
-  #         secrets: |
-  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+      - name: Authenticate Vault
+        id: secrets
+        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+        with:
+          exportToken: true
+          url: ${{ env.VAULT_ADDR }}
+          method: jwt
+          role: prod
+          # Even though it could look like separate calls to fetch the secrets
+          # the responses here are cached, so we're only issuing a single set of credentials
+          secrets: |
+            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-  #     - name: Docker image build through docker-build-push
-  #       uses: ./.github/actions/docker-build-push
-  #       id: build
-  #       with:
-  #         SHORTNAME: "temporal-setup"
-  #         CONTEXT_PATH: ${{ github.workspace }}//apps/hash-external-services/temporal
-  #         DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/temporal/setup.Dockerfile
-  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-  #         AWS_REGION: ${{ env.AWS_REGION }}
-  #         AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
-  #         IMAGE_NAME: ${{ env.HASH_TEMPORAL_SETUP_RESOURCE_NAME }}
-  #         IMAGE_TAG: ${{ env.HASH_TEMPORAL_VERSION }}
-  #         BUILD_ARGS: |
-  #           TEMPORAL_VERSION=${{ env.HASH_TEMPORAL_VERSION }}
+      - name: Docker image build through docker-build-push
+        uses: ./.github/actions/docker-build-push
+        id: build
+        with:
+          SHORTNAME: "temporal-setup"
+          CONTEXT_PATH: ${{ github.workspace }}//apps/hash-external-services/temporal
+          DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/temporal/setup.Dockerfile
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+          AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
+          IMAGE_NAME: ${{ env.HASH_TEMPORAL_SETUP_RESOURCE_NAME }}
+          IMAGE_TAG: ${{ env.HASH_TEMPORAL_VERSION }}
+          BUILD_ARGS: |
+            TEMPORAL_VERSION=${{ env.HASH_TEMPORAL_VERSION }}
 
-  # deploy-app:
-  #   name: Deploy HASH app images
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - build-ts-worker
-  #     - build-api
-  #     - build-kratos
-  #     - build-hydra
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  deploy-app:
+    name: Deploy HASH app images
+    runs-on: ubuntu-latest
+    needs:
+      - build-ts-worker
+      - build-api
+      - build-kratos
+      - build-hydra
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-  #     - name: Authenticate Vault
-  #       id: secrets
-  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-  #       with:
-  #         exportToken: true
-  #         url: ${{ env.VAULT_ADDR }}
-  #         method: jwt
-  #         role: prod
-  #         # Even though it could look like separate calls to fetch the secrets
-  #         # the responses here are cached, so we're only issuing a single set of credentials
-  #         secrets: |
-  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+      - name: Authenticate Vault
+        id: secrets
+        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+        with:
+          exportToken: true
+          url: ${{ env.VAULT_ADDR }}
+          method: jwt
+          role: prod
+          # Even though it could look like separate calls to fetch the secrets
+          # the responses here are cached, so we're only issuing a single set of credentials
+          secrets: |
+            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-  #     - uses: ./.github/actions/docker-ecr-login
-  #       with:
-  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-  #         AWS_REGION: ${{ env.AWS_REGION }}
+      - uses: ./.github/actions/docker-ecr-login
+        with:
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ env.AWS_REGION }}
 
-  #     - name: Redeploy HASH backend service
-  #       run: |
-  #         aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_APP_SERVICE_NAME }} --force-new-deployment 1> /dev/null
+      - name: Redeploy HASH backend service
+        run: |
+          aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_APP_SERVICE_NAME }} --force-new-deployment 1> /dev/null
 
-  # deploy-graph:
-  #   name: Deploy HASH graph images
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - build-graph
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  deploy-graph:
+    name: Deploy HASH graph images
+    runs-on: ubuntu-latest
+    needs:
+      - build-graph
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-  #     - name: Authenticate Vault
-  #       id: secrets
-  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-  #       with:
-  #         exportToken: true
-  #         url: ${{ env.VAULT_ADDR }}
-  #         method: jwt
-  #         role: prod
-  #         # Even though it could look like separate calls to fetch the secrets
-  #         # the responses here are cached, so we're only issuing a single set of credentials
-  #         secrets: |
-  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+      - name: Authenticate Vault
+        id: secrets
+        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+        with:
+          exportToken: true
+          url: ${{ env.VAULT_ADDR }}
+          method: jwt
+          role: prod
+          # Even though it could look like separate calls to fetch the secrets
+          # the responses here are cached, so we're only issuing a single set of credentials
+          secrets: |
+            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-  #     - uses: ./.github/actions/docker-ecr-login
-  #       with:
-  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-  #         AWS_REGION: ${{ env.AWS_REGION }}
+      - uses: ./.github/actions/docker-ecr-login
+        with:
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ env.AWS_REGION }}
 
-  #     - name: Redeploy HASH graph service
-  #       run: |
-  #         aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_GRAPH_SERVICE_NAME }} --force-new-deployment 1> /dev/null
+      - name: Redeploy HASH graph service
+        run: |
+          aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_GRAPH_SERVICE_NAME }} --force-new-deployment 1> /dev/null
 
-  # deploy-workers:
-  #   name: Deploy HASH worker images
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - build-integration-worker
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  deploy-workers:
+    name: Deploy HASH worker images
+    runs-on: ubuntu-latest
+    needs:
+      - build-integration-worker
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-  #     - name: Authenticate Vault
-  #       id: secrets
-  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-  #       with:
-  #         exportToken: true
-  #         url: ${{ env.VAULT_ADDR }}
-  #         method: jwt
-  #         role: prod
-  #         # Even though it could look like separate calls to fetch the secrets
-  #         # the responses here are cached, so we're only issuing a single set of credentials
-  #         secrets: |
-  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+      - name: Authenticate Vault
+        id: secrets
+        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+        with:
+          exportToken: true
+          url: ${{ env.VAULT_ADDR }}
+          method: jwt
+          role: prod
+          # Even though it could look like separate calls to fetch the secrets
+          # the responses here are cached, so we're only issuing a single set of credentials
+          secrets: |
+            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-  #     - uses: ./.github/actions/docker-ecr-login
-  #       with:
-  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-  #         AWS_REGION: ${{ env.AWS_REGION }}
+      - uses: ./.github/actions/docker-ecr-login
+        with:
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ env.AWS_REGION }}
 
-  #     - name: Redeploy HASH worker service
-  #       run: |
-  #         aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_WORKER_SERVICE_NAME }} --force-new-deployment 1> /dev/null
+      - name: Redeploy HASH worker service
+        run: |
+          aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_WORKER_SERVICE_NAME }} --force-new-deployment 1> /dev/null
 
-  # deploy-temporal:
-  #   name: Deploy Temporal images
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - build-temporal-migrate
-  #     - build-temporal-setup
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  deploy-temporal:
+    name: Deploy Temporal images
+    runs-on: ubuntu-latest
+    needs:
+      - build-temporal-migrate
+      - build-temporal-setup
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-  #     - name: Authenticate Vault
-  #       id: secrets
-  #       uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
-  #       with:
-  #         exportToken: true
-  #         url: ${{ env.VAULT_ADDR }}
-  #         method: jwt
-  #         role: prod
-  #         # Even though it could look like separate calls to fetch the secrets
-  #         # the responses here are cached, so we're only issuing a single set of credentials
-  #         secrets: |
-  #           aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-  #           aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-  #           aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+      - name: Authenticate Vault
+        id: secrets
+        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+        with:
+          exportToken: true
+          url: ${{ env.VAULT_ADDR }}
+          method: jwt
+          role: prod
+          # Even though it could look like separate calls to fetch the secrets
+          # the responses here are cached, so we're only issuing a single set of credentials
+          secrets: |
+            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
 
-  #     - uses: ./.github/actions/docker-ecr-login
-  #       with:
-  #         AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-  #         AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-  #         AWS_REGION: ${{ env.AWS_REGION }}
+      - uses: ./.github/actions/docker-ecr-login
+        with:
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ env.AWS_REGION }}
 
-  #     - name: Redeploy Temporal service
-  #       run: |
-  #         aws ecs update-service --cluster ${{ env.HASH_TEMPORAL_ECS_CLUSTER_NAME }} --service ${{ env.HASH_TEMPORAL_SERVICE_NAME }} --force-new-deployment 1> /dev/null
+      - name: Redeploy Temporal service
+        run: |
+          aws ecs update-service --cluster ${{ env.HASH_TEMPORAL_ECS_CLUSTER_NAME }} --service ${{ env.HASH_TEMPORAL_SERVICE_NAME }} --force-new-deployment 1> /dev/null
 
-  # notify-slack:
-  #   name: Notify Slack on failure
-  #   needs:
-  #     - deploy-app
-  #     - deploy-graph
-  #     - deploy-workers
-  #     - deploy-temporal
-  #   runs-on: ubuntu-latest
-  #   if: ${{ failure() }}
-  #   steps:
-  #     - name: Slack Notification
-  #       uses: rtCamp/action-slack-notify@c33737706dea87cd7784c687dadc9adf1be59990
-  #       env:
-  #         SLACK_LINK_NAMES: true
-  #         SLACK_MESSAGE: "Error deploying the HASH backend <@U0143NL4GMP> <@U02NLJY0FGX>" # Notifies C & T
-  #         SLACK_TITLE: Backend deployment failed
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-  #         SLACK_USERNAME: GitHub
-  #         VAULT_ADDR: ""
-  #         VAULT_TOKEN: ""
+  notify-slack:
+    name: Notify Slack on failure
+    needs:
+      - deploy-app
+      - deploy-graph
+      - deploy-workers
+      - deploy-temporal
+    runs-on: ubuntu-latest
+    if: ${{ failure() }}
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@c33737706dea87cd7784c687dadc9adf1be59990
+        env:
+          SLACK_LINK_NAMES: true
+          SLACK_MESSAGE: "Error deploying the HASH backend <@U0143NL4GMP> <@U02NLJY0FGX>" # Notifies C & T
+          SLACK_TITLE: Backend deployment failed
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_USERNAME: GitHub
+          VAULT_ADDR: ""
+          VAULT_TOKEN: ""

--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -48,7 +48,7 @@ name: HASH backend deployment
 jobs:
   build-graph:
     name: Build and push HASH graph image
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-24.04-arm
     permissions:
       id-token: write
       contents: read

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,6 +241,10 @@ winnow                   = { version = "=0.6.24", default-features = false }
 [profile.dev]
 codegen-backend = "cranelift"
 
+[profile.dev-llvm]
+codegen-backend = "llvm"
+inherits        = "dev"
+
 # We use LLVM for non-workspace crates, mainly due to the lack of AVX2 support in Cranelift
 [profile.dev.package."*"]
 codegen-backend = "llvm"
@@ -252,7 +256,7 @@ codegen-backend = "llvm"
 [profile.test.package."*"]
 codegen-backend = "llvm"
 
-# We use `llvm-cov` which requires LLVM`
+# We use `llvm-cov` which requires LLVM
 [profile.coverage]
 codegen-backend = "llvm"
 inherits        = "test"

--- a/apps/hash-graph/docker/Dockerfile
+++ b/apps/hash-graph/docker/Dockerfile
@@ -28,10 +28,8 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=:$PATH:/usr/local/cargo/bin
 
-COPY rust-toolchain.toml .
-RUN apk add --no-cache gcc musl-dev bash protobuf-dev && \
-    wget -q -O- https://sh.rustup.rs | sh -s -- -y --default-toolchain none --profile minimal && \
-    rustup show
+RUN apk add --no-cache gcc musl-dev bash protobuf-dev yq && \
+    wget -q -O- https://sh.rustup.rs | sh -s -- -y --default-toolchain none --profile minimal
 
 SHELL ["bash", "-c"]
 
@@ -58,16 +56,19 @@ WORKDIR /usr/local/src/apps/hash-graph
 ARG PROFILE=production
 ARG ENABLE_TEST_SERVER=no
 
+COPY rust-toolchain.toml .
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/usr/local/src/apps/hash-graph/target,sharing=locked \
+    --mount=type=cache,target=/usr/local/src/target,sharing=locked \
     FEATURES=(); \
     if [[ ${ENABLE_TEST_SERVER^^} == Y* || ${ENABLE_TEST_SERVER^^} == T* || $ENABLE_TEST_SERVER == 1 ]]; then \
     FEATURES+=("test-server"); \
     fi; \
     if [[ ${PROFILE} == dev ]]; then \
     export RUSTFLAGS="$RUSTFLAGS -C debuginfo=line-tables-only"; \
+    export PROFILE=dev-llvm; \
     fi; \
+    export RUSTUP_TOOLCHAIN="$(yq '.toolchain.channel' rust-toolchain.toml)"; \
     FEATURES=${FEATURES[@]}; \
     cargo install --path . --features "${FEATURES// /,}" --profile $PROFILE --locked;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Manually deploying Graph images currently is quite painful if not on a machine with x86. This changes the architecture for the Graph in AWS to `ARM64` instead. At the same time, the Docker Image building process was adjusted in GitHub Actions to use the ARM images so CD can build them smoothly.

## 🔍 What does this change?

- Change architecture for graph on AWS to ARM64
- Change GH CD to use ARM image for building the graph
- Tweak Dockerfile to use LLVM builds when using the `dev` profile
- Add a `dev-llvm` profile

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph