### PR TITLE
H-4250: Use a `IntoReport` trait to determine conversion to a `Report`

### DIFF
--- a/libs/error-stack/CHANGELOG.md
+++ b/libs/error-stack/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to `error-stack` will be documented in this file.
 
 - Report has been split into `Report<C>` and `Report<[C]>` to distinguish between a group of related errors and a single error. These errors can still be nested. ([#5047](https://github.com/hashintel/hash/pull/5047))
 - Introduce a new `unstable` flag, which is used to enable unstable features, these features are not covered by semver and may be modified or removed at any time. ([#5181](https://github.com/hashintel/hash/pull/5181))
+- Reintroduce a new `IntoReport` trait, which is used to determine when a type can be converted to a `Report`. This allows the usage of errors more idiomatically in traits, such as `type Error: IntoReport`.
 
 ### Breaking Changes
 

--- a/libs/error-stack/CHANGELOG.md
+++ b/libs/error-stack/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to `error-stack` will be documented in this file.
 
 - Report has been split into `Report<C>` and `Report<[C]>` to distinguish between a group of related errors and a single error. These errors can still be nested. ([#5047](https://github.com/hashintel/hash/pull/5047))
 - Introduce a new `unstable` flag, which is used to enable unstable features, these features are not covered by semver and may be modified or removed at any time. ([#5181](https://github.com/hashintel/hash/pull/5181))
-- Reintroduce a new `IntoReport` trait, which is used to determine when a type can be converted to a `Report`. This allows the usage of errors more idiomatically in traits, such as `type Error: IntoReport`.
+- Reintroduce a new `IntoReport` trait, which is used to determine when a type can be converted to a `Report`. This allows the usage of errors more idiomatically in traits, such as `type Error: IntoReport`. ([#6738](https://github.com/hashintel/hash/pull/6738))
 
 ### Breaking Changes
 

--- a/libs/error-stack/CHANGELOG.md
+++ b/libs/error-stack/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to `error-stack` will be documented in this file.
 
 - `Context`: Use `core::error::Error` instead ([#5533](https://github.com/hashintel/hash/pull/5533))
 - `Result<T, C>`: Use `core::result::Result<T, Report<C>>` instead ([#5533](https://github.com/hashintel/hash/pull/5533))
+- `report!`, use `IntoReport::into_report` instead. ([#6738](https://github.com/hashintel/hash/pull/6738))
 
 ## [0.5.0](https://github.com/hashintel/hash/tree/error-stack%400.5.0/libs/error-stack) - 2024-07-12
 

--- a/libs/error-stack/src/fmt/charset.rs
+++ b/libs/error-stack/src/fmt/charset.rs
@@ -63,7 +63,7 @@ impl Report<()> {
     /// # #![cfg_attr(not(nightly), allow(dead_code, unused_variables, unused_imports))]
     /// use std::io::{Error, ErrorKind};
     ///
-    /// use error_stack::{report, Report};
+    /// use error_stack::{Report, IntoReport};
     /// use error_stack::fmt::{Charset};
     ///
     /// struct Suggestion(&'static str);
@@ -76,7 +76,7 @@ impl Report<()> {
     /// });
     ///
     /// let report =
-    ///     report!(Error::from(ErrorKind::InvalidInput)).attach(Suggestion("oh no, try again"));
+    ///     Error::from(ErrorKind::InvalidInput).into_report().attach(Suggestion("oh no, try again"));
     ///
     /// # fn render(value: String) -> String {
     /// #     let backtrace = regex::Regex::new(r"backtrace no\. (\d+)\n(?:  .*\n)*  .*").unwrap();

--- a/libs/error-stack/src/fmt/color.rs
+++ b/libs/error-stack/src/fmt/color.rs
@@ -73,7 +73,7 @@ impl Report<()> {
     /// use std::io::{Error, ErrorKind};
     /// use owo_colors::OwoColorize;
     ///
-    /// use error_stack::{report, Report};
+    /// use error_stack::{Report, IntoReport};
     /// use error_stack::fmt::ColorMode;
     ///
     /// struct Suggestion(&'static str);
@@ -88,7 +88,7 @@ impl Report<()> {
     /// });
     ///
     /// let report =
-    ///     report!(Error::from(ErrorKind::InvalidInput)).attach(Suggestion("oh no, try again"));
+    ///     Error::from(ErrorKind::InvalidInput).into_report().attach(Suggestion("oh no, try again"));
     ///
     /// # fn render(value: String) -> String {
     /// #     let backtrace = regex::Regex::new(r"backtrace no\. (\d+)\n(?:  .*\n)*  .*").unwrap();

--- a/libs/error-stack/src/hook/mod.rs
+++ b/libs/error-stack/src/hook/mod.rs
@@ -33,7 +33,7 @@ impl Report<()> {
     /// use std::io::{Error, ErrorKind};
     ///
     /// use error_stack::{
-    ///     report, Report,
+    ///     Report, IntoReport,
     /// };
     ///
     /// struct Suggestion(&'static str);
@@ -43,7 +43,7 @@ impl Report<()> {
     /// });
     ///
     /// let report =
-    ///     report!(Error::from(ErrorKind::InvalidInput)).attach(Suggestion("oh no, try again"));
+    ///     Error::from(ErrorKind::InvalidInput).into_report().attach(Suggestion("oh no, try again"));
     ///
     /// # Report::set_color_mode(error_stack::fmt::ColorMode::Emphasis);
     /// # fn render(value: String) -> String {
@@ -83,7 +83,7 @@ impl Report<()> {
     /// # mod nightly {
     /// use core::error::{Request, Error};
     /// use core::fmt;
-    /// use error_stack::{Report, report};
+    /// use error_stack::{Report, IntoReport};
     ///
     /// struct Suggestion(&'static str);
     ///
@@ -117,7 +117,7 @@ impl Report<()> {
     ///     context.push_body(format!("error code: {value}"));
     /// });
     ///
-    /// let report = report!(UserError {code: ErrorCode(420)});
+    /// let report = UserError {code: ErrorCode(420)}.into_report();
     ///
     /// # Report::set_color_mode(error_stack::fmt::ColorMode::Emphasis);
     /// # fn render(value: String) -> String {
@@ -160,11 +160,13 @@ impl Report<()> {
     ///     panic::Location,
     /// };
     ///
+    /// use error_stack::IntoReport;
+    ///
     /// error_stack::Report::install_debug_hook::<Location>(|_location, _context| {
     ///     // Intentionally left empty so nothing will be printed
     /// });
     ///
-    /// let report = error_stack::report!(Error::from(ErrorKind::InvalidInput));
+    /// let report = Error::from(ErrorKind::InvalidInput).into_report();
     ///
     /// # error_stack::Report::set_color_mode(error_stack::fmt::ColorMode::Emphasis);
     /// # fn render(value: String) -> String {

--- a/libs/error-stack/src/lib.rs
+++ b/libs/error-stack/src/lib.rs
@@ -530,7 +530,7 @@ pub use self::{
     compat::IntoReportCompat,
     frame::{AttachmentKind, Frame, FrameKind},
     macros::*,
-    report::Report,
+    report::{IntoReport, Report},
 };
 #[doc(inline)]
 pub use self::{future::FutureExt, result::ResultExt};

--- a/libs/error-stack/src/lib.rs
+++ b/libs/error-stack/src/lib.rs
@@ -102,7 +102,8 @@
 //! ### Initializing a Report
 //!
 //! A [`Report`] can be created directly from anything that implements [`Error`] by using
-//! [`Report::new()`] or through any of the provided macros ([`report!`], [`bail!`], [`ensure!`]).
+//! [`Report::new()`], [`IntoReport::into_report()`], or through any of the provided macros
+//! ([`bail!`], [`ensure!`]).
 //!
 //! ```rust
 //! use std::{fs, io, path::Path};
@@ -405,14 +406,10 @@
 //!
 //! ### Macros for Convenience
 //!
-//! Three macros are provided to simplify the generation of a [`Report`].
+//! Two macros are provided to simplify the generation of a [`Report`].
 //!
-//! - [`report!`] will only create a [`Report`] from its parameter. It will take into account if the
-//!   passed type itself is a [`Report`] or a [`Error`]. For the former case, it will retain the
-//!   details stored on a [`Report`], for the latter case it will create a new [`Report`] from the
-//!   [`Error`].
-//! - [`bail!`] acts like [`report!`] but also immediately returns the [`Report`] as [`Err`]
-//!   variant.
+//! - [`bail!`] acts like calling [`IntoReport::into_report()`] but also immediately returns the
+//!   [`Report`] as [`Err`] variant.
 //! - [`ensure!`] will check an expression and if it's evaluated to `false`, it will act like
 //!   [`bail!`].
 //!

--- a/libs/error-stack/src/lib.rs
+++ b/libs/error-stack/src/lib.rs
@@ -529,7 +529,6 @@ pub use self::sink::ReportSink;
 pub use self::{
     compat::IntoReportCompat,
     frame::{AttachmentKind, Frame, FrameKind},
-    macros::*,
     report::{IntoReport, Report},
 };
 #[doc(inline)]

--- a/libs/error-stack/src/macros.rs
+++ b/libs/error-stack/src/macros.rs
@@ -54,6 +54,7 @@
 /// }
 /// # Ok(())
 /// ```
+#[deprecated(since = "0.6.0", note = "use `IntoReport::into_report` instead")]
 #[macro_export]
 macro_rules! report {
     ($err:expr $(,)?) => {{ $crate::IntoReport::into_report($err) }};
@@ -233,7 +234,7 @@ macro_rules! bail {
 #[macro_export]
 macro_rules! bail {
     ($err:expr) => {{
-        return ::core::result::Result::Err($crate::report!($err));
+        return ::core::result::Result::Err($crate::IntoReport::into_report($err));
     }};
 
     [$($err:expr),+ $(,)?] => {{

--- a/libs/error-stack/src/macros.rs
+++ b/libs/error-stack/src/macros.rs
@@ -123,7 +123,7 @@ macro_rules! report {
 #[macro_export]
 macro_rules! bail {
     ($err:expr) => {{
-        return ::core::result::Result::Err($crate::report!($err));
+        return ::core::result::Result::Err($crate::IntoReport::into_report($err));
     }};
 }
 

--- a/libs/error-stack/src/macros.rs
+++ b/libs/error-stack/src/macros.rs
@@ -11,6 +11,7 @@
 /// Create a [`Report`] from [`Error`]:
 ///
 /// ```rust
+/// # #![expect(deprecated, reason = "`report!` is deprecated")]
 /// use std::fs;
 ///
 /// use error_stack::report;
@@ -25,6 +26,7 @@
 /// ```
 ///
 /// ```rust
+/// # #![expect(deprecated, reason = "`report!` is deprecated")]
 /// # fn has_permission(_: &u32, _: &u32) -> bool { true }
 /// # type User = u32;
 /// # let user = 0;

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -948,7 +948,7 @@ impl<C> Extend<Self> for Report<[C]> {
     }
 }
 
-/// Provides methods to work with errors in the context of error-stack's reporting system.
+/// Provides unified way to convert an error-like structure to a [`Report`].
 ///
 /// This trait allows both [`Report<C>`] instances and regular error types to be converted into a
 /// [`Report`]. It is automatically implemented for any type that can be converted into a [`Report`]

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -965,6 +965,7 @@ impl<C> Extend<Self> for Report<[C]> {
 ///
 /// use error_stack::{IntoReport as _, Report};
 ///
+/// # #[expect(dead_code)]
 /// fn example() -> Result<(), Report<io::Error>> {
 ///     // io::Error implements Into<Report<io::Error>>, so we can use into_report()
 ///     let err = io::Error::new(io::ErrorKind::Other, "oh no!");

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -947,3 +947,46 @@ impl<C> Extend<Self> for Report<[C]> {
         }
     }
 }
+
+/// Provides methods to work with errors in the context of error-stack's reporting system.
+///
+/// This trait allows both [`Report<C>`] instances and regular [`Error`] types to directly
+/// use error-stack's context enrichment operations. It abstracts away the need to convert
+/// to a [`Report`] first before attaching context or changing the error type.
+pub trait IntoReport {
+    /// The [`Context`] type of the resulting [`Report`].
+    type Context: ?Sized;
+
+    /// Convert the value to a [`Report`] with the given context.
+    fn into_report(self) -> Report<Self::Context>;
+}
+
+impl<C> IntoReport for Report<C> {
+    type Context = C;
+
+    #[track_caller]
+    fn into_report(self) -> Report<Self::Context> {
+        self
+    }
+}
+
+impl<C> IntoReport for Report<[C]> {
+    type Context = [C];
+
+    #[track_caller]
+    fn into_report(self) -> Report<Self::Context> {
+        self
+    }
+}
+
+impl<E> IntoReport for E
+where
+    E: Context,
+{
+    type Context = E;
+
+    #[track_caller]
+    fn into_report(self) -> Report<Self::Context> {
+        Report::new(self)
+    }
+}

--- a/libs/error-stack/tests/snapshots/doc/fmt__charset_ascii.snap
+++ b/libs/error-stack/tests/snapshots/doc/fmt__charset_ascii.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-|-at <i>libs/error-stack/src/fmt/charset.rs:23:5</i>
+|-at <i>libs/error-stack/src/fmt/charset.rs:23:42</i>
 |-backtrace (1)
 |-suggestion: oh no, try again
 

--- a/libs/error-stack/tests/snapshots/doc/fmt__charset_utf8.snap
+++ b/libs/error-stack/tests/snapshots/doc/fmt__charset_utf8.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-├╴at <i>libs/error-stack/src/fmt/charset.rs:23:5</i>
+├╴at <i>libs/error-stack/src/fmt/charset.rs:23:42</i>
 ├╴backtrace (1)
 ╰╴📝 oh no, try again
 

--- a/libs/error-stack/tests/snapshots/doc/fmt__preference_color.snap
+++ b/libs/error-stack/tests/snapshots/doc/fmt__preference_color.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<span style='color:var(--red,#a00)'>├╴</span>at <span style='color:var(--bright-black,#555)'>libs/error-stack/src/fmt/color.rs:26:5</span>
+<span style='color:var(--red,#a00)'>├╴</span>at <span style='color:var(--bright-black,#555)'>libs/error-stack/src/fmt/color.rs:26:42</span>
 <span style='color:var(--red,#a00)'>├╴</span>backtrace (1)
 <span style='color:var(--red,#a00)'>╰╴</span><span style='color:var(--green,#0a0)'>suggestion: oh no, try again</span>
 

--- a/libs/error-stack/tests/snapshots/doc/fmt__preference_emphasis.snap
+++ b/libs/error-stack/tests/snapshots/doc/fmt__preference_emphasis.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-├╴at <i>libs/error-stack/src/fmt/color.rs:26:5</i>
+├╴at <i>libs/error-stack/src/fmt/color.rs:26:42</i>
 ├╴backtrace (1)
 ╰╴<i>suggestion: oh no, try again</i>
 

--- a/libs/error-stack/tests/snapshots/doc/fmt__preference_none.snap
+++ b/libs/error-stack/tests/snapshots/doc/fmt__preference_none.snap
@@ -1,5 +1,5 @@
 invalid input parameter
-├╴at libs/error-stack/src/fmt/color.rs:26:5
+├╴at libs/error-stack/src/fmt/color.rs:26:42
 ├╴backtrace (1)
 ╰╴suggestion: oh no, try again
 

--- a/libs/error-stack/tests/snapshots/doc/hook__debug_hook.snap
+++ b/libs/error-stack/tests/snapshots/doc/hook__debug_hook.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-├╴at <i>libs/error-stack/src/hook/mod.rs:21:5</i>
+├╴at <i>libs/error-stack/src/hook/mod.rs:21:42</i>
 ├╴backtrace (1)
 ╰╴suggestion: oh no, try again
 

--- a/libs/error-stack/tests/snapshots/doc/hook__debug_hook_provide.snap
+++ b/libs/error-stack/tests/snapshots/doc/hook__debug_hook_provide.snap
@@ -1,7 +1,7 @@
 <b>invalid user input</b>
 ├╴suggestion: try better next time!
 ├╴error code: 420
-├╴at <i>libs/error-stack/src/hook/mod.rs:50:14</i>
+├╴at <i>libs/error-stack/src/hook/mod.rs:50:47</i>
 ╰╴backtrace (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/libs/error-stack/tests/test_conversion.rs
+++ b/libs/error-stack/tests/test_conversion.rs
@@ -5,6 +5,8 @@
 use core::fmt;
 use std::{error::Error, io};
 
+#[cfg(nightly)]
+use error_stack::IntoReport;
 use error_stack::{FrameKind, Report, ResultExt as _};
 
 fn io_error() -> Result<(), io::Error> {
@@ -114,14 +116,19 @@ fn boxed_error() {
 #[cfg(nightly)]
 #[test]
 fn never_report() {
-    use error_stack::IntoReport;
-
-    #[expect(dead_code)]
-    trait NeverReport {
+    trait NeverReport: Sized {
         type Error: IntoReport;
+
+        fn never_report(self) -> Result<Self, Self::Error>;
     }
 
     impl NeverReport for () {
         type Error = !;
+
+        fn never_report(self) -> Result<Self, Self::Error> {
+            Ok(())
+        }
     }
+
+    let Ok(()) = ().never_report();
 }

--- a/libs/error-stack/tests/test_conversion.rs
+++ b/libs/error-stack/tests/test_conversion.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "std")]
-#![cfg_attr(nightly, feature(error_generic_member_access))]
+#![cfg_attr(nightly, feature(error_generic_member_access, never_type))]
 #![allow(clippy::std_instead_of_core)]
 
 use core::fmt;
@@ -109,4 +109,19 @@ fn boxed_error() {
         *core::error::request_ref::<u32>(report.as_ref()).expect("requested value not found"),
         10
     );
+}
+
+#[cfg(nightly)]
+#[test]
+fn never_report() {
+    use error_stack::IntoReport;
+
+    #[expect(dead_code)]
+    trait NeverReport {
+        type Error: IntoReport;
+    }
+
+    impl NeverReport for () {
+        type Error = !;
+    }
 }

--- a/libs/error-stack/tests/test_extend.rs
+++ b/libs/error-stack/tests/test_extend.rs
@@ -7,7 +7,7 @@ use core::{
 };
 
 use common::*;
-use error_stack::{Report, report};
+use error_stack::{IntoReport as _, Report};
 
 #[derive(Debug)]
 struct MyError;
@@ -22,9 +22,15 @@ impl Error for MyError {}
 
 #[test]
 fn push_append() {
-    let mut err1 = report!(MyError).attach_printable("Not Supported").expand();
-    let err2 = report!(MyError).attach_printable("Not Supported");
-    let mut err3 = report!(MyError).attach_printable("Not Supported").expand();
+    let mut err1 = MyError
+        .into_report()
+        .attach_printable("Not Supported")
+        .expand();
+    let err2 = MyError.into_report().attach_printable("Not Supported");
+    let mut err3 = MyError
+        .into_report()
+        .attach_printable("Not Supported")
+        .expand();
 
     let count = expect_count(2) * 3;
 
@@ -37,9 +43,12 @@ fn push_append() {
 
 #[test]
 fn push() {
-    let mut err1 = report!(MyError).attach_printable("Not Supported").expand();
-    let err2 = report!(MyError).attach_printable("Not Supported");
-    let err3 = report!(MyError).attach_printable("Not Supported");
+    let mut err1 = MyError
+        .into_report()
+        .attach_printable("Not Supported")
+        .expand();
+    let err2 = MyError.into_report().attach_printable("Not Supported");
+    let err3 = MyError.into_report().attach_printable("Not Supported");
 
     let count = expect_count(2) * 3;
 
@@ -52,9 +61,12 @@ fn push() {
 
 #[test]
 fn extend() {
-    let mut err1 = report!(MyError).attach_printable("Not Supported").expand();
-    let err2 = report!(MyError).attach_printable("Not Supported");
-    let err3 = report!(MyError).attach_printable("Not Supported");
+    let mut err1 = MyError
+        .into_report()
+        .attach_printable("Not Supported")
+        .expand();
+    let err2 = MyError.into_report().attach_printable("Not Supported");
+    let err3 = MyError.into_report().attach_printable("Not Supported");
 
     err1.extend([err2, err3]);
     assert_eq!(err1.current_frames().len(), 3);
@@ -63,10 +75,13 @@ fn extend() {
 
 #[test]
 fn collect_single() {
-    let report: Option<Report<[MyError]>> =
-        vec![report!(MyError), report!(MyError), report!(MyError)]
-            .into_iter()
-            .collect();
+    let report: Option<Report<[MyError]>> = vec![
+        MyError.into_report(),
+        MyError.into_report(),
+        MyError.into_report(),
+    ]
+    .into_iter()
+    .collect();
 
     let report = report.expect("should be some");
     assert_eq!(report.current_frames().len(), 3);
@@ -76,9 +91,9 @@ fn collect_single() {
 #[test]
 fn collect_multiple() {
     let report: Option<Report<[MyError]>> = vec![
-        report!(MyError).expand(),
-        report!(MyError).expand(),
-        report!(MyError).expand(),
+        MyError.into_report().expand(),
+        MyError.into_report().expand(),
+        MyError.into_report().expand(),
     ]
     .into_iter()
     .collect();

--- a/libs/error-stack/tests/test_iter.rs
+++ b/libs/error-stack/tests/test_iter.rs
@@ -8,7 +8,7 @@ use core::{
 };
 
 mod common;
-use error_stack::{Report, report};
+use error_stack::{IntoReport as _, Report};
 
 #[derive(Debug)]
 struct Char(char);
@@ -44,20 +44,20 @@ impl Error for Char {}
 /// ╰─▶ H
 /// ```
 fn build() -> Report<[Char]> {
-    let mut report_c = report!(Char('C')).expand();
-    let report_d = report!(Char('D'));
+    let mut report_c = Char('C').into_report().expand();
+    let report_d = Char('D').into_report();
 
     report_c.push(report_d);
     let mut report_b = report_c.change_context(Char('B')).expand();
 
-    let report_f = report!(Char('F'));
+    let report_f = Char('F').into_report();
     let report_e = report_f.change_context(Char('E'));
 
     report_b.push(report_e);
 
     let mut report_a = report_b.change_context(Char('A')).expand();
 
-    let report_h = report!(Char('H'));
+    let report_h = Char('H').into_report();
     let report_g = report_h.change_context(Char('G'));
 
     report_a.push(report_g);

--- a/libs/error-stack/tests/test_macros.rs
+++ b/libs/error-stack/tests/test_macros.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(nightly, feature(error_generic_member_access))]
+#![expect(deprecated, reason = "`report!` is deprecated")]
 
 mod common;
 

--- a/libs/error-stack/tests/ui/macro_invalid_args.rs
+++ b/libs/error-stack/tests/ui/macro_invalid_args.rs
@@ -1,3 +1,5 @@
+#![expect(deprecated, reason = "`report!` is deprecated")]
+
 use core::{error::Error, fmt};
 
 use error_stack::{Report, bail, ensure, report};

--- a/libs/error-stack/tests/ui/macro_invalid_args.stderr
+++ b/libs/error-stack/tests/ui/macro_invalid_args.stderr
@@ -7,7 +7,7 @@ error: unexpected end of macro invocation
 note: while trying to match meta-variable `$err:expr`
   --> src/macros.rs
    |
-   |     ($err:expr $(,)?) => {{
+   |     ($err:expr $(,)?) => {{ $crate::IntoReport::into_report($err) }};
    |      ^^^^^^^^^
 
 error: unexpected end of macro invocation
@@ -46,43 +46,114 @@ note: while trying to match meta-variable `$cond:expr`
    |     ($cond:expr, $err:expr $(,)?) => {{
    |      ^^^^^^^^^^
 
-error[E0599]: the method `__kind` exists for reference `&&str`, but its trait bounds were not satisfied
+error[E0277]: the trait bound `&str: IntoReport` is not satisfied
+  --> tests/ui/macro_invalid_args.rs:17:21
+   |
+17 |     let _ = report!("Error");
+   |             --------^^^^^^^-
+   |             |       |
+   |             |       the trait `std::error::Error` is not implemented for `str`
+   |             required by a bound introduced by this call
+   |
+   = help: the trait `IntoReport` is implemented for `error_stack::Report<C>`
+   = note: required for `&str` to implement `std::error::Error`
+   = note: required for `&str` to implement `error_stack::Context`
+   = note: required for `error_stack::Report<&str>` to implement `From<&str>`
+   = note: required for `&str` to implement `Into<error_stack::Report<&str>>`
+   = note: required for `&str` to implement `IntoReport`
+
+error[E0277]: the trait bound `&str: Into<error_stack::Report<&str>>` is not satisfied
   --> tests/ui/macro_invalid_args.rs:17:13
    |
 17 |     let _ = report!("Error");
-   |             ^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^ the trait `std::error::Error` is not implemented for `str`
    |
-   = note: the following trait bounds were not satisfied:
-           `str: error_stack::Context`
-           which is required by `&str: __private::specialization::ContextTag`
-           `&str: error_stack::Context`
-           which is required by `&&str: __private::specialization::ContextTag`
+   = help: the trait `IntoReport` is implemented for `error_stack::Report<C>`
+   = note: required for `&str` to implement `std::error::Error`
+   = note: required for `&str` to implement `error_stack::Context`
+   = note: required for `error_stack::Report<&str>` to implement `From<&str>`
+   = note: required for `&str` to implement `Into<error_stack::Report<&str>>`
+   = note: required for `&str` to implement `IntoReport`
    = note: this error originates in the macro `report` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0599]: the method `__kind` exists for reference `&&str`, but its trait bounds were not satisfied
+error[E0277]: the trait bound `&str: IntoReport` is not satisfied
+  --> tests/ui/macro_invalid_args.rs:29:11
+   |
+29 |     bail!("Error")
+   |     ------^^^^^^^-
+   |     |     |
+   |     |     the trait `std::error::Error` is not implemented for `str`
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `IntoReport` is implemented for `error_stack::Report<C>`
+   = note: required for `&str` to implement `std::error::Error`
+   = note: required for `&str` to implement `error_stack::Context`
+   = note: required for `error_stack::Report<&str>` to implement `From<&str>`
+   = note: required for `&str` to implement `Into<error_stack::Report<&str>>`
+   = note: required for `&str` to implement `IntoReport`
+
+error[E0308]: mismatched types
   --> tests/ui/macro_invalid_args.rs:29:5
    |
 29 |     bail!("Error")
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^ expected `Report<RootError>`, found `Report<&str>`
    |
-   = note: the following trait bounds were not satisfied:
-           `str: error_stack::Context`
-           which is required by `&str: __private::specialization::ContextTag`
-           `&str: error_stack::Context`
-           which is required by `&&str: __private::specialization::ContextTag`
+   = note: expected struct `error_stack::Report<RootError>`
+              found struct `error_stack::Report<&str>`
    = note: this error originates in the macro `$crate::report` which comes from the expansion of the macro `bail` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0599]: the method `__kind` exists for reference `&&str`, but its trait bounds were not satisfied
+error[E0277]: the trait bound `&str: Into<error_stack::Report<&str>>` is not satisfied
+  --> tests/ui/macro_invalid_args.rs:29:5
+   |
+29 |     bail!("Error")
+   |     ^^^^^^^^^^^^^^ the trait `std::error::Error` is not implemented for `str`
+   |
+   = help: the trait `IntoReport` is implemented for `error_stack::Report<C>`
+   = note: required for `&str` to implement `std::error::Error`
+   = note: required for `&str` to implement `error_stack::Context`
+   = note: required for `error_stack::Report<&str>` to implement `From<&str>`
+   = note: required for `&str` to implement `Into<error_stack::Report<&str>>`
+   = note: required for `&str` to implement `IntoReport`
+   = note: this error originates in the macro `$crate::report` which comes from the expansion of the macro `bail` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `&str: IntoReport` is not satisfied
+  --> tests/ui/macro_invalid_args.rs:37:27
+   |
+37 |     let _ = ensure!(true, "Error");
+   |             --------------^^^^^^^-
+   |             |             |
+   |             |             the trait `std::error::Error` is not implemented for `str`
+   |             required by a bound introduced by this call
+   |
+   = help: the trait `IntoReport` is implemented for `error_stack::Report<C>`
+   = note: required for `&str` to implement `std::error::Error`
+   = note: required for `&str` to implement `error_stack::Context`
+   = note: required for `error_stack::Report<&str>` to implement `From<&str>`
+   = note: required for `&str` to implement `Into<error_stack::Report<&str>>`
+   = note: required for `&str` to implement `IntoReport`
+
+error[E0308]: mismatched types
   --> tests/ui/macro_invalid_args.rs:37:13
    |
 37 |     let _ = ensure!(true, "Error");
-   |             ^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^ expected `Report<RootError>`, found `Report<&str>`
    |
-   = note: the following trait bounds were not satisfied:
-           `str: error_stack::Context`
-           which is required by `&str: __private::specialization::ContextTag`
-           `&str: error_stack::Context`
-           which is required by `&&str: __private::specialization::ContextTag`
+   = note: expected struct `error_stack::Report<RootError>`
+              found struct `error_stack::Report<&str>`
+   = note: this error originates in the macro `$crate::report` which comes from the expansion of the macro `ensure` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `&str: Into<error_stack::Report<&str>>` is not satisfied
+  --> tests/ui/macro_invalid_args.rs:37:13
+   |
+37 |     let _ = ensure!(true, "Error");
+   |             ^^^^^^^^^^^^^^^^^^^^^^ the trait `std::error::Error` is not implemented for `str`
+   |
+   = help: the trait `IntoReport` is implemented for `error_stack::Report<C>`
+   = note: required for `&str` to implement `std::error::Error`
+   = note: required for `&str` to implement `error_stack::Context`
+   = note: required for `error_stack::Report<&str>` to implement `From<&str>`
+   = note: required for `&str` to implement `Into<error_stack::Report<&str>>`
+   = note: required for `&str` to implement `IntoReport`
    = note: this error originates in the macro `$crate::report` which comes from the expansion of the macro `ensure` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types

--- a/libs/error-stack/tests/ui/macro_invalid_args.stderr
+++ b/libs/error-stack/tests/ui/macro_invalid_args.stderr
@@ -1,7 +1,7 @@
 error: unexpected end of macro invocation
-  --> tests/ui/macro_invalid_args.rs:23:13
+  --> tests/ui/macro_invalid_args.rs:25:13
    |
-23 |     let _ = report!();
+25 |     let _ = report!();
    |             ^^^^^^^^^ missing tokens in macro arguments
    |
 note: while trying to match meta-variable `$err:expr`
@@ -11,9 +11,9 @@ note: while trying to match meta-variable `$err:expr`
    |      ^^^^^^^^^
 
 error: unexpected end of macro invocation
-  --> tests/ui/macro_invalid_args.rs:33:5
+  --> tests/ui/macro_invalid_args.rs:35:5
    |
-33 |     bail!()
+35 |     bail!()
    |     ^^^^^^^ missing tokens in macro arguments
    |
 note: while trying to match meta-variable `$err:expr`
@@ -23,9 +23,9 @@ note: while trying to match meta-variable `$err:expr`
    |      ^^^^^^^^^
 
 error: unexpected end of macro invocation
-  --> tests/ui/macro_invalid_args.rs:49:25
+  --> tests/ui/macro_invalid_args.rs:51:25
    |
-49 |     let _ = ensure!(true);
+51 |     let _ = ensure!(true);
    |                         ^ missing tokens in macro arguments
    |
 note: while trying to match `,`
@@ -35,9 +35,9 @@ note: while trying to match `,`
    |                ^
 
 error: unexpected end of macro invocation
-  --> tests/ui/macro_invalid_args.rs:55:13
+  --> tests/ui/macro_invalid_args.rs:57:13
    |
-55 |     let _ = ensure!();
+57 |     let _ = ensure!();
    |             ^^^^^^^^^ missing tokens in macro arguments
    |
 note: while trying to match meta-variable `$cond:expr`
@@ -47,9 +47,9 @@ note: while trying to match meta-variable `$cond:expr`
    |      ^^^^^^^^^^
 
 error[E0277]: the trait bound `&str: IntoReport` is not satisfied
-  --> tests/ui/macro_invalid_args.rs:17:21
+  --> tests/ui/macro_invalid_args.rs:19:21
    |
-17 |     let _ = report!("Error");
+19 |     let _ = report!("Error");
    |             --------^^^^^^^-
    |             |       |
    |             |       the trait `std::error::Error` is not implemented for `str`
@@ -63,9 +63,9 @@ error[E0277]: the trait bound `&str: IntoReport` is not satisfied
    = note: required for `&str` to implement `IntoReport`
 
 error[E0277]: the trait bound `&str: Into<error_stack::Report<&str>>` is not satisfied
-  --> tests/ui/macro_invalid_args.rs:17:13
+  --> tests/ui/macro_invalid_args.rs:19:13
    |
-17 |     let _ = report!("Error");
+19 |     let _ = report!("Error");
    |             ^^^^^^^^^^^^^^^^ the trait `std::error::Error` is not implemented for `str`
    |
    = help: the trait `IntoReport` is implemented for `error_stack::Report<C>`
@@ -77,9 +77,9 @@ error[E0277]: the trait bound `&str: Into<error_stack::Report<&str>>` is not sat
    = note: this error originates in the macro `report` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `&str: IntoReport` is not satisfied
-  --> tests/ui/macro_invalid_args.rs:29:11
+  --> tests/ui/macro_invalid_args.rs:31:11
    |
-29 |     bail!("Error")
+31 |     bail!("Error")
    |     ------^^^^^^^-
    |     |     |
    |     |     the trait `std::error::Error` is not implemented for `str`
@@ -93,19 +93,32 @@ error[E0277]: the trait bound `&str: IntoReport` is not satisfied
    = note: required for `&str` to implement `IntoReport`
 
 error[E0308]: mismatched types
-  --> tests/ui/macro_invalid_args.rs:29:5
+  --> tests/ui/macro_invalid_args.rs:31:5
    |
-29 |     bail!("Error")
-   |     ^^^^^^^^^^^^^^ expected `Report<RootError>`, found `Report<&str>`
+31 |     bail!("Error")
+   |     ^^^^^^^^^^^^^^
+   |     |
+   |     expected `Report<RootError>`, found `Report<&str>`
+   |     arguments to this enum variant are incorrect
    |
    = note: expected struct `error_stack::Report<RootError>`
               found struct `error_stack::Report<&str>`
-   = note: this error originates in the macro `$crate::report` which comes from the expansion of the macro `bail` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: the type constructed contains `error_stack::Report<&str>` due to the type of the argument passed
+  --> tests/ui/macro_invalid_args.rs:31:5
+   |
+31 |     bail!("Error")
+   |     ^^^^^^^^^^^^^^ this argument influences the type of `Err`
+note: tuple variant defined here
+  --> $RUST/core/src/result.rs
+   |
+   |     Err(#[stable(feature = "rust1", since = "1.0.0")] E),
+   |     ^^^
+   = note: this error originates in the macro `bail` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `&str: Into<error_stack::Report<&str>>` is not satisfied
-  --> tests/ui/macro_invalid_args.rs:29:5
+  --> tests/ui/macro_invalid_args.rs:31:5
    |
-29 |     bail!("Error")
+31 |     bail!("Error")
    |     ^^^^^^^^^^^^^^ the trait `std::error::Error` is not implemented for `str`
    |
    = help: the trait `IntoReport` is implemented for `error_stack::Report<C>`
@@ -114,12 +127,12 @@ error[E0277]: the trait bound `&str: Into<error_stack::Report<&str>>` is not sat
    = note: required for `error_stack::Report<&str>` to implement `From<&str>`
    = note: required for `&str` to implement `Into<error_stack::Report<&str>>`
    = note: required for `&str` to implement `IntoReport`
-   = note: this error originates in the macro `$crate::report` which comes from the expansion of the macro `bail` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `bail` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `&str: IntoReport` is not satisfied
-  --> tests/ui/macro_invalid_args.rs:37:27
+  --> tests/ui/macro_invalid_args.rs:39:27
    |
-37 |     let _ = ensure!(true, "Error");
+39 |     let _ = ensure!(true, "Error");
    |             --------------^^^^^^^-
    |             |             |
    |             |             the trait `std::error::Error` is not implemented for `str`
@@ -133,19 +146,32 @@ error[E0277]: the trait bound `&str: IntoReport` is not satisfied
    = note: required for `&str` to implement `IntoReport`
 
 error[E0308]: mismatched types
-  --> tests/ui/macro_invalid_args.rs:37:13
+  --> tests/ui/macro_invalid_args.rs:39:13
    |
-37 |     let _ = ensure!(true, "Error");
-   |             ^^^^^^^^^^^^^^^^^^^^^^ expected `Report<RootError>`, found `Report<&str>`
+39 |     let _ = ensure!(true, "Error");
+   |             ^^^^^^^^^^^^^^^^^^^^^^
+   |             |
+   |             expected `Report<RootError>`, found `Report<&str>`
+   |             arguments to this enum variant are incorrect
    |
    = note: expected struct `error_stack::Report<RootError>`
               found struct `error_stack::Report<&str>`
-   = note: this error originates in the macro `$crate::report` which comes from the expansion of the macro `ensure` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: the type constructed contains `error_stack::Report<&str>` due to the type of the argument passed
+  --> tests/ui/macro_invalid_args.rs:39:13
+   |
+39 |     let _ = ensure!(true, "Error");
+   |             ^^^^^^^^^^^^^^^^^^^^^^ this argument influences the type of `Err`
+note: tuple variant defined here
+  --> $RUST/core/src/result.rs
+   |
+   |     Err(#[stable(feature = "rust1", since = "1.0.0")] E),
+   |     ^^^
+   = note: this error originates in the macro `$crate::bail` which comes from the expansion of the macro `ensure` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `&str: Into<error_stack::Report<&str>>` is not satisfied
-  --> tests/ui/macro_invalid_args.rs:37:13
+  --> tests/ui/macro_invalid_args.rs:39:13
    |
-37 |     let _ = ensure!(true, "Error");
+39 |     let _ = ensure!(true, "Error");
    |             ^^^^^^^^^^^^^^^^^^^^^^ the trait `std::error::Error` is not implemented for `str`
    |
    = help: the trait `IntoReport` is implemented for `error_stack::Report<C>`
@@ -154,12 +180,12 @@ error[E0277]: the trait bound `&str: Into<error_stack::Report<&str>>` is not sat
    = note: required for `error_stack::Report<&str>` to implement `From<&str>`
    = note: required for `&str` to implement `Into<error_stack::Report<&str>>`
    = note: required for `&str` to implement `IntoReport`
-   = note: this error originates in the macro `$crate::report` which comes from the expansion of the macro `ensure` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::bail` which comes from the expansion of the macro `ensure` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
-  --> tests/ui/macro_invalid_args.rs:43:21
+  --> tests/ui/macro_invalid_args.rs:45:21
    |
-43 |     let _ = ensure!("No boolean", RootError);
+45 |     let _ = ensure!("No boolean", RootError);
    |             --------^^^^^^^^^^^^------------
    |             |       |
    |             |       expected `bool`, found `&str`

--- a/undefined/settings.toml
+++ b/undefined/settings.toml
@@ -1,0 +1,3 @@
+version = "12"
+
+[overrides]

--- a/undefined/settings.toml
+++ b/undefined/settings.toml
@@ -1,3 +1,0 @@
-version = "12"
-
-[overrides]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, when using errors in traits, it's annoying that you cannot properly specify errors in associated types.
```rust
// Requires `Result<_, Report<Self::Error>>` as return to allow `.change_context()` 
type Error: Error + Send + Sync + 'static;
```

Also, `Result<_, Report<!>>` is not working as well as it could work.

This PR (re-)adds `IntoReport` to allow it in associated types, such as:
```rust
// Allows `impl Error`, `Report<impl Error>`, and `!` as type
type Error: IntoReport;
```


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

A trait is added to the interface but the trait is very simple and outweighs the drawbacks of a new trait.

## 🛡 What tests cover this?

The `ResultExt` trait was changed, so pretty much every test is using the new trait indirectly