### PR TITLE
H-4283: Update package name in `package.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ When you first create an account you may be placed on a waitlist. To jump the qu
 7. Launch external services (Postgres, the graph query layer, Kratos, Redis, and OpenSearch) as Docker containers:
 
    ```sh
-   yarn external-services up --wait
+   yarn external-services up -d
    ```
 
    1. You can optionally force a rebuild of the Docker containers by adding the `--build` argument(**this is necessary if changes have been made to the graph query layer). It's recommended to do this whenever updating your branch from upstream**.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dev:backend:realtime": "CARGO_TERM_PROGRESS_WHEN=never turbo dev --log-order stream --filter '@apps/hash-realtime' --",
     "dev:backend:search-loader": "CARGO_TERM_PROGRESS_WHEN=never turbo dev --log-order stream --filter '@apps/hash-search-loader' --",
     "dev:frontend": "CARGO_TERM_PROGRESS_WHEN=never turbo dev --log-order stream --filter '@apps/hash-frontend' --",
-    "start": "CARGO_TERM_PROGRESS_WHEN=never turbo run start start:healthcheck --filter @apps/hash-graph --filter @rust/type-fetcher --filter @apps/hash-api --filter @apps/hash-ai-worker-ts --filter @apps/hash-integration-worker --filter @apps/hash-frontend --env-mode=loose",
+    "start": "CARGO_TERM_PROGRESS_WHEN=never turbo run start start:healthcheck --filter @apps/hash-graph --filter @rust/hash-graph-type-fetcher --filter @apps/hash-api --filter @apps/hash-ai-worker-ts --filter @apps/hash-integration-worker --filter @apps/hash-frontend --env-mode=loose",
     "start:graph": "CARGO_TERM_PROGRESS_WHEN=never turbo run start start:healthcheck --filter @apps/hash-graph --filter @rust/hash-graph-type-fetcher --env-mode=loose",
     "start:backend": "CARGO_TERM_PROGRESS_WHEN=never turbo run start start:healthcheck --filter @apps/hash-api --env-mode=loose",
     "start:frontend": "CARGO_TERM_PROGRESS_WHEN=never turbo run start start:healthcheck --filter @apps/hash-frontend --env-mode=loose",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We renamed the `type-fetcher` package a while back but did not update it in `package.json`'s `start` script