### PR TITLE
H-4005: Allow flaky test to fail (once)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,8 @@
+[profile.ci]
+fail-fast = false
+status-level = "skip"
+failure-output = "final"
+
+[[profile.ci.overrides]]
+filter = 'package(harpc-net) and test(session::test::echo_tcp_concurrent)'
+retries = 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: hashintel
   TURBO_REMOTE_ONLY: true
+  TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+  NEXTEST_PROFILE: ci
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/libs/@local/harpc/net/src/session/test.rs
+++ b/libs/@local/harpc/net/src/session/test.rs
@@ -377,7 +377,6 @@ async fn echo_memory_concurrent() {
 
 #[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 8))]
 async fn echo_tcp_concurrent() {
-    panic!();
     let address: Multiaddr = [
         multiaddr::Protocol::Ip4(Ipv4Addr::LOCALHOST),
         multiaddr::Protocol::Tcp(0),

--- a/libs/@local/harpc/net/src/session/test.rs
+++ b/libs/@local/harpc/net/src/session/test.rs
@@ -377,6 +377,7 @@ async fn echo_memory_concurrent() {
 
 #[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 8))]
 async fn echo_tcp_concurrent() {
+    panic!();
     let address: Multiaddr = [
         multiaddr::Protocol::Ip4(Ipv4Addr::LOCALHOST),
         multiaddr::Protocol::Tcp(0),

--- a/turbo.json
+++ b/turbo.json
@@ -111,6 +111,9 @@
 
     // Dot-files
     ".*",
+    ".cargo/**",
+    ".config/**",
+    ".yarn/**",
 
     // Manifest files
     "*.lock",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `session::test::echo_tcp_concurrent` sometimes fail in CI, this adds it to fail once per run.

## 🔍 What does this change?

- Adds a new `NexTest` profile `ci`
- Add override for the mentioned test