### PR TITLE
H-4109: Fix ontology queries returning archived types instead of latest

### DIFF
--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
@@ -21,7 +21,7 @@ use hash_graph_store::{
     },
     error::{InsertionError, QueryError, UpdateError},
     filter::{Filter, FilterExpression, ParameterList},
-    query::{QueryResult as _, Read, ReadPaginated, VersionedUrlSorting},
+    query::{Ordering, QueryResult as _, Read, ReadPaginated, VersionedUrlSorting},
     subgraph::{
         Subgraph, SubgraphRecord as _,
         edges::{EdgeDirection, GraphResolveDepths, OntologyEdgeKind},
@@ -1436,7 +1436,7 @@ impl PostgresRecord for DataTypeWithMetadata {
             transaction_time: compiler.add_distinct_selection_with_ordering(
                 &DataTypeQueryPath::TransactionTime,
                 Distinctness::Distinct,
-                None,
+                Some((Ordering::Descending, None)),
             ),
             schema: compiler.add_selection_path(&DataTypeQueryPath::Schema(None)),
             edition_provenance: compiler

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
@@ -24,7 +24,7 @@ use hash_graph_store::{
     error::{InsertionError, QueryError, UpdateError},
     filter::{Filter, FilterExpression, ParameterList},
     property_type::{GetPropertyTypeSubgraphParams, PropertyTypeStore as _},
-    query::{QueryResult as _, Read, ReadPaginated, VersionedUrlSorting},
+    query::{Ordering, QueryResult as _, Read, ReadPaginated, VersionedUrlSorting},
     subgraph::{
         Subgraph, SubgraphRecord as _,
         edges::{EdgeDirection, GraphResolveDepths, OntologyEdgeKind, OutgoingEdgeResolveDepth},
@@ -1714,7 +1714,7 @@ impl PostgresRecord for EntityTypeWithMetadata {
             transaction_time: compiler.add_distinct_selection_with_ordering(
                 &EntityTypeQueryPath::TransactionTime,
                 Distinctness::Distinct,
-                None,
+                Some((Ordering::Descending, None)),
             ),
             schema: compiler.add_selection_path(&EntityTypeQueryPath::Schema(None)),
             edition_provenance: compiler

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/property_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/property_type.rs
@@ -20,7 +20,7 @@ use hash_graph_store::{
         GetPropertyTypesResponse, PropertyTypeQueryPath, PropertyTypeStore,
         UnarchivePropertyTypeParams, UpdatePropertyTypeEmbeddingParams, UpdatePropertyTypesParams,
     },
-    query::{QueryResult as _, Read as _, ReadPaginated, VersionedUrlSorting},
+    query::{Ordering, QueryResult as _, Read as _, ReadPaginated, VersionedUrlSorting},
     subgraph::{
         Subgraph, SubgraphRecord as _,
         edges::{EdgeDirection, GraphResolveDepths, OntologyEdgeKind},
@@ -1007,7 +1007,7 @@ impl PostgresRecord for PropertyTypeWithMetadata {
             transaction_time: compiler.add_distinct_selection_with_ordering(
                 &PropertyTypeQueryPath::TransactionTime,
                 Distinctness::Distinct,
-                None,
+                Some((Ordering::Descending, None)),
             ),
             schema: compiler.add_selection_path(&PropertyTypeQueryPath::Schema(None)),
             edition_provenance: compiler

--- a/tests/hash-backend-integration/src/tests/graph/ontology/primitive/entity-type.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/ontology/primitive/entity-type.test.ts
@@ -4,12 +4,15 @@ import type { Org } from "@apps/hash-api/src/graph/knowledge/system-types/org";
 import type { User } from "@apps/hash-api/src/graph/knowledge/system-types/user";
 import { joinOrg } from "@apps/hash-api/src/graph/knowledge/system-types/user";
 import {
+  archiveEntityType,
   createEntityType,
   getClosedEntityTypes,
   getClosedMultiEntityType,
   getEntityTypeById,
+  getEntityTypes,
   getEntityTypeSubgraph,
   getEntityTypeSubgraphById,
+  unarchiveEntityType,
   updateEntityType,
 } from "@apps/hash-api/src/graph/ontology/primitive/entity-type";
 import { createPropertyType } from "@apps/hash-api/src/graph/ontology/primitive/property-type";
@@ -28,6 +31,7 @@ import type {
 import type { OwnedById } from "@local/hash-graph-types/web";
 import {
   currentTimeInstantTemporalAxes,
+  fullTransactionTimeAxis,
   zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
@@ -514,6 +518,67 @@ describe("Entity type CRU", () => {
       isOwnedOntologyElementMetadata(updatedEntityType.metadata) &&
         updatedEntityType.metadata.provenance.edition.createdById,
     ).toBe(testUser2.accountId);
+  });
+
+  it("can archive a entity type", async () => {
+    const authentication = { actorId: testUser.accountId };
+
+    await archiveEntityType(graphContext, authentication, {
+      entityTypeId: createdEntityType.schema.$id,
+    });
+
+    const [archivedEntityType] = await getEntityTypes(
+      graphContext,
+      authentication,
+      {
+        filter: {
+          equal: [
+            { path: ["versionedUrl"] },
+            { parameter: createdEntityType.schema.$id },
+          ],
+        },
+        temporalAxes: fullTransactionTimeAxis,
+      },
+    );
+
+    expect(
+      await getEntityTypes(graphContext, authentication, {
+        filter: {
+          equal: [
+            { path: ["versionedUrl"] },
+            { parameter: createdEntityType.schema.$id },
+          ],
+        },
+        temporalAxes: currentTimeInstantTemporalAxes,
+      }),
+    ).toHaveLength(0);
+
+    expect(
+      archivedEntityType?.metadata.temporalVersioning.transactionTime.end.kind,
+    ).toBe("exclusive");
+
+    await unarchiveEntityType(graphContext, authentication, {
+      entityTypeId: createdEntityType.schema.$id,
+    });
+
+    const [unarchivedEntityType] = await getEntityTypes(
+      graphContext,
+      authentication,
+      {
+        filter: {
+          equal: [
+            { path: ["versionedUrl"] },
+            { parameter: createdEntityType.schema.$id },
+          ],
+        },
+        temporalAxes: fullTransactionTimeAxis,
+      },
+    );
+
+    expect(
+      unarchivedEntityType?.metadata.temporalVersioning.transactionTime.end
+        .kind,
+    ).toBe("unbounded");
   });
 
   it.skip("can load an external type on demand", async () => {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When archiving and then unarchiving a type, the returned types may be the archived one (with the upper timestamp set to `type: "exclusive"`). Instead, the latest should be returned, which will be the unarchived one if existing.

## 🔍 What does this change?

- Order the returned ontology type by transaction time
- Write tests for all ontology types to archive/unarchive

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- A test has been added for each ontology type which archives and the unarchives the type. Then it's checked if the correct version is returned.