### PR TITLE
H-3148, H-4586: Remove non-functional 'create entity type' button, fix draft entity type permission check

### DIFF
--- a/apps/hash-frontend/src/pages/shared/entity-type-selector.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-selector.tsx
@@ -77,10 +77,10 @@ export const EntityTypeSelector = <Multiple extends boolean = false>({
     <SelectorAutocomplete<EntityTypeWithMetadata, Multiple>
       dropdownProps={{
         query: search,
-        creationProps: {
-          createButtonProps: disableCreate
-            ? null
-            : {
+        creationProps: disableCreate
+          ? undefined
+          : {
+              createButtonProps: {
                 onMouseDown: (evt) => {
                   evt.preventDefault();
                   evt.stopPropagation();
@@ -88,8 +88,8 @@ export const EntityTypeSelector = <Multiple extends boolean = false>({
                 },
                 disabled: disableCreateNewEmpty && search === "",
               },
-          variant: "entity type",
-        },
+              variant: "entity type",
+            },
       }}
       autoFocus={autoFocus}
       inputHeight={inputHeight}

--- a/apps/hash-frontend/src/pages/shared/entity-type.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type.tsx
@@ -182,7 +182,9 @@ export const EntityType = ({
   const isDraft = !!draftEntityType;
 
   const { userPermissions, loading: loadingUserPermissions } =
-    useUserPermissionsOnEntityType(entityType?.schema.$id);
+    useUserPermissionsOnEntityType(
+      isDraft ? undefined : entityType?.schema.$id,
+    );
 
   const [entityTypeDependents, setEntityTypeDependents] = useState<
     Record<BaseUrl, EntityTypeDependent>
@@ -302,7 +304,7 @@ export const EntityType = ({
     }
   };
 
-  if (!entityType || !userPermissions) {
+  if (!entityType || (!userPermissions && !isDraft)) {
     if (loadingRemoteEntityType || loadingUserPermissions) {
       return <TypeEditorSkeleton />;
     } else if (isHrefExternal(entityTypeBaseUrl as string)) {
@@ -386,7 +388,7 @@ export const EntityType = ({
 
   const isLatest = !requestedVersion || requestedVersion === latestVersion;
 
-  const isReadonly = !draftEntityType && (!userPermissions.edit || !isLatest);
+  const isReadonly = !draftEntityType && (!userPermissions?.edit || !isLatest);
 
   const isArchived = isTypeArchived(entityType);
 
@@ -514,7 +516,7 @@ export const EntityType = ({
                   />
 
                   <EntityTypeTabs
-                    canCreateEntity={userPermissions.instantiate}
+                    canCreateEntity={!!userPermissions?.instantiate}
                     isDraft={isDraft}
                     isFile={isFile}
                     isImage={isImage}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A couple of small frontend fixes:
1. Remove a non-functional 'create entity type' button when using the type selector on the 'New Goal' page
2. Correctly skip permission checks for local draft entity types (blocks #7159)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

At some point we might want to reintroduce the 'create entity type' button to the new goal page, but it isn't a priority.

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- Create entity type test covers draft entity type
