### PR TITLE
H-3961: Implement `CreateWeb` policy and enforce it

### DIFF
--- a/apps/hash-api/src/graph/account-permission-management.ts
+++ b/apps/hash-api/src/graph/account-permission-management.ts
@@ -96,6 +96,7 @@ export const findWebByShortname: ImpureGraphFunction<
 export const createOrgWeb: ImpureGraphFunction<
   {
     shortname: string;
+    administrator: ActorEntityUuid;
   },
   Promise<{ webId: WebId; machineId: MachineId }>
 > = async ({ graphApi }, { actorId }, params) =>

--- a/apps/hash-api/src/graph/knowledge/system-types/org.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/org.ts
@@ -128,9 +128,14 @@ export const createOrg: ImpureGraphFunction<
   if (params.webId) {
     orgWebId = params.webId;
   } else {
-    orgWebId = await createOrgWeb(ctx, authentication, {
-      shortname,
-    }).then(({ webId }) => webId);
+    orgWebId = await createOrgWeb(
+      ctx,
+      { actorId: systemAccountId },
+      {
+        shortname,
+        administrator: authentication.actorId,
+      },
+    ).then(({ webId }) => webId);
   }
 
   const properties: OrganizationPropertiesWithMetadata = {

--- a/apps/hash-api/src/graph/system-account.ts
+++ b/apps/hash-api/src/graph/system-account.ts
@@ -20,5 +20,7 @@ export const ensureHashSystemAccountExists = async (params: {
     .getOrCreateSystemActor("h")
     .then(({ data: machineId }) => machineId as MachineId);
 
+  await context.graphApi.ensureSystemPolicies();
+
   logger.info(`Using system account ${systemAccountId}`);
 };

--- a/libs/@local/graph/api/openapi/openapi.json
+++ b/libs/@local/graph/api/openapi/openapi.json
@@ -292,7 +292,7 @@
       "post": {
         "tags": [
           "Graph",
-          "Actor"
+          "Policies"
         ],
         "operationId": "create_user_actor",
         "parameters": [
@@ -3147,6 +3147,23 @@
         }
       }
     },
+    "/system/policies/seed": {
+      "get": {
+        "tags": [
+          "Graph",
+          "Actor"
+        ],
+        "operationId": "ensure_system_policies",
+        "responses": {
+          "204": {
+            "description": "The system policies were created successfully"
+          },
+          "500": {
+            "description": "Store error occurred"
+          }
+        }
+      }
+    },
     "/webs": {
       "post": {
         "tags": [
@@ -4138,6 +4155,14 @@
           "shortname"
         ],
         "properties": {
+          "administrator": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ActorEntityUuid"
+              }
+            ],
+            "nullable": true
+          },
           "shortname": {
             "type": "string"
           }

--- a/libs/@local/graph/api/src/rest/actor.rs
+++ b/libs/@local/graph/api/src/rest/actor.rs
@@ -26,6 +26,7 @@ use hash_graph_store::{
     pool::StorePool,
 };
 use hash_temporal_client::TemporalClient;
+use http::StatusCode;
 use type_system::principal::{
     actor::{ActorEntityUuid, ActorId, ActorType, AiId, MachineId, UserId},
     actor_group::{ActorGroupEntityUuid, ActorGroupId, TeamId, WebId},
@@ -45,6 +46,7 @@ use crate::rest::{
         create_ai_actor,
         get_or_create_system_actor,
         find_instance_admins_team,
+        ensure_system_policies,
 
         check_account_group_permission,
         assign_actor_group_role,
@@ -99,6 +101,7 @@ impl ActorResource {
                         "/actor/:identifier",
                         get(get_or_create_system_actor::<S, A>),
                     )
+                    .route("/policies/seed", get(ensure_system_policies::<S, A>))
                     .route("/instance-admins", get(find_instance_admins_team::<S, A>)),
             )
             .nest(
@@ -173,9 +176,49 @@ where
 }
 
 #[utoipa::path(
+    get,
+    path = "/system/policies/seed",
+    tag = "Actor",
+    responses(
+        (status = 204, content_type = "application/json", description = "The system policies were created successfully"),
+
+        (status = 500, description = "Store error occurred"),
+    )
+)]
+#[tracing::instrument(
+    level = "info",
+    skip(store_pool, authorization_api_pool, temporal_client)
+)]
+async fn ensure_system_policies<S, A>(
+    authorization_api_pool: Extension<Arc<A>>,
+    temporal_client: Extension<Option<Arc<TemporalClient>>>,
+    store_pool: Extension<Arc<S>>,
+) -> Result<StatusCode, Response>
+where
+    S: StorePool + Send + Sync,
+    A: AuthorizationApiPool + Send + Sync,
+    for<'p, 'a> S::Store<'p, A::Api<'a>>: PrincipalStore,
+{
+    store_pool
+        .acquire(
+            authorization_api_pool
+                .acquire()
+                .await
+                .map_err(report_to_response)?,
+            temporal_client.0,
+        )
+        .await
+        .map_err(report_to_response)?
+        .ensure_system_policies()
+        .await
+        .map_err(report_to_response)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[utoipa::path(
     post,
     path = "/actors/user",
-    tag = "Actor",
+    tag = "Policies",
     request_body = CreateUserActorParams,
     params(
         ("X-Authenticated-User-Actor-Id" = ActorEntityUuid, Header, description = "The ID of the actor which is used to authorize the request"),

--- a/libs/@local/graph/authorization/src/policies/action/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/action/mod.rs
@@ -43,6 +43,10 @@ pub enum ActionName {
 }
 
 impl ActionName {
+    pub fn all() -> impl Iterator<Item = Self> {
+        enum_iterator::all::<Self>()
+    }
+
     #[must_use]
     pub const fn parent(self) -> Option<Self> {
         match self {
@@ -287,7 +291,7 @@ mod tests {
             .action_ids()
             .map(|action_id| ActionName::from_euid(action_id.name()).map(|name| (name, action_id)))
             .collect::<Result<HashMap<_, _>, _>>()?;
-        for action in enum_iterator::all::<ActionName>() {
+        for action in ActionName::all() {
             let action_id = action.to_euid();
             for parent in action.parents() {
                 assert!(

--- a/libs/@local/graph/authorization/src/policies/store/error.rs
+++ b/libs/@local/graph/authorization/src/policies/store/error.rs
@@ -24,6 +24,24 @@ pub enum GetSystemAccountError {
 impl Error for GetSystemAccountError {}
 
 #[derive(Debug, derive_more::Display)]
+#[display("Could not ensure system policies: {_variant}")]
+pub enum EnsureSystemPoliciesError {
+    #[display("Creating system machine failed")]
+    CreatingSystemMachineFailed,
+
+    #[display("Synchronizing actions failed")]
+    SynchronizeActions,
+    #[display("Reading policies failed")]
+    ReadPoliciesFailed,
+    #[display("Adding required policies failed")]
+    AddRequiredPoliciesFailed,
+    #[display("Removing old policy failed")]
+    RemoveOldPolicyFailed,
+}
+
+impl Error for EnsureSystemPoliciesError {}
+
+#[derive(Debug, derive_more::Display)]
 #[display("Could not create actor: {_variant}")]
 pub enum ActorCreationError {
     #[display("Web with ID `{web_id}` does not exist")]

--- a/libs/@local/graph/authorization/src/policies/store/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/store/mod.rs
@@ -19,9 +19,9 @@ use type_system::{
 use uuid::Uuid;
 
 use self::error::{
-    ActorCreationError, ContextCreationError, GetPoliciesError, GetSystemAccountError,
-    PolicyStoreError, RoleAssignmentError, TeamCreationError, TeamRoleCreationError,
-    WebCreationError, WebRoleCreationError,
+    ActorCreationError, ContextCreationError, EnsureSystemPoliciesError, GetPoliciesError,
+    GetSystemAccountError, PolicyStoreError, RoleAssignmentError, TeamCreationError,
+    TeamRoleCreationError, WebCreationError, WebRoleCreationError,
 };
 use super::{ContextBuilder, Policy, PolicyId, principal::PrincipalConstraint};
 
@@ -106,6 +106,27 @@ pub trait LocalPrincipalStore {
         &mut self,
         identifier: &str,
     ) -> Result<MachineId, Report<GetSystemAccountError>>;
+
+    /// Ensures that the system actor policies are present.
+    ///
+    /// This includes:
+    /// - Creating the system machine "h" if it does not exist
+    /// - Ensuring that the necessary policies for the system actor are present
+    ///
+    /// # Errors
+    ///
+    /// - [`CreatingSystemMachineFailed`] if the system machine could not be created
+    /// - [`SynchronizeActions`] if the actions could not be synchronized
+    /// - [`ReadPoliciesFailed`] if the policies could not be read
+    /// - [`AddRequiredPoliciesFailed`] if a required policies could not be added
+    /// - [`RemoveOldPolicyFailed`] if an old policy could not be removed
+    ///
+    /// [`CreatingSystemMachineFailed`]: EnsureSystemPolicies::CreatingSystemMachineFailed
+    /// [`SynchronizeActions`]: EnsureSystemPolicies::SynchronizeActions
+    /// [`ReadPoliciesFailed`]: EnsureSystemPolicies::ReadPoliciesFailed
+    /// [`AddRequiredPoliciesFailed`]: EnsureSystemPolicies::AddRequiredPoliciesFailed
+    /// [`RemoveOldPolicyFailed`]: EnsureSystemPolicies::RemoveOldPolicyFailed
+    async fn ensure_system_policies(&mut self) -> Result<(), Report<EnsureSystemPoliciesError>>;
 
     /// Creates a new web and returns its ID.
     ///

--- a/libs/@local/graph/postgres-store/postgres_migrations/V44__policies.sql
+++ b/libs/@local/graph/postgres-store/postgres_migrations/V44__policies.sql
@@ -1,0 +1,45 @@
+CREATE TYPE policy_effect AS ENUM ('permit', 'forbid');
+
+CREATE TABLE IF NOT EXISTS action (
+    name TEXT PRIMARY KEY,
+    parent TEXT REFERENCES action (name) ON DELETE RESTRICT,
+    CONSTRAINT no_self_parent CHECK (name != parent)
+);
+
+CREATE TABLE action_hierarchy (
+    parent_name TEXT NOT NULL REFERENCES action (name) ON DELETE CASCADE,
+    child_name TEXT NOT NULL REFERENCES action (name) ON DELETE CASCADE,
+    depth INTEGER NOT NULL,
+    CONSTRAINT depth_check CHECK (
+        depth = 0 AND parent_name = child_name
+        OR depth > 0 AND parent_name != child_name
+    )
+);
+
+-- Create an index to efficiently find the primary parent (depth=1) for each action
+CREATE UNIQUE INDEX idx_action_hierarchy_single_parent ON action_hierarchy (child_name) WHERE (
+    depth = 1
+);
+
+CREATE TABLE IF NOT EXISTS policy (
+    id UUID PRIMARY KEY,
+    effect POLICY_EFFECT NOT NULL,
+
+    -- Principal references
+    principal_id UUID,
+    principal_type PRINCIPAL_TYPE,
+    actor_type PRINCIPAL_TYPE,
+    FOREIGN KEY (principal_id, principal_type) REFERENCES principal (id, principal_type),
+    CONSTRAINT complete_principal CHECK ((principal_id IS NULL) = (principal_type IS NULL)),
+    CONSTRAINT check_actor_type CHECK (actor_type IN ('user', 'machine', 'ai')),
+
+    -- Resource specification
+    resource_constraint JSONB
+);
+
+-- Policy-Action junction table for multiple actions per policy
+CREATE TABLE IF NOT EXISTS policy_action (
+    policy_id UUID NOT NULL REFERENCES policy (id) ON DELETE CASCADE,
+    action_name TEXT NOT NULL REFERENCES action (name) ON DELETE CASCADE,
+    PRIMARY KEY (policy_id, action_name)
+);

--- a/libs/@local/graph/store/src/account/mod.rs
+++ b/libs/@local/graph/store/src/account/mod.rs
@@ -91,6 +91,7 @@ pub struct GetTeamResponse {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct CreateOrgWebParams {
     pub shortname: String,
+    pub administrator: Option<ActorEntityUuid>,
 }
 
 #[derive(Debug, Error)]

--- a/libs/@local/graph/type-fetcher/src/store.rs
+++ b/libs/@local/graph/type-fetcher/src/store.rs
@@ -8,7 +8,9 @@ use hash_graph_authorization::{
     policies::store::{
         CreateWebParameter, CreateWebResponse, PrincipalStore, RoleAssignmentStatus,
         RoleUnassignmentStatus,
-        error::{GetSystemAccountError, RoleAssignmentError, WebCreationError},
+        error::{
+            EnsureSystemPoliciesError, GetSystemAccountError, RoleAssignmentError, WebCreationError,
+        },
     },
     schema::{
         DataTypeRelationAndSubject, DataTypeViewerSubject, EntityRelationAndSubject,
@@ -186,6 +188,10 @@ where
         identifier: &str,
     ) -> Result<MachineId, Report<GetSystemAccountError>> {
         self.store.get_or_create_system_actor(identifier).await
+    }
+
+    async fn ensure_system_policies(&mut self) -> Result<(), Report<EnsureSystemPoliciesError>> {
+        self.store.ensure_system_policies().await
     }
 
     async fn create_web(

--- a/tests/graph/http/tests/friendship.http
+++ b/tests/graph/http/tests/friendship.http
@@ -32,10 +32,14 @@ X-Authenticated-User-Actor-Id: {{system_machine_id}}
 ### Create account group web
 POST http://127.0.0.1:4000/webs
 Content-Type: application/json
-X-Authenticated-User-Actor-Id: {{user_id}}
+X-Authenticated-User-Actor-Id: {{system_machine_id}}
 
 {
-   "shortname": "test-group"
+   "shortname": "test-group",
+   "administrator": {
+     "actorType": "user",
+     "id": "{{user_id}}"
+   }
 }
 
 > {%


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To complete the permission prototype in Cedar, we're adding a (in theory quite simple) permission: creating a web.

## 🔍 What does this change?

- Add storing of policies and actions
- Implement a way to synchronize actions with the database and removing policies
- Implement very simple seeding of system-policies
- Enforce `CreateWeb` policy when creating a web
- Extend the org-web creation with an `administrator` field so the actor can be the system type while the new admin can be another actor

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this
- [x] I am unsure / need advice

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted func