### PR TITLE
H-4324: HashQL J-Expr support use of JSONC

### DIFF
--- a/libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
@@ -342,6 +342,7 @@ mod test {
 
         // JSONC
         unclosed_multiline_comment("/* This comment never ends") => "Unclosed multi-line comment",
+        multiline_comment_too_smol("/*/") => "Multi-line comment is missing closing *",
     }
 
     #[test]

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
@@ -297,7 +297,7 @@ mod test {
         empty_multiline_comment("42/**/42") => "Empty multi-line comment should be skipped",
         multiline_comment_json_inside(r#"42/* This is a multi-line comment with JSON {"key": "value"} */42"#) => "JSON inside multi-line comment",
         multiline_linebreak("42/* This is a multi-line comment with line break\n inside*/42") => "Line break inside multi-line comment",
-        // see:
+        // see: https://linear.app/hash/issue/H-4325/hashql-j-expr-more-comprehensive-multiline-comment-support
         // multiline_almost_end("/* Almost closing comment **/42") => "Multi-line comment with extra asterisk that isn't the closing delimiter",
         multiline_with_asterisks("/* * * *\n * comment *\n * * */42") => "Multi-line comment with decorative asterisks",
     }

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
@@ -278,6 +278,16 @@ mod test {
             "JSON with already-escaped characters",
         escaped_controls(r#""\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007""#) =>
             "String with escaped control characters",
+
+        // JSONC
+        preceded_comment("// This is a comment\n42") => "Comment at the beginning should be skipped",
+        trailing_comment("42\n// This is a comment") => "Comment at the end should be skipped",
+        separated_comment("42\n// This is a comment\n42") => "Comment in the middle should be skipped",
+        adjacent_comment("42 // This is a comment\n42") => "Comment after element should be skipped",
+        adjacent_comment_no_space("42//This is a comment\n42") => "Comment after element without space",
+        empty_comment("42\n//\n42") => "Empty comment should be skipped",
+        comment_json_inside(r#"//"{"key": "value"}""#) => "JSON inside comment",
+        comment_no_space_between("//abc") => "JSON inside comment without space",
     }
 
     test_cases_fail! {

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
@@ -280,6 +280,7 @@ mod test {
             "String with escaped control characters",
 
         // JSONC
+        // Single line comments
         preceded_comment("// This is a comment\n42") => "Comment at the beginning should be skipped",
         trailing_comment("42\n// This is a comment") => "Comment at the end should be skipped",
         separated_comment("42\n// This is a comment\n42") => "Comment in the middle should be skipped",
@@ -288,6 +289,17 @@ mod test {
         empty_comment("42\n//\n42") => "Empty comment should be skipped",
         comment_json_inside(r#"//"{"key": "value"}""#) => "JSON inside comment",
         comment_no_space_between("//abc") => "JSON inside comment without space",
+
+        // Multi line comments
+        preceded_multiline_comment("/* This is a multi-line comment */42") => "Simple multi-line comment should be skipped",
+        trailing_multiline_comment("42/* This is a multi-line comment */") => "Simple multi-line comment should be skipped",
+        separated_multiline_comment("42/* This is a multi-line comment */42") => "Simple multi-line comment should be skipped",
+        empty_multiline_comment("42/**/42") => "Empty multi-line comment should be skipped",
+        multiline_comment_json_inside(r#"42/* This is a multi-line comment with JSON {"key": "value"} */42"#) => "JSON inside multi-line comment",
+        multiline_linebreak("42/* This is a multi-line comment with line break\n inside*/42") => "Line break inside multi-line comment",
+        // see:
+        // multiline_almost_end("/* Almost closing comment **/42") => "Multi-line comment with extra asterisk that isn't the closing delimiter",
+        multiline_with_asterisks("/* * * *\n * comment *\n * * */42") => "Multi-line comment with decorative asterisks",
     }
 
     test_cases_fail! {
@@ -327,6 +339,9 @@ mod test {
         emoji_sequence("🚀🦀💻") => "Multiple emoji characters in sequence",
         japanese_text("こんにちは") => "Multiple Japanese characters",
         mixed_characters("あa三b") => "Mix of single and multi-byte characters",
+
+        // JSONC
+        unclosed_multiline_comment("/* This comment never ends") => "Unclosed multi-line comment",
     }
 
     #[test]

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__adjacent_comment.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__adjacent_comment.snap
@@ -1,0 +1,6 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+description: Comment after element should be skipped
+expression: "42 // This is a comment\n42"
+---
+42 42

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__adjacent_comment_no_space.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__adjacent_comment_no_space.snap
@@ -1,0 +1,6 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+description: Comment after element without space
+expression: "42//This is a comment\n42"
+---
+42 42

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__comment_json_inside.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__comment_json_inside.snap
@@ -1,0 +1,6 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+description: JSON inside comment
+expression: "//\"{\"key\": \"value\"}\""
+---
+

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__comment_no_space_between.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__comment_no_space_between.snap
@@ -1,0 +1,6 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+description: JSON inside comment without space
+expression: //abc
+---
+

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__empty_comment.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__empty_comment.snap
@@ -1,0 +1,6 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+description: Empty comment should be skipped
+expression: "42\n//\n42"
+---
+42 42

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__empty_multiline_comment.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__empty_multiline_comment.snap
@@ -1,0 +1,6 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+description: Empty multi-line comment should be skipped
+expression: 42/**/42
+---
+42 42

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__multiline_comment_json_inside.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__multiline_comment_json_inside.snap
@@ -1,0 +1,6 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+description: JSON inside multi-line comment
+expression: "42/* This is a multi-line comment with JSON {\"key\": \"value\"} */42"
+---
+42 42

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__multiline_comment_too_smol.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__multiline_comment_too_smol.snap
@@ -1,0 +1,14 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+description: Multi-line comment is missing closing *
+expression: /*/
+---
+[31m[lexer::invalid-character] Error:[0m Lexer
+   ╭─[ <unknown>:1:1 ]
+   │
+ 1 │ /*/
+   │ ┬  
+   │ ╰── Unrecognized character
+   │ 
+   │ Help: J-Expr only supports standard JSON syntax. Make sure you're using valid JSON tokens like {}, [], strings, numbers, true/false, or null.
+───╯

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__multiline_linebreak.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__multiline_linebreak.snap
@@ -1,0 +1,6 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+description: Line break inside multi-line comment
+expression: "42/* This is a multi-line comment with line break\n inside*/42"
+---
+42 42

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__multiline_with_asterisks.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__multiline_with_asterisks.snap
@@ -1,0 +1,6 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+description: Multi-line comment with decorative asterisks
+expression: "/* * * *\n * comment *\n * * */42"
+---
+42

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__preceded_comment.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__preceded_comment.snap
@@ -1,0 +1,6 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+description: Comment at the beginning should be skipped
+expression: "// This is a comment\n42"
+---
+42

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__preceded_multiline_comment.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__preceded_multiline_comment.snap
@@ -1,0 +1,6 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+description: Simple multi-line comment should be skipped
+expression: /* This is a multi-line comment */42
+---
+42

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__separated_comment.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__separated_comment.snap
@@ -1,0 +1,6 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+description: Comment in the middle should be skipped
+expression: "42\n// This is a comment\n42"
+---
+42 42

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__separated_multiline_comment.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__separated_multiline_comment.snap
@@ -1,0 +1,6 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+description: Simple multi-line comment should be skipped
+expression: 42/* This is a multi-line comment */42
+---
+42 42

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__trailing_comment.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__trailing_comment.snap
@@ -1,0 +1,6 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+description: Comment at the end should be skipped
+expression: "42\n// This is a comment"
+---
+42

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__trailing_multiline_comment.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__trailing_multiline_comment.snap
@@ -1,0 +1,6 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+description: Simple multi-line comment should be skipped
+expression: 42/* This is a multi-line comment */
+---
+42

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__unclosed_multiline_comment.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/snapshots/hashql_syntax_jexpr__lexer__test__unclosed_multiline_comment.snap
@@ -1,0 +1,14 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+description: Unclosed multi-line comment
+expression: /* This comment never ends
+---
+[31m[lexer::invalid-character] Error:[0m Lexer
+   ╭─[ <unknown>:1:1 ]
+   │
+ 1 │ /* This comment never ends
+   │ ┬  
+   │ ╰── Unrecognized character
+   │ 
+   │ Help: J-Expr only supports standard JSON syntax. Make sure you're using valid JSON tokens like {}, [], strings, numbers, true/false, or null.
+───╯

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/token_kind.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/token_kind.rs
@@ -11,6 +11,7 @@ use crate::lexer::parse::{parse_number, parse_string};
 #[logos(error = LexerError)]
 #[logos(source = [u8])]
 #[logos(skip r"[ \t\r\n\f]+")]
+#[logos(skip r"//[^\n]*")]
 pub(crate) enum TokenKind<'source> {
     #[token("false", |_| false)]
     #[token("true", |_| true)]

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/token_kind.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/token_kind.rs
@@ -7,11 +7,13 @@ use logos::Logos;
 use super::{error::LexerError, syntax_kind::SyntaxKind};
 use crate::lexer::parse::{parse_number, parse_string};
 
+// https://github.com/maciejhirsz/logos/issues/133#issuecomment-619444615
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Logos)]
 #[logos(error = LexerError)]
 #[logos(source = [u8])]
 #[logos(skip r"[ \t\r\n\f]+")]
 #[logos(skip r"//[^\n]*")]
+#[logos(skip r"/\*(?:[^*]|\*[^/])*\*/")]
 pub(crate) enum TokenKind<'source> {
     #[token("false", |_| false)]
     #[token("true", |_| true)]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Allow for comments inside JSON. This is super straightforward to implement (a two line change in the lexer).


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
