### PR TITLE
H-4321: Fix slides and tooltips appearing in graph viz fullscreen mode

### DIFF
--- a/apps/hash-frontend/src/pages/shared/graph-visualizer/graph-container/shared/control-components.tsx
+++ b/apps/hash-frontend/src/pages/shared/graph-visualizer/graph-container/shared/control-components.tsx
@@ -1,9 +1,10 @@
 import { IconButton } from "@hashintel/design-system";
-import { Box, Stack, Tooltip, Typography } from "@mui/material";
+import { Box, Stack, Typography } from "@mui/material";
 import type { PropsWithChildren, ReactElement, RefObject } from "react";
 
 import { ArrowRightToLineIcon } from "../../../../../shared/icons/arrow-right-to-line-icon";
 import { CircleInfoIcon } from "../../../../../shared/icons/circle-info-icon";
+import { GraphVizTooltip } from "./graph-viz-tooltip";
 
 export const InfoIconTooltip = ({
   tooltip,
@@ -11,7 +12,7 @@ export const InfoIconTooltip = ({
   tooltip: string | ReactElement;
 }) => {
   return (
-    <Tooltip title={tooltip} placement="top">
+    <GraphVizTooltip title={tooltip} placement="top">
       <Box
         sx={{
           display: "flex",
@@ -21,7 +22,7 @@ export const InfoIconTooltip = ({
       >
         <CircleInfoIcon fontSize="inherit" />
       </Box>
-    </Tooltip>
+    </GraphVizTooltip>
   );
 };
 

--- a/apps/hash-frontend/src/pages/shared/graph-visualizer/graph-container/shared/graph-viz-tooltip.tsx
+++ b/apps/hash-frontend/src/pages/shared/graph-visualizer/graph-container/shared/graph-viz-tooltip.tsx
@@ -1,0 +1,17 @@
+import type { TooltipProps } from "@mui/material";
+import { Tooltip as MuiTooltip } from "@mui/material";
+
+import { useGraphContext } from "./graph-context";
+
+export const GraphVizTooltip = ({ children, ...props }: TooltipProps) => {
+  const { graphContainerRef } = useGraphContext();
+
+  return (
+    <MuiTooltip
+      {...props}
+      slotProps={{ popper: { container: graphContainerRef.current } }}
+    >
+      {children}
+    </MuiTooltip>
+  );
+};

--- a/apps/hash-frontend/src/pages/shared/graph-visualizer/graph-container/shared/simple-autocomplete.tsx
+++ b/apps/hash-frontend/src/pages/shared/graph-visualizer/graph-container/shared/simple-autocomplete.tsx
@@ -1,11 +1,12 @@
 import { Autocomplete } from "@hashintel/design-system";
-import { Box, outlinedInputClasses, Tooltip } from "@mui/material";
+import { Box, outlinedInputClasses } from "@mui/material";
 import type { CSSProperties, ReactElement, ReactNode, RefObject } from "react";
 import { createContext, forwardRef, useContext, useMemo } from "react";
 import { VariableSizeList } from "react-window";
 
 import { MenuItem } from "../../../../../shared/ui/menu-item";
 import { useGraphContext } from "./graph-context";
+import { GraphVizTooltip } from "./graph-viz-tooltip";
 
 const Row = ({
   data,
@@ -181,7 +182,7 @@ export const SimpleAutocomplete = <
         });
 
         return (
-          <Tooltip
+          <GraphVizTooltip
             key={option.valueForSelector}
             title={listComponent ? label : ""}
           >
@@ -211,7 +212,7 @@ export const SimpleAutocomplete = <
                 </Box>
               ))}
             </MenuItem>
-          </Tooltip>
+          </GraphVizTooltip>
         );
       }}
       value={value}

--- a/apps/hash-frontend/src/pages/shared/graph-visualizer/graph-container/shared/use-event-handlers.ts
+++ b/apps/hash-frontend/src/pages/shared/graph-visualizer/graph-container/shared/use-event-handlers.ts
@@ -17,17 +17,10 @@ export type RegisterEventsArgs = {
   graphState: GraphState;
   onEdgeClick?: (params: {
     edgeData: GraphVizEdge;
-    screenContainerRef?: RefObject<HTMLDivElement | null>;
   }) => void;
   onRender?: () => void;
   onNodeSecondClick?: (params: {
     nodeId: string;
-    /**
-     * In full-screen mode, only part of the DOM is displayed.
-     * This means that MUI components (and any others) that attach to the body will not be visible.
-     * If this is provided, components should attach any popups/modals to this ref's current element instead.
-     */
-    screenContainerRef?: RefObject<HTMLDivElement | null>;
   }) => void;
   setConfigPanelOpen: (open: boolean) => void;
   setFilterPanelOpen: (open: boolean) => void;
@@ -146,7 +139,6 @@ export const useEventHandlers = ({
 
           onEdgeClick({
             edgeData,
-            screenContainerRef: isFullScreen ? graphContainerRef : undefined,
           });
         }
       },
@@ -161,7 +153,6 @@ export const useEventHandlers = ({
            */
           onNodeSecondClick?.({
             nodeId: event.node,
-            screenContainerRef: isFullScreen ? graphContainerRef : undefined,
           });
           return;
         }

--- a/apps/hash-frontend/src/pages/shared/slide-stack.tsx
+++ b/apps/hash-frontend/src/pages/shared/slide-stack.tsx
@@ -1,4 +1,4 @@
-import { Backdrop, Box, Slide } from "@mui/material";
+import { Backdrop, Box, Portal, Slide } from "@mui/material";
 import type {
   Dispatch,
   FunctionComponent,
@@ -62,9 +62,9 @@ const StackSlide = ({
       <Box
         ref={slideRef}
         sx={{
-          height: "100vh",
+          height: "100%",
           width: SLIDE_WIDTH,
-          position: "absolute",
+          position: "fixed",
           top: 0,
           right: 0,
           overflowY: "scroll",
@@ -99,20 +99,23 @@ const StackSlide = ({
 
 export const SlideStack: FunctionComponent<{
   currentIndex: number;
+  closeSlideStack: () => void;
   items: { item: SlideItem; ref: RefObject<HTMLDivElement | null> }[];
   replaceItem: (item: SlideItem) => void;
   removeItem: () => void;
-  setCurrentIndex: Dispatch<SetStateAction<number>>;
-  setItems: (
-    items: { item: SlideItem; ref: RefObject<HTMLDivElement | null> }[],
-  ) => void;
+  setItems: Dispatch<
+    SetStateAction<{
+      items: { item: SlideItem; ref: RefObject<HTMLDivElement | null> }[];
+      currentIndex: number;
+    }>
+  >;
   slideContainerRef: RefObject<HTMLDivElement | null> | null;
 }> = ({
   currentIndex,
+  closeSlideStack,
   items,
   removeItem,
   replaceItem,
-  setCurrentIndex,
   setItems,
   slideContainerRef,
 }) => {
@@ -121,45 +124,53 @@ export const SlideStack: FunctionComponent<{
   useScrollLock(items.length > 0);
 
   const handleBack = useCallback(() => {
-    setCurrentIndex((prevIndex) => Math.max(prevIndex - 1, 0));
-  }, [setCurrentIndex]);
+    setItems((prev) => ({
+      currentIndex: Math.max(prev.currentIndex - 1, 0),
+      items: prev.items,
+    }));
+  }, [setItems]);
 
   const handleForward = useCallback(() => {
-    setCurrentIndex((prevIndex) => Math.min(prevIndex + 1, items.length - 1));
-  }, [items.length, setCurrentIndex]);
+    setItems((prev) => ({
+      currentIndex: Math.min(prev.currentIndex + 1, items.length - 1),
+      items: prev.items,
+    }));
+  }, [items.length, setItems]);
 
   const handleClose = useCallback(() => {
     setAnimateOut(true);
 
     setTimeout(() => {
       setAnimateOut(false);
-      setItems([]);
+      closeSlideStack();
     }, 200);
-  }, [setAnimateOut, setItems]);
+  }, [closeSlideStack, setAnimateOut]);
 
   return (
-    <Backdrop
-      open={items.length > 0 && !animateOut}
-      onClick={handleClose}
-      sx={{ zIndex: ({ zIndex }) => zIndex.drawer + 2 }}
-    >
-      {items.slice(0, currentIndex + 1).map(({ item, ref }, index) => (
-        <StackSlide
-          // eslint-disable-next-line react/no-array-index-key
-          key={`${index}-${item.itemId}`}
-          item={item}
-          open={!animateOut}
-          onBack={index > 0 ? handleBack : undefined}
-          onForward={index < items.length - 1 ? handleForward : undefined}
-          onClose={handleClose}
-          removeItem={removeItem}
-          replaceItem={replaceItem}
-          slideRef={ref}
-          slideContainerRef={slideContainerRef}
-          stackPosition={index}
-        />
-      ))}
-    </Backdrop>
+    <Portal container={slideContainerRef?.current ?? undefined}>
+      <Backdrop
+        open={items.length > 0 && !animateOut}
+        onClick={handleClose}
+        sx={{ zIndex: ({ zIndex }) => zIndex.drawer + 2 }}
+      >
+        {items.slice(0, currentIndex + 1).map(({ item, ref }, index) => (
+          <StackSlide
+            // eslint-disable-next-line react/no-array-index-key
+            key={`${index}-${item.itemId}`}
+            item={item}
+            open={!animateOut}
+            onBack={index > 0 ? handleBack : undefined}
+            onForward={index < items.length - 1 ? handleForward : undefined}
+            onClose={handleClose}
+            removeItem={removeItem}
+            replaceItem={replaceItem}
+            slideRef={ref}
+            slideContainerRef={slideContainerRef}
+            stackPosition={index}
+          />
+        ))}
+      </Backdrop>
+    </Portal>
   );
 };
 
@@ -178,53 +189,55 @@ export const SlideStackProvider = ({
    */
   rewriteSlideItemOverride?: (item: SlideItem) => SlideItem;
 }) => {
-  const [items, setItems] = useState<
-    { item: SlideItem; ref: RefObject<HTMLDivElement | null> }[]
-  >([]);
+  const [{ items, currentIndex }, setItems] = useState<{
+    currentIndex: number;
+    items: { item: SlideItem; ref: RefObject<HTMLDivElement | null> }[];
+  }>({ currentIndex: 0, items: [] });
 
-  const [currentIndex, setCurrentIndex] = useState<number>(0);
   const [slideContainerRef, setSlideContainerRef] =
     useState<RefObject<HTMLDivElement | null> | null>(null);
 
   if (currentIndex > 0 && items.length === 0) {
-    setCurrentIndex(0);
+    setItems({ currentIndex: 0, items: [] });
   }
 
   const pushToSlideStack = useCallback(
     (uncheckedItem: SlideItem) => {
       const item = rewriteSlideItemOverride?.(uncheckedItem) ?? uncheckedItem;
 
-      setItems((prev) => [
-        ...prev.slice(0, currentIndex + 1),
-        { item, ref: createRef() },
-      ]);
-
-      if (items.length === 0) {
-        setCurrentIndex(0);
-      } else {
-        setCurrentIndex((prevIndex) => prevIndex + 1);
-      }
+      setItems((prev) => {
+        return {
+          currentIndex: Math.min(prev.currentIndex + 1, prev.items.length),
+          items: [
+            ...prev.items.slice(0, prev.currentIndex + 1),
+            { item, ref: createRef() },
+          ],
+        };
+      });
     },
-    [currentIndex, items.length, rewriteSlideItemOverride],
+    [rewriteSlideItemOverride],
   );
 
-  const replaceItem = useCallback(
-    (item: SlideItem) => {
-      setItems((prev) => [
-        ...prev.slice(0, currentIndex),
-        { item, ref: createRef() },
-      ]);
-    },
-    [currentIndex],
-  );
+  const replaceItem = useCallback((item: SlideItem) => {
+    setItems((prev) => {
+      return {
+        currentIndex: prev.currentIndex,
+        items: [...prev.items.slice(0, 1), { item, ref: createRef() }],
+      };
+    });
+  }, []);
 
   const removeItem = useCallback(() => {
-    setItems((prev) => prev.slice(0, currentIndex));
-    setCurrentIndex((prevIndex) => Math.max(prevIndex - 1, 0));
-  }, [currentIndex]);
+    setItems((prev) => {
+      return {
+        currentIndex: Math.max(prev.currentIndex - 1, 0),
+        items: prev.items.slice(0, 1),
+      };
+    });
+  }, []);
 
   const closeSlideStack = useCallback(() => {
-    setItems([]);
+    setItems({ currentIndex: 0, items: [] });
   }, []);
 
   const value = useMemo(
@@ -248,17 +261,15 @@ export const SlideStackProvider = ({
   return (
     <SlideStackContext.Provider value={value}>
       {children}
-      {items.length > 0 && (
-        <SlideStack
-          currentIndex={currentIndex}
-          items={items}
-          removeItem={removeItem}
-          replaceItem={replaceItem}
-          setCurrentIndex={setCurrentIndex}
-          setItems={setItems}
-          slideContainerRef={slideContainerRef}
-        />
-      )}
+      <SlideStack
+        closeSlideStack={closeSlideStack}
+        currentIndex={currentIndex}
+        items={items}
+        removeItem={removeItem}
+        replaceItem={replaceItem}
+        setItems={setItems}
+        slideContainerRef={slideContainerRef}
+      />
     </SlideStackContext.Provider>
   );
 };

--- a/apps/hash-frontend/src/pages/shared/type-graph-visualizer.tsx
+++ b/apps/hash-frontend/src/pages/shared/type-graph-visualizer.tsx
@@ -6,7 +6,6 @@ import type {
 } from "@blockprotocol/type-system";
 import { typedEntries, typedValues } from "@local/advanced-types/typed-entries";
 import { useTheme } from "@mui/material";
-import type { RefObject } from "react";
 import { useCallback, useMemo } from "react";
 
 import { useEntityTypesContextRequired } from "../../shared/entity-types-context/hooks/use-entity-types-context-required";
@@ -40,10 +39,7 @@ export const TypeGraphVisualizer = ({
   onTypeClick,
   types,
 }: {
-  onTypeClick: (
-    typeId: VersionedUrl,
-    screenContainerRef?: RefObject<HTMLDivElement | null>,
-  ) => void;
+  onTypeClick: (typeId: VersionedUrl) => void;
   types: (
     | DataTypeWithMetadata
     | EntityTypeWithMetadata
@@ -250,14 +246,14 @@ export const TypeGraphVisualizer = ({
   const onNodeClick = useCallback<
     NonNullable<GraphVisualizerProps<StaticNodeSizing>["onNodeSecondClick"]>
   >(
-    ({ nodeId, screenContainerRef }) => {
+    ({ nodeId }) => {
       if (nodeId === anythingNodeId) {
         return;
       }
 
       const typeVersionedUrl = nodeId.split("~")[0] as VersionedUrl;
 
-      onTypeClick(typeVersionedUrl, screenContainerRef);
+      onTypeClick(typeVersionedUrl);
     },
     [onTypeClick],
   );


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When the graph visualization is fullscreened, fix the following things:
1. Tooltips weren't showing up (we need to tell MUI the non-`body` container to attach them to)
2. Opening a slide exited fullscreen (need to stop opening slides re-rendering components using information from the slide context, and `Portal` the slide stack)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Open 'Types' page, open graph viz, fullscreen, check tooltips (e.g. on filter component), and click on type to open slide in fullscreen

