### PR TITLE
H-4561: Allow updating resource constraints on policies

### DIFF
--- a/libs/@local/graph/authorization/src/policies/store/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/store/mod.rs
@@ -109,7 +109,6 @@ pub struct PolicyCreationParams {
     pub effect: Effect,
     pub principal: Option<PrincipalConstraint>,
     pub actions: Vec<ActionName>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resource: Option<ResourceConstraint>,
 }
 

--- a/libs/@local/graph/authorization/src/policies/store/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/store/mod.rs
@@ -109,6 +109,7 @@ pub struct PolicyCreationParams {
     pub effect: Effect,
     pub principal: Option<PrincipalConstraint>,
     pub actions: Vec<ActionName>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resource: Option<ResourceConstraint>,
 }
 
@@ -130,10 +131,18 @@ pub struct PolicyFilter {
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+#[serde(tag = "type", rename_all = "kebab-case", deny_unknown_fields)]
 pub enum PolicyUpdateOperation {
-    AddAction { action: ActionName },
-    RemoveAction { action: ActionName },
+    AddAction {
+        action: ActionName,
+    },
+    RemoveAction {
+        action: ActionName,
+    },
+    #[serde(rename_all = "camelCase")]
+    SetResourceConstraint {
+        resource_constraint: Option<ResourceConstraint>,
+    },
 }
 
 #[trait_variant::make(Send)]

--- a/libs/@local/graph/authorization/types/index.snap.d.ts
+++ b/libs/@local/graph/authorization/types/index.snap.d.ts
@@ -83,17 +83,20 @@ export interface PolicyCreationParams {
 	effect: Effect;
 	principal: (PrincipalConstraint | null);
 	actions: ActionName[];
-	resource: (ResourceConstraint | null);
+	resource?: ResourceConstraint;
 }
 export interface PolicyFilter {
 	principal?: PrincipalFilter;
 }
 export type PolicyUpdateOperation = {
-	type: "addAction"
+	type: "add-action"
 	action: ActionName
 } | {
-	type: "removeAction"
+	type: "remove-action"
 	action: ActionName
+} | {
+	type: "set-resource-constraint"
+	resourceConstraint: (ResourceConstraint | null)
 };
 export type PrincipalFilter = {
 	filter: "unconstrained"

--- a/libs/@local/graph/authorization/types/index.snap.d.ts
+++ b/libs/@local/graph/authorization/types/index.snap.d.ts
@@ -83,7 +83,7 @@ export interface PolicyCreationParams {
 	effect: Effect;
 	principal: (PrincipalConstraint | null);
 	actions: ActionName[];
-	resource?: ResourceConstraint;
+	resource: (ResourceConstraint | null);
 }
 export interface PolicyFilter {
 	principal?: PrincipalFilter;

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -922,9 +922,7 @@ where
                     principal_uuid: row.get(2),
                     principal_type: row.get(3),
                     actor_type: row.get(4),
-                    resource_constraint: row
-                        .get::<_, Option<Json<ResourceConstraint>>>(5)
-                        .map(|json| json.0),
+                    resource_constraint: row.get::<_, Json<Option<ResourceConstraint>>>(5).0,
                     actions: row.get(6),
                 }
                 .into_policy()
@@ -1214,6 +1212,18 @@ where
                             };
                             Report::new(error).change_context(policy_error)
                         })?;
+                }
+                PolicyUpdateOperation::SetResourceConstraint {
+                    resource_constraint,
+                } => {
+                    transaction
+                        .as_client()
+                        .execute(
+                            "UPDATE policy SET resource_constraint = $1 WHERE id = $2",
+                            &[&Json(resource_constraint), &policy_id],
+                        )
+                        .await
+                        .change_context(UpdatePolicyError::StoreError)?;
                 }
             }
         }

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -922,7 +922,9 @@ where
                     principal_uuid: row.get(2),
                     principal_type: row.get(3),
                     actor_type: row.get(4),
-                    resource_constraint: row.get::<_, Json<Option<ResourceConstraint>>>(5).0,
+                    resource_constraint: row
+                        .get::<_, Option<Json<ResourceConstraint>>>(5)
+                        .map(|json| json.0),
                     actions: row.get(6),
                 }
                 .into_policy()
@@ -1220,7 +1222,7 @@ where
                         .as_client()
                         .execute(
                             "UPDATE policy SET resource_constraint = $1 WHERE id = $2",
-                            &[&Json(resource_constraint), &policy_id],
+                            &[&resource_constraint.as_ref().map(Json), &policy_id],
                         )
                         .await
                         .change_context(UpdatePolicyError::StoreError)?;

--- a/tests/hash-backend-integration/src/tests/graph/authorization/policy.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/authorization/policy.test.ts
@@ -1,6 +1,7 @@
 import { deleteKratosIdentity } from "@apps/hash-api/src/auth/ory-kratos";
 import { ensureSystemGraphIsInitialized } from "@apps/hash-api/src/graph/ensure-system-graph-is-initialized";
 import type { User } from "@apps/hash-api/src/graph/knowledge/system-types/user";
+import { extractEntityUuidFromEntityId } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
 import {
   createPolicy,
@@ -13,11 +14,9 @@ import {
 import type {
   Policy,
   PolicyCreationParams,
-  ResourceConstraint,
 } from "@rust/hash-graph-authorization/types";
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { extractEntityUuidFromEntityId } from "@blockprotocol/type-system";
 import { resetGraph } from "../../test-server";
 import { createTestImpureGraphContext, createTestUser } from "../../util";
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Instead of creating an instantiation permission for every single entity type, it's useful to have one more broad permission. In order to create that policy, it's useful to allow updating an existing policy in place instead of removing the old one and creating a new one.