### PR TITLE
H-4071: Comment out unused/unsupported lint section in Cargo manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -279,7 +279,8 @@ nonstandard_style   = { level = "warn", priority = -1 }
 unreachable_pub = "warn"
 unsafe_code     = "deny"
 
-[workspace.lints.cargo]
+# TODO: Enable `cargo` lints when supported
+# [workspace.lints.cargo]
 
 [workspace.lints.clippy]
 all         = { level = "warn", priority = -1 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `workspace.lints.cargo` section is currently not used and also not part of the Cargo manifest schema. This results in linting errors in the IDE if the IDE supports schema validation.