### PR TITLE
H-4103: Write test for common Policies

### DIFF
--- a/libs/@local/graph/authorization/schemas/policies.cedarschema
+++ b/libs/@local/graph/authorization/schemas/policies.cedarschema
@@ -13,6 +13,8 @@ namespace HASH {
   };
 
   entity EntityType in [Web] {
+    base_url: String,
+    version: Long,
   };
 
   entity User, Machine in [HASH::Web::Role, HASH::Team::Role, HASH::Web::Team::Role] {

--- a/libs/@local/graph/authorization/src/policies/context.rs
+++ b/libs/@local/graph/authorization/src/policies/context.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use cedar_policy_core::{
     ast,
     entities::{Entities, TCComputation},
@@ -5,7 +7,15 @@ use cedar_policy_core::{
 };
 use error_stack::{Report, ResultExt as _};
 
-use super::{Validator, principal::Actor, resource::Resource};
+use super::{
+    PolicyValidator,
+    principal::{
+        machine::Machine,
+        user::User,
+        web::{Web, WebRole},
+    },
+    resource::{EntityResource, EntityTypeResource, Resource},
+};
 
 #[derive(Debug, derive_more::Display, derive_more::Error)]
 pub enum ContextError {
@@ -13,9 +23,15 @@ pub enum ContextError {
     TransitiveClosureError,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct Context {
     entities: Entities,
+}
+
+impl fmt::Debug for Context {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.entities, fmt)
+    }
 }
 
 impl Context {
@@ -31,15 +47,63 @@ pub struct ContextBuilder {
 }
 
 impl ContextBuilder {
+    pub fn add_machine(&mut self, machine: &Machine) {
+        self.entities.push(machine.to_cedar_entity());
+        self.entities.push(machine.entity.to_cedar_entity());
+    }
+
+    pub fn add_user(&mut self, user: &User) {
+        self.entities.push(user.to_cedar_entity());
+        self.entities.push(user.entity.to_cedar_entity());
+    }
+
+    pub fn add_resource(&mut self, resource: &Resource) {
+        self.entities.push(resource.to_cedar_entity());
+    }
+
+    pub fn add_entity(&mut self, entity: &EntityResource) {
+        self.entities.push(entity.to_cedar_entity());
+    }
+
+    pub fn add_entity_type(&mut self, entity_type: &EntityTypeResource) {
+        self.entities.push(entity_type.to_cedar_entity());
+    }
+
+    pub fn add_web(&mut self, web: &Web) {
+        self.entities.push(web.to_cedar_entity());
+    }
+
+    pub fn add_web_role(&mut self, web_role: &WebRole) {
+        self.entities.push(web_role.to_cedar_entity());
+    }
+
     #[must_use]
-    pub fn with_actor(mut self, actor: &Actor) -> Self {
-        self.entities.push(actor.to_cedar_entity());
+    pub fn with_user(mut self, user: &User) -> Self {
+        self.add_user(user);
+        self
+    }
+
+    #[must_use]
+    pub fn with_machine(mut self, machine: &Machine) -> Self {
+        self.add_machine(machine);
         self
     }
 
     #[must_use]
     pub fn with_resource(mut self, resource: &Resource) -> Self {
-        self.entities.push(resource.to_cedar_entity());
+        self.add_resource(resource);
+        self
+    }
+
+    #[must_use]
+    pub fn with_web(mut self, web: &Web) -> Self {
+        self.add_web(web);
+        self
+    }
+
+    #[must_use]
+    pub fn with_web_role(mut self, web_role: &WebRole) -> Self {
+        self.add_web_role(web_role);
         self
     }
 
@@ -54,7 +118,7 @@ impl ContextBuilder {
         Ok(Context {
             entities: Entities::from_entities(
                 self.entities,
-                Some(&Validator::core_schema()),
+                Some(&PolicyValidator::core_schema()),
                 TCComputation::ComputeNow,
                 Extensions::none(),
             )

--- a/libs/@local/graph/authorization/src/policies/principal/actor.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/actor.rs
@@ -1,9 +1,6 @@
 use cedar_policy_core::ast;
 
-use super::{
-    machine::{Machine, MachineId},
-    user::{User, UserId},
-};
+use super::{machine::MachineId, user::UserId};
 use crate::policies::cedar::CedarEntityId as _;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -17,30 +14,6 @@ impl ActorId {
         match self {
             Self::User(id) => id.to_euid(),
             Self::Machine(id) => id.to_euid(),
-        }
-    }
-}
-
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
-pub enum Actor {
-    User(User),
-    Machine(Machine),
-}
-
-impl Actor {
-    #[must_use]
-    pub const fn id(&self) -> ActorId {
-        match self {
-            Self::User(user) => ActorId::User(user.id),
-            Self::Machine(machine) => ActorId::Machine(machine.id),
-        }
-    }
-
-    pub(crate) fn to_cedar_entity(&self) -> ast::Entity {
-        match self {
-            Self::User(user) => user.to_entity(),
-            Self::Machine(machine) => machine.to_entity(),
         }
     }
 }

--- a/libs/@local/graph/authorization/src/policies/principal/machine.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/machine.rs
@@ -12,7 +12,9 @@ use error_stack::Report;
 use uuid::Uuid;
 
 use super::{InPrincipalConstraint, TeamPrincipalConstraint, role::RoleId};
-use crate::policies::{cedar::CedarEntityId, principal::web::WebPrincipalConstraint};
+use crate::policies::{
+    cedar::CedarEntityId, principal::web::WebPrincipalConstraint, resource::EntityResource,
+};
 
 #[derive(
     Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
@@ -70,10 +72,11 @@ impl CedarEntityId for MachineId {
 pub struct Machine {
     pub id: MachineId,
     pub roles: Vec<RoleId>,
+    pub entity: EntityResource<'static>,
 }
 
 impl Machine {
-    pub(crate) fn to_entity(&self) -> ast::Entity {
+    pub(crate) fn to_cedar_entity(&self) -> ast::Entity {
         ast::Entity::new(
             self.id.to_euid(),
             iter::empty(),
@@ -204,7 +207,7 @@ mod tests {
         check_deserialization_error::<PrincipalConstraint>(
             json!({
                 "type": "machine",
-                "machineId": machine_id,
+                "id": machine_id,
                 "additional": "unexpected",
             }),
             "data did not match any variant of untagged enum MachinePrincipalConstraint",

--- a/libs/@local/graph/authorization/src/policies/principal/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/mod.rs
@@ -7,7 +7,7 @@ use cedar_policy_core::ast;
 use error_stack::{Report, ResultExt as _, bail};
 use hash_graph_types::owned_by_id::OwnedById;
 
-pub use self::actor::{Actor, ActorId};
+pub use self::actor::ActorId;
 use self::{
     machine::{MachineId, MachinePrincipalConstraint},
     team::{TeamId, TeamPrincipalConstraint, TeamRoleId},

--- a/libs/@local/graph/authorization/src/policies/principal/role.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/role.rs
@@ -7,7 +7,12 @@ use super::{
 use crate::policies::cedar::CedarEntityId as _;
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+#[serde(
+    tag = "type",
+    content = "id",
+    rename_all = "camelCase",
+    deny_unknown_fields
+)]
 pub enum RoleId {
     Web(WebRoleId),
     WebTeam(WebTeamRoleId),

--- a/libs/@local/graph/authorization/src/policies/principal/user.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/user.rs
@@ -12,7 +12,9 @@ use error_stack::Report;
 use uuid::Uuid;
 
 use super::{InPrincipalConstraint, TeamPrincipalConstraint, role::RoleId};
-use crate::policies::{cedar::CedarEntityId, principal::web::WebPrincipalConstraint};
+use crate::policies::{
+    cedar::CedarEntityId, principal::web::WebPrincipalConstraint, resource::EntityResource,
+};
 
 #[derive(
     Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
@@ -70,10 +72,11 @@ impl CedarEntityId for UserId {
 pub struct User {
     pub id: UserId,
     pub roles: Vec<RoleId>,
+    pub entity: EntityResource<'static>,
 }
 
 impl User {
-    pub(crate) fn to_entity(&self) -> ast::Entity {
+    pub(crate) fn to_cedar_entity(&self) -> ast::Entity {
         ast::Entity::new(
             self.id.to_euid(),
             iter::empty(),

--- a/libs/@local/graph/authorization/src/policies/validation.rs
+++ b/libs/@local/graph/authorization/src/policies/validation.rs
@@ -33,9 +33,9 @@ static VALIDATOR: LazyLock<cedar_policy_validator::Validator> =
 pub struct PolicyValidationError;
 
 #[derive(Debug)]
-pub struct Validator;
+pub struct PolicyValidator;
 
-impl Validator {
+impl PolicyValidator {
     pub(crate) fn schema() -> &'static ValidatorSchema {
         &SCHEMA
     }

--- a/libs/@local/graph/authorization/tests/policies/definitions/forbid-update-web-machine.cedar
+++ b/libs/@local/graph/authorization/tests/policies/definitions/forbid-update-web-machine.cedar
@@ -1,0 +1,6 @@
+forbid (
+  principal is HASH::User,
+  action == HASH::Action::"update",
+  resource is HASH::Entity
+)
+when { resource.entity_types.contains(HASH::EntityType::"https://hash.ai/@h/types/entity-type/machine/v/2") };

--- a/libs/@local/graph/authorization/tests/policies/definitions/mod.rs
+++ b/libs/@local/graph/authorization/tests/policies/definitions/mod.rs
@@ -1,0 +1,276 @@
+use core::{error::Error, str::FromStr as _};
+
+use cedar_policy_core::parser::parse_policy_or_template;
+use error_stack::ResultExt as _;
+use hash_graph_authorization::policies::{
+    Effect, Policy, PolicyId, PolicySet, PolicyValidator,
+    action::{ActionConstraint, ActionId},
+    principal::{
+        PrincipalConstraint,
+        machine::{MachineId, MachinePrincipalConstraint},
+        team::TeamRoleId,
+        user::UserPrincipalConstraint,
+        web::WebRoleId,
+    },
+    resource::{
+        EntityResourceConstraint, EntityResourceFilter, EntityTypeResourceConstraint,
+        EntityTypeResourceFilter, ResourceConstraint,
+    },
+};
+use hash_graph_types::{knowledge::entity::EntityUuid, owned_by_id::OwnedById};
+use pretty_assertions::assert_eq;
+use type_system::url::{BaseUrl, VersionedUrl};
+use uuid::Uuid;
+
+#[track_caller]
+fn check_policy(policy: &Policy) -> Result<(), Box<dyn Error>> {
+    let mut policy_set = PolicySet::default();
+    if policy.principal.has_slot() || policy.resource.has_slot() {
+        policy_set.add_template(policy)?;
+    } else {
+        policy_set.add_policy(policy)?;
+    }
+
+    PolicyValidator
+        .validate_policy_set(&policy_set)
+        .attach_printable_lazy(|| format!("policy: {policy:?}"))?;
+
+    Ok(())
+}
+
+#[expect(clippy::panic_in_result_fn)]
+pub(crate) fn forbid_update_web_machine() -> Result<Vec<Policy>, Box<dyn Error>> {
+    const POLICIES: &str = include_str!("forbid-update-web-machine.cedar");
+
+    let policies = vec![Policy {
+        id: PolicyId::new(Uuid::new_v4()),
+        effect: Effect::Forbid,
+        principal: PrincipalConstraint::User(UserPrincipalConstraint::Any {}),
+        action: ActionConstraint::One {
+            action: ActionId::Update,
+        },
+        resource: ResourceConstraint::Entity(EntityResourceConstraint::Any {
+            filter: Some(EntityResourceFilter::IsType {
+                entity_type: VersionedUrl::from_str(
+                    "https://hash.ai/@h/types/entity-type/machine/v/2",
+                )?,
+            }),
+        }),
+        constraints: None,
+    }];
+
+    for (index, cedar_policy_string) in POLICIES
+        .split_inclusive(';')
+        .filter(|policy| !policy.trim().is_empty())
+        .enumerate()
+    {
+        assert_eq!(
+            parse_policy_or_template(None, cedar_policy_string)?.to_string(),
+            format!("{:?}", policies[index]),
+        );
+    }
+
+    Ok(policies)
+}
+
+pub(crate) fn permit_admin_web(
+    web_id: OwnedById,
+    admin_role: WebRoleId,
+) -> Result<Vec<Policy>, Box<dyn Error>> {
+    const POLICIES: &str = include_str!("permit-admin-web.cedar");
+
+    #[expect(clippy::literal_string_with_formatting_args)]
+    let policies = Policy::parse_cedar_policies(
+        &POLICIES
+            .replace("{web_id}", &web_id.to_string())
+            .replace("{role_id}", &admin_role.to_string()),
+    )?;
+    for policy in &policies {
+        check_policy(policy)?;
+    }
+
+    Ok(policies)
+}
+
+pub(crate) fn permit_hash_instance_admins(
+    admin_role: TeamRoleId,
+    member_role: TeamRoleId,
+    hash_instance_entity_id: EntityUuid,
+) -> Result<Vec<Policy>, Box<dyn Error>> {
+    const POLICIES: &str = include_str!("permit-hash-instance-admins.cedar");
+
+    let policies = Policy::parse_cedar_policies(
+        &POLICIES
+            .replace("{admin_role_id}", &admin_role.to_string())
+            .replace("{member_role_id}", &member_role.to_string())
+            .replace("{entity_id}", &hash_instance_entity_id.to_string()),
+    )?;
+    for policy in &policies {
+        check_policy(policy)?;
+    }
+
+    Ok(policies)
+}
+
+#[expect(clippy::panic_in_result_fn)]
+pub(crate) fn permit_instantiate(
+    system_machine_id: MachineId,
+) -> Result<Vec<Policy>, Box<dyn Error>> {
+    const POLICIES: &str = include_str!("permit-instantiate.cedar");
+
+    let policies = vec![
+        Policy {
+            id: PolicyId::new(Uuid::new_v4()),
+            effect: Effect::Permit,
+            principal: PrincipalConstraint::Public {},
+            action: ActionConstraint::One {
+                action: ActionId::Instantiate,
+            },
+            resource: ResourceConstraint::EntityType(EntityTypeResourceConstraint::Any {
+                filter: Some(EntityTypeResourceFilter::Not {
+                    filter: Box::new(EntityTypeResourceFilter::Any {
+                        filters: vec![
+                            EntityTypeResourceFilter::IsBaseUrl {
+                                base_url: BaseUrl::new(
+                                    "https://hash.ai/@h/types/entity-type/machine/".to_owned(),
+                                )?,
+                            },
+                            EntityTypeResourceFilter::IsBaseUrl {
+                                base_url: BaseUrl::new(
+                                    "https://hash.ai/@h/types/entity-type/user/".to_owned(),
+                                )?,
+                            },
+                            EntityTypeResourceFilter::IsBaseUrl {
+                                base_url: BaseUrl::new(
+                                    "https://hash.ai/@h/types/entity-type/organization/".to_owned(),
+                                )?,
+                            },
+                            EntityTypeResourceFilter::IsBaseUrl {
+                                base_url: BaseUrl::new(
+                                    "https://hash.ai/@h/types/entity-type/hash-instance/"
+                                        .to_owned(),
+                                )?,
+                            },
+                        ],
+                    }),
+                }),
+            }),
+            constraints: None,
+        },
+        Policy {
+            id: PolicyId::new(Uuid::new_v4()),
+            effect: Effect::Permit,
+            principal: PrincipalConstraint::Machine(MachinePrincipalConstraint::Exact {
+                machine_id: Some(system_machine_id),
+            }),
+            action: ActionConstraint::One {
+                action: ActionId::Instantiate,
+            },
+            resource: ResourceConstraint::EntityType(EntityTypeResourceConstraint::Any {
+                filter: None,
+            }),
+            constraints: None,
+        },
+    ];
+
+    #[expect(clippy::literal_string_with_formatting_args)]
+    for (index, cedar_policy_string) in POLICIES
+        .replace("{system_machine_id}", &system_machine_id.to_string())
+        .split_inclusive(';')
+        .filter(|policy| !policy.trim().is_empty())
+        .enumerate()
+    {
+        assert_eq!(
+            parse_policy_or_template(None, cedar_policy_string)?.to_string(),
+            format!("{:?}", policies[index]),
+        );
+    }
+
+    Ok(policies)
+}
+
+pub(crate) fn permit_member_crud_web(
+    web_id: OwnedById,
+    member_role: WebRoleId,
+) -> Result<Vec<Policy>, Box<dyn Error>> {
+    const POLICIES: &str = include_str!("permit-member-crud-web.cedar");
+
+    #[expect(clippy::literal_string_with_formatting_args)]
+    let policies = Policy::parse_cedar_policies(
+        &POLICIES
+            .replace("{web_id}", &web_id.to_string())
+            .replace("{role_id}", &member_role.to_string()),
+    )?;
+    for policy in &policies {
+        check_policy(policy)?;
+    }
+
+    Ok(policies)
+}
+
+pub(crate) fn permit_view_ontology() -> Result<Vec<Policy>, Box<dyn Error>> {
+    const POLICIES: &str = include_str!("permit-view-ontology.cedar");
+
+    let policies = Policy::parse_cedar_policies(POLICIES)?;
+    for policy in &policies {
+        check_policy(policy)?;
+    }
+
+    Ok(policies)
+}
+
+pub(crate) fn permit_view_system_entities(
+    system_web_id: OwnedById,
+) -> Result<Vec<Policy>, Box<dyn Error>> {
+    const POLICIES: &str = include_str!("permit-view-system-entities.cedar");
+
+    let policies = vec![
+        Policy {
+            id: PolicyId::new(Uuid::new_v4()),
+            effect: Effect::Permit,
+            principal: PrincipalConstraint::Public {},
+            action: ActionConstraint::One {
+                action: ActionId::View,
+            },
+            resource: ResourceConstraint::Entity(EntityResourceConstraint::Web {
+                web_id: Some(system_web_id),
+                filter: None,
+            }),
+            constraints: None,
+        },
+        Policy {
+            id: PolicyId::new(Uuid::new_v4()),
+            effect: Effect::Permit,
+            principal: PrincipalConstraint::Public {},
+            action: ActionConstraint::One {
+                action: ActionId::View,
+            },
+            resource: ResourceConstraint::Entity(EntityResourceConstraint::Any {
+                filter: Some(EntityResourceFilter::IsAnyType {
+                    entity_types: vec![
+                        VersionedUrl::from_str("https://hash.ai/@h/types/entity-type/actor/v/2")?,
+                        VersionedUrl::from_str(
+                            "https://hash.ai/@h/types/entity-type/organization/v/2",
+                        )?,
+                    ],
+                }),
+            }),
+            constraints: None,
+        },
+    ];
+
+    #[expect(clippy::literal_string_with_formatting_args)]
+    for (index, cedar_policy_string) in POLICIES
+        .replace("{system_web_id}", &system_web_id.to_string())
+        .split_inclusive(';')
+        .filter(|policy| !policy.trim().is_empty())
+        .enumerate()
+    {
+        assert_eq!(
+            parse_policy_or_template(None, cedar_policy_string)?.to_string(),
+            format!("{:?}", policies[index]),
+        );
+    }
+
+    Ok(policies)
+}

--- a/libs/@local/graph/authorization/tests/policies/definitions/permit-admin-web.cedar
+++ b/libs/@local/graph/authorization/tests/policies/definitions/permit-admin-web.cedar
@@ -1,0 +1,5 @@
+permit (
+  principal in HASH::Web::Role::"{role_id}",
+  action,
+  resource in HASH::Web::"{web_id}"
+);

--- a/libs/@local/graph/authorization/tests/policies/definitions/permit-hash-instance-admins.cedar
+++ b/libs/@local/graph/authorization/tests/policies/definitions/permit-hash-instance-admins.cedar
@@ -1,0 +1,11 @@
+permit (
+  principal in HASH::Team::Role::"{admin_role_id}",
+  action == HASH::Action::"update",
+  resource == HASH::Entity::"{entity_id}"
+);
+
+permit (
+  principal in HASH::Team::Role::"{member_role_id}",
+  action == HASH::Action::"update",
+  resource == HASH::Entity::"{entity_id}"
+);

--- a/libs/@local/graph/authorization/tests/policies/definitions/permit-instantiate.cedar
+++ b/libs/@local/graph/authorization/tests/policies/definitions/permit-instantiate.cedar
@@ -1,0 +1,18 @@
+permit (
+  principal,
+  action == HASH::Action::"instantiate",
+  resource is HASH::EntityType
+)
+unless
+{
+  resource.base_url == "https://hash.ai/@h/types/entity-type/machine/" ||
+  resource.base_url == "https://hash.ai/@h/types/entity-type/user/" ||
+  resource.base_url == "https://hash.ai/@h/types/entity-type/organization/" ||
+  resource.base_url == "https://hash.ai/@h/types/entity-type/hash-instance/"
+};
+
+permit (
+  principal == HASH::Machine::"{system_machine_id}",
+  action == HASH::Action::"instantiate",
+  resource is HASH::EntityType
+);

--- a/libs/@local/graph/authorization/tests/policies/definitions/permit-member-crud-web.cedar
+++ b/libs/@local/graph/authorization/tests/policies/definitions/permit-member-crud-web.cedar
@@ -1,0 +1,5 @@
+permit (
+  principal in HASH::Web::Role::"{role_id}",
+  action in [HASH::Action::"update", HASH::Action::"view"],
+  resource in HASH::Web::"{web_id}"
+);

--- a/libs/@local/graph/authorization/tests/policies/definitions/permit-view-ontology.cedar
+++ b/libs/@local/graph/authorization/tests/policies/definitions/permit-view-ontology.cedar
@@ -1,0 +1,5 @@
+permit (
+  principal,
+  action == HASH::Action::"view",
+  resource is HASH::EntityType
+);

--- a/libs/@local/graph/authorization/tests/policies/definitions/permit-view-system-entities.cedar
+++ b/libs/@local/graph/authorization/tests/policies/definitions/permit-view-system-entities.cedar
@@ -1,0 +1,20 @@
+permit (
+  principal,
+  action == HASH::Action::"view",
+  resource is HASH::Entity in HASH::Web::"{system_web_id}"
+);
+
+permit (
+  principal,
+  action == HASH::Action::"view",
+  resource is HASH::Entity
+)
+when
+{
+  resource.entity_types
+    .containsAny
+    (
+      [HASH::EntityType::"https://hash.ai/@h/types/entity-type/actor/v/2",
+       HASH::EntityType::"https://hash.ai/@h/types/entity-type/organization/v/2"]
+    )
+};

--- a/libs/@local/graph/authorization/tests/policies/main.rs
+++ b/libs/@local/graph/authorization/tests/policies/main.rs
@@ -1,0 +1,587 @@
+#![expect(
+    clippy::panic_in_result_fn,
+    reason = "Tests use assertions that may panic"
+)]
+
+extern crate alloc;
+
+mod definitions;
+
+use alloc::borrow::Cow;
+use core::{error::Error, str::FromStr as _};
+
+use hash_graph_authorization::policies::{
+    ContextBuilder, Policy, PolicySet, Request, RequestContext,
+    action::ActionId,
+    principal::{
+        ActorId,
+        machine::{Machine, MachineId},
+        role::RoleId,
+        team::{TeamId, TeamRoleId},
+        user::{User, UserId},
+        web::WebRoleId,
+    },
+    resource::{EntityResource, EntityTypeId, EntityTypeResource, ResourceId},
+};
+use hash_graph_types::{knowledge::entity::EntityUuid, owned_by_id::OwnedById};
+use type_system::url::VersionedUrl;
+use uuid::Uuid;
+
+use self::definitions::{
+    forbid_update_web_machine, permit_admin_web, permit_hash_instance_admins, permit_instantiate,
+    permit_member_crud_web, permit_view_ontology, permit_view_system_entities,
+};
+
+fn generate_machine(web_id: OwnedById, roles: Vec<RoleId>) -> Result<Machine, Box<dyn Error>> {
+    let machine_id = MachineId::new(Uuid::new_v4());
+    let entity = EntityResource {
+        web_id,
+        id: EntityUuid::new(machine_id.into_uuid()),
+        entity_type: Cow::Owned(vec![
+            VersionedUrl::from_str("https://hash.ai/@h/types/entity-type/machine/v/2")?,
+            VersionedUrl::from_str("https://hash.ai/@h/types/entity-type/actor/v/2")?,
+        ]),
+    };
+
+    Ok(Machine {
+        id: machine_id,
+        roles,
+        entity,
+    })
+}
+
+#[derive(Debug, serde::Serialize)]
+struct Web {
+    id: OwnedById,
+    admin_role: WebRoleId,
+    member_role: WebRoleId,
+    machine: Machine,
+}
+
+impl Web {
+    fn generate() -> Result<(Self, Vec<Policy>), Box<dyn Error>> {
+        let web_id = OwnedById::new(Uuid::new_v4());
+        let admin_role = WebRoleId::new(Uuid::new_v4());
+        let member_role = WebRoleId::new(Uuid::new_v4());
+        let machine = generate_machine(web_id, vec![RoleId::Web(member_role)])?;
+
+        let mut policies = permit_admin_web(web_id, admin_role)?;
+        policies.extend(permit_member_crud_web(web_id, member_role)?);
+
+        Ok((
+            Self {
+                id: web_id,
+                admin_role,
+                member_role,
+                machine,
+            },
+            policies,
+        ))
+    }
+}
+
+#[derive(Debug, serde::Serialize)]
+struct Team {
+    id: TeamId,
+    admin_role: TeamRoleId,
+    member_role: TeamRoleId,
+}
+
+impl Team {
+    fn generate() -> Self {
+        Self {
+            id: TeamId::new(Uuid::new_v4()),
+            admin_role: TeamRoleId::new(Uuid::new_v4()),
+            member_role: TeamRoleId::new(Uuid::new_v4()),
+        }
+    }
+}
+
+fn generate_user(web: &Web) -> Result<User, Box<dyn Error>> {
+    let user_id = UserId::new(web.id.into_uuid());
+    let entity = EntityResource {
+        web_id: web.id,
+        id: EntityUuid::new(user_id.into_uuid()),
+        entity_type: Cow::Owned(vec![
+            VersionedUrl::from_str("https://hash.ai/@h/types/entity-type/user/v/6")?,
+            VersionedUrl::from_str("https://hash.ai/@h/types/entity-type/actor/v/2")?,
+        ]),
+    };
+
+    Ok(User {
+        id: user_id,
+        roles: vec![RoleId::Web(web.admin_role)],
+        entity,
+    })
+}
+
+#[derive(Debug, serde::Serialize)]
+struct System {
+    web: Web,
+    machine: Machine,
+    hash_ai_machine: Machine,
+    hash_instance_admins: Team,
+    hash_instance_entity: EntityResource<'static>,
+}
+
+impl System {
+    fn generate() -> Result<(Self, Vec<Policy>), Box<dyn Error>> {
+        let (web, mut policies) = Web::generate()?;
+        let system_machine = generate_machine(web.id, vec![RoleId::Web(web.admin_role)])?;
+        let hash_ai_machine = generate_machine(web.id, Vec::new())?;
+
+        let hash_instance_admins = Team::generate();
+        let hash_instance_entity = EntityResource {
+            web_id: web.id,
+            id: EntityUuid::new(Uuid::new_v4()),
+            entity_type: Cow::Owned(vec![VersionedUrl::from_str(
+                "https://hash.ai/@h/types/entity-type/hash-instance/v/1",
+            )?]),
+        };
+
+        policies.extend(forbid_update_web_machine()?);
+        policies.extend(permit_view_system_entities(web.id)?);
+        policies.extend(permit_view_ontology()?);
+        policies.extend(permit_instantiate(system_machine.id)?);
+        policies.extend(permit_hash_instance_admins(
+            hash_instance_admins.admin_role,
+            hash_instance_admins.member_role,
+            hash_instance_entity.id,
+        )?);
+
+        Ok((
+            Self {
+                web,
+                machine: system_machine,
+                hash_ai_machine,
+                hash_instance_admins,
+                hash_instance_entity,
+            },
+            policies,
+        ))
+    }
+
+    fn extend_context(&self, context: &mut ContextBuilder) {
+        context.add_machine(&self.web.machine);
+        context.add_machine(&self.machine);
+        context.add_machine(&self.hash_ai_machine);
+        context.add_entity(&self.hash_instance_entity);
+    }
+}
+
+#[test]
+fn instantiate() -> Result<(), Box<dyn Error>> {
+    let mut context = ContextBuilder::default();
+
+    let (system, system_policies) = System::generate()?;
+    system.extend_context(&mut context);
+
+    let machine_type = EntityTypeResource {
+        web_id: system.web.id,
+        id: Cow::Owned(EntityTypeId::new(VersionedUrl::from_str(
+            "https://hash.ai/@h/types/entity-type/machine/v/2",
+        )?)),
+    };
+    context.add_entity_type(&machine_type);
+
+    let document_type = EntityTypeResource {
+        web_id: system.web.id,
+        id: Cow::Owned(EntityTypeId::new(VersionedUrl::from_str(
+            "https://hash.ai/@h/types/entity-type/document/v/1",
+        )?)),
+    };
+    context.add_entity_type(&document_type);
+
+    let context = context.build()?;
+    let policy_set = PolicySet::default().with_policies(&system_policies)?;
+
+    // Only the system machine can instantiate a machine
+    assert!(!policy_set.evaluate(
+        &Request {
+            actor: ActorId::Machine(system.web.machine.id),
+            action: ActionId::Instantiate,
+            resource: &ResourceId::EntityType(Cow::Borrowed(&machine_type.id)),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+    assert!(policy_set.evaluate(
+        &Request {
+            actor: ActorId::Machine(system.machine.id),
+            action: ActionId::Instantiate,
+            resource: &ResourceId::EntityType(Cow::Borrowed(&machine_type.id)),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+
+    assert!(policy_set.evaluate(
+        &Request {
+            actor: ActorId::Machine(system.web.machine.id),
+            action: ActionId::Instantiate,
+            resource: &ResourceId::EntityType(Cow::Borrowed(&document_type.id)),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+    assert!(policy_set.evaluate(
+        &Request {
+            actor: ActorId::Machine(system.machine.id),
+            action: ActionId::Instantiate,
+            resource: &ResourceId::EntityType(Cow::Borrowed(&document_type.id)),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+
+    Ok(())
+}
+
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Mostly asserting the correct policies are applied"
+)]
+fn user_web_permissions() -> Result<(), Box<dyn Error>> {
+    let mut context = ContextBuilder::default();
+
+    let (system, system_policies) = System::generate()?;
+    system.extend_context(&mut context);
+
+    let (user_web, user_web_policies) = Web::generate()?;
+    context.add_machine(&user_web.machine);
+    let user = generate_user(&user_web)?;
+    context.add_user(&user);
+
+    let machine_type = EntityTypeResource {
+        web_id: system.web.id,
+        id: Cow::Owned(EntityTypeId::new(VersionedUrl::from_str(
+            "https://hash.ai/@h/types/entity-type/machine/v/2",
+        )?)),
+    };
+    context.add_entity_type(&machine_type);
+
+    let document_type = EntityTypeResource {
+        web_id: system.web.id,
+        id: Cow::Owned(EntityTypeId::new(VersionedUrl::from_str(
+            "https://hash.ai/@h/types/entity-type/document/v/1",
+        )?)),
+    };
+    context.add_entity_type(&document_type);
+
+    let web_type = EntityTypeResource {
+        web_id: user_web.id,
+        id: Cow::Owned(EntityTypeId::new(VersionedUrl::from_str(
+            "https://hash.ai/@alice/types/entity-type/custom/v/1",
+        )?)),
+    };
+    context.add_entity_type(&web_type);
+
+    let web_entity = EntityResource {
+        web_id: user_web.id,
+        id: EntityUuid::new(Uuid::new_v4()),
+        entity_type: Cow::Owned(vec![web_type.id.as_url().clone()]),
+    };
+    context.add_entity(&web_entity);
+
+    let context = context.build()?;
+    let policy_set = PolicySet::default()
+        .with_policies(&system_policies)?
+        .with_policies(&user_web_policies)?;
+
+    assert!(!policy_set.evaluate(
+        &Request {
+            actor: ActorId::User(user.id),
+            action: ActionId::Instantiate,
+            resource: &ResourceId::EntityType(Cow::Borrowed(&machine_type.id)),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+    assert!(policy_set.evaluate(
+        &Request {
+            actor: ActorId::User(user.id),
+            action: ActionId::Instantiate,
+            resource: &ResourceId::EntityType(Cow::Borrowed(&document_type.id)),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+    assert!(policy_set.evaluate(
+        &Request {
+            actor: ActorId::User(user.id),
+            action: ActionId::Instantiate,
+            resource: &ResourceId::EntityType(Cow::Borrowed(&web_type.id)),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+
+    assert!(policy_set.evaluate(
+        &Request {
+            actor: ActorId::User(user.id),
+            action: ActionId::View,
+            resource: &ResourceId::Entity(web_entity.id),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+    assert!(policy_set.evaluate(
+        &Request {
+            actor: ActorId::Machine(user_web.machine.id),
+            action: ActionId::View,
+            resource: &ResourceId::Entity(web_entity.id),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+    assert!(!policy_set.evaluate(
+        &Request {
+            actor: ActorId::Machine(system.web.machine.id),
+            action: ActionId::View,
+            resource: &ResourceId::Entity(web_entity.id),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+
+    assert!(policy_set.evaluate(
+        &Request {
+            actor: ActorId::User(user.id),
+            action: ActionId::Update,
+            resource: &ResourceId::Entity(web_entity.id),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+    assert!(policy_set.evaluate(
+        &Request {
+            actor: ActorId::Machine(user_web.machine.id),
+            action: ActionId::Update,
+            resource: &ResourceId::Entity(web_entity.id),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+    assert!(!policy_set.evaluate(
+        &Request {
+            actor: ActorId::Machine(system.web.machine.id),
+            action: ActionId::Update,
+            resource: &ResourceId::Entity(web_entity.id),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+
+    Ok(())
+}
+
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "Mostly asserting the correct policies are applied"
+)]
+fn org_web_permissions() -> Result<(), Box<dyn Error>> {
+    let mut context = ContextBuilder::default();
+
+    let (system, system_policies) = System::generate()?;
+    system.extend_context(&mut context);
+
+    let (org_web, org_web_policies) = Web::generate()?;
+    context.add_machine(&org_web.machine);
+
+    let (user_web, user_web_policies) = Web::generate()?;
+    context.add_machine(&user_web.machine);
+    let mut user = generate_user(&user_web)?;
+    user.roles.push(RoleId::Web(org_web.member_role));
+    context.add_user(&user);
+
+    let web_type = EntityTypeResource {
+        web_id: org_web.id,
+        id: Cow::Owned(EntityTypeId::new(VersionedUrl::from_str(
+            "https://hash.ai/@alice/types/entity-type/custom/v/1",
+        )?)),
+    };
+    context.add_entity_type(&web_type);
+
+    let web_entity = EntityResource {
+        web_id: org_web.id,
+        id: EntityUuid::new(Uuid::new_v4()),
+        entity_type: Cow::Owned(vec![web_type.id.as_url().clone()]),
+    };
+    context.add_entity(&web_entity);
+
+    let context = context.build()?;
+    let policy_set = PolicySet::default()
+        .with_policies(&system_policies)?
+        .with_policies(&org_web_policies)?
+        .with_policies(&user_web_policies)?;
+    println!("context:\n{context:?}\npolicies:\n{policy_set:?}");
+    println!("{:?}", org_web.machine.id);
+
+    assert!(policy_set.evaluate(
+        &Request {
+            actor: ActorId::Machine(org_web.machine.id),
+            action: ActionId::View,
+            resource: &ResourceId::Entity(user_web.machine.entity.id),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+
+    assert!(policy_set.evaluate(
+        &Request {
+            actor: ActorId::User(user.id),
+            action: ActionId::View,
+            resource: &ResourceId::Entity(web_entity.id),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+    assert!(policy_set.evaluate(
+        &Request {
+            actor: ActorId::Machine(org_web.machine.id),
+            action: ActionId::View,
+            resource: &ResourceId::Entity(web_entity.id),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+    assert!(!policy_set.evaluate(
+        &Request {
+            actor: ActorId::Machine(user_web.machine.id),
+            action: ActionId::View,
+            resource: &ResourceId::Entity(web_entity.id),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+    assert!(!policy_set.evaluate(
+        &Request {
+            actor: ActorId::Machine(system.web.machine.id),
+            action: ActionId::View,
+            resource: &ResourceId::Entity(web_entity.id),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+
+    assert!(policy_set.evaluate(
+        &Request {
+            actor: ActorId::User(user.id),
+            action: ActionId::Update,
+            resource: &ResourceId::Entity(web_entity.id),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+    assert!(policy_set.evaluate(
+        &Request {
+            actor: ActorId::Machine(org_web.machine.id),
+            action: ActionId::Update,
+            resource: &ResourceId::Entity(web_entity.id),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+    assert!(!policy_set.evaluate(
+        &Request {
+            actor: ActorId::Machine(user_web.machine.id),
+            action: ActionId::Update,
+            resource: &ResourceId::Entity(web_entity.id),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+    assert!(!policy_set.evaluate(
+        &Request {
+            actor: ActorId::Machine(system.web.machine.id),
+            action: ActionId::Update,
+            resource: &ResourceId::Entity(web_entity.id),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+
+    Ok(())
+}
+
+#[test]
+fn instance_admin_without_access_permissions() -> Result<(), Box<dyn Error>> {
+    let mut context = ContextBuilder::default();
+
+    let (system, system_policies) = System::generate()?;
+    system.extend_context(&mut context);
+
+    let (user_web, user_web_policies) = Web::generate()?;
+    context.add_machine(&user_web.machine);
+    let user = generate_user(&user_web)?;
+    context.add_user(&user);
+
+    let context = context.build()?;
+    let policy_set = PolicySet::default()
+        .with_policies(&system_policies)?
+        .with_policies(&user_web_policies)?;
+
+    assert!(policy_set.evaluate(
+        &Request {
+            actor: ActorId::User(user.id),
+            action: ActionId::View,
+            resource: &ResourceId::Entity(system.hash_instance_entity.id),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+    assert!(!policy_set.evaluate(
+        &Request {
+            actor: ActorId::User(user.id),
+            action: ActionId::Update,
+            resource: &ResourceId::Entity(system.hash_instance_entity.id),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+
+    Ok(())
+}
+
+#[test]
+fn instance_admin_with_access_permissions() -> Result<(), Box<dyn Error>> {
+    let mut context = ContextBuilder::default();
+
+    let (system, system_policies) = System::generate()?;
+    system.extend_context(&mut context);
+
+    let (user_web, user_web_policies) = Web::generate()?;
+    context.add_machine(&user_web.machine);
+    let mut user = generate_user(&user_web)?;
+    user.roles
+        .push(RoleId::Team(system.hash_instance_admins.admin_role));
+    context.add_user(&user);
+
+    let context = context.build()?;
+    let policy_set = PolicySet::default()
+        .with_policies(&system_policies)?
+        .with_policies(&user_web_policies)?;
+
+    assert!(policy_set.evaluate(
+        &Request {
+            actor: ActorId::User(user.id),
+            action: ActionId::View,
+            resource: &ResourceId::Entity(system.hash_instance_entity.id),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+    assert!(policy_set.evaluate(
+        &Request {
+            actor: ActorId::User(user.id),
+            action: ActionId::Update,
+            resource: &ResourceId::Entity(system.hash_instance_entity.id),
+            context: RequestContext::default(),
+        },
+        &context,
+    )?);
+
+    Ok(())
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We require a set of policies to drive the Graph in general. This PR adds common policies and missing features associated with them.

## 🚫 Blocked by

- https://github.com/hashintel/hash/pull/6518

## 🔍 What does this change?

- Add `IsAllTypes` and `IsAnyType` to restrict policies to multiple (at least one or all) types in an entity
- Allow filtering entity types (A combination of `All`, `Any`, `Not`, `IsBaseUrl` and `IsVersion`
- Add a range of policies for testing
- Run different sets of request against the policies

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph