### PR TITLE
H-3949: Rename `recordCreatedAtTransactionTime` to `editionCreatedAtTransactionTime`

### DIFF
--- a/apps/hash-frontend/src/pages/shared/entities-visualizer.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-visualizer.tsx
@@ -51,8 +51,8 @@ import type {
   SortableEntitiesTableColumnKey,
 } from "./entities-visualizer/entities-table/types";
 import { useEntitiesVisualizerData } from "./entities-visualizer/use-entities-visualizer-data";
-import type { EntityEditorProps } from "./entity/entity-editor";
 import { EntityGraphVisualizer } from "./entity-graph-visualizer";
+import type { EntityEditorProps } from "./entity/entity-editor";
 import type {
   DynamicNodeSizing,
   GraphVizConfig,
@@ -102,7 +102,7 @@ const generateGraphSort = (
       break;
     case "lastEdited":
       path = [
-        "recordCreatedAtTransactionTime" satisfies EntityQuerySortingToken,
+        "editionCreatedAtTransactionTime" satisfies EntityQuerySortingToken,
       ];
       break;
     case "created":

--- a/libs/@local/graph/api/openapi/openapi.json
+++ b/libs/@local/graph/api/openapi/openapi.json
@@ -5307,8 +5307,8 @@
           "archived",
           "properties",
           "label",
-          "recordCreatedAtTransactionTime",
-          "recordCreatedAtDecisionTime",
+          "editionCreatedAtTransactionTime",
+          "editionCreatedAtDecisionTime",
           "createdAtTransactionTime",
           "createdAtDecisionTime",
           "typeTitle"

--- a/libs/@local/graph/store/src/entity/query.rs
+++ b/libs/@local/graph/store/src/entity/query.rs
@@ -827,8 +827,8 @@ pub enum EntityQuerySortingToken {
     Archived,
     Properties,
     Label,
-    RecordCreatedAtTransactionTime,
-    RecordCreatedAtDecisionTime,
+    EditionCreatedAtTransactionTime,
+    EditionCreatedAtDecisionTime,
     CreatedAtTransactionTime,
     CreatedAtDecisionTime,
     TypeTitle,
@@ -842,8 +842,8 @@ pub(crate) struct EntityQuerySortingVisitor {
 
 impl EntityQuerySortingVisitor {
     pub(crate) const EXPECTING: &'static str =
-        "one of `uuid`, `archived`, `properties`, `label`, `recordCreatedAtTransactionTime`, \
-         `recordCreatedAtDecisionTime`, `createdAtTransactionTime`, `createdAtDecisionTime`, \
+        "one of `uuid`, `archived`, `properties`, `label`, `editionCreatedAtTransactionTime`, \
+         `editionCreatedAtDecisionTime`, `createdAtTransactionTime`, `createdAtDecisionTime`, \
          `typeTitle`";
 
     #[must_use]
@@ -871,10 +871,10 @@ impl<'de> Visitor<'de> for EntityQuerySortingVisitor {
         Ok(match token {
             EntityQuerySortingToken::Uuid => EntityQueryPath::Uuid,
             EntityQuerySortingToken::Archived => EntityQueryPath::Archived,
-            EntityQuerySortingToken::RecordCreatedAtTransactionTime => {
+            EntityQuerySortingToken::EditionCreatedAtTransactionTime => {
                 EntityQueryPath::TransactionTime
             }
-            EntityQuerySortingToken::RecordCreatedAtDecisionTime => EntityQueryPath::DecisionTime,
+            EntityQuerySortingToken::EditionCreatedAtDecisionTime => EntityQueryPath::DecisionTime,
             EntityQuerySortingToken::CreatedAtTransactionTime => {
                 EntityQueryPath::Provenance(Some(JsonPath::from_path_tokens(vec![
                     PathToken::Field(Cow::Borrowed("createdAtTransactionTime")),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We use `record` only when specifying a sorting path, and we call this concept `edition` everywhere else. 