### PR TITLE
Make `exclusiveMinimum`/ `Maximum` number instead of boolean

### DIFF
--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/any_of.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/any_of.rs
@@ -30,7 +30,7 @@ impl From<AnyOfConstraints> for ValueConstraints {
             && constraints.any_of[0].description.is_none()
             && constraints.any_of[0].label.is_empty()
         {
-            Self::Typed(constraints.any_of.remove(0).constraints)
+            Self::Typed(Box::new(constraints.any_of.remove(0).constraints))
         } else {
             Self::AnyOf(constraints)
         }

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/array.rs
@@ -153,7 +153,7 @@ mod wasm {
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(untagged, rename_all = "camelCase")]
 pub enum ArraySchema {
-    Constrained(ArrayConstraints),
+    Constrained(Box<ArrayConstraints>),
     Tuple(TupleConstraints),
 }
 
@@ -164,10 +164,10 @@ impl Constraint for ArraySchema {
     ) -> Result<(Self, Option<Self>), Report<ResolveClosedDataTypeError>> {
         Ok(match (self, other) {
             (Self::Constrained(lhs), Self::Constrained(rhs)) => {
-                let (combined, remainder) = lhs.intersection(rhs)?;
+                let (combined, remainder) = lhs.intersection(*rhs)?;
                 (
-                    Self::Constrained(combined),
-                    remainder.map(Self::Constrained),
+                    Self::Constrained(Box::new(combined)),
+                    remainder.map(|remainder| Self::Constrained(Box::new(remainder))),
                 )
             }
             (Self::Tuple(lhs), Self::Constrained(rhs)) => {

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/constraint/string.rs
@@ -261,9 +261,9 @@ impl Constraint for StringSchema {
                         .try_collect_reports()
                         .change_context_lazy(|| {
                             ResolveClosedDataTypeError::UnsatisfiedEnumConstraint(
-                                ValueConstraints::Typed(SingleValueConstraints::String(
+                                ValueConstraints::Typed(Box::new(SingleValueConstraints::String(
                                     Self::Constrained(constraints.clone()),
-                                )),
+                                ))),
                             )
                         })?;
 
@@ -271,8 +271,8 @@ impl Constraint for StringSchema {
                     // should be caught by the schema validation, however, if this still happens
                     // we return an error as validating empty enum will always fail.
                     bail!(ResolveClosedDataTypeError::UnsatisfiedEnumConstraint(
-                        ValueConstraints::Typed(SingleValueConstraints::String(Self::Constrained(
-                            constraints
+                        ValueConstraints::Typed(Box::new(SingleValueConstraints::String(
+                            Self::Constrained(constraints),
                         ))),
                     ))
                 }
@@ -398,18 +398,18 @@ impl Constraint for StringConstraints {
                 ensure!(
                     lhs == rhs,
                     ResolveClosedDataTypeError::IncompatibleConstraints(
-                        ValueConstraints::Typed(SingleValueConstraints::String(
+                        ValueConstraints::Typed(Box::new(SingleValueConstraints::String(
                             StringSchema::Constrained(Self {
                                 format: Some(lhs),
                                 ..Self::default()
                             }),
-                        )),
-                        ValueConstraints::Typed(SingleValueConstraints::String(
+                        ))),
+                        ValueConstraints::Typed(Box::new(SingleValueConstraints::String(
                             StringSchema::Constrained(Self {
                                 format: Some(rhs),
                                 ..Self::default()
                             }),
-                        ))
+                        ))),
                     )
                 );
                 Some(lhs)
@@ -428,12 +428,14 @@ impl Constraint for StringConstraints {
             ensure!(
                 min_length <= max_length,
                 ResolveClosedDataTypeError::UnsatisfiableConstraint(ValueConstraints::Typed(
-                    SingleValueConstraints::String(StringSchema::Constrained(Self {
-                        min_length: Some(min_length),
-                        max_length: Some(max_length),
-                        ..Self::default()
-                    }),)
-                ),)
+                    Box::new(SingleValueConstraints::String(StringSchema::Constrained(
+                        Self {
+                            min_length: Some(min_length),
+                            max_length: Some(max_length),
+                            ..Self::default()
+                        }
+                    ))),
+                ))
             );
         }
 

--- a/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/schema/data_type/mod.rs
@@ -274,7 +274,7 @@ mod raw {
                 } => (
                     base,
                     metadata,
-                    ValueConstraints::Typed(SingleValueConstraints::Null),
+                    ValueConstraints::Typed(Box::new(SingleValueConstraints::Null)),
                 ),
                 DataType::Boolean {
                     r#type: _,
@@ -283,7 +283,7 @@ mod raw {
                 } => (
                     base,
                     metadata,
-                    ValueConstraints::Typed(SingleValueConstraints::Boolean),
+                    ValueConstraints::Typed(Box::new(SingleValueConstraints::Boolean)),
                 ),
                 DataType::Number {
                     r#type: _,
@@ -293,9 +293,9 @@ mod raw {
                 } => (
                     base,
                     metadata,
-                    ValueConstraints::Typed(SingleValueConstraints::Number(
+                    ValueConstraints::Typed(Box::new(SingleValueConstraints::Number(
                         NumberSchema::Constrained(constraints),
-                    )),
+                    ))),
                 ),
                 DataType::NumberEnum {
                     r#type: _,
@@ -305,9 +305,9 @@ mod raw {
                 } => (
                     base,
                     metadata,
-                    ValueConstraints::Typed(SingleValueConstraints::Number(NumberSchema::Enum {
-                        r#enum,
-                    })),
+                    ValueConstraints::Typed(Box::new(SingleValueConstraints::Number(
+                        NumberSchema::Enum { r#enum },
+                    ))),
                 ),
                 DataType::String {
                     r#type: _,
@@ -317,9 +317,9 @@ mod raw {
                 } => (
                     base,
                     metadata,
-                    ValueConstraints::Typed(SingleValueConstraints::String(
+                    ValueConstraints::Typed(Box::new(SingleValueConstraints::String(
                         StringSchema::Constrained(constraints),
-                    )),
+                    ))),
                 ),
                 DataType::StringEnum {
                     r#type: _,
@@ -329,9 +329,9 @@ mod raw {
                 } => (
                     base,
                     metadata,
-                    ValueConstraints::Typed(SingleValueConstraints::String(StringSchema::Enum {
-                        r#enum,
-                    })),
+                    ValueConstraints::Typed(Box::new(SingleValueConstraints::String(
+                        StringSchema::Enum { r#enum },
+                    ))),
                 ),
                 DataType::Object {
                     r#type: _,
@@ -340,7 +340,7 @@ mod raw {
                 } => (
                     base,
                     metadata,
-                    ValueConstraints::Typed(SingleValueConstraints::Object),
+                    ValueConstraints::Typed(Box::new(SingleValueConstraints::Object)),
                 ),
                 DataType::Array {
                     r#type: _,
@@ -350,9 +350,9 @@ mod raw {
                 } => (
                     base,
                     metadata,
-                    ValueConstraints::Typed(SingleValueConstraints::Array(
-                        ArraySchema::Constrained(constraints),
-                    )),
+                    ValueConstraints::Typed(Box::new(SingleValueConstraints::Array(
+                        ArraySchema::Constrained(Box::new(constraints)),
+                    ))),
                 ),
                 DataType::Tuple {
                     r#type: _,
@@ -362,8 +362,8 @@ mod raw {
                 } => (
                     base,
                     metadata,
-                    ValueConstraints::Typed(SingleValueConstraints::Array(ArraySchema::Tuple(
-                        constraints,
+                    ValueConstraints::Typed(Box::new(SingleValueConstraints::Array(
+                        ArraySchema::Tuple(constraints),
                     ))),
                 ),
                 DataType::AnyOf {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`exclusiveMinimum` / `Maximum` is a number in JSON schema for a while.

## 🔍 What does this change?

- Enhance number constraint handling with more precise minimum/maximum logic
- Improve exclusive minimum/maximum constraint validation
- Simplify constraint intersection logic for number and data type schemas
- Remove unnecessary helper functions for float comparisons
- Drive-by: Wrap `SingleValueConstraints` and `ArraySchema` in `Box` to reduce memory usage

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph