### PR TITLE
H-4026: Enable showing the modal to update dependent entity types

### DIFF
--- a/apps/hash-api/src/graphql/resolvers/ontology/entity-type.ts
+++ b/apps/hash-api/src/graphql/resolvers/ontology/entity-type.ts
@@ -21,6 +21,7 @@ import {
   getEntityTypeSubgraphById,
   unarchiveEntityType,
   updateEntityType,
+  updateEntityTypes,
 } from "../../../graph/ontology/primitive/entity-type";
 import type {
   GetClosedMultiEntityTypeResponse,
@@ -225,38 +226,36 @@ export const updateEntityTypesResolver: ResolverFn<
   LoggedInGraphQLContext,
   MutationUpdateEntityTypesArgs
 > = async (_, params, graphQLContext) =>
-  Promise.all(
-    params.updates.map((update) =>
-      updateEntityType(
-        graphQLContextToImpureGraphContext(graphQLContext),
-        graphQLContext.authentication,
-        {
-          entityTypeId: update.entityTypeId,
-          schema: update.updatedEntityType,
-          relationships: [
-            {
-              relation: "setting",
-              subject: {
-                kind: "setting",
-                subjectId: "updateFromWeb",
-              },
+  updateEntityTypes(
+    graphQLContextToImpureGraphContext(graphQLContext),
+    graphQLContext.authentication,
+    {
+      entityTypeUpdates: params.updates.map((update) => ({
+        entityTypeId: update.entityTypeId,
+        schema: update.updatedEntityType,
+        relationships: [
+          {
+            relation: "setting",
+            subject: {
+              kind: "setting",
+              subjectId: "updateFromWeb",
             },
-            {
-              relation: "viewer",
-              subject: {
-                kind: "public",
-              },
+          },
+          {
+            relation: "viewer",
+            subject: {
+              kind: "public",
             },
-            {
-              relation: "instantiator",
-              subject: {
-                kind: "public",
-              },
+          },
+          {
+            relation: "instantiator",
+            subject: {
+              kind: "public",
             },
-          ],
-        },
-      ),
-    ),
+          },
+        ],
+      })),
+    },
   );
 
 export const checkUserPermissionsOnEntityTypeResolver: ResolverFn<

--- a/apps/hash-frontend/src/pages/@/[shortname]/shared/use-route-namespace.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname]/shared/use-route-namespace.tsx
@@ -12,10 +12,20 @@ export const useRouteNamespace = (): {
   };
 } => {
   const router = useRouter();
-  const shortname = router.query.shortname;
+  let shortname = router.query.shortname;
 
   if (Array.isArray(shortname)) {
     throw new Error("shortname can't be an array");
+  }
+
+  if (!shortname) {
+    /**
+     * router.query is not populated in [...slug-maybe-version].page.tsx, probably some combination of the rewrite @[shortname] routes and the fact it is a catch all.
+     * We have to parse out the path ourselves.
+     *
+     * @see https://github.com/vercel/next.js/issues/50212 –– possibly related
+     */
+    shortname = router.asPath.match(/\/@([^/]+)/)?.[1];
   }
 
   const { loading, accountId } = useGetAccountIdForShortname(shortname);

--- a/apps/hash-frontend/src/pages/@/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
@@ -74,7 +74,7 @@ const Page: NextPageWithLayout = () => {
     if (loadingNamespace) {
       return null;
     } else {
-      throw new Error("Namespace for valid entity somehow missing");
+      throw new Error("Namespace for entity type somehow missing");
     }
   }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR un-hides the modal introduced in #6366 which allows users to update types which are dependent on the type being updated.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- Currently not all dependent types will be correctly found. This is because of an issue with `any` filters in the Graph API whereby if you use a query path which depends on a table join (e.g. `inheritsFrom`), only those types which have _some_ value for that path will be possible returns, even if types which _don't_ have anything they e.g. inherit from match _another_ of the `any` filter. In this context, this means that it will only find dependents which have _something_ they inherit from, and _some_ link. Types without either a parent or any links will not be found. Tracked in H-4015.

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

- The same 'offer to update type dependents' work needs to be done when updating a property type (H-4027) and data type (H-4061).

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- None yet.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Not possible locally as depends on Node API changes
