### PR TITLE
H-3979: Expose a `convert` token in query paths

### DIFF
--- a/libs/@local/graph/api/openapi/openapi.json
+++ b/libs/@local/graph/api/openapi/openapi.json
@@ -5495,6 +5495,12 @@
                       "$ref": "#/components/schemas/Selector"
                     },
                     {
+                      "type": "string",
+                      "enum": [
+                        "convert"
+                      ]
+                    },
+                    {
                       "type": "string"
                     },
                     {

--- a/libs/@local/graph/api/src/rest/mod.rs
+++ b/libs/@local/graph/api/src/rest/mod.rs
@@ -809,6 +809,11 @@ impl Modify for FilterSchemaAddon {
                                             .item(Ref::from_schema_name("Selector"))
                                             .item(
                                                 ObjectBuilder::new()
+                                                    .schema_type(SchemaType::String)
+                                                    .enum_values(Some(["convert"])),
+                                            )
+                                            .item(
+                                                ObjectBuilder::new()
                                                     .schema_type(SchemaType::String),
                                             )
                                             .item(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

It does not add any type safety as we have string in the list of possible tokens, however, having "convert" in the list of tokens will make DX easier.