### PR TITLE
H-4516: Use index signatures instead of Record

### DIFF
--- a/libs/@blockprotocol/type-system/rust/src/bin/export-types.rs
+++ b/libs/@blockprotocol/type-system/rust/src/bin/export-types.rs
@@ -20,6 +20,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     collection.register::<principal::actor_group::ActorGroupType>();
     collection.register::<principal::role::RoleType>();
 
+    // Knowledge types
+    collection.register::<knowledge::value::PropertyValue>();
+
     // We currently have to manually specify the branded types
     collection.register_branded::<knowledge::entity::id::EntityUuid>();
     collection.register_branded::<knowledge::entity::id::DraftId>();

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/value/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/value/mod.rs
@@ -52,21 +52,14 @@ pub use self::metadata::ValueMetadata;
 /// [`DataType`]: crate::ontology::data_type::DataType
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
 #[serde(untagged)]
 pub enum PropertyValue {
     Null,
     Bool(bool),
     String(String),
     Number(Real),
-    Array(#[cfg_attr(target_arch = "wasm32", tsify(type = "PropertyValue[]"))] Vec<Self>),
-    Object(
-        #[cfg_attr(
-            target_arch = "wasm32",
-            tsify(type = "{ [key: string]: PropertyValue }")
-        )]
-        HashMap<String, Self>,
-    ),
+    Array(Vec<Self>),
+    Object(HashMap<String, Self>),
 }
 
 impl fmt::Display for PropertyValue {

--- a/libs/@blockprotocol/type-system/rust/src/utils.rs
+++ b/libs/@blockprotocol/type-system/rust/src/utils.rs
@@ -14,6 +14,7 @@ mod wasm {
         ActorType,
         DraftId,
         EntityEditionId,
+        PropertyValue,
         UserId,
         WebId
     } from "../dist/types.js";

--- a/libs/@local/codegen/src/typescript.rs
+++ b/libs/@local/codegen/src/typescript.rs
@@ -558,14 +558,23 @@ impl<'a, 'c> TypeScriptGenerator<'a, 'c> {
     }
 
     fn visit_map(&self, map: &Map) -> ast::TSType<'a> {
-        self.ast.ts_type_type_reference(
+        self.ast.ts_type_type_literal(
             SPAN,
-            self.ast.ts_type_name_identifier_reference(SPAN, "Record"),
-            Some(
-                self.ast.ts_type_parameter_instantiation(
+            self.ast.vec1(
+                self.ast.ts_signature_index_signature(
                     SPAN,
+                    self.ast.vec1(
+                        self.ast.ts_index_signature_name(
+                            SPAN,
+                            "key",
+                            self.ast
+                                .alloc_ts_type_annotation(SPAN, self.visit_type(&map.key)),
+                        ),
+                    ),
                     self.ast
-                        .vec_from_array([self.visit_type(&map.key), self.visit_type(&map.value)]),
+                        .alloc_ts_type_annotation(SPAN, self.visit_type(&map.value)),
+                    false, // read-only
+                    false, // static
                 ),
             ),
         )

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__MapEnumKey::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__MapEnumKey::Typescript.snap
@@ -3,7 +3,13 @@ source: libs/@local/codegen/tests/standalone-types/main.rs
 expression: generated
 ---
 export interface MapEnumKey {
-	enum_to_string: Record<MapKeyEnum, string>;
-	enum_to_int: Record<MapKeyEnum, number>;
-	btree_enum_to_string: Record<MapKeyEnum, string>;
+	enum_to_string: {
+		[key: MapKeyEnum]: string
+	};
+	enum_to_int: {
+		[key: MapKeyEnum]: number
+	};
+	btree_enum_to_string: {
+		[key: MapKeyEnum]: string
+	};
 }

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__MapNested::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__MapNested::Typescript.snap
@@ -3,8 +3,28 @@ source: libs/@local/codegen/tests/standalone-types/main.rs
 expression: generated
 ---
 export interface MapNested {
-	nested_maps: Record<string, Record<string, number>>;
-	triple_nested: Record<string, Record<string, Record<string, boolean>>>;
-	btree_nested: Record<string, Record<number, string>>;
-	mixed_nesting: Record<string, Record<number, Record<string, boolean>>>;
+	nested_maps: {
+		[key: string]: {
+			[key: string]: number
+		}
+	};
+	triple_nested: {
+		[key: string]: {
+			[key: string]: {
+				[key: string]: boolean
+			}
+		}
+	};
+	btree_nested: {
+		[key: string]: {
+			[key: number]: string
+		}
+	};
+	mixed_nesting: {
+		[key: string]: {
+			[key: number]: {
+				[key: string]: boolean
+			}
+		}
+	};
 }

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__MapNumericKey::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__MapNumericKey::Typescript.snap
@@ -3,8 +3,16 @@ source: libs/@local/codegen/tests/standalone-types/main.rs
 expression: generated
 ---
 export interface MapNumericKey {
-	int_to_string: Record<number, string>;
-	int_to_int: Record<number, number>;
-	btree_int_to_string: Record<number, string>;
-	btree_int_to_int: Record<number, number>;
+	int_to_string: {
+		[key: number]: string
+	};
+	int_to_int: {
+		[key: number]: number
+	};
+	btree_int_to_string: {
+		[key: number]: string
+	};
+	btree_int_to_int: {
+		[key: number]: number
+	};
 }

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__MapOptional::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__MapOptional::Typescript.snap
@@ -3,8 +3,16 @@ source: libs/@local/codegen/tests/standalone-types/main.rs
 expression: generated
 ---
 export interface MapOptional {
-	maybe_map: (Record<string, number> | undefined);
-	map_of_optionals: Record<string, (number | undefined)>;
-	maybe_btree: (Record<string, string> | undefined);
-	btree_of_optionals: Record<string, (number | undefined)>;
+	maybe_map: ({
+		[key: string]: number
+	} | undefined);
+	map_of_optionals: {
+		[key: string]: (number | undefined)
+	};
+	maybe_btree: ({
+		[key: string]: string
+	} | undefined);
+	btree_of_optionals: {
+		[key: string]: (number | undefined)
+	};
 }

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__MapStringKey::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__MapStringKey::Typescript.snap
@@ -3,9 +3,19 @@ source: libs/@local/codegen/tests/standalone-types/main.rs
 expression: generated
 ---
 export interface MapStringKey {
-	string_to_string: Record<string, string>;
-	string_to_int: Record<string, number>;
-	string_to_bool: Record<string, boolean>;
-	btree_string_to_string: Record<string, string>;
-	btree_string_to_int: Record<string, number>;
+	string_to_string: {
+		[key: string]: string
+	};
+	string_to_int: {
+		[key: string]: number
+	};
+	string_to_bool: {
+		[key: string]: boolean
+	};
+	btree_string_to_string: {
+		[key: string]: string
+	};
+	btree_string_to_int: {
+		[key: string]: number
+	};
 }

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__MapStructValue::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__MapStructValue::Typescript.snap
@@ -3,8 +3,16 @@ source: libs/@local/codegen/tests/standalone-types/main.rs
 expression: generated
 ---
 export interface MapStructValue {
-	string_to_struct: Record<string, StructSimple>;
-	int_to_struct: Record<number, StructSimple>;
-	btree_string_to_struct: Record<string, StructSimple>;
-	btree_int_to_struct: Record<number, StructSimple>;
+	string_to_struct: {
+		[key: string]: StructSimple
+	};
+	int_to_struct: {
+		[key: number]: StructSimple
+	};
+	btree_string_to_struct: {
+		[key: string]: StructSimple
+	};
+	btree_int_to_struct: {
+		[key: number]: StructSimple
+	};
 }

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__PropertyValue::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__PropertyValue::Typescript.snap
@@ -2,4 +2,6 @@
 source: libs/@local/codegen/tests/standalone-types/main.rs
 expression: generated
 ---
-export type PropertyValue = null | boolean | string | Real | PropertyValue[] | Record<string, PropertyValue>;
+export type PropertyValue = null | boolean | string | Real | PropertyValue[] | {
+	[key: string]: PropertyValue
+};


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Record<K, V>might be more readable, however, it cannot be used recursively. E.g. 

```ts
type Property = Property[] | Record<BaseUrl, Property> | PropertyValue;
```

would fail. This, however, works just fine:

```ts
type Property = Property[] | { [key: BaseUrl]: Property } | PropertyValue;
```

## 🔍 What does this change?

- Use index signature notation over `Record`
- Use `PropertyValue` through the new codegen instead of `tsify`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph