### PR TITLE
H-4064: Restrict `User` and `Organization` instantiators

### DIFF
--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/001-create-hash-system-types.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/001-create-hash-system-types.migration.ts
@@ -569,7 +569,10 @@ const migrate: MigrationFunction = async ({
       },
       webShortname: "hash",
       migrationState,
-      instantiator: anyUserInstantiator,
+      instantiator: {
+        kind: "account",
+        subjectId: systemAccountId,
+      },
     },
   );
 

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/001-create-hash-system-types.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/001-create-hash-system-types.migration.ts
@@ -841,7 +841,10 @@ const migrate: MigrationFunction = async ({
       },
       webShortname: "hash",
       migrationState,
-      instantiator: anyUserInstantiator,
+      instantiator: {
+        kind: "account",
+        subjectId: systemAccountId,
+      },
     },
   );
 

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/005-create-hash-system-entities-and-web-bots.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/005-create-hash-system-entities-and-web-bots.migration.ts
@@ -104,10 +104,13 @@ const migrate: MigrationFunction = async ({
           { actorId: userAccountId as AccountId },
           {
             ownedById: userAccountId,
+            logger,
             machineEntityTypeId: currentMachineEntityTypeId,
           },
         );
-        logger.info(`Created web machine actor for user ${userAccountId}`);
+        logger.info(
+          `Created missing machine web actor for user ${user.metadata.recordId.entityId}`,
+        );
       } else {
         throw new Error(
           `Unexpected error attempting to retrieve machine web actor for user ${user.metadata.recordId.entityId}`,
@@ -128,17 +131,18 @@ const migrate: MigrationFunction = async ({
       if (err instanceof NotFoundError) {
         const orgAdminAccountId = org.metadata.provenance.edition.createdById;
 
-        const webActorId = await createWebMachineActor(
+        await createWebMachineActor(
           context,
           // We have to use an org admin's authority to add the machine to their web
           { actorId: orgAdminAccountId },
           {
             ownedById: orgAccountGroupId,
+            logger,
             machineEntityTypeId: currentMachineEntityTypeId,
           },
         );
         logger.info(
-          `Created web machine actor for org ${orgAccountGroupId} with accountId ${webActorId} (by actor ${orgAdminAccountId})`,
+          `Created missing machine web actor for org ${org.metadata.recordId.entityId}`,
         );
       } else {
         throw new Error(

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/005-create-hash-system-entities-and-web-bots.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/005-create-hash-system-entities-and-web-bots.migration.ts
@@ -128,7 +128,7 @@ const migrate: MigrationFunction = async ({
       if (err instanceof NotFoundError) {
         const orgAdminAccountId = org.metadata.provenance.edition.createdById;
 
-        await createWebMachineActor(
+        const webActorId = await createWebMachineActor(
           context,
           // We have to use an org admin's authority to add the machine to their web
           { actorId: orgAdminAccountId },
@@ -137,7 +137,9 @@ const migrate: MigrationFunction = async ({
             machineEntityTypeId: currentMachineEntityTypeId,
           },
         );
-        logger.info(`Created web machine actor for org ${orgAccountGroupId}`);
+        logger.info(
+          `Created web machine actor for org ${orgAccountGroupId} with accountId ${webActorId} (by actor ${orgAdminAccountId})`,
+        );
       } else {
         throw new Error(
           `Unexpected error attempting to retrieve machine web actor for organization ${org.metadata.recordId.entityId}`,

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/017-add-use-case-form-and-example-org.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/017-add-use-case-form-and-example-org.migration.ts
@@ -4,6 +4,7 @@ import {
   systemPropertyTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
+import { logger } from "../../../../logger";
 import {
   createOrg,
   getOrgByShortname,
@@ -144,6 +145,7 @@ const migrate: MigrationFunction = async ({
           systemEntityTypes.organization.entityTypeBaseUrl
         ],
     });
+    logger.info("Created @example org");
   }
 
   return migrationState;

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util/upgrade-entities.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util/upgrade-entities.ts
@@ -157,7 +157,10 @@ export const upgradeWebEntities = async ({
 
         let updateAuthentication = webBotAuthentication;
 
-        const temporaryEntityTypePermissionsGranted: VersionedUrl[] = [];
+        const temporaryEntityTypePermissionsGranted: Record<
+          VersionedUrl,
+          AccountId
+        > = {};
 
         /**
          * Determine the actor that should update the entity.
@@ -189,45 +192,51 @@ export const upgradeWebEntities = async ({
              */
             actorId: entity.metadata.provenance.createdById,
           };
+        }
 
-          for (const entityTypeId of [currentEntityTypeId, newEntityTypeId]) {
-            /**
-             * We may need to temporarily grant the machine account ID the ability
-             * to instantiate entities of both the old and new entityTypeId,
-             * because an actor cannot update or remove an entity type without being able to instantiate it.
-             */
-            const relationships = await context.graphApi
-              .getEntityTypeAuthorizationRelationships(
-                systemAccountId,
-                entityTypeId,
-              )
-              .then(({ data }) => data);
+        /**
+         * We may need to temporarily grant the actor the ability to instantiate entities of both the old and new entityTypeId,
+         * because an actor cannot remove or add an entity type without being able to instantiate it.
+         * Some entity types have their instantiator restricted, e.g. User, Org, so that they can only be created in special circumstances.
+         * If the actor being used here doesn't already have permission we'll grant it and then remove it after the update.
+         */
+        for (const entityTypeId of [currentEntityTypeId, newEntityTypeId]) {
+          const relationships = await context.graphApi
+            .getEntityTypeAuthorizationRelationships(
+              systemAccountId,
+              entityTypeId,
+            )
+            .then(({ data }) => data);
 
-            const relationAndSubject = {
-              subject: {
-                kind: "account",
-                subjectId: entity.metadata.provenance.createdById,
-              },
-              relation: "instantiator",
-            } as const;
+          const relationAndSubject = {
+            subject: {
+              kind: "account",
+              subjectId: updateAuthentication.actorId,
+            },
+            relation: "instantiator",
+          } as const;
 
-            if (
-              !relationships.find((relationship) =>
-                isEqual(relationship, relationAndSubject),
-              )
-            ) {
-              await context.graphApi.modifyEntityTypeAuthorizationRelationships(
-                systemAccountId,
-                [
-                  {
-                    operation: "create",
-                    resource: entityTypeId,
-                    relationAndSubject,
-                  },
-                ],
-              );
-              temporaryEntityTypePermissionsGranted.push(entityTypeId);
-            }
+          if (
+            !relationships.find(
+              ({ subject, relation }) =>
+                relation === "instantiator" &&
+                ((subject.kind === "account" &&
+                  subject.subjectId === updateAuthentication.actorId) ||
+                  subject.kind === "public"),
+            )
+          ) {
+            await context.graphApi.modifyEntityTypeAuthorizationRelationships(
+              systemAccountId,
+              [
+                {
+                  operation: "create",
+                  resource: entityTypeId,
+                  relationAndSubject,
+                },
+              ],
+            );
+            temporaryEntityTypePermissionsGranted[entityTypeId] =
+              updateAuthentication.actorId;
           }
         }
 
@@ -256,7 +265,9 @@ export const upgradeWebEntities = async ({
               : undefined,
           });
         } finally {
-          for (const entityTypeId of temporaryEntityTypePermissionsGranted) {
+          for (const [entityTypeId, actorId] of Object.entries(
+            temporaryEntityTypePermissionsGranted,
+          )) {
             /**
              * If we updated a machine entity and granted its actor ID a
              * new permission, we need to remove the temporary permission.
@@ -270,7 +281,7 @@ export const upgradeWebEntities = async ({
                   relationAndSubject: {
                     subject: {
                       kind: "account",
-                      subjectId: entity.metadata.provenance.createdById,
+                      subjectId: actorId,
                     },
                     relation: "instantiator",
                   },

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util/upgrade-entities.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util/upgrade-entities.ts
@@ -26,7 +26,6 @@ import {
   componentsFromVersionedUrl,
   versionedUrlFromComponents,
 } from "@local/hash-subgraph/type-system-patch";
-import isEqual from "lodash/isEqual";
 
 import type { ImpureGraphContext } from "../../../context-types";
 import {

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/system-webs-and-entities.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/system-webs-and-entities.ts
@@ -192,7 +192,6 @@ export const ensureSystemWebEntitiesExist = async ({
         identifier: webShortname,
         ownedById: accountGroupId as OwnedById,
         displayName,
-        shouldBeAbleToCreateMoreMachineEntities: false,
         systemAccountId,
         machineEntityTypeId,
       });
@@ -320,7 +319,6 @@ export const ensureSystemEntitiesExist = async (params: {
         machineAccountId: aiAssistantAccountId,
         ownedById: hashAccountGroupId as OwnedById,
         displayName: "HASH AI",
-        shouldBeAbleToCreateMoreMachineEntities: false,
         systemAccountId,
       });
 

--- a/apps/hash-api/src/graph/knowledge/system-types/hash-instance.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/hash-instance.ts
@@ -8,6 +8,7 @@ import type { OwnedById } from "@local/hash-graph-types/web";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import type { HASHInstance as HashInstanceEntity } from "@local/hash-isomorphic-utils/system-types/hashinstance";
 
+import { logger } from "../../../logger";
 import { createAccountGroup } from "../../account-permission-management";
 import type { ImpureGraphFunction } from "../../context-types";
 import { modifyEntityTypeAuthorizationRelationships } from "../../ontology/primitive/entity-type";
@@ -46,12 +47,6 @@ export const createHashInstance: ImpureGraphFunction<
     throw new Error("HASH instance entity already exists.");
   }
 
-  const hashInstanceAdminsAccountGroupId = await createAccountGroup(
-    ctx,
-    authentication,
-    {},
-  );
-
   const hashOrg = await getOrgByShortname(ctx, authentication, {
     shortname: "hash",
     permitOlderVersions: true,
@@ -62,6 +57,16 @@ export const createHashInstance: ImpureGraphFunction<
       "Cannot create HASH Instance entity before HASH Org is created",
     );
   }
+
+  const hashInstanceAdminsAccountGroupId = await createAccountGroup(
+    ctx,
+    authentication,
+    {},
+  );
+
+  logger.info(
+    `Created account group for hash instance admins with id: ${hashInstanceAdminsAccountGroupId}`,
+  );
 
   const entity = await createEntity<HashInstanceEntity>(ctx, authentication, {
     ownedById: hashOrg.accountGroupId as OwnedById,

--- a/apps/hash-api/src/graph/knowledge/system-types/org.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/org.ts
@@ -23,6 +23,7 @@ import {
   versionedUrlFromComponents,
 } from "@local/hash-subgraph/type-system-patch";
 
+import { logger } from "../../../logger";
 import {
   createAccountGroup,
   createWeb,
@@ -131,6 +132,7 @@ export const createOrg: ImpureGraphFunction<
     orgAccountGroupId = params.orgAccountGroupId;
   } else {
     orgAccountGroupId = await createAccountGroup(ctx, authentication, {});
+
     await createWeb(ctx, authentication, {
       ownedById: orgAccountGroupId as OwnedById,
       owner: { kind: "accountGroup", subjectId: orgAccountGroupId },
@@ -138,6 +140,7 @@ export const createOrg: ImpureGraphFunction<
 
     await createWebMachineActor(ctx, authentication, {
       ownedById: orgAccountGroupId as OwnedById,
+      logger,
     });
   }
 

--- a/apps/hash-api/src/graph/knowledge/system-types/user.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user.ts
@@ -29,6 +29,7 @@ import type {
   KratosUserIdentityTraits,
 } from "../../../auth/ory-kratos";
 import { kratosIdentityApi } from "../../../auth/ory-kratos";
+import { logger } from "../../../logger";
 import { createAccount, createWeb } from "../../account-permission-management";
 import type {
   ImpureGraphFunction,
@@ -321,6 +322,7 @@ export const createUser: ImpureGraphFunction<
     },
     {
       ownedById: userAccountId as OwnedById,
+      logger,
     },
   );
 

--- a/libs/@local/hash-backend-utils/src/machine-actors.ts
+++ b/libs/@local/hash-backend-utils/src/machine-actors.ts
@@ -102,7 +102,6 @@ export const createMachineActorEntity = async (
     machineAccountId,
     ownedById,
     displayName,
-    shouldBeAbleToCreateMoreMachineEntities,
     systemAccountId,
     machineEntityTypeId,
   }: {
@@ -114,8 +113,6 @@ export const createMachineActorEntity = async (
     ownedById: OwnedById;
     // A display name for the machine actor, to display to users
     displayName: string;
-    // Whether or not this machine should be able to create more machine entities after creating itself
-    shouldBeAbleToCreateMoreMachineEntities: boolean;
     // The accountId of the system account, used to grant the machine actor permissions to instantiate system types
     systemAccountId: AccountId;
     machineEntityTypeId?: VersionedUrl;
@@ -194,25 +191,22 @@ export const createMachineActorEntity = async (
     },
   );
 
-  if (!shouldBeAbleToCreateMoreMachineEntities) {
-    await context.graphApi.modifyEntityTypeAuthorizationRelationships(
-      systemAccountId,
-      [
-        {
-          operation: "delete",
-          resource:
-            machineEntityTypeId ?? systemEntityTypes.machine.entityTypeId,
-          relationAndSubject: {
-            subject: {
-              kind: "account",
-              subjectId: machineAccountId,
-            },
-            relation: "instantiator",
+  await context.graphApi.modifyEntityTypeAuthorizationRelationships(
+    systemAccountId,
+    [
+      {
+        operation: "delete",
+        resource: machineEntityTypeId ?? systemEntityTypes.machine.entityTypeId,
+        relationAndSubject: {
+          subject: {
+            kind: "account",
+            subjectId: machineAccountId,
           },
+          relation: "instantiator",
         },
-      ],
-    );
-  }
+      },
+    ],
+  );
 };
 
 /**
@@ -260,7 +254,6 @@ export const createWebMachineActor = async (
     machineAccountId: machineAccountId as AccountId,
     ownedById,
     displayName: "HASH",
-    shouldBeAbleToCreateMoreMachineEntities: true,
     systemAccountId,
     machineEntityTypeId,
   });

--- a/libs/@local/hash-backend-utils/src/machine-actors.ts
+++ b/libs/@local/hash-backend-utils/src/machine-actors.ts
@@ -16,6 +16,7 @@ import type { Machine } from "@local/hash-isomorphic-utils/system-types/machine"
 import { backOff } from "exponential-backoff";
 
 import { NotFoundError } from "./error.js";
+import type { Logger } from "./logger.js";
 
 export type WebMachineActorIdentifier = `system-${OwnedById}`;
 
@@ -99,6 +100,7 @@ export const createMachineActorEntity = async (
   context: { graphApi: GraphApi },
   {
     identifier,
+    logger,
     machineAccountId,
     ownedById,
     displayName,
@@ -107,6 +109,8 @@ export const createMachineActorEntity = async (
   }: {
     // A unique identifier for the machine actor
     identifier: MachineActorIdentifier;
+    // A logger instance
+    logger: Logger;
     // An existing accountId for the machine actor, which will also be used to authenticate the request
     machineAccountId: AccountId;
     // The OwnedById of the web the actor's entity will belong to
@@ -191,6 +195,10 @@ export const createMachineActorEntity = async (
     },
   );
 
+  logger.info(
+    `Created machine actor entity with identifier '${identifier}' with accountId: ${machineAccountId}, in web ${ownedById}`,
+  );
+
   await context.graphApi.modifyEntityTypeAuthorizationRelationships(
     systemAccountId,
     [
@@ -219,9 +227,11 @@ export const createWebMachineActor = async (
   authentication: { actorId: AccountId },
   {
     ownedById,
+    logger,
     machineEntityTypeId,
   }: {
     ownedById: OwnedById;
+    logger: Logger;
     machineEntityTypeId?: VersionedUrl;
   },
 ): Promise<AccountId> => {
@@ -251,6 +261,7 @@ export const createWebMachineActor = async (
 
   await createMachineActorEntity(context, {
     identifier: `system-${ownedById}`,
+    logger,
     machineAccountId: machineAccountId as AccountId,
     ownedById,
     displayName: "HASH",

--- a/libs/@local/hash-backend-utils/src/machine-actors.ts
+++ b/libs/@local/hash-backend-utils/src/machine-actors.ts
@@ -3,6 +3,7 @@ import type { GraphApi } from "@local/hash-graph-client";
 import type { EnforcedEntityEditionProvenance } from "@local/hash-graph-sdk/entity";
 import { Entity } from "@local/hash-graph-sdk/entity";
 import type { AccountId } from "@local/hash-graph-types/account";
+import type { EntityUuid } from "@local/hash-graph-types/entity";
 import type { OwnedById } from "@local/hash-graph-types/web";
 import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import {
@@ -150,6 +151,7 @@ export const createMachineActorEntity = async (
     { actorId: machineAccountId },
     {
       draft: false,
+      entityUuid: machineAccountId.toString() as EntityUuid,
       entityTypeIds: machineEntityTypeId
         ? ([machineEntityTypeId] as Machine["entityTypeIds"])
         : [systemEntityTypes.machine.entityTypeId],


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR does a few pieces of cleanup around permissions:
1. Restricts anyone from creating `User` and `Organization` entities outside of the dedicated routes (creating the entities elsewhere doesn't grant any permissions, but if someone does it we will have broken User/Orgs lying around)
2. Don't bother to maintain instantiator permission on `Machine` for anyone (just grant and remove it as needed)
3. Fix migration scripts to account for arbitrary needs to grant/remove permissions to add new types to entities

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- Migration scripts and some BE integration tests involve creating orgs

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Check that migrations still run as expected
2. Check that user can create an org via UI (workspace switcher -> create org)
3. Check that user cannot create an organisation or user entity via e.g. `createEntity`
