### PR TITLE
H-3995: Make `value` required for properties with metadata

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/propose-entities.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/propose-entities.ts
@@ -1,5 +1,6 @@
 import type { VersionedUrl } from "@blockprotocol/type-system";
 import { typedEntries } from "@local/advanced-types/typed-entries";
+import { mergePropertyObjectAndMetadata } from "@local/hash-graph-sdk/entity";
 import type { EntityUuid } from "@local/hash-graph-types/entity";
 import type { ProposedEntity } from "@local/hash-isomorphic-utils/ai-inference-types";
 import { entityIdFromComponents } from "@local/hash-subgraph";
@@ -422,12 +423,15 @@ export const proposeEntities = async (params: {
                       const { properties: simplifiedProperties } =
                         proposedEntityOfType;
 
-                      const properties = simplifiedProperties
-                        ? mapSimplifiedPropertiesToProperties({
-                            simplifiedProperties,
-                            simplifiedPropertyTypeMappings,
-                          })
-                        : {};
+                      const properties = mergePropertyObjectAndMetadata(
+                        simplifiedProperties
+                          ? mapSimplifiedPropertiesToProperties({
+                              simplifiedProperties,
+                              simplifiedPropertyTypeMappings,
+                            })
+                          : {},
+                        undefined,
+                      );
 
                       await graphApiClient.validateEntity(
                         userAuthentication.actorId,

--- a/libs/@local/codec/package.json
+++ b/libs/@local/codec/package.json
@@ -5,7 +5,8 @@
   "license": "AGPL-3",
   "scripts": {
     "fix:clippy": "just clippy --fix",
-    "lint:clippy": "just clippy"
+    "lint:clippy": "just clippy",
+    "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
   },
   "dependencies": {
     "@rust/error-stack": "0.5.0",

--- a/libs/@local/codec/src/serde/string_hash_map.rs
+++ b/libs/@local/codec/src/serde/string_hash_map.rs
@@ -15,7 +15,7 @@
 //!
 //! #[derive(Debug, PartialEq, Serialize, Deserialize)]
 //! struct MyStruct {
-//!     #[serde(with = "codec::serde::string_hash_map")]
+//!     #[serde(with = "hash_codec::serde::string_hash_map")]
 //!     map: HashMap<u32, String>,
 //! }
 //!

--- a/libs/@local/graph/api/openapi/openapi.json
+++ b/libs/@local/graph/api/openapi/openapi.json
@@ -8180,6 +8180,9 @@
           {
             "type": "object",
             "title": "PropertyMetadataArray",
+            "required": [
+              "value"
+            ],
             "properties": {
               "metadata": {
                 "$ref": "#/components/schemas/ArrayMetadata"
@@ -8195,6 +8198,9 @@
           {
             "type": "object",
             "title": "PropertyMetadataObject",
+            "required": [
+              "value"
+            ],
             "properties": {
               "metadata": {
                 "$ref": "#/components/schemas/ObjectMetadata"
@@ -8860,6 +8866,9 @@
       },
       "PropertyWithMetadataArray": {
         "type": "object",
+        "required": [
+          "value"
+        ],
         "properties": {
           "metadata": {
             "$ref": "#/components/schemas/ArrayMetadata"
@@ -8875,6 +8884,9 @@
       },
       "PropertyWithMetadataObject": {
         "type": "object",
+        "required": [
+          "value"
+        ],
         "properties": {
           "metadata": {
             "$ref": "#/components/schemas/ObjectMetadata"

--- a/libs/@local/graph/types/rust/src/knowledge/property/array.rs
+++ b/libs/@local/graph/types/rust/src/knowledge/property/array.rs
@@ -6,7 +6,8 @@ use crate::knowledge::property::{ArrayMetadata, PropertyWithMetadata};
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropertyWithMetadataArray {
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    #[cfg_attr(feature = "utoipa", schema(required))]
     pub value: Vec<PropertyWithMetadata>,
     #[serde(default, skip_serializing_if = "ArrayMetadata::is_empty")]
     pub metadata: ArrayMetadata,

--- a/libs/@local/graph/types/rust/src/knowledge/property/metadata/mod.rs
+++ b/libs/@local/graph/types/rust/src/knowledge/property/metadata/mod.rs
@@ -21,14 +21,16 @@ use type_system::url::BaseUrl;
 pub enum PropertyMetadata {
     #[cfg_attr(feature = "utoipa", schema(title = "PropertyMetadataArray"))]
     Array {
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        #[serde(default)]
+        #[cfg_attr(feature = "utoipa", schema(required))]
         value: Vec<Self>,
         #[serde(default, skip_serializing_if = "ArrayMetadata::is_empty")]
         metadata: ArrayMetadata,
     },
     #[cfg_attr(feature = "utoipa", schema(title = "PropertyMetadataObject"))]
     Object {
-        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        #[serde(default)]
+        #[cfg_attr(feature = "utoipa", schema(required))]
         value: HashMap<BaseUrl, Self>,
         #[serde(default, skip_serializing_if = "ObjectMetadata::is_empty")]
         metadata: ObjectMetadata,

--- a/libs/@local/graph/types/rust/src/knowledge/property/object.rs
+++ b/libs/@local/graph/types/rust/src/knowledge/property/object.rs
@@ -137,7 +137,8 @@ impl<'a> FromSql<'a> for PropertyObject {
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropertyWithMetadataObject {
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(default)]
+    #[cfg_attr(feature = "utoipa", schema(required))]
     pub value: HashMap<BaseUrl, PropertyWithMetadata>,
     #[serde(default, skip_serializing_if = "ObjectMetadata::is_empty")]
     pub metadata: ObjectMetadata,

--- a/libs/@local/graph/types/typescript/src/entity.ts
+++ b/libs/@local/graph/types/typescript/src/entity.ts
@@ -241,6 +241,21 @@ export type PropertyWithMetadata =
   | PropertyObjectWithMetadata
   | PropertyValueWithMetadata;
 
+export const isValueWithMetadata = (
+  metadata: PropertyWithMetadata,
+): metadata is PropertyValueWithMetadata =>
+  metadata.metadata !== undefined && "dataTypeId" in metadata.metadata;
+
+export const isArrayWithMetadata = (
+  metadata: PropertyWithMetadata,
+): metadata is PropertyArrayWithMetadata =>
+  !isValueMetadata(metadata) && Array.isArray(metadata.value);
+
+export const isObjectWithMetadata = (
+  metadata: PropertyWithMetadata,
+): metadata is PropertyObjectWithMetadata =>
+  !isValueMetadata(metadata) && !Array.isArray(metadata.value);
+
 /**
  * A path to a property in a properties object
  *


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To distinguish between the array and the object variant of properties, the `value` needs to be defined. Then, it's possible to check, if `value` is an array or an object.

There is one drive-by change to enable more tests in CI