### PR TITLE
H-4459: Export generated public types

### DIFF
--- a/libs/@local/codegen/src/definitions/type.rs
+++ b/libs/@local/codegen/src/definitions/type.rs
@@ -59,6 +59,7 @@ impl Type {
 pub struct TypeDefinition {
     pub name: Cow<'static, str>,
     pub r#type: Type,
+    pub public: bool,
 }
 
 impl TypeDefinition {
@@ -69,6 +70,9 @@ impl TypeDefinition {
         Self {
             name: data_type.name().clone(),
             r#type: Type::from_specta(data_type.ty(), type_collection),
+            // TODO: Only export public types
+            //  see https://linear.app/hash/issue/H-4498/only-export-public-types-from-codegen
+            public: true,
         }
     }
 }

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__Actor::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__Actor::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type Actor = {
+export type Actor = {
 	actorType: "user"
 } & User | {
 	actorType: "machine"

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__ActorEntityUuid::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__ActorEntityUuid::Typescript.snap
@@ -2,4 +2,4 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type ActorEntityUuid = EntityUuid;
+export type ActorEntityUuid = EntityUuid;

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__ActorGroup::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__ActorGroup::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type ActorGroup = {
+export type ActorGroup = {
 	actorGroupType: "web"
 } & Web | {
 	actorGroupType: "team"

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__ActorGroupEntityUuid::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__ActorGroupEntityUuid::Typescript.snap
@@ -2,4 +2,4 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type ActorGroupEntityUuid = EntityUuid;
+export type ActorGroupEntityUuid = EntityUuid;

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__ActorGroupId::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__ActorGroupId::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type ActorGroupId = {
+export type ActorGroupId = {
 	actorGroupType: "web"
 	id: WebId
 } | {

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__ActorGroupType::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__ActorGroupType::Typescript.snap
@@ -2,4 +2,4 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type ActorGroupType = "web" | "team";
+export type ActorGroupType = "web" | "team";

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__ActorId::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__ActorId::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type ActorId = {
+export type ActorId = {
 	actorType: "user"
 	id: UserId
 } | {

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__ActorType::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__ActorType::Typescript.snap
@@ -2,4 +2,4 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type ActorType = "user" | "machine" | "ai";
+export type ActorType = "user" | "machine" | "ai";

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__Ai::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__Ai::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type Ai = {
+export type Ai = {
 	id: AiId
 	identifier: string
 	roles: RoleId[]

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__AiId::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__AiId::Typescript.snap
@@ -2,4 +2,4 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type AiId = ActorEntityUuid;
+export type AiId = ActorEntityUuid;

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__EnumAdjacent::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__EnumAdjacent::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type EnumAdjacent = {
+export type EnumAdjacent = {
 	type: "Unit"
 } | {
 	type: "EmptyUnnamed"

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__EnumExternal::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__EnumExternal::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type EnumExternal = "Unit" | {
+export type EnumExternal = "Unit" | {
 	EmptyUnnamed: []
 } | {
 	SingleUnnamed: number

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__EnumInternal::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__EnumInternal::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type EnumInternal = {
+export type EnumInternal = {
 	type: "Unit"
 } | {
 	type: "SingleUnnamed"

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__EnumUntagged::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__EnumUntagged::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type EnumUntagged = null | [] | number | [boolean, string] | Record<string, never> | {
+export type EnumUntagged = null | [] | number | [boolean, string] | Record<string, never> | {
 	value: number
 } | {
 	value_1: number

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__ListCollections::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__ListCollections::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type ListCollections = {
+export type ListCollections = {
 	string_list: string[]
 	number_list: number[]
 	nested_list: StructSimple[]

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__ListNested::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__ListNested::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type ListNested = {
+export type ListNested = {
 	list_of_lists: number[][]
 	matrix: number[][][]
 	nested_sets: number[][]

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__ListOptionals::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__ListOptionals::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type ListOptionals = {
+export type ListOptionals = {
 	optional_strings: (string | undefined)[]
 	optional_integers: (number | undefined)[]
 	optional_arrays: (number[] | undefined)[]

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__ListPrimitives::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__ListPrimitives::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type ListPrimitives = {
+export type ListPrimitives = {
 	strings: string[]
 	integers: number[]
 	floats: number[]

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__ListStructs::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__ListStructs::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type ListStructs = {
+export type ListStructs = {
 	vec_items: StructSimple[]
 	array_items: StructSimple[]
 	set_items: StructSimple[]

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__Machine::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__Machine::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type Machine = {
+export type Machine = {
 	id: MachineId
 	identifier: string
 	roles: RoleId[]

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__MachineId::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__MachineId::Typescript.snap
@@ -2,4 +2,4 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type MachineId = ActorEntityUuid;
+export type MachineId = ActorEntityUuid;

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__MapEnumKey::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__MapEnumKey::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type MapEnumKey = {
+export type MapEnumKey = {
 	enum_to_string: Record<MapKeyEnum, string>
 	enum_to_int: Record<MapKeyEnum, number>
 	btree_enum_to_string: Record<MapKeyEnum, string>

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__MapNested::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__MapNested::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type MapNested = {
+export type MapNested = {
 	nested_maps: Record<string, Record<string, number>>
 	triple_nested: Record<string, Record<string, Record<string, boolean>>>
 	btree_nested: Record<string, Record<number, string>>

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__MapNumericKey::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__MapNumericKey::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type MapNumericKey = {
+export type MapNumericKey = {
 	int_to_string: Record<number, string>
 	int_to_int: Record<number, number>
 	btree_int_to_string: Record<number, string>

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__MapOptional::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__MapOptional::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type MapOptional = {
+export type MapOptional = {
 	maybe_map: (Record<string, number> | undefined)
 	map_of_optionals: Record<string, (number | undefined)>
 	maybe_btree: (Record<string, string> | undefined)

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__MapStringKey::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__MapStringKey::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type MapStringKey = {
+export type MapStringKey = {
 	string_to_string: Record<string, string>
 	string_to_int: Record<string, number>
 	string_to_bool: Record<string, boolean>

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__MapStructValue::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__MapStructValue::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type MapStructValue = {
+export type MapStructValue = {
 	string_to_struct: Record<string, StructSimple>
 	int_to_struct: Record<number, StructSimple>
 	btree_string_to_struct: Record<string, StructSimple>

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__Principal::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__Principal::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type Principal = {
+export type Principal = {
 	principalType: "actor"
 } & Actor | {
 	principalType: "actorGroup"

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__PrincipalId::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__PrincipalId::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type PrincipalId = {
+export type PrincipalId = {
 	principalType: "actor"
 } & ActorId | {
 	principalType: "actorGroup"

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__Role::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__Role::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type Role = {
+export type Role = {
 	roleType: "web"
 } & WebRole | {
 	roleType: "team"

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__RoleId::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__RoleId::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type RoleId = {
+export type RoleId = {
 	roleType: "web"
 	id: WebRoleId
 } | {

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__RoleName::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__RoleName::Typescript.snap
@@ -2,4 +2,4 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type RoleName = "administrator" | "member";
+export type RoleName = "administrator" | "member";

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__RoleType::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__RoleType::Typescript.snap
@@ -2,4 +2,4 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type RoleType = "web" | "team";
+export type RoleType = "web" | "team";

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__StructEmpty::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__StructEmpty::Typescript.snap
@@ -2,4 +2,4 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type StructEmpty = Record<string, never>;
+export type StructEmpty = Record<string, never>;

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__StructMultipleFlattened::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__StructMultipleFlattened::Typescript.snap
@@ -2,6 +2,6 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type StructMultipleFlattened = {
+export type StructMultipleFlattened = {
 	name: string
 } & StructSimpleFlattened & StructNested;

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__StructNested::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__StructNested::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type StructNested = {
+export type StructNested = {
 	name: string
 	simple: StructSimple
 };

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__StructOptional::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__StructOptional::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type StructOptional = {
+export type StructOptional = {
 	required: string
 	optional: (number | undefined)
 };

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__StructSimple::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__StructSimple::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type StructSimple = {
+export type StructSimple = {
 	integer: number
 	float: number
 	string: string

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__StructSimpleFlattened::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__StructSimpleFlattened::Typescript.snap
@@ -2,6 +2,6 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type StructSimpleFlattened = {
+export type StructSimpleFlattened = {
 	name: string
 } & StructSimple;

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__StructUnit::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__StructUnit::Typescript.snap
@@ -2,4 +2,4 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type StructUnit = null;
+export type StructUnit = null;

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__StructUnnamedDouble::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__StructUnnamedDouble::Typescript.snap
@@ -2,4 +2,4 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type StructUnnamedDouble = [number, string];
+export type StructUnnamedDouble = [number, string];

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__StructUnnamedSingle::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__StructUnnamedSingle::Typescript.snap
@@ -2,4 +2,4 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type StructUnnamedSingle = number;
+export type StructUnnamedSingle = number;

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__StructUnnamedTriple::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__StructUnnamedTriple::Typescript.snap
@@ -2,4 +2,4 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type StructUnnamedTriple = [number, string, boolean];
+export type StructUnnamedTriple = [number, string, boolean];

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__Team::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__Team::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type Team = {
+export type Team = {
 	id: TeamId
 	parentId: ActorGroupId
 	name: string

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__TeamId::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__TeamId::Typescript.snap
@@ -2,4 +2,4 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type TeamId = ActorGroupEntityUuid;
+export type TeamId = ActorGroupEntityUuid;

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__TeamRole::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__TeamRole::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type TeamRole = {
+export type TeamRole = {
 	id: TeamRoleId
 	teamId: TeamId
 	name: RoleName

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__TeamRoleId::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__TeamRoleId::Typescript.snap
@@ -2,4 +2,4 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type TeamRoleId = string;
+export type TeamRoleId = string;

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleDouble::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleDouble::Typescript.snap
@@ -2,6 +2,6 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type TupleDouble = {
+export type TupleDouble = {
 	double: [number, string]
 };

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleEmpty::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleEmpty::Typescript.snap
@@ -2,6 +2,6 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type TupleEmpty = {
+export type TupleEmpty = {
 	empty: []
 };

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleMultiple::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleMultiple::Typescript.snap
@@ -2,6 +2,6 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type TupleMultiple = {
+export type TupleMultiple = {
 	multiple: [number, string, boolean, number]
 };

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleNested::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleNested::Typescript.snap
@@ -2,6 +2,6 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type TupleNested = {
+export type TupleNested = {
 	nested: [string, [number, boolean]]
 };

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleOptional::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleOptional::Typescript.snap
@@ -2,6 +2,6 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type TupleOptional = {
+export type TupleOptional = {
 	optional: ([number, number] | undefined)
 };

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleSingle::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleSingle::Typescript.snap
@@ -2,6 +2,6 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type TupleSingle = {
+export type TupleSingle = {
 	single: [number]
 };

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__User::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__User::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type User = {
+export type User = {
 	id: UserId
 	roles: RoleId[]
 };

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__UserId::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__UserId::Typescript.snap
@@ -2,4 +2,4 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type UserId = ActorEntityUuid;
+export type UserId = ActorEntityUuid;

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__Web::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__Web::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type Web = {
+export type Web = {
 	id: WebId
 	shortname: (string | undefined)
 	roles: WebRoleId[]

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__WebId::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__WebId::Typescript.snap
@@ -2,4 +2,4 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type WebId = ActorGroupEntityUuid;
+export type WebId = ActorGroupEntityUuid;

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__WebRole::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__WebRole::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type WebRole = {
+export type WebRole = {
 	id: WebRoleId
 	webId: WebId
 	name: RoleName

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__WebRoleId::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__WebRoleId::Typescript.snap
@@ -2,4 +2,4 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-type WebRoleId = string;
+export type WebRoleId = string;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`pub` types should have the `export` keyword, otherwise they cannot be used.

Sadly, `specta` does not support `pub`, so we just assume `public = true` all the time. We could also use a `Visibility` enumeration, but only `Visibility::Public` would be used, so I went the simple boolean approach. I don't want dead code in the type definitions.