### PR TITLE
H-3928: Use closed types in drafts queue

### DIFF
--- a/apps/hash-frontend/src/pages/@/[shortname]/entities/[entity-uuid].page/entity-page-wrapper/draft-entity-banner.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname]/entities/[entity-uuid].page/entity-page-wrapper/draft-entity-banner.tsx
@@ -1,5 +1,6 @@
 import { FeatherRegularIcon } from "@hashintel/design-system";
 import type { Entity } from "@local/hash-graph-sdk/entity";
+import type { ClosedMultiEntityType } from "@local/hash-graph-types/ontology";
 import { generateEntityPath } from "@local/hash-isomorphic-utils/frontend-paths";
 import type { EntityRootType, Subgraph } from "@local/hash-subgraph";
 import { Box, Container, Typography } from "@mui/material";
@@ -33,12 +34,14 @@ const buttonSx: ButtonProps["sx"] = ({ palette }) => ({
 });
 
 export const DraftEntityBanner: FunctionComponent<{
+  closedMultiEntityType: ClosedMultiEntityType;
   draftEntity: Entity;
   draftEntitySubgraph: Subgraph<EntityRootType>;
   isModifyingEntity?: boolean;
   onAcceptedEntity: ((entity: Entity) => void) | null;
   owningShortname: string;
 }> = ({
+  closedMultiEntityType,
   draftEntity,
   draftEntitySubgraph,
   isModifyingEntity = false,
@@ -116,6 +119,7 @@ export const DraftEntityBanner: FunctionComponent<{
         ) : (
           <Box display="flex" gap={1.5}>
             <DiscardDraftEntityButton
+              closedMultiEntityType={closedMultiEntityType}
               draftEntity={draftEntity}
               draftEntitySubgraph={draftEntitySubgraph}
               onDiscardedEntity={handleDiscardedEntity}
@@ -125,6 +129,7 @@ export const DraftEntityBanner: FunctionComponent<{
               Discard draft
             </DiscardDraftEntityButton>
             <AcceptDraftEntityButton
+              closedMultiEntityType={closedMultiEntityType}
               draftEntity={draftEntity}
               draftEntitySubgraph={draftEntitySubgraph}
               onAcceptedEntity={onAcceptedEntity}

--- a/apps/hash-frontend/src/pages/@/[shortname]/entities/[entity-uuid].page/entity-page-wrapper/entity-page-header.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname]/entities/[entity-uuid].page/entity-page-wrapper/entity-page-header.tsx
@@ -82,11 +82,12 @@ export const EntityPageHeader = ({
         scrollToTop={() => {}}
       />
 
-      {entity && entitySubgraph ? (
+      {entity && entitySubgraph && closedMultiEntityType ? (
         <Collapse
           in={!!extractDraftIdFromEntityId(entity.metadata.recordId.entityId)}
         >
           <DraftEntityBanner
+            closedMultiEntityType={closedMultiEntityType}
             draftEntity={entity}
             draftEntitySubgraph={entitySubgraph}
             isModifyingEntity={isModifyingEntity}

--- a/apps/hash-frontend/src/pages/actions.page.tsx
+++ b/apps/hash-frontend/src/pages/actions.page.tsx
@@ -1,13 +1,20 @@
 import { useQuery } from "@apollo/client";
 import { CheckRegularIcon } from "@hashintel/design-system";
 import type { Filter } from "@local/hash-graph-client";
+import { getClosedMultiEntityTypeFromMap } from "@local/hash-graph-sdk/entity";
 import type { EntityId } from "@local/hash-graph-types/entity";
 import {
   currentTimeInstantTemporalAxes,
   mapGqlSubgraphFieldsFragmentToSubgraph,
+  zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import type { EntityRootType } from "@local/hash-subgraph";
-import { extractEntityUuidFromEntityId } from "@local/hash-subgraph";
+import {
+  extractEntityUuidFromEntityId,
+  linkEntityTypeUrl,
+} from "@local/hash-subgraph";
+import { getRoots } from "@local/hash-subgraph/stdlib";
+import { componentsFromVersionedUrl } from "@local/hash-subgraph/type-system-patch";
 import {
   Box,
   breadcrumbsClasses,
@@ -30,6 +37,7 @@ import { getLayoutWithSidebar } from "../shared/layout";
 import { MenuItem } from "../shared/ui";
 import type { SortOrder } from "./actions.page/draft-entities";
 import { DraftEntities } from "./actions.page/draft-entities";
+import type { EntityTypeDisplayInfoByBaseUrl } from "./actions.page/draft-entities/types";
 import { DraftEntitiesBulkActionsDropdown } from "./actions.page/draft-entities-bulk-actions-dropdown";
 import {
   DraftEntitiesContextProvider,
@@ -84,15 +92,11 @@ const ActionsPage = () => {
         includeDrafts: true,
         temporalAxes: currentTimeInstantTemporalAxes,
         graphResolveDepths: {
-          isOfType: { outgoing: 1 },
-          inheritsFrom: { outgoing: 255 },
-          constrainsPropertiesOn: { outgoing: 255 },
-          constrainsValuesOn: { outgoing: 255 },
-          constrainsLinksOn: { outgoing: 255 },
-          constrainsLinkDestinationsOn: { outgoing: 255 },
+          ...zeroedGraphResolveDepths,
           hasLeftEntity: { outgoing: 1, incoming: 1 },
           hasRightEntity: { outgoing: 1, incoming: 1 },
         },
+        includeEntityTypes: "resolved",
       },
       includePermissions: false,
     },
@@ -102,21 +106,98 @@ const ActionsPage = () => {
     fetchPolicy: "network-only",
   });
 
-  const draftEntitiesWithLinkedDataSubgraph = useMemo(
-    () =>
+  const {
+    draftEntitiesWithLinkedDataSubgraph,
+    entities,
+    closedMultiEntityTypesRootMap,
+  } = useMemo(() => {
+    if (
+      !draftEntitiesWithLinkedDataResponse &&
+      !previouslyFetchedDraftEntitiesWithLinkedDataResponse
+    ) {
+      return {
+        draftEntitiesWithLinkedDataSubgraph: undefined,
+        entities: undefined,
+        closedMultiEntityTypesRootMap: undefined,
+      };
+    }
+
+    const subgraph = mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
       (draftEntitiesWithLinkedDataResponse ??
-      previouslyFetchedDraftEntitiesWithLinkedDataResponse)
-        ? mapGqlSubgraphFieldsFragmentToSubgraph<EntityRootType>(
-            (draftEntitiesWithLinkedDataResponse ??
-              previouslyFetchedDraftEntitiesWithLinkedDataResponse)!
-              .getEntitySubgraph.subgraph,
-          )
-        : undefined,
-    [
-      draftEntitiesWithLinkedDataResponse,
-      previouslyFetchedDraftEntitiesWithLinkedDataResponse,
-    ],
-  );
+        previouslyFetchedDraftEntitiesWithLinkedDataResponse)!.getEntitySubgraph
+        .subgraph,
+    );
+
+    const roots = getRoots(subgraph);
+
+    const closedTypeMap = (draftEntitiesWithLinkedDataResponse ??
+      previouslyFetchedDraftEntitiesWithLinkedDataResponse)!.getEntitySubgraph
+      .closedMultiEntityTypes;
+
+    return {
+      draftEntitiesWithLinkedDataSubgraph: subgraph,
+      entities: roots,
+      closedMultiEntityTypesRootMap: closedTypeMap,
+    };
+  }, [
+    draftEntitiesWithLinkedDataResponse,
+    previouslyFetchedDraftEntitiesWithLinkedDataResponse,
+  ]);
+
+  const entityTypeDisplayInfoByBaseUrl = useMemo(() => {
+    if (!entities || !closedMultiEntityTypesRootMap) {
+      return undefined;
+    }
+
+    const displayInfoByBaseUrl: EntityTypeDisplayInfoByBaseUrl = {};
+
+    for (const entity of entities) {
+      const closedMultiEntityType = getClosedMultiEntityTypeFromMap(
+        closedMultiEntityTypesRootMap,
+        entity.metadata.entityTypeIds,
+      );
+
+      for (const displayMetadata of closedMultiEntityType.allOf) {
+        const { baseUrl, version } = componentsFromVersionedUrl(
+          displayMetadata.$id,
+        );
+
+        const existingEntry = displayInfoByBaseUrl[baseUrl];
+
+        if (existingEntry && existingEntry.version >= version) {
+          continue;
+        }
+
+        const { title } = displayMetadata;
+
+        let icon: string | undefined;
+        let isLink = false;
+        for (const selfOrAncestor of displayMetadata.allOf ?? []) {
+          if (selfOrAncestor.icon) {
+            icon = selfOrAncestor.icon;
+          }
+
+          if (selfOrAncestor.$id === linkEntityTypeUrl) {
+            isLink = true;
+          }
+
+          if (icon && isLink) {
+            break;
+          }
+        }
+
+        displayInfoByBaseUrl[baseUrl] = {
+          baseUrl,
+          icon,
+          isLink,
+          title,
+          version,
+        };
+      }
+    }
+
+    return displayInfoByBaseUrl;
+  }, [entities, closedMultiEntityTypesRootMap]);
 
   return (
     <>
@@ -196,6 +277,10 @@ const ActionsPage = () => {
         }
       />
       <DraftEntities
+        closedMultiEntityTypesRootMap={
+          closedMultiEntityTypesRootMap ?? undefined
+        }
+        entityTypeDisplayInfoByBaseUrl={entityTypeDisplayInfoByBaseUrl}
         sortOrder={sortOrder}
         selectedDraftEntityIds={selectedDraftEntityIds}
         setSelectedDraftEntityIds={setSelectedDraftEntityIds}

--- a/apps/hash-frontend/src/pages/actions.page/draft-entities/types.ts
+++ b/apps/hash-frontend/src/pages/actions.page/draft-entities/types.ts
@@ -1,0 +1,14 @@
+import type { BaseUrl } from "@local/hash-graph-types/ontology";
+
+type EntityTypeDisplayInfo = {
+  baseUrl: BaseUrl;
+  icon: string | undefined;
+  isLink: boolean;
+  title: string;
+  version: number;
+};
+
+export type EntityTypeDisplayInfoByBaseUrl = Record<
+  BaseUrl,
+  EntityTypeDisplayInfo
+>;

--- a/apps/hash-frontend/src/pages/actions.page/draft-entity.tsx
+++ b/apps/hash-frontend/src/pages/actions.page/draft-entity.tsx
@@ -1,5 +1,9 @@
-import type { Entity } from "@local/hash-graph-sdk/entity";
+import {
+  type Entity,
+  getClosedMultiEntityTypeFromMap,
+} from "@local/hash-graph-sdk/entity";
 import type { EntityId } from "@local/hash-graph-types/entity";
+import type { ClosedMultiEntityTypesRootMap } from "@local/hash-graph-types/ontology";
 import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import type { EntityRootType, Subgraph } from "@local/hash-subgraph";
 import { Box, Checkbox, Typography } from "@mui/material";
@@ -10,6 +14,7 @@ import { ArrowUpRightRegularIcon } from "../../shared/icons/arrow-up-right-regul
 import { Link } from "../../shared/ui";
 import { EntityEditorSlideStack } from "../shared/entity-editor-slide-stack";
 import { useEntityHref } from "../shared/use-entity-href";
+import type { EntityTypeDisplayInfoByBaseUrl } from "./draft-entities/types";
 import { useDraftEntities } from "./draft-entities-context";
 import { DraftEntityActionButtons } from "./draft-entity/draft-entity-action-buttons";
 import { DraftEntityProvenance } from "./draft-entity/draft-entity-provenance";
@@ -17,11 +22,20 @@ import { DraftEntityType } from "./draft-entity/draft-entity-type";
 import { DraftEntityWeb } from "./draft-entity/draft-entity-web";
 
 export const DraftEntity: FunctionComponent<{
-  subgraph: Subgraph<EntityRootType>;
+  closedMultiEntityTypesRootMap?: ClosedMultiEntityTypesRootMap;
   entity: Entity;
+  entityTypeDisplayInfoByBaseUrl: EntityTypeDisplayInfoByBaseUrl;
+  subgraph: Subgraph<EntityRootType>;
   selected: boolean;
   toggleSelected: () => void;
-}> = ({ entity, subgraph, selected, toggleSelected }) => {
+}> = ({
+  closedMultiEntityTypesRootMap,
+  entity,
+  entityTypeDisplayInfoByBaseUrl,
+  subgraph,
+  selected,
+  toggleSelected,
+}) => {
   const { refetch } = useDraftEntities();
 
   const [displayEntityIdInModal, setDisplayEntityIdInModal] =
@@ -29,9 +43,14 @@ export const DraftEntity: FunctionComponent<{
 
   const href = useEntityHref(entity, true);
 
+  const closedMultiEntityType = getClosedMultiEntityTypeFromMap(
+    closedMultiEntityTypesRootMap,
+    entity.metadata.entityTypeIds,
+  );
+
   const label = useMemo(
-    () => generateEntityLabel(subgraph, entity),
-    [subgraph, entity],
+    () => generateEntityLabel(closedMultiEntityType, entity),
+    [closedMultiEntityType, entity],
   );
 
   return (
@@ -117,11 +136,19 @@ export const DraftEntity: FunctionComponent<{
             </Box>
           </Link>
         </Box>
-        <DraftEntityActionButtons entity={entity} subgraph={subgraph} />
+
+        <DraftEntityActionButtons
+          closedMultiEntityType={closedMultiEntityType}
+          entity={entity}
+          subgraph={subgraph}
+        />
       </Box>
       <Box marginTop={1.5} display="flex" justifyContent="space-between">
         <Box display="flex" alignItems="center" columnGap={2}>
-          <DraftEntityType entity={entity} subgraph={subgraph} />
+          <DraftEntityType
+            entity={entity}
+            entityTypeDisplayInfoByBaseUrl={entityTypeDisplayInfoByBaseUrl}
+          />
           <DraftEntityWeb entity={entity} />
           {/*
            * @todo: bring back draft entity viewers when the GQL resolver

--- a/apps/hash-frontend/src/pages/actions.page/draft-entity/draft-entity-action-buttons.tsx
+++ b/apps/hash-frontend/src/pages/actions.page/draft-entity/draft-entity-action-buttons.tsx
@@ -1,5 +1,6 @@
 import { CloseIcon } from "@hashintel/design-system";
 import type { Entity } from "@local/hash-graph-sdk/entity";
+import type { ClosedMultiEntityType } from "@local/hash-graph-types/ontology";
 import type { EntityRootType, Subgraph } from "@local/hash-subgraph";
 import { Box, buttonClasses } from "@mui/material";
 import type { FunctionComponent } from "react";
@@ -10,14 +11,16 @@ import { DiscardDraftEntityButton } from "../../shared/discard-draft-entity-butt
 import { useDraftEntities } from "../draft-entities-context";
 
 export const DraftEntityActionButtons: FunctionComponent<{
+  closedMultiEntityType: ClosedMultiEntityType;
   entity: Entity;
   subgraph: Subgraph<EntityRootType>;
-}> = ({ entity, subgraph }) => {
+}> = ({ closedMultiEntityType, entity, subgraph }) => {
   const { refetch } = useDraftEntities();
 
   return (
     <Box marginLeft={1} display="flex" columnGap={1}>
       <DiscardDraftEntityButton
+        closedMultiEntityType={closedMultiEntityType}
         draftEntity={entity}
         draftEntitySubgraph={subgraph}
         onDiscardedEntity={refetch}
@@ -39,6 +42,7 @@ export const DraftEntityActionButtons: FunctionComponent<{
         Ignore
       </DiscardDraftEntityButton>
       <AcceptDraftEntityButton
+        closedMultiEntityType={closedMultiEntityType}
         draftEntity={entity}
         draftEntitySubgraph={subgraph}
         size="xs"

--- a/apps/hash-frontend/src/pages/shared/accept-draft-entity-button.tsx
+++ b/apps/hash-frontend/src/pages/shared/accept-draft-entity-button.tsx
@@ -1,6 +1,7 @@
 import { useMutation } from "@apollo/client";
 import { AlertModal, FeatherRegularIcon } from "@hashintel/design-system";
 import { Entity, LinkEntity } from "@local/hash-graph-sdk/entity";
+import type { ClosedMultiEntityType } from "@local/hash-graph-types/ontology";
 import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import type { EntityRootType, Subgraph } from "@local/hash-subgraph";
 import { extractDraftIdFromEntityId } from "@local/hash-subgraph";
@@ -73,11 +74,13 @@ const getRightOrLeftEntitySx = (params: {
  */
 export const AcceptDraftEntityButton: FunctionComponent<
   {
+    closedMultiEntityType: ClosedMultiEntityType;
     draftEntity: Entity;
     draftEntitySubgraph: Subgraph<EntityRootType>;
     onAcceptedEntity: ((acceptedEntity: Entity) => void) | null;
   } & ButtonProps
 > = ({
+  closedMultiEntityType,
   draftEntity,
   draftEntitySubgraph,
   onAcceptedEntity,
@@ -198,10 +201,9 @@ export const AcceptDraftEntityButton: FunctionComponent<
       });
     }, [draftLeftEntity, draftEntity, draftRightEntity, acceptDraftEntity]);
 
-  const label = useMemo(
-    () => generateEntityLabel(draftEntitySubgraph, draftEntity),
-    [draftEntitySubgraph, draftEntity],
-  );
+  const label = useMemo(() => {
+    return generateEntityLabel(closedMultiEntityType, draftEntity);
+  }, [closedMultiEntityType, draftEntity]);
 
   return (
     <>

--- a/apps/hash-frontend/src/pages/shared/discard-draft-entity-button.tsx
+++ b/apps/hash-frontend/src/pages/shared/discard-draft-entity-button.tsx
@@ -1,6 +1,7 @@
 import { useMutation } from "@apollo/client";
 import { AlertModal } from "@hashintel/design-system";
-import type { Entity } from "@local/hash-graph-sdk/entity";
+import { type Entity } from "@local/hash-graph-sdk/entity";
+import type { ClosedMultiEntityType } from "@local/hash-graph-types/ontology";
 import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import type { EntityRootType, Subgraph } from "@local/hash-subgraph";
 import { extractDraftIdFromEntityId } from "@local/hash-subgraph";
@@ -22,11 +23,13 @@ import { Button } from "../../shared/ui";
 
 export const DiscardDraftEntityButton: FunctionComponent<
   {
+    closedMultiEntityType: ClosedMultiEntityType;
     draftEntity: Entity;
     draftEntitySubgraph: Subgraph<EntityRootType>;
     onDiscardedEntity?: () => void;
   } & ButtonProps
 > = ({
+  closedMultiEntityType,
   draftEntity,
   draftEntitySubgraph,
   onDiscardedEntity,
@@ -134,10 +137,9 @@ export const DiscardDraftEntityButton: FunctionComponent<
     onDiscardedEntity,
   ]);
 
-  const label = useMemo(
-    () => generateEntityLabel(draftEntitySubgraph, draftEntity),
-    [draftEntitySubgraph, draftEntity],
-  );
+  const label = useMemo(() => {
+    return generateEntityLabel(closedMultiEntityType, draftEntity);
+  }, [closedMultiEntityType, draftEntity]);
 
   return (
     <>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR switches to using the 'closed' (fully resolved) entity types in the drafts action queue. This makes it easier to take account of inherited icons, labels etc.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
