### PR TITLE
H-4584: Cache yarn download in CI

### DIFF
--- a/.github/actions/install-corepack/action.yml
+++ b/.github/actions/install-corepack/action.yml
@@ -14,7 +14,7 @@ runs:
 
     - name: Restore yarn corepack cache
       id: cache-restore
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: .yarn/corepack.tgz
         key: yarn-corepack-${{ steps.find-version.outputs.version }}
@@ -27,7 +27,7 @@ runs:
         mv corepack.tgz .yarn/corepack.tgz
 
     - name: Save yarn corepack cache
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       if: steps.cache-restore.outputs.cache-hit != 'true'
       with:
         path: .yarn/corepack.tgz

--- a/.github/actions/install-corepack/action.yml
+++ b/.github/actions/install-corepack/action.yml
@@ -1,0 +1,39 @@
+name: Install package manager via corepack
+description: Installs the package manager via corepack with caching enabled
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Find the current yarn version used
+      id: find-version
+      shell: bash
+      run: |
+        YARN_VERSION=$(cat package.json | jq -r '.packageManager | ltrimstr("yarn@")')
+        echo "version=$YARN_VERSION" >> $GITHUB_OUTPUT
+
+    - name: Restore yarn corepack cache
+      id: cache-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: .yarn/corepack.tgz
+        key: yarn-corepack-${{ steps.find-version.outputs.version }}
+
+    - name: Download yarn corepack
+      if: steps.cache-restore.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        corepack pack yarn@${{ steps.find-version.outputs.version }}
+        mv corepack.tgz .yarn/corepack.tgz
+
+    - name: Save yarn corepack cache
+      uses: actions/cache/save@v4
+      if: steps.cache-restore.outputs.cache-hit != 'true'
+      with:
+        path: .yarn/corepack.tgz
+        key: yarn-corepack-${{ steps.find-version.outputs.version }}
+
+    - name: Install yarn from corepack
+      shell: bash
+      run: |
+        COREPACK_ENABLE_NETWORK=0 corepack install -g .yarn/corepack.tgz

--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -3,7 +3,11 @@ description: Installs Node, Rust, and WASM tools
 
 inputs:
   token:
+    description: GitHub token for authentication
     required: true
+  rust:
+    description: Install Rust
+    default: "true"
 
 runs:
   using: composite
@@ -28,6 +32,7 @@ runs:
         mise ls
 
     - name: "Install Rust"
+      if: ${{ inputs.rust == true || inputs.rust == 'true' }}
       shell: bash
       run: |
         COMPONENTS="$(yq '.toolchain.components[]' rust-toolchain.toml)"

--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: GitHub token for authentication
     required: true
   rust:
-    description: Install Rust
+    description: Should Rust be installed? Can either be `"true"` or `true`
     default: "true"
 
 runs:

--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -12,10 +12,13 @@ runs:
     - name: Run `mise install` with `ci` environment
       uses: jdx/mise-action@7a111ead46986ccad89a74ad013ba2a7c08c9e67 # v2.2.1
       with:
-        install_args: --env ci --jobs 1
+        install_args: --env=ci
       env:
         MISE_VERBOSE: 1
         GITHUB_TOKEN: ${{ inputs.token }}
+
+    - name: Install package manager via corepack
+      uses: ./.github/actions/install-corepack
 
     - name: Setup environment
       shell: bash

--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -12,7 +12,7 @@ runs:
     - name: Run `mise install` with `ci` environment
       uses: jdx/mise-action@7a111ead46986ccad89a74ad013ba2a7c08c9e67 # v2.2.1
       with:
-        install_args: --env=ci
+        install_args: --env ci --jobs 1
       env:
         MISE_VERBOSE: 1
         GITHUB_TOKEN: ${{ inputs.token }}

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: "Pull request number to review"
+        description: Pull request number to review
         required: true
         type: number
 

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'Pull request number to review'
+        description: "Pull request number to review"
         required: true
         type: number
 
@@ -127,12 +127,11 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Install node and turbo
-        uses: jdx/mise-action@7a111ead46986ccad89a74ad013ba2a7c08c9e67 # v2.2.1
+      - name: Install tools
+        uses: ./.github/actions/install-tools
         with:
-          install_args: node npm:turbo
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          rust: false
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,12 +29,11 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Install node and turbo
-        uses: jdx/mise-action@7a111ead46986ccad89a74ad013ba2a7c08c9e67 # v2.2.1
+      - name: Install tools
+        uses: ./.github/actions/install-tools
         with:
-          install_args: node npm:turbo
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          rust: false
 
       - name: Determine changed packages
         id: packages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,12 +27,11 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Install node and turbo
-        uses: jdx/mise-action@7a111ead46986ccad89a74ad013ba2a7c08c9e67 # v2.2.1
+      - name: Install tools
+        uses: ./.github/actions/install-tools
         with:
-          install_args: node npm:turbo
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          rust: false
 
       - name: Determine changed packages
         id: packages

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,12 +27,11 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Install node and turbo
-        uses: jdx/mise-action@7a111ead46986ccad89a74ad013ba2a7c08c9e67 # v2.2.1
+      - name: Install tools
+        uses: ./.github/actions/install-tools
         with:
-          install_args: node npm:turbo
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          rust: false
 
       - name: Determine changed packages
         id: packages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,12 +32,11 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Install node and turbo
-        uses: jdx/mise-action@7a111ead46986ccad89a74ad013ba2a7c08c9e67 # v2.2.1
+      - name: Install tools
+        uses: ./.github/actions/install-tools
         with:
-          install_args: node npm:turbo
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          rust: false
 
       - name: Determine changed packages
         id: packages


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Yarn has a 429 error in CI nowadays, so we need to be a more cautious in downloading yarn, a bit convoluted of a fix, but oh well.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

