### PR TITLE
H-1844: Prevent creating link entities directly

### DIFF
--- a/apps/hash-frontend/src/pages/@/[shortname].page/pinned-entity-type-tab-contents.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname].page/pinned-entity-type-tab-contents.tsx
@@ -87,6 +87,7 @@ const EntityRow: FunctionComponent<{
               /**
                * @todo H-3363 use closed schema to take account of indirectly inherited link status
                */
+              entityType?.schema.$id === linkEntityTypeUrl ||
               !!entityType?.schema.allOf?.some(
                 (allOf) => allOf.$ref === linkEntityTypeUrl,
               )

--- a/apps/hash-frontend/src/pages/shared/entity-type-page.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-page.tsx
@@ -114,7 +114,7 @@ export const EntityTypePage = ({
     [entityType, remotePropertyTypes],
   );
 
-  const isDirty = formMethods.formState.isDirty;
+  const isDirty = Object.keys(formMethods.formState.dirtyFields).length > 0;
   const isDraft = !!draftEntityType;
 
   const { userPermissions } = useUserPermissionsOnEntityType(

--- a/apps/hash-frontend/src/pages/shared/entity-type-page/edit-bar-type-editor.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-page/edit-bar-type-editor.tsx
@@ -14,11 +14,11 @@ import {
 } from "../../@/[shortname]/shared/edit-bar";
 
 const useFrozenValue = <T extends number | boolean | object>(value: T): T => {
-  const { isDirty } = useEntityTypeFormState<EntityTypeEditorFormData>();
+  const { dirtyFields } = useEntityTypeFormState<EntityTypeEditorFormData>();
 
   const [frozen, setFrozen] = useState(value);
 
-  if (isDirty && frozen !== value) {
+  if (Object.keys(dirtyFields).length > 0 && frozen !== value) {
     setFrozen(value);
   }
 
@@ -32,12 +32,13 @@ export const EditBarTypeEditor = ({
   currentVersion: number;
   discardButtonProps: Partial<ButtonProps>;
 }) => {
-  const { isDirty, isSubmitting } =
+  const { dirtyFields, isSubmitting } =
     useEntityTypeFormState<EntityTypeEditorFormData>();
   const frozenVersion = useFrozenValue(currentVersion);
   const ref = useFreezeScrollWhileTransitioning();
 
-  const collapseIn = currentVersion === 0 || isDirty;
+  const collapseIn =
+    currentVersion === 0 || Object.keys(dirtyFields).length > 0;
 
   const frozenDiscardButtonProps = useFrozenValue(discardButtonProps);
 

--- a/apps/hash-frontend/src/pages/shared/entity-type-page/type-slide-over-stack/type-slide-over-slide.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-page/type-slide-over-stack/type-slide-over-slide.tsx
@@ -127,7 +127,7 @@ export const TypeSlideOverSlide: FunctionComponent<TypeSlideOverSlideProps> = ({
   const { loading: loadingNamespace, routeNamespace } = useRouteNamespace();
 
   const formMethods = useEntityTypeForm<EntityTypeEditorFormData>({
-    defaultValues: { allOf: [], properties: [], links: [] },
+    defaultValues: { allOf: [], properties: [], links: [], inverse: {} },
   });
   const { reset } = formMethods;
 

--- a/apps/hash-frontend/src/shared/entity-types-context/shared/is-special-entity-type.ts
+++ b/apps/hash-frontend/src/shared/entity-types-context/shared/is-special-entity-type.ts
@@ -45,7 +45,7 @@ export const isSpecialEntityType = (
       systemEntityTypes.image.entityTypeBaseUrl
     : false;
 
-  let isLink = false;
+  let isLink = entityType.$id === linkEntityTypeUrl;
 
   for (const id of parentIds) {
     if (extractBaseUrl(id) === systemEntityTypes.file.entityTypeBaseUrl) {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The intended user flow for creating links from entities to other entities is that links are created from the source entity's page.

This PR catches a couple of places where it was possible to click 'create entity' on a link directly, which just goes to a page telling you that you can't.

It also fixes an issue with discarding changes in the type editor.


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. See if you can find anywhere to create a link entity directly.