### PR TITLE
H-4075: Explicitly declare repo in root `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "node": ">= v22"
   },
   "repository": {
-		"type": "git",
-		"url": "https://github.com/hashintel/hash.git"
-	}
+    "type": "git",
+    "url": "https://github.com/hashintel/hash.git"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -110,5 +110,9 @@
   "packageManager": "yarn@4.6.0",
   "engines": {
     "node": ">= v22"
-  }
+  },
+  "repository": {
+		"type": "git",
+		"url": "https://github.com/hashintel/hash.git"
+	}
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Minimal change to help track clones back to their original source, for basic software supply chain provenance per https://github.com/microsoft/Secure-Supply-Chain
