### PR TITLE
H-4449: HashQL: Minor type inference solver fixes

### DIFF
--- a/libs/@local/hashql/core/src/type/inference/solver/mod.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/mod.rs
@@ -954,14 +954,14 @@ impl<'env, 'heap> InferenceSolver<'env, 'heap> {
     /// Any error that is encountered during this process is deemed a compiler bug, as we have no
     /// span to associate with the error. This should usually never happen, as step 1 ensures every
     /// variable is registered.
-    fn verify_constrained(
+    fn verify_constrained<L, U>(
         &mut self,
         lookup: &VariableLookup,
-        substitution: &FastHashMap<VariableKind, TypeId>,
+        constraints: &FastHashMap<VariableKind, (Variable, VariableConstraint<L, U>)>,
     ) {
         for &variable in &self.unification.variables {
             let root = lookup[variable];
-            if !substitution.contains_key(&root) {
+            if !constraints.contains_key(&root) {
                 self.diagnostics
                     .push(unconstrained_type_variable_floating(&self.lattice));
             }
@@ -980,20 +980,16 @@ impl<'env, 'heap> InferenceSolver<'env, 'heap> {
     fn simplify_substitutions(
         &mut self,
         lookup: VariableLookup,
-        substitutions: FastHashMap<VariableKind, TypeId>,
-    ) -> FastHashMap<VariableKind, TypeId> {
+        substitutions: &mut FastHashMap<VariableKind, TypeId>,
+    ) {
         // Now that everything is solved, go over each substitution and simplify it
-        let mut simplified_substitutions = FastHashMap::default();
-
         // Make the simplifier aware of the substitutions
         self.simplify
             .set_substitution(Substitution::new(lookup, substitutions.clone()));
 
-        for (variable, type_id) in substitutions {
-            simplified_substitutions.insert(variable, self.simplify.simplify(type_id));
+        for (_, type_id) in substitutions {
+            *type_id = self.simplify.simplify(*type_id);
         }
-
-        simplified_substitutions
     }
 
     /// Solves type inference constraints and produces a type substitution.
@@ -1005,8 +1001,8 @@ impl<'env, 'heap> InferenceSolver<'env, 'heap> {
     /// 2. Solves anti-symmetry constraints to identify variables that must be equal
     /// 3. Sets up variable substitutions in the lattice environment
     /// 4. Applies constraints through forward and backward passes
-    /// 5. Validates constraints and computes substitutions
-    /// 6. Verifies that all variables are constrained
+    /// 5. Verifies that all variables are constrained
+    /// 6. Validates constraints and computes substitutions
     /// 7. Simplifies the final substitutions for better readability
     /// 8. Collects any diagnostics generated during solving
     ///
@@ -1031,14 +1027,14 @@ impl<'env, 'heap> InferenceSolver<'env, 'heap> {
         // Step 3 & 4: Apply constraints through forward and backward passes
         let constraints = self.apply_constraints();
 
-        // Step 5: Validate constraints and determine final types
-        let substitution = self.solve_constraints(constraints);
+        // Step 5: Verify that all variables have been constrained
+        self.verify_constrained(&lookup, &constraints);
 
-        // Step 6: Verify that all variables have been constrained
-        self.verify_constrained(&lookup, &substitution);
+        // Step 6: Validate constraints and determine final types
+        let mut substitution = self.solve_constraints(constraints);
 
         // Step 7: Simplify the final substitutions
-        let substitution = self.simplify_substitutions(lookup.clone(), substitution.clone());
+        self.simplify_substitutions(lookup.clone(), &mut substitution);
         let substitution = Substitution::new(lookup, substitution);
 
         // Step 8: Collect all diagnostics from the solving process

--- a/libs/@local/hashql/core/src/type/inference/solver/mod.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/mod.rs
@@ -987,7 +987,7 @@ impl<'env, 'heap> InferenceSolver<'env, 'heap> {
         self.simplify
             .set_substitution(Substitution::new(lookup, substitutions.clone()));
 
-        for (_, type_id) in substitutions {
+        for type_id in substitutions.values_mut() {
             *type_id = self.simplify.simplify(*type_id);
         }
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes that we no longer double emit on unconstrained variables, previously, if there was a "floating" variable (as in we constrain `_1 <: _2`) we would create two diagnostics:

1. compiler bug - detected unconstrained variable
2. error - unconstrained variable

This is because the order for both was flipped. We checked if all variables are constrained *after* checking if a variable actually exists. Therefore any error would remove a variable from the final substitution, leading to the compiler bug. The compiler bug is only there in cases where - like the name - suggests - a compiler bug exists, where we *somehow* know of a variable, but don't know where it came wrong. This is highly unusual, and is therefore only a sanity check (but better to have that instead of just silently swallowing the error).

A test case has been added to verify it's working and an integration test going from environment -> solver with a non-trivial case has been added as well.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
