### PR TITLE
H-4232: Avoid running multiple AI reviews at the same time

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -10,6 +10,16 @@ on:
         required: true
         type: number
 
+# Prevent multiple AI review jobs from running simultaneously on the same PR
+# This ensures reviews are sequential and prevents duplicate/conflicting reviews
+concurrency:
+  # For workflow_dispatch events, we use github.ref (branch name)
+  # For pull_request events, we use the PR number
+  # This ensures a unique concurrency group per PR
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.ref }}
+  # Don't cancel in-progress reviews, let them complete
+  cancel-in-progress: false
+
 jobs:
   check-conditions:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -18,6 +18,7 @@ concurrency:
   # This ensures a unique concurrency group per PR
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.ref }}
   # Don't cancel in-progress reviews, let them complete
+  # New reviews will wait in queue until active ones finish
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -76,12 +76,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Checking if $PR_AUTHOR is a maintainer on $REPO"
-          
+
           # Get the permission level of the PR author
           PERMISSION=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             "https://api.github.com/repos/$REPO/collaborators/$PR_AUTHOR/permission" | \
             jq -r '.permission')
-          
+
           # Check if the permission level indicates maintainer status (admin or write)
           if [[ "$PERMISSION" == "admin" || "$PERMISSION" == "write" ]]; then
             echo "✅ $PR_AUTHOR is a maintainer"
@@ -126,7 +126,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Install turbo
+      - name: Install node and turbo
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
           install_args: node npm:turbo
@@ -135,7 +135,7 @@ jobs:
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo
-      
+
       - name: Determine PR number
         id: pr-number
         env:
@@ -148,7 +148,7 @@ jobs:
           else
             echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
           fi
-      
+
       - name: Run AI Code PR Review
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -156,4 +156,3 @@ jobs:
           PR_NUMBER: ${{ steps.pr-number.outputs.number }}
           GH_TOKEN: ${{ secrets.MACHINE_USER_TOKEN }}
         run: yarn workspace @local/repo-chores exe scripts/ai-pr-review.ts "$PR_NUMBER"
-          

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Install turbo
+      - name: Install node and turbo
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
           install_args: node npm:turbo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Install turbo
+      - name: Install node and turbo
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
           install_args: node npm:turbo

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Install turbo
+      - name: Install node and turbo
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
           install_args: node npm:turbo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Install turbo
+      - name: Install node and turbo
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
           install_args: node npm:turbo

--- a/libs/@local/repo-chores/node/scripts/ai-pr-review.ts
+++ b/libs/@local/repo-chores/node/scripts/ai-pr-review.ts
@@ -243,7 +243,7 @@ const processReviewResults = async (
  *
  * NOTE: This script is designed to run with a concurrency limit in GitHub Actions
  * to prevent multiple instances from running simultaneously on the same PR.
- * The concurrency configuration in the workflow file ensures:
+ * The concurrency configuration in `.github/workflows/ai-pr-review.yml` ensures:
  *   1. Only one review process runs at a time per PR
  *   2. Reviews complete before new ones start on the same PR
  *   3. Reviews capture the state of the PR at the time they were requested

--- a/libs/@local/repo-chores/node/scripts/ai-pr-review.ts
+++ b/libs/@local/repo-chores/node/scripts/ai-pr-review.ts
@@ -238,6 +238,16 @@ const processReviewResults = async (
   });
 };
 
+/**
+ * Main function for the AI PR review process
+ *
+ * NOTE: This script is designed to run with a concurrency limit in GitHub Actions
+ * to prevent multiple instances from running simultaneously on the same PR.
+ * The concurrency configuration in the workflow file ensures:
+ *   1. Only one review process runs at a time per PR
+ *   2. Reviews complete before new ones start on the same PR
+ *   3. Reviews capture the state of the PR at the time they were requested
+ */
 const main = async (): Promise<void> => {
   // Check for GitHub CLI and authentication
   try {

--- a/libs/@local/repo-chores/node/scripts/ai-pr-review/generate-comment-replies.ts
+++ b/libs/@local/repo-chores/node/scripts/ai-pr-review/generate-comment-replies.ts
@@ -191,7 +191,6 @@ export const generateCommentReplies = async ({
         }
 
         // Extract tags with @ prefix from comment
-        // Extract tags with @ prefix from comment
         const tagsInComment = commentReply.comment.match(/@[a-zA-Z0-9_-]+/g) ?? [];
 
         // Create valid tags list WITHOUT @ prefix

--- a/libs/@local/repo-chores/node/scripts/ai-pr-review/generate-comment-replies.ts
+++ b/libs/@local/repo-chores/node/scripts/ai-pr-review/generate-comment-replies.ts
@@ -45,7 +45,7 @@ You are 'hashdotai', a senior software engineer providing responses to code revi
 You are responding to comments on a pull request. For each comment:
 1. Read the original comment and any existing replies carefully
 2. If a response is required, provide a helpful, constructive response. If it's optional, reply if you can add value. Don't reply for the sake of it – it takes up your time unnecessarily.
-3. Always @mention the relevant participants in the conversation by using the exact username with @ prefix (e.g., @username)
+3. Always @mention the relevant participants in the conversation by using the exact username with @ prefix (e.g., @username). For example, if responding to user 'johndoe', tag them as '@johndoe'.
 4. Don't tag yourself (@hashdotai) in your responses
 5. Never use general tags like "you" - always use specific GitHub usernames with the @ prefix
 6. Be specific and address the questions or concerns raised

--- a/libs/@local/repo-chores/node/scripts/ai-pr-review/generate-comment-replies.ts
+++ b/libs/@local/repo-chores/node/scripts/ai-pr-review/generate-comment-replies.ts
@@ -49,7 +49,7 @@ You are responding to comments on a pull request. For each comment:
 4. Don't tag yourself (@hashdotai) in your responses
 5. Never use general tags like "you" - always use specific GitHub usernames with the @ prefix
 6. Be specific and address the questions or concerns raised
-7. Provide code suggestions using GitHub's code suggestion format if you can suggest a specific code change / implementation
+7. Provide code suggestions using GitHub's code suggestion format if you can suggest a specific code change / implementation. When doing a suggestion, make sure you describe why you suggest the change.
 `;
 
 /**
@@ -175,7 +175,7 @@ export const generateCommentReplies = async ({
       const badTags: {
         incorrectTags: string[];
         threadId: number;
-        validTags: string[];
+        validTagsWithoutPrefix: string[];
       }[] = [];
 
       const invalidCommentIds: number[] = [];
@@ -216,7 +216,7 @@ export const generateCommentReplies = async ({
           badTags.push({
             incorrectTags: invalidTags,
             threadId: commentReply.threadId,
-            validTags: validTagsWithoutPrefix,
+            validTagsWithoutPrefix,
           });
         }
       }
@@ -224,11 +224,11 @@ export const generateCommentReplies = async ({
       const errorStrings = [
         ...(badTags.length
           ? badTags.map(
-              ({ threadId, validTags, incorrectTags }) =>
+              ({ threadId, validTagsWithoutPrefix, incorrectTags }) =>
                 `You provided a response to comment id ${threadId} and tagged these authors, but they are invalid: ${incorrectTags.join(
                   ", ",
-                )}. The valid tags are: ${validTags
-                  .map((tag) => tag.startsWith('@') ? tag : `@${tag}`) 
+                )}. The valid tags are: ${validTagsWithoutPrefix
+                  .map((tag) => (tag.startsWith("@") ? tag : `@${tag}`))
                   .join(
                     ", ",
                   )}. You must tag participants in the conversation (and not yourself – you are 'hashdotai')`,

--- a/libs/@local/repo-chores/node/scripts/ai-pr-review/generate-comment-replies.ts
+++ b/libs/@local/repo-chores/node/scripts/ai-pr-review/generate-comment-replies.ts
@@ -191,7 +191,8 @@ export const generateCommentReplies = async ({
         }
 
         // Extract tags with @ prefix from comment
-        const tagsInComment = commentReply.comment.match(/@[a-zA-Z0-9_-]+/g) ?? [];
+        const tagsInComment =
+          commentReply.comment.match(/@[a-zA-Z0-9_-]+/g) ?? [];
 
         // Create valid tags list WITHOUT @ prefix
         const validTagsWithoutPrefix = [

--- a/libs/@local/repo-chores/node/scripts/ai-pr-review/generate-comment-replies.ts
+++ b/libs/@local/repo-chores/node/scripts/ai-pr-review/generate-comment-replies.ts
@@ -228,7 +228,7 @@ export const generateCommentReplies = async ({
                 `You provided a response to comment id ${threadId} and tagged these authors, but they are invalid: ${incorrectTags.join(
                   ", ",
                 )}. The valid tags are: ${validTags
-                  .map((tag) => (tag.startsWith("@") ? tag : `@${tag}`))
+                  .map((tag) => tag.startsWith('@') ? tag : `@${tag}`) 
                   .join(
                     ", ",
                   )}. You must tag participants in the conversation (and not yourself – you are 'hashdotai')`,

--- a/libs/@local/repo-chores/node/scripts/ai-pr-review/generate-comment-replies.ts
+++ b/libs/@local/repo-chores/node/scripts/ai-pr-review/generate-comment-replies.ts
@@ -191,7 +191,8 @@ export const generateCommentReplies = async ({
         }
 
         // Extract tags with @ prefix from comment
-        const tagsInComment = commentReply.comment.match(/@[^\s]+/g) ?? [];
+        // Extract tags with @ prefix from comment
+        const tagsInComment = commentReply.comment.match(/@[a-zA-Z0-9_-]+/g) ?? [];
 
         // Create valid tags list WITHOUT @ prefix
         const validTagsWithoutPrefix = [


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR addresses two issues:

1. Prevents multiple AI reviews from running simultaneously on the same pull
request by adding concurrency configuration to the GitHub workflow
2. Fixes tag resolution bugs in AI comment replies that caused invalid tag errors

## 🔗 Related links

- [H-4232: Avoid running multiple AI reviews at the same time](https://linear.app/hash/issue/H-4232/avoid-running-multiple-ai-reviews-at-the-same-time)

## 🔍 What does this change?

### Concurrency Configuration:
- Adds concurrency configuration to the GitHub workflow file
`.github/workflows/ai-pr-review.yml`
- Configures concurrency group to use PR number or inputs for workflow_dispatch 
events
- Sets `cancel-in-progress: false` to ensure reviews complete before new ones 
start
- Adds explanatory comments documenting the concurrency behavior

### Tag Resolution Fixes:
- Improves tag handling in `generate-comment-replies.ts` to properly handle @ 
prefixes
- Filters out special tags like "hashdotai" and "you" from valid tags list
- Enhances error messages for invalid tags with clearer formatting
- Updates system prompt to provide better guidance on tag usage and suggestions

### Other Improvements:
- Adds comprehensive documentation to explain concurrency and tag validation
- Clarifies step names in GitHub workflow files (e.g., "Install node and turbo")
- Improves code suggestions guidance in the system prompt

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not
  need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- The concurrency configuration affects GitHub Actions workflow behavior which is 
challenging to test directly
- The tag resolution fixes were manually tested with actual PR comments

## ❓ How to test this?

1. Create a PR that triggers an AI review
2. While that review is running, trigger another review on the same PR
3. Confirm that the second review job waits for the first one to complete rather 
than running in parallel
4. Verify that tag resolution works correctly in AI comment replies by checking if
  the AI properly tags mentioned users