### PR TITLE
H-4008: Fix base branch detection for CI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Determine changed packages
         id: packages
         run: |
-          UNIT_BENCH_QUERY='query { affectedPackages(base: "[HEAD^]", filter: {has: {field: TASK_NAME, value: "bench:unit"}}) { items { name path } } }'
-          INTEGRATION_BENCH_QUERY='query { affectedPackages(base: "[HEAD^]", filter: {has: {field: TASK_NAME, value: "bench:integration"}}) { items { name path } } }'
+          UNIT_BENCH_QUERY='query { affectedPackages(base: "HEAD^", filter: {has: {field: TASK_NAME, value: "bench:unit"}}) { items { name path } } }'
+          INTEGRATION_BENCH_QUERY='query { affectedPackages(base: "HEAD^", filter: {has: {field: TASK_NAME, value: "bench:integration"}}) { items { name path } } }'
 
           UNIT_BENCH_PACKAGES=$(turbo query "$UNIT_BENCH_QUERY" \
             | jq --compact-output '.data.affectedPackages.items | [(.[] | select(.name != "//"))] | { name: [.[].name], include: . }')

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,7 +10,6 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: hashintel
   TURBO_REMOTE_ONLY: true
-  TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
 
   VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Determine changed packages
         id: packages
         run: |
-          UNIT_BENCH_QUERY="query { affectedPackages(base: \"$TURBO_SCM_BASE\", filter: {has: {field: TASK_NAME, value: \"bench:unit\"}}) { items { name path } } }"
-          INTEGRATION_BENCH_QUERY="query { affectedPackages(base: \"$TURBO_SCM_BASE\", filter: {has: {field: TASK_NAME, value: \"bench:integration\"}}) { items { name path } } }"
+          UNIT_BENCH_QUERY='query { affectedPackages(base: "[HEAD^]", filter: {has: {field: TASK_NAME, value: "bench:unit"}}) { items { name path } } }'
+          INTEGRATION_BENCH_QUERY='query { affectedPackages(base: "[HEAD^]", filter: {has: {field: TASK_NAME, value: "bench:integration"}}) { items { name path } } }'
 
           UNIT_BENCH_PACKAGES=$(turbo query "$UNIT_BENCH_QUERY" \
             | jq --compact-output '.data.affectedPackages.items | [(.[] | select(.name != "//"))] | { name: [.[].name], include: . }')

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,14 +36,12 @@ jobs:
       - name: Determine changed packages
         id: packages
         run: |
-          SOURCEMAPS_FILTER=$(turbo run sentry:sourcemaps --dry-run=json --filter '...[HEAD^]' | jq -e '.packages | contains(["//"])' > /dev/null && echo '' || echo '--filter ...[HEAD^]')
-          SOURCEMAPS_FILTER_TASKS=$(sh -c "turbo run sentry:sourcemaps --dry-run=json $SOURCEMAPS_FILTER_FILTER" | jq -c '.tasks[]')
-          SOURCEMAPS_FILTER_PACKAGES=$(echo "$SOURCEMAPS_FILTER_TASKS" \
-            | jq 'select(.task == "sentry:sourcemaps" and .command != "<NONEXISTENT>")' \
-            | jq --compact-output --slurp '{ package: [.[].package] | unique, include: [( .[] | {package: .package, directory: .directory })] | unique }')
+          SOURCEMAPS_QUERY='query { affectedPackages(base: "HEAD^", filter: {has: {field: TASK_NAME, value: "sentry:sourcemaps"}}) { items { name path } } }'
 
-          set -x
-          echo "sourcemaps=$SOURCEMAPS_FILTER_PACKAGES" | tee -a $GITHUB_OUTPUT
+          SOURCEMAPS_PACKAGES=$(turbo query "$SOURCEMAPS_QUERY" \
+            | jq --compact-output '.data.affectedPackages.items | [(.[] | select(.name != "//"))] | { name: [.[].name], include: . }')
+
+          echo "sourcemaps=$SOURCEMAPS_PACKAGES" | tee -a $GITHUB_OUTPUT
 
   sourcemaps:
     name: Sourcemaps
@@ -51,7 +49,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.sourcemaps) }}
       fail-fast: false
-    if: needs.setup.outputs.sourcemaps != '{"package":[],"include":[]}' && github.event.pull_request.head.repo.full_name == github.repository
+    if: needs.setup.outputs.sourcemaps != '{"name":[],"include":[]}' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
@@ -81,7 +79,7 @@ jobs:
       - name: Prune repository
         uses: ./.github/actions/prune-repository
         with:
-          scope: ${{ matrix.package }}
+          scope: ${{ matrix.name }}
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo
@@ -90,7 +88,7 @@ jobs:
         run: yarn sentry-cli login --auth-token ${{ steps.secrets.outputs.SENTRY_AUTH_TOKEN }}
 
       - name: Build sourcemaps
-        run: turbo run sentry:sourcemaps --env-mode=loose --filter "${{ matrix.package }}"
+        run: turbo run sentry:sourcemaps --env-mode=loose --filter "${{ matrix.name }}"
 
   passed:
     name: Deployments passed

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,6 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: hashintel
   TURBO_REMOTE_ONLY: true
-  TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -37,7 +36,7 @@ jobs:
       - name: Determine changed packages
         id: packages
         run: |
-          PACKAGES_QUERY="query { affectedPackages(base: \"$TURBO_SCM_BASE\") { items { name path } } }"
+          PACKAGES_QUERY='query { affectedPackages(base: "[HEAD^]") { items { name path } } }'
           PACKAGES=$(turbo query "$PACKAGES_QUERY" \
             | jq --compact-output '.data.affectedPackages.items | [(.[] | select(.name != "//"))] | { name: [.[].name], include: . }')
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Determine changed packages
         id: packages
         run: |
-          PACKAGES_QUERY='query { affectedPackages(base: "[HEAD^]") { items { name path } } }'
+          PACKAGES_QUERY='query { affectedPackages(base: "HEAD^") { items { name path } } }'
           PACKAGES=$(turbo query "$PACKAGES_QUERY" \
             | jq --compact-output '.data.affectedPackages.items | [(.[] | select(.name != "//"))] | { name: [.[].name], include: . }')
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,9 +41,9 @@ jobs:
       - name: Determine changed packages
         id: packages
         run: |
-          UNIT_TEST_QUERY='query { affectedPackages(base: "[HEAD^]", filter: {has: {field: TASK_NAME, value: "test:unit"}}) { items { name path } } }'
-          INTEGRATION_TEST_QUERY='query { affectedPackages(base: "[HEAD^]", filter: {has: {field: TASK_NAME, value: "test:integration"}}) { items { name path } } }'
-          DOCKER_TEST_QUERY='query { affectedPackages(base: "[HEAD^]", filter: {has: {field: TASK_NAME, value: "build:docker"}}) { items { name path } } }'
+          UNIT_TEST_QUERY='query { affectedPackages(base: "HEAD^", filter: {has: {field: TASK_NAME, value: "test:unit"}}) { items { name path } } }'
+          INTEGRATION_TEST_QUERY='query { affectedPackages(base: "HEAD^", filter: {has: {field: TASK_NAME, value: "test:integration"}}) { items { name path } } }'
+          DOCKER_TEST_QUERY='query { affectedPackages(base: "HEAD^", filter: {has: {field: TASK_NAME, value: "build:docker"}}) { items { name path } } }'
 
           UNIT_TEST_PACKAGES=$(turbo query "$UNIT_TEST_QUERY" \
             | jq --compact-output '.data.affectedPackages.items | [(.[] | select(.name != "//"))] | { name: [.[].name], include: . }')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: hashintel
   TURBO_REMOTE_ONLY: true
-  TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
   NEXTEST_PROFILE: ci
 
 concurrency:
@@ -42,9 +41,9 @@ jobs:
       - name: Determine changed packages
         id: packages
         run: |
-          UNIT_TEST_QUERY="query { affectedPackages(base: \"$TURBO_SCM_BASE\", filter: {has: {field: TASK_NAME, value: \"test:unit\"}}) { items { name path } } }"
-          INTEGRATION_TEST_QUERY="query { affectedPackages(base: \"$TURBO_SCM_BASE\", filter: {has: {field: TASK_NAME, value: \"test:integration\"}}) { items { name path } } }"
-          DOCKER_TEST_QUERY="query { affectedPackages(base: \"$TURBO_SCM_BASE\", filter: {has: {field: TASK_NAME, value: \"build:docker\"}}) { items { name path } } }"
+          UNIT_TEST_QUERY='query { affectedPackages(base: "[HEAD^]", filter: {has: {field: TASK_NAME, value: "test:unit"}}) { items { name path } } }'
+          INTEGRATION_TEST_QUERY='query { affectedPackages(base: "[HEAD^]", filter: {has: {field: TASK_NAME, value: "test:integration"}}) { items { name path } } }'
+          DOCKER_TEST_QUERY='query { affectedPackages(base: "[HEAD^]", filter: {has: {field: TASK_NAME, value: "build:docker"}}) { items { name path } } }'
 
           UNIT_TEST_PACKAGES=$(turbo query "$UNIT_TEST_QUERY" \
             | jq --compact-output '.data.affectedPackages.items | [(.[] | select(.name != "//"))] | { name: [.[].name], include: . }')
@@ -91,7 +90,6 @@ jobs:
 
           echo "unit-tests=$UNIT_TEST_PACKAGES" | tee -a $GITHUB_OUTPUT
           echo "integration-tests=$INTEGRATION_TEST_PACKAGES" | tee -a $GITHUB_OUTPUT
-          echo "system-tests=$SYSTEM_TEST_PACKAGES" | tee -a $GITHUB_OUTPUT
           echo "dockers=$DOCKER_PACKAGES" | tee -a $GITHUB_OUTPUT
           echo "publish=$PUBLISH_PACKAGES" | tee -a $GITHUB_OUTPUT
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`turbo` is not able to properly find the commit SHA. Instead, we use `HEAD^`.