### PR TITLE
H-4001: Improve VSCode/Zed file type handling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,8 @@
     "typescript",
     "typescriptreact"
   ],
-  "vitest.disableWorkspaceWarning": true
+  "vitest.disableWorkspaceWarning": true,
+  "files.associations": {
+    "turbo.json": "jsonc"
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,11 @@
   ],
   "vitest.disableWorkspaceWarning": true,
   "files.associations": {
-    "turbo.json": "jsonc"
+    "turbo.json": "jsonc",
+    ".sqlfluff": "toml",
+    ".prettierignore": "ignore",
+    ".markdownlintignore": "ignore",
+    ".dockerignore": "ignore",
+    ".sqlfluffignore": "ignore"
   }
 }

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -5,7 +5,13 @@
 {
   "file_types": {
     "TOML": [".sqlfluff"],
-    "JSONC": ["turbo.json"]
+    "JSONC": ["turbo.json"],
+    "Git Ignore": [
+      ".prettierignore",
+      ".markdownlintignore",
+      ".dockerignore",
+      ".sqlfluffignore"
+    ]
   },
   "auto_install_extensions": {
     "biome": true


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Turborepo does not support the `turbo.json` file being renamed to `.jsonc`, but it does correctly parse comments in the `.json` file (as introduced in https://github.com/hashintel/hash/pull/6314). This update to the repo `.vscode/settings.json` file tells VSCode/Cursor to treat the `turbo.json` file as if it were JSONC.

## 🔗 Related links

- Thread on [potential future support for the JSONC file extension in Turborepo](https://github.com/vercel/turborepo/issues/3793)