### PR TITLE
H-4091: Add a `start:test:graph` command in top level package

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "start:worker": "CARGO_TERM_PROGRESS_WHEN=never turbo run start start:healthcheck --filter '@apps/hash-*-worker*' --env-mode=loose",
     "start:test:worker": "CARGO_TERM_PROGRESS_WHEN=never turbo run start:test start:test:healthcheck --filter '@apps/hash-*-worker*' --env-mode=loose",
     "start:test": "CARGO_TERM_PROGRESS_WHEN=never turbo run start:test start:test:healthcheck --env-mode=loose",
+    "start:test:graph": "CARGO_TERM_PROGRESS_WHEN=never turbo run start:test start:test:healthcheck --filter @apps/hash-graph --filter @rust/hash-graph-type-fetcher --filter @rust/hash-graph-test-server --env-mode=loose",
     "graph:reset-database": "yarn workspace @rust/hash-graph-http-tests reset-database",
     "external-services": "turbo deploy --filter '@apps/hash-external-services' --",
     "external-services:offline": "turbo deploy:offline --filter '@apps/hash-external-services' --",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We have a `start:graph` and a `start:test` command, but no `start:test:graph` (but we have `start:test:worker`). The `start:graph` command uses a release build, the newly added `start:test:graph` is a debug build.