### PR TITLE
H-4399: Disable notification polling for waitlisted users

### DIFF
--- a/apps/hash-frontend/src/pages/actions.page/draft-entities-context.tsx
+++ b/apps/hash-frontend/src/pages/actions.page/draft-entities-context.tsx
@@ -16,7 +16,7 @@ import type {
 } from "../../graphql/api-types.gen";
 import { getEntitySubgraphQuery } from "../../graphql/queries/knowledge/entity.queries";
 import { useDraftEntitiesCount } from "../../shared/draft-entities-count-context";
-import { pollInterval } from "../../shared/poll-interval";
+import { usePollInterval } from "../../shared/use-poll-interval";
 import { useAuthInfo } from "../shared/auth-info-context";
 
 export type DraftEntitiesContextValue = {
@@ -54,6 +54,8 @@ export const DraftEntitiesContextProvider: FunctionComponent<
   const { authenticatedUser } = useAuthInfo();
 
   const { refetch: refetchDraftEntitiesCount } = useDraftEntitiesCount();
+
+  const pollInterval = usePollInterval();
 
   const {
     data: draftEntitiesData,

--- a/apps/hash-frontend/src/pages/notifications.page/notifications-with-links-context.tsx
+++ b/apps/hash-frontend/src/pages/notifications.page/notifications-with-links-context.tsx
@@ -47,7 +47,7 @@ import type {
 import { getEntitySubgraphQuery } from "../../graphql/queries/knowledge/entity.queries";
 import type { MinimalUser } from "../../lib/user-and-org";
 import { constructMinimalUser } from "../../lib/user-and-org";
-import { pollInterval } from "../../shared/poll-interval";
+import { usePollInterval } from "../../shared/use-poll-interval";
 import { useAuthInfo } from "../shared/auth-info-context";
 
 export type PageMentionNotification = {
@@ -124,6 +124,7 @@ const isLinkAndRightEntityWithLinkType =
 export const useNotificationsWithLinksContextValue =
   (): NotificationsWithLinksContextValue => {
     const { authenticatedUser } = useAuthInfo();
+    const pollInterval = usePollInterval();
 
     const { data: notificationsWithOutgoingLinksData, refetch } = useQuery<
       GetEntitySubgraphQuery,

--- a/apps/hash-frontend/src/pages/shared/entities-visualizer.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-visualizer.tsx
@@ -37,12 +37,12 @@ import type {
 import { countEntitiesQuery } from "../../graphql/queries/knowledge/entity.queries";
 import { useEntityTypesContextRequired } from "../../shared/entity-types-context/hooks/use-entity-types-context-required";
 import { HEADER_HEIGHT } from "../../shared/layout/layout-with-header/page-header";
-import { pollInterval } from "../../shared/poll-interval";
 import { tableContentSx } from "../../shared/table-content";
 import type { FilterState } from "../../shared/table-header";
 import { TableHeader, tableHeaderHeight } from "../../shared/table-header";
 import { generateUseEntityTypeEntitiesFilter } from "../../shared/use-entity-type-entities";
 import { useMemoCompare } from "../../shared/use-memo-compare";
+import { usePollInterval } from "../../shared/use-poll-interval";
 import { useAuthenticatedUser } from "./auth-info-context";
 import { EntitiesTable } from "./entities-visualizer/entities-table";
 import { GridView } from "./entities-visualizer/entities-table/grid-view";
@@ -232,6 +232,8 @@ export const EntitiesVisualizer: FunctionComponent<{
   } | null>(null);
 
   const [view, setView] = useState<VisualizerView>(defaultView);
+
+  const pollInterval = usePollInterval();
 
   /**
    * We want to show the count of entities in external webs, and need to query this count separately:

--- a/apps/hash-frontend/src/shared/draft-entities-count-context.tsx
+++ b/apps/hash-frontend/src/shared/draft-entities-count-context.tsx
@@ -9,7 +9,7 @@ import type {
 } from "../graphql/api-types.gen";
 import { countEntitiesQuery } from "../graphql/queries/knowledge/entity.queries";
 import { useAuthInfo } from "../pages/shared/auth-info-context";
-import { pollInterval } from "./poll-interval";
+import { usePollInterval } from "./use-poll-interval";
 
 export type DraftEntitiesCountContextValue = {
   count?: number;
@@ -34,6 +34,8 @@ export const DraftEntitiesCountContextProvider: FunctionComponent<
   PropsWithChildren
 > = ({ children }) => {
   const { authenticatedUser } = useAuthInfo();
+
+  const pollInterval = usePollInterval();
 
   const {
     data: draftEntitiesData,

--- a/apps/hash-frontend/src/shared/notification-count-context.tsx
+++ b/apps/hash-frontend/src/shared/notification-count-context.tsx
@@ -36,7 +36,7 @@ import {
   updateEntityMutation,
 } from "../graphql/queries/knowledge/entity.queries";
 import { useAuthInfo } from "../pages/shared/auth-info-context";
-import { pollInterval } from "./poll-interval";
+import { usePollInterval } from "./use-poll-interval";
 
 export type NotificationCountContextValues = {
   numberOfUnreadNotifications?: number;
@@ -84,6 +84,8 @@ export const NotificationCountContextProvider: FunctionComponent<
   PropsWithChildren
 > = ({ children }) => {
   const { authenticatedUser } = useAuthInfo();
+
+  const pollInterval = usePollInterval();
 
   const {
     data: notificationCountData,

--- a/apps/hash-frontend/src/shared/poll-interval.ts
+++ b/apps/hash-frontend/src/shared/poll-interval.ts
@@ -1,5 +1,0 @@
-export const pollInterval = parseInt(
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  process.env.NEXT_PUBLIC_NOTIFICATION_POLL_INTERVAL || "10000",
-  10,
-);

--- a/apps/hash-frontend/src/shared/use-poll-interval.ts
+++ b/apps/hash-frontend/src/shared/use-poll-interval.ts
@@ -1,0 +1,17 @@
+import { useAuthInfo } from "../pages/shared/auth-info-context";
+
+const pollInterval = parseInt(
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  process.env.NEXT_PUBLIC_NOTIFICATION_POLL_INTERVAL || "10000",
+  10,
+);
+
+export const usePollInterval = () => {
+  const authInfo = useAuthInfo();
+
+  if (!authInfo.authenticatedUser?.accountSignupComplete) {
+    return 0;
+  }
+
+  return pollInterval;
+};


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Waitlisted users are still shown the header navbar, which includes some logic related to notifications.

This PR disables polling for notifications (and actions) if a user hasn't completed signup, to avoid pointless API requests.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

