### PR TITLE
H-4578: Rework Rust crate coverage

### DIFF
--- a/.config/mise/tasks/test/unit.sh
+++ b/.config/mise/tasks/test/unit.sh
@@ -62,5 +62,5 @@ if [[ $POWERSET == "true" || ${TEST_POWERSET:-false} == 'true' || ${TEST_POWERSE
     exit 0
 fi
 
-cargo nextest run -p "$CRATE" $ARGUMENTS
+cargo nextest run -p "$CRATE" --all-targets $ARGUMENTS
 cargo test --all-features --doc -p "$CRATE"

--- a/.config/mise/tasks/test/unit.sh
+++ b/.config/mise/tasks/test/unit.sh
@@ -7,13 +7,13 @@ set -euo pipefail
 #USAGE arg "<package>" help="The package to run unit tests for"
 #USAGE arg "[arguments]..." double_dash="required" default="" help="Additional arguments to pass to the test runner"
 
-PACKAGE=$usage_package;
+PACKAGE=$usage_package
 COVERAGE=$usage_coverage
 POWERSET=$usage_powerset
 ARGUMENTS=$usage_arguments
 
 # Check if the package argument starts with `@rust/` if that isn't the case exit out
-if [[ "$PACKAGE" != "@rust/"* ]]; then
+if [[ $PACKAGE != "@rust/"* ]]; then
     echo "Error: Only rust crates are supported for now"
     exit 1
 fi
@@ -22,13 +22,15 @@ fi
 CRATE=${usage_package#*@rust/}
 
 # Run coverage instead of unit tests if `TEST_COVERAGE` is set to `true` or `1`
-if [[ "$COVERAGE" = "true" || "${TEST_COVERAGE:-false}" = 'true' || "${TEST_COVERAGE:-false}" = '1' ]]; then
-    EXCLUSIONS=$(cargo metadata --format-version=1 --no-deps | \
-        jq -r --arg crate "$CRATE" '.packages[] | select(.name != $crate) | .manifest_path | rtrimstr("/Cargo.toml") | gsub("/"; "\\/"; "g")' | \
-        paste -sd "|" -)
+if [[ $COVERAGE == "true" || ${TEST_COVERAGE:-false} == 'true' || ${TEST_COVERAGE:-false} == '1' ]]; then
+    EXCLUSIONS=$(
+        cargo metadata --format-version=1 --no-deps \
+            | jq -r --arg crate "$CRATE" '.packages[] | select(.name != $crate) | .manifest_path | rtrimstr("/Cargo.toml") | gsub("/"; "\\/"; "g")' \
+            | paste -sd "|" -
+    )
 
     # under CI we use LCOV
-    if [[ "${CI:-0}" = "1" ]]; then
+    if [[ ${CI:-0} == "1" ]]; then
         RENDER="--lcov --output-path lcov.info"
     else
         RENDER="--html --open"
@@ -42,7 +44,7 @@ if [[ "$COVERAGE" = "true" || "${TEST_COVERAGE:-false}" = 'true' || "${TEST_COVE
 fi
 
 # Run unit tests with powerset if `TEST_POWERSET` is set to `true` or `1`
-if [[ "$POWERSET" = "true" || "${TEST_POWERSET:-false}" = 'true' || "${TEST_POWERSET:-false}" = '1' ]]; then
+if [[ $POWERSET == "true" || ${TEST_POWERSET:-false} == 'true' || ${TEST_POWERSET:-false} == '1' ]]; then
     cargo hack --optional-deps --feature-powerset nextest run -p $CRATE $ARGUMENTS
     cargo test --all-features --doc -p $CRATE
     exit 0
@@ -51,7 +53,7 @@ fi
 LOGFILE=$(mktemp)
 trap 'rm -f "$LOGFILE"' EXIT
 
-cargo test --all-features --doc -p $CRATE >"$LOGFILE" 2>&1  &
+cargo test --all-features --doc -p $CRATE >"$LOGFILE" 2>&1 &
 DOC_PID=$!
 
 cargo nextest run -p $CRATE $ARGUMENTS

--- a/.config/mise/tasks/test/unit.sh
+++ b/.config/mise/tasks/test/unit.sh
@@ -19,7 +19,7 @@ if [[ $PACKAGE != "@rust/"* ]]; then
 fi
 
 # Remove the package namespace from the package to get the crate name
-CRATE=${usage_package#*@rust/}
+CRATE=${PACKAGE#*@rust/}
 
 # Run coverage instead of unit tests if `TEST_COVERAGE` is set to `true` or `1`
 if [[ $COVERAGE == "true" || ${TEST_COVERAGE:-false} == 'true' || ${TEST_COVERAGE:-false} == '1' ]]; then
@@ -45,18 +45,18 @@ fi
 
 # Run unit tests with powerset if `TEST_POWERSET` is set to `true` or `1`
 if [[ $POWERSET == "true" || ${TEST_POWERSET:-false} == 'true' || ${TEST_POWERSET:-false} == '1' ]]; then
-    cargo hack --optional-deps --feature-powerset nextest run -p $CRATE $ARGUMENTS
-    cargo test --all-features --doc -p $CRATE
+    cargo hack --optional-deps --feature-powerset nextest run -p "$CRATE" $ARGUMENTS
+    cargo test --all-features --doc -p "$CRATE"
     exit 0
 fi
 
 LOGFILE=$(mktemp)
 trap 'rm -f "$LOGFILE"' EXIT
 
-cargo test --all-features --doc -p $CRATE >"$LOGFILE" 2>&1 &
+cargo test --all-features --doc -p "$CRATE" >"$LOGFILE" 2>&1 &
 DOC_PID=$!
 
-cargo nextest run -p $CRATE $ARGUMENTS
+cargo nextest run -p "$CRATE" $ARGUMENTS
 
 # replay what’s buffered so far
 cat "$LOGFILE"

--- a/.config/mise/tasks/test/unit.sh
+++ b/.config/mise/tasks/test/unit.sh
@@ -57,7 +57,7 @@ fi
 
 # Run unit tests with powerset if `TEST_POWERSET` is set to `true` or `1`
 if [[ $POWERSET == "true" || ${TEST_POWERSET:-false} == 'true' || ${TEST_POWERSET:-false} == '1' ]]; then
-    cargo hack --optional-deps --feature-powerset nextest run -p "$CRATE" $ARGUMENTS
+    cargo hack --optional-deps --feature-powerset nextest run -p "$CRATE" --all-targets $ARGUMENTS
     cargo test --all-features --doc -p "$CRATE"
     exit 0
 fi

--- a/.config/mise/tasks/test/unit.sh
+++ b/.config/mise/tasks/test/unit.sh
@@ -31,14 +31,22 @@ if [[ $COVERAGE == "true" || ${TEST_COVERAGE:-false} == 'true' || ${TEST_COVERAG
 
     # under CI we use LCOV
     if [[ ${CI:-0} == "1" || ${CI:-0} == "true" ]]; then
-        RENDER="--lcov --output-path lcov.info"
+        REPORT_FLAGS="--lcov --output-path lcov.info"
     else
-        RENDER="--html --open"
+        REPORT_FLAGS="--html --open"
+    fi
+
+    if [[ $POWERSET == "true" || ${TEST_POWERSET:-false} == 'true' || ${TEST_POWERSET:-false} == '1' ]]; then
+        CARGO_COMMAND="hack --optional-deps --feature-powerset"
+        NEXTEST_ARGS=""
+    else
+        CARGO_COMMAND=""
+        NEXTEST_ARGS="--all-features"
     fi
 
     cargo llvm-cov clean --workspace
-    cargo llvm-cov --ignore-filename-regex "$EXCLUSIONS" -p "$CRATE" --branch --no-report nextest --all-features --all-targets --cargo-profile coverage $ARGUMENTS
-    cargo llvm-cov --ignore-filename-regex "$EXCLUSIONS" -p "$CRATE" --branch --no-clean $RENDER --doctests test --all-features --profile coverage --doc
+    cargo $CARGO_COMMAND llvm-cov --ignore-filename-regex "$EXCLUSIONS" -p "$CRATE" --branch --no-report nextest $NEXTEST_ARGS --all-targets --cargo-profile coverage $ARGUMENTS
+    cargo llvm-cov --ignore-filename-regex "$EXCLUSIONS" -p "$CRATE" --branch --no-clean $REPORT_FLAGS --doctests test --all-features --profile coverage --doc
 
     exit 0
 fi

--- a/.config/mise/tasks/test/unit.sh
+++ b/.config/mise/tasks/test/unit.sh
@@ -58,21 +58,5 @@ if [[ $POWERSET == "true" || ${TEST_POWERSET:-false} == 'true' || ${TEST_POWERSE
     exit 0
 fi
 
-LOGFILE=$(mktemp)
-trap 'rm -f "$LOGFILE"' EXIT
-
-cargo test --all-features --doc -p "$CRATE" >"$LOGFILE" 2>&1 &
-DOC_PID=$!
-
 cargo nextest run -p "$CRATE" $ARGUMENTS
-
-# replay what’s buffered so far
-cat "$LOGFILE"
-
-# now stream any new doc-test output until it completes
-tail -n 0 -f "$LOGFILE" &
-TAIL_PID=$!
-
-# wait for the doc-tests to finish, then kill the tail
-wait $DOC_PID
-kill $TAIL_PID 2>/dev/null || true
+cargo test --all-features --doc -p "$CRATE"

--- a/.config/mise/tasks/test/unit.sh
+++ b/.config/mise/tasks/test/unit.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#MISE description="Run unit tests"
+set -euo pipefail
+
+#USAGE flag "--coverage" negate="--no-coverage" default="false" help="Run unit tests with coverage, also reads `$TEST_COVERAGE`"
+#USAGE flag "--powerset" negate="--no-powerset" default="false" help="Run unit tests with powerset, also reads `$TEST_POWERSET`"
+#USAGE arg "<package>" help="The package to run unit tests for"
+#USAGE arg "[arguments]..." double_dash="required" default="" help="Additional arguments to pass to the test runner"
+
+PACKAGE=$usage_package;
+COVERAGE=$usage_coverage
+POWERSET=$usage_powerset
+ARGUMENTS=$usage_arguments
+
+# Check if the package argument starts with `@rust/` if that isn't the case exit out
+if [[ "$PACKAGE" != "@rust/"* ]]; then
+    echo "Error: Only rust crates are supported for now"
+    exit 1
+fi
+
+# Remove the package namespace from the package to get the crate name
+CRATE=${usage_package#*@rust/}
+
+# Run coverage instead of unit tests if `TEST_COVERAGE` is set to `true` or `1`
+if [[ "$COVERAGE" = "true" || "${TEST_COVERAGE:-false}" = 'true' || "${TEST_COVERAGE:-false}" = '1' ]]; then
+    EXCLUSIONS=$(cargo metadata --format-version=1 --no-deps | \
+        jq -r --arg crate "$CRATE" '.packages[] | select(.name != $crate) | .manifest_path | rtrimstr("/Cargo.toml") | gsub("/"; "\\/"; "g")' | \
+        paste -sd "|" -)
+
+    # under CI we use LCOV
+    if [[ "${CI:-0}" = "1" ]]; then
+        RENDER="--lcov --output-path lcov.info"
+    else
+        RENDER="--html --open"
+    fi
+
+    cargo llvm-cov clean --workspace
+    cargo llvm-cov --ignore-filename-regex "$EXCLUSIONS" -p "$CRATE" --branch --no-clean nextest --all-features --all-targets --cargo-profile coverage $ARGUMENTS
+    cargo llvm-cov --ignore-filename-regex "$EXCLUSIONS" -p "$CRATE" --branch --no-clean $RENDER --doctests test --all-features --profile coverage --doc
+
+    exit 0
+fi
+
+# Run unit tests with powerset if `TEST_POWERSET` is set to `true` or `1`
+if [[ "$POWERSET" = "true" || "${TEST_POWERSET:-false}" = 'true' || "${TEST_POWERSET:-false}" = '1' ]]; then
+    cargo hack --optional-deps --feature-powerset nextest run -p $CRATE $ARGUMENTS
+    cargo test --all-features --doc -p $CRATE
+    exit 0
+fi
+
+LOGFILE=$(mktemp)
+trap 'rm -f "$LOGFILE"' EXIT
+
+cargo test --all-features --doc -p $CRATE >"$LOGFILE" 2>&1  &
+DOC_PID=$!
+
+cargo nextest run -p $CRATE $ARGUMENTS
+
+# replay what’s buffered so far
+cat "$LOGFILE"
+
+# now stream any new doc-test output until it completes
+tail -n 0 -f "$LOGFILE" &
+TAIL_PID=$!
+
+# wait for the doc-tests to finish, then kill the tail
+wait $DOC_PID
+kill $TAIL_PID 2>/dev/null || true

--- a/.config/mise/tasks/test/unit.sh
+++ b/.config/mise/tasks/test/unit.sh
@@ -62,5 +62,5 @@ if [[ $POWERSET == "true" || ${TEST_POWERSET:-false} == 'true' || ${TEST_POWERSE
     exit 0
 fi
 
-cargo nextest run -p "$CRATE" --all-targets $ARGUMENTS
+cargo nextest run -p "$CRATE" --all-features --all-targets $ARGUMENTS
 cargo test --all-features --doc -p "$CRATE"

--- a/.config/mise/tasks/test/unit.sh
+++ b/.config/mise/tasks/test/unit.sh
@@ -30,14 +30,14 @@ if [[ $COVERAGE == "true" || ${TEST_COVERAGE:-false} == 'true' || ${TEST_COVERAG
     )
 
     # under CI we use LCOV
-    if [[ ${CI:-0} == "1" ]]; then
+    if [[ ${CI:-0} == "1" || ${CI:-0} == "true" ]]; then
         RENDER="--lcov --output-path lcov.info"
     else
         RENDER="--html --open"
     fi
 
     cargo llvm-cov clean --workspace
-    cargo llvm-cov --ignore-filename-regex "$EXCLUSIONS" -p "$CRATE" --branch --no-clean nextest --all-features --all-targets --cargo-profile coverage $ARGUMENTS
+    cargo llvm-cov --ignore-filename-regex "$EXCLUSIONS" -p "$CRATE" --branch --no-report nextest --all-features --all-targets --cargo-profile coverage $ARGUMENTS
     cargo llvm-cov --ignore-filename-regex "$EXCLUSIONS" -p "$CRATE" --branch --no-clean $RENDER --doctests test --all-features --profile coverage --doc
 
     exit 0

--- a/.justfile
+++ b/.justfile
@@ -143,20 +143,3 @@ miri *arguments:
 [no-cd]
 bench *arguments:
   cargo bench --all-features --all-targets {{arguments}}
-
-# Run the test suite and generate a coverage report
-[no-cd]
-coverage *arguments:
-  cargo llvm-cov nextest --all-features --all-targets --cargo-profile coverage {{arguments}}
-  cargo llvm-cov --all-features --profile coverage --doc
-
-# Run the test suite and optionally generate a coverage report when `$TEST_COVERAGE` is set to `true`
-[no-cd]
-test-or-coverage *arguments:
-  #!/usr/bin/env bash
-  set -eo pipefail
-  if [[ "$TEST_COVERAGE" = 'true' || "$TEST_COVERAGE" = '1' ]]; then
-    just coverage --lcov --output-path lcov.info {{arguments}}
-  else
-    just test --no-fail-fast {{arguments}}
-  fi

--- a/libs/@local/codec/package.json
+++ b/libs/@local/codec/package.json
@@ -20,7 +20,7 @@
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
     "lint:tsc": "tsc --noEmit",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets --no-tests warn && cargo test --all-features --doc"
+    "test:unit": "mise run test:unit @rust/hash-codec"
   },
   "dependencies": {
     "@rust/error-stack": "0.5.0",

--- a/libs/@local/graph/api/package.json
+++ b/libs/@local/graph/api/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "codegen:generate-openapi-specs": "cargo run --bin openapi-spec-generator",
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root hash-graph-api --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc && yarn codegen:generate-openapi-specs && git --no-pager diff --exit-code --color openapi"
+    "test:unit": "mise run test:unit @rust/hash-graph-api && yarn codegen:generate-openapi-specs && git --no-pager diff --exit-code --color openapi"
   },
   "dependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",

--- a/libs/@local/graph/authorization/package.json
+++ b/libs/@local/graph/authorization/package.json
@@ -21,7 +21,7 @@
     "lint:clippy": "just clippy",
     "lint:tsc": "tsc --noEmit",
     "test:integration": "cargo hack nextest run --feature-powerset --all-targets --filterset \"kind(test) | kind(bench)\"",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets --filterset \"not kind(test) & not kind(bench)\" && cargo test --all-features --doc"
+    "test:unit": "mise run test:unit @rust/hash-graph-authorization -- --filterset \"not kind(test) & not kind(bench)\""
   },
   "dependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",

--- a/libs/@local/graph/authorization/package.json
+++ b/libs/@local/graph/authorization/package.json
@@ -21,7 +21,7 @@
     "lint:clippy": "just clippy",
     "lint:tsc": "tsc --noEmit",
     "test:integration": "cargo hack nextest run --feature-powerset --all-targets --filterset \"kind(test) | kind(bench)\"",
-    "test:unit": "mise run test:unit @rust/hash-graph-authorization -- --filterset \"not kind(test) & not kind(bench)\""
+    "test:unit": "cargo hack nextest run --feature-powerset --all-targets --filterset \"not kind(test) & not kind(bench)\" && cargo test --all-features --doc"
   },
   "dependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",

--- a/libs/@local/graph/postgres-store/package.json
+++ b/libs/@local/graph/postgres-store/package.json
@@ -8,7 +8,7 @@
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
     "test:integration": "cargo hack nextest run --feature-powerset --tests",
-    "test:unit": "mise run test:unit @rust/hash-graph-postgres-store -- --lib"
+    "test:unit": "cargo hack nextest run --feature-powerset --lib && cargo test --all-features --doc"
   },
   "dependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",

--- a/libs/@local/graph/postgres-store/package.json
+++ b/libs/@local/graph/postgres-store/package.json
@@ -8,7 +8,7 @@
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
     "test:integration": "cargo hack nextest run --feature-powerset --tests",
-    "test:unit": "cargo hack nextest run --feature-powerset --lib && cargo test --all-features --doc"
+    "test:unit": "mise run test:unit @rust/hash-graph-postgres-store -- --lib"
   },
   "dependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",

--- a/libs/@local/graph/store/package.json
+++ b/libs/@local/graph/store/package.json
@@ -7,7 +7,7 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root hash-graph-store --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
+    "test:unit": "mise run test:unit @rust/hash-graph-store"
   },
   "dependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",

--- a/libs/@local/graph/temporal-versioning/package.json
+++ b/libs/@local/graph/temporal-versioning/package.json
@@ -7,7 +7,7 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root hash-graph-temporal-versioning --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
+    "test:unit": "mise run test:unit @rust/hash-graph-temporal-versioning"
   },
   "dependencies": {
     "@rust/hash-codec": "0.0.0-private"

--- a/libs/@local/graph/types/package.json
+++ b/libs/@local/graph/types/package.json
@@ -7,7 +7,7 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root hash-graph-types --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets --no-tests warn && cargo test --all-features --doc"
+    "test:unit": "mise run test:unit @rust/hash-graph-types -- --no-tests warn"
   },
   "dependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",

--- a/libs/@local/graph/validation/package.json
+++ b/libs/@local/graph/validation/package.json
@@ -7,7 +7,7 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root hash-graph-validation --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
+    "test:unit": "mise run test:unit @rust/hash-graph-validation"
   },
   "dependencies": {
     "@blockprotocol/type-system-rs": "0.0.0-private",

--- a/libs/@local/harpc/codec/package.json
+++ b/libs/@local/harpc/codec/package.json
@@ -7,7 +7,7 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root harpc-codec --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
+    "test:unit": "mise run test:unit @rust/harpc-codec"
   },
   "dependencies": {
     "@rust/error-stack": "0.5.0",

--- a/libs/@local/harpc/net/package.json
+++ b/libs/@local/harpc/net/package.json
@@ -7,7 +7,7 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root harpc-net --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
+    "test:unit": "mise run test:unit @rust/harpc-net"
   },
   "dependencies": {
     "@rust/error-stack": "0.5.0",

--- a/libs/@local/harpc/tower/package.json
+++ b/libs/@local/harpc/tower/package.json
@@ -7,7 +7,7 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root harpc-tower --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
+    "test:unit": "mise run test:unit @rust/harpc-tower"
   },
   "dependencies": {
     "@rust/error-stack": "0.5.0",

--- a/libs/@local/harpc/types/package.json
+++ b/libs/@local/harpc/types/package.json
@@ -7,6 +7,6 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root harpc-types --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets --no-tests warn && cargo test --all-features --doc"
+    "test:unit": "mise run test:unit @rust/harpc-types -- --no-tests warn && cargo test --all-features --doc"
   }
 }

--- a/libs/@local/harpc/types/package.json
+++ b/libs/@local/harpc/types/package.json
@@ -7,6 +7,6 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root harpc-types --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "mise run test:unit @rust/harpc-types -- --no-tests warn && cargo test --all-features --doc"
+    "test:unit": "mise run test:unit @rust/harpc-types -- --no-tests warn"
   }
 }

--- a/libs/@local/harpc/wire-protocol/package.json
+++ b/libs/@local/harpc/wire-protocol/package.json
@@ -9,7 +9,7 @@
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
     "test:miri": "just miri",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
+    "test:unit": "mise run test:unit @rust/harpc-wire-protocol"
   },
   "dependencies": {
     "@rust/error-stack": "0.5.0",

--- a/libs/@local/hashql/ast/package.json
+++ b/libs/@local/hashql/ast/package.json
@@ -7,7 +7,7 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root hashql-ast --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets --no-tests warn && cargo test --all-features --doc"
+    "test:unit": "mise run test:unit @rust/hashql-ast"
   },
   "dependencies": {
     "@rust/hashql-core": "0.0.0-private",

--- a/libs/@local/hashql/compiletest/package.json
+++ b/libs/@local/hashql/compiletest/package.json
@@ -7,7 +7,7 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root hashql-compiletest --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets --no-tests warn && cargo test --all-features --doc"
+    "test:unit": "mise run test:unit @rust/hashql-compiletest"
   },
   "dependencies": {
     "@rust/error-stack": "0.5.0",

--- a/libs/@local/hashql/core/package.json
+++ b/libs/@local/hashql/core/package.json
@@ -7,7 +7,7 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root hashql-core --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets --no-tests warn && cargo test --all-features --doc"
+    "test:unit": "mise run test:unit @rust/hashql-core"
   },
   "dependencies": {
     "@rust/hashql-diagnostics": "0.0.0-private"

--- a/libs/@local/hashql/diagnostics/package.json
+++ b/libs/@local/hashql/diagnostics/package.json
@@ -7,7 +7,7 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root hashql-diagnostics --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
+    "test:unit": "mise run test:unit @rust/hashql-diagnostics"
   },
   "dependencies": {
     "@rust/error-stack": "0.5.0"

--- a/libs/@local/hashql/hir/package.json
+++ b/libs/@local/hashql/hir/package.json
@@ -7,7 +7,7 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root hashql-hir --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
+    "test:unit": "mise run test:unit @rust/hashql-hir"
   },
   "dependencies": {
     "@rust/hashql-core": "0.0.0-private"

--- a/libs/@local/hashql/syntax-jexpr/package.json
+++ b/libs/@local/hashql/syntax-jexpr/package.json
@@ -7,7 +7,7 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root hashql-syntax-jexpr --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
+    "test:unit": "mise run test:unit @rust/hashql-syntax-jexpr"
   },
   "dependencies": {
     "@rust/hashql-ast": "0.0.0-private",

--- a/libs/antsi/package.json
+++ b/libs/antsi/package.json
@@ -7,6 +7,6 @@
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "mise run test:unit @rust/antsi"
+    "test:unit": "mise run test:unit @rust/antsi -- --no-tests warn"
   }
 }

--- a/libs/antsi/package.json
+++ b/libs/antsi/package.json
@@ -7,6 +7,6 @@
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "just test --no-tests warn"
+    "test:unit": "mise run test:unit @rust/antsi"
   }
 }

--- a/libs/deer/package.json
+++ b/libs/deer/package.json
@@ -8,7 +8,7 @@
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
     "test:miri": "just miri",
-    "test:unit": "just test-or-coverage"
+    "test:unit": "mise run test:unit @rust/deer"
   },
   "dependencies": {
     "@rust/error-stack": "0.5.0"

--- a/libs/error-stack/package.json
+++ b/libs/error-stack/package.json
@@ -8,7 +8,7 @@
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
     "test:miri": "just miri",
-    "test:unit": "mise run test:unit @rust/error-stack"
+    "test:unit": "RUST_BACKTRACE=1 mise run test:unit @rust/error-stack"
   },
   "dependencies": {
     "@rust/error-stack-macros": "0.0.0-reserved-private"

--- a/libs/error-stack/package.json
+++ b/libs/error-stack/package.json
@@ -8,7 +8,7 @@
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
     "test:miri": "just miri",
-    "test:unit": "just test-or-coverage"
+    "test:unit": "mise run test:unit @rust/error-stack"
   },
   "dependencies": {
     "@rust/error-stack-macros": "0.0.0-reserved-private"

--- a/libs/sarif/package.json
+++ b/libs/sarif/package.json
@@ -7,6 +7,6 @@
   "scripts": {
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "just test-or-coverage --no-tests warn"
+    "test:unit": "mise run test:unit @rust/sarif --no-tests warn"
   }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, most of the crates don't actually upload coverage information to codecov, this PR changes it by creating a mise task that can be used by any crate to do proper coverage, as well as centralizing configuration.

> There are several crates I've chosen not to convert yet, notably I needed to rollback converting both: `hash-graph-authorization` and `hash-graph-postgres-store`. This is left for a follow-up PR as it requires some more plumbing. Tracked in https://linear.app/hash/issue/H-4579/instrument-hash-graph-authorization-and-hash-graph-postgres-store

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

