### PR TITLE
H-4319: HashQL J-Expr parser should verify token on advance

### DIFF
--- a/libs/@local/hashql/syntax-jexpr/src/lexer/error.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/error.rs
@@ -10,6 +10,8 @@ use hashql_diagnostics::{
 };
 use text_size::TextRange;
 
+use super::syntax_kind_set::SyntaxKindSet;
+
 pub(crate) type LexerDiagnostic = Diagnostic<LexerDiagnosticCategory, SpanId>;
 
 const INVALID_STRING: TerminalDiagnosticCategory = TerminalDiagnosticCategory {

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/error.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/error.rs
@@ -114,10 +114,8 @@ pub(crate) fn unexpected_eof(span: SpanId, expected: SyntaxKindSet) -> LexerDiag
     let mut diagnostic = Diagnostic::new(LexerDiagnosticCategory::UnexpectedEof, Severity::ERROR);
 
     // Create a more specific label based on what was expected
-    let label = if expected.is_empty() {
+    let label = if expected.is_empty() || expected.is_complete() {
         "Unexpected end of file".to_owned()
-    } else if expected.is_complete() {
-        "Expected a valid JSON value".to_owned()
     } else {
         format!(
             "Unexpected end of file, expected {}",
@@ -157,9 +155,9 @@ pub(crate) fn unexpected_token(
 
     // Create a specific label based on what was found vs what was expected
     let label = if expected.is_empty() {
-        format!("Unexpected token {}", found)
+        format!("Unexpected token {found}")
     } else if expected.is_complete() {
-        format!("Invalid syntax found {}", found)
+        format!("Invalid syntax found {found}")
     } else {
         format!(
             "Unexpected {}, expected {}",

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/syntax_kind_set.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/syntax_kind_set.rs
@@ -34,13 +34,15 @@ pub(crate) struct SyntaxKindSet(Flag);
 
 impl SyntaxKindSet {
     /// Tokens that represent closing delimiters like `]` and `}`.
-    const CLOSING_DELIMITER: Self = Self::from_slice(&[SyntaxKind::RBracket, SyntaxKind::RBrace]);
+    pub(crate) const CLOSING_DELIMITER: Self =
+        Self::from_slice(&[SyntaxKind::RBracket, SyntaxKind::RBrace]);
     /// Tokens that represent opening delimiters like `[` and `{`.
-    const OPENING_DELIMITER: Self = Self::from_slice(&[SyntaxKind::LBracket, SyntaxKind::LBrace]);
+    pub(crate) const OPENING_DELIMITER: Self =
+        Self::from_slice(&[SyntaxKind::LBracket, SyntaxKind::LBrace]);
     /// Tokens that represent separators in JSON like `,` and `:`.
-    const SEPARATORS: Self = Self::from_slice(&[SyntaxKind::Comma, SyntaxKind::Colon]);
+    pub(crate) const SEPARATORS: Self = Self::from_slice(&[SyntaxKind::Comma, SyntaxKind::Colon]);
     /// Tokens that represent JSON values like strings, numbers, booleans, and null.
-    const VALUE: Self = Self::from_slice(&[
+    pub(crate) const VALUE: Self = Self::from_slice(&[
         SyntaxKind::String,
         SyntaxKind::Number,
         SyntaxKind::True,
@@ -60,6 +62,11 @@ impl SyntaxKindSet {
     pub(crate) const COMPLETE: Self = Self::from_slice(SyntaxKind::VARIANTS);
     /// An empty set with no syntax kinds.
     pub(crate) const EMPTY: Self = Self(0);
+
+    /// Creates a new set from a single syntax kind.
+    pub(crate) const fn from_kind(kind: SyntaxKind) -> Self {
+        Self(kind.into_flag())
+    }
 
     /// Creates a new set from a slice of syntax kinds.
     pub(crate) const fn from_slice(slice: &[SyntaxKind]) -> Self {
@@ -181,6 +188,12 @@ impl FromIterator<SyntaxKind> for SyntaxKindSet {
     }
 }
 
+impl From<SyntaxKind> for SyntaxKindSet {
+    fn from(kind: SyntaxKind) -> Self {
+        Self::from_kind(kind)
+    }
+}
+
 impl IntoIterator for SyntaxKindSet {
     type IntoIter = SyntaxKindSetIter;
     type Item = SyntaxKind;
@@ -222,6 +235,7 @@ impl Default for SyntaxKindSet {
 
 #[cfg(test)]
 mod tests {
+    #![expect(clippy::needless_raw_strings)]
     use super::*;
 
     #[test]

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/syntax_kind_set.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/syntax_kind_set.rs
@@ -54,7 +54,6 @@ impl SyntaxKindSet {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum Conjunction {
     Or,
-    And,
 }
 
 impl SyntaxKindSet {
@@ -156,8 +155,6 @@ impl SyntaxKindSet {
                             match verb {
                                 Some(Conjunction::Or) if len == 2 => fmt.write_str(" or ")?,
                                 Some(Conjunction::Or) => fmt.write_str("or ")?,
-                                Some(Conjunction::And) if len == 2 => fmt.write_str(" and ")?,
-                                Some(Conjunction::And) => fmt.write_str("and ")?,
                                 None if len == 2 => fmt.write_str(", ")?,
                                 None => {}
                             }
@@ -244,7 +241,6 @@ mod tests {
 
         insta::assert_snapshot!(set.display(None).to_string(), @r"none");
         insta::assert_snapshot!(set.display(Some(Conjunction::Or)).to_string(), @r"none");
-        insta::assert_snapshot!(set.display(Some(Conjunction::And)).to_string(), @r"none");
     }
 
     #[test]
@@ -253,7 +249,6 @@ mod tests {
 
         insta::assert_snapshot!(set.display(None).to_string(), @r"string");
         insta::assert_snapshot!(set.display(Some(Conjunction::Or)).to_string(), @r"string");
-        insta::assert_snapshot!(set.display(Some(Conjunction::And)).to_string(), @r"string");
     }
 
     #[test]
@@ -262,7 +257,6 @@ mod tests {
 
         insta::assert_snapshot!(set.display(None).to_string(), @r"string, number");
         insta::assert_snapshot!(set.display(Some(Conjunction::Or)).to_string(), @r"string or number");
-        insta::assert_snapshot!(set.display(Some(Conjunction::And)).to_string(), @r"string and number");
     }
 
     #[test]
@@ -272,7 +266,6 @@ mod tests {
 
         insta::assert_snapshot!(set.display(None).to_string(), @r"string, number, `true`");
         insta::assert_snapshot!(set.display(Some(Conjunction::Or)).to_string(), @"string, number, or `true`");
-        insta::assert_snapshot!(set.display(Some(Conjunction::And)).to_string(), @"string, number, and `true`");
     }
 
     #[test]
@@ -286,7 +279,6 @@ mod tests {
 
         insta::assert_snapshot!(set.display(None).to_string(), @r"string, number, `true`, `false`");
         insta::assert_snapshot!(set.display(Some(Conjunction::Or)).to_string(), @r"string, number, `true`, or `false`");
-        insta::assert_snapshot!(set.display(Some(Conjunction::And)).to_string(), @r"string, number, `true`, and `false`");
     }
 
     #[test]

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/syntax_kind_set.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/syntax_kind_set.rs
@@ -1,8 +1,11 @@
-use core::fmt::{self, Display};
+use core::{
+    fmt::{self, Display},
+    ops::{BitAnd, BitOr, BitXor},
+};
 
-use super::syntax_kind::SyntaxKind;
+use super::syntax_kind::{Flag, SyntaxKind};
 
-pub(crate) struct SyntaxKindSetIter(u128);
+pub(crate) struct SyntaxKindSetIter(Flag);
 
 impl Iterator for SyntaxKindSetIter {
     type Item = SyntaxKind;
@@ -14,49 +17,154 @@ impl Iterator for SyntaxKindSetIter {
 
         let kind = self.0.trailing_zeros();
         self.0 &= !(1 << kind);
-        Some(match kind {
-            0 => SyntaxKind::String,
-            1 => SyntaxKind::Number,
-            2 => SyntaxKind::True,
-            3 => SyntaxKind::False,
-            4 => SyntaxKind::Null,
-            5 => SyntaxKind::Comma,
-            6 => SyntaxKind::Colon,
-            7 => SyntaxKind::LBrace,
-            8 => SyntaxKind::RBrace,
-            9 => SyntaxKind::LBracket,
-            10 => SyntaxKind::RBracket,
-            _ => unreachable!(),
-        })
+
+        Some(SyntaxKind::from_exponent(kind))
     }
 }
 
+impl ExactSizeIterator for SyntaxKindSetIter {
+    fn len(&self) -> usize {
+        self.0.count_ones() as usize
+    }
+}
+
+/// A bitset representing a set of syntax kinds.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct SyntaxKindSet(u128);
+pub(crate) struct SyntaxKindSet(Flag);
 
 impl SyntaxKindSet {
+    /// Tokens that represent closing delimiters like `]` and `}`.
+    const CLOSING_DELIMITER: Self = Self::from_slice(&[SyntaxKind::RBracket, SyntaxKind::RBrace]);
+    /// Tokens that represent opening delimiters like `[` and `{`.
+    const OPENING_DELIMITER: Self = Self::from_slice(&[SyntaxKind::LBracket, SyntaxKind::LBrace]);
+    /// Tokens that represent separators in JSON like `,` and `:`.
+    const SEPARATORS: Self = Self::from_slice(&[SyntaxKind::Comma, SyntaxKind::Colon]);
+    /// Tokens that represent JSON values like strings, numbers, booleans, and null.
+    const VALUE: Self = Self::from_slice(&[
+        SyntaxKind::String,
+        SyntaxKind::Number,
+        SyntaxKind::True,
+        SyntaxKind::False,
+        SyntaxKind::Null,
+    ]);
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum Conjunction {
+    Or,
+    And,
+}
+
+impl SyntaxKindSet {
+    /// A set containing all possible syntax kinds.
+    pub(crate) const COMPLETE: Self = Self::from_slice(SyntaxKind::VARIANTS);
+    /// An empty set with no syntax kinds.
     pub(crate) const EMPTY: Self = Self(0);
 
+    /// Creates a new set from a slice of syntax kinds.
     pub(crate) const fn from_slice(slice: &[SyntaxKind]) -> Self {
         let mut set = 0;
 
         // cannot use for loop here, because it's not const
         let mut index = 0;
         while index < slice.len() {
-            set |= slice[index].into_u128();
+            set |= slice[index].into_flag();
             index += 1;
         }
 
         Self(set)
     }
 
+    /// Returns true if the set contains no syntax kinds.
     #[must_use]
-    pub(crate) const fn len(&self) -> usize {
+    pub(crate) const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    /// Returns true if the set contains all possible syntax kinds.
+    #[must_use]
+    pub(crate) const fn is_complete(self) -> bool {
+        self.0 == Self::COMPLETE.0
+    }
+
+    /// Returns the number of syntax kinds in the set.
+    #[must_use]
+    pub(crate) const fn len(self) -> usize {
         self.0.count_ones() as usize
     }
 
-    pub(crate) const fn contains(&self, kind: SyntaxKind) -> bool {
-        self.0 & kind.into_u128() != 0
+    /// Returns true if the set contains the given syntax kind.
+    pub(crate) const fn contains(self, kind: SyntaxKind) -> bool {
+        self.0 & kind.into_flag() != 0
+    }
+
+    /// Returns true if the set contains any of the syntax kinds in the given set.
+    pub(crate) const fn contains_any(self, set: Self) -> bool {
+        self.0 & set.0 != 0
+    }
+
+    /// Returns true if the set contains any closing delimiter (`]` or `}`).
+    pub(crate) const fn contains_closing_delimiter(self) -> bool {
+        self.contains_any(Self::CLOSING_DELIMITER)
+    }
+
+    /// Returns true if the set contains any opening delimiter (`[` or `{`).
+    pub(crate) const fn contains_opening_delimiter(self) -> bool {
+        self.contains_any(Self::OPENING_DELIMITER)
+    }
+
+    /// Returns true if the set contains any value token (string, number, true, false, null).
+    pub(crate) const fn contains_value(self) -> bool {
+        self.contains_any(Self::VALUE)
+    }
+
+    /// Returns true if the set contains any separator token (comma, colon).
+    pub(crate) const fn contains_separator(self) -> bool {
+        self.contains_any(Self::SEPARATORS)
+    }
+
+    pub(crate) const fn display(self, verb: Option<Conjunction>) -> impl Display {
+        #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+        struct Format(SyntaxKindSet, Option<Conjunction>);
+
+        impl Display for Format {
+            fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+                let Self(this, verb) = *self;
+                let count = this.len();
+
+                if count == 0 {
+                    return fmt.write_str("none");
+                }
+
+                let iter = this.into_iter();
+                let len = iter.len();
+
+                for (i, kind) in iter.enumerate() {
+                    if i > 0 {
+                        if i != len - 1 || len != 2 {
+                            fmt.write_str(", ")?;
+                        }
+
+                        if i == len - 1 {
+                            match verb {
+                                Some(Conjunction::Or) if len == 2 => fmt.write_str(" or ")?,
+                                Some(Conjunction::Or) => fmt.write_str("or ")?,
+                                Some(Conjunction::And) if len == 2 => fmt.write_str(" and ")?,
+                                Some(Conjunction::And) => fmt.write_str("and ")?,
+                                None if len == 2 => fmt.write_str(", ")?,
+                                None => {}
+                            }
+                        }
+                    }
+
+                    Display::fmt(&kind, fmt)?;
+                }
+
+                Ok(())
+            }
+        }
+
+        Format(self, verb)
     }
 }
 
@@ -67,7 +175,7 @@ impl FromIterator<SyntaxKind> for SyntaxKindSet {
     {
         let mut set = 0;
         for kind in iter {
-            set |= kind.into_u128();
+            set |= kind.into_flag();
         }
         Self(set)
     }
@@ -82,21 +190,98 @@ impl IntoIterator for SyntaxKindSet {
     }
 }
 
-impl Display for SyntaxKindSet {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let count = self.len();
-        if count == 0 {
-            return fmt.write_str("none");
-        }
+impl BitOr for SyntaxKindSet {
+    type Output = Self;
 
-        for (index, kind) in self.into_iter().enumerate() {
-            if index > 0 {
-                fmt.write_str(", ")?;
-            }
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+}
 
-            Display::fmt(&kind, fmt)?;
-        }
+impl BitAnd for SyntaxKindSet {
+    type Output = Self;
 
-        Ok(())
+    fn bitand(self, rhs: Self) -> Self {
+        Self(self.0 & rhs.0)
+    }
+}
+
+impl BitXor for SyntaxKindSet {
+    type Output = Self;
+
+    fn bitxor(self, rhs: Self) -> Self {
+        Self(self.0 ^ rhs.0)
+    }
+}
+
+impl Default for SyntaxKindSet {
+    fn default() -> Self {
+        Self::EMPTY
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_set_display() {
+        let set = SyntaxKindSet::EMPTY;
+
+        insta::assert_snapshot!(set.display(None).to_string(), @r"none");
+        insta::assert_snapshot!(set.display(Some(Conjunction::Or)).to_string(), @r"none");
+        insta::assert_snapshot!(set.display(Some(Conjunction::And)).to_string(), @r"none");
+    }
+
+    #[test]
+    fn singleton_set_display() {
+        let set = SyntaxKindSet::from_slice(&[SyntaxKind::String]);
+
+        insta::assert_snapshot!(set.display(None).to_string(), @r"string");
+        insta::assert_snapshot!(set.display(Some(Conjunction::Or)).to_string(), @r"string");
+        insta::assert_snapshot!(set.display(Some(Conjunction::And)).to_string(), @r"string");
+    }
+
+    #[test]
+    fn pair_set_display() {
+        let set = SyntaxKindSet::from_slice(&[SyntaxKind::String, SyntaxKind::Number]);
+
+        insta::assert_snapshot!(set.display(None).to_string(), @r"string, number");
+        insta::assert_snapshot!(set.display(Some(Conjunction::Or)).to_string(), @r"string or number");
+        insta::assert_snapshot!(set.display(Some(Conjunction::And)).to_string(), @r"string and number");
+    }
+
+    #[test]
+    fn triplet_set_display() {
+        let set =
+            SyntaxKindSet::from_slice(&[SyntaxKind::String, SyntaxKind::Number, SyntaxKind::True]);
+
+        insta::assert_snapshot!(set.display(None).to_string(), @r"string, number, `true`");
+        insta::assert_snapshot!(set.display(Some(Conjunction::Or)).to_string(), @"string, number, or `true`");
+        insta::assert_snapshot!(set.display(Some(Conjunction::And)).to_string(), @"string, number, and `true`");
+    }
+
+    #[test]
+    fn larger_set_display() {
+        let set = SyntaxKindSet::from_slice(&[
+            SyntaxKind::String,
+            SyntaxKind::Number,
+            SyntaxKind::True,
+            SyntaxKind::False,
+        ]);
+
+        insta::assert_snapshot!(set.display(None).to_string(), @r"string, number, `true`, `false`");
+        insta::assert_snapshot!(set.display(Some(Conjunction::Or)).to_string(), @r"string, number, `true`, or `false`");
+        insta::assert_snapshot!(set.display(Some(Conjunction::And)).to_string(), @r"string, number, `true`, and `false`");
+    }
+
+    #[test]
+    fn complete_set_display() {
+        // The complete set should list all items with proper formatting
+        let set = SyntaxKindSet::COMPLETE;
+
+        // Just check that the output contains some expected substrings
+        let display = set.display(Some(Conjunction::Or)).to_string();
+        insta::assert_snapshot!(display, @"string, number, `true`, `false`, `null`, `,`, `:`, `{`, `}`, `[`, or `]`");
     }
 }

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/token.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/token.rs
@@ -8,8 +8,8 @@ pub(crate) struct Token<'source> {
     pub span: TextRange,
 }
 
-impl<'source> AsRef<Token<'source>> for Token<'source> {
-    fn as_ref(&self) -> &Token<'source> {
+impl AsRef<Self> for Token<'_> {
+    fn as_ref(&self) -> &Self {
         self
     }
 }

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/token.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/token.rs
@@ -7,3 +7,9 @@ pub(crate) struct Token<'source> {
     pub kind: TokenKind<'source>,
     pub span: TextRange,
 }
+
+impl<'source> AsRef<Token<'source>> for Token<'source> {
+    fn as_ref(&self) -> &Token<'source> {
+        self
+    }
+}

--- a/libs/@local/hashql/syntax-jexpr/src/lib.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/lib.rs
@@ -10,7 +10,8 @@
     portable_simd,
     result_flattening,
     ascii_char,
-    if_let_guard
+    if_let_guard,
+    variant_count
 )]
 
 extern crate alloc;

--- a/libs/@local/hashql/syntax-jexpr/src/parser/array/error.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/array/error.rs
@@ -15,11 +15,6 @@ use crate::{lexer::error::LexerDiagnosticCategory, span::Span};
 
 pub(crate) type ArrayDiagnostic = Diagnostic<ArrayDiagnosticCategory, SpanId>;
 
-const EXPECTED_SEPARATOR: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
-    id: "expected-separator",
-    name: "Expected array separator (comma) or closing bracket",
-};
-
 const LEADING_COMMA: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
     id: "leading-comma",
     name: "Unexpected leading comma in array",
@@ -54,7 +49,6 @@ const LABELED_ARGUMENT_INVALID_IDENTIFIER: TerminalDiagnosticCategory =
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum ArrayDiagnosticCategory {
     Lexer(LexerDiagnosticCategory),
-    ExpectedSeparator,
     LeadingComma,
     TrailingComma,
     ConsecutiveComma,
@@ -81,7 +75,6 @@ impl DiagnosticCategory for ArrayDiagnosticCategory {
     fn subcategory(&self) -> Option<&dyn DiagnosticCategory> {
         match self {
             Self::Lexer(category) => Some(category),
-            Self::ExpectedSeparator => Some(&EXPECTED_SEPARATOR),
             Self::LeadingComma => Some(&LEADING_COMMA),
             Self::TrailingComma => Some(&TRAILING_COMMA),
             Self::ConsecutiveComma => Some(&CONSECUTIVE_COMMA),

--- a/libs/@local/hashql/syntax-jexpr/src/parser/array/mod.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/array/mod.rs
@@ -55,7 +55,9 @@ fn parse_labelled_argument<'heap>(
         return Ok(None);
     }
 
-    let token = state.advance().change_category(From::from)?;
+    let token = state
+        .advance(SyntaxKind::LBrace)
+        .change_category(From::from)?;
 
     let mut labeled_arguments = Vec::new();
 

--- a/libs/@local/hashql/syntax-jexpr/src/parser/array/snapshots/hashql_syntax_jexpr__parser__array__tests__parse_labeled_argument_missing_prefix.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/array/snapshots/hashql_syntax_jexpr__parser__array__tests__parse_labeled_argument_missing_prefix.snap
@@ -8,7 +8,7 @@ expression: "[\"greet\", {\"name\": {\"#literal\": \"Alice\"}}]"
    │
  1 │ ["greet", {"name": {"#literal": "Alice"}}]
    │            ───┬──  
-   │               ╰──── Unrecognized key `name`
+   │               ╰──── Replace `name` with a valid key
    │ 
    │ Help: This J-Expr object only accepts these specific keys: `#literal`, `#struct`, `#dict`, `#tuple`, `#list`, or `#type`
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/array/snapshots/hashql_syntax_jexpr__parser__array__visit__tests__missing_comma.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/array/snapshots/hashql_syntax_jexpr__parser__array__visit__tests__missing_comma.snap
@@ -3,12 +3,12 @@ source: libs/@local/hashql/syntax-jexpr/src/parser/array/visit.rs
 description: Array with missing comma should fail
 expression: "[1 2]"
 ---
-[31m[array::expected-separator] Error:[0m Array
+[31m[lexer::lexer::unexpected-token] Error:[0m Lexer
    ╭─[ <unknown>:1:4 ]
    │
  1 │ [1 2]
    │    ┬  
-   │    ╰── Unexpected token
+   │    ╰── Unexpected number, expected `,` or `]`
    │ 
-   │ Help: Expected `,`, or `]` at this position
+   │ Help: Missing closing bracket. Make sure all opening brackets have matching closing brackets.
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/array/snapshots/hashql_syntax_jexpr__parser__array__visit__tests__unclosed_array.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/array/snapshots/hashql_syntax_jexpr__parser__array__visit__tests__unclosed_array.snap
@@ -10,5 +10,5 @@ expression: "[1, 2"
    │      │ 
    │      ╰─ Unexpected end of file
    │ 
-   │ Help: Make sure all expressions, brackets, and string literals are properly closed
+   │ Help: Missing closing bracket. Make sure all opening brackets have matching closing brackets.
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/array/visit.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/array/visit.rs
@@ -46,7 +46,7 @@ where
 
     loop {
         let next = state
-            .peek_required()
+            .peek_expect()
             .change_category(ArrayDiagnosticCategory::Lexer)
             .change_category(C::from)?;
 

--- a/libs/@local/hashql/syntax-jexpr/src/parser/complex/mod.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/complex/mod.rs
@@ -22,9 +22,10 @@ pub(crate) fn verify_no_repeat<C>(
 where
     C: From<LexerDiagnosticCategory>,
 {
-    let next = state
-        .peek_expect(SyntaxKindSet::COMPLETE)
-        .change_category(C::from)?;
+    // Do a "soft peek" instead of a required peek. This way we can propagate the EOF upstream.
+    let Some(next) = state.peek().change_category(C::from)? else {
+        return Ok(());
+    };
     let next_syntax = next.kind.syntax();
 
     if !deny.contains(next_syntax) && !end.contains(next_syntax) {

--- a/libs/@local/hashql/syntax-jexpr/src/parser/complex/mod.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/complex/mod.rs
@@ -22,7 +22,7 @@ pub(crate) fn verify_no_repeat<C>(
 where
     C: From<LexerDiagnosticCategory>,
 {
-    let next = state.peek_required().change_category(C::from)?;
+    let next = state.peek_expect().change_category(C::from)?;
     let next_syntax = next.kind.syntax();
 
     if !deny.contains(next_syntax) && !end.contains(next_syntax) {
@@ -40,7 +40,7 @@ where
 
     loop {
         // in the first loop, we refetch here, but this just makes operating on the stream easier
-        let token = state.peek_required().change_category(C::from)?;
+        let token = state.peek_expect().change_category(C::from)?;
 
         let token_span = token.span;
         let token_syntax = token.kind.syntax();

--- a/libs/@local/hashql/syntax-jexpr/src/parser/complex/mod.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/complex/mod.rs
@@ -22,7 +22,9 @@ pub(crate) fn verify_no_repeat<C>(
 where
     C: From<LexerDiagnosticCategory>,
 {
-    let next = state.peek_expect().change_category(C::from)?;
+    let next = state
+        .peek_expect(SyntaxKindSet::COMPLETE)
+        .change_category(C::from)?;
     let next_syntax = next.kind.syntax();
 
     if !deny.contains(next_syntax) && !end.contains(next_syntax) {
@@ -40,7 +42,9 @@ where
 
     loop {
         // in the first loop, we refetch here, but this just makes operating on the stream easier
-        let token = state.peek_expect().change_category(C::from)?;
+        let token = state
+            .peek_expect(SyntaxKindSet::COMPLETE)
+            .change_category(C::from)?;
 
         let token_span = token.span;
         let token_syntax = token.kind.syntax();
@@ -60,7 +64,9 @@ where
 
         // Token that is denied, therefore advance the stream and add it to the spans
         spans.push(token_span);
-        state.advance().change_category(C::from)?;
+        state
+            .advance(SyntaxKindSet::COMPLETE)
+            .change_category(C::from)?;
     }
 
     // materialize the spans

--- a/libs/@local/hashql/syntax-jexpr/src/parser/error.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/error.rs
@@ -13,7 +13,7 @@ use super::{
     array::error::ArrayDiagnosticCategory, object::error::ObjectDiagnosticCategory,
     string::error::StringDiagnosticCategory,
 };
-use crate::lexer::{error::LexerDiagnosticCategory, syntax_kind_set::SyntaxKindSet};
+use crate::lexer::error::LexerDiagnosticCategory;
 
 pub(crate) type ParserDiagnostic = Diagnostic<ParserDiagnosticCategory, SpanId>;
 
@@ -86,38 +86,6 @@ impl From<ObjectDiagnosticCategory> for ParserDiagnosticCategory {
     fn from(value: ObjectDiagnosticCategory) -> Self {
         Self::Object(value)
     }
-}
-
-pub(crate) fn unexpected_token<C>(
-    span: SpanId,
-    category: C,
-    expected: SyntaxKindSet,
-) -> Diagnostic<C, SpanId> {
-    let mut diagnostic = Diagnostic::new(category, Severity::ERROR);
-
-    diagnostic.labels.push(Label::new(span, "Unexpected token"));
-
-    let length = expected.len();
-    let expected = expected
-        .into_iter()
-        .enumerate()
-        .fold(String::new(), |mut acc, (i, kind)| {
-            if i > 0 {
-                acc.push_str(", ");
-            }
-
-            if i == length - 1 && i > 0 {
-                acc.push_str("or ");
-            }
-
-            acc.push_str(&kind.to_string());
-
-            acc
-        });
-
-    diagnostic.help = Some(Help::new(format!("Expected {expected} at this position")));
-
-    diagnostic
 }
 
 const EXPECTED_EOF_HELP: &str =

--- a/libs/@local/hashql/syntax-jexpr/src/parser/expr.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/expr.rs
@@ -2,7 +2,7 @@ use hashql_ast::node::expr::Expr;
 
 use super::{
     array::parse_array,
-    error::{ParserDiagnostic, ParserDiagnosticCategory, unexpected_token},
+    error::{ParserDiagnostic, ParserDiagnosticCategory},
     object::parse_object,
     state::ParserState,
     string::parse_string,
@@ -10,7 +10,6 @@ use super::{
 use crate::{
     error::ResultExt as _,
     lexer::{syntax_kind::SyntaxKind, syntax_kind_set::SyntaxKindSet},
-    span::Span,
 };
 
 const PARSE_EXPR_KINDS: SyntaxKindSet = SyntaxKindSet::from_slice(&[
@@ -23,7 +22,7 @@ pub(crate) fn parse_expr<'heap>(
     state: &mut ParserState<'heap, '_>,
 ) -> Result<Expr<'heap>, ParserDiagnostic> {
     let token = state
-        .advance()
+        .advance(PARSE_EXPR_KINDS)
         .change_category(ParserDiagnosticCategory::Lexer)?;
 
     match token.kind.syntax() {
@@ -33,17 +32,7 @@ pub(crate) fn parse_expr<'heap>(
         SyntaxKind::LBracket => parse_array(state, token),
         SyntaxKind::LBrace => parse_object(state, token),
         _ => {
-            let span = state.insert_span(Span {
-                range: token.span,
-                pointer: Some(state.current_pointer()),
-                parent_id: None,
-            });
-
-            Err(unexpected_token(
-                span,
-                ParserDiagnosticCategory::ExpectedLanguageItem,
-                PARSE_EXPR_KINDS,
-            ))
+            unreachable!()
         }
     }
 }

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__dict__tests__parse_dict_incomplete.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__dict__tests__parse_dict_incomplete.snap
@@ -1,0 +1,14 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/parser/object/dict.rs
+description: Parses with a sudden EOF
+expression: "{\"#dict\": "
+---
+[31m[lexer::lexer::unexpected-eof] Error:[0m Lexer
+   ╭─[ <unknown>:1:11 ]
+   │
+ 1 │ {"#dict":
+   │           │ 
+   │           ╰─ Unexpected end of file, expected `{` or `[`
+   │ 
+   │ Help: The file ended where an opening bracket was expected. Complete the expression structure.
+───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__dict__tests__parse_dict_invalid_array_entry.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__dict__tests__parse_dict_invalid_array_entry.snap
@@ -8,7 +8,9 @@ expression: "{\"#dict\": [\n            {\"not\": \"an-array\"}\n        ]}"
    │
  2 │             {"not": "an-array"}
    │             ┬  
-   │             ╰── Unexpected token
+   │             ╰── Expected an array for dictionary entry
    │ 
-   │ Help: Expected `[` at this position
+   │ Help: Found `{`, but dictionary entries must be arrays with exactly two elements [key, value]
+   │ 
+   │ Note: In the array-of-pairs format for dictionaries, each entry must be a two-element array.
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__dict__tests__parse_empty_dict_object_incomplete.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__dict__tests__parse_empty_dict_object_incomplete.snap
@@ -1,0 +1,14 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/parser/object/dict.rs
+description: Parses an empty dict using object format
+expression: "{\"#dict\": "
+---
+[31m[lexer::lexer::unexpected-eof] Error:[0m Lexer
+   ╭─[ <unknown>:1:11 ]
+   │
+ 1 │ {"#dict":
+   │           │ 
+   │           ╰─ Unexpected end of file, expected `{` or `[`
+   │ 
+   │ Help: The file ended where an opening bracket was expected. Complete the expression structure.
+───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__dict__tests__parse_invalid_dict_format.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__dict__tests__parse_invalid_dict_format.snap
@@ -8,11 +8,11 @@ expression: "{\"#dict\": \"invalid\"}"
    │
  1 │ {"#dict": "invalid"}
    │           ────┬────  
-   │               ╰────── Expected object or array of pairs
+   │               ╰────── Expected an object or array of pairs here
    │ 
-   │ Help: Expected either an object {key: value, ...} or an array of pairs [[key, value], ...], found string
+   │ Help: Found string, but the #dict construct requires either an object {key: value, ...} or an array of pairs [[key, value], ...]
    │ 
-   │ Note: Dictionaries in J-Expr support two formats:
-   │       1. Object-like syntax: {"key1": value1, "key2": value2, ...}
-   │       2. Array of pairs: [[key1, value1], [key2, value2], ...]
+   │ Note: Valid dictionary formats:
+   │           1. Object syntax: {"key1": value1, "key2": value2, ...}
+   │           2. Array of pairs: [[key1, value1], [key2, value2], ...]
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__dict__tests__parse_unknown_key_in_dict.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__dict__tests__parse_unknown_key_in_dict.snap
@@ -8,7 +8,7 @@ expression: "{\"#dict\": {}, \"unknown\": {\"#literal\": \"value\"}}"
    │
  1 │ {"#dict": {}, "unknown": {"#literal": "value"}}
    │               ────┬────  
-   │                   ╰────── Unrecognized key `unknown`
+   │                   ╰────── Replace `unknown` with a valid key
    │ 
    │ Help: This J-Expr object only accepts these specific keys: `#type`
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__list__tests__parse_invalid_list_value.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__list__tests__parse_invalid_list_value.snap
@@ -8,7 +8,9 @@ expression: "{\"#list\": {\"not\": \"an-array\"}}"
    │
  1 │ {"#list": {"not": "an-array"}}
    │           ┬  
-   │           ╰── Unexpected token
+   │           ╰── Expected an array here
    │ 
-   │ Help: Expected `[` at this position
+   │ Help: The #list construct requires an array of elements, but found `{`. Use square brackets to define the list elements: [element1, element2, ...]
+   │ 
+   │ Note: Lists in J-Expr represent variable-length collections where all elements must have the same type.
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__list__tests__parse_tuple_incomplete.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__list__tests__parse_tuple_incomplete.snap
@@ -1,0 +1,14 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/parser/object/list.rs
+description: Parses with a sudden EOF
+expression: "{\"#tuple\": "
+---
+[31m[lexer::lexer::unexpected-eof] Error:[0m Lexer
+   ╭─[ <unknown>:1:12 ]
+   │
+ 1 │ {"#tuple":
+   │            │ 
+   │            ╰─ Unexpected end of file, expected `[`
+   │ 
+   │ Help: The file ended where an opening bracket was expected. Complete the expression structure.
+───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__list__tests__parse_unknown_key_in_list.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__list__tests__parse_unknown_key_in_list.snap
@@ -8,7 +8,7 @@ expression: "{\"#list\": [], \"unknown\": {\"#literal\": \"value\"}}"
    │
  1 │ {"#list": [], "unknown": {"#literal": "value"}}
    │               ────┬────  
-   │                   ╰────── Unrecognized key `unknown`
+   │                   ╰────── Replace `unknown` with a valid key
    │ 
    │ Help: This J-Expr object only accepts these specific keys: `#type`
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__literal__tests__parse_empty_object_as_literal.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__literal__tests__parse_empty_object_as_literal.snap
@@ -8,7 +8,7 @@ expression: "{}"
    │
  1 │ {}
    │ ─┬  
-   │  ╰── Empty object not allowed
+   │  ╰── Add required fields to this object
    │ 
    │ Help: J-Expr objects must contain at least one key-value pair with a specific structure. For example: `{"#literal": 42}` or `{"#struct": {"name": {"#literal": "value"}}}`
    │ 

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__literal__tests__parse_incomplete.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__literal__tests__parse_incomplete.snap
@@ -1,0 +1,14 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/parser/object/literal.rs
+description: Parses with a sudden EOF
+expression: "{\"#literal\": "
+---
+[31m[lexer::lexer::unexpected-eof] Error:[0m Lexer
+   ╭─[ <unknown>:1:14 ]
+   │
+ 1 │ {"#literal":
+   │              │ 
+   │              ╰─ Unexpected end of file, expected string, number, `true`, `false`, or `null`
+   │ 
+   │ Help: The file ended where a value was expected. Add a valid JSON value (string, number, object, array, true, false, or null).
+───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__literal__tests__parse_invalid_literal.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__literal__tests__parse_invalid_literal.snap
@@ -3,12 +3,12 @@ source: libs/@local/hashql/syntax-jexpr/src/parser/object/literal.rs
 description: Rejects invalid literal values
 expression: "{\"#literal\": {\"invalid\": \"object\"}}"
 ---
-[31m[parser::object::invalid-literal] Error:[0m Parser
+[31m[parser::object::literal-expected-primitive] Error:[0m Parser
    ╭─[ <unknown>:1:14 ]
    │
  1 │ {"#literal": {"invalid": "object"}}
    │              ┬  
-   │              ╰── Unexpected token
+   │              ╰── Invalid literal value in this context
    │ 
-   │ Help: Expected string, number, `true`, `false`, or `null` at this position
+   │ Help: Found `{`, which is not a valid primitive literal. Primitive literals are either strings, numbers, or booleans.
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__literal__tests__parse_unknown_key_in_literal.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__literal__tests__parse_unknown_key_in_literal.snap
@@ -8,7 +8,7 @@ expression: "{\"#literal\": 42, \"unknown\": \"value\"}"
    │
  1 │ {"#literal": 42, "unknown": "value"}
    │                  ────┬────  
-   │                      ╰────── Unrecognized key `unknown`
+   │                      ╰────── Replace `unknown` with a valid key
    │ 
    │ Help: This J-Expr object only accepts these specific keys: `#type`
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__r#struct__tests__parse_invalid_struct_value.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__r#struct__tests__parse_invalid_struct_value.snap
@@ -8,7 +8,9 @@ expression: "{\"#struct\": [\"not\", \"an-object\"]}"
    │
  1 │ {"#struct": ["not", "an-object"]}
    │             ┬  
-   │             ╰── Unexpected token
+   │             ╰── Expected an object here
    │ 
-   │ Help: Expected `{` at this position
+   │ Help: The #struct construct requires an object with field definitions, but found `[`. Use curly braces to define the struct fields: {"field1": value1, "field2": value2}
+   │ 
+   │ Note: Structs in J-Expr represent collections of named fields, where each field can have a different type.
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__r#struct__tests__parse_struct_incomplete.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__r#struct__tests__parse_struct_incomplete.snap
@@ -1,0 +1,14 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/parser/object/struct.rs
+description: Parses with a sudden EOF
+expression: "{\"#struct\": "
+---
+[31m[lexer::lexer::unexpected-eof] Error:[0m Lexer
+   ╭─[ <unknown>:1:13 ]
+   │
+ 1 │ {"#struct":
+   │             │ 
+   │             ╰─ Unexpected end of file, expected `{`
+   │ 
+   │ Help: The file ended where an opening bracket was expected. Complete the expression structure.
+───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__r#struct__tests__parse_unknown_key_in_struct.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__r#struct__tests__parse_unknown_key_in_struct.snap
@@ -8,7 +8,7 @@ expression: "{\"#struct\": {}, \"unknown\": {\"#literal\": \"value\"}}"
    │
  1 │ {"#struct": {}, "unknown": {"#literal": "value"}}
    │                 ────┬────  
-   │                     ╰────── Unrecognized key `unknown`
+   │                     ╰────── Replace `unknown` with a valid key
    │ 
    │ Help: This J-Expr object only accepts these specific keys: `#type`
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__r#type__tests__parse_incomplete.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__r#type__tests__parse_incomplete.snap
@@ -1,0 +1,14 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/parser/object/type.rs
+description: Parses with a sudden EOF
+expression: "{\"#type\": "
+---
+[31m[lexer::lexer::unexpected-eof] Error:[0m Lexer
+   ╭─[ <unknown>:1:11 ]
+   │
+ 1 │ {"#type":
+   │           │ 
+   │           ╰─ Unexpected end of file, expected string
+   │ 
+   │ Help: The file ended where a value was expected. Add a valid JSON value (string, number, object, array, true, false, or null).
+───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__r#type__tests__parse_invalid_syntax.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__r#type__tests__parse_invalid_syntax.snap
@@ -1,0 +1,16 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/parser/object/type.rs
+description: Parses invalid syntax
+expression: "{\"#type\": [\"a\"]}"
+---
+[31m[parser::object::type-expected-string] Error:[0m Parser
+   ╭─[ <unknown>:1:11 ]
+   │
+ 1 │ {"#type": ["a"]}
+   │           ┬  
+   │           ╰── Invalid type specification
+   │ 
+   │ Help: Found `[`, which is not a valid type specification. Types must be represented as a string.
+   │ 
+   │ Note: Types in J-Expr must be specified through an embedded language represented in a string that mimics that of Rust and TypeScript. See the language documentation for more details.
+───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__r#type__tests__parse_invalid_type.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__r#type__tests__parse_invalid_type.snap
@@ -1,0 +1,12 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/parser/object/type.rs
+description: Parses an invalid type
+expression: "{\"#type\": \"\"}"
+---
+[31m[parser::string::invalid-expression] Error:[0m Parser
+   ╭─[ <unknown>:1:11 ]
+   │
+ 1 │ {"#type": ""}
+   │           │ 
+   │           ╰─ Invalid type
+───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__tests__parse_empty_object.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__tests__parse_empty_object.snap
@@ -8,7 +8,7 @@ expression: "{}"
    │
  1 │ {}
    │ ─┬  
-   │  ╰── Empty object not allowed
+   │  ╰── Add required fields to this object
    │ 
    │ Help: J-Expr objects must contain at least one key-value pair with a specific structure. For example: `{"#literal": 42}` or `{"#struct": {"name": {"#literal": "value"}}}`
    │ 

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__tests__parse_multiple_expression_keys.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__tests__parse_multiple_expression_keys.snap
@@ -8,7 +8,7 @@ expression: "{\"#literal\": 42, \"#list\": []}"
    │
  1 │ {"#literal": 42, "#list": []}
    │                  ───┬───  
-   │                     ╰───── Unrecognized key `#list`
+   │                     ╰───── Replace `#list` with a valid key
    │ 
    │ Help: This J-Expr object only accepts these specific keys: `#type`
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__tests__parse_standalone_type.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__tests__parse_standalone_type.snap
@@ -8,12 +8,12 @@ expression: "{\"#type\": \"Int\"}"
    │
  1 │ {"#type": "Int"}
    │  ───────┬──────  
-   │         ╰──────── Cannot use this keyword alone
+   │         ╰──────── Add a primary construct to use with #type
    │ 
    │ Help: The `#type` field must be used alongside a primary construct like `#struct`, `#list`, etc. It cannot be used alone in an object.
    │ 
    │ Note: The `#type` field is used to annotate the type of a construct. Valid examples include:
-   │       - `{"#struct": {...}, "#type": "Person"}`
-   │       - `{"#list": [...], "#type": "List<Number>"}`
-   │       - `{"#literal": 42, "#type": "Int"}`
+   │           - `{"#struct": {...}, "#type": "Person"}`
+   │           - `{"#list": [...], "#type": "List<Number>"}`
+   │           - `{"#literal": 42, "#type": "Int"}`
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__tests__parse_unknown_top_level_key.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__tests__parse_unknown_top_level_key.snap
@@ -8,7 +8,7 @@ expression: "{\"invalid\": 42}"
    │
  1 │ {"invalid": 42}
    │  ────┬────  
-   │      ╰────── Unrecognized key `invalid`
+   │      ╰────── Replace `invalid` with a valid key
    │ 
    │ Help: This J-Expr object only accepts these specific keys: `#literal`, `#struct`, `#dict`, `#tuple`, `#list`, or `#type`
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__tuple__tests__parse_invalid_tuple_value.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__tuple__tests__parse_invalid_tuple_value.snap
@@ -8,7 +8,9 @@ expression: "{\"#tuple\": {\"not\": \"an-array\"}}"
    │
  1 │ {"#tuple": {"not": "an-array"}}
    │            ┬  
-   │            ╰── Unexpected token
+   │            ╰── Expected an array here
    │ 
-   │ Help: Expected `[` at this position
+   │ Help: The #tuple construct requires an array of elements, but found `{`. Use square brackets to define the tuple elements: [element1, element2, ...]
+   │ 
+   │ Note: Tuples in J-Expr represent fixed-size ordered collections where each position can have a different type.
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__tuple__tests__parse_tuple_incomplete.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__tuple__tests__parse_tuple_incomplete.snap
@@ -1,0 +1,14 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/parser/object/tuple.rs
+description: Parses with a sudden EOF
+expression: "{\"#tuple\": "
+---
+[31m[lexer::lexer::unexpected-eof] Error:[0m Lexer
+   ╭─[ <unknown>:1:12 ]
+   │
+ 1 │ {"#tuple":
+   │            │ 
+   │            ╰─ Unexpected end of file, expected `[`
+   │ 
+   │ Help: The file ended where an opening bracket was expected. Complete the expression structure.
+───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__tuple__tests__parse_unknown_key_in_tuple.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__tuple__tests__parse_unknown_key_in_tuple.snap
@@ -8,7 +8,7 @@ expression: "{\"#tuple\": [], \"unknown\": {\"#literal\": \"value\"}}"
    │
  1 │ {"#tuple": [], "unknown": {"#literal": "value"}}
    │                ────┬────  
-   │                    ╰────── Unrecognized key `unknown`
+   │                    ╰────── Replace `unknown` with a valid key
    │ 
    │ Help: This J-Expr object only accepts these specific keys: `#type`
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__visit__tests__missing_colon.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__visit__tests__missing_colon.snap
@@ -3,12 +3,12 @@ source: libs/@local/hashql/syntax-jexpr/src/parser/object/visit.rs
 description: Object with missing colon should fail
 expression: "{\"a\" 1}"
 ---
-[31m[object::expected-colon] Error:[0m Object
+[31m[lexer::lexer::unexpected-token] Error:[0m Lexer
    ╭─[ <unknown>:1:6 ]
    │
  1 │ {"a" 1}
    │      ┬  
-   │      ╰── Unexpected token
+   │      ╰── Unexpected number, expected `:`
    │ 
-   │ Help: Expected `:` at this position
+   │ Help: Check your JSON syntax. Make sure brackets are balanced and all required punctuation is present.
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__visit__tests__missing_comma.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__visit__tests__missing_comma.snap
@@ -3,12 +3,12 @@ source: libs/@local/hashql/syntax-jexpr/src/parser/object/visit.rs
 description: Object with missing comma should fail
 expression: "{\"a\": 1 \"b\": 2}"
 ---
-[31m[object::expected-separator] Error:[0m Object
+[31m[lexer::lexer::unexpected-token] Error:[0m Lexer
    ╭─[ <unknown>:1:9 ]
    │
  1 │ {"a": 1 "b": 2}
    │         ─┬─  
-   │          ╰─── Unexpected token
+   │          ╰─── Unexpected string, expected `,` or `}`
    │ 
-   │ Help: Expected `,`, or `}` at this position
+   │ Help: Missing closing bracket. Make sure all opening brackets have matching closing brackets.
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__visit__tests__non_string_key.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__visit__tests__non_string_key.snap
@@ -3,12 +3,12 @@ source: libs/@local/hashql/syntax-jexpr/src/parser/object/visit.rs
 description: Object with non-string key should fail
 expression: "{42: \"value\"}"
 ---
-[31m[object::expected-key] Error:[0m Object
+[31m[lexer::lexer::unexpected-token] Error:[0m Lexer
    ╭─[ <unknown>:1:2 ]
    │
  1 │ {42: "value"}
    │  ─┬  
-   │   ╰── Unexpected token
+   │   ╰── Unexpected number, expected string
    │ 
-   │ Help: Expected string at this position
+   │ Help: Check your JSON syntax. Make sure brackets are balanced and all required punctuation is present.
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__visit__tests__unclosed_object.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/snapshots/hashql_syntax_jexpr__parser__object__visit__tests__unclosed_object.snap
@@ -10,5 +10,5 @@ expression: "{\"a\": 1"
    │        │ 
    │        ╰─ Unexpected end of file
    │ 
-   │ Help: Make sure all expressions, brackets, and string literals are properly closed
+   │ Help: Missing closing bracket. Make sure all opening brackets have matching closing brackets.
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/struct.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/struct.rs
@@ -6,6 +6,7 @@ use text_size::TextRange;
 
 use super::{
     ObjectState, State,
+    error::struct_expected_object,
     r#type::{TypeNode, handle_typed},
     visit::Key,
 };
@@ -14,12 +15,9 @@ use crate::{
     error::ResultExt as _,
     lexer::{syntax_kind::SyntaxKind, syntax_kind_set::SyntaxKindSet},
     parser::{
-        error::{ParserDiagnostic, unexpected_token},
+        error::ParserDiagnostic,
         expr::parse_expr,
-        object::{
-            error::{ObjectDiagnosticCategory, struct_key_expected_identifier},
-            visit::visit_object,
-        },
+        object::{error::struct_key_expected_identifier, visit::visit_object},
         string::parse_ident_from_string,
     },
 };
@@ -79,16 +77,16 @@ impl<'heap> State<'heap> for StructNode<'heap> {
 fn parse_struct<'heap>(
     state: &mut ParserState<'heap, '_>,
 ) -> Result<StructExpr<'heap>, ParserDiagnostic> {
-    let token = state.advance().change_category(From::from)?;
+    // We do not use expected here, to give the user a better error message
+    let token = state
+        .advance(SyntaxKindSet::COMPLETE)
+        .change_category(From::from)?;
+
     if token.kind.syntax() != SyntaxKind::LBrace {
         let span = state.insert_range(token.span);
 
-        return Err(unexpected_token(
-            span,
-            ObjectDiagnosticCategory::StructExpectedObject,
-            SyntaxKindSet::from_slice(&[SyntaxKind::LBrace]),
-        ))
-        .change_category(From::from)?;
+        return Err(struct_expected_object(span, token.kind.syntax()))
+            .change_category(From::from)?;
     }
 
     let mut entries = Vec::new();

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/tuple.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/tuple.rs
@@ -6,7 +6,7 @@ use text_size::TextRange;
 
 use super::{
     ObjectState, State,
-    error::ObjectDiagnosticCategory,
+    error::tuple_expected_array,
     r#type::{TypeNode, handle_typed},
     visit::Key,
 };
@@ -14,11 +14,7 @@ use crate::{
     ParserState,
     error::ResultExt as _,
     lexer::{syntax_kind::SyntaxKind, syntax_kind_set::SyntaxKindSet},
-    parser::{
-        array::visit::visit_array,
-        error::{ParserDiagnostic, unexpected_token},
-        expr::parse_expr,
-    },
+    parser::{array::visit::visit_array, error::ParserDiagnostic, expr::parse_expr},
 };
 
 pub(crate) struct TupleNode<'heap> {
@@ -76,15 +72,17 @@ impl<'heap> State<'heap> for TupleNode<'heap> {
 fn parse_tuple<'heap>(
     state: &mut ParserState<'heap, '_>,
 ) -> Result<TupleExpr<'heap>, ParserDiagnostic> {
-    let token = state.advance().change_category(From::from)?;
+    // We do not use the `expected` of advance here, so that we're able to give the user a better
+    // error message.
+    let token = state
+        .advance(SyntaxKindSet::COMPLETE)
+        .change_category(From::from)?;
 
     if token.kind.syntax() != SyntaxKind::LBracket {
-        return Err(unexpected_token(
-            state.insert_range(token.span),
-            ObjectDiagnosticCategory::TupleExpectedArray,
-            SyntaxKindSet::from_slice(&[SyntaxKind::LBracket]),
-        )
-        .map_category(From::from));
+        return Err(
+            tuple_expected_array(state.insert_range(token.span), token.kind.syntax())
+                .map_category(From::from),
+        );
     }
 
     let mut elements = Vec::new();

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/tuple.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/tuple.rs
@@ -13,8 +13,10 @@ use super::{
 use crate::{
     ParserState,
     error::ResultExt as _,
-    lexer::{syntax_kind::SyntaxKind, syntax_kind_set::SyntaxKindSet},
-    parser::{array::visit::visit_array, error::ParserDiagnostic, expr::parse_expr},
+    lexer::syntax_kind::SyntaxKind,
+    parser::{
+        array::visit::visit_array, error::ParserDiagnostic, expr::parse_expr, state::Expected,
+    },
 };
 
 pub(crate) struct TupleNode<'heap> {
@@ -75,7 +77,7 @@ fn parse_tuple<'heap>(
     // We do not use the `expected` of advance here, so that we're able to give the user a better
     // error message.
     let token = state
-        .advance(SyntaxKindSet::COMPLETE)
+        .advance(Expected::hint(SyntaxKind::LBracket))
         .change_category(From::from)?;
 
     if token.kind.syntax() != SyntaxKind::LBracket {
@@ -130,6 +132,19 @@ mod tests {
             description => "Parses an empty tuple"
         }, {
             assert_snapshot!(insta::_macro_support::AutoName, result.dump, &result.input);
+        });
+    }
+
+    #[test]
+    fn parse_tuple_incomplete() {
+        // Empty tuple with object format
+        let result =
+            parse_object_expr(r##"{"#tuple": "##).expect_err("should not parse incomplete tuple");
+
+        with_settings!({
+            description => "Parses with a sudden EOF"
+        }, {
+            assert_snapshot!(insta::_macro_support::AutoName, result.diagnostic, &result.input);
         });
     }
 

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/visit.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/visit.rs
@@ -133,7 +133,7 @@ where
 
     loop {
         let next = state
-            .peek_required()
+            .peek_expect()
             .change_category(ObjectDiagnosticCategory::Lexer)
             .change_category(C::from)?;
 

--- a/libs/@local/hashql/syntax-jexpr/src/parser/state.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/state.rs
@@ -163,7 +163,7 @@ impl<'heap, 'source> ParserState<'heap, 'source> {
 
         let token = token?;
 
-        return self.context.validate_token(token, expected);
+        self.context.validate_token(token, expected)
     }
 
     // Peek at the first token

--- a/libs/@local/hashql/syntax-jexpr/src/parser/state.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/state.rs
@@ -11,6 +11,7 @@ use crate::{
     lexer::{
         Lexer,
         error::{LexerDiagnostic, unexpected_eof},
+        syntax_kind_set::SyntaxKindSet,
         token::Token,
     },
     span::Span,

--- a/libs/@local/hashql/syntax-jexpr/src/parser/test.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/test.rs
@@ -48,8 +48,7 @@ pub(crate) macro bind_parser(fn $name:ident($parser:ident, $expected:expr)) {
         bind_context!(let context = input);
         bind_state!(let mut state from context);
 
-        let token = state.advance().expect("should have at least one token");
-        assert_eq!(token.kind.syntax(), $expected);
+        let token = state.advance($expected).expect("should have at least one token");
 
         match $parser(&mut state, token) {
             Ok(expr) => Ok(ParseTestOk {

--- a/libs/@local/hashql/syntax-jexpr/src/snapshots/hashql_syntax_jexpr__tests__parse_incomplete_expression.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/snapshots/hashql_syntax_jexpr__tests__parse_incomplete_expression.snap
@@ -10,5 +10,5 @@ expression: error
    │              │ 
    │              ╰─ Unexpected end of file
    │ 
-   │ Help: Make sure all expressions, brackets, and string literals are properly closed
+   │ Help: Missing closing bracket. Make sure all opening brackets have matching closing brackets.
 ───╯


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently the callsite does verification that the token returned from the lexer is the correct one. Instead we can move this check to the `ParserState`. This allows us to have both cleaner code as well as better diagnostics on unexpected EOF.

There are some places where we don't make use of `advance` and `peek_expect`'s ability to expect for us, the primary place for this is the object parser. Where instead I've chosen custom methods. This allows us to give the user a lot more insight into *why* it failed and what the syntax is.


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

