### PR TITLE
H-3145: Show sources on property hover in entity editor; bug fixes

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/infer-metadata-from-document-action/get-llm-analysis-of-doc.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/infer-metadata-from-document-action/get-llm-analysis-of-doc.ts
@@ -468,13 +468,15 @@ const unsimplifyDocumentMetadata = (
     );
   }
 
+  const title = properties.title as string | undefined;
+
   const propertyProvenance: PropertyProvenance = {
     sources: [
       {
         authors: rest.authors?.map((author) => author.name),
         type: "document",
         entityId: provenance.entityId,
-        location: { uri: provenance.fileUrl },
+        location: { uri: provenance.fileUrl, name: title },
       },
     ],
   };

--- a/apps/hash-frontend/src/components/grid/grid.tsx
+++ b/apps/hash-frontend/src/components/grid/grid.tsx
@@ -522,14 +522,16 @@ export const Grid = <
         const { y: wrapperYPosition, x: wrapperXPosition } =
           wrapperRef.current!.getBoundingClientRect();
 
-        const left = wrapperXPosition + interactable.pos.left;
+        const left =
+          wrapperXPosition + interactable.posRelativeToVisibleGridArea.left;
 
-        const top = interactable.pos.top + wrapperYPosition;
+        const top =
+          interactable.posRelativeToVisibleGridArea.top + wrapperYPosition;
 
         return {
           width: 0,
           height: 0,
-          ...interactable.pos,
+          ...interactable.posRelativeToVisibleGridArea,
           left,
           top,
           x: left,
@@ -569,14 +571,16 @@ export const Grid = <
         const { y: wrapperYPosition, x: wrapperXPosition } =
           wrapperRef.current!.getBoundingClientRect();
 
-        const left = wrapperXPosition + interactable.pos.left;
+        const left =
+          wrapperXPosition + interactable.posRelativeToVisibleGridArea.left;
 
-        const top = interactable.pos.top + wrapperYPosition;
+        const top =
+          interactable.posRelativeToVisibleGridArea.top + wrapperYPosition;
 
         return {
           width: 0,
           height: 0,
-          ...interactable.pos,
+          ...interactable.posRelativeToVisibleGridArea,
           left,
           top,
           x: left,

--- a/apps/hash-frontend/src/components/grid/utils.ts
+++ b/apps/hash-frontend/src/components/grid/utils.ts
@@ -2,7 +2,7 @@ import type { CustomCell, DrawArgs, Theme } from "@glideapps/glide-data-grid";
 import { getMiddleCenterBias, GridCellKind } from "@glideapps/glide-data-grid";
 
 /**
- * @returns vertical center of a grid cell
+ * @returns vertical center of a grid cell, relative to the visible grid area
  */
 export const getYCenter = (
   args: Pick<DrawArgs<CustomCell>, "rect" | "ctx"> & { theme: Theme },

--- a/apps/hash-frontend/src/components/grid/utils/interactable-manager.ts
+++ b/apps/hash-frontend/src/components/grid/utils/interactable-manager.ts
@@ -52,7 +52,7 @@ class InteractableManagerClass {
 
     const hovered = isCursorOnInteractable(
       { posX: hoverX, posY: hoverY },
-      props.pos,
+      props.posRelativeToVisibleGridArea,
       rect,
     );
 
@@ -146,8 +146,9 @@ class InteractableManagerClass {
     const interactableMap = this.interactableStore[path] ?? {};
     const interactables = Object.values(interactableMap);
 
-    const foundInteractable = interactables.find(({ pos, cellRect }) =>
-      isCursorOnInteractable(event, pos, cellRect),
+    const foundInteractable = interactables.find(
+      ({ posRelativeToVisibleGridArea: pos, cellRect }) =>
+        isCursorOnInteractable(event, pos, cellRect),
     );
 
     if (!foundInteractable) {

--- a/apps/hash-frontend/src/components/grid/utils/interactable-manager/types.ts
+++ b/apps/hash-frontend/src/components/grid/utils/interactable-manager/types.ts
@@ -24,7 +24,7 @@ export type ColumnHeaderDrawArgs = Parameters<DrawHeaderCallback>[0] & {
 type InteractableEventHandler = (interactable: Interactable) => void;
 
 export interface Interactable {
-  pos: InteractablePosition;
+  posRelativeToVisibleGridArea: InteractablePosition;
   path: CellPath | ColumnHeaderPath;
   hovered: boolean;
   cellRect: Rectangle;

--- a/apps/hash-frontend/src/components/grid/utils/use-draw-header.ts
+++ b/apps/hash-frontend/src/components/grid/utils/use-draw-header.ts
@@ -127,7 +127,7 @@ export const useDrawHeader = <
             { ...args, tableId },
             {
               id: generateInteractableId("sort", columnKey),
-              pos: {
+              posRelativeToVisibleGridArea: {
                 left: sortIconStartX,
                 right: sortIconStartX + sortIconSize,
                 top: centerY - sortIconSize / 2,
@@ -178,14 +178,17 @@ export const useDrawHeader = <
             { ...args, tableId },
             {
               id: generateInteractableId("filter", columnKey),
-              pos: {
+              posRelativeToVisibleGridArea: {
                 left: columnFilterX,
                 right: columnFilterX + filterIconSize,
                 top: centerY - filterIconSize / 2,
                 bottom: centerY + filterIconSize / 2,
               },
               onClick: (interactable) =>
-                onFilterClick?.(columnKey, interactable.pos),
+                onFilterClick?.(
+                  columnKey,
+                  interactable.posRelativeToVisibleGridArea,
+                ),
             },
           ),
         );
@@ -228,14 +231,17 @@ export const useDrawHeader = <
             { ...args, tableId },
             {
               id: generateInteractableId("convert", columnKey),
-              pos: {
+              posRelativeToVisibleGridArea: {
                 left: calculatorIconStartX,
                 right: calculatorIconStartX + calculatorIconSize,
                 top: centerY - calculatorIconSize / 2,
                 bottom: centerY + calculatorIconSize / 2,
               },
               onClick: (interactable) =>
-                onConvertClicked?.(columnKey, interactable.pos),
+                onConvertClicked?.(
+                  columnKey,
+                  interactable.posRelativeToVisibleGridArea,
+                ),
             },
           ),
         );

--- a/apps/hash-frontend/src/components/grid/utils/use-grid-tooltip.tsx
+++ b/apps/hash-frontend/src/components/grid/utils/use-grid-tooltip.tsx
@@ -158,6 +158,7 @@ export const useGridTooltip = (
         PaperProps={{
           sx: {
             p: 0,
+            borderRadius: 2,
           },
         }}
       >
@@ -179,7 +180,10 @@ export const useGridTooltip = (
             </Typography>
           </Box>
         ) : (
-          <Box ref={tooltipRef} sx={{ maxWidth: bounds?.width }}>
+          <Box
+            ref={tooltipRef}
+            sx={{ maxWidth: bounds?.width, borderRadius: 2 }}
+          >
             {gridTooltip.content}
           </Box>
         )}

--- a/apps/hash-frontend/src/components/grid/utils/use-grid-tooltip/draw-interactable-tooltip-icons.ts
+++ b/apps/hash-frontend/src/components/grid/utils/use-grid-tooltip/draw-interactable-tooltip-icons.ts
@@ -39,12 +39,9 @@ export const drawInteractableTooltipIcons = (
      */
     const reversedIndex = tooltips.length - i - 1;
 
-    const tooltipX =
-      rect.x +
-      rect.width -
-      iconSize -
-      cellMargin -
-      reversedIndex * (iconGap + iconSize);
+    const rightOffset = cellMargin - reversedIndex * (iconGap + iconSize);
+
+    const tooltipX = rect.x + rect.width - iconSize - rightOffset;
 
     const yCenter = getYCenter(args);
 
@@ -59,11 +56,9 @@ export const drawInteractableTooltipIcons = (
       1,
     );
 
-    const actualTooltipX = tooltipX - rect.x;
-
     const interactable = InteractableManager.createCellInteractable(args, {
       id: `tooltip-${i}`,
-      pos: {
+      posRelativeToVisibleGridArea: {
         left: tooltipX,
         right: tooltipX + iconSize,
         top: yCenter - iconSize / 2,
@@ -71,8 +66,16 @@ export const drawInteractableTooltipIcons = (
       },
       onMouseEnter: () =>
         showTooltip({
-          text: tooltip.text,
-          iconX: actualTooltipX + iconSize / 2,
+          content: tooltip.text,
+          horizontalAlign: "center",
+          interactablePosRelativeToCell: {
+            right: rightOffset,
+            top: yCenter - rect.y - iconSize / 2,
+          },
+          interactableSize: {
+            width: iconSize,
+            height: iconSize,
+          },
           colIndex: col,
           rowIndex: row,
         }),

--- a/apps/hash-frontend/src/components/grid/utils/use-grid-tooltip/types.ts
+++ b/apps/hash-frontend/src/components/grid/utils/use-grid-tooltip/types.ts
@@ -6,8 +6,21 @@ import type { CustomIcon } from "../custom-grid-icons";
 export type GridTooltip = {
   colIndex: number;
   rowIndex: number;
-  text: string;
-  iconX: number;
+  content: string | ReactElement;
+  horizontalAlign: "left" | "center";
+  interactablePosRelativeToCell:
+    | {
+        right: number;
+        top: number;
+      }
+    | {
+        left: number;
+        top: number;
+      };
+  interactableSize: {
+    width: number;
+    height: number;
+  };
 };
 
 export type CellTooltipData = {

--- a/apps/hash-frontend/src/pages/@/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/outgoing-links-section/cells/linked-with-cell.ts
+++ b/apps/hash-frontend/src/pages/@/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/outgoing-links-section/cells/linked-with-cell.ts
@@ -96,7 +96,7 @@ export const renderLinkedWithCell: CustomRenderer<LinkedWithCell> = {
         interactables.push(
           InteractableManager.createCellInteractable(args, {
             id: `${cell.data.linkRow.rowId}-retry-upload`,
-            pos: {
+            posRelativeToVisibleGridArea: {
               left: leftDrawPosition,
               right: leftDrawPosition + retryIconWidth,
               top: yCenter - retryIconWidth / 2,
@@ -186,7 +186,7 @@ export const renderLinkedWithCell: CustomRenderer<LinkedWithCell> = {
 
     const deleteButton = InteractableManager.createCellInteractable(args, {
       id: "delete",
-      pos: {
+      posRelativeToVisibleGridArea: {
         left: buttonRight - iconSize,
         right: buttonRight,
         top: yCenter - iconSize / 2,
@@ -204,8 +204,8 @@ export const renderLinkedWithCell: CustomRenderer<LinkedWithCell> = {
       "bpTrash",
       "normal",
       ctx,
-      deleteButton.pos.left,
-      deleteButton.pos.top,
+      deleteButton.posRelativeToVisibleGridArea.left,
+      deleteButton.posRelativeToVisibleGridArea.top,
       iconSize,
       {
         ...theme,

--- a/apps/hash-frontend/src/pages/@/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table.tsx
@@ -26,7 +26,9 @@ export const PropertyTable = ({
   const gridRef = useRef<DataEditorRef>(null);
   const { togglePropertyExpand, propertyExpandStatus } = useEntityEditor();
   const [rows, sortAndFlattenRows] = useRows();
+
   const { tooltipElement, showTooltip, hideTooltip } = useGridTooltip(gridRef);
+
   const createGetCellContent = useCreateGetCellContent(
     showTooltip,
     hideTooltip,

--- a/apps/hash-frontend/src/pages/@/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
@@ -16,12 +16,28 @@ const Page: NextPageWithLayout = () => {
   const isDraft = !!router.query.draft;
   const { loading: loadingNamespace, routeNamespace } = useRouteNamespace();
 
-  const [slug, _, requestedVersionString] = router.query[
-    "slug-maybe-version"
-  ] as [string, "v" | undefined, `${number}` | undefined]; // @todo validate that the URL is formatted as expected;
+  /**
+   * router.query is not populated in this page, probably some combination of the rewrite @[shortname] routes and the fact this is a catch all.
+   * We have to parse out the path ourselves.
+   *
+   * @see https://github.com/vercel/next.js/issues/50212 –– possibly related
+   *
+   * @example /@hash/types/entity-type/user/v/1
+   * @example /@hash/types/entity-type/user
+   */
+  const [_, shortname, _types, _entityType, slug, _v, requestedVersionString] =
+    router.asPath.split("/") as [
+      "",
+      `@${string}`,
+      "types",
+      "entity-type",
+      string,
+      "v" | undefined,
+      `${number}` | undefined,
+    ];
 
   const entityTypeBaseUrl = !isDraft
-    ? getEntityTypeBaseUrl(slug, `@${router.query.shortname}`)
+    ? getEntityTypeBaseUrl(slug, shortname)
     : undefined;
 
   const draftEntityType = useMemo(() => {

--- a/apps/hash-frontend/src/pages/shared/chip-cell.tsx
+++ b/apps/hash-frontend/src/pages/shared/chip-cell.tsx
@@ -128,7 +128,7 @@ export const createRenderChipCell = (params?: {
         interactables.push(
           InteractableManager.createCellInteractable(args, {
             id: generateUuid(),
-            pos: {
+            posRelativeToVisibleGridArea: {
               left: chipLeft,
               right: chipLeft + width + arrowSize + arrowSpacing,
               top,

--- a/apps/hash-frontend/src/pages/shared/sources-popover.tsx
+++ b/apps/hash-frontend/src/pages/shared/sources-popover.tsx
@@ -4,7 +4,7 @@ import type { RefObject } from "react";
 
 import { Link } from "../../shared/ui/link";
 
-const SourcesList = ({ sources }: { sources: SourceProvenance[] }) => {
+export const SourcesList = ({ sources }: { sources: SourceProvenance[] }) => {
   return (
     <Box
       p={1.5}
@@ -100,7 +100,8 @@ export const SourcesPopover = ({
           sx: {
             borderRadius: 2,
             width: cellRef.current?.scrollWidth,
-            minWidth: "fit-content",
+            minWidth: 400,
+            maxWidth: 600,
           },
         },
         root: {

--- a/apps/hash-frontend/src/pages/shared/sources-popover.tsx
+++ b/apps/hash-frontend/src/pages/shared/sources-popover.tsx
@@ -39,31 +39,30 @@ export const SourcesList = ({ sources }: { sources: SourceProvenance[] }) => {
                 p: 1.5,
               })}
             >
-              <Typography
-                sx={{
-                  fontSize: 13,
-                  fontWeight: 600,
-                }}
-              >
-                {source.location?.name ?? "Unknown"}
-              </Typography>
-              <Box mt={0.5} sx={{ lineHeight: 1 }}>
-                {sourceUrl ? (
-                  <Link
-                    href={sourceUrl}
-                    target="_blank"
-                    sx={{
-                      fontSize: 13,
-                      textDecoration: "none",
-                      wordBreak: "break-word",
-                    }}
-                  >
-                    {sourceUrl}
-                  </Link>
-                ) : (
-                  "Unknown"
-                )}
-              </Box>
+              {sourceUrl ? (
+                <Link
+                  href={sourceUrl}
+                  target="_blank"
+                  sx={{
+                    display: "block",
+                    fontSize: 13,
+                    fontWeight: 600,
+                    lineHeight: 1.3,
+                    textDecoration: "none",
+                  }}
+                >
+                  {source.location?.name ?? sourceUrl}
+                </Link>
+              ) : (
+                <Typography
+                  sx={{
+                    fontSize: 13,
+                    fontWeight: 600,
+                  }}
+                >
+                  {source.location?.name ?? "[Unknown title]"}
+                </Typography>
+              )}
             </Box>
           );
         })}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR:
- Shows the sources for a given property value (if any) on hovering over the value in the entity editor
- Fixes some behavior issues with grid table tooltips in general (make them disappear when leaving the tooltip, not when leaving the cell)
- Fixes a couple of bugs in the document inference action
- Fixes a bug when navigating client-side to a type's page

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. If you have sources for properties, testable in preview deployment

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

https://github.com/user-attachments/assets/f5b2ab26-fd38-46f2-a8a6-11fc350e2aeb

