### PR TITLE
H-4567: Handle public actor explicitly in Graph

### DIFF
--- a/libs/@local/graph/authorization/src/policies/store/error.rs
+++ b/libs/@local/graph/authorization/src/policies/store/error.rs
@@ -110,6 +110,8 @@ impl Error for TeamRoleCreationError {}
 #[derive(Debug, derive_more::Display)]
 #[display("Could change role assignment: {_variant}")]
 pub enum RoleAssignmentError {
+    #[display("Actor was not provided")]
+    ActorNotProvided,
     #[display("Actor with ID `{actor_id}` does not exist")]
     ActorNotFound { actor_id: ActorId },
     #[display("{name} role for `{actor_group_id}` does not exist")]

--- a/libs/@local/graph/postgres-store/src/permissions/error.rs
+++ b/libs/@local/graph/postgres-store/src/permissions/error.rs
@@ -1,13 +1,17 @@
 use core::error::Error;
 
 use hash_graph_authorization::policies::{PolicyId, action::ActionName};
-use type_system::principal::{PrincipalId, actor_group::ActorGroupId, role::RoleName};
+use type_system::principal::{
+    PrincipalId, actor::ActorEntityUuid, actor_group::ActorGroupId, role::RoleName,
+};
 
 /// Errors that can occur during principal management operations.
 #[derive(Debug, derive_more::Display)]
 pub enum PrincipalError {
     #[display("Principal with ID {id} already exists")]
     PrincipalAlreadyExists { id: PrincipalId },
+    #[display("Actor with ID {id} doesn't exist")]
+    ActorNotFound { id: ActorEntityUuid },
     #[display("Principal with ID {id} doesn't exist")]
     PrincipalNotFound { id: PrincipalId },
     #[display("{name} role in {actor_group_id} doesn't exist")]

--- a/libs/@local/graph/postgres-store/src/permissions/mod.rs
+++ b/libs/@local/graph/postgres-store/src/permissions/mod.rs
@@ -149,25 +149,36 @@ where
 
     /// Determines the type of an actor by its ID.
     ///
+    /// Returns `None` if the ID is the public actor.
+    ///
     /// # Errors
     ///
     /// - [`StoreError`] if a database error occurs
+    /// - [`ActorNotFound`] if the actor with the given ID doesn't exist
     ///
     /// [`StoreError`]: PrincipalError::StoreError
+    /// [`ActorNotFound`]: PrincipalError::ActorNotFound
     pub async fn determine_actor(
         &self,
         id: ActorEntityUuid,
-    ) -> Result<ActorId, Report<PrincipalError>> {
-        self.as_client()
-            .query_one("SELECT principal_type FROM actor WHERE id = $1", &[&id])
+    ) -> Result<Option<ActorId>, Report<PrincipalError>> {
+        if Uuid::from(id).is_nil() {
+            return Ok(None);
+        }
+
+        let row = self
+            .as_client()
+            .query_opt("SELECT principal_type FROM actor WHERE id = $1", &[&id])
             .await
-            .map(|row| match row.get(0) {
-                PrincipalType::User => ActorId::User(UserId::new(id)),
-                PrincipalType::Machine => ActorId::Machine(MachineId::new(id)),
-                PrincipalType::Ai => ActorId::Ai(AiId::new(id)),
-                principal_type => unreachable!("Unexpected actor type: {principal_type:?}"),
-            })
-            .change_context(PrincipalError::StoreError)
+            .change_context(PrincipalError::StoreError)?
+            .ok_or(PrincipalError::ActorNotFound { id })?;
+
+        Ok(Some(match row.get(0) {
+            PrincipalType::User => ActorId::User(UserId::new(id)),
+            PrincipalType::Machine => ActorId::Machine(MachineId::new(id)),
+            PrincipalType::Ai => ActorId::Ai(AiId::new(id)),
+            principal_type => unreachable!("Unexpected actor type: {principal_type:?}"),
+        }))
     }
 
     /// Determines the type of an actor by its ID.

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -784,7 +784,9 @@ where
         let actor = self
             .determine_actor(actor_id)
             .await
-            .change_context(InsertionError)?;
+            .change_context(InsertionError)?
+            .ok_or(InsertionError)
+            .attach(StatusCode::Unauthenticated)?;
         self.build_principal_context(actor, &mut policy_context_builder)
             .await
             .change_context(InsertionError)?;
@@ -1660,7 +1662,9 @@ where
         let actor = self
             .determine_actor(actor_id)
             .await
-            .change_context(UpdateError)?;
+            .change_context(UpdateError)?
+            .ok_or(UpdateError)
+            .attach(StatusCode::Unauthenticated)?;
         self.build_principal_context(actor, &mut policy_context_builder)
             .await
             .change_context(UpdateError)?;

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
@@ -42,6 +42,7 @@ use hash_graph_store::{
 };
 use hash_graph_temporal_versioning::{RightBoundedTemporalInterval, Timestamp, TransactionTime};
 use hash_graph_types::Embedding;
+use hash_status::StatusCode;
 use postgres_types::{Json, ToSql};
 use serde::Deserialize as _;
 use serde_json::Value as JsonValue;
@@ -1741,7 +1742,9 @@ where
         let actor = self
             .determine_actor(authenticated_user)
             .await
-            .change_context(QueryError)?;
+            .change_context(QueryError)?
+            .ok_or(QueryError)
+            .attach(StatusCode::Unauthenticated)?;
         let policies = self
             .resolve_policies_for_actor(actor.into(), actor)
             .await


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We need to distinguish between an authenticated actor (= an actor which has an actor type assigned in the database), an unauthenticated actor (= a well-defined actor without a corresponding entry in the database), and an invalid actor (none of the above).

After a lot of attempts to properly handle this, this PR simply handles the public actor when determining the actor type. This results in a `401` (unauthenticated) error for most operations. In the future, we might want to more idiomatically handle the public user case, however, this is a larger undertaking, so we stick with the most simple solution for now (the actual authentication happens in the Node API).