### PR TITLE
H-2767: Create and allow assigning editor permissions on data types

### DIFF
--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
@@ -23,10 +23,7 @@ import {
   PROPERTY_TYPE_META_SCHEMA,
 } from "@blockprotocol/type-system";
 import { NotFoundError } from "@local/hash-backend-utils/error";
-import type {
-  DataTypeRelationAndSubject,
-  UpdatePropertyType,
-} from "@local/hash-graph-client";
+import type { UpdatePropertyType } from "@local/hash-graph-client";
 import type { Entity } from "@local/hash-graph-sdk/entity";
 import type { PropertyObjectWithMetadata } from "@local/hash-graph-types/entity";
 import type {
@@ -61,6 +58,7 @@ import type {
   EntityTypeInstantiatorSubject,
   EntityTypeRelationAndSubject,
   PropertyTypeRelationAndSubject,
+  DataTypeRelationAndSubject,
 } from "@local/hash-subgraph";
 import { extractOwnedByIdFromEntityId } from "@local/hash-subgraph";
 import {

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
@@ -55,10 +55,10 @@ import {
   generateTypeBaseUrl,
 } from "@local/hash-isomorphic-utils/ontology-types";
 import type {
+  DataTypeRelationAndSubject,
   EntityTypeInstantiatorSubject,
   EntityTypeRelationAndSubject,
   PropertyTypeRelationAndSubject,
-  DataTypeRelationAndSubject,
 } from "@local/hash-subgraph";
 import { extractOwnedByIdFromEntityId } from "@local/hash-subgraph";
 import {

--- a/libs/@local/graph/api/openapi/openapi.json
+++ b/libs/@local/graph/api/openapi/openapi.json
@@ -3691,6 +3691,49 @@
           }
         }
       },
+      "DataTypeEditorSubject": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "subjectId",
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "account"
+                ]
+              },
+              "subjectId": {
+                "$ref": "#/components/schemas/AccountId"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "subjectId",
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "accountGroup"
+                ]
+              },
+              "subjectId": {
+                "$ref": "#/components/schemas/AccountGroupId"
+              }
+            }
+          }
+        ],
+        "discriminator": {
+          "propertyName": "kind"
+        }
+      },
       "DataTypeInferenceError": {
         "oneOf": [
           {
@@ -3898,6 +3941,42 @@
               "relation": {
                 "type": "string",
                 "enum": [
+                  "setting"
+                ]
+              },
+              "subject": {
+                "$ref": "#/components/schemas/DataTypeSettingSubject"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "subject",
+              "relation"
+            ],
+            "properties": {
+              "relation": {
+                "type": "string",
+                "enum": [
+                  "editor"
+                ]
+              },
+              "subject": {
+                "$ref": "#/components/schemas/DataTypeEditorSubject"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "subject",
+              "relation"
+            ],
+            "properties": {
+              "relation": {
+                "type": "string",
+                "enum": [
                   "viewer"
                 ]
               },
@@ -3909,6 +3988,37 @@
         ],
         "discriminator": {
           "propertyName": "relation"
+        }
+      },
+      "DataTypeSetting": {
+        "type": "string",
+        "enum": [
+          "updateFromWeb"
+        ]
+      },
+      "DataTypeSettingSubject": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "subjectId",
+              "kind"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "setting"
+                ]
+              },
+              "subjectId": {
+                "$ref": "#/components/schemas/DataTypeSetting"
+              }
+            }
+          }
+        ],
+        "discriminator": {
+          "propertyName": "kind"
         }
       },
       "DataTypeVertexId": {

--- a/libs/@local/graph/api/src/rest/data_type.rs
+++ b/libs/@local/graph/api/src/rest/data_type.rs
@@ -15,7 +15,8 @@ use hash_graph_authorization::{
     AuthorizationApi as _, AuthorizationApiPool,
     backend::{ModifyRelationshipOperation, PermissionAssertion},
     schema::{
-        DataTypeOwnerSubject, DataTypePermission, DataTypeRelationAndSubject, DataTypeViewerSubject,
+        DataTypeEditorSubject, DataTypeOwnerSubject, DataTypePermission,
+        DataTypeRelationAndSubject, DataTypeSetting, DataTypeSettingSubject, DataTypeViewerSubject,
     },
     zanzibar::Consistency,
 };
@@ -85,8 +86,11 @@ use crate::rest::{
     components(
         schemas(
             DataTypeWithMetadata,
+            DataTypeSetting,
 
+            DataTypeSettingSubject,
             DataTypeOwnerSubject,
+            DataTypeEditorSubject,
             DataTypeViewerSubject,
             DataTypePermission,
             DataTypeRelationAndSubject,

--- a/libs/@local/graph/authorization/schemas/v1__initial_schema.zed
+++ b/libs/@local/graph/authorization/schemas/v1__initial_schema.zed
@@ -53,8 +53,8 @@ definition graph/web {
 	// Data types
 	relation level_00_data_type_viewer: graph/account:*
 
-	permission create_data_type = administrator
-	permission update_data_type = administrator
+	permission create_data_type = administrator + level_00_owner->member
+	permission update_data_type = administrator + level_00_owner->member
 	permission view_data_type = update_data_type + level_00_data_type_viewer
 }
 
@@ -110,11 +110,13 @@ definition graph/property_type {
 
 definition graph/data_type {
 	// Setup
+    relation level_00_setting: graph/setting
     relation level_00_owner: graph/web
 
 	// Permissions
+	relation level_00_editor: graph/account | graph/account_group#member
     relation level_00_viewer: graph/account:*
 
-	permission update = level_00_owner->update_data_type
-	permission view = level_00_viewer + level_00_owner->view_data_type
+	permission update = level_00_editor + (level_00_setting->level_00_update & level_00_owner->update_data_type)
+	permission view = update + level_00_viewer + level_00_owner->view_data_type
 }

--- a/libs/@local/graph/authorization/src/schema/mod.rs
+++ b/libs/@local/graph/authorization/src/schema/mod.rs
@@ -16,8 +16,9 @@ pub use self::{
         AccountGroupSubjectId,
     },
     data_type::{
-        DataTypeNamespace, DataTypeOwnerSubject, DataTypePermission, DataTypeRelationAndSubject,
-        DataTypeResourceRelation, DataTypeSubject, DataTypeSubjectId, DataTypeViewerSubject,
+        DataTypeEditorSubject, DataTypeNamespace, DataTypeOwnerSubject, DataTypePermission,
+        DataTypeRelationAndSubject, DataTypeResourceRelation, DataTypeSetting,
+        DataTypeSettingSubject, DataTypeSubject, DataTypeSubjectId, DataTypeViewerSubject,
     },
     entity::{
         EntityAdministratorSubject, EntityEditorSubject, EntityNamespace, EntityOwnerSubject,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "start:frontend": "CARGO_TERM_PROGRESS_WHEN=never turbo run start start:healthcheck --filter @apps/hash-frontend --env-mode=loose",
     "start:graph:test-server": "CARGO_TERM_PROGRESS_WHEN=never turbo run start start:healthcheck --filter @rust/hash-graph-test-server",
     "start:worker": "CARGO_TERM_PROGRESS_WHEN=never turbo run start start:healthcheck --filter '@apps/hash-*-worker*' --env-mode=loose",
+    "start:test:worker": "CARGO_TERM_PROGRESS_WHEN=never turbo run start:test start:test:healthcheck --filter '@apps/hash-*-worker*' --env-mode=loose",
     "start:test": "CARGO_TERM_PROGRESS_WHEN=never turbo run start:test start:test:healthcheck --env-mode=loose",
     "graph:reset-database": "yarn workspace @rust/hash-graph-http-tests reset-database",
     "external-services": "turbo deploy --filter '@apps/hash-external-services' --",

--- a/tests/graph/http/tests/friendship.http
+++ b/tests/graph/http/tests/friendship.http
@@ -144,12 +144,21 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     }
   ],
   "conversions": {},
-  "relationships": [{
-    "relation": "viewer",
-    "subject": {
-      "kind": "public"
+  "relationships": [
+    {
+      "relation": "viewer",
+      "subject": {
+        "kind": "public"
+      }
+    },
+    {
+      "relation": "setting",
+      "subject": {
+        "kind": "setting",
+        "subjectId": "updateFromWeb"
+      }
     }
-  }]
+  ]
 }
 
 > {%
@@ -293,12 +302,21 @@ X-Authenticated-User-Actor-Id: {{account_id}}
     "minimum": 0
   },
   "conversions": {},
-  "relationships": [{
-    "relation": "viewer",
-    "subject": {
-      "kind": "public"
+  "relationships": [
+    {
+      "relation": "viewer",
+      "subject": {
+        "kind": "public"
+      }
+    },
+    {
+      "relation": "setting",
+      "subject": {
+        "kind": "setting",
+        "subjectId": "updateFromWeb"
+      }
     }
-  }]
+  ]
 }
 
 > {%

--- a/tests/hash-backend-integration/src/tests/graph/ontology/primitive/data-type.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/ontology/primitive/data-type.test.ts
@@ -108,7 +108,13 @@ describe("Data type CRU", () => {
     createdDataType = await createDataType(graphContext, authentication, {
       ownedById: testOrg.accountGroupId as OwnedById,
       schema: dataTypeSchema,
-      relationships: [{ relation: "viewer", subject: { kind: "public" } }],
+      relationships: [
+        { relation: "viewer", subject: { kind: "public" } },
+        {
+          relation: "setting",
+          subject: { kind: "setting", subjectId: "updateFromWeb" },
+        },
+      ],
       conversions: {},
     });
   });
@@ -142,7 +148,7 @@ describe("Data type CRU", () => {
       relationships: [{ relation: "viewer", subject: { kind: "public" } }],
       conversions: {},
       // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-    }).catch((err) => Promise.reject(err.data));
+    }).catch((err) => Promise.reject(err));
 
     expect(
       isOwnedOntologyElementMetadata(updatedDataType.metadata) &&


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Data types needs to be updated eventually.

## 🔍 What does this change?

Aligns the permissions for data types with the other ontology types

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph