### PR TITLE
H-3999: Use `turbo query` to determine changed packages in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,11 +36,8 @@ jobs:
       - name: Determine changed packages
         id: packages
         run: |
-          FILTER=$(turbo run lint --dry-run=json --filter '...[HEAD^]' | jq -e '.packages | contains(["//"])' > /dev/null && echo '' || echo '--filter ...[HEAD^]')
-          PACKAGES=$(sh -c "turbo run lint --dry-run=json $FILTER" \
-            | jq '.tasks[]' \
-            | jq 'select(.task == "lint")' \
-            | jq --compact-output --slurp '{ package: [.[].package] | unique, include: [( .[] | {package: .package, directory: .directory })] | unique }')
+          PACKAGES=$(turbo query 'query { affectedPackages { items { name path } } }' \
+            | jq '.data.affectedPackages.items | [(.[] | select(.name != "//"))] | { name: [.[].name], include: . }')
 
           echo "packages=$PACKAGES" | tee -a $GITHUB_OUTPUT
 
@@ -50,7 +47,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.packages) }}
       fail-fast: false
-    if: needs.setup.outputs.packages != '{"package":[],"include":[]}'
+    if: needs.setup.outputs.packages != '{"name":[],"include":[]}'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -68,23 +65,23 @@ jobs:
         id: lints
         run: |
           set -x
-          ESLINT=$(turbo run lint:eslint --filter '${{ matrix.package }}' --dry-run=json \
+          ESLINT=$(turbo run lint:eslint --filter '${{ matrix.name }}' --dry-run=json \
             | jq '[.tasks[] | select(.task == "lint:eslint" and .command != "<NONEXISTENT>")] != []' || echo 'false')
           echo "eslint=$ESLINT" | tee -a $GITHUB_OUTPUT
 
-          TSC=$(turbo run lint:tsc --filter '${{ matrix.package }}' --dry-run=json \
+          TSC=$(turbo run lint:tsc --filter '${{ matrix.name }}' --dry-run=json \
             | jq '[.tasks[] | select(.task == "lint:tsc" and .command != "<NONEXISTENT>")] != []' || echo 'false')
           echo "tsc=$TSC" | tee -a $GITHUB_OUTPUT
 
-          CODEGEN=$(turbo run codegen --filter '${{ matrix.package }}' --dry-run=json \
+          CODEGEN=$(turbo run codegen --filter '${{ matrix.name }}' --dry-run=json \
             | jq '[.tasks[] | select(.task == "codegen" and .command != "<NONEXISTENT>")] != []' || echo 'false')
           echo "codegen=$CODEGEN" | tee -a $GITHUB_OUTPUT
 
-          HAS_RUST=$([[ -f "${{ matrix.directory }}/Cargo.toml" || ${{ matrix.directory }} = "apps/hash-graph" ]] && echo 'true' || echo 'false')
+          HAS_RUST=$([[ -f "${{ matrix.path }}/Cargo.toml" || ${{ matrix.path }} = "apps/hash-graph" ]] && echo 'true' || echo 'false')
           echo "has-rust=$HAS_RUST" | tee -a $GITHUB_OUTPUT
           if [[ $HAS_RUST = 'true' ]]; then
-            if [[ -f "${{ matrix.directory }}/rust-toolchain.toml" ]]; then
-              RUST_TOOLCHAIN_FILE="${{ matrix.directory }}/rust-toolchain.toml"
+            if [[ -f "${{ matrix.path }}/rust-toolchain.toml" ]]; then
+              RUST_TOOLCHAIN_FILE="${{ matrix.path }}/rust-toolchain.toml"
             else
               RUST_TOOLCHAIN_FILE="rust-toolchain.toml"
             fi
@@ -96,7 +93,7 @@ jobs:
       - name: Prune repository
         uses: ./.github/actions/prune-repository
         with:
-          scope: ${{ matrix.package }}
+          scope: ${{ matrix.name }}
 
       - name: Install Protobuf
         if: always() && steps.lints.outputs.has-rust == 'true'
@@ -107,7 +104,7 @@ jobs:
         uses: ./.github/actions/install-rust-toolchain
         with:
           toolchain: ${{ steps.lints.outputs.rust-toolchain }}
-          working-directory: ${{ matrix.directory }}
+          working-directory: ${{ matrix.path }}
 
       - name: Install Rust tools
         if: always() && steps.lints.outputs.has-rust == 'true'
@@ -122,7 +119,7 @@ jobs:
         if: always() && steps.lints.outputs.has-rust == 'true'
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
         with:
-          workspaces: ${{ matrix.directory }}
+          workspaces: ${{ matrix.path }}
           save-if: ${{ !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
 
       - name: Show disk usage
@@ -132,67 +129,67 @@ jobs:
         if: always() && steps.lints.outputs.codegen == 'true'
         run: |
           set -o pipefail
-          turbo run codegen --force --filter "${{ matrix.package }}"
+          turbo run codegen --force --filter "${{ matrix.name }}"
           while IFS= read -r line; do
             if [[ -n "$line" ]]; then
-              echo "Checking diff of ${{ matrix.directory }}/$line"
-              git --no-pager diff --exit-code --color -- "${{ matrix.directory }}/$line"
+              echo "Checking diff of ${{ matrix.path }}/$line"
+              git --no-pager diff --exit-code --color -- "${{ matrix.path }}/$line"
             fi
-          done <<< "$(cat ${{ matrix.directory }}/turbo.json | grep -v '^ *//' | jq -r '.pipeline.codegen.outputs | if . == null then "." else .[] end')"
+          done <<< "$(cat ${{ matrix.path }}/turbo.json | grep -v '^ *//' | jq -r '.pipeline.codegen.outputs | if . == null then "." else .[] end')"
 
       - name: Show disk usage
         run: df -h
 
       - name: Run ESLint
         if: always() && steps.lints.outputs.eslint == 'true'
-        run: turbo run lint:eslint --filter "${{ matrix.package }}"
+        run: turbo run lint:eslint --filter "${{ matrix.name }}"
 
       - name: Run TSC
         if: always() && steps.lints.outputs.tsc == 'true'
-        run: turbo run lint:tsc --filter "${{ matrix.package }}"
+        run: turbo run lint:tsc --filter "${{ matrix.name }}"
 
       - name: Run rustfmt
         if: always() && steps.lints.outputs.has-rustfmt == 'true'
-        working-directory: ${{ matrix.directory }}
+        working-directory: ${{ matrix.path }}
         run: just format --check
 
       - name: Run clippy
         if: always() && steps.lints.outputs.has-clippy == 'true'
         run: |
-          pushd ${{ matrix.directory }}
+          pushd ${{ matrix.path }}
           just clippy --message-format=json \
             | clippy-sarif \
             | jq '.runs[].results |= unique' \
             > clippy.sarif
           popd
-          cat ${{ matrix.directory }}/clippy.sarif | sarif-fmt
+          cat ${{ matrix.path }}/clippy.sarif | sarif-fmt
 
-          jq -e '.runs[].results == []' ${{ matrix.directory }}/clippy.sarif> /dev/null
+          jq -e '.runs[].results == []' ${{ matrix.path }}/clippy.sarif> /dev/null
 
       - name: Print clippy errors to summary
         if: failure() && steps.lints.outputs.has-clippy == 'true'
         run: |
           echo '```' >> $GITHUB_STEP_SUMMARY
-          cat ${{ matrix.directory }}/clippy.sarif | sarif-fmt >> $GITHUB_STEP_SUMMARY
+          cat ${{ matrix.path }}/clippy.sarif | sarif-fmt >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8
         if: always() && steps.lints.outputs.has-clippy == 'true'
         with:
-          sarif_file: ${{ matrix.directory }}/clippy.sarif
-          category: ${{ matrix.package }}
+          sarif_file: ${{ matrix.path }}/clippy.sarif
+          category: ${{ matrix.name }}
 
       - name: Check public documentation
         if: always() && steps.lints.outputs.has-rust == 'true'
-        working-directory: ${{ matrix.directory }}
+        working-directory: ${{ matrix.path }}
         env:
           RUSTDOCFLAGS: "--check -Z unstable-options -D warnings"
         run: cargo doc --all-features --no-deps -Zrustdoc-scrape-examples
 
       - name: Check private documentation
         if: always() && steps.lints.outputs.has-rust == 'true'
-        working-directory: ${{ matrix.directory }}
+        working-directory: ${{ matrix.path }}
         env:
           RUSTDOCFLAGS: "--check -Z unstable-options -D warnings"
         run: cargo doc --all-features --no-deps -Zrustdoc-scrape-examples  --document-private-items

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
         id: packages
         run: |
           PACKAGES=$(turbo query 'query { affectedPackages { items { name path } } }' \
-            | jq '.data.affectedPackages.items | [(.[] | select(.name != "//"))] | { name: [.[].name], include: . }')
+            | jq --compact-output '.data.affectedPackages.items | [(.[] | select(.name != "//"))] | { name: [.[].name], include: . }')
 
           echo "packages=$PACKAGES" | tee -a $GITHUB_OUTPUT
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,11 +41,11 @@ jobs:
         id: packages
         run: |
           UNIT_TEST_PACKAGES=$(turbo query 'query { affectedPackages(filter: {has: {field: TASK_NAME, value: "test:unit"}}) { items { name path } } }' \
-            | jq --compact-output '.data.affectedPackages.items | { name: [.[].name], include: . }')
+            | jq --compact-output '.data.affectedPackages.items | [(.[] | select(.name != "//"))] | { name: [.[].name], include: . }')
           INTEGRATION_TEST_PACKAGES=$(turbo query 'query { affectedPackages(filter: {has: {field: TASK_NAME, value: "test:integration"}}) { items { name path } } }' \
-            | jq --compact-output '.data.affectedPackages.items | { name: [.[].name], include: . }')
+            | jq --compact-output '.data.affectedPackages.items | [(.[] | select(.name != "//"))] | { name: [.[].name], include: . }')
           DOCKER_PACKAGES=$(turbo query 'query { affectedPackages(filter: {has: {field: TASK_NAME, value: "build:docker"}}) { items { name path } } }' \
-            | jq --compact-output '.data.affectedPackages.items | { name: [.[].name], include: . }')
+            | jq --compact-output '.data.affectedPackages.items | [(.[] | select(.name != "//"))] | { name: [.[].name], include: . }')
 
           PUBLISH_PACKAGES=[]
           PUBLISH_INCLUDES=[]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,11 +41,11 @@ jobs:
         id: packages
         run: |
           UNIT_TEST_PACKAGES=$(turbo query 'query { affectedPackages(filter: {has: {field: TASK_NAME, value: "test:unit"}}) { items { name path } } }' \
-            | jq '.data.affectedPackages.items | { name: [.[].name], include: . }')
+            | jq --compact-output '.data.affectedPackages.items | { name: [.[].name], include: . }')
           INTEGRATION_TEST_PACKAGES=$(turbo query 'query { affectedPackages(filter: {has: {field: TASK_NAME, value: "test:integration"}}) { items { name path } } }' \
-            | jq '.data.affectedPackages.items | { name: [.[].name], include: . }')
+            | jq --compact-output '.data.affectedPackages.items | { name: [.[].name], include: . }')
           DOCKER_PACKAGES=$(turbo query 'query { affectedPackages(filter: {has: {field: TASK_NAME, value: "build:docker"}}) { items { name path } } }' \
-            | jq '.data.affectedPackages.items | { name: [.[].name], include: . }')
+            | jq --compact-output '.data.affectedPackages.items | { name: [.[].name], include: . }')
 
           PUBLISH_PACKAGES=[]
           PUBLISH_INCLUDES=[]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,23 +40,12 @@ jobs:
       - name: Determine changed packages
         id: packages
         run: |
-          UNIT_TEST_FILTER=$(turbo run test:unit --dry-run=json --filter '...[HEAD^]' | jq -e '.packages | contains(["//"])' > /dev/null && echo '' || echo '--filter ...[HEAD^]')
-          UNIT_TEST_TASKS=$(sh -c "turbo run test:unit --dry-run=json $UNIT_TEST_FILTER" | jq -c '.tasks[]')
-          UNIT_TEST_PACKAGES=$(echo "$UNIT_TEST_TASKS" \
-            | jq 'select(.task == "test:unit" and .command != "<NONEXISTENT>")' \
-            | jq --compact-output --slurp '{ package: [.[].package] | unique, include: [( .[] | {package: .package, directory: .directory })] | unique }')
-
-          INTEGRATION_TEST_FILTER=$(turbo run test:integration --dry-run=json --filter '...[HEAD^]' | jq -e '.packages | contains(["//"])' > /dev/null && echo '' || echo '--filter ...[HEAD^]')
-          INTEGRATION_TEST_TASKS=$(sh -c "turbo run test:integration --dry-run=json $INTEGRATION_TEST_FILTER" | jq -c '.tasks[]')
-          INTEGRATION_TEST_PACKAGES=$(echo "$INTEGRATION_TEST_TASKS" \
-            | jq 'select(.task == "test:integration" and .command != "<NONEXISTENT>")' \
-            | jq --compact-output --slurp '{ package: [.[].package] | unique, include: [( .[] | {package: .package, directory: .directory })] | unique }')
-
-          DOCKER_PACKAGES_FILTER=$(turbo run build:docker --dry-run=json --filter '...[HEAD^]' | jq -e '.packages | contains(["//"])' > /dev/null && echo '' || echo '--filter ...[HEAD^]')
-          DOCKER_PACKAGES=$(sh -c "turbo run build:docker --dry-run=json $DOCKER_PACKAGES_FILTER" \
-            | jq '.tasks[]' \
-            | jq 'select(.task == "build:docker" and .command != "<NONEXISTENT>")' \
-            | jq --compact-output --slurp '{ package: [.[].package] | unique, include: [( .[] | {package: .package, directory: .directory })] | unique }')
+          UNIT_TEST_PACKAGES=$(turbo query 'query { affectedPackages(filter: {has: {field: TASK_NAME, value: "test:unit"}}) { items { name path } } }' \
+            | jq '.data.affectedPackages.items | { name: [.[].name], include: . }')
+          INTEGRATION_TEST_PACKAGES=$(turbo query 'query { affectedPackages(filter: {has: {field: TASK_NAME, value: "test:integration"}}) { items { name path } } }' \
+            | jq '.data.affectedPackages.items | { name: [.[].name], include: . }')
+          DOCKER_PACKAGES=$(turbo query 'query { affectedPackages(filter: {has: {field: TASK_NAME, value: "build:docker"}}) { items { name path } } }' \
+            | jq '.data.affectedPackages.items | { name: [.[].name], include: . }')
 
           PUBLISH_PACKAGES=[]
           PUBLISH_INCLUDES=[]
@@ -89,10 +78,10 @@ jobs:
               DIR=$(dirname "$file")
 
               PUBLISH_PACKAGES=$(echo "$PUBLISH_PACKAGES" | jq -c --arg package "$PACKAGE_NAME" '. += [$package]')
-              PUBLISH_INCLUDES=$(echo "$PUBLISH_INCLUDES" | jq -c --arg package "$PACKAGE_NAME" --arg directory "$DIR" '. += [{package: $package, directory: $directory}]')
+              PUBLISH_INCLUDES=$(echo "$PUBLISH_INCLUDES" | jq -c --arg package "$PACKAGE_NAME" --arg directory "$DIR" '. += [{name: $package, path: $directory}]')
             fi
           done <<< "$(find . -name 'Cargo.toml' -type f | sed 's|\./||')"
-          PUBLISH_PACKAGES=$(jq -c -n --argjson packages "$PUBLISH_PACKAGES" --argjson includes "$PUBLISH_INCLUDES" '{package: $packages, include: $includes}')
+          PUBLISH_PACKAGES=$(jq -c -n --argjson packages "$PUBLISH_PACKAGES" --argjson includes "$PUBLISH_INCLUDES" '{name: $packages, include: $includes}')
 
           echo "unit-tests=$UNIT_TEST_PACKAGES" | tee -a $GITHUB_OUTPUT
           echo "integration-tests=$INTEGRATION_TEST_PACKAGES" | tee -a $GITHUB_OUTPUT
@@ -106,7 +95,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.unit-tests) }}
       fail-fast: false
-    if: needs.setup.outputs.unit-tests != '{"package":[],"include":[]}'
+    if: needs.setup.outputs.unit-tests != '{"name":[],"include":[]}'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -121,11 +110,11 @@ jobs:
       - name: Find test steps to run
         id: tests
         run: |
-          HAS_RUST=$([[ -f "${{ matrix.directory }}/Cargo.toml" || ${{ matrix.directory }} = "apps/hash-graph" ]] && echo 'true' || echo 'false')
+          HAS_RUST=$([[ -f "${{ matrix.path }}/Cargo.toml" || ${{ matrix.path }} = "apps/hash-graph" ]] && echo 'true' || echo 'false')
           echo "has-rust=$HAS_RUST" | tee -a $GITHUB_OUTPUT
           if [[ $HAS_RUST = 'true' ]]; then
-            if [[ -f "${{ matrix.directory }}/rust-toolchain.toml" ]]; then
-              RUST_TOOLCHAIN_FILE="${{ matrix.directory }}/rust-toolchain.toml"
+            if [[ -f "${{ matrix.path }}/rust-toolchain.toml" ]]; then
+              RUST_TOOLCHAIN_FILE="${{ matrix.path }}/rust-toolchain.toml"
             else
               RUST_TOOLCHAIN_FILE="rust-toolchain.toml"
             fi
@@ -136,30 +125,30 @@ jobs:
       - name: Prune repository
         uses: ./.github/actions/prune-repository
         with:
-          scope: ${{ matrix.package }}
+          scope: ${{ matrix.name }}
 
       - name: Install Protobuf
         if: always() && steps.tests.outputs.has-rust == 'true'
         run: sudo apt install protobuf-compiler
 
       - name: Install PDFium
-        if: matrix.package == '@rust/chonky'
+        if: matrix.name == '@rust/chonky'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           temp_dir=$(mktemp -d)
           gh release download chromium/6721 --repo bblanchon/pdfium-binaries --pattern 'pdfium-linux-x64.tgz' --dir $temp_dir
           tar -xzf $temp_dir/pdfium-linux-x64.tgz -C $temp_dir
-          mv $temp_dir/lib/* "${{ matrix.directory }}/libs/"
+          mv $temp_dir/lib/* "${{ matrix.path }}/libs/"
           rm -rf $temp_dir
-          echo "PDFIUM_DYNAMIC_LIB_PATH=$(pwd)/${{ matrix.directory }}/libs/" >> $GITHUB_ENV
+          echo "PDFIUM_DYNAMIC_LIB_PATH=$(pwd)/${{ matrix.path }}/libs/" >> $GITHUB_ENV
 
       - name: Install Rust toolchain
         if: always() && steps.tests.outputs.has-rust == 'true'
         uses: ./.github/actions/install-rust-toolchain
         with:
           toolchain: ${{ steps.tests.outputs.rust-toolchain }}
-          working-directory: ${{ matrix.directory }}
+          working-directory: ${{ matrix.path }}
 
       - name: Install Rust tools
         if: always() && steps.tests.outputs.has-rust == 'true'
@@ -174,7 +163,7 @@ jobs:
         if: always() && steps.tests.outputs.has-rust == 'true'
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
         with:
-          workspaces: ${{ matrix.directory }}
+          workspaces: ${{ matrix.path }}
           save-if: ${{ !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
 
       - name: Show disk usage
@@ -185,8 +174,8 @@ jobs:
         env:
           TEST_COVERAGE: ${{ github.event_name != 'merge_group' }}
         run: |
-          turbo run test:unit --env-mode=loose --filter "${{ matrix.package }}"
-          echo "TRIMMED_PACKAGE_NAME=$(echo "${{ matrix.package }}" | sed 's|@||g' | sed 's|/|.|g')" >> $GITHUB_ENV
+          turbo run test:unit --env-mode=loose --filter "${{ matrix.name }}"
+          echo "TRIMMED_PACKAGE_NAME=$(echo "${{ matrix.name }}" | sed 's|@||g' | sed 's|/|.|g')" >> $GITHUB_ENV
 
       - name: Show disk usage
         run: df -h
@@ -200,7 +189,7 @@ jobs:
       - name: Run miri
         if: always() && steps.tests.outputs.has-miri == 'true'
         run: |
-          turbo run test:miri --filter "${{ matrix.package }}"
+          turbo run test:miri --filter "${{ matrix.name }}"
 
   build:
     name: Build
@@ -209,7 +198,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.dockers) }}
       fail-fast: false
-    if: needs.setup.outputs.dockers != '{"package":[],"include":[]}'
+    if: needs.setup.outputs.dockers != '{"name":[],"include":[]}'
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -218,11 +207,11 @@ jobs:
         uses: ./.github/actions/build-docker-images
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          hash-graph: ${{ matrix.package == '@apps/hash-graph' }}
-          hash-ai-worker-ts: ${{ matrix.package == '@apps/hash-ai-worker-ts' }}
-          hash-integration-worker: ${{ matrix.package == '@apps/hash-integration-worker' }}
+          hash-graph: ${{ matrix.name == '@apps/hash-graph' }}
+          hash-ai-worker-ts: ${{ matrix.name == '@apps/hash-ai-worker-ts' }}
+          hash-integration-worker: ${{ matrix.name == '@apps/hash-integration-worker' }}
           GOOGLE_CLOUD_WORKLOAD_IDENTITY_FEDERATION_CONFIG_JSON: ${{ secrets.GOOGLE_CLOUD_WORKLOAD_IDENTITY_FEDERATION_CONFIG_JSON }}
-          hash-api: ${{ matrix.package == '@apps/hash-api' }}
+          hash-api: ${{ matrix.name == '@apps/hash-api' }}
 
   integration-tests:
     name: Integration
@@ -230,7 +219,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.integration-tests) }}
       fail-fast: false
-    if: needs.setup.outputs.integration-tests != '{"package":[],"include":[]}'
+    if: needs.setup.outputs.integration-tests != '{"name":[],"include":[]}'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -246,21 +235,21 @@ jobs:
         uses: ./.github/actions/prune-repository
         with:
           scope: |
-            ${{ matrix.package }}
+            ${{ matrix.name }}
             @apps/hash-external-services
 
       - name: Find test steps to run
         id: tests
         run: |
-          TEST_TASKS=$(turbo run test:integration --env-mode=loose --dry-run=json --filter "${{ matrix.package }}" | jq -c '.tasks[]')
-          HAS_BACKGROUND_TASKS=$(turbo run start:test --dry-run json | jq -c '[.tasks[] | select(.command != "<NONEXISTENT>" and .package != "@apps/hash-external-services") | .package] != []' || echo 'false')
+          TEST_TASKS=$(turbo run test:integration --env-mode=loose --dry-run=json --filter "${{ matrix.name }}" | jq -c '.tasks[]')
+          HAS_BACKGROUND_TASKS=$(turbo run start:test --dry-run json | jq -c '[.tasks[] | select(.command != "<NONEXISTENT>" and .name != "@apps/hash-external-services") | .name] != []' || echo 'false')
           echo "has-background-tasks=$HAS_BACKGROUND_TASKS" | tee -a $GITHUB_OUTPUT
 
-          HAS_RUST=$([[ -f "${{ matrix.directory }}/Cargo.toml" || ${{ matrix.directory }} = "apps/hash-graph" ]] && echo 'true' || echo 'false')
+          HAS_RUST=$([[ -f "${{ matrix.path }}/Cargo.toml" || ${{ matrix.path }} = "apps/hash-graph" ]] && echo 'true' || echo 'false')
           echo "has-rust=$HAS_RUST" | tee -a $GITHUB_OUTPUT
 
-          if [[ -f "${{ matrix.directory }}/rust-toolchain.toml" ]]; then
-            RUST_TOOLCHAIN_FILE="${{ matrix.directory }}/rust-toolchain.toml"
+          if [[ -f "${{ matrix.path }}/rust-toolchain.toml" ]]; then
+            RUST_TOOLCHAIN_FILE="${{ matrix.path }}/rust-toolchain.toml"
           else
             RUST_TOOLCHAIN_FILE="rust-toolchain.toml"
           fi
@@ -277,7 +266,7 @@ jobs:
         uses: ./.github/actions/install-rust-toolchain
         with:
           toolchain: ${{ steps.tests.outputs.rust-toolchain }}
-          working-directory: ${{ matrix.directory }}
+          working-directory: ${{ matrix.path }}
 
       - name: Install Rust tools
         if: steps.tests.outputs.has-rust == 'true'
@@ -292,19 +281,19 @@ jobs:
         run: sudo apt install protobuf-compiler
 
       - name: Install PDFium
-        if: matrix.package == '@rust/chonky'
+        if: matrix.name == '@rust/chonky'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           temp_dir=$(mktemp -d)
           gh release download chromium/6721 --repo bblanchon/pdfium-binaries --pattern 'pdfium-linux-x64.tgz' --dir $temp_dir
           tar -xzf $temp_dir/pdfium-linux-x64.tgz -C $temp_dir
-          mv $temp_dir/lib/* "${{ matrix.directory }}/libs/"
+          mv $temp_dir/lib/* "${{ matrix.path }}/libs/"
           rm -rf $temp_dir
-          echo "PDFIUM_DYNAMIC_LIB_PATH=$(pwd)/${{ matrix.directory }}/libs/" >> $GITHUB_ENV
+          echo "PDFIUM_DYNAMIC_LIB_PATH=$(pwd)/${{ matrix.path }}/libs/" >> $GITHUB_ENV
 
       - name: Install playwright
-        if: matrix.package == '@tests/hash-playwright'
+        if: matrix.name == '@tests/hash-playwright'
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
         with:
           max_attempts: 3
@@ -316,7 +305,7 @@ jobs:
         if: steps.tests.outputs.has-rust == 'true'
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
         with:
-          workspaces: ${{ matrix.directory }}
+          workspaces: ${{ matrix.path }}
           save-if: ${{ !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
 
       - name: Show disk usage
@@ -361,8 +350,8 @@ jobs:
       - name: Run tests
         continue-on-error: ${{ steps.tests.outputs.allow-failure == 'true' }}
         run: |
-          turbo run test:integration --env-mode=loose --filter "${{ matrix.package }}"
-          echo "TRIMMED_PACKAGE_NAME=$(echo "${{ matrix.package }}" | sed 's|@||g' | sed 's|/|.|g')" >> $GITHUB_ENV
+          turbo run test:integration --env-mode=loose --filter "${{ matrix.name }}"
+          echo "TRIMMED_PACKAGE_NAME=$(echo "${{ matrix.name }}" | sed 's|@||g' | sed 's|/|.|g')" >> $GITHUB_ENV
 
       - name: Show disk usage
         run: df -h
@@ -384,7 +373,7 @@ jobs:
           cat var/logs/background-task.log
 
       - name: Upload artifact playwright-report
-        if: matrix.package == '@tests/hash-playwright' && success() || failure()
+        if: matrix.name == '@tests/hash-playwright' && success() || failure()
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: ${{ env.TRIMMED_PACKAGE_NAME }}_report
@@ -405,7 +394,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.setup.outputs.publish) }}
-    if: needs.setup.outputs.publish != '{"package":[],"include":[]}'
+    if: needs.setup.outputs.publish != '{"name":[],"include":[]}'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout source code
@@ -414,11 +403,11 @@ jobs:
       - name: Find publish jobs to run
         id: publish
         run: |
-          HAS_RUST=$([[ -f "${{ matrix.directory }}/Cargo.toml" || ${{ matrix.directory }} = "apps/hash-graph" ]] && echo 'true' || echo 'false')
+          HAS_RUST=$([[ -f "${{ matrix.path }}/Cargo.toml" || ${{ matrix.path }} = "apps/hash-graph" ]] && echo 'true' || echo 'false')
           echo "has-rust=$HAS_RUST" | tee -a $GITHUB_OUTPUT
           if [[ $HAS_RUST = 'true' ]]; then
-            if [[ -f "${{ matrix.directory }}/rust-toolchain.toml" ]]; then
-              RUST_TOOLCHAIN_FILE="${{ matrix.directory }}/rust-toolchain.toml"
+            if [[ -f "${{ matrix.path }}/rust-toolchain.toml" ]]; then
+              RUST_TOOLCHAIN_FILE="${{ matrix.path }}/rust-toolchain.toml"
             else
               RUST_TOOLCHAIN_FILE="rust-toolchain.toml"
             fi
@@ -430,7 +419,7 @@ jobs:
         uses: ./.github/actions/install-rust-toolchain
         with:
           toolchain: ${{ steps.publish.outputs.rust-toolchain }}
-          working-directory: ${{ matrix.directory }}
+          working-directory: ${{ matrix.path }}
 
       - name: Login
         run: |
@@ -439,12 +428,12 @@ jobs:
 
       - name: Publish (dry run)
         if: always() && steps.publish.outputs.has-rust == 'true' && github.event_name == 'pull_request' || github.event_name == 'merge_group'
-        working-directory: ${{ matrix.directory }}
+        working-directory: ${{ matrix.path }}
         run: cargo publish --all-features --dry-run --no-verify
 
       - name: Publish
         if: always() && steps.publish.outputs.has-rust == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        working-directory: ${{ matrix.directory }}
+        working-directory: ${{ matrix.path }}
         run: cargo publish --all-features --no-verify
 
   passed:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, we use `turbo run ... dry-run. Instead, we can use `turbo query`.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph