### PR TITLE
H-3948: Fix Terraform filter to find AZ regions

### DIFF
--- a/infra/terraform/modules/variables/main.tf
+++ b/infra/terraform/modules/variables/main.tf
@@ -2,7 +2,7 @@
   * # Terraform AWS module: Variables
   *
   * Module responsible for creating the variables used in the project.
-  * The module doesn't add any resources, it is primarily used to 
+  * The module doesn't add any resources, it is primarily used to
   * validate/generate variables that are used in other modules.
   */
 
@@ -15,7 +15,7 @@ data "aws_availability_zones" "region_availability_zones" {
 
   # Return only AZs by region
   filter {
-    name   = "group-name"
+    name   = "region-name"
     values = [var.region]
   }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For some reason, the `group-name` filter suddenly stopped working. The correct name is `region-name`, this PR changes the filter. This should not change any infrastructure.