### PR TITLE
H-4003: Permission to hard coded nil-UUID string denied, use constants instead

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/graph.ts
+++ b/apps/hash-ai-worker-ts/src/activities/graph.ts
@@ -1,4 +1,5 @@
 import { getHashInstanceAdminAccountGroupId } from "@local/hash-backend-utils/hash-instance";
+import { publicUserAccountId } from "@local/hash-backend-utils/public-user-account-id";
 import type {
   EntityQueryCursor,
   GetDataTypeSubgraphParams,
@@ -59,7 +60,7 @@ export const createGraphActivities = ({
 }) => ({
   async getUserAccountIds(): Promise<AccountId[]> {
     return graphApiClient
-      .getEntities("00000000-0000-0000-0000-000000000000", {
+      .getEntities(publicUserAccountId, {
         filter: {
           all: [
             {

--- a/apps/hash-ai-worker-ts/src/workflows.ts
+++ b/apps/hash-ai-worker-ts/src/workflows.ts
@@ -1,3 +1,4 @@
+import { publicUserAccountId } from "@local/hash-backend-utils/public-user-account-id";
 import type {
   Entity as GraphApiEntity,
   EntityQueryCursor,
@@ -462,7 +463,7 @@ export const updateAllDataTypeEmbeddings =
   async (): Promise<OpenAI.CreateEmbeddingResponse.Usage> =>
     await updateDataTypeEmbeddings({
       authentication: {
-        actorId: "00000000-0000-0000-0000-000000000000" as AccountId,
+        actorId: publicUserAccountId,
       },
       filter: {
         all: [
@@ -482,7 +483,7 @@ export const updateAllPropertyTypeEmbeddings =
   async (): Promise<OpenAI.CreateEmbeddingResponse.Usage> =>
     await updatePropertyTypeEmbeddings({
       authentication: {
-        actorId: "00000000-0000-0000-0000-000000000000" as AccountId,
+        actorId: publicUserAccountId,
       },
       filter: {
         all: [
@@ -502,7 +503,7 @@ export const updateAllEntityTypeEmbeddings =
   async (): Promise<OpenAI.CreateEmbeddingResponse.Usage> =>
     await updateEntityTypeEmbeddings({
       authentication: {
-        actorId: "00000000-0000-0000-0000-000000000000" as AccountId,
+        actorId: publicUserAccountId,
       },
       filter: {
         all: [

--- a/libs/@local/graph/validation/src/test_data_type.rs
+++ b/libs/@local/graph/validation/src/test_data_type.rs
@@ -294,7 +294,7 @@ async fn uuid() {
     .expect("validation failed");
 
     validate_data(
-        json!("00000000-0000-0000-0000-000000000000"),
+        json!(Uuid::nil()),
         &uuid_type,
         [hash_graph_test_data::data_type::VALUE_V1],
         ValidateEntityComponents::full(),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When possible we should use the constant `uuid.NIL` or the corresponding public account ID constant instead.