### PR TITLE
H-4334: Expose CRUD operations for Policies

### DIFF
--- a/libs/@blockprotocol/type-system/rust/package.json
+++ b/libs/@blockprotocol/type-system/rust/package.json
@@ -23,7 +23,7 @@
     }
   },
   "scripts": {
-    "build:types": "mise exec --env dev cargo:cargo-insta -- cargo-insta test --features codegen --test codegen --accept",
+    "build:types": "INSTA_UPDATE=always mise exec --env dev cargo:cargo-insta -- cargo-insta test --features codegen --test codegen",
     "build:wasm": "mise exec --env prod cargo:wasm-pack -- wasm-pack build --target web --out-name type-system --scope blockprotocol --release . && rm pkg/package.json",
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root type-system --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",

--- a/libs/@local/codec/package.json
+++ b/libs/@local/codec/package.json
@@ -15,7 +15,7 @@
     }
   },
   "scripts": {
-    "build:types": "mise exec --env dev cargo:cargo-insta -- cargo-insta test --features codegen,numeric --test codegen --accept",
+    "build:types": "INSTA_UPDATE=always mise exec --env dev cargo:cargo-insta -- cargo-insta test --features codegen,numeric --test codegen",
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root hash-codec --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",

--- a/libs/@local/graph/api/openapi/openapi.json
+++ b/libs/@local/graph/api/openapi/openapi.json
@@ -2950,6 +2950,47 @@
         }
       }
     },
+    "/policies": {
+      "post": {
+        "tags": [
+          "Graph",
+          "Permission"
+        ],
+        "operationId": "create_policy",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ActorEntityUuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The policy ID of the created policy",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "500": {
+            "description": "Store error occurred"
+          }
+        }
+      }
+    },
     "/policies/query": {
       "post": {
         "tags": [
@@ -3093,6 +3134,94 @@
                 }
               }
             }
+          },
+          "500": {
+            "description": "Store error occurred"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Graph",
+          "Permission"
+        ],
+        "operationId": "update_policy_by_id",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ActorEntityUuid"
+            }
+          },
+          {
+            "name": "policy_id",
+            "in": "path",
+            "description": "The ID of the policy to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {}
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The updated policy",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "500": {
+            "description": "Store error occurred"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Graph",
+          "Permission"
+        ],
+        "operationId": "delete_policy_by_id",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ActorEntityUuid"
+            }
+          },
+          {
+            "name": "policy_id",
+            "in": "path",
+            "description": "The ID of the policy to delete",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The policy was removed successfully"
           },
           "500": {
             "description": "Store error occurred"

--- a/libs/@local/graph/api/src/rest/permissions.rs
+++ b/libs/@local/graph/api/src/rest/permissions.rs
@@ -12,7 +12,7 @@ use hash_graph_authorization::{
     AuthorizationApiPool,
     policies::{
         Policy, PolicyId,
-        store::{PolicyFilter, PolicyStore},
+        store::{PolicyCreationParams, PolicyFilter, PolicyStore, PolicyUpdateOperation},
     },
 };
 use hash_graph_store::pool::StorePool;
@@ -26,9 +26,12 @@ use crate::rest::{AuthenticatedUserHeader, json::Json, status::report_to_respons
 #[derive(OpenApi)]
 #[openapi(
     paths(
+        create_policy,
         get_policy_by_id,
         query_policies,
         resolve_policies_for_actor,
+        update_policy_by_id,
+        delete_policy_by_id,
 
         seed_system_policies,
     ),
@@ -50,12 +53,64 @@ impl PermissionResource {
         Router::new().nest(
             "/policies",
             Router::new()
-                .route("/:policy_id", get(get_policy_by_id::<S, A>))
+                .route("/", post(create_policy::<S, A>))
+                .route(
+                    "/:policy_id",
+                    get(get_policy_by_id::<S, A>)
+                        .put(update_policy_by_id::<S, A>)
+                        .delete(delete_policy_by_id::<S, A>),
+                )
                 .route("/query", post(query_policies::<S, A>))
                 .route("/resolve/actor", post(resolve_policies_for_actor::<S, A>))
                 .route("/seed", get(seed_system_policies::<S, A>)),
         )
     }
+}
+
+#[utoipa::path(
+    post,
+    path = "/policies",
+    request_body = Value,
+    tag = "Permission",
+    params(
+        ("X-Authenticated-User-Actor-Id" = ActorEntityUuid, Header, description = "The ID of the actor which is used to authorize the request"),
+    ),
+    responses(
+        (status = 200, content_type = "application/json", description = "The policy ID of the created policy", body = Value),
+
+        (status = 500, description = "Store error occurred"),
+    )
+)]
+#[tracing::instrument(
+    level = "info",
+    skip(store_pool, authorization_api_pool, temporal_client)
+)]
+async fn create_policy<S, A>(
+    AuthenticatedUserHeader(authenticated_actor_id): AuthenticatedUserHeader,
+    store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
+    temporal_client: Extension<Option<Arc<TemporalClient>>>,
+    Json(policy): Json<PolicyCreationParams>,
+) -> Result<Json<PolicyId>, Response>
+where
+    S: StorePool + Send + Sync,
+    A: AuthorizationApiPool + Send + Sync,
+    for<'p, 'a> S::Store<'p, A::Api<'a>>: PolicyStore,
+{
+    store_pool
+        .acquire(
+            authorization_api_pool
+                .acquire()
+                .await
+                .map_err(report_to_response)?,
+            temporal_client.0,
+        )
+        .await
+        .map_err(report_to_response)?
+        .create_policy(authenticated_actor_id, policy)
+        .await
+        .map_err(report_to_response)
+        .map(Json)
 }
 
 #[utoipa::path(
@@ -194,6 +249,100 @@ where
         .await
         .map_err(report_to_response)
         .map(Json)
+}
+
+#[utoipa::path(
+    put,
+    path = "/policies/{policy_id}",
+    request_body = Vec<Value>,
+    tag = "Permission",
+    params(
+        ("X-Authenticated-User-Actor-Id" = ActorEntityUuid, Header, description = "The ID of the actor which is used to authorize the request"),
+        ("policy_id" = Uuid, Path, description = "The ID of the policy to update"),
+    ),
+    responses(
+        (status = 200, content_type = "application/json", description = "The updated policy", body = Value),
+
+        (status = 500, description = "Store error occurred"),
+    )
+)]
+#[tracing::instrument(
+    level = "info",
+    skip(store_pool, authorization_api_pool, temporal_client)
+)]
+async fn update_policy_by_id<S, A>(
+    AuthenticatedUserHeader(authenticated_actor_id): AuthenticatedUserHeader,
+    Path(policy_id): Path<PolicyId>,
+    store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
+    temporal_client: Extension<Option<Arc<TemporalClient>>>,
+    Json(operations): Json<Vec<PolicyUpdateOperation>>,
+) -> Result<Json<Policy>, Response>
+where
+    S: StorePool + Send + Sync,
+    A: AuthorizationApiPool + Send + Sync,
+    for<'p, 'a> S::Store<'p, A::Api<'a>>: PolicyStore,
+{
+    store_pool
+        .acquire(
+            authorization_api_pool
+                .acquire()
+                .await
+                .map_err(report_to_response)?,
+            temporal_client.0,
+        )
+        .await
+        .map_err(report_to_response)?
+        .update_policy_by_id(authenticated_actor_id, policy_id, &operations)
+        .await
+        .map_err(report_to_response)
+        .map(Json)
+}
+
+#[utoipa::path(
+    delete,
+    path = "/policies/{policy_id}",
+    tag = "Permission",
+    params(
+        ("X-Authenticated-User-Actor-Id" = ActorEntityUuid, Header, description = "The ID of the actor which is used to authorize the request"),
+        ("policy_id" = Uuid, Path, description = "The ID of the policy to delete"),
+    ),
+    responses(
+        (status = 204, content_type = "application/json", description = "The policy was removed successfully"),
+
+        (status = 500, description = "Store error occurred"),
+    )
+)]
+#[tracing::instrument(
+    level = "info",
+    skip(store_pool, authorization_api_pool, temporal_client)
+)]
+async fn delete_policy_by_id<S, A>(
+    AuthenticatedUserHeader(authenticated_actor_id): AuthenticatedUserHeader,
+    Path(policy_id): Path<PolicyId>,
+    store_pool: Extension<Arc<S>>,
+    authorization_api_pool: Extension<Arc<A>>,
+    temporal_client: Extension<Option<Arc<TemporalClient>>>,
+) -> Result<StatusCode, Response>
+where
+    S: StorePool + Send + Sync,
+    A: AuthorizationApiPool + Send + Sync,
+    for<'p, 'a> S::Store<'p, A::Api<'a>>: PolicyStore,
+{
+    store_pool
+        .acquire(
+            authorization_api_pool
+                .acquire()
+                .await
+                .map_err(report_to_response)?,
+            temporal_client.0,
+        )
+        .await
+        .map_err(report_to_response)?
+        .delete_policy_by_id(authenticated_actor_id, policy_id)
+        .await
+        .map_err(report_to_response)
+        .map(|()| StatusCode::NO_CONTENT)
 }
 
 #[utoipa::path(

--- a/libs/@local/graph/authorization/package.json
+++ b/libs/@local/graph/authorization/package.json
@@ -15,7 +15,7 @@
     }
   },
   "scripts": {
-    "build:types": "mise exec --env dev cargo:cargo-insta -- cargo-insta test --features codegen --test codegen --accept",
+    "build:types": "INSTA_UPDATE=always mise exec --env dev cargo:cargo-insta -- cargo-insta test --features codegen --test codegen",
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root hash-graph-authorization --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",

--- a/libs/@local/graph/authorization/src/policies/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/mod.rs
@@ -71,7 +71,6 @@ pub enum Effect {
     postgres(transparent)
 )]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[repr(transparent)]
 pub struct PolicyId(Uuid);
 

--- a/libs/@local/graph/authorization/src/policies/resource/entity.rs
+++ b/libs/@local/graph/authorization/src/policies/resource/entity.rs
@@ -26,17 +26,15 @@ pub struct EntityResource<'a> {
 
 #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[serde(
-    tag = "type",
-    rename_all = "camelCase",
-    rename_all_fields = "camelCase",
-    deny_unknown_fields
-)]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
 pub enum EntityResourceFilter {
+    #[serde(rename_all = "camelCase")]
     All { filters: Vec<Self> },
+    #[serde(rename_all = "camelCase")]
     Any { filters: Vec<Self> },
+    #[serde(rename_all = "camelCase")]
     Not { filter: Box<Self> },
-
+    #[serde(rename_all = "camelCase")]
     IsOfType { entity_type: VersionedUrl },
 }
 
@@ -170,14 +168,13 @@ impl ToCedarEntityId for EntityUuid {
 
 #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[serde(untagged, rename_all_fields = "camelCase", deny_unknown_fields)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum EntityResourceConstraint {
-    Any {
-        filter: EntityResourceFilter,
-    },
-    Exact {
-        id: EntityUuid,
-    },
+    #[serde(rename_all = "camelCase")]
+    Any { filter: EntityResourceFilter },
+    #[serde(rename_all = "camelCase")]
+    Exact { id: EntityUuid },
+    #[serde(rename_all = "camelCase")]
     Web {
         web_id: WebId,
         filter: EntityResourceFilter,

--- a/libs/@local/graph/authorization/src/policies/resource/entity_type.rs
+++ b/libs/@local/graph/authorization/src/policies/resource/entity_type.rs
@@ -77,17 +77,17 @@ impl EntityTypeResource<'_> {
 
 #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[serde(
-    tag = "type",
-    rename_all = "camelCase",
-    rename_all_fields = "camelCase",
-    deny_unknown_fields
-)]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
 pub enum EntityTypeResourceFilter {
+    #[serde(rename_all = "camelCase")]
     All { filters: Vec<Self> },
+    #[serde(rename_all = "camelCase")]
     Any { filters: Vec<Self> },
+    #[serde(rename_all = "camelCase")]
     Not { filter: Box<Self> },
+    #[serde(rename_all = "camelCase")]
     IsBaseUrl { base_url: BaseUrl },
+    #[serde(rename_all = "camelCase")]
     IsVersion { version: OntologyTypeVersion },
 }
 
@@ -193,14 +193,13 @@ impl ToCedarEntityId for EntityTypeId {
 
 #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[serde(untagged, rename_all_fields = "camelCase", deny_unknown_fields)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum EntityTypeResourceConstraint {
-    Any {
-        filter: EntityTypeResourceFilter,
-    },
-    Exact {
-        id: EntityTypeId,
-    },
+    #[serde(rename_all = "camelCase")]
+    Any { filter: EntityTypeResourceFilter },
+    #[serde(rename_all = "camelCase")]
+    Exact { id: EntityTypeId },
+    #[serde(rename_all = "camelCase")]
     Web {
         web_id: WebId,
         filter: EntityTypeResourceFilter,

--- a/libs/@local/graph/authorization/src/policies/resource/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/resource/mod.rs
@@ -45,14 +45,12 @@ impl CedarExpressionVisitor for ResourceVariableVisitor {
 
 #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[serde(
-    tag = "type",
-    rename_all = "camelCase",
-    rename_all_fields = "camelCase",
-    deny_unknown_fields
-)]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
 pub enum ResourceConstraint {
-    Web { web_id: WebId },
+    #[serde(rename_all = "camelCase")]
+    Web {
+        web_id: WebId,
+    },
     Entity(EntityResourceConstraint),
     EntityType(EntityTypeResourceConstraint),
 }

--- a/libs/@local/graph/authorization/src/policies/store/error.rs
+++ b/libs/@local/graph/authorization/src/policies/store/error.rs
@@ -1,10 +1,13 @@
 use core::error::Error;
 
 use type_system::principal::{
+    PrincipalId,
     actor::ActorId,
     actor_group::{ActorGroupId, TeamId, WebId},
     role::RoleName,
 };
+
+use crate::policies::{PolicyId, action::ActionName};
 
 #[derive(Debug, derive_more::Display)]
 #[display("Could not get system account: {_variant}")]
@@ -149,6 +152,51 @@ pub enum PolicyStoreError {
 }
 
 impl Error for PolicyStoreError {}
+
+#[derive(Debug, derive_more::Display)]
+#[display("Policy operation failed: {_variant}")]
+pub enum CreatePolicyError {
+    #[display("Principal with ID `{id}` doesn't exist")]
+    PrincipalNotFound { id: PrincipalId },
+    #[display("Action `{id}` doesn't exist")]
+    ActionNotFound { id: ActionName },
+    #[display("Policy with ID `{id}` already exists")]
+    PolicyAlreadyExists { id: PolicyId },
+    #[display("No actions specified in policy")]
+    PolicyHasNoActions,
+    #[display("Invalid principal constraint")]
+    InvalidPrincipalConstraint,
+    #[display("Store operation failed")]
+    StoreError,
+}
+
+impl Error for CreatePolicyError {}
+
+#[derive(Debug, derive_more::Display)]
+#[display("Could not remove policy: {_variant}")]
+pub enum RemovePolicyError {
+    #[display("Policy with ID `{id}` does not exist")]
+    PolicyNotFound { id: PolicyId },
+    #[display("Store operation failed")]
+    StoreError,
+}
+
+impl Error for RemovePolicyError {}
+
+#[derive(Debug, derive_more::Display)]
+#[display("Could not update policy: {_variant}")]
+pub enum UpdatePolicyError {
+    #[display("Policy with ID `{id}` does not exist")]
+    PolicyNotFound { id: PolicyId },
+    #[display("Action `{id}` doesn't exist")]
+    ActionNotFound { id: ActionName },
+    #[display("No actions specified in policy")]
+    PolicyHasNoActions,
+    #[display("Store operation failed")]
+    StoreError,
+}
+
+impl Error for UpdatePolicyError {}
 
 #[derive(Debug, derive_more::Display)]
 #[display("Could not get policies for actor: {_variant}")]

--- a/libs/@local/graph/authorization/src/policies/store/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/store/mod.rs
@@ -93,6 +93,15 @@ pub enum RoleUnassignmentStatus {
     NotAssigned,
 }
 
+/// Parameters passed to [`PolicyStore::create_policy`].
+///
+/// This struct is used to create a new policy in the backing store. It contains the effect of the
+/// policy, the principal to which it applies, the actions that are allowed or denied, and the
+/// resource to which it applies.
+///
+/// See [`create_policy`] for more details.
+///
+/// [`create_policy`]: PolicyStore::create_policy
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]

--- a/libs/@local/graph/authorization/src/policies/store/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/store/mod.rs
@@ -19,11 +19,15 @@ use type_system::{
 use uuid::Uuid;
 
 use self::error::{
-    ActorCreationError, ContextCreationError, EnsureSystemPoliciesError, GetPoliciesError,
-    GetSystemAccountError, PolicyStoreError, RoleAssignmentError, TeamCreationError,
-    TeamRoleCreationError, WebCreationError, WebRoleCreationError,
+    ActorCreationError, ContextCreationError, CreatePolicyError, EnsureSystemPoliciesError,
+    GetPoliciesError, GetSystemAccountError, PolicyStoreError, RemovePolicyError,
+    RoleAssignmentError, TeamCreationError, TeamRoleCreationError, UpdatePolicyError,
+    WebCreationError, WebRoleCreationError,
 };
-use super::{ContextBuilder, Policy, PolicyId, principal::PrincipalConstraint};
+use super::{
+    ContextBuilder, Effect, Policy, PolicyId, action::ActionName, principal::PrincipalConstraint,
+    resource::ResourceConstraint,
+};
 
 #[derive(Debug, derive_more::Display)]
 #[display("Actor with ID `{actor}` already exists")]
@@ -91,6 +95,16 @@ pub enum RoleUnassignmentStatus {
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct PolicyCreationParams {
+    pub effect: Effect,
+    pub principal: Option<PrincipalConstraint>,
+    pub actions: Vec<ActionName>,
+    pub resource: Option<ResourceConstraint>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "codegen", derive(specta::Type))]
 #[serde(rename_all = "kebab-case", tag = "filter", deny_unknown_fields)]
 pub enum PrincipalFilter {
     Unconstrained,
@@ -104,8 +118,41 @@ pub struct PolicyFilter {
     pub principal: Option<PrincipalFilter>,
 }
 
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "codegen", derive(specta::Type))]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+pub enum PolicyUpdateOperation {
+    AddAction { action: ActionName },
+    RemoveAction { action: ActionName },
+}
+
 #[trait_variant::make(Send)]
 pub trait PolicyStore {
+    /// Creates a new policy in the backing store.
+    ///
+    /// Inserts the [`Policy`] as specified in the [`PolicyCreationParams`] and returns its
+    /// [`PolicyId`] if successful. The implementation must ensure the referenced principal
+    /// exists and the policy has at least one action.
+    ///
+    /// # Errors
+    ///
+    /// - [`PolicyAlreadyExists`] if a policy with the same ID already exists
+    /// - [`PrincipalNotFound`] if the referenced principal does not exist
+    /// - [`PolicyHasNoActions`] if the policy is missing actions
+    /// - [`ActionNotFound`] if any of the actions do not exist
+    /// - [`StoreError`] if a database or storage level error occurs
+    ///
+    /// [`PolicyAlreadyExists`]: CreatePolicyError::PolicyAlreadyExists
+    /// [`PrincipalNotFound`]: CreatePolicyError::PrincipalNotFound
+    /// [`PolicyHasNoActions`]: CreatePolicyError::PolicyHasNoActions
+    /// [`ActionNotFound`]: CreatePolicyError::ActionNotFound
+    /// [`StoreError`]: CreatePolicyError::StoreError
+    async fn create_policy(
+        &mut self,
+        authenticated_actor: ActorEntityUuid,
+        policy: PolicyCreationParams,
+    ) -> Result<PolicyId, Report<CreatePolicyError>>;
+
     /// Retrieves a policy by its ID.
     ///
     /// # Errors
@@ -167,6 +214,45 @@ pub trait PolicyStore {
         authenticated_actor: ActorEntityUuid,
         actor_id: ActorId,
     ) -> Result<Vec<Policy>, Report<GetPoliciesError>>;
+
+    /// Updates the policy specified by it's ID.
+    ///
+    /// All specified operations are applied to the policy in the order they are provided.
+    ///
+    /// # Errors
+    ///
+    /// - [`PolicyNotFound`] if the policy does not exist
+    /// - [`ActionNotFound`] if any of the actions do not exist
+    /// - [`PolicyHasNoActions`] if the update would result in the policy not having any actions
+    /// - [`StoreError`] if a database or storage level error occurs
+    ///
+    /// [`PolicyNotFound`]: UpdatePolicyError::PolicyNotFound
+    /// [`ActionNotFound`]: UpdatePolicyError::ActionNotFound
+    /// [`PolicyHasNoActions`]: UpdatePolicyError::PolicyHasNoActions
+    /// [`StoreError`]: UpdatePolicyError::StoreError
+    async fn update_policy_by_id(
+        &mut self,
+        authenticated_actor: ActorEntityUuid,
+        policy_id: PolicyId,
+        operations: &[PolicyUpdateOperation],
+    ) -> Result<Policy, Report<UpdatePolicyError>>;
+
+    /// Updates the policy specified by it's ID.
+    ///
+    /// All specified operations are applied to the policy in the order they are provided.
+    ///
+    /// # Errors
+    ///
+    /// - [`PolicyNotFound`] if the policy does not exist
+    /// - [`StoreError`] if a database or storage level error occurs
+    ///
+    /// [`PolicyNotFound`]: RemovePolicyError::PolicyNotFound
+    /// [`StoreError`]: RemovePolicyError::StoreError
+    async fn delete_policy_by_id(
+        &mut self,
+        authenticated_actor: ActorEntityUuid,
+        policy_id: PolicyId,
+    ) -> Result<(), Report<RemovePolicyError>>;
 
     /// Ensures that the system actor policies are present.
     ///

--- a/libs/@local/graph/authorization/types/index.snap.d.ts
+++ b/libs/@local/graph/authorization/types/index.snap.d.ts
@@ -17,17 +17,17 @@ export type PrincipalConstraint = {
 	type: "actor"
 } & ActorId | {
 	type: "actorType"
-	actor_type: ActorType
+	actorType: ActorType
 } | {
 	type: "actorGroup"
-	actor_type?: ActorType
+	actorType?: ActorType
 } & ActorGroupId | {
 	type: "role"
-	actor_type?: ActorType
+	actorType?: ActorType
 } & RoleId;
 export type ResourceConstraint = {
 	type: "web"
-	web_id: WebId
+	webId: WebId
 } | {
 	type: "entity"
 } & EntityResourceConstraint | {
@@ -38,7 +38,7 @@ export type EntityResourceConstraint = {
 } | {
 	id: EntityUuid
 } | {
-	web_id: WebId
+	webId: WebId
 	filter: EntityResourceFilter
 };
 export type EntityResourceFilter = {
@@ -52,7 +52,7 @@ export type EntityResourceFilter = {
 	filter: EntityResourceFilter
 } | {
 	type: "isOfType"
-	entity_type: VersionedUrl
+	entityType: VersionedUrl
 };
 export type EntityTypeId = string;
 export type EntityTypeResourceConstraint = {
@@ -60,7 +60,7 @@ export type EntityTypeResourceConstraint = {
 } | {
 	id: EntityTypeId
 } | {
-	web_id: WebId
+	webId: WebId
 	filter: EntityTypeResourceFilter
 };
 export type EntityTypeResourceFilter = {
@@ -74,14 +74,27 @@ export type EntityTypeResourceFilter = {
 	filter: EntityTypeResourceFilter
 } | {
 	type: "isBaseUrl"
-	base_url: BaseUrl
+	baseUrl: BaseUrl
 } | {
 	type: "isVersion"
 	version: OntologyTypeVersion
 };
+export interface PolicyCreationParams {
+	effect: Effect;
+	principal?: PrincipalConstraint;
+	actions: ActionName[];
+	resource?: ResourceConstraint;
+}
 export interface PolicyFilter {
 	principal?: PrincipalFilter;
 }
+export type PolicyUpdateOperation = {
+	type: "addAction"
+	action: ActionName
+} | {
+	type: "removeAction"
+	action: ActionName
+};
 export type PrincipalFilter = {
 	filter: "unconstrained"
 } | {

--- a/libs/@local/graph/postgres-store/tests/principals/policies.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/policies.rs
@@ -4,11 +4,11 @@ use std::collections::{HashMap, HashSet};
 use hash_graph_authorization::{
     AuthorizationApi,
     policies::{
-        Effect, Policy, PolicyId,
+        Effect, PolicyId,
         action::ActionName,
         principal::PrincipalConstraint,
         resource::{EntityResourceConstraint, EntityResourceFilter, ResourceConstraint},
-        store::{CreateWebParameter, PolicyStore as _, PrincipalStore as _},
+        store::{CreateWebParameter, PolicyCreationParams, PolicyStore as _, PrincipalStore as _},
     },
 };
 use hash_graph_postgres_store::store::{AsClient, PostgresStore};
@@ -204,114 +204,122 @@ async fn setup_policy_test_environment(
 
     // 1. Global policies (no principal constraint)
     let global_policy_id = client
-        .create_policy(Policy {
-            id: PolicyId::new(Uuid::new_v4()),
-            effect: Effect::Permit,
-            principal: None,
-            actions: vec![ActionName::All],
-            resource: None,
-            constraints: None,
-        })
+        .create_policy(
+            actor_id.into(),
+            PolicyCreationParams {
+                effect: Effect::Permit,
+                principal: None,
+                actions: vec![ActionName::All],
+                resource: None,
+            },
+        )
         .await?;
 
     // 2. Actor type specific policies
     let user_type_policy_id = client
-        .create_policy(Policy {
-            id: PolicyId::new(Uuid::new_v4()),
-            effect: Effect::Permit,
-            principal: Some(PrincipalConstraint::ActorType {
-                actor_type: ActorType::User,
-            }),
-            actions: vec![ActionName::View],
-            resource: None,
-            constraints: None,
-        })
+        .create_policy(
+            actor_id.into(),
+            PolicyCreationParams {
+                effect: Effect::Permit,
+                principal: Some(PrincipalConstraint::ActorType {
+                    actor_type: ActorType::User,
+                }),
+                actions: vec![ActionName::View],
+                resource: None,
+            },
+        )
         .await?;
 
     let machine_type_policy_id = client
-        .create_policy(Policy {
-            id: PolicyId::new(Uuid::new_v4()),
-            effect: Effect::Permit,
-            principal: Some(PrincipalConstraint::ActorType {
-                actor_type: ActorType::Machine,
-            }),
-            actions: vec![ActionName::Update],
-            resource: None,
-            constraints: None,
-        })
+        .create_policy(
+            actor_id.into(),
+            PolicyCreationParams {
+                effect: Effect::Permit,
+                principal: Some(PrincipalConstraint::ActorType {
+                    actor_type: ActorType::Machine,
+                }),
+                actions: vec![ActionName::Update],
+                resource: None,
+            },
+        )
         .await?;
 
     // 3. Specific actor policies
     let user1_policy_id = client
-        .create_policy(Policy {
-            id: PolicyId::new(Uuid::new_v4()),
-            effect: Effect::Permit,
-            principal: Some(PrincipalConstraint::Actor {
-                actor: ActorId::User(user1_id),
-            }),
-            actions: vec![ActionName::Create],
-            resource: None,
-            constraints: None,
-        })
+        .create_policy(
+            actor_id.into(),
+            PolicyCreationParams {
+                effect: Effect::Permit,
+                principal: Some(PrincipalConstraint::Actor {
+                    actor: ActorId::User(user1_id),
+                }),
+                actions: vec![ActionName::Create],
+                resource: None,
+            },
+        )
         .await?;
 
     // 4. Role-based policies
     let web1_role_policy_id = client
-        .create_policy(Policy {
-            id: PolicyId::new(Uuid::new_v4()),
-            effect: Effect::Permit,
-            principal: Some(PrincipalConstraint::Role {
-                role: web_1_role_id,
-                actor_type: None,
-            }),
-            actions: vec![ActionName::Instantiate],
-            resource: None,
-            constraints: None,
-        })
+        .create_policy(
+            actor_id.into(),
+            PolicyCreationParams {
+                effect: Effect::Permit,
+                principal: Some(PrincipalConstraint::Role {
+                    role: web_1_role_id,
+                    actor_type: None,
+                }),
+                actions: vec![ActionName::Instantiate],
+                resource: None,
+            },
+        )
         .await?;
 
     // 5. Team-based policies
     let team1_policy_id = client
-        .create_policy(Policy {
-            id: PolicyId::new(Uuid::new_v4()),
-            effect: Effect::Permit,
-            principal: Some(PrincipalConstraint::ActorGroup {
-                actor_group: ActorGroupId::Team(team_1_id),
-                actor_type: None,
-            }),
-            actions: vec![ActionName::ViewEntity],
-            resource: None,
-            constraints: None,
-        })
+        .create_policy(
+            actor_id.into(),
+            PolicyCreationParams {
+                effect: Effect::Permit,
+                principal: Some(PrincipalConstraint::ActorGroup {
+                    actor_group: ActorGroupId::Team(team_1_id),
+                    actor_type: None,
+                }),
+                actions: vec![ActionName::ViewEntity],
+                resource: None,
+            },
+        )
         .await?;
 
     // 6. Role with actor type constraint
     let web2_role_user_policy_id = client
-        .create_policy(Policy {
-            id: PolicyId::new(Uuid::new_v4()),
-            effect: Effect::Permit,
-            principal: Some(PrincipalConstraint::Role {
-                role: web_2_role_id,
-                actor_type: Some(ActorType::User),
-            }),
-            actions: vec![ActionName::Create],
-            resource: None,
-            constraints: None,
-        })
+        .create_policy(
+            actor_id.into(),
+            PolicyCreationParams {
+                effect: Effect::Permit,
+                principal: Some(PrincipalConstraint::Role {
+                    role: web_2_role_id,
+                    actor_type: Some(ActorType::User),
+                }),
+                actions: vec![ActionName::Create],
+                resource: None,
+            },
+        )
         .await?;
 
     // 7. Deny policies for testing priority
     let deny_user1_policy_id = client
-        .create_policy(Policy {
-            id: PolicyId::new(Uuid::new_v4()),
-            effect: Effect::Forbid,
-            principal: Some(PrincipalConstraint::Actor {
-                actor: ActorId::User(user1_id),
-            }),
-            actions: vec![ActionName::Update],
-            resource: None,
-            constraints: None,
-        })
+        .create_policy(
+            actor_id.into(),
+            PolicyCreationParams {
+                effect: Effect::Forbid,
+                principal: Some(PrincipalConstraint::Actor {
+                    actor: ActorId::User(user1_id),
+                }),
+                actions: vec![ActionName::Update],
+                resource: None,
+            },
+        )
         .await?;
 
     Ok(TestPolicyEnvironment {
@@ -771,20 +779,21 @@ async fn resource_constraints_are_preserved() -> Result<(), Box<dyn Error>> {
 
     // Create a policy with resource constraints
     let resource_policy_id = client
-        .create_policy(Policy {
-            id: PolicyId::new(Uuid::new_v4()),
-            effect: Effect::Permit,
-            principal: Some(PrincipalConstraint::Actor {
-                actor: ActorId::User(user_id),
-            }),
-            actions: vec![ActionName::All],
-            resource: Some(ResourceConstraint::Entity(EntityResourceConstraint::Any {
-                filter: EntityResourceFilter::All {
-                    filters: Vec::new(),
-                },
-            })),
-            constraints: None,
-        })
+        .create_policy(
+            actor_id.into(),
+            PolicyCreationParams {
+                effect: Effect::Permit,
+                principal: Some(PrincipalConstraint::Actor {
+                    actor: ActorId::User(user_id),
+                }),
+                actions: vec![ActionName::All],
+                resource: Some(ResourceConstraint::Entity(EntityResourceConstraint::Any {
+                    filter: EntityResourceFilter::All {
+                        filters: Vec::new(),
+                    },
+                })),
+            },
+        )
         .await?;
 
     let policies = client
@@ -863,45 +872,48 @@ async fn deep_team_hierarchy() -> Result<(), Box<dyn Error>> {
 
     // Create policies
     let web_policy_id = client
-        .create_policy(Policy {
-            id: PolicyId::new(Uuid::new_v4()),
-            effect: Effect::Permit,
-            principal: Some(PrincipalConstraint::ActorGroup {
-                actor_group: ActorGroupId::Web(web_id),
-                actor_type: None,
-            }),
-            actions: vec![ActionName::All],
-            resource: None,
-            constraints: None,
-        })
+        .create_policy(
+            actor_id.into(),
+            PolicyCreationParams {
+                effect: Effect::Permit,
+                principal: Some(PrincipalConstraint::ActorGroup {
+                    actor_group: ActorGroupId::Web(web_id),
+                    actor_type: None,
+                }),
+                actions: vec![ActionName::All],
+                resource: None,
+            },
+        )
         .await?;
 
     let team1_policy_id = client
-        .create_policy(Policy {
-            id: PolicyId::new(Uuid::new_v4()),
-            effect: Effect::Permit,
-            principal: Some(PrincipalConstraint::ActorGroup {
-                actor_group: ActorGroupId::Team(team1_id),
-                actor_type: None,
-            }),
-            actions: vec![ActionName::All],
-            resource: None,
-            constraints: None,
-        })
+        .create_policy(
+            actor_id.into(),
+            PolicyCreationParams {
+                effect: Effect::Permit,
+                principal: Some(PrincipalConstraint::ActorGroup {
+                    actor_group: ActorGroupId::Team(team1_id),
+                    actor_type: None,
+                }),
+                actions: vec![ActionName::All],
+                resource: None,
+            },
+        )
         .await?;
 
     let team5_policy_id = client
-        .create_policy(Policy {
-            id: PolicyId::new(Uuid::new_v4()),
-            effect: Effect::Permit,
-            principal: Some(PrincipalConstraint::ActorGroup {
-                actor_group: ActorGroupId::Team(team5_id),
-                actor_type: None,
-            }),
-            actions: vec![ActionName::All],
-            resource: None,
-            constraints: None,
-        })
+        .create_policy(
+            actor_id.into(),
+            PolicyCreationParams {
+                effect: Effect::Permit,
+                principal: Some(PrincipalConstraint::ActorGroup {
+                    actor_group: ActorGroupId::Team(team5_id),
+                    actor_type: None,
+                }),
+                actions: vec![ActionName::All],
+                resource: None,
+            },
+        )
         .await?;
 
     // User should get all policies through the hierarchy

--- a/libs/@local/graph/sdk/typescript/src/policy.ts
+++ b/libs/@local/graph/sdk/typescript/src/policy.ts
@@ -2,11 +2,29 @@ import type { ActorId } from "@blockprotocol/type-system";
 import type { GraphApi } from "@local/hash-graph-client";
 import type {
   Policy,
+  PolicyCreationParams,
   PolicyFilter,
   PolicyId,
+  PolicyUpdateOperation,
 } from "@rust/hash-graph-authorization/types";
 
 import type { AuthenticationContext } from "./authentication-context.js";
+
+/**
+ * Creates a new policy in the backing store.
+ *
+ * Inserts the [`Policy`] as specified in the [`PolicyCreationParams`] and returns its
+ * [`PolicyId`] if successful. The implementation must ensure the referenced principal
+ * exists and the policy has at least one action.
+ */
+export const createPolicy = (
+  graphAPI: GraphApi,
+  authentication: AuthenticationContext,
+  policy: PolicyCreationParams,
+): Promise<PolicyId> =>
+  graphAPI
+    .createPolicy(authentication.actorId, policy)
+    .then(({ data: policyId }) => policyId as PolicyId);
 
 /**
  * Retrieves a policy by its ID.
@@ -63,3 +81,30 @@ export const resolvePoliciesForActor = (
   graphAPI
     .resolvePoliciesForActor(authentication.actorId, actorId)
     .then(({ data: policies }) => policies as Policy[]);
+
+/**
+ * Updates the policy specified by it's ID.
+ *
+ * All specified operations are applied to the policy in the order they are provided.
+ */
+export const updatePolicyById = (
+  graphAPI: GraphApi,
+  authentication: AuthenticationContext,
+  policyId: PolicyId,
+  operations: PolicyUpdateOperation[],
+): Promise<Policy> =>
+  graphAPI
+    .updatePolicyById(authentication.actorId, policyId, operations)
+    .then(({ data: policy }) => policy as Policy);
+
+/**
+ * Permanently removes the policy specified by it's ID.
+ */
+export const deletePolicyById = (
+  graphAPI: GraphApi,
+  authentication: AuthenticationContext,
+  policyId: PolicyId,
+): Promise<void> =>
+  graphAPI
+    .deletePolicyById(authentication.actorId, policyId)
+    .then(({ data }) => data);

--- a/tests/hash-backend-integration/src/tests/graph/authorization/policy.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/authorization/policy.test.ts
@@ -4,11 +4,18 @@ import type { User } from "@apps/hash-api/src/graph/knowledge/system-types/user"
 import { systemAccountId } from "@apps/hash-api/src/graph/system-account";
 import { Logger } from "@local/hash-backend-utils/logger";
 import {
+  createPolicy,
+  deletePolicyById,
   getPolicyById,
   queryPolicies,
   resolvePoliciesForActor,
+  updatePolicyById,
 } from "@local/hash-graph-sdk/policy";
-import type { Policy, PolicyId } from "@rust/hash-graph-authorization/types";
+import type {
+  Policy,
+  PolicyCreationParams,
+  PolicyId,
+} from "@rust/hash-graph-authorization/types";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import { resetGraph } from "../../test-server";
@@ -41,12 +48,37 @@ describe("Policy CRUD", () => {
     };
   });
 
+  it("can create a policy", async () => {
+    const authentication = { actorId: testUser.accountId };
+
+    const policyCreationParams = {
+      effect: "permit",
+      principal: {
+        type: "actor",
+        actorType: "user",
+        id: testUser.accountId,
+      },
+      actions: ["instantiate"],
+      resource: {
+        type: "web",
+        webId: testUser.accountId,
+      },
+    } satisfies PolicyCreationParams;
+
+    const policyId = await createPolicy(
+      graphApi,
+      authentication,
+      policyCreationParams,
+    );
+    testPolicy = { id: policyId, ...policyCreationParams };
+  });
+
   it("can query all policies", async () => {
     const authentication = { actorId: testUser.accountId };
 
     const policies = await queryPolicies(graphApi, authentication, {});
 
-    expect(policies.length).toBeGreaterThan(0);
+    expect(policies).toContainEqual(testPolicy);
   });
 
   it("can query system-actor policies", async () => {
@@ -56,13 +88,12 @@ describe("Policy CRUD", () => {
       principal: {
         filter: "constrained",
         type: "actor",
-        actorType: "machine",
-        id: systemAccountId,
+        actorType: "user",
+        id: testUser.accountId,
       },
     });
 
-    expect(policies.length).toBeGreaterThan(0);
-    testPolicy = policies[0]!;
+    expect(policies).toContainEqual(testPolicy);
   });
 
   it("can get specific policies", async () => {
@@ -71,14 +102,6 @@ describe("Policy CRUD", () => {
     expect(
       await getPolicyById(graphApi, authentication, testPolicy.id),
     ).toStrictEqual(testPolicy);
-
-    expect(
-      await getPolicyById(
-        graphApi,
-        authentication,
-        "00000000-0000-0000-0000-000000000000" as PolicyId,
-      ),
-    ).toBeNull();
   });
 
   it("can find policies for an actor", async () => {
@@ -86,16 +109,96 @@ describe("Policy CRUD", () => {
 
     expect(
       await resolvePoliciesForActor(graphApi, authentication, {
-        actorType: "machine",
-        id: systemAccountId,
+        actorType: "user",
+        id: testUser.accountId,
       }),
     ).toContainEqual(testPolicy);
+  });
+
+  it("can update a policy", async () => {
+    const authentication = { actorId: testUser.accountId };
+
+    let updatedPolicy = await updatePolicyById(
+      graphApi,
+      authentication,
+      testPolicy.id,
+      [
+        {
+          type: "addAction",
+          action: "view",
+        },
+        {
+          type: "addAction",
+          action: "create",
+        },
+        {
+          type: "removeAction",
+          action: "instantiate",
+        },
+      ],
+    );
+
+    expect(testPolicy).not.toEqual(updatedPolicy);
+    expect(updatedPolicy.actions.length).toBe(2);
+
+    updatedPolicy = await updatePolicyById(
+      graphApi,
+      authentication,
+      testPolicy.id,
+      [
+        {
+          type: "removeAction",
+          action: "create",
+        },
+      ],
+    );
+    expect(updatedPolicy.actions).toStrictEqual(["view"]);
+
+    // At least one action must exist ...
+    await expect(
+      updatePolicyById(graphApi, authentication, testPolicy.id, [
+        {
+          type: "removeAction",
+          action: "view",
+        },
+      ]),
+    ).rejects.toThrowError(
+      "Could not update policy: No actions specified in policy",
+    );
+
+    // ... but we can remove the last action and add a new one
+    updatedPolicy = await updatePolicyById(
+      graphApi,
+      authentication,
+      testPolicy.id,
+      [
+        {
+          type: "removeAction",
+          action: "view",
+        },
+        {
+          type: "addAction",
+          action: "instantiate",
+        },
+      ],
+    );
+    expect(updatedPolicy).toStrictEqual(testPolicy);
+  });
+
+  it("can delete a policy", async () => {
+    const authentication = { actorId: testUser.accountId };
+
+    await deletePolicyById(graphApi, authentication, testPolicy.id);
+
+    expect(
+      await getPolicyById(graphApi, authentication, testPolicy.id),
+    ).toBeNull();
 
     expect(
       await resolvePoliciesForActor(graphApi, authentication, {
         actorType: "user",
         id: testUser.accountId,
       }),
-    ).toStrictEqual([]);
+    ).not.toContainEqual(testPolicy);
   });
 });

--- a/tests/hash-backend-integration/src/tests/graph/authorization/policy.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/authorization/policy.test.ts
@@ -1,7 +1,6 @@
 import { deleteKratosIdentity } from "@apps/hash-api/src/auth/ory-kratos";
 import { ensureSystemGraphIsInitialized } from "@apps/hash-api/src/graph/ensure-system-graph-is-initialized";
 import type { User } from "@apps/hash-api/src/graph/knowledge/system-types/user";
-import { systemAccountId } from "@apps/hash-api/src/graph/system-account";
 import { Logger } from "@local/hash-backend-utils/logger";
 import {
   createPolicy,
@@ -14,7 +13,6 @@ import {
 import type {
   Policy,
   PolicyCreationParams,
-  PolicyId,
 } from "@rust/hash-graph-authorization/types";
 import { beforeAll, describe, expect, it } from "vitest";
 
@@ -182,6 +180,7 @@ describe("Policy CRUD", () => {
         },
       ],
     );
+    // The original policy should be restored
     expect(updatedPolicy).toStrictEqual(testPolicy);
   });
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Policies needs to be queried/created/updated and potentially removed.

The goal is to manage policies from the Node API in the migration files. This means, that we need to query for existing policies to avoid creating duplicate policies. This in particular is important as long as we continue running the same migrations. But it's also required if we only run a migration once because we later need to find these policies.

- to create policies from the Node API
- to remove policies from the Node API
- to update policies from the Node API, i.e. adding another action 

## 🔍 What does this change?

- Move policy creation and deletion to `PolicyStore`
- Implement policy updating
- Expose endpoints
- Implement tests

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- New tests have been added