### PR TITLE
H-3998: Adjust global `turbo` dependencies

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -101,15 +101,26 @@
     }
   },
   "globalDependencies": [
+    // Changing any `turbo.json` file will trigger a full rebuild
     "**/turbo.json",
-    ".github/actions/**/*.yml",
-    ".github/scripts/**/*.rs",
-    ".github/workflows/**/*",
-    ".env*",
-    ".justfile",
-    ".yarnrc",
+
+    // Changing workflows should trigger a full rebuild so it's checked in CI
+    ".github/actions/**",
+    ".github/scripts/**",
+    ".github/workflows/**",
+
+    // Dot-files
+    ".*",
+
+    // Manifest files
+    "*.lock",
     "Cargo.toml",
     "package.json",
+    "pyproject.toml",
+    "rust-toolchain.toml",
+    "yarn*",
+
+    // External services
     "apps/hash-external-services/**"
   ]
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The current global dependencies are quite outdated and many files are not included so we manually do it by parsing the // package (the root package) in CI.

To avoid that, the global dependencies should be overhauled.

## 🔍 What does this change?

See the changed files

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this