### PR TITLE
H-3975: Add `linkDestinations` as possible entity type query path token

### DIFF
--- a/libs/@local/graph/api/openapi/openapi.json
+++ b/libs/@local/graph/api/openapi/openapi.json
@@ -4876,6 +4876,7 @@
           "icon",
           "editionProvenance",
           "links",
+          "linkDestinations",
           "inheritsFrom",
           "children",
           "embedding"

--- a/libs/@local/graph/store/package.json
+++ b/libs/@local/graph/store/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0-private",
   "private": true,
   "license": "AGPL-3",
+  "scripts": {
+    "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
+  },
   "dependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",
     "@rust/error-stack": "0.5.0",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, it's not possible to explore link destinations for entity types. This completes the picture of outgoing edges for ontology types.

<img width="951" alt="image" src="https://github.com/user-attachments/assets/2a6f946f-4761-40e0-be4a-6fea8e53478e" />


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph