### PR TITLE
H-4543: HashQL: Implement deferred type checking

### DIFF
--- a/libs/@local/hashql/ast/src/lowering/special_form_expander/mod.rs
+++ b/libs/@local/hashql/ast/src/lowering/special_form_expander/mod.rs
@@ -6,7 +6,7 @@ use core::{
 };
 
 use hashql_core::{
-    collection::FastHashMap,
+    collection::{FastHashMap, fast_hash_map},
     heap::{self, Heap},
     span::SpanId,
     symbol::Ident,
@@ -472,7 +472,7 @@ impl<'heap> SpecialFormExpander<'heap> {
     ) -> Option<heap::Vec<'heap, GenericConstraint<'heap>>> {
         let mut constraints = self.heap.vec(Some(arguments.len()));
 
-        let mut seen = FastHashMap::default();
+        let mut seen = fast_hash_map(arguments.len());
 
         for argument in arguments {
             match argument {

--- a/libs/@local/hashql/core/src/collection.rs
+++ b/libs/@local/hashql/core/src/collection.rs
@@ -1,10 +1,44 @@
+use alloc::alloc::{Allocator, Global};
+
 use hashbrown::{HashMap, HashSet};
 
 pub type ConcurrentHashMap<K, V> = scc::HashMap<K, V, foldhash::fast::RandomState>;
 pub type ConcurrentHashSet<T> = scc::HashSet<T, foldhash::fast::RandomState>;
 
-pub type FastHashMap<K, V> = HashMap<K, V, foldhash::fast::RandomState>;
-pub type FastHashSet<T> = HashSet<T, foldhash::fast::RandomState>;
+pub type FastHashMap<K, V, A = Global> = HashMap<K, V, foldhash::fast::RandomState, A>;
+pub type FastHashSet<T, A = Global> = HashSet<T, foldhash::fast::RandomState, A>;
+
+#[inline]
+#[must_use]
+pub fn fast_hash_map<K, V>(capacity: usize) -> FastHashMap<K, V> {
+    FastHashMap::with_capacity_and_hasher(capacity, foldhash::fast::RandomState::default())
+}
+
+#[inline]
+#[must_use]
+pub fn fast_hash_map_in<K, V, A: Allocator>(capacity: usize, allocator: A) -> FastHashMap<K, V, A> {
+    FastHashMap::with_capacity_and_hasher_in(
+        capacity,
+        foldhash::fast::RandomState::default(),
+        allocator,
+    )
+}
+
+#[inline]
+#[must_use]
+pub fn fast_hash_set<T>(capacity: usize) -> FastHashSet<T> {
+    FastHashSet::with_capacity_and_hasher(capacity, foldhash::fast::RandomState::default())
+}
+
+#[inline]
+#[must_use]
+pub fn fast_hash_set_in<T, A: Allocator>(capacity: usize, allocator: A) -> FastHashSet<T, A> {
+    FastHashSet::with_capacity_and_hasher_in(
+        capacity,
+        foldhash::fast::RandomState::default(),
+        allocator,
+    )
+}
 
 pub type TinyVec<T> = smallvec::SmallVec<T, 4>;
 pub type SmallVec<T> = smallvec::SmallVec<T, 16>;

--- a/libs/@local/hashql/core/src/collection.rs
+++ b/libs/@local/hashql/core/src/collection.rs
@@ -1,4 +1,5 @@
-use alloc::alloc::{Allocator, Global};
+use alloc::alloc::Global;
+use core::alloc::Allocator;
 
 use hashbrown::{HashMap, HashSet};
 

--- a/libs/@local/hashql/core/src/type/environment/analysis.rs
+++ b/libs/@local/hashql/core/src/type/environment/analysis.rs
@@ -80,7 +80,7 @@ impl<'env, 'heap> AnalysisEnvironment<'env, 'heap> {
     }
 
     pub fn take_diagnostics(&mut self) -> Option<Diagnostics> {
-        core::mem::take(&mut self.diagnostics)
+        self.diagnostics.as_mut().map(core::mem::take)
     }
 
     pub fn fatal_diagnostics(&self) -> usize {

--- a/libs/@local/hashql/core/src/type/environment/context/diagnostics.rs
+++ b/libs/@local/hashql/core/src/type/environment/context/diagnostics.rs
@@ -22,6 +22,11 @@ impl Diagnostics {
         }
     }
 
+    pub fn clear(&mut self) {
+        self.inner.clear();
+        self.fatal = 0;
+    }
+
     /// Returns the number of fatal errors in the diagnostics collection.
     #[must_use]
     pub const fn fatal(&self) -> usize {

--- a/libs/@local/hashql/core/src/type/inference/solver/mod.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/mod.rs
@@ -290,7 +290,7 @@ impl<'env, 'heap> InferenceSolver<'env, 'heap> {
     ///
     /// Additionally, structural edges (from constraints like `_1 <: (name: _2)` and `_2 <: 1`)
     /// are included in this analysis, as they can also create equality relationships.
-    fn solve_anti_symmetry(&mut self) {
+    fn solve_anti_symmetry(&mut self) -> Graph {
         // We first create a graph of all the inference variables, that's then used to see if there
         // are any variables that can be equalized.
         // We can do this because our type lattice is a partially ordered set, this we can make use
@@ -331,6 +331,9 @@ impl<'env, 'heap> InferenceSolver<'env, 'heap> {
                 self.unification.unify(lhs, rhs);
             }
         }
+
+        graph.condense(&mut self.unification);
+        graph
     }
 
     /// Collects and organizes all constraints by variable.

--- a/libs/@local/hashql/core/src/type/inference/solver/tarjan.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/tarjan.rs
@@ -73,6 +73,8 @@ impl<'graph, A> Tarjan<'graph, A>
 where
     A: Allocator,
 {
+    const EXPECTED_SCC_RATIO: usize = 4;
+
     /// Creates a new Tarjan algorithm instance for the given graph in the given allocator.
     ///
     /// Initializes all the necessary data structures to track the state of the algorithm.
@@ -88,12 +90,18 @@ where
         Self {
             graph,
             next_discovery_index: 0,
-            node_stack: Vec::with_capacity_in(node_count / 4, allocator.clone()),
+            node_stack: Vec::with_capacity_in(
+                node_count / Self::EXPECTED_SCC_RATIO,
+                allocator.clone(),
+            ),
             on_node_stack: bitbox![0; node_count],
             discovery_time: alloc::vec::from_elem_in(0, node_count, allocator.clone()),
             visited: bitbox![0; node_count],
             lowlink: alloc::vec::from_elem_in(0, node_count, allocator.clone()),
-            strongly_connected_components: Vec::with_capacity_in(node_count / 4, allocator),
+            strongly_connected_components: Vec::with_capacity_in(
+                node_count / Self::EXPECTED_SCC_RATIO,
+                allocator,
+            ),
         }
     }
 

--- a/libs/@local/hashql/core/src/type/inference/solver/tarjan.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/tarjan.rs
@@ -1,3 +1,6 @@
+use alloc::alloc::Global;
+use core::alloc::Allocator;
+
 use bitvec::{bitbox, boxed::BitBox};
 use roaring::RoaringBitmap;
 
@@ -20,7 +23,7 @@ use super::graph::Graph;
 /// - Tarjan, R. E. (1972). Depth-first search and linear graph algorithms. SIAM Journal on
 ///   Computing, 1(2), 146-160.
 #[derive(Debug, Clone)]
-pub(crate) struct Tarjan<'graph> {
+pub(crate) struct Tarjan<'graph, A: Allocator = Global> {
     /// The directed graph
     graph: &'graph Graph,
 
@@ -29,7 +32,7 @@ pub(crate) struct Tarjan<'graph> {
     next_discovery_index: usize,
 
     /// Stack of nodes in the current DFS path, used to identify SCCs.
-    node_stack: Vec<usize>,
+    node_stack: Vec<usize, A>,
 
     /// Bit vector tracking which nodes are currently on the stack.
     /// Provides O(1) membership testing compared to searching the stack.
@@ -37,7 +40,7 @@ pub(crate) struct Tarjan<'graph> {
 
     /// Discovery time for each node, recording when it was first visited.
     /// `discovery_time[node]` = the discovery index of `node`.
-    discovery_time: Vec<usize>,
+    discovery_time: Vec<usize, A>,
 
     /// Bit vector tracking which nodes have been visited.
     /// Using a `BitBox` instead of a `Vec<bool>` or `Option<usize>` reduces memory usage from 8
@@ -46,38 +49,51 @@ pub(crate) struct Tarjan<'graph> {
 
     /// The lowest discovery time reachable from each node following tree edges and at most one
     /// back edge. This is key to identifying the root nodes of SCCs.
-    lowlink: Vec<usize>,
+    lowlink: Vec<usize, A>,
 
     /// Collection of all identified strongly connected components.
     /// Each component is represented as a `RoaringBitmap` where set bits indicate nodes in the
     /// component.
-    strongly_connected_components: Vec<RoaringBitmap>,
+    strongly_connected_components: Vec<RoaringBitmap, A>,
 }
 
+#[cfg(test)]
 impl<'graph> Tarjan<'graph> {
     /// Creates a new Tarjan algorithm instance for the given graph.
     ///
     /// Initializes all the necessary data structures to track the state of the algorithm.
     /// The capacities of vectors are pre-allocated based on the graph size to minimize
-    /// reallocations during execution.
-    ///
-    /// # Arguments
-    ///
-    /// * `graph` - The directed graph represented as a slice of `BitBoxe`s where each `BitBox`
-    ///   represents the outgoing edges from a node.
-    #[expect(clippy::integer_division, clippy::integer_division_remainder_used)]
+    /// re-allocations during execution.
     pub(crate) fn new(graph: &'graph Graph) -> Self {
+        Self::new_in(graph, alloc::alloc::Global)
+    }
+}
+
+impl<'graph, A> Tarjan<'graph, A>
+where
+    A: Allocator,
+{
+    /// Creates a new Tarjan algorithm instance for the given graph in the given allocator.
+    ///
+    /// Initializes all the necessary data structures to track the state of the algorithm.
+    /// The capacities of vectors are pre-allocated based on the graph size to minimize
+    /// re-allocations during execution.
+    #[expect(clippy::integer_division, clippy::integer_division_remainder_used)]
+    pub(crate) fn new_in(graph: &'graph Graph, allocator: A) -> Self
+    where
+        A: Clone,
+    {
         let node_count = graph.node_count();
 
-        Tarjan {
+        Self {
             graph,
             next_discovery_index: 0,
-            node_stack: Vec::with_capacity(node_count / 4),
+            node_stack: Vec::with_capacity_in(node_count / 4, allocator.clone()),
             on_node_stack: bitbox![0; node_count],
-            discovery_time: vec![0; node_count],
+            discovery_time: alloc::vec::from_elem_in(0, node_count, allocator.clone()),
             visited: bitbox![0; node_count],
-            lowlink: vec![0; node_count],
-            strongly_connected_components: Vec::with_capacity(node_count / 4),
+            lowlink: alloc::vec::from_elem_in(0, node_count, allocator.clone()),
+            strongly_connected_components: Vec::with_capacity_in(node_count / 4, allocator),
         }
     }
 
@@ -97,7 +113,7 @@ impl<'graph> Tarjan<'graph> {
     ///
     /// * Time: O(V + E) where V is the number of vertices and E is the number of edges
     /// * Space: O(V) additional space beyond the input graph
-    pub(crate) fn compute(mut self) -> Vec<RoaringBitmap> {
+    pub(crate) fn compute(mut self) -> Vec<RoaringBitmap, A> {
         let total_nodes = self.graph.node_count();
 
         for node in 0..total_nodes {

--- a/libs/@local/hashql/core/src/type/inference/solver/test.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/test.rs
@@ -1,3 +1,5 @@
+use bumpalo::Bump;
+
 use super::{Constraint, InferenceSolver, VariableConstraint};
 use crate::{
     collection::{FastHashMap, SmallVec},
@@ -206,7 +208,8 @@ fn apply_constraints() {
     solver.solve_anti_symmetry(&mut graph);
 
     let mut variables = FastHashMap::default();
-    solver.apply_constraints(&graph, &mut variables);
+    let bump = Bump::new();
+    solver.apply_constraints(&graph, &bump, &mut variables);
 
     assert_eq!(variables.len(), 1);
     let (_, (_, constraint)) = variables.iter().next().expect("Should have one constraint");
@@ -238,7 +241,8 @@ fn apply_constraints_equality() {
     solver.solve_anti_symmetry(&mut graph);
 
     let mut variables = FastHashMap::default();
-    solver.apply_constraints(&graph, &mut variables);
+    let bump = Bump::new();
+    solver.apply_constraints(&graph, &bump, &mut variables);
 
     assert_eq!(variables.len(), 1);
     let (_, (_, constraint)) = variables.iter().next().expect("Should have one constraint");
@@ -288,7 +292,8 @@ fn apply_constraints_with_unification() {
     solver.solve_anti_symmetry(&mut graph);
 
     let mut variables = FastHashMap::default();
-    solver.apply_constraints(&graph, &mut variables);
+    let bump = Bump::new();
+    solver.apply_constraints(&graph, &bump, &mut variables);
 
     // Only one entry since the variables are unified
     assert_eq!(variables.len(), 1);
@@ -548,9 +553,10 @@ fn redundant_constraints() {
     solver.solve_anti_symmetry(&mut graph);
 
     let mut variables = FastHashMap::default();
+    let bump = Bump::new();
 
     // Apply the constraints
-    solver.apply_constraints(&graph, &mut variables);
+    solver.apply_constraints(&graph, &bump, &mut variables);
 
     // Despite having duplicate constraints, there should be one entry with one equality
     assert_eq!(variables.len(), 1);
@@ -687,7 +693,8 @@ fn bounds_at_lattice_extremes() {
 
     // Apply the constraints
     let mut variables = FastHashMap::default();
-    solver.apply_constraints(&graph, &mut variables);
+    let bump = Bump::new();
+    solver.apply_constraints(&graph, &bump, &mut variables);
 
     assert_eq!(variables.len(), 1);
     let (_, (_, constraint)) = variables.iter().next().expect("Should have one constraint");

--- a/libs/@local/hashql/core/src/type/inference/solver/test.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/test.rs
@@ -334,7 +334,8 @@ fn solve_constraints() {
     let mut solver = InferenceSolver::new(&env, Unification::new(), vec![]);
 
     // Directly call solve_constraints
-    let substitutions = solver.solve_constraints(&applied_constraints);
+    let mut substitutions = FastHashMap::default();
+    solver.solve_constraints(&applied_constraints, &mut substitutions);
 
     // Verify the substitution
     assert_eq!(substitutions.len(), 1);
@@ -362,7 +363,8 @@ fn solve_constraints_with_equality() {
 
     let mut solver = InferenceSolver::new(&env, Unification::new(), vec![]);
 
-    let substitutions = solver.solve_constraints(&applied_constraints);
+    let mut substitutions = FastHashMap::default();
+    solver.solve_constraints(&applied_constraints, &mut substitutions);
 
     assert_eq!(substitutions.len(), 1);
     assert_eq!(substitutions[&var.kind], string);
@@ -391,7 +393,8 @@ fn solve_constraints_with_incompatible_bounds() {
     let mut solver = InferenceSolver::new(&env, Unification::new(), vec![]);
 
     // These bounds are incompatible, so a diagnostic should be created
-    solver.solve_constraints(&applied_constraints);
+    let mut substitutions = FastHashMap::default();
+    solver.solve_constraints(&applied_constraints, &mut substitutions);
 
     let diagnostics = solver.diagnostics.into_vec();
     assert_eq!(diagnostics.len(), 1);
@@ -424,7 +427,8 @@ fn solve_constraints_with_incompatible_equality() {
 
     let mut solver = InferenceSolver::new(&env, Unification::new(), vec![]);
 
-    solver.solve_constraints(&applied_constraints);
+    let mut substitutions = FastHashMap::default();
+    solver.solve_constraints(&applied_constraints, &mut substitutions);
 
     let diagnostics = solver.diagnostics.into_vec();
     assert_eq!(diagnostics.len(), 1);
@@ -458,7 +462,8 @@ fn solve_constraints_with_incompatible_upper_equal_constraint() {
     let mut solver = InferenceSolver::new(&env, Unification::new(), vec![]);
 
     // This should exercise lines 916-929
-    solver.solve_constraints(&applied_constraints);
+    let mut substitutions = FastHashMap::default();
+    solver.solve_constraints(&applied_constraints, &mut substitutions);
 
     // Should have a diagnostic for incompatible upper equal constraint
     let diagnostics = solver.diagnostics.into_vec();
@@ -693,7 +698,8 @@ fn bounds_at_lattice_extremes() {
     assert_eq!(constraint.upper, [unknown]);
 
     // These bounds should be compatible
-    let substitutions = solver.solve_constraints(&applied);
+    let mut substitutions = FastHashMap::default();
+    solver.solve_constraints(&applied, &mut substitutions);
     assert!(solver.diagnostics.is_empty());
 
     // The variable should be inferred to the lower bound (Never)

--- a/libs/@local/hashql/core/src/type/inference/solver/test.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/test.rs
@@ -127,7 +127,8 @@ fn solve_anti_symmetry() {
     solver.upsert_variables();
 
     let mut graph = Graph::new(&mut solver.unification);
-    solver.solve_anti_symmetry(&mut graph);
+    let bump = Bump::new();
+    solver.solve_anti_symmetry(&mut graph, &bump);
 
     assert!(solver.unification.is_unioned(kind1.kind, kind2.kind));
 }
@@ -164,7 +165,8 @@ fn solve_anti_symmetry_with_cycles() {
 
     solver.upsert_variables();
     let mut graph = Graph::new(&mut solver.unification);
-    solver.solve_anti_symmetry(&mut graph);
+    let bump = Bump::new();
+    solver.solve_anti_symmetry(&mut graph, &bump);
 
     // All three variables should be unified
     assert!(
@@ -205,7 +207,8 @@ fn apply_constraints() {
     solver.upsert_variables();
 
     let mut graph = Graph::new(&mut solver.unification);
-    solver.solve_anti_symmetry(&mut graph);
+    let bump = Bump::new();
+    solver.solve_anti_symmetry(&mut graph, &bump);
 
     let mut variables = FastHashMap::default();
     let bump = Bump::new();
@@ -238,10 +241,10 @@ fn apply_constraints_equality() {
     solver.upsert_variables();
 
     let mut graph = Graph::new(&mut solver.unification);
-    solver.solve_anti_symmetry(&mut graph);
+    let bump = Bump::new();
+    solver.solve_anti_symmetry(&mut graph, &bump);
 
     let mut variables = FastHashMap::default();
-    let bump = Bump::new();
     solver.apply_constraints(&graph, &bump, &mut variables);
 
     assert_eq!(variables.len(), 1);
@@ -289,10 +292,10 @@ fn apply_constraints_with_unification() {
     solver.upsert_variables();
 
     let mut graph = Graph::new(&mut solver.unification);
-    solver.solve_anti_symmetry(&mut graph);
+    let bump = Bump::new();
+    solver.solve_anti_symmetry(&mut graph, &bump);
 
     let mut variables = FastHashMap::default();
-    let bump = Bump::new();
     solver.apply_constraints(&graph, &bump, &mut variables);
 
     // Only one entry since the variables are unified
@@ -550,10 +553,10 @@ fn redundant_constraints() {
     solver.upsert_variables();
 
     let mut graph = Graph::new(&mut solver.unification);
-    solver.solve_anti_symmetry(&mut graph);
+    let bump = Bump::new();
+    solver.solve_anti_symmetry(&mut graph, &bump);
 
     let mut variables = FastHashMap::default();
-    let bump = Bump::new();
 
     // Apply the constraints
     solver.apply_constraints(&graph, &bump, &mut variables);
@@ -598,7 +601,8 @@ fn cyclic_ordering_constraints() {
     // Directly call the anti-symmetry solver
     solver.upsert_variables();
     let mut graph = Graph::new(&mut solver.unification);
-    solver.solve_anti_symmetry(&mut graph);
+    let bump = Bump::new();
+    solver.solve_anti_symmetry(&mut graph, &bump);
 
     // Verify all variables are unified
     assert!(
@@ -647,7 +651,8 @@ fn cyclic_structural_edges_constraints() {
     // Directly call the anti-symmetry solver
     solver.upsert_variables();
     let mut graph = Graph::new(&mut solver.unification);
-    solver.solve_anti_symmetry(&mut graph);
+    let bump = Bump::new();
+    solver.solve_anti_symmetry(&mut graph, &bump);
 
     // Verify all variables are unified
     assert!(
@@ -689,11 +694,11 @@ fn bounds_at_lattice_extremes() {
     solver.upsert_variables();
 
     let mut graph = Graph::new(&mut solver.unification);
-    solver.solve_anti_symmetry(&mut graph);
+    let bump = Bump::new();
+    solver.solve_anti_symmetry(&mut graph, &bump);
 
     // Apply the constraints
     let mut variables = FastHashMap::default();
-    let bump = Bump::new();
     solver.apply_constraints(&graph, &bump, &mut variables);
 
     assert_eq!(variables.len(), 1);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This is required for projections and indices (so field access and indexing into collections), currently these are unsupported. Primarily what we need to do to implement them is fix-point evaluation.

As this means that the hot code will be run more than once, the code now takes more care about it's allocation behaviour, trying to re-use as much space as possible (while still remaining ergonomic). This is done through a multiple systems:

The graph condense algorithm has been implemented in-place, meaning the graph is now persistent (this is required for iteration either way, as we need to keep track of any relationships)

Other operations use a temporary heap, this means the space required we only allocate once in the initial loop, each subsequent loop will re-use the same scratch space, as any space used will be either the same or slightly less/more. This gives us a nice balance that isn't too intrusive. I tried using a scratch space before where we just store the maps and re-use them but that turned out to be quite intrusive.

As we expect that this code is very hot, every easy initial optimisation counts.

There's still a lot of potential optimisation potential here that we could employ in the future, but that's a lot more intrusive and therefore slated until we have actual performance statistics. (Think memoization, incremental computation using salsa, etc. etc.)

> The in-place condense operation really nerd-sniped me^^

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
