### PR TITLE
H-4135, H-4136: Disable automatic updates for PDFium-render

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>hashintel/.github:renovate-config"],
   "description": "HASH public monorepo (hashintel/hash) Renovate configuration",
-  "dependencyDashboardOSVVulnerabilitySummary": "none"
+  "dependencyDashboardOSVVulnerabilitySummary": "none",
+  "packageRules": [
+    {
+      "matchManagers": ["cargo"],
+      "matchFileNames": ["libs/error-stack/Cargo.toml"],
+      "matchPackageNames": ["anyhow"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["pdfium-render"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Updating PDFium-render cannot easily be automated because the external libraries needs to be updated as well. This includes the GH actions and the readme.

## 🔍 What does this change?

- Disable automatic updating for PDFium-render
- Move the `error-stack` rule to not update `anyhow` from `hashintel/.github`