### PR TITLE
H-4296: Remove docs reference to `Empty List` data type as a primitive

### DIFF
--- a/apps/hashdotai/guide/04_types/04_data-types.mdx
+++ b/apps/hashdotai/guide/04_types/04_data-types.mdx
@@ -28,7 +28,6 @@ The following primtive data types are also supported in HASH:
 - `Null`: A placeholder value representing 'nothing'
 - `Object`: A plain JSON object with no predefined structure
 
-Historically, an `Empty List` data type was also supported, ensuring that all possible values representable within JavaScript Object Notation (JSON) were also representable in HASH by default, but this was later removed as a generally-available "primitive".
 
 </Toggle>
 

--- a/apps/hashdotai/guide/04_types/04_data-types.mdx
+++ b/apps/hashdotai/guide/04_types/04_data-types.mdx
@@ -28,7 +28,6 @@ The following primtive data types are also supported in HASH:
 - `Null`: A placeholder value representing 'nothing'
 - `Object`: A plain JSON object with no predefined structure
 
-
 </Toggle>
 
 # Custom data types

--- a/apps/hashdotai/guide/04_types/04_data-types.mdx
+++ b/apps/hashdotai/guide/04_types/04_data-types.mdx
@@ -19,15 +19,16 @@ HASH contains a series of primitive data types, which are widely used, and from 
 - `Number`: an arithmetical value (in the [real number](https://en.wikipedia.org/wiki/Real_number) system)
 - `Boolean`: a "true" or "false" value
 
-HASH also contains three other primitive data types, which are unlikely to be useful to most users.
+HASH also contains a small number of other primitive data types, which are unlikely to be useful to most users.
 
-<Toggle title="The 3 advanced primitive data types">
+<Toggle title="Advanced primitive data types">
 
-The following primtive data types are also supported in HASH, ensuring that all values representable within JavaScript Object Notation (JSON) are also representable in HASH:
+The following primtive data types are also supported in HASH:
 
 - `Null`: A placeholder value representing 'nothing'
 - `Object`: A plain JSON object with no predefined structure
-- `Empty List`: An empty List
+
+Historically, an `Empty List` data type was also supported, ensuring that all possible values representable within JavaScript Object Notation (JSON) were also representable in HASH by default, but this was later removed as a generally-available "primitive".
 
 </Toggle>
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Removes references to `Empty List` as a primitive data type from the docs.