### PR TITLE
H-4003: Use `uuid.NIL` for public account ID

### DIFF
--- a/libs/@local/hash-backend-utils/package.json
+++ b/libs/@local/hash-backend-utils/package.json
@@ -52,6 +52,7 @@
     "logform": "2.7.0",
     "redis": "4.7.0",
     "slonik": "24.2.0",
+    "uuid": "11.0.5",
     "wait-on": "8.0.2",
     "winston": "3.17.0"
   },
@@ -60,6 +61,7 @@
     "@local/tsconfig": "0.0.0-private",
     "@types/dotenv-flow": "3.3.3",
     "@types/node": "22.13.0",
+    "@types/uuid": "9.0.8",
     "@types/wait-on": "5.3.4",
     "@vitest/coverage-istanbul": "2.1.8",
     "eslint": "9.19.0",

--- a/libs/@local/hash-backend-utils/src/public-user-account-id.ts
+++ b/libs/@local/hash-backend-utils/src/public-user-account-id.ts
@@ -1,5 +1,4 @@
 import type { AccountId } from "@local/hash-graph-types/account";
+import { NIL as UUID_NIL } from "uuid";
 
-// nosemgrep:
-export const publicUserAccountId: AccountId =
-  "00000000-0000-0000-0000-000000000000" as AccountId;
+export const publicUserAccountId: AccountId = UUID_NIL as AccountId;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9060,6 +9060,7 @@ __metadata:
     "@temporalio/workflow": "npm:1.11.7"
     "@types/dotenv-flow": "npm:3.3.3"
     "@types/node": "npm:22.13.0"
+    "@types/uuid": "npm:9.0.8"
     "@types/wait-on": "npm:5.3.4"
     "@vitest/coverage-istanbul": "npm:2.1.8"
     agentkeepalive: "npm:4.6.0"
@@ -9074,6 +9075,7 @@ __metadata:
     rimraf: "npm:6.0.1"
     slonik: "npm:24.2.0"
     typescript: "npm:5.7.3"
+    uuid: "npm:11.0.5"
     vitest: "npm:2.1.8"
     wait-on: "npm:8.0.2"
     winston: "npm:3.17.0"
@@ -18722,7 +18724,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/uuid@npm:^9.0.1":
+"@types/uuid@npm:9.0.8, @types/uuid@npm:^9.0.1":
   version: 9.0.8
   resolution: "@types/uuid@npm:9.0.8"
   checksum: 10c0/b411b93054cb1d4361919579ef3508a1f12bf15b5fdd97337d3d351bece6c921b52b6daeef89b62340fd73fd60da407878432a1af777f40648cbe53a01723489


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Semgrep complains about hardcoding an account ID. As this is a well-known constant, we can just use that instead.