### PR TITLE
H-4540: Standardize SDK function naming and return conventions for principal types

### DIFF
--- a/apps/hash-api/src/graph/account-permission-management.ts
+++ b/apps/hash-api/src/graph/account-permission-management.ts
@@ -6,7 +6,6 @@ import type {
   UserId,
   WebId,
 } from "@blockprotocol/type-system";
-import { NotFoundError } from "@local/hash-backend-utils/error";
 import type {
   RoleAssignmentStatus,
   RoleUnassignmentStatus,
@@ -84,52 +83,6 @@ export const createAiActor: ImpureGraphFunction<
   Promise<AiId>
 > = async ({ graphApi }, { actorId }, params) =>
   graphApi.createAiActor(actorId, params).then(({ data }) => data as AiId);
-
-export const getWeb: ImpureGraphFunction<
-  {
-    webId: WebId;
-  },
-  Promise<{ webId: WebId; machineId: MachineId; shortname?: string }>
-> = async ({ graphApi }, { actorId }, params) =>
-  graphApi
-    .getWeb(actorId, params.webId)
-    .then(({ data }) => ({
-      webId: params.webId,
-      machineId: data.machineId as MachineId,
-      shortname: data.shortname,
-    }))
-    .catch((error) => {
-      if (error.response?.status === 404) {
-        throw new NotFoundError(
-          `No web with id ${params.webId} found in the graph.`,
-        );
-      } else {
-        throw error;
-      }
-    });
-
-export const findWebByShortname: ImpureGraphFunction<
-  {
-    shortname: string;
-  },
-  Promise<{ webId: WebId; machineId: MachineId; shortname: string }>
-> = async ({ graphApi }, { actorId }, params) =>
-  graphApi
-    .getWebByShortname(actorId, params.shortname)
-    .then(({ data }) => ({
-      webId: data.webId as WebId,
-      machineId: data.machineId as MachineId,
-      shortname: params.shortname,
-    }))
-    .catch((error) => {
-      if (error.response?.status === 404) {
-        throw new NotFoundError(
-          `No web with shortname ${params.shortname} found in the graph.`,
-        );
-      } else {
-        throw error;
-      }
-    });
 
 export const createOrgWeb: ImpureGraphFunction<
   {

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/005-create-hash-system-entities-and-web-bots.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/005-create-hash-system-entities-and-web-bots.migration.ts
@@ -5,9 +5,9 @@ import {
   createMachineActorEntity,
   getMachineIdByIdentifier,
 } from "@local/hash-backend-utils/machine-actors";
+import { getWebById } from "@local/hash-graph-sdk/principal/web";
 
 import { logger } from "../../../../logger";
-import { getWeb } from "../../../account-permission-management";
 import { createHashInstance } from "../../../knowledge/system-types/hash-instance";
 import { systemAccountId } from "../../../system-account";
 import {
@@ -98,8 +98,17 @@ const migrate: MigrationFunction = async ({
       });
     } catch (err) {
       if (err instanceof NotFoundError) {
-        const { webId, machineId } = await getWeb(context, authentication, {
-          webId: userAccountId,
+        const { webId, machineId } = await getWebById(
+          context.graphApi,
+          authentication,
+          userAccountId,
+        ).then((web) => {
+          if (!web) {
+            throw new NotFoundError(
+              `Failed to get web for account ID: ${userAccountId}`,
+            );
+          }
+          return web;
         });
 
         await createMachineActorEntity(context, {
@@ -133,8 +142,17 @@ const migrate: MigrationFunction = async ({
       });
     } catch (err) {
       if (err instanceof NotFoundError) {
-        const { webId, machineId } = await getWeb(context, authentication, {
-          webId: orgAccountGroupId,
+        const { webId, machineId } = await getWebById(
+          context.graphApi,
+          authentication,
+          orgAccountGroupId,
+        ).then((web) => {
+          if (!web) {
+            throw new NotFoundError(
+              `Failed to get web for organization ID: ${orgAccountGroupId}`,
+            );
+          }
+          return web;
         });
 
         await createMachineActorEntity(context, {

--- a/apps/hash-api/src/graph/knowledge/system-types/org.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/org.ts
@@ -7,6 +7,7 @@ import {
 import { EntityTypeMismatchError } from "@local/hash-backend-utils/error";
 import { createWebMachineActorEntity } from "@local/hash-backend-utils/machine-actors";
 import type { HashEntity } from "@local/hash-graph-sdk/entity";
+import { getWebById } from "@local/hash-graph-sdk/principal/web";
 import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import {
   systemEntityTypes,
@@ -21,7 +22,7 @@ import type {
 } from "@local/hash-isomorphic-utils/system-types/shared";
 
 import { logger } from "../../../logger";
-import { createOrgWeb, getWeb } from "../../account-permission-management";
+import { createOrgWeb } from "../../account-permission-management";
 import type {
   ImpureGraphFunction,
   PureGraphFunction,
@@ -132,8 +133,15 @@ export const createOrg: ImpureGraphFunction<
   let orgWebMachineId: MachineId;
   if (params.webId) {
     orgWebId = params.webId;
-    const { machineId } = await getWeb(ctx, authentication, {
-      webId: orgWebId,
+    const { machineId } = await getWebById(
+      ctx.graphApi,
+      authentication,
+      orgWebId,
+    ).then((web) => {
+      if (!web) {
+        throw new Error(`Failed to get web for shortname: ${orgWebId}`);
+      }
+      return web;
     });
     orgWebMachineId = machineId;
   } else {

--- a/libs/@local/graph/api/openapi/openapi.json
+++ b/libs/@local/graph/api/openapi/openapi.json
@@ -12,13 +12,13 @@
     "version": "0.0.0"
   },
   "paths": {
-    "/actor-groups/teams/instance-admins": {
+    "/actor-groups/teams/name/{name}": {
       "get": {
         "tags": [
           "Graph",
           "Team"
         ],
-        "operationId": "get_instance_admins_team",
+        "operationId": "get_team_by_name",
         "parameters": [
           {
             "name": "X-Authenticated-User-Actor-Id",
@@ -28,6 +28,15 @@
             "schema": {
               "$ref": "#/components/schemas/ActorEntityUuid"
             }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The ID of the team to retrieve",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -36,13 +45,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GetTeamResponse"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetTeamResponse"
+                    }
+                  ],
+                  "nullable": true
                 }
               }
             }
-          },
-          "404": {
-            "description": "The team was not found"
           },
           "500": {
             "description": "Store error occurred"
@@ -174,9 +185,6 @@
               }
             }
           },
-          "404": {
-            "description": "The web was not found"
-          },
           "500": {
             "description": "Store error occurred"
           }
@@ -189,7 +197,7 @@
           "Graph",
           "Web"
         ],
-        "operationId": "get_web",
+        "operationId": "get_web_by_id",
         "parameters": [
           {
             "name": "X-Authenticated-User-Actor-Id",
@@ -220,9 +228,6 @@
                 }
               }
             }
-          },
-          "404": {
-            "description": "The web was not found"
           },
           "500": {
             "description": "Store error occurred"

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -1805,7 +1805,7 @@ impl<C: AsClient, A: AuthorizationApi> AccountStore for PostgresStore<C, A> {
         Ok(response)
     }
 
-    async fn find_web(
+    async fn get_web_by_id(
         &mut self,
         _actor_id: ActorEntityUuid,
         web_id: WebId,
@@ -1842,7 +1842,7 @@ impl<C: AsClient, A: AuthorizationApi> AccountStore for PostgresStore<C, A> {
         }))
     }
 
-    async fn find_web_by_shortname(
+    async fn get_web_by_shortname(
         &mut self,
         _actor_id: ActorEntityUuid,
         shortname: &str,
@@ -1960,7 +1960,7 @@ impl<C: AsClient, A: AuthorizationApi> AccountStore for PostgresStore<C, A> {
         }
     }
 
-    async fn find_team_by_name(
+    async fn get_team_by_name(
         &mut self,
         _actor_id: ActorEntityUuid,
         name: &str,

--- a/libs/@local/graph/sdk/typescript/src/principal/team.ts
+++ b/libs/@local/graph/sdk/typescript/src/principal/team.ts
@@ -1,0 +1,30 @@
+import type { ActorGroupId, TeamId } from "@blockprotocol/type-system";
+import type { GetTeamResponse, GraphApi } from "@local/hash-graph-client";
+
+import type { AuthenticationContext } from "../authentication-context.js";
+
+/**
+ * Retrieves a web by its shortname.
+ *
+ * Returns the web if it exists, or `null` if not found.
+ */
+export const getTeamByName = (
+  graphAPI: GraphApi,
+  authentication: AuthenticationContext,
+  name: "instance-admins",
+): Promise<{
+  teamId: TeamId;
+  parentId: ActorGroupId;
+  name: string;
+} | null> =>
+  graphAPI.getTeamByName(authentication.actorId, name).then(({ data }) => {
+    const response = data as GetTeamResponse | null;
+    if (!response) {
+      return null;
+    }
+    return {
+      teamId: response.teamId as TeamId,
+      parentId: response.parentId as ActorGroupId,
+      name,
+    };
+  });

--- a/libs/@local/graph/sdk/typescript/src/principal/web.ts
+++ b/libs/@local/graph/sdk/typescript/src/principal/web.ts
@@ -1,0 +1,50 @@
+import type { MachineId, WebId } from "@blockprotocol/type-system";
+import type { GetWebResponse, GraphApi } from "@local/hash-graph-client";
+
+import type { AuthenticationContext } from "../authentication-context.js";
+
+/**
+ * Retrieves a web by its ID.
+ *
+ * Returns the web if it exists, or `null` if not found.
+ */
+export const getWebById = (
+  graphAPI: GraphApi,
+  authentication: AuthenticationContext,
+  webId: WebId,
+): Promise<{ webId: WebId; machineId: MachineId; shortname?: string } | null> =>
+  graphAPI.getWebById(authentication.actorId, webId).then(({ data }) => {
+    const response = data as GetWebResponse | null;
+    if (!response) {
+      return null;
+    }
+    return {
+      webId,
+      machineId: response.machineId as MachineId,
+      shortname: response.shortname,
+    };
+  });
+
+/**
+ * Retrieves a web by its shortname.
+ *
+ * Returns the web if it exists, or `null` if not found.
+ */
+export const getWebByShortname = (
+  graphAPI: GraphApi,
+  authentication: AuthenticationContext,
+  shortname: string,
+): Promise<{ webId: WebId; machineId: MachineId; shortname: string } | null> =>
+  graphAPI
+    .getWebByShortname(authentication.actorId, shortname)
+    .then(({ data }) => {
+      const response = data as GetWebResponse | null;
+      if (!response) {
+        return null;
+      }
+      return {
+        webId: response.webId as WebId,
+        machineId: response.machineId as MachineId,
+        shortname,
+      };
+    });

--- a/libs/@local/graph/store/src/account/mod.rs
+++ b/libs/@local/graph/store/src/account/mod.rs
@@ -138,7 +138,7 @@ pub trait AccountStore {
     /// # Errors
     ///
     /// - If reading the web failed.
-    fn find_web(
+    fn get_web_by_id(
         &mut self,
         actor_id: ActorEntityUuid,
         web_id: WebId,
@@ -149,7 +149,7 @@ pub trait AccountStore {
     /// # Errors
     ///
     /// - If reading the web failed.
-    fn find_web_by_shortname(
+    fn get_web_by_shortname(
         &mut self,
         actor_id: ActorEntityUuid,
         shortname: &str,
@@ -182,7 +182,7 @@ pub trait AccountStore {
     /// # Errors
     ///
     /// - If reading the team failed.
-    fn find_team_by_name(
+    fn get_team_by_name(
         &mut self,
         actor_id: ActorEntityUuid,
         name: &str,

--- a/libs/@local/graph/type-fetcher/src/store.rs
+++ b/libs/@local/graph/type-fetcher/src/store.rs
@@ -904,20 +904,20 @@ where
         self.store.create_ai_actor(actor_id, params).await
     }
 
-    async fn find_web(
+    async fn get_web_by_id(
         &mut self,
         actor_id: ActorEntityUuid,
         web_id: WebId,
     ) -> Result<Option<GetWebResponse>, Report<WebRetrievalError>> {
-        self.store.find_web(actor_id, web_id).await
+        self.store.get_web_by_id(actor_id, web_id).await
     }
 
-    async fn find_web_by_shortname(
+    async fn get_web_by_shortname(
         &mut self,
         actor_id: ActorEntityUuid,
         shortname: &str,
     ) -> Result<Option<GetWebResponse>, Report<WebRetrievalError>> {
-        self.store.find_web_by_shortname(actor_id, shortname).await
+        self.store.get_web_by_shortname(actor_id, shortname).await
     }
 
     async fn create_org_web(
@@ -936,12 +936,12 @@ where
         self.store.create_team(actor_id, params).await
     }
 
-    async fn find_team_by_name(
+    async fn get_team_by_name(
         &mut self,
         actor_id: ActorEntityUuid,
         name: &str,
     ) -> Result<Option<GetTeamResponse>, Report<TeamRetrievalError>> {
-        self.store.find_team_by_name(actor_id, name).await
+        self.store.get_team_by_name(actor_id, name).await
     }
 
     async fn identify_subject_id(

--- a/libs/@local/hash-backend-utils/src/machine-actors.ts
+++ b/libs/@local/hash-backend-utils/src/machine-actors.ts
@@ -8,6 +8,7 @@ import type {
 } from "@blockprotocol/type-system";
 import type { GraphApi } from "@local/hash-graph-client";
 import { HashEntity } from "@local/hash-graph-sdk/entity";
+import { getWebById } from "@local/hash-graph-sdk/principal/web";
 import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import {
   systemEntityTypes,
@@ -38,9 +39,12 @@ export const getWebMachineId = async (
     webId: WebId;
   },
 ): Promise<MachineId> =>
-  context.graphApi
-    .getWeb(authentication.actorId, webId)
-    .then(({ data }) => data.machineId as MachineId);
+  getWebById(context.graphApi, authentication, webId).then((web) => {
+    if (!web) {
+      throw new NotFoundError(`Failed to get web for shortname: ${webId}`);
+    }
+    return web.machineId;
+  });
 
 /**
  * Retrieve a machine actor's accountId by its unique identifier


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We want our API surface to be clear and consistent so that developers can intuitively predict function names, expected parameters, and return types. By systematically naming functions as getXById for simple, direct lookups (always returning Value | null), and queryX for filter-based array results, we remove ambiguity and set concrete expectations both for new and experienced SDK users.

## 🔗 Related links

- H-4538 -- the parent task of this

## 🔍 What does this change?

This changes the signatures for principal types (we don't have many exposed to the Node API, yet).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph