### PR TITLE
H-4595: Allow reading of web roles and team roles

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/persist-entity-action.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/persist-entity-action.ts
@@ -100,7 +100,14 @@ export const persistEntityAction: FlowActionActivity = async ({ inputs }) => {
         { graphApi: graphApiClient },
         { actorId },
         { webId },
-      );
+      ).then((maybeMachineId) => {
+        if (!maybeMachineId) {
+          throw new Error(
+            `Failed to get web bot account ID for web ID: ${webId}`,
+          );
+        }
+        return maybeMachineId;
+      });
 
   if (!webBotActorId) {
     throw new Error(

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/create-file-entity-from-url.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/shared/create-file-entity-from-url.ts
@@ -224,7 +224,14 @@ export const createFileEntityFromUrl = async (params: {
         { graphApi: graphApiClient },
         { actorId: userAuthentication.actorId },
         { webId },
-      );
+      ).then((maybeMachineId) => {
+        if (!maybeMachineId) {
+          throw new Error(
+            `Failed to get web machine for user account ID: ${userAuthentication.actorId}`,
+          );
+        }
+        return maybeMachineId;
+      });
 
   if (!webBotActorId) {
     throw new Error(

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/write-google-sheet-action.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/write-google-sheet-action.ts
@@ -366,7 +366,12 @@ export const writeGoogleSheetAction: FlowActionActivity<{
     { graphApi: graphApiClient },
     { actorId: userAccountId },
     { webId },
-  );
+  ).then((maybeMachineId) => {
+    if (!maybeMachineId) {
+      throw new Error(`Failed to get web bot account ID for web ID: ${webId}`);
+    }
+    return maybeMachineId;
+  });
 
   const provenance: ProvidedEntityEditionProvenance = {
     actorType: "machine",

--- a/apps/hash-ai-worker-ts/src/activities/get-ai-assistant-account-id-activity.ts
+++ b/apps/hash-ai-worker-ts/src/activities/get-ai-assistant-account-id-activity.ts
@@ -13,15 +13,12 @@ export const getAiAssistantAccountIdActivity = async (params: {
   const { authentication, graphApiClient, grantCreatePermissionForWeb } =
     params;
 
-  let aiAssistantAccountId: ActorEntityUuid;
-
-  try {
-    aiAssistantAccountId = await getMachineIdByIdentifier(
-      { graphApi: graphApiClient },
-      authentication,
-      { identifier: "hash-ai" },
-    );
-  } catch {
+  const aiAssistantAccountId = await getMachineIdByIdentifier(
+    { graphApi: graphApiClient },
+    authentication,
+    { identifier: "hash-ai" },
+  );
+  if (!aiAssistantAccountId) {
     return null;
   }
 
@@ -39,10 +36,15 @@ export const getAiAssistantAccountIdActivity = async (params: {
       const webMachineActorId = await getWebMachineId(
         { graphApi: graphApiClient },
         authentication,
-        {
-          webId: grantCreatePermissionForWeb,
-        },
-      );
+        { webId: grantCreatePermissionForWeb },
+      ).then((maybeMachineId) => {
+        if (!maybeMachineId) {
+          throw new Error(
+            `Failed to get web machine for web ID: ${grantCreatePermissionForWeb}`,
+          );
+        }
+        return maybeMachineId;
+      });
 
       await graphApiClient.modifyWebAuthorizationRelationships(
         webMachineActorId,

--- a/apps/hash-ai-worker-ts/src/activities/graph.ts
+++ b/apps/hash-ai-worker-ts/src/activities/graph.ts
@@ -272,6 +272,6 @@ export const createGraphActivities = ({
     return getInstanceAdminsTeam(
       { graphApi: graphApiClient },
       authentication,
-    ).then(({ teamId }) => teamId);
+    ).then(({ id }) => id);
   },
 });

--- a/apps/hash-ai-worker-ts/src/activities/shared/create-inferred-entity-notification.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/create-inferred-entity-notification.ts
@@ -1,4 +1,4 @@
-import type { ActorEntityUuid } from "@blockprotocol/type-system";
+import type { UserId } from "@blockprotocol/type-system";
 import { extractDraftIdFromEntityId } from "@blockprotocol/type-system";
 import { createGraphChangeNotification } from "@local/hash-backend-utils/notifications";
 import type { GraphApi } from "@local/hash-graph-client";
@@ -13,7 +13,7 @@ export const createInferredEntityNotification = async ({
   entity: HashEntity;
   graphApiClient: GraphApi;
   operation: "create" | "update";
-  notifiedUserAccountId: ActorEntityUuid;
+  notifiedUserAccountId: UserId;
 }) => {
   const entityIsDraft = !!extractDraftIdFromEntityId(
     entity.metadata.recordId.entityId,

--- a/apps/hash-ai-worker-ts/src/activities/shared/get-flow-context.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/get-flow-context.ts
@@ -1,7 +1,7 @@
 import type {
-  ActorEntityUuid,
   EntityId,
   EntityUuid,
+  UserId,
   WebId,
 } from "@blockprotocol/type-system";
 import {
@@ -137,7 +137,7 @@ type FlowContext = {
   dataSources: FlowDataSources;
   flowEntityId: EntityId;
   stepId: string;
-  userAuthentication: { actorId: ActorEntityUuid };
+  userAuthentication: { actorId: UserId };
   webId: WebId;
 };
 

--- a/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response.ts
@@ -190,7 +190,7 @@ export const getLlmResponse = async <T extends LlmParams>(
     const { incurredInEntities } = usageTrackingParams;
 
     if (incurredInEntities.length > 0) {
-      const { teamId: hashInstanceAdminGroupId } = await getInstanceAdminsTeam(
+      const { id: hashInstanceAdminGroupId } = await getInstanceAdminsTeam(
         { graphApi: graphApiClient },
         { actorId: aiAssistantAccountId },
       );

--- a/apps/hash-ai-worker-ts/src/shared/testing-utilities/get-alice-user-account-id.ts
+++ b/apps/hash-ai-worker-ts/src/shared/testing-utilities/get-alice-user-account-id.ts
@@ -1,4 +1,4 @@
-import type { ActorEntityUuid } from "@blockprotocol/type-system";
+import type { UserId } from "@blockprotocol/type-system";
 import {
   extractBaseUrl,
   extractWebIdFromEntityId,
@@ -55,5 +55,5 @@ export const getAliceUserAccountId = async () => {
     aliceUserEntity.metadata.recordId.entityId,
   );
 
-  return aliceUserAccountId as ActorEntityUuid;
+  return aliceUserAccountId as UserId;
 };

--- a/apps/hash-ai-worker-ts/src/shared/testing-utilities/mock-get-flow-context.ts
+++ b/apps/hash-ai-worker-ts/src/shared/testing-utilities/mock-get-flow-context.ts
@@ -137,7 +137,7 @@ vi.mock("@local/hash-backend-utils/temporal", async (importOriginal) => {
               flowTrigger: {
                 triggerDefinitionId: "userTrigger",
               },
-              webId: aliceUserAccountId as WebId,
+              webId: aliceUserAccountId,
               userAuthentication: {
                 actorId: aliceUserAccountId,
               },

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/014-add-instance-admin-permission.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/014-add-instance-admin-permission.migration.ts
@@ -17,8 +17,10 @@ const migrate: MigrationFunction = async ({
    * Step 1. Ensure the `hashInstanceAdmins` account group has the `editor` permission on all user entities
    */
 
-  const { teamId: hashInstanceAdminsAccountGroupId } =
-    await getInstanceAdminsTeam(context, authentication);
+  const { id: hashInstanceAdminsAccountGroupId } = await getInstanceAdminsTeam(
+    context,
+    authentication,
+  );
 
   const userEntities = await getEntities(context, authentication, {
     filter: {

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util/upgrade-entities.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util/upgrade-entities.ts
@@ -56,6 +56,11 @@ export const upgradeWebEntities = async ({
 }) => {
   const webBotAccountId = await getWebMachineId(context, authentication, {
     webId,
+  }).then((maybeMachineId) => {
+    if (!maybeMachineId) {
+      throw new Error(`Failed to get web bot account ID for web ID: ${webId}`);
+    }
+    return maybeMachineId;
   });
 
   const webBotAuthentication = { actorId: webBotAccountId as ActorEntityUuid };

--- a/apps/hash-api/src/graph/knowledge/primitive/entity/after-update-entity-hooks/file-document-after-update-entity-hook-callback.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity/after-update-entity-hooks/file-document-after-update-entity-hook-callback.ts
@@ -95,6 +95,13 @@ export const parseTextFromFileAfterUpdateEntityHookCallback: AfterUpdateEntityHo
 
       const webMachineActorId = await getWebMachineId(context, authentication, {
         webId: fileEntityWebId,
+      }).then((maybeMachineId) => {
+        if (!maybeMachineId) {
+          throw new Error(
+            `Failed to get web bot account ID for web ID: ${fileEntityWebId}`,
+          );
+        }
+        return maybeMachineId;
       });
 
       try {

--- a/apps/hash-api/src/graph/knowledge/system-types/hash-instance.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/hash-instance.ts
@@ -45,7 +45,10 @@ export const createHashInstance: ImpureGraphFunction<
     throw new Error("HASH instance entity already exists.");
   }
 
-  const { teamId, webId } = await getInstanceAdminsTeam(ctx, authentication);
+  const { id: teamId, webId } = await getInstanceAdminsTeam(
+    ctx,
+    authentication,
+  );
 
   logger.info(
     `Retrieved account group for hash instance admins with id: ${teamId}`,

--- a/apps/hash-api/src/graph/knowledge/system-types/notification.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/notification.ts
@@ -133,7 +133,15 @@ export const createMentionNotification: ImpureGraphFunction<
 
   const webMachineActorId = await getWebMachineId(context, userAuthentication, {
     webId,
+  }).then((maybeMachineId) => {
+    if (!maybeMachineId) {
+      throw new Error(
+        `Failed to get web machine for user account ID: ${userAuthentication.actorId}`,
+      );
+    }
+    return maybeMachineId;
   });
+
   const botAuthentication = { actorId: webMachineActorId };
 
   const { linkEntityRelationships, notificationEntityRelationships } =
@@ -399,6 +407,13 @@ export const createCommentNotification: ImpureGraphFunction<
 
   const webMachineActorId = await getWebMachineId(context, userAuthentication, {
     webId,
+  }).then((maybeMachineId) => {
+    if (!maybeMachineId) {
+      throw new Error(
+        `Failed to get web machine for user account ID: ${userAuthentication.actorId}`,
+      );
+    }
+    return maybeMachineId;
   });
   const authentication = { actorId: webMachineActorId };
 

--- a/apps/hash-api/src/graph/knowledge/system-types/user.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user.ts
@@ -379,8 +379,10 @@ export const createUser: ImpureGraphFunction<
   // TODO: Move User-Entity creation to Graph
   //   see https://linear.app/hash/issue/H-4559/move-user-entity-creation-to-graph
 
-  const { teamId: hashInstanceAdminsAccountGroupId } =
-    await getInstanceAdminsTeam(ctx, authentication);
+  const { id: hashInstanceAdminsAccountGroupId } = await getInstanceAdminsTeam(
+    ctx,
+    authentication,
+  );
 
   const entity = await createEntity<UserEntity>(
     ctx,
@@ -421,7 +423,7 @@ export const createUser: ImpureGraphFunction<
   if (isInstanceAdmin) {
     const instanceAdmins = await getInstanceAdminsTeam(ctx, authentication);
     await addActorGroupMember(ctx, authentication, {
-      actorGroupId: instanceAdmins.teamId,
+      actorGroupId: instanceAdmins.id,
       actorId: user.accountId,
     });
   }

--- a/apps/hash-api/src/graph/system-account.ts
+++ b/apps/hash-api/src/graph/system-account.ts
@@ -17,7 +17,7 @@ export const ensureHashSystemAccountExists = async (params: {
   const { logger, context } = params;
 
   systemAccountId = await context.graphApi
-    .getOrCreateSystemActor("h")
+    .getOrCreateSystemMachine("h")
     .then(({ data: machineId }) => machineId as MachineId);
 
   await context.graphApi.seedSystemPolicies();

--- a/apps/hash-api/src/graphql/resolvers/knowledge/file/create-file-from-url.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/file/create-file-from-url.ts
@@ -42,7 +42,7 @@ export const createFileFromUrl: ResolverFn<
     await triggerPdfAnalysisWorkflow({
       entity,
       temporalClient: temporal,
-      userAccountId: authentication.actorId,
+      userAccountId: user.accountId,
       webId: extractWebIdFromEntityId(entity.entityId),
     });
   }

--- a/apps/hash-api/src/graphql/resolvers/knowledge/file/request-file-upload.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/file/request-file-upload.ts
@@ -65,7 +65,7 @@ export const requestFileUpload: ResolverFn<
     await triggerPdfAnalysisWorkflow({
       entity,
       temporalClient: temporal,
-      userAccountId: authentication.actorId,
+      userAccountId: user.accountId,
       webId: extractWebIdFromEntityId(entity.entityId),
     });
   }

--- a/apps/hash-api/src/graphql/resolvers/knowledge/file/shared.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/file/shared.ts
@@ -1,8 +1,4 @@
-import type {
-  ActorEntityUuid,
-  Entity,
-  WebId,
-} from "@blockprotocol/type-system";
+import type { Entity, UserId, WebId } from "@blockprotocol/type-system";
 import type { TemporalClient } from "@local/hash-backend-utils/temporal";
 import { inferMetadataFromDocumentFlowDefinition } from "@local/hash-isomorphic-utils/flows/file-flow-definitions";
 import type {
@@ -20,7 +16,7 @@ export const triggerPdfAnalysisWorkflow = async ({
 }: {
   entity: Entity<File>;
   temporalClient: TemporalClient;
-  userAccountId: ActorEntityUuid;
+  userAccountId: UserId;
   webId: WebId;
 }) => {
   const { entityId, properties } = entity;

--- a/apps/hash-api/src/graphql/resolvers/knowledge/user/submit-early-access-form.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/user/submit-early-access-form.ts
@@ -22,7 +22,7 @@ export const submitEarlyAccessFormResolver: ResolverFn<
   const { user } = graphQLContext;
   const context = graphQLContextToImpureGraphContext(graphQLContext);
 
-  const { teamId: adminAccountGroupId } = await getInstanceAdminsTeam(context, {
+  const { id: adminAccountGroupId } = await getInstanceAdminsTeam(context, {
     actorId: systemAccountId,
   });
 

--- a/apps/hash-api/src/integrations/google/oauth-callback.ts
+++ b/apps/hash-api/src/integrations/google/oauth-callback.ts
@@ -1,4 +1,5 @@
 import type { WebId } from "@blockprotocol/type-system";
+import { NotFoundError } from "@local/hash-backend-utils/error";
 import {
   createGoogleOAuth2Client,
   getGoogleAccountById,
@@ -78,7 +79,12 @@ export const googleOAuthCallback: RequestHandler<
     req.context,
     authentication,
     { identifier: "google" },
-  );
+  ).then((maybeMachineId) => {
+    if (!maybeMachineId) {
+      throw new NotFoundError("Failed to get google bot");
+    }
+    return maybeMachineId;
+  });
 
   /**
    * Create the Google Account entity if it doesn't exist

--- a/apps/hash-api/src/integrations/linear/oauth.ts
+++ b/apps/hash-api/src/integrations/linear/oauth.ts
@@ -253,7 +253,12 @@ export const oAuthLinearCallback: RequestHandler<
     req.context,
     authentication,
     { identifier: "linear" },
-  );
+  ).then((maybeMachineId) => {
+    if (!maybeMachineId) {
+      throw new Error("Failed to get linear bot");
+    }
+    return maybeMachineId;
+  });
 
   await createUserSecret({
     /**

--- a/apps/hash-api/src/integrations/linear/sync-back.ts
+++ b/apps/hash-api/src/integrations/linear/sync-back.ts
@@ -56,7 +56,12 @@ export const processEntityChange = async (
     { graphApi },
     { actorId: systemAccountId },
     { identifier: "linear" },
-  );
+  ).then((maybeMachineId) => {
+    if (!maybeMachineId) {
+      throw new Error("Failed to get linear bot");
+    }
+    return maybeMachineId;
+  });
 
   if (entity.metadata.provenance.edition.createdById === linearMachineActorId) {
     /**

--- a/apps/hash-api/src/integrations/linear/webhook.ts
+++ b/apps/hash-api/src/integrations/linear/webhook.ts
@@ -88,7 +88,12 @@ export const linearWebhook: RequestHandler<
     req.context,
     { actorId: systemAccountId },
     { identifier: "linear" },
-  );
+  ).then((maybeMachineId) => {
+    if (!maybeMachineId) {
+      throw new Error("Failed to get linear bot account ID");
+    }
+    return maybeMachineId;
+  });
 
   const graphContext: ImpureGraphContext = {
     graphApi,

--- a/apps/hash-api/src/integrations/sync-back-watcher.ts
+++ b/apps/hash-api/src/integrations/sync-back-watcher.ts
@@ -53,7 +53,12 @@ export const createIntegrationSyncBackWatcher = async (
           { graphApi: graphApiClient },
           { actorId: systemAccountId },
           { identifier: "linear" },
-        );
+        ).then((maybeMachineId) => {
+          if (!maybeMachineId) {
+            throw new Error("Failed to get linear bot");
+          }
+          return maybeMachineId;
+        });
 
         const entity = (
           await graphApiClient

--- a/apps/hash-api/src/seed-data/seed-flow-test-types.ts
+++ b/apps/hash-api/src/seed-data/seed-flow-test-types.ts
@@ -176,7 +176,12 @@ const seedFlowTestTypes = async () => {
     context,
     { actorId: publicUserAccountId },
     { identifier: "h" },
-  );
+  ).then((maybeMachineId) => {
+    if (!maybeMachineId) {
+      throw new Error("Failed to get hash bot");
+    }
+    return maybeMachineId;
+  });
 
   const authentication = { actorId: hashBotActorId };
 

--- a/libs/@blockprotocol/type-system/rust/src/principal/actor/ai.rs
+++ b/libs/@blockprotocol/type-system/rust/src/principal/actor/ai.rs
@@ -58,5 +58,6 @@ impl From<AiId> for Uuid {
 pub struct Ai {
     pub id: AiId,
     pub identifier: String,
+    #[cfg_attr(feature = "codegen", specta(skip))]
     pub roles: HashSet<RoleId>,
 }

--- a/libs/@blockprotocol/type-system/rust/src/principal/actor/machine.rs
+++ b/libs/@blockprotocol/type-system/rust/src/principal/actor/machine.rs
@@ -58,5 +58,6 @@ impl From<MachineId> for Uuid {
 pub struct Machine {
     pub id: MachineId,
     pub identifier: String,
+    #[cfg_attr(feature = "codegen", specta(skip))]
     pub roles: HashSet<RoleId>,
 }

--- a/libs/@blockprotocol/type-system/rust/src/principal/actor/user.rs
+++ b/libs/@blockprotocol/type-system/rust/src/principal/actor/user.rs
@@ -80,5 +80,6 @@ impl From<UserId> for WebId {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct User {
     pub id: UserId,
+    #[cfg_attr(feature = "codegen", specta(skip))]
     pub roles: HashSet<RoleId>,
 }

--- a/libs/@blockprotocol/type-system/rust/src/principal/actor_group/team.rs
+++ b/libs/@blockprotocol/type-system/rust/src/principal/actor_group/team.rs
@@ -59,5 +59,6 @@ pub struct Team {
     pub id: TeamId,
     pub parent_id: ActorGroupId,
     pub name: String,
+    #[cfg_attr(feature = "codegen", specta(skip))]
     pub roles: HashSet<TeamRoleId>,
 }

--- a/libs/@blockprotocol/type-system/rust/src/principal/actor_group/web.rs
+++ b/libs/@blockprotocol/type-system/rust/src/principal/actor_group/web.rs
@@ -58,5 +58,6 @@ impl From<WebId> for Uuid {
 pub struct Web {
     pub id: WebId,
     pub shortname: Option<String>,
+    #[cfg_attr(feature = "codegen", specta(skip))]
     pub roles: HashSet<WebRoleId>,
 }

--- a/libs/@blockprotocol/type-system/rust/types/index.snap.d.ts
+++ b/libs/@blockprotocol/type-system/rust/types/index.snap.d.ts
@@ -46,18 +46,15 @@ export type ActorType = "user" | "machine" | "ai";
 export interface Ai {
 	id: AiId;
 	identifier: string;
-	roles: RoleId[];
 }
 export type AiId = Brand<ActorEntityUuid, "AiId">;
 export interface Machine {
 	id: MachineId;
 	identifier: string;
-	roles: RoleId[];
 }
 export type MachineId = Brand<ActorEntityUuid, "MachineId">;
 export interface User {
 	id: UserId;
-	roles: RoleId[];
 }
 export type UserId = Brand<ActorEntityUuid & WebId, "UserId">;
 export type ActorGroup = {
@@ -78,13 +75,11 @@ export interface Team {
 	id: TeamId;
 	parentId: ActorGroupId;
 	name: string;
-	roles: TeamRoleId[];
 }
 export type TeamId = Brand<ActorGroupEntityUuid, "TeamId">;
 export interface Web {
 	id: WebId;
 	shortname: (string | null);
-	roles: WebRoleId[];
 }
 export type WebId = Brand<ActorGroupEntityUuid | ActorEntityUuid, "WebId">;
 export type Role = {

--- a/libs/@local/graph/api/openapi/openapi.json
+++ b/libs/@local/graph/api/openapi/openapi.json
@@ -61,6 +61,51 @@
         }
       }
     },
+    "/actor-groups/teams/{team_id}/roles": {
+      "get": {
+        "tags": [
+          "Graph",
+          "Team"
+        ],
+        "operationId": "get_team_roles",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ActorEntityUuid"
+            }
+          },
+          {
+            "name": "team_id",
+            "in": "path",
+            "description": "The ID of the team to retrieve",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/TeamId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The team roles were retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Store error occurred"
+          }
+        }
+      }
+    },
     "/actor-groups/webs": {
       "post": {
         "tags": [
@@ -331,6 +376,51 @@
           },
           "403": {
             "description": "Permission denied"
+          }
+        }
+      }
+    },
+    "/actor-groups/webs/{web_id}/roles": {
+      "get": {
+        "tags": [
+          "Graph",
+          "Web"
+        ],
+        "operationId": "get_web_roles",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ActorEntityUuid"
+            }
+          },
+          {
+            "name": "web_id",
+            "in": "path",
+            "description": "The ID of the web to retrieve",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/WebId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The web roles were retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Store error occurred"
           }
         }
       }

--- a/libs/@local/graph/api/openapi/openapi.json
+++ b/libs/@local/graph/api/openapi/openapi.json
@@ -45,11 +45,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetTeamResponse"
-                    }
-                  ],
                   "nullable": true
                 }
               }
@@ -225,7 +220,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GetWebResponse"
+                  "nullable": true
                 }
               }
             }
@@ -269,7 +264,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GetWebResponse"
+                  "nullable": true
                 }
               }
             }
@@ -823,13 +818,13 @@
         }
       }
     },
-    "/actors/system/{identifier}": {
+    "/actors/machine/identifier/system/{identifier}": {
       "get": {
         "tags": [
           "Graph",
           "Principal"
         ],
-        "operationId": "get_or_create_system_actor",
+        "operationId": "get_or_create_system_machine",
         "parameters": [
           {
             "name": "identifier",
@@ -848,6 +843,50 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MachineId"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Store error occurred"
+          }
+        }
+      }
+    },
+    "/actors/machine/identifier/{identifier}": {
+      "get": {
+        "tags": [
+          "Graph",
+          "Web"
+        ],
+        "operationId": "get_machine_by_identifier",
+        "parameters": [
+          {
+            "name": "X-Authenticated-User-Actor-Id",
+            "in": "header",
+            "description": "The ID of the actor which is used to authorize the request",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ActorEntityUuid"
+            }
+          },
+          {
+            "name": "identifier",
+            "in": "path",
+            "description": "The identifier of the machine to get",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The web was retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "nullable": true
                 }
               }
             }
@@ -7624,41 +7663,6 @@
             }
           }
         }
-      },
-      "GetTeamResponse": {
-        "type": "object",
-        "required": [
-          "teamId",
-          "parentId"
-        ],
-        "properties": {
-          "parentId": {
-            "$ref": "#/components/schemas/ActorGroupId"
-          },
-          "teamId": {
-            "$ref": "#/components/schemas/TeamId"
-          }
-        },
-        "additionalProperties": false
-      },
-      "GetWebResponse": {
-        "type": "object",
-        "required": [
-          "webId",
-          "machineId"
-        ],
-        "properties": {
-          "machineId": {
-            "$ref": "#/components/schemas/MachineId"
-          },
-          "shortname": {
-            "type": "string"
-          },
-          "webId": {
-            "$ref": "#/components/schemas/WebId"
-          }
-        },
-        "additionalProperties": false
       },
       "GraphElementVertexId": {
         "oneOf": [

--- a/libs/@local/graph/authorization/src/policies/store/error.rs
+++ b/libs/@local/graph/authorization/src/policies/store/error.rs
@@ -77,6 +77,17 @@ pub enum WebCreationError {
 impl Error for WebCreationError {}
 
 #[derive(Debug, derive_more::Display)]
+#[display("Could not create web: {_variant}")]
+pub enum WebRoleError {
+    #[display("Web with ID `{web_id}` does not exist")]
+    NotFound { web_id: WebId },
+    #[display("Store operation failed")]
+    StoreError,
+}
+
+impl Error for WebRoleError {}
+
+#[derive(Debug, derive_more::Display)]
 #[display("Could not create web role: {_variant}")]
 pub enum WebRoleCreationError {
     #[display("Web with ID `{web_id}` does not exist")]
@@ -106,6 +117,17 @@ pub enum TeamRoleCreationError {
 }
 
 impl Error for TeamRoleCreationError {}
+
+#[derive(Debug, derive_more::Display)]
+#[display("Could not create web: {_variant}")]
+pub enum TeamRoleError {
+    #[display("Team with ID `{team_id}` does not exist")]
+    NotFound { team_id: TeamId },
+    #[display("Store operation failed")]
+    StoreError,
+}
+
+impl Error for TeamRoleError {}
 
 #[derive(Debug, derive_more::Display)]
 #[display("Could change role assignment: {_variant}")]

--- a/libs/@local/graph/authorization/src/policies/store/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/store/mod.rs
@@ -21,8 +21,8 @@ use uuid::Uuid;
 use self::error::{
     ActorCreationError, ContextCreationError, CreatePolicyError, EnsureSystemPoliciesError,
     GetPoliciesError, GetSystemAccountError, PolicyStoreError, RemovePolicyError,
-    RoleAssignmentError, TeamCreationError, TeamRoleCreationError, UpdatePolicyError,
-    WebCreationError, WebRoleCreationError,
+    RoleAssignmentError, TeamCreationError, TeamRoleCreationError, TeamRoleError,
+    UpdatePolicyError, WebCreationError, WebRoleCreationError, WebRoleError,
 };
 use super::{
     ContextBuilder, Effect, Policy, PolicyId, action::ActionName, principal::PrincipalConstraint,
@@ -330,6 +330,36 @@ pub trait LocalPrincipalStore {
         actor: ActorId,
         parameter: CreateWebParameter,
     ) -> Result<CreateWebResponse, Report<WebCreationError>>;
+
+    /// Returns all roles assigned to the given web.
+    ///
+    /// # Errors
+    ///
+    /// - [`NotFound`] if the web does not exist
+    /// - [`StoreError`] if the underlying store returns an error
+    ///
+    /// [`NotFound`]: WebRoleError::NotFound
+    /// [`StoreError`]: WebRoleError::StoreError
+    async fn get_web_roles(
+        &mut self,
+        actor: ActorEntityUuid,
+        web_id: WebId,
+    ) -> Result<HashMap<WebRoleId, WebRole>, Report<WebRoleError>>;
+
+    /// Returns all roles assigned to the given team.
+    ///
+    /// # Errors
+    ///
+    /// - [`NotFound`] if the team does not exist
+    /// - [`StoreError`] if the underlying store returns an error
+    ///
+    /// [`NotFound`]: TeamRoleError::NotFound
+    /// [`StoreError`]: TeamRoleError::StoreError
+    async fn get_team_roles(
+        &mut self,
+        actor: ActorEntityUuid,
+        team_id: TeamId,
+    ) -> Result<HashMap<TeamRoleId, TeamRole>, Report<TeamRoleError>>;
 
     /// Assigns an actor to a role.
     ///

--- a/libs/@local/graph/authorization/src/policies/store/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/store/mod.rs
@@ -311,7 +311,7 @@ pub trait LocalPrincipalStore {
     /// - [`StoreError`] if the underlying store returns an error
     ///
     /// [`StoreError`]: GetSystemAccountError::StoreError
-    async fn get_or_create_system_actor(
+    async fn get_or_create_system_machine(
         &mut self,
         identifier: &str,
     ) -> Result<MachineId, Report<GetSystemAccountError>>;

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -2651,7 +2651,7 @@ impl<C: AsClient, A: AuthorizationApi> AccountStore for PostgresStore<C, A> {
                 let role_ids = row.get::<_, Vec<WebRoleId>>(1);
                 Web {
                     id,
-                    shortname: Some(row.get(0)),
+                    shortname: row.get(0),
                     roles: role_ids.into_iter().collect(),
                 }
             }))

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -44,8 +44,8 @@ use hash_graph_store::{
     account::{
         AccountGroupInsertionError, AccountInsertionError, AccountStore, CreateAiActorParams,
         CreateMachineActorParams, CreateOrgWebParams, CreateTeamParams, CreateUserActorParams,
-        CreateUserActorResponse, GetTeamResponse, GetWebResponse, QueryWebError,
-        TeamRetrievalError, WebInsertionError, WebRetrievalError,
+        CreateUserActorResponse, GetActorError, QueryWebError, TeamRetrievalError,
+        WebInsertionError, WebRetrievalError,
     },
     error::{InsertionError, QueryError, UpdateError},
     query::ConflictBehavior,
@@ -75,9 +75,9 @@ use type_system::{
     },
     principal::{
         PrincipalId, PrincipalType,
-        actor::{ActorEntityUuid, ActorId, ActorType, AiId, MachineId},
-        actor_group::{ActorGroupEntityUuid, ActorGroupId, TeamId, WebId},
-        role::{RoleName, TeamRole, TeamRoleId, WebRole, WebRoleId},
+        actor::{ActorEntityUuid, ActorId, ActorType, Ai, AiId, Machine, MachineId, User, UserId},
+        actor_group::{ActorGroupEntityUuid, ActorGroupId, Team, TeamId, Web, WebId},
+        role::{RoleId, RoleName, TeamRole, TeamRoleId, WebRole, WebRoleId},
     },
 };
 use uuid::Uuid;
@@ -169,7 +169,7 @@ where
     C: AsClient,
     A: AuthorizationApi + Send + Sync,
 {
-    async fn get_or_create_system_actor(
+    async fn get_or_create_system_machine(
         &mut self,
         identifier: &str,
     ) -> Result<MachineId, Report<GetSystemAccountError>> {
@@ -1357,7 +1357,7 @@ where
 
     async fn seed_system_policies(&mut self) -> Result<(), Report<EnsureSystemPoliciesError>> {
         let system_machine_actor = self
-            .get_or_create_system_actor("h")
+            .get_or_create_system_machine("h")
             .await
             .change_context(EnsureSystemPoliciesError::CreatingSystemMachineFailed)
             .map(ActorId::Machine)?;
@@ -2366,6 +2366,209 @@ impl<C: AsClient, A: AuthorizationApi> AccountStore for PostgresStore<C, A> {
             .change_context(AccountInsertionError)
     }
 
+    async fn get_user_by_id(
+        &self,
+        _actor_id: ActorEntityUuid,
+        id: UserId,
+    ) -> Result<Option<User>, Report<GetActorError>> {
+        Ok(self
+            .as_client()
+            .query_opt(
+                "
+                SELECT
+                    array_remove(array_agg(role.id), NULL),
+                    array_remove(array_agg(role.principal_type), NULL)
+                FROM user_actor
+                LEFT OUTER JOIN actor_role ON user_actor.id = actor_role.actor_id
+                LEFT OUTER JOIN role ON actor_role.role_id = role.id
+                WHERE user_actor.id = $1
+                GROUP BY user_actor.id",
+                &[&id],
+            )
+            .await
+            .change_context(GetActorError)?
+            .map(|row| {
+                let role_ids = row.get::<_, Vec<Uuid>>(1);
+                let principal_types = row.get::<_, Vec<PrincipalType>>(1);
+                User {
+                    id,
+                    roles: role_ids
+                        .into_iter()
+                        .zip(principal_types)
+                        .map(|(id, principal_type)| match principal_type {
+                            PrincipalType::WebRole => RoleId::Web(WebRoleId::new(id)),
+                            PrincipalType::TeamRole => RoleId::Team(TeamRoleId::new(id)),
+                            _ => unreachable!("Unexpected role type: {principal_type:?}"),
+                        })
+                        .collect(),
+                }
+            }))
+    }
+
+    async fn get_machine_by_id(
+        &self,
+        _actor_id: ActorEntityUuid,
+        id: MachineId,
+    ) -> Result<Option<Machine>, Report<GetActorError>> {
+        Ok(self
+            .as_client()
+            .query_opt(
+                "
+                SELECT
+                    machine_actor.identifier,
+                    array_remove(array_agg(role.id), NULL),
+                    array_remove(array_agg(role.principal_type), NULL)
+                FROM machine_actor
+                LEFT OUTER JOIN actor_role ON machine_actor.id = actor_role.actor_id
+                LEFT OUTER JOIN role ON actor_role.role_id = role.id
+                WHERE machine_actor.id = $1
+                GROUP BY machine_actor.id, machine_actor.identifier",
+                &[&id],
+            )
+            .await
+            .change_context(GetActorError)?
+            .map(|row| {
+                let role_ids = row.get::<_, Vec<Uuid>>(1);
+                let principal_types = row.get::<_, Vec<PrincipalType>>(2);
+                Machine {
+                    id,
+                    identifier: row.get(0),
+                    roles: role_ids
+                        .into_iter()
+                        .zip(principal_types)
+                        .map(|(id, principal_type)| match principal_type {
+                            PrincipalType::WebRole => RoleId::Web(WebRoleId::new(id)),
+                            PrincipalType::TeamRole => RoleId::Team(TeamRoleId::new(id)),
+                            _ => unreachable!("Unexpected role type: {principal_type:?}"),
+                        })
+                        .collect(),
+                }
+            }))
+    }
+
+    async fn get_machine_by_identifier(
+        &self,
+        _actor_id: ActorEntityUuid,
+        identifier: &str,
+    ) -> Result<Option<Machine>, Report<GetActorError>> {
+        Ok(self
+            .as_client()
+            .query_opt(
+                "
+                SELECT
+                    machine_actor.id,
+                    array_remove(array_agg(role.id), NULL),
+                    array_remove(array_agg(role.principal_type), NULL)
+                FROM machine_actor
+                LEFT OUTER JOIN actor_role ON machine_actor.id = actor_role.actor_id
+                LEFT OUTER JOIN role ON actor_role.role_id = role.id
+                WHERE machine_actor.identifier = $1
+                GROUP BY machine_actor.id, machine_actor.identifier",
+                &[&identifier],
+            )
+            .await
+            .change_context(GetActorError)?
+            .map(|row| {
+                let role_ids = row.get::<_, Vec<Uuid>>(1);
+                let principal_types = row.get::<_, Vec<PrincipalType>>(2);
+                Machine {
+                    id: row.get(0),
+                    identifier: identifier.to_owned(),
+                    roles: role_ids
+                        .into_iter()
+                        .zip(principal_types)
+                        .map(|(id, principal_type)| match principal_type {
+                            PrincipalType::WebRole => RoleId::Web(WebRoleId::new(id)),
+                            PrincipalType::TeamRole => RoleId::Team(TeamRoleId::new(id)),
+                            _ => unreachable!("Unexpected role type: {principal_type:?}"),
+                        })
+                        .collect(),
+                }
+            }))
+    }
+
+    async fn get_ai_by_id(
+        &self,
+        _actor_id: ActorEntityUuid,
+        id: AiId,
+    ) -> Result<Option<Ai>, Report<GetActorError>> {
+        Ok(self
+            .as_client()
+            .query_opt(
+                "
+                SELECT
+                    ai_actor.identifier,
+                    array_remove(array_agg(role.id), NULL),
+                    array_remove(array_agg(role.principal_type), NULL)
+                FROM ai_actor
+                LEFT OUTER JOIN actor_role ON ai_actor.id = actor_role.actor_id
+                LEFT OUTER JOIN role ON actor_role.role_id = role.id
+                WHERE ai_actor.id = $1
+                GROUP BY ai_actor.id, ai_actor.identifier",
+                &[&id],
+            )
+            .await
+            .change_context(GetActorError)?
+            .map(|row| {
+                let role_ids = row.get::<_, Vec<Uuid>>(1);
+                let principal_types = row.get::<_, Vec<PrincipalType>>(2);
+                Ai {
+                    id,
+                    identifier: row.get(0),
+                    roles: role_ids
+                        .into_iter()
+                        .zip(principal_types)
+                        .map(|(id, principal_type)| match principal_type {
+                            PrincipalType::WebRole => RoleId::Web(WebRoleId::new(id)),
+                            PrincipalType::TeamRole => RoleId::Team(TeamRoleId::new(id)),
+                            _ => unreachable!("Unexpected role type: {principal_type:?}"),
+                        })
+                        .collect(),
+                }
+            }))
+    }
+
+    async fn get_ai_by_identifier(
+        &self,
+        _actor_id: ActorEntityUuid,
+        identifier: &str,
+    ) -> Result<Option<Ai>, Report<GetActorError>> {
+        Ok(self
+            .as_client()
+            .query_opt(
+                "
+                SELECT
+                    ai_actor.id,
+                    array_remove(array_agg(role.id), NULL),
+                    array_remove(array_agg(role.principal_type), NULL)
+                FROM ai_actor
+                LEFT OUTER JOIN actor_role ON ai_actor.id = actor_role.actor_id
+                LEFT OUTER JOIN role ON actor_role.role_id = role.id
+                WHERE ai_actor.identifier = $1
+                GROUP BY ai_actor.id, ai_actor.identifier",
+                &[&identifier],
+            )
+            .await
+            .change_context(GetActorError)?
+            .map(|row| {
+                let role_ids = row.get::<_, Vec<Uuid>>(1);
+                let principal_types = row.get::<_, Vec<PrincipalType>>(2);
+                Ai {
+                    id: row.get(0),
+                    identifier: identifier.to_owned(),
+                    roles: role_ids
+                        .into_iter()
+                        .zip(principal_types)
+                        .map(|(id, principal_type)| match principal_type {
+                            PrincipalType::WebRole => RoleId::Web(WebRoleId::new(id)),
+                            PrincipalType::TeamRole => RoleId::Team(TeamRoleId::new(id)),
+                            _ => unreachable!("Unexpected role type: {principal_type:?}"),
+                        })
+                        .collect(),
+                }
+            }))
+    }
+
     async fn create_ai_actor(
         &mut self,
         _actor_id: ActorEntityUuid,
@@ -2424,79 +2627,65 @@ impl<C: AsClient, A: AuthorizationApi> AccountStore for PostgresStore<C, A> {
     }
 
     async fn get_web_by_id(
-        &mut self,
+        &self,
         _actor_id: ActorEntityUuid,
-        web_id: WebId,
-    ) -> Result<Option<GetWebResponse>, Report<WebRetrievalError>> {
-        let Some(shortname) = self
-            .as_client()
-            .query_opt("SELECT shortname FROM web WHERE id = $1", &[&web_id])
-            .await
-            .change_context(WebRetrievalError)?
-            .map(|row| row.get(0))
-        else {
-            return Ok(None);
-        };
-
-        let Some(machine_id) = self
+        id: WebId,
+    ) -> Result<Option<Web>, Report<WebRetrievalError>> {
+        Ok(self
             .as_client()
             .query_opt(
-                "SELECT id FROM machine_actor WHERE identifier = $1",
-                &[&format!("system-{web_id}")],
+                "
+                SELECT
+                    web.shortname,
+                    array_remove(array_agg(role.id), NULL)
+                FROM web
+                LEFT OUTER JOIN role ON web.id = role.actor_group_id
+                WHERE web.id = $1
+                GROUP BY web.shortname
+                ",
+                &[&id],
             )
             .await
             .change_context(WebRetrievalError)?
-            .map(|row| row.get(0))
-        else {
-            return Ok(None);
-        };
-
-        tracing::info!("Found web with id {web_id} and machine id {machine_id}");
-
-        Ok(Some(GetWebResponse {
-            web_id,
-            machine_id,
-            shortname,
-        }))
+            .map(|row| {
+                let role_ids = row.get::<_, Vec<WebRoleId>>(3);
+                Web {
+                    id,
+                    shortname: Some(row.get(0)),
+                    roles: role_ids.into_iter().collect(),
+                }
+            }))
     }
 
     async fn get_web_by_shortname(
-        &mut self,
+        &self,
         _actor_id: ActorEntityUuid,
         shortname: &str,
-    ) -> Result<Option<GetWebResponse>, Report<WebRetrievalError>> {
-        let Some(web_id) = self
-            .as_client()
-            .query_opt("SELECT id FROM web WHERE shortname = $1", &[&shortname])
-            .await
-            .change_context(WebRetrievalError)?
-            .map(|row| row.get(0))
-        else {
-            return Ok(None);
-        };
-
-        let Some(machine_id) = self
+    ) -> Result<Option<Web>, Report<WebRetrievalError>> {
+        Ok(self
             .as_client()
             .query_opt(
-                "SELECT id FROM machine_actor WHERE identifier = $1",
-                &[&format!("system-{web_id}")],
+                "
+                SELECT
+                    web.id,
+                    array_remove(array_agg(role.id), NULL)
+                FROM web
+                LEFT OUTER JOIN role ON web.id = role.actor_group_id
+                WHERE web.shortname = $1
+                GROUP BY web.id
+                ",
+                &[&shortname],
             )
             .await
             .change_context(WebRetrievalError)?
-            .map(|row| row.get(0))
-        else {
-            return Ok(None);
-        };
-
-        tracing::info!(
-            "Found web with id {web_id} and machine id {machine_id} for shortname {shortname}"
-        );
-
-        Ok(Some(GetWebResponse {
-            web_id,
-            machine_id,
-            shortname: Some(shortname.to_owned()),
-        }))
+            .map(|row| {
+                let role_ids = row.get::<_, Vec<WebRoleId>>(3);
+                Web {
+                    id: row.get(0),
+                    shortname: Some(shortname.to_owned()),
+                    roles: role_ids.into_iter().collect(),
+                }
+            }))
     }
 
     #[tracing::instrument(level = "info", skip(self))]
@@ -2580,30 +2769,85 @@ impl<C: AsClient, A: AuthorizationApi> AccountStore for PostgresStore<C, A> {
         }
     }
 
-    async fn get_team_by_name(
-        &mut self,
+    async fn get_team_by_id(
+        &self,
         _actor_id: ActorEntityUuid,
-        name: &str,
-    ) -> Result<Option<GetTeamResponse>, Report<TeamRetrievalError>> {
+        id: TeamId,
+    ) -> Result<Option<Team>, Report<TeamRetrievalError>> {
         Ok(self
             .as_client()
             .query_opt(
                 "
-                SELECT team.id, parent.principal_type, parent.id
+                SELECT
+                    parent.principal_type,
+                    parent.id,
+                    team.name,
+                    array_remove(array_agg(role.id), NULL)
                 FROM team
-                JOIN principal AS parent ON parent.id = team.parent_id
-                WHERE team.name = $1",
+                JOIN actor_group AS parent ON parent.id = parent_id
+                LEFT OUTER JOIN role ON team.id = role.actor_group_id
+                WHERE team.id = $1
+                GROUP BY team.id, parent.principal_type, parent.id
+                ",
+                &[&id],
+            )
+            .await
+            .change_context(TeamRetrievalError)?
+            .map(|row| {
+                let role_ids = row.get::<_, Vec<TeamRoleId>>(3);
+                Team {
+                    id,
+                    parent_id: match row.get(0) {
+                        PrincipalType::Web => ActorGroupId::Web(row.get(1)),
+                        PrincipalType::Team => ActorGroupId::Team(row.get(1)),
+                        principal_type => {
+                            unreachable!("Unexpected principal type {principal_type}")
+                        }
+                    },
+                    name: row.get(2),
+                    roles: role_ids.into_iter().collect(),
+                }
+            }))
+    }
+
+    async fn get_team_by_name(
+        &self,
+        _actor_id: ActorEntityUuid,
+        name: &str,
+    ) -> Result<Option<Team>, Report<TeamRetrievalError>> {
+        Ok(self
+            .as_client()
+            .query_opt(
+                "
+                SELECT
+                    team.id,
+                    parent.principal_type,
+                    parent.id,
+                    array_remove(array_agg(role.id), NULL)
+                FROM team
+                JOIN actor_group AS parent ON parent.id = parent_id
+                LEFT OUTER JOIN role ON team.id = role.actor_group_id
+                WHERE team.name = $1
+                GROUP BY team.id, parent.principal_type, parent.id
+                ",
                 &[&name],
             )
             .await
             .change_context(TeamRetrievalError)?
-            .map(|row| GetTeamResponse {
-                team_id: row.get(0),
-                parent_id: match row.get(1) {
-                    PrincipalType::Web => ActorGroupId::Web(row.get(2)),
-                    PrincipalType::Team => ActorGroupId::Team(row.get(2)),
-                    other => unreachable!("Unexpected actor group type: {other:?}"),
-                },
+            .map(|row| {
+                let role_ids = row.get::<_, Vec<TeamRoleId>>(3);
+                Team {
+                    id: row.get(0),
+                    parent_id: match row.get(1) {
+                        PrincipalType::Web => ActorGroupId::Web(row.get(2)),
+                        PrincipalType::Team => ActorGroupId::Team(row.get(2)),
+                        principal_type => {
+                            unreachable!("Unexpected principal type {principal_type}")
+                        }
+                    },
+                    name: name.to_owned(),
+                    roles: role_ids.into_iter().collect(),
+                }
             }))
     }
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -2388,7 +2388,7 @@ impl<C: AsClient, A: AuthorizationApi> AccountStore for PostgresStore<C, A> {
             .await
             .change_context(GetActorError)?
             .map(|row| {
-                let role_ids = row.get::<_, Vec<Uuid>>(1);
+                let role_ids = row.get::<_, Vec<Uuid>>(0);
                 let principal_types = row.get::<_, Vec<PrincipalType>>(1);
                 User {
                     id,
@@ -2648,7 +2648,7 @@ impl<C: AsClient, A: AuthorizationApi> AccountStore for PostgresStore<C, A> {
             .await
             .change_context(WebRetrievalError)?
             .map(|row| {
-                let role_ids = row.get::<_, Vec<WebRoleId>>(3);
+                let role_ids = row.get::<_, Vec<WebRoleId>>(1);
                 Web {
                     id,
                     shortname: Some(row.get(0)),
@@ -2679,7 +2679,7 @@ impl<C: AsClient, A: AuthorizationApi> AccountStore for PostgresStore<C, A> {
             .await
             .change_context(WebRetrievalError)?
             .map(|row| {
-                let role_ids = row.get::<_, Vec<WebRoleId>>(3);
+                let role_ids = row.get::<_, Vec<WebRoleId>>(1);
                 Web {
                     id: row.get(0),
                     shortname: Some(shortname.to_owned()),

--- a/libs/@local/graph/postgres-store/tests/principals/ai.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/ai.rs
@@ -77,10 +77,12 @@ async fn create_ai_with_duplicate_id() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn get_non_existent_ai() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let (client, _actor_id) = db.seed([]).await?;
+    let (client, actor_id) = db.seed([]).await?;
 
     let non_existent_id = AiId::new(Uuid::new_v4());
-    let result = client.get_ai_by_id(non_existent_id).await?;
+    let result = client
+        .get_ai_by_id(actor_id.into(), non_existent_id)
+        .await?;
 
     assert!(
         result.is_none(),

--- a/libs/@local/graph/postgres-store/tests/principals/ai.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/ai.rs
@@ -5,6 +5,7 @@ use hash_graph_authorization::policies::{
     store::{CreateWebParameter, PrincipalStore as _},
 };
 use hash_graph_postgres_store::permissions::PrincipalError;
+use hash_graph_store::account::AccountStore as _;
 use pretty_assertions::assert_eq;
 use type_system::principal::{
     PrincipalId,
@@ -79,7 +80,7 @@ async fn get_non_existent_ai() -> Result<(), Box<dyn Error>> {
     let (client, _actor_id) = db.seed([]).await?;
 
     let non_existent_id = AiId::new(Uuid::new_v4());
-    let result = client.get_ai(non_existent_id).await?;
+    let result = client.get_ai_by_id(non_existent_id).await?;
 
     assert!(
         result.is_none(),

--- a/libs/@local/graph/postgres-store/tests/principals/machine.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/machine.rs
@@ -5,6 +5,7 @@ use hash_graph_authorization::policies::{
     store::{CreateWebParameter, PrincipalStore as _},
 };
 use hash_graph_postgres_store::permissions::PrincipalError;
+use hash_graph_store::account::AccountStore as _;
 use pretty_assertions::assert_eq;
 use type_system::principal::{
     PrincipalId,
@@ -122,7 +123,7 @@ async fn get_non_existent_machine() -> Result<(), Box<dyn Error>> {
     let (client, _actor_id) = db.seed([]).await?;
 
     let non_existent_id = MachineId::new(Uuid::new_v4());
-    let result = client.get_machine(non_existent_id).await?;
+    let result = client.get_machine_by_id(non_existent_id).await?;
 
     assert!(
         result.is_none(),
@@ -139,7 +140,7 @@ async fn get_machine() -> Result<(), Box<dyn Error>> {
 
     let machine_id = client.create_machine(None, "test-machine").await?;
     let retrieved = client
-        .get_machine(machine_id)
+        .get_machine_by_identifier("test-machine")
         .await?
         .expect("Machine should exist");
 

--- a/libs/@local/graph/postgres-store/tests/principals/machine.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/machine.rs
@@ -120,10 +120,12 @@ async fn create_web_machine_relation() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn get_non_existent_machine() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let (client, _actor_id) = db.seed([]).await?;
+    let (client, actor_id) = db.seed([]).await?;
 
     let non_existent_id = MachineId::new(Uuid::new_v4());
-    let result = client.get_machine_by_id(non_existent_id).await?;
+    let result = client
+        .get_machine_by_id(actor_id.into(), non_existent_id)
+        .await?;
 
     assert!(
         result.is_none(),
@@ -136,11 +138,11 @@ async fn get_non_existent_machine() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn get_machine() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let (mut client, _actor_id) = db.seed([]).await?;
+    let (mut client, actor_id) = db.seed([]).await?;
 
     let machine_id = client.create_machine(None, "test-machine").await?;
     let retrieved = client
-        .get_machine_by_identifier("test-machine")
+        .get_machine_by_identifier(actor_id.into(), "test-machine")
         .await?
         .expect("Machine should exist");
 

--- a/libs/@local/graph/postgres-store/tests/principals/user.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/user.rs
@@ -1,6 +1,7 @@
 use core::{assert_matches::assert_matches, error::Error};
 
 use hash_graph_postgres_store::permissions::PrincipalError;
+use hash_graph_store::account::AccountStore as _;
 use pretty_assertions::assert_eq;
 use type_system::principal::{
     PrincipalId,
@@ -72,7 +73,7 @@ async fn get_non_existent_user() -> Result<(), Box<dyn Error>> {
     let (client, _actor_id) = db.seed([]).await?;
 
     let non_existent_id = UserId::new(Uuid::new_v4());
-    let result = client.get_user(non_existent_id).await?;
+    let result = client.get_user_by_id(non_existent_id).await?;
 
     assert!(
         result.is_none(),

--- a/libs/@local/graph/postgres-store/tests/principals/user.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/user.rs
@@ -70,10 +70,12 @@ async fn create_user_with_duplicate_id() -> Result<(), Box<dyn Error>> {
 #[tokio::test]
 async fn get_non_existent_user() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
-    let (client, _actor_id) = db.seed([]).await?;
+    let (client, actor_id) = db.seed([]).await?;
 
     let non_existent_id = UserId::new(Uuid::new_v4());
-    let result = client.get_user_by_id(non_existent_id).await?;
+    let result = client
+        .get_user_by_id(actor_id.into(), non_existent_id)
+        .await?;
 
     assert!(
         result.is_none(),

--- a/libs/@local/graph/sdk/typescript/src/principal/team.ts
+++ b/libs/@local/graph/sdk/typescript/src/principal/team.ts
@@ -1,10 +1,10 @@
 import type {
-  ActorGroupId,
+  Team,
   TeamId,
   TeamRole,
   TeamRoleId,
 } from "@blockprotocol/type-system";
-import type { GetTeamResponse, GraphApi } from "@local/hash-graph-client";
+import type { GraphApi } from "@local/hash-graph-client";
 
 import type { AuthenticationContext } from "../authentication-context.js";
 
@@ -17,21 +17,13 @@ export const getTeamByName = (
   graphAPI: GraphApi,
   authentication: AuthenticationContext,
   name: "instance-admins",
-): Promise<{
-  teamId: TeamId;
-  parentId: ActorGroupId;
-  name: string;
-} | null> =>
+): Promise<Team | null> =>
   graphAPI.getTeamByName(authentication.actorId, name).then(({ data }) => {
-    const response = data as GetTeamResponse | null;
-    if (!response) {
+    const team = data as Team | null;
+    if (!team) {
       return null;
     }
-    return {
-      teamId: response.teamId as TeamId,
-      parentId: response.parentId as ActorGroupId,
-      name,
-    };
+    return team;
   });
 
 /**

--- a/libs/@local/graph/sdk/typescript/src/principal/team.ts
+++ b/libs/@local/graph/sdk/typescript/src/principal/team.ts
@@ -1,4 +1,9 @@
-import type { ActorGroupId, TeamId } from "@blockprotocol/type-system";
+import type {
+  ActorGroupId,
+  TeamId,
+  TeamRole,
+  TeamRoleId,
+} from "@blockprotocol/type-system";
 import type { GetTeamResponse, GraphApi } from "@local/hash-graph-client";
 
 import type { AuthenticationContext } from "../authentication-context.js";
@@ -28,3 +33,15 @@ export const getTeamByName = (
       name,
     };
   });
+
+/**
+ * Returns all roles assigned to the given team.
+ */
+export const getTeamRoles = (
+  graphAPI: GraphApi,
+  authentication: AuthenticationContext,
+  teamId: TeamId,
+): Promise<Record<TeamRoleId, TeamRole>> =>
+  graphAPI
+    .getTeamRoles(authentication.actorId, teamId)
+    .then(({ data: roles }) => roles as Record<TeamRoleId, TeamRole>);

--- a/libs/@local/graph/sdk/typescript/src/principal/web.ts
+++ b/libs/@local/graph/sdk/typescript/src/principal/web.ts
@@ -1,10 +1,11 @@
 import type {
-  MachineId,
+  Machine,
+  Web,
   WebId,
   WebRole,
   WebRoleId,
 } from "@blockprotocol/type-system";
-import type { GetWebResponse, GraphApi } from "@local/hash-graph-client";
+import type { GraphApi } from "@local/hash-graph-client";
 
 import type { AuthenticationContext } from "../authentication-context.js";
 
@@ -17,17 +18,13 @@ export const getWebById = (
   graphAPI: GraphApi,
   authentication: AuthenticationContext,
   webId: WebId,
-): Promise<{ webId: WebId; machineId: MachineId; shortname?: string } | null> =>
+): Promise<Web | null> =>
   graphAPI.getWebById(authentication.actorId, webId).then(({ data }) => {
-    const response = data as GetWebResponse | null;
-    if (!response) {
+    const web = data as Web | null;
+    if (!web) {
       return null;
     }
-    return {
-      webId,
-      machineId: response.machineId as MachineId,
-      shortname: response.shortname,
-    };
+    return web;
   });
 
 /**
@@ -39,19 +36,30 @@ export const getWebByShortname = (
   graphAPI: GraphApi,
   authentication: AuthenticationContext,
   shortname: string,
-): Promise<{ webId: WebId; machineId: MachineId; shortname: string } | null> =>
+): Promise<Web | null> =>
   graphAPI
     .getWebByShortname(authentication.actorId, shortname)
     .then(({ data }) => {
-      const response = data as GetWebResponse | null;
-      if (!response) {
+      const web = data as Web | null;
+      if (!web) {
         return null;
       }
-      return {
-        webId: response.webId as WebId,
-        machineId: response.machineId as MachineId,
-        shortname,
-      };
+      return web;
+    });
+
+export const getMachineByIdentifier = (
+  graphAPI: GraphApi,
+  authentication: AuthenticationContext,
+  identifier: string,
+): Promise<Machine | null> =>
+  graphAPI
+    .getMachineByIdentifier(authentication.actorId, identifier)
+    .then(({ data }) => {
+      const machine = data as Machine | null;
+      if (!machine) {
+        return null;
+      }
+      return machine;
     });
 
 /**

--- a/libs/@local/graph/sdk/typescript/src/principal/web.ts
+++ b/libs/@local/graph/sdk/typescript/src/principal/web.ts
@@ -1,4 +1,9 @@
-import type { MachineId, WebId } from "@blockprotocol/type-system";
+import type {
+  MachineId,
+  WebId,
+  WebRole,
+  WebRoleId,
+} from "@blockprotocol/type-system";
 import type { GetWebResponse, GraphApi } from "@local/hash-graph-client";
 
 import type { AuthenticationContext } from "../authentication-context.js";
@@ -48,3 +53,15 @@ export const getWebByShortname = (
         shortname,
       };
     });
+
+/**
+ * Returns all roles assigned to the given web.
+ */
+export const getWebRoles = (
+  graphAPI: GraphApi,
+  authentication: AuthenticationContext,
+  webId: WebId,
+): Promise<Record<WebRoleId, WebRole>> =>
+  graphAPI
+    .getWebRoles(authentication.actorId, webId)
+    .then(({ data: roles }) => roles as Record<WebRoleId, WebRole>);

--- a/libs/@local/graph/type-fetcher/src/store.rs
+++ b/libs/@local/graph/type-fetcher/src/store.rs
@@ -28,8 +28,8 @@ use hash_graph_store::{
     account::{
         AccountGroupInsertionError, AccountInsertionError, AccountStore, CreateAiActorParams,
         CreateMachineActorParams, CreateOrgWebParams, CreateTeamParams, CreateUserActorParams,
-        CreateUserActorResponse, GetTeamResponse, GetWebResponse, QueryWebError,
-        TeamRetrievalError, WebInsertionError, WebRetrievalError,
+        CreateUserActorResponse, GetActorError, QueryWebError, TeamRetrievalError,
+        WebInsertionError, WebRetrievalError,
     },
     data_type::{
         ArchiveDataTypeParams, CountDataTypesParams, CreateDataTypeParams, DataTypeStore,
@@ -88,8 +88,8 @@ use type_system::{
         provenance::{OntologyOwnership, ProvidedOntologyEditionProvenance},
     },
     principal::{
-        actor::{ActorEntityUuid, ActorId, ActorType, AiId, MachineId},
-        actor_group::{ActorGroupEntityUuid, TeamId, WebId},
+        actor::{ActorEntityUuid, ActorId, ActorType, Ai, AiId, Machine, MachineId, User, UserId},
+        actor_group::{ActorGroupEntityUuid, Team, TeamId, Web, WebId},
         role::{RoleName, TeamRole, TeamRoleId, WebRole, WebRoleId},
     },
     provenance::{OriginProvenance, OriginType},
@@ -188,11 +188,11 @@ where
     S: PrincipalStore + Send,
     A: Send,
 {
-    async fn get_or_create_system_actor(
+    async fn get_or_create_system_machine(
         &mut self,
         identifier: &str,
     ) -> Result<MachineId, Report<GetSystemAccountError>> {
-        self.store.get_or_create_system_actor(identifier).await
+        self.store.get_or_create_system_machine(identifier).await
     }
 
     async fn create_web(
@@ -985,19 +985,61 @@ where
         self.store.create_ai_actor(actor_id, params).await
     }
 
-    async fn get_web_by_id(
-        &mut self,
+    async fn get_user_by_id(
+        &self,
         actor_id: ActorEntityUuid,
-        web_id: WebId,
-    ) -> Result<Option<GetWebResponse>, Report<WebRetrievalError>> {
-        self.store.get_web_by_id(actor_id, web_id).await
+        id: UserId,
+    ) -> Result<Option<User>, Report<GetActorError>> {
+        self.store.get_user_by_id(actor_id, id).await
+    }
+
+    async fn get_machine_by_id(
+        &self,
+        actor_id: ActorEntityUuid,
+        id: MachineId,
+    ) -> Result<Option<Machine>, Report<GetActorError>> {
+        self.store.get_machine_by_id(actor_id, id).await
+    }
+
+    async fn get_machine_by_identifier(
+        &self,
+        actor_id: ActorEntityUuid,
+        identifier: &str,
+    ) -> Result<Option<Machine>, Report<GetActorError>> {
+        self.store
+            .get_machine_by_identifier(actor_id, identifier)
+            .await
+    }
+
+    async fn get_ai_by_id(
+        &self,
+        actor_id: ActorEntityUuid,
+        id: AiId,
+    ) -> Result<Option<Ai>, Report<GetActorError>> {
+        self.store.get_ai_by_id(actor_id, id).await
+    }
+
+    async fn get_ai_by_identifier(
+        &self,
+        actor_id: ActorEntityUuid,
+        identifier: &str,
+    ) -> Result<Option<Ai>, Report<GetActorError>> {
+        self.store.get_ai_by_identifier(actor_id, identifier).await
+    }
+
+    async fn get_web_by_id(
+        &self,
+        actor_id: ActorEntityUuid,
+        id: WebId,
+    ) -> Result<Option<Web>, Report<WebRetrievalError>> {
+        self.store.get_web_by_id(actor_id, id).await
     }
 
     async fn get_web_by_shortname(
-        &mut self,
+        &self,
         actor_id: ActorEntityUuid,
         shortname: &str,
-    ) -> Result<Option<GetWebResponse>, Report<WebRetrievalError>> {
+    ) -> Result<Option<Web>, Report<WebRetrievalError>> {
         self.store.get_web_by_shortname(actor_id, shortname).await
     }
 
@@ -1017,11 +1059,19 @@ where
         self.store.create_team(actor_id, params).await
     }
 
+    async fn get_team_by_id(
+        &self,
+        actor_id: ActorEntityUuid,
+        id: TeamId,
+    ) -> Result<Option<Team>, Report<TeamRetrievalError>> {
+        self.store.get_team_by_id(actor_id, id).await
+    }
+
     async fn get_team_by_name(
-        &mut self,
+        &self,
         actor_id: ActorEntityUuid,
         name: &str,
-    ) -> Result<Option<GetTeamResponse>, Report<TeamRetrievalError>> {
+    ) -> Result<Option<Team>, Report<TeamRetrievalError>> {
         self.store.get_team_by_name(actor_id, name).await
     }
 

--- a/libs/@local/graph/type-fetcher/src/store.rs
+++ b/libs/@local/graph/type-fetcher/src/store.rs
@@ -12,8 +12,8 @@ use hash_graph_authorization::{
             PolicyUpdateOperation, PrincipalStore, RoleAssignmentStatus, RoleUnassignmentStatus,
             error::{
                 CreatePolicyError, EnsureSystemPoliciesError, GetPoliciesError,
-                GetSystemAccountError, RemovePolicyError, RoleAssignmentError, UpdatePolicyError,
-                WebCreationError,
+                GetSystemAccountError, RemovePolicyError, RoleAssignmentError, TeamRoleError,
+                UpdatePolicyError, WebCreationError, WebRoleError,
             },
         },
     },
@@ -90,7 +90,7 @@ use type_system::{
     principal::{
         actor::{ActorEntityUuid, ActorId, ActorType, AiId, MachineId},
         actor_group::{ActorGroupEntityUuid, TeamId, WebId},
-        role::RoleName,
+        role::{RoleName, TeamRole, TeamRoleId, WebRole, WebRoleId},
     },
     provenance::{OriginProvenance, OriginType},
 };
@@ -201,6 +201,22 @@ where
         parameter: CreateWebParameter,
     ) -> Result<CreateWebResponse, Report<WebCreationError>> {
         self.store.create_web(actor, parameter).await
+    }
+
+    async fn get_web_roles(
+        &mut self,
+        actor: ActorEntityUuid,
+        web_id: WebId,
+    ) -> Result<HashMap<WebRoleId, WebRole>, Report<WebRoleError>> {
+        self.store.get_web_roles(actor, web_id).await
+    }
+
+    async fn get_team_roles(
+        &mut self,
+        actor: ActorEntityUuid,
+        team_id: TeamId,
+    ) -> Result<HashMap<TeamRoleId, TeamRole>, Report<TeamRoleError>> {
+        self.store.get_team_roles(actor, team_id).await
     }
 
     async fn assign_role(

--- a/libs/@local/hash-backend-utils/src/hash-instance.ts
+++ b/libs/@local/hash-backend-utils/src/hash-instance.ts
@@ -1,8 +1,4 @@
-import type {
-  ActorEntityUuid,
-  TeamId,
-  WebId,
-} from "@blockprotocol/type-system";
+import type { ActorEntityUuid, Team, WebId } from "@blockprotocol/type-system";
 import type { GraphApi } from "@local/hash-graph-client";
 import type { HashEntity } from "@local/hash-graph-sdk/entity";
 import { getTeamByName } from "@local/hash-graph-sdk/principal/team";
@@ -30,7 +26,7 @@ export type HashInstance = {
 export const getInstanceAdminsTeam = async (
   ctx: { graphApi: GraphApi },
   authentication: { actorId: ActorEntityUuid },
-): Promise<{ teamId: TeamId; webId: WebId }> =>
+): Promise<Omit<Team, "parentId"> & { webId: WebId }> =>
   getTeamByName(ctx.graphApi, authentication, "instance-admins").then(
     (team) => {
       if (!team) {
@@ -40,9 +36,8 @@ export const getInstanceAdminsTeam = async (
         throw new Error("Instance admins parent is not a web");
       }
       return {
-        teamId: team.teamId,
+        ...team,
         webId: team.parentId.id,
-        name: team.name,
       };
     },
   );
@@ -127,7 +122,7 @@ export const isUserHashInstanceAdmin = async (
     ctx.graphApi
       .hasActorGroupRole(
         authentication.actorId,
-        team.teamId,
+        team.id,
         "member",
         userAccountId,
       )

--- a/libs/@local/hash-backend-utils/src/notifications.ts
+++ b/libs/@local/hash-backend-utils/src/notifications.ts
@@ -3,6 +3,7 @@ import type {
   EntityId,
   ProvidedEntityEditionProvenance,
   Timestamp,
+  UserId,
   WebId,
 } from "@blockprotocol/type-system";
 import type { GraphApi } from "@local/hash-graph-client";
@@ -74,7 +75,7 @@ export const createGraphChangeNotification = async (
     changedEntityId: EntityId;
     changedEntityEditionId: Timestamp;
     operation: "create" | "update";
-    notifiedUserAccountId: ActorEntityUuid;
+    notifiedUserAccountId: UserId;
   },
 ) => {
   const { graphApi } = context;
@@ -89,7 +90,14 @@ export const createGraphChangeNotification = async (
   const userAuthentication = { actorId: notifiedUserAccountId };
 
   const webMachineActorId = await getWebMachineId(context, userAuthentication, {
-    webId: notifiedUserAccountId as WebId,
+    webId: notifiedUserAccountId,
+  }).then((maybeMachineId) => {
+    if (!maybeMachineId) {
+      throw new Error(
+        `Failed to get web machine for user account ID: ${notifiedUserAccountId}`,
+      );
+    }
+    return maybeMachineId;
   });
 
   const { linkEntityRelationships, notificationEntityRelationships } =

--- a/libs/@local/hash-backend-utils/src/service-usage.ts
+++ b/libs/@local/hash-backend-utils/src/service-usage.ts
@@ -200,7 +200,7 @@ export const createUsageRecord = async (
    */
   const authentication = { actorId: userAccountId };
 
-  const { teamId: hashInstanceAdminGroupId } = await getInstanceAdminsTeam(
+  const { id: hashInstanceAdminGroupId } = await getInstanceAdminsTeam(
     context,
     authentication,
   );

--- a/libs/@local/hash-isomorphic-utils/src/flows/temporal-types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/flows/temporal-types.ts
@@ -1,4 +1,4 @@
-import type { ActorEntityUuid, WebId } from "@blockprotocol/type-system";
+import type { UserId, WebId } from "@blockprotocol/type-system";
 import type { Status } from "@local/status";
 
 import type {
@@ -12,7 +12,7 @@ export type RunFlowWorkflowParams = {
   dataSources: FlowDataSources;
   flowTrigger: FlowTrigger;
   flowDefinition: FlowDefinition;
-  userAuthentication: { actorId: ActorEntityUuid };
+  userAuthentication: { actorId: UserId };
   webId: WebId;
 };
 

--- a/tests/graph/benches/read_scaling/knowledge/complete/entity.rs
+++ b/tests/graph/benches/read_scaling/knowledge/complete/entity.rs
@@ -76,7 +76,7 @@ async fn seed_db<A: AuthorizationApi>(
     eprintln!("Seeding database: {}", store_wrapper.bench_db_name);
 
     let system_account_id = transaction
-        .get_or_create_system_actor("h")
+        .get_or_create_system_machine("h")
         .await
         .expect("could not read system account");
 

--- a/tests/graph/benches/read_scaling/knowledge/linkless/entity.rs
+++ b/tests/graph/benches/read_scaling/knowledge/linkless/entity.rs
@@ -64,7 +64,7 @@ async fn seed_db<A: AuthorizationApi>(
     eprintln!("Seeding database: {}", store_wrapper.bench_db_name);
 
     let system_account_id = transaction
-        .get_or_create_system_actor("h")
+        .get_or_create_system_machine("h")
         .await
         .expect("could not read system account");
 

--- a/tests/graph/benches/representative_read/seed.rs
+++ b/tests/graph/benches/representative_read/seed.rs
@@ -153,7 +153,7 @@ async fn seed_db<A: AuthorizationApi>(
         .expect("Should be able to check actor")
     {
         let system_account_id = transaction
-            .get_or_create_system_actor("h")
+            .get_or_create_system_machine("h")
             .await
             .expect("could not read system account");
 

--- a/tests/graph/http/tests/ambiguous.http
+++ b/tests/graph/http/tests/ambiguous.http
@@ -1,7 +1,7 @@
 # This file either runs with JetBrains' http requests or using httpYac (https://httpyac.github.io).
 
 ### Get system user
-GET http://127.0.0.1:4000/actors/system/h
+GET http://127.0.0.1:4000/actors/machine/identifier/system/h
 Content-Type: application/json
 
 > {%

--- a/tests/graph/http/tests/circular-links.http
+++ b/tests/graph/http/tests/circular-links.http
@@ -1,7 +1,7 @@
 # This file either runs with JetBrains' http requests or using httpYac (https://httpyac.github.io).
 
 ### Get system user
-GET http://127.0.0.1:4000/actors/system/h
+GET http://127.0.0.1:4000/actors/machine/identifier/system/h
 Content-Type: application/json
 
 > {%

--- a/tests/graph/http/tests/friendship.http
+++ b/tests/graph/http/tests/friendship.http
@@ -1,7 +1,7 @@
 # This file either runs with JetBrains' http requests or using httpYac (https://httpyac.github.io).
 
 ### Get system user
-GET http://127.0.0.1:4000/actors/system/h
+GET http://127.0.0.1:4000/actors/machine/identifier/system/h
 Content-Type: application/json
 
 > {%

--- a/tests/graph/http/tests/link-inheritance.http
+++ b/tests/graph/http/tests/link-inheritance.http
@@ -1,7 +1,7 @@
 # This file either runs with JetBrains' http requests or using httpYac (https://httpyac.github.io).
 
 ### Get system user
-GET http://127.0.0.1:4000/actors/system/h
+GET http://127.0.0.1:4000/actors/machine/identifier/system/h
 Content-Type: application/json
 
 > {%

--- a/tests/graph/integration/postgres/lib.rs
+++ b/tests/graph/integration/postgres/lib.rs
@@ -227,7 +227,7 @@ impl<A: AuthorizationApi> DatabaseTestWrapper<A> {
             .expect("could not start test transaction");
 
         let system_account_id = store
-            .get_or_create_system_actor("h")
+            .get_or_create_system_machine("h")
             .await
             .change_context(InsertionError)?;
         let user_id = store

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/hash-instance.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/hash-instance.test.ts
@@ -18,6 +18,7 @@ import { publicUserAccountId } from "@local/hash-backend-utils/public-user-accou
 import type { AuthenticationContext } from "@local/hash-graph-sdk/authentication-context";
 import { beforeAll, describe, expect, it } from "vitest";
 
+import { getTeamRoles } from "@local/hash-graph-sdk/principal/team";
 import { resetGraph } from "../../../test-server";
 import { createTestImpureGraphContext, createTestUser } from "../../../util";
 
@@ -156,5 +157,28 @@ describe("Hash Instance", () => {
         actorGroupId: instanceAdminTeamId,
       }),
     ).toBeFalsy();
+  });
+
+  it("can read the hash instance team roles", async () => {
+    const teamRoleMap = await getTeamRoles(
+      graphContext.graphApi,
+      authentication,
+      instanceAdminTeamId,
+    );
+
+    expect(Object.keys(teamRoleMap).length).toStrictEqual(2);
+
+    const teamRoles = Object.values(teamRoleMap).map(({ teamId, name }) => ({
+      teamId,
+      name,
+    }));
+    expect(teamRoles).toContainEqual({
+      teamId: instanceAdminTeamId,
+      name: "member",
+    });
+    expect(teamRoles).toContainEqual({
+      teamId: instanceAdminTeamId,
+      name: "administrator",
+    });
   });
 });

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/hash-instance.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/hash-instance.test.ts
@@ -16,9 +16,9 @@ import {
 import { Logger } from "@local/hash-backend-utils/logger";
 import { publicUserAccountId } from "@local/hash-backend-utils/public-user-account-id";
 import type { AuthenticationContext } from "@local/hash-graph-sdk/authentication-context";
+import { getTeamRoles } from "@local/hash-graph-sdk/principal/team";
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { getTeamRoles } from "@local/hash-graph-sdk/principal/team";
 import { resetGraph } from "../../../test-server";
 import { createTestImpureGraphContext, createTestUser } from "../../../util";
 
@@ -52,7 +52,7 @@ describe("Hash Instance", () => {
   let instanceAdminTeamId: TeamId;
 
   it("can get the instance admin team id", async () => {
-    const { teamId } = await getInstanceAdminsTeam(graphContext, {
+    const { id: teamId } = await getInstanceAdminsTeam(graphContext, {
       actorId: systemAccountId,
     });
     instanceAdminTeamId = teamId;

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/org.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/org.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@apps/hash-api/src/graph/knowledge/system-types/org";
 import { systemAccountId } from "@apps/hash-api/src/graph/system-account";
 import { Logger } from "@local/hash-backend-utils/logger";
+import { getWebRoles } from "@local/hash-graph-sdk/principal/web";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { resetGraph } from "../../../test-server";
@@ -61,5 +62,31 @@ describe("Org", () => {
     });
 
     expect(fetchedOrg).toEqual(createdOrg);
+  });
+
+  it("can read the org roles", async () => {
+    const authentication = { actorId: systemAccountId };
+
+    const orgRoleMap = await getWebRoles(
+      graphContext.graphApi,
+      authentication,
+      createdOrg.webId,
+    );
+
+    expect(Object.keys(orgRoleMap).length).toStrictEqual(2);
+
+    const orgRoles = Object.values(orgRoleMap).map(({ webId, name }) => ({
+      webId,
+      name,
+    }));
+
+    expect(orgRoles).toContainEqual({
+      webId: createdOrg.webId,
+      name: "member",
+    });
+    expect(orgRoles).toContainEqual({
+      webId: createdOrg.webId,
+      name: "administrator",
+    });
   });
 });

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/user.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/user.test.ts
@@ -14,6 +14,7 @@ import {
 import { systemAccountId } from "@apps/hash-api/src/graph/system-account";
 import { extractEntityUuidFromEntityId } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
+import { getWebRoles } from "@local/hash-graph-sdk/principal/web";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { resetGraph } from "../../../test-server";
@@ -134,6 +135,34 @@ describe("User model class", () => {
         orgEntityUuid,
       }),
     ).toBe(true);
+  });
+
+  it("can read the user-web roles", async () => {
+    const authentication = { actorId: systemAccountId };
+
+    const UserWebRoleMap = await getWebRoles(
+      graphContext.graphApi,
+      authentication,
+      createdUser.accountId,
+    );
+
+    expect(Object.keys(UserWebRoleMap).length).toStrictEqual(2);
+
+    const userWebRoles = Object.values(UserWebRoleMap).map(
+      ({ webId, name }) => ({
+        webId,
+        name,
+      }),
+    );
+
+    expect(userWebRoles).toContainEqual({
+      webId: createdUser.accountId,
+      name: "member",
+    });
+    expect(userWebRoles).toContainEqual({
+      webId: createdUser.accountId,
+      name: "administrator",
+    });
   });
 
   afterAll(async () => {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For certain scenarios, we need to read web roles and team roles.
First, I wanted to expose them alongside the webs/teams, but that is an additional join each time, which is not necessary. However, I still made the API more consistent and cleaned up both, Rust and Node on this.
