### PR TITLE
H-4598: Allow multiple filters in a single request in the Postgres query builder

### DIFF
--- a/libs/@local/graph/postgres-store/src/snapshot/entity/batch.rs
+++ b/libs/@local/graph/postgres-store/src/snapshot/entity/batch.rs
@@ -8,7 +8,6 @@ use hash_graph_authorization::{
 use hash_graph_store::{
     entity::{EntityStore as _, EntityValidationReport, ValidateEntityComponents},
     error::InsertionError,
-    filter::Filter,
     query::Read,
 };
 use hash_graph_types::{
@@ -292,10 +291,9 @@ where
             .await
             .change_context(InsertionError)?;
 
-        let entities =
-            Read::<Entity>::read_vec(postgres_client, &Filter::All(Vec::new()), None, true)
-                .await
-                .change_context(InsertionError)?;
+        let entities = Read::<Entity>::read_vec(postgres_client, &[], None, true)
+            .await
+            .change_context(InsertionError)?;
 
         let validator_provider = StoreProvider {
             store: postgres_client,

--- a/libs/@local/graph/postgres-store/src/snapshot/mod.rs
+++ b/libs/@local/graph/postgres-store/src/snapshot/mod.rs
@@ -39,12 +39,7 @@ use hash_graph_authorization::{
         types::{RelationshipFilter, ResourceFilter},
     },
 };
-use hash_graph_store::{
-    error::InsertionError,
-    filter::{Filter, QueryRecord},
-    pool::StorePool,
-    query::Read,
-};
+use hash_graph_store::{error::InsertionError, filter::QueryRecord, pool::StorePool, query::Read};
 use hash_status::StatusCode;
 use postgres_types::ToSql;
 use serde::{Deserialize, Serialize};

--- a/libs/@local/graph/postgres-store/src/snapshot/mod.rs
+++ b/libs/@local/graph/postgres-store/src/snapshot/mod.rs
@@ -613,7 +613,7 @@ impl PostgresStorePool {
                 .acquire(NoAuthorization, None)
                 .await
                 .change_context(SnapshotDumpError::Query)?,
-            &Filter::All(vec![]),
+            &[],
             None,
             true,
         )

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
@@ -189,7 +189,7 @@ where
         let (data, artifacts) =
             ReadPaginated::<DataTypeWithMetadata, VersionedUrlSorting>::read_paginated_vec(
                 self,
-                &params.filter,
+                &[params.filter],
                 Some(temporal_axes),
                 &VersionedUrlSorting {
                     cursor: params.after,
@@ -679,7 +679,7 @@ where
 
         Ok(self
             .read(
-                &params.filter,
+                &[params.filter],
                 Some(&params.temporal_axes.resolve()),
                 params.include_drafts,
             )
@@ -1277,22 +1277,17 @@ where
 
         let mut ontology_type_resolver = OntologyTypeResolver::default();
 
-        let data_types = Read::<DataTypeWithMetadata>::read_vec(
-            &transaction,
-            &Filter::All(Vec::new()),
-            None,
-            true,
-        )
-        .await
-        .change_context(UpdateError)?
-        .into_iter()
-        .map(|data_type| {
-            let schema = Arc::new(data_type.schema);
-            let data_type_id = DataTypeUuid::from_url(&schema.id);
-            ontology_type_resolver.add_unresolved_data_type(data_type_id, Arc::clone(&schema));
-            (data_type_id, schema)
-        })
-        .collect::<Vec<_>>();
+        let data_types = Read::<DataTypeWithMetadata>::read_vec(&transaction, &[], None, true)
+            .await
+            .change_context(UpdateError)?
+            .into_iter()
+            .map(|data_type| {
+                let schema = Arc::new(data_type.schema);
+                let data_type_id = DataTypeUuid::from_url(&schema.id);
+                ontology_type_resolver.add_unresolved_data_type(data_type_id, Arc::clone(&schema));
+                (data_type_id, schema)
+            })
+            .collect::<Vec<_>>();
 
         let data_type_validator = DataTypeValidator;
         let num_data_types = data_types.len();

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/property_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/property_type.rs
@@ -133,7 +133,7 @@ where
         let (data, artifacts) =
             ReadPaginated::<PropertyTypeWithMetadata, VersionedUrlSorting>::read_paginated_vec(
                 self,
-                &params.filter,
+                &[params.filter],
                 Some(temporal_axes),
                 &VersionedUrlSorting {
                     cursor: params.after,
@@ -540,7 +540,7 @@ where
 
         Ok(self
             .read(
-                &params.filter,
+                &[params.filter],
                 Some(&params.temporal_axes.resolve()),
                 params.include_drafts,
             )

--- a/libs/@local/graph/postgres-store/src/store/postgres/traversal_context.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/traversal_context.rs
@@ -39,12 +39,12 @@ where
     ) -> Result<(), Report<QueryError>> {
         for data_type in <Self as Read<DataTypeWithMetadata>>::read_vec(
             self,
-            &Filter::<DataTypeWithMetadata>::In(
+            &[Filter::<DataTypeWithMetadata>::In(
                 FilterExpression::Path {
                     path: DataTypeQueryPath::OntologyId,
                 },
                 ParameterList::DataTypeIds(data_type_ids),
-            ),
+            )],
             Some(&subgraph.temporal_axes.resolved),
             false,
         )
@@ -67,12 +67,12 @@ where
     ) -> Result<(), Report<QueryError>> {
         for property_type in <Self as Read<PropertyTypeWithMetadata>>::read_vec(
             self,
-            &Filter::<PropertyTypeWithMetadata>::In(
+            &[Filter::<PropertyTypeWithMetadata>::In(
                 FilterExpression::Path {
                     path: PropertyTypeQueryPath::OntologyId,
                 },
                 ParameterList::PropertyTypeIds(property_type_ids),
-            ),
+            )],
             Some(&subgraph.temporal_axes.resolved),
             false,
         )
@@ -95,12 +95,12 @@ where
     ) -> Result<(), Report<QueryError>> {
         for entity_type in <Self as Read<EntityTypeWithMetadata>>::read_vec(
             self,
-            &Filter::<EntityTypeWithMetadata>::In(
+            &[Filter::<EntityTypeWithMetadata>::In(
                 FilterExpression::Path {
                     path: EntityTypeQueryPath::OntologyId,
                 },
                 ParameterList::EntityTypeIds(entity_type_ids),
-            ),
+            )],
             Some(&subgraph.temporal_axes.resolved),
             false,
         )
@@ -124,12 +124,12 @@ where
     ) -> Result<(), Report<QueryError>> {
         let entities = <Self as Read<Entity>>::read_vec(
             self,
-            &Filter::<Entity>::In(
+            &[Filter::<Entity>::In(
                 FilterExpression::Path {
                     path: EntityQueryPath::EditionId,
                 },
                 ParameterList::EntityEditionIds(edition_ids),
-            ),
+            )],
             Some(&subgraph.temporal_axes.resolved),
             include_drafts,
         )

--- a/libs/@local/graph/postgres-store/src/store/validation.rs
+++ b/libs/@local/graph/postgres-store/src/store/validation.rs
@@ -195,7 +195,7 @@ where
         let schema = self
             .store
             .read_one(
-                &Filter::for_data_type_uuid(data_type_uuid),
+                &[Filter::for_data_type_uuid(data_type_uuid)],
                 Some(
                     &QueryTemporalAxesUnresolved::DecisionTime {
                         pinned: PinnedTemporalAxisUnresolved::new(None),
@@ -397,7 +397,9 @@ where
         let schema = self
             .store
             .read_one(
-                &Filter::<PropertyTypeWithMetadata>::for_versioned_url(type_id),
+                &[Filter::<PropertyTypeWithMetadata>::for_versioned_url(
+                    type_id,
+                )],
                 Some(
                     &QueryTemporalAxesUnresolved::DecisionTime {
                         pinned: PinnedTemporalAxisUnresolved::new(None),
@@ -602,7 +604,7 @@ where
         let entity = self
             .store
             .read_one(
-                &Filter::for_entity_by_entity_id(entity_id),
+                &[Filter::for_entity_by_entity_id(entity_id)],
                 Some(
                     &QueryTemporalAxesUnresolved::DecisionTime {
                         pinned: PinnedTemporalAxisUnresolved::new(None),

--- a/libs/@local/graph/store/src/query/mod.rs
+++ b/libs/@local/graph/store/src/query/mod.rs
@@ -45,7 +45,7 @@ pub trait ReadPaginated<R: QueryRecord, S: Sorting + Sync>: Read<R> {
     )]
     fn read_paginated(
         &self,
-        filter: &Filter<'_, R>,
+        filters: &[Filter<'_, R>],
         temporal_axes: Option<&QueryTemporalAxes>,
         sorting: &S,
         limit: Option<usize>,
@@ -64,10 +64,10 @@ pub trait ReadPaginated<R: QueryRecord, S: Sorting + Sync>: Read<R> {
         clippy::type_complexity,
         reason = "simplification of type would lead to more unreadable code"
     )]
-    #[instrument(level = "info", skip(self, filter, sorting))]
+    #[instrument(level = "info", skip(self, filters, sorting))]
     fn read_paginated_vec(
         &self,
-        filter: &Filter<'_, R>,
+        filters: &[Filter<'_, R>],
         temporal_axes: Option<&QueryTemporalAxes>,
         sorting: &S,
         limit: Option<usize>,
@@ -83,7 +83,7 @@ pub trait ReadPaginated<R: QueryRecord, S: Sorting + Sync>: Read<R> {
     > + Send {
         async move {
             let (stream, artifacts) = self
-                .read_paginated(filter, temporal_axes, sorting, limit, include_drafts)
+                .read_paginated(filters, temporal_axes, sorting, limit, include_drafts)
                 .await?;
             Ok((stream.try_collect().await?, artifacts))
         }
@@ -96,25 +96,25 @@ pub trait Read<R: QueryRecord>: Sync {
 
     fn read(
         &self,
-        filter: &Filter<'_, R>,
+        filters: &[Filter<'_, R>],
         temporal_axes: Option<&QueryTemporalAxes>,
         include_drafts: bool,
     ) -> impl Future<Output = Result<Self::ReadStream, Report<QueryError>>> + Send;
 
-    #[instrument(level = "info", skip(self, filter))]
+    #[instrument(level = "info", skip(self, filters))]
     fn read_vec(
         &self,
-        filter: &Filter<'_, R>,
+        filters: &[Filter<'_, R>],
         temporal_axes: Option<&QueryTemporalAxes>,
         include_drafts: bool,
     ) -> impl Future<Output = Result<Vec<R>, Report<QueryError>>> + Send {
-        self.read(filter, temporal_axes, include_drafts)
+        self.read(filters, temporal_axes, include_drafts)
             .and_then(TryStreamExt::try_collect)
     }
 
     fn read_one(
         &self,
-        filter: &Filter<'_, R>,
+        filters: &[Filter<'_, R>],
         temporal_axes: Option<&QueryTemporalAxes>,
         include_drafts: bool,
     ) -> impl Future<Output = Result<R, Report<QueryError>>> + Send;

--- a/libs/@local/graph/type-fetcher/src/store.rs
+++ b/libs/@local/graph/type-fetcher/src/store.rs
@@ -893,7 +893,7 @@ where
 
     async fn read_paginated(
         &self,
-        filter: &Filter<'_, R>,
+        filters: &[Filter<'_, R>],
         temporal_axes: Option<&QueryTemporalAxes>,
         sorting: &S,
         limit: Option<usize>,
@@ -906,7 +906,7 @@ where
         Report<QueryError>,
     > {
         self.store
-            .read_paginated(filter, temporal_axes, sorting, limit, include_drafts)
+            .read_paginated(filters, temporal_axes, sorting, limit, include_drafts)
             .await
     }
 }
@@ -921,21 +921,23 @@ where
 
     async fn read(
         &self,
-        filter: &Filter<'_, R>,
+        filters: &[Filter<'_, R>],
         temporal_axes: Option<&QueryTemporalAxes>,
         include_drafts: bool,
     ) -> Result<Self::ReadStream, Report<QueryError>> {
-        self.store.read(filter, temporal_axes, include_drafts).await
+        self.store
+            .read(filters, temporal_axes, include_drafts)
+            .await
     }
 
     async fn read_one(
         &self,
-        filter: &Filter<'_, R>,
+        filters: &[Filter<'_, R>],
         temporal_axes: Option<&QueryTemporalAxes>,
         include_drafts: bool,
     ) -> Result<R, Report<QueryError>> {
         self.store
-            .read_one(filter, temporal_axes, include_drafts)
+            .read_one(filters, temporal_axes, include_drafts)
             .await
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When policies are partially evaluated, we want to add that as a dedicated filters.


## 🔍 What does this change?

- Changes the signatures of the `read`-functions to take a slice instead of a simple reference (an iterator would also work, but that makes the signature even more complex, so I chose to use a simple slice here for now)
- Put every call in a slice instead and remove the filter if it's an `all([])`-filter

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph