### PR TITLE
H-4262: Bump tool versions

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -7,7 +7,7 @@ node        = { version = "22.14.0", postinstall = "corepack enable" }
 'npm:turbo' = "2.4.4"
 
 # Helper to install tools
-cargo-binstall = "1.10.22"
+cargo-binstall = "1.12.2"
 uv             = "0.6.9"
 
 # Tools to compile the project
@@ -18,15 +18,15 @@ protoc            = "30.1"
 
 # CLI tools
 biome                  = "1.9.5-nightly.ff02a0b"
-"cargo:cargo-hack"     = "0.6.35"
-"cargo:cargo-insta"    = "1.42.1"
+"cargo:cargo-hack"     = "0.6.36"
+"cargo:cargo-insta"    = "1.42.2"
 "cargo:cargo-llvm-cov" = "0.6.16"
-"cargo:cargo-nextest"  = "0.9.80"
+"cargo:cargo-nextest"  = "0.9.92"
 just                   = "1.40.0"
 markdownlint-cli2      = "0.17.2"
 "npm:@napi-rs/cli"     = "2.18.4"
-"npm:@redocly/cli"     = "1.32.1"
-"npm:renovate"         = "39.166.0"
+"npm:@redocly/cli"     = "1.34.0"
+"npm:renovate"         = "39.212.2"
 "pipx:sqlfluff"        = "3.3.1"
-sentry-cli             = "2.41.1"
+sentry-cli             = "2.42.4"
 taplo                  = "0.9.3"

--- a/.justfile
+++ b/.justfile
@@ -148,15 +148,15 @@ bench *arguments:
 [no-cd]
 coverage *arguments:
   cargo llvm-cov nextest --all-features --all-targets --cargo-profile coverage {{arguments}}
-  cargo llvm-cov --all-features --profile coverage --doc {{arguments}}
+  cargo llvm-cov --all-features --profile coverage --doc
 
 # Run the test suite and optionally generate a coverage report when `$TEST_COVERAGE` is set to `true`
 [no-cd]
-test-or-coverage:
+test-or-coverage *arguments:
   #!/usr/bin/env bash
   set -eo pipefail
   if [[ "$TEST_COVERAGE" = 'true' || "$TEST_COVERAGE" = '1' ]]; then
-    just coverage --lcov --output-path lcov.info
+    just coverage --lcov --output-path lcov.info {{arguments}}
   else
-    just test --no-fail-fast
+    just test --no-fail-fast {{arguments}}
   fi

--- a/libs/@local/codec/package.json
+++ b/libs/@local/codec/package.json
@@ -7,7 +7,7 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root hash-codec --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
+    "test:unit": "cargo hack nextest run --feature-powerset --all-targets --no-tests warn && cargo test --all-features --doc"
   },
   "dependencies": {
     "@rust/error-stack": "0.5.0",

--- a/libs/@local/graph/types/rust/package.json
+++ b/libs/@local/graph/types/rust/package.json
@@ -7,7 +7,7 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root hash-graph-types --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
+    "test:unit": "cargo hack nextest run --feature-powerset --all-targets --no-tests warn && cargo test --all-features --doc"
   },
   "dependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",

--- a/libs/@local/harpc/types/package.json
+++ b/libs/@local/harpc/types/package.json
@@ -7,6 +7,6 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root harpc-types --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
+    "test:unit": "cargo hack nextest run --feature-powerset --all-targets --no-tests warn && cargo test --all-features --doc"
   }
 }

--- a/libs/@local/hql/cst/package.json
+++ b/libs/@local/hql/cst/package.json
@@ -7,7 +7,7 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root hql-cst --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
+    "test:unit": "cargo hack nextest run --feature-powerset --all-targets --no-tests warn && cargo test --all-features --doc"
   },
   "dependencies": {
     "@rust/hql-span": "0.0.0-private"

--- a/libs/@local/hql/span/package.json
+++ b/libs/@local/hql/span/package.json
@@ -7,6 +7,6 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root hql-span --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
+    "test:unit": "cargo hack nextest run --feature-powerset --all-targets --no-tests warn && cargo test --all-features --doc"
   }
 }

--- a/libs/antsi/package.json
+++ b/libs/antsi/package.json
@@ -7,6 +7,6 @@
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "just test"
+    "test:unit": "just test --no-tests warn"
   }
 }

--- a/libs/sarif/package.json
+++ b/libs/sarif/package.json
@@ -7,6 +7,6 @@
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "just test-or-coverage"
+    "test:unit": "just test-or-coverage --no-tests warn"
   }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Renovate currently does not cover all dependency updates

## 🔍 What does this change?

- `mise upgrade --bump`
- Revert bumping `node`