### PR TITLE
H-4097: Revert 'Lock File Maintenance' in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,11 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>hashintel/.github:renovate-config"],
   "description": "HASH public monorepo (hashintel/hash) Renovate configuration",
-  "dependencyDashboardOSVVulnerabilitySummary": "none",
-  "lockFileMaintenance": {
-    "enabled": true,
-    "branchTopic": "lock-regenerate",
-    "commitMessageAction": "Regenerate lock files",
-    "schedule": ["before 4am on sunday"]
-  }
+  "dependencyDashboardOSVVulnerabilitySummary": "none"
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The lockfile maintenance for Rust downgrades some crates, which then will be upgraded again by renovate. Renovate just does a bad job in determining changes in Rust, so we remove lockfile maintenance for Rust. As we had issues with the Node-lockfile PR as well, so we simply remove the feature completely, again.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, blog posts) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- https://github.com/hashintel/hash/pull/6478
