### PR TITLE
H-4523: Fix turbos @local/eslint dependency

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -90,7 +90,7 @@
       "dependsOn": ["codegen"]
     },
     "fix:eslint": {
-      "dependsOn": ["codegen"]
+      "dependsOn": ["codegen", "@local/eslint#build"]
     },
     "fix:clippy": {},
     "sentry:sourcemaps": {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Ensures ESLint configuration is properly built before running the `fix:eslint` task in Turborepo pipeline.