### PR TITLE
H-4562: Properly distinguish between optionals and nullables in codegen

### DIFF
--- a/libs/@blockprotocol/type-system/rust/types/index.snap.d.ts
+++ b/libs/@blockprotocol/type-system/rust/types/index.snap.d.ts
@@ -83,7 +83,7 @@ export interface Team {
 export type TeamId = Brand<ActorGroupEntityUuid, "TeamId">;
 export interface Web {
 	id: WebId;
-	shortname?: string;
+	shortname: (string | null);
 	roles: WebRoleId[];
 }
 export type WebId = Brand<ActorGroupEntityUuid | ActorEntityUuid, "WebId">;

--- a/libs/@local/codegen/src/definitions/fields.rs
+++ b/libs/@local/codegen/src/definitions/fields.rs
@@ -22,21 +22,17 @@ impl Field {
             .ty()
             .map(|ty| Type::from_specta(ty, type_collection))?;
 
-        if !field.flatten()
-            && let Type::Optional(optional) = r#type
-        {
-            Some(Self {
-                r#type: *optional,
-                flatten: field.flatten(),
-                optional: true,
-            })
-        } else {
-            Some(Self {
-                r#type,
-                flatten: field.flatten(),
-                optional: field.optional(),
-            })
-        }
+        // If the field is optional, we don't want to use `null` but only the optional
+        // type.
+        let field_type = match r#type {
+            Type::Nullable(r#type) if field.optional() && !field.flatten() => *r#type,
+            field_type => field_type,
+        };
+        Some(Self {
+            r#type: field_type,
+            flatten: field.flatten(),
+            optional: field.optional(),
+        })
     }
 }
 

--- a/libs/@local/codegen/src/definitions/type.rs
+++ b/libs/@local/codegen/src/definitions/type.rs
@@ -30,7 +30,7 @@ pub enum Type {
     Tuple(Tuple),
     List(List),
     Map(Map),
-    Optional(Box<Self>),
+    Nullable(Box<Self>),
 }
 
 impl Type {
@@ -56,7 +56,7 @@ impl Type {
                 Self::List(List::from_specta(list_type, type_collection))
             }
             specta::DataType::Nullable(nullable) => {
-                Self::Optional(Box::new(Self::from_specta(nullable, type_collection)))
+                Self::Nullable(Box::new(Self::from_specta(nullable, type_collection)))
             }
             specta::DataType::Map(map_type) => {
                 Self::Map(Map::from_specta(map_type, type_collection))

--- a/libs/@local/codegen/src/typescript.rs
+++ b/libs/@local/codegen/src/typescript.rs
@@ -604,7 +604,7 @@ impl<'a, 'c> TypeScriptGenerator<'a, 'c> {
                 SPAN,
                 self.ast.vec_from_array([
                     self.visit_type(optional),
-                    self.ast.ts_type_undefined_keyword(SPAN),
+                    self.ast.ts_type_null_keyword(SPAN),
                 ]),
             ),
         )
@@ -619,7 +619,7 @@ impl<'a, 'c> TypeScriptGenerator<'a, 'c> {
             Type::Tuple(tuple) => self.visit_tuple(tuple),
             Type::List(list) => self.visit_list(list),
             Type::Map(map) => self.visit_map(map),
-            Type::Optional(optional) => self.visit_optional(optional),
+            Type::Nullable(optional) => self.visit_optional(optional),
         }
     }
 }

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__ListOptionals::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__ListOptionals::Typescript.snap
@@ -3,8 +3,8 @@ source: libs/@local/codegen/tests/standalone-types/main.rs
 expression: generated
 ---
 export interface ListOptionals {
-	optional_strings: (string | undefined)[];
-	optional_integers: (number | undefined)[];
-	optional_arrays: (number[] | undefined)[];
-	optional_sets: (string[] | undefined)[];
+	optional_strings: (string | null)[];
+	optional_integers: (number | null)[];
+	optional_arrays: (number[] | null)[];
+	optional_sets: (string[] | null)[];
 }

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__MapOptional::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__MapOptional::Typescript.snap
@@ -3,16 +3,16 @@ source: libs/@local/codegen/tests/standalone-types/main.rs
 expression: generated
 ---
 export interface MapOptional {
-	maybe_map?: {
+	maybe_map: ({
 		[key: string]: number
-	};
+	} | null);
 	map_of_optionals: {
-		[key: string]: (number | undefined)
+		[key: string]: (number | null)
 	};
-	maybe_btree?: {
+	maybe_btree: ({
 		[key: string]: string
-	};
+	} | null);
 	btree_of_optionals: {
-		[key: string]: (number | undefined)
+		[key: string]: (number | null)
 	};
 }

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__StructOptional::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__StructOptional::Typescript.snap
@@ -4,5 +4,8 @@ expression: generated
 ---
 export interface StructOptional {
 	required: string;
-	optional?: number;
+	nullable: (number | null);
+	optional_ser?: number;
+	optional_de?: number;
+	optional_ser_de?: number;
 }

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__TupleOptional::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__TupleOptional::Typescript.snap
@@ -3,5 +3,8 @@ source: libs/@local/codegen/tests/standalone-types/main.rs
 expression: generated
 ---
 export interface TupleOptional {
-	optional?: [number, number];
+	nullable: ([number, number] | null);
+	optional_ser?: [number, number];
+	optional_de?: [number, number];
+	optional_ser_de?: [number, number];
 }

--- a/libs/@local/codegen/tests/standalone-types/structs.rs
+++ b/libs/@local/codegen/tests/standalone-types/structs.rs
@@ -35,7 +35,13 @@ pub(crate) struct StructEmpty {}
 #[derive(specta::Type)]
 pub(crate) struct StructOptional {
     required: String,
-    optional: Option<i32>,
+    nullable: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    optional_ser: Option<f32>,
+    #[serde(default)]
+    optional_de: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    optional_ser_de: Option<f32>,
 }
 
 // Struct with nested structs

--- a/libs/@local/codegen/tests/standalone-types/tuples.rs
+++ b/libs/@local/codegen/tests/standalone-types/tuples.rs
@@ -33,5 +33,11 @@ pub(crate) struct TupleNested {
 // Struct with optional tuple field
 #[derive(specta::Type)]
 pub(crate) struct TupleOptional {
-    optional: Option<(f32, f32)>,
+    nullable: Option<(f32, f32)>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    optional_ser: Option<(f32, f32)>,
+    #[serde(default)]
+    optional_de: Option<(f32, f32)>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    optional_ser_de: Option<(f32, f32)>,
 }

--- a/libs/@local/graph/authorization/src/policies/store/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/store/mod.rs
@@ -124,6 +124,7 @@ pub enum PrincipalFilter {
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PolicyFilter {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub principal: Option<PrincipalFilter>,
 }
 

--- a/libs/@local/graph/authorization/types/index.snap.d.ts
+++ b/libs/@local/graph/authorization/types/index.snap.d.ts
@@ -6,9 +6,9 @@ export type Effect = "permit" | "forbid";
 export interface Policy {
 	id: PolicyId;
 	effect: Effect;
-	principal?: PrincipalConstraint;
+	principal: (PrincipalConstraint | null);
 	actions: ActionName[];
-	resource?: ResourceConstraint;
+	resource: (ResourceConstraint | null);
 }
 import type { Brand } from "@local/advanced-types/brand";
 export type PolicyId = Brand<string, "PolicyId">;
@@ -81,9 +81,9 @@ export type EntityTypeResourceFilter = {
 };
 export interface PolicyCreationParams {
 	effect: Effect;
-	principal?: PrincipalConstraint;
+	principal: (PrincipalConstraint | null);
 	actions: ActionName[];
-	resource?: ResourceConstraint;
+	resource: (ResourceConstraint | null);
 }
 export interface PolicyFilter {
 	principal?: PrincipalFilter;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Passing `null` or passing nothing is different. Even though, `serde_json` does ignore the difference (which, to be honest, is quite annoying), but this does not mean that our generated types should not reflect these changes.