### PR TITLE
H-4022: Don't error if $id is passed when updating a schema

### DIFF
--- a/libs/@local/graph/postgres-store/src/ontology/mod.rs
+++ b/libs/@local/graph/postgres-store/src/ontology/mod.rs
@@ -39,19 +39,14 @@ where
     for<'de> T: Deserialize<'de>,
 {
     if let Some(object) = value.as_object_mut() {
-        if let Some(previous_val) = object.insert(
+        object.insert(
             "$id".to_owned(),
             serde_json::to_value(id).expect("failed to deserialize id"),
-        ) {
-            return Err(PatchAndParseError)
-                .attach_printable("schema already had an $id")
-                .attach_printable(previous_val);
-        }
+        );
+        serde_json::from_value(value).change_context(PatchAndParseError)
     } else {
-        return Err(PatchAndParseError)
+        Err(PatchAndParseError)
             .attach_printable("unexpected schema format, couldn't parse as object")
-            .attach_printable(value);
+            .attach_printable(value)
     }
-
-    serde_json::from_value(value).change_context(PatchAndParseError)
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `$id` field is not required when updating a type, however, we should not error in this case as for updating in batches this is additional work which is not needed.