### PR TITLE
H-4068: Fix codegen in `typesystem` to generate `number` instead of `Real`

### DIFF
--- a/libs/@blockprotocol/type-system/rust/Cargo.toml
+++ b/libs/@blockprotocol/type-system/rust/Cargo.toml
@@ -60,3 +60,9 @@ console_error_panic_hook = { version = "0.1.7" }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3.49"
+
+
+[package.metadata.sync.turborepo]
+extra-dev-dependencies = [
+    { name = "@local/tsconfig", version = "0.0.0-private" },
+]

--- a/libs/@blockprotocol/type-system/rust/package.json
+++ b/libs/@blockprotocol/type-system/rust/package.json
@@ -22,6 +22,7 @@
     "build:wasm": "wasm-pack build --target web --out-name type-system --scope blockprotocol --release . && rm pkg/package.json",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy && just clippy --target wasm32-unknown-unknown",
+    "lint:tsc": "tsc --noEmit",
     "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
   },
   "dependencies": {
@@ -29,7 +30,9 @@
     "@rust/hash-codec": "0.0.0-private"
   },
   "devDependencies": {
+    "@local/tsconfig": "0.0.0-private",
     "@rust/hash-graph-test-data": "0.0.0-private",
+    "typescript": "5.7.3",
     "wasm-pack": "0.13.1"
   }
 }

--- a/libs/@blockprotocol/type-system/rust/src/lib.rs
+++ b/libs/@blockprotocol/type-system/rust/src/lib.rs
@@ -33,14 +33,17 @@ use serde::Serialize as _;
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[serde(untagged)]
+#[serde(untagged, rename = "JsonValue")]
 pub enum Value {
     Null,
     Bool(bool),
     String(String),
-    Number(Real),
-    Array(Vec<Self>),
-    Object(HashMap<String, Self>),
+    Number(#[cfg_attr(target_arch = "wasm32", tsify(type = "number"))] Real),
+    Array(#[cfg_attr(target_arch = "wasm32", tsify(type = "JsonValue[]"))] Vec<Self>),
+    Object(
+        #[cfg_attr(target_arch = "wasm32", tsify(type = "{ [key: string]: JsonValue }"))]
+        HashMap<String, Self>,
+    ),
 }
 
 impl fmt::Display for Value {

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
@@ -67,6 +67,7 @@ pub enum NumberTypeTag {
 pub enum NumberSchema {
     Constrained(NumberConstraints),
     Const {
+        #[cfg_attr(target_arch = "wasm32", tsify(type = "number"))]
         r#const: Real,
     },
     Enum {
@@ -295,14 +296,17 @@ impl ConstraintValidator<Real> for NumberSchema {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct NumberConstraints {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(target_arch = "wasm32", tsify(type = "number"))]
     pub minimum: Option<Real>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub exclusive_minimum: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(target_arch = "wasm32", tsify(type = "number"))]
     pub maximum: Option<Real>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub exclusive_maximum: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(target_arch = "wasm32", tsify(type = "number"))]
     pub multiple_of: Option<Real>,
 }
 

--- a/libs/@blockprotocol/type-system/rust/src/utils.rs
+++ b/libs/@blockprotocol/type-system/rust/src/utils.rs
@@ -30,16 +30,6 @@ mod wasm {
             }
         }
     }
-
-    #[derive(Tsify)]
-    #[serde(rename = "JsonValue")]
-    #[expect(dead_code, reason = "Used in the generated TypeScript types")]
-    pub struct VersionedUrlPatch(
-        #[tsify(
-            type = "null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue; }"
-        )]
-        (),
-    );
 }
 
 #[cfg(test)]

--- a/libs/@blockprotocol/type-system/rust/tsconfig.json
+++ b/libs/@blockprotocol/type-system/rust/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@local/tsconfig/legacy-base-tsconfig-to-refactor.json",
+  "files": ["pkg/type-system.d.ts"],
+  "compilerOptions": {
+    "lib": ["DOM", "ES2024"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "skipLibCheck": false,
+    "types": []
+  }
+}

--- a/libs/@blockprotocol/type-system/rust/turbo.json
+++ b/libs/@blockprotocol/type-system/rust/turbo.json
@@ -3,6 +3,9 @@
   "tasks": {
     "build:wasm": {
       "outputs": ["pkg/**"]
+    },
+    "lint:tsc": {
+      "dependsOn": ["build:wasm"]
     }
   }
 }

--- a/libs/@local/effect-dns/hickory/Cargo.toml
+++ b/libs/@local/effect-dns/hickory/Cargo.toml
@@ -26,5 +26,10 @@ napi-build = { workspace = true }
 [lints]
 workspace = true
 
+
 [package.metadata.sync.turborepo]
-ignore = true
+package-name = "@local/effect-dns-hickory"
+extra-dev-dependencies = [
+    { name = "@local/eslint", version = "0.0.0-private" },
+    { name = "@local/tsconfig", version = "0.0.0-private" },
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4466,9 +4466,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@blockprotocol/type-system-rs@workspace:libs/@blockprotocol/type-system/rust"
   dependencies:
+    "@local/tsconfig": "npm:0.0.0-private"
     "@rust/error-stack": "npm:0.5.0"
     "@rust/hash-codec": "npm:0.0.0-private"
     "@rust/hash-graph-test-data": "npm:0.0.0-private"
+    typescript: "npm:5.7.3"
     wasm-pack: "npm:0.13.1"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When we added higher precision conversions, the type system did not generate valid TS. This fixes the generations for number constraints to use `number` instead of `Real` and also fix the `Value` type.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
