### PR TITLE
H-4200: Fix Vercel frontend pointing to localhost

### DIFF
--- a/apps/hash-frontend/vercel-build.sh
+++ b/apps/hash-frontend/vercel-build.sh
@@ -5,15 +5,15 @@ set -euo pipefail
 source "$HOME/.cargo/env"
 eval "$(mise activate bash --shims)"
 
+echo "Changing dir to root"
+cd ../..
+
 # TODO: Mise is picking up `.env` files. We need to overhaul our approach for
 #   environment variables. To avoid this in the meantime, we'll remove the
 #   `.env` file.
 # See: https://linear.app/hash/issue/H-3213/use-consistent-naming-schema-for-environment-variables
 # See: https://linear.app/hash/issue/H-4202/sort-out-which-environment-variables-are-defined-where
 rm .env
-
-echo "Changing dir to root"
-cd ../..
 
 echo "Building frontend"
 turbo build --filter='@apps/hash-frontend' --env-mode=loose

--- a/apps/hash-frontend/vercel-build.sh
+++ b/apps/hash-frontend/vercel-build.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
+cat ~/.bashrc
+
 set -euo pipefail
+
 
 source "$HOME/.cargo/env"
 eval "$(mise activate bash --shims)"

--- a/apps/hash-frontend/vercel-build.sh
+++ b/apps/hash-frontend/vercel-build.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
 
-cat ~/.bashrc
-
 set -euo pipefail
-
 
 source "$HOME/.cargo/env"
 eval "$(mise activate bash --shims)"
 
 echo "FRONTEND_URL: $FRONTEND_URL"
 mise exec bash -- bash -c 'echo $FRONTEND_URL'
+
+rm .env
 
 echo "Changing dir to root"
 cd ../..

--- a/apps/hash-frontend/vercel-build.sh
+++ b/apps/hash-frontend/vercel-build.sh
@@ -5,9 +5,11 @@ set -euo pipefail
 source "$HOME/.cargo/env"
 eval "$(mise activate bash --shims)"
 
-echo "FRONTEND_URL: $FRONTEND_URL"
-mise exec bash -- bash -c 'echo $FRONTEND_URL'
-
+# TODO: Mise is picking up `.env` files. We need to overhaul our approach for
+#   environment variables. To avoid this in the meantime, we'll remove the
+#   `.env` file.
+# See: https://linear.app/hash/issue/H-3213/use-consistent-naming-schema-for-environment-variables
+# See: https://linear.app/hash/issue/H-4202/sort-out-which-environment-variables-are-defined-where
 rm .env
 
 echo "Changing dir to root"

--- a/apps/hash-frontend/vercel-build.sh
+++ b/apps/hash-frontend/vercel-build.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 source "$HOME/.cargo/env"
 eval "$(mise activate bash --shims)"
 
+echo "FRONTEND_URL: $FRONTEND_URL"
+mise exec bash -- bash -c 'echo $FRONTEND_URL'
+
 echo "Changing dir to root"
 cd ../..
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Mise is picking up the `.env` files which we currently don't want when building the Frontend. This removes the `.env` files before it get's built.

## 🐾 Next steps

- H-3213: Use consistent naming schema for environment variables
- H-4202: Sort out which environment variables are defined where