### PR TITLE
H-4048: Don't suggest ignoring a warning in vitest extension

### DIFF
--- a/.config/_examples/vscode/settings.json
+++ b/.config/_examples/vscode/settings.json
@@ -5,7 +5,6 @@
     "typescript",
     "typescriptreact"
   ],
-  "vitest.disableWorkspaceWarning": true,
   "files.associations": {
     "turbo.json": "jsonc",
     ".sqlfluff": "toml",
@@ -13,5 +12,16 @@
     ".markdownlintignore": "ignore",
     ".dockerignore": "ignore",
     ".sqlfluffignore": "ignore"
+  },
+  "rust-analyzer.imports.prefix": "crate",
+  "rust-analyzer.imports.preferNoStd": true,
+  "rust-analyzer.imports.granularity.enforce": true,
+  "rust-analyzer.cargo.extraEnv": {
+    "PDFIUM_STATIC_LIB_PATH": "${workspaceFolder}/libs/chonky/libs/",
+    "PDFIUM_DYNAMIC_LIB_PATH": "${workspaceFolder}/libs/chonky/libs/"
+  },
+  "rust-analyzer.runnables.extraEnv": {
+    "PDFIUM_STATIC_LIB_PATH": "${workspaceFolder}/libs/chonky/libs/",
+    "PDFIUM_DYNAMIC_LIB_PATH": "${workspaceFolder}/libs/chonky/libs/"
   }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Instead of suggesting to ignore a warning the warning should be fixed. This removes the setting from the `.vscode/settings.json`. Also, it adds a few other recommended settings.