### PR TITLE
H-3348: Use `tsify-next` instead of `tsify`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,9 +2812,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-utils"
-version = "0.1.7"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037fcb07216cb3a30f7292bd0176b050b7b9a052ba830ef7d5d65f6dc64ba58e"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
 dependencies = [
  "js-sys",
  "serde",
@@ -7276,9 +7276,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.28.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e578a843d40b4189a4d66bba51d7684f57da5bd7c304c64e14bd63efbef49509"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8596,23 +8596,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "tsify"
-version = "0.4.5"
+name = "tsify-next"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b26cf145f2f3b9ff84e182c448eaf05468e247f148cf3d2a7d67d78ff023a0"
+checksum = "9a8bf7232b89b86f63b5f0ef22c64960f9cf4fb52c6698f1e7f60de93bc3292f"
 dependencies = [
  "gloo-utils",
  "serde",
  "serde_json",
- "tsify-macros",
+ "tsify-next-macros",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "tsify-macros"
-version = "0.4.5"
+name = "tsify-next-macros"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a94b0f0954b3e59bfc2c246b4c8574390d94a4ad4ad246aaf2fb07d7dfd3b47"
+checksum = "ab2d85ebe93eedca20d3fe6d65814c856467a649674aa7763ebd42e3bb815fec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8645,7 +8645,7 @@ dependencies = [
  "thiserror 2.0.12",
  "time",
  "tokio",
- "tsify",
+ "tsify-next",
  "url",
  "utoipa",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,7 +244,7 @@ tracing-opentelemetry    = { version = "=0.29.0", default-features = false }
 tracing-subscriber       = { version = "=0.3.19", default-features = false }
 trait-variant            = { version = "=0.1.2", default-features = false }
 trybuild                 = { version = "=1.0.104", default-features = false }
-tsify                    = { version = "=0.4.5", default-features = false }
+tsify-next               = { version = "=0.5.5", default-features = false }
 unicode-ident            = { version = "=1.0.18", default-features = false }
 url                      = { version = "=2.5.4", default-features = false }
 utoipa                   = { version = "=4.2.3", default-features = false }

--- a/libs/@blockprotocol/type-system/rust/Cargo.toml
+++ b/libs/@blockprotocol/type-system/rust/Cargo.toml
@@ -59,7 +59,7 @@ workspace = true
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.7" }
-tsify                    = { workspace = true, features = ["json"] }
+tsify-next               = { workspace = true, features = ["json"] }
 wasm-bindgen             = { version = "0.2.99", features = ["serde-serialize"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/confidence.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/confidence.rs
@@ -8,7 +8,7 @@ use utoipa::{
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Serialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "postgres", derive(FromSql, ToSql), postgres(transparent))]
 #[repr(transparent)]
 pub struct Confidence(

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/entity/id.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/entity/id.rs
@@ -15,7 +15,7 @@ use crate::web::OwnedById;
 #[derive(
     Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "postgres", derive(FromSql, ToSql), postgres(transparent))]
 #[cfg_attr(feature = "utoipa", derive(ToSchema))]
 #[repr(transparent)]
@@ -49,7 +49,7 @@ impl fmt::Display for EntityUuid {
 #[derive(
     Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "postgres", derive(FromSql, ToSql), postgres(transparent))]
 #[cfg_attr(feature = "utoipa", derive(ToSchema))]
 #[repr(transparent)]
@@ -165,15 +165,16 @@ impl ToSchema<'_> for EntityId {
 }
 
 #[cfg(target_arch = "wasm32")]
-#[derive(tsify::Tsify)]
-#[serde(rename = "EntityId")]
 #[expect(dead_code, reason = "Used in the generated TypeScript types")]
-pub struct EntityIdPatch(#[tsify(type = "Brand<string, \"EntityId\">")] String);
+mod patch {
+    #[derive(tsify_next::Tsify)]
+    pub struct EntityId(#[tsify(type = "Brand<string, \"EntityId\">")] String);
+}
 
 #[derive(
     Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "postgres", derive(FromSql, ToSql), postgres(transparent))]
 #[cfg_attr(feature = "utoipa", derive(ToSchema))]
 #[repr(transparent)]
@@ -203,7 +204,7 @@ impl EntityEditionId {
 }
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct EntityRecordId {

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/entity/link.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/entity/link.rs
@@ -6,7 +6,7 @@ use crate::knowledge::{Confidence, property::metadata::PropertyProvenance};
 /// The associated information for 'Link' entities
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct LinkData {
     pub left_entity_id: EntityId,

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/entity/metadata/diff.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/entity/metadata/diff.rs
@@ -6,7 +6,7 @@ use crate::ontology::VersionedUrl;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", tag = "op")]
 pub enum EntityTypeIdDiff<'e> {
     Added { added: Cow<'e, VersionedUrl> },

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/entity/metadata/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/entity/metadata/mod.rs
@@ -30,7 +30,7 @@ use crate::{
 /// This metadata provides context for interpreting and validating the entity's properties.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct EntityMetadata {
     /// Unique identifier for this entity record.
@@ -87,7 +87,7 @@ pub struct EntityMetadata {
 /// versus when it was recorded, enabling accurate historical queries.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EntityTemporalMetadata {
     /// The interval during which this entity version was decided to be inserted or considered

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/entity/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/entity/mod.rs
@@ -38,7 +38,7 @@ pub use self::{
 /// [`VersionedUrl`]: crate::ontology::VersionedUrl
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub struct Entity {
     /// The entity's properties, structured as a hierarchical object with keys that correspond to

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/entity/provenance.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/entity/provenance.rs
@@ -13,7 +13,7 @@ use crate::provenance::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct EntityEditionProvenance {
@@ -53,7 +53,7 @@ impl ToSql for EntityEditionProvenance {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct ProvidedEntityEditionProvenance {
@@ -64,7 +64,7 @@ pub struct ProvidedEntityEditionProvenance {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct InferredEntityProvenance {
@@ -111,7 +111,7 @@ impl ToSql for InferredEntityProvenance {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct EntityProvenance {

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/array.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/array.rs
@@ -1,7 +1,7 @@
 use super::{PropertyWithMetadata, metadata::ArrayMetadata};
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropertyArrayWithMetadata {

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/diff.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/diff.rs
@@ -21,7 +21,7 @@ use crate::knowledge::property::{Property, PropertyPath};
 /// particular path.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", tag = "op")]
 pub enum PropertyDiff<'e> {
     /// A property was added at the specified path.

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/metadata/array.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/metadata/array.rs
@@ -3,7 +3,7 @@ use crate::knowledge::Confidence;
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ArrayMetadata {
     #[serde(default, skip_serializing_if = "PropertyProvenance::is_empty")]
@@ -22,7 +22,7 @@ impl ArrayMetadata {
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropertyArrayMetadata {
     /// Metadata for each item in the array.

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/metadata/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/metadata/mod.rs
@@ -34,7 +34,7 @@ use serde::{Deserialize, Serialize};
 /// [`Property`]: crate::knowledge::property::Property
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(untagged)]
 pub enum PropertyMetadata {
     /// Metadata for an array property, containing element-level and array-level metadata.

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/metadata/object.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/metadata/object.rs
@@ -12,7 +12,7 @@ use crate::{knowledge::Confidence, ontology::BaseUrl};
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ObjectMetadata {
     #[serde(default, skip_serializing_if = "PropertyProvenance::is_empty")]
@@ -31,7 +31,7 @@ impl ObjectMetadata {
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropertyObjectMetadata {
     /// Metadata for each field in the object.

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/metadata/provenance.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/metadata/provenance.rs
@@ -10,7 +10,7 @@ use crate::provenance::SourceProvenance;
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropertyProvenance {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/metadata/value.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/metadata/value.rs
@@ -2,7 +2,7 @@ use crate::knowledge::value::ValueMetadata;
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropertyValueMetadata {
     /// Comprehensive metadata for a primitive value, including provenance,

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/mod.rs
@@ -60,7 +60,7 @@ use crate::ontology::{
 ///
 /// [`PropertyType`]: crate::ontology::property_type::PropertyType
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(untagged)]
 pub enum Property {
@@ -94,7 +94,7 @@ pub enum Property {
 /// The structure mirrors the [`Property`] enum, with specialized types for arrays, objects,
 /// and values that maintain metadata at each level of the hierarchy.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(untagged)]
 pub enum PropertyWithMetadata {

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/object.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/object.rs
@@ -17,7 +17,7 @@ use crate::{knowledge::PropertyValue, ontology::BaseUrl};
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 pub struct PropertyObject(HashMap<BaseUrl, Property>);
 
 impl PropertyObject {
@@ -135,7 +135,7 @@ impl<'a> FromSql<'a> for PropertyObject {
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropertyObjectWithMetadata {
     pub value: HashMap<BaseUrl, PropertyWithMetadata>,

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/patch.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/patch.rs
@@ -5,7 +5,7 @@ use crate::knowledge::property::{PropertyPath, PropertyWithMetadata};
 
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", tag = "op")]
 pub enum PropertyPatchOperation {
     Add {

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/path.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/path.rs
@@ -22,7 +22,7 @@ use crate::ontology::BaseUrl;
 /// deeply nested properties within the property hierarchy.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(untagged)]
 pub enum PropertyPathElement<'k> {
     /// A property key that addresses a specific field in an object property.
@@ -79,7 +79,7 @@ impl PropertyPathElement<'_> {
 /// A path can be empty (representing the root property) or contain any number of elements
 /// representing navigation through objects and arrays.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(transparent)]
 pub struct PropertyPath<'k> {
     /// The sequence of path elements that make up this property path.

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/value.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/value.rs
@@ -16,7 +16,7 @@ use crate::knowledge::value::{PropertyValue, ValueMetadata};
 /// [`PropertyWithMetadata`]: crate::knowledge::property::PropertyWithMetadata
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropertyValueWithMetadata {
     /// The primitive value data, such as a string, number, or boolean.

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/value/metadata/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/value/metadata/mod.rs
@@ -11,7 +11,7 @@ use crate::{
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ValueMetadata {
     #[serde(default, skip_serializing_if = "ValueProvenance::is_empty")]

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/value/metadata/provenance.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/value/metadata/provenance.rs
@@ -9,7 +9,7 @@ use postgres_types::{FromSql, IsNull, Json, ToSql, Type};
 use crate::provenance::SourceProvenance;
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ValueProvenance {

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/value/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/value/mod.rs
@@ -51,7 +51,7 @@ pub use self::metadata::ValueMetadata;
 ///
 /// [`DataType`]: crate::ontology::data_type::DataType
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(untagged)]
 pub enum PropertyValue {
     Null,

--- a/libs/@blockprotocol/type-system/rust/src/ontology/data_type/metadata.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/data_type/metadata.rs
@@ -26,20 +26,24 @@ pub struct DataTypeMetadata {
 }
 
 #[cfg(target_arch = "wasm32")]
-#[derive(tsify::Tsify)]
-#[serde(rename = "DataTypeMetadata", untagged)]
 #[expect(dead_code, reason = "Used in the generated TypeScript types")]
-enum DataTypeMetadataPatch {
-    #[serde(rename_all = "camelCase")]
-    Impl {
-        record_id: OntologyTypeRecordId,
-        #[serde(flatten)]
-        ownership: OntologyOwnership,
-        temporal_versioning: OntologyTemporalMetadata,
-        provenance: OntologyProvenance,
-        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-        conversions: HashMap<BaseUrl, Conversions>,
-    },
+mod metadata_patch {
+    use super::*;
+
+    #[derive(tsify_next::Tsify)]
+    #[serde(untagged)]
+    enum DataTypeMetadata {
+        #[serde(rename_all = "camelCase")]
+        Impl {
+            record_id: OntologyTypeRecordId,
+            #[serde(flatten)]
+            ownership: OntologyOwnership,
+            temporal_versioning: OntologyTemporalMetadata,
+            provenance: OntologyProvenance,
+            #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+            conversions: HashMap<BaseUrl, Conversions>,
+        },
+    }
 }
 
 #[cfg(feature = "utoipa")]
@@ -103,12 +107,15 @@ impl ToSchema<'static> for DataTypeMetadata {
 pub type DataTypeWithMetadata = OntologyTypeWithMetadata<DataType>;
 
 #[cfg(target_arch = "wasm32")]
-#[derive(tsify::Tsify)]
-#[serde(rename = "DataTypeWithMetadata")]
 #[expect(dead_code, reason = "Used in the generated TypeScript types")]
-struct DataTypeWithMetadataPatch {
-    schema: DataType,
-    metadata: DataTypeMetadata,
+mod with_metadata_patch {
+    use super::*;
+
+    #[derive(tsify_next::Tsify)]
+    struct DataTypeWithMetadata {
+        schema: DataType,
+        metadata: DataTypeMetadata,
+    }
 }
 
 #[cfg(feature = "utoipa")]

--- a/libs/@blockprotocol/type-system/rust/src/ontology/data_type/schema/closed.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/data_type/schema/closed.rs
@@ -22,7 +22,7 @@ use crate::{
 /// data types (via `allOf` references). It represents the complete set of constraints
 /// and metadata that apply to a particular data type after resolution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ClosedDataType {
     #[serde(rename = "$id")]

--- a/libs/@blockprotocol/type-system/rust/src/ontology/data_type/schema/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/data_type/schema/mod.rs
@@ -13,7 +13,7 @@ use crate::ontology::{
 };
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub struct ValueLabel {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -30,14 +30,14 @@ impl ValueLabel {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum DataTypeTag {
     DataType,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum DataTypeSchemaTag {
     #[serde(rename = "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type")]
@@ -45,7 +45,7 @@ pub enum DataTypeSchemaTag {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ValueSchemaMetadata {
     pub description: String,
@@ -71,7 +71,7 @@ mod raw {
     };
 
     #[derive(serde::Serialize, serde::Deserialize)]
-    #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+    #[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
     #[serde(rename_all = "camelCase", deny_unknown_fields)]
     pub struct DataTypeBase {
         #[serde(rename = "$schema")]
@@ -185,7 +185,7 @@ mod raw {
     mod wasm {
         use super::*;
 
-        #[derive(tsify::Tsify)]
+        #[derive(tsify_next::Tsify)]
         #[serde(untagged)]
         enum DataType {
             Schema {
@@ -560,7 +560,7 @@ impl OntologyTypeSchema for DataType {
 #[derive(
     Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(deny_unknown_fields)]
 #[repr(transparent)]
 pub struct DataTypeReference {

--- a/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/metadata.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/metadata.rs
@@ -22,18 +22,22 @@ pub struct EntityTypeMetadata {
 }
 
 #[cfg(target_arch = "wasm32")]
-#[derive(tsify::Tsify)]
-#[serde(rename = "EntityTypeMetadata", untagged)]
 #[expect(dead_code, reason = "Used in the generated TypeScript types")]
-enum EntityTypeMetadataPatch {
-    #[serde(rename_all = "camelCase")]
-    Impl {
-        record_id: OntologyTypeRecordId,
-        #[serde(flatten)]
-        ownership: OntologyOwnership,
-        temporal_versioning: OntologyTemporalMetadata,
-        provenance: OntologyProvenance,
-    },
+mod metadata_patch {
+    use super::*;
+
+    #[derive(tsify_next::Tsify)]
+    #[serde(untagged)]
+    enum EntityTypeMetadata {
+        #[serde(rename_all = "camelCase")]
+        Impl {
+            record_id: OntologyTypeRecordId,
+            #[serde(flatten)]
+            ownership: OntologyOwnership,
+            temporal_versioning: OntologyTemporalMetadata,
+            provenance: OntologyProvenance,
+        },
+    }
 }
 
 #[cfg(feature = "utoipa")]
@@ -85,12 +89,15 @@ impl ToSchema<'static> for EntityTypeMetadata {
 pub type EntityTypeWithMetadata = OntologyTypeWithMetadata<EntityType>;
 
 #[cfg(target_arch = "wasm32")]
-#[derive(tsify::Tsify)]
-#[serde(rename = "EntityTypeWithMetadata")]
 #[expect(dead_code, reason = "Used in the generated TypeScript types")]
-struct EntityTypeWithMetadataPatch {
-    schema: EntityType,
-    metadata: EntityTypeMetadata,
+mod with_metadata_patch {
+    use super::*;
+
+    #[derive(tsify_next::Tsify)]
+    struct EntityTypeWithMetadata {
+        schema: EntityType,
+        metadata: EntityTypeMetadata,
+    }
 }
 
 #[cfg(feature = "utoipa")]

--- a/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/schema/closed.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/schema/closed.rs
@@ -16,7 +16,7 @@ use crate::ontology::{
 };
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ClosedEntityTypeMetadata {
     #[serde(rename = "$id")]
@@ -49,7 +49,7 @@ impl ClosedEntityTypeMetadata {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ClosedEntityType {
     #[serde(rename = "$id")]
@@ -153,12 +153,25 @@ impl ClosedEntityType {
     }
 }
 
+/// Entities can have multiple types, each of which can inherit from multiple other types.
+///
+/// We refer to the act of resolving all information about a given type (including inherited
+/// information) as 'Closing' it. Therefore, a `ClosedMultiEntityType` is the result of closing
+/// multiple types together to provide a single schema, which represents the shape of the entity
+/// with those types (e.g. valid properties, links, etc).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ClosedMultiEntityType {
+    /// The merged constraints for all the types in this type.
     #[serde(flatten)]
     pub constraints: EntityConstraints,
+
+    /// Each entry in `allOf` represents the metadata for each of the types in this type.
+    ///
+    /// Some attributes such as type `title` and `icon` cannot be meaningfully combined, so they
+    /// are provided for each type. The un-mergeable information on each type's parents is
+    /// nested within each entry.
     #[cfg_attr(
         target_arch = "wasm32",
         tsify(type = "[ClosedEntityTypeMetadata, ...ClosedEntityTypeMetadata[]]")

--- a/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/schema/constraints.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/schema/constraints.rs
@@ -8,7 +8,7 @@ use crate::ontology::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EntityConstraints {
     pub properties: HashMap<BaseUrl, ValueOrArray<PropertyTypeReference>>,

--- a/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/schema/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/schema/mod.rs
@@ -21,7 +21,7 @@ use crate::ontology::{
 };
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct InverseEntityTypeMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -38,14 +38,14 @@ impl InverseEntityTypeMetadata {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase")]
 enum EntityTypeKindTag {
     EntityType,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase")]
 enum EntityTypeSchemaTag {
     #[serde(rename = "https://blockprotocol.org/types/modules/graph/0.3/schema/entity-type")]
@@ -53,7 +53,7 @@ enum EntityTypeSchemaTag {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EntityTypeSchemaMetadata {
     pub title: String,
@@ -65,7 +65,7 @@ pub struct EntityTypeSchemaMetadata {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EntityTypeDisplayMetadata {
     #[serde(rename = "$id")]
@@ -194,7 +194,7 @@ pub struct EntityTypeDisplayMetadata {
 /// assert_eq!(links.len(), 1, "Should have exactly one link type");
 /// ```
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EntityType {
     #[serde(rename = "$schema")]
@@ -224,7 +224,7 @@ pub struct EntityType {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PartialEntityType {
     #[serde(rename = "$id")]
@@ -480,7 +480,7 @@ impl OntologyTypeSchema for EntityType {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(deny_unknown_fields)]
 #[repr(transparent)]
 pub struct EntityTypeReference {

--- a/libs/@blockprotocol/type-system/rust/src/ontology/id/error.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/id/error.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 #[cfg(target_arch = "wasm32")]
-use tsify::Tsify;
+use tsify_next::Tsify;
 
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Error)]

--- a/libs/@blockprotocol/type-system/rust/src/ontology/id/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/id/mod.rs
@@ -84,7 +84,7 @@ mod error;
 /// [`MissingTrailingSlash`]: ParseBaseUrlError::MissingTrailingSlash
 /// [`UrlParseError`]: ParseBaseUrlError::UrlParseError
 /// [`CannotBeABase`]: ParseBaseUrlError::CannotBeABase
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "postgres", derive(ToSql), postgres(transparent))]
 #[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub struct BaseUrl(
@@ -234,7 +234,7 @@ impl<'a> FromSql<'a> for BaseUrl {
 /// assert_eq!(version.inner(), 1);
 /// ```
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[repr(transparent)]
 pub struct OntologyTypeVersion(
@@ -347,10 +347,11 @@ pub struct VersionedUrl {
 }
 
 #[cfg(target_arch = "wasm32")]
-#[derive(tsify::Tsify)]
-#[serde(rename = "VersionedUrl")]
-#[expect(dead_code, reason = "Used in the generated TypeScript types")]
-pub struct VersionedUrlPatch(#[tsify(type = "`${string}v/${number}`")] String);
+mod patch {
+    #[derive(tsify_next::Tsify)]
+    #[expect(dead_code, reason = "Used in the generated TypeScript types")]
+    struct VersionedUrl(#[tsify(type = "`${string}v/${number}`")] String);
+}
 
 impl VersionedUrl {
     /// Converts this [`VersionedUrl`] to a standard [`Url`] instance.
@@ -517,7 +518,7 @@ impl ToSchema<'_> for VersionedUrl {
 /// # Ok::<(), Box<dyn core::error::Error>>(())
 /// ```
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct OntologyTypeRecordId {

--- a/libs/@blockprotocol/type-system/rust/src/ontology/id/wasm.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/id/wasm.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use tsify::Tsify;
+use tsify_next::Tsify;
 use wasm_bindgen::{JsValue, prelude::wasm_bindgen};
 
 use crate::ontology::{BaseUrl, VersionedUrl};

--- a/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/any_of.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/any_of.rs
@@ -8,7 +8,7 @@ use super::{
 use crate::{knowledge::PropertyValue, ontology::data_type::schema::ResolveClosedDataTypeError};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AnyOfConstraints {
     #[cfg_attr(

--- a/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/array.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/array.rs
@@ -34,14 +34,14 @@ pub enum ArrayValidationError {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum ArrayTypeTag {
     Array,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum ArrayItemConstraints {
     Boolean,
@@ -133,7 +133,7 @@ impl Constraint for ArrayItemsSchema {
 mod wasm {
     use super::*;
 
-    #[derive(tsify::Tsify)]
+    #[derive(tsify_next::Tsify)]
     #[serde(untagged)]
     enum ArrayItemsSchema {
         Schema {
@@ -148,7 +148,7 @@ mod wasm {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(untagged, rename_all = "camelCase")]
 pub enum ArraySchema {
     Constrained(Box<ArrayConstraints>),
@@ -231,7 +231,7 @@ impl ConstraintValidator<[PropertyValue]> for ArraySchema {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ArrayConstraints {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -292,7 +292,7 @@ impl ConstraintValidator<[PropertyValue]> for ArrayConstraints {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct TupleConstraints {
     #[cfg_attr(target_arch = "wasm32", tsify(type = "false"))]

--- a/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/mod.rs
@@ -73,7 +73,7 @@ pub trait ConstraintValidator<V: ?Sized>: Constraint {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(untagged, rename_all = "camelCase")]
 pub enum ValueConstraints {
     Typed(Box<SingleValueConstraints>),
@@ -186,7 +186,7 @@ impl ConstraintValidator<PropertyValue> for ValueConstraints {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "kebab-case")]
 pub enum JsonSchemaValueType {
@@ -212,7 +212,7 @@ impl fmt::Display for JsonSchemaValueType {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum SingleValueConstraints {
     Null,
@@ -331,7 +331,7 @@ impl Constraint for SingleValueSchema {
 mod wasm {
     use super::*;
 
-    #[derive(tsify::Tsify)]
+    #[derive(tsify_next::Tsify)]
     #[serde(untagged)]
     enum SingleValueSchema {
         Schema {

--- a/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/number.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/number.rs
@@ -46,14 +46,14 @@ pub enum NumberValidationError {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum NumberTypeTag {
     Number,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(untagged, rename_all = "camelCase", deny_unknown_fields)]
 pub enum NumberSchema {
     Constrained(NumberConstraints),
@@ -208,7 +208,7 @@ impl ConstraintValidator<Real> for NumberSchema {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct NumberConstraints {
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/object.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/object.rs
@@ -11,7 +11,7 @@ use crate::{knowledge::PropertyValue, ontology::data_type::schema::ResolveClosed
 pub enum ObjectValidationError {}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum ObjectTypeTag {
     Object,

--- a/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/string.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/string.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "kebab-case")]
 pub enum StringFormat {
     Uri,
@@ -214,7 +214,7 @@ pub enum StringTypeTag {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(untagged, rename_all = "camelCase", deny_unknown_fields)]
 pub enum StringSchema {
     Constrained(StringConstraints),
@@ -358,7 +358,7 @@ impl ConstraintValidator<str> for StringSchema {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct StringConstraints {
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/one_of/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/one_of/mod.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 pub use self::validation::{OneOfSchemaValidationError, OneOfSchemaValidator};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct OneOfSchema<T> {
     #[serde(rename = "oneOf")]

--- a/libs/@blockprotocol/type-system/rust/src/ontology/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/mod.rs
@@ -73,7 +73,7 @@ pub struct OntologyTypeWithMetadata<S: OntologyTypeSchema> {
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct OntologyTemporalMetadata {

--- a/libs/@blockprotocol/type-system/rust/src/ontology/property_type/metadata.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/property_type/metadata.rs
@@ -22,18 +22,22 @@ pub struct PropertyTypeMetadata {
 }
 
 #[cfg(target_arch = "wasm32")]
-#[derive(tsify::Tsify)]
-#[serde(rename = "PropertyTypeMetadata", untagged)]
 #[expect(dead_code, reason = "Used in the generated TypeScript types")]
-enum PropertyTypeMetadataPatch {
-    #[serde(rename_all = "camelCase")]
-    Impl {
-        record_id: OntologyTypeRecordId,
-        #[serde(flatten)]
-        ownership: OntologyOwnership,
-        temporal_versioning: OntologyTemporalMetadata,
-        provenance: OntologyProvenance,
-    },
+mod metadata_patch {
+    use super::*;
+
+    #[derive(tsify_next::Tsify)]
+    #[serde(untagged)]
+    enum PropertyTypeMetadata {
+        #[serde(rename_all = "camelCase")]
+        Impl {
+            record_id: OntologyTypeRecordId,
+            #[serde(flatten)]
+            ownership: OntologyOwnership,
+            temporal_versioning: OntologyTemporalMetadata,
+            provenance: OntologyProvenance,
+        },
+    }
 }
 
 #[cfg(feature = "utoipa")]
@@ -85,12 +89,15 @@ impl ToSchema<'static> for PropertyTypeMetadata {
 pub type PropertyTypeWithMetadata = OntologyTypeWithMetadata<PropertyType>;
 
 #[cfg(target_arch = "wasm32")]
-#[derive(tsify::Tsify)]
-#[serde(rename = "PropertyTypeWithMetadata", rename_all = "camelCase")]
 #[expect(dead_code, reason = "Used in the generated TypeScript types")]
-struct PropertyTypeWithMetadataPatch {
-    schema: PropertyType,
-    metadata: PropertyTypeMetadata,
+mod with_metadata_patch {
+    use super::*;
+
+    #[derive(tsify_next::Tsify)]
+    struct PropertyTypeWithMetadata {
+        schema: PropertyType,
+        metadata: PropertyTypeMetadata,
+    }
 }
 
 #[cfg(feature = "utoipa")]

--- a/libs/@blockprotocol/type-system/rust/src/ontology/property_type/schema/array/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/property_type/schema/array/mod.rs
@@ -29,7 +29,7 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(untagged)]
 pub enum ValueOrArray<T> {
     Value(T),

--- a/libs/@blockprotocol/type-system/rust/src/ontology/property_type/schema/array/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/property_type/schema/array/raw.rs
@@ -1,7 +1,7 @@
 use crate::ontology::json_schema::ArrayTypeTag;
 
 #[derive(serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub(super) struct PropertyValueArray<T> {
     #[serde(rename = "type")]

--- a/libs/@blockprotocol/type-system/rust/src/ontology/property_type/schema/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/property_type/schema/mod.rs
@@ -248,7 +248,7 @@ impl Serialize for PropertyType {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(deny_unknown_fields)]
 #[repr(transparent)]
 pub struct PropertyTypeReference {
@@ -264,7 +264,7 @@ impl From<&VersionedUrl> for &PropertyTypeReference {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(
     untagged,
     expecting = "Expected a data type reference, a property type object, or an array of property \

--- a/libs/@blockprotocol/type-system/rust/src/ontology/property_type/schema/object/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/property_type/schema/object/raw.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use crate::ontology::{BaseUrl, json_schema::ObjectTypeTag};
 
 #[derive(serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub(super) struct PropertyValueObject<T> {
     #[serde(rename = "type")]

--- a/libs/@blockprotocol/type-system/rust/src/ontology/property_type/schema/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/property_type/schema/raw.rs
@@ -6,7 +6,7 @@ use super::PropertyValues;
 use crate::ontology::VersionedUrl;
 
 #[derive(Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase")]
 enum PropertyTypeSchemaTag {
     #[serde(rename = "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type")]
@@ -14,14 +14,14 @@ enum PropertyTypeSchemaTag {
 }
 
 #[derive(Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase")]
 enum PropertyTypeTag {
     PropertyType,
 }
 
 #[derive(Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropertyType<'a> {
     #[serde(rename = "$schema")]

--- a/libs/@blockprotocol/type-system/rust/src/ontology/provenance/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/provenance/mod.rs
@@ -32,7 +32,7 @@ use crate::{
 /// - Types that are created and owned by the local system
 /// - Types that have been fetched from external sources
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(untagged)]
 pub enum OntologyOwnership {
@@ -53,7 +53,7 @@ pub enum OntologyOwnership {
     },
 }
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct OntologyProvenance {
@@ -61,7 +61,7 @@ pub struct OntologyProvenance {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct ProvidedOntologyEditionProvenance {
@@ -72,7 +72,7 @@ pub struct ProvidedOntologyEditionProvenance {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct OntologyEditionProvenance {

--- a/libs/@blockprotocol/type-system/rust/src/provenance/actor.rs
+++ b/libs/@blockprotocol/type-system/rust/src/provenance/actor.rs
@@ -3,7 +3,7 @@ use core::fmt;
 use uuid::Uuid;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub enum ActorType {
@@ -14,7 +14,7 @@ pub enum ActorType {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(
     feature = "postgres",
@@ -77,7 +77,7 @@ macro_rules! define_provenance_id {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(
     feature = "postgres",
@@ -95,7 +95,7 @@ pub struct CreatedById(
 define_provenance_id!(CreatedById);
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(
     feature = "postgres",
@@ -113,7 +113,7 @@ pub struct EditionArchivedById(
 define_provenance_id!(EditionArchivedById);
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(
     feature = "postgres",

--- a/libs/@blockprotocol/type-system/rust/src/provenance/origin.rs
+++ b/libs/@blockprotocol/type-system/rust/src/provenance/origin.rs
@@ -7,7 +7,7 @@ use utoipa::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(deny_unknown_fields, tag = "type", rename_all = "kebab-case")]
 pub enum OriginType {
     WebApp,
@@ -66,35 +66,39 @@ impl OriginProvenance {
 }
 
 #[cfg(target_arch = "wasm32")]
-#[derive(tsify::Tsify)]
-#[serde(rename = "OriginProvenance", untagged)]
 #[expect(dead_code, reason = "Used in the generated TypeScript types")]
-pub enum OriginProvenancePatch {
-    #[serde(rename_all = "camelCase")]
-    Impl {
-        #[serde(flatten)]
-        ty: OriginType,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        id: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        version: Option<String>,
-        #[cfg_attr(
-            target_arch = "wasm32",
-            tsify(type = "Brand<string, \"SemanticVersion\">")
-        )]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        semantic_version: Option<semver::Version>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        environment: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        device_id: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        session_id: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        api_key_public_id: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        user_agent: Option<String>,
-    },
+mod patch {
+    use super::*;
+
+    #[derive(tsify_next::Tsify)]
+    #[serde(untagged)]
+    pub enum OriginProvenance {
+        #[serde(rename_all = "camelCase")]
+        Impl {
+            #[serde(flatten)]
+            ty: OriginType,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            id: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            version: Option<String>,
+            #[cfg_attr(
+                target_arch = "wasm32",
+                tsify(type = "Brand<string, \"SemanticVersion\">")
+            )]
+            #[serde(skip_serializing_if = "Option::is_none")]
+            semantic_version: Option<semver::Version>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            environment: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            device_id: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            session_id: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            api_key_public_id: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            user_agent: Option<String>,
+        },
+    }
 }
 
 #[cfg(feature = "utoipa")]

--- a/libs/@blockprotocol/type-system/rust/src/provenance/source.rs
+++ b/libs/@blockprotocol/type-system/rust/src/provenance/source.rs
@@ -7,7 +7,7 @@ use crate::knowledge::entity::EntityId;
 // This enumeration is expected to grow over time, thus it's marked as non-exhaustive.
 // To generate the OpenAPI specs pass `--write-openapi-specs` when running the HASH Graph server.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[non_exhaustive]
@@ -18,7 +18,7 @@ pub enum SourceType {
 
 /// A location where the source material can be found.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct Location {
@@ -41,7 +41,7 @@ pub struct Location {
 
 /// The source material used in producing a value.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SourceProvenance {

--- a/libs/@blockprotocol/type-system/rust/src/utils.rs
+++ b/libs/@blockprotocol/type-system/rust/src/utils.rs
@@ -1,7 +1,7 @@
 #[cfg(target_arch = "wasm32")]
 mod wasm {
     use serde::{Deserialize, Serialize};
-    use tsify::Tsify;
+    use tsify_next::Tsify;
     use wasm_bindgen::prelude::wasm_bindgen;
 
     #[wasm_bindgen(typescript_custom_section)]
@@ -11,15 +11,15 @@ mod wasm {
 
     // Common types
 
-    #[derive(tsify::Tsify)]
+    #[derive(tsify_next::Tsify)]
     #[expect(dead_code, reason = "Used in the generated TypeScript types")]
     struct Url(#[tsify(type = "Brand<string, \"Url\">")] String);
 
-    #[derive(tsify::Tsify)]
+    #[derive(tsify_next::Tsify)]
     #[expect(dead_code, reason = "Used in the generated TypeScript types")]
     struct Timestamp(#[tsify(type = "Brand<string, \"Timestamp\">")] String);
 
-    #[derive(tsify::Tsify)]
+    #[derive(tsify_next::Tsify)]
     #[serde(rename_all = "camelCase", tag = "kind", content = "limit")]
     #[expect(dead_code, reason = "Used in the generated TypeScript types")]
     enum TemporalBound {
@@ -27,20 +27,20 @@ mod wasm {
         Inclusive(Timestamp),
         Exclusive(Timestamp),
     }
-    #[derive(tsify::Tsify)]
+    #[derive(tsify_next::Tsify)]
     #[serde(rename_all = "camelCase", tag = "kind", content = "limit")]
     #[expect(dead_code, reason = "Used in the generated TypeScript types")]
     enum LimitedTemporalBound {
         Inclusive(Timestamp),
         Exclusive(Timestamp),
     }
-    #[derive(tsify::Tsify)]
+    #[derive(tsify_next::Tsify)]
     #[serde(rename_all = "camelCase", tag = "kind", content = "limit")]
     #[expect(dead_code, reason = "Used in the generated TypeScript types")]
     enum ClosedTemporalBound {
         Inclusive(Timestamp),
     }
-    #[derive(tsify::Tsify)]
+    #[derive(tsify_next::Tsify)]
     #[serde(rename_all = "camelCase", tag = "kind", content = "limit")]
     #[expect(dead_code, reason = "Used in the generated TypeScript types")]
     enum OpenTemporalBound {
@@ -48,19 +48,19 @@ mod wasm {
         Unbounded,
     }
 
-    #[derive(tsify::Tsify)]
+    #[derive(tsify_next::Tsify)]
     #[expect(dead_code, reason = "Used in the generated TypeScript types")]
     struct TemporalInterval<Start, End> {
         start: Start,
         end: End,
     }
-    #[derive(tsify::Tsify)]
+    #[derive(tsify_next::Tsify)]
     #[expect(dead_code, reason = "Used in the generated TypeScript types")]
     struct RightBoundedTemporalInterval {
         start: TemporalBound,
         end: LimitedTemporalBound,
     }
-    #[derive(tsify::Tsify)]
+    #[derive(tsify_next::Tsify)]
     #[expect(dead_code, reason = "Used in the generated TypeScript types")]
     struct LeftClosedTemporalInterval {
         start: ClosedTemporalBound,

--- a/libs/@blockprotocol/type-system/rust/src/web.rs
+++ b/libs/@blockprotocol/type-system/rust/src/web.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 use crate::provenance::ActorId;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "postgres", derive(FromSql, ToSql), postgres(transparent))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[repr(transparent)]
@@ -52,7 +52,7 @@ impl From<ActorId> for OwnedById {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(
     feature = "postgres",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`tsify-next` supports exporting doc-comments as well. We previously had errors with `tsify-next` but I was able to resolve them.