### PR TITLE
H-4496, H-4501: Process editor: add save bar; link input & output places in sub-processes

### DIFF
--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/022-add-petri-nets.dev.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/022-add-petri-nets.dev.migration.ts
@@ -47,6 +47,34 @@ const migrate: MigrationFunction = async ({
     },
   );
 
+  const inputPlaceIdPropertyType = await createSystemPropertyTypeIfNotExists(
+    context,
+    authentication,
+    {
+      propertyTypeDefinition: {
+        title: "Input Place ID",
+        description: "An identifier for an input place.",
+        possibleValues: [{ primitiveDataType: "text" }],
+      },
+      migrationState,
+      webShortname: "h",
+    },
+  );
+
+  const outputPlaceIdPropertyType = await createSystemPropertyTypeIfNotExists(
+    context,
+    authentication,
+    {
+      propertyTypeDefinition: {
+        title: "Output Place ID",
+        description: "An identifier for an output place.",
+        possibleValues: [{ primitiveDataType: "text" }],
+      },
+      migrationState,
+      webShortname: "h",
+    },
+  );
+
   const subProcessOfLinkEntityType = await createSystemEntityTypeIfNotExists(
     context,
     authentication,
@@ -62,6 +90,16 @@ const migrate: MigrationFunction = async ({
           {
             propertyType: transitionIdPropertyType,
             required: true,
+          },
+          {
+            propertyType: inputPlaceIdPropertyType,
+            required: true,
+            array: true,
+          },
+          {
+            propertyType: outputPlaceIdPropertyType,
+            required: true,
+            array: true,
           },
         ],
       },

--- a/apps/hash-frontend/src/pages/process.page/process-editor.tsx
+++ b/apps/hash-frontend/src/pages/process.page/process-editor.tsx
@@ -1,5 +1,6 @@
 import "reactflow/dist/style.css";
 
+import { generateUuid } from "@local/hash-isomorphic-utils/generate-uuid";
 import { Box, Stack } from "@mui/material";
 import type { DragEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -64,9 +65,7 @@ const ProcessEditorContent = () => {
 
   const {
     arcs,
-    entityId,
     nodes,
-    persistToGraph,
     setArcs,
     setEntityId,
     setNodes,
@@ -75,7 +74,6 @@ const ProcessEditorContent = () => {
     setTitle,
     setUserEditable,
     tokenTypes,
-    userEditable,
   } = useEditorContext();
 
   const [selectedPlaceId, setSelectedPlaceId] = useState<string | null>(null);
@@ -188,9 +186,10 @@ const ProcessEditorContent = () => {
       });
 
       const newNode: NodeType = {
-        id: `${nodeType}_${nodes.length}`,
+        id: `${nodeType}_${generateUuid()}`,
         type: nodeType,
         position,
+        ...nodeDimensions[nodeType],
         data: {
           label: `${nodeType} ${nodes.length + 1}`,
           ...(nodeType === "place"

--- a/apps/hash-frontend/src/pages/process.page/process-editor.tsx
+++ b/apps/hash-frontend/src/pages/process.page/process-editor.tsx
@@ -31,6 +31,7 @@ import { exampleCPN } from "./process-editor/examples";
 import { LogPane } from "./process-editor/log-pane";
 import { PlaceEditor } from "./process-editor/place-editor";
 import { PlaceNode } from "./process-editor/place-node";
+import { ProcessEditBar } from "./process-editor/process-edit-bar";
 import { Sidebar } from "./process-editor/sidebar";
 import {
   SimulationContextProvider,
@@ -473,6 +474,7 @@ const ProcessEditorContent = () => {
 
   return (
     <Stack sx={{ height: "100%" }}>
+      <ProcessEditBar />
       <TitleAndNetSelect />
 
       <Stack direction="row" sx={{ flex: 1 }}>
@@ -519,9 +521,6 @@ const ProcessEditorContent = () => {
             </Button>
             <Button onClick={handleResetAll} size="xs" variant="danger">
               New
-            </Button>
-            <Button onClick={persistToGraph} size="xs" variant="primary">
-              {entityId && userEditable ? "Update" : "Create"}
             </Button>
           </Stack>
 

--- a/apps/hash-frontend/src/pages/process.page/process-editor/editor-context/sub-process-nodes.ts
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/editor-context/sub-process-nodes.ts
@@ -1,0 +1,190 @@
+import { generateUuid } from "@local/hash-isomorphic-utils/generate-uuid";
+
+import { nodeDimensions } from "../styling";
+import type { NodeType, PersistedNet } from "../types";
+
+/**
+ * Updates the input and output place nodes in a sub-process net to include new input and output places from the parent transition,
+ * and remove links to input and output places in the parent which are no longer selected as relevant to the sub-process.
+ *
+ * New input places are positioned above the leftmost node(s), and new output places above the rightmost node(s).
+ *
+ * @param subProcessNet - The sub-process net to update
+ * @param inputPlaceLabelById - A map of relevant input place IDs to their labels
+ * @param outputPlaceLabelById - A map of relevant output place IDs to their labels
+ *
+ * @returns The new sub-process nodes, or null if no changes were made
+ */
+export const updateSubProcessDefinitionForParentPlaces = ({
+  subProcessNet,
+  inputPlaceLabelById,
+  outputPlaceLabelById,
+}: {
+  subProcessNet: PersistedNet;
+  inputPlaceLabelById: Record<string, string>;
+  outputPlaceLabelById: Record<string, string>;
+}): NodeType[] | null => {
+  const { nodes } = subProcessNet.definition;
+
+  /**
+   * We want to find the leftmost and rightmost places, and the minimum y-coordinates for the leftmost and rightmost places,
+   * so that we can position the new input and output places above the leftmost and rightmost places, respectively.
+   */
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minYLeft = Infinity;
+  let minYRight = Infinity;
+
+  const newNodes: NodeType[] = [];
+
+  const inputPlaceIds = Object.keys(inputPlaceLabelById);
+  const outputPlaceIds = Object.keys(outputPlaceLabelById);
+
+  const inputPlaceIdsToAdd = new Set<string>(inputPlaceIds);
+  const outputPlaceIdsToAdd = new Set<string>(outputPlaceIds);
+
+  let nodesUnlinkedCount = 0;
+
+  for (const node of nodes) {
+    /**
+     * Register the node's position so that we can position any new input and output places correctly later.
+     */
+    const x = node.position.x;
+    const y = node.position.y;
+
+    if (x < minX) {
+      minX = x;
+      minYLeft = y;
+    } else if (x === minX) {
+      minYLeft = Math.min(minYLeft, y);
+    }
+
+    if (x > maxX) {
+      maxX = x;
+      minYRight = y;
+    } else if (x === maxX) {
+      minYRight = Math.min(minYRight, y);
+    }
+
+    if (
+      node.data.type === "place" &&
+      node.data.parentProcessNode &&
+      ((node.data.parentProcessNode.type === "input" &&
+        !inputPlaceIds.includes(node.data.parentProcessNode.id)) ||
+        (node.data.parentProcessNode.type === "output" &&
+          !outputPlaceIds.includes(node.data.parentProcessNode.id)))
+    ) {
+      /**
+       * This is an input or output place node from the parent which is no longer relevant to the sub-process,
+       * so we remove the link to the parent process node.
+       */
+      const { parentProcessNode: _, ...restData } = node.data;
+
+      newNodes.push({
+        ...node,
+        data: restData,
+      });
+
+      nodesUnlinkedCount++;
+
+      continue;
+    }
+
+    if (node.data.type === "place" && node.data.parentProcessNode) {
+      /**
+       * Register the fact that we've seen a linked input or output place, so that it doesn't need adding as a new node.
+       */
+      if (node.data.parentProcessNode.type === "input") {
+        inputPlaceIdsToAdd.delete(node.data.parentProcessNode.id);
+      } else {
+        outputPlaceIdsToAdd.delete(node.data.parentProcessNode.id);
+      }
+    }
+
+    newNodes.push(node);
+  }
+
+  if (
+    inputPlaceIdsToAdd.size === 0 &&
+    outputPlaceIdsToAdd.size === 0 &&
+    nodesUnlinkedCount === 0
+  ) {
+    /**
+     * No changes were necessary to the sub-process, so we return null.
+     */
+    return null;
+  }
+
+  if (minX === Infinity) {
+    minX = 0;
+  }
+  if (maxX === -Infinity) {
+    maxX = 0;
+  }
+  if (minYLeft === Infinity) {
+    minYLeft = 0;
+  }
+  if (minYRight === Infinity) {
+    minYRight = 0;
+  }
+
+  for (const [index, inputPlaceId] of [...inputPlaceIdsToAdd].entries()) {
+    const id = generateUuid();
+
+    const label = inputPlaceLabelById[inputPlaceId];
+
+    if (!label) {
+      throw new Error(`Input place label not found for id ${inputPlaceId}`);
+    }
+
+    newNodes.push({
+      id,
+      type: "place",
+      position: {
+        x: minX,
+        y: minYLeft - (nodeDimensions.place.height + 80) * (index + 1), // stack above leftmost
+      },
+      ...nodeDimensions.place,
+      data: {
+        label,
+        tokenCounts: {},
+        type: "place",
+        parentProcessNode: {
+          id: inputPlaceId,
+          type: "input",
+        },
+      },
+    });
+  }
+
+  for (const [index, outputPlaceId] of [...outputPlaceIdsToAdd].entries()) {
+    const id = generateUuid();
+
+    const label = outputPlaceLabelById[outputPlaceId];
+
+    if (!label) {
+      throw new Error(`Output place label not found for id ${outputPlaceId}`);
+    }
+
+    newNodes.push({
+      id,
+      type: "place",
+      position: {
+        x: maxX,
+        y: minYRight - (nodeDimensions.place.height + 80) * (index + 1), // stack above rightmost
+      },
+      ...nodeDimensions.place,
+      data: {
+        label,
+        tokenCounts: {},
+        type: "place",
+        parentProcessNode: {
+          id: outputPlaceId,
+          type: "output",
+        },
+      },
+    });
+  }
+
+  return newNodes;
+};

--- a/apps/hash-frontend/src/pages/process.page/process-editor/editor-context/use-persisted-nets.ts
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/editor-context/use-persisted-nets.ts
@@ -96,6 +96,14 @@ export const getPersistedNetsFromSubgraph = (
             ],
           subProcessEntityId: subProcess.entityId,
           linkEntityId: subProcessOfLink.entityId,
+          inputPlaceIds:
+            subProcessOfLink.properties[
+              "https://hash.ai/@h/types/property-type/input-place-id/"
+            ],
+          outputPlaceIds:
+            subProcessOfLink.properties[
+              "https://hash.ai/@h/types/property-type/output-place-id/"
+            ],
         },
       );
     }

--- a/apps/hash-frontend/src/pages/process.page/process-editor/persisted-net-selector.tsx
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/persisted-net-selector.tsx
@@ -1,7 +1,7 @@
 import type { EntityId } from "@blockprotocol/type-system";
 import { Autocomplete, CaretDownSolidIcon } from "@hashintel/design-system";
 import { outlinedInputClasses } from "@mui/material";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 
 import { MenuItem } from "../../../shared/ui";
 import type { PersistedNet } from "./types";
@@ -10,16 +10,20 @@ export const PersistedNetSelector = ({
   disabledOptions,
   onSelect,
   options,
+  placeholder,
   value,
 }: {
   disabledOptions?: EntityId[];
   onSelect: (option: PersistedNet) => void;
   options: PersistedNet[];
+  placeholder?: string;
   value: EntityId | null;
 }) => {
   const selectedOption = useMemo(() => {
     return options.find((option) => option.entityId === value);
   }, [options, value]);
+
+  const inputRef = useRef<HTMLInputElement>(null);
 
   if (options.length === 0) {
     return null;
@@ -47,7 +51,7 @@ export const PersistedNetSelector = ({
       inputHeight={40}
       inputProps={{
         endAdornment: <CaretDownSolidIcon sx={{ fontSize: 14 }} />,
-        placeholder: "Select a net to load",
+        placeholder: placeholder ?? "Select a net to load",
         sx: () => ({
           [`&.${outlinedInputClasses.root}`]: {
             py: 0.3,
@@ -59,6 +63,7 @@ export const PersistedNetSelector = ({
           },
         }),
       }}
+      inputRef={inputRef}
       isOptionEqualToValue={(option, selectedValue) =>
         option?.entityId === selectedValue?.entityId
       }
@@ -76,6 +81,7 @@ export const PersistedNetSelector = ({
         }
 
         onSelect(option);
+        inputRef.current?.blur();
       }}
       options={options}
       sx={{ maxWidth: 300 }}

--- a/apps/hash-frontend/src/pages/process.page/process-editor/place-node.tsx
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/place-node.tsx
@@ -1,4 +1,5 @@
-import { Box } from "@mui/material";
+import { IconDiagramRegular } from "@hashintel/design-system";
+import { Box, Tooltip } from "@mui/material";
 import { Handle, type NodeProps, Position } from "reactflow";
 
 import { useEditorContext } from "./editor-context";
@@ -29,8 +30,24 @@ export const PlaceNode = ({ data, isConnectable }: NodeProps) => {
     ([_, count]) => count > 0,
   );
 
+  const { parentProcessNode } = data;
+
   return (
-    <div>
+    <Box sx={{ position: "relative" }}>
+      {parentProcessNode && (
+        <Tooltip title="Place from parent process">
+          <IconDiagramRegular
+            sx={{
+              fill: ({ palette }) => palette.gray[60],
+              position: "absolute",
+              top: 10,
+              left: nodeDimensions.place.width / 2 - 8,
+              fontSize: 16,
+              zIndex: 3,
+            }}
+          />
+        </Tooltip>
+      )}
       <Handle
         type="target"
         position={Position.Left}
@@ -75,6 +92,6 @@ export const PlaceNode = ({ data, isConnectable }: NodeProps) => {
         isConnectable={isConnectable}
         style={handleStyling}
       />
-    </div>
+    </Box>
   );
 };

--- a/apps/hash-frontend/src/pages/process.page/process-editor/process-edit-bar.tsx
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/process-edit-bar.tsx
@@ -1,0 +1,47 @@
+import { PencilSimpleLine } from "../../../shared/icons/svg";
+import {
+  EditBarCollapse,
+  EditBarContainer,
+  EditBarContents,
+  useFreezeScrollWhileTransitioning,
+} from "../../shared/shared/edit-bar-contents";
+import { useEditorContext } from "./editor-context";
+
+export const ProcessEditBar = () => {
+  const ref = useFreezeScrollWhileTransitioning();
+
+  const {
+    discardChanges,
+    entityId,
+    isDirty,
+    persistPending,
+    persistToGraph,
+    userEditable,
+  } = useEditorContext();
+
+  return (
+    <EditBarCollapse in={isDirty && !persistPending} ref={ref}>
+      <EditBarContainer hasErrors={false}>
+        <EditBarContents
+          hideConfirm={false}
+          hideDiscard={!discardChanges}
+          icon={<PencilSimpleLine />}
+          title={entityId ? "Currently editing – " : "New process –"}
+          label={
+            userEditable
+              ? "changes not yet saved to your web"
+              : "you can't edit the original, but can create a copy"
+          }
+          discardButtonProps={{
+            children: "Discard changes",
+            onClick: discardChanges ?? undefined,
+          }}
+          confirmButtonProps={{
+            children: entityId ? "Update" : "Create",
+            onClick: persistToGraph,
+          }}
+        />
+      </EditBarContainer>
+    </EditBarCollapse>
+  );
+};

--- a/apps/hash-frontend/src/pages/process.page/process-editor/title-and-net-select.tsx
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/title-and-net-select.tsx
@@ -9,9 +9,9 @@ import { PersistedNetSelector } from "./persisted-net-selector";
 export const TitleAndNetSelect = () => {
   const {
     entityId,
-    loadPersistedNet,
     parentProcess,
     persistedNets,
+    switchToNet,
     setTitle,
     title,
   } = useEditorContext();
@@ -37,7 +37,7 @@ export const TitleAndNetSelect = () => {
             <Typography
               component="button"
               onClick={() => {
-                loadPersistedNet(parentProcessPersistedNet);
+                switchToNet(parentProcessPersistedNet);
               }}
               sx={({ palette, transitions }) => ({
                 background: "none",
@@ -74,7 +74,7 @@ export const TitleAndNetSelect = () => {
       </Stack>
 
       <PersistedNetSelector
-        onSelect={loadPersistedNet}
+        onSelect={switchToNet}
         options={persistedNets}
         value={entityId}
       />

--- a/apps/hash-frontend/src/pages/process.page/process-editor/transition-node.tsx
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/transition-node.tsx
@@ -12,7 +12,7 @@ export const TransitionNode = ({
 }: NodeProps<TransitionNodeData>) => {
   const { label, description, subProcess } = data;
 
-  const { loadPersistedNet, persistedNets } = useEditorContext();
+  const { switchToNet, persistedNets } = useEditorContext();
 
   return (
     <div
@@ -38,7 +38,7 @@ export const TransitionNode = ({
               );
 
               if (subProcessPersistedNet) {
-                loadPersistedNet(subProcessPersistedNet);
+                switchToNet(subProcessPersistedNet);
               } else {
                 throw new Error("Sub process not available locally");
               }

--- a/apps/hash-frontend/src/pages/process.page/process-editor/transition-node.tsx
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/transition-node.tsx
@@ -1,5 +1,5 @@
 import { IconButton, IconDiagramRegular } from "@hashintel/design-system";
-import { Box, Typography } from "@mui/material";
+import { Box, Tooltip, Typography } from "@mui/material";
 import { Handle, type NodeProps, Position } from "reactflow";
 
 import { useEditorContext } from "./editor-context";
@@ -29,34 +29,38 @@ export const TransitionNode = ({
       />
       <Box sx={transitionStyling}>
         {subProcess && (
-          <IconButton
-            onClick={(event) => {
-              event.stopPropagation();
-
-              const subProcessPersistedNet = persistedNets.find(
-                (net) => net.entityId === subProcess.subProcessEntityId,
-              );
-
-              if (subProcessPersistedNet) {
-                switchToNet(subProcessPersistedNet);
-              } else {
-                throw new Error("Sub process not available locally");
-              }
-            }}
-            sx={{
-              position: "absolute",
-              top: 0,
-              left: 0,
-              "&:hover": {
-                background: "transparent",
-                "& svg": {
-                  fill: ({ palette }) => palette.blue[70],
-                },
-              },
-            }}
+          <Tooltip
+            title={`Switch to sub process ${subProcess.subProcessTitle}`}
           >
-            <IconDiagramRegular sx={{ fontSize: 12 }} />
-          </IconButton>
+            <IconButton
+              onClick={(event) => {
+                event.stopPropagation();
+
+                const subProcessPersistedNet = persistedNets.find(
+                  (net) => net.entityId === subProcess.subProcessEntityId,
+                );
+
+                if (subProcessPersistedNet) {
+                  switchToNet(subProcessPersistedNet);
+                } else {
+                  throw new Error("Sub process not available locally");
+                }
+              }}
+              sx={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                "&:hover": {
+                  background: "transparent",
+                  "& svg": {
+                    fill: ({ palette }) => palette.blue[70],
+                  },
+                },
+              }}
+            >
+              <IconDiagramRegular sx={{ fontSize: 12 }} />
+            </IconButton>
+          </Tooltip>
         )}
 
         {label}

--- a/apps/hash-frontend/src/pages/process.page/process-editor/types.ts
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/types.ts
@@ -12,6 +12,15 @@ export type ArcType = Omit<Edge<ArcData>, "style">;
 export type PlaceNodeData = {
   label: string;
   initialTokenCounts?: TokenCounts;
+  /**
+   * If the process is a subprocess, it represents the detail of a transition from the parent.
+   * It must contain at least one each of input and output places to that parent transition.
+   * This field indicates if this place corresponds to an input or output place to the transition in the parent.
+   */
+  parentProcessNode?: {
+    id: string;
+    type: "input" | "output";
+  };
   tokenCounts: TokenCounts;
   type: "place";
 };

--- a/apps/hash-frontend/src/pages/process.page/process-editor/types.ts
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/types.ts
@@ -34,6 +34,16 @@ export type TransitionNodeData = {
     linkEntityId?: EntityId;
     subProcessEntityId: EntityId;
     subProcessTitle: string;
+    /**
+     * The IDs of the input places for this transition which are represented in the subprocess (which should appear as starting places there).
+     * There must be at least one, but not all input places to this transition (in the parent) must appear in the subprocess.
+     */
+    inputPlaceIds: string[];
+    /**
+     * The IDs of the output places for this transition which are represented in the subprocess (which should appear as ending places there).
+     * There must be at least one, but not all output places to this transition (in the parent) must appear in the subprocess.
+     */
+    outputPlaceIds: string[];
   };
   /**
    * Although a reactflow {@link Node} has a 'type' field, the library types don't discriminate on this field in all methods,

--- a/apps/hash-frontend/src/pages/process.page/process-editor/types.ts
+++ b/apps/hash-frontend/src/pages/process.page/process-editor/types.ts
@@ -31,7 +31,7 @@ export type TransitionNodeData = {
   delay?: number;
   description?: string;
   subProcess?: {
-    linkEntityId: EntityId;
+    linkEntityId?: EntityId;
     subProcessEntityId: EntityId;
     subProcessTitle: string;
   };

--- a/apps/hash-frontend/src/pages/shared/shared/edit-bar-contents.tsx
+++ b/apps/hash-frontend/src/pages/shared/shared/edit-bar-contents.tsx
@@ -14,6 +14,7 @@ import { Button } from "../../../shared/ui/button";
 
 export const EditBarContents = ({
   hideConfirm,
+  hideDiscard,
   icon,
   title,
   label,
@@ -21,12 +22,17 @@ export const EditBarContents = ({
   confirmButtonProps,
 }: {
   hideConfirm?: boolean;
+  hideDiscard?: boolean;
   icon: ReactNode;
   title: ReactNode;
   label: ReactNode;
   discardButtonProps: ButtonProps;
   confirmButtonProps: ButtonProps;
 }) => {
+  if (hideDiscard && hideConfirm) {
+    throw new Error("hideDiscard and hideConfirm cannot both be true");
+  }
+
   return (
     <Container
       sx={{
@@ -43,25 +49,27 @@ export const EditBarContents = ({
         {label}
       </Typography>
       <Stack spacing={1.25} sx={{ marginLeft: "auto" }} direction="row">
-        <Button
-          variant="tertiary"
-          size="xs"
-          sx={[
-            (theme) => ({
-              borderColor: theme.palette.blue[50],
-              backgroundColor: "transparent",
-              color: "white",
-              "&:hover": {
-                backgroundColor: theme.palette.blue[80],
+        {!hideDiscard && (
+          <Button
+            variant="tertiary"
+            size="xs"
+            sx={[
+              (theme) => ({
+                borderColor: theme.palette.blue[50],
+                backgroundColor: "transparent",
                 color: "white",
-              },
-            }),
-            ...(Array.isArray(discardSx) ? discardSx : [discardSx]),
-          ]}
-          {...discardButtonProps}
-        >
-          {discardButtonProps.children}
-        </Button>
+                "&:hover": {
+                  backgroundColor: theme.palette.blue[80],
+                  color: "white",
+                },
+              }),
+              ...(Array.isArray(discardSx) ? discardSx : [discardSx]),
+            ]}
+            {...discardButtonProps}
+          >
+            {discardButtonProps.children}
+          </Button>
+        )}
         {!hideConfirm && (
           <Button
             variant="secondary"

--- a/libs/@local/hash-isomorphic-utils/src/ontology-type-ids.ts
+++ b/libs/@local/hash-isomorphic-utils/src/ontology-type-ids.ts
@@ -689,6 +689,11 @@ export const systemPropertyTypes = {
     propertyTypeBaseUrl:
       "https://hash.ai/@h/types/property-type/inclusion-criteria/" as BaseUrl,
   },
+  inputPlaceId: {
+    propertyTypeId: "https://hash.ai/@h/types/property-type/input-place-id/v/1",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@h/types/property-type/input-place-id/" as BaseUrl,
+  },
   inputUnitCost: {
     propertyTypeId:
       "https://hash.ai/@h/types/property-type/input-unit-cost/v/1",
@@ -809,6 +814,12 @@ export const systemPropertyTypes = {
       "https://hash.ai/@h/types/property-type/output-definitions/v/1",
     propertyTypeBaseUrl:
       "https://hash.ai/@h/types/property-type/output-definitions/" as BaseUrl,
+  },
+  outputPlaceId: {
+    propertyTypeId:
+      "https://hash.ai/@h/types/property-type/output-place-id/v/1",
+    propertyTypeBaseUrl:
+      "https://hash.ai/@h/types/property-type/output-place-id/" as BaseUrl,
   },
   outputUnitCost: {
     propertyTypeId:

--- a/libs/@local/hash-isomorphic-utils/src/system-types/petrinet.ts
+++ b/libs/@local/hash-isomorphic-utils/src/system-types/petrinet.ts
@@ -2,7 +2,7 @@
  * This file was automatically generated – do not edit it.
  */
 
-import type { ObjectMetadata } from "@blockprotocol/type-system";
+import type { ArrayMetadata, ObjectMetadata } from "@blockprotocol/type-system";
 
 import type {
   Link,
@@ -39,6 +39,20 @@ export type DefinitionObjectPropertyValue = ObjectDataType;
 
 export type DefinitionObjectPropertyValueWithMetadata =
   ObjectDataTypeWithMetadata;
+
+/**
+ * An identifier for an input place.
+ */
+export type InputPlaceIDPropertyValue = TextDataType;
+
+export type InputPlaceIDPropertyValueWithMetadata = TextDataTypeWithMetadata;
+
+/**
+ * An identifier for an output place.
+ */
+export type OutputPlaceIDPropertyValue = TextDataType;
+
+export type OutputPlaceIDPropertyValueWithMetadata = TextDataTypeWithMetadata;
 
 /**
  * A Petri net is a mathematical model of a system that can be used to represent and analyze complex systems.
@@ -93,12 +107,22 @@ export type SubProcessOfOutgoingLinksByLinkEntityTypeId = {};
  * A process which contains this process.
  */
 export type SubProcessOfProperties = LinkProperties & {
+  "https://hash.ai/@h/types/property-type/input-place-id/": InputPlaceIDPropertyValue[];
+  "https://hash.ai/@h/types/property-type/output-place-id/": OutputPlaceIDPropertyValue[];
   "https://hash.ai/@h/types/property-type/transition-id/": TransitionIDPropertyValue;
 };
 
 export type SubProcessOfPropertiesWithMetadata = LinkPropertiesWithMetadata & {
   metadata?: ObjectMetadata;
   value: {
+    "https://hash.ai/@h/types/property-type/input-place-id/": {
+      value: InputPlaceIDPropertyValueWithMetadata[];
+      metadata?: ArrayMetadata;
+    };
+    "https://hash.ai/@h/types/property-type/output-place-id/": {
+      value: OutputPlaceIDPropertyValueWithMetadata[];
+      metadata?: ArrayMetadata;
+    };
     "https://hash.ai/@h/types/property-type/transition-id/": TransitionIDPropertyValueWithMetadata;
   };
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Makes the following improvements to the process (Petri net) editor:
1. Show a bar similar to the entity/type editors which indicates when a net has unsaved changes
2. When a sub-process is linked a transition, i.e. the sub-process represents the details of what is going on inside the transition, we want to represent at least one of the input and output places to the transition in the sub-process. The PR makes it so that the user can select the relevant input/output places to represent in the sub-process, and updates the sub-process when these are changed to make sure that corresponding places appear in it.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- Styling remains basic / functional, I have not spent much time on it on the assumption that it will be significantly overhauled at some point.
<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- None yet

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Only possible locally as we do not seed the necessary types in production yet

## 📹 Demo


https://github.com/user-attachments/assets/015c6a14-86dc-4df3-a856-24622f8b963d

