### PR TITLE
H-4448: HashQL: Recursive types should be simplified more intelligently

### DIFF
--- a/libs/@local/hashql/core/src/type/environment/simplify.rs
+++ b/libs/@local/hashql/core/src/type/environment/simplify.rs
@@ -121,6 +121,7 @@ impl<'env, 'heap> SimplifyEnvironment<'env, 'heap> {
         self.analysis.contains_substitution(kind)
     }
 
+    #[inline]
     pub(crate) fn take_diagnostics(&mut self) -> Option<Diagnostics> {
         self.analysis.take_diagnostics()
     }

--- a/libs/@local/hashql/core/src/type/environment/simplify.rs
+++ b/libs/@local/hashql/core/src/type/environment/simplify.rs
@@ -1,18 +1,87 @@
-use core::ops::Deref;
+use alloc::rc::Rc;
+use core::{cell::RefCell, ops::Deref};
 
 use smallvec::SmallVec;
 
 use super::{AnalysisEnvironment, Diagnostics, Environment};
-use crate::r#type::{
-    Type, TypeId,
-    inference::{Substitution, VariableKind, VariableLookup},
-    lattice::Lattice as _,
-    recursion::RecursionBoundary,
+use crate::{
+    collection::FastHashMap,
+    intern::Provisioned,
+    r#type::{
+        PartialType, Type, TypeId,
+        inference::{Substitution, VariableKind, VariableLookup},
+        lattice::Lattice as _,
+        recursion::RecursionBoundary,
+    },
 };
+
+pub struct ProvisionGuard {
+    inner: Rc<Provision>,
+
+    id: TypeId,
+    provisioned: Provisioned<TypeId>,
+    previous: Option<Provisioned<TypeId>>,
+}
+
+impl Drop for ProvisionGuard {
+    fn drop(&mut self) {
+        self.inner.exit(self);
+    }
+}
+
+#[derive(Debug, Default)]
+struct Provision {
+    // RefCell is sufficient here, because we take a `&mut self` for the simplify environment,
+    // therefore we always have mutable access to the inner map, the RefCell is only used, so that
+    // we can properly cleanup on Drop, as the client is unable to access anything in the simplify
+    // environment (especially the provisioned map) by himself. The only places that interact with
+    // the provisioned map are the `provision` function and the `simplify` function, for short
+    // periods of time, and never over longer than a single expression.
+    forward: RefCell<FastHashMap<TypeId, Provisioned<TypeId>>>,
+    reverse: RefCell<FastHashMap<TypeId, TypeId>>,
+}
+
+impl Provision {
+    fn enter(self: Rc<Self>, id: TypeId, provisioned: Provisioned<TypeId>) -> ProvisionGuard {
+        let previous = { self.forward.borrow_mut().insert(id, provisioned) };
+
+        self.reverse.borrow_mut().insert(provisioned.value(), id);
+
+        ProvisionGuard {
+            inner: Rc::clone(&self),
+            id,
+            provisioned,
+            previous,
+        }
+    }
+
+    fn exit(&self, guard: &ProvisionGuard) {
+        if let Some(previous) = guard.previous {
+            self.forward.borrow_mut().insert(guard.id, previous);
+        } else {
+            self.forward.borrow_mut().remove(&guard.id);
+        }
+
+        self.reverse.borrow_mut().remove(&guard.provisioned.value());
+    }
+
+    fn substitute(&self, id: TypeId) -> Option<TypeId> {
+        self.forward
+            .borrow()
+            .get(&id)
+            .map(|provisioned| provisioned.value())
+    }
+
+    fn substitution_of(&self, id: TypeId) -> Option<TypeId> {
+        self.reverse.borrow().get(&id).copied()
+    }
+}
 
 pub struct SimplifyEnvironment<'env, 'heap> {
     pub environment: &'env Environment<'heap>,
     boundary: RecursionBoundary,
+
+    provisioned: Rc<Provision>,
 
     analysis: AnalysisEnvironment<'env, 'heap>,
 }
@@ -22,6 +91,7 @@ impl<'env, 'heap> SimplifyEnvironment<'env, 'heap> {
         Self {
             environment,
             boundary: RecursionBoundary::new(),
+            provisioned: Rc::default(),
             analysis: AnalysisEnvironment::new(environment),
         }
     }
@@ -61,50 +131,114 @@ impl<'env, 'heap> SimplifyEnvironment<'env, 'heap> {
     }
 
     #[inline]
-    pub fn is_equivalent(&mut self, lhs: TypeId, rhs: TypeId) -> bool {
+    pub fn is_equivalent(&mut self, mut lhs: TypeId, mut rhs: TypeId) -> bool {
+        if let Some(previous) = self.provisioned.substitution_of(lhs) {
+            lhs = previous;
+        }
+
+        if let Some(previous) = self.provisioned.substitution_of(rhs) {
+            rhs = previous;
+        }
+
         self.analysis.is_equivalent(lhs, rhs)
     }
 
     #[inline]
-    pub fn is_subtype_of(&mut self, subtype: TypeId, supertype: TypeId) -> bool {
+    pub fn is_subtype_of(&mut self, mut subtype: TypeId, mut supertype: TypeId) -> bool {
+        if let Some(previous) = self.provisioned.substitution_of(subtype) {
+            subtype = previous;
+        }
+
+        if let Some(previous) = self.provisioned.substitution_of(supertype) {
+            supertype = previous;
+        }
+
         self.analysis.is_subtype_of(subtype, supertype)
     }
 
     // Two types are disjoint if neither is a subtype of the other
     // This means they share no common values and their intersection is empty
     #[inline]
-    pub fn is_disjoint(&mut self, lhs: TypeId, rhs: TypeId) -> bool {
+    pub fn is_disjoint(&mut self, mut lhs: TypeId, mut rhs: TypeId) -> bool {
+        if let Some(previous) = self.provisioned.substitution_of(lhs) {
+            lhs = previous;
+        }
+
+        if let Some(previous) = self.provisioned.substitution_of(rhs) {
+            rhs = previous;
+        }
+
         self.analysis.is_disjoint(lhs, rhs)
     }
 
     #[inline]
-    pub fn is_bottom(&mut self, id: TypeId) -> bool {
+    pub fn is_bottom(&mut self, mut id: TypeId) -> bool {
+        if let Some(previous) = self.provisioned.substitution_of(id) {
+            id = previous;
+        }
+
         self.analysis.is_bottom(id)
     }
 
     #[inline]
-    pub fn is_top(&mut self, id: TypeId) -> bool {
+    pub fn is_top(&mut self, mut id: TypeId) -> bool {
+        if let Some(previous) = self.provisioned.substitution_of(id) {
+            id = previous;
+        }
+
         self.analysis.is_top(id)
     }
 
     #[inline]
-    pub fn is_concrete(&mut self, id: TypeId) -> bool {
+    pub fn is_concrete(&mut self, mut id: TypeId) -> bool {
+        if let Some(previous) = self.provisioned.substitution_of(id) {
+            id = previous;
+        }
+
         self.analysis.is_concrete(id)
     }
 
     #[inline]
-    pub fn distribute_union(&mut self, id: TypeId) -> SmallVec<TypeId, 16> {
+    pub fn distribute_union(&mut self, mut id: TypeId) -> SmallVec<TypeId, 16> {
+        if let Some(previous) = self.provisioned.substitution_of(id) {
+            id = previous;
+        }
+
         self.analysis.distribute_union(id)
     }
 
     #[inline]
-    pub fn distribute_intersection(&mut self, id: TypeId) -> SmallVec<TypeId, 16> {
+    pub fn distribute_intersection(&mut self, mut id: TypeId) -> SmallVec<TypeId, 16> {
+        if let Some(previous) = self.provisioned.substitution_of(id) {
+            id = previous;
+        }
+
         self.analysis.distribute_intersection(id)
     }
 
+    /// Simplifies the given type ID.
+    ///
+    /// # Panics
+    ///
+    /// In debug builds, this function will panic if a type should have been provisioned but wasn't.
     pub fn simplify(&mut self, id: TypeId) -> TypeId {
         if !self.boundary.enter(id, id) {
-            // We have discovered a recursive type, as such we stop simplification
+            // See if the type has been substituted
+            if let Some(substitution) = self.provisioned.substitute(id) {
+                return substitution;
+            }
+
+            #[expect(
+                clippy::manual_assert,
+                reason = "false positive, this is a manual `debug_panic`"
+            )]
+            if cfg!(debug_assertions) {
+                panic!("type should have been provisioned");
+            }
+
+            // in debug builds this panics if the type should have been provisioned but wasn't, as
+            // we can recover from this error (we simply return the original - unsimplified - type
+            // id) we do not need to panic here in release builds.
             return id;
         }
 
@@ -113,6 +247,26 @@ impl<'env, 'heap> SimplifyEnvironment<'env, 'heap> {
 
         self.boundary.exit(id, id);
         result
+    }
+
+    #[expect(
+        clippy::needless_pass_by_ref_mut,
+        reason = "prove ownership of environment, so that we can borrow safely"
+    )]
+    pub fn provision(&mut self, id: TypeId) -> (ProvisionGuard, Provisioned<TypeId>) {
+        let provisioned = self.environment.types.provision();
+        let guard = Rc::clone(&self.provisioned).enter(id, provisioned);
+
+        (guard, provisioned)
+    }
+
+    #[must_use]
+    pub fn intern_provisioned(
+        &self,
+        id: Provisioned<TypeId>,
+        r#type: PartialType<'heap>,
+    ) -> TypeId {
+        self.environment.types.intern_provisioned(id, r#type).id
     }
 }
 

--- a/libs/@local/hashql/core/src/type/kind/struct.rs
+++ b/libs/@local/hashql/core/src/type/kind/struct.rs
@@ -1926,7 +1926,6 @@ mod test {
         );
     }
 
-    #[expect(clippy::missing_asserts_for_indexing, reason = "false positive")]
     #[test]
     fn simplify_recursive_struct() {
         let heap = Heap::new();

--- a/libs/@local/hashql/core/src/type/kind/struct.rs
+++ b/libs/@local/hashql/core/src/type/kind/struct.rs
@@ -419,6 +419,8 @@ impl<'heap> Lattice<'heap> for StructType<'heap> {
     }
 
     fn simplify(self: Type<'heap, Self>, env: &mut SimplifyEnvironment<'_, 'heap>) -> TypeId {
+        let (_guard, id) = env.provision(self.id);
+
         let mut fields = SmallVec::<_, 16>::with_capacity(self.kind.fields.len());
 
         for &field in &*self.kind.fields {
@@ -430,21 +432,27 @@ impl<'heap> Lattice<'heap> for StructType<'heap> {
 
         // Check if any of the fields are uninhabited, in that case simplify down to never
         if fields.iter().any(|field| env.is_bottom(field.value)) {
-            return env.intern_type(PartialType {
-                span: self.span,
-                kind: env.intern_kind(TypeKind::Never),
-            });
+            return env.intern_provisioned(
+                id,
+                PartialType {
+                    span: self.span,
+                    kind: env.intern_kind(TypeKind::Never),
+                },
+            );
         }
 
-        env.intern_type(PartialType {
-            span: self.span,
-            kind: env.intern_kind(TypeKind::Struct(Self {
-                fields: env
-                    .intern_struct_fields(&mut fields)
-                    .unwrap_or_else(|_| unreachable!()),
-                arguments: self.kind.arguments,
-            })),
-        })
+        env.intern_provisioned(
+            id,
+            PartialType {
+                span: self.span,
+                kind: env.intern_kind(TypeKind::Struct(Self {
+                    fields: env
+                        .intern_struct_fields(&mut fields)
+                        .unwrap_or_else(|_| unreachable!()),
+                    arguments: self.kind.arguments,
+                })),
+            },
+        )
     }
 }
 
@@ -510,11 +518,14 @@ impl PrettyPrint for StructType<'_> {
 #[cfg(test)]
 mod test {
     #![expect(clippy::min_ident_chars)]
+    use core::assert_matches::assert_matches;
+
     use super::{StructField, StructType};
     use crate::{
         heap::Heap,
         span::SpanId,
         r#type::{
+            PartialType,
             environment::{
                 AnalysisEnvironment, Environment, InferenceEnvironment, LatticeEnvironment,
                 SimplifyEnvironment,
@@ -524,7 +535,7 @@ mod test {
             },
             kind::{
                 TypeKind,
-                generic_argument::{GenericArgument, GenericArgumentId},
+                generic_argument::{GenericArgument, GenericArgumentId, GenericArguments},
                 infer::HoleId,
                 intersection::IntersectionType,
                 primitive::PrimitiveType,
@@ -1912,6 +1923,37 @@ mod test {
                 source: edge_var,
                 target: Variable::synthetic(VariableKind::Hole(hole)),
             }]
+        );
+    }
+
+    #[expect(clippy::missing_asserts_for_indexing, reason = "false positive")]
+    #[test]
+    fn recursive_struct() {
+        let heap = Heap::new();
+        let env = Environment::new(SpanId::SYNTHETIC, &heap);
+
+        // Create a recursive struct
+        let r#type = env.types.intern(|id| PartialType {
+            span: SpanId::SYNTHETIC,
+            kind: env.intern_kind(TypeKind::Struct(StructType {
+                fields: env
+                    .intern_struct_fields(&mut [struct_field!(env, "self", id.value())])
+                    .expect("fields should be unique"),
+                arguments: GenericArguments::empty(),
+            })),
+        });
+
+        let mut simplify = SimplifyEnvironment::new(&env);
+        let type_id = simplify.simplify(r#type.id);
+
+        let r#type = env.r#type(type_id);
+
+        assert_matches!(
+            r#type.kind,
+            TypeKind::Struct(StructType { fields, arguments }) if fields.len() == 1
+                && fields[0].name.as_str() == "self"
+                && fields[0].value == type_id
+                && arguments.is_empty()
         );
     }
 }

--- a/libs/@local/hashql/core/src/type/kind/struct.rs
+++ b/libs/@local/hashql/core/src/type/kind/struct.rs
@@ -1928,7 +1928,7 @@ mod test {
 
     #[expect(clippy::missing_asserts_for_indexing, reason = "false positive")]
     #[test]
-    fn recursive_struct() {
+    fn simplify_recursive_struct() {
         let heap = Heap::new();
         let env = Environment::new(SpanId::SYNTHETIC, &heap);
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, when we try to simplify and we encounter a recursive type, we simply abort and return the original type. This has the fundamental problem that simplifications naturally "cascade" down on further simplifications, branching of at every recursion point. This is not ideal. Instead we should make use of the proposed API changes in [H-4409](https://linear.app/hash/issue/H-4409/hashql-intern-types). When we first start simplification, we get a provisional id. We then register said id with the simplify functions. Once simplification has hit a recursion point, we return the provisional id. Because that id hasn't been seen yet, the interner will always create a new type, instead of interning and will cascade up to the recursive type, leading to the provisional id to be used.


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
