### PR TITLE
H-4422: Petri net editor auto-layout and fit to viewport

### DIFF
--- a/apps/hash-frontend/src/pages/process.page/process-editor/place-node.tsx
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/place-node.tsx
@@ -2,7 +2,7 @@ import { Box } from "@mui/material";
 import { Handle, type NodeProps, Position } from "reactflow";
 
 import { useEditorContext } from "./editor-context";
-import { nodeDimensions, placeStyling } from "./styling";
+import { handleStyling, nodeDimensions, placeStyling } from "./styling";
 import type { TokenCounts } from "./types";
 
 const tokenSize = 22;
@@ -35,7 +35,7 @@ export const PlaceNode = ({ data, isConnectable }: NodeProps) => {
         type="target"
         position={Position.Left}
         isConnectable={isConnectable}
-        style={{ background: "#555" }}
+        style={handleStyling}
       />
       <Box sx={placeStyling}>
         {data.label}
@@ -73,7 +73,7 @@ export const PlaceNode = ({ data, isConnectable }: NodeProps) => {
         type="source"
         position={Position.Right}
         isConnectable={isConnectable}
-        style={{ background: "#555" }}
+        style={handleStyling}
       />
     </div>
   );

--- a/apps/hash-frontend/src/pages/process.page/process-editor/sidebar.tsx
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/sidebar.tsx
@@ -2,7 +2,10 @@ import { Box, Stack } from "@mui/material";
 import type { DragEvent } from "react";
 import { useCallback } from "react";
 
+import { Button } from "../../../shared/ui";
+import { useEditorContext } from "./editor-context";
 import { placeStyling, transitionStyling } from "./styling";
+import { useLayoutGraph } from "./use-layout-graph";
 
 export const Sidebar = () => {
   const onDragStart = useCallback(
@@ -15,6 +18,10 @@ export const Sidebar = () => {
     [],
   );
 
+  const { nodes, arcs, setNodes } = useEditorContext();
+
+  const layoutGraph = useLayoutGraph({ setNodes });
+
   return (
     <Stack
       alignItems="center"
@@ -26,36 +33,56 @@ export const Sidebar = () => {
         borderRight: ({ palette }) => `1px solid ${palette.gray[30]}`,
       }}
     >
+      <Stack alignItems="center" gap={2}>
+        <Box
+          sx={[
+            placeStyling,
+            {
+              cursor: "grab",
+              width: 80,
+              height: 80,
+              fontSize: 14,
+            },
+          ]}
+          draggable
+          onDragStart={(event) => onDragStart(event, "place")}
+        >
+          Place
+        </Box>
+        <Box
+          sx={[
+            transitionStyling,
+            {
+              cursor: "grab",
+              width: 100,
+              height: 50,
+              fontSize: 14,
+            },
+          ]}
+          draggable
+          onDragStart={(event) => onDragStart(event, "transition")}
+        >
+          Transition
+        </Box>
+      </Stack>
       <Box
-        sx={[
-          placeStyling,
-          {
-            cursor: "grab",
-            width: 80,
-            height: 80,
-            fontSize: 14,
-          },
-        ]}
-        draggable
-        onDragStart={(event) => onDragStart(event, "place")}
-      >
-        Place
-      </Box>
-      <Box
-        sx={[
-          transitionStyling,
-          {
-            cursor: "grab",
-            width: 100,
-            height: 50,
-            fontSize: 14,
-          },
-        ]}
-        draggable
-        onDragStart={(event) => onDragStart(event, "transition")}
-      >
-        Transition
-      </Box>
+        sx={{
+          background: ({ palette }) => palette.gray[30],
+          height: "1px",
+          width: "100%",
+          my: 2,
+        }}
+      />
+      <Stack alignItems="center" gap={2}>
+        <Button
+          onClick={() => layoutGraph({ nodes, arcs, animationDuration: 200 })}
+          size="xs"
+          variant="tertiary"
+          sx={{ display: "block", fontWeight: 400 }}
+        >
+          Layout
+        </Button>
+      </Stack>
     </Stack>
   );
 };

--- a/apps/hash-frontend/src/pages/process.page/process-editor/styling.ts
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/styling.ts
@@ -1,3 +1,4 @@
+import { customColors } from "@hashintel/design-system/theme";
 import type { Theme } from "@mui/material";
 import type { SystemStyleObject } from "@mui/system";
 
@@ -42,3 +43,11 @@ export const transitionStyling: (theme: Theme) => SystemStyleObject<Theme> = ({
   boxSizing: "border-box",
   position: "relative",
 });
+
+export const handleStyling = {
+  background: customColors.gray[60],
+  width: 10,
+  height: 10,
+  borderRadius: "50%",
+  zIndex: 3,
+};

--- a/apps/hash-frontend/src/pages/process.page/process-editor/token-types.tsx
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/token-types.tsx
@@ -1,0 +1,63 @@
+import { Box, Stack, Typography } from "@mui/material";
+import { useState } from "react";
+
+import { Button } from "../../../shared/ui";
+import { useEditorContext } from "./editor-context";
+import { TokenTypeEditor } from "./token-types/token-type-editor";
+
+export { defaultTokenTypes } from "./token-types/token-type-editor";
+
+export const TokenTypes = () => {
+  const [tokenTypeEditorOpen, setTokenTypeEditorOpen] = useState(false);
+
+  const { tokenTypes } = useEditorContext();
+
+  return (
+    <>
+      <TokenTypeEditor
+        open={tokenTypeEditorOpen}
+        onClose={() => setTokenTypeEditorOpen(false)}
+      />
+      <Stack
+        alignItems="center"
+        direction="row"
+        gap={2}
+        sx={{
+          p: 1,
+          borderRadius: 1,
+          bgcolor: "background.paper",
+          boxShadow: 1,
+        }}
+      >
+        {tokenTypes.map((token) => (
+          <Stack
+            key={token.id}
+            direction="row"
+            spacing={0.5}
+            alignItems="center"
+            sx={{
+              cursor: "pointer",
+              borderRadius: 1,
+            }}
+          >
+            <Box
+              sx={{
+                width: 16,
+                height: 16,
+                borderRadius: "50%",
+                bgcolor: token.color,
+                border: "1px solid",
+                borderColor: "divider",
+              }}
+            />
+            <Typography sx={{ fontSize: "0.875rem" }}>{token.name}</Typography>
+          </Stack>
+        ))}
+
+        <Button size="xs" onClick={() => setTokenTypeEditorOpen(true)}>
+          Edit Types
+        </Button>
+      </Stack>
+    </>
+  );
+};

--- a/apps/hash-frontend/src/pages/process.page/process-editor/token-types/token-type-editor.tsx
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/token-types/token-type-editor.tsx
@@ -9,9 +9,9 @@ import {
 } from "@mui/material";
 import { useEffect, useState } from "react";
 
-import { Button } from "../../../shared/ui";
-import { useEditorContext } from "./editor-context";
-import type { TokenType } from "./types";
+import { Button } from "../../../../shared/ui";
+import { useEditorContext } from "../editor-context";
+import type { TokenType } from "../types";
 
 export const defaultTokenTypes: TokenType[] = [
   { id: "default", name: "Default", color: "#3498db" },

--- a/apps/hash-frontend/src/pages/process.page/process-editor/transition-node.tsx
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/transition-node.tsx
@@ -1,7 +1,7 @@
 import { Box, Typography } from "@mui/material";
 import { Handle, type NodeProps, Position } from "reactflow";
 
-import { transitionStyling } from "./styling";
+import { handleStyling, transitionStyling } from "./styling";
 import type { TransitionNodeData } from "./types";
 
 export const TransitionNode = ({
@@ -19,7 +19,7 @@ export const TransitionNode = ({
         type="target"
         position={Position.Left}
         isConnectable={isConnectable}
-        style={{ background: "#555" }}
+        style={handleStyling}
       />
       <Box sx={transitionStyling}>
         {data.label}
@@ -41,7 +41,7 @@ export const TransitionNode = ({
         type="source"
         position={Position.Right}
         isConnectable={isConnectable}
-        style={{ background: "#555" }}
+        style={handleStyling}
       />
     </div>
   );

--- a/apps/hash-frontend/src/pages/process.page/process-editor/use-layout-graph.ts
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/use-layout-graph.ts
@@ -1,0 +1,95 @@
+import type { ElkNode } from "elkjs/lib/elk.bundled.js";
+import ELK from "elkjs/lib/elk.bundled.js";
+import { type Dispatch, type SetStateAction, useCallback } from "react";
+import { useReactFlow } from "reactflow";
+
+import { nodeDimensions } from "./styling";
+import type { ArcType, NodeType } from "./types";
+
+/**
+ * @see https://eclipse.dev/elk/documentation/tooldevelopers
+ * @see https://rtsys.informatik.uni-kiel.de/elklive/json.html for JSON playground
+ */
+const elk = new ELK();
+
+const graphPadding = 30;
+
+/**
+ * @see https://eclipse.dev/elk/reference.html
+ */
+const elkLayoutOptions: ElkNode["layoutOptions"] = {
+  "elk.algorithm": "layered",
+  "org.eclipse.elk.layered.spacing.nodeNodeBetweenLayers": "100",
+  "elk.direction": "RIGHT",
+  "elk.padding": `[left=${graphPadding},top=${
+    graphPadding
+  },right=${graphPadding},bottom=${graphPadding}]`,
+};
+
+export const useLayoutGraph = ({
+  setNodes,
+}: {
+  setNodes: Dispatch<SetStateAction<NodeType[]>>;
+}) => {
+  const { fitView } = useReactFlow();
+
+  const layoutGraph = useCallback(
+    ({
+      nodes,
+      arcs,
+      animationDuration,
+    }: {
+      nodes: NodeType[];
+      arcs: ArcType[];
+      animationDuration: number;
+    }) => {
+      if (nodes.length === 0) {
+        return;
+      }
+
+      const graph: ElkNode = {
+        id: "root",
+        children: JSON.parse(
+          JSON.stringify(
+            nodes.map((node) => ({
+              ...node,
+              /**
+               * If we are loading a graph in full (e.g. from an example or PNML file), we need to set the visible width and height,
+               * so that ELK knows how much space to reserve for the node.
+               *
+               * @todo encode width/height as part of the graph data
+               */
+              width: nodeDimensions[node.data.type].width,
+              height: nodeDimensions[node.data.type].height,
+            })),
+          ),
+        ),
+        edges: JSON.parse(JSON.stringify(arcs)),
+        layoutOptions: elkLayoutOptions,
+      };
+
+      void elk.layout(graph).then((elements) => {
+        const newNodes: NodeType[] = [];
+
+        /**
+         * ELK inserts the calculated position as a root 'x' and 'y', but reactflow wants these in a position object
+         */
+        for (const { x, y, ...rest } of elements.children as (NodeType & {
+          x: number;
+          y: number;
+        })[]) {
+          newNodes.push({ ...rest, position: { x, y } });
+        }
+
+        setNodes(newNodes);
+
+        window.requestAnimationFrame(() =>
+          fitView({ duration: animationDuration, padding: 0.03, maxZoom: 1 }),
+        );
+      });
+    },
+    [setNodes, fitView],
+  );
+
+  return layoutGraph;
+};

--- a/apps/hash-frontend/src/pages/process.page/process-editor/use-load-from-pnml.ts
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/use-load-from-pnml.ts
@@ -164,20 +164,18 @@ const parsePnml = (
 };
 
 export const useLoadFromPnml = () => {
-  const { setNodes, setArcs, setTokenTypes } = useEditorContext();
+  const { setGraph } = useEditorContext();
   const { resetSimulation } = useSimulation();
 
   const load = useCallback(
     (xml: string) => {
       const { nodes, arcs, tokenTypes } = parsePnml(xml);
 
-      setNodes(nodes);
-      setArcs(arcs);
-      setTokenTypes(tokenTypes);
+      setGraph({ nodes, arcs, tokenTypes });
 
       resetSimulation();
     },
-    [resetSimulation, setArcs, setNodes, setTokenTypes],
+    [resetSimulation, setGraph],
   );
 
   return load;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To make it easier to layout and work with the Petri net editor:
1. Add a button to automatically lay out the net nicely (using [elkjs](https://github.com/kieler/elkjs))
2. When loading a net from a file or the example, automatically fit the net to the container

Note that it does NOT:
1. Add a switch to automatically re-layout the net any time a node is added. I tried this and found it extremely annoying, because the algorithm will pack nodes together as soon as they're added, making it a pain to then connect them (since they're tightly packed until connected). There is possibly some tweaking we could do to get a good algorithm in 'auto-layout' mode, maybe only doing autolayout only on connected nodes or similar
2. Automatically layout a net loaded from a file. The user might have manually positioned it how they want it.

Other tweaks:
1. Make handles on nodes bigger, to allow for drawing edges more easily
2. Some code organization

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Visit `/process` on the preview deployment

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

https://github.com/user-attachments/assets/f9a79353-daaa-4865-86a3-56434ae6d9e0

