### PR TITLE
H-4272, H-4273: Add categories, audiences and missing descriptions to `Integrations`

### DIFF
--- a/apps/hashdotai/integrations/integration-list.json
+++ b/apps/hashdotai/integrations/integration-list.json
@@ -70,7 +70,7 @@
   {
     "name": "Slack",
     "logoUrl": "https://app.hash.ai/icons/integrations/icon_slack.svg",
-    "productUrl": "https://slack.com/"
+    "productUrl": "https://slack.com/",
     "summaryHtml": "<div><strong>In HASH:</strong> see messages and teammates</div><div><strong>In Slack:</strong> create/find entities and types</div>",
     "integrationUrl": "https://app.hash.ai/settings/integrations/slack",
     "availability": "Considered",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

- Adds categories to all integrations
- Adds audiences to all integrations
- Adds `summaryHtml` descriptions where previously missing
- Adds `productUrl`s where previously missing