### PR TITLE
H-4377: HashQL: Implement Import Resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3801,6 +3801,7 @@ dependencies = [
  "serde",
  "simple-mermaid",
  "smallvec 2.0.0-alpha.11",
+ "strsim",
  "test-case",
  "text-size",
  "tracing",

--- a/libs/@local/hashql/ast/src/lib.rs
+++ b/libs/@local/hashql/ast/src/lib.rs
@@ -53,7 +53,8 @@
     decl_macro,
     macro_metavar_expr,
     let_chains,
-    if_let_guard
+    if_let_guard,
+    iter_intersperse
 )]
 #![cfg_attr(test, feature(assert_matches))]
 

--- a/libs/@local/hashql/ast/src/lowering/import_resolver.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver.rs
@@ -1,0 +1,30 @@
+use hashql_core::module::namespace::ModuleNamespace;
+
+use crate::{
+    node::expr::{UseExpr, r#use::UseKind},
+    visit::Visitor,
+};
+
+pub struct ImportResolver<'env, 'heap> {
+    namespace: ModuleNamespace<'env, 'heap>,
+}
+
+impl<'env, 'heap> ImportResolver<'env, 'heap> {}
+
+impl<'env, 'heap> Visitor<'heap> for ImportResolver<'env, 'heap> {
+    fn visit_use_expr(
+        &mut self,
+        UseExpr {
+            id,
+            span,
+            path,
+            kind,
+            body,
+        }: &mut UseExpr<'heap>,
+    ) {
+        match kind {
+            UseKind::Named(use_bindings) => todo!(),
+            UseKind::Glob(glob) => todo!(),
+        }
+    }
+}

--- a/libs/@local/hashql/ast/src/lowering/import_resolver.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver.rs
@@ -1,11 +1,19 @@
+use core::{iter, mem};
+
 use hashql_core::{
     heap::Heap,
-    module::namespace::{ImportOptions, ModuleNamespace},
+    module::namespace::{ResolutionMode, ImportOptions, ModuleNamespace},
 };
 
 use crate::{
-    node::expr::{UseExpr, r#use::UseKind},
-    visit::Visitor,
+    node::{
+        expr::{
+            Expr, ExprKind, UseExpr,
+            r#use::{UseBinding, UseKind},
+        },
+        path::Path,
+    },
+    visit::{Visitor, walk_expr},
 };
 
 pub struct ImportResolver<'env, 'heap> {
@@ -13,19 +21,20 @@ pub struct ImportResolver<'env, 'heap> {
     namespace: ModuleNamespace<'env, 'heap>,
 }
 
-impl<'env, 'heap> ImportResolver<'env, 'heap> {}
-
-impl<'env, 'heap> Visitor<'heap> for ImportResolver<'env, 'heap> {
+impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
     fn visit_use_expr(
         &mut self,
         UseExpr {
-            id,
-            span,
+            id: _,
+            span: _,
             path,
             kind,
             body,
         }: &mut UseExpr<'heap>,
     ) {
+        // We don't need to walk the path here, because the import resolution already does the
+        // normalization for us
+
         let mut query = Vec::with_capacity(path.segments.len());
 
         // We'll replace ourselves with the body once walked, therefore save to drain
@@ -37,28 +46,71 @@ impl<'env, 'heap> Visitor<'heap> for ImportResolver<'env, 'heap> {
             }
         }
 
-        let imports = match kind {
-            UseKind::Named(use_bindings) => {
-                // TODO:
-                true
-            }
-            UseKind::Glob(_) => {
-                if path.rooted {
-                    self.namespace.import_absolute(
-                        self.heap.intern_symbol("*"),
-                        query.iter().copied(),
-                        ImportOptions { glob: true },
-                    )
-                } else {
-                    self.namespace.import_relative(
-                        self.heap.intern_symbol("*"),
-                        query.iter().copied(),
-                        ImportOptions { glob: true },
-                    )
-                }
-            }
+        let mode = if path.rooted {
+            ResolutionMode::Absolute
+        } else {
+            ResolutionMode::Relative
         };
 
-        // })
+        let snapshot = self.namespace.snapshot();
+
+        match kind {
+            UseKind::Named(use_bindings) => {
+                for UseBinding {
+                    id: _,
+                    span: _,
+                    name,
+                    alias,
+                } in use_bindings.drain(..)
+                {
+                    let name = name.value.intern(self.heap);
+                    let alias = alias.map_or(name, |alias| alias.value.intern(self.heap));
+
+                    let success = self.namespace.import(
+                        alias,
+                        query.iter().copied().chain(iter::once(name)),
+                        ImportOptions { glob: false, mode },
+                    );
+
+                    if !success {
+                        todo!("record diagnostic")
+                    }
+                }
+            }
+            UseKind::Glob(_) => {
+                let success = self.namespace.import(
+                    self.heap.intern_symbol("*"),
+                    query.iter().copied(),
+                    ImportOptions { glob: true, mode },
+                );
+
+                if !success {
+                    todo!("record diagnostic")
+                }
+            }
+        }
+
+        self.visit_expr(body);
+
+        self.namespace.rollback_to(snapshot);
+    }
+
+    fn visit_path(&mut self, path: &mut Path<'heap>) {
+        self.namespace.resolve_name(name, universe)
+
+        todo!()
+    }
+
+    fn visit_expr(&mut self, expr: &mut Expr<'heap>) {
+        // Process the node first
+        walk_expr(self, expr);
+
+        // Replace any use statement with it's body
+        let ExprKind::Use(use_expr) = &mut expr.kind else {
+            return;
+        };
+
+        let inner = mem::replace(&mut *use_expr.body, Expr::dummy());
+        *expr = inner;
     }
 }

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/error.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/error.rs
@@ -1,12 +1,39 @@
 use std::borrow::Cow;
 
-use hashql_core::span::SpanId;
-use hashql_diagnostics::{Diagnostic, category::DiagnosticCategory};
+use hashql_core::{span::SpanId, symbol::Symbol};
+use hashql_diagnostics::{
+    Category, Diagnostic, Help, Label, Note, Severity, category::DiagnosticCategory,
+};
 
 pub(crate) type ImportResolverDiagnostic = Diagnostic<ImportResolverDiagnosticCategory, SpanId>;
 
+const GENERIC_ARGUMENTS_IN_USE_PATH: Category = Category {
+    id: "generic-arguments-in-use-path",
+    name: "Generic arguments not allowed in import paths",
+};
+
+const EMPTY_PATH: Category = Category {
+    id: "empty-path",
+    name: "Empty path in import statement",
+};
+
+const GENERIC_ARGUMENTS_IN_MODULE: Category = Category {
+    id: "generic-arguments-in-module",
+    name: "Generic arguments only allowed in final path segment",
+};
+
+const UNKNOWN_IMPORT: Category = Category {
+    id: "unknown-import",
+    name: "Unknown import path",
+};
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum ImportResolverDiagnosticCategory {}
+pub enum ImportResolverDiagnosticCategory {
+    GenericArgumentsInUsePath,
+    EmptyPath,
+    GenericArgumentsInModule,
+    UnknownImport,
+}
 
 impl DiagnosticCategory for ImportResolverDiagnosticCategory {
     fn id(&self) -> Cow<'_, str> {
@@ -18,6 +45,218 @@ impl DiagnosticCategory for ImportResolverDiagnosticCategory {
     }
 
     fn subcategory(&self) -> Option<&dyn DiagnosticCategory> {
-        match self {}
+        match self {
+            Self::GenericArgumentsInUsePath => Some(&GENERIC_ARGUMENTS_IN_USE_PATH),
+            Self::EmptyPath => Some(&EMPTY_PATH),
+            Self::GenericArgumentsInModule => Some(&GENERIC_ARGUMENTS_IN_MODULE),
+            Self::UnknownImport => Some(&UNKNOWN_IMPORT),
+        }
     }
+}
+
+/// Error when generic arguments are used in a use path segment
+pub(crate) fn generic_arguments_in_use_path(span: SpanId) -> ImportResolverDiagnostic {
+    let mut diagnostic = Diagnostic::new(
+        ImportResolverDiagnosticCategory::GenericArgumentsInUsePath,
+        Severity::ERROR,
+    );
+
+    diagnostic
+        .labels
+        .push(Label::new(span, "Remove these generic arguments"));
+
+    diagnostic.help = Some(Help::new(
+        "Use statements don't accept generic type parameters. Remove the angle brackets and type \
+         parameters.",
+    ));
+
+    diagnostic.note = Some(Note::new(
+        "Import paths only identify modules and items to bring into scope, not specific generic \
+         instantiations.",
+    ));
+
+    diagnostic
+}
+
+/// Error when a path has no segments
+pub(crate) fn empty_path(span: SpanId) -> ImportResolverDiagnostic {
+    let mut diagnostic =
+        Diagnostic::new(ImportResolverDiagnosticCategory::EmptyPath, Severity::ERROR);
+
+    diagnostic
+        .labels
+        .push(Label::new(span, "Specify a path here"));
+
+    diagnostic.help = Some(Help::new(
+        "Add a valid path with at least one identifier, such as `module` or `module::item`.",
+    ));
+
+    diagnostic
+}
+
+/// Error when generic arguments are used in a module path segment
+pub(crate) fn generic_arguments_in_module(span: SpanId) -> ImportResolverDiagnostic {
+    let mut diagnostic = Diagnostic::new(
+        ImportResolverDiagnosticCategory::GenericArgumentsInModule,
+        Severity::ERROR,
+    );
+
+    diagnostic
+        .labels
+        .push(Label::new(span, "Remove these generic arguments"));
+
+    diagnostic.help = Some(Help::new(
+        "Generic arguments can only appear on the final type in a path. Remove them from this \
+         module segment.",
+    ));
+
+    diagnostic.note = Some(Note::new(
+        "To use generic parameters, apply them only to the final type: \
+         `module::submodule::Type<T>`.",
+    ));
+
+    diagnostic
+}
+
+/// A struct to hold name suggestions with similarity scores
+#[derive(Debug, Clone)]
+pub struct Suggestion {
+    /// The suggested name
+    pub name: String,
+    /// Similarity score (higher is better, typically 0.0-1.0)
+    pub score: f64,
+}
+
+/// Represents problem location in an import path
+pub enum ImportProblem {
+    /// A module in the path doesn't exist
+    Module {
+        /// Index of the problematic segment
+        segment_index: usize,
+        /// Possible alternative modules
+        suggestions: Vec<Suggestion>,
+    },
+    /// The symbol being imported doesn't exist in the module
+    Symbol {
+        /// The symbol that wasn't found
+        symbol: Symbol,
+        /// Possible alternative symbols
+        suggestions: Vec<Suggestion>,
+    },
+    /// No symbols were found for a glob import
+    EmptyGlob,
+    /// The path couldn't be resolved for an unknown reason
+    Unknown,
+}
+
+/// Error when an import path cannot be resolved
+pub(crate) fn unknown_import(
+    span: SpanId,
+    path: &[Symbol],
+    problem: ImportProblem,
+) -> ImportResolverDiagnostic {
+    let mut diagnostic = Diagnostic::new(
+        ImportResolverDiagnosticCategory::UnknownImport,
+        Severity::ERROR,
+    );
+
+    let path_str = path
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>()
+        .join("::");
+
+    match &problem {
+        ImportProblem::Module {
+            segment_index,
+            suggestions,
+        } => {
+            // Get the problematic module name
+            let module_name = if *segment_index < path.len() {
+                path[*segment_index].to_string()
+            } else {
+                "<unknown>".to_string()
+            };
+
+            diagnostic
+                .labels
+                .push(Label::new(span, format!("Unknown module '{module_name}'")));
+
+            let mut help = format!("The module '{module_name}' doesn't exist in this scope.");
+
+            // Add suggestions if available
+            if !suggestions.is_empty() {
+                let top_suggestions: Vec<_> = suggestions.iter()
+                    .filter(|s| s.score > 0.7) // Only include reasonably good matches
+                    .take(3)                  // Limit to top 3
+                    .map(|s| s.name.clone())
+                    .collect();
+
+                if !top_suggestions.is_empty() {
+                    let suggestion_str = top_suggestions.join("', '");
+                    help.push_str(&format!("\n\nDid you mean: '{suggestion_str}'?"));
+                }
+            }
+
+            diagnostic.help = Some(Help::new(help));
+        }
+
+        ImportProblem::Symbol {
+            symbol,
+            suggestions,
+        } => {
+            diagnostic
+                .labels
+                .push(Label::new(span, format!("Symbol '{symbol}' not found")));
+
+            let mut help = format!("The symbol '{symbol}' doesn't exist in module '{path_str}'.");
+
+            // Add suggestions if available
+            if !suggestions.is_empty() {
+                let top_suggestions: Vec<_> = suggestions.iter()
+                    .filter(|s| s.score > 0.7) // Only include reasonably good matches
+                    .take(3)                  // Limit to top 3
+                    .map(|s| s.name.clone())
+                    .collect();
+
+                if !top_suggestions.is_empty() {
+                    let suggestion_str = top_suggestions.join("', '");
+                    help.push_str(&format!("\n\nDid you mean: '{suggestion_str}'?"));
+                }
+            }
+
+            diagnostic.help = Some(Help::new(help));
+
+            diagnostic.note = Some(Note::new(
+                "Check if the symbol is public and spelled correctly, or if it needs to be \
+                 imported from another module.",
+            ));
+        }
+
+        ImportProblem::EmptyGlob => {
+            diagnostic
+                .labels
+                .push(Label::new(span, "No importable symbols found"));
+
+            diagnostic.help = Some(Help::new(format!(
+                "Module '{path_str}' exists but contains no public symbols that can be imported."
+            )));
+
+            diagnostic.note = Some(Note::new(
+                "Consider using a specific import instead of a glob import, or check if the \
+                 module is empty.",
+            ));
+        }
+
+        ImportProblem::Unknown => {
+            diagnostic.labels.push(Label::new(span, "Import not found"));
+
+            diagnostic.help = Some(Help::new(format!(
+                "Unable to resolve the import path '{path_str}'. Check that it exists and is \
+                 spelled correctly."
+            )));
+        }
+    }
+
+    diagnostic
 }

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/error.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/error.rs
@@ -2,27 +2,32 @@ use std::borrow::Cow;
 
 use hashql_core::{span::SpanId, symbol::Symbol};
 use hashql_diagnostics::{
-    Category, Diagnostic, Help, Label, Note, Severity, category::DiagnosticCategory,
+    Diagnostic,
+    category::{DiagnosticCategory, TerminalDiagnosticCategory},
+    help::Help,
+    label::Label,
+    note::Note,
+    severity::Severity,
 };
 
 pub(crate) type ImportResolverDiagnostic = Diagnostic<ImportResolverDiagnosticCategory, SpanId>;
 
-const GENERIC_ARGUMENTS_IN_USE_PATH: Category = Category {
+const GENERIC_ARGUMENTS_IN_USE_PATH: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
     id: "generic-arguments-in-use-path",
     name: "Generic arguments not allowed in import paths",
 };
 
-const EMPTY_PATH: Category = Category {
+const EMPTY_PATH: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
     id: "empty-path",
     name: "Empty path in import statement",
 };
 
-const GENERIC_ARGUMENTS_IN_MODULE: Category = Category {
+const GENERIC_ARGUMENTS_IN_MODULE: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
     id: "generic-arguments-in-module",
     name: "Generic arguments only allowed in final path segment",
 };
 
-const UNKNOWN_IMPORT: Category = Category {
+const UNKNOWN_IMPORT: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
     id: "unknown-import",
     name: "Unknown import path",
 };

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/error.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/error.rs
@@ -1,13 +1,13 @@
 use std::borrow::Cow;
 
-use hashql_core::{span::SpanId, symbol::Symbol};
+use hashql_core::{
+    module::error::{ResolutionError, Suggestion as ResolutionSuggestion},
+    span::SpanId,
+    symbol::{InternedSymbol, Symbol},
+};
 use hashql_diagnostics::{
-    Diagnostic,
+    Diagnostic, Help, Label, Note, Severity,
     category::{DiagnosticCategory, TerminalDiagnosticCategory},
-    help::Help,
-    label::Label,
-    note::Note,
-    severity::Severity,
 };
 
 pub(crate) type ImportResolverDiagnostic = Diagnostic<ImportResolverDiagnosticCategory, SpanId>;
@@ -29,7 +29,7 @@ const GENERIC_ARGUMENTS_IN_MODULE: TerminalDiagnosticCategory = TerminalDiagnost
 
 const UNRESOLVED_IMPORT: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
     id: "unresolved-import",
-    name: "Unresolved import path",
+    name: "Unresolved import",
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -123,66 +123,213 @@ pub(crate) fn generic_arguments_in_module(span: SpanId) -> ImportResolverDiagnos
     diagnostic
 }
 
-/// A struct to hold name suggestions with similarity scores
-#[derive(Debug, Clone)]
-pub struct Suggestion {
-    /// The suggested name
-    pub name: String,
-    /// Similarity score (higher is better, typically 0.0-1.0)
-    pub score: f64,
+/// Format suggestions for display in diagnostics
+fn format_suggestions<T: std::fmt::Display>(
+    suggestions: &[ResolutionSuggestion<T>],
+) -> Option<String> {
+    let top_suggestions: Vec<_> = suggestions.iter()
+        .filter(|s| s.score > 0.7) // Only include reasonably good matches
+        .take(3)                   // Limit to top 3
+        .map(|s| s.item.to_string())
+        .collect();
+
+    if top_suggestions.is_empty() {
+        None
+    } else {
+        let suggestion_str = top_suggestions.join("', '");
+        Some(format!("\n\nDid you mean: '{suggestion_str}'?"))
+    }
 }
 
-/// Error when an import path cannot be resolved
-pub(crate) fn unresolved_import(
+/// Format a module path for display in error messages
+fn format_path(path: &[InternedSymbol<'_>], depth: usize, rooted: bool) -> String {
+    if depth == 0 {
+        return String::new();
+    }
+
+    let prefix = if rooted { "::" } else { "" };
+
+    let path_str = path[..depth]
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>()
+        .join("::");
+
+    format!("{prefix}{path_str}")
+}
+
+/// Convert a resolution error to a diagnostic
+pub(crate) fn from_resolution_error<'heap>(
     span: SpanId,
-    path: &[Symbol],
-    suggestions: Option<Vec<Suggestion>>,
+    path: &[InternedSymbol<'heap>],
+    rooted: bool,
+    error: ResolutionError<'heap>,
 ) -> ImportResolverDiagnostic {
     let mut diagnostic = Diagnostic::new(
         ImportResolverDiagnosticCategory::UnresolvedImport,
         Severity::ERROR,
     );
 
-    let path_str = if path.is_empty() {
-        "<empty>".to_string()
-    } else {
-        path.iter()
-            .map(|symbol| symbol.to_string())
-            .collect::<Vec<_>>()
-            .join("::")
-    };
+    match &error {
+        ResolutionError::InvalidQueryLength { expected } => {
+            diagnostic
+                .labels
+                .push(Label::new(span, "Expected more path segments"));
 
-    diagnostic
-        .labels
-        .push(Label::new(span, "Unresolved import"));
+            diagnostic.help = Some(Help::new(format!(
+                "This import path needs at least {expected} segments to be valid."
+            )));
+        }
 
-    let mut help = format!(
-        "Cannot resolve the import path '{path_str}'. Check that it exists and is spelled \
-         correctly."
-    );
+        ResolutionError::ModuleRequired { depth, found } => {
+            let item_name = path[*depth].to_string();
+            let path_prefix = format_path(path, *depth, rooted);
+            let full_path = if path_prefix.is_empty() {
+                item_name.clone()
+            } else {
+                format!("{path_prefix}::{item_name}")
+            };
 
-    // Add suggestions if available
-    if let Some(suggestions) = suggestions {
-        if !suggestions.is_empty() {
-            let top_suggestions: Vec<_> = suggestions.iter()
-                .filter(|s| s.score > 0.7) // Only include reasonably good matches
-                .take(3)                  // Limit to top 3
-                .map(|s| s.name.clone())
-                .collect();
+            diagnostic.labels.push(Label::new(
+                span,
+                format!("'{item_name}' cannot contain other items"),
+            ));
 
-            if !top_suggestions.is_empty() {
-                let suggestion_str = top_suggestions.join("', '");
-                help.push_str(&format!("\n\nDid you mean: '{suggestion_str}'?"));
+            let universe_str = match found {
+                Some(hashql_core::module::item::Universe::Value) => "a value",
+                Some(hashql_core::module::item::Universe::Type) => "a type",
+                None => "not a module",
+            };
+
+            diagnostic.help = Some(Help::new(format!(
+                "'{full_path}' is {universe_str}, not a module. Only modules can contain other \
+                 items."
+            )));
+
+            diagnostic.note = Some(Note::new(
+                "The '::' syntax can only be used with modules to access their members.",
+            ));
+        }
+
+        ResolutionError::PackageNotFound { depth, suggestions } => {
+            let package_name = path[*depth].to_string();
+
+            diagnostic.labels.push(Label::new(
+                span,
+                format!("Missing package '{package_name}'"),
+            ));
+
+            let mut help = format!(
+                "This package couldn't be found, make sure it is spelled correctly and installed."
+            );
+
+            if let Some(suggestion_str) = format_suggestions(suggestions) {
+                help.push_str(&suggestion_str);
             }
+
+            diagnostic.help = Some(Help::new(help));
+        }
+
+        ResolutionError::ImportNotFound { depth, suggestions } => {
+            let import_name = path[*depth].to_string();
+
+            diagnostic.labels.push(Label::new(
+                span,
+                format!("'{import_name}' needs to be imported first"),
+            ));
+
+            let mut help = format!("Add an import statement for '{import_name}' before using it.");
+
+            if let Some(suggestion_str) = format_suggestions(suggestions) {
+                help.push_str(&suggestion_str);
+            }
+
+            diagnostic.help = Some(Help::new(help));
+        }
+
+        ResolutionError::ModuleNotFound { depth, suggestions } => {
+            let module_name = path[*depth].to_string();
+            let path_prefix = format_path(path, *depth, rooted);
+            let full_path = if path_prefix.is_empty() {
+                module_name.clone()
+            } else {
+                format!("{path_prefix}::{module_name}")
+            };
+
+            diagnostic.labels.push(Label::new(
+                span,
+                format!("Module '{module_name}' not found"),
+            ));
+
+            let mut help = format!("The module '{full_path}' doesn't exist in this scope.");
+
+            if let Some(suggestion_str) = format_suggestions(suggestions) {
+                help.push_str(&suggestion_str);
+            }
+
+            diagnostic.help = Some(Help::new(help));
+        }
+
+        ResolutionError::ItemNotFound { depth, suggestions } => {
+            let item_name = path[*depth].to_string();
+            let module_path = format_path(path, *depth, rooted);
+
+            let label_text = if module_path.is_empty() {
+                format!("'{item_name}' not found in current scope")
+            } else {
+                format!("'{item_name}' not found in module '{module_path}'")
+            };
+
+            diagnostic.labels.push(Label::new(span, label_text));
+
+            let mut help = "Check the spelling or ensure the item is public and properly imported.";
+
+            if let Some(suggestion_str) = format_suggestions(suggestions) {
+                help = format!("{help}{suggestion_str}");
+            }
+
+            diagnostic.help = Some(Help::new(help.to_string()));
+        }
+
+        ResolutionError::Ambiguous(item) => {
+            diagnostic
+                .labels
+                .push(Label::new(span, format!("'{item}' is ambiguous")));
+
+            diagnostic.help = Some(Help::new(format!(
+                "The name '{item}' could refer to multiple different items. Use a fully qualified \
+                 path to clarify."
+            )));
+
+            diagnostic.note = Some(Note::new(
+                "When the same name exists in multiple modules, you need to specify which one you \
+                 want.",
+            ));
+        }
+
+        ResolutionError::ModuleEmpty { depth } => {
+            let module_path = format_path(path, *depth, rooted);
+            let path_str = if module_path.is_empty() && *depth < path.len() {
+                path[*depth].to_string()
+            } else {
+                module_path
+            };
+
+            diagnostic.labels.push(Label::new(
+                span,
+                format!("Module '{path_str}' has no exported members"),
+            ));
+
+            diagnostic.help = Some(Help::new(
+                "This module exists but doesn't expose any items that can be imported.",
+            ));
+
+            diagnostic.note = Some(Note::new(
+                "Try using specific imports instead of a glob pattern, or check that the module \
+                 exports what you need.",
+            ));
         }
     }
-
-    diagnostic.help = Some(Help::new(help));
-
-    diagnostic.note = Some(Note::new(
-        "Make sure you've imported any required modules and that exported items are public and \
-         spelled correctly.",
-    ));
 
     diagnostic
 }

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/error.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/error.rs
@@ -1,0 +1,23 @@
+use std::borrow::Cow;
+
+use hashql_core::span::SpanId;
+use hashql_diagnostics::{Diagnostic, category::DiagnosticCategory};
+
+pub(crate) type ImportResolverDiagnostic = Diagnostic<ImportResolverDiagnosticCategory, SpanId>;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum ImportResolverDiagnosticCategory {}
+
+impl DiagnosticCategory for ImportResolverDiagnosticCategory {
+    fn id(&self) -> Cow<'_, str> {
+        Cow::Borrowed("import-resolver")
+    }
+
+    fn name(&self) -> Cow<'_, str> {
+        Cow::Borrowed("Import Resolver")
+    }
+
+    fn subcategory(&self) -> Option<&dyn DiagnosticCategory> {
+        match self {}
+    }
+}

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/error.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/error.rs
@@ -106,8 +106,10 @@ pub(crate) fn generic_arguments_in_use_path(
 
 /// Error when a path has no segments
 pub(crate) fn empty_path(span: SpanId) -> ImportResolverDiagnostic {
-    let mut diagnostic =
-        Diagnostic::new(ImportResolverDiagnosticCategory::EmptyPath, Severity::ERROR);
+    let mut diagnostic = Diagnostic::new(
+        ImportResolverDiagnosticCategory::EmptyPath,
+        Severity::COMPILER_BUG,
+    );
 
     diagnostic.labels.push(
         Label::new(span, "Specify a path here")
@@ -121,7 +123,9 @@ pub(crate) fn empty_path(span: SpanId) -> ImportResolverDiagnostic {
 
     diagnostic.note = Some(Note::new(
         "Import statements require a non-empty path to identify what module or item you want to \
-         bring into scope.",
+         bring into scope. This error is still valid, but should've been caught in an earlier \
+         stage of the compiler pipeline. Please report this issue to the HashQL team with a \
+         minimal reproduction case.",
     ));
 
     diagnostic

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
@@ -26,7 +26,9 @@ use crate::{
         path::{Path, PathSegment},
         r#type::Type,
     },
-    visit::{Visitor, walk_expr, walk_let_expr, walk_newtype_expr, walk_type, walk_type_expr},
+    visit::{
+        Visitor, walk_expr, walk_let_expr, walk_newtype_expr, walk_path, walk_type, walk_type_expr,
+    },
 };
 
 #[derive(Debug, Default)]
@@ -256,6 +258,8 @@ impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
                 arguments: self.heap.vec(None),
             }),
         );
+
+        walk_path(self, path);
     }
 
     fn visit_expr(&mut self, expr: &mut Expr<'heap>) {
@@ -319,4 +323,6 @@ impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
             self.scope.r#type.remove(&symbol);
         }
     }
+
+    // TODO: generic constraints
 }

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
@@ -133,6 +133,9 @@ impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
                     ImportOptions { glob: true, mode },
                 );
 
+                // TODO: the problem is we don't know *why* we failed, and it isn't that easy to
+                // find out why. We currently return a Vec, the problem is that we don't know how to
+                // continue, we will have to make a thonk about how to solve this issue.
                 if !success {
                     todo!("record diagnostic")
                 }
@@ -206,6 +209,7 @@ impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
         let span = path.segments.first().unwrap_or_else(|| unreachable!()).span;
         segments.truncate(segments.len() - path.segments.len());
 
+        path.rooted = true;
         path.segments.splice(
             0..0,
             segments.into_iter().map(|ident| PathSegment {

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
@@ -239,18 +239,18 @@ impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
         }
 
         // We don't support generics except for the *last* segment
-        let mut r#continue = true;
+        let mut should_continue = true;
         for module in modules {
             if !module.arguments.is_empty() {
                 self.diagnostics.push(generic_arguments_in_module(
                     module.arguments.iter().map(PathSegmentArgument::span),
                 ));
 
-                r#continue = false;
+                should_continue = false;
             }
         }
 
-        if !r#continue {
+        if !should_continue {
             // While in theory we could continue processing here, the problem would be that any
             // generic parameter would double emit errors, which adds additional visual noise.
             return;

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
@@ -1,3 +1,5 @@
+pub mod error;
+
 use core::{iter, mem};
 
 use hashql_core::{

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
@@ -115,28 +115,36 @@ impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
                     let name = name.value.intern(self.heap);
                     let alias = alias.map_or(name, |alias| alias.value.intern(self.heap));
 
-                    let success = self.namespace.import(
+                    let result = self.namespace.import(
                         alias,
                         query.iter().copied().chain(iter::once(name)),
-                        ImportOptions { glob: false, mode },
+                        ImportOptions {
+                            glob: false,
+                            mode,
+                            suggestions: true,
+                        },
                     );
 
-                    if !success {
+                    if let Err(error) = result {
                         todo!("record diagnostic")
                     }
                 }
             }
             UseKind::Glob(_) => {
-                let success = self.namespace.import(
+                let result = self.namespace.import(
                     self.heap.intern_symbol("*"),
                     query.iter().copied(),
-                    ImportOptions { glob: true, mode },
+                    ImportOptions {
+                        glob: true,
+                        mode,
+                        suggestions: true,
+                    },
                 );
 
                 // TODO: the problem is we don't know *why* we failed, and it isn't that easy to
                 // find out why. We currently return a Vec, the problem is that we don't know how to
                 // continue, we will have to make a thonk about how to solve this issue.
-                if !success {
+                if let Err(error) = result {
                     todo!("record diagnostic")
                 }
             }

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
@@ -13,8 +13,8 @@ use hashql_core::{
 };
 
 use self::error::{
-    ImportResolverDiagnostic, failed_import, failed_path_resolution, generic_arguments_in_use_path,
-    invalid_path_segments, module_with_generic_arguments,
+    ImportResolverDiagnostic, empty_path, generic_arguments_in_module,
+    generic_arguments_in_use_path,
 };
 use crate::{
     node::{
@@ -147,7 +147,8 @@ impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
     fn visit_path(&mut self, path: &mut Path<'heap>) {
         // We don't support generics except for the *last* segment
         let [modules @ .., ident] = &*path.segments else {
-            todo!("record diagnostic")
+            self.diagnostics.push(empty_path(path.span));
+            return;
         };
 
         if modules.is_empty()
@@ -161,7 +162,8 @@ impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
 
         for module in modules {
             if !module.arguments.is_empty() {
-                todo!("record diagnostic")
+                self.diagnostics
+                    .push(generic_arguments_in_module(module.span));
             }
         }
 

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
@@ -141,9 +141,6 @@ impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
                     },
                 );
 
-                // TODO: the problem is we don't know *why* we failed, and it isn't that easy to
-                // find out why. We currently return a Vec, the problem is that we don't know how to
-                // continue, we will have to make a thonk about how to solve this issue.
                 if let Err(error) = result {
                     todo!("record diagnostic")
                 }

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
@@ -453,5 +453,5 @@ impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
         });
     }
 
-    // TODO: generic constraints
+    // TODO: closures
 }

--- a/libs/@local/hashql/ast/src/lowering/mod.rs
+++ b/libs/@local/hashql/ast/src/lowering/mod.rs
@@ -1,4 +1,5 @@
 pub mod error;
+pub mod import_resolver;
 pub mod name_mangler;
 pub mod node_renumberer;
 pub mod pre_expansion_name_resolver;

--- a/libs/@local/hashql/ast/src/lowering/name_mangler.rs
+++ b/libs/@local/hashql/ast/src/lowering/name_mangler.rs
@@ -37,7 +37,7 @@ use core::fmt::Write as _;
 
 use foldhash::fast::RandomState;
 use hashbrown::HashMap;
-use hashql_core::{heap, symbol::Symbol};
+use hashql_core::{collection::FastHashMap, heap, symbol::Symbol};
 
 use crate::{
     node::{
@@ -61,15 +61,15 @@ struct Binding {
 }
 
 struct Namespaces {
-    value: HashMap<Symbol, Symbol, RandomState>,
-    r#type: HashMap<Symbol, Symbol, RandomState>,
+    value: FastHashMap<Symbol, Symbol>,
+    r#type: FastHashMap<Symbol, Symbol>,
 }
 
 impl Namespaces {
     fn new() -> Self {
         Self {
-            value: HashMap::with_hasher(RandomState::default()),
-            r#type: HashMap::with_hasher(RandomState::default()),
+            value: FastHashMap::default(),
+            r#type: FastHashMap::default(),
         }
     }
 

--- a/libs/@local/hashql/ast/src/lowering/pre_expansion_name_resolver.rs
+++ b/libs/@local/hashql/ast/src/lowering/pre_expansion_name_resolver.rs
@@ -230,7 +230,7 @@ impl<'env, 'heap> PreExpansionNameResolver<'env, 'heap> {
 
         let import = self
             .namespace
-            .lookup_import(name.intern(self.heap), Universe::Value)?;
+            .resolve_name(name.intern(self.heap), Universe::Value)?;
 
         // We're only interested in intrinsics
         let ItemKind::Intrinsic(IntrinsicItem {

--- a/libs/@local/hashql/ast/src/lowering/pre_expansion_name_resolver.rs
+++ b/libs/@local/hashql/ast/src/lowering/pre_expansion_name_resolver.rs
@@ -230,7 +230,7 @@ impl<'env, 'heap> PreExpansionNameResolver<'env, 'heap> {
 
         let import = self
             .namespace
-            .lookup_import(self.heap.intern_symbol(name.as_str()), Universe::Value)?;
+            .lookup_import(name.intern(self.heap), Universe::Value)?;
 
         // We're only interested in intrinsics
         let ItemKind::Intrinsic(IntrinsicItem {

--- a/libs/@local/hashql/ast/src/lowering/pre_expansion_name_resolver.rs
+++ b/libs/@local/hashql/ast/src/lowering/pre_expansion_name_resolver.rs
@@ -228,14 +228,19 @@ impl<'env, 'heap> PreExpansionNameResolver<'env, 'heap> {
             return Some(path.clone());
         }
 
-        // TODO: this is incorrect, any only works for single names and not for relative imports
-        let import = self.namespace.resolve_relative(
-            [name.intern(self.heap)],
-            ResolveOptions {
-                mode: ResolutionMode::Relative,
-                universe: Universe::Value,
-            },
-        )?;
+        // This is very conservative, in *theory* we should take a look at the whole path and use
+        // that as import, but as we're only interested in special-forms, which are only imported as
+        // name, we can safely just use the name.
+        let import = self
+            .namespace
+            .resolve_relative(
+                [name.intern(self.heap)],
+                ResolveOptions {
+                    mode: ResolutionMode::Relative,
+                    universe: Universe::Value,
+                },
+            )
+            .ok()?;
 
         // We're only interested in intrinsics
         let ItemKind::Intrinsic(IntrinsicItem {

--- a/libs/@local/hashql/ast/src/lowering/pre_expansion_name_resolver.rs
+++ b/libs/@local/hashql/ast/src/lowering/pre_expansion_name_resolver.rs
@@ -96,7 +96,7 @@ use hashql_core::{
     module::{
         ModuleRegistry,
         item::{IntrinsicItem, ItemKind, Universe},
-        namespace::ModuleNamespace,
+        namespace::{ModuleNamespace, ResolutionMode, ResolveOptions},
     },
     span::SpanId,
     symbol::{Ident, IdentKind, Symbol},
@@ -228,15 +228,20 @@ impl<'env, 'heap> PreExpansionNameResolver<'env, 'heap> {
             return Some(path.clone());
         }
 
-        let import = self
-            .namespace
-            .resolve_name(name.intern(self.heap), Universe::Value)?;
+        // TODO: this is incorrect, any only works for single names and not for relative imports
+        let import = self.namespace.resolve_relative_import(
+            [name.intern(self.heap)],
+            ResolveOptions {
+                mode: ResolutionMode::Relative,
+                universe: Universe::Value,
+            },
+        )?;
 
         // We're only interested in intrinsics
         let ItemKind::Intrinsic(IntrinsicItem {
             name: path,
             universe: _,
-        }) = import.item.kind
+        }) = import.kind
         else {
             return None;
         };

--- a/libs/@local/hashql/ast/src/lowering/pre_expansion_name_resolver.rs
+++ b/libs/@local/hashql/ast/src/lowering/pre_expansion_name_resolver.rs
@@ -229,7 +229,7 @@ impl<'env, 'heap> PreExpansionNameResolver<'env, 'heap> {
         }
 
         // TODO: this is incorrect, any only works for single names and not for relative imports
-        let import = self.namespace.resolve_relative_import(
+        let import = self.namespace.resolve_relative(
             [name.intern(self.heap)],
             ResolveOptions {
                 mode: ResolutionMode::Relative,

--- a/libs/@local/hashql/ast/src/node/expr/mod.rs
+++ b/libs/@local/hashql/ast/src/node/expr/mod.rs
@@ -551,3 +551,13 @@ pub struct Expr<'heap> {
 
     pub kind: ExprKind<'heap>,
 }
+
+impl<'heap> Expr<'heap> {
+    pub(crate) fn dummy() -> Self {
+        Self {
+            id: NodeId::PLACEHOLDER,
+            span: SpanId::SYNTHETIC,
+            kind: ExprKind::Dummy,
+        }
+    }
+}

--- a/libs/@local/hashql/ast/src/node/expr/mod.rs
+++ b/libs/@local/hashql/ast/src/node/expr/mod.rs
@@ -552,8 +552,8 @@ pub struct Expr<'heap> {
     pub kind: ExprKind<'heap>,
 }
 
-impl<'heap> Expr<'heap> {
-    pub(crate) fn dummy() -> Self {
+impl Expr<'_> {
+    pub(crate) const fn dummy() -> Self {
         Self {
             id: NodeId::PLACEHOLDER,
             span: SpanId::SYNTHETIC,

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/.spec.toml
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/.spec.toml
@@ -1,0 +1,1 @@
+suite = "ast/lowering/import-resolver"

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-absolute-imports.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-absolute-imports.jsonc
@@ -1,0 +1,3 @@
+//@ run: pass
+//@ description: Basic absolute imports should be supported
+["use", "::math", { "#tuple": ["lshift"] }, "lshift"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-absolute-imports.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-absolute-imports.jsonc
@@ -1,3 +1,3 @@
 //@ run: pass
-//@ description: Basic absolute imports should be supported
+//@ description: Tests that absolute imports (with :: prefix) resolve correctly and are normalized
 ["use", "::math", { "#tuple": ["lshift"] }, "lshift"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-absolute-imports.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-absolute-imports.stdout
@@ -1,0 +1,5 @@
+Expr#4294967040@17
+  ExprKind (Path)
+    Path#4294967040@17 (rooted: true)
+      PathSegment#4294967040@16 (name: math)
+      PathSegment#4294967040@16 (name: lshift)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-glob-import.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-glob-import.jsonc
@@ -1,0 +1,12 @@
+//@ run: pass
+//@ description: Basic glob imports should be supported
+[
+  "use",
+  "math",
+  "*",
+  [
+    "lshift",
+    ["rshift", { "#literal": 2 }, { "#literal": 3 }],
+    { "#literal": 4 }
+  ]
+]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-glob-import.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-glob-import.jsonc
@@ -1,5 +1,5 @@
 //@ run: pass
-//@ description: Basic glob imports should be supported
+//@ description: Tests that glob imports (*) bring all module items into scope and resolve correctly
 [
   "use",
   "math",

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-glob-import.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-glob-import.stdout
@@ -1,0 +1,35 @@
+Expr#4294967040@27
+  ExprKind (Call)
+    CallExpr#4294967040@27
+      Expr#4294967040@15
+        ExprKind (Path)
+          Path#4294967040@15 (rooted: true)
+            PathSegment#4294967040@14 (name: math)
+            PathSegment#4294967040@14 (name: lshift)
+      Argument#4294967040@24
+        Expr#4294967040@24
+          ExprKind (Call)
+            CallExpr#4294967040@24
+              Expr#4294967040@19
+                ExprKind (Path)
+                  Path#4294967040@19 (rooted: true)
+                    PathSegment#4294967040@18 (name: math)
+                    PathSegment#4294967040@18 (name: rshift)
+              Argument#4294967040@21
+                Expr#4294967040@21
+                  ExprKind (Literal)
+                    LiteralExpr#4294967040@20
+                      LiteralKind (Integer)
+                        IntegerLiteral (2)
+              Argument#4294967040@23
+                Expr#4294967040@23
+                  ExprKind (Literal)
+                    LiteralExpr#4294967040@22
+                      LiteralKind (Integer)
+                        IntegerLiteral (3)
+      Argument#4294967040@26
+        Expr#4294967040@26
+          ExprKind (Literal)
+            LiteralExpr#4294967040@25
+              LiteralKind (Integer)
+                IntegerLiteral (4)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-relative-import.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-relative-import.jsonc
@@ -1,3 +1,3 @@
 //@ run: pass
-//@ description: Basic relative imports should be supported
+//@ description: Tests that relative imports (without :: prefix) resolve correctly and get normalized to absolute paths
 ["use", "math", { "#tuple": ["lshift"] }, "lshift"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-relative-import.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-relative-import.jsonc
@@ -1,0 +1,3 @@
+//@ run: pass
+//@ description: Basic relative imports should be supported
+["use", "math", { "#tuple": ["lshift"] }, "lshift"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-relative-import.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-relative-import.stdout
@@ -1,0 +1,5 @@
+Expr#4294967040@17
+  ExprKind (Path)
+    Path#4294967040@17 (rooted: true)
+      PathSegment#4294967040@16 (name: math)
+      PathSegment#4294967040@16 (name: lshift)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-renamed-import.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-renamed-import.jsonc
@@ -1,3 +1,3 @@
 //@ run: pass
-//@ description: Renamed imports should be supported
+//@ description: Tests that imports with aliases resolve correctly and the alias maps to the original item
 ["use", "math", { "#struct": { "lshift": "<<<" } }, "<<<"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-renamed-import.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-renamed-import.jsonc
@@ -1,0 +1,3 @@
+//@ run: pass
+//@ description: Renamed imports should be supported
+["use", "math", { "#struct": { "lshift": "<<<" } }, "<<<"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-renamed-import.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/basic-renamed-import.stdout
@@ -1,0 +1,5 @@
+Expr#4294967040@20
+  ExprKind (Path)
+    Path#4294967040@20 (rooted: true)
+      PathSegment#4294967040@19 (name: math)
+      PathSegment#4294967040@19 (name: lshift)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/closure-complex-return-type.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/closure-complex-return-type.jsonc
@@ -1,0 +1,13 @@
+//@ run: pass
+//@ description: Tests that closures with complex return types correctly resolve type paths
+[
+  "fn",
+  { "#tuple": [] },
+  {
+    "#struct": {
+      "x": "Number"
+    }
+  },
+  "kernel::type::Option<Number>",
+  ["Some", "x"]
+]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/closure-complex-return-type.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/closure-complex-return-type.stdout
@@ -1,0 +1,40 @@
+Expr#4294967040@37
+  ExprKind (Closure)
+    ClosureExpr#4294967040@37
+      ClosureSignature#4294967040@37
+        Generics#4294967040@4
+        ClosureParam#4294967040@12 (name: x)
+          Type#4294967040@11
+            TypeKind (Path)
+              Path#4294967040@11 (rooted: true)
+                PathSegment#4294967040@10 (name: kernel)
+                PathSegment#4294967040@10 (name: type)
+                PathSegment#4294967040@10 (name: Number)
+        Type#4294967040@27
+          TypeKind (Path)
+            Path#4294967040@27 (rooted: true)
+              PathSegment#4294967040@17 (name: kernel)
+              PathSegment#4294967040@19 (name: type)
+              PathSegment#4294967040@26 (name: Option)
+                PathSegmentArgument (GenericArgument)
+                  GenericArgument#4294967040@25
+                    Type#4294967040@24
+                      TypeKind (Path)
+                        Path#4294967040@24 (rooted: true)
+                          PathSegment#4294967040@23 (name: kernel)
+                          PathSegment#4294967040@23 (name: type)
+                          PathSegment#4294967040@23 (name: Number)
+      Expr#4294967040@36
+        ExprKind (Call)
+          CallExpr#4294967040@36
+            Expr#4294967040@31
+              ExprKind (Path)
+                Path#4294967040@31 (rooted: true)
+                  PathSegment#4294967040@30 (name: kernel)
+                  PathSegment#4294967040@30 (name: type)
+                  PathSegment#4294967040@30 (name: Some)
+            Argument#4294967040@35
+              Expr#4294967040@35
+                ExprKind (Path)
+                  Path#4294967040@35 (rooted: false)
+                    PathSegment#4294967040@34 (name: x)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/closure-generic-not-resolved.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/closure-generic-not-resolved.jsonc
@@ -1,0 +1,13 @@
+//@ run: pass
+//@ description: Tests that generic parameter names in closures are recognized in type context and not resolved as paths
+[
+  "fn",
+  { "#tuple": ["Dict"] }, // Generic parameter named the same as a common type
+  {
+    "#struct": {
+      "x": "Dict" // Should reference the generic parameter, not resolve as a path
+    }
+  },
+  "Dict", // Should reference the generic parameter, not resolve as a path
+  "x"
+]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/closure-generic-not-resolved.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/closure-generic-not-resolved.stdout
@@ -1,0 +1,19 @@
+Expr#4294967040@27
+  ExprKind (Closure)
+    ClosureExpr#4294967040@27
+      ClosureSignature#4294967040@27
+        Generics#4294967040@8
+          GenericParam#4294967040@7 (name: Dict)
+        ClosureParam#4294967040@16 (name: x)
+          Type#4294967040@15
+            TypeKind (Path)
+              Path#4294967040@15 (rooted: false)
+                PathSegment#4294967040@14 (name: Dict)
+        Type#4294967040@22
+          TypeKind (Path)
+            Path#4294967040@22 (rooted: false)
+              PathSegment#4294967040@21 (name: Dict)
+      Expr#4294967040@26
+        ExprKind (Path)
+          Path#4294967040@26 (rooted: false)
+            PathSegment#4294967040@25 (name: x)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/closure-mixed-resolution.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/closure-mixed-resolution.jsonc
@@ -1,0 +1,13 @@
+//@ run: pass
+//@ description: Tests that path segments in closures are correctly resolved when not shadowed by parameters
+[
+  "fn",
+  { "#tuple": [] },
+  {
+    "#struct": {
+      "x": "Number"
+    }
+  },
+  "Number",
+  ["math::add", "x", { "#literal": 1 }] // 'math::add' should be resolved as a path, 'x' as a parameter
+]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/closure-mixed-resolution.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/closure-mixed-resolution.stdout
@@ -1,0 +1,37 @@
+Expr#4294967040@32
+  ExprKind (Closure)
+    ClosureExpr#4294967040@32
+      ClosureSignature#4294967040@32
+        Generics#4294967040@4
+        ClosureParam#4294967040@12 (name: x)
+          Type#4294967040@11
+            TypeKind (Path)
+              Path#4294967040@11 (rooted: true)
+                PathSegment#4294967040@10 (name: kernel)
+                PathSegment#4294967040@10 (name: type)
+                PathSegment#4294967040@10 (name: Number)
+        Type#4294967040@18
+          TypeKind (Path)
+            Path#4294967040@18 (rooted: true)
+              PathSegment#4294967040@17 (name: kernel)
+              PathSegment#4294967040@17 (name: type)
+              PathSegment#4294967040@17 (name: Number)
+      Expr#4294967040@31
+        ExprKind (Call)
+          CallExpr#4294967040@31
+            Expr#4294967040@24
+              ExprKind (Path)
+                Path#4294967040@24 (rooted: true)
+                  PathSegment#4294967040@21 (name: math)
+                  PathSegment#4294967040@23 (name: add)
+            Argument#4294967040@28
+              Expr#4294967040@28
+                ExprKind (Path)
+                  Path#4294967040@28 (rooted: false)
+                    PathSegment#4294967040@27 (name: x)
+            Argument#4294967040@30
+              Expr#4294967040@30
+                ExprKind (Literal)
+                  LiteralExpr#4294967040@29
+                    LiteralKind (Integer)
+                      IntegerLiteral (1)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/closure-param-not-resolved.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/closure-param-not-resolved.jsonc
@@ -1,0 +1,13 @@
+//@ run: pass
+//@ description: Tests that parameter names in closures are recognized as local bindings and not resolved as paths
+[
+  "fn",
+  { "#tuple": [] },
+  {
+    "#struct": {
+      "Dict": "Number" // Parameter named the same as a common type
+    }
+  },
+  "Number",
+  "Dict" // Should be treated as a parameter, not resolved as a path
+]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/closure-param-not-resolved.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/closure-param-not-resolved.stdout
@@ -1,0 +1,22 @@
+Expr#4294967040@23
+  ExprKind (Closure)
+    ClosureExpr#4294967040@23
+      ClosureSignature#4294967040@23
+        Generics#4294967040@4
+        ClosureParam#4294967040@12 (name: Dict)
+          Type#4294967040@11
+            TypeKind (Path)
+              Path#4294967040@11 (rooted: true)
+                PathSegment#4294967040@10 (name: kernel)
+                PathSegment#4294967040@10 (name: type)
+                PathSegment#4294967040@10 (name: Number)
+        Type#4294967040@18
+          TypeKind (Path)
+            Path#4294967040@18 (rooted: true)
+              PathSegment#4294967040@17 (name: kernel)
+              PathSegment#4294967040@17 (name: type)
+              PathSegment#4294967040@17 (name: Number)
+      Expr#4294967040@22
+        ExprKind (Path)
+          Path#4294967040@22 (rooted: false)
+            PathSegment#4294967040@21 (name: Dict)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/complex-nested-type-parameters.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/complex-nested-type-parameters.jsonc
@@ -1,0 +1,3 @@
+//@ run: pass
+//@ description: Tests that complex nested type parameters with generic arguments resolve correctly
+["type", "Foo<T, E>", "List<Option<Result<T, E>>>", "_"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/complex-nested-type-parameters.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/complex-nested-type-parameters.stdout
@@ -1,0 +1,41 @@
+Expr#4294967040@44
+  ExprKind (Type)
+    TypeExpr#4294967040@44 (name: Foo)
+      GenericConstraint#4294967040@10 (name: T)
+      GenericConstraint#4294967040@15 (name: E)
+      Type#4294967040@41
+        TypeKind (Path)
+          Path#4294967040@41 (rooted: true)
+            PathSegment#4294967040@40 (name: kernel)
+            PathSegment#4294967040@40 (name: type)
+            PathSegment#4294967040@40 (name: List)
+              PathSegmentArgument (GenericArgument)
+                GenericArgument#4294967040@39
+                  Type#4294967040@38
+                    TypeKind (Path)
+                      Path#4294967040@38 (rooted: true)
+                        PathSegment#4294967040@37 (name: kernel)
+                        PathSegment#4294967040@37 (name: type)
+                        PathSegment#4294967040@37 (name: Option)
+                          PathSegmentArgument (GenericArgument)
+                            GenericArgument#4294967040@36
+                              Type#4294967040@35
+                                TypeKind (Path)
+                                  Path#4294967040@35 (rooted: true)
+                                    PathSegment#4294967040@34 (name: kernel)
+                                    PathSegment#4294967040@34 (name: type)
+                                    PathSegment#4294967040@34 (name: Result)
+                                      PathSegmentArgument (GenericArgument)
+                                        GenericArgument#4294967040@28
+                                          Type#4294967040@27
+                                            TypeKind (Path)
+                                              Path#4294967040@27 (rooted: false)
+                                                PathSegment#4294967040@26 (name: T)
+                                      PathSegmentArgument (GenericArgument)
+                                        GenericArgument#4294967040@33
+                                          Type#4294967040@32
+                                            TypeKind (Path)
+                                              Path#4294967040@32 (rooted: false)
+                                                PathSegment#4294967040@31 (name: E)
+      Expr#4294967040@43
+        ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/complex-path-resolution.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/complex-path-resolution.jsonc
@@ -1,0 +1,3 @@
+//@ run: pass
+//@ description: Tests that complex paths with multiple segments and nested types are correctly resolved
+["type", "Foo", "kernel::type::List<Option<Number>>", "_"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/complex-path-resolution.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/complex-path-resolution.stdout
@@ -1,0 +1,27 @@
+Expr#4294967040@28
+  ExprKind (Type)
+    TypeExpr#4294967040@28 (name: Foo)
+      Type#4294967040@25
+        TypeKind (Path)
+          Path#4294967040@25 (rooted: true)
+            PathSegment#4294967040@10 (name: kernel)
+            PathSegment#4294967040@12 (name: type)
+            PathSegment#4294967040@24 (name: List)
+              PathSegmentArgument (GenericArgument)
+                GenericArgument#4294967040@23
+                  Type#4294967040@22
+                    TypeKind (Path)
+                      Path#4294967040@22 (rooted: true)
+                        PathSegment#4294967040@21 (name: kernel)
+                        PathSegment#4294967040@21 (name: type)
+                        PathSegment#4294967040@21 (name: Option)
+                          PathSegmentArgument (GenericArgument)
+                            GenericArgument#4294967040@20
+                              Type#4294967040@19
+                                TypeKind (Path)
+                                  Path#4294967040@19 (rooted: true)
+                                    PathSegment#4294967040@18 (name: kernel)
+                                    PathSegment#4294967040@18 (name: type)
+                                    PathSegment#4294967040@18 (name: Number)
+      Expr#4294967040@27
+        ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-argument-absolute-path.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-argument-absolute-path.jsonc
@@ -1,0 +1,4 @@
+//@ run: fail
+//@ description: Generic arguments in the absolute path should fail
+["::math<T>::add", { "#literal": 2 }, { "#literal": 3 }]
+//~^ ERROR Remove this generic argument

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-argument-absolute-path.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-argument-absolute-path.jsonc
@@ -1,4 +1,4 @@
 //@ run: fail
-//@ description: Generic arguments in the absolute path should fail
+//@ description: Tests that generic arguments in non-final segments of paths are rejected with appropriate error
 ["::math<T>::add", { "#literal": 2 }, { "#literal": 3 }]
 //~^ ERROR Remove this generic argument

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-argument-absolute-path.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-argument-absolute-path.stderr
@@ -1,0 +1,16 @@
+[31m[import-resolver::generic-arguments-in-module] Error:[0m Generic arguments only allowed in final path segment
+   ╭─[ <unknown>:3:10 ]
+   │
+ 3 │ ["::math<T>::add", { "#literal": 2 }, { "#literal": 3 }]
+   │          ┬  
+   │          ╰── Remove this generic argument
+   │ 
+   │ Help: Generic arguments can only appear on the final type in a path. Remove them from this module segment or move them to the final type in the path.
+   │       
+   │       Correct: `module::submodule::Type<T>`
+   │       Incorrect: `module<T>::submodule::Type`
+   │ 
+   │ Note: Module paths don't accept generic parameters because modules themselves aren't generic. Only the final type in a path can have generic parameters.
+   │       
+   │       The path resolution happens before any generic type checking, so generic arguments can only be applied after the item is found.
+───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-argument-use-path.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-argument-use-path.jsonc
@@ -1,4 +1,4 @@
 //@ run: fail
-//@ description: Generic arguments in the use path should
+//@ description: Tests that generic arguments in 'use' statements are rejected with appropriate error
 ["use", "kernel::type<T>", { "#tuple": ["T"] }, "_"]
 //~^ ERROR Generic arguments are not allowed here

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-argument-use-path.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-argument-use-path.jsonc
@@ -1,0 +1,4 @@
+//@ run: fail
+//@ description: Generic arguments in the use path should
+["use", "kernel::type<T>", { "#tuple": ["T"] }, "_"]
+//~^ ERROR Generic arguments are not allowed here

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-argument-use-path.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-argument-use-path.stderr
@@ -1,0 +1,13 @@
+[31m[special-form-expander::use-path-with-generics] Error:[0m Use path with generic arguments
+   ╭─[ <unknown>:3:10 ]
+   │
+ 3 │ ["use", "kernel::type<T>", { "#tuple": ["T"] }, "_"]
+   │          ───────┬───┬───  
+   │                 │   ╰───── Generic arguments are not allowed here
+   │                 │         
+   │                 ╰───────── Remove these generic arguments
+   │ 
+   │ Help: The 'use' special form does not support generic arguments in import paths. Remove all generic arguments from the path.
+   │ 
+   │ Note: Use statements in HashQL can only import modules or specific symbols, but cannot specify generic parameters during import.
+───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-arguments-in-final-segment.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-arguments-in-final-segment.jsonc
@@ -1,0 +1,3 @@
+//@ run: pass
+//@ description: Tests that generic arguments in the final segment of a path are accepted and resolved correctly
+["`+`<Number>", { "#literal": 2 }, { "#literal": 3 }]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-arguments-in-final-segment.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-arguments-in-final-segment.stdout
@@ -1,0 +1,28 @@
+Expr#4294967040@13
+  ExprKind (Call)
+    CallExpr#4294967040@13
+      Expr#4294967040@8
+        ExprKind (Path)
+          Path#4294967040@8 (rooted: true)
+            PathSegment#4294967040@7 (name: math)
+            PathSegment#4294967040@7 (name: add)
+              PathSegmentArgument (GenericArgument)
+                GenericArgument#4294967040@6
+                  Type#4294967040@5
+                    TypeKind (Path)
+                      Path#4294967040@5 (rooted: true)
+                        PathSegment#4294967040@4 (name: kernel)
+                        PathSegment#4294967040@4 (name: type)
+                        PathSegment#4294967040@4 (name: Number)
+      Argument#4294967040@10
+        Expr#4294967040@10
+          ExprKind (Literal)
+            LiteralExpr#4294967040@9
+              LiteralKind (Integer)
+                IntegerLiteral (2)
+      Argument#4294967040@12
+        Expr#4294967040@12
+          ExprKind (Literal)
+            LiteralExpr#4294967040@11
+              LiteralKind (Integer)
+                IntegerLiteral (3)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-constraints-type.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-constraints-type.jsonc
@@ -1,3 +1,3 @@
 //@ run: pass
-//@ description: Generic constraints should be unaffected
+//@ description: Tests that generic constraints in type declarations are preserved and don't trigger path resolution
 ["type", "Dict<Number>", "Number", "_"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-constraints-type.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-constraints-type.jsonc
@@ -1,0 +1,3 @@
+//@ run: pass
+//@ description: Generic constraints should be unaffected
+["type", "Dict<Number>", "Number", "_"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-constraints-type.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-constraints-type.stdout
@@ -1,0 +1,12 @@
+Expr#4294967040@19
+  ExprKind (Type)
+    TypeExpr#4294967040@19 (name: Dict)
+      GenericConstraint#4294967040@10 (name: Number)
+      Type#4294967040@16
+        TypeKind (Path)
+          Path#4294967040@16 (rooted: true)
+            PathSegment#4294967040@15 (name: kernel)
+            PathSegment#4294967040@15 (name: type)
+            PathSegment#4294967040@15 (name: Number)
+      Expr#4294967040@18
+        ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-constraints-type.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-constraints-type.stdout
@@ -4,9 +4,7 @@ Expr#4294967040@19
       GenericConstraint#4294967040@10 (name: Number)
       Type#4294967040@16
         TypeKind (Path)
-          Path#4294967040@16 (rooted: true)
-            PathSegment#4294967040@15 (name: kernel)
-            PathSegment#4294967040@15 (name: type)
+          Path#4294967040@16 (rooted: false)
             PathSegment#4294967040@15 (name: Number)
       Expr#4294967040@18
         ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-constraints.newtype.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-constraints.newtype.jsonc
@@ -1,0 +1,3 @@
+//@ run: pass
+//@ description: Generic constraints should be unaffected
+["newtype", "Dict<Number>", "Number", "_"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-constraints.newtype.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-constraints.newtype.jsonc
@@ -1,3 +1,3 @@
 //@ run: pass
-//@ description: Generic constraints should be unaffected
+//@ description: Tests that generic constraints in newtype declarations are preserved and correctly scoped
 ["newtype", "Dict<Number>", "Number", "_"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-constraints.newtype.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-constraints.newtype.stdout
@@ -1,0 +1,12 @@
+Expr#4294967040@19
+  ExprKind (NewType)
+    NewTypeExpr#4294967040@19 (name: Dict)
+      GenericConstraint#4294967040@10 (name: Number)
+      Type#4294967040@16
+        TypeKind (Path)
+          Path#4294967040@16 (rooted: true)
+            PathSegment#4294967040@15 (name: kernel)
+            PathSegment#4294967040@15 (name: type)
+            PathSegment#4294967040@15 (name: Number)
+      Expr#4294967040@18
+        ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-constraints.newtype.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/generic-constraints.newtype.stdout
@@ -4,9 +4,7 @@ Expr#4294967040@19
       GenericConstraint#4294967040@10 (name: Number)
       Type#4294967040@16
         TypeKind (Path)
-          Path#4294967040@16 (rooted: true)
-            PathSegment#4294967040@15 (name: kernel)
-            PathSegment#4294967040@15 (name: type)
+          Path#4294967040@16 (rooted: false)
             PathSegment#4294967040@15 (name: Number)
       Expr#4294967040@18
         ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/glob-not-found.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/glob-not-found.jsonc
@@ -1,0 +1,4 @@
+//@ run: fail
+//@ description: Tests that importing from a non-existent module produces an appropriate error with suggestions
+["use", "kernel::foo", "*", "_"]
+//~^ ERROR Module 'foo' not found

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/glob-not-found.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/glob-not-found.stderr
@@ -1,0 +1,15 @@
+[31m[import-resolver::unresolved-import] Error:[0m Unresolved import
+   ╭─[ <unknown>:3:18 ]
+   │
+ 3 │ ["use", "kernel::foo", "*", "_"]
+   │          ─────┬───┬─  
+   │               │   ╰─── Module 'foo' not found
+   │               │       
+   │               ╰─────── In this path
+   │ 
+   │ Help: The module 'kernel::foo' doesn't exist in this scope. Check the spelling and ensure the module is available.
+   │       
+   │       Possible alternatives are `special_form`, `type`.
+   │ 
+   │ Note: Modules must be properly defined and exported from their parent module to be accessible.
+───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/item-not-found.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/item-not-found.jsonc
@@ -1,4 +1,4 @@
 //@ run: fail
-//@ description: should error out if item does not exist
+//@ description: Tests that importing a non-existent item produces an appropriate error with suggestions
 ["use", "math", { "#tuple": ["llshift"] }, "_"]
 //~^ ERROR 'llshift' not found in module 'math'

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/item-not-found.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/item-not-found.jsonc
@@ -1,0 +1,4 @@
+//@ run: fail
+//@ description: should error out if item does not exist
+["use", "math", { "#tuple": ["llshift"] }, "_"]
+//~^ ERROR 'llshift' not found in module 'math'

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/item-not-found.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/item-not-found.stderr
@@ -1,0 +1,15 @@
+[31m[import-resolver::unresolved-import] Error:[0m Unresolved import
+   ╭─[ <unknown>:3:31 ]
+   │
+ 3 │ ["use", "math", { "#tuple": ["llshift"] }, "_"]
+   │          ──┬─                 ───┬───  
+   │            │                     ╰───── 'llshift' not found in module 'math'
+   │            │                           
+   │            ╰─────────────────────────── This module
+   │ 
+   │ Help: Check the spelling and ensure the item is exported and available in this context.
+   │       
+   │       Did you mean: `lshift`, `rshift`?
+   │ 
+   │ Note: Items must be defined and accessible from the importing location. Make sure the item exists and is public.
+───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-recursive-type.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-recursive-type.jsonc
@@ -1,0 +1,3 @@
+//@ run: pass
+//@ description: Local (recursive) bindings should be unaffected
+["type", "Dict", "Dict", "_"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-recursive-type.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-recursive-type.jsonc
@@ -1,3 +1,3 @@
 //@ run: pass
-//@ description: Local (recursive) bindings should be unaffected
+//@ description: Tests that recursive type references in the same declaration aren't resolved as paths
 ["type", "Dict", "Dict", "_"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-recursive-type.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-recursive-type.stdout
@@ -1,0 +1,9 @@
+Expr#4294967040@14
+  ExprKind (Type)
+    TypeExpr#4294967040@14 (name: Dict)
+      Type#4294967040@11
+        TypeKind (Path)
+          Path#4294967040@11 (rooted: false)
+            PathSegment#4294967040@10 (name: Dict)
+      Expr#4294967040@13
+        ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-recursive-value.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-recursive-value.jsonc
@@ -1,3 +1,3 @@
 //@ run: pass
 //@ description: Local (recursive) bindings should be affected
-["let", "Dict", "Dict", "_"]
+["let", "Dict", ["+", "Dict", "Dict"], "Dict"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-recursive-value.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-recursive-value.jsonc
@@ -1,0 +1,3 @@
+//@ run: pass
+//@ description: Local (recursive) bindings should be affected
+["let", "Dict", "Dict", "_"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-recursive-value.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-recursive-value.jsonc
@@ -1,3 +1,3 @@
 //@ run: pass
-//@ description: Local (recursive) bindings should be affected
+//@ description: Tests that recursive value references are resolved as paths since they occur in the value expression
 ["let", "Dict", ["+", "Dict", "Dict"], "Dict"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-recursive-value.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-recursive-value.stdout
@@ -1,11 +1,29 @@
-Expr#4294967040@14
+Expr#4294967040@25
   ExprKind (Let)
-    LetExpr#4294967040@14 (name: Dict)
-      Expr#4294967040@11
+    LetExpr#4294967040@25 (name: Dict)
+      Expr#4294967040@20
+        ExprKind (Call)
+          CallExpr#4294967040@20
+            Expr#4294967040@11
+              ExprKind (Path)
+                Path#4294967040@11 (rooted: true)
+                  PathSegment#4294967040@10 (name: math)
+                  PathSegment#4294967040@10 (name: add)
+            Argument#4294967040@15
+              Expr#4294967040@15
+                ExprKind (Path)
+                  Path#4294967040@15 (rooted: true)
+                    PathSegment#4294967040@14 (name: kernel)
+                    PathSegment#4294967040@14 (name: type)
+                    PathSegment#4294967040@14 (name: Dict)
+            Argument#4294967040@19
+              Expr#4294967040@19
+                ExprKind (Path)
+                  Path#4294967040@19 (rooted: true)
+                    PathSegment#4294967040@18 (name: kernel)
+                    PathSegment#4294967040@18 (name: type)
+                    PathSegment#4294967040@18 (name: Dict)
+      Expr#4294967040@24
         ExprKind (Path)
-          Path#4294967040@11 (rooted: true)
-            PathSegment#4294967040@10 (name: kernel)
-            PathSegment#4294967040@10 (name: type)
-            PathSegment#4294967040@10 (name: Dict)
-      Expr#4294967040@13
-        ExprKind (Underscore)
+          Path#4294967040@24 (rooted: false)
+            PathSegment#4294967040@23 (name: Dict)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-recursive-value.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-recursive-value.stdout
@@ -1,0 +1,11 @@
+Expr#4294967040@14
+  ExprKind (Let)
+    LetExpr#4294967040@14 (name: Dict)
+      Expr#4294967040@11
+        ExprKind (Path)
+          Path#4294967040@11 (rooted: true)
+            PathSegment#4294967040@10 (name: kernel)
+            PathSegment#4294967040@10 (name: type)
+            PathSegment#4294967040@10 (name: Dict)
+      Expr#4294967040@13
+        ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-type.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-type.jsonc
@@ -1,0 +1,3 @@
+//@ run: pass
+//@ description: Local bindings should not be resolved
+["type", "Dict", "Number", ["type", "Bar", "Dict", "_"]]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-type.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-type.jsonc
@@ -1,3 +1,3 @@
 //@ run: pass
-//@ description: Local bindings should not be resolved
+//@ description: Tests that local type bindings are properly tracked in scope and not resolved as paths
 ["type", "Dict", "Number", ["type", "Bar", "Dict", "_"]]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-type.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-type.stdout
@@ -1,0 +1,18 @@
+Expr#4294967040@27
+  ExprKind (Type)
+    TypeExpr#4294967040@27 (name: Dict)
+      Type#4294967040@11
+        TypeKind (Path)
+          Path#4294967040@11 (rooted: true)
+            PathSegment#4294967040@10 (name: kernel)
+            PathSegment#4294967040@10 (name: type)
+            PathSegment#4294967040@10 (name: Number)
+      Expr#4294967040@26
+        ExprKind (Type)
+          TypeExpr#4294967040@26 (name: Bar)
+            Type#4294967040@23
+              TypeKind (Path)
+                Path#4294967040@23 (rooted: false)
+                  PathSegment#4294967040@22 (name: Dict)
+            Expr#4294967040@25
+              ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-value.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-value.jsonc
@@ -1,0 +1,3 @@
+//@ run: pass
+//@ description: Local bindings should not be resolved
+["let", "Dict", { "#literal": 2 }, "Dict"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-value.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-value.jsonc
@@ -1,3 +1,3 @@
 //@ run: pass
-//@ description: Local bindings should not be resolved
+//@ description: Tests that local value bindings are properly tracked in scope and not resolved as paths
 ["let", "Dict", { "#literal": 2 }, "Dict"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-value.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/local-binding-value.stdout
@@ -1,0 +1,12 @@
+Expr#4294967040@14
+  ExprKind (Let)
+    LetExpr#4294967040@14 (name: Dict)
+      Expr#4294967040@9
+        ExprKind (Literal)
+          LiteralExpr#4294967040@8
+            LiteralKind (Integer)
+              IntegerLiteral (2)
+      Expr#4294967040@13
+        ExprKind (Path)
+          Path#4294967040@13 (rooted: false)
+            PathSegment#4294967040@12 (name: Dict)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/module-not-found.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/module-not-found.jsonc
@@ -1,3 +1,4 @@
 //@ run: fail
 //@ description: module shouldn't be found
 ["use", "kernel::foo", { "#tuple": ["baz"] }, "_"]
+//~^ ERROR Module 'foo' not found

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/module-not-found.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/module-not-found.jsonc
@@ -1,0 +1,3 @@
+//@ run: fail
+//@ description: module shouldn't be found
+["use", "kernel::foo", { "#tuple": ["baz"] }, "_"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/module-not-found.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/module-not-found.jsonc
@@ -1,4 +1,4 @@
 //@ run: fail
-//@ description: module shouldn't be found
+//@ description: Tests that importing from a non-existent module produces an appropriate error with suggestions
 ["use", "kernel::foo", { "#tuple": ["baz"] }, "_"]
 //~^ ERROR Module 'foo' not found

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/module-not-found.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/module-not-found.stderr
@@ -1,0 +1,13 @@
+[31m[import-resolver::unresolved-import] Error:[0m Unresolved import
+   ╭─[ <unknown>:3:10 ]
+   │
+ 3 │ ["use", "kernel::foo", { "#tuple": ["baz"] }, "_"]
+   │          ───┬─┬─────  
+   │             ╰───────── Module 'kernel' not found
+   │               │       
+   │               ╰─────── In this path
+   │ 
+   │ Help: The module 'kernel' doesn't exist in this scope. Check the spelling and ensure the module is available.
+   │ 
+   │ Note: Modules must be properly defined and exported from their parent module to be accessible.
+───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/module-not-found.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/module-not-found.stderr
@@ -1,13 +1,15 @@
 [31m[import-resolver::unresolved-import] Error:[0m Unresolved import
-   ╭─[ <unknown>:3:10 ]
+   ╭─[ <unknown>:3:18 ]
    │
  3 │ ["use", "kernel::foo", { "#tuple": ["baz"] }, "_"]
-   │          ───┬─┬─────  
-   │             ╰───────── Module 'kernel' not found
+   │          ─────┬───┬─  
+   │               │   ╰─── Module 'foo' not found
    │               │       
    │               ╰─────── In this path
    │ 
-   │ Help: The module 'kernel' doesn't exist in this scope. Check the spelling and ensure the module is available.
+   │ Help: The module 'kernel::foo' doesn't exist in this scope. Check the spelling and ensure the module is available.
+   │       
+   │       Possible alternatives are `special_form`, `type`.
    │ 
    │ Note: Modules must be properly defined and exported from their parent module to be accessible.
 ───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/multiple-named-imports.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/multiple-named-imports.jsonc
@@ -1,0 +1,12 @@
+//@ run: pass
+//@ description: Tests that a single use statement can import multiple items from the same module
+[
+  "use",
+  "math",
+  { "#struct": { "add": "plus", "sub": "minus", "mul": "times" } },
+  [
+    "plus",
+    ["minus", { "#literal": 5 }, { "#literal": 3 }],
+    ["times", { "#literal": 2 }, { "#literal": 2 }]
+  ]
+]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/multiple-named-imports.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/multiple-named-imports.stdout
@@ -1,0 +1,50 @@
+Expr#4294967040@53
+  ExprKind (Call)
+    CallExpr#4294967040@53
+      Expr#4294967040@34
+        ExprKind (Path)
+          Path#4294967040@34 (rooted: true)
+            PathSegment#4294967040@33 (name: math)
+            PathSegment#4294967040@33 (name: add)
+      Argument#4294967040@43
+        Expr#4294967040@43
+          ExprKind (Call)
+            CallExpr#4294967040@43
+              Expr#4294967040@38
+                ExprKind (Path)
+                  Path#4294967040@38 (rooted: true)
+                    PathSegment#4294967040@37 (name: math)
+                    PathSegment#4294967040@37 (name: sub)
+              Argument#4294967040@40
+                Expr#4294967040@40
+                  ExprKind (Literal)
+                    LiteralExpr#4294967040@39
+                      LiteralKind (Integer)
+                        IntegerLiteral (5)
+              Argument#4294967040@42
+                Expr#4294967040@42
+                  ExprKind (Literal)
+                    LiteralExpr#4294967040@41
+                      LiteralKind (Integer)
+                        IntegerLiteral (3)
+      Argument#4294967040@52
+        Expr#4294967040@52
+          ExprKind (Call)
+            CallExpr#4294967040@52
+              Expr#4294967040@47
+                ExprKind (Path)
+                  Path#4294967040@47 (rooted: true)
+                    PathSegment#4294967040@46 (name: math)
+                    PathSegment#4294967040@46 (name: mul)
+              Argument#4294967040@49
+                Expr#4294967040@49
+                  ExprKind (Literal)
+                    LiteralExpr#4294967040@48
+                      LiteralKind (Integer)
+                        IntegerLiteral (2)
+              Argument#4294967040@51
+                Expr#4294967040@51
+                  ExprKind (Literal)
+                    LiteralExpr#4294967040@50
+                      LiteralKind (Integer)
+                        IntegerLiteral (2)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/nested-resolution.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/nested-resolution.jsonc
@@ -1,3 +1,3 @@
 //@ run: pass
-//@ description: nested resolution should work
+//@ description: Tests that multi-level path resolution works after importing a parent module
 ["use", "kernel", { "#tuple": ["type"] }, "type::Dict"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/nested-resolution.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/nested-resolution.jsonc
@@ -1,0 +1,3 @@
+//@ run: pass
+//@ description: nested resolution should work
+["use", "kernel", { "#tuple": ["type"] }, "type::Dict"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/nested-resolution.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/nested-resolution.stdout
@@ -1,0 +1,6 @@
+Expr#4294967040@19
+  ExprKind (Path)
+    Path#4294967040@19 (rooted: true)
+      PathSegment#4294967040@16 (name: kernel)
+      PathSegment#4294967040@16 (name: type)
+      PathSegment#4294967040@18 (name: Dict)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/newtype-scope.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/newtype-scope.jsonc
@@ -1,0 +1,3 @@
+//@ run: pass
+//@ description: newtype should affect both value and type scope
+["newtype", "Integer", "Number", ["type", "Bar", "Integer", "Integer"]]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/newtype-scope.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/newtype-scope.jsonc
@@ -1,3 +1,3 @@
 //@ run: pass
-//@ description: newtype should affect both value and type scope
+//@ description: Tests that newtype declarations add bindings to both value and type universes simultaneously
 ["newtype", "Integer", "Number", ["type", "Bar", "Integer", "Integer"]]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/newtype-scope.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/newtype-scope.stdout
@@ -1,0 +1,20 @@
+Expr#4294967040@29
+  ExprKind (NewType)
+    NewTypeExpr#4294967040@29 (name: Integer)
+      Type#4294967040@11
+        TypeKind (Path)
+          Path#4294967040@11 (rooted: true)
+            PathSegment#4294967040@10 (name: kernel)
+            PathSegment#4294967040@10 (name: type)
+            PathSegment#4294967040@10 (name: Number)
+      Expr#4294967040@28
+        ExprKind (Type)
+          TypeExpr#4294967040@28 (name: Bar)
+            Type#4294967040@23
+              TypeKind (Path)
+                Path#4294967040@23 (rooted: false)
+                  PathSegment#4294967040@22 (name: Integer)
+            Expr#4294967040@27
+              ExprKind (Path)
+                Path#4294967040@27 (rooted: false)
+                  PathSegment#4294967040@26 (name: Integer)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/path-normalization.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/path-normalization.jsonc
@@ -1,3 +1,3 @@
 //@ run: pass
-//@ description: Paths should be normalized
+//@ description: Tests that relative paths are normalized to absolute paths in nested expressions
 ["use", "kernel", { "#tuple": ["type"] }, ["type", "Foo", "type::Dict", "_"]]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/path-normalization.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/path-normalization.jsonc
@@ -1,0 +1,3 @@
+//@ run: pass
+//@ description: Paths should be normalized
+["use", "kernel", { "#tuple": ["type"] }, ["type", "Foo", "type::Dict", "_"]]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/path-normalization.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/path-normalization.stdout
@@ -1,0 +1,11 @@
+Expr#4294967040@30
+  ExprKind (Type)
+    TypeExpr#4294967040@30 (name: Foo)
+      Type#4294967040@27
+        TypeKind (Path)
+          Path#4294967040@27 (rooted: true)
+            PathSegment#4294967040@24 (name: kernel)
+            PathSegment#4294967040@24 (name: type)
+            PathSegment#4294967040@26 (name: Dict)
+      Expr#4294967040@29
+        ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/prelude.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/prelude.jsonc
@@ -1,3 +1,3 @@
 //@ run: pass
-//@ description: Prelude should be imported and used for both types and values
+//@ description: Tests that prelude items are automatically available in both type and value universes
 ["type", "Foo", "Option<Number>", "Some"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/prelude.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/prelude.jsonc
@@ -1,0 +1,3 @@
+//@ run: pass
+//@ description: Prelude should be imported and used for both types and values
+["type", "Foo", "Option<Number>", "Some"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/prelude.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/prelude.stdout
@@ -1,0 +1,23 @@
+Expr#4294967040@21
+  ExprKind (Type)
+    TypeExpr#4294967040@21 (name: Foo)
+      Type#4294967040@16
+        TypeKind (Path)
+          Path#4294967040@16 (rooted: true)
+            PathSegment#4294967040@15 (name: kernel)
+            PathSegment#4294967040@15 (name: type)
+            PathSegment#4294967040@15 (name: Option)
+              PathSegmentArgument (GenericArgument)
+                GenericArgument#4294967040@14
+                  Type#4294967040@13
+                    TypeKind (Path)
+                      Path#4294967040@13 (rooted: true)
+                        PathSegment#4294967040@12 (name: kernel)
+                        PathSegment#4294967040@12 (name: type)
+                        PathSegment#4294967040@12 (name: Number)
+      Expr#4294967040@20
+        ExprKind (Path)
+          Path#4294967040@20 (rooted: true)
+            PathSegment#4294967040@19 (name: kernel)
+            PathSegment#4294967040@19 (name: type)
+            PathSegment#4294967040@19 (name: Some)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/rollback.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/rollback.jsonc
@@ -1,0 +1,9 @@
+//@ run: fail
+//@ description: imports should be properly scoped
+[
+  "if",
+  { "#literal": true },
+  ["use", "math", { "#tuple": ["lshift"] }, "lshift"],
+  "lshift"
+  //~^ ERROR 'lshift' needs to be imported first
+]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/rollback.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/rollback.jsonc
@@ -1,5 +1,5 @@
 //@ run: fail
-//@ description: imports should be properly scoped
+//@ description: Tests that imports are properly scoped and don't leak outside their containing expression
 [
   "if",
   { "#literal": true },

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/rollback.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/rollback.stderr
@@ -1,0 +1,13 @@
+[31m[import-resolver::unresolved-import] Error:[0m Unresolved import
+   ╭─[ <unknown>:7:4 ]
+   │
+ 7 │   "lshift"
+   │    ───┬──  
+   │       ╰──── 'lshift' needs to be imported first
+   │ 
+   │ Help: Add an import statement for 'lshift' before using it. Check if the name is spelled correctly.
+   │       
+   │       Possible alternatives are `List`, `Dict`, `is` and 41 others.
+   │ 
+   │ Note: Before using an item from another module, you must import it with a 'use' statement or access it with a fully qualified path.
+───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/shadowed-imports.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/shadowed-imports.jsonc
@@ -1,0 +1,8 @@
+//@ run: pass
+//@ description: shadowed imports should work
+[
+  "use",
+  "kernel::type",
+  { "#tuple": ["Dict"] },
+  ["use", "math", { "#struct": { "add": "Dict" } }, "Dict"]
+]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/shadowed-imports.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/shadowed-imports.jsonc
@@ -1,5 +1,5 @@
 //@ run: pass
-//@ description: shadowed imports should work
+//@ description: Tests that later imports can shadow earlier ones with the same name
 [
   "use",
   "kernel::type",

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/shadowed-imports.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/shadowed-imports.stdout
@@ -1,0 +1,5 @@
+Expr#4294967040@36
+  ExprKind (Path)
+    Path#4294967040@36 (rooted: true)
+      PathSegment#4294967040@35 (name: math)
+      PathSegment#4294967040@35 (name: add)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/shadowed-prelude.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/shadowed-prelude.jsonc
@@ -1,0 +1,14 @@
+//@ run: pass
+//@ description: Tests that prelude items can be shadowed by explicit imports but still accessible via absolute paths
+[
+  "use",
+  "kernel::type",
+  { "#struct": { "Dict": "Option" } },
+  [
+    "let",
+    "x",
+    "Option<Number>", // Should resolve to custom::Option
+    { "#literal": "2" },
+    ["let", "y", "kernel::type::Option<Number>", { "#literal": 3 }, "_"] // Should resolve to prelude Option via absolute path
+  ]
+]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/shadowed-prelude.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/shadowed-prelude.stdout
@@ -1,0 +1,46 @@
+Expr#4294967040@64
+  ExprKind (Let)
+    LetExpr#4294967040@64 (name: x)
+      Expr#4294967040@37
+        ExprKind (Literal)
+          LiteralExpr#4294967040@36
+            LiteralKind (String)
+              StringLiteral (2)
+      Type#4294967040@35
+        TypeKind (Path)
+          Path#4294967040@35 (rooted: true)
+            PathSegment#4294967040@34 (name: kernel)
+            PathSegment#4294967040@34 (name: type)
+            PathSegment#4294967040@34 (name: Dict)
+              PathSegmentArgument (GenericArgument)
+                GenericArgument#4294967040@33
+                  Type#4294967040@32
+                    TypeKind (Path)
+                      Path#4294967040@32 (rooted: true)
+                        PathSegment#4294967040@31 (name: kernel)
+                        PathSegment#4294967040@31 (name: type)
+                        PathSegment#4294967040@31 (name: Number)
+      Expr#4294967040@63
+        ExprKind (Let)
+          LetExpr#4294967040@63 (name: y)
+            Expr#4294967040@60
+              ExprKind (Literal)
+                LiteralExpr#4294967040@59
+                  LiteralKind (Integer)
+                    IntegerLiteral (3)
+            Type#4294967040@58
+              TypeKind (Path)
+                Path#4294967040@58 (rooted: true)
+                  PathSegment#4294967040@48 (name: kernel)
+                  PathSegment#4294967040@50 (name: type)
+                  PathSegment#4294967040@57 (name: Option)
+                    PathSegmentArgument (GenericArgument)
+                      GenericArgument#4294967040@56
+                        Type#4294967040@55
+                          TypeKind (Path)
+                            Path#4294967040@55 (rooted: true)
+                              PathSegment#4294967040@54 (name: kernel)
+                              PathSegment#4294967040@54 (name: type)
+                              PathSegment#4294967040@54 (name: Number)
+            Expr#4294967040@62
+              ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/substitution.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/substitution.jsonc
@@ -1,0 +1,3 @@
+//@ run: pass
+//@ description: `use` paths should be eliminated
+["use", "kernel", { "#tuple": ["type"] }, "_"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/substitution.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/substitution.jsonc
@@ -1,3 +1,3 @@
 //@ run: pass
-//@ description: `use` paths should be eliminated
+//@ description: Tests that use expressions are properly replaced with their body after processing
 ["use", "kernel", { "#tuple": ["type"] }, "_"]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/substitution.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/substitution.stdout
@@ -1,0 +1,2 @@
+Expr#4294967040@15
+  ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/universe-ambiguity-resolution.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/universe-ambiguity-resolution.jsonc
@@ -1,0 +1,13 @@
+//@ run: pass
+//@ description: Tests that ambiguous names are correctly resolved based on the current universe (type vs value)
+[
+  "use",
+  "math",
+  { "#struct": { "add": "Dict" } },
+  [
+    "type",
+    "X",
+    "Dict", // Should resolve in type universe
+    "Dict" // Should resolve in value universe
+  ]
+]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/universe-ambiguity-resolution.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/universe-ambiguity-resolution.stdout
@@ -1,0 +1,14 @@
+Expr#4294967040@33
+  ExprKind (Type)
+    TypeExpr#4294967040@33 (name: X)
+      Type#4294967040@28
+        TypeKind (Path)
+          Path#4294967040@28 (rooted: true)
+            PathSegment#4294967040@27 (name: kernel)
+            PathSegment#4294967040@27 (name: type)
+            PathSegment#4294967040@27 (name: Dict)
+      Expr#4294967040@32
+        ExprKind (Path)
+          Path#4294967040@32 (rooted: true)
+            PathSegment#4294967040@31 (name: math)
+            PathSegment#4294967040@31 (name: add)

--- a/libs/@local/hashql/compiletest/src/suite/ast_lowering_import_resolver.rs
+++ b/libs/@local/hashql/compiletest/src/suite/ast_lowering_import_resolver.rs
@@ -1,0 +1,54 @@
+use hashql_ast::{
+    format::SyntaxDump as _,
+    lowering::{
+        import_resolver::ImportResolver, pre_expansion_name_resolver::PreExpansionNameResolver,
+        special_form_expander::SpecialFormExpander,
+    },
+    node::expr::Expr,
+    visit::Visitor as _,
+};
+use hashql_core::{
+    heap::Heap,
+    module::{ModuleRegistry, namespace::ModuleNamespace},
+    span::SpanId,
+    r#type::environment::Environment,
+};
+
+use super::{Suite, SuiteDiagnostic, common::process_diagnostics};
+
+pub(crate) struct AstLoweringImportResolverSuite;
+
+impl Suite for AstLoweringImportResolverSuite {
+    fn name(&self) -> &'static str {
+        "ast/lowering/import-resolver"
+    }
+
+    fn run<'heap>(
+        &self,
+        heap: &'heap Heap,
+        mut expr: Expr<'heap>,
+        diagnostics: &mut Vec<SuiteDiagnostic>,
+    ) -> Result<String, SuiteDiagnostic> {
+        let environment = Environment::new(SpanId::SYNTHETIC, heap);
+        let registry = ModuleRegistry::new(&environment);
+
+        let mut resolver = PreExpansionNameResolver::new(&registry);
+
+        resolver.visit_expr(&mut expr);
+
+        let mut expander = SpecialFormExpander::new(heap);
+        expander.visit_expr(&mut expr);
+
+        process_diagnostics(diagnostics, expander.take_diagnostics())?;
+
+        let mut namespace = ModuleNamespace::new(&registry);
+        namespace.import_prelude();
+
+        let mut resolver = ImportResolver::new(heap, namespace);
+        resolver.visit_expr(&mut expr);
+
+        process_diagnostics(diagnostics, resolver.take_diagnostics())?;
+
+        Ok(expr.syntax_dump_to_string())
+    }
+}

--- a/libs/@local/hashql/compiletest/src/suite/mod.rs
+++ b/libs/@local/hashql/compiletest/src/suite/mod.rs
@@ -1,3 +1,4 @@
+mod ast_lowering_import_resolver;
 mod ast_lowering_node_mangler;
 mod ast_lowering_node_renumberer;
 mod ast_lowering_pre_expansion_name_resolver;
@@ -10,6 +11,7 @@ use hashql_core::{heap::Heap, span::SpanId};
 use hashql_diagnostics::{Diagnostic, category::DiagnosticCategory, span::AbsoluteDiagnosticSpan};
 
 use self::{
+    ast_lowering_import_resolver::AstLoweringImportResolverSuite,
     ast_lowering_node_mangler::AstLoweringNameManglerSuite,
     ast_lowering_node_renumberer::AstLoweringNodeRenumbererSuite,
     ast_lowering_pre_expansion_name_resolver::AstLoweringNameResolverSuite,
@@ -38,6 +40,7 @@ const SUITES: &[&dyn Suite] = &[
     &AstLoweringSpecialFormExpanderSuite,
     &AstLoweringNodeRenumbererSuite,
     &AstLoweringNameManglerSuite,
+    &AstLoweringImportResolverSuite,
 ];
 
 pub(crate) fn find_suite(name: &str) -> Option<&'static dyn Suite> {

--- a/libs/@local/hashql/core/Cargo.toml
+++ b/libs/@local/hashql/core/Cargo.toml
@@ -33,6 +33,7 @@ roaring        = { workspace = true, features = ["std", "simd"] }
 rpds           = { workspace = true }
 serde          = { workspace = true, optional = true, features = ["alloc", "derive"] }
 simple-mermaid = { workspace = true }
+strsim         = "0.11.1"
 tracing        = { workspace = true }
 
 

--- a/libs/@local/hashql/core/src/lib.rs
+++ b/libs/@local/hashql/core/src/lib.rs
@@ -11,7 +11,8 @@
     let_chains,
     generic_arg_infer,
     iter_map_windows,
-    cold_path
+    cold_path,
+    type_alias_impl_trait
 )]
 
 extern crate alloc;

--- a/libs/@local/hashql/core/src/module/error.rs
+++ b/libs/@local/hashql/core/src/module/error.rs
@@ -5,7 +5,7 @@ use super::{
 };
 
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub struct Suggestion<T> {
+pub struct ResolutionSuggestion<T> {
     pub item: T,
     pub score: f64,
 }
@@ -22,21 +22,21 @@ pub enum ResolutionError<'heap> {
 
     PackageNotFound {
         depth: usize,
-        suggestions: Vec<Suggestion<ModuleId>>,
+        suggestions: Vec<ResolutionSuggestion<ModuleId>>,
     },
     ImportNotFound {
         depth: usize,
-        suggestions: Vec<Suggestion<Import<'heap>>>,
+        suggestions: Vec<ResolutionSuggestion<Import<'heap>>>,
     },
 
     ModuleNotFound {
         depth: usize,
-        suggestions: Vec<Suggestion<Item<'heap>>>,
+        suggestions: Vec<ResolutionSuggestion<Item<'heap>>>,
     },
 
     ItemNotFound {
         depth: usize,
-        suggestions: Vec<Suggestion<Item<'heap>>>,
+        suggestions: Vec<ResolutionSuggestion<Item<'heap>>>,
     },
 
     Ambiguous(Item<'heap>),

--- a/libs/@local/hashql/core/src/module/error.rs
+++ b/libs/@local/hashql/core/src/module/error.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Suggestion<T> {
+    pub item: T,
+    pub score: f64,
+}

--- a/libs/@local/hashql/core/src/module/error.rs
+++ b/libs/@local/hashql/core/src/module/error.rs
@@ -1,5 +1,47 @@
+use super::{
+    ModuleId,
+    import::Import,
+    item::{Item, Universe},
+};
+
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Suggestion<T> {
     pub item: T,
     pub score: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ResolutionError<'heap> {
+    InvalidQueryLength {
+        expected: usize,
+    },
+    ModuleRequired {
+        depth: usize,
+        found: Option<Universe>,
+    },
+
+    PackageNotFound {
+        depth: usize,
+        suggestions: Vec<Suggestion<ModuleId>>,
+    },
+    ImportNotFound {
+        depth: usize,
+        suggestions: Vec<Suggestion<Import<'heap>>>,
+    },
+
+    ModuleNotFound {
+        depth: usize,
+        suggestions: Vec<Suggestion<Item<'heap>>>,
+    },
+
+    ItemNotFound {
+        depth: usize,
+        suggestions: Vec<Suggestion<Item<'heap>>>,
+    },
+
+    Ambiguous(Item<'heap>),
+
+    ModuleEmpty {
+        depth: usize,
+    },
 }

--- a/libs/@local/hashql/core/src/module/import.rs
+++ b/libs/@local/hashql/core/src/module/import.rs
@@ -3,6 +3,10 @@
 //! This module provides functionality for managing imports within the HashQL
 //! language, including both absolute and relative imports, as well as the standard
 //! prelude of built-in items.
+use core::marker::PhantomData;
+
+use ena::snapshot_vec::SnapshotVecDelegate;
+
 use super::item::Item;
 use crate::symbol::InternedSymbol;
 
@@ -16,4 +20,15 @@ pub struct Import<'heap> {
     pub name: InternedSymbol<'heap>,
 
     pub item: Item<'heap>,
+}
+
+// This needs to be a separate struct, as to not leak `ena` as a dependency
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ImportDelegate<'heap>(PhantomData<&'heap ()>);
+
+impl<'heap> SnapshotVecDelegate for ImportDelegate<'heap> {
+    type Undo = ();
+    type Value = Import<'heap>;
+
+    fn reverse(_: &mut Vec<Self::Value>, (): ()) {}
 }

--- a/libs/@local/hashql/core/src/module/item.rs
+++ b/libs/@local/hashql/core/src/module/item.rs
@@ -61,31 +61,6 @@ pub struct Item<'heap> {
 }
 
 impl<'heap> Item<'heap> {
-    // TODO: when `gen` blocks have proper r-a support revisit this, currently, due to lifetime
-    // constraints and recursive types this cannot be written as a simple iterator.
-    pub(crate) fn search(
-        &self,
-        registry: &ModuleRegistry<'heap>,
-        query: impl IntoIterator<Item = InternedSymbol<'heap>, IntoIter: Clone>,
-    ) -> Vec<Self> {
-        let mut query = query.into_iter();
-        let Some(name) = query.next() else {
-            return vec![*self];
-        };
-
-        let ItemKind::Module(module) = self.kind else {
-            return Vec::new();
-        };
-
-        let module = registry.modules.index(module);
-        let items = module.find(name);
-
-        items
-            .into_iter()
-            .flat_map(move |item| item.search(registry, query.clone()))
-            .collect()
-    }
-
     pub fn ancestors(
         &self,
         registry: &ModuleRegistry<'heap>,

--- a/libs/@local/hashql/core/src/module/item.rs
+++ b/libs/@local/hashql/core/src/module/item.rs
@@ -63,7 +63,7 @@ pub struct Item<'heap> {
 impl<'heap> Item<'heap> {
     // TODO: when `gen` blocks have proper r-a support revisit this, currently, due to lifetime
     // constraints and recursive types this cannot be written as a simple iterator.
-    pub fn search(
+    pub(crate) fn search(
         &self,
         registry: &ModuleRegistry<'heap>,
         query: impl IntoIterator<Item = InternedSymbol<'heap>, IntoIter: Clone>,

--- a/libs/@local/hashql/core/src/module/namespace.rs
+++ b/libs/@local/hashql/core/src/module/namespace.rs
@@ -49,6 +49,7 @@ pub struct ModuleNamespace<'env, 'heap> {
 }
 
 impl<'env, 'heap> ModuleNamespace<'env, 'heap> {
+    /// Create a new module namespace.
     pub fn new(registry: &'env ModuleRegistry<'heap>) -> Self {
         Self {
             registry,

--- a/libs/@local/hashql/core/src/module/namespace.rs
+++ b/libs/@local/hashql/core/src/module/namespace.rs
@@ -202,8 +202,9 @@ impl<'env, 'heap> ModuleNamespace<'env, 'heap> {
 
         let mut iter = resolver.resolve_relative(query, &self.imports)?;
 
-        // ResolveIter guarantees that at least one item is returned
-        let item = iter.next().unwrap_or_else(|| unreachable!());
+        let item = iter.next().unwrap_or_else(|| {
+            unreachable!("ResolveIter guarantees at least one item is returned")
+        });
         if iter.next().is_some() {
             Err(ResolutionError::Ambiguous(item))
         } else {
@@ -232,8 +233,9 @@ impl<'env, 'heap> ModuleNamespace<'env, 'heap> {
         };
 
         let mut iter = resolver.resolve_absolute(query)?;
-        // ResolveIter guarantees that at least one item is returned
-        let item = iter.next().unwrap_or_else(|| unreachable!());
+        let item = iter.next().unwrap_or_else(|| {
+            unreachable!("ResolveIter guarantees at least one item is returned")
+        });
         if iter.next().is_some() {
             Err(ResolutionError::Ambiguous(item))
         } else {
@@ -792,8 +794,6 @@ mod tests {
                 },
             )
             .expect("should be able to import glob from absolute");
-
-        println!("{:?}", namespace.imports);
 
         // We should be able to import `Dict` now
         let import = namespace

--- a/libs/@local/hashql/core/src/module/namespace.rs
+++ b/libs/@local/hashql/core/src/module/namespace.rs
@@ -1,8 +1,11 @@
 //! Namespace management for the HashQL module system.
+use core::iter;
+
 use ena::snapshot_vec::{Snapshot, SnapshotVec};
 
 use super::{
-    ModuleRegistry,
+    Module, ModuleRegistry,
+    error::Suggestion,
     import::{Import, ImportDelegate},
     item::{Item, ItemKind, Universe},
 };
@@ -31,6 +34,18 @@ pub struct ResolveOptions {
 pub enum Transaction<T> {
     Commit(T),
     Rollback(T),
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+enum ResolverMode {
+    Single(Universe),
+    Glob,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+struct ResolverOptions {
+    mode: ResolverMode,
+    suggestions: bool,
 }
 
 /// Represents the namespace of a module.

--- a/libs/@local/hashql/core/src/module/namespace.rs
+++ b/libs/@local/hashql/core/src/module/namespace.rs
@@ -528,9 +528,10 @@ mod tests {
             ImportOptions {
                 glob: false,
                 mode: ResolutionMode::Absolute,
+                suggestions: false,
             },
         );
-        assert!(success);
+        assert!(success.is_ok());
 
         let item = namespace
             .resolve_relative(
@@ -599,14 +600,19 @@ mod tests {
             })
         );
 
-        assert!(namespace.import_absolute(
-            heap.intern_symbol("Dict"),
-            [heap.intern_symbol("foo"), heap.intern_symbol("bar")],
-            ImportOptions {
-                glob: false,
-                mode: ResolutionMode::Absolute
-            }
-        ));
+        assert!(
+            namespace
+                .import_absolute(
+                    heap.intern_symbol("Dict"),
+                    [heap.intern_symbol("foo"), heap.intern_symbol("bar")],
+                    ImportOptions {
+                        glob: false,
+                        mode: ResolutionMode::Absolute,
+                        suggestions: false
+                    }
+                )
+                .is_ok()
+        );
 
         let import = namespace
             .resolve_relative(
@@ -645,9 +651,10 @@ mod tests {
             ImportOptions {
                 glob: false,
                 mode: ResolutionMode::Absolute,
+                suggestions: false,
             },
         );
-        assert!(success);
+        assert!(success.is_ok());
 
         // import `Dict` relative from type (now that it is imported)
         let success = namespace.import_relative(
@@ -656,9 +663,10 @@ mod tests {
             ImportOptions {
                 glob: false,
                 mode: ResolutionMode::Relative,
+                suggestions: false,
             },
         );
-        assert!(success);
+        assert!(success.is_ok());
 
         // We should be able to import `Dict` now
         let import = namespace
@@ -690,9 +698,10 @@ mod tests {
             ImportOptions {
                 glob: false,
                 mode: ResolutionMode::Absolute,
+                suggestions: false,
             },
         );
-        assert!(success);
+        assert!(success.is_ok());
 
         // import `Dict` relative from type (now that it is imported)
         let success = namespace.import_relative(
@@ -701,9 +710,10 @@ mod tests {
             ImportOptions {
                 glob: false,
                 mode: ResolutionMode::Relative,
+                suggestions: false,
             },
         );
-        assert!(success);
+        assert!(success.is_ok());
 
         // // We should be able to import `Dict` now
         // let import = namespace
@@ -735,9 +745,10 @@ mod tests {
             ImportOptions {
                 glob: true,
                 mode: ResolutionMode::Absolute,
+                suggestions: false,
             },
         );
-        assert!(success);
+        assert!(success.is_ok());
 
         // We should be able to import `Dict` now
         let import = namespace
@@ -768,8 +779,9 @@ mod tests {
             ImportOptions {
                 glob: true,
                 mode: ResolutionMode::Absolute,
+                suggestions: false,
             },
         );
-        assert!(!success);
+        assert!(!success.is_ok());
     }
 }

--- a/libs/@local/hashql/core/src/module/namespace.rs
+++ b/libs/@local/hashql/core/src/module/namespace.rs
@@ -38,7 +38,7 @@ pub enum Transaction<T> {
 /// A `ModuleNamespace` defines the collection of names that are available within a module.
 #[derive(Debug, Clone)]
 pub struct ModuleNamespace<'env, 'heap> {
-    registry: &'env ModuleRegistry<'heap>,
+    pub registry: &'env ModuleRegistry<'heap>,
     imports: SnapshotVec<ImportDelegate<'heap>>,
 }
 
@@ -405,7 +405,7 @@ mod tests {
     use crate::{
         heap::Heap,
         module::{
-            ModuleRegistry, PartialModule,
+            ModuleId, ModuleRegistry, PartialModule,
             item::{IntrinsicItem, Item, ItemKind, Universe},
             namespace::{ImportOptions, ResolutionMode, ResolveOptions},
         },
@@ -596,8 +596,11 @@ mod tests {
         namespace.import_prelude();
 
         let module = registry.intern_module(|id| PartialModule {
+            parent: ModuleId::ROOT,
+            name: heap.intern_symbol("foo"),
+
             items: registry.intern_items(&[Item {
-                parent: Some(id.value()),
+                module: id.value(),
                 name: heap.intern_symbol("bar"),
                 kind: ItemKind::Intrinsic(IntrinsicItem {
                     name: "::foo::bar",
@@ -605,7 +608,7 @@ mod tests {
                 }),
             }]),
         });
-        registry.register(heap.intern_symbol("foo"), module);
+        registry.register(module);
 
         let import = namespace
             .resolve_relative_import(

--- a/libs/@local/hashql/core/src/module/namespace.rs
+++ b/libs/@local/hashql/core/src/module/namespace.rs
@@ -4,9 +4,10 @@ use ena::snapshot_vec::{Snapshot, SnapshotVec};
 
 use super::{
     ModuleRegistry,
+    error::ResolutionError,
     import::{Import, ImportDelegate},
     item::{Item, Universe},
-    resolver::{ResolutionError, ResolveIter},
+    resolver::ResolveIter,
 };
 use crate::{
     module::resolver::{Resolver, ResolverMode, ResolverOptions},
@@ -402,9 +403,9 @@ mod tests {
         heap::Heap,
         module::{
             ModuleId, ModuleRegistry, PartialModule,
+            error::ResolutionError,
             item::{IntrinsicItem, Item, ItemKind, Universe},
             namespace::{ImportOptions, ResolutionMode, ResolveOptions},
-            resolver::ResolutionError,
         },
         span::SpanId,
         r#type::environment::Environment,

--- a/libs/@local/hashql/core/src/module/namespace.rs
+++ b/libs/@local/hashql/core/src/module/namespace.rs
@@ -365,6 +365,11 @@ impl<'env, 'heap> ModuleNamespace<'env, 'heap> {
             }
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn imports_as_slice(&self) -> &[Import<'heap>] {
+        &*self.imports
+    }
 }
 
 #[cfg(test)]

--- a/libs/@local/hashql/core/src/module/resolver.rs
+++ b/libs/@local/hashql/core/src/module/resolver.rs
@@ -4,7 +4,7 @@ use strsim::jaro_winkler;
 
 use super::{
     Module, ModuleRegistry,
-    error::{ResolutionError, Suggestion},
+    error::{ResolutionError, ResolutionSuggestion},
     import::Import,
     item::{Item, ItemKind, Universe},
 };
@@ -54,7 +54,10 @@ pub(crate) struct Resolver<'env, 'heap> {
 }
 
 impl<'heap> Resolver<'_, 'heap> {
-    fn suggest<T>(&self, call: impl FnOnce() -> Vec<Suggestion<T>>) -> Vec<Suggestion<T>> {
+    fn suggest<T>(
+        &self,
+        call: impl FnOnce() -> Vec<ResolutionSuggestion<T>>,
+    ) -> Vec<ResolutionSuggestion<T>> {
         if self.options.suggestions {
             call()
         } else {
@@ -260,7 +263,7 @@ impl<'heap> Resolver<'_, 'heap> {
                         .filter(|import| import.item.kind.universe() == Some(universe))
                         .map(|&import| {
                             let score = jaro_winkler(import.name.as_str(), name.as_str());
-                            Suggestion {
+                            ResolutionSuggestion {
                                 item: import,
                                 score,
                             }
@@ -304,7 +307,7 @@ impl<'heap> Resolver<'_, 'heap> {
                         .iter()
                         .map(|&import| {
                             let score = jaro_winkler(import.name.as_str(), name.as_str());
-                            Suggestion {
+                            ResolutionSuggestion {
                                 item: import,
                                 score,
                             }

--- a/libs/@local/hashql/core/src/module/resolver.rs
+++ b/libs/@local/hashql/core/src/module/resolver.rs
@@ -1,0 +1,171 @@
+use core::iter;
+
+use super::{
+    Module, ModuleRegistry,
+    error::Suggestion,
+    item::{Item, ItemKind, Universe},
+};
+use crate::symbol::InternedSymbol;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ResolveError<'heap> {
+    NotEnoughLengthChangeName,
+    ExpectedModule {
+        depth: usize,
+        found: Option<Universe>,
+    },
+    ModuleNotFound {
+        depth: usize,
+        suggestions: Vec<Suggestion<Item<'heap>>>,
+    },
+    ItemNotFound {
+        depth: usize,
+        suggestions: Vec<Suggestion<Item<'heap>>>,
+    },
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum ResolverMode {
+    Single(Universe),
+    Glob,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ResolverOptions {
+    mode: ResolverMode,
+    suggestions: bool,
+}
+
+pub(crate) struct Resolver<'env, 'heap> {
+    pub registry: &'env ModuleRegistry<'heap>,
+    pub options: ResolverOptions,
+}
+
+impl<'heap> Resolver<'_, 'heap> {
+    fn suggest<T>(&self, call: impl FnOnce() -> Vec<Suggestion<T>>) -> Vec<Suggestion<T>> {
+        if self.options.suggestions {
+            call()
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn resolve_single(
+        &self,
+        module: Module<'heap>,
+        universe: Universe,
+        name: InternedSymbol<'heap>,
+        depth: usize,
+    ) -> Result<impl IntoIterator<Item = Item<'heap>>, ResolveError<'heap>> {
+        let item = module
+            .items
+            .iter()
+            .copied()
+            .find(|item| item.name == name && item.kind.universe() == Some(universe));
+
+        let Some(item) = item else {
+            return Err(ResolveError::ItemNotFound {
+                depth,
+                suggestions: self.suggest(|| {
+                    module.suggestions(name, |item| item.kind.universe() == Some(universe))
+                }),
+            });
+        };
+
+        Ok(iter::once(item))
+    }
+
+    fn resolve_glob(
+        &self,
+        module: Module<'heap>,
+        name: InternedSymbol<'heap>,
+        depth: usize,
+    ) -> Result<impl IntoIterator<Item = Item<'heap>>, ResolveError<'heap>> {
+        let candidate = module
+            .items
+            .iter()
+            .copied()
+            .find_map(|item| match item.kind {
+                ItemKind::Module(module) if item.name == name => Some(module),
+                _ => None,
+            });
+
+        let Some(module) = candidate else {
+            return Err(ResolveError::ModuleNotFound {
+                depth,
+                suggestions: self.suggest(|| {
+                    module.suggestions(name, |item| matches!(item.kind, ItemKind::Module(_)))
+                }),
+            });
+        };
+
+        Ok(self
+            .registry
+            .modules
+            .index(module)
+            .items
+            .into_iter()
+            .copied())
+    }
+
+    pub(crate) fn resolve(
+        &self,
+        mut module: Module<'heap>,
+        query: impl IntoIterator<Item = InternedSymbol<'heap>>,
+    ) -> Result<impl IntoIterator<Item = Item<'heap>>, ResolveError<'heap>> {
+        let mut query = query.into_iter().enumerate().peekable();
+
+        // Traverse the entry until we're at the last item
+        let (depth, name) = loop {
+            let Some((mut depth, name)) = query.next() else {
+                return Err(ResolveError::NotEnoughLengthChangeName);
+            };
+
+            // We start at 1, because the entry (the one we're starting at) is selected by the user
+            depth += 1;
+
+            if query.peek().is_none() {
+                // The last item is the entry we're trying to resolve to
+                break (depth, name);
+            }
+
+            let Some(&item) = module.items.iter().find(|item| item.name == name) else {
+                return Err(ResolveError::ModuleNotFound {
+                    depth,
+                    suggestions: self.suggest(|| {
+                        module.suggestions(name, |item| matches!(item.kind, ItemKind::Module(_)))
+                    }),
+                });
+            };
+
+            // Because we're not at the last item, the item needs to be a module
+            let ItemKind::Module(next) = item.kind else {
+                return Err(ResolveError::ExpectedModule {
+                    depth,
+                    found: item.kind.universe(),
+                });
+            };
+
+            module = self.registry.modules.index(next);
+        };
+
+        let mut iter_single = None;
+        let mut iter_glob = None;
+
+        match self.options.mode {
+            ResolverMode::Single(universe) => {
+                iter_single = Some(self.resolve_single(module, universe, name, depth)?);
+            }
+            ResolverMode::Glob => {
+                iter_glob = Some(self.resolve_glob(module, name, depth)?);
+            }
+        }
+
+        // This might look weird, but allows us to use a single `Iterator`, without a custom type
+        // which is pretty neat!
+        Ok(iter_single
+            .into_iter()
+            .flatten()
+            .chain(iter_glob.into_iter().flatten()))
+    }
+}

--- a/libs/@local/hashql/core/src/module/resolver.rs
+++ b/libs/@local/hashql/core/src/module/resolver.rs
@@ -936,6 +936,25 @@ mod test {
                 .iter()
                 .any(|item| item.kind.universe() == Some(Universe::Value))
         );
+
+        let result = resolver
+            .resolve_relative([heap.intern_symbol("Dict")], namespace.imports_as_slice())
+            .expect("Resolution should succeed");
+
+        let items: Vec<_> = result.collect();
+        assert_eq!(items.len(), 2);
+
+        // Verify we have both Type and Value universes
+        assert!(
+            items
+                .iter()
+                .any(|item| item.kind.universe() == Some(Universe::Type))
+        );
+        assert!(
+            items
+                .iter()
+                .any(|item| item.kind.universe() == Some(Universe::Value))
+        );
     }
 
     #[test]

--- a/libs/@local/hashql/core/src/module/resolver.rs
+++ b/libs/@local/hashql/core/src/module/resolver.rs
@@ -3,8 +3,8 @@ use core::{fmt::Debug, iter};
 use strsim::jaro_winkler;
 
 use super::{
-    Module, ModuleId, ModuleRegistry,
-    error::Suggestion,
+    Module, ModuleRegistry,
+    error::{ResolutionError, Suggestion},
     import::Import,
     item::{Item, ItemKind, Universe},
 };
@@ -33,42 +33,6 @@ impl<'heap> Iterator for ResolveIter<'heap> {
             ResolveIter::Glob(iter) => iter.next(),
         }
     }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum ResolutionError<'heap> {
-    InvalidQueryLength {
-        expected: usize,
-    },
-    ModuleRequired {
-        depth: usize,
-        found: Option<Universe>,
-    },
-
-    PackageNotFound {
-        depth: usize,
-        suggestions: Vec<Suggestion<ModuleId>>,
-    },
-    ImportNotFound {
-        depth: usize,
-        suggestions: Vec<Suggestion<Import<'heap>>>,
-    },
-
-    ModuleNotFound {
-        depth: usize,
-        suggestions: Vec<Suggestion<Item<'heap>>>,
-    },
-
-    ItemNotFound {
-        depth: usize,
-        suggestions: Vec<Suggestion<Item<'heap>>>,
-    },
-
-    Ambiguous(Item<'heap>),
-
-    ModuleEmpty {
-        depth: usize,
-    },
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/libs/@local/hashql/core/src/module/resolver.rs
+++ b/libs/@local/hashql/core/src/module/resolver.rs
@@ -61,6 +61,10 @@ pub enum ResolveError<'heap> {
     },
 
     Ambiguous(Item<'heap>),
+
+    ModuleEmpty {
+        depth: usize,
+    },
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -175,6 +179,10 @@ impl<'heap> Resolver<'_, 'heap> {
         };
 
         let module = self.registry.modules.index(module);
+
+        if module.items.is_empty() {
+            return Err(ResolveError::ModuleEmpty { depth });
+        }
 
         Ok(module.items.into_iter().copied())
     }
@@ -297,6 +305,10 @@ impl<'heap> Resolver<'_, 'heap> {
         };
 
         let module = self.registry.modules.index(module);
+
+        if module.items.is_empty() {
+            return Err(ResolveError::ModuleEmpty { depth: 0 });
+        }
 
         Ok(module.items.into_iter().copied())
     }

--- a/libs/@local/hashql/core/src/symbol/mod.rs
+++ b/libs/@local/hashql/core/src/symbol/mod.rs
@@ -27,7 +27,7 @@ use core::{
 
 use ecow::EcoString;
 
-use crate::span::SpanId;
+use crate::{heap::Heap, span::SpanId};
 
 /// A string-like value used throughout the HashQL compiler.
 ///
@@ -161,6 +161,11 @@ impl Symbol {
     /// ```
     pub fn push_str(&mut self, string: impl AsRef<str>) {
         self.0.push_str(string.as_ref());
+    }
+
+    pub fn intern<'heap>(&self, heap: &'heap Heap) -> InternedSymbol<'heap> {
+        // This is just a proxy method that makes switching from symbol to interned symbol easier
+        heap.intern_symbol(self.as_str())
     }
 }
 

--- a/libs/@local/hashql/diagnostics/src/lib.rs
+++ b/libs/@local/hashql/diagnostics/src/lib.rs
@@ -16,6 +16,8 @@ pub mod note;
 pub mod severity;
 pub mod span;
 
+pub use anstyle as color;
+
 #[cfg(feature = "serde")]
 pub(crate) mod encoding;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The import resolver takes any `use` imports and resolves them to their absolute counterpart. This is basically the `NameResolverPostExpansion`.

This is required to make the type checking easier, as this means we do not need to special case any modules in our types and it can remain pure.

After this stage `use` statements are discarded from the tree.

To give the user the opportunity to remedy their issues, the resolver needed to be reworked (and split into a separate module). The new system is superior in the sense that it doesn't allocate and that it's errors are a lot more rich.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

