### PR TITLE
H-3921: Update migration files to access the correct ids for data and property types

### DIFF
--- a/.cursor/rules/ai-assistant-guidelines.mdc
+++ b/.cursor/rules/ai-assistant-guidelines.mdc
@@ -15,6 +15,11 @@ This file contains standards for how AI assistants should interact with codebase
 3. **Proactivity**: Anticipate rule requirements before starting work on any task.
 4. **Accuracy**: Ensure adherence to all relevant guidelines in every implementation.
 
+## Things to avoid
+
+1. Making changes unrelated to the task at hand - if you see other things in a file that could be improved, suggest them to the user!
+2. Getting stuck for a long time without asking for help - if you're struggling, just ask.
+
 ## Self-Checking Process
 
 When working on any project task:

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/017-add-use-case-form-and-example-org.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/017-add-use-case-form-and-example-org.migration.ts
@@ -14,6 +14,7 @@ import {
   anyUserInstantiator,
   createSystemEntityTypeIfNotExists,
   createSystemPropertyTypeIfNotExists,
+  getCurrentHashPropertyTypeId,
 } from "../util";
 
 const migrate: MigrationFunction = async ({
@@ -101,11 +102,17 @@ const migrate: MigrationFunction = async ({
         labelProperty: systemPropertyTypes.email.propertyTypeBaseUrl,
         properties: [
           {
-            propertyType: systemPropertyTypes.websiteUrl.propertyTypeId,
+            propertyType: getCurrentHashPropertyTypeId({
+              propertyTypeKey: "websiteUrl",
+              migrationState,
+            }),
             required: true,
           },
           {
-            propertyType: systemPropertyTypes.email.propertyTypeId,
+            propertyType: getCurrentHashPropertyTypeId({
+              propertyTypeKey: "email",
+              migrationState,
+            }),
             required: true,
           },
           {

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/019-add-doc-company-and-person-types.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/019-add-doc-company-and-person-types.migration.ts
@@ -13,6 +13,7 @@ import {
   createSystemPropertyTypeIfNotExists,
   getCurrentHashDataTypeId,
   getCurrentHashLinkEntityTypeId,
+  getCurrentHashPropertyTypeId,
 } from "../util";
 
 const migrate: MigrationFunction = async ({
@@ -379,7 +380,10 @@ const migrate: MigrationFunction = async ({
             propertyType: blockProtocolPropertyTypes.description.propertyTypeId,
           },
           {
-            propertyType: systemPropertyTypes.email.propertyTypeId,
+            propertyType: getCurrentHashPropertyTypeId({
+              propertyTypeKey: "email",
+              migrationState,
+            }),
             array: true,
           },
         ],
@@ -427,7 +431,10 @@ const migrate: MigrationFunction = async ({
         labelProperty: systemPropertyTypes.title.propertyTypeBaseUrl,
         properties: [
           {
-            propertyType: systemPropertyTypes.title.propertyTypeId,
+            propertyType: getCurrentHashPropertyTypeId({
+              propertyTypeKey: "title",
+              migrationState,
+            }),
             required: true,
           },
           {
@@ -488,7 +495,10 @@ const migrate: MigrationFunction = async ({
         description: "A paper describing academic research",
         properties: [
           {
-            propertyType: systemPropertyTypes.title.propertyTypeId,
+            propertyType: getCurrentHashPropertyTypeId({
+              propertyTypeKey: "title",
+              migrationState,
+            }),
             required: true,
           },
           {

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/020-add-study-record-type.dev.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/020-add-study-record-type.dev.migration.ts
@@ -1,7 +1,6 @@
 import {
   blockProtocolDataTypes,
   blockProtocolPropertyTypes,
-  systemDataTypes,
   systemPropertyTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { linkEntityTypeUrl } from "@local/hash-subgraph";
@@ -12,6 +11,8 @@ import {
   createSystemDataTypeIfNotExists,
   createSystemEntityTypeIfNotExists,
   createSystemPropertyTypeIfNotExists,
+  getCurrentHashDataTypeId,
+  getCurrentHashPropertyTypeId,
   getCurrentHashSystemEntityTypeId,
 } from "../util";
 
@@ -86,16 +87,26 @@ const migrate: MigrationFunction = async ({
     },
   );
 
+  const integerDataTypeId = getCurrentHashDataTypeId({
+    dataTypeKey: "integer",
+    migrationState,
+  });
+
   const actualEnrollmentPropertyType =
     await createSystemPropertyTypeIfNotExists(context, authentication, {
       propertyTypeDefinition: {
         title: "Actual Enrollment",
         description: "The actual number of participants enrolled in something.",
-        possibleValues: [{ dataTypeId: systemDataTypes.integer.dataTypeId }],
+        possibleValues: [{ dataTypeId: integerDataTypeId }],
       },
       migrationState,
       webShortname: "h",
     });
+
+  const dateDataTypeId = getCurrentHashDataTypeId({
+    dataTypeKey: "date",
+    migrationState,
+  });
 
   const actualStudyStartDatePropertyType =
     await createSystemPropertyTypeIfNotExists(context, authentication, {
@@ -103,7 +114,7 @@ const migrate: MigrationFunction = async ({
         title: "Actual Study Start Date",
         description:
           "The actual date on which the first participant was enrolled in a clinical study.",
-        possibleValues: [{ dataTypeId: systemDataTypes.date.dataTypeId }],
+        possibleValues: [{ dataTypeId: dateDataTypeId }],
       },
       migrationState,
       webShortname: "h",
@@ -115,7 +126,7 @@ const migrate: MigrationFunction = async ({
         title: "Actual Study Primary Completion Date",
         description:
           "The date on which the last participant in a study was examined or received an intervention to collect final data for the primary outcome measure.",
-        possibleValues: [{ dataTypeId: systemDataTypes.date.dataTypeId }],
+        possibleValues: [{ dataTypeId: dateDataTypeId }],
       },
       migrationState,
       webShortname: "h",
@@ -127,7 +138,7 @@ const migrate: MigrationFunction = async ({
         title: "Actual Study Completion Date",
         description:
           "The date on which the last participant in a clinical study was examined or received an intervention to collect final data for the primary outcome measures, secondary outcome measures, and adverse events (that is, the last participant's last visit).",
-        possibleValues: [{ dataTypeId: systemDataTypes.date.dataTypeId }],
+        possibleValues: [{ dataTypeId: dateDataTypeId }],
       },
       migrationState,
       webShortname: "h",
@@ -139,7 +150,7 @@ const migrate: MigrationFunction = async ({
         title: "Estimated Enrollment",
         description:
           "The estimated number of participants that will be enrolled in something.",
-        possibleValues: [{ dataTypeId: systemDataTypes.integer.dataTypeId }],
+        possibleValues: [{ dataTypeId: integerDataTypeId }],
       },
       migrationState,
       webShortname: "h",
@@ -151,7 +162,7 @@ const migrate: MigrationFunction = async ({
         title: "Estimated Study Start Date",
         description:
           "The estimated date on which the first participant will be enrolled in a clinical study.",
-        possibleValues: [{ dataTypeId: systemDataTypes.date.dataTypeId }],
+        possibleValues: [{ dataTypeId: dateDataTypeId }],
       },
       migrationState,
       webShortname: "h",
@@ -163,7 +174,7 @@ const migrate: MigrationFunction = async ({
         title: "Estimated Primary Completion Date",
         description:
           "The estimated date on which the last participant in a study will be examined or receive an intervention to collect final data for the primary outcome measure.",
-        possibleValues: [{ dataTypeId: systemDataTypes.date.dataTypeId }],
+        possibleValues: [{ dataTypeId: dateDataTypeId }],
       },
       migrationState,
       webShortname: "h",
@@ -175,7 +186,7 @@ const migrate: MigrationFunction = async ({
         title: "Estimated Study Completion Date",
         description:
           "The estimated date on which the last participant in a clinical study will be examined or receive an intervention to collect final data for the primary outcome measures, secondary outcome measures, and adverse events (that is, the last participant's last visit).",
-        possibleValues: [{ dataTypeId: systemDataTypes.date.dataTypeId }],
+        possibleValues: [{ dataTypeId: dateDataTypeId }],
       },
       migrationState,
       webShortname: "h",
@@ -333,7 +344,10 @@ const migrate: MigrationFunction = async ({
                 $ref: interventionPropertyType.schema.$id,
               },
               [systemPropertyTypes.methodology.propertyTypeBaseUrl]: {
-                $ref: systemPropertyTypes.methodology.propertyTypeId,
+                $ref: getCurrentHashPropertyTypeId({
+                  propertyTypeKey: "methodology",
+                  migrationState,
+                }),
               },
             },
             propertyTypeObjectRequiredProperties: [
@@ -465,7 +479,10 @@ const migrate: MigrationFunction = async ({
         icon: "/icons/types/microscope.svg",
         properties: [
           {
-            propertyType: systemPropertyTypes.methodology.propertyTypeId,
+            propertyType: getCurrentHashPropertyTypeId({
+              propertyTypeKey: "methodology",
+              migrationState,
+            }),
             required: true,
           },
           {
@@ -483,13 +500,22 @@ const migrate: MigrationFunction = async ({
             propertyType: isrctnIdPropertyType.schema.$id,
           },
           {
-            propertyType: systemPropertyTypes.doi.propertyTypeId,
+            propertyType: getCurrentHashPropertyTypeId({
+              propertyTypeKey: "doi",
+              migrationState,
+            }),
           },
           {
-            propertyType: systemPropertyTypes.doiLink.propertyTypeId,
+            propertyType: getCurrentHashPropertyTypeId({
+              propertyTypeKey: "doiLink",
+              migrationState,
+            }),
           },
           {
-            propertyType: systemPropertyTypes.location.propertyTypeId,
+            propertyType: getCurrentHashPropertyTypeId({
+              propertyTypeKey: "location",
+              migrationState,
+            }),
           },
           {
             propertyType: trialPhasePropertyType.schema.$id,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, the migration files access the ids for `DataType`s and `PropertyType`s required in the migrations from the in-repo generated type object, which always has the latest version.

When we ever create `v2` of a data type or property type (hasn't happened yet), depending on where in the migration the id is accessed, it might be incorrect if the instance hasn't yet run the migration to create that version.

This PR updates the id access to take it from the current migration state rather than the fixed 'latest versions' object.

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- ...

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- Migrations will fail if it's wrong.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Check AI passes

