### PR TITLE
H-4119: Fix `yarn start:test:graph` not properly compiling Rust crates

### DIFF
--- a/libs/@local/graph/test-server/turbo.json
+++ b/libs/@local/graph/test-server/turbo.json
@@ -4,8 +4,14 @@
     "start": {
       "dependsOn": ["@apps/hash-graph#start:migrate"]
     },
+    "start:healthcheck": {
+      "dependsOn": ["@apps/hash-graph#compile:release"]
+    },
     "start:test": {
       "dependsOn": ["@apps/hash-graph#start:test:migrate"]
+    },
+    "start:test:healthcheck": {
+      "dependsOn": ["@apps/hash-graph#compile"]
     }
   }
 }

--- a/libs/@local/graph/type-fetcher/turbo.json
+++ b/libs/@local/graph/type-fetcher/turbo.json
@@ -9,6 +9,9 @@
     },
     "start:test": {
       "dependsOn": ["@apps/hash-graph#compile"]
+    },
+    "start:test:healthcheck": {
+      "dependsOn": ["@apps/hash-graph#compile"]
     }
   }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`yarn start:test:graph` did not wait for the compilation to be finished.

## 🔍 What does this change?

Let the `compile` task a dependency of the healthcheck tasks

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this