### PR TITLE
H-4457: Properly handle optional fields

### DIFF
--- a/libs/@local/codegen/src/definitions/fields.rs
+++ b/libs/@local/codegen/src/definitions/fields.rs
@@ -10,6 +10,7 @@ pub struct Field {
     //   see https://linear.app/hash/issue/H-4473/export-doc-strings-in-codegen
     pub r#type: Type,
     pub flatten: bool,
+    pub optional: bool,
 }
 
 impl Field {
@@ -17,14 +18,26 @@ impl Field {
         field: &datatype::Field,
         type_collection: &specta::TypeCollection,
     ) -> Self {
-        Self {
-            r#type: Type::from_specta(
-                field.ty().unwrap_or_else(|| {
-                    todo!("https://linear.app/hash/issue/H-4472/allow-field-skipping-in-codegen")
-                }),
-                type_collection,
-            ),
-            flatten: field.flatten(),
+        let r#type = Type::from_specta(
+            field.ty().unwrap_or_else(|| {
+                todo!("https://linear.app/hash/issue/H-4472/allow-field-skipping-in-codegen")
+            }),
+            type_collection,
+        );
+        if !field.flatten()
+            && let Type::Optional(optional) = r#type
+        {
+            Self {
+                r#type: *optional,
+                flatten: field.flatten(),
+                optional: true,
+            }
+        } else {
+            Self {
+                r#type,
+                flatten: field.flatten(),
+                optional: field.optional(),
+            }
         }
     }
 }

--- a/libs/@local/codegen/src/typescript.rs
+++ b/libs/@local/codegen/src/typescript.rs
@@ -269,7 +269,7 @@ impl<'a, 'c> TypeScriptGenerator<'a, 'c> {
                             self.ast.ts_signature_property_signature(
                                 SPAN,
                                 false, // computed
-                                false, // optional
+                                field.optional,
                                 false, // read-only
                                 self.ast
                                     .property_key_static_identifier(SPAN, field_name.as_ref()),
@@ -352,7 +352,7 @@ impl<'a, 'c> TypeScriptGenerator<'a, 'c> {
                         self.ast.ts_signature_property_signature(
                             SPAN,
                             false, // computed
-                            false, // optional
+                            field.optional,
                             false, // read-only
                             self.ast
                                 .property_key_static_identifier(SPAN, field_name.as_ref()),
@@ -455,7 +455,7 @@ impl<'a, 'c> TypeScriptGenerator<'a, 'c> {
                         self.ast.ts_signature_property_signature(
                             SPAN,
                             false, // computed
-                            false, // optional
+                            field.optional,
                             false, // readonly
                             self.ast
                                 .property_key_static_identifier(SPAN, field_name.as_ref()),
@@ -598,8 +598,6 @@ impl<'a, 'c> TypeScriptGenerator<'a, 'c> {
     }
 
     fn visit_optional(&self, optional: &Type) -> ast::TSType<'a> {
-        // TODO: Properly implement optional handling
-        //   see https://linear.app/hash/issue/H-4457/capture-field-optionality-in-codegen
         self.ast.ts_type_parenthesized_type(
             SPAN,
             self.ast.ts_type_union_type(

--- a/libs/@local/codegen/tests/full-exports/snapshots/full_exports__type_system::Typescript.snap
+++ b/libs/@local/codegen/tests/full-exports/snapshots/full_exports__type_system::Typescript.snap
@@ -57,7 +57,7 @@ export interface Team {
 export type TeamId = ActorGroupEntityUuid;
 export interface Web {
 	id: WebId;
-	shortname: (string | undefined);
+	shortname?: string;
 	roles: WebRoleId[];
 }
 export type WebId = ActorGroupEntityUuid;

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__MapOptional::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__MapOptional::Typescript.snap
@@ -3,15 +3,15 @@ source: libs/@local/codegen/tests/standalone-types/main.rs
 expression: generated
 ---
 export interface MapOptional {
-	maybe_map: ({
+	maybe_map?: {
 		[key: string]: number
-	} | undefined);
+	};
 	map_of_optionals: {
 		[key: string]: (number | undefined)
 	};
-	maybe_btree: ({
+	maybe_btree?: {
 		[key: string]: string
-	} | undefined);
+	};
 	btree_of_optionals: {
 		[key: string]: (number | undefined)
 	};

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__StructOptional::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__StructOptional::Typescript.snap
@@ -4,5 +4,5 @@ expression: generated
 ---
 export interface StructOptional {
 	required: string;
-	optional: (number | undefined);
+	optional?: number;
 }

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__TupleOptional::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__TupleOptional::Typescript.snap
@@ -3,5 +3,5 @@ source: libs/@local/codegen/tests/standalone-types/main.rs
 expression: generated
 ---
 export interface TupleOptional {
-	optional: ([number, number] | undefined);
+	optional?: [number, number];
 }

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__Web::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__Web::Typescript.snap
@@ -4,6 +4,6 @@ expression: generated
 ---
 export interface Web {
 	id: WebId;
-	shortname: (string | undefined);
+	shortname?: string;
 	roles: WebRoleId[];
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Optional fields (`field?: type`) are different from unions with `undefined` (i.e. `field: type | undefined`). This handles them correctly.