### PR TITLE
H-4565: Expose querying for specific permissions

### DIFF
--- a/libs/@local/graph/api/openapi/openapi.json
+++ b/libs/@local/graph/api/openapi/openapi.json
@@ -2611,6 +2611,57 @@
         }
       }
     },
+    "/entity-types/permissions/instantiate": {
+      "post": {
+        "tags": [
+          "Graph",
+          "EntityType"
+        ],
+        "operationId": "can_instantiate_entity_types",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ActorEntityUuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/VersionedUrl"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A list with the same indices as the input which determines which entity type can be instantiated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Store error occurred"
+          }
+        }
+      }
+    },
     "/entity-types/query": {
       "post": {
         "tags": [

--- a/libs/@local/graph/authorization/src/policies/resource/entity_type.rs
+++ b/libs/@local/graph/authorization/src/policies/resource/entity_type.rs
@@ -23,13 +23,21 @@ use crate::policies::cedar::{
 #[repr(transparent)]
 pub struct EntityTypeId(#[cfg_attr(feature = "codegen", specta(type = String))] VersionedUrl);
 
-#[expect(
-    unsafe_code,
-    reason = "There is no way to transmute from `&VersionedUrl` and `&EntityTypeId` without \
-              `unsafe`"
-)]
 impl From<&VersionedUrl> for &EntityTypeId {
+    #[expect(
+        unsafe_code,
+        reason = "There is no way to transmute from `&VersionedUrl` to `&EntityTypeId` without \
+                  `unsafe`"
+    )]
     fn from(url: &VersionedUrl) -> Self {
+        const {
+            // We cannot compile-check that `VersionedUrl` is the inner type of `EntityTypeId`,
+            // which in theory should be possible with `Facet`, but having a few checks
+            // here is better than none.
+            assert!(size_of::<VersionedUrl>() == size_of::<EntityTypeId>());
+            assert!(align_of::<VersionedUrl>() == align_of::<EntityTypeId>());
+        }
+
         // SAFETY: Self is `repr(transparent)`
         unsafe { &*ptr::from_ref::<VersionedUrl>(url).cast::<EntityTypeId>() }
     }

--- a/libs/@local/graph/postgres-store/src/permissions/mod.rs
+++ b/libs/@local/graph/postgres-store/src/permissions/mod.rs
@@ -14,6 +14,7 @@ use hash_graph_authorization::{
     },
 };
 use hash_graph_store::error::QueryError;
+use hash_status::StatusCode;
 use tokio_postgres::{GenericClient as _, error::SqlState};
 use type_system::{
     ontology::VersionedUrl,
@@ -1390,7 +1391,8 @@ where
                 )))
             })
             .try_collect_reports()
-            .change_context(QueryError)?;
+            .change_context(QueryError)
+            .attach(StatusCode::NotFound)?;
 
         self.as_client()
             .query(

--- a/libs/@local/graph/postgres-store/src/permissions/mod.rs
+++ b/libs/@local/graph/postgres-store/src/permissions/mod.rs
@@ -2,7 +2,7 @@ use alloc::borrow::Cow;
 use core::str::FromStr as _;
 use std::collections::{HashMap, HashSet};
 
-use error_stack::{Report, ResultExt as _, TryReportIteratorExt as _, ensure};
+use error_stack::{Report, ResultExt as _, ensure};
 use futures::TryStreamExt as _;
 use hash_graph_authorization::{
     AuthorizationApi,
@@ -1354,17 +1354,24 @@ where
 
     /// Builds a context used to evaluate policies for a set of entity types.
     ///
+    /// Returns the set of indices of the entity types that were not found in the database.
+    ///
     /// # Errors
     ///
     /// - [`QueryError`] if a database error occurs
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "The index is 1-based and is always less than or equal to the length of the array"
+    )]
     pub async fn build_entity_type_context(
         &self,
         entity_type_ids: &[VersionedUrl],
         context_builder: &mut ContextBuilder,
-    ) -> Result<(), Report<QueryError>> {
-        let () = self
+    ) -> Result<HashSet<usize>, Report<QueryError>> {
+        let not_found = self
             .as_client()
-            .query(
+            .query_raw(
                 "
                     SELECT input.idx
                     FROM unnest($1::text[]) WITH ORDINALITY AS input(url, idx)
@@ -1372,24 +1379,13 @@ where
                         SELECT 1 FROM entity_types
                         WHERE entity_types.schema ->> '$id' = input.url
                     )",
-                &[&entity_type_ids],
+                &[entity_type_ids],
             )
             .await
             .change_context(QueryError)?
-            .into_iter()
-            .map(|row| {
-                #[expect(
-                    clippy::cast_possible_truncation,
-                    clippy::cast_sign_loss,
-                    reason = "The index is 1-based and is always less than or equal to the length \
-                              of the array"
-                )]
-                Err(Report::new(QueryError).attach_printable(format!(
-                    "Entity type not found: `{}`",
-                    entity_type_ids[row.get::<_, i64>(0) as usize - 1]
-                )))
-            })
-            .try_collect_reports()
+            .map_ok(|row| row.get::<_, i64>(0) as usize - 1)
+            .try_collect()
+            .await
             .change_context(QueryError)?;
 
         self.as_client()
@@ -1440,6 +1436,6 @@ where
                 });
             });
 
-        Ok(())
+        Ok(not_found)
     }
 }

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
@@ -1754,8 +1754,7 @@ where
         self.build_principal_context(actor, &mut policy_context_builder)
             .await
             .change_context(QueryError)?;
-        let unknown_entity_types = self
-            .build_entity_type_context(entity_type_ids, &mut policy_context_builder)
+        self.build_entity_type_context(entity_type_ids, &mut policy_context_builder)
             .await
             .change_context(QueryError)?;
 
@@ -1763,26 +1762,21 @@ where
 
         entity_type_ids
             .iter()
-            .enumerate()
-            .map(|(index, entity_type_id)| {
-                Ok(if unknown_entity_types.contains(&index) {
-                    false
-                } else {
-                    let authorized = policy_set
-                        .evaluate(
-                            &Request {
-                                actor,
-                                action: ActionName::Instantiate,
-                                resource: Some(&PartialResourceId::EntityType(Some(
-                                    Cow::Borrowed(entity_type_id.into()),
-                                ))),
-                                context: RequestContext::default(),
-                            },
-                            &policy_context,
-                        )
-                        .change_context(QueryError)?;
-
-                    match authorized {
+            .map(|entity_type_id| {
+                policy_set
+                    .evaluate(
+                        &Request {
+                            actor,
+                            action: ActionName::Instantiate,
+                            resource: Some(&PartialResourceId::EntityType(Some(Cow::Borrowed(
+                                entity_type_id.into(),
+                            )))),
+                            context: RequestContext::default(),
+                        },
+                        &policy_context,
+                    )
+                    .change_context(QueryError)
+                    .map(|authorized| match authorized {
                         Authorized::Always => true,
                         Authorized::Never => false,
                         Authorized::Partial(partial) => {
@@ -1793,8 +1787,7 @@ where
                             );
                             false
                         }
-                    }
-                })
+                    })
             })
             .collect()
     }

--- a/libs/@local/graph/sdk/typescript/src/entity-type.ts
+++ b/libs/@local/graph/sdk/typescript/src/entity-type.ts
@@ -1,0 +1,25 @@
+import type { VersionedUrl } from "@blockprotocol/type-system";
+import type { GraphApi } from "@local/hash-graph-client";
+
+import type { AuthenticationContext } from "./authentication-context.js";
+
+/**
+ * Returns whether the user can instantiate the given entity types.
+ *
+ * The returned array has the same length and order as the input array of `entityTypeIds`.
+ * Each boolean value at index `i` indicates whether the user is permitted to instantiate the
+ * entity type at `entityTypeIds[i]`.
+ */
+export const canInstantiateEntityTypes = <
+  T extends readonly [VersionedUrl, ...VersionedUrl[]],
+>(
+  graphAPI: GraphApi,
+  authentication: AuthenticationContext,
+  entityTypeIds: T,
+): Promise<{ [K in keyof T]: boolean }> =>
+  graphAPI
+    .canInstantiateEntityTypes(
+      authentication.actorId,
+      entityTypeIds as unknown as VersionedUrl[],
+    )
+    .then(({ data: permitted }) => permitted as { [K in keyof T]: boolean });

--- a/libs/@local/graph/store/src/entity_type/store.rs
+++ b/libs/@local/graph/store/src/entity_type/store.rs
@@ -434,4 +434,15 @@ pub trait EntityTypeStore {
     fn reindex_entity_type_cache(
         &mut self,
     ) -> impl Future<Output = Result<(), Report<UpdateError>>> + Send;
+
+    /// Checks if the given entity types can be instantiated by the actor.
+    ///
+    /// # Errors
+    ///
+    /// - If reading the entity types fails.
+    fn can_instantiate_entity_types(
+        &self,
+        authenticated_user: ActorEntityUuid,
+        entity_type_ids: &[VersionedUrl],
+    ) -> impl Future<Output = Result<Vec<bool>, Report<QueryError>>> + Send;
 }

--- a/libs/@local/graph/type-fetcher/src/store.rs
+++ b/libs/@local/graph/type-fetcher/src/store.rs
@@ -1452,6 +1452,16 @@ where
     async fn reindex_entity_type_cache(&mut self) -> Result<(), Report<UpdateError>> {
         self.store.reindex_entity_type_cache().await
     }
+
+    async fn can_instantiate_entity_types(
+        &self,
+        authenticated_user: ActorEntityUuid,
+        entity_type_ids: &[VersionedUrl],
+    ) -> Result<Vec<bool>, Report<QueryError>> {
+        self.store
+            .can_instantiate_entity_types(authenticated_user, entity_type_ids)
+            .await
+    }
 }
 
 impl<S, A> EntityStore for FetchingStore<S, A>

--- a/tests/graph/integration/postgres/lib.rs
+++ b/tests/graph/integration/postgres/lib.rs
@@ -750,6 +750,16 @@ impl<A: AuthorizationApi> EntityTypeStore for DatabaseApi<'_, A> {
     async fn reindex_entity_type_cache(&mut self) -> Result<(), Report<UpdateError>> {
         self.store.reindex_entity_type_cache().await
     }
+
+    async fn can_instantiate_entity_types(
+        &self,
+        authenticated_user: ActorEntityUuid,
+        entity_type_ids: &[VersionedUrl],
+    ) -> Result<Vec<bool>, Report<QueryError>> {
+        self.store
+            .can_instantiate_entity_types(authenticated_user, entity_type_ids)
+            .await
+    }
 }
 
 impl<A> EntityStore for DatabaseApi<'_, A>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In some locations, we need to check for a specific permission outside of the graph. For this, we need a function exposed in the Node API.

## 🔍 What does this change?

Implement the logic to query for the instantiation permission. Other permissions can easily be added in the future and this function can be parameterized.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change
- [x] are in a state where docs changes are not _yet_ re

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph