### PR TITLE
H-4504: HashQL: Compiletest should respect run mode

### DIFF
--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/fn-params-tuple.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/fn-params-tuple.jsonc
@@ -1,4 +1,4 @@
-//@ run: pass
+//@ run: fail
 //@ description: fn/4 tuple params should fail to compile
 [
   "::kernel::special_form::fn",

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/fn-params-type.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/fn-params-type.jsonc
@@ -1,4 +1,4 @@
-//@ run: pass
+//@ run: fail
 //@ description: fn/4 struct params with type annotations should fail to compile
 [
   "::kernel::special_form::fn",

--- a/libs/@local/hashql/compiletest/src/executor/mod.rs
+++ b/libs/@local/hashql/compiletest/src/executor/mod.rs
@@ -35,6 +35,10 @@ pub(crate) enum TrialError {
     UnfulfilledAnnotation(DiagnosticAnnotation),
     #[display("unexpected diagnostic:\n{_0}")]
     UnexpectedDiagnostic(String),
+    #[display("Expected trial to fail, but it passed instead")]
+    TrialShouldFail,
+    #[display("Expected trial to pass, but it failed")]
+    TrialShouldPass,
 }
 
 impl error::Error for TrialError {}

--- a/libs/@local/hashql/compiletest/src/executor/trial.rs
+++ b/libs/@local/hashql/compiletest/src/executor/trial.rs
@@ -266,6 +266,14 @@ impl Trial {
 
         let result = self.suite.run(heap, expr, &mut diagnostics);
 
+        if self.annotations.directive.run == RunMode::Pass && result.is_err() {
+            return Err(Report::new(TrialError::TrialShouldPass));
+        }
+
+        if self.annotations.directive.run == RunMode::Fail && result.is_ok() {
+            return Err(Report::new(TrialError::TrialShouldFail));
+        }
+
         let (received_stdout, fatal_diagnostic) = match result {
             Ok(stdout) => (Some(stdout), None),
             Err(error) => (None, Some(error)),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Before we just ignored the `RunMode`, even though we were parsing it. This change remedies this, by actually enforcing that `RunMode` is as expected.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

