### PR TITLE
H-4363: HashQL: Allow for generics on newtypes

### DIFF
--- a/libs/@local/hashql/ast/src/format/dump.rs
+++ b/libs/@local/hashql/ast/src/format/dump.rs
@@ -360,7 +360,7 @@ impl_syntax_dump!(struct LetExpr(name); value ?r#type body);
 
 impl_syntax_dump!(struct TypeExpr(name); value []constraints body);
 
-impl_syntax_dump!(struct NewTypeExpr(name); value body);
+impl_syntax_dump!(struct NewTypeExpr(name); value []constraints body);
 
 impl SyntaxDump for UseBinding {
     fn syntax_dump(&self, fmt: &mut Formatter, depth: usize) -> fmt::Result {

--- a/libs/@local/hashql/ast/src/format/dump.rs
+++ b/libs/@local/hashql/ast/src/format/dump.rs
@@ -358,9 +358,9 @@ impl_syntax_dump!(struct LiteralExpr(); kind ?r#type);
 
 impl_syntax_dump!(struct LetExpr(name); value ?r#type body);
 
-impl_syntax_dump!(struct TypeExpr(name); value []constraints body);
+impl_syntax_dump!(struct TypeExpr(name); []constraints value body);
 
-impl_syntax_dump!(struct NewTypeExpr(name); value []constraints body);
+impl_syntax_dump!(struct NewTypeExpr(name); []constraints value body);
 
 impl SyntaxDump for UseBinding {
     fn syntax_dump(&self, fmt: &mut Formatter, depth: usize) -> fmt::Result {

--- a/libs/@local/hashql/ast/src/lowering/name_mangler.rs
+++ b/libs/@local/hashql/ast/src/lowering/name_mangler.rs
@@ -399,6 +399,7 @@ impl<'heap> Visitor<'heap> for NameMangler {
             id,
             span,
             name,
+            constraints,
             value,
             body,
         } = expr;
@@ -406,9 +407,15 @@ impl<'heap> Visitor<'heap> for NameMangler {
         self.visit_id(id);
         self.visit_span(span);
         self.visit_ident(name);
-        self.visit_type(value);
+
+        let mangled_constraints =
+            self.mangle_constraints(original.clone(), mangled.clone(), constraints);
 
         self.enter(Scope::Type, original.clone(), mangled.clone(), |this| {
+            this.enter_many(Scope::Type, mangled_constraints, |this| {
+                this.visit_type(value);
+            });
+
             // unlike types, newtypes also bring a constructor into scope
             this.enter(Scope::Value, original, mangled, |this| {
                 this.visit_expr(body);

--- a/libs/@local/hashql/ast/src/lowering/special_form_expander/mod.rs
+++ b/libs/@local/hashql/ast/src/lowering/special_form_expander/mod.rs
@@ -691,15 +691,20 @@ impl<'heap> SpecialFormExpander<'heap> {
 
         let [name, value, body] = call.arguments.try_into().unwrap_or_else(|_| unreachable!());
 
-        let (name, value) = Option::zip(
-            self.lower_argument_to_ident(BindingMode::Newtype, name),
+        let ((name, arguments), value) = Option::zip(
+            self.lower_argument_to_generic_ident(BindingMode::Newtype, name),
             self.lower_expr_to_type(*value.value),
         )?;
+
+        let constraints = self.lower_path_segment_arguments_to_constraints(arguments)?;
 
         Some(ExprKind::NewType(NewTypeExpr {
             id: call.id,
             span: call.span,
+
             name,
+            constraints,
+
             value: self.heap.boxed(value),
             body: body.value,
         }))

--- a/libs/@local/hashql/ast/src/node/expr/newtype.rs
+++ b/libs/@local/hashql/ast/src/node/expr/newtype.rs
@@ -1,7 +1,7 @@
 use hashql_core::{heap, span::SpanId, symbol::Ident};
 
 use super::Expr;
-use crate::node::{id::NodeId, r#type::Type};
+use crate::node::{generic::GenericConstraint, id::NodeId, r#type::Type};
 
 /// A new type definition expression in the HashQL Abstract Syntax Tree.
 ///
@@ -18,11 +18,13 @@ use crate::node::{id::NodeId, r#type::Type};
 ///
 /// ```json
 /// ["newtype", "UserId", "String", <body>]
-/// ["newtype", "Coordinates", {"#type": {"lat": "Float", "lng": "Float"}}, <body>]
+/// ["newtype", "Coordinates", {"#struct": {"lat": "Float", "lng": "Float"}}, <body>]
 ///
 /// ["newtype", "AccountId", "String"
 ///     ["AccountId", {"#literal": "1234"}]
 /// ]
+///
+/// ["newtype", "Person<T>", {"#struct": {"properties": T}}, <body>]
 /// ```
 ///
 /// ## Documentation Format
@@ -40,6 +42,8 @@ pub struct NewTypeExpr<'heap> {
     pub span: SpanId,
 
     pub name: Ident,
+    pub constraints: heap::Vec<'heap, GenericConstraint<'heap>>,
+
     pub value: heap::Box<'heap, Type<'heap>>,
 
     pub body: heap::Box<'heap, Expr<'heap>>,

--- a/libs/@local/hashql/ast/src/visit.rs
+++ b/libs/@local/hashql/ast/src/visit.rs
@@ -685,6 +685,7 @@ pub fn walk_newtype_expr<'heap, T: Visitor<'heap> + ?Sized>(
         id,
         span,
         name,
+        constraints,
         value,
         body,
     }: &mut NewTypeExpr<'heap>,
@@ -693,6 +694,11 @@ pub fn walk_newtype_expr<'heap, T: Visitor<'heap> + ?Sized>(
     visitor.visit_span(span);
 
     visitor.visit_ident(name);
+
+    for constraint in constraints {
+        visitor.visit_generic_constraint(constraint);
+    }
+
     visitor.visit_type(value);
     visitor.visit_expr(body);
 }

--- a/libs/@local/hashql/ast/tests/ui/lowering/name-mangler/newtype-generics.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/name-mangler/newtype-generics.jsonc
@@ -1,0 +1,10 @@
+//@ run: pass
+//@ description: mangle the name of the generics
+[
+  "newtype",
+  "Foo<T: Bar, U: V, V>",
+  {
+    "#struct": { "foo": "T", "bar": "U", "baz": "V", "inner": "Foo<T, U, V>" }
+  },
+  "_"
+]

--- a/libs/@local/hashql/ast/tests/ui/lowering/name-mangler/newtype-generics.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/name-mangler/newtype-generics.stdout
@@ -1,6 +1,17 @@
 Expr#4294967040@70
   ExprKind (NewType)
     NewTypeExpr#4294967040@70 (name: Foo:0)
+      GenericConstraint#4294967040@10 (name: T:0)
+        Type#4294967040@9
+          TypeKind (Path)
+            Path#4294967040@9 (rooted: false)
+              PathSegment#4294967040@8 (name: Bar)
+      GenericConstraint#4294967040@15 (name: U:0)
+        Type#4294967040@14
+          TypeKind (Path)
+            Path#4294967040@14 (rooted: false)
+              PathSegment#4294967040@13 (name: V:0)
+      GenericConstraint#4294967040@20 (name: V:0)
       Type#4294967040@66
         TypeKind (Struct)
           StructType#4294967040@66
@@ -42,16 +53,5 @@ Expr#4294967040@70
                             TypeKind (Path)
                               Path#4294967040@61 (rooted: false)
                                 PathSegment#4294967040@60 (name: V:0)
-      GenericConstraint#4294967040@10 (name: T:0)
-        Type#4294967040@9
-          TypeKind (Path)
-            Path#4294967040@9 (rooted: false)
-              PathSegment#4294967040@8 (name: Bar)
-      GenericConstraint#4294967040@15 (name: U:0)
-        Type#4294967040@14
-          TypeKind (Path)
-            Path#4294967040@14 (rooted: false)
-              PathSegment#4294967040@13 (name: V:0)
-      GenericConstraint#4294967040@20 (name: V:0)
       Expr#4294967040@69
         ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/name-mangler/newtype-generics.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/name-mangler/newtype-generics.stdout
@@ -1,0 +1,57 @@
+Expr#4294967040@70
+  ExprKind (NewType)
+    NewTypeExpr#4294967040@70 (name: Foo:0)
+      Type#4294967040@66
+        TypeKind (Struct)
+          StructType#4294967040@66
+            StructField#4294967040@29 (name: foo)
+              Type#4294967040@28
+                TypeKind (Path)
+                  Path#4294967040@28 (rooted: false)
+                    PathSegment#4294967040@27 (name: T:0)
+            StructField#4294967040@36 (name: bar)
+              Type#4294967040@35
+                TypeKind (Path)
+                  Path#4294967040@35 (rooted: false)
+                    PathSegment#4294967040@34 (name: U:0)
+            StructField#4294967040@43 (name: baz)
+              Type#4294967040@42
+                TypeKind (Path)
+                  Path#4294967040@42 (rooted: false)
+                    PathSegment#4294967040@41 (name: V:0)
+            StructField#4294967040@65 (name: inner)
+              Type#4294967040@64
+                TypeKind (Path)
+                  Path#4294967040@64 (rooted: false)
+                    PathSegment#4294967040@63 (name: Foo:0)
+                      PathSegmentArgument (GenericArgument)
+                        GenericArgument#4294967040@52
+                          Type#4294967040@51
+                            TypeKind (Path)
+                              Path#4294967040@51 (rooted: false)
+                                PathSegment#4294967040@50 (name: T:0)
+                      PathSegmentArgument (GenericArgument)
+                        GenericArgument#4294967040@57
+                          Type#4294967040@56
+                            TypeKind (Path)
+                              Path#4294967040@56 (rooted: false)
+                                PathSegment#4294967040@55 (name: U:0)
+                      PathSegmentArgument (GenericArgument)
+                        GenericArgument#4294967040@62
+                          Type#4294967040@61
+                            TypeKind (Path)
+                              Path#4294967040@61 (rooted: false)
+                                PathSegment#4294967040@60 (name: V:0)
+      GenericConstraint#4294967040@10 (name: T:0)
+        Type#4294967040@9
+          TypeKind (Path)
+            Path#4294967040@9 (rooted: false)
+              PathSegment#4294967040@8 (name: Bar)
+      GenericConstraint#4294967040@15 (name: U:0)
+        Type#4294967040@14
+          TypeKind (Path)
+            Path#4294967040@14 (rooted: false)
+              PathSegment#4294967040@13 (name: V:0)
+      GenericConstraint#4294967040@20 (name: V:0)
+      Expr#4294967040@69
+        ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/name-mangler/type-generics-constraints.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/name-mangler/type-generics-constraints.stdout
@@ -1,6 +1,11 @@
 Expr#4294967040@24
   ExprKind (Type)
     TypeExpr#4294967040@24 (name: Foo:0)
+      GenericConstraint#4294967040@10 (name: Bar:0)
+        Type#4294967040@9
+          TypeKind (Path)
+            Path#4294967040@9 (rooted: false)
+              PathSegment#4294967040@8 (name: Baz)
       Type#4294967040@20
         TypeKind (Struct)
           StructType#4294967040@20
@@ -9,10 +14,5 @@ Expr#4294967040@24
                 TypeKind (Path)
                   Path#4294967040@18 (rooted: false)
                     PathSegment#4294967040@17 (name: Bar:0)
-      GenericConstraint#4294967040@10 (name: Bar:0)
-        Type#4294967040@9
-          TypeKind (Path)
-            Path#4294967040@9 (rooted: false)
-              PathSegment#4294967040@8 (name: Baz)
       Expr#4294967040@23
         ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/name-mangler/type-generics-interdependent-generics.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/name-mangler/type-generics-interdependent-generics.stdout
@@ -1,6 +1,12 @@
 Expr#4294967040@36
   ExprKind (Type)
     TypeExpr#4294967040@36 (name: Foo:0)
+      GenericConstraint#4294967040@10 (name: T:0)
+        Type#4294967040@9
+          TypeKind (Path)
+            Path#4294967040@9 (rooted: false)
+              PathSegment#4294967040@8 (name: U:0)
+      GenericConstraint#4294967040@15 (name: U:0)
       Type#4294967040@32
         TypeKind (Struct)
           StructType#4294967040@32
@@ -14,11 +20,5 @@ Expr#4294967040@36
                 TypeKind (Path)
                   Path#4294967040@30 (rooted: false)
                     PathSegment#4294967040@29 (name: U:0)
-      GenericConstraint#4294967040@10 (name: T:0)
-        Type#4294967040@9
-          TypeKind (Path)
-            Path#4294967040@9 (rooted: false)
-              PathSegment#4294967040@8 (name: U:0)
-      GenericConstraint#4294967040@15 (name: U:0)
       Expr#4294967040@35
         ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/name-mangler/type-generics-nested.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/name-mangler/type-generics-nested.stdout
@@ -8,6 +8,11 @@ Expr#4294967040@37
       Expr#4294967040@36
         ExprKind (Type)
           TypeExpr#4294967040@36 (name: Bar:0)
+            GenericConstraint#4294967040@22 (name: T:0)
+              Type#4294967040@21
+                TypeKind (Path)
+                  Path#4294967040@21 (rooted: false)
+                    PathSegment#4294967040@20 (name: Foo:0)
             Type#4294967040@32
               TypeKind (Struct)
                 StructType#4294967040@32
@@ -16,10 +21,5 @@ Expr#4294967040@37
                       TypeKind (Path)
                         Path#4294967040@30 (rooted: false)
                           PathSegment#4294967040@29 (name: T:0)
-            GenericConstraint#4294967040@22 (name: T:0)
-              Type#4294967040@21
-                TypeKind (Path)
-                  Path#4294967040@21 (rooted: false)
-                    PathSegment#4294967040@20 (name: Foo:0)
             Expr#4294967040@35
               ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/name-mangler/type-generics.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/name-mangler/type-generics.stdout
@@ -1,6 +1,7 @@
 Expr#4294967040@24
   ExprKind (Type)
     TypeExpr#4294967040@24 (name: Foo:0)
+      GenericConstraint#4294967040@10 (name: Bar:0)
       Type#4294967040@20
         TypeKind (Struct)
           StructType#4294967040@20
@@ -9,6 +10,5 @@ Expr#4294967040@24
                 TypeKind (Path)
                   Path#4294967040@18 (rooted: false)
                     PathSegment#4294967040@17 (name: Bar:0)
-      GenericConstraint#4294967040@10 (name: Bar:0)
       Expr#4294967040@23
         ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/newtype-collect-all-errors.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/newtype-collect-all-errors.jsonc
@@ -1,5 +1,5 @@
 //@ run: fail
 //@ description: We should collect all errors when lowering newtype/3, and not only report the first one.
 ["::kernel::special_form::newtype", "::x", { "#literal": 1 }, "x"]
-//~^ ERROR Replace this with a simple identifier
+//~^ ERROR Replace this qualified path with a simple identifier
 //~| ERROR Replace this literal with a type name

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/newtype-collect-all-errors.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/newtype-collect-all-errors.stderr
@@ -22,9 +22,9 @@
    │
  3 │ ["::kernel::special_form::newtype", "::x", { "#literal": 1 }, "x"]
    │                                      ─┬─  
-   │                                       ╰─── Replace this with a simple identifier
+   │                                       ╰─── Replace this qualified path with a simple identifier
    │ 
-   │ Help: newtype binding names must be simple identifiers without any path qualification. Qualified paths cannot be used as binding names.
+   │ Help: The newtype binding requires a simple type name (like 'String' or 'MyType<T>'), not a qualified path (like 'std::string::String'). Remove the path segments.
    │ 
-   │ Note: Valid identifiers are simple names like 'x', 'counter', '+', or 'user_name' without any namespace qualification, generic parameters, or path separators.
+   │ Note: Valid type names are simple identifiers, optionally followed by generic arguments (e.g., 'Identifier' or 'Container<Param>'). They cannot contain '::' path separators in this context.
 ───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/newtype-constraints.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/newtype-constraints.jsonc
@@ -1,0 +1,3 @@
+//@ run: pass
+//@ description: Constraints should be converted to an AST node
+["::kernel::special_form::newtype", "Foo<T, U: Bar>", "Integer", "_"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/newtype-constraints.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/newtype-constraints.stdout
@@ -1,0 +1,15 @@
+Expr#4294967040@28
+  ExprKind (NewType)
+    NewTypeExpr#4294967040@28 (name: Foo)
+      Type#4294967040@25
+        TypeKind (Path)
+          Path#4294967040@25 (rooted: false)
+            PathSegment#4294967040@24 (name: Integer)
+      GenericConstraint#4294967040@14 (name: T)
+      GenericConstraint#4294967040@19 (name: U)
+        Type#4294967040@18
+          TypeKind (Path)
+            Path#4294967040@18 (rooted: false)
+              PathSegment#4294967040@17 (name: Bar)
+      Expr#4294967040@27
+        ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/newtype-constraints.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/newtype-constraints.stdout
@@ -1,15 +1,15 @@
 Expr#4294967040@28
   ExprKind (NewType)
     NewTypeExpr#4294967040@28 (name: Foo)
-      Type#4294967040@25
-        TypeKind (Path)
-          Path#4294967040@25 (rooted: false)
-            PathSegment#4294967040@24 (name: Integer)
       GenericConstraint#4294967040@14 (name: T)
       GenericConstraint#4294967040@19 (name: U)
         Type#4294967040@18
           TypeKind (Path)
             Path#4294967040@18 (rooted: false)
               PathSegment#4294967040@17 (name: Bar)
+      Type#4294967040@25
+        TypeKind (Path)
+          Path#4294967040@25 (rooted: false)
+            PathSegment#4294967040@24 (name: Integer)
       Expr#4294967040@27
         ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/type-generic-constraint.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/type-generic-constraint.stdout
@@ -1,6 +1,11 @@
 Expr#4294967040@28
   ExprKind (Type)
     TypeExpr#4294967040@28 (name: Foo)
+      GenericConstraint#4294967040@14 (name: Bar)
+        Type#4294967040@13
+          TypeKind (Path)
+            Path#4294967040@13 (rooted: false)
+              PathSegment#4294967040@12 (name: Baz)
       Type#4294967040@24
         TypeKind (Struct)
           StructType#4294967040@24
@@ -9,10 +14,5 @@ Expr#4294967040@28
                 TypeKind (Path)
                   Path#4294967040@22 (rooted: false)
                     PathSegment#4294967040@21 (name: Bar)
-      GenericConstraint#4294967040@14 (name: Bar)
-        Type#4294967040@13
-          TypeKind (Path)
-            Path#4294967040@13 (rooted: false)
-              PathSegment#4294967040@12 (name: Baz)
       Expr#4294967040@27
         ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/type-generic.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/type-generic.stdout
@@ -1,6 +1,7 @@
 Expr#4294967040@28
   ExprKind (Type)
     TypeExpr#4294967040@28 (name: Foo)
+      GenericConstraint#4294967040@14 (name: Bar)
       Type#4294967040@24
         TypeKind (Struct)
           StructType#4294967040@24
@@ -9,6 +10,5 @@ Expr#4294967040@28
                 TypeKind (Path)
                   Path#4294967040@22 (rooted: false)
                     PathSegment#4294967040@21 (name: Bar)
-      GenericConstraint#4294967040@14 (name: Bar)
       Expr#4294967040@27
         ExprKind (Underscore)


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Allow for generics (with constraints) in newtypes, for example:

```
newtype User<T: String> = (name: T, birthday: ZonedDateTime) in
...
```

now works as intended. This is largely a follow-up to https://linear.app/hash/issue/H-4362/hashql-allow-for-generics-on-types as both require the same logic.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

