### PR TITLE
H-4511: HashQL: Implement AST stage to disallow any GenericConstraint's on paths

### DIFF
--- a/libs/@local/hashql/ast/src/lowering/generic_constraint_sanitizer.rs
+++ b/libs/@local/hashql/ast/src/lowering/generic_constraint_sanitizer.rs
@@ -1,0 +1,110 @@
+use alloc::borrow::Cow;
+use core::mem;
+
+use hashql_core::span::SpanId;
+use hashql_diagnostics::{
+    Diagnostic,
+    category::{DiagnosticCategory, TerminalDiagnosticCategory},
+    help::Help,
+    label::Label,
+    note::Note,
+    severity::Severity,
+};
+
+use crate::{
+    node::{generic::GenericConstraint, path::PathSegmentArgument},
+    visit::Visitor,
+};
+
+pub(crate) type GenericConstraintSanitizerDiagnostic =
+    Diagnostic<GenericConstraintSanitizerDiagnosticCategory, SpanId>;
+
+const INVALID_GENERIC_CONSTRAINT: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    id: "invalid-generic-constraint",
+    name: "Invalid generic constraint",
+};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum GenericConstraintSanitizerDiagnosticCategory {
+    InvalidGenericConstraint,
+}
+
+impl DiagnosticCategory for GenericConstraintSanitizerDiagnosticCategory {
+    fn id(&self) -> Cow<'_, str> {
+        Cow::Borrowed("import-resolver")
+    }
+
+    fn name(&self) -> Cow<'_, str> {
+        Cow::Borrowed("Import Resolver")
+    }
+
+    fn subcategory(&self) -> Option<&dyn DiagnosticCategory> {
+        match self {
+            Self::InvalidGenericConstraint => Some(&INVALID_GENERIC_CONSTRAINT),
+        }
+    }
+}
+
+fn invalid_generic_constraint(span: SpanId, name: &str) -> GenericConstraintSanitizerDiagnostic {
+    let mut diagnostic = Diagnostic::new(
+        GenericConstraintSanitizerDiagnosticCategory::InvalidGenericConstraint,
+        Severity::ERROR,
+    );
+
+    diagnostic.labels.push(Label::new(
+        span,
+        format!("Generic constraint with bound is not allowed here"),
+    ));
+
+    diagnostic.help = Some(Help::new(format!(
+        "Generic parameter '{name}' cannot have constraints in this context. Remove the \
+         constraint."
+    )));
+
+    diagnostic.note = Some(Note::new(
+        "Generic constraints with bounds are only allowed in certain positions like function \
+         declarations.",
+    ));
+
+    diagnostic
+}
+
+pub struct GenericConstraintSanitizer {
+    diagnostics: Vec<GenericConstraintSanitizerDiagnostic>,
+}
+
+impl GenericConstraintSanitizer {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            diagnostics: Vec::new(),
+        }
+    }
+
+    pub fn take_diagnostics(&mut self) -> Vec<GenericConstraintSanitizerDiagnostic> {
+        mem::take(&mut self.diagnostics)
+    }
+}
+
+impl<'heap> Visitor<'heap> for GenericConstraintSanitizer {
+    fn visit_path_segment_argument(&mut self, argument: &mut PathSegmentArgument<'heap>) {
+        if let PathSegmentArgument::Constraint(GenericConstraint {
+            id,
+            span,
+            name,
+            bound: bound @ Some(_),
+        }) = argument
+        {
+            // Remove the bound for further processing
+            *bound = None;
+
+            todo!("emit diagnostic")
+        }
+    }
+}
+
+impl Default for GenericConstraintSanitizer {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/libs/@local/hashql/ast/src/lowering/mod.rs
+++ b/libs/@local/hashql/ast/src/lowering/mod.rs
@@ -1,4 +1,5 @@
 pub mod error;
+pub mod generic_constraint_sanitizer;
 pub mod import_resolver;
 pub mod name_mangler;
 pub mod node_renumberer;

--- a/libs/@local/hashql/ast/tests/ui/lowering/generic-constraint-sanitizer/.spec.toml
+++ b/libs/@local/hashql/ast/tests/ui/lowering/generic-constraint-sanitizer/.spec.toml
@@ -1,0 +1,1 @@
+suite = "ast/lowering/generic-constraint-sanitizer"

--- a/libs/@local/hashql/ast/tests/ui/lowering/generic-constraint-sanitizer/constraint.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/generic-constraint-sanitizer/constraint.jsonc
@@ -1,0 +1,8 @@
+//@ run: fail
+//@ description: Generic constraints with bounds should be sanitized and error out
+[
+  "add<T: Number>",
+  //~^ ERROR Remove this constraint from generic parameter 'T'
+  { "#literal": 1 },
+  { "#literal": 2 }
+]

--- a/libs/@local/hashql/ast/tests/ui/lowering/generic-constraint-sanitizer/constraint.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/generic-constraint-sanitizer/constraint.stderr
@@ -1,0 +1,11 @@
+[31m[generic-constraint-sanitizer::invalid-generic-constraint] Error:[0m Invalid generic constraint
+   ╭─[ <unknown>:4:8 ]
+   │
+ 4 │   "add<T: Number>",
+   │        ────┬────  
+   │            ╰────── Remove this constraint from generic parameter 'T'
+   │ 
+   │ Help: Generic constraints (like 'T: Bound') are not allowed in this context. Use just the generic parameter name without bounds: 'T'.
+   │ 
+   │ Note: Generic constraints with bounds can only be used in certain positions such as function declarations, type declarations and newtype declarations
+───╯

--- a/libs/@local/hashql/compiletest/src/suite/ast_lowering_generic_constraint_sanitizer.rs
+++ b/libs/@local/hashql/compiletest/src/suite/ast_lowering_generic_constraint_sanitizer.rs
@@ -1,0 +1,49 @@
+use hashql_ast::{
+    format::SyntaxDump as _,
+    lowering::{
+        generic_constraint_sanitizer::GenericConstraintSanitizer,
+        pre_expansion_name_resolver::PreExpansionNameResolver,
+        special_form_expander::SpecialFormExpander,
+    },
+    node::expr::Expr,
+    visit::Visitor as _,
+};
+use hashql_core::{
+    heap::Heap, module::ModuleRegistry, span::SpanId, r#type::environment::Environment,
+};
+
+use super::{Suite, SuiteDiagnostic, common::process_diagnostics};
+
+pub(crate) struct AstLoweringGenericConstraintSanitizerSuite;
+
+impl Suite for AstLoweringGenericConstraintSanitizerSuite {
+    fn name(&self) -> &'static str {
+        "ast/lowering/generic-constraint-sanitizer"
+    }
+
+    fn run<'heap>(
+        &self,
+        heap: &'heap Heap,
+        mut expr: Expr<'heap>,
+        diagnostics: &mut Vec<SuiteDiagnostic>,
+    ) -> Result<String, SuiteDiagnostic> {
+        let environment = Environment::new(SpanId::SYNTHETIC, heap);
+        let registry = ModuleRegistry::new(&environment);
+
+        let mut resolver = PreExpansionNameResolver::new(&registry);
+
+        resolver.visit_expr(&mut expr);
+
+        let mut expander = SpecialFormExpander::new(heap);
+        expander.visit_expr(&mut expr);
+
+        process_diagnostics(diagnostics, expander.take_diagnostics())?;
+
+        let mut sanitizer = GenericConstraintSanitizer::new();
+        sanitizer.visit_expr(&mut expr);
+
+        process_diagnostics(diagnostics, sanitizer.take_diagnostics())?;
+
+        Ok(expr.syntax_dump_to_string())
+    }
+}

--- a/libs/@local/hashql/compiletest/src/suite/mod.rs
+++ b/libs/@local/hashql/compiletest/src/suite/mod.rs
@@ -1,3 +1,4 @@
+mod ast_lowering_generic_constraint_sanitizer;
 mod ast_lowering_import_resolver;
 mod ast_lowering_node_mangler;
 mod ast_lowering_node_renumberer;
@@ -12,6 +13,7 @@ use hashql_core::{heap::Heap, span::SpanId};
 use hashql_diagnostics::{Diagnostic, category::DiagnosticCategory, span::AbsoluteDiagnosticSpan};
 
 use self::{
+    ast_lowering_generic_constraint_sanitizer::AstLoweringGenericConstraintSanitizerSuite,
     ast_lowering_import_resolver::AstLoweringImportResolverSuite,
     ast_lowering_node_mangler::AstLoweringNameManglerSuite,
     ast_lowering_node_renumberer::AstLoweringNodeRenumbererSuite,
@@ -44,6 +46,7 @@ const SUITES: &[&dyn Suite] = &[
     &AstLoweringNameManglerSuite,
     &AstLoweringImportResolverSuite,
     &AstLoweringTypeExtractorSuite,
+    &AstLoweringGenericConstraintSanitizerSuite,
 ];
 
 pub(crate) fn find_suite(name: &str) -> Option<&'static dyn Suite> {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

These should only be used for `Type` and `Newtype` constructors, so we should error out otherwise.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

