### PR TITLE
Preserve order for `enum` data type constraints

### DIFF
--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
@@ -697,8 +697,7 @@ mod tests {
     fn duplicate_enum_values() {
         from_value::<ValueConstraints>(json!({
             "type": "number",
-            "enum": [50],
-            "minimum": 0,
+            "enum": [50, 50],
         }))
         .expect_err("Deserialized number schema with mixed properties");
     }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
@@ -699,7 +699,7 @@ mod tests {
             "type": "number",
             "enum": [50, 50],
         }))
-        .expect_err("Deserialized number schema with mixed properties");
+        .expect_err("Deserialized number schema with duplicate enum values");
     }
 
     #[test]

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/number.rs
@@ -138,14 +138,14 @@ impl Constraint for NumberSchema {
                     bail!(ResolveClosedDataTypeError::UnsatisfiedEnumConstraint(
                         ValueConstraints::Typed(SingleValueConstraints::Number(Self::Constrained(
                             constraints
-                        ),)),
+                        ))),
                     ))
                 }
 
                 (Self::Enum { r#enum: passed }, None)
             }
             (Self::Enum { r#enum: lhs }, Self::Enum { r#enum: rhs }) => {
-                // We use a `HashSet` to find the actual intersection of the two enums. It's not
+                // We use a `BTreeSet` to find the actual intersection of the two enums. It's not
                 // required to clone the values.
                 let lhs_set = lhs.iter().collect::<BTreeSet<_>>();
                 let rhs_set = rhs.iter().collect::<BTreeSet<_>>();

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
@@ -220,17 +220,14 @@ pub enum StringTypeTag {
 #[serde(untagged, rename_all = "camelCase", deny_unknown_fields)]
 pub enum StringSchema {
     Constrained(StringConstraints),
-    Const {
-        r#const: String,
-    },
     Enum {
         #[cfg_attr(target_arch = "wasm32", tsify(type = "[string, ...string[]]"))]
-        r#enum: HashSet<String>,
+        #[serde(deserialize_with = "hash_codec::serde::unique_vec::hashed")]
+        r#enum: Vec<String>,
     },
 }
 
 impl Constraint for StringSchema {
-    #[expect(clippy::too_many_lines)]
     fn intersection(
         self,
         other: Self,
@@ -239,21 +236,6 @@ impl Constraint for StringSchema {
             (Self::Constrained(lhs), Self::Constrained(rhs)) => lhs
                 .intersection(rhs)
                 .map(|(lhs, rhs)| (Self::Constrained(lhs), rhs.map(Self::Constrained)))?,
-            (Self::Const { r#const }, Self::Constrained(constraints))
-            | (Self::Constrained(constraints), Self::Const { r#const }) => {
-                constraints
-                    .validate_value(&r#const)
-                    .change_context_lazy(|| {
-                        ResolveClosedDataTypeError::UnsatisfiedConstraint(
-                            Value::String(r#const.clone()),
-                            ValueConstraints::Typed(SingleValueConstraints::String(
-                                Self::Constrained(constraints),
-                            )),
-                        )
-                    })?;
-
-                (Self::Const { r#const }, None)
-            }
             (Self::Enum { r#enum }, Self::Constrained(constraints))
             | (Self::Constrained(constraints), Self::Enum { r#enum }) => {
                 // We use the fast way to filter the values that pass the constraints and collect
@@ -263,99 +245,64 @@ impl Constraint for StringSchema {
                     .iter()
                     .filter(|&value| constraints.is_valid(value))
                     .cloned()
-                    .collect::<HashSet<_>>();
+                    .collect::<Vec<_>>();
 
-                match passed.len() {
-                    0 => {
-                        // We now properly capture errors to return it to the caller.
-                        let () = r#enum
-                            .into_iter()
-                            .map(|value| {
-                                constraints.validate_value(&value).change_context(
-                                    ResolveClosedDataTypeError::UnsatisfiedEnumConstraintVariant(
-                                        Value::String(value),
-                                    ),
-                                )
-                            })
-                            .try_collect_reports()
-                            .change_context_lazy(|| {
-                                ResolveClosedDataTypeError::UnsatisfiedEnumConstraint(
-                                    ValueConstraints::Typed(SingleValueConstraints::String(
-                                        Self::Constrained(constraints.clone()),
-                                    )),
-                                )
-                            })?;
+                if passed.is_empty() {
+                    // We now properly capture errors to return it to the caller.
+                    let () = r#enum
+                        .into_iter()
+                        .map(|value| {
+                            constraints.validate_value(&value).change_context(
+                                ResolveClosedDataTypeError::UnsatisfiedEnumConstraintVariant(
+                                    Value::String(value),
+                                ),
+                            )
+                        })
+                        .try_collect_reports()
+                        .change_context_lazy(|| {
+                            ResolveClosedDataTypeError::UnsatisfiedEnumConstraint(
+                                ValueConstraints::Typed(SingleValueConstraints::String(
+                                    Self::Constrained(constraints.clone()),
+                                )),
+                            )
+                        })?;
 
-                        // This should only happen if `enum` is malformed and has no values. This
-                        // should be caught by the schema validation, however, if this still happens
-                        // we return an error as validating empty enum will always fail.
-                        bail!(ResolveClosedDataTypeError::UnsatisfiedEnumConstraint(
-                            ValueConstraints::Typed(SingleValueConstraints::String(
-                                Self::Constrained(constraints),
-                            )),
-                        ))
-                    }
-                    1 => (
-                        Self::Const {
-                            r#const: passed.into_iter().next().unwrap_or_else(|| {
-                                unreachable!(
-                                    "we have exactly one value in the enum that passed the \
-                                     constraints"
-                                )
-                            }),
-                        },
-                        None,
-                    ),
-                    _ => (Self::Enum { r#enum: passed }, None),
-                }
-            }
-            (Self::Const { r#const: lhs }, Self::Const { r#const: rhs }) => {
-                if lhs == rhs {
-                    (Self::Const { r#const: lhs }, None)
-                } else {
-                    bail!(ResolveClosedDataTypeError::ConflictingConstValues(
-                        Value::String(lhs),
-                        Value::String(rhs),
+                    // This should only happen if `enum` is malformed and has no values. This
+                    // should be caught by the schema validation, however, if this still happens
+                    // we return an error as validating empty enum will always fail.
+                    bail!(ResolveClosedDataTypeError::UnsatisfiedEnumConstraint(
+                        ValueConstraints::Typed(SingleValueConstraints::String(Self::Constrained(
+                            constraints
+                        ),)),
                     ))
                 }
+
+                (Self::Enum { r#enum: passed }, None)
             }
             (Self::Enum { r#enum: lhs }, Self::Enum { r#enum: rhs }) => {
-                let intersection = lhs.intersection(&rhs).cloned().collect::<HashSet<_>>();
+                // We use a `HashSet` to find the actual intersection of the two enums. It's not
+                // required to clone the values.
+                let lhs_set = lhs.iter().collect::<HashSet<_>>();
+                let rhs_set = rhs.iter().collect::<HashSet<_>>();
+                let intersection = lhs_set.intersection(&rhs_set).collect::<HashSet<_>>();
 
-                match intersection.len() {
-                    0 => bail!(ResolveClosedDataTypeError::ConflictingEnumValues(
+                ensure!(
+                    !intersection.is_empty(),
+                    ResolveClosedDataTypeError::ConflictingEnumValues(
                         lhs.into_iter().map(Value::String).collect(),
                         rhs.into_iter().map(Value::String).collect(),
-                    )),
-                    1 => (
-                        Self::Const {
-                            r#const: intersection.into_iter().next().unwrap_or_else(|| {
-                                unreachable!(
-                                    "we have exactly least one value in the enum intersection"
-                                )
-                            }),
-                        },
-                        None,
-                    ),
-                    _ => (
-                        Self::Enum {
-                            r#enum: intersection,
-                        },
-                        None,
-                    ),
-                }
-            }
-            (Self::Const { r#const }, Self::Enum { r#enum })
-            | (Self::Enum { r#enum }, Self::Const { r#const }) => {
-                ensure!(
-                    r#enum.contains(&r#const),
-                    ResolveClosedDataTypeError::ConflictingConstEnumValue(
-                        Value::String(r#const),
-                        r#enum.into_iter().map(Value::String).collect(),
                     )
                 );
 
-                (Self::Const { r#const }, None)
+                (
+                    Self::Enum {
+                        r#enum: lhs
+                            .into_iter()
+                            .filter(|value| rhs.contains(value))
+                            .collect(),
+                    },
+                    None,
+                )
             }
         })
     }
@@ -390,8 +337,7 @@ impl ConstraintValidator<str> for StringSchema {
     fn is_valid(&self, value: &str) -> bool {
         match self {
             Self::Constrained(constraints) => constraints.is_valid(value),
-            Self::Const { r#const } => value == r#const,
-            Self::Enum { r#enum } => r#enum.contains(value),
+            Self::Enum { r#enum } => r#enum.iter().any(|item| item == value),
         }
     }
 
@@ -400,16 +346,8 @@ impl ConstraintValidator<str> for StringSchema {
             Self::Constrained(constraints) => constraints
                 .validate_value(value)
                 .change_context(ConstraintError::ValueConstraint)?,
-            Self::Const { r#const } => {
-                if value != *r#const {
-                    bail!(ConstraintError::InvalidConstValue {
-                        actual: Value::String(value.to_owned()),
-                        expected: Value::String(r#const.clone()),
-                    });
-                }
-            }
             Self::Enum { r#enum } => {
-                if !r#enum.contains(value) {
+                if !r#enum.iter().any(|item| item == value) {
                     bail!(ConstraintError::InvalidEnumValue {
                         actual: Value::String(value.to_owned()),
                         expected: r#enum.iter().cloned().map(Value::String).collect(),
@@ -579,12 +517,12 @@ mod tests {
     use crate::{
         Value,
         schema::{
-            JsonSchemaValueType, SingleValueConstraints,
+            JsonSchemaValueType,
             data_type::constraint::{
                 ValueConstraints,
                 tests::{
                     check_constraints, check_constraints_error, check_schema_intersection,
-                    check_schema_intersection_error, intersect_schemas, read_schema,
+                    check_schema_intersection_error, read_schema,
                 },
             },
         },
@@ -644,24 +582,6 @@ mod tests {
     }
 
     #[test]
-    fn constant() {
-        let string_schema = read_schema(&json!({
-            "type": "string",
-            "const": "foo",
-        }));
-
-        check_constraints(&string_schema, json!("foo"));
-        check_constraints_error(
-            &string_schema,
-            json!("bar"),
-            [ConstraintError::InvalidConstValue {
-                actual: Value::String("bar".to_owned()),
-                expected: Value::String("foo".to_owned()),
-            }],
-        );
-    }
-
-    #[test]
     fn enumeration() {
         let string_schema = read_schema(&json!({
             "type": "string",
@@ -716,6 +636,15 @@ mod tests {
             "enum": ["foo", "bar"],
         }))
         .expect_err("Deserialized string schema with mixed properties");
+    }
+
+    #[test]
+    fn duplicate_enum_values() {
+        from_value::<ValueConstraints>(json!({
+            "type": "string",
+            "enum": ["foo", "foo"],
+        }))
+        .expect_err("Deserialized string schema with duplicate enum values");
     }
 
     #[test]
@@ -944,123 +873,27 @@ mod tests {
     }
 
     #[test]
-    fn intersect_const_const_same() {
-        check_schema_intersection(
-            [
-                json!({
-                    "type": "string",
-                    "const": "foo",
-                }),
-                json!({
-                    "type": "string",
-                    "const": "foo",
-                }),
-            ],
-            [json!({
-                "type": "string",
-                "const": "foo",
-            })],
-        );
-    }
-
-    #[test]
-    fn intersect_const_const_different() {
-        check_schema_intersection_error(
-            [
-                json!({
-                    "type": "string",
-                    "const": "foo",
-                }),
-                json!({
-                    "type": "string",
-                    "const": "bar",
-                }),
-            ],
-            [ResolveClosedDataTypeError::ConflictingConstValues(
-                Value::String("foo".to_owned()),
-                Value::String("bar".to_owned()),
-            )],
-        );
-    }
-
-    #[test]
-    fn intersect_const_enum_compatible() {
-        check_schema_intersection(
-            [
-                json!({
-                    "type": "string",
-                    "const": "foo",
-                }),
-                json!({
-                    "type": "string",
-                    "enum": ["foo", "bar"],
-                }),
-            ],
-            [json!({
-                "type": "string",
-                "const": "foo",
-            })],
-        );
-    }
-
-    #[test]
-    fn intersect_const_enum_incompatible() {
-        let report = intersect_schemas([
-            json!({
-                "type": "string",
-                "const": "foo",
-            }),
-            json!({
-                "type": "string",
-                "enum": ["bar", "baz"],
-            }),
-        ])
-        .expect_err("Intersected invalid schemas");
-
-        let Some(ResolveClosedDataTypeError::ConflictingConstEnumValue(lhs, rhs)) =
-            report.downcast_ref::<ResolveClosedDataTypeError>()
-        else {
-            panic!("Expected conflicting const-enum values error");
-        };
-        assert_eq!(lhs, &Value::String("foo".to_owned()));
-
-        assert_eq!(rhs.len(), 2);
-        assert!(rhs.contains(&Value::String("bar".to_owned())));
-        assert!(rhs.contains(&Value::String("baz".to_owned())));
-    }
-
-    #[test]
     fn intersect_enum_enum_compatible_multi() {
-        let intersection = intersect_schemas([
-            json!({
+        check_schema_intersection(
+            [
+                json!({
+                    "type": "string",
+                    "enum": ["foo", "bar", "baz"],
+                }),
+                json!({
+                    "type": "string",
+                    "enum": ["foo", "baz", "qux"],
+                }),
+                json!({
+                    "type": "string",
+                    "enum": ["foo", "bar", "qux", "baz"],
+                }),
+            ],
+            [json!({
                 "type": "string",
-                "enum": ["foo", "bar", "baz"],
-            }),
-            json!({
-                "type": "string",
-                "enum": ["foo", "baz", "qux"],
-            }),
-            json!({
-                "type": "string",
-                "enum": ["foo", "bar", "qux", "baz"],
-            }),
-        ])
-        .expect("Intersected invalid constraints")
-        .into_iter()
-        .map(|schema| {
-            from_value::<SingleValueConstraints>(schema).expect("Failed to deserialize schema")
-        })
-        .collect::<Vec<_>>();
-
-        // We need to manually check the intersection because the order of the enum values is not
-        // guaranteed.
-        assert_eq!(intersection.len(), 1);
-        let SingleValueConstraints::String(StringSchema::Enum { r#enum }) = &intersection[0] else {
-            panic!("Expected string enum schema");
-        };
-        assert_eq!(r#enum.len(), 2);
-        assert!(r#enum.contains("foo"));
-        assert!(r#enum.contains("baz"));
+                "enum": ["foo", "baz"],
+            })],
+        );
     }
 
     #[test]
@@ -1082,79 +915,27 @@ mod tests {
             ],
             [json!({
                 "type": "string",
-                "const": "foo",
+                "enum": ["foo"],
             })],
         );
     }
 
     #[test]
     fn intersect_enum_enum_incompatible() {
-        let report = intersect_schemas([
-            json!({
-                "type": "string",
-                "enum": ["foo", "bar"],
-            }),
-            json!({
-                "type": "string",
-                "enum": ["baz", "qux"],
-            }),
-        ])
-        .expect_err("Intersected invalid schemas");
-
-        let Some(ResolveClosedDataTypeError::ConflictingEnumValues(lhs, rhs)) =
-            report.downcast_ref::<ResolveClosedDataTypeError>()
-        else {
-            panic!("Expected conflicting enum values error");
-        };
-        assert_eq!(lhs.len(), 2);
-        assert!(lhs.contains(&Value::String("foo".to_owned())));
-        assert!(lhs.contains(&Value::String("bar".to_owned())));
-
-        assert_eq!(rhs.len(), 2);
-        assert!(rhs.contains(&Value::String("baz".to_owned())));
-        assert!(rhs.contains(&Value::String("qux".to_owned())));
-    }
-
-    #[test]
-    fn intersect_const_constraint_compatible() {
-        check_schema_intersection(
-            [
-                json!({
-                    "type": "string",
-                    "const": "foo",
-                }),
-                json!({
-                    "type": "string",
-                    "minLength": 3,
-                }),
-            ],
-            [json!({
-                "type": "string",
-                "const": "foo",
-            })],
-        );
-    }
-
-    #[test]
-    fn intersect_const_constraint_incompatible() {
         check_schema_intersection_error(
             [
                 json!({
                     "type": "string",
-                    "const": "foo",
+                    "enum": ["foo", "bar"],
                 }),
                 json!({
                     "type": "string",
-                    "minLength": 5,
+                    "enum": ["baz", "qux"],
                 }),
             ],
-            [ResolveClosedDataTypeError::UnsatisfiedConstraint(
-                Value::String("foo".to_owned()),
-                from_value(json!({
-                    "type": "string",
-                    "minLength": 5,
-                }))
-                .expect("Failed to parse schema"),
+            [ResolveClosedDataTypeError::ConflictingEnumValues(
+                from_value(json!(["foo", "bar"])).expect("Failed to parse enum"),
+                from_value(json!(["baz", "qux"])).expect("Failed to parse enum"),
             )],
         );
     }
@@ -1174,39 +955,29 @@ mod tests {
             ],
             [json!({
                 "type": "string",
-                "const": "foobar",
+                "enum": ["foobar"],
             })],
         );
     }
 
     #[test]
     fn intersect_enum_constraint_compatible_multi() {
-        let intersection = intersect_schemas([
-            json!({
+        check_schema_intersection(
+            [
+                json!({
+                    "type": "string",
+                    "enum": ["foo", "foobar", "bar"],
+                }),
+                json!({
+                    "type": "string",
+                    "maxLength": 3,
+                }),
+            ],
+            [json!({
                 "type": "string",
-                "enum": ["foo", "foobar", "bar"],
-            }),
-            json!({
-                "type": "string",
-                "maxLength": 3,
-            }),
-        ])
-        .expect("Intersected invalid constraints")
-        .into_iter()
-        .map(|schema| {
-            from_value::<SingleValueConstraints>(schema).expect("Failed to deserialize schema")
-        })
-        .collect::<Vec<_>>();
-
-        // We need to manually check the intersection because the order of the enum values is not
-        // guaranteed.
-        assert_eq!(intersection.len(), 1);
-        let SingleValueConstraints::String(StringSchema::Enum { r#enum }) = &intersection[0] else {
-            panic!("Expected string enum schema");
-        };
-        assert_eq!(r#enum.len(), 2);
-        assert!(r#enum.contains("foo"));
-        assert!(r#enum.contains("bar"));
+                "enum": ["foo", "bar"],
+            })],
+        );
     }
 
     #[test]
@@ -1313,7 +1084,7 @@ mod tests {
             ],
             [json!({
                 "type": "string",
-                "const": "foo",
+                "enum": ["foo"],
             })],
         );
     }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
@@ -273,7 +273,7 @@ impl Constraint for StringSchema {
                     bail!(ResolveClosedDataTypeError::UnsatisfiedEnumConstraint(
                         ValueConstraints::Typed(SingleValueConstraints::String(Self::Constrained(
                             constraints
-                        ),)),
+                        ))),
                     ))
                 }
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -112,7 +112,6 @@ pub struct ValueSchemaMetadata {
 
 mod raw {
     use alloc::collections::BTreeSet;
-    use std::collections::HashSet;
 
     use hash_codec::numeric::Real;
     use serde::{Deserialize, Serialize};
@@ -176,21 +175,13 @@ mod raw {
             #[serde(flatten)]
             constraints: NumberConstraints,
         },
-        NumberConst {
-            r#type: NumberTypeTag,
-            #[serde(flatten)]
-            base: DataTypeBase,
-            #[serde(flatten)]
-            metadata: ValueSchemaMetadata,
-            r#const: Real,
-        },
         NumberEnum {
             r#type: NumberTypeTag,
             #[serde(flatten)]
             base: DataTypeBase,
             #[serde(flatten)]
             metadata: ValueSchemaMetadata,
-            r#enum: BTreeSet<Real>,
+            r#enum: Vec<Real>,
         },
         String {
             r#type: StringTypeTag,
@@ -201,21 +192,13 @@ mod raw {
             #[serde(flatten)]
             constraints: StringConstraints,
         },
-        StringConst {
-            r#type: StringTypeTag,
-            #[serde(flatten)]
-            base: DataTypeBase,
-            #[serde(flatten)]
-            metadata: ValueSchemaMetadata,
-            r#const: String,
-        },
         StringEnum {
             r#type: StringTypeTag,
             #[serde(flatten)]
             base: DataTypeBase,
             #[serde(flatten)]
             metadata: ValueSchemaMetadata,
-            r#enum: HashSet<String>,
+            r#enum: Vec<String>,
         },
         Object {
             r#type: ObjectTypeTag,
@@ -314,18 +297,6 @@ mod raw {
                         NumberSchema::Constrained(constraints),
                     )),
                 ),
-                DataType::NumberConst {
-                    r#type: _,
-                    base,
-                    metadata,
-                    r#const,
-                } => (
-                    base,
-                    metadata,
-                    ValueConstraints::Typed(SingleValueConstraints::Number(NumberSchema::Const {
-                        r#const,
-                    })),
-                ),
                 DataType::NumberEnum {
                     r#type: _,
                     base,
@@ -349,18 +320,6 @@ mod raw {
                     ValueConstraints::Typed(SingleValueConstraints::String(
                         StringSchema::Constrained(constraints),
                     )),
-                ),
-                DataType::StringConst {
-                    r#type: _,
-                    base,
-                    metadata,
-                    r#const,
-                } => (
-                    base,
-                    metadata,
-                    ValueConstraints::Typed(SingleValueConstraints::String(StringSchema::Const {
-                        r#const,
-                    })),
                 ),
                 DataType::StringEnum {
                     r#type: _,

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/validation.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/validation.rs
@@ -4,22 +4,13 @@ use std::{collections::HashSet, sync::LazyLock};
 use thiserror::Error;
 
 use crate::{
-    Valid, Validator, Value,
+    Valid, Validator,
     schema::{ClosedDataType, DataType, DataTypeReference},
     url::VersionedUrl,
 };
 
 #[derive(Debug, Error)]
 pub enum ValidateDataTypeError {
-    #[error("Enum values are not compatible with `const` value")]
-    EnumValuesNotCompatibleWithConst {
-        const_value: Value,
-        enum_values: Vec<Value>,
-    },
-    #[error("Missing data type `{data_type_id}`")]
-    MissingDataType { data_type_id: VersionedUrl },
-    #[error("Cyclic data type reference detected for type `{data_type_id}`")]
-    CyclicDataTypeReference { data_type_id: VersionedUrl },
     #[error("A data type requires a parent specified in `allOf`")]
     MissingParent,
     #[error("Only primitive data types can inherit from the value data type")]

--- a/libs/@local/codec/src/serde/mod.rs
+++ b/libs/@local/codec/src/serde/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod constant;
 pub mod string_hash_map;
+pub mod unique_vec;
 
 mod size_hint;
 

--- a/libs/@local/codec/src/serde/unique_vec.rs
+++ b/libs/@local/codec/src/serde/unique_vec.rs
@@ -1,0 +1,41 @@
+use alloc::collections::BTreeSet;
+use core::hash::Hash;
+use std::collections::HashSet;
+
+use serde::{Deserialize, Deserializer, de};
+
+/// Deserialize a vector of values that are unique.
+///
+/// Uses a [`HashSet`] to ensure that the values are unique.
+///
+/// # Errors
+///
+/// - If the vector contains duplicate values.
+pub fn hashed<'de, D, T: Hash + Eq + Deserialize<'de>>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let vec = Vec::deserialize(deserializer)?;
+    if vec.len() != vec.iter().collect::<HashSet<_>>().len() {
+        return Err(de::Error::custom("duplicate value"));
+    }
+    Ok(vec)
+}
+
+/// Deserialize a vector of values that are unique.
+///
+/// Uses a [`BTreeSet`] to ensure that the values are unique.
+///
+/// # Errors
+///
+/// - If the vector contains duplicate values.
+pub fn btree<'de, D, T: Ord + Deserialize<'de>>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let vec = Vec::deserialize(deserializer)?;
+    if vec.len() != vec.iter().collect::<BTreeSet<_>>().len() {
+        return Err(de::Error::custom("duplicate value"));
+    }
+    Ok(vec)
+}

--- a/libs/@local/hash-isomorphic-utils/src/data-types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/data-types.ts
@@ -248,7 +248,7 @@ const transformConstraint = (
   const { description, label, type } = constraint;
 
   if (type === "string") {
-    if ("enum" in constraint || "const" in constraint) {
+    if ("enum" in constraint) {
       return constraint;
     }
 
@@ -258,7 +258,7 @@ const transformConstraint = (
     };
   }
   if (type === "number") {
-    if ("enum" in constraint || "const" in constraint) {
+    if ("enum" in constraint) {
       return constraint;
     }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We want to preserve the ordering when creating data types. For simplicity, we also remove the `const` constraint as it's effectively the same as a single-element `enum` constraint.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing
### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph