### PR TITLE
H-4345: Prepare evaluation of policies when calling from API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3247,6 +3247,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "trait-variant",
  "type-system",
  "utoipa",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2318,6 +2318,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c280b9e6b3ae19e152d8e31cf47f18389781e119d4013a2a2bb0180e5facc635"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3231,6 +3251,7 @@ dependencies = [
  "cedar-policy-validator",
  "derive-where",
  "derive_more 2.0.1",
+ "enum-iterator",
  "error-stack",
  "futures",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ dotenv-flow              = { version = "=0.16.2", default-features = false }
 ecow                     = { version = "=0.2.4", default-features = false }
 either                   = { version = "=1.15.0", default-features = false }
 email_address            = { version = "=0.2.9", default-features = false }
+enum-iterator            = { version = "=2.1.0", default-features = false }
 enumflags2               = { version = "=0.7.11", default-features = false }
 erased-serde             = { version = "=0.4.6", default-features = false }
 expect-test              = { version = "=1.5.1", default-features = false }

--- a/apps/hash-graph/src/subcommand/server.rs
+++ b/apps/hash-graph/src/subcommand/server.rs
@@ -20,6 +20,7 @@ use hash_graph_api::{
 use hash_graph_authorization::{
     AuthorizationApi as _, AuthorizationApiPool, NoAuthorization,
     backend::{SpiceDbOpenApi, ZanzibarBackend as _},
+    policies::store::PrincipalStore,
     zanzibar::ZanzibarClient,
 };
 use hash_graph_postgres_store::store::{
@@ -190,6 +191,7 @@ fn server_rpc<S, A>(
 where
     S: StorePool + Send + Sync + 'static,
     A: AuthorizationApiPool + Send + Sync + 'static,
+    for<'p, 'a> S::Store<'p, A::Api<'a>>: PrincipalStore,
 {
     let server = Server::new(harpc_server::ServerConfig::default()).change_context(GraphError)?;
 

--- a/libs/@local/graph/api/src/rest/web.rs
+++ b/libs/@local/graph/api/src/rest/web.rs
@@ -13,6 +13,7 @@ use error_stack::Report;
 use hash_graph_authorization::{
     AuthorizationApi as _, AuthorizationApiPool,
     backend::{ModifyRelationshipOperation, PermissionAssertion},
+    policies::store::{CreateWebParameter, PrincipalStore},
     schema::{
         WebDataTypeViewerSubject, WebEntityCreatorSubject, WebEntityEditorSubject,
         WebEntityTypeViewerSubject, WebEntityViewerSubject, WebOwnerSubject, WebPermission,
@@ -26,10 +27,12 @@ use hash_graph_store::{
 };
 use hash_temporal_client::TemporalClient;
 use serde::Deserialize;
-use type_system::web::OwnedById;
+use type_system::{
+    provenance::{ActorId, UserId},
+    web::OwnedById,
+};
 use utoipa::{OpenApi, ToSchema};
 
-use super::api_resource::RoutedResource;
 use crate::rest::{AuthenticatedUserHeader, PermissionResponse, status::report_to_response};
 
 #[derive(OpenApi)]
@@ -62,12 +65,13 @@ use crate::rest::{AuthenticatedUserHeader, PermissionResponse, status::report_to
 )]
 pub(crate) struct WebResource;
 
-impl RoutedResource for WebResource {
+impl WebResource {
     /// Create routes for interacting with accounts.
-    fn routes<S, A>() -> Router
+    pub(crate) fn routes<S, A>() -> Router
     where
         S: StorePool + Send + Sync + 'static,
         A: AuthorizationApiPool + Send + Sync + 'static,
+        for<'p, 'a> S::Store<'p, A::Api<'a>>: PrincipalStore,
     {
         Router::new().nest(
             "/webs",
@@ -118,6 +122,7 @@ async fn create_web<S, A>(
 where
     S: StorePool + Send + Sync,
     A: AuthorizationApiPool + Send + Sync,
+    for<'p, 'a> S::Store<'p, A::Api<'a>>: PrincipalStore,
 {
     let authorization_api = authorization_api_pool.acquire().await.map_err(|error| {
         tracing::error!(?error, "Could not acquire access to the authorization API");
@@ -131,6 +136,21 @@ where
             tracing::error!(error=?report, "Could not acquire store");
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
+
+    // TODO: Uncomment this once we use the new principals
+    // store
+    //     .create_web(
+    //         ActorId::User(UserId::new(actor_id)),
+    //         CreateWebParameter {
+    //             id: Some(params.owned_by_id.into_uuid()),
+    //         },
+    //     )
+    //     .await
+    //     .map_err(|report| {
+    //         tracing::error!(error=?report, "Could not create web id");
+
+    //         StatusCode::INTERNAL_SERVER_ERROR
+    //     })?;
 
     store
         .insert_web_id(actor_id, params)

--- a/libs/@local/graph/api/src/rest/web.rs
+++ b/libs/@local/graph/api/src/rest/web.rs
@@ -13,7 +13,7 @@ use error_stack::Report;
 use hash_graph_authorization::{
     AuthorizationApi as _, AuthorizationApiPool,
     backend::{ModifyRelationshipOperation, PermissionAssertion},
-    policies::store::{CreateWebParameter, PrincipalStore},
+    policies::store::PrincipalStore,
     schema::{
         WebDataTypeViewerSubject, WebEntityCreatorSubject, WebEntityEditorSubject,
         WebEntityTypeViewerSubject, WebEntityViewerSubject, WebOwnerSubject, WebPermission,
@@ -27,10 +27,7 @@ use hash_graph_store::{
 };
 use hash_temporal_client::TemporalClient;
 use serde::Deserialize;
-use type_system::{
-    provenance::{ActorId, UserId},
-    web::OwnedById,
-};
+use type_system::web::OwnedById;
 use utoipa::{OpenApi, ToSchema};
 
 use crate::rest::{AuthenticatedUserHeader, PermissionResponse, status::report_to_response};

--- a/libs/@local/graph/authorization/Cargo.toml
+++ b/libs/@local/graph/authorization/Cargo.toml
@@ -34,6 +34,7 @@ smol_str               = { workspace = true }
 tokio                  = { workspace = true }
 tokio-util             = { workspace = true, features = ["io"] }
 tracing                = { workspace = true, features = ["attributes"] }
+trait-variant          = { workspace = true }
 utoipa                 = { workspace = true, optional = true }
 uuid                   = { workspace = true, features = ["v4"] }
 

--- a/libs/@local/graph/authorization/Cargo.toml
+++ b/libs/@local/graph/authorization/Cargo.toml
@@ -25,6 +25,7 @@ cedar-policy-core      = { workspace = true }
 cedar-policy-validator = { workspace = true }
 derive-where           = { workspace = true }
 derive_more            = { workspace = true, features = ["display", "error", "from"] }
+enum-iterator          = { workspace = true }
 futures                = { workspace = true }
 serde                  = { workspace = true, features = ["derive", "unstable"] }
 serde_json             = { workspace = true }

--- a/libs/@local/graph/authorization/schemas/policies.cedarschema
+++ b/libs/@local/graph/authorization/schemas/policies.cedarschema
@@ -20,12 +20,29 @@ namespace HASH {
   entity User, Machine, Ai in [HASH::Web::Role, HASH::Subteam::Role] {
   };
 
-  action create, view, update appliesTo {
+  action all;
+
+  action createWeb in [all] appliesTo {
+    principal: [User, Machine, Ai],
+    resource: [Web],
+  };
+
+  action create, view, update in [all] appliesTo {
     principal: [User, Machine, Ai],
     resource: [Entity, EntityType],
   };
 
-  action instantiate appliesTo {
+  action viewEntity in [view] appliesTo {
+    principal: [User, Machine, Ai],
+    resource: [Entity],
+  };
+
+  action viewEntityType in [view] appliesTo {
+    principal: [User, Machine, Ai],
+    resource: [EntityType],
+  };
+
+  action instantiate in [all] appliesTo {
     principal: [User, Machine, Ai],
     resource: [EntityType],
   };

--- a/libs/@local/graph/authorization/src/policies/action/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/action/mod.rs
@@ -13,7 +13,17 @@ use serde::Serialize as _;
 use crate::policies::cedar::CedarEntityId;
 
 #[derive(
-    Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+    enum_iterator::Sequence,
 )]
 #[serde(rename_all = "camelCase")]
 pub enum ActionName {
@@ -132,6 +142,7 @@ pub enum InvalidActionConstraint {
 #[expect(clippy::panic_in_result_fn, reason = "Assertions in test are expected")]
 mod tests {
     use core::error::Error;
+    use std::collections::{HashMap, HashSet};
 
     use indoc::formatdoc;
     use pretty_assertions::assert_eq;
@@ -228,12 +239,18 @@ mod tests {
         Ok(())
     }
 
+    /// Validates consistency between the Rust `ActionName` enum hierarchy and the Cedar schema.
+    /// This test ensures that:
+    /// - Each action defined in the Cedar schema can be mapped to a Rust `ActionName`
+    /// - The parent-child relationships defined by `action.parents()` match the hierarchical
+    ///   relationships in the Cedar schema (descendants)
     #[test]
     fn action_ids() -> Result<(), Box<dyn Error>> {
         for action_id in validation::PolicyValidator::schema().action_ids() {
             let action_name = ActionName::from_euid(action_id.name())?;
             for descendant_id in action_id.descendants() {
                 let descendant = ActionName::from_euid(descendant_id)?;
+                println!("{action_name} is parent of {descendant}");
                 assert!(
                     action_name.is_parent_of(descendant),
                     "{action_name} is not a parent of {descendant}"
@@ -246,5 +263,107 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    /// Complements the `action_ids` test by validating consistency in the reverse direction.
+    /// This test ensures that:
+    /// - Every `ActionName` enum variant is present in the Cedar schema
+    /// - For each action, its `parents()` method returns actions that are consistent with the
+    ///   descendants relationship in the Cedar schema
+    /// - Every descendant of an action in the Cedar schema is correctly identified as a child of
+    ///   that action in the Rust code
+    #[test]
+    fn action_names() -> Result<(), Box<dyn Error>> {
+        let action_ids = validation::PolicyValidator::schema()
+            .action_ids()
+            .map(|action_id| ActionName::from_euid(action_id.name()).map(|name| (name, action_id)))
+            .collect::<Result<HashMap<_, _>, _>>()?;
+        for action in enum_iterator::all::<ActionName>() {
+            let action_id = action.to_euid();
+            for parent in action.parents() {
+                assert!(
+                    action_ids[&parent]
+                        .descendants()
+                        .any(|descendant| *descendant == action_id),
+                    "{parent} is not a parent of {action}"
+                );
+            }
+            let action_id = action_ids
+                .get(&action)
+                .unwrap_or_else(|| panic!("Action {action:?} is not present in the schema"));
+            for descendant_id in action_id.descendants() {
+                let descendant = ActionName::from_euid(descendant_id)?;
+                assert!(
+                    descendant.is_child_of(action),
+                    "{descendant} is not a child of {action}"
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parents_method() {
+        // All has no parents
+        assert_eq!(ActionName::All.parents().collect::<Vec<_>>(), vec![]);
+
+        // First level actions have All as their only parent
+        assert_eq!(
+            ActionName::Create.parents().collect::<Vec<_>>(),
+            vec![ActionName::All]
+        );
+        assert_eq!(
+            ActionName::CreateWeb.parents().collect::<Vec<_>>(),
+            vec![ActionName::All]
+        );
+        assert_eq!(
+            ActionName::View.parents().collect::<Vec<_>>(),
+            vec![ActionName::All]
+        );
+        assert_eq!(
+            ActionName::Update.parents().collect::<Vec<_>>(),
+            vec![ActionName::All]
+        );
+        assert_eq!(
+            ActionName::Instantiate.parents().collect::<Vec<_>>(),
+            vec![ActionName::All]
+        );
+
+        // Second level actions have their direct parent and All as ancestors
+        assert_eq!(
+            ActionName::ViewEntity.parents().collect::<Vec<_>>(),
+            vec![ActionName::View, ActionName::All]
+        );
+        assert_eq!(
+            ActionName::ViewEntityType.parents().collect::<Vec<_>>(),
+            vec![ActionName::View, ActionName::All]
+        );
+    }
+
+    #[test]
+    fn test_is_parent_of_method() {
+        // View is parent of ViewEntity and ViewEntityType
+        assert!(ActionName::View.is_parent_of(ActionName::ViewEntity));
+        assert!(ActionName::View.is_parent_of(ActionName::ViewEntityType));
+
+        // Negative cases
+        assert!(!ActionName::Create.is_parent_of(ActionName::View));
+        assert!(!ActionName::View.is_parent_of(ActionName::Create));
+        assert!(!ActionName::All.is_parent_of(ActionName::All));
+        assert!(!ActionName::ViewEntity.is_parent_of(ActionName::View));
+    }
+
+    #[test]
+    fn test_is_child_of_method() {
+        // ViewEntity and ViewEntityType are children of View
+        assert!(ActionName::ViewEntity.is_child_of(ActionName::View));
+        assert!(ActionName::ViewEntityType.is_child_of(ActionName::View));
+
+        // Negative cases
+        assert!(!ActionName::View.is_child_of(ActionName::Create));
+        assert!(!ActionName::Create.is_child_of(ActionName::View));
+        assert!(!ActionName::All.is_child_of(ActionName::All));
+        assert!(!ActionName::View.is_child_of(ActionName::ViewEntity));
     }
 }

--- a/libs/@local/graph/authorization/src/policies/action/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/action/mod.rs
@@ -142,7 +142,7 @@ pub enum InvalidActionConstraint {
 #[expect(clippy::panic_in_result_fn, reason = "Assertions in test are expected")]
 mod tests {
     use core::error::Error;
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashMap;
 
     use indoc::formatdoc;
     use pretty_assertions::assert_eq;

--- a/libs/@local/graph/authorization/src/policies/context.rs
+++ b/libs/@local/graph/authorization/src/policies/context.rs
@@ -9,7 +9,7 @@ use error_stack::{Report, ResultExt as _};
 
 use super::{
     PolicyValidator,
-    principal::{Actor, actor::Machine, role::Role, team::Team},
+    principal::{Actor, role::Role, team::Team},
     resource::{EntityResource, EntityTypeResource},
 };
 

--- a/libs/@local/graph/authorization/src/policies/context.rs
+++ b/libs/@local/graph/authorization/src/policies/context.rs
@@ -43,18 +43,26 @@ pub struct ContextBuilder {
 }
 
 impl ContextBuilder {
-    pub fn add_machine(&mut self, machine: &Machine) {
-        self.entities.push(machine.to_cedar_entity());
-    }
-
+    /// Adds an actor to the context for policy evaluation.
+    ///
+    /// This allows the actor to be identified as a principal during authorization,
+    /// making it available for matching against principal constraints in policies.
     pub fn add_actor(&mut self, actor: &Actor) {
         self.entities.push(actor.to_cedar_entity());
     }
 
+    /// Adds a role to the context for policy evaluation.
+    ///
+    /// This allows policies associated with the role to be considered during authorization,
+    /// enabling role-based access control as part of the Cedar evaluation context.
     pub fn add_role(&mut self, role: &Role) {
         self.entities.push(role.to_cedar_entity());
     }
 
+    /// Adds a team to the context for policy evaluation.
+    ///
+    /// This allows policies associated with the team to be considered during authorization,
+    /// making the team available as a potential principal in the Cedar evaluation context.
     pub fn add_team(&mut self, team: &Team) {
         self.entities.push(team.to_cedar_entity());
     }

--- a/libs/@local/graph/authorization/src/policies/context.rs
+++ b/libs/@local/graph/authorization/src/policies/context.rs
@@ -9,7 +9,7 @@ use error_stack::{Report, ResultExt as _};
 
 use super::{
     PolicyValidator,
-    principal::{Actor, actor::Machine, role::Role},
+    principal::{Actor, actor::Machine, role::Role, team::Team},
     resource::{EntityResource, EntityTypeResource},
 };
 
@@ -19,7 +19,7 @@ pub enum ContextError {
     TransitiveClosureError,
 }
 
-#[derive(Default)]
+#[derive(Default, derive_more::Display)]
 pub struct Context {
     entities: Entities,
 }
@@ -53,6 +53,10 @@ impl ContextBuilder {
 
     pub fn add_role(&mut self, role: &Role) {
         self.entities.push(role.to_cedar_entity());
+    }
+
+    pub fn add_team(&mut self, team: &Team) {
+        self.entities.push(team.to_cedar_entity());
     }
 
     pub fn add_entity(&mut self, entity: &EntityResource) {

--- a/libs/@local/graph/authorization/src/policies/principal/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/mod.rs
@@ -10,8 +10,8 @@ use uuid::Uuid;
 
 pub use self::actor::Actor;
 use self::{
-    role::{RoleId, SubteamRoleId, WebRoleId},
-    team::{SubteamId, TeamId},
+    role::{Role, RoleId, SubteamRoleId, WebRoleId},
+    team::{SubteamId, Team, TeamId},
 };
 use super::cedar::CedarEntityId as _;
 
@@ -44,6 +44,13 @@ impl PrincipalId {
             Self::Role(role_id) => role_id.into_uuid(),
         }
     }
+}
+
+#[derive(Debug)]
+pub enum Principal {
+    Actor(Actor),
+    Team(Team),
+    Role(Role),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/libs/@local/graph/authorization/src/policies/principal/role/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/role/mod.rs
@@ -8,6 +8,7 @@ pub use self::{
     subteam::{SubteamRole, SubteamRoleId},
     web::{WebRole, WebRoleId},
 };
+use super::team::TeamId;
 use crate::policies::cedar::CedarEntityId as _;
 
 #[derive(
@@ -68,6 +69,14 @@ impl Role {
         match self {
             Self::Web(web_role) => web_role.to_cedar_entity(),
             Self::Subteam(subteam_role) => subteam_role.to_cedar_entity(),
+        }
+    }
+
+    #[must_use]
+    pub const fn team_id(&self) -> TeamId {
+        match self {
+            Self::Web(web_role) => TeamId::Web(web_role.web_id),
+            Self::Subteam(subteam_role) => TeamId::Subteam(subteam_role.subteam_id),
         }
     }
 }

--- a/libs/@local/graph/authorization/src/policies/principal/team/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/team/mod.rs
@@ -59,6 +59,14 @@ pub enum Team {
     Subteam(Subteam),
 }
 
+impl Team {
+    pub(crate) fn to_cedar_entity(&self) -> ast::Entity {
+        match self {
+            Self::Web(web) => web.to_cedar_entity(),
+            Self::Subteam(subteam) => subteam.to_cedar_entity(),
+        }
+    }
+}
 #[cfg(test)]
 mod tests {
     use core::error::Error;

--- a/libs/@local/graph/authorization/src/policies/principal/team/subteam.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/team/subteam.rs
@@ -1,8 +1,8 @@
 use alloc::sync::Arc;
-use core::str::FromStr as _;
+use core::{iter, str::FromStr as _};
 use std::{collections::HashSet, sync::LazyLock};
 
-use cedar_policy_core::ast;
+use cedar_policy_core::{ast, extensions::Extensions};
 use error_stack::Report;
 use uuid::Uuid;
 
@@ -64,6 +64,19 @@ pub struct Subteam {
     pub id: SubteamId,
     pub parents: Vec<TeamId>,
     pub roles: HashSet<SubteamRoleId>,
+}
+
+impl Subteam {
+    pub(crate) fn to_cedar_entity(&self) -> ast::Entity {
+        ast::Entity::new(
+            self.id.to_euid(),
+            iter::empty(),
+            self.parents.iter().copied().map(TeamId::to_euid).collect(),
+            iter::empty(),
+            Extensions::none(),
+        )
+        .expect("subteam should be a valid Cedar entity")
+    }
 }
 
 #[cfg(test)]

--- a/libs/@local/graph/authorization/src/policies/principal/team/web.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/team/web.rs
@@ -1,8 +1,8 @@
 use alloc::sync::Arc;
-use core::str::FromStr as _;
+use core::{iter, str::FromStr as _};
 use std::{collections::HashSet, sync::LazyLock};
 
-use cedar_policy_core::ast;
+use cedar_policy_core::{ast, extensions::Extensions};
 use error_stack::Report;
 use type_system::web::OwnedById;
 use uuid::Uuid;
@@ -31,6 +31,19 @@ impl CedarEntityId for OwnedById {
 pub struct Web {
     pub id: OwnedById,
     pub roles: HashSet<WebRoleId>,
+}
+
+impl Web {
+    pub(crate) fn to_cedar_entity(&self) -> ast::Entity {
+        ast::Entity::new(
+            self.id.to_euid(),
+            iter::empty(),
+            HashSet::new(),
+            iter::empty(),
+            Extensions::none(),
+        )
+        .expect("web should be a valid Cedar entity")
+    }
 }
 
 #[cfg(test)]

--- a/libs/@local/graph/authorization/src/policies/store/error.rs
+++ b/libs/@local/graph/authorization/src/policies/store/error.rs
@@ -20,6 +20,10 @@ impl Error for ActorCreationError {}
 #[derive(Debug, derive_more::Display)]
 #[display("Could not create web: {_variant}")]
 pub enum WebCreationError {
+    #[display("Web with ID `{web_id}` already exists")]
+    AlreadyExists { web_id: OwnedById },
+    #[display("Permission to create web was denied")]
+    NotAuthorized,
     #[display("Store operation failed")]
     StoreError,
 }

--- a/libs/@local/graph/authorization/src/policies/store/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/store/mod.rs
@@ -51,6 +51,29 @@ pub enum RoleCreationParameter {
     Subteam { web_id: OwnedById, parent: TeamId },
 }
 
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct CreateWebParameter {
+    pub id: Option<Uuid>,
+}
+
+#[trait_variant::make(PrincipalStore: Send)]
+pub trait LocalPrincipalStore {
+    /// Creates a new web and returns its ID.
+    ///
+    /// # Errors
+    ///
+    /// - [`AlreadyExists`] if the web already exists
+    /// - [`StoreError`] if the underlying store returns an error
+    ///
+    /// [`AlreadyExists`]: WebCreationError::AlreadyExists
+    /// [`StoreError`]: WebCreationError::StoreError
+    async fn create_web(
+        &mut self,
+        actor: ActorId,
+        parameter: CreateWebParameter,
+    ) -> Result<OwnedById, Report<WebCreationError>>;
+}
+
 pub trait PolicyStore {
     /// Creates a new user within the given web and returns its ID.
     ///

--- a/libs/@local/graph/postgres-store/src/permissions/error.rs
+++ b/libs/@local/graph/postgres-store/src/permissions/error.rs
@@ -10,6 +10,9 @@ pub enum PrincipalError {
     #[display("Principal with ID {id} doesn't exist")]
     PrincipalNotFound { id: PrincipalId },
 
+    #[display("Context builder error")]
+    ContextBuilderError,
+
     #[display("Database error")]
     StoreError,
 }
@@ -25,8 +28,6 @@ pub enum ActionError {
     NotFound { id: ActionName },
     #[display("Action `{id}` has children which must be unregistered first")]
     HasChildren { id: ActionName },
-    #[display("Action `{id}` has no parent")]
-    HasNoParent { id: ActionName },
     #[display("Action `{id}` has a self-cycle")]
     HasSelfCycle { id: ActionName },
 

--- a/libs/@local/graph/postgres-store/src/permissions/mod.rs
+++ b/libs/@local/graph/postgres-store/src/permissions/mod.rs
@@ -1245,6 +1245,15 @@ impl<C: AsClient, A: Send + Sync> PostgresStore<C, A> {
     ///
     /// [`PrincipalNotFound`]: PrincipalError::PrincipalNotFound
     /// [`StoreError`]: PrincipalError::StoreError
+    ///
+    /// # Performance considerations
+    ///
+    /// This function performs multiple database queries to collect all entities needed for policy
+    /// evaluation, which could become a performance bottleneck for frequently accessed actors.
+    /// Future optimizations may include:
+    ///   - Combining some queries into a single more complex query
+    ///   - Implementing caching strategies for frequently accessed contexts
+    ///   - Prefetching contexts for related actors in batch operations
     pub async fn build_principal_context(
         &self,
         actor_id: ActorId,

--- a/libs/@local/graph/postgres-store/tests/principals/actions.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/actions.rs
@@ -8,10 +8,10 @@ use crate::DatabaseTestWrapper;
 #[tokio::test]
 async fn register_actions() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
     assert!(!client.has_action(ActionName::All).await?);
-    client.register_action(ActionName::All, None).await?;
+    client.register_action(ActionName::All).await?;
     assert!(client.has_action(ActionName::All).await?);
     client.unregister_action(ActionName::All).await?;
     assert!(!client.has_action(ActionName::All).await?);
@@ -22,16 +22,14 @@ async fn register_actions() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn register_with_parent() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
     assert!(!client.has_action(ActionName::All).await?);
-    client.register_action(ActionName::All, None).await?;
+    client.register_action(ActionName::All).await?;
     assert!(client.has_action(ActionName::All).await?);
 
     assert!(!client.has_action(ActionName::Create).await?);
-    client
-        .register_action(ActionName::Create, Some(ActionName::All))
-        .await?;
+    client.register_action(ActionName::Create).await?;
     assert!(client.has_action(ActionName::Create).await?);
 
     client.unregister_action(ActionName::Create).await?;
@@ -46,10 +44,10 @@ async fn register_with_parent() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn register_action_twice() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
-    client.register_action(ActionName::All, None).await?;
-    let result = client.register_action(ActionName::All, None).await;
+    client.register_action(ActionName::All).await?;
+    let result = client.register_action(ActionName::All).await;
 
     assert_matches!(
         result
@@ -67,12 +65,10 @@ async fn register_action_twice() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn register_with_non_existent_parent() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
     assert!(!client.has_action(ActionName::View).await?);
-    let result = client
-        .register_action(ActionName::View, Some(ActionName::All))
-        .await;
+    let result = client.register_action(ActionName::View).await;
 
     assert_matches!(
         result
@@ -88,30 +84,9 @@ async fn register_with_non_existent_parent() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test]
-async fn register_without_parent() -> Result<(), Box<dyn Error>> {
-    let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
-
-    assert!(!client.has_action(ActionName::View).await?);
-    let result = client.register_action(ActionName::View, None).await;
-
-    assert_matches!(
-        result
-            .expect_err("Unregistering a non-existent action should fail")
-            .current_context(),
-        ActionError::HasNoParent {
-            id: ActionName::View
-        },
-        "Error should indicate that action does not have a parent"
-    );
-
-    Ok(())
-}
-
-#[tokio::test]
 async fn unregister_non_existent_action() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
     assert!(!client.has_action(ActionName::All).await?);
     let result = client.unregister_action(ActionName::All).await;
@@ -132,48 +107,44 @@ async fn unregister_non_existent_action() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn action_hierarchy() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
-    // Create a hierarchy: all -> create -> instantiate
-    client.register_action(ActionName::All, None).await?;
-    client
-        .register_action(ActionName::Create, Some(ActionName::All))
-        .await?;
-    client
-        .register_action(ActionName::Instantiate, Some(ActionName::Create))
-        .await?;
+    // Create a hierarchy: all -> view -> view entity
+    client.register_action(ActionName::All).await?;
+    client.register_action(ActionName::View).await?;
+    client.register_action(ActionName::ViewEntity).await?;
 
     // Verify hierarchy is correctly established
-    let parent_actions = client.get_parent_actions(ActionName::Instantiate).await?;
+    let parent_actions = client.get_parent_actions(ActionName::ViewEntity).await?;
     assert_eq!(
         parent_actions,
-        [ActionName::Create, ActionName::All],
+        [ActionName::View, ActionName::All],
         "Parent actions should be in order of depth"
     );
 
     // Delete hierarchy in correct order - bottom-up
     // Delete instantiate action first
-    client.unregister_action(ActionName::Instantiate).await?;
+    client.unregister_action(ActionName::ViewEntity).await?;
 
     // Verify instantiate action no longer exists
     assert!(
-        !client.has_action(ActionName::Instantiate).await?,
-        "Instantiate action should be deleted"
+        !client.has_action(ActionName::ViewEntity).await?,
+        "ViewEntity action should be deleted"
     );
 
     // Verify create action still exists
     assert!(
-        client.has_action(ActionName::Create).await?,
-        "Create action should still exist"
+        client.has_action(ActionName::View).await?,
+        "View action should still exist"
     );
 
     // Now we can delete create action since it no longer has children
-    client.unregister_action(ActionName::Create).await?;
+    client.unregister_action(ActionName::View).await?;
 
     // Verify create action no longer exists
     assert!(
-        !client.has_action(ActionName::Create).await?,
-        "Create action should be deleted"
+        !client.has_action(ActionName::View).await?,
+        "View action should be deleted"
     );
 
     // Finally delete the root action
@@ -189,13 +160,11 @@ async fn action_hierarchy() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn cannot_delete_action_with_children() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
     // Create a simple parent-child hierarchy
-    client.register_action(ActionName::All, None).await?;
-    client
-        .register_action(ActionName::Create, Some(ActionName::All))
-        .await?;
+    client.register_action(ActionName::All).await?;
+    client.register_action(ActionName::Create).await?;
 
     // Delete the parent action
     let result = client.unregister_action(ActionName::All).await;
@@ -216,9 +185,9 @@ async fn cannot_delete_action_with_children() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn get_empty_parent_actions() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
-    client.register_action(ActionName::All, None).await?;
+    client.register_action(ActionName::All).await?;
     let parent_actions = client.get_parent_actions(ActionName::All).await?;
 
     // Should return an empty vector for non-existent actions
@@ -233,7 +202,7 @@ async fn get_empty_parent_actions() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn get_parent_actions_non_existent() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let client = db.client().await?;
+    let (client, _actor_id) = db.seed([]).await?;
 
     // Try to get parent actions for an action that doesn't exist
     let result = client.get_parent_actions(ActionName::View).await;
@@ -253,46 +222,40 @@ async fn get_parent_actions_non_existent() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn complex_action_hierarchy() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
     // Create a more complex hierarchy:
     //                    All
     //                   /   \
-    //               Create   View
-    //              /      \
-    //     Instantiate    Update
+    //               View    Create
+    //              /    \
+    //     ViewEntity    ViewEntityType
 
-    client.register_action(ActionName::All, None).await?;
+    client.register_action(ActionName::All).await?;
 
     // First branch
-    client
-        .register_action(ActionName::Create, Some(ActionName::All))
-        .await?;
-    client
-        .register_action(ActionName::Instantiate, Some(ActionName::Create))
-        .await?;
-    client
-        .register_action(ActionName::Update, Some(ActionName::Create))
-        .await?;
+    client.register_action(ActionName::View).await?;
+    client.register_action(ActionName::ViewEntity).await?;
+    client.register_action(ActionName::ViewEntityType).await?;
 
     // Second branch
-    client
-        .register_action(ActionName::View, Some(ActionName::All))
-        .await?;
+    client.register_action(ActionName::Create).await?;
 
     // Verify hierarchies
-    let instantiate_parents = client.get_parent_actions(ActionName::Instantiate).await?;
+    let instantiate_parents = client.get_parent_actions(ActionName::ViewEntity).await?;
     assert_eq!(
         instantiate_parents,
-        [ActionName::Create, ActionName::All],
-        "Instantiate should have Create and All as parents"
+        [ActionName::View, ActionName::All],
+        "ViewEntity should have View and All as parents"
     );
 
-    let update_parents = client.get_parent_actions(ActionName::Update).await?;
+    let update_parents = client
+        .get_parent_actions(ActionName::ViewEntityType)
+        .await?;
     assert_eq!(
         update_parents,
-        [ActionName::Create, ActionName::All],
-        "Update should have Create and All as parents"
+        [ActionName::View, ActionName::All],
+        "Update should have View and All as parents"
     );
 
     let view_parents = client.get_parent_actions(ActionName::View).await?;
@@ -303,76 +266,24 @@ async fn complex_action_hierarchy() -> Result<(), Box<dyn Error>> {
     );
 
     // Verify proper deletion order works
-    client.unregister_action(ActionName::Instantiate).await?;
-    client.unregister_action(ActionName::Update).await?;
+    client.unregister_action(ActionName::ViewEntityType).await?;
+    client.unregister_action(ActionName::ViewEntity).await?;
 
-    // Now Create can be deleted
-    client.unregister_action(ActionName::Create).await?;
+    // Now View can be deleted
+    client.unregister_action(ActionName::View).await?;
 
     // Delete the other branch
-    client.unregister_action(ActionName::View).await?;
+    client.unregister_action(ActionName::Create).await?;
 
     // Finally delete the root
     client.unregister_action(ActionName::All).await?;
 
     // Verify all actions are gone
     assert!(!client.has_action(ActionName::All).await?);
-    assert!(!client.has_action(ActionName::Create).await?);
-    assert!(!client.has_action(ActionName::Instantiate).await?);
-    assert!(!client.has_action(ActionName::Update).await?);
     assert!(!client.has_action(ActionName::View).await?);
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn prevent_action_cycles() -> Result<(), Box<dyn Error>> {
-    let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
-
-    // Create a simple hierarchy
-    client.register_action(ActionName::All, None).await?;
-    client
-        .register_action(ActionName::Create, Some(ActionName::All))
-        .await?;
-
-    // Try to create a cycle by making All a child of Create
-    // This should fail because it would create a cycle
-    let result = client
-        .register_action(ActionName::All, Some(ActionName::Create))
-        .await;
-
-    // We expect an error because ActionId::All already exists
-    assert_matches!(
-        result
-            .expect_err("Creating a cycle should fail")
-            .current_context(),
-        ActionError::AlreadyExists {
-            id: ActionName::All
-        },
-        "Error should indicate that action already exists"
-    );
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn prevent_self_cycles() -> Result<(), Box<dyn Error>> {
-    let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
-
-    let result = client
-        .register_action(ActionName::All, Some(ActionName::All))
-        .await;
-    assert_matches!(
-        result
-            .expect_err("Creating a self-cycle should fail")
-            .current_context(),
-        ActionError::HasSelfCycle {
-            id: ActionName::All
-        },
-        "Error should indicate that action has a self-cycle"
-    );
+    assert!(!client.has_action(ActionName::ViewEntity).await?);
+    assert!(!client.has_action(ActionName::ViewEntityType).await?);
+    assert!(!client.has_action(ActionName::Create).await?);
 
     Ok(())
 }

--- a/libs/@local/graph/postgres-store/tests/principals/ai.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/ai.rs
@@ -1,6 +1,10 @@
 use core::{assert_matches::assert_matches, error::Error};
 
-use hash_graph_authorization::policies::principal::{PrincipalId, team::TeamId};
+use hash_graph_authorization::policies::{
+    action::ActionName,
+    principal::{PrincipalId, team::TeamId},
+    store::{CreateWebParameter, PrincipalStore as _},
+};
 use hash_graph_postgres_store::permissions::PrincipalError;
 use pretty_assertions::assert_eq;
 use type_system::{
@@ -14,7 +18,7 @@ use crate::DatabaseTestWrapper;
 #[tokio::test]
 async fn create_ai() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
     let ai_id = client.create_ai(None).await?;
     assert!(client.is_ai(ai_id).await?);
@@ -25,7 +29,7 @@ async fn create_ai() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn create_ai_with_id() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
     let id = Uuid::new_v4();
     let ai_id = client.create_ai(Some(id)).await?;
@@ -39,7 +43,7 @@ async fn create_ai_with_id() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn delete_ai() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
     let ai_id = client.create_ai(None).await?;
     assert!(client.is_ai(ai_id).await?);
@@ -53,14 +57,14 @@ async fn delete_ai() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn create_ai_with_duplicate_id() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
     let ai_id = client.create_ai(Some(Uuid::new_v4())).await?;
-    let result = client.create_ai(Some(*ai_id.as_uuid())).await;
+    let result = client.create_ai(Some(ai_id.into_uuid())).await;
     drop(client);
 
     let expected_actor_id = ActorId::Ai(AiId::new(ActorEntityUuid::new(EntityUuid::new(
-        *ai_id.as_uuid(),
+        ai_id.into_uuid(),
     ))));
 
     assert_matches!(
@@ -74,7 +78,7 @@ async fn create_ai_with_duplicate_id() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn get_non_existent_ai() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let client = db.client().await?;
+    let (client, _actor_id) = db.seed([]).await?;
 
     let non_existent_id = AiId::new(ActorEntityUuid::new(EntityUuid::new(Uuid::new_v4())));
     let result = client.get_ai(non_existent_id).await?;
@@ -90,13 +94,13 @@ async fn get_non_existent_ai() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn delete_non_existent_ai() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
     let non_existent_id = AiId::new(ActorEntityUuid::new(EntityUuid::new(Uuid::new_v4())));
     let result = client.delete_ai(non_existent_id).await;
 
     let expected_actor_id = ActorId::Ai(AiId::new(ActorEntityUuid::new(EntityUuid::new(
-        *non_existent_id.as_uuid(),
+        non_existent_id.into_uuid(),
     ))));
 
     assert_matches!(
@@ -110,9 +114,11 @@ async fn delete_non_existent_ai() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn create_web_ai_relation() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, actor_id) = db.seed([ActionName::All, ActionName::CreateWeb]).await?;
 
-    let web_id = client.create_web(None).await?;
+    let web_id = client
+        .create_web(actor_id, CreateWebParameter { id: None })
+        .await?;
     let ai_id = client.create_ai(None).await?;
 
     assert!(client.is_web(web_id).await?);
@@ -124,14 +130,16 @@ async fn create_web_ai_relation() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn ai_role_assignment() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, actor_id) = db.seed([ActionName::All, ActionName::CreateWeb]).await?;
 
     let ai_id = client.create_ai(None).await?;
-    let web_id = client.create_web(None).await?;
+    let web_id = client
+        .create_web(actor_id, CreateWebParameter { id: None })
+        .await?;
     let role_id = client.create_role(None, TeamId::Web(web_id)).await?;
 
     let actor_id = ActorId::Ai(AiId::new(ActorEntityUuid::new(EntityUuid::new(
-        *ai_id.as_uuid(),
+        ai_id.into_uuid(),
     ))));
 
     // Assign the role to the AI
@@ -139,7 +147,7 @@ async fn ai_role_assignment() -> Result<(), Box<dyn Error>> {
 
     // Check that the AI has the role assigned
     let ai_roles = client.get_actor_roles(actor_id).await?;
-    assert!(ai_roles.contains(&role_id));
+    assert!(ai_roles.contains_key(&role_id));
 
     // Check that the role has the AI assigned
     let role_actors = client.get_role_actors(role_id).await?;
@@ -150,7 +158,7 @@ async fn ai_role_assignment() -> Result<(), Box<dyn Error>> {
 
     // Check that the AI no longer has the role assigned
     let ai_roles_after = client.get_actor_roles(actor_id).await?;
-    assert!(!ai_roles_after.contains(&role_id));
+    assert!(!ai_roles_after.contains_key(&role_id));
 
     Ok(())
 }

--- a/libs/@local/graph/postgres-store/tests/principals/policies.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/policies.rs
@@ -11,6 +11,7 @@ use hash_graph_authorization::{
             team::{SubteamId, TeamId},
         },
         resource::{EntityResourceConstraint, EntityResourceFilter, ResourceConstraint},
+        store::{CreateWebParameter, PrincipalStore as _},
     },
 };
 use hash_graph_postgres_store::store::{AsClient, PostgresStore};
@@ -108,28 +109,22 @@ struct TestPolicyIds {
 #[expect(clippy::too_many_lines)]
 async fn setup_policy_test_environment(
     client: &mut PostgresStore<impl AsClient, impl AuthorizationApi>,
+    actor_id: ActorId,
 ) -> Result<TestPolicyEnvironment, Box<dyn Error>> {
     // Register actions
-    client.register_action(ActionName::All, None).await?;
-    client
-        .register_action(ActionName::Create, Some(ActionName::All))
-        .await?;
-    client
-        .register_action(ActionName::View, Some(ActionName::All))
-        .await?;
-    client
-        .register_action(ActionName::ViewEntity, Some(ActionName::View))
-        .await?;
-    client
-        .register_action(ActionName::Update, Some(ActionName::All))
-        .await?;
-    client
-        .register_action(ActionName::Instantiate, Some(ActionName::All))
-        .await?;
+    client.register_action(ActionName::Create).await?;
+    client.register_action(ActionName::View).await?;
+    client.register_action(ActionName::ViewEntity).await?;
+    client.register_action(ActionName::Update).await?;
+    client.register_action(ActionName::Instantiate).await?;
 
     // Create web teams (top level)
-    let web1_id = client.create_web(None).await?;
-    let web2_id = client.create_web(None).await?;
+    let web1_id = client
+        .create_web(actor_id, CreateWebParameter { id: None })
+        .await?;
+    let web2_id = client
+        .create_web(actor_id, CreateWebParameter { id: None })
+        .await?;
 
     // Create subteams with different hierarchies
     let subteam_1_id = client.create_subteam(None, TeamId::Web(web1_id)).await?;
@@ -326,9 +321,9 @@ async fn setup_policy_test_environment(
 #[tokio::test]
 async fn global_policies() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, actor_id) = db.seed([ActionName::All, ActionName::CreateWeb]).await?;
 
-    let env = setup_policy_test_environment(&mut client).await?;
+    let env = setup_policy_test_environment(&mut client, actor_id).await?;
 
     // Every actor should get global policies
     let user1_policies = client
@@ -377,9 +372,9 @@ async fn global_policies() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn actor_type_policies() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, actor_id) = db.seed([ActionName::All, ActionName::CreateWeb]).await?;
 
-    let env = setup_policy_test_environment(&mut client).await?;
+    let env = setup_policy_test_environment(&mut client, actor_id).await?;
 
     // Test user type policies
     let user1_policies = client
@@ -439,9 +434,9 @@ async fn actor_type_policies() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn specific_actor_policies() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, actor_id) = db.seed([ActionName::All, ActionName::CreateWeb]).await?;
 
-    let env = setup_policy_test_environment(&mut client).await?;
+    let env = setup_policy_test_environment(&mut client, actor_id).await?;
 
     // user1 has a specific policy assigned
     let user1_policies = client
@@ -476,9 +471,9 @@ async fn specific_actor_policies() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn role_based_policies() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, actor_id) = db.seed([ActionName::All, ActionName::CreateWeb]).await?;
 
-    let env = setup_policy_test_environment(&mut client).await?;
+    let env = setup_policy_test_environment(&mut client, actor_id).await?;
 
     // Test role-based policies
     let user1_policies = client
@@ -530,9 +525,9 @@ async fn role_based_policies() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn team_hierarchy_policies() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, actor_id) = db.seed([ActionName::All, ActionName::CreateWeb]).await?;
 
-    let env = setup_policy_test_environment(&mut client).await?;
+    let env = setup_policy_test_environment(&mut client, actor_id).await?;
 
     // Test team hierarchies
     // User2 has subteam1_role, AI has nested_subteam_role which is under subteam1
@@ -561,9 +556,9 @@ async fn team_hierarchy_policies() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn policy_count_and_content() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, actor_id) = db.seed([ActionName::All, ActionName::CreateWeb]).await?;
 
-    let env = setup_policy_test_environment(&mut client).await?;
+    let env = setup_policy_test_environment(&mut client, actor_id).await?;
 
     let nonexistent_id = UserId::new(ActorEntityUuid::new(EntityUuid::new(Uuid::new_v4())));
 
@@ -616,9 +611,9 @@ async fn policy_count_and_content() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn role_assignment_changes() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, actor_id) = db.seed([ActionName::All, ActionName::CreateWeb]).await?;
 
-    let env = setup_policy_test_environment(&mut client).await?;
+    let env = setup_policy_test_environment(&mut client, actor_id).await?;
 
     // Initial policy count
     let user2_policies = client
@@ -678,10 +673,10 @@ async fn role_assignment_changes() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn resource_constraints_are_preserved() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
     let user_id = client.create_user(None).await?;
-    client.register_action(ActionName::All, None).await?;
+    client.register_action(ActionName::All).await?;
 
     // Create a policy with resource constraints
     let resource_policy_id = client
@@ -729,10 +724,12 @@ async fn resource_constraints_are_preserved() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn multiple_actor_roles() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, actor_id) = db.seed([ActionName::All, ActionName::CreateWeb]).await?;
 
     // Create teams and roles
-    let web_id = client.create_web(None).await?;
+    let web_id = client
+        .create_web(actor_id, CreateWebParameter { id: None })
+        .await?;
     let role1_id = client.create_role(None, TeamId::Web(web_id)).await?;
     let role2_id = client.create_role(None, TeamId::Web(web_id)).await?;
     let role3_id = client.create_role(None, TeamId::Web(web_id)).await?;
@@ -748,8 +745,6 @@ async fn multiple_actor_roles() -> Result<(), Box<dyn Error>> {
     client
         .assign_role_to_actor(ActorId::User(user_id), role3_id)
         .await?;
-
-    client.register_action(ActionName::All, None).await?;
 
     // Create policies for each role
     let policy1_id = client
@@ -822,10 +817,12 @@ async fn multiple_actor_roles() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn deep_team_hierarchy() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, actor_id) = db.seed([ActionName::All, ActionName::CreateWeb]).await?;
 
     // Create a deep team hierarchy
-    let web_id = client.create_web(None).await?;
+    let web_id = client
+        .create_web(actor_id, CreateWebParameter { id: None })
+        .await?;
     let subteam1_id = client.create_subteam(None, TeamId::Web(web_id)).await?;
     let subteam2_id = client
         .create_subteam(None, TeamId::Subteam(subteam1_id))
@@ -850,8 +847,6 @@ async fn deep_team_hierarchy() -> Result<(), Box<dyn Error>> {
     client
         .assign_role_to_actor(ActorId::User(user_id), subteam5_role_id)
         .await?;
-
-    client.register_action(ActionName::All, None).await?;
 
     // Create policies
     let web_policy_id = client

--- a/libs/@local/graph/postgres-store/tests/principals/team.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/team.rs
@@ -1,8 +1,12 @@
 use core::{assert_matches::assert_matches, error::Error};
 
-use hash_graph_authorization::policies::principal::{
-    PrincipalId,
-    team::{SubteamId, TeamId},
+use hash_graph_authorization::policies::{
+    action::ActionName,
+    principal::{
+        PrincipalId,
+        team::{SubteamId, TeamId},
+    },
+    store::{CreateWebParameter, PrincipalStore as _},
 };
 use hash_graph_postgres_store::permissions::PrincipalError;
 use pretty_assertions::assert_eq;
@@ -13,14 +17,16 @@ use crate::DatabaseTestWrapper;
 #[tokio::test]
 async fn create_subteam() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, actor_id) = db.seed([ActionName::All, ActionName::CreateWeb]).await?;
 
-    let web_id = client.create_web(None).await?;
+    let web_id = client
+        .create_web(actor_id, CreateWebParameter { id: None })
+        .await?;
     let subteam_id = client.create_subteam(None, TeamId::Web(web_id)).await?;
     assert!(client.is_subteam(subteam_id).await?);
 
     let subteam = client
-        .get_subteam(SubteamId::new(*subteam_id.as_uuid()))
+        .get_subteam(SubteamId::new(subteam_id.into_uuid()))
         .await?
         .expect("Subteam should exist");
 
@@ -32,13 +38,15 @@ async fn create_subteam() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn create_subteam_with_id() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, actor_id) = db.seed([ActionName::All, ActionName::CreateWeb]).await?;
 
-    let web_id = client.create_web(None).await?;
+    let web_id = client
+        .create_web(actor_id, CreateWebParameter { id: None })
+        .await?;
     let id = Uuid::new_v4();
     let subteam_id = client.create_subteam(Some(id), TeamId::Web(web_id)).await?;
 
-    assert_eq!(*subteam_id.as_uuid(), id);
+    assert_eq!(subteam_id.into_uuid(), id);
     assert!(client.is_subteam(subteam_id).await?);
 
     Ok(())
@@ -47,10 +55,12 @@ async fn create_subteam_with_id() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn delete_subteam_with_hierarchy() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, actor_id) = db.seed([ActionName::All, ActionName::CreateWeb]).await?;
 
     // Create a hierarchy: web -> mid_team -> bottom_team
-    let web_id = client.create_web(None).await?;
+    let web_id = client
+        .create_web(actor_id, CreateWebParameter { id: None })
+        .await?;
     let mid_subteam_id = client.create_subteam(None, TeamId::Web(web_id)).await?;
     let bottom_subteam_id = client
         .create_subteam(None, TeamId::Subteam(mid_subteam_id))
@@ -58,7 +68,7 @@ async fn delete_subteam_with_hierarchy() -> Result<(), Box<dyn Error>> {
 
     // Verify hierarchy is correctly established
     let subteam = client
-        .get_subteam(SubteamId::new(*bottom_subteam_id.as_uuid()))
+        .get_subteam(SubteamId::new(bottom_subteam_id.into_uuid()))
         .await?
         .expect("Subteam should exist");
 
@@ -98,7 +108,7 @@ async fn delete_subteam_with_hierarchy() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn delete_non_existent_subteam() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
     // Try to delete a non-existent subteam
     let non_existent_id = SubteamId::new(Uuid::new_v4());
@@ -117,10 +127,12 @@ async fn delete_non_existent_subteam() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn can_delete_subteam_with_children() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, actor_id) = db.seed([ActionName::All, ActionName::CreateWeb]).await?;
 
     // Create a simple parent-child hierarchy
-    let web_id = client.create_web(None).await?;
+    let web_id = client
+        .create_web(actor_id, CreateWebParameter { id: None })
+        .await?;
     let parent_subteam_id = client.create_subteam(None, TeamId::Web(web_id)).await?;
     let child_subteam_id = client
         .create_subteam(None, TeamId::Subteam(parent_subteam_id))
@@ -139,10 +151,12 @@ async fn can_delete_subteam_with_children() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn create_subteam_with_duplicate_id() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, actor_id) = db.seed([ActionName::All, ActionName::CreateWeb]).await?;
 
     // Create a parent team
-    let web_id = client.create_web(None).await?;
+    let web_id = client
+        .create_web(actor_id, CreateWebParameter { id: None })
+        .await?;
 
     // Create a subteam with a specific ID
     let id = Uuid::new_v4();
@@ -170,10 +184,12 @@ async fn create_subteam_with_duplicate_id() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn get_subteam() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, actor_id) = db.seed([ActionName::All, ActionName::CreateWeb]).await?;
 
     // Create a parent team and subteam
-    let web_id = client.create_web(None).await?;
+    let web_id = client
+        .create_web(actor_id, CreateWebParameter { id: None })
+        .await?;
     let subteam_id = client.create_subteam(None, TeamId::Web(web_id)).await?;
 
     // Get the subteam and verify it matches
@@ -189,7 +205,7 @@ async fn get_subteam() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn get_non_existent_subteam() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let client = db.client().await?;
+    let (client, _actor_id) = db.seed([]).await?;
 
     // Try to get a non-existent subteam
     let non_existent_id = SubteamId::new(Uuid::new_v4());

--- a/libs/@local/graph/postgres-store/tests/principals/user.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/user.rs
@@ -14,7 +14,7 @@ use crate::DatabaseTestWrapper;
 #[tokio::test]
 async fn create_user() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
     let user_id = client.create_user(None).await?;
     assert!(client.is_user(user_id).await?);
@@ -25,7 +25,7 @@ async fn create_user() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn create_user_with_id() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
     let id = Uuid::new_v4();
     let user_id = client.create_user(Some(id)).await?;
@@ -42,7 +42,7 @@ async fn create_user_with_id() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn delete_user() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
     let user_id = client.create_user(None).await?;
     assert!(client.is_user(user_id).await?);
@@ -56,10 +56,10 @@ async fn delete_user() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn create_user_with_duplicate_id() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
     let user_id = client.create_user(Some(Uuid::new_v4())).await?;
-    let result = client.create_user(Some(*user_id.as_uuid())).await;
+    let result = client.create_user(Some(user_id.into_uuid())).await;
     drop(client);
 
     assert_matches!(
@@ -73,7 +73,7 @@ async fn create_user_with_duplicate_id() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn get_non_existent_user() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let client = db.client().await?;
+    let (client, _actor_id) = db.seed([]).await?;
 
     let non_existent_id = UserId::new(ActorEntityUuid::new(EntityUuid::new(Uuid::new_v4())));
     let result = client.get_user(non_existent_id).await?;
@@ -89,7 +89,7 @@ async fn get_non_existent_user() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn delete_non_existent_user() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
     let non_existent_id = UserId::new(ActorEntityUuid::new(EntityUuid::new(Uuid::new_v4())));
     let result = client.delete_user(non_existent_id).await;

--- a/libs/@local/graph/postgres-store/tests/principals/web.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/web.rs
@@ -1,6 +1,10 @@
 use core::{assert_matches::assert_matches, error::Error};
 
-use hash_graph_authorization::policies::principal::{PrincipalId, team::TeamId};
+use hash_graph_authorization::policies::{
+    action::ActionName,
+    principal::{PrincipalId, team::TeamId},
+    store::{CreateWebParameter, PrincipalStore as _, error::WebCreationError},
+};
 use hash_graph_postgres_store::permissions::PrincipalError;
 use pretty_assertions::assert_eq;
 use type_system::web::OwnedById;
@@ -11,9 +15,11 @@ use crate::DatabaseTestWrapper;
 #[tokio::test]
 async fn create_web() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, actor_id) = db.seed([ActionName::All, ActionName::CreateWeb]).await?;
 
-    let web_id = client.create_web(None).await?;
+    let web_id = client
+        .create_web(actor_id, CreateWebParameter { id: None })
+        .await?;
     assert!(client.is_web(web_id).await?);
 
     let retrieved = client.get_web(web_id).await?.expect("Web should exist");
@@ -25,10 +31,12 @@ async fn create_web() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn create_web_with_id() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, actor_id) = db.seed([ActionName::All, ActionName::CreateWeb]).await?;
 
     let id = Uuid::new_v4();
-    let web_id = client.create_web(Some(id)).await?;
+    let web_id = client
+        .create_web(actor_id, CreateWebParameter { id: Some(id) })
+        .await?;
     assert_eq!(web_id, OwnedById::new(id));
     assert!(client.is_web(web_id).await?);
 
@@ -38,9 +46,11 @@ async fn create_web_with_id() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn delete_web() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, actor_id) = db.seed([ActionName::All, ActionName::CreateWeb]).await?;
 
-    let web_id = client.create_web(None).await?;
+    let web_id = client
+        .create_web(actor_id, CreateWebParameter { id: None })
+        .await?;
     assert!(client.is_web(web_id).await?);
 
     client.delete_web(web_id).await?;
@@ -52,15 +62,29 @@ async fn delete_web() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn create_web_with_duplicate_id() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, actor_id) = db.seed([ActionName::All, ActionName::CreateWeb]).await?;
 
-    let web_id = client.create_web(Some(Uuid::new_v4())).await?;
-    let result = client.create_web(Some(*web_id.as_uuid())).await;
+    let web_id = client
+        .create_web(
+            actor_id,
+            CreateWebParameter {
+                id: Some(Uuid::new_v4()),
+            },
+        )
+        .await?;
+    let result = client
+        .create_web(
+            actor_id,
+            CreateWebParameter {
+                id: Some(web_id.into_uuid()),
+            },
+        )
+        .await;
     drop(client);
 
     assert_matches!(
         result.expect_err("Creating a web with duplicate ID should fail").current_context(),
-        PrincipalError::PrincipalAlreadyExists { id } if *id == PrincipalId::Team(TeamId::Web(web_id))
+        WebCreationError::AlreadyExists { web_id: id } if *id == web_id
     );
 
     Ok(())
@@ -69,7 +93,7 @@ async fn create_web_with_duplicate_id() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn get_non_existent_web() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let client = db.client().await?;
+    let (client, _actor_id) = db.seed([]).await?;
 
     let non_existent_id = OwnedById::new(Uuid::new_v4());
     let result = client.get_web(non_existent_id).await?;
@@ -85,7 +109,7 @@ async fn get_non_existent_web() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn delete_non_existent_web() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let mut client = db.client().await?;
+    let (mut client, _actor_id) = db.seed([]).await?;
 
     let non_existent_id = OwnedById::new(Uuid::new_v4());
     let result = client.delete_web(non_existent_id).await;

--- a/libs/@local/graph/type-fetcher/src/store.rs
+++ b/libs/@local/graph/type-fetcher/src/store.rs
@@ -5,6 +5,7 @@ use std::collections::{HashMap, HashSet};
 use error_stack::{Report, ResultExt as _};
 use hash_graph_authorization::{
     AuthorizationApi,
+    policies::store::{CreateWebParameter, PrincipalStore, error::WebCreationError},
     schema::{
         DataTypeRelationAndSubject, DataTypeViewerSubject, EntityRelationAndSubject,
         EntityTypeInstantiatorSubject, EntityTypeRelationAndSubject, EntityTypeViewerSubject,
@@ -71,7 +72,7 @@ use type_system::{
         property_type::{PropertyType, PropertyTypeMetadata},
         provenance::{OntologyOwnership, ProvidedOntologyEditionProvenance},
     },
-    provenance::{ActorEntityUuid, ActorType, OriginProvenance, OriginType},
+    provenance::{ActorEntityUuid, ActorId, ActorType, OriginProvenance, OriginType},
     web::OwnedById,
 };
 
@@ -161,6 +162,20 @@ where
 pub struct FetchingStore<S, A> {
     store: S,
     connection_info: Option<TypeFetcherConnectionInfo<A>>,
+}
+
+impl<S, A> PrincipalStore for FetchingStore<S, A>
+where
+    S: PrincipalStore + Send,
+    A: Send,
+{
+    async fn create_web(
+        &mut self,
+        actor: ActorId,
+        parameter: CreateWebParameter,
+    ) -> Result<OwnedById, Report<WebCreationError>> {
+        self.store.create_web(actor, parameter).await
+    }
 }
 
 const DATA_TYPE_RELATIONSHIPS: [DataTypeRelationAndSubject; 1] =


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To allow the usage of the new policies we need to bubble up the interface to the Graph API layer. Also, it has to be possible to create a principal context which can be used in Cedar.

## 🔍 What does this change?

- Implement a `PrincipalStore`
- Expose `PrincipalStore` up to the `rest` module (but with commented out functionality to not interfere with the current permission system)
- Implement creation of principal context creation
- Greatly simplify handling of actions by creating a list of parents in Rust.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Previous tests were adjusted to use the new `create_web` function signature
- A seeding logic was added to tests
- A new test was added to verify consistency of the Cedar schema and the Rust implementation