### PR TITLE
H-4531: HashQL: Make `ImportResolver` able to continue compilation

### DIFF
--- a/libs/@local/hashql/ast/src/format/dump.rs
+++ b/libs/@local/hashql/ast/src/format/dump.rs
@@ -198,6 +198,7 @@ impl SyntaxDump for TypeKind<'_> {
 
                 intersection_type.syntax_dump(fmt, depth + 1)
             }
+            TypeKind::Dummy => write_header(fmt, depth, "TypeKind", None, None, Some("Dummy")),
         }
     }
 }

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
@@ -87,7 +87,7 @@ impl<'env, 'heap> ImportResolver<'env, 'heap> {
         mem::take(&mut self.diagnostics)
     }
 
-    fn fatal_diagnostics(&self) -> usize {
+    fn fatal_diagnostics_count(&self) -> usize {
         self.diagnostics
             .iter()
             .filter(|diagnostic| diagnostic.severity.is_fatal())
@@ -358,7 +358,7 @@ impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
             }
             // Replace any path, which has had diagnostics emitted with a dummy expression
             kind @ ExprKind::Path(_) => {
-                let fatal = self.fatal_diagnostics();
+                let fatal = self.fatal_diagnostics_count();
                 if self.handled_diagnostics < fatal {
                     *kind = ExprKind::Dummy;
                     self.handled_diagnostics = fatal;
@@ -377,7 +377,7 @@ impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
 
         // Replace any path, which has had diagnostics emitted with a dummy expression
         if matches!(r#type.kind, TypeKind::Path(_)) {
-            let fatal = self.fatal_diagnostics();
+            let fatal = self.fatal_diagnostics_count();
             if self.handled_diagnostics < fatal {
                 r#type.kind = TypeKind::Dummy;
                 self.handled_diagnostics = fatal;

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
@@ -26,7 +26,7 @@ use crate::{
         },
         id::NodeId,
         path::{Path, PathSegment},
-        r#type::Type,
+        r#type::{Type, TypeKind},
     },
     visit::{Visitor, walk_closure_expr, walk_expr, walk_path, walk_type},
 };
@@ -68,6 +68,7 @@ pub struct ImportResolver<'env, 'heap> {
     current_universe: Universe,
     scope: Scope<'heap>,
     diagnostics: Vec<ImportResolverDiagnostic>,
+    handled_diagnostics: usize,
 }
 
 impl<'env, 'heap> ImportResolver<'env, 'heap> {
@@ -78,11 +79,19 @@ impl<'env, 'heap> ImportResolver<'env, 'heap> {
             current_universe: Universe::Value,
             scope: Scope::default(),
             diagnostics: Vec::new(),
+            handled_diagnostics: 0,
         }
     }
 
     pub fn take_diagnostics(&mut self) -> Vec<ImportResolverDiagnostic> {
         mem::take(&mut self.diagnostics)
+    }
+
+    fn fatal_diagnostics(&self) -> usize {
+        self.diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.severity.is_fatal())
+            .count()
     }
 
     fn enter<T>(
@@ -341,13 +350,22 @@ impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
         // Process the node first
         walk_expr(self, expr);
 
-        // Replace any use statement with it's body
-        let ExprKind::Use(use_expr) = &mut expr.kind else {
-            return;
-        };
-
-        let inner = mem::replace(&mut *use_expr.body, Expr::dummy());
-        *expr = inner;
+        match &mut expr.kind {
+            // Replace any use statement with it's body
+            ExprKind::Use(use_expr) => {
+                let inner = mem::replace(&mut *use_expr.body, Expr::dummy());
+                *expr = inner;
+            }
+            // Replace any path, which has had diagnostics emitted with a dummy expression
+            kind @ ExprKind::Path(_) => {
+                let fatal = self.fatal_diagnostics();
+                if self.handled_diagnostics < fatal {
+                    *kind = ExprKind::Dummy;
+                    self.handled_diagnostics = fatal;
+                }
+            }
+            _ => {}
+        }
     }
 
     fn visit_type(&mut self, r#type: &mut Type<'heap>) {
@@ -356,6 +374,15 @@ impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
         self.current_universe = Universe::Type;
         walk_type(self, r#type);
         self.current_universe = previous;
+
+        // Replace any path, which has had diagnostics emitted with a dummy expression
+        if matches!(r#type.kind, TypeKind::Path(_)) {
+            let fatal = self.fatal_diagnostics();
+            if self.handled_diagnostics < fatal {
+                r#type.kind = TypeKind::Dummy;
+                self.handled_diagnostics = fatal;
+            }
+        }
     }
 
     fn visit_let_expr(

--- a/libs/@local/hashql/ast/src/lowering/type_extractor/translate.rs
+++ b/libs/@local/hashql/ast/src/lowering/type_extractor/translate.rs
@@ -507,6 +507,7 @@ impl<'env, 'heap> TranslationUnit<'env, '_, 'heap> {
                     variants: self.env.intern_type_ids(&variants),
                 })
             }
+            node::r#type::TypeKind::Dummy => TypeKind::Never,
         }
     }
 

--- a/libs/@local/hashql/ast/src/node/type.rs
+++ b/libs/@local/hashql/ast/src/node/type.rs
@@ -175,6 +175,21 @@ pub enum TypeKind<'heap> {
     ///
     /// Represents a type that must satisfy all of several component types.
     Intersection(IntersectionType<'heap>),
+
+    /// A placeholder type used exclusively during AST transformation phases.
+    ///
+    /// The `Dummy` variant serves as a temporary placeholder during processes
+    /// like AST lowering, where a `TypeKind` might need to be extracted or
+    /// replaced. It allows for the safe manipulation of type structures
+    /// without requiring an immediate valid replacement.
+    ///
+    /// # Implementation Note
+    ///
+    /// This variant is intended only as an intermediate state during
+    /// transformations and should not be present in a finalized AST.
+    /// The presence of a `Dummy` type after all transformations are complete
+    /// would indicate an issue in the transformation logic.
+    Dummy,
 }
 
 /// A type in the HashQL Abstract Syntax Tree.

--- a/libs/@local/hashql/ast/src/visit.rs
+++ b/libs/@local/hashql/ast/src/visit.rs
@@ -321,7 +321,7 @@ pub fn walk_type<'heap, T: Visitor<'heap> + ?Sized>(
     visitor.visit_span(span);
 
     match kind {
-        TypeKind::Infer => {}
+        TypeKind::Infer | TypeKind::Dummy => {}
         TypeKind::Path(path) => visitor.visit_path(path),
         TypeKind::Tuple(tuple_type) => visitor.visit_tuple_type(tuple_type),
         TypeKind::Struct(struct_type) => visitor.visit_struct_type(struct_type),

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/.spec.toml
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/.spec.toml
@@ -1,0 +1,1 @@
+suite = "ast/lowering/import-resolver/continue"

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-nested.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-nested.jsonc
@@ -1,0 +1,9 @@
+//@ run: pass
+//@ description: Tests that unresolved nested type variables are handled by dummy replacement, allowing lowering to continue.
+[
+  "type",
+  "Foo<T: Bar>",
+  //~^ ERROR Cannot find variable 'Bar'
+  "Number",
+  "_"
+]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-nested.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-nested.stderr
@@ -1,0 +1,17 @@
+[31m[import-resolver::unresolved-variable] Error:[0m Unresolved variable
+   ╭─[ <unknown>:5:11 ]
+   │
+ 5 │   "Foo<T: Bar>",
+   │           ─┬─  
+   │            ╰─── Cannot find variable 'Bar'
+   │ 
+   │ Help: The name 'Bar' doesn't exist in this scope.
+   │       
+   │       Perhaps you meant one of these imported items?
+   │         - `BaseUrl`
+   │         - `Err`
+   │         - `String`
+   │         - and 16 more imported items
+   │ 
+   │ Note: Variables must be defined before they can be used. This could be a typo, a variable used outside its scope, or a missing declaration. If it's a function or type from another module, you might need to import it first.
+───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-nested.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-nested.stdout
@@ -1,0 +1,14 @@
+Expr#4294967040@19
+  ExprKind (Type)
+    TypeExpr#4294967040@19 (name: Foo)
+      GenericConstraint#4294967040@10 (name: T)
+        Type#4294967040@9
+          TypeKind (Dummy)
+      Type#4294967040@16
+        TypeKind (Path)
+          Path#4294967040@16 (rooted: true)
+            PathSegment#4294967040@15 (name: kernel)
+            PathSegment#4294967040@15 (name: type)
+            PathSegment#4294967040@15 (name: Number)
+      Expr#4294967040@18
+        ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-type.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-type.jsonc
@@ -1,0 +1,9 @@
+//@ run: pass
+//@ description: Tests that an unresolved type is handled by dummy replacement, allowing lowering to continue.
+[
+  "type",
+  "Foo",
+  "T",
+  //~^ ERROR Cannot find variable 'T'
+  "_"
+]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-type.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-type.stderr
@@ -1,0 +1,17 @@
+[31m[import-resolver::unresolved-variable] Error:[0m Unresolved variable
+   ╭─[ <unknown>:6:4 ]
+   │
+ 6 │   "T",
+   │    ┬  
+   │    ╰── Cannot find variable 'T'
+   │ 
+   │ Help: The name 'T' doesn't exist in this scope.
+   │       
+   │       Perhaps you meant one of these imported items?
+   │         - `Boolean`
+   │         - `Number`
+   │         - `Integer`
+   │         - and 16 more imported items
+   │ 
+   │ Note: Variables must be defined before they can be used. This could be a typo, a variable used outside its scope, or a missing declaration. If it's a function or type from another module, you might need to import it first.
+───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-type.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-type.stdout
@@ -1,0 +1,7 @@
+Expr#4294967040@14
+  ExprKind (Type)
+    TypeExpr#4294967040@14 (name: Foo)
+      Type#4294967040@11
+        TypeKind (Dummy)
+      Expr#4294967040@13
+        ExprKind (Underscore)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-value.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-value.jsonc
@@ -1,0 +1,8 @@
+//@ run: pass
+//@ description: Tests that an unresolved value (function `bit_shl`) is handled by dummy replacement, allowing lowering to continue.
+[
+  "bit_shl",
+  //~^ ERROR Cannot find variable 'bit_shl'
+  { "#literal": 1 },
+  { "#literal": 4 }
+]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-value.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-value.stderr
@@ -1,0 +1,26 @@
+[31m[import-resolver::unresolved-variable] Error:[0m Unresolved variable
+   ╭─[ <unknown>:4:4 ]
+   │
+ 4 │   "bit_shl",
+   │    ───┬───  
+   │       ╰───── Cannot find variable 'bit_shl'
+   │ 
+   │ Help: The name 'bit_shl' doesn't exist in this scope.
+   │       
+   │       Perhaps you meant one of these imported items?
+   │         - `List`
+   │         - `Dict`
+   │         - `input`
+   │         - and 41 more imported items
+   │       
+   │       Additionally, items with a similar name exist in other modules:
+   │         - `::math::bit_shl`
+   │       
+   │       To use an item like `::math::bit_shl`, you can either:
+   │       1. Add an import at the beginning of your file:
+   │            use ::math::bit_shl in
+   │       2. Use its fully qualified path directly in your code:
+   │            ::math::bit_shl
+   │ 
+   │ Note: Variables must be defined before they can be used. This could be a typo, a variable used outside its scope, or a missing declaration. If it's a function or type from another module, you might need to import it first.
+───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-value.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-value.stdout
@@ -1,0 +1,17 @@
+Expr#4294967040@8
+  ExprKind (Call)
+    CallExpr#4294967040@8
+      Expr#4294967040@3
+        ExprKind (Dummy)
+      Argument#4294967040@5
+        Expr#4294967040@5
+          ExprKind (Literal)
+            LiteralExpr#4294967040@4
+              LiteralKind (Integer)
+                IntegerLiteral (1)
+      Argument#4294967040@7
+        Expr#4294967040@7
+          ExprKind (Literal)
+            LiteralExpr#4294967040@6
+              LiteralKind (Integer)
+                IntegerLiteral (4)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/use-not-found.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/use-not-found.jsonc
@@ -1,0 +1,9 @@
+//@ run: pass
+//@ description: Tests that a `use` statement for a non-existent module (`kernel::foo`) is handled by dummy replacement, allowing lowering to continue.
+[
+  "use",
+  "kernel::foo",
+  //~^ ERROR Module 'foo' not found
+  "*",
+  ["add", { "#literal": 1 }, { "#literal": 2 }]
+]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/use-not-found.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/use-not-found.stderr
@@ -1,0 +1,15 @@
+[31m[import-resolver::unresolved-import] Error:[0m Unresolved import
+   ╭─[ <unknown>:5:12 ]
+   │
+ 5 │   "kernel::foo",
+   │    ─────┬───┬─  
+   │         │   ╰─── Module 'foo' not found
+   │         │       
+   │         ╰─────── In this path
+   │ 
+   │ Help: The module 'kernel::foo' doesn't exist in this scope. Check the spelling and ensure the module is available.
+   │       
+   │       Possible alternatives are `special_form`, `type`.
+   │ 
+   │ Note: Modules must be properly defined and exported from their parent module to be accessible.
+───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/use-not-found.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/use-not-found.stdout
@@ -1,0 +1,2 @@
+Expr#4294967040@4294967295
+  ExprKind (Dummy)

--- a/libs/@local/hashql/compiletest/src/suite/ast_lowering_import_resolver_continue.rs
+++ b/libs/@local/hashql/compiletest/src/suite/ast_lowering_import_resolver_continue.rs
@@ -1,0 +1,65 @@
+use hashql_ast::{
+    format::SyntaxDump as _,
+    lowering::{
+        import_resolver::ImportResolver, pre_expansion_name_resolver::PreExpansionNameResolver,
+        special_form_expander::SpecialFormExpander,
+    },
+    node::expr::Expr,
+    visit::Visitor as _,
+};
+use hashql_core::{
+    heap::Heap,
+    module::{ModuleRegistry, namespace::ModuleNamespace},
+    span::SpanId,
+    r#type::environment::Environment,
+};
+use hashql_diagnostics::Diagnostic;
+
+use super::{Suite, SuiteDiagnostic};
+
+pub(crate) struct AstLoweringImportResolverContinueSuite;
+
+impl Suite for AstLoweringImportResolverContinueSuite {
+    fn name(&self) -> &'static str {
+        "ast/lowering/import-resolver/continue"
+    }
+
+    fn run<'heap>(
+        &self,
+        heap: &'heap Heap,
+        mut expr: Expr<'heap>,
+        diagnostics: &mut Vec<SuiteDiagnostic>,
+    ) -> Result<String, SuiteDiagnostic> {
+        let environment = Environment::new(SpanId::SYNTHETIC, heap);
+        let registry = ModuleRegistry::new(&environment);
+
+        let mut resolver = PreExpansionNameResolver::new(&registry);
+
+        resolver.visit_expr(&mut expr);
+
+        let mut expander = SpecialFormExpander::new(heap);
+        expander.visit_expr(&mut expr);
+
+        diagnostics.extend(
+            expander
+                .take_diagnostics()
+                .into_iter()
+                .map(Diagnostic::boxed),
+        );
+
+        let mut namespace = ModuleNamespace::new(&registry);
+        namespace.import_prelude();
+
+        let mut resolver = ImportResolver::new(heap, namespace);
+        resolver.visit_expr(&mut expr);
+
+        diagnostics.extend(
+            resolver
+                .take_diagnostics()
+                .into_iter()
+                .map(Diagnostic::boxed),
+        );
+
+        Ok(expr.syntax_dump_to_string())
+    }
+}

--- a/libs/@local/hashql/compiletest/src/suite/mod.rs
+++ b/libs/@local/hashql/compiletest/src/suite/mod.rs
@@ -1,4 +1,5 @@
 mod ast_lowering_import_resolver;
+mod ast_lowering_import_resolver_continue;
 mod ast_lowering_node_mangler;
 mod ast_lowering_node_renumberer;
 mod ast_lowering_pre_expansion_name_resolver;
@@ -13,6 +14,7 @@ use hashql_diagnostics::{Diagnostic, category::DiagnosticCategory, span::Absolut
 
 use self::{
     ast_lowering_import_resolver::AstLoweringImportResolverSuite,
+    ast_lowering_import_resolver_continue::AstLoweringImportResolverContinueSuite,
     ast_lowering_node_mangler::AstLoweringNameManglerSuite,
     ast_lowering_node_renumberer::AstLoweringNodeRenumbererSuite,
     ast_lowering_pre_expansion_name_resolver::AstLoweringNameResolverSuite,
@@ -43,6 +45,7 @@ const SUITES: &[&dyn Suite] = &[
     &AstLoweringNodeRenumbererSuite,
     &AstLoweringNameManglerSuite,
     &AstLoweringImportResolverSuite,
+    &AstLoweringImportResolverContinueSuite,
     &AstLoweringTypeExtractorSuite,
 ];
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `ImportResolver` is one of the compilation passes that does not replace many or any nodes with dummy nodes to support continued compilation.

The reason for that is that is simple - any unbound or unknown variable leads to the problem that we're unable to confidently report over any error that's happening and will likely lead to a cascade of issues. Considering that `Dummy` nodes (the replacement) are effectively ignored this shouldn't be *too much* of a problem.

The other problem is just that implementation itself is a bit more obtuse considering the control flow, we operate on a path level, which is present for both types and expressions, to be able to able to mark out specific parts of as dummy nodes we'd need to: (A) introduce a type dummy node and (B) have a way of tracking the if any diagnostics have bubbled up.

This isn't a required feature, as the current system works just fine but would elevate the overall editing experience.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

