### PR TITLE
H-4536: HashQL: Implement HIR Visitor traits and infrastructor

### DIFF
--- a/libs/@local/hashql/ast/src/visit.rs
+++ b/libs/@local/hashql/ast/src/visit.rs
@@ -134,7 +134,7 @@ pub trait Visitor<'heap> {
         // do nothing, no fields to walk
     }
 
-    fn visit_ident(&mut self, ident: &mut Ident) {
+    fn visit_ident(&mut self, ident: &mut Ident<'heap>) {
         walk_ident(self, ident);
     }
 
@@ -254,7 +254,7 @@ pub trait Visitor<'heap> {
         walk_use_expr(self, expr);
     }
 
-    fn visit_use_expr_binding(&mut self, binding: &mut UseBinding) {
+    fn visit_use_expr_binding(&mut self, binding: &mut UseBinding<'heap>) {
         walk_use_expr_binding(self, binding);
     }
 
@@ -737,7 +737,7 @@ pub fn walk_use_expr_binding<'heap, T: Visitor<'heap> + ?Sized>(
         span,
         name,
         alias,
-    }: &mut UseBinding,
+    }: &mut UseBinding<'heap>,
 ) {
     visitor.visit_id(id);
     visitor.visit_span(span);

--- a/libs/@local/hashql/core/src/intern/mod.rs
+++ b/libs/@local/hashql/core/src/intern/mod.rs
@@ -130,3 +130,12 @@ impl<'heap, T> IntoIterator for Interned<'heap, [T]> {
         self.0.iter()
     }
 }
+
+impl<'heap, T> IntoIterator for &Interned<'heap, [T]> {
+    type IntoIter = core::slice::Iter<'heap, T>;
+    type Item = &'heap T;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}

--- a/libs/@local/hashql/core/src/intern/set.rs
+++ b/libs/@local/hashql/core/src/intern/set.rs
@@ -1,5 +1,5 @@
 #![expect(clippy::type_repetition_in_bounds)]
-use core::{fmt::Debug, hash::Hash, hint::cold_path};
+use core::{hash::Hash, hint::cold_path};
 
 use super::Interned;
 use crate::{collection::ConcurrentHashSet, heap::Heap};
@@ -242,7 +242,7 @@ where
 
 impl<'heap, T> InternSet<'heap, [T]>
 where
-    T: Debug + Copy + Eq + Hash,
+    T: Copy + Eq + Hash,
 {
     /// Assertion that ensures T is not a zero-sized type.
     ///

--- a/libs/@local/hashql/hir/src/fold.rs
+++ b/libs/@local/hashql/hir/src/fold.rs
@@ -1,0 +1,673 @@
+use core::ops::{FromResidual, Try};
+
+use hashql_core::{
+    collection::SmallVec, intern::Interned, span::SpanId, symbol::Ident, r#type::TypeId,
+};
+
+use self::nested::NestedFilter;
+use crate::{
+    intern::Interner,
+    node::{
+        HirId, Node, PartialNode,
+        access::{Access, AccessKind, field::FieldAccess, index::IndexAccess},
+        branch::Branch,
+        call::Call,
+        closure::{Closure, ClosureSignature},
+        data::{Data, DataKind, Literal},
+        graph::Graph,
+        input::Input,
+        kind::NodeKind,
+        r#let::Let,
+        operation::{
+            BinaryOperation, Operation, OperationKind, TypeOperation, UnaryOperation,
+            r#type::{TypeAssertion, TypeConstructor, TypeOperationKind},
+        },
+        variable::{LocalVariable, QualifiedVariable, Variable, VariableKind},
+    },
+    path::QualifiedPath,
+};
+
+pub mod nested {
+    pub trait NestedFilter {
+        const DEEP: bool;
+        const LIST: bool;
+    }
+
+    pub struct Shallow(());
+    impl NestedFilter for Shallow {
+        const DEEP: bool = false;
+        const LIST: bool = false;
+    }
+
+    pub struct Deep(());
+    impl NestedFilter for Deep {
+        const DEEP: bool = true;
+        const LIST: bool = false;
+    }
+
+    pub struct DeepRecursive(());
+    impl NestedFilter for DeepRecursive {
+        const DEEP: bool = false;
+        const LIST: bool = true;
+    }
+}
+
+pub trait Fold<'heap> {
+    type Residual;
+    type Output<T>: Try<Output = T, Residual = Self::Residual> + FromResidual<Self::Residual>
+    where
+        T: 'heap;
+
+    type NestedFilter: NestedFilter = nested::Shallow;
+
+    fn interner(&self) -> &Interner<'heap>;
+
+    fn fold_id(&mut self, id: HirId) -> Self::Output<HirId> {
+        Try::from_output(id)
+    }
+
+    fn fold_type_id(&mut self, id: TypeId) -> Self::Output<TypeId> {
+        Try::from_output(id)
+    }
+
+    fn fold_span(&mut self, span: SpanId) -> Self::Output<SpanId> {
+        Try::from_output(span)
+    }
+
+    fn fold_ident(&mut self, ident: Ident<'heap>) -> Self::Output<Ident<'heap>> {
+        walk_ident(self, ident)
+    }
+
+    fn fold_idents(
+        &mut self,
+        idents: Interned<'heap, [Ident<'heap>]>,
+    ) -> Self::Output<Interned<'heap, [Ident<'heap>]>> {
+        walk_idents(self, idents)
+    }
+
+    fn fold_qualified_path(
+        &mut self,
+        path: QualifiedPath<'heap>,
+    ) -> Self::Output<QualifiedPath<'heap>> {
+        walk_qualified_path(self, path)
+    }
+
+    fn fold_node(&mut self, node: Node<'heap>) -> Self::Output<Node<'heap>> {
+        walk_node(self, node)
+    }
+
+    fn fold_nested_node(&mut self, node: Node<'heap>) -> Self::Output<Node<'heap>> {
+        walk_nested_node(self, node)
+    }
+
+    fn fold_nodes(
+        &mut self,
+        nodes: Interned<'heap, [Node<'heap>]>,
+    ) -> Self::Output<Interned<'heap, [Node<'heap>]>> {
+        walk_nodes(self, nodes)
+    }
+
+    fn fold_data(&mut self, data: Data<'heap>) -> Self::Output<Data<'heap>> {
+        walk_data(self, data)
+    }
+
+    fn fold_literal(&mut self, literal: Literal<'heap>) -> Self::Output<Literal<'heap>> {
+        walk_literal(self, literal)
+    }
+
+    fn fold_variable(&mut self, variable: Variable<'heap>) -> Self::Output<Variable<'heap>> {
+        walk_variable(self, variable)
+    }
+
+    fn fold_local_variable(
+        &mut self,
+        variable: LocalVariable<'heap>,
+    ) -> Self::Output<LocalVariable<'heap>> {
+        walk_local_variable(self, variable)
+    }
+
+    fn fold_qualified_variable(
+        &mut self,
+        variable: QualifiedVariable<'heap>,
+    ) -> Self::Output<QualifiedVariable<'heap>> {
+        walk_qualified_variable(self, variable)
+    }
+
+    fn fold_let(&mut self, r#let: Let<'heap>) -> Self::Output<Let<'heap>> {
+        walk_let(self, r#let)
+    }
+
+    fn fold_input(&mut self, input: Input<'heap>) -> Self::Output<Input<'heap>> {
+        walk_input(self, input)
+    }
+
+    fn fold_operation(&mut self, operation: Operation<'heap>) -> Self::Output<Operation<'heap>> {
+        walk_operation(self, operation)
+    }
+
+    fn fold_type_operation(
+        &mut self,
+        operation: TypeOperation<'heap>,
+    ) -> Self::Output<TypeOperation<'heap>> {
+        walk_type_operation(self, operation)
+    }
+
+    fn fold_type_assertion(
+        &mut self,
+        assertion: TypeAssertion<'heap>,
+    ) -> Self::Output<TypeAssertion<'heap>> {
+        walk_type_assertion(self, assertion)
+    }
+
+    fn fold_type_constructor(
+        &mut self,
+        constructor: TypeConstructor<'heap>,
+    ) -> Self::Output<TypeConstructor<'heap>> {
+        walk_type_constructor(self, constructor)
+    }
+
+    fn fold_binary_operation(
+        &mut self,
+        operation: BinaryOperation<'heap>,
+    ) -> Self::Output<BinaryOperation<'heap>> {
+        walk_binary_operation(self, operation)
+    }
+
+    fn fold_unary_operation(
+        &mut self,
+        operation: UnaryOperation<'heap>,
+    ) -> Self::Output<UnaryOperation<'heap>> {
+        walk_unary_operation(self, operation)
+    }
+
+    fn fold_access(&mut self, access: Access<'heap>) -> Self::Output<Access<'heap>> {
+        walk_access(self, access)
+    }
+
+    fn fold_field_access(
+        &mut self,
+        access: FieldAccess<'heap>,
+    ) -> Self::Output<FieldAccess<'heap>> {
+        walk_field_access(self, access)
+    }
+
+    fn fold_index_access(
+        &mut self,
+        access: IndexAccess<'heap>,
+    ) -> Self::Output<IndexAccess<'heap>> {
+        walk_index_access(self, access)
+    }
+
+    fn fold_call(&mut self, call: Call<'heap>) -> Self::Output<Call<'heap>> {
+        walk_call(self, call)
+    }
+
+    fn fold_branch(&mut self, branch: Branch<'heap>) -> Self::Output<Branch<'heap>> {
+        walk_branch(self, branch)
+    }
+
+    fn fold_closure(&mut self, closure: Closure<'heap>) -> Self::Output<Closure<'heap>> {
+        walk_closure(self, closure)
+    }
+
+    fn fold_closure_signature(
+        &mut self,
+        signature: ClosureSignature<'heap>,
+    ) -> Self::Output<ClosureSignature<'heap>> {
+        walk_closure_signature(self, signature)
+    }
+
+    fn fold_graph(&mut self, graph: Graph<'heap>) -> Self::Output<Graph<'heap>> {
+        walk_graph(self, graph)
+    }
+}
+
+pub fn walk_ident<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    Ident { value, span, kind }: Ident<'heap>,
+) -> T::Output<Ident<'heap>> {
+    let span = visitor.fold_span(span)?;
+
+    Try::from_output(Ident { value, span, kind })
+}
+
+pub fn walk_idents<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    idents: Interned<'heap, [Ident<'heap>]>,
+) -> T::Output<Interned<'heap, [Ident<'heap>]>> {
+    if !T::NestedFilter::LIST {
+        return Try::from_output(idents);
+    }
+
+    if idents.is_empty() {
+        return Try::from_output(idents);
+    }
+
+    let mut replacement = SmallVec::with_capacity(idents.len());
+
+    for &ident in idents {
+        replacement.push(visitor.fold_ident(ident)?);
+    }
+
+    Try::from_output(visitor.interner().intern_idents(&replacement))
+}
+
+pub fn walk_qualified_path<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    QualifiedPath(path, _): QualifiedPath<'heap>,
+) -> T::Output<QualifiedPath<'heap>> {
+    let idents = visitor.fold_idents(path)?;
+
+    Try::from_output(QualifiedPath::new_unchecked(idents))
+}
+
+pub fn walk_node<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    Node { id: _, span, kind }: Node<'heap>,
+) -> T::Output<Node<'heap>> {
+    // We don't fold the id, because said id might not be the future id of the interned type
+    let span = visitor.fold_span(span)?;
+
+    let kind = match *kind {
+        NodeKind::Data(data) => NodeKind::Data(visitor.fold_data(data)?),
+        NodeKind::Variable(variable) => NodeKind::Variable(visitor.fold_variable(variable)?),
+        NodeKind::Let(r#let) => NodeKind::Let(visitor.fold_let(r#let)?),
+        NodeKind::Input(input) => NodeKind::Input(visitor.fold_input(input)?),
+        NodeKind::Operation(operation) => NodeKind::Operation(visitor.fold_operation(operation)?),
+        NodeKind::Access(access) => NodeKind::Access(visitor.fold_access(access)?),
+        NodeKind::Call(call) => NodeKind::Call(visitor.fold_call(call)?),
+        NodeKind::Branch(branch) => NodeKind::Branch(visitor.fold_branch(branch)?),
+        NodeKind::Closure(closure) => NodeKind::Closure(visitor.fold_closure(closure)?),
+        NodeKind::Graph(graph) => NodeKind::Graph(visitor.fold_graph(graph)?),
+    };
+
+    Try::from_output(visitor.interner().intern_node(PartialNode { span, kind }))
+}
+
+pub fn walk_nested_node<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    node: Node<'heap>,
+) -> T::Output<Node<'heap>> {
+    if !T::NestedFilter::DEEP {
+        return Try::from_output(node);
+    }
+
+    visitor.fold_node(node)
+}
+
+pub fn walk_nodes<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    nodes: Interned<'heap, [Node<'heap>]>,
+) -> T::Output<Interned<'heap, [Node<'heap>]>> {
+    if !T::NestedFilter::LIST {
+        return Try::from_output(nodes);
+    }
+
+    if nodes.is_empty() {
+        return Try::from_output(nodes);
+    }
+
+    let mut replacement = SmallVec::with_capacity(nodes.len());
+
+    for node in nodes {
+        replacement.push(visitor.fold_nested_node(*node)?);
+    }
+
+    Try::from_output(visitor.interner().intern_nodes(&replacement))
+}
+
+pub fn walk_data<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    Data { span, kind }: Data<'heap>,
+) -> T::Output<Data<'heap>> {
+    let span = visitor.fold_span(span)?;
+
+    let kind = match kind {
+        DataKind::Literal(literal) => DataKind::Literal(visitor.fold_literal(literal)?),
+    };
+
+    Try::from_output(Data { span, kind })
+}
+
+pub fn walk_literal<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    Literal { span, kind }: Literal<'heap>,
+) -> T::Output<Literal<'heap>> {
+    let span = visitor.fold_span(span)?;
+
+    Try::from_output(Literal { span, kind })
+}
+
+pub fn walk_variable<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    Variable { span, kind }: Variable<'heap>,
+) -> T::Output<Variable<'heap>> {
+    let span = visitor.fold_span(span)?;
+
+    match kind {
+        VariableKind::Local(variable) => {
+            VariableKind::Local(visitor.fold_local_variable(variable)?)
+        }
+        VariableKind::Qualified(variable) => {
+            VariableKind::Qualified(visitor.fold_qualified_variable(variable)?)
+        }
+    };
+
+    Try::from_output(Variable { span, kind })
+}
+
+pub fn walk_local_variable<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    LocalVariable {
+        span,
+        name,
+        arguments,
+    }: LocalVariable<'heap>,
+) -> T::Output<LocalVariable<'heap>> {
+    let span = visitor.fold_span(span)?;
+    let ident = visitor.fold_ident(name)?;
+    let arguments = visitor.fold_nodes(arguments)?;
+
+    Try::from_output(LocalVariable {
+        span,
+        name: ident,
+        arguments,
+    })
+}
+
+pub fn walk_qualified_variable<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    QualifiedVariable {
+        span,
+        path,
+        arguments,
+    }: QualifiedVariable<'heap>,
+) -> T::Output<QualifiedVariable<'heap>> {
+    let span = visitor.fold_span(span)?;
+    let path = visitor.fold_qualified_path(path)?;
+    let arguments = visitor.fold_nodes(arguments)?;
+
+    Try::from_output(QualifiedVariable {
+        span,
+        path,
+        arguments,
+    })
+}
+
+pub fn walk_let<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    Let {
+        span,
+        name,
+        value,
+        body,
+    }: Let<'heap>,
+) -> T::Output<Let<'heap>> {
+    let span = visitor.fold_span(span)?;
+    let name = visitor.fold_ident(name)?;
+
+    let value = visitor.fold_nested_node(value)?;
+    let body = visitor.fold_nested_node(body)?;
+
+    Try::from_output(Let {
+        span,
+        name,
+        value,
+        body,
+    })
+}
+
+pub fn walk_input<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    Input {
+        span,
+        name,
+        r#type,
+        default,
+    }: Input<'heap>,
+) -> T::Output<Input<'heap>> {
+    let span = visitor.fold_span(span)?;
+    let name = visitor.fold_ident(name)?;
+
+    let r#type = visitor.fold_type_id(r#type)?;
+
+    let default = if let Some(default) = default {
+        Some(visitor.fold_nested_node(default)?)
+    } else {
+        None
+    };
+
+    Try::from_output(Input {
+        span,
+        name,
+        r#type,
+        default,
+    })
+}
+
+pub fn walk_operation<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    Operation { span, kind }: Operation<'heap>,
+) -> T::Output<Operation<'heap>> {
+    let span = visitor.fold_span(span)?;
+
+    let kind = match kind {
+        OperationKind::Type(operation) => {
+            OperationKind::Type(visitor.fold_type_operation(operation)?)
+        }
+        OperationKind::Binary(operation) => {
+            OperationKind::Binary(visitor.fold_binary_operation(operation)?)
+        }
+    };
+
+    Try::from_output(Operation { span, kind })
+}
+
+pub fn walk_type_operation<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    TypeOperation { span, kind }: TypeOperation<'heap>,
+) -> T::Output<TypeOperation<'heap>> {
+    let span = visitor.fold_span(span)?;
+
+    let kind = match kind {
+        TypeOperationKind::Assertion(assertion) => {
+            TypeOperationKind::Assertion(visitor.fold_type_assertion(assertion)?)
+        }
+        TypeOperationKind::Constructor(constructor) => {
+            TypeOperationKind::Constructor(visitor.fold_type_constructor(constructor)?)
+        }
+    };
+
+    Try::from_output(TypeOperation { span, kind })
+}
+
+pub fn walk_type_assertion<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    TypeAssertion {
+        span,
+        value,
+        r#type,
+        force,
+    }: TypeAssertion<'heap>,
+) -> T::Output<TypeAssertion<'heap>> {
+    let span = visitor.fold_span(span)?;
+    let value = visitor.fold_nested_node(value)?;
+    let r#type = visitor.fold_type_id(r#type)?;
+
+    Try::from_output(TypeAssertion {
+        span,
+        value,
+        r#type,
+        force,
+    })
+}
+
+pub fn walk_type_constructor<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    TypeConstructor {
+        span,
+        value,
+        r#type,
+    }: TypeConstructor<'heap>,
+) -> T::Output<TypeConstructor<'heap>> {
+    let span = visitor.fold_span(span)?;
+    let value = visitor.fold_nested_node(value)?;
+    let r#type = visitor.fold_type_id(r#type)?;
+
+    Try::from_output(TypeConstructor {
+        span,
+        value,
+        r#type,
+    })
+}
+
+pub fn walk_binary_operation<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    BinaryOperation {
+        span,
+        op,
+        left,
+        right,
+    }: BinaryOperation<'heap>,
+) -> T::Output<BinaryOperation<'heap>> {
+    let span = visitor.fold_span(span)?;
+    let left = visitor.fold_nested_node(left)?;
+    let right = visitor.fold_nested_node(right)?;
+
+    Try::from_output(BinaryOperation {
+        span,
+        op,
+        left,
+        right,
+    })
+}
+
+pub fn walk_unary_operation<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    UnaryOperation { span, op, expr }: UnaryOperation<'heap>,
+) -> T::Output<UnaryOperation<'heap>> {
+    let span = visitor.fold_span(span)?;
+    let expr = visitor.fold_nested_node(expr)?;
+
+    Try::from_output(UnaryOperation { span, op, expr })
+}
+
+pub fn walk_access<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    Access { span, kind }: Access<'heap>,
+) -> T::Output<Access<'heap>> {
+    let span = visitor.fold_span(span)?;
+
+    let kind = match kind {
+        AccessKind::Field(access) => AccessKind::Field(visitor.fold_field_access(access)?),
+        AccessKind::Index(access) => AccessKind::Index(visitor.fold_index_access(access)?),
+    };
+
+    Try::from_output(Access { span, kind })
+}
+
+pub fn walk_field_access<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    FieldAccess { span, expr, field }: FieldAccess<'heap>,
+) -> T::Output<FieldAccess<'heap>> {
+    let span = visitor.fold_span(span)?;
+    let expr = visitor.fold_nested_node(expr)?;
+    let field = visitor.fold_ident(field)?;
+
+    Try::from_output(FieldAccess { span, expr, field })
+}
+
+pub fn walk_index_access<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    IndexAccess { span, expr, index }: IndexAccess<'heap>,
+) -> T::Output<IndexAccess<'heap>> {
+    let span = visitor.fold_span(span)?;
+    let expr = visitor.fold_nested_node(expr)?;
+    let index = visitor.fold_nested_node(index)?;
+
+    Try::from_output(IndexAccess { span, expr, index })
+}
+
+pub fn walk_call<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    Call {
+        span,
+        function,
+        arguments,
+    }: Call<'heap>,
+) -> T::Output<Call<'heap>> {
+    let span = visitor.fold_span(span)?;
+    let function = visitor.fold_nested_node(function)?;
+    let arguments = visitor.fold_nodes(arguments)?;
+
+    Try::from_output(Call {
+        span,
+        function,
+        arguments,
+    })
+}
+
+pub fn walk_branch<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    Branch {
+        span,
+        kind,
+        _marker: _,
+    }: Branch<'heap>,
+) -> T::Output<Branch<'heap>> {
+    let _span = visitor.fold_span(span)?;
+
+    match kind {}
+}
+
+pub fn walk_closure<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    Closure {
+        span,
+        signature,
+        body,
+    }: Closure<'heap>,
+) -> T::Output<Closure<'heap>> {
+    let span = visitor.fold_span(span)?;
+    let signature = visitor.fold_closure_signature(signature)?;
+    let body = visitor.fold_node(body)?;
+
+    Try::from_output(Closure {
+        span,
+        signature,
+        body,
+    })
+}
+
+pub fn walk_closure_signature<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    ClosureSignature {
+        span,
+        r#type,
+        params,
+    }: ClosureSignature<'heap>,
+) -> T::Output<ClosureSignature<'heap>> {
+    let span = visitor.fold_span(span)?;
+    let r#type = visitor.fold_type_id(r#type)?;
+
+    let params = visitor.fold_idents(params)?;
+
+    Try::from_output(ClosureSignature {
+        span,
+        r#type,
+        params,
+    })
+}
+
+pub fn walk_graph<'heap, T: Fold<'heap> + ?Sized>(
+    visitor: &mut T,
+    Graph {
+        span,
+        kind,
+        _marker: _,
+    }: Graph<'heap>,
+) -> T::Output<Graph<'heap>> {
+    let _span = visitor.fold_span(span)?;
+
+    match kind {}
+}

--- a/libs/@local/hashql/hir/src/fold/beef.rs
+++ b/libs/@local/hashql/hir/src/fold/beef.rs
@@ -1,0 +1,566 @@
+//! This module provides a copy-on-write slice implementation optimized for interned data.
+//!
+//! The primary type is [`Beef`], which allows efficient element-wise modification
+//! of interned slices by only copying the underlying data when a modification
+//! actually occurs.
+//!
+//! The name "Beef" is a wordplay - it's a "slice" of a "`CoW`" (Copy-on-Write).
+
+use core::{hash::Hash, ops::Try};
+
+use hashql_core::{
+    collection::SmallVec,
+    intern::{InternSet, Interned},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum BeefData<'heap, T> {
+    Owned(SmallVec<T>),
+    Interned(Interned<'heap, [T]>),
+}
+
+/// A Copy-on-Write slice optimized for element-wise operations on interned data.
+///
+/// `Beef` (a play on `CoW` - Copy on Write - as in a "slice of `CoW`") provides efficient
+/// element-wise transformation capabilities while minimizing copying. It only
+/// transitions from a shared interned state to an owned state when an actual
+/// modification occurs.
+///
+/// This is particularly useful in scenarios in which no modifications occur, allowing for zero-copy
+/// operations. For comparison, given a `SmallVec<T>` as comparison, `Beef` is consistently about
+/// 25x faster, whenever no modifications occur, with a negligible overhead in case of modification
+/// (5-10%). The overhead is only present due to the fact that we have branching logic to transition
+/// between the stages, which is negligible in most cases.
+///
+/// This is particularly useful for transformation passes that often don't modify
+/// every element, allowing zero-copy operations when no changes are needed.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Beef<'heap, T>(BeefData<'heap, T>);
+
+impl<'heap, T> Beef<'heap, T>
+where
+    T: Copy + Eq + Hash,
+{
+    /// Creates a new [`Beef`] instance from an interned slice.
+    ///
+    /// This is a zero-cost operation that simply wraps the interned slice in the [`Beef`] container
+    /// without any copying.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use hashql_core::intern::{InternSet, Interned};
+    /// # use hashql_core::heap::Heap;
+    /// # use hashql_hir::fold::beef::Beef;
+    /// # let heap = Heap::new();
+    /// # let interner = InternSet::new(&heap);
+    /// let interned = interner.intern_slice(&[1, 2, 3]);
+    /// let beef = Beef::new(interned);
+    /// ```
+    #[must_use]
+    pub const fn new(slice: Interned<'heap, [T]>) -> Self {
+        Self(BeefData::Interned(slice))
+    }
+
+    /// Maps each element in the slice using the provided closure.
+    ///
+    /// This method applies a transformation function to each element. The key
+    /// optimization is that it only transitions to an owned state when an actual
+    /// modification occurs (when the mapped value differs from the original).
+    ///
+    /// The implementation is optimized to:
+    /// 1. Avoid copying if no elements change
+    /// 2. Only perform the copy operation once, at the first modification
+    /// 3. Efficiently handle both small slices (using `SmallVec` inline storage) and larger slices
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use hashql_core::intern::{InternSet, Interned};
+    /// # use hashql_core::heap::Heap;
+    /// # use hashql_hir::fold::beef::Beef;
+    /// # let heap = Heap::new();
+    /// # let interner = InternSet::new(&heap);
+    /// let interned = interner.intern_slice(&[1, 2, 3]);
+    /// let mut beef = Beef::new(interned);
+    ///
+    /// // Double each element
+    /// beef.map(|x| x * 2);
+    /// assert_eq!(beef.as_slice(), &[2, 4, 6]);
+    ///
+    /// // No-op mapping doesn't create a copy
+    /// let interned = interner.intern_slice(&[1, 2, 3]);
+    /// let mut beef = Beef::new(interned);
+    /// beef.map(|x| x); // No change to any element
+    /// // Still in interned state, no allocation occurred
+    /// ```
+    #[inline]
+    #[expect(clippy::min_ident_chars)]
+    pub fn map(&mut self, mut closure: impl FnMut(T) -> T) {
+        const CHUNK_SIZE: usize = 4;
+
+        let remaining = match &mut self.0 {
+            BeefData::Owned(slice) => slice.as_mut_slice(),
+            BeefData::Interned(interned) => {
+                let mut index = 0;
+                let mut remaining = &mut [] as &mut [T];
+
+                while index < interned.len() {
+                    // Loop through every item (until the end) of the interned slice, if the item
+                    // changed, transition to the smallvec, then use that smallvec instead
+                    let value = interned[index];
+                    let mapped = closure(value);
+
+                    if value != mapped {
+                        // Transition to a smallvec, then use that smallvec in the final iteration
+                        let mut owned = SmallVec::from_slice(interned.0);
+                        owned[index] = mapped;
+                        self.0 = BeefData::Owned(owned);
+
+                        remaining = match &mut self.0 {
+                            BeefData::Owned(owned) => &mut owned[index + 1..],
+                            BeefData::Interned(_) => unreachable!(),
+                        };
+
+                        break;
+                    }
+
+                    index += 1;
+                }
+
+                remaining
+            }
+        };
+
+        let (chunks, remaining) = remaining.as_chunks_mut::<CHUNK_SIZE>();
+
+        // Unroll the loop for better performance (~10% performance benefit)
+        for [a, b, c, d] in chunks {
+            *a = closure(*a);
+            *b = closure(*b);
+            *c = closure(*c);
+            *d = closure(*d);
+        }
+
+        for item in remaining {
+            *item = closure(*item);
+        }
+    }
+
+    /// Maps each element in the slice using the provided fallible closure.
+    ///
+    /// This method applies a transformation function that might fail to each element.
+    /// Like [`map`](Self::map), it only transitions to an owned state when an actual
+    /// modification occurs (when the mapped value differs from the original).
+    ///
+    /// If the closure returns an error for any element, the mapping process will
+    /// short-circuit at that point and return the error. Any modifications made before
+    /// the error occurred will be preserved.
+    ///
+    /// # Type Parameters
+    ///
+    /// - `F`: A type implementing [`Try`] representing the result type of the mapping closure
+    /// - `U`: A type implementing [`Try`] with compatible residual type, representing the overall
+    ///   result
+    ///
+    /// This method works with various `Try` types including `Result<T, E>` and `Option<T>`.
+    ///
+    /// # Examples
+    ///
+    /// Using with `Result`:
+    ///
+    /// ```
+    /// # use hashql_core::intern::{InternSet, Interned};
+    /// # use hashql_core::heap::Heap;
+    /// # use hashql_hir::fold::beef::Beef;
+    /// # let heap = Heap::new();
+    /// # let interner = InternSet::new(&heap);
+    /// let interned = interner.intern_slice(&[1, 2, 3, 4]);
+    /// let mut beef = Beef::new(interned);
+    ///
+    /// // Multiply each element by 2, but fail if we encounter a value > 3
+    /// let result: Result<(), &str> = beef.try_map(|x| {
+    ///     if x > 3 {
+    ///         Err("Value too large")
+    ///     } else {
+    ///         Ok(x * 2)
+    ///     }
+    /// });
+    ///
+    /// assert!(result.is_err());
+    /// // The slice should have been partially modified before the error
+    /// assert_eq!(beef.as_slice(), &[2, 4, 6, 4]);
+    /// ```
+    ///
+    /// Using with `Option`:
+    ///
+    /// ```
+    /// # use hashql_core::intern::{InternSet, Interned};
+    /// # use hashql_core::heap::Heap;
+    /// # use hashql_hir::fold::beef::Beef;
+    /// # let heap = Heap::new();
+    /// # let interner = InternSet::new(&heap);
+    /// let interned = interner.intern_slice(&[1, 2, 3]);
+    /// let mut beef = Beef::new(interned);
+    ///
+    /// // Double even numbers, return None for odd numbers
+    /// let result: Option<()> = beef.try_map(|x| if x % 2 == 0 { Some(x * 2) } else { None });
+    ///
+    /// assert!(result.is_none()); // Fails on first odd number
+    /// assert_eq!(beef.as_slice(), &[1, 2, 3]); // No changes made
+    ///
+    /// // Successful transformation
+    /// let mut beef = Beef::new(interner.intern_slice(&[2, 4, 6]));
+    /// let result: Option<()> = beef.try_map(|x| Some(x / 2));
+    /// assert!(result.is_some());
+    /// assert_eq!(beef.as_slice(), &[1, 2, 3]);
+    /// ```
+    pub fn try_map<F, U>(&mut self, mut closure: impl FnMut(T) -> F) -> U
+    where
+        F: Try<Output = T>,
+        U: Try<Output = (), Residual = F::Residual>,
+    {
+        let remaining = match &mut self.0 {
+            BeefData::Owned(slice) => slice.as_mut_slice(),
+            BeefData::Interned(interned) => {
+                let mut index = 0;
+                let mut remaining = &mut [] as &mut [T];
+
+                while index < interned.len() {
+                    // Loop through every item (until the end) of the interned slice, if the item
+                    // changed, transition to the smallvec, then use that smallvec instead
+                    let value = interned[index];
+                    let mapped = closure(value)?;
+
+                    if value != mapped {
+                        // Transition to a smallvec, then use that smallvec in the final iteration
+                        let mut owned = SmallVec::from_slice(interned.0);
+                        owned[index] = mapped;
+                        self.0 = BeefData::Owned(owned);
+
+                        remaining = match &mut self.0 {
+                            BeefData::Owned(owned) => &mut owned[index + 1..],
+                            BeefData::Interned(_) => unreachable!(),
+                        };
+
+                        break;
+                    }
+
+                    index += 1;
+                }
+
+                remaining
+            }
+        };
+
+        for item in remaining {
+            *item = closure(*item)?;
+        }
+
+        Try::from_output(())
+    }
+
+    /// Returns the number of elements in the slice.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        match &self.0 {
+            BeefData::Owned(slice) => slice.len(),
+            BeefData::Interned(slice) => slice.len(),
+        }
+    }
+
+    /// Returns whether the slice is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        match &self.0 {
+            BeefData::Owned(slice) => slice.is_empty(),
+            BeefData::Interned(slice) => slice.is_empty(),
+        }
+    }
+
+    /// Returns a reference to the underlying slice.
+    ///
+    /// This provides access to the slice contents without copying,
+    /// regardless of whether the [`Beef`] is in the owned or interned state.
+    #[must_use]
+    pub fn as_slice(&self) -> &[T] {
+        match &self.0 {
+            BeefData::Owned(slice) => slice.as_slice(),
+            BeefData::Interned(slice) => slice.as_ref(),
+        }
+    }
+
+    /// Consumes the [`Beef`] and returns an interned slice.
+    ///
+    /// This method efficiently handles both cases:
+    /// - If the [`Beef`] is still in its original interned state (no modifications), it simply
+    ///   returns the original interned slice without any copying or re-interning.
+    /// - If the [`Beef`] has been modified, it interns the current state of the slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use hashql_core::intern::{InternSet, Interned};
+    /// # use hashql_core::heap::Heap;
+    /// # use hashql_hir::fold::beef::Beef;
+    /// # let heap = Heap::new();
+    /// # let interner = InternSet::new(&heap);
+    /// // Example with modification
+    /// let original = interner.intern_slice(&[1, 2, 3]);
+    /// let mut beef = Beef::new(original);
+    /// beef.map(|x| x * 2);
+    /// let result = beef.finish(&interner);
+    /// assert_eq!(result.as_ref(), &[2, 4, 6]);
+    ///
+    /// // Example without modification - returns original efficiently
+    /// let original = interner.intern_slice(&[1, 2, 3]);
+    /// let beef = Beef::new(original);
+    /// let result = beef.finish(&interner);
+    /// assert!(std::ptr::eq(original.as_ref(), result.as_ref())); // Same memory
+    /// ```
+    #[must_use]
+    pub fn finish(self, interner: &InternSet<'heap, [T]>) -> Interned<'heap, [T]> {
+        match self.0 {
+            BeefData::Owned(slice) => interner.intern_slice(&slice),
+            BeefData::Interned(slice) => slice,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::ptr;
+
+    use hashql_core::{heap::Heap, intern::InternSet};
+
+    use crate::fold::beef::Beef;
+
+    // Test finish with no modifications
+    #[test]
+    fn finish_no_modifications() {
+        let heap = Heap::new();
+        let interner = InternSet::new(&heap);
+        let original = interner.intern_slice(&[1, 2, 3]);
+
+        let beef = Beef::new(original);
+        let result = beef.finish(&interner);
+
+        // Should be the exact same Interned instance
+        assert_eq!(result.as_ref(), original.as_ref());
+        assert!(ptr::eq(result.as_ref(), original.as_ref())); // Same memory address
+    }
+
+    // Test finish with modifications
+    #[test]
+    fn finish_with_modifications() {
+        let heap = Heap::new();
+        let interner = InternSet::new(&heap);
+        let original = interner.intern_slice(&[1, 2, 3]);
+
+        let mut beef = Beef::new(original);
+        beef.map(|x| x + 10);
+        let result = beef.finish(&interner);
+
+        // Should be a different interned slice with the new values
+        assert_eq!(result.as_ref(), &[11, 12, 13]);
+        assert!(!ptr::eq(result.as_ref(), original.as_ref())); // Different memory address
+    }
+
+    #[test]
+    fn map() {
+        let heap = Heap::new();
+        let interner = InternSet::new(&heap);
+        let original = interner.intern_slice(&[1, 2, 3, 4, 5]);
+
+        // Partial Modification
+        let mut beef = Beef::new(original);
+        beef.map(|x| if x == 3 { 30 } else { x });
+        assert_eq!(beef.as_slice(), &[1, 2, 30, 4, 5]);
+        assert_eq!(beef.finish(&interner).as_ref(), &[1, 2, 30, 4, 5]);
+
+        // Early Modification
+        let mut beef = Beef::new(original);
+        beef.map(|x| if x == 1 { 100 } else { x });
+        assert_eq!(beef.as_slice(), &[100, 2, 3, 4, 5]);
+
+        // Late Modification
+        let mut beef = Beef::new(original);
+        beef.map(|x| if x == 5 { 500 } else { x });
+        assert_eq!(beef.as_slice(), &[1, 2, 3, 4, 500]);
+    }
+
+    #[test]
+    #[expect(clippy::integer_division_remainder_used)]
+    fn map_repeat() {
+        let heap = Heap::new();
+        let interner = InternSet::new(&heap);
+        let original = interner.intern_slice(&[1, 2, 3, 4, 5]);
+
+        let mut beef = Beef::new(original);
+
+        // First modification
+        beef.map(|x| if x % 2 == 0 { x * 2 } else { x });
+        assert_eq!(beef.as_slice(), &[1, 4, 3, 8, 5]);
+
+        // Second modification
+        beef.map(|x| x + 1);
+        assert_eq!(beef.as_slice(), &[2, 5, 4, 9, 6]);
+
+        // Result should be interned with all modifications applied
+        let result = beef.finish(&interner);
+        assert_eq!(result.as_ref(), &[2, 5, 4, 9, 6]);
+    }
+
+    #[test]
+    fn map_edge_cases() {
+        let heap = Heap::new();
+        let interner = InternSet::new(&heap);
+
+        // Empty slice
+        let empty = interner.intern_slice(&[]);
+        let mut empty_beef = Beef::new(empty);
+        empty_beef.map(|x| x + 1); // Should be a no-op since there are no elements
+        assert_eq!(empty_beef.as_slice(), &[] as &[i32]);
+
+        // Single-element slice
+        let single = interner.intern_slice(&[42]);
+        let mut single_beef = Beef::new(single);
+        single_beef.map(|x| x + 1);
+        assert_eq!(single_beef.as_slice(), &[43]);
+    }
+
+    #[test]
+    fn try_map_success() {
+        let heap = Heap::new();
+        let interner = InternSet::new(&heap);
+        let original = interner.intern_slice(&[1, 2, 3, 4, 5]);
+
+        // All transformations succeed
+        let mut beef = Beef::new(original);
+        let result: Result<(), &str> = beef.try_map(|x| Ok(x * 2));
+        assert_eq!(result, Ok(()));
+        assert_eq!(beef.as_slice(), &[2, 4, 6, 8, 10]);
+
+        // No changes (identity function)
+        let mut beef = Beef::new(original);
+        let result: Result<(), &str> = beef.try_map(Ok);
+        assert_eq!(result, Ok(()));
+        assert_eq!(beef.as_slice(), &[1, 2, 3, 4, 5]);
+
+        // Should still be in interned state (verify with finish)
+        let result = beef.finish(&interner);
+        assert!(ptr::eq(result.as_ref(), original.as_ref())); // Same memory address
+    }
+
+    #[test]
+    fn try_map_failure() {
+        let heap = Heap::new();
+        let interner = InternSet::new(&heap);
+        let original = interner.intern_slice(&[1, 2, 3, 4, 5]);
+
+        // Fail on the third element
+        let mut beef = Beef::new(original);
+        let result: Result<(), &str> = beef.try_map(|x| {
+            if x == 3 {
+                Err("Error on value 3")
+            } else {
+                Ok(x * 10)
+            }
+        });
+        assert_eq!(result, Err("Error on value 3"));
+        // First two elements should be transformed
+        assert_eq!(beef.as_slice(), &[10, 20, 3, 4, 5]);
+
+        // Fail on the first element
+        let mut beef = Beef::new(original);
+        let result: Result<(), &str> = beef.try_map(|x| {
+            if x == 1 {
+                Err("Error on first element")
+            } else {
+                Ok(x)
+            }
+        });
+        assert_eq!(result, Err("Error on first element"));
+        // Should still be in interned state since no modifications happened
+        assert_eq!(beef.as_slice(), original.as_ref());
+    }
+
+    #[test]
+    fn try_map_empty_and_edge_cases() {
+        let heap = Heap::new();
+        let interner = InternSet::new(&heap);
+
+        // Empty slice
+        let empty = interner.intern_slice(&[]);
+        let mut empty_beef = Beef::new(empty);
+        let result: Result<(), &str> = empty_beef.try_map(|x| Ok(x + 1));
+        assert_eq!(result, Ok(()));
+        assert_eq!(empty_beef.as_slice(), &[] as &[i32]);
+
+        // Single element success
+        let single = interner.intern_slice(&[42]);
+        let mut single_beef = Beef::new(single);
+        let result: Result<(), &str> = single_beef.try_map(|x| Ok(x + 1));
+        assert_eq!(result, Ok(()));
+        assert_eq!(single_beef.as_slice(), &[43]);
+
+        // Single element failure
+        let mut single_beef = Beef::new(single);
+        let result: Result<(), &str> = single_beef.try_map(|_| Err("Failed"));
+        assert_eq!(result, Err("Failed"));
+        assert_eq!(single_beef.as_slice(), single.as_ref());
+    }
+
+    #[test]
+    #[expect(clippy::integer_division_remainder_used)]
+    fn try_map_with_option() {
+        let heap = Heap::new();
+        let interner = InternSet::new(&heap);
+        let original = interner.intern_slice(&[1, 2, 3, 4, 5]);
+
+        // All transformations succeed
+        let mut beef = Beef::new(original);
+        let result: Option<()> = beef.try_map(|x| Some(x * 3));
+        assert!(result.is_some());
+        assert_eq!(beef.as_slice(), &[3, 6, 9, 12, 15]);
+
+        // Transformation fails on even numbers
+        let mut beef = Beef::new(original);
+        let result: Option<()> = beef.try_map(|x| if x % 2 == 0 { None } else { Some(x * 10) });
+        assert!(result.is_none());
+        // The first value should be transformed, then it should fail on 2
+        assert_eq!(beef.as_slice(), &[10, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn try_map_multiple_calls() {
+        let heap = Heap::new();
+        let interner = InternSet::new(&heap);
+        let original = interner.intern_slice(&[1, 2, 3, 4, 5]);
+
+        // Call try_map multiple times with success
+        let mut beef = Beef::new(original);
+
+        // First call - double all values
+        let result1: Result<(), &str> = beef.try_map(|x| Ok(x * 2));
+        assert_eq!(result1, Ok(()));
+        assert_eq!(beef.as_slice(), &[2, 4, 6, 8, 10]);
+
+        // Second call - add 5 to all values
+        let result2: Result<(), &str> = beef.try_map(|x| Ok(x + 5));
+        assert_eq!(result2, Ok(()));
+        assert_eq!(beef.as_slice(), &[7, 9, 11, 13, 15]);
+
+        // Third call with partial failure
+        let result3: Result<(), &str> = beef.try_map(|x| {
+            if x > 10 {
+                Err("Value too large")
+            } else {
+                Ok(x - 5)
+            }
+        });
+        assert_eq!(result3, Err("Value too large"));
+        // First two elements should be transformed before error
+        assert_eq!(beef.as_slice(), &[2, 4, 11, 13, 15]);
+    }
+}

--- a/libs/@local/hashql/hir/src/fold/beef.rs
+++ b/libs/@local/hashql/hir/src/fold/beef.rs
@@ -25,7 +25,7 @@
 //!
 //! [`Cow`]: std::borrow::Cow
 
-use core::{hash::Hash, ops::Try};
+use core::{fmt, fmt::Debug, hash::Hash, ops::Try};
 
 use hashql_core::{
     collection::SmallVec,
@@ -55,7 +55,7 @@ enum BeefData<'heap, T> {
 /// every element, allowing zero-copy operations when no changes are needed.
 ///
 /// [`Cow`]: std::borrow::Cow
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone)]
 pub struct Beef<'heap, T>(BeefData<'heap, T>);
 
 impl<'heap, T> Beef<'heap, T>
@@ -346,6 +346,22 @@ where
             BeefData::Owned(slice) => interner.intern_slice(&slice),
             BeefData::Interned(slice) => slice,
         }
+    }
+}
+
+impl<T> Debug for Beef<'_, T>
+where
+    T: Debug,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = fmt.debug_tuple("Beef");
+
+        match &self.0 {
+            BeefData::Owned(owned) => debug.field(owned),
+            BeefData::Interned(interned) => debug.field(interned),
+        };
+
+        debug.finish()
     }
 }
 

--- a/libs/@local/hashql/hir/src/fold/mod.rs
+++ b/libs/@local/hashql/hir/src/fold/mod.rs
@@ -38,8 +38,9 @@ pub trait Fold<'heap> {
 
     fn interner(&self) -> &Interner<'heap>;
 
-    fn fold_id(&mut self, id: HirId) -> Self::Output<HirId> {
-        Try::from_output(id)
+    #[expect(unused_variables, reason = "trait definition")]
+    fn visit_id(&mut self, id: HirId) {
+        // do nothing, no fields to walk
     }
 
     fn fold_type_id(&mut self, id: TypeId) -> Self::Output<TypeId> {
@@ -250,7 +251,13 @@ pub fn walk_node<'heap, T: Fold<'heap> + ?Sized>(
         NodeKind::Graph(graph) => NodeKind::Graph(visitor.fold_graph(graph)?),
     };
 
-    Try::from_output(visitor.interner().intern_node(PartialNode { span, kind }))
+    let interner = visitor.interner();
+
+    let node = interner.intern_node(PartialNode { span, kind });
+
+    visitor.visit_id(node.id);
+
+    Try::from_output(node)
 }
 
 pub fn walk_nested_node<'heap, T: Fold<'heap> + ?Sized>(

--- a/libs/@local/hashql/hir/src/fold/nested.rs
+++ b/libs/@local/hashql/hir/src/fold/nested.rs
@@ -1,0 +1,13 @@
+pub trait NestedFilter {
+    const DEEP: bool;
+}
+
+pub struct Shallow(());
+impl NestedFilter for Shallow {
+    const DEEP: bool = false;
+}
+
+pub struct Deep(());
+impl NestedFilter for Deep {
+    const DEEP: bool = true;
+}

--- a/libs/@local/hashql/hir/src/fold/nested.rs
+++ b/libs/@local/hashql/hir/src/fold/nested.rs
@@ -1,12 +1,56 @@
+//! Control of traversal depth for HIR folding.
+//!
+//! This module defines strategies for how deeply a fold operation traverses the HIR tree. The key
+//! distinction is whether to process nested nodes or only the immediate structure.
+//!
+//! These strategies allow transformation passes to be more efficient by only processing the parts
+//! of the tree that are relevant to their task.
+//!
+//! # Use Cases
+//!
+//! - **Shallow traversal**: Use when your transformation only affects top-level structure and
+//!   doesn't need to process nested expressions. This is more efficient when deep traversal isn't
+//!   necessary.
+//!
+//! - **Deep traversal**: Use when your transformation needs to process all nodes in the tree,
+//!   including deeply nested ones. This is necessary for transforms that might apply anywhere in
+//!   the code.
+
+/// Trait defining the traversal depth strategy for HIR folding.
+///
+/// This trait controls whether a folder should process only the immediate structure or traverse
+/// into nested nodes as well.
+///
+/// # Use Cases
+///
+/// Choose the appropriate implementation based on your transformation needs:
+/// - [`Shallow`]: For transformations that only affect top-level structure
+/// - [`Deep`]: For transformations that need to process all nodes
 pub trait NestedFilter {
+    /// Whether to process deeply nested nodes.
+    ///
+    /// When `true`, the folder will recursively process all nodes in the tree.
+    /// When `false`, the folder will only process the immediate structure.
     const DEEP: bool;
 }
 
+/// Filter that only processes the immediate structure.
+///
+/// # Use Case
+///
+/// Use this when you only need to transform top-level nodes without recursing into nested
+/// structures. This is more efficient for passes that don't need to examine every node in the tree.
 pub struct Shallow(());
 impl NestedFilter for Shallow {
     const DEEP: bool = false;
 }
 
+/// Filter that recursively processes all nested nodes.
+///
+/// # Use Case
+///
+/// Use this when you need to transform the entire tree, including all nested structures. This is
+/// necessary for transformations that could apply to any node at any level of nesting.
 pub struct Deep(());
 impl NestedFilter for Deep {
     const DEEP: bool = true;

--- a/libs/@local/hashql/hir/src/intern.rs
+++ b/libs/@local/hashql/hir/src/intern.rs
@@ -6,9 +6,9 @@ use hashql_core::{
 use crate::node::{Node, PartialNode};
 
 pub struct Interner<'heap> {
-    idents: InternSet<'heap, [Ident<'heap>]>,
-    nodes: InternSet<'heap, [Node<'heap>]>,
-    node: InternMap<'heap, Node<'heap>>,
+    pub idents: InternSet<'heap, [Ident<'heap>]>,
+    pub nodes: InternSet<'heap, [Node<'heap>]>,
+    pub node: InternMap<'heap, Node<'heap>>,
 }
 
 impl<'heap> Interner<'heap> {

--- a/libs/@local/hashql/hir/src/intern.rs
+++ b/libs/@local/hashql/hir/src/intern.rs
@@ -1,0 +1,26 @@
+use hashql_core::{
+    intern::{InternMap, InternSet, Interned},
+    symbol::Ident,
+};
+
+use crate::node::{Node, PartialNode};
+
+pub struct Interner<'heap> {
+    idents: InternSet<'heap, [Ident<'heap>]>,
+    nodes: InternSet<'heap, [Node<'heap>]>,
+    node: InternMap<'heap, Node<'heap>>,
+}
+
+impl<'heap> Interner<'heap> {
+    pub fn intern_idents(&self, idents: &[Ident<'heap>]) -> Interned<'heap, [Ident<'heap>]> {
+        self.idents.intern_slice(idents)
+    }
+
+    pub fn intern_nodes(&self, nodes: &[Node<'heap>]) -> Interned<'heap, [Node<'heap>]> {
+        self.nodes.intern_slice(nodes)
+    }
+
+    pub fn intern_node(&self, node: PartialNode<'heap>) -> Node<'heap> {
+        self.node.intern_partial(node)
+    }
+}

--- a/libs/@local/hashql/hir/src/intern.rs
+++ b/libs/@local/hashql/hir/src/intern.rs
@@ -1,4 +1,5 @@
 use hashql_core::{
+    heap::Heap,
     intern::{InternMap, InternSet, Interned},
     symbol::Ident,
 };
@@ -6,18 +7,28 @@ use hashql_core::{
 use crate::node::{Node, PartialNode};
 
 pub struct Interner<'heap> {
-    pub idents: InternSet<'heap, [Ident<'heap>]>,
     pub nodes: InternSet<'heap, [Node<'heap>]>,
+    pub idents: InternSet<'heap, [Ident<'heap>]>,
+
     pub node: InternMap<'heap, Node<'heap>>,
 }
 
 impl<'heap> Interner<'heap> {
-    pub fn intern_idents(&self, idents: &[Ident<'heap>]) -> Interned<'heap, [Ident<'heap>]> {
-        self.idents.intern_slice(idents)
+    pub fn new(heap: &'heap Heap) -> Self {
+        Self {
+            nodes: InternSet::new(heap),
+            idents: InternSet::new(heap),
+
+            node: InternMap::new(heap),
+        }
     }
 
     pub fn intern_nodes(&self, nodes: &[Node<'heap>]) -> Interned<'heap, [Node<'heap>]> {
         self.nodes.intern_slice(nodes)
+    }
+
+    pub fn intern_idents(&self, idents: &[Ident<'heap>]) -> Interned<'heap, [Ident<'heap>]> {
+        self.idents.intern_slice(idents)
     }
 
     pub fn intern_node(&self, node: PartialNode<'heap>) -> Node<'heap> {

--- a/libs/@local/hashql/hir/src/lib.rs
+++ b/libs/@local/hashql/hir/src/lib.rs
@@ -2,8 +2,10 @@
 //!
 //! ## Workspace dependencies
 #![cfg_attr(doc, doc = simple_mermaid::mermaid!("../docs/dependency-diagram.mmd"))]
-#![feature(never_type)]
+#![feature(never_type, exhaustive_patterns)]
 pub mod node;
+pub mod path;
+pub mod visit;
 
 #[cfg(test)]
 mod tests {

--- a/libs/@local/hashql/hir/src/lib.rs
+++ b/libs/@local/hashql/hir/src/lib.rs
@@ -1,8 +1,19 @@
 //! # HashQL HIR
 //!
 //! ## Workspace dependencies
+#![feature(
+    never_type,
+    exhaustive_patterns,
+    try_trait_v2,
+    associated_type_defaults
+)]
 #![cfg_attr(doc, doc = simple_mermaid::mermaid!("../docs/dependency-diagram.mmd"))]
-#![feature(never_type, exhaustive_patterns)]
+    exhaustive_patterns,
+    try_trait_v2,
+    associated_type_defaults
+)]
+pub mod fold;
+pub mod intern;
 pub mod node;
 pub mod path;
 pub mod visit;

--- a/libs/@local/hashql/hir/src/lib.rs
+++ b/libs/@local/hashql/hir/src/lib.rs
@@ -5,7 +5,8 @@
     never_type,
     exhaustive_patterns,
     try_trait_v2,
-    associated_type_defaults
+    associated_type_defaults,
+    array_chunks
 )]
 #![cfg_attr(doc, doc = simple_mermaid::mermaid!("../docs/dependency-diagram.mmd"))]
     exhaustive_patterns,

--- a/libs/@local/hashql/hir/src/lib.rs
+++ b/libs/@local/hashql/hir/src/lib.rs
@@ -9,10 +9,6 @@
     array_chunks
 )]
 #![cfg_attr(doc, doc = simple_mermaid::mermaid!("../docs/dependency-diagram.mmd"))]
-    exhaustive_patterns,
-    try_trait_v2,
-    associated_type_defaults
-)]
 pub mod fold;
 pub mod intern;
 pub mod node;

--- a/libs/@local/hashql/hir/src/node/access/field.rs
+++ b/libs/@local/hashql/hir/src/node/access/field.rs
@@ -1,4 +1,4 @@
-use hashql_core::{intern::Interned, span::SpanId, symbol::Symbol};
+use hashql_core::{intern::Interned, span::SpanId, symbol::Ident};
 
 use crate::node::Node;
 
@@ -10,5 +10,5 @@ pub struct FieldAccess<'heap> {
     pub span: SpanId,
 
     pub expr: Interned<'heap, Node<'heap>>,
-    pub field: Symbol<'heap>,
+    pub field: Ident<'heap>,
 }

--- a/libs/@local/hashql/hir/src/node/access/field.rs
+++ b/libs/@local/hashql/hir/src/node/access/field.rs
@@ -1,4 +1,4 @@
-use hashql_core::{intern::Interned, span::SpanId, symbol::Ident};
+use hashql_core::{span::SpanId, symbol::Ident};
 
 use crate::node::Node;
 
@@ -9,6 +9,6 @@ use crate::node::Node;
 pub struct FieldAccess<'heap> {
     pub span: SpanId,
 
-    pub expr: Interned<'heap, Node<'heap>>,
+    pub expr: Node<'heap>,
     pub field: Ident<'heap>,
 }

--- a/libs/@local/hashql/hir/src/node/access/index.rs
+++ b/libs/@local/hashql/hir/src/node/access/index.rs
@@ -1,4 +1,4 @@
-use hashql_core::{intern::Interned, span::SpanId};
+use hashql_core::span::SpanId;
 
 use crate::node::Node;
 
@@ -10,6 +10,6 @@ use crate::node::Node;
 pub struct IndexAccess<'heap> {
     pub span: SpanId,
 
-    pub expr: Interned<'heap, Node<'heap>>,
-    pub index: Interned<'heap, Node<'heap>>,
+    pub expr: Node<'heap>,
+    pub index: Node<'heap>,
 }

--- a/libs/@local/hashql/hir/src/node/branch/mod.rs
+++ b/libs/@local/hashql/hir/src/node/branch/mod.rs
@@ -14,7 +14,7 @@ use hashql_core::span::SpanId;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum BranchKind {
     /// Conditional branching with if/else (currently a placeholder)
-    If(!),
+    Never(!),
 }
 
 /// A branch node in the HashQL HIR.
@@ -30,5 +30,5 @@ pub struct Branch<'heap> {
 
     pub kind: BranchKind,
 
-    _marker: PhantomData<&'heap ()>,
+    pub _marker: PhantomData<&'heap ()>,
 }

--- a/libs/@local/hashql/hir/src/node/call.rs
+++ b/libs/@local/hashql/hir/src/node/call.rs
@@ -15,6 +15,6 @@ use super::Node;
 pub struct Call<'heap> {
     pub span: SpanId,
 
-    pub function: Interned<'heap, Node<'heap>>,
+    pub function: Node<'heap>,
     pub arguments: Interned<'heap, [Node<'heap>]>,
 }

--- a/libs/@local/hashql/hir/src/node/closure.rs
+++ b/libs/@local/hashql/hir/src/node/closure.rs
@@ -29,5 +29,5 @@ pub struct Closure<'heap> {
     pub span: SpanId,
 
     pub signature: ClosureSignature<'heap>,
-    pub body: Interned<'heap, Node<'heap>>,
+    pub body: Node<'heap>,
 }

--- a/libs/@local/hashql/hir/src/node/data/dict.rs
+++ b/libs/@local/hashql/hir/src/node/data/dict.rs
@@ -9,8 +9,8 @@ use crate::node::Node;
 /// rather than static identifiers, allowing for runtime-determined property access.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct DictField<'heap> {
-    pub key: Interned<'heap, Node<'heap>>,
-    pub value: Interned<'heap, Node<'heap>>,
+    pub key: Node<'heap>,
+    pub value: Node<'heap>,
 }
 
 /// A dictionary expression in the HashQL HIR.

--- a/libs/@local/hashql/hir/src/node/data/struct.rs
+++ b/libs/@local/hashql/hir/src/node/data/struct.rs
@@ -11,7 +11,7 @@ use crate::node::Node;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct StructField<'heap> {
     pub name: Ident<'heap>,
-    pub value: Interned<'heap, Node<'heap>>,
+    pub value: Node<'heap>,
 }
 
 /// A struct expression in the HashQL HIR.

--- a/libs/@local/hashql/hir/src/node/graph/mod.rs
+++ b/libs/@local/hashql/hir/src/node/graph/mod.rs
@@ -32,5 +32,5 @@ pub struct Graph<'heap> {
 
     pub kind: GraphKind,
 
-    _marker: PhantomData<&'heap ()>,
+    pub _marker: PhantomData<&'heap ()>,
 }

--- a/libs/@local/hashql/hir/src/node/input.rs
+++ b/libs/@local/hashql/hir/src/node/input.rs
@@ -1,4 +1,4 @@
-use hashql_core::{intern::Interned, span::SpanId, symbol::Ident, r#type::TypeId};
+use hashql_core::{span::SpanId, symbol::Ident, r#type::TypeId};
 
 use super::Node;
 
@@ -18,5 +18,5 @@ pub struct Input<'heap> {
 
     pub name: Ident<'heap>,
     pub r#type: TypeId,
-    pub default: Option<Interned<'heap, Node<'heap>>>,
+    pub default: Option<Node<'heap>>,
 }

--- a/libs/@local/hashql/hir/src/node/let.rs
+++ b/libs/@local/hashql/hir/src/node/let.rs
@@ -1,4 +1,4 @@
-use hashql_core::{intern::Interned, span::SpanId, symbol::Ident};
+use hashql_core::{span::SpanId, symbol::Ident};
 
 use super::Node;
 
@@ -12,7 +12,7 @@ pub struct Let<'heap> {
     pub span: SpanId,
 
     pub name: Ident<'heap>,
-    pub value: Interned<'heap, Node<'heap>>,
+    pub value: Node<'heap>,
 
-    pub body: Interned<'heap, Node<'heap>>,
+    pub body: Node<'heap>,
 }

--- a/libs/@local/hashql/hir/src/node/let.rs
+++ b/libs/@local/hashql/hir/src/node/let.rs
@@ -1,4 +1,4 @@
-use hashql_core::{intern::Interned, span::SpanId, symbol::Symbol};
+use hashql_core::{intern::Interned, span::SpanId, symbol::Ident};
 
 use super::Node;
 
@@ -11,7 +11,7 @@ use super::Node;
 pub struct Let<'heap> {
     pub span: SpanId,
 
-    pub name: Symbol<'heap>,
+    pub name: Ident<'heap>,
     pub value: Interned<'heap, Node<'heap>>,
 
     pub body: Interned<'heap, Node<'heap>>,

--- a/libs/@local/hashql/hir/src/node/mod.rs
+++ b/libs/@local/hashql/hir/src/node/mod.rs
@@ -64,6 +64,7 @@ pub struct Node<'heap> {
     pub id: HirId,
     pub span: SpanId,
 
+    // Consider if we want to intern the `NodeKind` separately
     pub kind: &'heap NodeKind<'heap>,
 }
 

--- a/libs/@local/hashql/hir/src/node/operation/binary.rs
+++ b/libs/@local/hashql/hir/src/node/operation/binary.rs
@@ -1,4 +1,4 @@
-use hashql_core::{intern::Interned, span::SpanId};
+use hashql_core::span::SpanId;
 
 use crate::node::Node;
 
@@ -71,6 +71,6 @@ pub struct BinaryOperation<'heap> {
     pub span: SpanId,
 
     pub op: BinOp,
-    pub left: Interned<'heap, Node<'heap>>,
-    pub right: Interned<'heap, Node<'heap>>,
+    pub left: Node<'heap>,
+    pub right: Node<'heap>,
 }

--- a/libs/@local/hashql/hir/src/node/operation/type.rs
+++ b/libs/@local/hashql/hir/src/node/operation/type.rs
@@ -1,4 +1,4 @@
-use hashql_core::{intern::Interned, span::SpanId, r#type::TypeId};
+use hashql_core::{span::SpanId, r#type::TypeId};
 
 use crate::node::Node;
 
@@ -25,7 +25,7 @@ use crate::node::Node;
 pub struct TypeAssertion<'heap> {
     pub span: SpanId,
 
-    pub value: Interned<'heap, Node<'heap>>,
+    pub value: Node<'heap>,
     pub r#type: TypeId,
 
     pub force: bool,
@@ -43,7 +43,7 @@ pub struct TypeAssertion<'heap> {
 pub struct TypeConstructor<'heap> {
     pub span: SpanId,
 
-    pub value: Interned<'heap, Node<'heap>>,
+    pub value: Node<'heap>,
     pub r#type: TypeId,
 }
 

--- a/libs/@local/hashql/hir/src/node/operation/unary.rs
+++ b/libs/@local/hashql/hir/src/node/operation/unary.rs
@@ -1,4 +1,4 @@
-use hashql_core::{intern::Interned, span::SpanId};
+use hashql_core::span::SpanId;
 
 use crate::node::Node;
 
@@ -36,5 +36,5 @@ pub struct UnaryOperation<'heap> {
     pub span: SpanId,
 
     pub op: UnOp,
-    pub expr: Interned<'heap, Node<'heap>>,
+    pub expr: Node<'heap>,
 }

--- a/libs/@local/hashql/hir/src/node/variable.rs
+++ b/libs/@local/hashql/hir/src/node/variable.rs
@@ -1,6 +1,7 @@
 use hashql_core::{intern::Interned, span::SpanId, symbol::Ident};
 
 use super::Node;
+use crate::path::QualifiedPath;
 
 /// A reference to a locally defined variable in the HashQL HIR.
 ///
@@ -30,7 +31,7 @@ pub struct LocalVariable<'heap> {
 pub struct QualifiedVariable<'heap> {
     pub span: SpanId,
 
-    pub path: Interned<'heap, [Ident<'heap>]>,
+    pub path: QualifiedPath<'heap>,
     pub arguments: Interned<'heap, [Node<'heap>]>,
 }
 

--- a/libs/@local/hashql/hir/src/path.rs
+++ b/libs/@local/hashql/hir/src/path.rs
@@ -1,0 +1,21 @@
+use hashql_core::{intern::Interned, symbol::Ident};
+
+mod private {
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+    pub struct Marker;
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct QualifiedPath<'heap>(pub Interned<'heap, [Ident<'heap>]>, pub private::Marker);
+
+impl<'heap> QualifiedPath<'heap> {
+    /// Create a new `QualifiedPath` value.
+    ///
+    /// The value referred to *must* follow all the constraints and guarantees that are required for
+    /// the `QualifiedPath` type.
+    #[inline]
+    #[must_use]
+    pub const fn new_unchecked(value: Interned<'heap, [Ident<'heap>]>) -> Self {
+        Self(value, private::Marker)
+    }
+}

--- a/libs/@local/hashql/hir/src/visit.rs
+++ b/libs/@local/hashql/hir/src/visit.rs
@@ -1,0 +1,452 @@
+use hashql_core::{span::SpanId, symbol::Ident, r#type::TypeId};
+
+use crate::{
+    node::{
+        HirId, Node,
+        access::{Access, AccessKind, field::FieldAccess, index::IndexAccess},
+        branch::{Branch, BranchKind},
+        call::Call,
+        closure::{Closure, ClosureSignature},
+        data::{Data, DataKind, Literal},
+        graph::{Graph, GraphKind},
+        input::Input,
+        kind::NodeKind,
+        r#let::Let,
+        operation::{
+            BinaryOperation, Operation, OperationKind, TypeOperation, UnaryOperation,
+            r#type::{TypeAssertion, TypeConstructor, TypeOperationKind},
+        },
+        variable::{LocalVariable, QualifiedVariable, Variable, VariableKind},
+    },
+    path::QualifiedPath,
+};
+
+pub trait Visitor<'heap> {
+    #[expect(unused_variables, reason = "trait definition")]
+    fn visit_id(&mut self, id: HirId) {
+        // do nothing, no fields to walk
+    }
+
+    #[expect(unused_variables, reason = "trait definition")]
+    fn visit_type_id(&mut self, id: TypeId) {
+        // do nothing, no fields to walk
+    }
+
+    #[expect(unused_variables, reason = "trait definition")]
+    fn visit_span(&mut self, span: SpanId) {
+        // do nothing, no fields to walk
+    }
+
+    fn visit_ident(&mut self, ident: &'heap Ident<'heap>) {
+        walk_ident(self, ident);
+    }
+
+    fn visit_qualified_path(&mut self, path: &'heap QualifiedPath<'heap>) {
+        walk_qualified_path(self, path);
+    }
+
+    fn visit_node(&mut self, node: &'heap Node<'heap>) {
+        walk_node(self, node);
+    }
+
+    fn visit_data(&mut self, data: &'heap Data<'heap>) {
+        walk_data(self, data);
+    }
+
+    fn visit_literal(&mut self, literal: &'heap Literal<'heap>) {
+        walk_literal(self, literal);
+    }
+
+    fn visit_variable(&mut self, variable: &'heap Variable<'heap>) {
+        walk_variable(self, variable);
+    }
+
+    fn visit_local_variable(&mut self, variable: &'heap LocalVariable<'heap>) {
+        walk_local_variable(self, variable);
+    }
+
+    fn visit_qualified_variable(&mut self, variable: &'heap QualifiedVariable<'heap>) {
+        walk_qualified_variable(self, variable);
+    }
+
+    fn visit_let(&mut self, r#let: &'heap Let<'heap>) {
+        walk_let(self, r#let);
+    }
+
+    fn visit_input(&mut self, input: &'heap Input<'heap>) {
+        walk_input(self, input);
+    }
+
+    fn visit_operation(&mut self, operation: &'heap Operation<'heap>) {
+        walk_operation(self, operation);
+    }
+
+    fn visit_type_operation(&mut self, operation: &'heap TypeOperation<'heap>) {
+        walk_type_operation(self, operation);
+    }
+
+    fn visit_type_assertion(&mut self, assertion: &'heap TypeAssertion<'heap>) {
+        walk_type_assertion(self, assertion);
+    }
+
+    fn visit_type_constructor(&mut self, constructor: &'heap TypeConstructor<'heap>) {
+        walk_type_constructor(self, constructor);
+    }
+
+    fn visit_binary_operation(&mut self, operation: &'heap BinaryOperation<'heap>) {
+        walk_binary_operation(self, operation);
+    }
+
+    fn visit_unary_operation(&mut self, operation: &'heap UnaryOperation<'heap>) {
+        walk_unary_operation(self, operation);
+    }
+
+    fn visit_access(&mut self, access: &'heap Access<'heap>) {
+        walk_access(self, access);
+    }
+
+    fn visit_field_access(&mut self, access: &'heap FieldAccess<'heap>) {
+        walk_field_access(self, access);
+    }
+
+    fn visit_index_access(&mut self, access: &'heap IndexAccess<'heap>) {
+        walk_index_access(self, access);
+    }
+
+    fn visit_call(&mut self, call: &'heap Call<'heap>) {
+        walk_call(self, call);
+    }
+
+    fn visit_branch(&mut self, branch: &'heap Branch<'heap>) {
+        walk_branch(self, branch);
+    }
+
+    fn visit_closure(&mut self, closure: &'heap Closure<'heap>) {
+        walk_closure(self, closure);
+    }
+
+    fn visit_closure_signature(&mut self, signature: &'heap ClosureSignature<'heap>) {
+        walk_closure_signature(self, signature);
+    }
+
+    fn visit_graph(&mut self, graph: &'heap Graph<'heap>) {
+        walk_graph(self, graph);
+    }
+}
+
+pub fn walk_ident<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    Ident {
+        value: _,
+        span,
+        kind: _,
+    }: &'heap Ident<'heap>,
+) {
+    visitor.visit_span(*span);
+}
+
+pub fn walk_qualified_path<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    QualifiedPath(path, _): &'heap QualifiedPath<'heap>,
+) {
+    for ident in path {
+        visitor.visit_ident(ident);
+    }
+}
+
+pub fn walk_node<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    Node { id, span, kind }: &'heap Node<'heap>,
+) {
+    visitor.visit_id(*id);
+    visitor.visit_span(*span);
+
+    match &kind {
+        NodeKind::Data(data) => visitor.visit_data(data),
+        NodeKind::Variable(variable) => visitor.visit_variable(variable),
+        NodeKind::Let(r#let) => visitor.visit_let(r#let),
+        NodeKind::Input(input) => visitor.visit_input(input),
+        NodeKind::Operation(operation) => visitor.visit_operation(operation),
+        NodeKind::Access(access) => visitor.visit_access(access),
+        NodeKind::Call(call) => visitor.visit_call(call),
+        NodeKind::Branch(branch) => visitor.visit_branch(branch),
+        NodeKind::Closure(closure) => visitor.visit_closure(closure),
+        NodeKind::Graph(graph) => visitor.visit_graph(graph),
+    }
+}
+
+pub fn walk_data<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    Data { span, kind }: &'heap Data<'heap>,
+) {
+    visitor.visit_span(*span);
+
+    match kind {
+        DataKind::Literal(literal) => visitor.visit_literal(literal),
+    }
+}
+
+pub fn walk_literal<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    Literal { span, kind: _ }: &'heap Literal<'heap>,
+) {
+    visitor.visit_span(*span);
+}
+
+pub fn walk_variable<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    Variable { span, kind }: &'heap Variable<'heap>,
+) {
+    visitor.visit_span(*span);
+
+    match kind {
+        VariableKind::Local(variable) => visitor.visit_local_variable(variable),
+        VariableKind::Qualified(variable) => visitor.visit_qualified_variable(variable),
+    }
+}
+
+pub fn walk_local_variable<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    LocalVariable {
+        span,
+        name,
+        arguments,
+    }: &'heap LocalVariable<'heap>,
+) {
+    visitor.visit_span(*span);
+    visitor.visit_ident(name);
+
+    for argument in arguments {
+        visitor.visit_node(argument);
+    }
+}
+
+pub fn walk_qualified_variable<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    QualifiedVariable {
+        span,
+        path,
+        arguments,
+    }: &'heap QualifiedVariable<'heap>,
+) {
+    visitor.visit_span(*span);
+    visitor.visit_qualified_path(path);
+
+    for argument in arguments {
+        visitor.visit_node(argument);
+    }
+}
+
+pub fn walk_let<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    Let {
+        span,
+        name,
+        value,
+        body,
+    }: &'heap Let<'heap>,
+) {
+    visitor.visit_span(*span);
+    visitor.visit_ident(name);
+
+    visitor.visit_node(value);
+    visitor.visit_node(body);
+}
+
+pub fn walk_input<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    Input {
+        span,
+        name,
+        r#type,
+        default,
+    }: &'heap Input<'heap>,
+) {
+    visitor.visit_span(*span);
+    visitor.visit_ident(name);
+
+    visitor.visit_type_id(*r#type);
+
+    if let Some(default) = default {
+        visitor.visit_node(default);
+    }
+}
+
+pub fn walk_operation<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    Operation { span, kind }: &'heap Operation<'heap>,
+) {
+    visitor.visit_span(*span);
+
+    match kind {
+        OperationKind::Type(operation) => visitor.visit_type_operation(operation),
+        OperationKind::Binary(operation) => visitor.visit_binary_operation(operation),
+    }
+}
+
+pub fn walk_type_operation<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    TypeOperation { span, kind }: &'heap TypeOperation<'heap>,
+) {
+    visitor.visit_span(*span);
+
+    match kind {
+        TypeOperationKind::Assertion(assertion) => visitor.visit_type_assertion(assertion),
+        TypeOperationKind::Constructor(constructor) => visitor.visit_type_constructor(constructor),
+    }
+}
+
+pub fn walk_type_assertion<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    TypeAssertion {
+        span,
+        value,
+        r#type,
+        force: _,
+    }: &'heap TypeAssertion<'heap>,
+) {
+    visitor.visit_span(*span);
+    visitor.visit_node(value);
+    visitor.visit_type_id(*r#type);
+}
+
+pub fn walk_type_constructor<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    TypeConstructor {
+        span,
+        value,
+        r#type,
+    }: &'heap TypeConstructor<'heap>,
+) {
+    visitor.visit_span(*span);
+    visitor.visit_node(value);
+    visitor.visit_type_id(*r#type);
+}
+
+pub fn walk_binary_operation<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    BinaryOperation {
+        span,
+        op: _,
+        left,
+        right,
+    }: &'heap BinaryOperation<'heap>,
+) {
+    visitor.visit_span(*span);
+
+    visitor.visit_node(left);
+    visitor.visit_node(right);
+}
+
+pub fn walk_unary_operation<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    UnaryOperation { span, op: _, expr }: &'heap UnaryOperation<'heap>,
+) {
+    visitor.visit_span(*span);
+    visitor.visit_node(expr);
+}
+
+pub fn walk_access<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    Access { span, kind }: &'heap Access<'heap>,
+) {
+    visitor.visit_span(*span);
+
+    match kind {
+        AccessKind::Field(access) => visitor.visit_field_access(access),
+        AccessKind::Index(access) => visitor.visit_index_access(access),
+    }
+}
+
+pub fn walk_field_access<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    FieldAccess { span, expr, field }: &'heap FieldAccess<'heap>,
+) {
+    visitor.visit_span(*span);
+    visitor.visit_node(expr);
+    visitor.visit_ident(field);
+}
+
+pub fn walk_index_access<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    IndexAccess { span, expr, index }: &'heap IndexAccess<'heap>,
+) {
+    visitor.visit_span(*span);
+    visitor.visit_node(expr);
+    visitor.visit_node(index);
+}
+
+pub fn walk_call<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    Call {
+        span,
+        function,
+        arguments,
+    }: &'heap Call<'heap>,
+) {
+    visitor.visit_span(*span);
+    visitor.visit_node(function);
+
+    for argument in arguments {
+        visitor.visit_node(argument);
+    }
+}
+
+pub fn walk_branch<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    Branch {
+        span,
+        kind,
+        _marker: _,
+    }: &'heap Branch<'heap>,
+) {
+    visitor.visit_span(*span);
+
+    match kind {
+        BranchKind::Never(_) => unreachable!(),
+    }
+}
+
+pub fn walk_closure<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    Closure {
+        span,
+        signature,
+        body,
+    }: &'heap Closure<'heap>,
+) {
+    visitor.visit_span(*span);
+    visitor.visit_closure_signature(signature);
+    visitor.visit_node(body);
+}
+
+pub fn walk_closure_signature<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    ClosureSignature {
+        span,
+        r#type,
+        params,
+    }: &'heap ClosureSignature<'heap>,
+) {
+    visitor.visit_span(*span);
+    visitor.visit_type_id(*r#type);
+
+    for param in params {
+        visitor.visit_ident(param);
+    }
+}
+
+pub fn walk_graph<'heap, T: Visitor<'heap> + ?Sized>(
+    visitor: &mut T,
+    Graph {
+        span,
+        kind,
+        _marker: _,
+    }: &'heap Graph<'heap>,
+) {
+    visitor.visit_span(*span);
+
+    match kind {
+        GraphKind::Never(_) => unreachable!(),
+    }
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Implements two complementary traits for working with the HIR:

* `Visitor` - For immutable traversal of the HIR tree, useful for analysis, linting, and type-checking
* `Fold` - For transforming the HIR tree while preserving node identity where possible

### Visitor

The `Visitor` trait enables immutable traversal of the HIR tree, similar to rustc's [`intravisit`](https://github.com/rust-lang/rust/blob/dbab4e152bd9eed57ccfc096ef6060dd9af45a99/compiler/rustc_hir/src/intravisit.rs#L177) module. It's designed for:

* Linting and static analysis
* Type checking
* Collecting information from the HIR without modifying it

### Fold

The `Fold` trait supports tree transformations by creating new nodes as needed, inspired by [swc_visit](https://docs.rs/swc_visit/latest/swc_visit/). Key features:

* Uses copy-on-write semantics to minimize allocations
* Preserves sharing between unmodified subtrees
* Particularly useful for optimizations like dead-code elimination, alias propagation, and inlining

### Beef

This PR introduces a `Beef` type, which is optimized for cases where modifications rarely occur:

* Benchmarked against alternative implementations for our use case
* Provides efficient copy-on-write semantics, but unlike `Cow` does so on an per-element basis
* Minimizes memory allocations during tree transformations

### Interned HIR

HIR nodes are interned to automatically deduplicate identical subtrees, which:

1. Reduces memory usage
2. Speeds up equality comparisons
3. Allows efficient structural sharing during transformations

#### Example: Inlining Let Literals

Given this HIR structure:

```mermaid
flowchart TD
    a["let x"]
    a -->|value| e["2"]
    a -->|body| b["\+"]
    b -->|left| c["x"]
    b -->|right| d["x"]
```

After transformation with our `Fold` implementation:

```mermaid
flowchart TD
    e["2"]
    b["\+"]
    b -->|left| e
    b -->|right| e
```

The transformation creates a new tree with shared references to the original literal node, without modifying any existing nodes, and automatically deduplicating the duplicate reference.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
