### PR TITLE
H-3966: Sort entities table column by normalized value where possible

### DIFF
--- a/apps/hash-frontend/src/components/grid/utils/conversion-menu.tsx
+++ b/apps/hash-frontend/src/components/grid/utils/conversion-menu.tsx
@@ -16,7 +16,11 @@ import { MenuItem } from "../../../shared/ui";
 
 export type ConversionTargetsByColumnKey = Record<
   string,
-  { title: string; dataTypeId: VersionedUrl }[] | undefined
+  {
+    title: string;
+    dataTypeId: VersionedUrl;
+    guessedAsCanonical?: boolean;
+  }[]
 >;
 
 export const ConversionMenu = ({

--- a/apps/hash-frontend/src/pages/shared/entities-visualizer.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-visualizer.tsx
@@ -96,6 +96,7 @@ const allFileEntityTypeBaseUrl = allFileEntityTypeOntologyIds.map(
 const generateGraphSort = (
   columnKey: SortableEntitiesTableColumnKey,
   direction: "asc" | "desc",
+  convertTo?: BaseUrl,
 ): EntityQuerySortingRecord => {
   const nulls: NullOrdering = direction === "asc" ? "last" : "first";
   const ordering: Ordering = direction === "asc" ? "ascending" : "descending";
@@ -124,7 +125,11 @@ const generateGraphSort = (
       if (!isBaseUrl(columnKey)) {
         throw new Error(`Unexpected sorting column key: ${columnKey}`);
       }
-      path = ["properties", columnKey];
+      path = ["properties" satisfies EntityQuerySortingToken, columnKey];
+
+      if (convertTo) {
+        path.push("convert", convertTo);
+      }
     }
   }
 
@@ -277,13 +282,15 @@ export const EntitiesVisualizer: FunctionComponent<{
     fetchPolicy: "network-only",
   });
 
-  const [sort, setSort] = useState<ColumnSort<SortableEntitiesTableColumnKey>>({
+  const [sort, setSort] = useState<
+    ColumnSort<SortableEntitiesTableColumnKey> & { convertTo?: BaseUrl }
+  >({
     columnKey: "entityLabel",
     direction: "asc",
   });
 
   const graphSort = useMemo(
-    () => generateGraphSort(sort.columnKey, sort.direction),
+    () => generateGraphSort(sort.columnKey, sort.direction, sort.convertTo),
     [sort],
   );
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Following the introduction of data type conversions to the frontend in #6237, this PR sorts table columns by the converted value rather than the stored number where available. 

e.g. Length as shown here is sorted by the value in the world, not the numbers.

<img width="698" alt="Screenshot 2025-01-28 at 20 40 56" src="https://github.com/user-attachments/assets/8641d126-b600-46d7-8ab1-915d292bc8fe" />

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Possible to test in preview deployment if you have appropriate types.

## 📹 Demo

See description.