### PR TITLE
H-3545, H-4032: Update readonly array display in editor, fix scroll behavior in editor slide

### DIFF
--- a/apps/hash-frontend/src/components/grid/utils/override-custom-renderers.tsx
+++ b/apps/hash-frontend/src/components/grid/utils/override-custom-renderers.tsx
@@ -1,11 +1,25 @@
 import type { DataEditorProps } from "@glideapps/glide-data-grid";
 import { isObjectEditorCallbackResult } from "@glideapps/glide-data-grid";
-import type { ReactNode, RefObject } from "react";
+import { type ReactNode, type RefObject } from "react";
 
 import { useEditBarContext } from "../../../shared/edit-bar-scroller";
 import { useScrollLock } from "../../../shared/use-scroll-lock";
 import { InteractableManager } from "./interactable-manager";
 
+/**
+ * Lock scrolling outside when a Grid editor overlay is open.
+ *
+ * Note that because the EditBarContext is set at the Layout level, it passes the `body` as the scrollable component that should be locked.
+ * This doesn't apply when a grid editor is open in a drawer/slide with scroll, which _won't_ have its scroll locked.
+ *
+ * Fixing this requires being able to lock _both_ the body and the slide scroll, which means getting the slide element into this component somehow.
+ * Or having some global context tracking which slide is open, or finding it via classes.
+ *
+ * The type editor slide stack is also relying on useScrollLock to lock the body.
+ * The entity editor slide stack doesn't.
+ *
+ * @todo make the slide stacks consistent when this becomes an issue, and lock the slide scroll.
+ */
 const ScrollLockWrapper = ({
   children,
 }: { children: ReactNode | Promise<ReactNode> }) => {

--- a/apps/hash-frontend/src/pages/@/[shortname].page/pinned-entity-type-tab-contents.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname].page/pinned-entity-type-tab-contents.tsx
@@ -196,7 +196,7 @@ export const PinnedEntityTypeTabContents: FunctionComponent<{
     <Box mb={6}>
       <Box display="flex" alignItems="center" columnGap={1.5} marginBottom={1}>
         <ProfileSectionHeading>{currentTab.pluralTitle}</ProfileSectionHeading>
-        <Box display="flex" alignItems="center" columnGap={1}>
+        <Box display="flex" alignItems="center" columnGap={0.5}>
           <Typography
             sx={{
               fontSize: 12,
@@ -221,7 +221,6 @@ export const PinnedEntityTypeTabContents: FunctionComponent<{
                 fontSize: 12,
                 marginRight: 0.5,
                 position: "relative",
-                top: -1,
               },
             }}
             value={sortOrder}

--- a/apps/hash-frontend/src/pages/@/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell.tsx
@@ -157,7 +157,7 @@ export const renderValueCell: CustomRenderer<ValueCell> = {
     return undefined;
   },
   provideEditor: ({ data }) => {
-    if (data.readonly) {
+    if (data.readonly && !data.propertyRow.isArray) {
       return {
         disableStyling: true,
         disablePadding: true,

--- a/apps/hash-frontend/src/pages/@/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/array-editor.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/array-editor.tsx
@@ -52,6 +52,9 @@ export const ArrayEditor: ValueCellEditorComponent = ({
   onChange,
 }) => {
   const listWrapperRef = useRef<HTMLDivElement>(null);
+
+  const { readonly } = cell.data;
+
   const {
     value: propertyValue,
     valueMetadata,
@@ -291,7 +294,8 @@ export const ArrayEditor: ValueCellEditorComponent = ({
     updateItem(index, value);
   };
 
-  const canAddMore = isNumber(maxItems) ? items.length < maxItems : true;
+  const canAddMore =
+    !readonly && (isNumber(maxItems) ? items.length < maxItems : true);
   const isAddingDraft = editingRow === DRAFT_ROW_KEY;
 
   const hasConstraints = minItems !== undefined || maxItems !== undefined;
@@ -308,9 +312,10 @@ export const ArrayEditor: ValueCellEditorComponent = ({
           onDragEnd={handleDragEnd}
         >
           <SortableContext items={items} strategy={verticalListSortingStrategy}>
-            {items.map((item) => (
+            {items.map((item, index) => (
               <SortableRow
                 key={item.id}
+                isLastRow={index === items.length - 1}
                 item={item}
                 onRemove={removeItem}
                 onEditClicked={(id) => setEditingRow(id)}
@@ -320,6 +325,7 @@ export const ArrayEditor: ValueCellEditorComponent = ({
                 selected={selectedRow === item.id}
                 onSelect={toggleSelectedRow}
                 expectedTypes={permittedDataTypes}
+                readonly={readonly}
               />
             ))}
           </SortableContext>
@@ -343,7 +349,7 @@ export const ArrayEditor: ValueCellEditorComponent = ({
         />
       )}
 
-      {!canAddMore && hasConstraints && (
+      {!canAddMore && !readonly && hasConstraints && (
         <ItemLimitInfo min={minItems} max={maxItems} />
       )}
     </GridEditorWrapper>

--- a/apps/hash-frontend/src/pages/@/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/array-editor/draft-row.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/array-editor/draft-row.tsx
@@ -82,6 +82,8 @@ export const DraftRow = ({
         }}
         onDiscardChanges={onDraftDiscarded}
         expectedTypes={expectedTypes}
+        readonly={false}
+        isLastRow
       />
       {arrayConstraints && (
         <ItemLimitInfo

--- a/apps/hash-frontend/src/pages/@/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/array-editor/sortable-row.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname]/entities/[entity-uuid].page/entity-editor/properties-section/property-table/cells/value-cell/array-editor/sortable-row.tsx
@@ -32,11 +32,14 @@ interface SortableRowProps {
   onEditClicked?: (id: string) => void;
   editing: boolean;
   expectedTypes: ClosedDataTypeDefinition[];
+  isLastRow: boolean;
   onSaveChanges: (index: number, value: unknown) => void;
   onDiscardChanges: () => void;
+  readonly: boolean;
 }
 
 export const SortableRow = ({
+  isLastRow,
   item,
   onRemove,
   selected,
@@ -45,6 +48,7 @@ export const SortableRow = ({
   onSaveChanges,
   onDiscardChanges,
   editing,
+  readonly,
 }: SortableRowProps) => {
   const { id, value, index, dataType } = item;
   const {
@@ -80,7 +84,7 @@ export const SortableRow = ({
   const { arrayEditException } = editorSpec;
 
   const shouldShowActions =
-    !isDragging && !isSorting && (hovered || selected || editing);
+    !readonly && !isDragging && !isSorting && (hovered || selected || editing);
 
   if (prevEditing !== editing) {
     setPrevEditing(editing);
@@ -177,7 +181,7 @@ export const SortableRow = ({
         minHeight: 48,
         display: "flex",
         alignItems: "center",
-        borderBottom: "1px solid",
+        borderBottom: isLastRow ? "none" : "1px solid",
         borderColor: isDragging ? "transparent" : "gray.20",
         position: "relative",
         outline: "none",
@@ -186,23 +190,26 @@ export const SortableRow = ({
       onMouseLeave={() => setHovered(false)}
       onClick={() => onSelect?.(id)}
     >
-      <Box
-        {...listeners}
-        sx={{
-          cursor: isDragging || isSorting ? "grabbing" : "grab",
-          px: 1.5,
-          height: "100%",
-          display: "flex",
-          alignItems: "center",
-        }}
-      >
-        <DragIndicatorIcon sx={{ fontSize: 14, color: "gray.50" }} />
-      </Box>
+      {!readonly && (
+        <Box
+          {...listeners}
+          sx={{
+            cursor: isDragging || isSorting ? "grabbing" : "grab",
+            pl: 1.5,
+            height: "100%",
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          <DragIndicatorIcon sx={{ fontSize: 14, color: "gray.50" }} />
+        </Box>
+      )}
 
       <Typography
         variant="smallTextLabels"
         sx={{
           color: "gray.50",
+          ml: 1.5,
           mr: 1,
         }}
       >

--- a/apps/hash-frontend/src/pages/actions.page.tsx
+++ b/apps/hash-frontend/src/pages/actions.page.tsx
@@ -223,10 +223,9 @@ const ActionsPage = () => {
             <Box
               display="flex"
               alignItems="center"
-              columnGap={1}
+              columnGap={0.5}
               sx={{
                 "> div": {
-                  lineHeight: 0,
                   [`.${selectClasses.select}.${inputBaseClasses.input}`]: {
                     fontSize: 14,
                     height: 14,
@@ -239,6 +238,7 @@ const ActionsPage = () => {
                   fontSize: 14,
                   fontWeight: 500,
                   color: ({ palette }) => palette.gray[70],
+                  lineHeight: 1,
                 }}
               >
                 <BarsSortRegularIcon

--- a/apps/hash-frontend/src/pages/shared/inline-select.tsx
+++ b/apps/hash-frontend/src/pages/shared/inline-select.tsx
@@ -24,12 +24,12 @@ export const InlineSelect = styled(
   ),
 )(({ theme }) => ({
   position: "relative",
-  top: 1,
+  top: 0.5,
   svg: {
     fontSize: 12,
     marginRight: 0.5,
     position: "relative",
-    top: -1,
+    top: -0.5,
   },
   [`.${selectClasses.select}.${inputBaseClasses.input}`]: {
     fontSize: 12,
@@ -37,6 +37,7 @@ export const InlineSelect = styled(
     fontWeight: 500,
     color: theme.palette.gray[90],
     minHeight: "unset",
+    padding: 0,
     paddingRight: 18,
     "&:focus": {
       background: "transparent",

--- a/apps/hash-frontend/src/shared/use-scroll-lock.ts
+++ b/apps/hash-frontend/src/shared/use-scroll-lock.ts
@@ -60,14 +60,23 @@ export const useScrollLock = (
 ) => {
   const scrollbarSize = useLastScrollbarSize(elementToLock);
 
+  const madeChangesRequiringRemoval = useRef(false);
+
   useLayoutEffect(() => {
-    if (active && scrollbarSize) {
+    const overflow = elementToLock.style.overflow;
+
+    const overflowWasAlreadyHidden = overflow === "hidden";
+
+    if (active && scrollbarSize && !overflowWasAlreadyHidden) {
       elementToLock.style.setProperty("padding-right", `${scrollbarSize}px`);
       elementToLock.style.setProperty("overflow", `hidden`);
-    } else {
-      removeStylesFromElement(elementToLock);
+      madeChangesRequiringRemoval.current = true;
     }
 
-    return () => removeStylesFromElement(elementToLock);
+    return () => {
+      if (madeChangesRequiringRemoval.current) {
+        removeStylesFromElement(elementToLock);
+      }
+    };
   }, [active, scrollbarSize, elementToLock]);
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

1. Updates the full display of readonly array values in the entity editor to be the same as in editing mode 
2. Fixes an issue when clicking on a cell in the entity editor in a slide, where you'd end up with two scroll bars (body and slide)
3. Fixes styling issue with a sort dropdown in the actions queue

See demo.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


## ⚠️ Known issues

There's still an issue when clicking into a cell in the entity editor whereby the slide remains scrollable. Fixing this requires reworking a bit of how we lock scrolling, if it becomes annoying.
<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Not possible in preview deployment because entities in prod lack metadata which the editor relies on.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

### Old behavior

Shows both scroll issue and previous readonly array display

https://github.com/user-attachments/assets/3653e963-18f1-4790-8008-13a123213fa2




### New behavior

https://github.com/user-attachments/assets/dfb999ef-4915-4727-a2ea-2f49f3efc214

### Action queue sort

<img width="1562" alt="Screenshot 2025-02-07 at 17 01 32" src="https://github.com/user-attachments/assets/ea9e89dc-3664-41f0-a9fc-393caab27064" />

