### PR TITLE
H-4486: Implement a TypeId to distinguish between different references with the same name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3218,6 +3218,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simple-mermaid",
+ "specta",
  "time",
  "tokio-util",
  "utoipa",

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/value/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/value/mod.rs
@@ -50,7 +50,7 @@ pub use self::metadata::ValueMetadata;
 /// ```
 ///
 /// [`DataType`]: crate::ontology::data_type::DataType
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, specta::Type)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(untagged)]
 pub enum PropertyValue {

--- a/libs/@local/codec/Cargo.toml
+++ b/libs/@local/codec/Cargo.toml
@@ -16,6 +16,7 @@ serde               = { workspace = true, public = true, optional = true }
 # Public third-party dependencies
 bytes      = { workspace = true, public = true }
 regex      = { workspace = true, public = true, optional = true }
+specta     = { workspace = true, public = true, optional = true, features = ["derive"] }
 tokio-util = { workspace = true, public = true, optional = true, features = ["codec"] }
 utoipa     = { workspace = true, public = true, optional = true }
 
@@ -45,7 +46,7 @@ bytes = [
 ]
 serde = ["dep:serde", "dep:time", "dep:regex"]
 harpc = ["dep:harpc-wire-protocol", "dep:tokio-util", "dep:error-stack"]
-numeric = ["dep:dashu-base", "dep:dashu-float", "dep:derive_more"]
+numeric = ["dep:dashu-base", "dep:dashu-float", "dep:derive_more", "dep:specta"]
 postgres = ["dep:postgres-types"]
 utoipa = ["dep:utoipa"]
 

--- a/libs/@local/codec/src/numeric/real.rs
+++ b/libs/@local/codec/src/numeric/real.rs
@@ -65,8 +65,8 @@ pub struct ConversionError(dashu_base::ConversionError);
 /// let maybe_int = value.to_i32(); // Some(42)
 /// let float_val = value.to_f64(); // 42.0
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Real(dashu_float::DBig);
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, specta::Type)]
+pub struct Real(#[specta(type = f64)] dashu_float::DBig);
 
 const MIN_PRECISION: usize = 64;
 

--- a/libs/@local/codegen/src/definitions/mod.rs
+++ b/libs/@local/codegen/src/definitions/mod.rs
@@ -15,5 +15,5 @@ pub use self::{
     primitive::Primitive,
     r#struct::Struct,
     tuple::Tuple,
-    r#type::{Type, TypeDefinition},
+    r#type::{Type, TypeDefinition, TypeId},
 };

--- a/libs/@local/codegen/src/definitions/type.rs
+++ b/libs/@local/codegen/src/definitions/type.rs
@@ -4,6 +4,10 @@ use specta::{SpectaID, datatype};
 
 use super::{Enum, List, Map, Primitive, Struct, Tuple};
 
+/// A wrapper around `specta::SpectaID` that uniquely identifies types.
+///
+/// This solves the problem of distinguishing between different type references that might have the
+/// same name but are from different scopes or modules.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TypeId(specta::SpectaID);
 

--- a/libs/@local/codegen/src/definitions/type.rs
+++ b/libs/@local/codegen/src/definitions/type.rs
@@ -8,11 +8,11 @@ use super::{Enum, List, Map, Primitive, Struct, Tuple};
 pub struct TypeId(specta::SpectaID);
 
 impl TypeId {
-    pub(crate) fn from_specta(id: specta::SpectaID) -> Self {
+    pub(crate) const fn from_specta(id: specta::SpectaID) -> Self {
         Self(id)
     }
 
-    pub(crate) fn to_specta(self) -> SpectaID {
+    pub(crate) const fn to_specta(self) -> SpectaID {
         self.0
     }
 }

--- a/libs/@local/codegen/src/typescript.rs
+++ b/libs/@local/codegen/src/typescript.rs
@@ -192,12 +192,12 @@ impl<'a> TypeScriptGenerator<'a> {
         }
     }
 
-    fn visit_reference(&self, reference: TypeId) -> ast::TSType<'a> {
+    fn visit_reference(&self, type_id: TypeId) -> ast::TSType<'a> {
         self.ast.ts_type_type_reference(
             SPAN,
             self.ast.ts_type_name_identifier_reference(
                 SPAN,
-                self.collection.types[&reference].name.as_ref(),
+                self.collection.types[&type_id].name.as_ref(),
             ),
             None::<ast::TSTypeParameterInstantiation<'a>>,
         )

--- a/libs/@local/codegen/tests/codegen/main.rs
+++ b/libs/@local/codegen/tests/codegen/main.rs
@@ -84,19 +84,19 @@ fn main() -> ExitCode {
     register_types(&mut collection);
     collection.register_transitive_types();
 
-    let names = collection
+    let types = collection
         .iter()
-        .map(|(name, _)| name.to_owned())
+        .map(|(type_id, _, def)| (type_id, def.name.clone()))
         .collect::<Vec<_>>();
 
     let settings = TypeScriptGeneratorSettings::default();
     let generator = TypeScriptGenerator::new(&settings, collection);
 
     let mut tests = Vec::new();
-    for name in &names {
+    for (type_id, name) in types {
         for target in &targets {
             let test_name = format!("{name}::{target:?}");
-            let generated = generator.generate(name);
+            let generated = generator.generate(type_id);
             tests.push(Trial::test(test_name.clone(), move || {
                 assert_snapshot!(test_name, generated);
                 Ok(())

--- a/libs/@local/codegen/tests/codegen/main.rs
+++ b/libs/@local/codegen/tests/codegen/main.rs
@@ -66,6 +66,9 @@ fn register_types(collection: &mut TypeCollection) {
     collection.register::<tuples::TupleNested>();
     collection.register::<tuples::TupleOptional>();
 
+    // Register a recursive type
+    collection.register::<type_system::knowledge::PropertyValue>();
+
     // Register principals
     // Note, that transitive types can be completed by the codegen
     collection.register::<principal::Principal>();

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__PropertyValue::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__PropertyValue::Typescript.snap
@@ -1,0 +1,5 @@
+---
+source: libs/@local/codegen/tests/codegen/main.rs
+expression: generated
+---
+export type PropertyValue = null | boolean | string | Real | PropertyValue[] | Record<string, PropertyValue>;

--- a/libs/@local/codegen/tests/codegen/snapshots/codegen__Real::Typescript.snap
+++ b/libs/@local/codegen/tests/codegen/snapshots/codegen__Real::Typescript.snap
@@ -1,0 +1,5 @@
+---
+source: libs/@local/codegen/tests/codegen/main.rs
+expression: generated
+---
+export type Real = number;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When two types have the same name the codegen behaves wrongly. In particular with transitive types this is likely to happen.