### PR TITLE
H-4086: Add remaining types for Permission MVP

### DIFF
--- a/.config/_examples/vscode/extensions-backend.json
+++ b/.config/_examples/vscode/extensions-backend.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "rust-lang.rust-analyzer",
+    "tamasfe.even-better-toml",
+    "cedar-policy.vscode-cedar"
+  ]
+}

--- a/.config/_examples/vscode/extensions-rust.json
+++ b/.config/_examples/vscode/extensions-rust.json
@@ -1,3 +1,0 @@
-{
-  "recommendations": ["rust-lang.rust-analyzer", "tamasfe.even-better-toml"]
-}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3055,6 +3055,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_plain",
+ "smol_str",
  "tokio",
  "tokio-util",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,6 +1199,7 @@ dependencies = [
  "miette",
  "nonempty",
  "ref-cast",
+ "regex",
  "rustc_lexer",
  "serde",
  "serde_json",
@@ -1206,6 +1207,30 @@ dependencies = [
  "smol_str",
  "stacker",
  "thiserror 2.0.11",
+]
+
+[[package]]
+name = "cedar-policy-validator"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ac79a187b0722589a08fa49143301e5829055788fca5ff3b015918c0bd4c8f0"
+dependencies = [
+ "cedar-policy-core",
+ "educe 0.6.0",
+ "itertools 0.14.0",
+ "lalrpop",
+ "lalrpop-util",
+ "lazy_static",
+ "miette",
+ "nonempty",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smol_str",
+ "stacker",
+ "thiserror 2.0.11",
+ "unicode-security",
 ]
 
 [[package]]
@@ -3015,6 +3040,7 @@ name = "hash-graph-authorization"
 version = "0.0.0"
 dependencies = [
  "cedar-policy-core",
+ "cedar-policy-validator",
  "derive-where",
  "derive_more 2.0.1",
  "error-stack",
@@ -7194,6 +7220,7 @@ version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
+ "indexmap 2.7.1",
  "itoa",
  "memchr",
  "ryu",
@@ -8638,6 +8665,22 @@ name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb421b350c9aff471779e262955939f565ec18b86c15364e6bdf0d662ca7c1f"
+
+[[package]]
+name = "unicode-security"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e4ddba1535dd35ed8b61c52166b7155d7f4e4b8847cec6f48e71dc66d8b5e50"
+dependencies = [
+ "unicode-normalization",
+ "unicode-script",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,6 +220,7 @@ serde_plain              = { version = "=1.0.2", default-features = false }
 serde_with               = { version = "=3.12.0", default-features = false }
 sha2                     = { version = "=0.10.8", default-features = false }
 similar-asserts          = { version = "=1.6.1", default-features = false }
+smol_str                 = { version = "=0.3.2" }
 supports-color           = { version = "=3.0.2", default-features = false }
 supports-unicode         = { version = "=3.0.0", default-features = false }
 syn                      = { version = "=2.0.98", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,6 +163,7 @@ aws-sdk-s3               = { version = "=1.76.0", default-features = false }
 bitvec                   = { version = "=1.0.1", default-features = false }
 bytes-utils              = { version = "=0.1.4", default-features = false }
 cedar-policy-core        = { version = "=4.3.2", default-features = false }
+cedar-policy-validator   = { version = "=4.3.2", default-features = false }
 clap                     = { version = "=4.5.30", features = ["color", "error-context", "help", "std", "suggestions", "usage"] }
 clap_complete            = { version = "=4.5.45", default-features = false }
 convert_case             = { version = "=0.7.1", default-features = false }

--- a/libs/@local/graph/authorization/Cargo.toml
+++ b/libs/@local/graph/authorization/Cargo.toml
@@ -20,19 +20,20 @@ hash-codec  = { workspace = true }
 type-system = { workspace = true }
 
 # Private third-party dependencies
-cedar-policy-core = { workspace = true }
-derive-where      = { workspace = true }
-derive_more       = { workspace = true, features = ["display", "error", "from"] }
-futures           = { workspace = true }
-postgres-types    = { workspace = true, features = ["derive", "with-uuid-1"], optional = true }
-serde             = { workspace = true, features = ["derive", "unstable"] }
-serde_json        = { workspace = true }
-serde_plain       = { workspace = true }
-tokio             = { workspace = true }
-tokio-util        = { workspace = true, features = ["io"] }
-tracing           = { workspace = true, features = ["attributes"] }
-utoipa            = { workspace = true, optional = true }
-uuid              = { workspace = true, features = ["v4"] }
+cedar-policy-core      = { workspace = true }
+cedar-policy-validator = { workspace = true }
+derive-where           = { workspace = true }
+derive_more            = { workspace = true, features = ["display", "error", "from"] }
+futures                = { workspace = true }
+postgres-types         = { workspace = true, features = ["derive", "with-uuid-1"], optional = true }
+serde                  = { workspace = true, features = ["derive", "unstable"] }
+serde_json             = { workspace = true }
+serde_plain            = { workspace = true }
+tokio                  = { workspace = true }
+tokio-util             = { workspace = true, features = ["io"] }
+tracing                = { workspace = true, features = ["attributes"] }
+utoipa                 = { workspace = true, optional = true }
+uuid                   = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 indoc             = { workspace = true }

--- a/libs/@local/graph/authorization/Cargo.toml
+++ b/libs/@local/graph/authorization/Cargo.toml
@@ -32,13 +32,12 @@ tokio             = { workspace = true }
 tokio-util        = { workspace = true, features = ["io"] }
 tracing           = { workspace = true, features = ["attributes"] }
 utoipa            = { workspace = true, optional = true }
-uuid              = { workspace = true }
+uuid              = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 indoc             = { workspace = true }
 pretty_assertions = { workspace = true }
 tokio             = { workspace = true, features = ["macros", "rt-multi-thread"] }
-uuid              = { workspace = true, features = ["v4"] }
 
 [features]
 utoipa   = ["dep:utoipa"]

--- a/libs/@local/graph/authorization/Cargo.toml
+++ b/libs/@local/graph/authorization/Cargo.toml
@@ -29,6 +29,7 @@ postgres-types         = { workspace = true, features = ["derive", "with-uuid-1"
 serde                  = { workspace = true, features = ["derive", "unstable"] }
 serde_json             = { workspace = true }
 serde_plain            = { workspace = true }
+smol_str               = { workspace = true }
 tokio                  = { workspace = true }
 tokio-util             = { workspace = true, features = ["io"] }
 tracing                = { workspace = true, features = ["attributes"] }

--- a/libs/@local/graph/authorization/schemas/policies.cedarschema
+++ b/libs/@local/graph/authorization/schemas/policies.cedarschema
@@ -9,6 +9,10 @@ namespace HASH {
   };
 
   entity Entity in [Web] {
+    entity_types: Set<EntityType>,
+  };
+
+  entity EntityType in [Web] {
   };
 
   entity User in [HASH::Web::Role, HASH::Team::Role, HASH::Web::Team::Role] {
@@ -16,7 +20,12 @@ namespace HASH {
 
   action create, view, update appliesTo {
     principal: User,
-    resource: [Entity],
+    resource: [Entity, EntityType],
+  };
+
+  action instantiate appliesTo {
+    principal: User,
+    resource: [EntityType],
   };
 }
 

--- a/libs/@local/graph/authorization/schemas/policies.cedarschema
+++ b/libs/@local/graph/authorization/schemas/policies.cedarschema
@@ -1,0 +1,39 @@
+namespace HASH {
+  entity Role  {
+  };
+
+  entity Web {
+  };
+
+  entity Team {
+  };
+
+  entity Entity in [Web] {
+  };
+
+  entity User in [HASH::Web::Role, HASH::Team::Role, HASH::Web::Team::Role] {
+  };
+
+  action create, view, update appliesTo {
+    principal: User,
+    resource: [Entity],
+  };
+}
+
+namespace HASH::Team {
+  entity Role in [HASH::Team] {
+  };
+}
+
+namespace HASH::Web {
+  entity Team in [HASH::Web] {
+  };
+
+  entity Role in [HASH::Web] {
+  };
+}
+
+namespace HASH::Web::Team {
+  entity Role in [HASH::Web::Team] {
+  };
+}

--- a/libs/@local/graph/authorization/src/policies/action/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/action/mod.rs
@@ -16,9 +16,10 @@ use crate::policies::cedar::CedarEntityId;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum ActionId {
+    Create,
     View,
-    ViewProperties,
-    ViewMetadata,
+    Update,
+    Instantiate,
 }
 
 impl CedarEntityId for ActionId {
@@ -48,16 +49,6 @@ impl FromStr for ActionId {
 impl fmt::Display for ActionId {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.serialize(fmt)
-    }
-}
-
-impl ActionId {
-    #[must_use]
-    pub const fn parents(self) -> &'static [Self] {
-        match self {
-            Self::View => &[],
-            Self::ViewProperties | Self::ViewMetadata => &[Self::View],
-        }
     }
 }
 
@@ -171,7 +162,7 @@ mod tests {
 
     #[test]
     fn constraint_one() -> Result<(), Box<dyn Error>> {
-        let action = ActionId::ViewProperties;
+        let action = ActionId::View;
         check_action(
             &ActionConstraint::One { action },
             json!({
@@ -202,7 +193,7 @@ mod tests {
 
     #[test]
     fn constraint_many() -> Result<(), Box<dyn Error>> {
-        let actions = [ActionId::ViewProperties, ActionId::ViewMetadata];
+        let actions = [ActionId::View, ActionId::Update];
         check_action(
             &ActionConstraint::Many {
                 actions: actions.to_vec(),

--- a/libs/@local/graph/authorization/src/policies/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/mod.rs
@@ -171,6 +171,7 @@ impl Policy {
     }
 
     pub(crate) fn to_cedar(&self) -> ast::Template {
+        let (resource_constraint, resource_expr) = self.resource.to_cedar();
         ast::Template::new(
             ast::PolicyID::from_string(self.id.to_string()),
             None,
@@ -181,8 +182,8 @@ impl Policy {
             },
             self.principal.to_cedar(),
             self.action.to_cedar(),
-            self.resource.to_cedar(),
-            ast::Expr::val(true),
+            resource_constraint,
+            resource_expr,
         )
     }
 

--- a/libs/@local/graph/authorization/src/policies/principal/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/mod.rs
@@ -5,17 +5,20 @@
 
 use cedar_policy_core::ast;
 use error_stack::{Report, ResultExt as _, bail};
+use hash_graph_types::owned_by_id::OwnedById;
 
-pub use self::{
-    organization::{OrganizationId, OrganizationPrincipalConstraint, OrganizationRoleId},
+use self::{
+    team::{TeamId, TeamPrincipalConstraint, TeamRoleId},
     user::{UserId, UserPrincipalConstraint},
+    web::{WebPrincipalConstraint, WebRoleId, WebTeamId, WebTeamRoleId},
 };
 use super::cedar::CedarEntityId as _;
 
-mod organization;
-mod user;
+pub mod team;
+pub mod user;
+pub mod web;
 
-#[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(
     tag = "type",
     rename_all = "camelCase",
@@ -29,7 +32,76 @@ pub enum PrincipalConstraint {
     )]
     Public {},
     User(UserPrincipalConstraint),
-    Organization(OrganizationPrincipalConstraint),
+    Web(WebPrincipalConstraint),
+    Team(TeamPrincipalConstraint),
+}
+
+enum InPrincipalConstraint {
+    Web(WebPrincipalConstraint),
+    Team(TeamPrincipalConstraint),
+}
+
+impl InPrincipalConstraint {
+    pub(crate) fn try_from_cedar_in(
+        principal: &ast::EntityUID,
+    ) -> Result<Self, Report<InvalidPrincipalConstraint>> {
+        if *principal.entity_type() == **OwnedById::entity_type() {
+            Ok(Self::Web(WebPrincipalConstraint::InWeb {
+                id: Some(
+                    OwnedById::from_eid(principal.eid())
+                        .change_context(InvalidPrincipalConstraint::InvalidPrincipalId)?,
+                ),
+            }))
+        } else if *principal.entity_type() == **WebRoleId::entity_type() {
+            Ok(Self::Web(WebPrincipalConstraint::InRole {
+                role_id: Some(
+                    WebRoleId::from_eid(principal.eid())
+                        .change_context(InvalidPrincipalConstraint::InvalidPrincipalId)?,
+                ),
+            }))
+        } else if *principal.entity_type() == **WebTeamId::entity_type() {
+            Ok(Self::Web(WebPrincipalConstraint::InTeam {
+                team_id: Some(
+                    WebTeamId::from_eid(principal.eid())
+                        .change_context(InvalidPrincipalConstraint::InvalidPrincipalId)?,
+                ),
+            }))
+        } else if *principal.entity_type() == **WebTeamRoleId::entity_type() {
+            Ok(Self::Web(WebPrincipalConstraint::InTeamRole {
+                team_role_id: Some(
+                    WebTeamRoleId::from_eid(principal.eid())
+                        .change_context(InvalidPrincipalConstraint::InvalidPrincipalId)?,
+                ),
+            }))
+        } else if *principal.entity_type() == **TeamId::entity_type() {
+            Ok(Self::Team(TeamPrincipalConstraint::InTeam {
+                id: Some(
+                    TeamId::from_eid(principal.eid())
+                        .change_context(InvalidPrincipalConstraint::InvalidPrincipalId)?,
+                ),
+            }))
+        } else if *principal.entity_type() == **TeamRoleId::entity_type() {
+            Ok(Self::Team(TeamPrincipalConstraint::InRole {
+                role_id: Some(
+                    TeamRoleId::from_eid(principal.eid())
+                        .change_context(InvalidPrincipalConstraint::InvalidPrincipalId)?,
+                ),
+            }))
+        } else {
+            bail!(InvalidPrincipalConstraint::UnexpectedEntityType(
+                ast::EntityType::clone(principal.entity_type())
+            ))
+        }
+    }
+}
+
+impl From<InPrincipalConstraint> for PrincipalConstraint {
+    fn from(value: InPrincipalConstraint) -> Self {
+        match value {
+            InPrincipalConstraint::Web(web) => Self::Web(web),
+            InPrincipalConstraint::Team(team) => Self::Team(team),
+        }
+    }
 }
 
 #[derive(Debug, derive_more::Display, derive_more::Error)]
@@ -49,7 +121,8 @@ impl PrincipalConstraint {
         match self {
             Self::Public {} => false,
             Self::User(user) => user.has_slot(),
-            Self::Organization(organization) => organization.has_slot(),
+            Self::Web(web) => web.has_slot(),
+            Self::Team(team) => team.has_slot(),
         }
     }
 
@@ -58,107 +131,60 @@ impl PrincipalConstraint {
     ) -> Result<Self, Report<InvalidPrincipalConstraint>> {
         Ok(match constraint.as_inner() {
             ast::PrincipalOrResourceConstraint::Any => Self::Public {},
-
-            ast::PrincipalOrResourceConstraint::Is(principal_type)
-                if **principal_type == **UserId::entity_type() =>
-            {
-                Self::User(UserPrincipalConstraint::Any {})
-            }
             ast::PrincipalOrResourceConstraint::Is(principal_type) => {
-                bail!(InvalidPrincipalConstraint::UnexpectedEntityType(
-                    ast::EntityType::clone(principal_type)
-                ))
+                Self::try_from_cedar_is_in(principal_type, None)?
             }
-
-            ast::PrincipalOrResourceConstraint::Eq(ast::EntityReference::EUID(principal))
-                if *principal.entity_type() == **UserId::entity_type() =>
-            {
-                Self::User(UserPrincipalConstraint::Exact {
-                    user_id: Some(
-                        UserId::from_eid(principal.eid())
-                            .change_context(InvalidPrincipalConstraint::InvalidPrincipalId)?,
-                    ),
-                })
-            }
-            ast::PrincipalOrResourceConstraint::Eq(ast::EntityReference::EUID(principal)) => {
-                bail!(InvalidPrincipalConstraint::UnexpectedEntityType(
-                    ast::EntityType::clone(principal.entity_type())
-                ))
-            }
-            ast::PrincipalOrResourceConstraint::Eq(ast::EntityReference::Slot(_)) => {
-                bail!(InvalidPrincipalConstraint::AmbiguousSlot)
-            }
-
-            ast::PrincipalOrResourceConstraint::IsIn(
-                principal_type,
-                ast::EntityReference::EUID(principal),
-            ) if **principal_type == **UserId::entity_type() => {
-                if *principal.entity_type() == **OrganizationId::entity_type() {
-                    Self::User(UserPrincipalConstraint::Organization(
-                        OrganizationPrincipalConstraint::InOrganization {
-                            organization_id: Some(
-                                OrganizationId::from_eid(principal.eid()).change_context(
-                                    InvalidPrincipalConstraint::InvalidPrincipalId,
-                                )?,
-                            ),
-                        },
-                    ))
-                } else if *principal.entity_type() == **OrganizationRoleId::entity_type() {
-                    Self::User(UserPrincipalConstraint::Organization(
-                        OrganizationPrincipalConstraint::InRole {
-                            organization_role_id: Some(
-                                OrganizationRoleId::from_eid(principal.eid()).change_context(
-                                    InvalidPrincipalConstraint::InvalidPrincipalId,
-                                )?,
-                            ),
-                        },
-                    ))
-                } else {
-                    bail!(InvalidPrincipalConstraint::UnexpectedEntityType(
-                        ast::EntityType::clone(principal.entity_type())
-                    ))
-                }
+            ast::PrincipalOrResourceConstraint::Eq(ast::EntityReference::EUID(entity_ref)) => {
+                Self::try_from_cedar_eq(entity_ref)?
             }
             ast::PrincipalOrResourceConstraint::IsIn(
                 principal_type,
-                ast::EntityReference::EUID(_),
-            ) => bail!(InvalidPrincipalConstraint::UnexpectedEntityType(
-                ast::EntityType::clone(principal_type)
-            )),
-            ast::PrincipalOrResourceConstraint::IsIn(_, ast::EntityReference::Slot(_)) => {
-                bail!(InvalidPrincipalConstraint::AmbiguousSlot)
-            }
-
-            ast::PrincipalOrResourceConstraint::In(ast::EntityReference::EUID(principal))
-                if *principal.entity_type() == **OrganizationId::entity_type() =>
-            {
-                Self::Organization(OrganizationPrincipalConstraint::InOrganization {
-                    organization_id: Some(
-                        OrganizationId::from_eid(principal.eid())
-                            .change_context(InvalidPrincipalConstraint::InvalidPrincipalId)?,
-                    ),
-                })
-            }
-            ast::PrincipalOrResourceConstraint::In(ast::EntityReference::EUID(principal))
-                if *principal.entity_type() == **OrganizationRoleId::entity_type() =>
-            {
-                // Organization from cedar (Some(principal))
-                Self::Organization(OrganizationPrincipalConstraint::InRole {
-                    organization_role_id: Some(
-                        OrganizationRoleId::from_eid(principal.eid())
-                            .change_context(InvalidPrincipalConstraint::InvalidPrincipalId)?,
-                    ),
-                })
-            }
+                ast::EntityReference::EUID(entity_ref),
+            ) => Self::try_from_cedar_is_in(principal_type, Some(entity_ref))?,
             ast::PrincipalOrResourceConstraint::In(ast::EntityReference::EUID(principal)) => {
-                bail!(InvalidPrincipalConstraint::UnexpectedEntityType(
-                    ast::EntityType::clone(principal.entity_type())
-                ))
+                Self::from(InPrincipalConstraint::try_from_cedar_in(principal)?)
             }
-            ast::PrincipalOrResourceConstraint::In(ast::EntityReference::Slot(_)) => {
-                bail!(InvalidPrincipalConstraint::AmbiguousSlot)
+            ast::PrincipalOrResourceConstraint::Eq(ast::EntityReference::Slot(_))
+            | ast::PrincipalOrResourceConstraint::IsIn(_, ast::EntityReference::Slot(_))
+            | ast::PrincipalOrResourceConstraint::In(ast::EntityReference::Slot(_)) => {
+                bail!(InvalidPrincipalConstraint::AmbiguousSlot);
             }
         })
+    }
+
+    pub(crate) fn try_from_cedar_eq(
+        principal: &ast::EntityUID,
+    ) -> Result<Self, Report<InvalidPrincipalConstraint>> {
+        if *principal.entity_type() == **UserId::entity_type() {
+            Ok(Self::User(UserPrincipalConstraint::Exact {
+                user_id: Some(
+                    UserId::from_eid(principal.eid())
+                        .change_context(InvalidPrincipalConstraint::InvalidPrincipalId)?,
+                ),
+            }))
+        } else {
+            bail!(InvalidPrincipalConstraint::UnexpectedEntityType(
+                ast::EntityType::clone(principal.entity_type())
+            ))
+        }
+    }
+
+    pub(crate) fn try_from_cedar_is_in(
+        principal_type: &ast::EntityType,
+        in_principal: Option<&ast::EntityUID>,
+    ) -> Result<Self, Report<InvalidPrincipalConstraint>> {
+        if *principal_type == **UserId::entity_type() {
+            let Some(in_principal) = in_principal else {
+                return Ok(Self::User(UserPrincipalConstraint::Any {}));
+            };
+            Ok(Self::User(UserPrincipalConstraint::from(
+                InPrincipalConstraint::try_from_cedar_in(in_principal)?,
+            )))
+        } else {
+            bail!(InvalidPrincipalConstraint::UnexpectedEntityType(
+                ast::EntityType::clone(principal_type)
+            ))
+        }
     }
 
     #[must_use]
@@ -166,7 +192,8 @@ impl PrincipalConstraint {
         match self {
             Self::Public {} => ast::PrincipalConstraint::any(),
             Self::User(user) => user.to_cedar(),
-            Self::Organization(organization) => organization.to_cedar(),
+            Self::Web(organization) => organization.to_cedar(),
+            Self::Team(team) => team.to_cedar(),
         }
     }
 }

--- a/libs/@local/graph/authorization/src/policies/principal/team.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/team.rs
@@ -187,7 +187,7 @@ mod tests {
     fn in_team() -> Result<(), Box<dyn Error>> {
         let team_id = TeamId::new(Uuid::new_v4());
         check_principal(
-            &PrincipalConstraint::Team(TeamPrincipalConstraint::InTeam { id: Some(team_id) }),
+            PrincipalConstraint::Team(TeamPrincipalConstraint::InTeam { id: Some(team_id) }),
             json!({
                 "type": "team",
                 "id": team_id,
@@ -196,7 +196,7 @@ mod tests {
         )?;
 
         check_principal(
-            &PrincipalConstraint::Team(TeamPrincipalConstraint::InTeam { id: None }),
+            PrincipalConstraint::Team(TeamPrincipalConstraint::InTeam { id: None }),
             json!({
                 "type": "team",
                 "id": null,
@@ -227,7 +227,7 @@ mod tests {
     fn in_role() -> Result<(), Box<dyn Error>> {
         let role_id = TeamRoleId::new(Uuid::new_v4());
         check_principal(
-            &PrincipalConstraint::Team(TeamPrincipalConstraint::InRole {
+            PrincipalConstraint::Team(TeamPrincipalConstraint::InRole {
                 role_id: Some(role_id),
             }),
             json!({
@@ -238,7 +238,7 @@ mod tests {
         )?;
 
         check_principal(
-            &PrincipalConstraint::Team(TeamPrincipalConstraint::InRole { role_id: None }),
+            PrincipalConstraint::Team(TeamPrincipalConstraint::InRole { role_id: None }),
             json!({
                 "type": "team",
                 "roleId": null,

--- a/libs/@local/graph/authorization/src/policies/principal/user.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/user.rs
@@ -11,9 +11,8 @@ use cedar_policy_core::ast;
 use error_stack::Report;
 use uuid::Uuid;
 
-use crate::policies::{
-    cedar::CedarEntityId, principal::organization::OrganizationPrincipalConstraint,
-};
+use super::{InPrincipalConstraint, TeamPrincipalConstraint, TeamRoleId, WebRoleId, WebTeamRoleId};
+use crate::policies::{cedar::CedarEntityId, principal::web::WebPrincipalConstraint};
 
 #[derive(
     Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
@@ -66,7 +65,22 @@ impl CedarEntityId for UserId {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+pub enum RoleId {
+    Web(WebRoleId),
+    WebTeam(WebTeamRoleId),
+    Team(TeamRoleId),
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct User {
+    pub id: UserId,
+    pub roles: Vec<RoleId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(untagged, rename_all_fields = "camelCase", deny_unknown_fields)]
 pub enum UserPrincipalConstraint {
     #[expect(
@@ -78,7 +92,8 @@ pub enum UserPrincipalConstraint {
         #[serde(deserialize_with = "Option::deserialize")]
         user_id: Option<UserId>,
     },
-    Organization(OrganizationPrincipalConstraint),
+    Web(WebPrincipalConstraint),
+    Team(TeamPrincipalConstraint),
 }
 
 impl UserPrincipalConstraint {
@@ -87,7 +102,8 @@ impl UserPrincipalConstraint {
         match self {
             Self::Any {} | Self::Exact { user_id: Some(_) } => false,
             Self::Exact { user_id: None } => true,
-            Self::Organization(organization) => organization.has_slot(),
+            Self::Web(web) => web.has_slot(),
+            Self::Team(team) => team.has_slot(),
         }
     }
 
@@ -101,7 +117,17 @@ impl UserPrincipalConstraint {
                 .map_or_else(ast::PrincipalConstraint::is_eq_slot, |user_id| {
                     ast::PrincipalConstraint::is_eq(Arc::new(user_id.to_euid()))
                 }),
-            Self::Organization(organization) => organization.to_cedar_in_type::<UserId>(),
+            Self::Web(web) => web.to_cedar_in_type::<UserId>(),
+            Self::Team(team) => team.to_cedar_in_type::<UserId>(),
+        }
+    }
+}
+
+impl From<InPrincipalConstraint> for UserPrincipalConstraint {
+    fn from(value: InPrincipalConstraint) -> Self {
+        match value {
+            InPrincipalConstraint::Web(web) => Self::Web(web),
+            InPrincipalConstraint::Team(team) => Self::Team(team),
         }
     }
 }
@@ -110,14 +136,15 @@ impl UserPrincipalConstraint {
 mod tests {
     use core::error::Error;
 
+    use hash_graph_types::owned_by_id::OwnedById;
     use serde_json::json;
     use uuid::Uuid;
 
-    use super::OrganizationPrincipalConstraint;
+    use super::{UserId, WebPrincipalConstraint};
     use crate::{
         policies::{
-            OrganizationId, OrganizationRoleId, PrincipalConstraint, UserId,
-            principal::{UserPrincipalConstraint, tests::check_principal},
+            PrincipalConstraint,
+            principal::{UserPrincipalConstraint, tests::check_principal, web::WebRoleId},
         },
         test_utils::check_deserialization_error,
     };
@@ -180,29 +207,25 @@ mod tests {
 
     #[test]
     fn organization() -> Result<(), Box<dyn Error>> {
-        let organization_id = OrganizationId::new(Uuid::new_v4());
+        let web_id = OwnedById::new(Uuid::new_v4());
         check_principal(
-            &PrincipalConstraint::User(UserPrincipalConstraint::Organization(
-                OrganizationPrincipalConstraint::InOrganization {
-                    organization_id: Some(organization_id),
-                },
+            &PrincipalConstraint::User(UserPrincipalConstraint::Web(
+                WebPrincipalConstraint::InWeb { id: Some(web_id) },
             )),
             json!({
                 "type": "user",
-                "organizationId": organization_id,
+                "id": web_id,
             }),
-            format!(r#"principal is HASH::User in HASH::Organization::"{organization_id}""#),
+            format!(r#"principal is HASH::User in HASH::Web::"{web_id}""#),
         )?;
 
         check_principal(
-            &PrincipalConstraint::User(UserPrincipalConstraint::Organization(
-                OrganizationPrincipalConstraint::InOrganization {
-                    organization_id: None,
-                },
+            &PrincipalConstraint::User(UserPrincipalConstraint::Web(
+                WebPrincipalConstraint::InWeb { id: None },
             )),
             json!({
                 "type": "user",
-                "organizationId": null,
+                "id": null,
             }),
             "principal is HASH::User in ?principal",
         )?;
@@ -210,7 +233,7 @@ mod tests {
         check_deserialization_error::<PrincipalConstraint>(
             json!({
                 "type": "user",
-                "organizationId": organization_id,
+                "id": web_id,
                 "additional": "unexpected",
             }),
             "data did not match any variant of untagged enum UserPrincipalConstraint",
@@ -221,31 +244,27 @@ mod tests {
 
     #[test]
     fn organization_role() -> Result<(), Box<dyn Error>> {
-        let organization_role_id = OrganizationRoleId::new(Uuid::new_v4());
+        let web_role_id = WebRoleId::new(Uuid::new_v4());
         check_principal(
-            &PrincipalConstraint::User(UserPrincipalConstraint::Organization(
-                OrganizationPrincipalConstraint::InRole {
-                    organization_role_id: Some(organization_role_id),
+            &PrincipalConstraint::User(UserPrincipalConstraint::Web(
+                WebPrincipalConstraint::InRole {
+                    role_id: Some(web_role_id),
                 },
             )),
             json!({
                 "type": "user",
-                "organizationRoleId": organization_role_id,
+                "roleId": web_role_id,
             }),
-            format!(
-                r#"principal is HASH::User in HASH::Organization::Role::"{organization_role_id}""#
-            ),
+            format!(r#"principal is HASH::User in HASH::Web::Role::"{web_role_id}""#),
         )?;
 
         check_principal(
-            &PrincipalConstraint::User(UserPrincipalConstraint::Organization(
-                OrganizationPrincipalConstraint::InRole {
-                    organization_role_id: None,
-                },
+            &PrincipalConstraint::User(UserPrincipalConstraint::Web(
+                WebPrincipalConstraint::InRole { role_id: None },
             )),
             json!({
                 "type": "user",
-                "organizationRoleId": null,
+                "roleId": null,
             }),
             "principal is HASH::User in ?principal",
         )?;
@@ -253,7 +272,7 @@ mod tests {
         check_deserialization_error::<PrincipalConstraint>(
             json!({
                 "type": "user",
-                "organizationRoleId": organization_role_id,
+                "webRoleId": web_role_id,
                 "additional": "unexpected",
             }),
             "data did not match any variant of untagged enum UserPrincipalConstraint",

--- a/libs/@local/graph/authorization/src/policies/principal/user.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/user.rs
@@ -152,7 +152,7 @@ mod tests {
     #[test]
     fn any() -> Result<(), Box<dyn Error>> {
         check_principal(
-            &PrincipalConstraint::User(UserPrincipalConstraint::Any {}),
+            PrincipalConstraint::User(UserPrincipalConstraint::Any {}),
             json!({
                 "type": "user",
             }),
@@ -174,7 +174,7 @@ mod tests {
     fn exact() -> Result<(), Box<dyn Error>> {
         let user_id = UserId::new(Uuid::new_v4());
         check_principal(
-            &PrincipalConstraint::User(UserPrincipalConstraint::Exact {
+            PrincipalConstraint::User(UserPrincipalConstraint::Exact {
                 user_id: Some(user_id),
             }),
             json!({
@@ -185,7 +185,7 @@ mod tests {
         )?;
 
         check_principal(
-            &PrincipalConstraint::User(UserPrincipalConstraint::Exact { user_id: None }),
+            PrincipalConstraint::User(UserPrincipalConstraint::Exact { user_id: None }),
             json!({
                 "type": "user",
                 "userId": null,
@@ -209,7 +209,7 @@ mod tests {
     fn organization() -> Result<(), Box<dyn Error>> {
         let web_id = OwnedById::new(Uuid::new_v4());
         check_principal(
-            &PrincipalConstraint::User(UserPrincipalConstraint::Web(
+            PrincipalConstraint::User(UserPrincipalConstraint::Web(
                 WebPrincipalConstraint::InWeb { id: Some(web_id) },
             )),
             json!({
@@ -220,7 +220,7 @@ mod tests {
         )?;
 
         check_principal(
-            &PrincipalConstraint::User(UserPrincipalConstraint::Web(
+            PrincipalConstraint::User(UserPrincipalConstraint::Web(
                 WebPrincipalConstraint::InWeb { id: None },
             )),
             json!({
@@ -246,7 +246,7 @@ mod tests {
     fn organization_role() -> Result<(), Box<dyn Error>> {
         let web_role_id = WebRoleId::new(Uuid::new_v4());
         check_principal(
-            &PrincipalConstraint::User(UserPrincipalConstraint::Web(
+            PrincipalConstraint::User(UserPrincipalConstraint::Web(
                 WebPrincipalConstraint::InRole {
                     role_id: Some(web_role_id),
                 },
@@ -259,7 +259,7 @@ mod tests {
         )?;
 
         check_principal(
-            &PrincipalConstraint::User(UserPrincipalConstraint::Web(
+            PrincipalConstraint::User(UserPrincipalConstraint::Web(
                 WebPrincipalConstraint::InRole { role_id: None },
             )),
             json!({

--- a/libs/@local/graph/authorization/src/policies/principal/web.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/web.rs
@@ -298,7 +298,7 @@ mod tests {
     fn in_web() -> Result<(), Box<dyn Error>> {
         let web_id = OwnedById::new(Uuid::new_v4());
         check_principal(
-            &PrincipalConstraint::Web(WebPrincipalConstraint::InWeb { id: Some(web_id) }),
+            PrincipalConstraint::Web(WebPrincipalConstraint::InWeb { id: Some(web_id) }),
             json!({
                 "type": "web",
                 "id": web_id,
@@ -307,7 +307,7 @@ mod tests {
         )?;
 
         check_principal(
-            &PrincipalConstraint::Web(WebPrincipalConstraint::InWeb { id: None }),
+            PrincipalConstraint::Web(WebPrincipalConstraint::InWeb { id: None }),
             json!({
                 "type": "web",
                 "id": null,
@@ -338,7 +338,7 @@ mod tests {
     fn in_role() -> Result<(), Box<dyn Error>> {
         let role_id = WebRoleId::new(Uuid::new_v4());
         check_principal(
-            &PrincipalConstraint::Web(WebPrincipalConstraint::InRole {
+            PrincipalConstraint::Web(WebPrincipalConstraint::InRole {
                 role_id: Some(role_id),
             }),
             json!({
@@ -349,7 +349,7 @@ mod tests {
         )?;
 
         check_principal(
-            &PrincipalConstraint::Web(WebPrincipalConstraint::InRole { role_id: None }),
+            PrincipalConstraint::Web(WebPrincipalConstraint::InRole { role_id: None }),
             json!({
                 "type": "web",
                 "roleId": null,
@@ -373,7 +373,7 @@ mod tests {
     fn in_team() -> Result<(), Box<dyn Error>> {
         let team_id = WebTeamId::new(Uuid::new_v4());
         check_principal(
-            &PrincipalConstraint::Web(WebPrincipalConstraint::InTeam {
+            PrincipalConstraint::Web(WebPrincipalConstraint::InTeam {
                 team_id: Some(team_id),
             }),
             json!({
@@ -384,7 +384,7 @@ mod tests {
         )?;
 
         check_principal(
-            &PrincipalConstraint::Web(WebPrincipalConstraint::InTeam { team_id: None }),
+            PrincipalConstraint::Web(WebPrincipalConstraint::InTeam { team_id: None }),
             json!({
                 "type": "web",
                 "teamId": null,
@@ -415,7 +415,7 @@ mod tests {
     fn in_team_role() -> Result<(), Box<dyn Error>> {
         let role_id = WebTeamRoleId::new(Uuid::new_v4());
         check_principal(
-            &PrincipalConstraint::Web(WebPrincipalConstraint::InTeamRole {
+            PrincipalConstraint::Web(WebPrincipalConstraint::InTeamRole {
                 team_role_id: Some(role_id),
             }),
             json!({
@@ -426,7 +426,7 @@ mod tests {
         )?;
 
         check_principal(
-            &PrincipalConstraint::Web(WebPrincipalConstraint::InTeamRole { team_role_id: None }),
+            PrincipalConstraint::Web(WebPrincipalConstraint::InTeamRole { team_role_id: None }),
             json!({
                 "type": "web",
                 "teamRoleId": null,

--- a/libs/@local/graph/authorization/src/policies/principal/web.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/web.rs
@@ -1,0 +1,448 @@
+use alloc::sync::Arc;
+use core::{error::Error, fmt, str::FromStr as _};
+use std::sync::LazyLock;
+
+use cedar_policy_core::ast;
+use error_stack::Report;
+use hash_graph_types::owned_by_id::OwnedById;
+use uuid::Uuid;
+
+use crate::policies::cedar::CedarEntityId;
+
+impl CedarEntityId for OwnedById {
+    fn entity_type() -> &'static Arc<ast::EntityType> {
+        static ENTITY_TYPE: LazyLock<Arc<ast::EntityType>> =
+            LazyLock::new(|| crate::policies::cedar_resource_type(["Web"]));
+        &ENTITY_TYPE
+    }
+
+    fn to_eid(&self) -> ast::Eid {
+        ast::Eid::new(self.as_uuid().to_string())
+    }
+
+    fn from_eid(eid: &ast::Eid) -> Result<Self, Report<impl Error + Send + Sync + 'static>> {
+        Ok(Self::new(Uuid::from_str(eid.as_ref())?))
+    }
+}
+
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+#[cfg_attr(
+    feature = "postgres",
+    derive(postgres_types::FromSql, postgres_types::ToSql),
+    postgres(transparent)
+)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[repr(transparent)]
+pub struct WebRoleId(Uuid);
+
+impl WebRoleId {
+    #[must_use]
+    pub const fn new(uuid: Uuid) -> Self {
+        Self(uuid)
+    }
+
+    #[must_use]
+    pub const fn into_uuid(self) -> Uuid {
+        self.0
+    }
+
+    #[must_use]
+    pub const fn as_uuid(&self) -> &Uuid {
+        &self.0
+    }
+}
+
+impl fmt::Display for WebRoleId {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, fmt)
+    }
+}
+
+impl CedarEntityId for WebRoleId {
+    fn entity_type() -> &'static Arc<ast::EntityType> {
+        static ENTITY_TYPE: LazyLock<Arc<ast::EntityType>> =
+            LazyLock::new(|| crate::policies::cedar_resource_type(["Web", "Role"]));
+        &ENTITY_TYPE
+    }
+
+    fn to_eid(&self) -> ast::Eid {
+        ast::Eid::new(self.0.to_string())
+    }
+
+    fn from_eid(eid: &ast::Eid) -> Result<Self, Report<impl Error + Send + Sync + 'static>> {
+        Ok(Self::new(Uuid::from_str(eid.as_ref())?))
+    }
+}
+
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+#[cfg_attr(
+    feature = "postgres",
+    derive(postgres_types::FromSql, postgres_types::ToSql),
+    postgres(transparent)
+)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[repr(transparent)]
+pub struct WebTeamId(Uuid);
+
+impl WebTeamId {
+    #[must_use]
+    pub const fn new(uuid: Uuid) -> Self {
+        Self(uuid)
+    }
+
+    #[must_use]
+    pub const fn into_uuid(self) -> Uuid {
+        self.0
+    }
+
+    #[must_use]
+    pub const fn as_uuid(&self) -> &Uuid {
+        &self.0
+    }
+}
+
+impl fmt::Display for WebTeamId {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, fmt)
+    }
+}
+
+impl CedarEntityId for WebTeamId {
+    fn entity_type() -> &'static Arc<ast::EntityType> {
+        static ENTITY_TYPE: LazyLock<Arc<ast::EntityType>> =
+            LazyLock::new(|| crate::policies::cedar_resource_type(["Web", "Team"]));
+        &ENTITY_TYPE
+    }
+
+    fn to_eid(&self) -> ast::Eid {
+        ast::Eid::new(self.0.to_string())
+    }
+
+    fn from_eid(eid: &ast::Eid) -> Result<Self, Report<impl Error + Send + Sync + 'static>> {
+        Ok(Self::new(Uuid::from_str(eid.as_ref())?))
+    }
+}
+
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+#[cfg_attr(
+    feature = "postgres",
+    derive(postgres_types::FromSql, postgres_types::ToSql),
+    postgres(transparent)
+)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[repr(transparent)]
+pub struct WebTeamRoleId(Uuid);
+
+impl WebTeamRoleId {
+    #[must_use]
+    pub const fn new(uuid: Uuid) -> Self {
+        Self(uuid)
+    }
+
+    #[must_use]
+    pub const fn into_uuid(self) -> Uuid {
+        self.0
+    }
+
+    #[must_use]
+    pub const fn as_uuid(&self) -> &Uuid {
+        &self.0
+    }
+}
+
+impl fmt::Display for WebTeamRoleId {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, fmt)
+    }
+}
+
+impl CedarEntityId for WebTeamRoleId {
+    fn entity_type() -> &'static Arc<ast::EntityType> {
+        static ENTITY_TYPE: LazyLock<Arc<ast::EntityType>> =
+            LazyLock::new(|| crate::policies::cedar_resource_type(["Web", "Team", "Role"]));
+        &ENTITY_TYPE
+    }
+
+    fn to_eid(&self) -> ast::Eid {
+        ast::Eid::new(self.0.to_string())
+    }
+
+    fn from_eid(eid: &ast::Eid) -> Result<Self, Report<impl Error + Send + Sync + 'static>> {
+        Ok(Self::new(Uuid::from_str(eid.as_ref())?))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(untagged, rename_all_fields = "camelCase", deny_unknown_fields)]
+pub enum WebPrincipalConstraint {
+    InWeb {
+        #[serde(deserialize_with = "Option::deserialize")]
+        id: Option<OwnedById>,
+    },
+    InRole {
+        #[serde(deserialize_with = "Option::deserialize")]
+        role_id: Option<WebRoleId>,
+    },
+    InTeam {
+        #[serde(deserialize_with = "Option::deserialize")]
+        team_id: Option<WebTeamId>,
+    },
+    InTeamRole {
+        #[serde(deserialize_with = "Option::deserialize")]
+        team_role_id: Option<WebTeamRoleId>,
+    },
+}
+
+impl WebPrincipalConstraint {
+    #[must_use]
+    pub const fn has_slot(&self) -> bool {
+        match self {
+            Self::InWeb { id: Some(_) }
+            | Self::InRole { role_id: Some(_) }
+            | Self::InTeam { team_id: Some(_) }
+            | Self::InTeamRole {
+                team_role_id: Some(_),
+            } => false,
+            Self::InWeb { id: None }
+            | Self::InRole { role_id: None }
+            | Self::InTeam { team_id: None }
+            | Self::InTeamRole { team_role_id: None } => true,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn to_cedar(&self) -> ast::PrincipalConstraint {
+        match self {
+            Self::InWeb { id } => id.map_or_else(ast::PrincipalConstraint::is_in_slot, |id| {
+                ast::PrincipalConstraint::is_in(Arc::new(id.to_euid()))
+            }),
+            Self::InRole { role_id } => role_id
+                .map_or_else(ast::PrincipalConstraint::is_in_slot, |role_id| {
+                    ast::PrincipalConstraint::is_in(Arc::new(role_id.to_euid()))
+                }),
+            Self::InTeam { team_id } => team_id
+                .map_or_else(ast::PrincipalConstraint::is_in_slot, |team_id| {
+                    ast::PrincipalConstraint::is_in(Arc::new(team_id.to_euid()))
+                }),
+            Self::InTeamRole { team_role_id } => team_role_id
+                .map_or_else(ast::PrincipalConstraint::is_in_slot, |team_role_id| {
+                    ast::PrincipalConstraint::is_in(Arc::new(team_role_id.to_euid()))
+                }),
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn to_cedar_in_type<C: CedarEntityId>(&self) -> ast::PrincipalConstraint {
+        match self {
+            Self::InWeb { id } => id.map_or_else(
+                || ast::PrincipalConstraint::is_entity_type_in_slot(Arc::clone(C::entity_type())),
+                |id| {
+                    ast::PrincipalConstraint::is_entity_type_in(
+                        Arc::clone(C::entity_type()),
+                        Arc::new(id.to_euid()),
+                    )
+                },
+            ),
+            Self::InRole { role_id } => role_id.map_or_else(
+                || ast::PrincipalConstraint::is_entity_type_in_slot(Arc::clone(C::entity_type())),
+                |role_id| {
+                    ast::PrincipalConstraint::is_entity_type_in(
+                        Arc::clone(C::entity_type()),
+                        Arc::new(role_id.to_euid()),
+                    )
+                },
+            ),
+            Self::InTeam { team_id } => team_id.map_or_else(
+                || ast::PrincipalConstraint::is_entity_type_in_slot(Arc::clone(C::entity_type())),
+                |team_id| {
+                    ast::PrincipalConstraint::is_entity_type_in(
+                        Arc::clone(C::entity_type()),
+                        Arc::new(team_id.to_euid()),
+                    )
+                },
+            ),
+            Self::InTeamRole { team_role_id } => team_role_id.map_or_else(
+                || ast::PrincipalConstraint::is_entity_type_in_slot(Arc::clone(C::entity_type())),
+                |team_role_id| {
+                    ast::PrincipalConstraint::is_entity_type_in(
+                        Arc::clone(C::entity_type()),
+                        Arc::new(team_role_id.to_euid()),
+                    )
+                },
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::error::Error;
+
+    use hash_graph_types::owned_by_id::OwnedById;
+    use serde_json::json;
+    use uuid::Uuid;
+
+    use super::{WebPrincipalConstraint, WebRoleId, WebTeamId, WebTeamRoleId};
+    use crate::{
+        policies::{PrincipalConstraint, principal::tests::check_principal},
+        test_utils::check_deserialization_error,
+    };
+
+    #[test]
+    fn in_web() -> Result<(), Box<dyn Error>> {
+        let web_id = OwnedById::new(Uuid::new_v4());
+        check_principal(
+            &PrincipalConstraint::Web(WebPrincipalConstraint::InWeb { id: Some(web_id) }),
+            json!({
+                "type": "web",
+                "id": web_id,
+            }),
+            format!(r#"principal in HASH::Web::"{web_id}""#),
+        )?;
+
+        check_principal(
+            &PrincipalConstraint::Web(WebPrincipalConstraint::InWeb { id: None }),
+            json!({
+                "type": "web",
+                "id": null,
+            }),
+            "principal in ?principal",
+        )?;
+
+        check_deserialization_error::<PrincipalConstraint>(
+            json!({
+                "type": "web",
+            }),
+            "data did not match any variant of untagged enum WebPrincipalConstraint",
+        )?;
+
+        check_deserialization_error::<PrincipalConstraint>(
+            json!({
+                "type": "web",
+                "id": web_id,
+                "additional": "unexpected",
+            }),
+            "data did not match any variant of untagged enum WebPrincipalConstraint",
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn in_role() -> Result<(), Box<dyn Error>> {
+        let role_id = WebRoleId::new(Uuid::new_v4());
+        check_principal(
+            &PrincipalConstraint::Web(WebPrincipalConstraint::InRole {
+                role_id: Some(role_id),
+            }),
+            json!({
+                "type": "web",
+                "roleId": role_id,
+            }),
+            format!(r#"principal in HASH::Web::Role::"{role_id}""#),
+        )?;
+
+        check_principal(
+            &PrincipalConstraint::Web(WebPrincipalConstraint::InRole { role_id: None }),
+            json!({
+                "type": "web",
+                "roleId": null,
+            }),
+            "principal in ?principal",
+        )?;
+
+        check_deserialization_error::<PrincipalConstraint>(
+            json!({
+                "type": "web",
+                "id": Uuid::new_v4(),
+                "roleId": role_id,
+            }),
+            "data did not match any variant of untagged enum WebPrincipalConstraint",
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn in_team() -> Result<(), Box<dyn Error>> {
+        let team_id = WebTeamId::new(Uuid::new_v4());
+        check_principal(
+            &PrincipalConstraint::Web(WebPrincipalConstraint::InTeam {
+                team_id: Some(team_id),
+            }),
+            json!({
+                "type": "web",
+                "teamId": team_id,
+            }),
+            format!(r#"principal in HASH::Web::Team::"{team_id}""#),
+        )?;
+
+        check_principal(
+            &PrincipalConstraint::Web(WebPrincipalConstraint::InTeam { team_id: None }),
+            json!({
+                "type": "web",
+                "teamId": null,
+            }),
+            "principal in ?principal",
+        )?;
+
+        check_deserialization_error::<PrincipalConstraint>(
+            json!({
+                "type": "web",
+            }),
+            "data did not match any variant of untagged enum WebPrincipalConstraint",
+        )?;
+
+        check_deserialization_error::<PrincipalConstraint>(
+            json!({
+                "type": "web",
+                "teamId": team_id,
+                "additional": "unexpected",
+            }),
+            "data did not match any variant of untagged enum WebPrincipalConstraint",
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn in_team_role() -> Result<(), Box<dyn Error>> {
+        let role_id = WebTeamRoleId::new(Uuid::new_v4());
+        check_principal(
+            &PrincipalConstraint::Web(WebPrincipalConstraint::InTeamRole {
+                team_role_id: Some(role_id),
+            }),
+            json!({
+                "type": "web",
+                "teamRoleId": role_id,
+            }),
+            format!(r#"principal in HASH::Web::Team::Role::"{role_id}""#),
+        )?;
+
+        check_principal(
+            &PrincipalConstraint::Web(WebPrincipalConstraint::InTeamRole { team_role_id: None }),
+            json!({
+                "type": "web",
+                "teamRoleId": null,
+            }),
+            "principal in ?principal",
+        )?;
+
+        check_deserialization_error::<PrincipalConstraint>(
+            json!({
+                "type": "web",
+                "teamRoleId": role_id,
+                "teamId": Uuid::new_v4(),
+            }),
+            "data did not match any variant of untagged enum WebPrincipalConstraint",
+        )?;
+
+        Ok(())
+    }
+}

--- a/libs/@local/graph/authorization/src/policies/resource/entity.rs
+++ b/libs/@local/graph/authorization/src/policies/resource/entity.rs
@@ -18,19 +18,51 @@ pub struct EntityResource<'a> {
     pub entity_type: Cow<'a, [VersionedUrl]>,
 }
 
+#[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(
+    tag = "type",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+pub enum EntityResourceFilter {
+    IsType { entity_type: VersionedUrl },
+}
+
+fn versioned_url_to_euid(url: &VersionedUrl) -> ast::EntityUID {
+    ast::EntityUID::from_components(
+        ast::EntityType::clone(EntityTypeId::entity_type()),
+        ast::Eid::new(url.to_string()),
+        None,
+    )
+}
+
+impl EntityResourceFilter {
+    #[must_use]
+    pub(crate) fn to_cedar(&self) -> ast::Expr {
+        match self {
+            Self::IsType { entity_type } => ast::Expr::contains(
+                ast::Expr::get_attr(
+                    ast::Expr::var(ast::Var::Resource),
+                    SmolStr::new_static("entity_types"),
+                ),
+                ast::Expr::val(versioned_url_to_euid(entity_type)),
+            ),
+        }
+    }
+}
+
 impl EntityResource<'_> {
     pub(crate) fn to_cedar_entity(&self) -> Result<ast::Entity, Box<dyn Error>> {
         Ok(ast::Entity::new(
             self.id.to_euid(),
             [(
                 SmolStr::new_static("entity_types"),
-                ast::RestrictedExpr::set(self.entity_type.iter().map(|url| {
-                    ast::RestrictedExpr::val(ast::EntityUID::from_components(
-                        ast::EntityType::clone(EntityTypeId::entity_type()),
-                        ast::Eid::new(url.to_string()),
-                        None,
-                    ))
-                })),
+                ast::RestrictedExpr::set(
+                    self.entity_type
+                        .iter()
+                        .map(|url| ast::RestrictedExpr::val(versioned_url_to_euid(url))),
+                ),
             )],
             iter::once(self.web_id.to_euid()).collect(),
             iter::empty(),
@@ -58,11 +90,10 @@ impl CedarEntityId for EntityUuid {
 #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(untagged, rename_all_fields = "camelCase", deny_unknown_fields)]
 pub enum EntityResourceConstraint {
-    #[expect(
-        clippy::empty_enum_variants_with_brackets,
-        reason = "Serialization is different"
-    )]
-    Any {},
+    Any {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        filter: Option<EntityResourceFilter>,
+    },
     Exact {
         #[serde(deserialize_with = "Option::deserialize")]
         id: Option<EntityUuid>,
@@ -70,6 +101,8 @@ pub enum EntityResourceConstraint {
     Web {
         #[serde(deserialize_with = "Option::deserialize")]
         web_id: Option<OwnedById>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        filter: Option<EntityResourceFilter>,
     },
 }
 
@@ -77,32 +110,50 @@ impl EntityResourceConstraint {
     #[must_use]
     pub const fn has_slot(&self) -> bool {
         match self {
-            Self::Any {} | Self::Exact { id: Some(_) } | Self::Web { web_id: Some(_) } => false,
-            Self::Exact { id: None } | Self::Web { web_id: None } => true,
+            Self::Any { .. }
+            | Self::Exact { id: Some(_) }
+            | Self::Web {
+                web_id: Some(_), ..
+            } => false,
+            Self::Exact { id: None } | Self::Web { web_id: None, .. } => true,
         }
     }
 
     #[must_use]
-    pub(crate) fn to_cedar(&self) -> ast::ResourceConstraint {
+    pub(crate) fn to_cedar_resource_constraint(&self) -> (ast::ResourceConstraint, ast::Expr) {
         match self {
-            Self::Any {} => {
-                ast::ResourceConstraint::is_entity_type(Arc::clone(EntityUuid::entity_type()))
-            }
-            Self::Exact { id } => id.map_or_else(ast::ResourceConstraint::is_eq_slot, |id| {
-                ast::ResourceConstraint::is_eq(Arc::new(id.to_euid()))
-            }),
-            Self::Web { web_id } => web_id.map_or_else(
-                || {
-                    ast::ResourceConstraint::is_entity_type_in_slot(Arc::clone(
-                        EntityUuid::entity_type(),
-                    ))
-                },
-                |web_id| {
-                    ast::ResourceConstraint::is_entity_type_in(
-                        Arc::clone(EntityUuid::entity_type()),
-                        Arc::new(web_id.to_euid()),
+            Self::Any { filter } => (
+                ast::ResourceConstraint::is_entity_type(Arc::clone(EntityUuid::entity_type())),
+                filter
+                    .as_ref()
+                    .map_or_else(|| ast::Expr::val(true), EntityResourceFilter::to_cedar),
+            ),
+            Self::Exact { id } => id.map_or_else(
+                || (ast::ResourceConstraint::is_eq_slot(), ast::Expr::val(true)),
+                |id| {
+                    (
+                        ast::ResourceConstraint::is_eq(Arc::new(id.to_euid())),
+                        ast::Expr::val(true),
                     )
                 },
+            ),
+            Self::Web { web_id, filter } => (
+                web_id.map_or_else(
+                    || {
+                        ast::ResourceConstraint::is_entity_type_in_slot(Arc::clone(
+                            EntityUuid::entity_type(),
+                        ))
+                    },
+                    |web_id| {
+                        ast::ResourceConstraint::is_entity_type_in(
+                            Arc::clone(EntityUuid::entity_type()),
+                            Arc::new(web_id.to_euid()),
+                        )
+                    },
+                ),
+                filter
+                    .as_ref()
+                    .map_or_else(|| ast::Expr::val(true), EntityResourceFilter::to_cedar),
             ),
         }
     }
@@ -110,13 +161,14 @@ impl EntityResourceConstraint {
 
 #[cfg(test)]
 mod tests {
-    use core::error::Error;
+    use core::{error::Error, str::FromStr as _};
 
     use hash_graph_types::{knowledge::entity::EntityUuid, owned_by_id::OwnedById};
     use serde_json::json;
+    use type_system::url::VersionedUrl;
     use uuid::Uuid;
 
-    use super::EntityResourceConstraint;
+    use super::{EntityResourceConstraint, EntityResourceFilter};
     use crate::{
         policies::{ResourceConstraint, resource::tests::check_resource},
         test_utils::check_deserialization_error,
@@ -125,9 +177,40 @@ mod tests {
     #[test]
     fn constraint_any() -> Result<(), Box<dyn Error>> {
         check_resource(
-            ResourceConstraint::Entity(EntityResourceConstraint::Any {}),
+            ResourceConstraint::Entity(EntityResourceConstraint::Any { filter: None }),
             json!({
                 "type": "entity"
+            }),
+            "resource is HASH::Entity",
+        )?;
+
+        check_deserialization_error::<ResourceConstraint>(
+            json!({
+                "type": "entity",
+                "additional": "unexpected"
+            }),
+            "data did not match any variant of untagged enum EntityResourceConstraint",
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn constraint_any_with_filter() -> Result<(), Box<dyn Error>> {
+        check_resource(
+            ResourceConstraint::Entity(EntityResourceConstraint::Any {
+                filter: Some(EntityResourceFilter::IsType {
+                    entity_type: VersionedUrl::from_str(
+                        "https://hash.ai/@h/types/entity-type/machine/v/1",
+                    )?,
+                }),
+            }),
+            json!({
+                "type": "entity",
+                "filter": {
+                    "type": "isType",
+                    "entityType": "https://hash.ai/@h/types/entity-type/machine/v/1"
+                },
             }),
             "resource is HASH::Entity",
         )?;
@@ -184,6 +267,7 @@ mod tests {
         check_resource(
             ResourceConstraint::Entity(EntityResourceConstraint::Web {
                 web_id: Some(web_id),
+                filter: None,
             }),
             json!({
                 "type": "entity",
@@ -193,7 +277,10 @@ mod tests {
         )?;
 
         check_resource(
-            ResourceConstraint::Entity(EntityResourceConstraint::Web { web_id: None }),
+            ResourceConstraint::Entity(EntityResourceConstraint::Web {
+                web_id: None,
+                filter: None,
+            }),
             json!({
                 "type": "entity",
                 "webId": null,
@@ -208,6 +295,52 @@ mod tests {
                 "id": EntityUuid::new(Uuid::new_v4()),
             }),
             "data did not match any variant of untagged enum EntityResourceConstraint",
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn constraint_in_web_with_filter() -> Result<(), Box<dyn Error>> {
+        let web_id = OwnedById::new(Uuid::new_v4());
+        check_resource(
+            ResourceConstraint::Entity(EntityResourceConstraint::Web {
+                web_id: Some(web_id),
+                filter: Some(EntityResourceFilter::IsType {
+                    entity_type: VersionedUrl::from_str(
+                        "https://hash.ai/@h/types/entity-type/machine/v/1",
+                    )?,
+                }),
+            }),
+            json!({
+                "type": "entity",
+                "webId": web_id,
+                "filter": {
+                    "type": "isType",
+                    "entityType": "https://hash.ai/@h/types/entity-type/machine/v/1"
+                },
+            }),
+            format!(r#"resource is HASH::Entity in HASH::Web::"{web_id}""#),
+        )?;
+
+        check_resource(
+            ResourceConstraint::Entity(EntityResourceConstraint::Web {
+                web_id: None,
+                filter: Some(EntityResourceFilter::IsType {
+                    entity_type: VersionedUrl::from_str(
+                        "https://hash.ai/@h/types/entity-type/machine/v/1",
+                    )?,
+                }),
+            }),
+            json!({
+                "type": "entity",
+                "webId": null,
+                "filter": {
+                    "type": "isType",
+                    "entityType": "https://hash.ai/@h/types/entity-type/machine/v/1"
+                },
+            }),
+            "resource is HASH::Entity in ?resource",
         )?;
 
         Ok(())

--- a/libs/@local/graph/authorization/src/policies/resource/entity.rs
+++ b/libs/@local/graph/authorization/src/policies/resource/entity.rs
@@ -1,13 +1,20 @@
-use alloc::sync::Arc;
+use alloc::{borrow::Cow, sync::Arc};
 use core::{error::Error, str::FromStr as _};
 use std::sync::LazyLock;
 
 use cedar_policy_core::ast;
 use error_stack::Report;
 use hash_graph_types::{knowledge::entity::EntityUuid, owned_by_id::OwnedById};
+use type_system::url::VersionedUrl;
 use uuid::Uuid;
 
 use crate::policies::cedar::CedarEntityId;
+
+pub struct EntityResource<'a> {
+    pub web_id: OwnedById,
+    pub entity_uuid: EntityUuid,
+    pub entity_type: Cow<'a, [VersionedUrl]>,
+}
 
 impl CedarEntityId for EntityUuid {
     fn entity_type() -> &'static Arc<ast::EntityType> {

--- a/libs/@local/graph/authorization/src/policies/resource/entity.rs
+++ b/libs/@local/graph/authorization/src/policies/resource/entity.rs
@@ -107,7 +107,7 @@ mod tests {
     #[test]
     fn constraint_any() -> Result<(), Box<dyn Error>> {
         check_resource(
-            &ResourceConstraint::Entity(EntityResourceConstraint::Any {}),
+            ResourceConstraint::Entity(EntityResourceConstraint::Any {}),
             json!({
                 "type": "entity"
             }),
@@ -129,7 +129,7 @@ mod tests {
     fn constraint_exact() -> Result<(), Box<dyn Error>> {
         let entity_uuid = EntityUuid::new(Uuid::new_v4());
         check_resource(
-            &ResourceConstraint::Entity(EntityResourceConstraint::Exact {
+            ResourceConstraint::Entity(EntityResourceConstraint::Exact {
                 entity_uuid: Some(entity_uuid),
             }),
             json!({
@@ -140,7 +140,7 @@ mod tests {
         )?;
 
         check_resource(
-            &ResourceConstraint::Entity(EntityResourceConstraint::Exact { entity_uuid: None }),
+            ResourceConstraint::Entity(EntityResourceConstraint::Exact { entity_uuid: None }),
             json!({
                 "type": "entity",
                 "entityUuid": null,
@@ -164,7 +164,7 @@ mod tests {
     fn constraint_in_web() -> Result<(), Box<dyn Error>> {
         let web_id = OwnedById::new(Uuid::new_v4());
         check_resource(
-            &ResourceConstraint::Entity(EntityResourceConstraint::Web {
+            ResourceConstraint::Entity(EntityResourceConstraint::Web {
                 web_id: Some(web_id),
             }),
             json!({
@@ -175,7 +175,7 @@ mod tests {
         )?;
 
         check_resource(
-            &ResourceConstraint::Entity(EntityResourceConstraint::Web { web_id: None }),
+            ResourceConstraint::Entity(EntityResourceConstraint::Web { web_id: None }),
             json!({
                 "type": "entity",
                 "webId": null,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To support an MVP of permissions using policies, we require a few more things in the policies itself.

## 🔍 What does this change?

- Replace the `Organization` principal with the `Web` principal. Technically, we don't even need the `User` principal anymore but could use a role per web instead.
- Add the `Team` principal
- Add the `EntityType` resource
- Add a Schema for policies
- Collect information about principals and resources before evaluation (this means, that the policy engine is aware of a user's web, the type of an entity, or the base URL and version for an entity type
- Support filtering entities by type

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- We use a Versioned URL to safe ontology types. In comparison to Entity UUIDs, this does not implement `Copy` as it internally uses a `String`. Related ticket: BP-57

## 🐾 Next steps

- Implement CRUD operations for policies

## 🛡 What tests cover this?

- All new principals were checked
- All policies are now validated using the provided schema
