### PR TITLE
H-4270: Bump tool dependencies

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -4,10 +4,10 @@ _.file = [".env", ".env.local"]
 [tools]
 # Basic tools
 node        = { version = "22.14.0", postinstall = "corepack enable" }
-'npm:turbo' = "2.4.4"
+"npm:turbo" = "2.5.0"
 
 # Helper to install tools
-cargo-binstall = "1.12.2"
+cargo-binstall = "1.12.3"
 uv             = "0.6.12"
 
 # Tools to compile the project
@@ -21,12 +21,12 @@ biome                  = "1.9.5-nightly.ff02a0b"
 "cargo:cargo-hack"     = "0.6.36"
 "cargo:cargo-insta"    = "1.42.2"
 "cargo:cargo-llvm-cov" = "0.6.16"
-"cargo:cargo-nextest"  = "0.9.92"
+"cargo:cargo-nextest"  = "0.9.93"
 just                   = "1.40.0"
 markdownlint-cli2      = "0.17.2"
 "npm:@napi-rs/cli"     = "2.18.4"
-"npm:@redocly/cli"     = "1.34.0"
-"npm:renovate"         = "39.212.2"
+"npm:@redocly/cli"     = "1.34.1"
+"npm:renovate"         = "39.233.6"
 "pipx:sqlfluff"        = "3.3.1"
-sentry-cli             = "2.42.4"
+sentry-cli             = "2.43.0"
 taplo                  = "0.9.3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3498,7 +3498,7 @@ dependencies = [
  "globset",
  "hash-tracing",
  "inferno",
- "petgraph",
+ "petgraph 0.8.0",
  "serde",
  "serde_json",
  "simple-mermaid",
@@ -4384,7 +4384,7 @@ dependencies = [
  "ena",
  "itertools 0.14.0",
  "lalrpop-util",
- "petgraph",
+ "petgraph 0.7.1",
  "pico-args",
  "regex",
  "regex-syntax 0.8.5",
@@ -5851,6 +5851,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96dc3f2709da98e228764d8f4c01c39a101dcc441547e8036372ee0522eb108"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.2",
+ "indexmap 2.8.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6239,7 +6250,7 @@ dependencies = [
  "log",
  "multimap",
  "once_cell",
- "petgraph",
+ "petgraph 0.7.1",
  "prettyplease",
  "prost",
  "prost-types",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Renovate currently does not cover all dependency updates. To update them manually, the easiest way is to use `mise ugrade --bump`.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph