### PR TITLE
H-3071: Fix hash.design vercel builds

### DIFF
--- a/apps/hashdotdesign/vercel-build.sh
+++ b/apps/hashdotdesign/vercel-build.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-# shellcheck disable=SC1090
-source ~/.bashrc
 
 set -euo pipefail
+
+source "$HOME/.cargo/env"
 
 echo "Changing dir to root"
 cd ../..

--- a/apps/hashdotdev/vercel-build.sh
+++ b/apps/hashdotdev/vercel-build.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
+
 set -euo pipefail
+
+source "$HOME/.cargo/env"
 
 echo "Changing dir to root"
 cd ../..


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The vercel-builds did not source the correct file, so they couldn't find `cargo metadata`.