### PR TITLE
H-4461: Implement type branding in codegen

### DIFF
--- a/apps/hash-frontend/src/pages/shared/block-collection/block-context-menu/block-context-menu.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/block-context-menu/block-context-menu.tsx
@@ -156,7 +156,7 @@ const BlockContextMenu: ForwardRefRenderFunction<
         icon: <FontAwesomeIcon icon={faLink} />,
         onClick: () => {
           const url = new URL(document.location.href);
-          url.hash = getBlockDomId((entityId ?? undefined)!);
+          url.hash = getBlockDomId(entityId ?? undefined);
           void navigator.clipboard.writeText(url.toString());
         },
       },

--- a/apps/hash-frontend/src/pages/shared/block-collection/block-context-menu/block-context-menu.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/block-context-menu/block-context-menu.tsx
@@ -156,7 +156,7 @@ const BlockContextMenu: ForwardRefRenderFunction<
         icon: <FontAwesomeIcon icon={faLink} />,
         onClick: () => {
           const url = new URL(document.location.href);
-          url.hash = getBlockDomId(entityId ?? undefined);
+          url.hash = getBlockDomId((entityId ?? undefined)!);
           void navigator.clipboard.writeText(url.toString());
         },
       },

--- a/apps/hash-frontend/src/pages/shared/entity/shared/use-handle-type-changes.ts
+++ b/apps/hash-frontend/src/pages/shared/entity/shared/use-handle-type-changes.ts
@@ -3,12 +3,12 @@ import {
   getOutgoingLinksForEntity,
   getRoots,
 } from "@blockprotocol/graph/stdlib";
-import { extractBaseUrl, mustHaveAtLeastOne } from "@blockprotocol/type-system";
 import type {
   BaseUrl,
   EntityId,
   VersionedUrl,
-} from "@blockprotocol/type-system-rs/pkg/type-system";
+} from "@blockprotocol/type-system";
+import { extractBaseUrl, mustHaveAtLeastOne } from "@blockprotocol/type-system";
 import {
   getClosedMultiEntityTypeFromMap,
   type HashEntity,

--- a/libs/@blockprotocol/type-system/rust/src/bin/export-types.rs
+++ b/libs/@blockprotocol/type-system/rust/src/bin/export-types.rs
@@ -8,16 +8,32 @@ use hash_codegen::{
     TypeCollection,
     typescript::{TypeScriptGenerator, TypeScriptGeneratorSettings},
 };
-use type_system::principal;
+use type_system::{knowledge, principal};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let mut collection = TypeCollection::default();
 
+    // Principal types
     collection.register::<principal::Principal>();
     collection.register::<principal::PrincipalId>();
     collection.register::<principal::actor::ActorType>();
     collection.register::<principal::actor_group::ActorGroupType>();
     collection.register::<principal::role::RoleType>();
+
+    // We currently have to manually specify the branded types
+    collection.register_branded::<knowledge::entity::id::EntityUuid>();
+    collection.register_branded::<knowledge::entity::id::DraftId>();
+    collection.register_branded::<knowledge::entity::id::EntityEditionId>();
+
+    collection.register_branded::<principal::actor::ActorEntityUuid>();
+    collection.register_branded::<principal::actor::UserId>();
+    collection.register_branded::<principal::actor::MachineId>();
+    collection.register_branded::<principal::actor::AiId>();
+    collection.register_branded::<principal::actor_group::ActorGroupEntityUuid>();
+    collection.register_branded::<principal::actor_group::WebId>();
+    collection.register_branded::<principal::actor_group::TeamId>();
+    collection.register_branded::<principal::role::WebRoleId>();
+    collection.register_branded::<principal::role::TeamRoleId>();
 
     collection.register_transitive_types();
 

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/entity/id.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/entity/id.rs
@@ -24,13 +24,10 @@ use crate::principal::actor_group::WebId;
     derive_more::Display,
 )]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "postgres", derive(FromSql, ToSql), postgres(transparent))]
 #[cfg_attr(feature = "utoipa", derive(ToSchema))]
 #[repr(transparent)]
-pub struct EntityUuid(
-    #[cfg_attr(target_arch = "wasm32", tsify(type = "Brand<string, \"EntityUuid\">"))] Uuid,
-);
+pub struct EntityUuid(Uuid);
 
 impl EntityUuid {
     #[must_use]
@@ -56,13 +53,11 @@ impl From<EntityUuid> for Uuid {
     serde::Deserialize,
     derive_more::Display,
 )]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(feature = "codegen", derive(specta::Type))]
 #[cfg_attr(feature = "postgres", derive(FromSql, ToSql), postgres(transparent))]
 #[cfg_attr(feature = "utoipa", derive(ToSchema))]
 #[repr(transparent)]
-pub struct DraftId(
-    #[cfg_attr(target_arch = "wasm32", tsify(type = "Brand<string, \"DraftId\">"))] Uuid,
-);
+pub struct DraftId(Uuid);
 
 impl DraftId {
     #[must_use]
@@ -167,17 +162,11 @@ mod patch {
 #[derive(
     Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(feature = "codegen", derive(specta::Type))]
 #[cfg_attr(feature = "postgres", derive(FromSql, ToSql), postgres(transparent))]
 #[cfg_attr(feature = "utoipa", derive(ToSchema))]
 #[repr(transparent)]
-pub struct EntityEditionId(
-    #[cfg_attr(
-        target_arch = "wasm32",
-        tsify(type = "Brand<string, \"EntityEditionId\">")
-    )]
-    Uuid,
-);
+pub struct EntityEditionId(Uuid);
 
 impl EntityEditionId {
     #[must_use]

--- a/libs/@blockprotocol/type-system/rust/src/principal/actor/ai.rs
+++ b/libs/@blockprotocol/type-system/rust/src/principal/actor/ai.rs
@@ -17,7 +17,6 @@ use crate::{knowledge::entity::id::EntityUuid, principal::role::RoleId};
     derive_more::Display,
 )]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(
     feature = "postgres",
@@ -25,13 +24,7 @@ use crate::{knowledge::entity::id::EntityUuid, principal::role::RoleId};
     postgres(transparent)
 )]
 #[repr(transparent)]
-pub struct AiId(
-    #[cfg_attr(
-        target_arch = "wasm32",
-        tsify(type = "Brand<ActorEntityUuid, \"AiId\">")
-    )]
-    ActorEntityUuid,
-);
+pub struct AiId(ActorEntityUuid);
 
 impl AiId {
     #[must_use]
@@ -60,7 +53,6 @@ impl From<AiId> for Uuid {
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Ai {

--- a/libs/@blockprotocol/type-system/rust/src/principal/actor/machine.rs
+++ b/libs/@blockprotocol/type-system/rust/src/principal/actor/machine.rs
@@ -17,7 +17,6 @@ use crate::{knowledge::entity::id::EntityUuid, principal::role::RoleId};
     derive_more::Display,
 )]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(
     feature = "postgres",
@@ -25,13 +24,7 @@ use crate::{knowledge::entity::id::EntityUuid, principal::role::RoleId};
     postgres(transparent)
 )]
 #[repr(transparent)]
-pub struct MachineId(
-    #[cfg_attr(
-        target_arch = "wasm32",
-        tsify(type = "Brand<ActorEntityUuid, \"MachineId\">")
-    )]
-    ActorEntityUuid,
-);
+pub struct MachineId(ActorEntityUuid);
 
 impl MachineId {
     #[must_use]
@@ -60,7 +53,6 @@ impl From<MachineId> for Uuid {
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Machine {

--- a/libs/@blockprotocol/type-system/rust/src/principal/actor/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/principal/actor/mod.rs
@@ -37,7 +37,6 @@ use crate::knowledge::entity::id::EntityUuid;
     derive_more::Display,
 )]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(
     feature = "postgres",
@@ -45,13 +44,7 @@ use crate::knowledge::entity::id::EntityUuid;
     postgres(transparent)
 )]
 #[repr(transparent)]
-pub struct ActorEntityUuid(
-    #[cfg_attr(
-        target_arch = "wasm32",
-        tsify(type = "Brand<EntityUuid, \"ActorEntityUuid\">")
-    )]
-    EntityUuid,
-);
+pub struct ActorEntityUuid(EntityUuid);
 
 impl ActorEntityUuid {
     /// Creates a new `ActorEntityUuid` from any value that can be converted to a `Uuid`.
@@ -80,7 +73,6 @@ impl From<ActorEntityUuid> for Uuid {
 /// Represents the different categories of entities that can perform actions.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub enum ActorType {
@@ -106,7 +98,6 @@ pub enum ActorType {
     derive_more::From,
 )]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(tag = "actorType", content = "id", rename_all = "camelCase")]
 pub enum ActorId {
@@ -200,7 +191,6 @@ impl postgres_types::ToSql for ActorId {
 /// Each variant corresponds to a specific [`ActorType`].
 #[derive(Debug, serde::Serialize, serde::Deserialize, derive_more::From)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(tag = "actorType", rename_all = "camelCase")]
 pub enum Actor {

--- a/libs/@blockprotocol/type-system/rust/src/principal/actor/user.rs
+++ b/libs/@blockprotocol/type-system/rust/src/principal/actor/user.rs
@@ -28,7 +28,6 @@ use crate::{
     derive_more::Display,
 )]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(
     feature = "postgres",
@@ -36,13 +35,7 @@ use crate::{
     postgres(transparent)
 )]
 #[repr(transparent)]
-pub struct UserId(
-    #[cfg_attr(
-        target_arch = "wasm32",
-        tsify(type = "Brand<ActorEntityUuid & WebId, \"UserId\">")
-    )]
-    ActorEntityUuid,
-);
+pub struct UserId(ActorEntityUuid);
 
 impl UserId {
     /// Creates a new [`UserId`] from any value that can be converted to a `Uuid`.
@@ -83,7 +76,6 @@ impl From<UserId> for WebId {
 /// Represents a user with their unique identifier and assigned roles.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct User {

--- a/libs/@blockprotocol/type-system/rust/src/principal/actor_group/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/principal/actor_group/mod.rs
@@ -33,7 +33,6 @@ use crate::knowledge::entity::id::EntityUuid;
     derive_more::Display,
 )]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(
     feature = "postgres",
@@ -41,13 +40,7 @@ use crate::knowledge::entity::id::EntityUuid;
     postgres(transparent)
 )]
 #[repr(transparent)]
-pub struct ActorGroupEntityUuid(
-    #[cfg_attr(
-        target_arch = "wasm32",
-        tsify(type = "Brand<EntityUuid, \"ActorGroupEntityUuid\">")
-    )]
-    EntityUuid,
-);
+pub struct ActorGroupEntityUuid(EntityUuid);
 
 impl ActorGroupEntityUuid {
     /// Creates a new [`ActorGroupEntityUuid`] from any value that can be converted to a `Uuid`.
@@ -76,7 +69,6 @@ impl From<ActorGroupEntityUuid> for Uuid {
 /// Represents the different categories of actor groupings.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub enum ActorGroupType {
@@ -101,7 +93,6 @@ pub enum ActorGroupType {
     derive_more::From,
 )]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(tag = "actorGroupType", content = "id", rename_all = "camelCase")]
 pub enum ActorGroupId {
@@ -187,7 +178,6 @@ impl postgres_types::ToSql for ActorGroupId {
 /// Each variant corresponds to a specific [`ActorGroupType`].
 #[derive(Debug, serde::Serialize, serde::Deserialize, derive_more::From)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(tag = "actorGroupType", rename_all = "camelCase")]
 pub enum ActorGroup {

--- a/libs/@blockprotocol/type-system/rust/src/principal/actor_group/team.rs
+++ b/libs/@blockprotocol/type-system/rust/src/principal/actor_group/team.rs
@@ -17,7 +17,6 @@ use crate::{knowledge::entity::id::EntityUuid, principal::role::TeamRoleId};
     derive_more::Display,
 )]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(
     feature = "postgres",
@@ -25,13 +24,7 @@ use crate::{knowledge::entity::id::EntityUuid, principal::role::TeamRoleId};
     postgres(transparent)
 )]
 #[repr(transparent)]
-pub struct TeamId(
-    #[cfg_attr(
-        target_arch = "wasm32",
-        tsify(type = "Brand<ActorGroupEntityUuid, \"TeamId\">")
-    )]
-    ActorGroupEntityUuid,
-);
+pub struct TeamId(ActorGroupEntityUuid);
 
 impl TeamId {
     #[must_use]
@@ -60,7 +53,6 @@ impl From<TeamId> for Uuid {
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Team {

--- a/libs/@blockprotocol/type-system/rust/src/principal/actor_group/web.rs
+++ b/libs/@blockprotocol/type-system/rust/src/principal/actor_group/web.rs
@@ -17,7 +17,6 @@ use crate::{knowledge::entity::id::EntityUuid, principal::role::WebRoleId};
     derive_more::Display,
 )]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(
     feature = "postgres",
@@ -25,13 +24,7 @@ use crate::{knowledge::entity::id::EntityUuid, principal::role::WebRoleId};
     postgres(transparent)
 )]
 #[repr(transparent)]
-pub struct WebId(
-    #[cfg_attr(
-        target_arch = "wasm32",
-        tsify(type = "Brand<ActorEntityUuid | ActorGroupEntityUuid, \"WebId\">")
-    )]
-    ActorGroupEntityUuid,
-);
+pub struct WebId(ActorGroupEntityUuid);
 
 impl WebId {
     #[must_use]
@@ -60,7 +53,6 @@ impl From<WebId> for Uuid {
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Web {

--- a/libs/@blockprotocol/type-system/rust/src/principal/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/principal/mod.rs
@@ -117,7 +117,6 @@ impl From<RoleType> for PrincipalType {
     derive_more::From,
 )]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(tag = "principalType", rename_all = "camelCase")]
 pub enum PrincipalId {
@@ -199,7 +198,6 @@ impl postgres_types::ToSql for PrincipalId {
 /// and provenance tracking purposes.
 #[derive(Debug, serde::Serialize, serde::Deserialize, derive_more::From)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(tag = "principalType", rename_all = "camelCase")]
 pub enum Principal {

--- a/libs/@blockprotocol/type-system/rust/src/principal/role/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/principal/role/mod.rs
@@ -21,7 +21,6 @@ use super::actor_group::ActorGroupId;
     derive_more::Display,
 )]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub enum RoleName {
@@ -68,7 +67,6 @@ impl<'a> postgres_types::FromSql<'a> for RoleName {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub enum RoleType {
@@ -89,7 +87,6 @@ pub enum RoleType {
     derive_more::From,
 )]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(tag = "roleType", content = "id", rename_all = "camelCase")]
 pub enum RoleId {
@@ -146,7 +143,6 @@ impl postgres_types::ToSql for RoleId {
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, derive_more::From)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(tag = "roleType", rename_all = "camelCase")]
 pub enum Role {

--- a/libs/@blockprotocol/type-system/rust/src/principal/role/team.rs
+++ b/libs/@blockprotocol/type-system/rust/src/principal/role/team.rs
@@ -15,7 +15,6 @@ use crate::principal::actor_group::TeamId;
     derive_more::Display,
 )]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(
     feature = "postgres",
@@ -23,9 +22,7 @@ use crate::principal::actor_group::TeamId;
     postgres(transparent)
 )]
 #[repr(transparent)]
-pub struct TeamRoleId(
-    #[cfg_attr(target_arch = "wasm32", tsify(type = "Brand<string, \"TeamRoleId\">"))] Uuid,
-);
+pub struct TeamRoleId(Uuid);
 
 impl TeamRoleId {
     #[must_use]
@@ -42,7 +39,6 @@ impl From<TeamRoleId> for Uuid {
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct TeamRole {

--- a/libs/@blockprotocol/type-system/rust/src/principal/role/web.rs
+++ b/libs/@blockprotocol/type-system/rust/src/principal/role/web.rs
@@ -15,7 +15,6 @@ use crate::principal::actor_group::WebId;
     derive_more::Display,
 )]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(
     feature = "postgres",
@@ -23,9 +22,7 @@ use crate::principal::actor_group::WebId;
     postgres(transparent)
 )]
 #[repr(transparent)]
-pub struct WebRoleId(
-    #[cfg_attr(target_arch = "wasm32", tsify(type = "Brand<string, \"WebRoleId\">"))] Uuid,
-);
+pub struct WebRoleId(Uuid);
 
 impl WebRoleId {
     #[must_use]
@@ -42,7 +39,6 @@ impl From<WebRoleId> for Uuid {
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct WebRole {

--- a/libs/@blockprotocol/type-system/rust/src/utils.rs
+++ b/libs/@blockprotocol/type-system/rust/src/utils.rs
@@ -8,6 +8,15 @@ mod wasm {
     const TS_APPEND_CONTENT: &'static str = r#"
     import type { Brand } from "@local/advanced-types/brand";
     import type { Real } from "@rust/hash-codec/types";
+    import type {
+        ActorEntityUuid,
+        ActorGroupEntityUuid,
+        ActorType,
+        DraftId,
+        EntityEditionId,
+        UserId,
+        WebId
+    } from "../dist/types.js";
     "#;
 
     // Common types

--- a/libs/@blockprotocol/type-system/typescript/src/main-slim.ts
+++ b/libs/@blockprotocol/type-system/typescript/src/main-slim.ts
@@ -3,6 +3,7 @@ import type { EntityMetadata } from "./native/entity.js";
 export { atLeastOne } from "./common.js";
 export * from "./native.js";
 export * from "@blockprotocol/type-system-rs";
+export * from "@blockprotocol/type-system-rs/types";
 
 /**
  * This explicit re-export is necessary as we're overwriting EntityMetadata from @blockprotocol/type-system-rs,

--- a/libs/@blockprotocol/type-system/typescript/src/main.ts
+++ b/libs/@blockprotocol/type-system/typescript/src/main.ts
@@ -10,6 +10,7 @@ export {
 } from "./common.js";
 export * from "./native.js";
 export * from "@blockprotocol/type-system-rs";
+export * from "@blockprotocol/type-system-rs/types";
 
 /**
  * This explicit re-export is necessary as we're overwriting EntityMetadata from @blockprotocol/type-system-rs,

--- a/libs/@blockprotocol/type-system/typescript/src/native/entity.ts
+++ b/libs/@blockprotocol/type-system/typescript/src/native/entity.ts
@@ -1,8 +1,6 @@
 import type {
-  DraftId,
   EntityId,
   EntityMetadata as RustEntityMetadata,
-  EntityUuid,
   LinkData,
   PropertyArrayMetadata,
   PropertyArrayWithMetadata,
@@ -15,8 +13,12 @@ import type {
   PropertyValueWithMetadata,
   PropertyWithMetadata,
   VersionedUrl,
-  WebId,
 } from "@blockprotocol/type-system-rs";
+import type {
+  DraftId,
+  EntityUuid,
+  WebId,
+} from "@blockprotocol/type-system-rs/types";
 import { validate as validateUuid } from "uuid";
 
 export type TypeIdsAndPropertiesForEntity = {

--- a/libs/@local/codegen/src/definitions/type.rs
+++ b/libs/@local/codegen/src/definitions/type.rs
@@ -72,6 +72,7 @@ pub struct TypeDefinition {
     pub r#type: Type,
     pub public: bool,
     pub module: Cow<'static, str>,
+    pub branded: bool,
 }
 
 impl TypeDefinition {
@@ -86,6 +87,16 @@ impl TypeDefinition {
             //  see https://linear.app/hash/issue/H-4498/only-export-public-types-from-codegen
             public: true,
             module: data_type.module_path().clone(),
+            branded: false,
         }
+    }
+
+    pub(crate) fn from_specta_branded(
+        data_type: &datatype::NamedDataType,
+        type_collection: &specta::TypeCollection,
+    ) -> Self {
+        let mut def = Self::from_specta(data_type, type_collection);
+        def.branded = true;
+        def
     }
 }

--- a/libs/@local/codegen/src/lib.rs
+++ b/libs/@local/codegen/src/lib.rs
@@ -54,6 +54,19 @@ impl TypeCollection {
         );
     }
 
+    /// Registers a "branded" type `T` with the collection.
+    ///
+    /// Type branding allows creating a new, distinct type identity for an
+    /// existing underlying type. This is useful for conveying specific semantic
+    /// meaning or for instructing the code generator to handle this type
+    /// differently, even if its structure is identical to another.
+    ///
+    /// For example, you might have a generic `String` type, but you want to
+    /// treat `EmailString` (which is also a `String`) as a special type
+    /// in your generated code (e.g., for client-side validation or specific UI
+    /// rendering). `register_branded` facilitates this by marking the type
+    /// such that `TypeDefinition::from_specta_branded` is used, allowing
+    /// for custom logic based on this "brand".
     // TODO: We want to allow specifying branding in the Rust code itself, rather than relying on
     //       the code generator to specify it.
     //   see https://linear.app/hash/issue/H-4514/allow-specifying-type-branding-in-rust-itself

--- a/libs/@local/codegen/src/lib.rs
+++ b/libs/@local/codegen/src/lib.rs
@@ -54,6 +54,19 @@ impl TypeCollection {
         );
     }
 
+    // TODO: We want to allow specifying branding in the Rust code itself, rather than relying on
+    //       the code generator to specify it.
+    //   see https://linear.app/hash/issue/H-4514/allow-specifying-type-branding-in-rust-itself
+    pub fn register_branded<T: specta::NamedType>(&mut self) {
+        self.collection.register_mut::<T>();
+        let data_type = self.collection.get(T::ID).unwrap_or_else(|| unreachable!());
+        self.ordered_keys.insert(OrderedTypeId::from(data_type));
+        self.types.insert(
+            TypeId::from_specta(T::ID),
+            TypeDefinition::from_specta_branded(data_type, &self.collection),
+        );
+    }
+
     /// Registers transitive types that are not directly registered with the collection.
     ///
     /// # Example

--- a/libs/@local/codegen/src/typescript.rs
+++ b/libs/@local/codegen/src/typescript.rs
@@ -26,6 +26,7 @@ pub struct TypeScriptGenerator<'a, 'c> {
     collection: &'c TypeCollection,
     ast: AstBuilder<'a>,
     program: ast::Program<'a>,
+    has_branded_types: bool,
 }
 
 impl<'a, 'c> TypeScriptGenerator<'a, 'c> {
@@ -45,6 +46,7 @@ impl<'a, 'c> TypeScriptGenerator<'a, 'c> {
             collection,
             ast: ast_builder,
             program,
+            has_branded_types: false,
         }
     }
 
@@ -148,15 +150,84 @@ impl<'a, 'c> TypeScriptGenerator<'a, 'c> {
         }
     }
 
-    fn visit_type_definition(&self, definition: &TypeDefinition) -> ast::Declaration<'a> {
-        if self.should_export_as_interface(&definition.r#type) {
+    fn visit_type_definition(&mut self, definition: &TypeDefinition) -> ast::Declaration<'a> {
+        if !definition.branded && self.should_export_as_interface(&definition.r#type) {
             self.generate_interface(definition)
         } else {
+            let mut r#type = self.visit_type(&definition.r#type);
+
+            if definition.branded {
+                if !self.has_branded_types {
+                    self.has_branded_types = true;
+                    self.add_import_declaration("@local/advanced-types/brand", ["Brand"]);
+                }
+
+                // TODO: This is a workaround for the fact that we don't have a way to
+                //       represent the `WebId` type in the AST. We should find a way to
+                //       represent it properly in the AST and remove this workaround.
+                //   see https://linear.app/hash/issue/H-4514/allow-specifying-type-branding-in-rust-itself
+                if definition.module == "type_system::principal::actor::user"
+                    && definition.name == "UserId"
+                {
+                    r#type = self.ast.ts_type_intersection_type(
+                        SPAN,
+                        self.ast.vec_from_array([
+                            r#type,
+                            self.ast.ts_type_type_reference(
+                                SPAN,
+                                self.ast.ts_type_name_identifier_reference(SPAN, "WebId"),
+                                None::<ast::TSTypeParameterInstantiation<'a>>,
+                            ),
+                        ]),
+                    );
+                }
+
+                // TODO: This is a workaround for the fact that we don't have a way to
+                //       represent the `WebId` type in the AST. We should find a way to
+                //       represent it properly in the AST and remove this workaround.
+                //   see https://linear.app/hash/issue/H-4514/allow-specifying-type-branding-in-rust-itself
+                if definition.module == "type_system::principal::actor_group::web"
+                    && definition.name == "WebId"
+                {
+                    r#type = self.ast.ts_type_union_type(
+                        SPAN,
+                        self.ast.vec_from_array([
+                            r#type,
+                            self.ast.ts_type_type_reference(
+                                SPAN,
+                                self.ast
+                                    .ts_type_name_identifier_reference(SPAN, "ActorEntityUuid"),
+                                None::<ast::TSTypeParameterInstantiation<'a>>,
+                            ),
+                        ]),
+                    );
+                }
+
+                r#type = self.ast.ts_type_type_reference(
+                    SPAN,
+                    self.ast.ts_type_name_identifier_reference(SPAN, "Brand"),
+                    Some(self.ast.ts_type_parameter_instantiation(
+                        SPAN,
+                        self.ast.vec_from_array([
+                            r#type,
+                            self.ast.ts_type_literal_type(
+                                SPAN,
+                                self.ast.ts_literal_string_literal(
+                                    SPAN,
+                                    definition.name.as_ref(),
+                                    None,
+                                ),
+                            ),
+                        ]),
+                    )),
+                );
+            }
+
             self.ast.declaration_ts_type_alias(
                 SPAN,
                 self.ast.binding_identifier(SPAN, definition.name.as_ref()),
                 None::<ast::TSTypeParameterDeclaration<'a>>,
-                self.visit_type(&definition.r#type),
+                r#type,
                 false,
             )
         }

--- a/libs/@local/codegen/src/typescript.rs
+++ b/libs/@local/codegen/src/typescript.rs
@@ -162,9 +162,10 @@ impl<'a, 'c> TypeScriptGenerator<'a, 'c> {
                     self.add_import_declaration("@local/advanced-types/brand", ["Brand"]);
                 }
 
-                // TODO: This is a workaround for the fact that we don't have a way to
-                //       represent the `WebId` type in the AST. We should find a way to
-                //       represent it properly in the AST and remove this workaround.
+                // This extends the `UserId` type by intersecting it with the `WebId` type. We
+                // currently, don't have a way to represent the `UserId` type in the
+                // AST, so we have to do this manually.
+                // TODO: Allow this to be done from the Rust code directly
                 //   see https://linear.app/hash/issue/H-4514/allow-specifying-type-branding-in-rust-itself
                 if definition.module == "type_system::principal::actor::user"
                     && definition.name == "UserId"
@@ -182,11 +183,12 @@ impl<'a, 'c> TypeScriptGenerator<'a, 'c> {
                     );
                 }
 
-                // TODO: This is a workaround for the fact that we don't have a way to
-                //       represent the `WebId` type in the AST. We should find a way to
-                //       represent it properly in the AST and remove this workaround.
+                // This extends the `WebId` type by unifying it with the `ActorEntityUuid` type. We
+                // currently, don't have a way to represent the `WebId` type in the
+                // AST, so we have to do this manually.
+                // TODO: Allow this to be done from the Rust code directly
                 //   see https://linear.app/hash/issue/H-4514/allow-specifying-type-branding-in-rust-itself
-                if definition.module == "type_system::principal::actor_group::web"
+                if definition.module == "type_system::principal::actor::user"
                     && definition.name == "WebId"
                 {
                     r#type = self.ast.ts_type_union_type(

--- a/libs/@local/codegen/src/typescript.rs
+++ b/libs/@local/codegen/src/typescript.rs
@@ -188,7 +188,7 @@ impl<'a, 'c> TypeScriptGenerator<'a, 'c> {
                 // AST, so we have to do this manually.
                 // TODO: Allow this to be done from the Rust code directly
                 //   see https://linear.app/hash/issue/H-4514/allow-specifying-type-branding-in-rust-itself
-                if definition.module == "type_system::principal::actor::user"
+                if definition.module == "type_system::principal::actor_group::web"
                     && definition.name == "WebId"
                 {
                     r#type = self.ast.ts_type_union_type(

--- a/libs/@local/codegen/tests/standalone-types/main.rs
+++ b/libs/@local/codegen/tests/standalone-types/main.rs
@@ -78,6 +78,15 @@ fn register_types(collection: &mut TypeCollection) {
     collection.register::<principal::actor::ActorType>();
     collection.register::<principal::actor_group::ActorGroupType>();
     collection.register::<principal::role::RoleType>();
+
+    // We currently have to manually specify the branded types
+    collection.register_branded::<principal::actor::UserId>();
+    collection.register_branded::<principal::actor::MachineId>();
+    collection.register_branded::<principal::actor::AiId>();
+    collection.register_branded::<principal::actor_group::WebId>();
+    collection.register_branded::<principal::actor_group::TeamId>();
+    collection.register_branded::<principal::role::WebRoleId>();
+    collection.register_branded::<principal::role::TeamRoleId>();
 }
 
 fn find_available_types() -> Vec<(TypeId, Cow<'static, str>)> {

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__AiId::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__AiId::Typescript.snap
@@ -2,4 +2,5 @@
 source: libs/@local/codegen/tests/standalone-types/main.rs
 expression: generated
 ---
-export type AiId = ActorEntityUuid;
+import type { Brand } from "@local/advanced-types/brand";
+export type AiId = Brand<ActorEntityUuid, "AiId">;

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__MachineId::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__MachineId::Typescript.snap
@@ -2,4 +2,5 @@
 source: libs/@local/codegen/tests/standalone-types/main.rs
 expression: generated
 ---
-export type MachineId = ActorEntityUuid;
+import type { Brand } from "@local/advanced-types/brand";
+export type MachineId = Brand<ActorEntityUuid, "MachineId">;

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__TeamId::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__TeamId::Typescript.snap
@@ -2,4 +2,5 @@
 source: libs/@local/codegen/tests/standalone-types/main.rs
 expression: generated
 ---
-export type TeamId = ActorGroupEntityUuid;
+import type { Brand } from "@local/advanced-types/brand";
+export type TeamId = Brand<ActorGroupEntityUuid, "TeamId">;

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__TeamRoleId::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__TeamRoleId::Typescript.snap
@@ -2,4 +2,5 @@
 source: libs/@local/codegen/tests/standalone-types/main.rs
 expression: generated
 ---
-export type TeamRoleId = string;
+import type { Brand } from "@local/advanced-types/brand";
+export type TeamRoleId = Brand<string, "TeamRoleId">;

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__UserId::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__UserId::Typescript.snap
@@ -2,4 +2,5 @@
 source: libs/@local/codegen/tests/standalone-types/main.rs
 expression: generated
 ---
-export type UserId = ActorEntityUuid;
+import type { Brand } from "@local/advanced-types/brand";
+export type UserId = Brand<ActorEntityUuid & WebId, "UserId">;

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__WebId::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__WebId::Typescript.snap
@@ -3,4 +3,4 @@ source: libs/@local/codegen/tests/standalone-types/main.rs
 expression: generated
 ---
 import type { Brand } from "@local/advanced-types/brand";
-export type WebId = Brand<ActorGroupEntityUuid, "WebId">;
+export type WebId = Brand<ActorGroupEntityUuid | ActorEntityUuid, "WebId">;

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__WebId::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__WebId::Typescript.snap
@@ -2,4 +2,5 @@
 source: libs/@local/codegen/tests/standalone-types/main.rs
 expression: generated
 ---
-export type WebId = ActorGroupEntityUuid;
+import type { Brand } from "@local/advanced-types/brand";
+export type WebId = Brand<ActorGroupEntityUuid, "WebId">;

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__WebRoleId::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__WebRoleId::Typescript.snap
@@ -2,4 +2,5 @@
 source: libs/@local/codegen/tests/standalone-types/main.rs
 expression: generated
 ---
-export type WebRoleId = string;
+import type { Brand } from "@local/advanced-types/brand";
+export type WebRoleId = Brand<string, "WebRoleId">;

--- a/tests/hash-backend-load/src/graph/api.ts
+++ b/tests/hash-backend-load/src/graph/api.ts
@@ -1,4 +1,4 @@
-import type { ActorEntityUuid } from "@blockprotocol/type-system-rs";
+import type { ActorEntityUuid } from "@blockprotocol/type-system";
 import { createGraphClient } from "@local/hash-backend-utils/create-graph-client";
 import { getRequiredEnv } from "@local/hash-backend-utils/environment";
 import { Logger } from "@local/hash-backend-utils/logger";


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Support exporting types as "Branded" types, i.e. it wraps it in `Brand<type, name>`.

This PR enables usage of the types in the Node API, so it also removes `tsify` where possible.
## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

- Properly implement optionality so we can use more types from the Codegen
- Replace `Record` codegen with index syntax to enable recursive types