### PR TITLE
H-4487: Special-case {} type to `Record<string, never>`

### DIFF
--- a/libs/@local/codegen/src/definitions/fields.rs
+++ b/libs/@local/codegen/src/definitions/fields.rs
@@ -33,6 +33,7 @@ impl Field {
 pub enum Fields {
     Named {
         fields: Vec<(Cow<'static, str>, Field)>,
+        deny_unknown: bool,
     },
     Unnamed {
         fields: Vec<Field>,
@@ -54,6 +55,9 @@ impl Fields {
                         (name.clone(), Field::from_specta(data_type, type_collection))
                     })
                     .collect(),
+                // TODO: Specta currently does not have `deny_unknown_fields` support
+                //   see https://linear.app/hash/issue/H-4489/implement-deny-unknown-fields-detection
+                deny_unknown: true,
             },
             datatype::Fields::Unnamed(unnamed_fields) => Self::Unnamed {
                 fields: unnamed_fields

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__EnumAdjacent::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__EnumAdjacent::Typescript.snap
@@ -15,7 +15,7 @@ type EnumAdjacent = {
 	content: [boolean, string]
 } | {
 	type: "EmptyNamed"
-	content: {}
+	content: Record<string, never>
 } | {
 	type: "SingleNamed"
 	content: {

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__EnumExternal::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__EnumExternal::Typescript.snap
@@ -9,7 +9,7 @@ type EnumExternal = "Unit" | {
 } | {
 	DoubleUnnamed: [boolean, string]
 } | {
-	EmptyNamed: {}
+	EmptyNamed: Record<string, never>
 } | {
 	SingleNamed: {
 		value: number

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__EnumUntagged::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__EnumUntagged::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type EnumUntagged = null | [] | number | [boolean, string] | {} | {
+type EnumUntagged = null | [] | number | [boolean, string] | Record<string, never> | {
 	value: number
 } | {
 	value_1: number

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__StructEmpty::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__StructEmpty::Typescript.snap
@@ -2,4 +2,4 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type StructEmpty = {};
+type StructEmpty = Record<string, never>;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We don't have situation where `{}` is appropriate. Instead, we use `Record<string, never>`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph