### PR TITLE
H-4436: Add import/export Petri net from/to PNML

### DIFF
--- a/apps/hash-frontend/src/pages/process.page/process-editor.tsx
+++ b/apps/hash-frontend/src/pages/process.page/process-editor.tsx
@@ -38,13 +38,17 @@ import {
 } from "./process-editor/simulation-context";
 import { SimulationControls } from "./process-editor/simulation-controls";
 import { nodeDimensions } from "./process-editor/styling";
-import { TokenTypeEditor } from "./process-editor/token-type-editor";
+import {
+  defaultTokenTypes,
+  TokenTypeEditor,
+} from "./process-editor/token-type-editor";
 import { TransitionEditor } from "./process-editor/transition-editor";
 import { TransitionNode } from "./process-editor/transition-node";
 import {
   type ArcData,
   type ArcType,
   type NodeData,
+  type NodeType,
   type PlaceNodeType,
   type TokenCounts,
 } from "./process-editor/types";
@@ -172,7 +176,7 @@ const FlowCanvas = () => {
         y: event.clientY - reactFlowBounds.top - height / 2,
       });
 
-      const newNode: Node = {
+      const newNode: NodeType = {
         id: `${nodeType}_${nodes.length}`,
         type: nodeType,
         position,
@@ -180,10 +184,11 @@ const FlowCanvas = () => {
           label: `${nodeType} ${nodes.length + 1}`,
           ...(nodeType === "place"
             ? {
+                type: "place",
                 tokenCounts: {},
                 tokenTypes,
               }
-            : {}),
+            : { type: "transition" }),
         },
       };
 
@@ -291,8 +296,9 @@ const FlowCanvas = () => {
   const handleResetAll = useCallback(() => {
     setNodes([]);
     setArcs([]);
+    setTokenTypes(defaultTokenTypes);
     resetSimulation();
-  }, [setNodes, setArcs, resetSimulation]);
+  }, [setNodes, setArcs, setTokenTypes, resetSimulation]);
 
   const handleLoadExample = useCallback(() => {
     setTokenTypes(exampleCPN.tokenTypes);
@@ -500,7 +506,9 @@ const FlowCanvas = () => {
         spacing={1}
         sx={{ position: "absolute", bottom: 16, right: 16, zIndex: 100 }}
       >
-        {" "}
+        <Button onClick={handleLoadExample} size="xs" variant="tertiary">
+          Load Example
+        </Button>
         <input
           type="file"
           ref={fileInputRef}
@@ -511,14 +519,11 @@ const FlowCanvas = () => {
         <Button onClick={handleImportClick} size="xs" variant="tertiary">
           Import
         </Button>
-        <Button onClick={handleLoadExample} size="xs" variant="tertiary">
-          Load Example
-        </Button>
         <Button onClick={handleExport} size="xs" variant="tertiary">
           Export
         </Button>
-        <Button onClick={handleResetAll} size="xs" variant="tertiary">
-          New
+        <Button onClick={handleResetAll} size="xs" variant="danger">
+          Clear
         </Button>
       </Stack>
 

--- a/apps/hash-frontend/src/pages/process.page/process-editor/token-type-editor.tsx
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/token-type-editor.tsx
@@ -7,7 +7,7 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Button } from "../../../shared/ui";
 import { useEditorContext } from "./editor-context";
@@ -27,6 +27,10 @@ export const TokenTypeEditor = ({ open, onClose }: TokenTypeEditorProps) => {
 
   const [localTokenTypes, setLocalTokenTypes] =
     useState<TokenType[]>(tokenTypes);
+
+  useEffect(() => {
+    setLocalTokenTypes(tokenTypes);
+  }, [tokenTypes]);
 
   const [newTokenName, setNewTokenName] = useState("");
   const [newTokenColor, setNewTokenColor] = useState("#3498db");

--- a/apps/hash-frontend/src/pages/process.page/process-editor/types.ts
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/types.ts
@@ -27,8 +27,8 @@ export type Condition = {
 export type TransitionNodeData = {
   conditions?: Condition[];
   label: string;
-  delay: number | undefined;
-  description: string;
+  delay?: number;
+  description?: string;
   /**
    * Although a reactflow {@link Node} has a 'type' field, the library types don't discriminate on this field in all methods,
    * so we add our own discriminating field here to make it easier to narrow between Transition and Place nodes.

--- a/apps/hash-frontend/src/pages/process.page/process-editor/use-convert-to-pnml.ts
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/use-convert-to-pnml.ts
@@ -1,0 +1,169 @@
+import { useEditorContext } from "./editor-context";
+import type { PlaceNodeData, TransitionNodeData } from "./types";
+
+const escapeXml = (str: string) =>
+  str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+
+/**
+ * Convert the current process to an ISO-15909-2-conformant HLPN PNML document.
+ */
+export const useConvertToPnml = () => {
+  const { nodes, arcs, tokenTypes } = useEditorContext();
+
+  const convertToPnml = (): string => {
+    /* ---------- Header & namespaces---------- */
+    let pnml = `<?xml version="1.0" encoding="UTF-8"?>
+<pnml
+  xmlns="http://www.pnml.org/version-2009/grammar/pnml"
+  xmlns:hlpn="http://www.pnml.org/version-2009/grammar/hlpn">
+
+  <net id="net0" type="http://www.pnml.org/version-2009/grammar/hlpn">
+    <name><text>HASH Process</text></name>`;
+
+    /* ---------- HLPN colour-set declarations ---------- */
+    pnml += `
+    <hlpn:declarations>`;
+    for (const tok of tokenTypes) {
+      pnml += `
+      <hlpn:colset id="${escapeXml(tok.id)}">
+        <hlpn:list>
+          <hlpn:atom>${escapeXml(tok.name)}</hlpn:atom>
+        </hlpn:list>
+
+        <!-- HASH-specific visual hint -->
+        <toolspecific tool="HASH" version="1.0">
+          <color>${escapeXml(tok.color)}</color>
+        </toolspecific>
+      </hlpn:colset>`;
+    }
+    pnml += `
+    </hlpn:declarations>`;
+
+    pnml += `
+    <page id="page0">`;
+
+    /* ---------- Places & initial markings ---------- */
+    for (const node of nodes) {
+      if (node.type !== "place") {
+        continue;
+      }
+      const placeData = node.data as PlaceNodeData;
+
+      pnml += `
+      <place id="${escapeXml(node.id)}">
+        <name><text>${escapeXml(placeData.label)}</text></name>
+        <graphics><position x="${node.position.x}" y="${node.position.y}"/></graphics>
+        <initialMarking>
+          <hlpn:multiset>`;
+
+      for (const [tokId, count] of Object.entries(placeData.tokenCounts)) {
+        if (count > 0) {
+          pnml += `
+            <hlpn:element multiplicity="${count}">
+              <hlpn:constant>${escapeXml(tokId)}</hlpn:constant>
+            </hlpn:element>`;
+        }
+      }
+
+      pnml += `
+          </hlpn:multiset>
+        </initialMarking>
+      </place>`;
+    }
+
+    /* ---------- Transitions ---------- */
+    for (const node of nodes) {
+      if (node.type !== "transition") {
+        continue;
+      }
+      const transitionData = node.data as TransitionNodeData;
+
+      pnml += `
+      <transition id="${escapeXml(node.id)}">
+        <name><text>${escapeXml(transitionData.label)}</text></name>
+        <graphics><position x="${node.position.x}" y="${node.position.y}"/></graphics>`;
+
+      if (
+        typeof transitionData.delay === "number" ||
+        transitionData.conditions?.length ||
+        transitionData.description
+      ) {
+        pnml += `
+        <toolspecific tool="HASH" version="1.0">`;
+
+        if (transitionData.description) {
+          pnml += `
+            <description>${escapeXml(transitionData.description)}</description>`;
+        }
+
+        if (typeof transitionData.delay === "number") {
+          pnml += `
+          <timing>
+            <delay unit="h">${transitionData.delay}</delay>
+          </timing>`;
+        }
+
+        if (transitionData.conditions?.length) {
+          pnml += `
+          <routing>`;
+          for (const condition of transitionData.conditions) {
+            pnml += `
+            <branch id="${escapeXml(condition.id)}"
+                    outputArc="${escapeXml(condition.outputEdgeId)}"
+                    probability="${condition.probability}">
+              <name><text>${escapeXml(condition.name)}</text></name>
+            </branch>`;
+          }
+          pnml += `
+          </routing>`;
+        }
+
+        pnml += `
+        </toolspecific>`;
+      }
+
+      pnml += `
+      </transition>`;
+    }
+
+    /* ---------- Arcs & HLPN inscriptions ---------- */
+    for (const arc of arcs) {
+      pnml += `
+      <arc id="${escapeXml(arc.id)}" source="${escapeXml(
+        arc.source,
+      )}" target="${escapeXml(arc.target)}">
+        <inscription>
+          <hlpn:multiset>`;
+
+      for (const [tokId, count] of Object.entries(
+        arc.data?.tokenWeights ?? {},
+      )) {
+        if (count) {
+          pnml += `
+            <hlpn:element multiplicity="${count}">
+              <hlpn:constant>${escapeXml(tokId)}</hlpn:constant>
+            </hlpn:element>`;
+        }
+      }
+
+      pnml += `
+          </hlpn:multiset>
+        </inscription>
+      </arc>`;
+    }
+
+    pnml += `
+    </page>
+  </net>
+</pnml>`;
+
+    return pnml;
+  };
+
+  return convertToPnml;
+};

--- a/apps/hash-frontend/src/pages/process.page/process-editor/use-load-from-pnml.ts
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/use-load-from-pnml.ts
@@ -1,0 +1,184 @@
+import { useCallback } from "react";
+import type { Edge, Node } from "reactflow";
+
+import { useEditorContext } from "./editor-context";
+import { useSimulation } from "./simulation-context";
+import type {
+  ArcData,
+  ArcType,
+  Condition,
+  NodeType,
+  PlaceNodeData,
+  TokenCounts,
+  TokenType,
+  TransitionNodeData,
+} from "./types";
+
+const elementToText = (el: Element | null): string =>
+  el?.textContent?.trim() ?? "";
+
+const getElementsBySelector = (selector: string, parentNode: ParentNode) =>
+  Array.from(parentNode.querySelectorAll(selector));
+
+const readMultiset = (multiset: Element | null): TokenCounts => {
+  const counts: TokenCounts = {};
+
+  if (!multiset) {
+    return counts;
+  }
+
+  for (const el of getElementsBySelector("element", multiset)) {
+    const tokId = elementToText(el.querySelector("constant"));
+    const mult = parseInt(el.getAttribute("multiplicity") ?? "1", 10);
+    counts[tokId] = (counts[tokId] ?? 0) + mult;
+  }
+  return counts;
+};
+
+/**
+ * Parse a PNML document that follows the HASH “HLPN + toolspecific” dialect
+ * back into React-Flow nodes, edges and token-type tables.
+ */
+const parsePnml = (
+  xml: string,
+): {
+  nodes: NodeType[];
+  arcs: ArcType[];
+  tokenTypes: TokenType[];
+} => {
+  const document = new DOMParser().parseFromString(xml, "application/xml");
+
+  const tokenTypes: TokenType[] = getElementsBySelector("colset", document).map(
+    (colset) => {
+      const id = colset.getAttribute("id") ?? "";
+      const name = elementToText(colset.querySelector("atom"));
+      const color = elementToText(
+        colset.querySelector('toolspecific[tool="HASH"] > color'),
+      );
+      return { id, name, color };
+    },
+  );
+
+  const placeNodes: Node<PlaceNodeData>[] = getElementsBySelector(
+    "place",
+    document,
+  ).map((placeNode) => {
+    const id = placeNode.getAttribute("id")!;
+
+    const posEl = placeNode.querySelector("graphics > position");
+    const position = {
+      x: parseFloat(posEl?.getAttribute("x") ?? "0"),
+      y: parseFloat(posEl?.getAttribute("y") ?? "0"),
+    };
+
+    const label = elementToText(placeNode.querySelector("name > text"));
+
+    const tokenCounts = readMultiset(
+      placeNode.querySelector("initialMarking > multiset"),
+    );
+
+    const data: PlaceNodeData = {
+      label,
+      initialTokenCounts: tokenCounts,
+      tokenCounts,
+      type: "place",
+    };
+
+    return { id, type: "place", position, data };
+  });
+
+  const transitionNodes: Node<TransitionNodeData>[] = getElementsBySelector(
+    "transition",
+    document,
+  ).map((transitionNode) => {
+    const id = transitionNode.getAttribute("id")!;
+
+    const posEl = transitionNode.querySelector("graphics > position");
+    const position = {
+      x: parseFloat(posEl?.getAttribute("x") ?? "0"),
+      y: parseFloat(posEl?.getAttribute("y") ?? "0"),
+    };
+
+    const label = elementToText(transitionNode.querySelector("name > text"));
+
+    const toolSpecificContainer = transitionNode.querySelector(
+      'toolspecific[tool="HASH"]',
+    );
+
+    const description = elementToText(
+      toolSpecificContainer?.querySelector("description") ?? null,
+    );
+
+    const delay = toolSpecificContainer
+      ? parseFloat(
+          elementToText(toolSpecificContainer.querySelector("timing > delay")),
+        )
+      : undefined;
+
+    const conditions: Condition[] = toolSpecificContainer
+      ? getElementsBySelector("routing > branch", toolSpecificContainer).map(
+          (b) => ({
+            id: b.getAttribute("id") ?? "",
+            name: elementToText(b.querySelector("name > text")),
+            probability: parseFloat(b.getAttribute("probability") ?? "0"),
+            outputEdgeId: b.getAttribute("outputArc") ?? "",
+          }),
+        )
+      : [];
+
+    const data: TransitionNodeData = {
+      label,
+      delay: Number.isNaN(delay) ? undefined : delay,
+      description,
+      conditions: conditions.length ? conditions : undefined,
+      type: "transition",
+    };
+
+    return { id, type: "transition", position, data };
+  });
+
+  const arcs: Edge<ArcData>[] = getElementsBySelector("arc", document).map(
+    (a): ArcType => {
+      const id = a.getAttribute("id") ?? "";
+      const source = a.getAttribute("source") ?? "";
+      const target = a.getAttribute("target") ?? "";
+
+      const tokenWeights = readMultiset(
+        a.querySelector("inscription > multiset"),
+      );
+
+      return {
+        id,
+        source,
+        target,
+        data: { tokenWeights },
+      };
+    },
+  );
+
+  return {
+    nodes: [...placeNodes, ...transitionNodes],
+    arcs,
+    tokenTypes,
+  };
+};
+
+export const useLoadFromPnml = () => {
+  const { setNodes, setArcs, setTokenTypes } = useEditorContext();
+  const { resetSimulation } = useSimulation();
+
+  const load = useCallback(
+    (xml: string) => {
+      const { nodes, arcs, tokenTypes } = parsePnml(xml);
+
+      setNodes(nodes);
+      setArcs(arcs);
+      setTokenTypes(tokenTypes);
+
+      resetSimulation();
+    },
+    [resetSimulation, setArcs, setNodes, setTokenTypes],
+  );
+
+  return load;
+};


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds buttons to export to or import from a PNML file.

Some of the information is non-standard and the exact field names / representation to be used are TBC, but this works to at least save the HASH representation to a file and then load it again later.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

- Confirm proper representation for things like probabilistic branching, delays.

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Draw a process then export / import

## 📹 Demo


https://github.com/user-attachments/assets/6f2c2d2b-f10b-432d-9456-cb2a6726edad
