### PR TITLE
H-3931: Update `.nvmrc` files

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/iron
+lts/jod

--- a/apps/hashdotdev/.nvmrc
+++ b/apps/hashdotdev/.nvmrc
@@ -1,1 +1,1 @@
-lts/iron
+lts/jod


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We have 3 .`nvmrc` files in this repo.
- @indietyp flagged we specify Node 22+ in the root `package.json` and only Node 20 in the corresponding `.nvmrc` file (used to provide `fnm` auto-switching support amongst others) should be updated to avoid conflicts (also for `nvm`, `mise`, `volta`, etc.)
- This was also true for the HDEV site.
- Meanwhile the HDESIGN nvm file is accurate, as our Storybook still runs on Node 20.