### PR TITLE
H-4384, H-4499: HashQL: Implement Type Instantiation

### DIFF
--- a/libs/@local/hashql/core/src/intern/map.rs
+++ b/libs/@local/hashql/core/src/intern/map.rs
@@ -1,4 +1,5 @@
 use core::{
+    borrow::Borrow,
     hash::Hash,
     hint::cold_path,
     sync::atomic::{AtomicU32, Ordering},
@@ -46,6 +47,24 @@ where
     /// Returns the underlying ID value.
     pub const fn value(self) -> T {
         self.0
+    }
+}
+
+impl<T> AsRef<T> for Provisioned<T>
+where
+    T: Id,
+{
+    fn as_ref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> Borrow<T> for Provisioned<T>
+where
+    T: Id,
+{
+    fn borrow(&self) -> &T {
+        &self.0
     }
 }
 

--- a/libs/@local/hashql/core/src/intern/map.rs
+++ b/libs/@local/hashql/core/src/intern/map.rs
@@ -550,6 +550,46 @@ where
         Some(T::from_parts(id, Interned::new_unchecked(partial)))
     }
 
+    /// Checks if an ID exists in the map.
+    ///
+    /// This method determines whether an ID has been interned in this map without
+    /// reconstructing the complete object.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use hashql_core::{heap::Heap, intern::{InternMap, Decompose, Interned}, id::{HasId, Id}, newtype};
+    /// # newtype!(struct ValueId(u32 is 0..=0xFFFF_FF00));
+    /// # #[derive(Debug, PartialEq, Eq, Hash)]
+    /// # struct Value {
+    /// #     id: ValueId,
+    /// #     value: i32,
+    /// # }
+    /// # impl HasId for Value {
+    /// #     type Id = ValueId;
+    /// #     fn id(&self) -> Self::Id { self.id }
+    /// # }
+    /// # impl<'heap> Decompose<'heap> for Value {
+    /// #     type Partial = i32;
+    /// #     fn from_parts(id: ValueId, partial: Interned<'heap, i32>) -> Self {
+    /// #         Self { id, value: *partial.as_ref() }
+    /// #     }
+    /// # }
+    /// # let heap = Heap::new();
+    /// # let map = InternMap::<Value>::new(&heap);
+    /// let obj = map.intern_partial(42);
+    /// let id = obj.id();
+    ///
+    /// // Check if the ID exists
+    /// assert!(map.contains(id));
+    ///
+    /// // Check a non-existent ID
+    /// assert!(!map.contains(ValueId::from_u32(999)));
+    /// ```
+    pub fn contains(&self, id: T::Id) -> bool {
+        self.lookup.contains(&id)
+    }
+
     /// Returns the interned value for the given ID.
     ///
     /// This method is similar to `get`, but panics if no value with the given ID exists.

--- a/libs/@local/hashql/core/src/lib.rs
+++ b/libs/@local/hashql/core/src/lib.rs
@@ -4,7 +4,6 @@
 #![cfg_attr(doc, doc = simple_mermaid::mermaid!("../docs/dependency-diagram.mmd"))]
 #![feature(
     never_type,
-    decl_macro,
     assert_matches,
     arbitrary_self_types,
     allocator_api,
@@ -14,8 +13,6 @@
     iter_map_windows,
     cold_path
 )]
-#![cfg_attr(test, feature(custom_test_frameworks))]
-#![expect(clippy::todo)]
 
 extern crate alloc;
 

--- a/libs/@local/hashql/core/src/type/collection/type_id_set.rs
+++ b/libs/@local/hashql/core/src/type/collection/type_id_set.rs
@@ -28,6 +28,7 @@ fn ptr_eq<T: ?Sized>(lhs: *const T, rhs: *const T) -> bool {
 ///
 /// This collection uses `SmallVec` to avoid heap allocations for small sets
 /// (up to `CAPACITY` items).
+#[derive(Debug)]
 pub(crate) struct TypeIdSet<'env, 'heap, const CAPACITY: usize> {
     env: &'env Environment<'heap>,
     items: SmallVec<TypeId, CAPACITY>,

--- a/libs/@local/hashql/core/src/type/environment/analysis.rs
+++ b/libs/@local/hashql/core/src/type/environment/analysis.rs
@@ -323,7 +323,13 @@ impl<'env, 'heap> AnalysisEnvironment<'env, 'heap> {
         let supertype = self.environment.r#type(supertype);
 
         if !self.boundary.enter(subtype.id, supertype.id) {
-            return self.is_subtype_of_recursive(subtype, supertype);
+            return self.is_subtype_of_recursive(
+                subtype,
+                supertype,
+                // should discharge:
+                self.subtype_scope.contains(subtype.id)
+                    && self.supertype_scope.contains(supertype.id),
+            );
         }
 
         if let Some(result) = self.is_quick_subtype(&subtype, &supertype) {

--- a/libs/@local/hashql/core/src/type/environment/analysis.rs
+++ b/libs/@local/hashql/core/src/type/environment/analysis.rs
@@ -9,13 +9,13 @@ use crate::r#type::{
     inference::{Substitution, VariableKind, VariableLookup},
     kind::{Infer, Param, TypeKind},
     lattice::Lattice as _,
-    recursion::RecursionBoundary,
+    recursion::{RecursionBoundary, RecursionCycle},
 };
 
 #[derive(Debug)]
 pub struct AnalysisEnvironment<'env, 'heap> {
     environment: &'env Environment<'heap>,
-    boundary: RecursionBoundary,
+    boundary: RecursionBoundary<'heap>,
     diagnostics: Option<Diagnostics>,
     variance: Variance,
     variables: Option<VariableLookup>,
@@ -105,29 +105,31 @@ impl<'env, 'heap> AnalysisEnvironment<'env, 'heap> {
     }
 
     pub fn is_bottom(&mut self, id: TypeId) -> bool {
-        if !self.boundary.enter(id, id) {
+        let r#type = self.environment.r#type(id);
+
+        if self.boundary.enter(r#type, r#type).is_break() {
             // We have found a recursive type, meaning it can't be bottom
             return false;
         }
 
-        let r#type = self.environment.r#type(id);
         let result = r#type.is_bottom(self);
 
-        self.boundary.exit(id, id);
+        self.boundary.exit(r#type, r#type);
 
         result
     }
 
     pub fn is_top(&mut self, id: TypeId) -> bool {
-        if !self.boundary.enter(id, id) {
+        let r#type = self.environment.r#type(id);
+
+        if self.boundary.enter(r#type, r#type).is_break() {
             // We have found a recursive type, meaning it can't be top
             return false;
         }
 
-        let r#type = self.environment.r#type(id);
         let result = r#type.is_top(self);
 
-        self.boundary.exit(id, id);
+        self.boundary.exit(r#type, r#type);
 
         result
     }
@@ -140,45 +142,48 @@ impl<'env, 'heap> AnalysisEnvironment<'env, 'heap> {
     }
 
     pub fn is_concrete(&mut self, id: TypeId) -> bool {
-        if !self.boundary.enter(id, id) {
+        let r#type = self.environment.r#type(id);
+
+        if self.boundary.enter(r#type, r#type).is_break() {
             // We have found a recursive type with no holes, therefore it must be concrete
             return true;
         }
 
-        let r#type = self.environment.r#type(id);
         let result = r#type.is_concrete(self);
 
-        self.boundary.exit(id, id);
+        self.boundary.exit(r#type, r#type);
 
         result
     }
 
     pub fn distribute_union(&mut self, id: TypeId) -> SmallVec<TypeId, 16> {
-        if !self.boundary.enter(id, id) {
+        let r#type = self.environment.r#type(id);
+
+        if self.boundary.enter(r#type, r#type).is_break() {
             // We have found a recursive type, due to coinductive reasoning, this means it can no
             // longer be distributed
             return SmallVec::from_slice(&[id]);
         }
 
-        let r#type = self.environment.r#type(id);
         let result = r#type.distribute_union(self);
 
-        self.boundary.exit(id, id);
+        self.boundary.exit(r#type, r#type);
 
         result
     }
 
     pub fn distribute_intersection(&mut self, id: TypeId) -> SmallVec<TypeId, 16> {
-        if !self.boundary.enter(id, id) {
+        let r#type = self.environment.r#type(id);
+
+        if self.boundary.enter(r#type, r#type).is_break() {
             // We have found a recursive type, due to coinductive reasoning, this means it can no
             // longer be distributed
             return SmallVec::from_slice(&[id]);
         }
 
-        let r#type = self.environment.r#type(id);
         let result = r#type.distribute_intersection(self);
 
-        self.boundary.exit(id, id);
+        self.boundary.exit(r#type, r#type);
 
         result
     }
@@ -303,13 +308,18 @@ impl<'env, 'heap> AnalysisEnvironment<'env, 'heap> {
     /// See <https://en.wikipedia.org/wiki/Coinduction> and
     /// Chapter 21.1 of "Types and Programming Languages" by Benjamin C. Pierce
     #[inline]
-    fn is_subtype_of_recursive(&mut self, subtype: Type<'heap>, supertype: Type<'heap>) -> bool {
+    fn is_subtype_of_recursive(
+        &mut self,
+        subtype: Type<'heap>,
+        supertype: Type<'heap>,
+        cycle: RecursionCycle,
+    ) -> bool {
         // Issue a non-fatal diagnostic to inform that a cycle was detected, but don't treat
         // it as an error for subtyping.
         let _: ControlFlow<()> =
             self.record_diagnostic(|env| circular_type_reference(env.source, subtype, supertype));
 
-        true
+        cycle.should_discharge()
     }
 
     pub fn is_subtype_of(&mut self, subtype: TypeId, supertype: TypeId) -> bool {
@@ -322,25 +332,19 @@ impl<'env, 'heap> AnalysisEnvironment<'env, 'heap> {
         let subtype = self.environment.r#type(subtype);
         let supertype = self.environment.r#type(supertype);
 
-        if !self.boundary.enter(subtype.id, supertype.id) {
-            return self.is_subtype_of_recursive(
-                subtype,
-                supertype,
-                // should discharge:
-                self.subtype_scope.contains(subtype.id)
-                    && self.supertype_scope.contains(supertype.id),
-            );
+        if let ControlFlow::Break(cycle) = self.boundary.enter(subtype, supertype) {
+            return self.is_subtype_of_recursive(subtype, supertype, cycle);
         }
 
         if let Some(result) = self.is_quick_subtype(&subtype, &supertype) {
-            self.boundary.exit(subtype.id, supertype.id);
+            self.boundary.exit(subtype, supertype);
 
             return result;
         }
 
         let result = subtype.is_subtype_of(supertype, self);
 
-        self.boundary.exit(subtype.id, supertype.id);
+        self.boundary.exit(subtype, supertype);
 
         result
     }
@@ -395,31 +399,37 @@ impl<'env, 'heap> AnalysisEnvironment<'env, 'heap> {
     /// See <https://en.wikipedia.org/wiki/Coinduction> and
     /// Chapter 21.1 of "Types and Programming Languages" by Benjamin C. Pierce
     #[inline]
-    fn is_equivalent_recursive(&mut self, lhs: Type<'heap>, rhs: Type<'heap>) -> bool {
+    fn is_equivalent_recursive(
+        &mut self,
+        lhs: Type<'heap>,
+        rhs: Type<'heap>,
+        cycle: RecursionCycle,
+    ) -> bool {
         // Issue a non-fatal diagnostic to inform that a cycle was detected, but don't treat
         // it as an error for subtyping.
         let _: ControlFlow<()> =
             self.record_diagnostic(|env| circular_type_reference(env.source, lhs, rhs));
 
-        true
+        cycle.should_discharge()
     }
 
     pub fn is_equivalent(&mut self, lhs: TypeId, rhs: TypeId) -> bool {
         let lhs = self.environment.r#type(lhs);
         let rhs = self.environment.r#type(rhs);
 
-        if !self.boundary.enter(lhs.id, rhs.id) {
-            return self.is_equivalent_recursive(lhs, rhs);
+        if let ControlFlow::Break(cycle) = self.boundary.enter(lhs, rhs) {
+            return self.is_equivalent_recursive(lhs, rhs, cycle);
         }
 
         if let Some(result) = self.is_quick_equivalent(&lhs, &rhs) {
+            self.boundary.exit(lhs, rhs);
+
             return result;
         }
 
         let result = lhs.is_equivalent(rhs, self);
 
-        self.boundary.exit(lhs.id, rhs.id);
-
+        self.boundary.exit(lhs, rhs);
         result
     }
 

--- a/libs/@local/hashql/core/src/type/environment/analysis.rs
+++ b/libs/@local/hashql/core/src/type/environment/analysis.rs
@@ -12,6 +12,7 @@ use crate::r#type::{
     recursion::RecursionBoundary,
 };
 
+#[derive(Debug)]
 pub struct AnalysisEnvironment<'env, 'heap> {
     environment: &'env Environment<'heap>,
     boundary: RecursionBoundary,

--- a/libs/@local/hashql/core/src/type/environment/context/mod.rs
+++ b/libs/@local/hashql/core/src/type/environment/context/mod.rs
@@ -1,3 +1,4 @@
 pub mod diagnostics;
 pub(crate) mod provision;
+pub(crate) mod replace;
 pub mod variance;

--- a/libs/@local/hashql/core/src/type/environment/context/mod.rs
+++ b/libs/@local/hashql/core/src/type/environment/context/mod.rs
@@ -1,2 +1,3 @@
 pub mod diagnostics;
+pub(crate) mod provision;
 pub mod variance;

--- a/libs/@local/hashql/core/src/type/environment/context/provision.rs
+++ b/libs/@local/hashql/core/src/type/environment/context/provision.rs
@@ -1,0 +1,120 @@
+use alloc::rc::Rc;
+use core::cell::RefCell;
+
+use crate::{collection::FastHashMap, id::Id, intern::Provisioned};
+
+pub struct ProvisionedGuard<T: Id> {
+    inner: Rc<ProvisionedScope<T>>,
+
+    id: T,
+    provisioned: Provisioned<T>,
+    previous: Option<Provisioned<T>>,
+}
+
+impl<T> Drop for ProvisionedGuard<T>
+where
+    T: Id,
+{
+    fn drop(&mut self) {
+        self.inner.exit(self);
+    }
+}
+
+/// Manages provisional type mappings during the type simplification process.
+///
+/// This struct holds the forward (`T` -> `Provisioned<T>`) and reverse
+/// (`Provisioned<T>` -> `T`) mappings used to track types that have been
+/// temporarily 'provisioned' (allocated a placeholder ID) before their final
+/// simplified form is determined and interned.
+///
+/// It is shared via `Rc` between the `SimplifyEnvironment` and active `ProvisionGuard`
+/// instances, enabling RAII cleanup of provisional mappings when guards go out of scope.
+///
+/// ## Implementation Details: `RefCell` Usage
+///
+/// The `forward` and `reverse` maps are wrapped in `RefCell` for the following reasons:
+///
+/// 1. **Shared Ownership (`Rc`)**: The `Provision` struct itself is wrapped in an `Rc`. This allows
+///    shared ownership between the `SimplifyEnvironment` and multiple active `ProvisionGuard`
+///    instances.
+///
+/// 2. **Interior Mutability for Guards**: `ProvisionGuard` instances need to modify the `forward`
+///    and `reverse` maps within their `Drop` implementation for RAII cleanup (removing the
+///    provisional mappings they created). Since the `Provision` data is shared via `Rc`, direct
+///    mutable borrowing (`&mut`) isn't possible from the guards. `RefCell` provides the necessary
+///    interior mutability, allowing `borrow_mut()` within the guard's `drop` method (specifically,
+///    in `Provision::exit`).
+///
+/// 3. **Enabling Mutation via Shared Reference (`Rc`)**: The core challenge is that
+///    `ProvisionGuard` needs to mutate the `Provision` state during `drop`, but it only holds an
+///    `Rc<Provision>` (a shared reference). `RefCell` provides the mechanism (`borrow_mut()`) to
+///    achieve this *interior mutability*. The safety of these mutations, and reads like
+///    `substitute`, (i.e., preventing conflicting borrows at runtime) is guaranteed because all
+///    operations accessing the `Provision` struct occur through `SimplifyEnvironment` methods that
+///    require `&mut self`. This `&mut self` ensures exclusive access to the `SimplifyEnvironment`
+///    (and thus indirectly to the `Provision` maps) within the single thread at any given time.
+///
+/// 4. **Single-Threaded Context**: This approach relies on the assumption of a single-threaded
+///    execution environment (consistent with `Heap` not being thread-safe). `RefCell` is suitable
+///    here; a `Mutex` would be unnecessary overhead and incorrect as it implies thread safety which
+///    isn't present.
+///
+/// **In Summary**: `RefCell` is used here primarily because `Provision` is shared via `Rc`. It
+/// provides the necessary *interior mutability* for `ProvisionGuard`'s RAII cleanup
+/// (`Drop` impl) to modify the shared state through the `Rc`. The exclusive `&mut self`
+/// required by the public methods of `SimplifyEnvironment` that interact with `Provision`
+/// guarantees that there are no concurrent accesses within the same thread, making the use
+/// of `RefCell` safe without needing a `Mutex`.
+#[derive(Debug)]
+pub(crate) struct ProvisionedScope<T> {
+    forward: RefCell<FastHashMap<T, Provisioned<T>>>,
+    reverse: RefCell<FastHashMap<Provisioned<T>, T>>,
+}
+
+impl<T> ProvisionedScope<T>
+where
+    T: Id,
+{
+    pub(crate) fn enter(self: Rc<Self>, id: T, provisioned: Provisioned<T>) -> ProvisionedGuard<T> {
+        let previous = { self.forward.borrow_mut().insert(id, provisioned) };
+
+        self.reverse.borrow_mut().insert(provisioned, id);
+
+        ProvisionedGuard {
+            inner: Rc::clone(&self),
+            id,
+            provisioned,
+            previous,
+        }
+    }
+
+    fn exit(&self, guard: &ProvisionedGuard<T>) {
+        if let Some(previous) = guard.previous {
+            self.forward.borrow_mut().insert(guard.id, previous);
+        } else {
+            self.forward.borrow_mut().remove(&guard.id);
+        }
+
+        self.reverse.borrow_mut().remove(&guard.provisioned);
+    }
+
+    pub(crate) fn get_substitution(&self, id: T) -> Option<T> {
+        self.forward
+            .borrow()
+            .get(&id)
+            .map(|provisioned| provisioned.value())
+    }
+
+    pub(crate) fn get_source(&self, id: T) -> Option<T> {
+        self.reverse.borrow().get(&id).copied()
+    }
+}
+
+impl<T> Default for ProvisionedScope<T> {
+    fn default() -> Self {
+        Self {
+            forward: RefCell::default(),
+            reverse: RefCell::default(),
+        }
+    }
+}

--- a/libs/@local/hashql/core/src/type/environment/context/replace.rs
+++ b/libs/@local/hashql/core/src/type/environment/context/replace.rs
@@ -1,0 +1,73 @@
+use alloc::rc::Rc;
+use core::{cell::RefCell, hash::Hash};
+
+use crate::collection::FastHashMap;
+
+pub struct ReplacementGuard<T: Copy + Eq + Hash> {
+    inner: Rc<ReplacementScope<T>>,
+
+    items: Vec<(T, Option<T>)>,
+}
+
+impl<T> Drop for ReplacementGuard<T>
+where
+    T: Copy + Eq + Hash,
+{
+    fn drop(&mut self) {
+        self.inner.exit(&mut self.items);
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ReplacementScope<T> {
+    // For the motivation of using RefCell, please refer to the documentation on
+    // `ProvisionedScope`.
+    lookup: RefCell<FastHashMap<T, T>>,
+}
+
+impl<T> ReplacementScope<T>
+where
+    T: Copy + Eq + Hash,
+{
+    pub(crate) fn enter_many(self: Rc<Self>, items: Vec<(T, T)>) -> ReplacementGuard<T> {
+        let mut lookup = self.lookup.borrow_mut();
+        let items = items
+            .into_iter()
+            .map(|(original, replacement)| {
+                let previous = lookup.insert(original, replacement);
+                (original, previous)
+            })
+            .collect();
+        drop(lookup);
+
+        ReplacementGuard { inner: self, items }
+    }
+
+    pub(crate) fn exit(&self, items: &mut Vec<(T, Option<T>)>) {
+        if items.is_empty() {
+            return;
+        }
+
+        let mut lookup = self.lookup.borrow_mut();
+
+        for (original, previous) in items.drain(..) {
+            if let Some(previous) = previous {
+                lookup.insert(original, previous);
+            } else {
+                lookup.remove(&original);
+            }
+        }
+    }
+
+    pub(crate) fn lookup(&self, id: T) -> Option<T> {
+        self.lookup.borrow().get(&id).copied()
+    }
+}
+
+impl<T> Default for ReplacementScope<T> {
+    fn default() -> Self {
+        Self {
+            lookup: RefCell::default(),
+        }
+    }
+}

--- a/libs/@local/hashql/core/src/type/environment/infer.rs
+++ b/libs/@local/hashql/core/src/type/environment/infer.rs
@@ -10,6 +10,7 @@ use crate::r#type::{
     recursion::RecursionBoundary,
 };
 
+#[derive(Debug)]
 pub struct InferenceEnvironment<'env, 'heap> {
     pub environment: &'env Environment<'heap>,
     boundary: RecursionBoundary,

--- a/libs/@local/hashql/core/src/type/environment/instantiate.rs
+++ b/libs/@local/hashql/core/src/type/environment/instantiate.rs
@@ -1,0 +1,157 @@
+use alloc::rc::Rc;
+use core::ops::Deref;
+
+use smallvec::SmallVec;
+
+use super::{
+    Diagnostics, Environment,
+    context::{
+        provision::{ProvisionedGuard, ProvisionedScope},
+        replace::{ReplacementGuard, ReplacementScope},
+    },
+};
+use crate::{
+    intern::Provisioned,
+    r#type::{
+        PartialType, TypeId,
+        error::TypeCheckDiagnostic,
+        inference::Inference as _,
+        kind::generic_argument::{GenericArgument, GenericArgumentId, GenericArguments},
+        recursion::RecursionBoundary,
+    },
+};
+
+// This was moved out of the `InferenceEnvironment`, as the requirements (especially provision
+// scoping) are too different and there's nearly 0 overlap.
+#[derive(Debug)]
+pub struct InstantiateEnvironment<'env, 'heap> {
+    pub environment: &'env Environment<'heap>,
+    boundary: RecursionBoundary,
+    diagnostics: Diagnostics,
+
+    argument_scope: Rc<ReplacementScope<GenericArgumentId>>,
+
+    provisioned: Rc<ProvisionedScope<TypeId>>,
+}
+
+impl<'env, 'heap> InstantiateEnvironment<'env, 'heap> {
+    pub fn new(environment: &'env Environment<'heap>) -> Self {
+        Self {
+            environment,
+            boundary: RecursionBoundary::new(),
+            diagnostics: Diagnostics::default(),
+
+            argument_scope: Rc::default(),
+
+            provisioned: Rc::default(),
+        }
+    }
+
+    #[inline]
+    pub fn take_diagnostics(&mut self) -> Diagnostics {
+        core::mem::take(&mut self.diagnostics)
+    }
+
+    #[inline]
+    pub fn record_diagnostic(&mut self, diagnostic: TypeCheckDiagnostic) {
+        self.diagnostics.push(diagnostic);
+    }
+
+    #[expect(
+        clippy::needless_pass_by_ref_mut,
+        reason = "prove ownership of environment, so that we can borrow safely"
+    )]
+    pub fn instantiate_arguments(
+        &mut self,
+        arguments: GenericArguments<'heap>,
+    ) -> (ReplacementGuard<GenericArgumentId>, GenericArguments<'heap>) {
+        let mut replacements = SmallVec::<_, 16>::with_capacity(arguments.len());
+        let mut mapping = Vec::with_capacity(arguments.len());
+
+        for generic in &*arguments {
+            let id = self.environment.counter.generic_argument.next();
+            mapping.push((generic.id, id));
+
+            replacements.push(GenericArgument {
+                id,
+                name: generic.name,
+                constraint: generic.constraint,
+            });
+        }
+
+        let arguments = self.environment.intern_generic_arguments(&mut replacements);
+
+        let scope = Rc::clone(&self.argument_scope);
+        let guard = scope.enter_many(mapping);
+
+        (guard, arguments)
+    }
+
+    /// Instantiates a type.
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug mode if a type should have been provisioned but wasn't.
+    pub fn instantiate(&mut self, id: TypeId) -> TypeId {
+        if !self.boundary.enter(id, id) {
+            // See if the type has been substituted
+            if let Some(substitution) = self.provisioned.get_substitution(id) {
+                return substitution;
+            }
+
+            #[expect(
+                clippy::manual_assert,
+                reason = "false positive, this is a manual `debug_panic`"
+            )]
+            if cfg!(debug_assertions) {
+                panic!("type id {id} should have been provisioned, but wasn't");
+            }
+
+            // in debug builds this panics if the type should have been provisioned but wasn't, as
+            // we can recover from this error (we simply return the original - uninstantiated - type
+            // id) we do not need to panic here in release builds.
+            return id;
+        }
+
+        let r#type = self.environment.r#type(id);
+        let result = r#type.instantiate(self);
+
+        self.boundary.exit(id, id);
+        result
+    }
+
+    #[expect(
+        clippy::needless_pass_by_ref_mut,
+        reason = "prove ownership of environment, so that we can borrow safely"
+    )]
+    pub fn provision(&mut self, id: TypeId) -> (ProvisionedGuard<TypeId>, Provisioned<TypeId>) {
+        let provisioned = self.environment.types.provision();
+        let guard = Rc::clone(&self.provisioned).enter(id, provisioned);
+
+        (guard, provisioned)
+    }
+
+    #[must_use]
+    pub fn intern_provisioned(
+        &self,
+        id: Provisioned<TypeId>,
+        r#type: PartialType<'heap>,
+    ) -> TypeId {
+        self.environment.types.intern_provisioned(id, r#type).id
+    }
+
+    #[must_use]
+    pub fn lookup_argument(&self, argument: GenericArgumentId) -> Option<GenericArgumentId> {
+        self.argument_scope.lookup(argument)
+    }
+}
+
+// We usually try to avoid `Deref` and `DerefMut`, but it makes sense in this case.
+// As the unification environment is just a wrapper around the environment with an additional guard.
+impl<'heap> Deref for InstantiateEnvironment<'_, 'heap> {
+    type Target = Environment<'heap>;
+
+    fn deref(&self) -> &Self::Target {
+        self.environment
+    }
+}

--- a/libs/@local/hashql/core/src/type/environment/lattice.rs
+++ b/libs/@local/hashql/core/src/type/environment/lattice.rs
@@ -150,7 +150,12 @@ impl<'env, 'heap> LatticeEnvironment<'env, 'heap> {
         let lhs = self.environment.r#type(lhs);
         let rhs = self.environment.r#type(rhs);
 
-        if let ControlFlow::Break(cycle) = self.boundary.enter(lhs, rhs) {
+        if self.boundary.enter(lhs, rhs).is_break() {
+            let cycle = RecursionCycle {
+                lhs: self.is_recursive(lhs.id),
+                rhs: self.is_recursive(rhs.id),
+            };
+
             return self.join_recursive(lhs, rhs, cycle);
         }
 
@@ -255,7 +260,12 @@ impl<'env, 'heap> LatticeEnvironment<'env, 'heap> {
         let lhs = self.environment.r#type(lhs);
         let rhs = self.environment.r#type(rhs);
 
-        if let ControlFlow::Break(cycle) = self.boundary.enter(lhs, rhs) {
+        if self.boundary.enter(lhs, rhs).is_break() {
+            let cycle = RecursionCycle {
+                lhs: self.is_recursive(lhs.id),
+                rhs: self.is_recursive(rhs.id),
+            };
+
             return self.meet_recursive(lhs, rhs, cycle);
         }
 
@@ -323,6 +333,11 @@ impl<'env, 'heap> LatticeEnvironment<'env, 'heap> {
     #[inline]
     pub fn is_concrete(&mut self, id: TypeId) -> bool {
         self.simplify.is_concrete(id)
+    }
+
+    #[inline]
+    pub fn is_recursive(&mut self, id: TypeId) -> bool {
+        self.simplify.is_recursive(id)
     }
 
     #[inline]

--- a/libs/@local/hashql/core/src/type/environment/lattice.rs
+++ b/libs/@local/hashql/core/src/type/environment/lattice.rs
@@ -12,6 +12,7 @@ use crate::r#type::{
     recursion::RecursionBoundary,
 };
 
+#[derive(Debug)]
 pub struct LatticeEnvironment<'env, 'heap> {
     pub environment: &'env Environment<'heap>,
     boundary: RecursionBoundary,

--- a/libs/@local/hashql/core/src/type/environment/lattice.rs
+++ b/libs/@local/hashql/core/src/type/environment/lattice.rs
@@ -1,4 +1,4 @@
-use core::ops::{ControlFlow, Deref};
+use core::ops::Deref;
 
 use smallvec::SmallVec;
 

--- a/libs/@local/hashql/core/src/type/environment/mod.rs
+++ b/libs/@local/hashql/core/src/type/environment/mod.rs
@@ -1,6 +1,7 @@
 pub mod analysis;
 pub mod context;
 pub mod infer;
+pub mod instantiate;
 pub mod lattice;
 pub mod simplify;
 
@@ -19,7 +20,7 @@ use super::{
         generic_argument::{
             GenericArgument, GenericArgumentId, GenericArgumentIdProducer, GenericArguments,
         },
-        infer::HoleId,
+        infer::{HoleId, HoleIdProducer},
         r#struct::{StructField, StructFields},
     },
 };
@@ -29,9 +30,10 @@ use crate::{
     span::SpanId,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Counter {
     pub generic_argument: GenericArgumentIdProducer,
+    pub hole: HoleIdProducer,
 }
 
 #[derive(Debug)]
@@ -72,9 +74,7 @@ impl<'heap> Environment<'heap> {
             generic_arguments: InternSet::new(heap),
             struct_fields: InternSet::new(heap),
 
-            counter: Counter {
-                generic_argument: GenericArgumentIdProducer::new(),
-            },
+            counter: Counter::default(),
             substitution: Substitution::default(),
         }
     }

--- a/libs/@local/hashql/core/src/type/environment/simplify.rs
+++ b/libs/@local/hashql/core/src/type/environment/simplify.rs
@@ -141,6 +141,15 @@ impl<'env, 'heap> SimplifyEnvironment<'env, 'heap> {
     }
 
     #[inline]
+    pub fn is_recursive(&mut self, mut id: TypeId) -> bool {
+        if let Some(previous) = self.provisioned.get_source(id) {
+            id = previous;
+        }
+
+        self.analysis.is_recursive(id)
+    }
+
+    #[inline]
     pub fn distribute_union(&mut self, mut id: TypeId) -> SmallVec<TypeId, 16> {
         if let Some(previous) = self.provisioned.get_source(id) {
             id = previous;

--- a/libs/@local/hashql/core/src/type/environment/simplify.rs
+++ b/libs/@local/hashql/core/src/type/environment/simplify.rs
@@ -1,11 +1,13 @@
 use alloc::rc::Rc;
-use core::{cell::RefCell, ops::Deref};
+use core::ops::Deref;
 
 use smallvec::SmallVec;
 
-use super::{AnalysisEnvironment, Diagnostics, Environment};
+use super::{
+    AnalysisEnvironment, Diagnostics, Environment,
+    context::provision::{ProvisionedGuard, ProvisionedScope},
+};
 use crate::{
-    collection::FastHashMap,
     intern::Provisioned,
     r#type::{
         PartialType, Type, TypeId,
@@ -15,76 +17,12 @@ use crate::{
     },
 };
 
-pub struct ProvisionGuard {
-    inner: Rc<Provision>,
-
-    id: TypeId,
-    provisioned: Provisioned<TypeId>,
-    previous: Option<Provisioned<TypeId>>,
-}
-
-impl Drop for ProvisionGuard {
-    fn drop(&mut self) {
-        self.inner.exit(self);
-    }
-}
-
-#[derive(Debug, Default)]
-struct Provision {
-    // We use `RefCell` here, as we make use of a guard, in a truly concurrent environment (which
-    // this isn't due to the fact that `Heap` is not thread-safe) `RefCell` would be insufficient.
-    // RefCell is sufficient here, because we take a `&mut self` for the simplify environment,
-    // therefore we always have mutable (and exclusive) access to the environment, the `RefCell` is
-    // only used, so that we can properly cleanup on Drop, as the client is unable to access
-    // anything in the simplify environment (especially the provisioned map) by itself. The
-    // only places that interact with the provisioned map are the `provision` function and the
-    // `simplify` function, for short periods of time, and never over longer than a single
-    // expression.
-    forward: RefCell<FastHashMap<TypeId, Provisioned<TypeId>>>,
-    reverse: RefCell<FastHashMap<TypeId, TypeId>>,
-}
-
-impl Provision {
-    fn enter(self: Rc<Self>, id: TypeId, provisioned: Provisioned<TypeId>) -> ProvisionGuard {
-        let previous = { self.forward.borrow_mut().insert(id, provisioned) };
-
-        self.reverse.borrow_mut().insert(provisioned.value(), id);
-
-        ProvisionGuard {
-            inner: Rc::clone(&self),
-            id,
-            provisioned,
-            previous,
-        }
-    }
-
-    fn exit(&self, guard: &ProvisionGuard) {
-        if let Some(previous) = guard.previous {
-            self.forward.borrow_mut().insert(guard.id, previous);
-        } else {
-            self.forward.borrow_mut().remove(&guard.id);
-        }
-
-        self.reverse.borrow_mut().remove(&guard.provisioned.value());
-    }
-
-    fn substitute(&self, id: TypeId) -> Option<TypeId> {
-        self.forward
-            .borrow()
-            .get(&id)
-            .map(|provisioned| provisioned.value())
-    }
-
-    fn substitution_of(&self, id: TypeId) -> Option<TypeId> {
-        self.reverse.borrow().get(&id).copied()
-    }
-}
-
+#[derive(Debug)]
 pub struct SimplifyEnvironment<'env, 'heap> {
     pub environment: &'env Environment<'heap>,
     boundary: RecursionBoundary,
 
-    provisioned: Rc<Provision>,
+    provisioned: Rc<ProvisionedScope<TypeId>>,
 
     analysis: AnalysisEnvironment<'env, 'heap>,
 }
@@ -136,11 +74,11 @@ impl<'env, 'heap> SimplifyEnvironment<'env, 'heap> {
 
     #[inline]
     pub fn is_equivalent(&mut self, mut lhs: TypeId, mut rhs: TypeId) -> bool {
-        if let Some(previous) = self.provisioned.substitution_of(lhs) {
+        if let Some(previous) = self.provisioned.get_source(lhs) {
             lhs = previous;
         }
 
-        if let Some(previous) = self.provisioned.substitution_of(rhs) {
+        if let Some(previous) = self.provisioned.get_source(rhs) {
             rhs = previous;
         }
 
@@ -149,11 +87,11 @@ impl<'env, 'heap> SimplifyEnvironment<'env, 'heap> {
 
     #[inline]
     pub fn is_subtype_of(&mut self, mut subtype: TypeId, mut supertype: TypeId) -> bool {
-        if let Some(previous) = self.provisioned.substitution_of(subtype) {
+        if let Some(previous) = self.provisioned.get_source(subtype) {
             subtype = previous;
         }
 
-        if let Some(previous) = self.provisioned.substitution_of(supertype) {
+        if let Some(previous) = self.provisioned.get_source(supertype) {
             supertype = previous;
         }
 
@@ -164,11 +102,11 @@ impl<'env, 'heap> SimplifyEnvironment<'env, 'heap> {
     // This means they share no common values and their intersection is empty
     #[inline]
     pub fn is_disjoint(&mut self, mut lhs: TypeId, mut rhs: TypeId) -> bool {
-        if let Some(previous) = self.provisioned.substitution_of(lhs) {
+        if let Some(previous) = self.provisioned.get_source(lhs) {
             lhs = previous;
         }
 
-        if let Some(previous) = self.provisioned.substitution_of(rhs) {
+        if let Some(previous) = self.provisioned.get_source(rhs) {
             rhs = previous;
         }
 
@@ -177,7 +115,7 @@ impl<'env, 'heap> SimplifyEnvironment<'env, 'heap> {
 
     #[inline]
     pub fn is_bottom(&mut self, mut id: TypeId) -> bool {
-        if let Some(previous) = self.provisioned.substitution_of(id) {
+        if let Some(previous) = self.provisioned.get_source(id) {
             id = previous;
         }
 
@@ -186,7 +124,7 @@ impl<'env, 'heap> SimplifyEnvironment<'env, 'heap> {
 
     #[inline]
     pub fn is_top(&mut self, mut id: TypeId) -> bool {
-        if let Some(previous) = self.provisioned.substitution_of(id) {
+        if let Some(previous) = self.provisioned.get_source(id) {
             id = previous;
         }
 
@@ -195,7 +133,7 @@ impl<'env, 'heap> SimplifyEnvironment<'env, 'heap> {
 
     #[inline]
     pub fn is_concrete(&mut self, mut id: TypeId) -> bool {
-        if let Some(previous) = self.provisioned.substitution_of(id) {
+        if let Some(previous) = self.provisioned.get_source(id) {
             id = previous;
         }
 
@@ -204,7 +142,7 @@ impl<'env, 'heap> SimplifyEnvironment<'env, 'heap> {
 
     #[inline]
     pub fn distribute_union(&mut self, mut id: TypeId) -> SmallVec<TypeId, 16> {
-        if let Some(previous) = self.provisioned.substitution_of(id) {
+        if let Some(previous) = self.provisioned.get_source(id) {
             id = previous;
         }
 
@@ -213,7 +151,7 @@ impl<'env, 'heap> SimplifyEnvironment<'env, 'heap> {
 
     #[inline]
     pub fn distribute_intersection(&mut self, mut id: TypeId) -> SmallVec<TypeId, 16> {
-        if let Some(previous) = self.provisioned.substitution_of(id) {
+        if let Some(previous) = self.provisioned.get_source(id) {
             id = previous;
         }
 
@@ -228,7 +166,7 @@ impl<'env, 'heap> SimplifyEnvironment<'env, 'heap> {
     pub fn simplify(&mut self, id: TypeId) -> TypeId {
         if !self.boundary.enter(id, id) {
             // See if the type has been substituted
-            if let Some(substitution) = self.provisioned.substitute(id) {
+            if let Some(substitution) = self.provisioned.get_substitution(id) {
                 return substitution;
             }
 
@@ -257,7 +195,7 @@ impl<'env, 'heap> SimplifyEnvironment<'env, 'heap> {
         clippy::needless_pass_by_ref_mut,
         reason = "prove ownership of environment, so that we can borrow safely"
     )]
-    pub fn provision(&mut self, id: TypeId) -> (ProvisionGuard, Provisioned<TypeId>) {
+    pub fn provision(&mut self, id: TypeId) -> (ProvisionedGuard<TypeId>, Provisioned<TypeId>) {
         let provisioned = self.environment.types.provision();
         let guard = Rc::clone(&self.provisioned).enter(id, provisioned);
 

--- a/libs/@local/hashql/core/src/type/inference/mod.rs
+++ b/libs/@local/hashql/core/src/type/inference/mod.rs
@@ -8,7 +8,7 @@ pub use self::{
 };
 use super::{
     Type, TypeId,
-    environment::{AnalysisEnvironment, InferenceEnvironment},
+    environment::{InferenceEnvironment, instantiate::InstantiateEnvironment},
     kind::{generic_argument::GenericArgumentId, infer::HoleId},
 };
 use crate::collection::FastHashMap;
@@ -171,5 +171,5 @@ pub trait Inference<'heap> {
     /// # Returns
     ///
     /// A new type ID representing the instantiated type.
-    fn instantiate(self: Type<'heap, Self>, env: &mut AnalysisEnvironment<'_, 'heap>) -> TypeId;
+    fn instantiate(self: Type<'heap, Self>, env: &mut InstantiateEnvironment<'_, 'heap>) -> TypeId;
 }

--- a/libs/@local/hashql/core/src/type/inference/solver/mod.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/mod.rs
@@ -36,6 +36,7 @@ use crate::{
 /// - Maintaining a mapping between variable kinds and their internal IDs
 /// - Unifying variables when they are determined to be equivalent
 /// - Finding the canonical representative for each variable
+#[derive(Debug)]
 pub(crate) struct Unification {
     /// The underlying union-find data structure that tracks variable equivalence classes
     table: InPlaceUnificationTable<VariableId>,

--- a/libs/@local/hashql/core/src/type/kind/closure.rs
+++ b/libs/@local/hashql/core/src/type/kind/closure.rs
@@ -120,6 +120,14 @@ impl<'heap> Lattice<'heap> for ClosureType<'heap> {
             && env.is_concrete(self.kind.returns)
     }
 
+    fn is_recursive(self: Type<'heap, Self>, env: &mut AnalysisEnvironment<'_, 'heap>) -> bool {
+        self.kind
+            .params
+            .iter()
+            .any(|&param| env.is_recursive(param))
+            || env.is_recursive(self.kind.returns)
+    }
+
     fn distribute_union(
         self: Type<'heap, Self>,
         _: &mut AnalysisEnvironment<'_, 'heap>,

--- a/libs/@local/hashql/core/src/type/kind/closure.rs
+++ b/libs/@local/hashql/core/src/type/kind/closure.rs
@@ -1305,10 +1305,16 @@ mod test {
         let constraints = inference_env.take_constraints();
         assert_eq!(
             constraints,
-            [Constraint::Ordering {
-                lower: Variable::synthetic(VariableKind::Generic(arg2)),
-                upper: Variable::synthetic(VariableKind::Generic(arg1)),
-            }]
+            [
+                Constraint::Ordering {
+                    lower: Variable::synthetic(VariableKind::Generic(arg2)),
+                    upper: Variable::synthetic(VariableKind::Generic(arg1)),
+                },
+                Constraint::Ordering {
+                    lower: Variable::synthetic(VariableKind::Generic(arg1)),
+                    upper: Variable::synthetic(VariableKind::Generic(arg2)),
+                }
+            ]
         );
     }
 

--- a/libs/@local/hashql/core/src/type/kind/infer.rs
+++ b/libs/@local/hashql/core/src/type/kind/infer.rs
@@ -1,8 +1,10 @@
-use crate::newtype;
+use crate::{newtype, newtype_producer};
 
 newtype!(
     pub struct HoleId(u32 is 0..=0xFFFF_FF00)
 );
+
+newtype_producer!(pub struct HoleIdProducer(HoleId));
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Infer {

--- a/libs/@local/hashql/core/src/type/kind/intersection.rs
+++ b/libs/@local/hashql/core/src/type/kind/intersection.rs
@@ -13,7 +13,7 @@ use crate::{
         collection::TypeIdSet,
         environment::{
             AnalysisEnvironment, Environment, InferenceEnvironment, LatticeEnvironment,
-            SimplifyEnvironment,
+            SimplifyEnvironment, instantiate::InstantiateEnvironment,
         },
         error::{cannot_be_supertype_of_unknown, intersection_variant_mismatch, type_mismatch},
         inference::Inference,
@@ -511,8 +511,28 @@ impl<'heap> Inference<'heap> for IntersectionType<'heap> {
         }
     }
 
-    fn instantiate(self: Type<'heap, Self>, _: &mut AnalysisEnvironment<'_, 'heap>) -> TypeId {
-        todo!("https://linear.app/hash/issue/H-4384/hashql-type-instantiation")
+    // TODO: test
+    fn instantiate(self: Type<'heap, Self>, env: &mut InstantiateEnvironment<'_, 'heap>) -> TypeId {
+        let (_provision_guard, id) = env.provision(self.id);
+
+        let mut variants =
+            TypeIdSet::<16>::with_capacity(env.environment, self.kind.variants.len());
+
+        for &variant in self.kind.variants {
+            variants.push(env.instantiate(variant));
+        }
+
+        let variants = variants.finish();
+
+        env.intern_provisioned(
+            id,
+            PartialType {
+                span: self.span,
+                kind: env.intern_kind(TypeKind::Intersection(Self {
+                    variants: env.intern_type_ids(&variants),
+                })),
+            },
+        )
     }
 }
 

--- a/libs/@local/hashql/core/src/type/kind/intersection.rs
+++ b/libs/@local/hashql/core/src/type/kind/intersection.rs
@@ -345,6 +345,10 @@ impl<'heap> Lattice<'heap> for IntersectionType<'heap> {
         self.kind.variants.iter().all(|&id| env.is_concrete(id))
     }
 
+    fn is_recursive(self: Type<'heap, Self>, env: &mut AnalysisEnvironment<'_, 'heap>) -> bool {
+        self.kind.variants.iter().any(|&id| env.is_recursive(id))
+    }
+
     fn distribute_union(
         self: Type<'heap, Self>,
         _: &mut AnalysisEnvironment<'_, 'heap>,

--- a/libs/@local/hashql/core/src/type/kind/intersection.rs
+++ b/libs/@local/hashql/core/src/type/kind/intersection.rs
@@ -511,7 +511,6 @@ impl<'heap> Inference<'heap> for IntersectionType<'heap> {
         }
     }
 
-    // TODO: test
     fn instantiate(self: Type<'heap, Self>, env: &mut InstantiateEnvironment<'_, 'heap>) -> TypeId {
         let (_provision_guard, id) = env.provision(self.id);
 
@@ -573,19 +572,20 @@ mod test {
             PartialType,
             environment::{
                 AnalysisEnvironment, Environment, InferenceEnvironment, LatticeEnvironment,
-                SimplifyEnvironment,
+                SimplifyEnvironment, instantiate::InstantiateEnvironment,
             },
             inference::{
                 Constraint, Inference as _, PartialStructuralEdge, Variable, VariableKind,
             },
             kind::{
-                TypeKind,
-                generic_argument::GenericArgumentId,
+                OpaqueType, Param, TypeKind,
+                generic_argument::{GenericArgument, GenericArgumentId},
                 infer::HoleId,
                 intrinsic::{DictType, IntrinsicType},
                 primitive::PrimitiveType,
                 test::{
-                    assert_equiv, assert_sorted_eq, dict, intersection, primitive, tuple, union,
+                    assert_equiv, assert_sorted_eq, dict, intersection, opaque, primitive, tuple,
+                    union,
                 },
                 tuple::TupleType,
                 union::UnionType,
@@ -2044,5 +2044,57 @@ mod test {
             TypeKind::Intersection(IntersectionType { variants }) if variants.len() == 1
                 && variants[0] == type_id
         );
+    }
+
+    #[test]
+    fn instantiate_intersection() {
+        let heap = Heap::new();
+        let env = Environment::new(SpanId::SYNTHETIC, &heap);
+
+        let argument = env.counter.generic_argument.next();
+        let param = instantiate_param(&env, argument);
+
+        let inner = opaque!(
+            env,
+            "A",
+            param,
+            [GenericArgument {
+                id: argument,
+                name: heap.intern_symbol("T"),
+                constraint: None
+            }]
+        );
+
+        intersection!(env, value, [inner, inner]);
+
+        let mut instantiate = InstantiateEnvironment::new(&env);
+        let type_id = value.instantiate(&mut instantiate);
+        assert!(instantiate.take_diagnostics().is_empty());
+
+        let result = env.r#type(type_id);
+        let intersection = result
+            .kind
+            .intersection()
+            .expect("should be an intersection");
+        assert_eq!(intersection.variants.len(), 2);
+
+        for variant in &*intersection.variants {
+            let variant = env.r#type(*variant);
+            let opaque = variant.kind.opaque().expect("should be an opaque type");
+            let repr = env
+                .r#type(opaque.repr)
+                .kind
+                .param()
+                .expect("should be a param");
+
+            assert_eq!(opaque.arguments.len(), 1);
+            assert_eq!(
+                *repr,
+                Param {
+                    argument: opaque.arguments[0].id
+                }
+            );
+            assert_ne!(repr.argument, argument);
+        }
     }
 }

--- a/libs/@local/hashql/core/src/type/kind/intrinsic.rs
+++ b/libs/@local/hashql/core/src/type/kind/intrinsic.rs
@@ -65,6 +65,10 @@ impl<'heap> Lattice<'heap> for ListType {
         env.is_concrete(self.kind.element)
     }
 
+    fn is_recursive(self: Type<'heap, Self>, env: &mut AnalysisEnvironment<'_, 'heap>) -> bool {
+        env.is_recursive(self.kind.element)
+    }
+
     fn distribute_union(
         self: Type<'heap, Self>,
         env: &mut AnalysisEnvironment<'_, 'heap>,
@@ -337,6 +341,10 @@ impl<'heap> Lattice<'heap> for DictType {
         env.is_concrete(self.kind.key) && env.is_concrete(self.kind.value)
     }
 
+    fn is_recursive(self: Type<'heap, Self>, env: &mut AnalysisEnvironment<'_, 'heap>) -> bool {
+        env.is_recursive(self.kind.key) || env.is_recursive(self.kind.value)
+    }
+
     fn distribute_union(
         self: Type<'heap, Self>,
         env: &mut AnalysisEnvironment<'_, 'heap>,
@@ -584,6 +592,13 @@ impl<'heap> Lattice<'heap> for IntrinsicType {
         match self.kind {
             Self::List(inner) => self.with(inner).is_concrete(env),
             Self::Dict(inner) => self.with(inner).is_concrete(env),
+        }
+    }
+
+    fn is_recursive(self: Type<'heap, Self>, env: &mut AnalysisEnvironment<'_, 'heap>) -> bool {
+        match self.kind {
+            Self::List(inner) => self.with(inner).is_recursive(env),
+            Self::Dict(inner) => self.with(inner).is_recursive(env),
         }
     }
 

--- a/libs/@local/hashql/core/src/type/kind/intrinsic.rs
+++ b/libs/@local/hashql/core/src/type/kind/intrinsic.rs
@@ -448,7 +448,6 @@ impl<'heap> Inference<'heap> for DictType {
         env.in_covariant(|env| env.collect_structural_edges(self.kind.value, variable));
     }
 
-    // TODO: test
     fn instantiate(self: Type<'heap, Self>, env: &mut InstantiateEnvironment<'_, 'heap>) -> TypeId {
         let (_provision_guard, id) = env.provision(self.id);
 
@@ -725,22 +724,23 @@ mod tests {
             PartialType,
             environment::{
                 AnalysisEnvironment, Environment, InferenceEnvironment, LatticeEnvironment,
-                SimplifyEnvironment,
+                SimplifyEnvironment, instantiate::InstantiateEnvironment,
             },
             inference::{
                 Constraint, Inference as _, PartialStructuralEdge, Variable, VariableKind,
             },
             kind::{
-                TypeKind,
+                OpaqueType, Param, TypeKind,
+                generic_argument::GenericArgument,
                 infer::HoleId,
                 intersection::IntersectionType,
                 primitive::PrimitiveType,
-                test::{assert_equiv, dict, intersection, list, primitive, union},
+                test::{assert_equiv, dict, intersection, list, opaque, primitive, union},
                 union::UnionType,
             },
             lattice::{Lattice as _, test::assert_lattice_laws},
             pretty_print::PrettyPrint as _,
-            test::{instantiate, instantiate_infer},
+            test::{instantiate, instantiate_infer, instantiate_param},
         },
     };
 
@@ -2129,5 +2129,113 @@ mod tests {
             r#type.kind,
             TypeKind::Intrinsic(IntrinsicType::Dict(DictType { key, value })) if *key == type_id && *value == type_id
         );
+    }
+
+    #[test]
+    fn instantiate_list() {
+        let heap = Heap::new();
+        let env = Environment::new(SpanId::SYNTHETIC, &heap);
+
+        let argument = env.counter.generic_argument.next();
+        let param = instantiate_param(&env, argument);
+
+        opaque!(
+            env,
+            value,
+            "A",
+            list!(env, param),
+            [GenericArgument {
+                id: argument,
+                name: heap.intern_symbol("T"),
+                constraint: None
+            }]
+        );
+
+        let mut instantiate = InstantiateEnvironment::new(&env);
+        let type_id = value.instantiate(&mut instantiate);
+        assert!(instantiate.take_diagnostics().is_empty());
+
+        let result = env.r#type(type_id);
+        let opaque = result.kind.opaque().expect("should be an opaque type");
+        let element = env
+            .r#type(opaque.repr)
+            .kind
+            .intrinsic()
+            .expect("should be an intrinsic type")
+            .list()
+            .expect("should be a list")
+            .element;
+        let element = env.r#type(element).kind.param().expect("should be a param");
+
+        assert_eq!(opaque.arguments.len(), 1);
+        assert_eq!(
+            *element,
+            Param {
+                argument: opaque.arguments[0].id
+            }
+        );
+        assert_ne!(element.argument, argument);
+    }
+
+    #[test]
+    fn instantiate_dict() {
+        let heap = Heap::new();
+        let env = Environment::new(SpanId::SYNTHETIC, &heap);
+
+        let argument = env.counter.generic_argument.next();
+        let param = instantiate_param(&env, argument);
+
+        opaque!(
+            env,
+            value,
+            "A",
+            dict!(env, param, param),
+            [GenericArgument {
+                id: argument,
+                name: heap.intern_symbol("T"),
+                constraint: None
+            }]
+        );
+
+        let mut instantiate = InstantiateEnvironment::new(&env);
+        let type_id = value.instantiate(&mut instantiate);
+        assert!(instantiate.take_diagnostics().is_empty());
+
+        let result = env.r#type(type_id);
+        let opaque = result.kind.opaque().expect("should be an opaque type");
+        let dict = env
+            .r#type(opaque.repr)
+            .kind
+            .intrinsic()
+            .expect("should be an intrinsic type")
+            .dict()
+            .expect("should be a dict");
+        let key = env
+            .r#type(dict.key)
+            .kind
+            .param()
+            .expect("should be a param");
+        let value = env
+            .r#type(dict.value)
+            .kind
+            .param()
+            .expect("should be a param");
+
+        assert_eq!(opaque.arguments.len(), 1);
+        assert_eq!(
+            *key,
+            Param {
+                argument: opaque.arguments[0].id
+            }
+        );
+        assert_ne!(key.argument, argument);
+
+        assert_eq!(
+            *value,
+            Param {
+                argument: opaque.arguments[0].id
+            }
+        );
+        assert_ne!(value.argument, argument);
     }
 }

--- a/libs/@local/hashql/core/src/type/kind/mod.rs
+++ b/libs/@local/hashql/core/src/type/kind/mod.rs
@@ -308,7 +308,7 @@ impl<'heap> Lattice<'heap> for TypeKind<'heap> {
                 | Self::Closure(_)
                 | Self::Intersection(_),
             ) => {
-                let lhs_variants = lhs.unnest(env);
+                let lhs_variants = lhs.unnest(self.id, self.span, env);
                 let rhs_variants = [other.id];
 
                 UnionType::join_variants(&lhs_variants, &rhs_variants, env)
@@ -324,7 +324,7 @@ impl<'heap> Lattice<'heap> for TypeKind<'heap> {
                 Self::Union(rhs),
             ) => {
                 let lhs_variants = [self.id];
-                let rhs_variants = rhs.unnest(env);
+                let rhs_variants = rhs.unnest(other.id, other.span, env);
 
                 UnionType::join_variants(&lhs_variants, &rhs_variants, env)
             }
@@ -342,7 +342,7 @@ impl<'heap> Lattice<'heap> for TypeKind<'heap> {
                 | Self::Tuple(_)
                 | Self::Closure(_),
             ) => {
-                let lhs_variants = lhs.unnest(env);
+                let lhs_variants = lhs.unnest(self.id, env);
                 let rhs_variants = [other.id];
 
                 IntersectionType::join_variants(self.span, &lhs_variants, &rhs_variants, env)
@@ -357,7 +357,7 @@ impl<'heap> Lattice<'heap> for TypeKind<'heap> {
                 Self::Intersection(rhs),
             ) => {
                 let lhs_variants = [self.id];
-                let rhs_variants = rhs.unnest(env);
+                let rhs_variants = rhs.unnest(other.id, env);
 
                 IntersectionType::join_variants(self.span, &lhs_variants, &rhs_variants, env)
             }
@@ -536,7 +536,7 @@ impl<'heap> Lattice<'heap> for TypeKind<'heap> {
                 | Self::Closure(_)
                 | Self::Intersection(_),
             ) => {
-                let lhs_variants = lhs.unnest(env);
+                let lhs_variants = lhs.unnest(self.id, self.span, env);
                 let rhs_variants = [other.id];
 
                 UnionType::meet_variants(self.span, &lhs_variants, &rhs_variants, env)
@@ -552,7 +552,7 @@ impl<'heap> Lattice<'heap> for TypeKind<'heap> {
                 Self::Union(rhs),
             ) => {
                 let lhs_variants = [self.id];
-                let rhs_variants = rhs.unnest(env);
+                let rhs_variants = rhs.unnest(other.id, other.span, env);
 
                 UnionType::meet_variants(self.span, &lhs_variants, &rhs_variants, env)
             }
@@ -570,7 +570,7 @@ impl<'heap> Lattice<'heap> for TypeKind<'heap> {
                 | Self::Closure(_)
                 | Self::Tuple(_),
             ) => {
-                let lhs_variants = lhs.unnest(env);
+                let lhs_variants = lhs.unnest(self.id, env);
                 let rhs_variants = [other.id];
 
                 IntersectionType::meet_variants(self.span, &lhs_variants, &rhs_variants, env)
@@ -585,7 +585,7 @@ impl<'heap> Lattice<'heap> for TypeKind<'heap> {
                 Self::Intersection(rhs),
             ) => {
                 let lhs_variants = [self.id];
-                let rhs_variants = rhs.unnest(env);
+                let rhs_variants = rhs.unnest(other.id, env);
 
                 IntersectionType::meet_variants(self.span, &lhs_variants, &rhs_variants, env)
             }
@@ -1458,7 +1458,7 @@ impl<'heap> Inference<'heap> for TypeKind<'heap> {
                 | Self::Closure(_)
                 | Self::Intersection(_),
             ) => {
-                let self_variants = lhs.unnest(env);
+                let self_variants = lhs.unnest(self.id, self.span, env);
                 let super_variants = [supertype.id];
 
                 UnionType::collect_constraints_variants(
@@ -1480,7 +1480,7 @@ impl<'heap> Inference<'heap> for TypeKind<'heap> {
                 Self::Union(rhs),
             ) => {
                 let self_variants = [self.id];
-                let super_variants = rhs.unnest(env);
+                let super_variants = rhs.unnest(supertype.id, supertype.span, env);
 
                 UnionType::collect_constraints_variants(
                     supertype.id,
@@ -1504,7 +1504,7 @@ impl<'heap> Inference<'heap> for TypeKind<'heap> {
                 | Self::Tuple(_)
                 | Self::Closure(_),
             ) => {
-                let self_variants = lhs.unnest(env);
+                let self_variants = lhs.unnest(self.id, env);
                 let super_variants = [supertype.id];
 
                 IntersectionType::collect_constraints_variants(
@@ -1525,7 +1525,7 @@ impl<'heap> Inference<'heap> for TypeKind<'heap> {
                 Self::Intersection(rhs),
             ) => {
                 let self_variants = [self.id];
-                let super_variants = rhs.unnest(env);
+                let super_variants = rhs.unnest(supertype.id, env);
 
                 IntersectionType::collect_constraints_variants(
                     self.span,

--- a/libs/@local/hashql/core/src/type/kind/opaque.rs
+++ b/libs/@local/hashql/core/src/type/kind/opaque.rs
@@ -306,7 +306,6 @@ impl<'heap> Inference<'heap> for OpaqueType<'heap> {
         env.in_invariant(|env| env.collect_structural_edges(self.kind.repr, variable));
     }
 
-    // TODO: test
     fn instantiate(self: Type<'heap, Self>, env: &mut InstantiateEnvironment<'_, 'heap>) -> TypeId {
         let (_provision_guard, id) = env.provision(self.id);
         let (_argument_guard, arguments) = env.instantiate_arguments(self.kind.arguments);
@@ -355,13 +354,13 @@ mod test {
             PartialType,
             environment::{
                 AnalysisEnvironment, Environment, InferenceEnvironment, LatticeEnvironment,
-                SimplifyEnvironment,
+                SimplifyEnvironment, instantiate::InstantiateEnvironment,
             },
             inference::{
                 Constraint, Inference as _, PartialStructuralEdge, Variable, VariableKind,
             },
             kind::{
-                TypeKind,
+                Param, TypeKind,
                 generic_argument::{GenericArgument, GenericArgumentId, GenericArguments},
                 infer::HoleId,
                 primitive::PrimitiveType,
@@ -987,5 +986,47 @@ mod test {
                 && *repr == type_id
                 && arguments.is_empty()
         );
+    }
+
+    #[test]
+    fn instantiate_opaque() {
+        let heap = Heap::new();
+        let env = Environment::new(SpanId::SYNTHETIC, &heap);
+
+        let argument = env.counter.generic_argument.next();
+        let param = instantiate_param(&env, argument);
+
+        opaque!(
+            env,
+            value,
+            "A",
+            param,
+            [GenericArgument {
+                id: argument,
+                name: heap.intern_symbol("T"),
+                constraint: None
+            }]
+        );
+
+        let mut instantiate = InstantiateEnvironment::new(&env);
+        let type_id = value.instantiate(&mut instantiate);
+        assert!(instantiate.take_diagnostics().is_empty());
+
+        let result = env.r#type(type_id);
+        let opaque = result.kind.opaque().expect("should be an opaque type");
+        let repr = env
+            .r#type(opaque.repr)
+            .kind
+            .param()
+            .expect("should be a param");
+
+        assert_eq!(opaque.arguments.len(), 1);
+        assert_eq!(
+            *repr,
+            Param {
+                argument: opaque.arguments[0].id
+            }
+        );
+        assert_ne!(repr.argument, argument);
     }
 }

--- a/libs/@local/hashql/core/src/type/kind/opaque.rs
+++ b/libs/@local/hashql/core/src/type/kind/opaque.rs
@@ -202,6 +202,10 @@ impl<'heap> Lattice<'heap> for OpaqueType<'heap> {
         env.is_concrete(self.kind.repr)
     }
 
+    fn is_recursive(self: Type<'heap, Self>, env: &mut AnalysisEnvironment<'_, 'heap>) -> bool {
+        env.is_recursive(self.kind.repr)
+    }
+
     fn distribute_union(
         self: Type<'heap, Self>,
         _: &mut AnalysisEnvironment<'_, 'heap>,

--- a/libs/@local/hashql/core/src/type/kind/primitive.rs
+++ b/libs/@local/hashql/core/src/type/kind/primitive.rs
@@ -7,7 +7,7 @@ use crate::r#type::{
     Type, TypeId,
     environment::{
         AnalysisEnvironment, Environment, InferenceEnvironment, LatticeEnvironment,
-        SimplifyEnvironment,
+        SimplifyEnvironment, instantiate::InstantiateEnvironment,
     },
     error::type_mismatch,
     inference::{Inference, PartialStructuralEdge},
@@ -194,7 +194,7 @@ impl<'heap> Inference<'heap> for PrimitiveType {
     ) {
     }
 
-    fn instantiate(self: Type<'heap, Self>, _: &mut AnalysisEnvironment<'_, 'heap>) -> TypeId {
+    fn instantiate(self: Type<'heap, Self>, _: &mut InstantiateEnvironment<'_, 'heap>) -> TypeId {
         self.id
     }
 }

--- a/libs/@local/hashql/core/src/type/kind/primitive.rs
+++ b/libs/@local/hashql/core/src/type/kind/primitive.rs
@@ -75,6 +75,10 @@ impl<'heap> Lattice<'heap> for PrimitiveType {
         true
     }
 
+    fn is_recursive(self: Type<'heap, Self>, _: &mut AnalysisEnvironment<'_, 'heap>) -> bool {
+        false
+    }
+
     fn distribute_union(
         self: Type<'heap, Self>,
         _: &mut AnalysisEnvironment<'_, 'heap>,

--- a/libs/@local/hashql/core/src/type/kind/struct.rs
+++ b/libs/@local/hashql/core/src/type/kind/struct.rs
@@ -286,6 +286,13 @@ impl<'heap> Lattice<'heap> for StructType<'heap> {
             .all(|field| env.is_concrete(field.value))
     }
 
+    fn is_recursive(self: Type<'heap, Self>, env: &mut AnalysisEnvironment<'_, 'heap>) -> bool {
+        self.kind
+            .fields
+            .iter()
+            .any(|&field| env.is_recursive(field.value))
+    }
+
     fn distribute_union(
         self: Type<'heap, Self>,
         env: &mut AnalysisEnvironment<'_, 'heap>,

--- a/libs/@local/hashql/core/src/type/kind/tuple.rs
+++ b/libs/@local/hashql/core/src/type/kind/tuple.rs
@@ -302,7 +302,6 @@ impl<'heap> Inference<'heap> for TupleType<'heap> {
         }
     }
 
-    // TODO: test
     fn instantiate(self: Type<'heap, Self>, env: &mut InstantiateEnvironment<'_, 'heap>) -> TypeId {
         let (_provision_guard, id) = env.provision(self.id);
         let (_argument_guard, arguments) = env.instantiate_arguments(self.kind.arguments);
@@ -370,7 +369,7 @@ mod test {
             PartialType,
             environment::{
                 AnalysisEnvironment, Environment, InferenceEnvironment, LatticeEnvironment,
-                SimplifyEnvironment,
+                SimplifyEnvironment, instantiate::InstantiateEnvironment,
             },
             inference::{
                 Constraint, Inference as _, PartialStructuralEdge, Variable, VariableKind,
@@ -1559,5 +1558,37 @@ mod test {
                 && fields[0] == type_id
                 && arguments.is_empty()
         );
+    }
+
+    #[test]
+    fn instantiate_tuple() {
+        let heap = Heap::new();
+        let env = Environment::new(SpanId::SYNTHETIC, &heap);
+
+        let argument = env.counter.generic_argument.next();
+
+        tuple!(
+            env,
+            value,
+            [GenericArgument {
+                id: argument,
+                name: env.heap.intern_symbol("T"),
+                constraint: None
+            }],
+            [instantiate_param(&env, argument)]
+        );
+
+        let mut instantiate = InstantiateEnvironment::new(&env);
+        let type_id = value.instantiate(&mut instantiate);
+
+        let r#type = env.r#type(type_id).kind.tuple().expect("should be tuple");
+        assert_eq!(r#type.fields.len(), 1);
+        assert_eq!(r#type.arguments.len(), 1);
+
+        let field = env.r#type(r#type.fields[0]);
+        let param = field.kind.param().expect("should be param");
+
+        assert_eq!(param.argument, r#type.arguments[0].id);
+        assert_ne!(param.argument, argument);
     }
 }

--- a/libs/@local/hashql/core/src/type/kind/tuple.rs
+++ b/libs/@local/hashql/core/src/type/kind/tuple.rs
@@ -132,6 +132,13 @@ impl<'heap> Lattice<'heap> for TupleType<'heap> {
         self.kind.fields.iter().all(|&field| env.is_concrete(field))
     }
 
+    fn is_recursive(self: Type<'heap, Self>, env: &mut AnalysisEnvironment<'_, 'heap>) -> bool {
+        self.kind
+            .fields
+            .iter()
+            .any(|&field| env.is_recursive(field))
+    }
+
     fn distribute_union(
         self: Type<'heap, Self>,
         env: &mut AnalysisEnvironment<'_, 'heap>,

--- a/libs/@local/hashql/core/src/type/kind/union.rs
+++ b/libs/@local/hashql/core/src/type/kind/union.rs
@@ -2230,6 +2230,31 @@ mod test {
     }
 
     #[test]
+    fn simplify_recursive_union_multiple_elements() {
+        let heap = Heap::new();
+        let env = Environment::new(SpanId::SYNTHETIC, &heap);
+
+        let r#type = env.types.intern(|id| PartialType {
+            span: SpanId::SYNTHETIC,
+            kind: env.intern_kind(TypeKind::Union(UnionType {
+                variants: env
+                    .intern_type_ids(&[id.value(), primitive!(env, PrimitiveType::Number)]),
+            })),
+        });
+
+        let mut simplify = SimplifyEnvironment::new(&env);
+        let type_id = simplify.simplify(r#type.id);
+
+        let r#type = env.r#type(type_id);
+
+        assert_matches!(
+            r#type.kind,
+            TypeKind::Union(UnionType { variants }) if variants.len() == 2
+                && variants[0] == type_id
+        );
+    }
+
+    #[test]
     fn instantiate_union() {
         let heap = Heap::new();
         let env = Environment::new(SpanId::SYNTHETIC, &heap);

--- a/libs/@local/hashql/core/src/type/lattice.rs
+++ b/libs/@local/hashql/core/src/type/lattice.rs
@@ -173,7 +173,8 @@ pub trait Lattice<'heap> {
     /// In a type lattice, a top type is a supertype of every other type, forming the
     /// greatest element of the lattice. This corresponds to the `?` (`Unknown`) type.
     ///
-    /// Examples:
+    /// # Examples
+    ///
     /// - The `any` type in TypeScript is a top type
     /// - Any union type with the `Unknown` type as a variant is a top type
     /// - Empty intersection types (intersections with no variants) are top types

--- a/libs/@local/hashql/core/src/type/lattice.rs
+++ b/libs/@local/hashql/core/src/type/lattice.rs
@@ -202,6 +202,35 @@ pub trait Lattice<'heap> {
     /// - Inference types that need further resolution
     fn is_concrete(self: Type<'heap, Self>, env: &mut AnalysisEnvironment<'_, 'heap>) -> bool;
 
+    /// Determines if a type is recursive (self-referential in its definition).
+    ///
+    /// Recursive types are types that directly or indirectly refer to themselves in their own
+    /// definition. These types are essential for representing data structures with cyclical
+    /// relationships, such as linked lists, trees, and graphs.
+    ///
+    /// In type theory, recursive types are formalized using fixed-point operators or μ-types,
+    /// written as μX.T where X may appear in T, representing the recursive binding of X to the
+    /// structure T.
+    ///
+    /// # Implementation Considerations
+    ///
+    /// Detecting recursion in types is critical for:
+    /// - Preventing infinite loops during type checking and inference.
+    /// - Proper handling of type simplification and normalization.
+    /// - Calculating the memory layout of recursive data structures.
+    /// - Appropriate error reporting for circular type definitions.
+    /// - Co-inductive discharge of type constraints.
+    ///
+    /// # Examples
+    ///
+    /// Recursive types commonly include:
+    /// - Self-referential structures: `type LinkedList<T> = (data: T, next: Option<LinkedList<T>>)`
+    /// - Mutually recursive types: `type Tree = (newtype Leaf i32) | (newtype Node List<Tree>)`
+    /// - Recursive type aliases: `type Json = null | boolean | number | string | Json[] |
+    ///   Dict<String, Json>`
+    /// - Recursive function types: `type Recursive = fn(x: Recursive) -> void`
+    fn is_recursive(self: Type<'heap, Self>, env: &mut AnalysisEnvironment<'_, 'heap>) -> bool;
+
     /// Applies distribution laws to expressions containing union types in covariant positions.
     ///
     /// This function handles union distribution in type expressions, focusing primarily on

--- a/libs/@local/hashql/core/src/type/pretty_print.rs
+++ b/libs/@local/hashql/core/src/type/pretty_print.rs
@@ -76,18 +76,12 @@ pub trait PrettyPrint {
         let mut output = Vec::new();
         let mut writer = WriteColored::new(&mut output);
 
-        self.pretty(
-            env,
-            RecursionDepthBoundary {
-                depth: 0,
-                limit: 32,
-            },
-        )
-        .render_raw(width, &mut writer)
-        .expect(
-            "should not fail during diagnostic rendering - if it does, this indicates a bug in \
-             the pretty printer",
-        );
+        self.pretty(env, RecursionDepthBoundary { depth: 0, limit: 4 })
+            .render_raw(width, &mut writer)
+            .expect(
+                "should not fail during diagnostic rendering - if it does, this indicates a bug \
+                 in the pretty printer",
+            );
 
         String::from_utf8(output)
             .expect("should never fail as all bytes come from valid UTF-8 strings")

--- a/libs/@local/hashql/core/src/type/recursion.rs
+++ b/libs/@local/hashql/core/src/type/recursion.rs
@@ -1,8 +1,12 @@
-use hashbrown::HashSet;
+use core::{marker::PhantomData, ops::ControlFlow};
+
+use hashbrown::{HashSet, hash_map::Entry};
 use pretty::RcDoc;
 
-use super::{TypeId, environment::Environment, pretty_print::PrettyPrint as _};
-use crate::collection::FastHashSet;
+use super::{
+    Type, TypeId, environment::Environment, kind::TypeKind, pretty_print::PrettyPrint as _,
+};
+use crate::collection::{FastHashMap, FastHashSet};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct RecursionDepthBoundary {
@@ -31,41 +35,98 @@ impl RecursionDepthBoundary {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct RecursionBoundary {
-    inner: FastHashSet<(TypeId, TypeId)>,
-
-    lhs: FastHashSet<TypeId>,
-    rhs: FastHashSet<TypeId>,
+/// Recursive Cycle
+///
+/// Represents whether both ends of a recursive subtype check have been seen in the current call
+/// stack, allowing coinductive discharge when a cycle is detected.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) struct RecursionCycle {
+    /// Was the left-hand type already on the stack.
+    lhs: bool,
+    /// Was the right-hand type already on the stack.
+    rhs: bool,
 }
 
-impl RecursionBoundary {
+impl RecursionCycle {
+    /// Determine if we should discharge the cycle.
+    pub(crate) const fn should_discharge(self) -> bool {
+        self.lhs && self.rhs
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RecursionBoundary<'heap> {
+    inner: FastHashSet<(*const TypeKind<'heap>, *const TypeKind<'heap>)>,
+
+    lhs: FastHashMap<*const TypeKind<'heap>, usize>,
+    rhs: FastHashMap<*const TypeKind<'heap>, usize>,
+}
+
+impl<'heap> RecursionBoundary<'heap> {
     pub(crate) fn new() -> Self {
         Self {
-            inner: HashSet::default(),
-            lhs: HashSet::default(),
-            rhs: HashSet::default(),
+            inner: FastHashSet::default(),
+            lhs: FastHashMap::default(),
+            rhs: FastHashMap::default(),
         }
     }
 
-    pub(crate) fn enter(&mut self, lhs: TypeId, rhs: TypeId) -> bool {
+    pub(crate) fn reset(&mut self) {
+        self.inner.clear();
+        self.lhs.clear();
+        self.rhs.clear();
+    }
+
+    pub(crate) fn enter(
+        &mut self,
+        lhs: Type<'heap>,
+        rhs: Type<'heap>,
+    ) -> ControlFlow<RecursionCycle> {
+        let lhs_kind = core::ptr::from_ref(lhs.kind);
+        let rhs_kind = core::ptr::from_ref(rhs.kind);
+
         // Insert returns true if the element was not already in the set
-        let should_enter = self.inner.insert((lhs, rhs));
+        let should_enter = self.inner.insert((lhs_kind, rhs_kind));
 
         // Only insert if the element was not already in the set, otherwise our coinductive
         // recursion detection will always discharge.
-        if !should_enter {
-            self.lhs.insert(lhs);
-            self.rhs.insert(rhs);
-        }
+        if should_enter {
+            *self.lhs.entry(lhs_kind).or_default() += 1;
+            *self.rhs.entry(rhs_kind).or_default() += 1;
 
-        should_enter
+            ControlFlow::Continue(())
+        } else {
+            let cycle = RecursionCycle {
+                lhs: self.lhs.contains_key(&lhs_kind),
+                rhs: self.rhs.contains_key(&rhs_kind),
+            };
+
+            println!("Cycle detected: {:?}", cycle);
+
+            ControlFlow::Break(cycle)
+        }
     }
 
-    pub(crate) fn exit(&mut self, lhs: TypeId, rhs: TypeId) -> bool {
-        self.lhs.remove(&lhs);
-        self.rhs.remove(&rhs);
+    pub(crate) fn exit(&mut self, lhs: Type<'heap>, rhs: Type<'heap>) -> bool {
+        let lhs_kind = core::ptr::from_ref(lhs.kind);
+        let rhs_kind = core::ptr::from_ref(rhs.kind);
 
-        self.inner.remove(&(lhs, rhs))
+        if let Entry::Occupied(mut entry) = self.lhs.entry(lhs_kind) {
+            let value = entry.get_mut();
+            if *value == 1 {
+                entry.remove();
+            } else {
+                *value -= 1;
+            }
+        }
+        if let Entry::Occupied(mut entry) = self.rhs.entry(rhs_kind) {
+            let value = entry.get_mut();
+            if *value == 1 {
+                entry.remove();
+            } else {
+                *value -= 1;
+            }
+        }
+
+        self.inner.remove(&(lhs_kind, rhs_kind))
     }
 }

--- a/libs/@local/hashql/core/src/type/test.rs
+++ b/libs/@local/hashql/core/src/type/test.rs
@@ -18,12 +18,14 @@ use crate::{
     },
 };
 
-pub(crate) macro setup_analysis($name:ident) {
-    let heap = Heap::new();
-    let environment = Environment::new(SpanId::SYNTHETIC, &heap);
+macro_rules! setup_analysis {
+    ($name:ident) => {
+        let heap = Heap::new();
+        let environment = Environment::new(SpanId::SYNTHETIC, &heap);
 
-    let mut $name = AnalysisEnvironment::new(&environment);
-    $name.with_diagnostics();
+        let mut $name = AnalysisEnvironment::new(&environment);
+        $name.with_diagnostics();
+    };
 }
 
 pub(crate) fn instantiate<'heap>(env: &Environment<'heap>, kind: TypeKind<'heap>) -> TypeId {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Allow for types to be instantiated. This means that we need to create new types, depending on the context, e.g. if a struct has params it needs to be instantiated by cloning and then remapping said arguments.

Note that we only instantiate **bound** (generic parameters) like any other language does.

---

Unions and Intersections are quite complicated, as they refer to unmaterialized versions of our types. Therefore we needed to do some cleanup. We now properly follow co-inductive semantics, meaning that:

```
type A = Number | A
// is the same as:
type A = Unknown

type B = Number & B
// is the same as:
type B = Number
```

This might seem counterintuitive at a glance, but is the correct interpretation for co-inductive type systems, in particular, one might expect that `type A = Number | Number | Number | …` this is the case in an *inductive* type system, but an inductive type system does not admit arbitrary recursive types, therefore we chose to implement a co-inductive system.

A co-inductive system is necessary to be able to implement:

```
type A = (name: A)
type B = (name: B)
```

under a coinductive system, we can reason about these types (we wouldn't be able to do so in an inductive system, as recursive types would endlessly expand) and say that indeed `A <: B`.

For more information about coinduction, please take a look at: [https://en.wikipedia.org/wiki/Coinduction](https://en.wikipedia.org/wiki/Coinduction) or page 282 (chapter 21.1) of the book "Types and Programming Languages" by Benjamin C. Pierce.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
