### PR TITLE
H-4242: Exclude `.venv` from TOML linting

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,4 +1,4 @@
-exclude = ["node_modules/**"]
+exclude = ["**/.venv/**", "**/node_modules/**", "**/venv/**"]
 
 [formatting]
 align_entries       = true


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The world doesn't need to know that `/.venv/lib/python3.12/site-packages/pandas/pyproject.toml` doesn't match our lint rules. And we don't care! 