### PR TITLE
H-4563: Support reading of closed entity types with metadata

### DIFF
--- a/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/metadata.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/metadata.rs
@@ -4,7 +4,7 @@ use utoipa::{
     openapi::{Ref, RefOr, Schema, schema},
 };
 
-use super::EntityType;
+use super::{ClosedEntityType, EntityType};
 use crate::ontology::{
     OntologyTemporalMetadata, OntologyTypeWithMetadata,
     id::OntologyTypeRecordId,
@@ -87,6 +87,8 @@ impl ToSchema<'static> for EntityTypeMetadata {
 }
 
 pub type EntityTypeWithMetadata = OntologyTypeWithMetadata<EntityType>;
+
+pub type ClosedEntityTypeWithMetadata = OntologyTypeWithMetadata<ClosedEntityType>;
 
 #[cfg(target_arch = "wasm32")]
 #[expect(dead_code, reason = "Used in the generated TypeScript types")]

--- a/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/mod.rs
@@ -4,7 +4,7 @@ pub mod schema;
 use uuid::Uuid;
 
 pub use self::{
-    metadata::{EntityTypeMetadata, EntityTypeWithMetadata},
+    metadata::{ClosedEntityTypeWithMetadata, EntityTypeMetadata, EntityTypeWithMetadata},
     schema::{ClosedEntityType, ClosedMultiEntityType, EntityType},
 };
 use super::id::{OntologyTypeUuid, VersionedUrl};

--- a/libs/@local/graph/authorization/src/policies/resource/entity_type.rs
+++ b/libs/@local/graph/authorization/src/policies/resource/entity_type.rs
@@ -48,7 +48,7 @@ impl fmt::Display for EntityTypeId {
 
 #[derive(Debug)]
 pub struct EntityTypeResource<'a> {
-    pub web_id: WebId,
+    pub web_id: Option<WebId>,
     pub id: Cow<'a, EntityTypeId>,
 }
 
@@ -67,7 +67,11 @@ impl EntityTypeResource<'_> {
                 ),
             ],
             HashSet::new(),
-            iter::once(self.web_id.to_euid()).collect(),
+            self.web_id
+                .as_ref()
+                .into_iter()
+                .map(WebId::to_euid)
+                .collect(),
             iter::empty(),
             Extensions::none(),
         )

--- a/libs/@local/graph/authorization/tests/policies/main.rs
+++ b/libs/@local/graph/authorization/tests/policies/main.rs
@@ -240,7 +240,7 @@ fn instantiate() -> Result<(), Box<dyn Error>> {
     let system = TestSystem::generate(&mut policy_store, &mut context)?;
 
     let machine_type = EntityTypeResource {
-        web_id: system.web.id,
+        web_id: Some(system.web.id),
         id: Cow::Owned(EntityTypeId::new(VersionedUrl::from_str(
             "https://hash.ai/@h/types/entity-type/machine/v/2",
         )?)),
@@ -248,7 +248,7 @@ fn instantiate() -> Result<(), Box<dyn Error>> {
     context.add_entity_type(&machine_type);
 
     let document_type = EntityTypeResource {
-        web_id: system.web.id,
+        web_id: Some(system.web.id),
         id: Cow::Owned(EntityTypeId::new(VersionedUrl::from_str(
             "https://hash.ai/@h/types/entity-type/document/v/1",
         )?)),
@@ -343,7 +343,7 @@ fn user_web_permissions() -> Result<(), Box<dyn Error>> {
     let user = TestUser::generate(&mut policy_store, &mut context, "alice")?;
 
     let machine_type = EntityTypeResource {
-        web_id: system.web.id,
+        web_id: Some(system.web.id),
         id: Cow::Owned(EntityTypeId::new(VersionedUrl::from_str(
             "https://hash.ai/@h/types/entity-type/machine/v/2",
         )?)),
@@ -351,7 +351,7 @@ fn user_web_permissions() -> Result<(), Box<dyn Error>> {
     context.add_entity_type(&machine_type);
 
     let document_type = EntityTypeResource {
-        web_id: system.web.id,
+        web_id: Some(system.web.id),
         id: Cow::Owned(EntityTypeId::new(VersionedUrl::from_str(
             "https://hash.ai/@h/types/entity-type/document/v/1",
         )?)),
@@ -359,7 +359,7 @@ fn user_web_permissions() -> Result<(), Box<dyn Error>> {
     context.add_entity_type(&document_type);
 
     let web_type = EntityTypeResource {
-        web_id: user.web.id,
+        web_id: Some(user.web.id),
         id: Cow::Owned(EntityTypeId::new(VersionedUrl::from_str(
             "https://hash.ai/@alice/types/entity-type/custom/v/1",
         )?)),
@@ -528,7 +528,7 @@ fn org_web_permissions() -> Result<(), Box<dyn Error>> {
     )?;
 
     let web_type = EntityTypeResource {
-        web_id: org_web.id,
+        web_id: Some(org_web.id),
         id: Cow::Owned(EntityTypeId::new(VersionedUrl::from_str(
             "https://hash.ai/@alice/types/entity-type/custom/v/1",
         )?)),

--- a/libs/@local/graph/postgres-store/src/permissions/mod.rs
+++ b/libs/@local/graph/postgres-store/src/permissions/mod.rs
@@ -6,7 +6,7 @@ use futures::TryStreamExt as _;
 use hash_graph_authorization::{
     AuthorizationApi,
     policies::{
-        Context, ContextBuilder,
+        ContextBuilder,
         action::ActionName,
         store::{RoleAssignmentStatus, RoleUnassignmentStatus},
     },
@@ -1260,9 +1260,8 @@ where
     pub async fn build_principal_context(
         &self,
         actor_id: ActorId,
-    ) -> Result<Context, Report<PrincipalError>> {
-        let mut context_builder = ContextBuilder::default();
-
+        context_builder: &mut ContextBuilder,
+    ) -> Result<(), Report<PrincipalError>> {
         let actor = self
             .get_actor(actor_id)
             .await?
@@ -1344,8 +1343,6 @@ where
                 context_builder.add_actor_group(&actor_group);
             });
 
-        context_builder
-            .build()
-            .change_context(PrincipalError::ContextBuilderError)
+        Ok(())
     }
 }

--- a/libs/@local/graph/store/src/entity/store.rs
+++ b/libs/@local/graph/store/src/entity/store.rs
@@ -390,7 +390,7 @@ pub trait EntityStore {
         params: CreateEntityParams<R>,
     ) -> impl Future<Output = Result<Entity, Report<InsertionError>>> + Send
     where
-        R: IntoIterator<Item = EntityRelationAndSubject> + Send,
+        R: IntoIterator<Item = EntityRelationAndSubject> + Send + Sync,
     {
         self.create_entities(actor_id, vec![params])
             .map_ok(|mut entities| {
@@ -407,7 +407,7 @@ pub trait EntityStore {
         params: Vec<CreateEntityParams<R>>,
     ) -> impl Future<Output = Result<Vec<Entity>, Report<InsertionError>>> + Send
     where
-        R: IntoIterator<Item = EntityRelationAndSubject> + Send;
+        R: IntoIterator<Item = EntityRelationAndSubject> + Send + Sync;
 
     /// Validates an [`Entity`].
     ///

--- a/libs/@local/graph/type-fetcher/src/store.rs
+++ b/libs/@local/graph/type-fetcher/src/store.rs
@@ -1465,7 +1465,7 @@ where
         params: Vec<CreateEntityParams<R>>,
     ) -> Result<Vec<Entity>, Report<InsertionError>>
     where
-        R: IntoIterator<Item = EntityRelationAndSubject> + Send,
+        R: IntoIterator<Item = EntityRelationAndSubject> + Send + Sync,
     {
         let type_ids = params
             .iter()

--- a/tests/graph/integration/postgres/lib.rs
+++ b/tests/graph/integration/postgres/lib.rs
@@ -762,7 +762,7 @@ where
         params: Vec<CreateEntityParams<R>>,
     ) -> Result<Vec<Entity>, Report<InsertionError>>
     where
-        R: IntoIterator<Item = EntityRelationAndSubject> + Send,
+        R: IntoIterator<Item = EntityRelationAndSubject> + Send + Sync,
     {
         self.store.create_entities(actor_id, params).await
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We can read closed entity types and entity types with metadata, but not the combination of it which is required to fill the policy context when instantiating entities.

## 🔍 What does this change?

- Define a `ClosedEntityTypeWithMetadata`
- Also return the metadata alongside the closed entity types in queryies
- Extend the `StoreCache` to support `ClosedEntityTypeWithMetadata`
- drive-by: Make the web-ID in `EntityTypeResource` optional (for remote types)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph