### PR TITLE
H-4596: Support the public actor in Cedar

### DIFF
--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util/upgrade-policies.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util/upgrade-policies.ts
@@ -1,0 +1,59 @@
+import type { ActorEntityUuid } from "@blockprotocol/type-system";
+import {
+  createPolicy,
+  deletePolicyById,
+  queryPolicies,
+} from "@local/hash-graph-sdk/policy";
+import type {
+  PolicyCreationParams,
+  PrincipalConstraint,
+} from "@rust/hash-graph-authorization/types";
+
+import type { ImpureGraphContext } from "../../../context-types";
+
+export type NamedPartialPolicy = Omit<
+  PolicyCreationParams,
+  "principal" | "name"
+> & {
+  name: string;
+};
+
+export const createOrUpgradePolicies = async ({
+  authentication,
+  context,
+  policies,
+  principal,
+}: {
+  authentication: { actorId: ActorEntityUuid };
+  context: ImpureGraphContext<false, true>;
+  policies: NamedPartialPolicy[];
+  principal: PrincipalConstraint | null;
+}) =>
+  Promise.all(
+    policies.map(async (policy) => {
+      const [existingPolicy] = await queryPolicies(
+        context.graphApi,
+        authentication,
+        {
+          name: policy.name,
+          principal: principal
+            ? { filter: "constrained", ...principal }
+            : { filter: "unconstrained" },
+        },
+      );
+
+      if (existingPolicy) {
+        // TODO: Properly update the policy to match the new one
+        await deletePolicyById(
+          context.graphApi,
+          authentication,
+          existingPolicy.id,
+        );
+      }
+
+      await createPolicy(context.graphApi, authentication, {
+        ...policy,
+        principal,
+      });
+    }),
+  );

--- a/libs/@blockprotocol/type-system/rust/src/principal/actor/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/principal/actor/mod.rs
@@ -54,6 +54,16 @@ impl ActorEntityUuid {
     pub fn new(entity_uuid: impl Into<Uuid>) -> Self {
         Self(EntityUuid::new(entity_uuid))
     }
+
+    #[must_use]
+    pub fn public_actor() -> Self {
+        Self::new(Uuid::nil())
+    }
+
+    #[must_use]
+    pub fn is_public_actor(self) -> bool {
+        Uuid::from(self).is_nil()
+    }
 }
 
 impl From<ActorEntityUuid> for EntityUuid {

--- a/libs/@local/graph/api/src/rest/permissions.rs
+++ b/libs/@local/graph/api/src/rest/permissions.rs
@@ -245,7 +245,7 @@ where
         )
         .await
         .map_err(report_to_response)?
-        .resolve_policies_for_actor(authenticated_actor_id, actor_id)
+        .resolve_policies_for_actor(authenticated_actor_id, Some(actor_id))
         .await
         .map_err(report_to_response)
         .map(Json)

--- a/libs/@local/graph/authorization/schemas/policies.cedarschema
+++ b/libs/@local/graph/authorization/schemas/policies.cedarschema
@@ -20,6 +20,9 @@ namespace HASH {
   entity User, Machine, Ai in [HASH::Web::Role, HASH::Team::Role] {
   };
 
+  entity Public {
+  };
+
   action all;
 
   action createWeb in [all] appliesTo {
@@ -33,12 +36,12 @@ namespace HASH {
   };
 
   action viewEntity in [view] appliesTo {
-    principal: [User, Machine, Ai],
+    principal: [User, Machine, Ai, Public],
     resource: [Entity],
   };
 
   action viewEntityType in [view] appliesTo {
-    principal: [User, Machine, Ai],
+    principal: [User, Machine, Ai, Public],
     resource: [EntityType],
   };
 

--- a/libs/@local/graph/authorization/src/policies/principal/actor/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/actor/mod.rs
@@ -3,6 +3,7 @@ mod machine;
 mod user;
 
 use alloc::sync::Arc;
+use std::sync::LazyLock;
 
 use cedar_policy_core::ast;
 use error_stack::{Report, ResultExt as _};
@@ -12,6 +13,20 @@ use crate::policies::{
     cedar::{FromCedarEntityId as _, FromCedarEntityUId, ToCedarEntity, ToCedarEntityId},
     error::FromCedarRefernceError,
 };
+
+pub struct PublicActor;
+
+impl ToCedarEntityId for PublicActor {
+    fn to_cedar_entity_type(&self) -> &'static Arc<ast::EntityType> {
+        pub(crate) static ENTITY_TYPE: LazyLock<Arc<ast::EntityType>> =
+            LazyLock::new(|| crate::policies::cedar_resource_type(["Public"]));
+        &ENTITY_TYPE
+    }
+
+    fn to_eid(&self) -> ast::Eid {
+        ast::Eid::new("public")
+    }
+}
 
 impl FromCedarEntityUId for ActorId {
     fn from_euid(euid: &ast::EntityUID) -> Result<Self, Report<FromCedarRefernceError>> {

--- a/libs/@local/graph/authorization/src/policies/store/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/store/mod.rs
@@ -234,7 +234,7 @@ pub trait PolicyStore {
     async fn resolve_policies_for_actor(
         &self,
         authenticated_actor: ActorEntityUuid,
-        actor_id: ActorId,
+        actor_id: Option<ActorId>,
     ) -> Result<Vec<Policy>, Report<GetPoliciesError>>;
 
     /// Updates the policy specified by it's ID.

--- a/libs/@local/graph/authorization/tests/policies/main.rs
+++ b/libs/@local/graph/authorization/tests/policies/main.rs
@@ -271,7 +271,7 @@ fn instantiate() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         system_web_machine_policy_set.evaluate(
             &Request {
-                actor: ActorId::Machine(system.web.machine.id),
+                actor: Some(ActorId::Machine(system.web.machine.id)),
                 action: ActionName::Instantiate,
                 resource: Some(&PartialResourceId::EntityType(Some(Cow::Borrowed(
                     &machine_type.id
@@ -285,7 +285,7 @@ fn instantiate() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         system_machine_policy_set.evaluate(
             &Request {
-                actor: ActorId::Machine(system.machine.id),
+                actor: Some(ActorId::Machine(system.machine.id)),
                 action: ActionName::Instantiate,
                 resource: Some(&PartialResourceId::EntityType(Some(Cow::Borrowed(
                     &machine_type.id
@@ -300,7 +300,7 @@ fn instantiate() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         system_machine_policy_set.evaluate(
             &Request {
-                actor: ActorId::Machine(system.machine.id),
+                actor: Some(ActorId::Machine(system.machine.id)),
                 action: ActionName::Instantiate,
                 resource: Some(&PartialResourceId::EntityType(Some(Cow::Borrowed(
                     &document_type.id
@@ -314,7 +314,7 @@ fn instantiate() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         system_machine_policy_set.evaluate(
             &Request {
-                actor: ActorId::Machine(system.machine.id),
+                actor: Some(ActorId::Machine(system.machine.id)),
                 action: ActionName::Instantiate,
                 resource: Some(&PartialResourceId::EntityType(Some(Cow::Borrowed(
                     &document_type.id
@@ -390,7 +390,7 @@ fn user_web_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         user_policy_set.evaluate(
             &Request {
-                actor: ActorId::User(user.id),
+                actor: Some(ActorId::User(user.id)),
                 action: ActionName::Instantiate,
                 resource: Some(&PartialResourceId::EntityType(Some(Cow::Borrowed(
                     &machine_type.id
@@ -404,7 +404,7 @@ fn user_web_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         user_policy_set.evaluate(
             &Request {
-                actor: ActorId::User(user.id),
+                actor: Some(ActorId::User(user.id)),
                 action: ActionName::Instantiate,
                 resource: Some(&PartialResourceId::EntityType(Some(Cow::Borrowed(
                     &document_type.id
@@ -418,7 +418,7 @@ fn user_web_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         user_policy_set.evaluate(
             &Request {
-                actor: ActorId::User(user.id),
+                actor: Some(ActorId::User(user.id)),
                 action: ActionName::Instantiate,
                 resource: Some(&PartialResourceId::EntityType(Some(Cow::Borrowed(
                     &web_type.id
@@ -433,7 +433,7 @@ fn user_web_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         user_policy_set.evaluate(
             &Request {
-                actor: ActorId::User(user.id),
+                actor: Some(ActorId::User(user.id)),
                 action: ActionName::View,
                 resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
                 context: RequestContext::default(),
@@ -445,7 +445,7 @@ fn user_web_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         user_machine_policy_set.evaluate(
             &Request {
-                actor: ActorId::Machine(user.web.machine.id),
+                actor: Some(ActorId::Machine(user.web.machine.id)),
                 action: ActionName::View,
                 resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
                 context: RequestContext::default(),
@@ -457,7 +457,7 @@ fn user_web_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         user_machine_policy_set.evaluate(
             &Request {
-                actor: ActorId::Machine(system.machine.id),
+                actor: Some(ActorId::Machine(system.machine.id)),
                 action: ActionName::View,
                 resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
                 context: RequestContext::default(),
@@ -470,7 +470,7 @@ fn user_web_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         user_policy_set.evaluate(
             &Request {
-                actor: ActorId::User(user.id),
+                actor: Some(ActorId::User(user.id)),
                 action: ActionName::Update,
                 resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
                 context: RequestContext::default(),
@@ -482,7 +482,7 @@ fn user_web_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         user_machine_policy_set.evaluate(
             &Request {
-                actor: ActorId::Machine(user.web.machine.id),
+                actor: Some(ActorId::Machine(user.web.machine.id)),
                 action: ActionName::Update,
                 resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
                 context: RequestContext::default(),
@@ -494,7 +494,7 @@ fn user_web_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         user_machine_policy_set.evaluate(
             &Request {
-                actor: ActorId::Machine(system.machine.id),
+                actor: Some(ActorId::Machine(system.machine.id)),
                 action: ActionName::Update,
                 resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
                 context: RequestContext::default(),
@@ -566,7 +566,7 @@ fn org_web_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         org_machine_policy_set.evaluate(
             &Request {
-                actor: ActorId::Machine(org_web.machine.id),
+                actor: Some(ActorId::Machine(org_web.machine.id)),
                 action: ActionName::View,
                 resource: Some(&PartialResourceId::Entity(Some(user.web.machine.id.into()))),
                 context: RequestContext::default(),
@@ -579,7 +579,7 @@ fn org_web_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         user_policy_set.evaluate(
             &Request {
-                actor: ActorId::User(user.id),
+                actor: Some(ActorId::User(user.id)),
                 action: ActionName::View,
                 resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
                 context: RequestContext::default(),
@@ -591,7 +591,7 @@ fn org_web_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         org_machine_policy_set.evaluate(
             &Request {
-                actor: ActorId::Machine(org_web.machine.id),
+                actor: Some(ActorId::Machine(org_web.machine.id)),
                 action: ActionName::View,
                 resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
                 context: RequestContext::default(),
@@ -603,7 +603,7 @@ fn org_web_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         system_machine_policy_set.evaluate(
             &Request {
-                actor: ActorId::Machine(user.web.machine.id),
+                actor: Some(ActorId::Machine(user.web.machine.id)),
                 action: ActionName::View,
                 resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
                 context: RequestContext::default(),
@@ -615,7 +615,7 @@ fn org_web_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         system_machine_policy_set.evaluate(
             &Request {
-                actor: ActorId::Machine(system.web.machine.id),
+                actor: Some(ActorId::Machine(system.web.machine.id)),
                 action: ActionName::View,
                 resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
                 context: RequestContext::default(),
@@ -628,7 +628,7 @@ fn org_web_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         user_policy_set.evaluate(
             &Request {
-                actor: ActorId::User(user.id),
+                actor: Some(ActorId::User(user.id)),
                 action: ActionName::Update,
                 resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
                 context: RequestContext::default(),
@@ -640,7 +640,7 @@ fn org_web_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         org_machine_policy_set.evaluate(
             &Request {
-                actor: ActorId::Machine(org_web.machine.id),
+                actor: Some(ActorId::Machine(org_web.machine.id)),
                 action: ActionName::Update,
                 resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
                 context: RequestContext::default(),
@@ -652,7 +652,7 @@ fn org_web_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         user_machine_policy_set.evaluate(
             &Request {
-                actor: ActorId::Machine(user.web.machine.id),
+                actor: Some(ActorId::Machine(user.web.machine.id)),
                 action: ActionName::Update,
                 resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
                 context: RequestContext::default(),
@@ -664,7 +664,7 @@ fn org_web_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         system_machine_policy_set.evaluate(
             &Request {
-                actor: ActorId::Machine(system.web.machine.id),
+                actor: Some(ActorId::Machine(system.web.machine.id)),
                 action: ActionName::Update,
                 resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
                 context: RequestContext::default(),
@@ -697,7 +697,7 @@ fn instance_admin_without_access_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         user_policy_set.evaluate(
             &Request {
-                actor: ActorId::User(user.id),
+                actor: Some(ActorId::User(user.id)),
                 action: ActionName::View,
                 resource: Some(&PartialResourceId::Entity(Some(
                     system.hash_instance_entity.id
@@ -711,7 +711,7 @@ fn instance_admin_without_access_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         user_policy_set.evaluate(
             &Request {
-                actor: ActorId::User(user.id),
+                actor: Some(ActorId::User(user.id)),
                 action: ActionName::Update,
                 resource: Some(&PartialResourceId::Entity(Some(
                     system.hash_instance_entity.id
@@ -750,7 +750,7 @@ fn instance_admin_with_access_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         user_policy_set.evaluate(
             &Request {
-                actor: ActorId::User(user.id),
+                actor: Some(ActorId::User(user.id)),
                 action: ActionName::View,
                 resource: Some(&PartialResourceId::Entity(Some(
                     system.hash_instance_entity.id
@@ -764,7 +764,7 @@ fn instance_admin_with_access_permissions() -> Result<(), Box<dyn Error>> {
     assert_matches!(
         user_policy_set.evaluate(
             &Request {
-                actor: ActorId::User(user.id),
+                actor: Some(ActorId::User(user.id)),
                 action: ActionName::Update,
                 resource: Some(&PartialResourceId::Entity(Some(
                     system.hash_instance_entity.id
@@ -802,7 +802,7 @@ fn partial_resource_evaluation() -> Result<(), Box<dyn Error>> {
 
     match user_policy_set.evaluate(
         &Request {
-            actor: ActorId::User(user.id),
+            actor: Some(ActorId::User(user.id)),
             action: ActionName::Instantiate,
             resource: Some(&PartialResourceId::EntityType(None)),
             context: RequestContext::default(),

--- a/libs/@local/graph/postgres-store/src/permissions/mod.rs
+++ b/libs/@local/graph/postgres-store/src/permissions/mod.rs
@@ -162,7 +162,7 @@ where
         &self,
         id: ActorEntityUuid,
     ) -> Result<Option<ActorId>, Report<PrincipalError>> {
-        if Uuid::from(id).is_nil() {
+        if id.is_public_actor() {
             return Ok(None);
         }
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -791,7 +791,7 @@ where
             .await
             .change_context(InsertionError)?;
         let policies = self
-            .resolve_policies_for_actor(actor.into(), actor)
+            .resolve_policies_for_actor(actor.into(), Some(actor))
             .await
             .change_context(InsertionError)?;
         let policy_set = PolicySet::default()
@@ -1035,7 +1035,7 @@ where
             match policy_set
                 .evaluate(
                     &Request {
-                        actor,
+                        actor: Some(actor),
                         action: ActionName::Instantiate,
                         resource: Some(&PartialResourceId::EntityType(Some(Cow::Borrowed(
                             entity_type_id.into(),
@@ -1669,7 +1669,7 @@ where
             .await
             .change_context(UpdateError)?;
         let policies = self
-            .resolve_policies_for_actor(actor.into(), actor)
+            .resolve_policies_for_actor(actor.into(), Some(actor))
             .await
             .change_context(UpdateError)?;
         let policy_set = PolicySet::default()
@@ -1805,7 +1805,7 @@ where
                 match policy_set
                     .evaluate(
                         &Request {
-                            actor,
+                            actor: Some(actor),
                             action: ActionName::Instantiate,
                             resource: Some(&PartialResourceId::EntityType(Some(Cow::Borrowed(
                                 entity_type_id.into(),

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -1060,7 +1060,7 @@ where
         actor_id: Option<ActorId>,
     ) -> Result<Vec<Policy>, Report<GetPoliciesError>> {
         let Some(actor_id) = actor_id else {
-            // If no actor is provided, only policies wihtout principal constraints are returned.
+            // If no actor is provided, only policies without principal constraints are returned.
             return self
                 .query_policies(
                     authenticated_actor,

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -123,7 +123,7 @@ where
     ) -> Result<(), Report<EnsureSystemPoliciesError>> {
         tracing::info!("Seeding system policies");
         for policy in self
-            .resolve_policies_for_actor(system_machine_actor.into(), system_machine_actor)
+            .resolve_policies_for_actor(system_machine_actor.into(), Some(system_machine_actor))
             .await
             .change_context(EnsureSystemPoliciesError::ReadPoliciesFailed)?
         {
@@ -275,7 +275,7 @@ where
             .build()
             .change_context(WebCreationError::StoreError)?;
         let policies = self
-            .resolve_policies_for_actor(actor.into(), actor)
+            .resolve_policies_for_actor(actor.into(), Some(actor))
             .await
             .change_context(WebCreationError::StoreError)?;
 
@@ -287,7 +287,7 @@ where
         match policy_set
             .evaluate(
                 &Request {
-                    actor,
+                    actor: Some(actor),
                     action: ActionName::CreateWeb,
                     resource: Some(&PartialResourceId::Web(Some(web_id))),
                     context: RequestContext::default(),
@@ -1056,9 +1056,22 @@ where
 
     async fn resolve_policies_for_actor(
         &self,
-        _authenticated_actor: ActorEntityUuid,
-        actor_id: ActorId,
+        authenticated_actor: ActorEntityUuid,
+        actor_id: Option<ActorId>,
     ) -> Result<Vec<Policy>, Report<GetPoliciesError>> {
+        let Some(actor_id) = actor_id else {
+            // If no actor is provided, only policies wihtout principal constraints are returned.
+            return self
+                .query_policies(
+                    authenticated_actor,
+                    &PolicyFilter {
+                        name: None,
+                        principal: Some(PrincipalFilter::Unconstrained),
+                    },
+                )
+                .await;
+        };
+
         // The below query does several things. It:
         //   1. gets all principals that the actor can act as
         //   2. gets all policies that apply to those principals

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
@@ -1746,7 +1746,7 @@ where
             .ok_or(QueryError)
             .attach(StatusCode::Unauthenticated)?;
         let policies = self
-            .resolve_policies_for_actor(actor.into(), actor)
+            .resolve_policies_for_actor(actor.into(), Some(actor))
             .await
             .change_context(QueryError)?;
         let policy_set = PolicySet::default()
@@ -1769,7 +1769,7 @@ where
                 policy_set
                     .evaluate(
                         &Request {
-                            actor,
+                            actor: Some(actor),
                             action: ActionName::Instantiate,
                             resource: Some(&PartialResourceId::EntityType(Some(Cow::Borrowed(
                                 entity_type_id.into(),

--- a/libs/@local/graph/postgres-store/tests/principals/policies.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/policies.rs
@@ -374,31 +374,34 @@ async fn global_policies() -> Result<(), Box<dyn Error>> {
 
     // Every actor should get global policies
     let user1_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::User(env.user1))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user1)))
         .await?
         .into_iter()
         .map(|policy| policy.id)
         .collect::<HashSet<_>>();
     let user2_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::User(env.user2))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user2)))
         .await?
         .into_iter()
         .map(|policy| policy.id)
         .collect::<HashSet<_>>();
     let machine_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::Machine(env.machine_id))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::Machine(env.machine_id)))
         .await?
         .into_iter()
         .map(|policy| policy.id)
         .collect::<HashSet<_>>();
     let ai_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::Ai(env.ai_id))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::Ai(env.ai_id)))
         .await?
         .into_iter()
         .map(|policy| policy.id)
         .collect::<HashSet<_>>();
     let nonexisting_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::User(UserId::new(Uuid::new_v4())))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::User(UserId::new(Uuid::new_v4()))),
+        )
         .await?
         .into_iter()
         .map(|policy| policy.id)
@@ -438,19 +441,19 @@ async fn actor_type_policies() -> Result<(), Box<dyn Error>> {
 
     // Test user type policies
     let user1_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::User(env.user1))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user1)))
         .await?
         .into_iter()
         .map(|policy| policy.id)
         .collect::<HashSet<_>>();
     let user2_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::User(env.user2))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user2)))
         .await?
         .into_iter()
         .map(|policy| policy.id)
         .collect::<HashSet<_>>();
     let machine_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::Machine(env.machine_id))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::Machine(env.machine_id)))
         .await?
         .into_iter()
         .map(|policy| policy.id)
@@ -458,7 +461,7 @@ async fn actor_type_policies() -> Result<(), Box<dyn Error>> {
     let nonexisting_machine_policies = client
         .resolve_policies_for_actor(
             actor_id.into(),
-            ActorId::Machine(MachineId::new(Uuid::new_v4())),
+            Some(ActorId::Machine(MachineId::new(Uuid::new_v4()))),
         )
         .await?
         .into_iter()
@@ -513,19 +516,22 @@ async fn specific_actor_policies() -> Result<(), Box<dyn Error>> {
 
     // user1 has a specific policy assigned
     let user1_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::User(env.user1))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user1)))
         .await?
         .into_iter()
         .map(|policy| policy.id)
         .collect::<HashSet<_>>();
     let user2_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::User(env.user2))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user2)))
         .await?
         .into_iter()
         .map(|policy| policy.id)
         .collect::<HashSet<_>>();
     let nonexisting_user_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::User(UserId::new(Uuid::new_v4())))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::User(UserId::new(Uuid::new_v4()))),
+        )
         .await?
         .into_iter()
         .map(|policy| policy.id)
@@ -557,13 +563,13 @@ async fn role_based_policies() -> Result<(), Box<dyn Error>> {
 
     // Test role-based policies
     let user1_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::User(env.user1))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user1)))
         .await?
         .into_iter()
         .map(|policy| policy.id)
         .collect::<HashSet<_>>();
     let user2_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::User(env.user2))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user2)))
         .await?
         .into_iter()
         .map(|policy| policy.id)
@@ -591,7 +597,7 @@ async fn role_based_policies() -> Result<(), Box<dyn Error>> {
         .await?;
 
     let machine_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::Machine(special_machine_id))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::Machine(special_machine_id)))
         .await?
         .into_iter()
         .map(|policy| policy.id)
@@ -621,13 +627,13 @@ async fn team_hierarchy_policies() -> Result<(), Box<dyn Error>> {
     // Test team hierarchies
     // User2 has team1_role, AI has nested_team_role which is under team1
     let user2_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::User(env.user2))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user2)))
         .await?
         .into_iter()
         .map(|policy| policy.id)
         .collect::<HashSet<_>>();
     let ai_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::Ai(env.ai_id))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::Ai(env.ai_id)))
         .await?
         .into_iter()
         .map(|policy| policy.id)
@@ -658,22 +664,22 @@ async fn policy_count_and_content() -> Result<(), Box<dyn Error>> {
     let nonexistent_id = UserId::new(Uuid::new_v4());
 
     let user1_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::User(env.user1))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user1)))
         .await?
         .into_iter()
         .map(|policy| (policy.id, policy))
         .collect::<HashMap<_, _>>();
     let user2_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::User(env.user2))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user2)))
         .await?;
     let machine_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::Machine(env.machine_id))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::Machine(env.machine_id)))
         .await?;
     let ai_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::Ai(env.ai_id))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::Ai(env.ai_id)))
         .await?;
     let nonexistent_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::User(nonexistent_id))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(nonexistent_id)))
         .await?;
 
     // Verify that we have at least one policy for each actor
@@ -715,7 +721,7 @@ async fn role_assignment_changes() -> Result<(), Box<dyn Error>> {
 
     // Initial policy count
     let user2_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::User(env.user2))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user2)))
         .await?
         .into_iter()
         .map(|policy| policy.id)
@@ -734,7 +740,7 @@ async fn role_assignment_changes() -> Result<(), Box<dyn Error>> {
 
     // Should have fewer policies now
     let updated_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::User(env.user2))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user2)))
         .await?
         .into_iter()
         .map(|policy| policy.id)
@@ -755,7 +761,7 @@ async fn role_assignment_changes() -> Result<(), Box<dyn Error>> {
 
     // Should have different policies now after adding a new role
     let final_policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::User(env.user2))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user2)))
         .await?
         .into_iter()
         .map(|policy| policy.id)
@@ -806,7 +812,7 @@ async fn resource_constraints_are_preserved() -> Result<(), Box<dyn Error>> {
         .await?;
 
     let policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::User(user_id))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(user_id)))
         .await?
         .into_iter()
         .map(|policy| (policy.id, policy))
@@ -930,7 +936,7 @@ async fn deep_team_hierarchy() -> Result<(), Box<dyn Error>> {
 
     // User should get all policies through the hierarchy
     let policies = client
-        .resolve_policies_for_actor(actor_id.into(), ActorId::User(user_id))
+        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(user_id)))
         .await?
         .into_iter()
         .map(|policy| policy.id)

--- a/libs/@local/graph/type-fetcher/src/store.rs
+++ b/libs/@local/graph/type-fetcher/src/store.rs
@@ -276,7 +276,7 @@ where
     async fn resolve_policies_for_actor(
         &self,
         authenticated_actor: ActorEntityUuid,
-        actor_id: ActorId,
+        actor_id: Option<ActorId>,
     ) -> Result<Vec<Policy>, Report<GetPoliciesError>> {
         self.store
             .resolve_policies_for_actor(authenticated_actor, actor_id)


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

[H-4567](https://linear.app/hash/issue/H-4567/properly-handle-public-actors) adds support public actors in general, but we did not have policies with public actor support, yet

## 🔍 What does this change?

- Add a `PublicActor` type which is used in requests by the public actor
- Simplify policy migration in Node and make sure, instantiation permission is only granted to authenticated users.