### PR TITLE
H-4575: Fix entity validation not returning all validation errors

### DIFF
--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -1257,8 +1257,7 @@ where
                 )
                 .await
             {
-                validation_reports.entry(index).or_default().properties =
-                    property_validation.properties;
+                validation_report.properties = property_validation.properties;
             }
 
             validation_report.link = params


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When the properties object is invalid it gets overwritten when also the link validation failed.