### PR TITLE
H-4397: Add integration tests to make sure instantiation of special system types is not possible

### DIFF
--- a/libs/@local/graph/authorization/tests/policies/definitions/permit-instantiate.cedar
+++ b/libs/@local/graph/authorization/tests/policies/definitions/permit-instantiate.cedar
@@ -5,6 +5,7 @@ permit (
 )
 unless
 {
+  resource.base_url == "https://hash.ai/@h/types/entity-type/actor/" ||
   resource.base_url == "https://hash.ai/@h/types/entity-type/machine/" ||
   resource.base_url == "https://hash.ai/@h/types/entity-type/user/" ||
   resource.base_url == "https://hash.ai/@h/types/entity-type/organization/" ||

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/primitive/entity.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/primitive/entity.test.ts
@@ -43,6 +43,13 @@ import {
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { generateTypeId } from "@local/hash-isomorphic-utils/ontology-types";
 import { mapGraphApiSubgraphToSubgraph } from "@local/hash-isomorphic-utils/subgraph-mapping";
+import type { HASHInstance } from "@local/hash-isomorphic-utils/system-types/hashinstance";
+import type { Machine } from "@local/hash-isomorphic-utils/system-types/machine";
+import type {
+  Actor,
+  Organization,
+  User as UserEntity,
+} from "@local/hash-isomorphic-utils/system-types/shared";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import { resetGraph } from "../../../test-server";
@@ -517,5 +524,160 @@ describe("Entity CRU", () => {
     expect(linkEntity.metadata.entityTypeIds).toContain(
       linkEntityTypeFriend.schema.$id,
     );
+  });
+
+  it("Cannot instantiate actor entity type", async () => {
+    const authentication = { actorId: testUser.accountId };
+
+    await expect(
+      createEntity<Actor>(graphContext, authentication, {
+        webId: testUser.accountId as WebId,
+        properties: {
+          value: {
+            "https://blockprotocol.org/@blockprotocol/types/property-type/display-name/":
+              {
+                value: "Test-Actor",
+                metadata: {
+                  dataTypeId: blockProtocolDataTypes.text.dataTypeId,
+                },
+              },
+          },
+        },
+        entityTypeIds: [systemEntityTypes.actor.entityTypeId],
+        relationships: createDefaultAuthorizationRelationships(authentication),
+      }),
+    ).rejects.toThrowError(`Could not insert into store`);
+  });
+
+  it("Cannot instantiate user entity type", async () => {
+    const authentication = { actorId: testUser.accountId };
+
+    await expect(
+      createEntity<UserEntity>(graphContext, authentication, {
+        webId: testUser.accountId as WebId,
+        properties: {
+          value: {
+            "https://blockprotocol.org/@blockprotocol/types/property-type/display-name/":
+              {
+                value: "Test-Machine",
+                metadata: {
+                  dataTypeId: blockProtocolDataTypes.text.dataTypeId,
+                },
+              },
+            "https://hash.ai/@h/types/property-type/email/": {
+              value: [],
+            },
+            "https://hash.ai/@h/types/property-type/kratos-identity-id/": {
+              value: "Not-kratos-identity-id",
+              metadata: {
+                dataTypeId: blockProtocolDataTypes.text.dataTypeId,
+              },
+            },
+          },
+        },
+        entityTypeIds: [systemEntityTypes.user.entityTypeId],
+        relationships: createDefaultAuthorizationRelationships(authentication),
+      }),
+    ).rejects.toThrowError(`Could not insert into store`);
+  });
+
+  it("Cannot instantiate machine entity type", async () => {
+    const authentication = { actorId: testUser.accountId };
+
+    await expect(
+      createEntity<Machine>(graphContext, authentication, {
+        webId: testUser.accountId as WebId,
+        properties: {
+          value: {
+            "https://blockprotocol.org/@blockprotocol/types/property-type/display-name/":
+              {
+                value: "Test-Machine",
+                metadata: {
+                  dataTypeId: blockProtocolDataTypes.text.dataTypeId,
+                },
+              },
+            "https://hash.ai/@h/types/property-type/machine-identifier/": {
+              value: "Test-Machine",
+              metadata: {
+                dataTypeId: blockProtocolDataTypes.text.dataTypeId,
+              },
+            },
+          },
+        },
+        entityTypeIds: [systemEntityTypes.machine.entityTypeId],
+        relationships: createDefaultAuthorizationRelationships(authentication),
+      }),
+    ).rejects.toThrowError(`Could not insert into store`);
+  });
+
+  it("Cannot instantiate organization entity type", async () => {
+    const authentication = { actorId: testUser.accountId };
+
+    await expect(
+      createEntity<Organization>(graphContext, authentication, {
+        webId: testUser.accountId as WebId,
+        properties: {
+          value: {
+            "https://hash.ai/@h/types/property-type/shortname/": {
+              value: "Test-Org",
+              metadata: {
+                dataTypeId: blockProtocolDataTypes.text.dataTypeId,
+              },
+            },
+            "https://hash.ai/@h/types/property-type/organization-name/": {
+              value: "Test Org",
+              metadata: {
+                dataTypeId: blockProtocolDataTypes.text.dataTypeId,
+              },
+            },
+          },
+        },
+        entityTypeIds: [systemEntityTypes.organization.entityTypeId],
+        relationships: createDefaultAuthorizationRelationships(authentication),
+      }),
+    ).rejects.toThrowError(`Could not insert into store`);
+  });
+
+  it("Cannot instantiate hash-instance entity type", async () => {
+    const authentication = { actorId: testUser.accountId };
+
+    await expect(
+      createEntity<HASHInstance>(graphContext, authentication, {
+        webId: testUser.accountId as WebId,
+        properties: {
+          value: {
+            "https://hash.ai/@h/types/property-type/org-self-registration-is-enabled/":
+              {
+                value: false,
+                metadata: {
+                  dataTypeId: blockProtocolDataTypes.boolean.dataTypeId,
+                },
+              },
+            "https://hash.ai/@h/types/property-type/pages-are-enabled/": {
+              value: false,
+              metadata: {
+                dataTypeId: blockProtocolDataTypes.boolean.dataTypeId,
+              },
+            },
+            "https://hash.ai/@h/types/property-type/user-registration-by-invitation-is-enabled/":
+              {
+                value: false,
+                metadata: {
+                  dataTypeId: blockProtocolDataTypes.boolean.dataTypeId,
+                },
+              },
+            "https://hash.ai/@h/types/property-type/user-self-registration-is-enabled/":
+              {
+                value: false,
+                metadata: {
+                  dataTypeId: blockProtocolDataTypes.boolean.dataTypeId,
+                },
+              },
+          },
+        },
+        entityTypeIds: [systemEntityTypes.hashInstance.entityTypeId],
+        relationships: createDefaultAuthorizationRelationships(authentication),
+      }),
+    ).rejects.toThrowError(`Could not insert into store`);
   });
 });

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/primitive/entity.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/primitive/entity.test.ts
@@ -559,7 +559,7 @@ describe("Entity CRU", () => {
           value: {
             "https://blockprotocol.org/@blockprotocol/types/property-type/display-name/":
               {
-                value: "Test-Machine",
+                value: "Test-User",
                 metadata: {
                   dataTypeId: blockProtocolDataTypes.text.dataTypeId,
                 },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Before we migrate to the new permission engine we need to add tests if certain types cannot be instantiated directly. This includes

- `Actor`
- `User`
- `Machine`
- `Organization`
- `HashInstance`

## 🔍 What does this change?

- Add tests for the above entity types
- Add it to the example Cedar file to instantiate

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change
### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph