### PR TITLE
Export interface instead of type alias in codegen for structs

### DIFF
--- a/libs/@local/codegen/src/typescript.rs
+++ b/libs/@local/codegen/src/typescript.rs
@@ -116,6 +116,12 @@ impl<'a> TypeScriptGenerator<'a> {
                     let mut extends = self.ast.vec();
                     for (field_name, field) in fields {
                         if field.flatten {
+                            // TODO: Implement struct inlining.
+                            //       If it would be a struct, we couldn't add it as `extends`, so we
+                            //       actually need a reference here. If we encounter a `panic!` here
+                            //       due to `field.r#type` being a `Type::Struct` we can workaround
+                            //       it by truely flatten the struct into the interface.
+                            //   see https://linear.app/hash/issue/H-4506/support-inlining-of-flattened-structs
                             let Type::Reference(reference) = &field.r#type else {
                                 panic!("Expected reference type for flattened field");
                             };

--- a/libs/@local/codegen/tests/codegen/main.rs
+++ b/libs/@local/codegen/tests/codegen/main.rs
@@ -39,6 +39,9 @@ fn register_types(collection: &mut TypeCollection) {
     collection.register::<structs::StructNested>();
     collection.register::<structs::StructSimpleFlattened>();
     collection.register::<structs::StructMultipleFlattened>();
+    collection.register::<structs::StructFlattenedEnum>();
+    collection.register::<structs::StructNestedTypeFlattened>();
+    collection.register::<structs::StructNestedInterfaceFlattened>();
 
     // Register lists
     collection.register::<lists::ListPrimitives>();

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__Ai::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__Ai::Typescript.snap
@@ -2,8 +2,8 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type Ai = {
-	id: AiId
-	identifier: string
-	roles: RoleId[]
-};
+export interface Ai {
+	id: AiId;
+	identifier: string;
+	roles: RoleId[];
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__ListCollections::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__ListCollections::Typescript.snap
@@ -2,8 +2,8 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type ListCollections = {
-	string_list: string[]
-	number_list: number[]
-	nested_list: StructSimple[]
-};
+export interface ListCollections {
+	string_list: string[];
+	number_list: number[];
+	nested_list: StructSimple[];
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__ListNested::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__ListNested::Typescript.snap
@@ -2,9 +2,9 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type ListNested = {
-	list_of_lists: number[][]
-	matrix: number[][][]
-	nested_sets: number[][]
-	mixed_nesting: number[][]
-};
+export interface ListNested {
+	list_of_lists: number[][];
+	matrix: number[][][];
+	nested_sets: number[][];
+	mixed_nesting: number[][];
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__ListOptionals::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__ListOptionals::Typescript.snap
@@ -2,9 +2,9 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type ListOptionals = {
-	optional_strings: (string | undefined)[]
-	optional_integers: (number | undefined)[]
-	optional_arrays: (number[] | undefined)[]
-	optional_sets: (string[] | undefined)[]
-};
+export interface ListOptionals {
+	optional_strings: (string | undefined)[];
+	optional_integers: (number | undefined)[];
+	optional_arrays: (number[] | undefined)[];
+	optional_sets: (string[] | undefined)[];
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__ListPrimitives::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__ListPrimitives::Typescript.snap
@@ -2,18 +2,18 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type ListPrimitives = {
-	strings: string[]
-	integers: number[]
-	floats: number[]
-	booleans: boolean[]
-	small_array: number[]
-	string_array: string[]
-	boolean_array: boolean[]
-	string_set: string[]
-	integer_set: number[]
-	btree_string_set: string[]
-	btree_integer_set: number[]
-	linked_string_list: string[]
-	linked_integer_list: number[]
-};
+export interface ListPrimitives {
+	strings: string[];
+	integers: number[];
+	floats: number[];
+	booleans: boolean[];
+	small_array: number[];
+	string_array: string[];
+	boolean_array: boolean[];
+	string_set: string[];
+	integer_set: number[];
+	btree_string_set: string[];
+	btree_integer_set: number[];
+	linked_string_list: string[];
+	linked_integer_list: number[];
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__ListStructs::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__ListStructs::Typescript.snap
@@ -2,9 +2,9 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type ListStructs = {
-	vec_items: StructSimple[]
-	array_items: StructSimple[]
-	set_items: StructSimple[]
-	linked_items: StructSimple[]
-};
+export interface ListStructs {
+	vec_items: StructSimple[];
+	array_items: StructSimple[];
+	set_items: StructSimple[];
+	linked_items: StructSimple[];
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__Machine::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__Machine::Typescript.snap
@@ -2,8 +2,8 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type Machine = {
-	id: MachineId
-	identifier: string
-	roles: RoleId[]
-};
+export interface Machine {
+	id: MachineId;
+	identifier: string;
+	roles: RoleId[];
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__MapEnumKey::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__MapEnumKey::Typescript.snap
@@ -2,8 +2,8 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type MapEnumKey = {
-	enum_to_string: Record<MapKeyEnum, string>
-	enum_to_int: Record<MapKeyEnum, number>
-	btree_enum_to_string: Record<MapKeyEnum, string>
-};
+export interface MapEnumKey {
+	enum_to_string: Record<MapKeyEnum, string>;
+	enum_to_int: Record<MapKeyEnum, number>;
+	btree_enum_to_string: Record<MapKeyEnum, string>;
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__MapNested::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__MapNested::Typescript.snap
@@ -2,9 +2,9 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type MapNested = {
-	nested_maps: Record<string, Record<string, number>>
-	triple_nested: Record<string, Record<string, Record<string, boolean>>>
-	btree_nested: Record<string, Record<number, string>>
-	mixed_nesting: Record<string, Record<number, Record<string, boolean>>>
-};
+export interface MapNested {
+	nested_maps: Record<string, Record<string, number>>;
+	triple_nested: Record<string, Record<string, Record<string, boolean>>>;
+	btree_nested: Record<string, Record<number, string>>;
+	mixed_nesting: Record<string, Record<number, Record<string, boolean>>>;
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__MapNumericKey::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__MapNumericKey::Typescript.snap
@@ -2,9 +2,9 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type MapNumericKey = {
-	int_to_string: Record<number, string>
-	int_to_int: Record<number, number>
-	btree_int_to_string: Record<number, string>
-	btree_int_to_int: Record<number, number>
-};
+export interface MapNumericKey {
+	int_to_string: Record<number, string>;
+	int_to_int: Record<number, number>;
+	btree_int_to_string: Record<number, string>;
+	btree_int_to_int: Record<number, number>;
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__MapOptional::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__MapOptional::Typescript.snap
@@ -2,9 +2,9 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type MapOptional = {
-	maybe_map: (Record<string, number> | undefined)
-	map_of_optionals: Record<string, (number | undefined)>
-	maybe_btree: (Record<string, string> | undefined)
-	btree_of_optionals: Record<string, (number | undefined)>
-};
+export interface MapOptional {
+	maybe_map: (Record<string, number> | undefined);
+	map_of_optionals: Record<string, (number | undefined)>;
+	maybe_btree: (Record<string, string> | undefined);
+	btree_of_optionals: Record<string, (number | undefined)>;
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__MapStringKey::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__MapStringKey::Typescript.snap
@@ -2,10 +2,10 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type MapStringKey = {
-	string_to_string: Record<string, string>
-	string_to_int: Record<string, number>
-	string_to_bool: Record<string, boolean>
-	btree_string_to_string: Record<string, string>
-	btree_string_to_int: Record<string, number>
-};
+export interface MapStringKey {
+	string_to_string: Record<string, string>;
+	string_to_int: Record<string, number>;
+	string_to_bool: Record<string, boolean>;
+	btree_string_to_string: Record<string, string>;
+	btree_string_to_int: Record<string, number>;
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__MapStructValue::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__MapStructValue::Typescript.snap
@@ -2,9 +2,9 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type MapStructValue = {
-	string_to_struct: Record<string, StructSimple>
-	int_to_struct: Record<number, StructSimple>
-	btree_string_to_struct: Record<string, StructSimple>
-	btree_int_to_struct: Record<number, StructSimple>
-};
+export interface MapStructValue {
+	string_to_struct: Record<string, StructSimple>;
+	int_to_struct: Record<number, StructSimple>;
+	btree_string_to_struct: Record<string, StructSimple>;
+	btree_int_to_struct: Record<number, StructSimple>;
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__StructEmpty::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__StructEmpty::Typescript.snap
@@ -2,4 +2,4 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type StructEmpty = Record<string, never>;
+export interface StructEmpty {}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__StructFlattenedEnum::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__StructFlattenedEnum::Typescript.snap
@@ -2,6 +2,6 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export interface StructSimpleFlattened extends StructSimple {
-	name: string;
-}
+export type StructFlattenedEnum = {
+	name: string
+} & EnumInternal;

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__StructMultipleFlattened::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__StructMultipleFlattened::Typescript.snap
@@ -2,6 +2,6 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type StructMultipleFlattened = {
-	name: string
-} & StructSimpleFlattened & StructNested;
+export interface StructMultipleFlattened extends StructSimpleFlattened, StructNested {
+	name: string;
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__StructNested::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__StructNested::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type StructNested = {
-	name: string
-	simple: StructSimple
-};
+export interface StructNested {
+	name: string;
+	simple: StructSimple;
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__StructNestedInterfaceFlattened::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__StructNestedInterfaceFlattened::Typescript.snap
@@ -2,6 +2,6 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export interface StructSimpleFlattened extends StructSimple {
+export interface StructNestedInterfaceFlattened extends StructMultipleFlattened {
 	name: string;
 }

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__StructNestedTypeFlattened::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__StructNestedTypeFlattened::Typescript.snap
@@ -1,0 +1,7 @@
+---
+source: libs/@local/codegen/tests/codegen/main.rs
+expression: generated
+---
+export type StructNestedTypeFlattened = {
+	name: string
+} & StructFlattenedEnum;

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__StructOptional::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__StructOptional::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type StructOptional = {
-	required: string
-	optional: (number | undefined)
-};
+export interface StructOptional {
+	required: string;
+	optional: (number | undefined);
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__StructSimple::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__StructSimple::Typescript.snap
@@ -2,9 +2,9 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type StructSimple = {
-	integer: number
-	float: number
-	string: string
-	boolean: boolean
-};
+export interface StructSimple {
+	integer: number;
+	float: number;
+	string: string;
+	boolean: boolean;
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__Team::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__Team::Typescript.snap
@@ -2,9 +2,9 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type Team = {
-	id: TeamId
-	parentId: ActorGroupId
-	name: string
-	roles: TeamRoleId[]
-};
+export interface Team {
+	id: TeamId;
+	parentId: ActorGroupId;
+	name: string;
+	roles: TeamRoleId[];
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__TeamRole::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__TeamRole::Typescript.snap
@@ -2,8 +2,8 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type TeamRole = {
-	id: TeamRoleId
-	teamId: TeamId
-	name: RoleName
-};
+export interface TeamRole {
+	id: TeamRoleId;
+	teamId: TeamId;
+	name: RoleName;
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleDouble::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleDouble::Typescript.snap
@@ -2,6 +2,6 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type TupleDouble = {
-	double: [number, string]
-};
+export interface TupleDouble {
+	double: [number, string];
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleEmpty::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleEmpty::Typescript.snap
@@ -2,6 +2,6 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type TupleEmpty = {
-	empty: []
-};
+export interface TupleEmpty {
+	empty: [];
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleMultiple::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleMultiple::Typescript.snap
@@ -2,6 +2,6 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type TupleMultiple = {
-	multiple: [number, string, boolean, number]
-};
+export interface TupleMultiple {
+	multiple: [number, string, boolean, number];
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleNested::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleNested::Typescript.snap
@@ -2,6 +2,6 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type TupleNested = {
-	nested: [string, [number, boolean]]
-};
+export interface TupleNested {
+	nested: [string, [number, boolean]];
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleOptional::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleOptional::Typescript.snap
@@ -2,6 +2,6 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type TupleOptional = {
-	optional: ([number, number] | undefined)
-};
+export interface TupleOptional {
+	optional: ([number, number] | undefined);
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleSingle::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__TupleSingle::Typescript.snap
@@ -2,6 +2,6 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type TupleSingle = {
-	single: [number]
-};
+export interface TupleSingle {
+	single: [number];
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__User::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__User::Typescript.snap
@@ -2,7 +2,7 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type User = {
-	id: UserId
-	roles: RoleId[]
-};
+export interface User {
+	id: UserId;
+	roles: RoleId[];
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__Web::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__Web::Typescript.snap
@@ -2,8 +2,8 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type Web = {
-	id: WebId
-	shortname: (string | undefined)
-	roles: WebRoleId[]
-};
+export interface Web {
+	id: WebId;
+	shortname: (string | undefined);
+	roles: WebRoleId[];
+}

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__WebRole::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__WebRole::Typescript.snap
@@ -2,8 +2,8 @@
 source: libs/@local/codegen/tests/codegen/main.rs
 expression: generated
 ---
-export type WebRole = {
-	id: WebRoleId
-	webId: WebId
-	name: RoleName
-};
+export interface WebRole {
+	id: WebRoleId;
+	webId: WebId;
+	name: RoleName;
+}

--- a/libs/@local/codegen/tests/codegen/structs.rs
+++ b/libs/@local/codegen/tests/codegen/structs.rs
@@ -2,6 +2,8 @@
 
 use oxc::allocator::HashMap;
 
+use crate::enums::EnumInternal;
+
 // Unit struct (no fields or braces)
 #[derive(specta::Type)]
 pub(crate) struct StructUnit;
@@ -59,4 +61,29 @@ pub(crate) struct StructMultipleFlattened {
     simple: StructSimpleFlattened,
     #[serde(flatten)]
     nested: StructNested,
+}
+
+/// Nesting interfaces should simply work without any special handling
+#[derive(specta::Type)]
+pub(crate) struct StructNestedInterfaceFlattened {
+    name: String,
+    #[serde(flatten)]
+    nested: StructMultipleFlattened,
+}
+
+/// This should generate a `type` alias as [`EnumInternal`] cannot be represented as an interface
+#[derive(specta::Type)]
+pub(crate) struct StructFlattenedEnum {
+    name: String,
+    #[serde(flatten)]
+    map: EnumInternal,
+}
+
+/// This also generates a `type` alias as the {`EnumInternal`} within [`StructFlattenedEnum`] cannot
+/// be represented as an interface
+#[derive(specta::Type)]
+pub(crate) struct StructNestedTypeFlattened {
+    name: String,
+    #[serde(flatten)]
+    nested: StructFlattenedEnum,
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

If a struct does not contain any flatten fields and does not allow additional properties, it can be exported through `interface` instead of `type =`

## 🔍 What does this change?

- detect if a field contains an enum which cannot be used in an interface
- export `interface` instead of type aliases for structs

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


## 🐾 Next steps


This does not change the inlined enum definitions. This is subject to a follow-up: H-4502