### PR TITLE
H-4522: Make codegen ordering consistent

### DIFF
--- a/libs/@local/codegen/src/definitions/type.rs
+++ b/libs/@local/codegen/src/definitions/type.rs
@@ -8,7 +8,7 @@ use super::{Enum, List, Map, Primitive, Struct, Tuple};
 ///
 /// This solves the problem of distinguishing between different type references that might have the
 /// same name but are from different scopes or modules.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct TypeId(specta::SpectaID);
 
 impl TypeId {

--- a/libs/@local/codegen/src/lib.rs
+++ b/libs/@local/codegen/src/lib.rs
@@ -6,9 +6,10 @@
 #![cfg_attr(doc, doc = simple_mermaid::mermaid!("../docs/dependency-diagram.mmd"))]
 #![expect(clippy::todo)]
 
-use alloc::collections::BTreeMap;
+use alloc::{borrow::Cow, collections::BTreeSet};
+use std::collections::HashMap;
 
-use specta::datatype::NamedDataType;
+use specta::{SpectaID, datatype::NamedDataType};
 
 use self::definitions::{TypeDefinition, TypeId};
 
@@ -20,14 +21,33 @@ pub mod typescript;
 
 #[derive(Debug, Default)]
 pub struct TypeCollection {
-    types: BTreeMap<TypeId, TypeDefinition>,
+    ordered_keys: BTreeSet<OrderedTypeId>,
+    types: HashMap<TypeId, TypeDefinition>,
     collection: specta::TypeCollection,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct OrderedTypeId {
+    module_path: Cow<'static, str>,
+    name: Cow<'static, str>,
+    id: SpectaID,
+}
+
+impl From<&NamedDataType> for OrderedTypeId {
+    fn from(data_type: &NamedDataType) -> Self {
+        Self {
+            module_path: data_type.module_path().clone(),
+            name: data_type.name().clone(),
+            id: data_type.sid(),
+        }
+    }
 }
 
 impl TypeCollection {
     pub fn register<T: specta::NamedType>(&mut self) {
         self.collection.register_mut::<T>();
         let data_type = self.collection.get(T::ID).unwrap_or_else(|| unreachable!());
+        self.ordered_keys.insert(OrderedTypeId::from(data_type));
         self.types.insert(
             TypeId::from_specta(T::ID),
             TypeDefinition::from_specta(data_type, &self.collection),
@@ -69,6 +89,7 @@ impl TypeCollection {
                 .entry(TypeId::from_specta(data_type.sid()))
                 .or_insert_with(|| {
                     num_added += 1;
+                    self.ordered_keys.insert(OrderedTypeId::from(data_type));
                     TypeDefinition::from_specta(data_type, &self.collection)
                 });
         }
@@ -76,13 +97,19 @@ impl TypeCollection {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (TypeId, &NamedDataType, &TypeDefinition)> {
-        self.types.iter().map(|(id, def)| {
+        debug_assert_eq!(
+            self.ordered_keys.len(),
+            self.types.len(),
+            "Bug: ordered keys and types should be the same length. The implementation forgot to \
+             update one of them."
+        );
+        self.ordered_keys.iter().map(|key| {
             (
-                *id,
+                TypeId::from_specta(key.id),
                 self.collection
-                    .get(id.to_specta())
+                    .get(key.id)
                     .unwrap_or_else(|| unreachable!()),
-                def,
+                &self.types[&TypeId::from_specta(key.id)],
             )
         })
     }

--- a/libs/@local/codegen/tests/full-exports/snapshots/full_exports__type_system::Typescript.snap
+++ b/libs/@local/codegen/tests/full-exports/snapshots/full_exports__type_system::Typescript.snap
@@ -2,74 +2,7 @@
 source: libs/@local/codegen/tests/full-exports/main.rs
 expression: generator.write()
 ---
-export type WebId = ActorGroupEntityUuid;
-export type WebRoleId = string;
-export type RoleId = {
-	roleType: "web"
-	id: WebRoleId
-} | {
-	roleType: "team"
-	id: TeamRoleId
-};
-export interface Web {
-	id: WebId;
-	shortname: (string | undefined);
-	roles: WebRoleId[];
-}
-export type Role = {
-	roleType: "web"
-} & WebRole | {
-	roleType: "team"
-} & TeamRole;
-export type Actor = {
-	actorType: "user"
-} & User | {
-	actorType: "machine"
-} & Machine | {
-	actorType: "ai"
-} & Ai;
-export interface TeamRole {
-	id: TeamRoleId;
-	teamId: TeamId;
-	name: RoleName;
-}
-export type UserId = ActorEntityUuid;
-export interface WebRole {
-	id: WebRoleId;
-	webId: WebId;
-	name: RoleName;
-}
-export type ActorGroup = {
-	actorGroupType: "web"
-} & Web | {
-	actorGroupType: "team"
-} & Team;
-export type ActorGroupEntityUuid = EntityUuid;
-export interface Team {
-	id: TeamId;
-	parentId: ActorGroupId;
-	name: string;
-	roles: TeamRoleId[];
-}
-export type ActorEntityUuid = EntityUuid;
-export type TeamRoleId = string;
-export interface Ai {
-	id: AiId;
-	identifier: string;
-	roles: RoleId[];
-}
-export type ActorGroupId = {
-	actorGroupType: "web"
-	id: WebId
-} | {
-	actorGroupType: "team"
-	id: TeamId
-};
-export interface User {
-	id: UserId;
-	roles: RoleId[];
-}
-export type MachineId = ActorEntityUuid;
+export type EntityUuid = string;
 export type Principal = {
 	principalType: "actor"
 } & Actor | {
@@ -77,12 +10,79 @@ export type Principal = {
 } & ActorGroup | {
 	principalType: "role"
 } & Role;
-export type TeamId = ActorGroupEntityUuid;
+export type Actor = {
+	actorType: "user"
+} & User | {
+	actorType: "machine"
+} & Machine | {
+	actorType: "ai"
+} & Ai;
+export type ActorEntityUuid = EntityUuid;
+export interface Ai {
+	id: AiId;
+	identifier: string;
+	roles: RoleId[];
+}
+export type AiId = ActorEntityUuid;
 export interface Machine {
 	id: MachineId;
 	identifier: string;
 	roles: RoleId[];
 }
-export type AiId = ActorEntityUuid;
-export type EntityUuid = string;
+export type MachineId = ActorEntityUuid;
+export interface User {
+	id: UserId;
+	roles: RoleId[];
+}
+export type UserId = ActorEntityUuid;
+export type ActorGroup = {
+	actorGroupType: "web"
+} & Web | {
+	actorGroupType: "team"
+} & Team;
+export type ActorGroupEntityUuid = EntityUuid;
+export type ActorGroupId = {
+	actorGroupType: "web"
+	id: WebId
+} | {
+	actorGroupType: "team"
+	id: TeamId
+};
+export interface Team {
+	id: TeamId;
+	parentId: ActorGroupId;
+	name: string;
+	roles: TeamRoleId[];
+}
+export type TeamId = ActorGroupEntityUuid;
+export interface Web {
+	id: WebId;
+	shortname: (string | undefined);
+	roles: WebRoleId[];
+}
+export type WebId = ActorGroupEntityUuid;
+export type Role = {
+	roleType: "web"
+} & WebRole | {
+	roleType: "team"
+} & TeamRole;
+export type RoleId = {
+	roleType: "web"
+	id: WebRoleId
+} | {
+	roleType: "team"
+	id: TeamRoleId
+};
 export type RoleName = "administrator" | "member";
+export interface TeamRole {
+	id: TeamRoleId;
+	teamId: TeamId;
+	name: RoleName;
+}
+export type TeamRoleId = string;
+export interface WebRole {
+	id: WebRoleId;
+	webId: WebId;
+	name: RoleName;
+}
+export type WebRoleId = string;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently use BTreeMap with TypeId as key while TypeId is an opaque SpectaId. The ID is not stable so the generated files change quite badly eventually.

Instead, we should use a more robust approach, such as putting the module path and name of the type in there as well.

## 🔍 What does this change?

This adds a new internal type 
```rust
struct OrderedTypeId {
    module_path: Cow<'static, str>,
    name: Cow<'static, str>,
    id: SpectaID,
}
```

which is ordered by the module path and the type name before the actual internal ID. The internal ID is only used as a fail-safe if `module_name` and `name` is the same for two types for whatever reason.

This is used as a key in the type collection to determine iteration order. While this might not be the fastest implementation as the key needs to be constructed, it's faster than sorting on the fly. Also, with `facet` and the strings being known statically, this becomes faster again.