### PR TITLE
H-4339: HashQL: Switch from `Box<[T]>` to `Vec<T>`

### DIFF
--- a/libs/@local/hashql/ast/src/heap.rs
+++ b/libs/@local/hashql/ast/src/heap.rs
@@ -97,10 +97,6 @@ impl Heap {
         }
     }
 
-    pub fn empty_slice<T>(&self) -> Box<[T]> {
-        Box::new_in([], self)
-    }
-
     /// Creates a new vector allocated on this heap.
     ///
     /// The capacity is an optional initial capacity for the vector, a value of [`None`] indicates
@@ -112,11 +108,14 @@ impl Heap {
         )
     }
 
-    pub fn boxed_slice<T>(&self, vec: ::alloc::vec::Vec<T>) -> Box<[T]> {
+    /// Moves a vector allocated on the heap into this heap.
+    ///
+    /// The vector is moved into this heap, and the original vector is dropped.
+    pub fn transfer_vec<T>(&self, vec: alloc::vec::Vec<T>) -> Vec<T> {
         let mut target = Vec::with_capacity_in(vec.len(), self);
         target.extend(vec);
 
-        target.into_boxed_slice()
+        target
     }
 
     /// Creates a new hash map allocated on this heap.

--- a/libs/@local/hashql/ast/src/node/expr/call.rs
+++ b/libs/@local/hashql/ast/src/node/expr/call.rs
@@ -98,6 +98,6 @@ pub struct CallExpr<'heap> {
 
     pub function: heap::Box<'heap, Expr<'heap>>,
 
-    pub arguments: heap::Box<'heap, [Argument<'heap>]>,
-    pub labeled_arguments: heap::Box<'heap, [LabeledArgument<'heap>]>,
+    pub arguments: heap::Vec<'heap, Argument<'heap>>,
+    pub labeled_arguments: heap::Vec<'heap, LabeledArgument<'heap>>,
 }

--- a/libs/@local/hashql/ast/src/node/expr/closure.rs
+++ b/libs/@local/hashql/ast/src/node/expr/closure.rs
@@ -30,7 +30,7 @@ pub struct ClosureSig<'heap> {
 
     pub generics: Generics<'heap>,
 
-    pub inputs: heap::Box<'heap, [ClosureParam<'heap>]>,
+    pub inputs: heap::Vec<'heap, ClosureParam<'heap>>,
     pub output: heap::Box<'heap, Type<'heap>>,
 }
 

--- a/libs/@local/hashql/ast/src/node/expr/dict.rs
+++ b/libs/@local/hashql/ast/src/node/expr/dict.rs
@@ -46,6 +46,6 @@ pub struct DictExpr<'heap> {
     pub id: NodeId,
     pub span: SpanId,
 
-    pub entries: heap::Box<'heap, [DictEntry<'heap>]>,
+    pub entries: heap::Vec<'heap, DictEntry<'heap>>,
     pub r#type: Option<heap::Box<'heap, Type<'heap>>>,
 }

--- a/libs/@local/hashql/ast/src/node/expr/list.rs
+++ b/libs/@local/hashql/ast/src/node/expr/list.rs
@@ -44,6 +44,6 @@ pub struct ListExpr<'heap> {
     pub id: NodeId,
     pub span: SpanId,
 
-    pub elements: heap::Box<'heap, [ListElement<'heap>]>,
+    pub elements: heap::Vec<'heap, ListElement<'heap>>,
     pub r#type: Option<heap::Box<'heap, Type<'heap>>>,
 }

--- a/libs/@local/hashql/ast/src/node/expr/struct.rs
+++ b/libs/@local/hashql/ast/src/node/expr/struct.rs
@@ -50,6 +50,6 @@ pub struct StructExpr<'heap> {
     pub id: NodeId,
     pub span: SpanId,
 
-    pub entries: heap::Box<'heap, [StructEntry<'heap>]>,
+    pub entries: heap::Vec<'heap, StructEntry<'heap>>,
     pub r#type: Option<heap::Box<'heap, Type<'heap>>>,
 }

--- a/libs/@local/hashql/ast/src/node/expr/tuple.rs
+++ b/libs/@local/hashql/ast/src/node/expr/tuple.rs
@@ -50,6 +50,6 @@ pub struct TupleExpr<'heap> {
     pub id: NodeId,
     pub span: SpanId,
 
-    pub elements: heap::Box<'heap, [TupleElement<'heap>]>,
+    pub elements: heap::Vec<'heap, TupleElement<'heap>>,
     pub r#type: Option<heap::Box<'heap, Type<'heap>>>,
 }

--- a/libs/@local/hashql/ast/src/node/expr/use.rs
+++ b/libs/@local/hashql/ast/src/node/expr/use.rs
@@ -36,7 +36,7 @@ pub struct Glob {
 /// items are being imported with a glob.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum UseKind<'heap> {
-    Named(heap::Box<'heap, [UseBinding]>),
+    Named(heap::Vec<'heap, UseBinding>),
     Glob(Glob),
 }
 

--- a/libs/@local/hashql/ast/src/node/generic.rs
+++ b/libs/@local/hashql/ast/src/node/generic.rs
@@ -57,5 +57,5 @@ pub struct Generics<'heap> {
     pub id: NodeId,
     pub span: SpanId,
 
-    pub params: heap::Box<'heap, [GenericParam<'heap>]>,
+    pub params: heap::Vec<'heap, GenericParam<'heap>>,
 }

--- a/libs/@local/hashql/ast/src/node/path.rs
+++ b/libs/@local/hashql/ast/src/node/path.rs
@@ -22,7 +22,7 @@ pub struct PathSegment<'heap> {
 
     pub name: Ident,
     /// Type parameters attached to this path segment
-    pub arguments: heap::Box<'heap, [GenericArgument<'heap>]>,
+    pub arguments: heap::Vec<'heap, GenericArgument<'heap>>,
 }
 
 /// A path expression in the HashQL Abstract Syntax Tree.
@@ -67,5 +67,5 @@ pub struct Path<'heap> {
 
     /// Whether the path is rooted (starts with a double colon `::`).
     pub rooted: bool,
-    pub segments: heap::Box<'heap, [PathSegment<'heap>]>,
+    pub segments: heap::Vec<'heap, PathSegment<'heap>>,
 }

--- a/libs/@local/hashql/ast/src/node/type.rs
+++ b/libs/@local/hashql/ast/src/node/type.rs
@@ -41,7 +41,7 @@ pub struct StructType<'heap> {
     pub id: NodeId,
     pub span: SpanId,
 
-    pub fields: heap::Box<'heap, [StructField<'heap>]>,
+    pub fields: heap::Vec<'heap, StructField<'heap>>,
 }
 
 /// A field in a tuple type.
@@ -84,7 +84,7 @@ pub struct TupleType<'heap> {
     pub id: NodeId,
     pub span: SpanId,
 
-    pub fields: heap::Box<'heap, [TupleField<'heap>]>,
+    pub fields: heap::Vec<'heap, TupleField<'heap>>,
 }
 
 /// A union type definition.
@@ -114,7 +114,7 @@ pub struct UnionType<'heap> {
     pub id: NodeId,
     pub span: SpanId,
 
-    pub types: heap::Box<'heap, [Type<'heap>]>,
+    pub types: heap::Vec<'heap, Type<'heap>>,
 }
 
 /// An intersection type definition.
@@ -134,7 +134,7 @@ pub struct IntersectionType<'heap> {
     pub id: NodeId,
     pub span: SpanId,
 
-    pub types: heap::Box<'heap, [Type<'heap>]>,
+    pub types: heap::Vec<'heap, Type<'heap>>,
 }
 
 /// The different kinds of types in the HashQL type system.

--- a/libs/@local/hashql/syntax-jexpr/src/parser/array/mod.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/array/mod.rs
@@ -154,8 +154,8 @@ pub(crate) fn parse_array<'heap, 'source>(
             id: NodeId::PLACEHOLDER,
             span,
             function: heap.boxed(function),
-            arguments: heap.boxed_slice(arguments),
-            labeled_arguments: heap.boxed_slice(labeled_arguments),
+            arguments: heap.transfer_vec(arguments),
+            labeled_arguments: heap.transfer_vec(labeled_arguments),
         }),
     })
 }

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/dict.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/dict.rs
@@ -120,7 +120,7 @@ fn parse_dict_object<'heap, 'source>(
     Ok(DictExpr {
         id: NodeId::PLACEHOLDER,
         span: state.insert_range(span),
-        entries: state.heap().boxed_slice(entries),
+        entries: state.heap().transfer_vec(entries),
         r#type: None,
     })
 }
@@ -194,7 +194,7 @@ fn parse_dict_array<'heap, 'source>(
     Ok(DictExpr {
         id: NodeId::PLACEHOLDER,
         span: state.insert_range(span),
-        entries: state.heap().boxed_slice(entries),
+        entries: state.heap().transfer_vec(entries),
         r#type: None,
     })
 }

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/list.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/list.rs
@@ -106,7 +106,7 @@ fn parse_list<'heap>(
     Ok(ListExpr {
         id: NodeId::PLACEHOLDER,
         span: state.insert_range(range),
-        elements: state.heap().boxed_slice(elements),
+        elements: state.heap().transfer_vec(elements),
         r#type: None,
     })
 }

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/struct.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/struct.rs
@@ -121,7 +121,7 @@ fn parse_struct<'heap>(
     Ok(StructExpr {
         id: NodeId::PLACEHOLDER,
         span: state.insert_range(span),
-        entries: state.heap().boxed_slice(entries),
+        entries: state.heap().transfer_vec(entries),
         r#type: None,
     })
 }

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/tuple.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/tuple.rs
@@ -106,7 +106,7 @@ fn parse_tuple<'heap>(
     Ok(TupleExpr {
         id: NodeId::PLACEHOLDER,
         span: state.insert_range(range),
-        elements: state.heap().boxed_slice(elements),
+        elements: state.heap().transfer_vec(elements),
         r#type: None,
     })
 }

--- a/libs/@local/hashql/syntax-jexpr/src/parser/string/generic.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/string/generic.rs
@@ -9,7 +9,7 @@ use winnow::{
 };
 
 use super::{
-    combinator::{separated_boxed1, ws},
+    combinator::{separated_alloc1, ws},
     context::Input,
     ident::parse_ident,
     r#type::parse_type,
@@ -72,7 +72,7 @@ where
 
     delimited(
         ws("<"),
-        separated_boxed1(context.heap, parse_generic_param, ws(",")),
+        separated_alloc1(context.heap, parse_generic_param, ws(",")),
         ws(cut_err(">").context(StrContext::Expected(StrContextValue::CharLiteral('>')))),
     )
     .with_span()

--- a/libs/@local/hashql/syntax-jexpr/src/parser/string/type.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/string/type.rs
@@ -105,7 +105,7 @@ where
                     kind: TypeKind::Tuple(TupleType {
                         id: NodeId::PLACEHOLDER,
                         span,
-                        fields: context.heap.empty_slice(),
+                        fields: context.heap.vec(None),
                     }),
                 }
             })
@@ -138,7 +138,7 @@ where
                     kind: TypeKind::Struct(StructType {
                         id: NodeId::PLACEHOLDER,
                         span,
-                        fields: context.heap.empty_slice(),
+                        fields: context.heap.vec(None),
                     }),
                 }
             })
@@ -199,7 +199,7 @@ where
                 kind: TypeKind::Struct(StructType {
                     id: NodeId::PLACEHOLDER,
                     span,
-                    fields: context.heap.boxed_slice(fields),
+                    fields: context.heap.transfer_vec(fields),
                 }),
             }
         })
@@ -255,7 +255,7 @@ where
                 kind: TypeKind::Tuple(TupleType {
                     id: NodeId::PLACEHOLDER,
                     span,
-                    fields: context.heap.boxed_slice(fields),
+                    fields: context.heap.transfer_vec(fields),
                 }),
             }
         })
@@ -381,7 +381,7 @@ where
                 kind: TypeKind::Union(UnionType {
                     id: NodeId::PLACEHOLDER,
                     span,
-                    types: types.into_boxed_slice(),
+                    types,
                 }),
             }
         })
@@ -415,7 +415,7 @@ where
                 kind: TypeKind::Intersection(IntersectionType {
                     id: NodeId::PLACEHOLDER,
                     span,
-                    types: types.into_boxed_slice(),
+                    types,
                 }),
             }
         })


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Switch from `Box<[T]>` to `Vec<T>`. This is required as during lowering we need to do some changes to the underlying structure, like expanding etc.

This has the caveat that we're potentially have "wasted" space whenever the vector is re-allocating, but that amount should be negligible. There's precedence for this, `swc_allocator` and `oxc_allocator` both make use of this exact same technique.

The other possibility would be to use a split-vec (like [https://docs.rs/orx-split-vec/latest/orx_split_vec/](https://docs.rs/orx-split-vec/latest/orx_split_vec/)), but there is sadly no crate out there that supports split-vec *and* the allocator API.

> `biome` forgoes a custom allocator completely, but only because they never leave the syntax tree (`rowan` behind).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
