### PR TITLE
H-4585: Rename `COMPILER_BUG` into `ICE`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
+name = "anstyle-lossy"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "934ff8719effd2023a48cf63e69536c1c3ced9d3895068f6f5cc9a4ff845e59b"
+dependencies = [
+ "anstyle",
+]
+
+[[package]]
 name = "anstyle-parse"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3826,11 +3835,13 @@ name = "hashql-diagnostics"
 version = "0.0.0"
 dependencies = [
  "anstyle",
+ "anstyle-lossy",
  "anstyle-yansi",
  "ariadne",
  "derive_more 2.0.1",
  "error-stack",
  "jsonptr",
+ "rstest",
  "serde",
  "serde_json",
  "serde_with",
@@ -6855,6 +6866,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7511,6 +7531,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7604,6 +7630,36 @@ dependencies = [
  "base64 0.13.1",
  "bitflags 1.3.2",
  "serde",
+]
+
+[[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.101",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3844,7 +3844,6 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
- "serde_with",
  "simple-mermaid",
  "text-size",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,6 @@ hash-codec.path                     = "libs/@local/codec"
 hash-codegen.path                   = "libs/@local/codegen"
 hash-graph-api.path                 = "libs/@local/graph/api"
 hash-graph-authorization.path       = "libs/@local/graph/authorization"
-hash-graph-migrations.path          = "libs/@local/graph/migrations"
 hash-graph-migrations-macros.path   = "libs/@local/graph/migrations-macros"
 hash-graph-postgres-store.path      = "libs/@local/graph/postgres-store"
 hash-graph-store.path               = "libs/@local/graph/store"
@@ -98,7 +97,6 @@ type-system.path                    = "libs/@blockprotocol/type-system/rust"
 
 # External dependencies
 ada-url                  = { version = "=3.2.4", default-features = false }
-ahash                    = { version = "=0.8.12", default-features = false }
 ansi-to-html             = { version = "=0.2.2", default-features = false }
 anstyle                  = { version = "=1.0.10", default-features = false }
 anstyle-yansi            = { version = "=2.0.2", default-features = false }
@@ -200,7 +198,6 @@ owo-colors               = { version = "=4.2.0", default-features = false }
 oxc                      = { version = "=0.67.0", default-features = false, features = ["allocator_api"] }
 paste                    = { version = "=1.0.15", default-features = false }
 pdfium-render            = { version = "=0.8.26" }
-petgraph                 = { version = "=0.8.1", default-features = false }
 pin-project              = { version = "=1.1.10", default-features = false }
 pin-project-lite         = { version = "=0.2.16", default-features = false }
 postgres-protocol        = { version = "=0.6.8", default-features = false }

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/error.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/error.rs
@@ -91,7 +91,7 @@ pub(crate) fn generic_arguments_in_use_path(
 ) -> ImportResolverDiagnostic {
     let mut diagnostic = Diagnostic::new(
         ImportResolverDiagnosticCategory::GenericArgumentsInUsePath,
-        Severity::COMPILER_BUG,
+        Severity::Bug,
     );
 
     // Add primary and secondary labels
@@ -104,12 +104,12 @@ pub(crate) fn generic_arguments_in_use_path(
             .with_color(Color::Ansi(AnsiColor::Blue)),
     ]);
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Use statements don't accept generic type parameters. Remove the angle brackets and type \
          parameters.\n\nExample: Use `module::Type` instead of `module::Type<T>`.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "This error is still valid, but should've been caught in an earlier stage of the compiler \
          pipeline. Please report this issue to the HashQL team with a minimal reproduction case.",
     ));
@@ -119,10 +119,8 @@ pub(crate) fn generic_arguments_in_use_path(
 
 /// Error when a path has no segments
 pub(crate) fn empty_path(span: SpanId) -> ImportResolverDiagnostic {
-    let mut diagnostic = Diagnostic::new(
-        ImportResolverDiagnosticCategory::EmptyPath,
-        Severity::COMPILER_BUG,
-    );
+    let mut diagnostic =
+        Diagnostic::new(ImportResolverDiagnosticCategory::EmptyPath, Severity::Bug);
 
     diagnostic.labels.push(
         Label::new(span, "Specify a path here")
@@ -130,11 +128,11 @@ pub(crate) fn empty_path(span: SpanId) -> ImportResolverDiagnostic {
             .with_color(Color::Ansi(AnsiColor::Red)),
     );
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Add a valid path with at least one identifier, such as `module` or `module::item`.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Import statements require a non-empty path to identify what module or item you want to \
          bring into scope. This error is still valid, but should've been caught in an earlier \
          stage of the compiler pipeline. Please report this issue to the HashQL team with a \
@@ -150,7 +148,7 @@ pub(crate) fn generic_arguments_in_module(
 ) -> ImportResolverDiagnostic {
     let mut diagnostic = Diagnostic::new(
         ImportResolverDiagnosticCategory::GenericArgumentsInModule,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     let mut spans = spans.into_iter();
@@ -172,13 +170,13 @@ pub(crate) fn generic_arguments_in_module(
         );
     }
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Generic arguments can only appear on the final type in a path. Remove them from this \
          module segment or move them to the final type in the path.\n\nCorrect: \
          `module::submodule::Type<T>`\nIncorrect: `module<T>::submodule::Type`",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Module paths don't accept generic parameters because modules themselves aren't generic. \
          Only the final type in a path can have generic parameters.\n\nThe path resolution \
          happens before any generic type checking, so generic arguments can only be applied after \
@@ -275,7 +273,7 @@ pub(crate) fn unresolved_variable<'heap>(
 ) -> ImportResolverDiagnostic {
     let mut diagnostic = Diagnostic::new(
         ImportResolverDiagnosticCategory::UnresolvedVariable,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic.labels.push(
@@ -406,9 +404,9 @@ pub(crate) fn unresolved_variable<'heap>(
         let _: fmt::Result = writeln!(help, "     {absolute_path}");
     }
 
-    diagnostic.help = Some(Help::new(help));
+    diagnostic.add_help(Help::new(help));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Variables must be defined before they can be used. This could be a typo, a variable used \
          outside its scope, or a missing declaration. If it's a function or type from another \
          module, you might need to import it first.",
@@ -427,7 +425,7 @@ pub(crate) fn from_resolution_error<'heap>(
 ) -> ImportResolverDiagnostic {
     let mut diagnostic = Diagnostic::new(
         ImportResolverDiagnosticCategory::UnresolvedImport,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     let segments: Vec<_> = path
@@ -455,12 +453,12 @@ pub(crate) fn from_resolution_error<'heap>(
                 );
             }
 
-            diagnostic.help = Some(Help::new(format!(
+            diagnostic.add_help(Help::new(format!(
                 "This import path needs at least {expected} segments to be valid. Add the missing \
                  segments to complete the path."
             )));
 
-            diagnostic.note = Some(Note::new(
+            diagnostic.add_note(Note::new(
                 "Import paths must be complete to properly identify the item you want to import. \
                  Incomplete paths cannot be resolved.",
             ));
@@ -492,12 +490,12 @@ pub(crate) fn from_resolution_error<'heap>(
                 None => "not a module",
             };
 
-            diagnostic.help = Some(Help::new(format!(
+            diagnostic.add_help(Help::new(format!(
                 "'{}' is {universe}. Only modules can contain other items. Check your import path.",
                 FormatPath(path.rooted, &segments, Some(depth))
             )));
 
-            diagnostic.note = Some(Note::new(
+            diagnostic.add_note(Note::new(
                 "The '::' syntax can only be used with modules to access their members. Values \
                  and types cannot contain other items.",
             ));
@@ -533,9 +531,9 @@ pub(crate) fn from_resolution_error<'heap>(
                 help.push_str(&suggestion);
             }
 
-            diagnostic.help = Some(Help::new(help));
+            diagnostic.add_help(Help::new(help));
 
-            diagnostic.note = Some(Note::new(
+            diagnostic.add_note(Note::new(
                 "Packages must be installed and properly configured in your project dependencies \
                  before they can be imported.",
             ));
@@ -574,9 +572,9 @@ pub(crate) fn from_resolution_error<'heap>(
                 help.push_str(&suggestion);
             }
 
-            diagnostic.help = Some(Help::new(help));
+            diagnostic.add_help(Help::new(help));
 
-            diagnostic.note = Some(Note::new(
+            diagnostic.add_note(Note::new(
                 "Before using an item from another module, you must import it with a 'use' \
                  statement or access it with a fully qualified path.",
             ));
@@ -608,9 +606,9 @@ pub(crate) fn from_resolution_error<'heap>(
                 help.push_str(&suggestion);
             }
 
-            diagnostic.help = Some(Help::new(help));
+            diagnostic.add_help(Help::new(help));
 
-            diagnostic.note = Some(Note::new(
+            diagnostic.add_note(Note::new(
                 "Modules must be properly defined and exported from their parent module to be \
                  accessible.",
             ));
@@ -661,9 +659,9 @@ pub(crate) fn from_resolution_error<'heap>(
                 help.push_str(&suggestion);
             }
 
-            diagnostic.help = Some(Help::new(help));
+            diagnostic.add_help(Help::new(help));
 
-            diagnostic.note = Some(Note::new(
+            diagnostic.add_note(Note::new(
                 "Items must be defined and accessible from the importing location. Make sure the \
                  item exists and is public.",
             ));
@@ -689,14 +687,14 @@ pub(crate) fn from_resolution_error<'heap>(
                     .with_color(Color::Ansi(AnsiColor::Blue)),
             ]);
 
-            diagnostic.help = Some(Help::new(format!(
+            diagnostic.add_help(Help::new(format!(
                 "The name '{}' could refer to multiple different items in {}. Use a fully \
                  qualified path to specify which one you want.",
                 item.name,
                 FormatPath(path.rooted, &segments, None)
             )));
 
-            diagnostic.note = Some(Note::new(
+            diagnostic.add_note(Note::new(
                 "When multiple items with the same name are in scope, you must use a fully \
                  qualified path to avoid ambiguity. Consider using explicit imports instead of \
                  glob imports to prevent name conflicts.",
@@ -723,12 +721,12 @@ pub(crate) fn from_resolution_error<'heap>(
                     .with_color(Color::Ansi(AnsiColor::Blue)),
             ]);
 
-            diagnostic.help = Some(Help::new(
+            diagnostic.add_help(Help::new(
                 "This module exists but doesn't expose any items that can be imported. Check if \
                  you're importing the correct module or if the module has any public exports.",
             ));
 
-            diagnostic.note = Some(Note::new(
+            diagnostic.add_note(Note::new(
                 "To use items from a module, they must be marked as public/exported. If you're \
                  using a glob import pattern like 'module::*', try using specific imports instead \
                  to see what's available.",

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/error.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/error.rs
@@ -111,7 +111,7 @@ pub(crate) fn generic_arguments_in_use_path(
 
     diagnostic.add_note(Note::new(
         "This error is still valid, but should've been caught in an earlier stage of the compiler \
-         pipeline. Please report this issue to the HashQL team with a minimal reproduction case.",
+         pipeline.",
     ));
 
     diagnostic
@@ -135,8 +135,7 @@ pub(crate) fn empty_path(span: SpanId) -> ImportResolverDiagnostic {
     diagnostic.add_note(Note::new(
         "Import statements require a non-empty path to identify what module or item you want to \
          bring into scope. This error is still valid, but should've been caught in an earlier \
-         stage of the compiler pipeline. Please report this issue to the HashQL team with a \
-         minimal reproduction case.",
+         stage of the compiler pipeline.",
     ));
 
     diagnostic

--- a/libs/@local/hashql/ast/src/lowering/sanitizer.rs
+++ b/libs/@local/hashql/ast/src/lowering/sanitizer.rs
@@ -60,7 +60,7 @@ impl DiagnosticCategory for SanitizerDiagnosticCategory {
 fn invalid_generic_constraint(span: SpanId, name: Symbol) -> SanitizerDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SanitizerDiagnosticCategory::InvalidGenericConstraint,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic.labels.push(
@@ -69,12 +69,12 @@ fn invalid_generic_constraint(span: SpanId, name: Symbol) -> SanitizerDiagnostic
             .with_color(Color::Ansi(AnsiColor::Red)),
     );
 
-    diagnostic.help = Some(Help::new(format!(
+    diagnostic.add_help(Help::new(format!(
         "Generic constraints (like '{name}: Bound') are not allowed in this context. Use just the \
          parameter name without bounds: '{name}'. For example, change 'T: Clone' to just 'T'."
     )));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Generic constraints with bounds can only be used in certain positions such as function \
          declarations, type declarations and newtype declarations. In other contexts, like usage \
          sites, only the parameter name should be specified.",
@@ -85,7 +85,7 @@ fn invalid_generic_constraint(span: SpanId, name: Symbol) -> SanitizerDiagnostic
 fn special_form_not_supported(path: &Path, universe: Universe) -> SanitizerDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SanitizerDiagnosticCategory::InvalidSpecialForm,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     // Primary label - the direct issue with context-specific message
@@ -114,13 +114,13 @@ fn special_form_not_supported(path: &Path, universe: Universe) -> SanitizerDiagn
         Universe::Type => "type annotation or declaration",
     };
 
-    diagnostic.help = Some(Help::new(format!(
+    diagnostic.add_help(Help::new(format!(
         "The special form '{special_form}' must be called directly with arguments. It cannot be \
          used as a {context} or passed to other functions. Instead, use it in a direct function \
          call syntax.",
     )));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Special forms in HashQL are compile-time constructs that must be expanded during \
          compilation. They can only be used in call position with their expected arguments, not \
          as regular values, types, or function references.",

--- a/libs/@local/hashql/ast/src/lowering/special_form_expander/error.rs
+++ b/libs/@local/hashql/ast/src/lowering/special_form_expander/error.rs
@@ -186,7 +186,7 @@ pub(crate) fn unknown_special_form_length(
 ) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::UnknownSpecialForm,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
@@ -204,12 +204,12 @@ pub(crate) fn unknown_special_form_length(
         }
     }
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Special form paths must follow the pattern '::kernel::special_form::<name>' with exactly \
          3 segments",
     ));
 
-    diagnostic.note = Some(Note::new(format!(
+    diagnostic.add_note(Note::new(format!(
         "Found path with {} segments, but special form paths must have exactly 3 segments",
         path.segments.len()
     )));
@@ -223,7 +223,7 @@ pub(crate) fn unknown_special_form_name(
 ) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::UnknownSpecialForm,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     let function_name = &path.segments[2].name.value;
@@ -250,14 +250,14 @@ pub(crate) fn unknown_special_form_name(
         Cow::Borrowed("Special forms must use one of the predefined names shown in the note below")
     };
 
-    diagnostic.help = Some(Help::new(help));
+    diagnostic.add_help(Help::new(help));
 
     let names = enum_iterator::all::<SpecialFormKind>()
         .map(SpecialFormKind::as_str)
         .collect::<Vec<_>>()
         .join(", ");
 
-    diagnostic.note = Some(Note::new(format!(
+    diagnostic.add_note(Note::new(format!(
         "Available special forms include: {names}"
     )));
 
@@ -269,7 +269,7 @@ pub(crate) fn unknown_special_form_generics(
 ) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::UnknownSpecialForm,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     let (first, rest) = generics
@@ -287,12 +287,12 @@ pub(crate) fn unknown_special_form_generics(
             .push(Label::new(arg.span(), "... and these too").with_order((index + 1) as i32));
     }
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Special form paths must not include generic arguments. Remove the angle brackets and \
          their contents.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Special forms are built-in language constructs that don't support generics in their path \
          reference.",
     ));
@@ -308,7 +308,7 @@ pub(super) fn invalid_argument_length(
 ) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::SpecialFormArgumentLength,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     let actual = arguments.len();
@@ -371,9 +371,9 @@ pub(super) fn invalid_argument_length(
         SpecialFormKind::Index => "The index/2 form should look like: ([] object index)",
     };
 
-    diagnostic.help = Some(Help::new(help_text));
+    diagnostic.add_help(Help::new(help_text));
 
-    diagnostic.note = Some(Note::new(format!(
+    diagnostic.add_note(Note::new(format!(
         "The {kind} function has {} variant{}: {}",
         expected.len(),
         if expected.len() == 1 { "" } else { "s" },
@@ -389,7 +389,7 @@ pub(crate) fn labeled_arguments_not_supported(
 ) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::LabeledArgumentsNotSupported,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
@@ -410,12 +410,12 @@ pub(crate) fn labeled_arguments_not_supported(
         );
     }
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Special forms only accept positional arguments. Convert all labeled arguments to \
          positional arguments in the correct order.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Unlike regular functions, special forms have fixed parameter positions and cannot use \
          labeled arguments.",
     ));
@@ -482,7 +482,7 @@ pub(crate) fn invalid_type_expression(
 ) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::InvalidTypeExpression,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     let message = match kind {
@@ -512,9 +512,9 @@ pub(crate) fn invalid_type_expression(
         _ => "Replace this expression with a valid type reference, struct type, or tuple type",
     };
 
-    diagnostic.help = Some(Help::new(help_text));
+    diagnostic.add_help(Help::new(help_text));
 
-    diagnostic.note = Some(Note::new(TYPE_EXPRESSION_NOTE));
+    diagnostic.add_note(Note::new(TYPE_EXPRESSION_NOTE));
 
     diagnostic
 }
@@ -522,7 +522,7 @@ pub(crate) fn invalid_type_expression(
 pub(crate) fn invalid_type_call_function(span: SpanId) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::InvalidTypeExpression,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic.labels.push(Label::new(
@@ -530,12 +530,12 @@ pub(crate) fn invalid_type_call_function(span: SpanId) -> SpecialFormExpanderDia
         "Function call with non-path callee cannot be used as a type",
     ));
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Only specific type constructors like intersection (&) and union (|) operators can be \
          used in type expressions.",
     ));
 
-    diagnostic.note = Some(Note::new(TYPE_EXPRESSION_NOTE));
+    diagnostic.add_note(Note::new(TYPE_EXPRESSION_NOTE));
 
     diagnostic
 }
@@ -543,7 +543,7 @@ pub(crate) fn invalid_type_call_function(span: SpanId) -> SpecialFormExpanderDia
 pub(crate) fn unsupported_type_constructor_function(span: SpanId) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::InvalidTypeExpression,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic.labels.push(Label::new(
@@ -551,12 +551,12 @@ pub(crate) fn unsupported_type_constructor_function(span: SpanId) -> SpecialForm
         "This function cannot be used as a type constructor",
     ));
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Only specific type constructors like intersection (&) and union (|) operators can be \
          used in type expressions.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Currently supported type operations are:\n- Intersection: math::bit_and (written as & in \
          source)\n- Union: math::bit_or (written as | in source)",
     ));
@@ -586,7 +586,7 @@ pub(crate) fn invalid_binding_name_not_path(
 ) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::InvalidBindingName,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic.labels.push(Label::new(
@@ -594,7 +594,7 @@ pub(crate) fn invalid_binding_name_not_path(
         "Replace this expression with a simple identifier",
     ));
 
-    diagnostic.help = Some(Help::new(format!(
+    diagnostic.add_help(Help::new(format!(
         "The {mode} binding name must be a simple identifier. Complex expressions are not allowed \
          in binding positions."
     )));
@@ -626,7 +626,7 @@ pub(crate) fn invalid_binding_name_not_path(
         }
     };
 
-    diagnostic.note = Some(Note::new(note));
+    diagnostic.add_note(Note::new(note));
 
     diagnostic
 }
@@ -637,19 +637,19 @@ pub(crate) fn invalid_let_name_qualified_path(
 ) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::QualifiedBindingName,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
         .labels
         .push(Label::new(span, "Replace this with a simple identifier"));
 
-    diagnostic.help = Some(Help::new(format!(
+    diagnostic.add_help(Help::new(format!(
         "{mode} binding names must be simple identifiers without any path qualification. \
          Qualified paths cannot be used as binding names."
     )));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Valid identifiers are simple names like 'x', 'counter', '+', or 'user_name' without any \
          namespace qualification, generic parameters, or path separators.",
     ));
@@ -663,7 +663,7 @@ pub(crate) fn invalid_type_name_qualified_path(
 ) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::QualifiedBindingName,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic.labels.push(Label::new(
@@ -671,12 +671,12 @@ pub(crate) fn invalid_type_name_qualified_path(
         "Replace this qualified path with a simple identifier",
     ));
 
-    diagnostic.help = Some(Help::new(format!(
+    diagnostic.add_help(Help::new(format!(
         "The {mode} binding requires a simple type name (like 'String' or 'MyType<T>'), not a \
          qualified path (like 'std::string::String'). Remove the path segments."
     )));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Valid type names are simple identifiers, optionally followed by generic arguments (e.g., \
          'Identifier' or 'Container<Param>'). They cannot contain '::' path separators in this \
          context.",
@@ -688,19 +688,19 @@ pub(crate) fn invalid_type_name_qualified_path(
 pub(crate) fn type_with_existing_annotation(span: SpanId) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::TypeWithExistingAnnotation,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
         .labels
         .push(Label::new(span, "Remove this type annotation"));
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Type expressions used in special forms cannot have their own type annotations. The \
          expression itself defines a type and cannot be annotated with another type.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "When constructing type expressions for special forms like 'type', 'newtype', or 'is', \
          the expression itself represents a type definition and cannot have a separate type \
          annotation.",
@@ -712,19 +712,19 @@ pub(crate) fn type_with_existing_annotation(span: SpanId) -> SpecialFormExpander
 pub(crate) fn invalid_use_import(span: SpanId) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::InvalidUseImport,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
         .labels
         .push(Label::new(span, "Replace with a valid import expression"));
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Use imports must be either a glob (*), a tuple of identifiers, or a struct of bindings. \
          Other expression types are not valid in this context.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Valid import expressions include:\n- Glob: *\n- Tuple of identifiers: (name1, name2)\n- \
          Struct with aliases: (name1: alias1, name2: alias2) or (name1: _, name2: _)",
     ));
@@ -735,19 +735,19 @@ pub(crate) fn invalid_use_import(span: SpanId) -> SpecialFormExpanderDiagnostic 
 pub(crate) fn use_imports_with_type_annotation(span: SpanId) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::InvalidUseImport,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
         .labels
         .push(Label::new(span, "Remove this type annotation"));
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Use import expressions cannot have type annotations. Import expressions define which \
          symbols to import, and do not have a meaningful type in this context.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Import expressions in the 'use' special form can only be a glob (*), a tuple of \
          identifiers, or a struct of bindings, none of which should have type annotations.",
     ));
@@ -758,19 +758,19 @@ pub(crate) fn use_imports_with_type_annotation(span: SpanId) -> SpecialFormExpan
 pub(crate) fn invalid_path_in_use_binding(span: SpanId) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::InvalidUseImport,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
         .labels
         .push(Label::new(span, "Use a simple identifier here"));
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Use binding names must be simple identifiers. Qualified paths or complex expressions \
          cannot be used in this context.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "In tuple imports, each element must be a simple identifier. For example: (name1, name2) \
          is valid, but (path::to::name,) is not.",
     ));
@@ -784,7 +784,7 @@ pub(crate) fn use_path_with_generics(
 ) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::UsePathWithGenerics,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
@@ -802,12 +802,12 @@ pub(crate) fn use_path_with_generics(
         }
     }
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "The 'use' special form does not support generic arguments in import paths. Remove all \
          generic arguments from the path.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Use statements in HashQL can only import modules or specific symbols, but cannot specify \
          generic parameters during import.",
     ));
@@ -818,19 +818,19 @@ pub(crate) fn use_path_with_generics(
 pub(crate) fn fn_generics_with_type_annotation(span: SpanId) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::FnGenericsWithTypeAnnotation,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
         .labels
         .push(Label::new(span, "Remove this type annotation"));
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Function generics declarations cannot have type annotations. Generic parameter lists \
          define type parameters for the function, and do not have a meaningful type themselves.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "In the 'fn' special form, the generics argument should be either a tuple of identifiers \
          such as (T, U) or a struct of bounded type parameters such as (T: SomeBound, U: \
          OtherBound, V: _), where an underscore indicates no bound.",
@@ -842,19 +842,19 @@ pub(crate) fn fn_generics_with_type_annotation(span: SpanId) -> SpecialFormExpan
 pub(crate) fn invalid_fn_generics_expression(span: SpanId) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::InvalidFnGenericsExpression,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
         .labels
         .push(Label::new(span, "Use a valid generics expression"));
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Function generics must be specified as either a tuple of identifiers or a struct of \
          bounded type parameters. Other expression types are not valid in this context.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Valid generics expressions include:\n- Empty: ()\n- Tuple of identifiers: (T, U, V)\n- \
          Struct with bounds: (T: SomeBound, U: OtherBound) or (T: _, U: _) for unbounded types",
     ));
@@ -865,19 +865,19 @@ pub(crate) fn invalid_fn_generics_expression(span: SpanId) -> SpecialFormExpande
 pub(crate) fn invalid_fn_generic_param(span: SpanId) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::InvalidFnGenericParam,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
         .labels
         .push(Label::new(span, "Use a simple identifier here"));
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Generic type parameters must be simple identifiers. Qualified paths or complex \
          expressions cannot be used in this context.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "In function generic parameter lists, each element must be a simple identifier. For \
          example: (T, U, V) is valid, but (some::path,) is not.",
     ));
@@ -888,20 +888,20 @@ pub(crate) fn invalid_fn_generic_param(span: SpanId) -> SpecialFormExpanderDiagn
 pub(crate) fn fn_params_with_type_annotation(span: SpanId) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::FnParamsWithTypeAnnotation,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
         .labels
         .push(Label::new(span, "Remove this type annotation"));
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Function parameter declarations cannot have type annotations at the struct level. The \
          struct itself represents the parameter list, and each field represents a parameter with \
          its type.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "In the 'fn' special form, parameter lists should be structured as (param1: Type1, \
          param2: Type2), where the struct itself does not have a type annotation.",
     ));
@@ -912,20 +912,20 @@ pub(crate) fn fn_params_with_type_annotation(span: SpanId) -> SpecialFormExpande
 pub(crate) fn invalid_fn_params_expression(span: SpanId) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::InvalidFnParamsExpression,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
         .labels
         .push(Label::new(span, "Use a struct expression for parameters"));
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Function parameters must be specified as a struct where field names are parameter names \
          and field values are parameter types. Other expression types are not valid in this \
          context.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Valid parameter expression is a struct in the form: (param1: Type1, param2: Type2, ...)",
     ));
 
@@ -935,19 +935,19 @@ pub(crate) fn invalid_fn_params_expression(span: SpanId) -> SpecialFormExpanderD
 pub(crate) fn invalid_generic_argument_path(span: SpanId) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::InvalidGenericArgumentPath,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
         .labels
         .push(Label::new(span, "Replace with a simple identifier"));
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Generic arguments must be simple identifiers. Qualified paths cannot be used as generic \
          arguments in this context.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "In generic parameter constraints, arguments should be simple identifiers like 'T', 'U', \
          or 'Element' without namespace qualification or path separators.",
     ));
@@ -958,19 +958,19 @@ pub(crate) fn invalid_generic_argument_path(span: SpanId) -> SpecialFormExpander
 pub(crate) fn invalid_generic_argument_type(span: SpanId) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::InvalidGenericArgumentType,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
         .labels
         .push(Label::new(span, "Use a simple type identifier here"));
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Generic argument types must be simple path identifiers. Complex types like structs, \
          tuples, or function types cannot be used as generic argument types in this context.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Valid generic argument types are simple identifiers that refer to type names, such as \
          'String', 'Number', or type parameters like 'T'.",
     ));
@@ -985,7 +985,7 @@ pub(crate) fn duplicate_generic_constraint(
 ) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::DuplicateGenericConstraint,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic.labels.push(Label::new(
@@ -1001,12 +1001,12 @@ pub(crate) fn duplicate_generic_constraint(
         .with_order(1),
     );
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Each generic parameter can only be declared once in a function or type definition. \
          Remove the duplicate declaration or use a different name.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Generic parameter names must be unique within a single generic parameter list. For \
          example, in foo<T: Bound, U: OtherBound>, 'T' and 'U' are unique parameters.",
     ));
@@ -1021,7 +1021,7 @@ pub(crate) fn duplicate_closure_parameter(
 ) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::DuplicateClosureParameter,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic.labels.push(Label::new(
@@ -1037,12 +1037,12 @@ pub(crate) fn duplicate_closure_parameter(
         .with_order(1),
     );
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Each function parameter must have a unique name. Rename this parameter or remove the \
          duplicate declaration.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Function parameters must have unique names within the same parameter list. For example, \
          in fn(x: Int, y: String): ReturnType body), 'x' and 'y' are unique parameters.",
     ));
@@ -1057,7 +1057,7 @@ pub(crate) fn duplicate_closure_generic(
 ) -> SpecialFormExpanderDiagnostic {
     let mut diagnostic = Diagnostic::new(
         SpecialFormExpanderDiagnosticCategory::DuplicateGenericConstraint,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic.labels.push(Label::new(
@@ -1073,12 +1073,12 @@ pub(crate) fn duplicate_closure_generic(
         .with_order(1),
     );
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Each generic parameter can only be declared once in a function definition. Remove the \
          duplicate declaration or use a different name.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Generic parameter names must be unique within a function's generic parameter list. For \
          example, in fn<T, U>(param: T): U -> body), 'T' and 'U' are unique parameters.",
     ));

--- a/libs/@local/hashql/ast/src/lowering/type_extractor/error.rs
+++ b/libs/@local/hashql/ast/src/lowering/type_extractor/error.rs
@@ -157,8 +157,7 @@ pub(crate) fn duplicate_type_alias(
 
     diagnostic.add_note(Note::new(
         "This likely represents a compiler bug in the name mangling pass. The name mangler should \
-         have given these identical names unique internal identifiers to avoid this collision. \
-         Please report this issue to the HashQL team with a minimal reproduction case.",
+         have given these identical names unique internal identifiers to avoid this collision.",
     ));
 
     diagnostic
@@ -231,8 +230,7 @@ pub(crate) fn duplicate_newtype(
         "This likely represents a compiler bug in the name mangling pass. The compiler \
          encountered duplicate newtype definitions with the same name that should have been given \
          unique internal identifiers. The name mangler should have prevented this collision \
-         automatically. Please report this issue to the HashQL team with a minimal reproduction \
-         case.",
+         automatically.",
     ));
 
     diagnostic
@@ -397,8 +395,7 @@ pub(crate) fn unbound_type_variable<'heap>(
     diagnostic.add_note(Note::new(
         "This is likely a compiler bug in the name resolution system. The type checker has \
          encountered a name that wasn't properly resolved earlier in compilation. The name \
-         resolution pass should have caught this error or provided a more specific error message. \
-         Please report this issue to the HashQL team with a minimal reproduction case.",
+         resolution pass should have caught this error or provided a more specific error message.",
     ));
 
     diagnostic
@@ -525,8 +522,7 @@ pub(crate) fn unknown_intrinsic_type(
         "Available intrinsic types: `{available}`\n\nIntrinsic types are fundamental building \
          blocks provided by the language runtime. They form the basis of the type system and \
          cannot be redefined by user code.\n\nThis is likely a compiler bug. The import resolver \
-         should've caught this error beforehand. Please report this issue to the HashQL team with \
-         a minimal reproduction case that demonstrates how to trigger this error."
+         should've caught this error beforehand."
     )));
 
     diagnostic
@@ -573,8 +569,7 @@ pub(crate) fn invalid_resolved_item(
     diagnostic.add_note(Note::new(
         "This is likely a compiler bug in the import resolution system. The compiler has confused \
          types and values during name resolution. The import resolver should have caught this \
-         error before reaching this stage. Please report this issue to the HashQL team with a \
-         minimal reproduction case that demonstrates how to trigger this error.",
+         error before reaching this stage.",
     ));
 
     diagnostic
@@ -607,15 +602,13 @@ pub(crate) fn resolution_error(path: &Path, error: &ResolutionError) -> TypeExtr
             .with_color(Color::Ansi(AnsiColor::Red)),
     );
 
-    diagnostic.add_note(Note::new(format!(
+    diagnostic.add_note(Note::new(
         "This is likely a compiler bug in the name resolution system. During type checking, the \
          compiler failed to resolve a path that should have been properly processed by earlier \
          compilation stages. Either the path resolution should have succeeded or a more specific \
-         error should have been reported earlier in compilation. \n\nPlease report this issue to \
-         the HashQL team with a minimal reproduction case that triggers this error. Include the \
-         path you were trying to reference and any relevant type definitions.\n\nTechnical error \
-         details:\n{error:#?}"
-    )));
+         error should have been reported earlier in compilation.",
+    ));
+    diagnostic.add_note(Note::new(format!("Technical error details:\n{error:#?}")));
 
     diagnostic
 }

--- a/libs/@local/hashql/ast/src/lowering/type_extractor/error.rs
+++ b/libs/@local/hashql/ast/src/lowering/type_extractor/error.rs
@@ -143,7 +143,7 @@ pub(crate) fn duplicate_type_alias(
 ) -> TypeExtractorDiagnostic {
     let mut diagnostic = Diagnostic::new(
         TypeExtractorDiagnosticCategory::DuplicateTypeAlias,
-        Severity::COMPILER_BUG,
+        Severity::Bug,
     );
 
     diagnostic.labels.extend([
@@ -155,7 +155,7 @@ pub(crate) fn duplicate_type_alias(
             .with_color(Color::Ansi(AnsiColor::Red)),
     ]);
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "This likely represents a compiler bug in the name mangling pass. The name mangler should \
          have given these identical names unique internal identifiers to avoid this collision. \
          Please report this issue to the HashQL team with a minimal reproduction case.",
@@ -175,7 +175,7 @@ pub(crate) fn generic_constraint_not_allowed(
 ) -> TypeExtractorDiagnostic {
     let mut diagnostic = Diagnostic::new(
         TypeExtractorDiagnosticCategory::GenericConstraintNotAllowed,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic.labels.extend([
@@ -190,9 +190,9 @@ pub(crate) fn generic_constraint_not_allowed(
             .with_color(Color::Ansi(AnsiColor::Blue)),
     ]);
 
-    diagnostic.help = Some(Help::new(format!("Use `{name}` without a constraint")));
+    diagnostic.add_help(Help::new(format!("Use `{name}` without a constraint")));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Type constraints cannot be specified at the usage site in HashQL. Constraints on type \
          parameters must be declared where the type is defined, not where it is used.",
     ));
@@ -212,7 +212,7 @@ pub(crate) fn duplicate_newtype(
 ) -> TypeExtractorDiagnostic {
     let mut diagnostic = Diagnostic::new(
         TypeExtractorDiagnosticCategory::DuplicateNewtype,
-        Severity::COMPILER_BUG,
+        Severity::Bug,
     );
 
     diagnostic.labels.extend([
@@ -227,7 +227,7 @@ pub(crate) fn duplicate_newtype(
             .with_color(Color::Ansi(AnsiColor::Red)),
     ]);
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "This likely represents a compiler bug in the name mangling pass. The compiler \
          encountered duplicate newtype definitions with the same name that should have been given \
          unique internal identifiers. The name mangler should have prevented this collision \
@@ -262,7 +262,7 @@ where
 {
     let mut diagnostic = Diagnostic::new(
         TypeExtractorDiagnosticCategory::GenericParameterMismatch,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     let name = match variable {
@@ -346,9 +346,9 @@ where
         Ordering::Equal => format!("Use: {usage}"),
     };
 
-    diagnostic.help = Some(Help::new(help));
+    diagnostic.add_help(Help::new(help));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Generic type parameters allow types to work with different data types while maintaining \
          type safety. Each generic type has specific requirements for the number and names of \
          type parameters it accepts. For example, List<T> requires exactly one type parameter, \
@@ -370,7 +370,7 @@ pub(crate) fn unbound_type_variable<'heap>(
 ) -> TypeExtractorDiagnostic {
     let mut diagnostic = Diagnostic::new(
         TypeExtractorDiagnosticCategory::UnboundTypeVariable,
-        Severity::COMPILER_BUG,
+        Severity::Bug,
     );
 
     diagnostic.labels.push(
@@ -391,10 +391,10 @@ pub(crate) fn unbound_type_variable<'heap>(
             .intersperse("`, `")
             .collect();
 
-        diagnostic.help = Some(Help::new(format!("Did you mean `{suggestions}`?")));
+        diagnostic.add_help(Help::new(format!("Did you mean `{suggestions}`?")));
     }
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "This is likely a compiler bug in the name resolution system. The type checker has \
          encountered a name that wasn't properly resolved earlier in compilation. The name \
          resolution pass should have caught this error or provided a more specific error message. \
@@ -416,7 +416,7 @@ pub(crate) fn intrinsic_parameter_count_mismatch(
 ) -> TypeExtractorDiagnostic {
     let mut diagnostic = Diagnostic::new(
         TypeExtractorDiagnosticCategory::IntrinsicParameterMismatch,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     let message = if actual < expected {
@@ -454,7 +454,7 @@ pub(crate) fn intrinsic_parameter_count_mismatch(
         format!("Remove extra parameter(s): `{help_example}`")
     };
 
-    diagnostic.help = Some(Help::new(help_message));
+    diagnostic.add_help(Help::new(help_message));
 
     // Add a note explaining the purpose of the intrinsic type
     let note_message = match name {
@@ -475,7 +475,7 @@ pub(crate) fn intrinsic_parameter_count_mismatch(
         }
     };
 
-    diagnostic.note = Some(Note::new(note_message));
+    diagnostic.add_note(Note::new(note_message));
 
     diagnostic
 }
@@ -491,7 +491,7 @@ pub(crate) fn unknown_intrinsic_type(
 ) -> TypeExtractorDiagnostic {
     let mut diagnostic = Diagnostic::new(
         TypeExtractorDiagnosticCategory::UnknownIntrinsicType,
-        Severity::COMPILER_BUG,
+        Severity::Bug,
     );
 
     diagnostic.labels.push(
@@ -508,7 +508,7 @@ pub(crate) fn unknown_intrinsic_type(
 
     if similar.is_empty() {
         // Provide helpful guidance even without close matches
-        diagnostic.help = Some(Help::new(
+        diagnostic.add_help(Help::new(
             "Check the HashQL documentation for a complete list of available intrinsic types. \
              Make sure you're using the correct namespace and capitalization for the type you're \
              trying to use.",
@@ -516,12 +516,12 @@ pub(crate) fn unknown_intrinsic_type(
     } else {
         let suggestions: String = similar.into_iter().intersperse("`, `").collect();
 
-        diagnostic.help = Some(Help::new(format!("Did you mean `{suggestions}`?")));
+        diagnostic.add_help(Help::new(format!("Did you mean `{suggestions}`?")));
     }
 
     let available: String = available.iter().copied().intersperse("`, `").collect();
 
-    diagnostic.note = Some(Note::new(format!(
+    diagnostic.add_note(Note::new(format!(
         "Available intrinsic types: `{available}`\n\nIntrinsic types are fundamental building \
          blocks provided by the language runtime. They form the basis of the type system and \
          cannot be redefined by user code.\n\nThis is likely a compiler bug. The import resolver \
@@ -544,7 +544,7 @@ pub(crate) fn invalid_resolved_item(
 ) -> TypeExtractorDiagnostic {
     let mut diagnostic = Diagnostic::new(
         TypeExtractorDiagnosticCategory::InvalidResolution,
-        Severity::COMPILER_BUG,
+        Severity::Bug,
     );
 
     diagnostic.labels.push(
@@ -561,7 +561,7 @@ pub(crate) fn invalid_resolved_item(
         .with_color(Color::Ansi(AnsiColor::Red)),
     );
 
-    diagnostic.help = Some(Help::new(format!(
+    diagnostic.add_help(Help::new(format!(
         "Found a {actual:?} instead of a {}. This is an internal compiler issue with type \
          resolution, not a problem with your code.",
         match expected {
@@ -570,7 +570,7 @@ pub(crate) fn invalid_resolved_item(
         }
     )));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "This is likely a compiler bug in the import resolution system. The compiler has confused \
          types and values during name resolution. The import resolver should have caught this \
          error before reaching this stage. Please report this issue to the HashQL team with a \
@@ -587,7 +587,7 @@ pub(crate) fn invalid_resolved_item(
 pub(crate) fn resolution_error(path: &Path, error: &ResolutionError) -> TypeExtractorDiagnostic {
     let mut diagnostic = Diagnostic::new(
         TypeExtractorDiagnosticCategory::ResolutionError,
-        Severity::COMPILER_BUG,
+        Severity::Bug,
     );
 
     let path_display = path
@@ -607,7 +607,7 @@ pub(crate) fn resolution_error(path: &Path, error: &ResolutionError) -> TypeExtr
             .with_color(Color::Ansi(AnsiColor::Red)),
     );
 
-    diagnostic.note = Some(Note::new(format!(
+    diagnostic.add_note(Note::new(format!(
         "This is likely a compiler bug in the name resolution system. During type checking, the \
          compiler failed to resolve a path that should have been properly processed by earlier \
          compilation stages. Either the path resolution should have succeeded or a more specific \
@@ -630,7 +630,7 @@ pub(crate) fn duplicate_struct_fields(
 ) -> TypeExtractorDiagnostic {
     let mut diagnostic = Diagnostic::new(
         TypeExtractorDiagnosticCategory::DuplicateStructField,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic.labels.push(
@@ -653,12 +653,12 @@ pub(crate) fn duplicate_struct_fields(
         index -= 1;
     }
 
-    diagnostic.help = Some(Help::new(format!(
+    diagnostic.add_help(Help::new(format!(
         "To fix this error, you can either:\n1. Rename the duplicate `{field_name}` field to a \
          different name, or\n2. Remove the redundant field definition entirely if it's not needed"
     )));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Struct types in HashQL require that each field has a unique name. Having multiple fields \
          with the same name would create ambiguity when accessing fields through dot notation or \
          destructuring. The compiler enforces this constraint to ensure clear and predictable \
@@ -680,7 +680,7 @@ pub(crate) fn unused_generic_parameter(
 ) -> TypeExtractorDiagnostic {
     let mut diagnostic = Diagnostic::new(
         TypeExtractorDiagnosticCategory::UnusedGenericParameter,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic.labels.push(
@@ -700,13 +700,13 @@ pub(crate) fn unused_generic_parameter(
             .with_color(Color::Ansi(AnsiColor::Blue)),
     );
 
-    diagnostic.help = Some(Help::new(format!(
+    diagnostic.add_help(Help::new(format!(
         "Generic parameter `{}` is declared but not referenced. Either remove the unused \
          parameter or incorporate it into your type definition.",
         demangle(&param.name)
     )));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Each generic parameter should serve a purpose in parameterizing the type. Unused \
          parameters can make code harder to understand and may indicate a design oversight or \
          incomplete implementation. They are unconstrained variables, and therefore considered \

--- a/libs/@local/hashql/compiletest/src/annotation/diagnostic.rs
+++ b/libs/@local/hashql/compiletest/src/annotation/diagnostic.rs
@@ -2,20 +2,10 @@ use core::str::pattern::{Pattern as _, Searcher as _};
 
 use hashql_diagnostics::severity::Severity;
 
-type Severities = [&'static Severity; 6];
-const SUPPORTED_SEVERITIES: Severities = [
-    &Severity::COMPILER_BUG,
-    &Severity::CRITICAL,
-    &Severity::ERROR,
-    &Severity::WARNING,
-    &Severity::INFO,
-    &Severity::DEBUG,
-];
-
 #[derive(Debug, Clone, PartialEq, Eq, derive_more::Display)]
 pub(crate) enum DiagnosticParseError {
     /// No supported severity found in the annotation
-    #[display("missing severity, expected one of: {SUPPORTED_SEVERITIES:?}")]
+    #[display("missing severity, expected one of: {:?}", Severity::variants())]
     MissingSeverity,
     /// Pipe reference used without a previous diagnostic annotation line
     #[display("pipe reference used without a previous diagnostic annotation line")]
@@ -108,11 +98,11 @@ impl DiagnosticAnnotation {
         value = value.trim();
 
         // Figure out the severity
-        for severity in SUPPORTED_SEVERITIES {
+        for severity in Severity::variants() {
             if let Some(next) = value.strip_prefix(&severity.name().to_ascii_uppercase()) {
                 value = next.trim();
 
-                annotation_severity = Some((*severity).clone());
+                annotation_severity = Some(*severity);
 
                 break;
             }
@@ -158,7 +148,7 @@ mod tests {
         assert_eq!(
             annotation,
             DiagnosticAnnotation {
-                severity: Severity::ERROR,
+                severity: Severity::Error,
                 message: "message text".to_owned(),
                 category: None,
                 line: Some(10),
@@ -168,7 +158,7 @@ mod tests {
 
     #[test]
     fn severity_levels() {
-        for &severity in &SUPPORTED_SEVERITIES {
+        for &severity in Severity::variants() {
             let input = format!("{} test message", severity.name().to_ascii_uppercase());
             let annotation =
                 DiagnosticAnnotation::parse(&input, 5, Some(4)).expect("should successfully parse");
@@ -176,7 +166,7 @@ mod tests {
             assert_eq!(
                 annotation,
                 DiagnosticAnnotation {
-                    severity: severity.clone(),
+                    severity,
                     message: "test message".to_owned(),
                     category: None,
                     line: Some(5),
@@ -193,7 +183,7 @@ mod tests {
         assert_eq!(
             annotation,
             DiagnosticAnnotation {
-                severity: Severity::ERROR,
+                severity: Severity::Error,
                 message: "categorized error".to_owned(),
                 category: Some("E001".to_owned()),
                 line: Some(15),
@@ -209,7 +199,7 @@ mod tests {
         assert_eq!(
             annotation,
             DiagnosticAnnotation {
-                severity: Severity::ERROR,
+                severity: Severity::Error,
                 message: "missing semicolon".to_owned(),
                 category: None,
                 line: Some(17),
@@ -225,7 +215,7 @@ mod tests {
         assert_eq!(
             annotation,
             DiagnosticAnnotation {
-                severity: Severity::ERROR,
+                severity: Severity::Error,
                 message: "undefined variable".to_owned(),
                 category: None,
                 line: Some(23),
@@ -241,7 +231,7 @@ mod tests {
         assert_eq!(
             annotation,
             DiagnosticAnnotation {
-                severity: Severity::ERROR,
+                severity: Severity::Error,
                 message: "previous line error".to_owned(),
                 category: None,
                 line: Some(9),
@@ -265,7 +255,7 @@ mod tests {
         assert_eq!(
             annotation,
             DiagnosticAnnotation {
-                severity: Severity::WARNING,
+                severity: Severity::Warning,
                 message: "might occur anywhere".to_owned(),
                 category: None,
                 line: None,
@@ -282,7 +272,7 @@ mod tests {
         assert_eq!(
             annotation,
             DiagnosticAnnotation {
-                severity: Severity::ERROR,
+                severity: Severity::Error,
                 message: "complex error description".to_owned(),
                 category: Some("E100".to_owned()),
                 line: Some(13),
@@ -297,7 +287,7 @@ mod tests {
         assert_eq!(
             annotation,
             DiagnosticAnnotation {
-                severity: Severity::WARNING,
+                severity: Severity::Warning,
                 message: "previous line warning".to_owned(),
                 category: Some("W200".to_owned()),
                 line: Some(24),
@@ -314,7 +304,7 @@ mod tests {
         assert_eq!(
             annotation,
             DiagnosticAnnotation {
-                severity: Severity::ERROR,
+                severity: Severity::Error,
                 message: "spaced   message".to_owned(),
                 category: Some("E001".to_owned()),
                 line: Some(10),
@@ -338,7 +328,7 @@ mod tests {
         assert_eq!(
             annotation,
             DiagnosticAnnotation {
-                severity: Severity::ERROR,
+                severity: Severity::Error,
                 message: "[incomplete category".to_owned(),
                 category: None,
                 line: Some(10),
@@ -354,7 +344,7 @@ mod tests {
         assert_eq!(
             annotation,
             DiagnosticAnnotation {
-                severity: Severity::ERROR,
+                severity: Severity::Error,
                 message: String::new(),
                 category: None,
                 line: Some(10),
@@ -370,7 +360,7 @@ mod tests {
         assert_eq!(
             annotation,
             DiagnosticAnnotation {
-                severity: Severity::ERROR,
+                severity: Severity::Error,
                 message: "empty category".to_owned(),
                 category: None,
                 line: Some(10),

--- a/libs/@local/hashql/compiletest/src/executor/annotations.rs
+++ b/libs/@local/hashql/compiletest/src/executor/annotations.rs
@@ -77,8 +77,8 @@ pub(crate) fn verify_annotations(
                 let mut sources = labels
                     .iter()
                     .map(|label| label.message())
-                    .chain(diagnostic.help.as_ref().map(Help::message))
-                    .chain(diagnostic.note.as_ref().map(Note::message))
+                    .chain(diagnostic.help.iter().map(Help::message))
+                    .chain(diagnostic.notes.iter().map(Note::message))
                     .chain(iter::once(canonical_name.as_str()));
 
                 sources.any(|source| source.contains(query))
@@ -87,7 +87,7 @@ pub(crate) fn verify_annotations(
                 // 4) Find if all the other expectations are fulfilled
                 // - severity
                 // - category
-                let severity_matches = annotation.severity == *diagnostic.severity;
+                let severity_matches = annotation.severity == diagnostic.severity;
 
                 let category_matches = annotation.category.as_ref().is_none_or(|category| {
                     let diagnostic_id =
@@ -188,13 +188,13 @@ mod tests {
 
         let diagnostics = vec![make_diagnostic(
             "test",
-            Severity::ERROR,
+            Severity::Error,
             "test error",
             make_span(6, 11),
         ) /* spans "line2" */];
 
         let annotations = vec![
-            make_annotation("error", Some(2), Severity::ERROR), // matches line2
+            make_annotation("error", Some(2), Severity::Error), // matches line2
         ];
 
         let mut sink = ReportSink::<TrialError>::new();
@@ -216,13 +216,13 @@ mod tests {
 
         let diagnostics = vec![make_diagnostic(
             "test",
-            Severity::ERROR,
+            Severity::Error,
             "test error",
             make_span(0, 5),
         ) /* spans "line1" */];
 
         let annotations = vec![
-            make_annotation("warning", Some(2), Severity::WARNING), // doesn't match
+            make_annotation("warning", Some(2), Severity::Warning), // doesn't match
         ];
 
         let mut sink = ReportSink::<TrialError>::new();
@@ -244,7 +244,7 @@ mod tests {
 
         let diagnostics = vec![make_diagnostic(
             "test",
-            Severity::ERROR,
+            Severity::Error,
             "test error",
             make_span(0, 5),
         ) /* spans "line1" */];
@@ -269,12 +269,12 @@ mod tests {
         let line_index = LineIndex::new(source);
 
         let diagnostics = vec![
-            make_diagnostic("test1", Severity::ERROR, "first error", make_span(0, 5)), // line1
-            make_diagnostic("test2", Severity::ERROR, "second error", make_span(6, 11)), // line2
+            make_diagnostic("test1", Severity::Error, "first error", make_span(0, 5)), // line1
+            make_diagnostic("test2", Severity::Error, "second error", make_span(6, 11)), // line2
         ];
 
         let annotations = vec![
-            make_annotation("error", Some(1), Severity::ERROR), // matches first diagnostic
+            make_annotation("error", Some(1), Severity::Error), // matches first diagnostic
         ];
 
         let mut sink = ReportSink::<TrialError>::new();
@@ -295,10 +295,10 @@ mod tests {
 
         // Create two diagnostics at the same line with similar messages
         let diagnostics = vec![
-            make_diagnostic("test1", Severity::ERROR, "error in line1", make_span(0, 5)), // line1
+            make_diagnostic("test1", Severity::Error, "error in line1", make_span(0, 5)), // line1
             make_diagnostic(
                 "test2",
-                Severity::ERROR,
+                Severity::Error,
                 "another error in line1",
                 make_span(0, 5),
             ), /* also line1 */
@@ -306,7 +306,7 @@ mod tests {
 
         // Only one annotation for the line
         let annotations = vec![
-            make_annotation("error", Some(1), Severity::ERROR), // matches both diagnostics
+            make_annotation("error", Some(1), Severity::Error), // matches both diagnostics
         ];
 
         let mut sink = ReportSink::<TrialError>::new();

--- a/libs/@local/hashql/core/src/type/error.rs
+++ b/libs/@local/hashql/core/src/type/error.rs
@@ -798,10 +798,8 @@ pub(crate) fn unconstrained_type_variable_floating(env: &Environment) -> TypeChe
     );
 
     diagnostic.add_help(Help::new(
-        "This is an internal compiler error, not a problem with your code. The type system \
-         encountered a variable that has no constraints, but also lacks source location \
-         information to properly report the error. Please report this issue to the HashQL team \
-         with a minimal reproduction case.",
+        "The type system encountered a variable that has no constraints, but also lacks source \
+         location information to properly report the error.",
     ));
 
     diagnostic.add_note(Note::new(
@@ -1192,11 +1190,9 @@ where
 {
     let mut diagnostic = Diagnostic::new(
         TypeCheckDiagnosticCategory::TypeParameterNotFound,
-        // This is a compiler bug in the error reporting sequence
         Severity::Bug,
     );
 
-    // Primary label indicating the invalid reference
     diagnostic.labels.push(
         Label::new(
             param.span,
@@ -1205,7 +1201,6 @@ where
         .with_order(1),
     );
 
-    // Secondary label for context about error reporting
     diagnostic.labels.push(
         Label::new(
             env.source,
@@ -1214,21 +1209,17 @@ where
         .with_order(2),
     );
 
-    // Help message explaining the situation
     diagnostic.add_help(Help::new(
         "This error indicates your code contains an invalid type parameter reference that should \
          have been caught by an earlier validation step. While the code is indeed incorrect, the \
-         compiler should have reported this error in a more specific way at an earlier stage. \
-         Please report this issue to the HashQL team with a minimal reproduction case.",
+         compiler should have reported this error in a more specific way at an earlier stage.",
     ));
 
-    // Technical explanation with more details
     diagnostic.add_note(Note::new(format!(
         "Technical details: Parameter ?{argument} is referenced but not defined in the current \
          environment. This represents both an invalid program and a flaw in the error reporting \
          sequence. The compiler should validate all parameter references during an earlier \
-         compilation phase and provide more specific error messages. Please report this as a \
-         compiler issue so we can improve error reporting for similar cases.",
+         compilation phase and provide more specific error messages.",
     )));
 
     diagnostic

--- a/libs/@local/hashql/core/src/type/error.rs
+++ b/libs/@local/hashql/core/src/type/error.rs
@@ -174,7 +174,7 @@ where
     U: PrettyPrint<'heap>,
 {
     let mut diagnostic =
-        Diagnostic::new(TypeCheckDiagnosticCategory::TypeMismatch, Severity::ERROR);
+        Diagnostic::new(TypeCheckDiagnosticCategory::TypeMismatch, Severity::Error);
 
     diagnostic
         .labels
@@ -203,10 +203,10 @@ where
     );
 
     if let Some(text) = help {
-        diagnostic.help = Some(Help::new(text));
+        diagnostic.add_help(Help::new(text.to_owned()));
     }
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "This type system uses a combination of nominal and structural typing. Types are \
          compatible when they have the same structure (same fields/elements with compatible \
          types) or when they represent the same named type. Union types must have at least one \
@@ -230,7 +230,7 @@ where
     let mut diagnostic = Diagnostic::new(
         TypeCheckDiagnosticCategory::NoTypeInference,
         // This is a compiler bug, as we should've encountered the `Infer` at an earlier stage
-        Severity::COMPILER_BUG,
+        Severity::Bug,
     );
 
     diagnostic.labels.push(
@@ -249,12 +249,12 @@ where
         .with_order(2),
     );
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "This error occurs when the type system cannot determine a specific type for an \
          expression. Add explicit type annotations to help the compiler understand your intent.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Type inference requires sufficient context to determine types. When a type variable has \
          no constraints from usage, the compiler cannot choose an appropriate type. Consider \
          adding an explicit type annotation or using the expression in a context that provides \
@@ -274,7 +274,7 @@ where
     K: PrettyPrint<'heap>,
 {
     let mut diagnostic =
-        Diagnostic::new(TypeCheckDiagnosticCategory::CircularType, Severity::WARNING);
+        Diagnostic::new(TypeCheckDiagnosticCategory::CircularType, Severity::Warning);
 
     diagnostic.labels.push(
         Label::new(span, "Circular type reference detected in this expression").with_order(3),
@@ -288,13 +288,13 @@ where
         .labels
         .push(Label::new(rhs.span, "... through this reference").with_order(2));
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "While circular type references are allowed, they can lead to infinite type expansion and \
          potential issues with type checking and serialization. Consider removing the circular \
          dependency.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Circular type references create types that can expand infinitely. This may lead to \
          unpredictable behavior in some contexts like serialization, code generation, or when \
          working with external systems. While supported, use circular types with caution and \
@@ -316,7 +316,7 @@ where
 {
     let mut diagnostic = Diagnostic::new(
         TypeCheckDiagnosticCategory::TupleLengthMismatch,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
@@ -347,12 +347,12 @@ where
         .with_order(2),
     );
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Tuples must have the same number of elements to be compatible. You need to adjust one of \
          the tuples to match the other's length.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Unlike some collections, tuples have a fixed length that is part of their type. This \
          means (String, Number) and (String, Number, Boolean) are completely different types.",
     ));
@@ -375,7 +375,7 @@ where
 {
     let mut diagnostic = Diagnostic::new(
         TypeCheckDiagnosticCategory::OpaqueTypeNameMismatch,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic.labels.push(
@@ -394,13 +394,13 @@ where
         .labels
         .push(Label::new(rhs.span, format!("This is type '{rhs_name}'")).with_order(2));
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Named types can only be used with other instances of the exact same type. This is \
          similar to how 'UserId' and 'PostId' would be different types even if they're both \
          numbers underneath.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "This distinction prevents accidentally mixing up different types that happen to have the \
          same internal structure, helping catch logical errors in your code.",
     ));
@@ -421,7 +421,7 @@ where
 {
     let mut diagnostic = Diagnostic::new(
         TypeCheckDiagnosticCategory::UnionVariantMismatch,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     // Primary: point at the failing variant
@@ -442,13 +442,13 @@ where
         ),
     ));
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "For a type `A | B` to be a subtype of `C | D`, every variant (A, B) must be a subtype of \
          at least one variant in the expected union (C, D).\nIn other words: (A <: C \u{2228} A \
          <: D) \u{2227} (B <: C \u{2228} B <: D)",
     ));
 
-    diagnostic.note = Some(Note::new(format!(
+    diagnostic.add_note(Note::new(format!(
         "expected union: `{}`\nfound variant: `{}` which is not a subtype of any expected variants",
         expected_union
             .kind
@@ -477,7 +477,7 @@ where
 {
     let mut diagnostic = Diagnostic::new(
         TypeCheckDiagnosticCategory::FunctionParameterCountMismatch,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
@@ -508,12 +508,12 @@ where
         .with_order(2),
     );
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Function types must have the same number of parameters to be compatible. Check that \
          you're using the correct function type with the right number of parameters.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "In strongly typed languages, functions with different numbers of parameters are \
          considered different types, even if the parameters they do have are compatible.",
     ));
@@ -529,7 +529,7 @@ where
     K: PrettyPrint<'heap>,
 {
     let mut diagnostic =
-        Diagnostic::new(TypeCheckDiagnosticCategory::TypeMismatch, Severity::ERROR);
+        Diagnostic::new(TypeCheckDiagnosticCategory::TypeMismatch, Severity::Error);
 
     diagnostic
         .labels
@@ -546,12 +546,12 @@ where
         .with_order(1),
     );
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Only the `!` (Never) type itself can be a subtype of `!`. Any type with values cannot be \
          a subtype of `!`, which by definition has no values.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "In type theory, the `!` type (also called 'bottom type' or 'Never') is a type with no \
          values. It can be a subtype of any type, but only `!` can be a subtype of `!`.",
     ));
@@ -567,7 +567,7 @@ where
     K: PrettyPrint<'heap>,
 {
     let mut diagnostic =
-        Diagnostic::new(TypeCheckDiagnosticCategory::TypeMismatch, Severity::ERROR);
+        Diagnostic::new(TypeCheckDiagnosticCategory::TypeMismatch, Severity::Error);
 
     diagnostic
         .labels
@@ -584,11 +584,11 @@ where
         .with_order(1),
     );
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Only the `?` (Unknown) type itself can be a supertype of `?`.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "In type theory, the `?` type (also called 'top type' or 'Unknown') is a type that \
          encompasses all values. It can be a supertype of any type, but only `?` can be a \
          supertype of `?`.",
@@ -608,7 +608,7 @@ where
 {
     let mut diagnostic = Diagnostic::new(
         TypeCheckDiagnosticCategory::IntersectionVariantMismatch,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     // Primary: point at the failing variant
@@ -629,13 +629,13 @@ where
         ),
     ));
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "For a type `A & B` to be a subtype of `C & D`, every variant (A, B) must be a subtype of \
          every variant in the expected intersection (C, D).\nIn other words: (A <: C) \u{2227} (A \
          <: D) \u{2227} (B <: C) \u{2227} (B <: D)",
     ));
 
-    diagnostic.note = Some(Note::new(format!(
+    diagnostic.add_note(Note::new(format!(
         "expected intersection: `{}`\nfound variant: `{}` which is not a subtype of all expected \
          variants",
         expected_intersection
@@ -661,7 +661,7 @@ where
 {
     let mut diagnostic = Diagnostic::new(
         TypeCheckDiagnosticCategory::StructFieldMismatch,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
@@ -676,12 +676,12 @@ where
         .labels
         .push(Label::new(rhs.span, "... than this struct").with_order(2));
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "For structs to be equivalent, they must have exactly the same field names. Check that \
          both structs define the same set of fields.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "When comparing structs for equivalence, they must have the exact same field names. \
          Subtyping allows a struct with more fields to be a subtype of one with fewer fields, but \
          for equivalence they must match exactly.",
@@ -704,7 +704,7 @@ where
 {
     let mut diagnostic = Diagnostic::new(
         TypeCheckDiagnosticCategory::DuplicateStructField,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic.labels.push(
@@ -723,11 +723,11 @@ where
         .with_order(1),
     );
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Each field in a struct must have a unique name. Remove or rename duplicate fields.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Structs cannot have multiple fields with the same name, as this would make field access \
          ambiguous. Each field name must be unique within a struct.",
     ));
@@ -750,7 +750,7 @@ where
 {
     let mut diagnostic = Diagnostic::new(
         TypeCheckDiagnosticCategory::MissingStructField,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
@@ -769,12 +769,12 @@ where
         .with_order(2),
     );
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "For a struct to be a subtype of another, it must contain all fields from the supertype. \
          Add the missing field to fix this error.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "In structural subtyping, a subtype can have more fields than its supertype (width \
          subtyping), but it must include all fields from the supertype with compatible types.",
     ));
@@ -785,7 +785,7 @@ where
 pub(crate) fn unconstrained_type_variable_floating(env: &Environment) -> TypeCheckDiagnostic {
     let mut diagnostic = Diagnostic::new(
         TypeCheckDiagnosticCategory::UnconstrainedTypeVariable,
-        Severity::COMPILER_BUG,
+        Severity::Bug,
     );
 
     // We don't have a specific span, so we have to report this as a general error
@@ -797,14 +797,14 @@ pub(crate) fn unconstrained_type_variable_floating(env: &Environment) -> TypeChe
         .with_order(1),
     );
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "This is an internal compiler error, not a problem with your code. The type system \
          encountered a variable that has no constraints, but also lacks source location \
          information to properly report the error. Please report this issue to the HashQL team \
          with a minimal reproduction case.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "During type inference, the compiler manages variables that represent unknown types. \
          These variables should either be resolved to concrete types or be reported with specific \
          source locations when unconstrained. This error indicates a bug in the type inference \
@@ -819,7 +819,7 @@ pub(crate) fn unconstrained_type_variable_floating(env: &Environment) -> TypeChe
 pub(crate) fn unconstrained_type_variable(variable: Variable) -> TypeCheckDiagnostic {
     let mut diagnostic = Diagnostic::new(
         TypeCheckDiagnosticCategory::UnconstrainedTypeVariable,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     // Point to the variable's location
@@ -831,13 +831,13 @@ pub(crate) fn unconstrained_type_variable(variable: Variable) -> TypeCheckDiagno
         .with_order(1),
     );
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "Add an explicit type annotation to provide the necessary context. For example:\n- Change \
          `let x = ...` to `let x: Type = ...`\n- Provide type parameters like `function<T: \
          SomeType>(...)`\n- Use the value in a way that constrains its type",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Type inference needs constraints that come from how variables are used. When a variable \
          lacks both usage context and explicit annotations, the type system cannot determine an \
          appropriate type. This commonly occurs with empty collections, unused variables, or \
@@ -859,7 +859,7 @@ where
 {
     let mut diagnostic = Diagnostic::new(
         TypeCheckDiagnosticCategory::IncompatibleLowerEqualConstraint,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     // Primary label - point to the variable's location
@@ -896,7 +896,7 @@ where
     );
 
     // Provide actionable help message
-    diagnostic.help = Some(Help::new(format!(
+    diagnostic.add_help(Help::new(format!(
         "Resolve this type conflict by either:\n1. Changing the equality constraint to be \
          compatible with `{}`\n2. Modifying the lower bound type to be a subtype of `{}`\n3. \
          Ensuring both types are compatible in the type hierarchy",
@@ -916,7 +916,7 @@ where
         )
     )));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "When a type variable has both lower bound and equality constraints, the lower bound must \
          be a subtype of the equality type (lower <: equal). This ensures the variable can \
          satisfy both constraints simultaneously. Check for inconsistent type annotations or \
@@ -938,7 +938,7 @@ where
 {
     let mut diagnostic = Diagnostic::new(
         TypeCheckDiagnosticCategory::IncompatibleUpperEqualConstraint,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     // Primary label - point to the variable's location
@@ -975,7 +975,7 @@ where
     );
 
     // Provide actionable help message
-    diagnostic.help = Some(Help::new(format!(
+    diagnostic.add_help(Help::new(format!(
         "To fix this conflict, you can:\n1. Change the equality constraint `{}` to be a subtype \
          of the upper bound\n2. Adjust the upper bound `{}` to be a supertype of the equality \
          constraint\n3. Review your type annotations to ensure they're consistent",
@@ -995,7 +995,7 @@ where
         )
     )));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Type inference requires that when a variable has both an equality constraint and an \
          upper bound, the equality type must be a subtype of the upper bound (equal <: upper). \
          This error indicates your code has contradictory requirements for the same type variable.",
@@ -1016,7 +1016,7 @@ where
 {
     let mut diagnostic = Diagnostic::new(
         TypeCheckDiagnosticCategory::BoundConstraintViolation,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     // Primary label - point to the variable's location
@@ -1053,7 +1053,7 @@ where
     );
 
     // Provide actionable help
-    diagnostic.help = Some(Help::new(format!(
+    diagnostic.add_help(Help::new(format!(
         "These type bounds create an impossible constraint. To fix this:\n1. Modify `{}` to be a \
          proper subtype of `{}`\n2. Or adjust `{}` to be a supertype of `{}`\n3. Or check your \
          code for contradictory type assertions",
@@ -1087,7 +1087,7 @@ where
         )
     )));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "During type inference, when a variable has both upper and lower bounds, the relationship \
          'lower <: upper' must hold. This ensures a valid solution exists in the type system. \
          When this relationship is violated, it means your code is requiring contradictory types \
@@ -1109,7 +1109,7 @@ where
 {
     let mut diagnostic = Diagnostic::new(
         TypeCheckDiagnosticCategory::ConflictingEqualityConstraints,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     // Primary label - point to the variable's location
@@ -1146,7 +1146,7 @@ where
     );
 
     // Provide actionable help message
-    diagnostic.help = Some(Help::new(format!(
+    diagnostic.add_help(Help::new(format!(
         "A type variable can only be equal to one concrete type at a time. This variable has \
          multiple conflicting equality constraints.\nTo fix this issue:\n1. Ensure consistent \
          type usage - either use `{}` everywhere\n2. Or use `{}` everywhere\n3. Add explicit type \
@@ -1167,7 +1167,7 @@ where
         )
     )));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "During type inference, all constraints on a type variable must be satisfied \
          simultaneously. When equality constraints conflict (e.g., T = String and T = Number), no \
          valid solution exists. This typically occurs when you've specified different types for \
@@ -1193,7 +1193,7 @@ where
     let mut diagnostic = Diagnostic::new(
         TypeCheckDiagnosticCategory::TypeParameterNotFound,
         // This is a compiler bug in the error reporting sequence
-        Severity::COMPILER_BUG,
+        Severity::Bug,
     );
 
     // Primary label indicating the invalid reference
@@ -1215,7 +1215,7 @@ where
     );
 
     // Help message explaining the situation
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "This error indicates your code contains an invalid type parameter reference that should \
          have been caught by an earlier validation step. While the code is indeed incorrect, the \
          compiler should have reported this error in a more specific way at an earlier stage. \
@@ -1223,7 +1223,7 @@ where
     ));
 
     // Technical explanation with more details
-    diagnostic.note = Some(Note::new(format!(
+    diagnostic.add_note(Note::new(format!(
         "Technical details: Parameter ?{argument} is referenced but not defined in the current \
          environment. This represents both an invalid program and a flaw in the error reporting \
          sequence. The compiler should validate all parameter references during an earlier \

--- a/libs/@local/hashql/diagnostics/Cargo.toml
+++ b/libs/@local/hashql/diagnostics/Cargo.toml
@@ -22,7 +22,6 @@ text-size = { workspace = true, public = true }
 anstyle-lossy  = { version = "1.1.3", optional = true }
 anstyle-yansi  = { workspace = true }
 derive_more    = { workspace = true, features = ["display"] }
-serde_with     = { workspace = true, optional = true, features = ["std", "macros"] }
 simple-mermaid = { workspace = true }
 
 [dev-dependencies]
@@ -31,7 +30,7 @@ rstest     = "0.25.0"
 serde_json = { workspace = true }
 
 [features]
-serde = ["dep:serde", "dep:serde_with", "dep:anstyle-lossy"]
+serde = ["dep:serde", "dep:anstyle-lossy"]
 
 [lints]
 workspace = true

--- a/libs/@local/hashql/diagnostics/Cargo.toml
+++ b/libs/@local/hashql/diagnostics/Cargo.toml
@@ -19,6 +19,7 @@ text-size = { workspace = true, public = true }
 # Private workspace dependencies
 
 # Private third-party dependencies
+anstyle-lossy  = { version = "1.1.3", optional = true }
 anstyle-yansi  = { workspace = true }
 derive_more    = { workspace = true, features = ["display"] }
 serde_with     = { workspace = true, optional = true, features = ["std", "macros"] }
@@ -26,10 +27,11 @@ simple-mermaid = { workspace = true }
 
 [dev-dependencies]
 jsonptr    = { workspace = true, features = ["json"] }
+rstest     = "0.25.0"
 serde_json = { workspace = true }
 
 [features]
-serde = ["dep:serde", "dep:serde_with"]
+serde = ["dep:serde", "dep:serde_with", "dep:anstyle-lossy"]
 
 [lints]
 workspace = true

--- a/libs/@local/hashql/diagnostics/package.json
+++ b/libs/@local/hashql/diagnostics/package.json
@@ -7,7 +7,7 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root hashql-diagnostics --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "test:unit": "mise run test:unit @rust/hashql-diagnostics"
+    "test:unit": "mise run test:unit @rust/hashql-diagnostics --test-strategy=powerset"
   },
   "dependencies": {
     "@rust/error-stack": "0.5.0"

--- a/libs/@local/hashql/diagnostics/src/diagnostic.rs
+++ b/libs/@local/hashql/diagnostics/src/diagnostic.rs
@@ -28,7 +28,7 @@ pub type AbsoluteDiagnostic<C> = Diagnostic<C, AbsoluteDiagnosticSpan>;
 #[must_use = "A diagnostic must be reported"]
 pub struct Diagnostic<C, S> {
     pub category: C,
-    pub severity: Box<Severity>,
+    pub severity: Severity,
 
     pub message: Option<Cow<'static, str>>,
 
@@ -38,10 +38,10 @@ pub struct Diagnostic<C, S> {
 }
 
 impl<C, S> Diagnostic<C, S> {
-    pub fn new(category: impl Into<C>, severity: impl Into<Box<Severity>>) -> Self {
+    pub fn new(category: impl Into<C>, severity: Severity) -> Self {
         Self {
             category: category.into(),
-            severity: severity.into(),
+            severity,
             message: None,
             labels: Vec::new(),
             note: None,
@@ -114,7 +114,7 @@ where
 
         let mut generator = ColorGenerator::new();
 
-        let mut builder = ariadne::Report::build(self.severity.as_ref().kind(), span)
+        let mut builder = ariadne::Report::build(self.severity.kind(), span)
             .with_code(CanonicalDiagnosticCategoryId::new(&self.category));
 
         builder.set_message(

--- a/libs/@local/hashql/diagnostics/src/help.rs
+++ b/libs/@local/hashql/diagnostics/src/help.rs
@@ -1,11 +1,10 @@
 use anstyle::Color;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", cfg_eval, serde_with::serde_as)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Help {
     message: Box<str>,
-    #[cfg_attr(feature = "serde", serde_as(as = "Option<crate::encoding::Color>"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::encoding::color_option"))]
     color: Option<Color>,
 }
 

--- a/libs/@local/hashql/diagnostics/src/help.rs
+++ b/libs/@local/hashql/diagnostics/src/help.rs
@@ -19,7 +19,7 @@ impl Help {
     }
 
     #[must_use]
-    pub const fn new_const(message: &'static str) -> Self {
+    pub const fn from_static(message: &'static str) -> Self {
         Self {
             message: Cow::Borrowed(message),
             color: None,

--- a/libs/@local/hashql/diagnostics/src/label.rs
+++ b/libs/@local/hashql/diagnostics/src/label.rs
@@ -11,7 +11,6 @@ use crate::{
 
 // See: https://docs.rs/serde_with/3.9.0/serde_with/guide/serde_as/index.html#gating-serde_as-on-features
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", cfg_eval, serde_with::serde_as)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Label<S> {
     span: S,
@@ -19,7 +18,7 @@ pub struct Label<S> {
 
     order: Option<i32>,
     priority: Option<i32>,
-    #[cfg_attr(feature = "serde", serde_as(as = "Option<crate::encoding::Color>"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::encoding::color_option"))]
     color: Option<Color>,
 }
 

--- a/libs/@local/hashql/diagnostics/src/lib.rs
+++ b/libs/@local/hashql/diagnostics/src/lib.rs
@@ -2,13 +2,15 @@
 //!
 //! ## Workspace dependencies
 #![cfg_attr(doc, doc = simple_mermaid::mermaid!("../docs/dependency-diagram.mmd"))]
-#![feature(cfg_eval, trait_alias)]
+#![feature(trait_alias, variant_count, int_from_ascii)]
 
 extern crate alloc;
 
 pub mod category;
 pub mod config;
 pub mod diagnostic;
+#[cfg(feature = "serde")]
+pub mod encoding;
 pub mod error;
 pub mod help;
 pub mod label;
@@ -18,7 +20,4 @@ pub mod span;
 
 pub use anstyle as color;
 
-#[cfg(feature = "serde")]
-pub(crate) mod encoding;
-
-pub use diagnostic::Diagnostic;
+pub use self::{diagnostic::Diagnostic, help::Help, note::Note, severity::Severity};

--- a/libs/@local/hashql/diagnostics/src/note.rs
+++ b/libs/@local/hashql/diagnostics/src/note.rs
@@ -2,13 +2,11 @@ use core::fmt::Display;
 
 use anstyle::Color;
 
-// See: https://docs.rs/serde_with/3.9.0/serde_with/guide/serde_as/index.html#gating-serde_as-on-features
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", cfg_eval, serde_with::serde_as)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Note {
     message: Box<str>,
-    #[cfg_attr(feature = "serde", serde_as(as = "Option<crate::encoding::Color>"))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::encoding::color_option"))]
     color: Option<Color>,
 }
 

--- a/libs/@local/hashql/diagnostics/src/note.rs
+++ b/libs/@local/hashql/diagnostics/src/note.rs
@@ -20,7 +20,7 @@ impl Note {
     }
 
     #[must_use]
-    pub const fn new_const(message: &'static str) -> Self {
+    pub const fn from_static(message: &'static str) -> Self {
         Self {
             message: Cow::Borrowed(message),
             color: None,

--- a/libs/@local/hashql/diagnostics/src/severity.rs
+++ b/libs/@local/hashql/diagnostics/src/severity.rs
@@ -254,11 +254,11 @@ impl Severity {
             Self::Bug => {
                 const {
                     &[
-                        Help::new_const(
+                        Help::from_static(
                             "This is a bug in the compiler, not an issue with your code.",
                         )
                         .with_color(Color::Ansi(anstyle::AnsiColor::Green)),
-                        Help::new_const(
+                        Help::from_static(
                             "Please report this issue along with a minimal code example that \
                              reproduces the error.",
                         )
@@ -276,7 +276,7 @@ impl Severity {
                 const {
                     // TODO: in the future we might want to include a link to create the issue
                     // directly
-                    &[Note::new_const(
+                    &[Note::from_static(
                         "Internal compiler errors indicate a bug in the compiler itself that \
                          needs to be fixed.\n\nWe would appreciate if you could file a GitHub or \
                          Linear issue and reference this error.\n\nWhen reporting this issue, \

--- a/libs/@local/hashql/diagnostics/src/severity.rs
+++ b/libs/@local/hashql/diagnostics/src/severity.rs
@@ -1,121 +1,378 @@
-use alloc::borrow::Cow;
-use core::fmt::Display;
+use core::{fmt::Display, mem};
 
-use anstyle::{Ansi256Color, AnsiColor, Color};
+use anstyle::Color;
+
+#[cfg(feature = "serde")]
+#[derive(Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+#[expect(unused, reason = "required for `deny_unknown_fields")]
+struct OwnedSeverityInfo {
+    id: String,
+    code: u16,
+    name: String,
+    description: String,
+    #[serde(with = "crate::encoding::color")]
+    color: Color,
+}
+
+/// Internal information about a severity level.
+///
+/// This struct contains all the static information associated with a
+/// severity level, including its identifier, code, name, description, and display color.
+/// It provides the backing data for the public [`Severity`] enum.
+///
+/// The information in this struct is used to provide consistent metadata across
+/// all severity levels and is not intended to be used directly by consumers.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+pub struct SeverityInfo {
+    /// Unique (human readable) identifier of the severity.
+    pub id: &'static str,
+    /// Unique numeric code of the severity.
+    ///
+    /// Higher codes indicate more severe diagnostics. Any code >= `400` is considered fatal.
+    pub code: u16,
+    /// Human-readable name of the severity.
+    pub name: &'static str,
+    /// Human-readable description of the severity.
+    pub description: &'static str,
+    /// Color used to display the severity.
+    ///
+    /// Should be used to colorize the severity in any human readable output.
+    // default color is fine here as during deserialization we only care about the id and none of
+    // the other fields
+    #[cfg_attr(feature = "serde", serde(with = "crate::encoding::color"))]
+    pub color: Color,
+}
 
 /// Severity of a diagnostic.
 ///
 /// Indicates the severity of a diagnostic, such as an error or warning.
+/// Severity levels are ordered by their importance:
 ///
-/// A severity can be referred to by its `id` or `code`.
+/// | Variant  | Code | Identifier | Description                   |
+/// |----------|------|------------|-------------------------------|
+/// | `Bug`    | 600  | `"ice"`    | Internal compiler error       |
+/// | `Fatal`  | 500  | `"fatal"`  | Immediate abort               |
+/// | `Error`  | 400  | `"error"`  | Prevents compilation          |
+/// | `Warning`| 300  | `"warning"`| Potential issues              |
+/// | `Note`   | 200  | `"note"`   | Additional information        |
+/// | `Debug`  | 100  | `"debug"`  | Low-level debug information   |
 ///
-/// Any code over `400` is considered fatal.
-// See: https://docs.rs/serde_with/3.9.0/serde_with/guide/serde_as/index.html#gating-serde_as-on-features
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", cfg_eval, serde_with::serde_as)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Severity {
-    /// Unique identifier of the severity.
-    id: Cow<'static, str>,
-
-    /// Priority code of the severity.
+/// Any severity level with code >= `400` (i.e., `Error`, `Fatal`, or `Bug`) is considered
+/// fatal and should stop program execution.
+///
+/// # Examples
+///
+/// ```
+/// use hashql_diagnostics::Severity;
+///
+/// // Fatal severity levels
+/// let bug = Severity::Bug; // Code: 600
+/// let fatal = Severity::Fatal; // Code: 500
+/// let error = Severity::Error; // Code: 400
+/// assert!(bug.is_fatal());
+/// assert!(fatal.is_fatal());
+/// assert!(error.is_fatal());
+///
+/// // Non-fatal severity levels
+/// let warning = Severity::Warning; // Code: 300
+/// let note = Severity::Note; // Code: 200
+/// let debug = Severity::Debug; // Code: 100
+/// assert!(!warning.is_fatal());
+/// assert!(!note.is_fatal());
+/// assert!(!debug.is_fatal());
+/// ```
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Severity {
+    /// For bugs in the compiler. Manifests as an ICE (internal compiler error).
     ///
-    /// Higher priority codes indicate more severe diagnostics.
+    /// These represent problems in the compiler itself, not in the code being compiled.
     ///
-    /// Any code over 400 is considered fatal, and should stop program execution.
-    code: u16,
+    /// * Code: `600`
+    /// * Identifier: `"ice"`
+    /// * Display name: `"Internal Compiler Error"`
+    /// * Color: Red
+    Bug,
 
-    /// Human-readable name of the severity.
-    name: Cow<'static, str>,
-
-    /// Color of the severity.
+    /// An error that causes an immediate abort, such as configuration errors.
     ///
-    /// Should be used to colorize the severity in any human readable output.
-    #[cfg_attr(feature = "serde", serde_as(as = "crate::encoding::Color"))]
-    color: Color,
-}
+    /// These errors prevent any further processing.
+    ///
+    /// * Code: `500`
+    /// * Identifier: `"fatal"`
+    /// * Display name: `"Fatal"`
+    /// * Color: Red
+    Fatal,
 
-// the impl is split into multiple blocks because of rustfmt reordering. The severity values are
-// always descending.
-impl Severity {
-    pub const COMPILER_BUG: Self = Self {
-        id: Cow::Borrowed("compiler_bug"),
-        code: 600,
+    /// An error in the code being compiled, which prevents compilation from finishing.
+    ///
+    /// These are problems in the source code that make it impossible to produce a valid output.
+    ///
+    /// * Code: `400`
+    /// * Identifier: `"error"`
+    /// * Display name: `"Error"`
+    /// * Color: Red
+    Error,
 
-        name: Cow::Borrowed("Compiler Bug"),
-        color: Color::Ansi(AnsiColor::Red),
-    };
-    pub const CRITICAL: Self = Self {
-        id: Cow::Borrowed("critical"),
-        code: 500,
+    /// A warning about the code being compiled. Does not prevent compilation from finishing.
+    ///
+    /// These indicate potential problems or code smells that should be addressed but don't
+    /// prevent successful compilation.
+    ///
+    /// * Code: `300`
+    /// * Identifier: `"warning"`
+    /// * Display name: `"Warning"`
+    /// * Color: Yellow
+    Warning,
 
-        name: Cow::Borrowed("Critical"),
-        color: Color::Ansi(AnsiColor::Red),
-    };
-    pub const ERROR: Self = Self {
-        id: Cow::Borrowed("error"),
-        code: 400,
+    /// A note about the code being compiled. Does not prevent compilation from finishing.
+    ///
+    /// These provide additional information about the code being compiled.
+    /// Often used alongside other diagnostic messages to provide context.
+    ///
+    /// * Code: `200`
+    /// * Identifier: `"note"`
+    /// * Display name: `"Note"`
+    /// * Color: Purple (Ansi256 color 147)
+    Note,
 
-        name: Cow::Borrowed("Error"),
-        color: Color::Ansi(AnsiColor::Red),
-    };
-    pub const WARNING: Self = Self {
-        id: Cow::Borrowed("warning"),
-        code: 300,
-
-        name: Cow::Borrowed("Warning"),
-        color: Color::Ansi(AnsiColor::Yellow),
-    };
-}
-
-impl Severity {
-    pub const INFO: Self = Self {
-        id: Cow::Borrowed("note"),
-        code: 200,
-
-        name: Cow::Borrowed("Note"),
-        color: Color::Ansi256(Ansi256Color(147)),
-    };
-}
-
-impl Severity {
-    pub const DEBUG: Self = Self {
-        id: Cow::Borrowed("debug"),
-        code: 100,
-
-        name: Cow::Borrowed("Debug"),
-        color: Color::Ansi256(Ansi256Color(39)),
-    };
+    /// A debug message about the code being compiled. Does not prevent compilation from finishing.
+    ///
+    /// These provide low-level information that is typically only useful for debugging
+    /// the compiler itself.
+    ///
+    /// * Code: `100`
+    /// * Identifier: `"debug"`
+    /// * Display name: `"Debug"`
+    /// * Color: Blue (Ansi256 color 39)
+    Debug,
 }
 
 impl Severity {
     #[must_use]
-    pub fn id(&self) -> &str {
-        &self.id
+    pub const fn variants() -> &'static [Self] {
+        const LEN: usize = mem::variant_count::<Severity>();
+        const VARIANTS: [Severity; LEN] = [
+            Severity::Bug,
+            Severity::Fatal,
+            Severity::Error,
+            Severity::Warning,
+            Severity::Note,
+            Severity::Debug,
+        ];
+
+        const {
+            // assert that the variants are in the correct order
+            let mut index = 0;
+
+            while index < LEN {
+                let variant = VARIANTS[index] as usize;
+
+                assert!(
+                    variant == index,
+                    "Expected consistent ordering between variant and index"
+                );
+
+                index += 1;
+            }
+        }
+
+        &VARIANTS
     }
 
+    /// Returns static information about this severity level.
+    ///
+    /// This method provides access to the identifier, code, name, description, and display color
+    /// associated with this severity level.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::Severity;
+    ///
+    /// let error = Severity::Error;
+    /// let info = error.info();
+    ///
+    /// assert_eq!(info.id, "error");
+    /// assert_eq!(info.code, 400);
+    /// assert_eq!(info.name, "Error");
+    /// ```
     #[must_use]
-    pub fn name(&self) -> &str {
-        &self.name
+    pub const fn info(self) -> &'static SeverityInfo {
+        match self {
+            Self::Bug => &SeverityInfo {
+                id: "ice",
+                code: 600,
+                name: "Internal Compiler Error",
+                description: "An internal compiler error, indicating a bug in the compiler itself.",
+                color: Color::Ansi(anstyle::AnsiColor::Red),
+            },
+            Self::Fatal => &SeverityInfo {
+                id: "fatal",
+                code: 500,
+                name: "Fatal",
+                description: "A fatal error that causes an immediate abort.",
+                color: Color::Ansi(anstyle::AnsiColor::Red),
+            },
+            Self::Error => &SeverityInfo {
+                id: "error",
+                code: 400,
+                name: "Error",
+                description: "An error that prevents compilation from finishing.",
+                color: Color::Ansi(anstyle::AnsiColor::Red),
+            },
+            Self::Warning => &SeverityInfo {
+                id: "warning",
+                code: 300,
+                name: "Warning",
+                description: "A warning about potential issues that doesn't prevent compilation.",
+                color: Color::Ansi(anstyle::AnsiColor::Yellow),
+            },
+            Self::Note => &SeverityInfo {
+                id: "note",
+                code: 200,
+                name: "Note",
+                description: "Additional information about the code being compiled.",
+                color: Color::Ansi256(anstyle::Ansi256Color(147)),
+            },
+            Self::Debug => &SeverityInfo {
+                id: "debug",
+                code: 100,
+                name: "Debug",
+                description: "Low-level debugging information.",
+                color: Color::Ansi256(anstyle::Ansi256Color(39)),
+            },
+        }
     }
 
+    /// Returns the unique identifier for this severity level.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::Severity;
+    ///
+    /// assert_eq!(Severity::Error.id(), "error");
+    /// assert_eq!(Severity::Warning.id(), "warning");
+    /// assert_eq!(Severity::Note.id(), "note");
+    /// ```
     #[must_use]
-    pub const fn code(&self) -> u16 {
-        self.code
+    pub const fn id(self) -> &'static str {
+        self.info().id
     }
 
+    /// Returns the numeric code for this severity level.
+    ///
+    /// Higher codes indicate more severe diagnostics.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::Severity;
+    ///
+    /// assert_eq!(Severity::Bug.code(), 600);
+    /// assert_eq!(Severity::Error.code(), 400);
+    /// assert_eq!(Severity::Warning.code(), 300);
+    /// ```
     #[must_use]
-    pub const fn is_fatal(&self) -> bool {
-        self.code >= 400
+    pub const fn code(self) -> u16 {
+        self.info().code
     }
 
-    pub(crate) fn kind(&self) -> ariadne::ReportKind {
-        ariadne::ReportKind::Custom(&self.name, anstyle_yansi::to_yansi_color(self.color))
+    /// Returns the human-readable name for this severity level.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::Severity;
+    ///
+    /// assert_eq!(Severity::Error.name(), "Error");
+    /// assert_eq!(Severity::Warning.name(), "Warning");
+    /// assert_eq!(Severity::Bug.name(), "Internal Compiler Error");
+    /// ```
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        self.info().name
+    }
+
+    /// Returns whether this severity level is fatal.
+    ///
+    /// A severity is considered fatal if its code is >= 400.
+    /// Fatal severities are `Error`, `Fatal`, and `Bug`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::Severity;
+    ///
+    /// // Fatal severities
+    /// assert!(Severity::Bug.is_fatal());
+    /// assert!(Severity::Fatal.is_fatal());
+    /// assert!(Severity::Error.is_fatal());
+    ///
+    /// // Non-fatal severities
+    /// assert!(!Severity::Warning.is_fatal());
+    /// assert!(!Severity::Note.is_fatal());
+    /// assert!(!Severity::Debug.is_fatal());
+    /// ```
+    #[must_use]
+    pub const fn is_fatal(self) -> bool {
+        self.code() >= 400
+    }
+
+    /// Returns the display color for this severity level.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use anstyle::Color;
+    /// use hashql_diagnostics::Severity;
+    ///
+    /// let error_color = Severity::Error.color();
+    /// let warning_color = Severity::Warning.color();
+    /// ```
+    #[must_use]
+    pub const fn color(self) -> Color {
+        self.info().color
+    }
+
+    pub(crate) fn kind(self) -> ariadne::ReportKind<'static> {
+        ariadne::ReportKind::Custom(self.name(), anstyle_yansi::to_yansi_color(self.color()))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Severity {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.info().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Severity {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let info = OwnedSeverityInfo::deserialize(deserializer)?;
+
+        for severity in Self::variants() {
+            if severity.code() == info.code {
+                return Ok(*severity);
+            }
+        }
+
+        Err(serde::de::Error::custom("invalid severity code"))
     }
 }
 
 impl Display for Severity {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        Display::fmt(&self.name, fmt)
+        Display::fmt(self.name(), fmt)
     }
 }

--- a/libs/@local/hashql/diagnostics/src/severity.rs
+++ b/libs/@local/hashql/diagnostics/src/severity.rs
@@ -2,6 +2,8 @@ use core::{fmt::Display, mem};
 
 use anstyle::Color;
 
+use crate::{Help, Note};
+
 #[cfg(feature = "serde")]
 #[derive(Debug, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -244,6 +246,46 @@ impl Severity {
                 description: "Low-level debugging information.",
                 color: Color::Ansi256(anstyle::Ansi256Color(39)),
             },
+        }
+    }
+
+    pub(crate) const fn help(self) -> &'static [Help] {
+        match self {
+            Self::Bug => {
+                const {
+                    &[
+                        Help::new_const(
+                            "This is a bug in the compiler, not an issue with your code.",
+                        )
+                        .with_color(Color::Ansi(anstyle::AnsiColor::Green)),
+                        Help::new_const(
+                            "Please report this issue along with a minimal code example that \
+                             reproduces the error.",
+                        )
+                        .with_color(Color::Ansi(anstyle::AnsiColor::Blue)),
+                    ] as &[_]
+                }
+            }
+            _ => &[],
+        }
+    }
+
+    pub(crate) const fn notes(self) -> &'static [Note] {
+        match self {
+            Self::Bug => {
+                const {
+                    // TODO: in the future we might want to include a link to create the issue
+                    // directly
+                    &[Note::new_const(
+                        "Internal compiler errors indicate a bug in the compiler itself that \
+                         needs to be fixed.\n\nWe would appreciate if you could file a GitHub or \
+                         Linear issue and reference this error.\n\nWhen reporting this issue, \
+                         please include your query, any relevant type definitions, and the \
+                         complete error message shown above.",
+                    )] as &[_]
+                }
+            }
+            _ => &[],
         }
     }
 

--- a/libs/@local/hashql/hir/src/reify/error.rs
+++ b/libs/@local/hashql/hir/src/reify/error.rs
@@ -112,7 +112,7 @@ pub(crate) fn dummy_expression(span: SpanId) -> ReificationDiagnostic {
         .push(Label::new(span, "fatal error occurred here").with_order(0));
 
     diagnostic.add_help(Help::new(
-        "The compiler encountered a serious error in an earlier phase but continued processing. \
+        "The compiler encountered a fatal error in an earlier phase but continued processing. \
          This should not happen and indicates a bug in the error handling system. The original \
          error message should appear above this one and contains more specific information about \
          what went wrong with your code.",
@@ -121,8 +121,7 @@ pub(crate) fn dummy_expression(span: SpanId) -> ReificationDiagnostic {
     diagnostic.add_note(Note::new(
         "HashQL compiles your code in several phases, and errors in early phases should prevent \
          later phases from running. When you see this message, it means the compiler tried to \
-         continue despite a fatal error. Please report this issue along with the full error \
-         output.",
+         continue despite a fatal error.",
     ));
 
     diagnostic
@@ -150,15 +149,15 @@ pub(crate) fn unprocessed_expression(
     );
 
     diagnostic.add_help(Help::new(format!(
-        "This is a compiler bug. The {expr_kind} expression should have been processed during an \
-         earlier phase ({phase_name}) but reached the final processing stage unchanged. This \
-         suggests a problem in the compiler pipeline."
+        "The {expr_kind} expression should have been processed during an earlier phase \
+         ({phase_name}) but reached the final processing stage unchanged. This suggests a problem \
+         in the compiler pipeline."
     )));
 
     diagnostic.add_note(Note::new(
         "The HashQL compiler transforms your code through several phases before generating the \
-         final output. Some language constructs should be handled by specific phases. Please \
-         report this issue with a minimal code example.",
+         final output. Some language constructs should be handled by specific phases and be \
+         removed from the AST before reaching the final processing stage.",
     ));
 
     diagnostic
@@ -176,13 +175,13 @@ pub(crate) fn internal_error(span: SpanId, message: &str) -> ReificationDiagnost
 
     diagnostic.add_help(Help::new(format!(
         "The compiler encountered an unexpected situation while processing your code: \
-         \"{message}\". This is a bug in the HashQL compiler, not an error in your code."
+         \"{message}\"."
     )));
 
     diagnostic.add_note(Note::new(
         "This indicates that an earlier compilation stage failed without reporting any errors. \
          The compiler continued with incomplete or invalid information, which was only detected \
-         during the final processing phase. Please report this issue with a minimal code example.",
+         during the final processing phase.",
     ));
 
     diagnostic

--- a/libs/@local/hashql/hir/src/reify/error.rs
+++ b/libs/@local/hashql/hir/src/reify/error.rs
@@ -77,20 +77,20 @@ pub(crate) fn unsupported_construct(
 ) -> ReificationDiagnostic {
     let mut diagnostic = Diagnostic::new(
         ReificationDiagnosticCategory::UnsupportedConstruct,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
         .labels
         .push(Label::new(span, format!("`{construct_name}` not supported yet")).with_order(0));
 
-    diagnostic.help = Some(Help::new(format!(
+    diagnostic.add_help(Help::new(format!(
         "The {construct_name} syntax is valid HashQL code, but support for this feature is still \
          in development. For now, you'll need to use alternative approaches to achieve the same \
          result. Check issue {issue_url} for implementation status and updates."
     )));
 
-    diagnostic.note = Some(Note::new(format!(
+    diagnostic.add_note(Note::new(format!(
         "This is a temporary limitation. We're actively working on supporting {construct_name} \
          constructs and other advanced features to make HashQL more expressive and powerful."
     )));
@@ -104,23 +104,21 @@ pub(crate) fn unsupported_construct(
 /// but the error wasn't properly handled.
 #[coverage(off)] // compiler bugs should never be hit
 pub(crate) fn dummy_expression(span: SpanId) -> ReificationDiagnostic {
-    let mut diagnostic = Diagnostic::new(
-        ReificationDiagnosticCategory::UnhandledError,
-        Severity::COMPILER_BUG,
-    );
+    let mut diagnostic =
+        Diagnostic::new(ReificationDiagnosticCategory::UnhandledError, Severity::Bug);
 
     diagnostic
         .labels
         .push(Label::new(span, "fatal error occurred here").with_order(0));
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "The compiler encountered a serious error in an earlier phase but continued processing. \
          This should not happen and indicates a bug in the error handling system. The original \
          error message should appear above this one and contains more specific information about \
          what went wrong with your code.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "HashQL compiles your code in several phases, and errors in early phases should prevent \
          later phases from running. When you see this message, it means the compiler tried to \
          continue despite a fatal error. Please report this issue along with the full error \
@@ -140,7 +138,7 @@ pub(crate) fn unprocessed_expression(
 ) -> ReificationDiagnostic {
     let mut diagnostic = Diagnostic::new(
         ReificationDiagnosticCategory::UnprocessedExpression,
-        Severity::COMPILER_BUG,
+        Severity::Bug,
     );
 
     diagnostic.labels.push(
@@ -151,13 +149,13 @@ pub(crate) fn unprocessed_expression(
         .with_order(0),
     );
 
-    diagnostic.help = Some(Help::new(format!(
+    diagnostic.add_help(Help::new(format!(
         "This is a compiler bug. The {expr_kind} expression should have been processed during an \
          earlier phase ({phase_name}) but reached the final processing stage unchanged. This \
          suggests a problem in the compiler pipeline."
     )));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "The HashQL compiler transforms your code through several phases before generating the \
          final output. Some language constructs should be handled by specific phases. Please \
          report this issue with a minimal code example.",
@@ -169,21 +167,19 @@ pub(crate) fn unprocessed_expression(
 /// Creates a diagnostic for general internal compiler errors.
 #[coverage(off)] // compiler bugs should never be hit
 pub(crate) fn internal_error(span: SpanId, message: &str) -> ReificationDiagnostic {
-    let mut diagnostic = Diagnostic::new(
-        ReificationDiagnosticCategory::InternalError,
-        Severity::COMPILER_BUG,
-    );
+    let mut diagnostic =
+        Diagnostic::new(ReificationDiagnosticCategory::InternalError, Severity::Bug);
 
     diagnostic
         .labels
         .push(Label::new(span, "compiler error occurred here").with_order(0));
 
-    diagnostic.help = Some(Help::new(format!(
+    diagnostic.add_help(Help::new(format!(
         "The compiler encountered an unexpected situation while processing your code: \
          \"{message}\". This is a bug in the HashQL compiler, not an error in your code."
     )));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "This indicates that an earlier compilation stage failed without reporting any errors. \
          The compiler continued with incomplete or invalid information, which was only detected \
          during the final processing phase. Please report this issue with a minimal code example.",
@@ -198,18 +194,18 @@ pub(crate) fn internal_error(span: SpanId, message: &str) -> ReificationDiagnost
 pub(crate) fn underscore_expression(span: SpanId) -> ReificationDiagnostic {
     let mut diagnostic = Diagnostic::new(
         ReificationDiagnosticCategory::UnderscoreExpression,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
         .labels
         .push(Label::new(span, "`_` not allowed here").with_order(0));
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "In expressions, `_` can only be used on the left-hand side of an assignment.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "The underscore symbol `_` is a special placeholder that can only be used in specific \
          contexts. Currently, it's only valid as an assignment target, not as a value in \
          expressions.",

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/error.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/error.rs
@@ -83,7 +83,7 @@ pub(crate) fn from_hifijson_str_error(
     error: &hifijson::str::Error,
     span: SpanId,
 ) -> Diagnostic<LexerDiagnosticCategory, SpanId> {
-    let mut diagnostic = Diagnostic::new(LexerDiagnosticCategory::InvalidString, Severity::ERROR);
+    let mut diagnostic = Diagnostic::new(LexerDiagnosticCategory::InvalidString, Severity::Error);
 
     let (message, help) = match error {
         hifijson::str::Error::Control => (
@@ -104,14 +104,14 @@ pub(crate) fn from_hifijson_str_error(
     diagnostic.labels.push(Label::new(span, message));
 
     if let Some(help) = help {
-        diagnostic.help = Some(Help::new(help));
+        diagnostic.add_help(Help::new(help));
     }
 
     diagnostic
 }
 
 pub(crate) fn unexpected_eof(span: SpanId, expected: SyntaxKindSet) -> LexerDiagnostic {
-    let mut diagnostic = Diagnostic::new(LexerDiagnosticCategory::UnexpectedEof, Severity::ERROR);
+    let mut diagnostic = Diagnostic::new(LexerDiagnosticCategory::UnexpectedEof, Severity::Error);
 
     // Create a more specific label based on what was expected
     let label = if expected.is_empty() || expected.is_complete() {
@@ -141,7 +141,7 @@ pub(crate) fn unexpected_eof(span: SpanId, expected: SyntaxKindSet) -> LexerDiag
          properly closed."
     };
 
-    diagnostic.help = Some(Help::new(Cow::Borrowed(help)));
+    diagnostic.add_help(Help::new(Cow::Borrowed(help)));
 
     diagnostic
 }
@@ -151,7 +151,7 @@ pub(crate) fn unexpected_token(
     found: SyntaxKind,
     expected: SyntaxKindSet,
 ) -> LexerDiagnostic {
-    let mut diagnostic = Diagnostic::new(LexerDiagnosticCategory::UnexpectedToken, Severity::ERROR);
+    let mut diagnostic = Diagnostic::new(LexerDiagnosticCategory::UnexpectedToken, Severity::Error);
 
     // Create a specific label based on what was found vs what was expected
     let label = if expected.is_empty() {
@@ -188,7 +188,7 @@ pub(crate) fn unexpected_token(
          present."
     };
 
-    diagnostic.help = Some(Help::new(Cow::Borrowed(help)));
+    diagnostic.add_help(Help::new(Cow::Borrowed(help)));
 
     diagnostic
 }
@@ -200,14 +200,14 @@ pub(crate) fn from_hifijson_num_error(
     error: &hifijson::num::Error,
     span: SpanId,
 ) -> LexerDiagnostic {
-    let mut diagnostic = Diagnostic::new(LexerDiagnosticCategory::InvalidNumber, Severity::ERROR);
+    let mut diagnostic = Diagnostic::new(LexerDiagnosticCategory::InvalidNumber, Severity::Error);
 
     let message = match error {
         hifijson::num::Error::ExpectedDigit => "Missing digit in number",
     };
 
     diagnostic.labels.push(Label::new(span, message));
-    diagnostic.help = Some(Help::new(INVALID_NUMBER_HELP));
+    diagnostic.add_help(Help::new(INVALID_NUMBER_HELP));
 
     diagnostic
 }
@@ -218,13 +218,13 @@ const UNRECOGNIZED_CHAR_HELP: &str = "J-Expr only supports standard JSON syntax.
 
 pub(crate) fn from_unrecognized_character_error(span: SpanId) -> LexerDiagnostic {
     let mut diagnostic =
-        Diagnostic::new(LexerDiagnosticCategory::InvalidCharacter, Severity::ERROR);
+        Diagnostic::new(LexerDiagnosticCategory::InvalidCharacter, Severity::Error);
 
     diagnostic
         .labels
         .push(Label::new(span, "Unrecognized character"));
 
-    diagnostic.help = Some(Help::new(UNRECOGNIZED_CHAR_HELP));
+    diagnostic.add_help(Help::new(UNRECOGNIZED_CHAR_HELP));
 
     diagnostic
 }
@@ -233,13 +233,13 @@ const INVALID_UTF8_HELP: &str = "J-Expr requires valid UTF-8 encoded input. Chec
                                  characters or ensure your source is properly encoded as UTF-8.";
 
 pub(crate) fn from_invalid_utf8_error(span: SpanId) -> LexerDiagnostic {
-    let mut diagnostic = Diagnostic::new(LexerDiagnosticCategory::InvalidUtf8, Severity::ERROR);
+    let mut diagnostic = Diagnostic::new(LexerDiagnosticCategory::InvalidUtf8, Severity::Error);
 
     diagnostic
         .labels
         .push(Label::new(span, "Invalid UTF-8 byte sequence"));
 
-    diagnostic.help = Some(Help::new(INVALID_UTF8_HELP));
+    diagnostic.add_help(Help::new(INVALID_UTF8_HELP));
 
     diagnostic
 }

--- a/libs/@local/hashql/syntax-jexpr/src/parser/array/error.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/array/error.rs
@@ -108,14 +108,14 @@ const EMPTY_NOTE: &str = r##"Valid examples:
 "##;
 
 pub(crate) fn empty(span: SpanId) -> ArrayDiagnostic {
-    let mut diagnostic = Diagnostic::new(ArrayDiagnosticCategory::Empty, Severity::ERROR);
+    let mut diagnostic = Diagnostic::new(ArrayDiagnosticCategory::Empty, Severity::Error);
 
     diagnostic
         .labels
         .push(Label::new(span, "Empty array not allowed"));
 
-    diagnostic.help = Some(Help::new(EMPTY_HELP));
-    diagnostic.note = Some(Note::new(EMPTY_NOTE));
+    diagnostic.add_help(Help::new(EMPTY_HELP));
+    diagnostic.add_note(Note::new(EMPTY_NOTE));
 
     diagnostic
 }
@@ -125,7 +125,7 @@ const TRAILING_COMMA_HELP: &str = "J-Expr does not support trailing commas in ar
 
 #[expect(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 pub(crate) fn trailing_commas(spans: &[SpanId]) -> ArrayDiagnostic {
-    let mut diagnostic = Diagnostic::new(ArrayDiagnosticCategory::TrailingComma, Severity::ERROR);
+    let mut diagnostic = Diagnostic::new(ArrayDiagnosticCategory::TrailingComma, Severity::Error);
 
     for (index, &span) in spans.iter().rev().enumerate() {
         let message = if index == 0 {
@@ -139,7 +139,7 @@ pub(crate) fn trailing_commas(spans: &[SpanId]) -> ArrayDiagnostic {
             .push(Label::new(span, message).with_order(index as i32));
     }
 
-    diagnostic.help = Some(Help::new(TRAILING_COMMA_HELP));
+    diagnostic.add_help(Help::new(TRAILING_COMMA_HELP));
 
     diagnostic
 }
@@ -149,7 +149,7 @@ const LEADING_COMMA_HELP: &str =
 
 #[expect(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 pub(crate) fn leading_commas(spans: &[SpanId]) -> ArrayDiagnostic {
-    let mut diagnostic = Diagnostic::new(ArrayDiagnosticCategory::LeadingComma, Severity::ERROR);
+    let mut diagnostic = Diagnostic::new(ArrayDiagnosticCategory::LeadingComma, Severity::Error);
 
     for (index, &span) in spans.iter().rev().enumerate() {
         let message = if index == 0 {
@@ -163,7 +163,7 @@ pub(crate) fn leading_commas(spans: &[SpanId]) -> ArrayDiagnostic {
             .push(Label::new(span, message).with_order(index as i32));
     }
 
-    diagnostic.help = Some(Help::new(LEADING_COMMA_HELP));
+    diagnostic.add_help(Help::new(LEADING_COMMA_HELP));
 
     diagnostic
 }
@@ -174,7 +174,7 @@ const CONSECUTIVE_COMMA_HELP: &str =
 #[expect(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 pub(crate) fn consecutive_commas(spans: &[SpanId]) -> ArrayDiagnostic {
     let mut diagnostic =
-        Diagnostic::new(ArrayDiagnosticCategory::ConsecutiveComma, Severity::ERROR);
+        Diagnostic::new(ArrayDiagnosticCategory::ConsecutiveComma, Severity::Error);
 
     for (index, &span) in spans.iter().rev().enumerate() {
         let message = if index == 0 {
@@ -188,7 +188,7 @@ pub(crate) fn consecutive_commas(spans: &[SpanId]) -> ArrayDiagnostic {
             .push(Label::new(span, message).with_order(index as i32));
     }
 
-    diagnostic.help = Some(Help::new(CONSECUTIVE_COMMA_HELP));
+    diagnostic.add_help(Help::new(CONSECUTIVE_COMMA_HELP));
 
     diagnostic
 }
@@ -205,7 +205,7 @@ pub(crate) fn labeled_argument_missing_prefix(
 ) -> ArrayDiagnostic {
     let mut diagnostic = Diagnostic::new(
         ArrayDiagnosticCategory::LabeledArgumentMissingPrefix,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
@@ -216,9 +216,9 @@ pub(crate) fn labeled_argument_missing_prefix(
         "Add ':' prefix to '{}' to make it a valid labeled argument",
         actual.as_ref()
     );
-    diagnostic.help = Some(Help::new(help_message));
+    diagnostic.add_help(Help::new(help_message));
 
-    diagnostic.note = Some(Note::new(LABELED_ARGUMENT_PREFIX_NOTE));
+    diagnostic.add_note(Note::new(LABELED_ARGUMENT_PREFIX_NOTE));
 
     diagnostic
 }
@@ -233,7 +233,7 @@ pub(crate) fn labeled_argument_invalid_identifier<I>(
 ) -> ArrayDiagnostic {
     let mut diagnostic = Diagnostic::new(
         ArrayDiagnosticCategory::LabeledArgumentInvalidIdentifier,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
@@ -244,10 +244,10 @@ pub(crate) fn labeled_argument_invalid_identifier<I>(
         crate::parser::string::error::convert_parse_error(spans, label_span, parse_error);
 
     if let Some(expected) = expected {
-        diagnostic.help = Some(Help::new(expected));
+        diagnostic.add_help(Help::new(expected));
     }
 
-    diagnostic.note = Some(Note::new(LABELED_ARGUMENT_IDENTIFIER_HELP));
+    diagnostic.add_note(Note::new(LABELED_ARGUMENT_IDENTIFIER_HELP));
 
     diagnostic
 }

--- a/libs/@local/hashql/syntax-jexpr/src/parser/error.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/error.rs
@@ -96,13 +96,13 @@ const EXPECTED_EOF_HELP: &str =
     "Remove this token or check for missing delimiters in the preceding expression";
 
 pub(crate) fn expected_eof(span: SpanId) -> ParserDiagnostic {
-    let mut diagnostic = Diagnostic::new(ParserDiagnosticCategory::ExpectedEof, Severity::ERROR);
+    let mut diagnostic = Diagnostic::new(ParserDiagnosticCategory::ExpectedEof, Severity::Error);
 
     diagnostic
         .labels
         .push(Label::new(span, "Extra content after expression"));
 
-    diagnostic.help = Some(Help::new(EXPECTED_EOF_HELP));
+    diagnostic.add_help(Help::new(EXPECTED_EOF_HELP));
 
     diagnostic
 }

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/error.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/error.rs
@@ -200,14 +200,14 @@ Empty objects don't have semantic meaning in J-Expr.
 "##;
 
 pub(crate) fn empty(span: SpanId) -> ObjectDiagnostic {
-    let mut diagnostic = Diagnostic::new(ObjectDiagnosticCategory::Empty, Severity::ERROR);
+    let mut diagnostic = Diagnostic::new(ObjectDiagnosticCategory::Empty, Severity::Error);
 
     diagnostic
         .labels
         .push(Label::new(span, "Add required fields to this object"));
 
-    diagnostic.help = Some(Help::new(EMPTY_HELP));
-    diagnostic.note = Some(Note::new(EMPTY_NOTE));
+    diagnostic.add_help(Help::new(EMPTY_HELP));
+    diagnostic.add_note(Note::new(EMPTY_NOTE));
 
     diagnostic
 }
@@ -216,7 +216,7 @@ const TRAILING_COMMA_HELP: &str = r#"J-Expr does not support trailing commas in 
 
 #[expect(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 pub(crate) fn trailing_commas(spans: &[SpanId]) -> ObjectDiagnostic {
-    let mut diagnostic = Diagnostic::new(ObjectDiagnosticCategory::TrailingComma, Severity::ERROR);
+    let mut diagnostic = Diagnostic::new(ObjectDiagnosticCategory::TrailingComma, Severity::Error);
 
     for (index, &span) in spans.iter().rev().enumerate() {
         let message = if index == 0 {
@@ -230,7 +230,7 @@ pub(crate) fn trailing_commas(spans: &[SpanId]) -> ObjectDiagnostic {
             .push(Label::new(span, message).with_order(index as i32));
     }
 
-    diagnostic.help = Some(Help::new(TRAILING_COMMA_HELP));
+    diagnostic.add_help(Help::new(TRAILING_COMMA_HELP));
 
     diagnostic
 }
@@ -239,7 +239,7 @@ const LEADING_COMMA_HELP: &str = r#"J-Expr does not support leading commas in ob
 
 #[expect(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 pub(crate) fn leading_commas(spans: &[SpanId]) -> ObjectDiagnostic {
-    let mut diagnostic = Diagnostic::new(ObjectDiagnosticCategory::LeadingComma, Severity::ERROR);
+    let mut diagnostic = Diagnostic::new(ObjectDiagnosticCategory::LeadingComma, Severity::Error);
 
     for (index, &span) in spans.iter().rev().enumerate() {
         let message = if index == 0 {
@@ -253,7 +253,7 @@ pub(crate) fn leading_commas(spans: &[SpanId]) -> ObjectDiagnostic {
             .push(Label::new(span, message).with_order(index as i32));
     }
 
-    diagnostic.help = Some(Help::new(LEADING_COMMA_HELP));
+    diagnostic.add_help(Help::new(LEADING_COMMA_HELP));
 
     diagnostic
 }
@@ -263,7 +263,7 @@ const CONSECUTIVE_COMMA_HELP: &str = r#"J-Expr requires exactly one comma betwee
 #[expect(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 pub(crate) fn consecutive_commas(spans: &[SpanId]) -> ObjectDiagnostic {
     let mut diagnostic =
-        Diagnostic::new(ObjectDiagnosticCategory::ConsecutiveComma, Severity::ERROR);
+        Diagnostic::new(ObjectDiagnosticCategory::ConsecutiveComma, Severity::Error);
 
     for (index, &span) in spans.iter().rev().enumerate() {
         let message = if index == 0 {
@@ -277,7 +277,7 @@ pub(crate) fn consecutive_commas(spans: &[SpanId]) -> ObjectDiagnostic {
             .push(Label::new(span, message).with_order(index as i32));
     }
 
-    diagnostic.help = Some(Help::new(CONSECUTIVE_COMMA_HELP));
+    diagnostic.add_help(Help::new(CONSECUTIVE_COMMA_HELP));
 
     diagnostic
 }
@@ -287,7 +287,7 @@ const CONSECUTIVE_COLON_HELP: &str = r#"J-Expr requires exactly one colon betwee
 #[expect(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 pub(crate) fn consecutive_colons(spans: &[SpanId]) -> ObjectDiagnostic {
     let mut diagnostic =
-        Diagnostic::new(ObjectDiagnosticCategory::ConsecutiveColon, Severity::ERROR);
+        Diagnostic::new(ObjectDiagnosticCategory::ConsecutiveColon, Severity::Error);
 
     for (index, &span) in spans.iter().rev().enumerate() {
         let message = if index == 0 {
@@ -301,7 +301,7 @@ pub(crate) fn consecutive_colons(spans: &[SpanId]) -> ObjectDiagnostic {
             .push(Label::new(span, message).with_order(index as i32));
     }
 
-    diagnostic.help = Some(Help::new(CONSECUTIVE_COLON_HELP));
+    diagnostic.add_help(Help::new(CONSECUTIVE_COLON_HELP));
 
     diagnostic
 }
@@ -311,7 +311,7 @@ pub(crate) fn unknown_key(
     key: impl AsRef<str>,
     expected: &[&'static str],
 ) -> Diagnostic<ObjectDiagnosticCategory, SpanId> {
-    let mut diagnostic = Diagnostic::new(ObjectDiagnosticCategory::UnknownKey, Severity::ERROR);
+    let mut diagnostic = Diagnostic::new(ObjectDiagnosticCategory::UnknownKey, Severity::Error);
 
     diagnostic.labels.push(Label::new(
         span,
@@ -352,25 +352,25 @@ pub(crate) fn unknown_key(
         ))
     };
 
-    diagnostic.help = Some(Help::new(help_message));
+    diagnostic.add_help(Help::new(help_message));
 
     diagnostic
 }
 
 pub(crate) fn orphaned_type(span: SpanId) -> ObjectDiagnostic {
-    let mut diagnostic = Diagnostic::new(ObjectDiagnosticCategory::OrphanedType, Severity::ERROR);
+    let mut diagnostic = Diagnostic::new(ObjectDiagnosticCategory::OrphanedType, Severity::Error);
 
     diagnostic.labels.push(Label::new(
         span,
         "Add a primary construct to use with #type",
     ));
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "The `#type` field must be used alongside a primary construct like `#struct`, `#list`, \
          etc. It cannot be used alone in an object.",
     ));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         r##"The `#type` field is used to annotate the type of a construct. Valid examples include:
     - `{"#struct": {...}, "#type": "Person"}`
     - `{"#list": [...], "#type": "List<Number>"}`
@@ -392,7 +392,7 @@ pub(crate) fn duplicate_key(
     duplicate_span: SpanId,
     key: impl AsRef<str>,
 ) -> ObjectDiagnostic {
-    let mut diagnostic = Diagnostic::new(ObjectDiagnosticCategory::DuplicateKey, Severity::ERROR);
+    let mut diagnostic = Diagnostic::new(ObjectDiagnosticCategory::DuplicateKey, Severity::Error);
 
     diagnostic
         .labels
@@ -406,7 +406,7 @@ pub(crate) fn duplicate_key(
         .with_order(1),
     );
 
-    diagnostic.help = Some(Help::new(
+    diagnostic.add_help(Help::new(
         "J-Expr does not allow duplicate keys in the same object. Each key must be unique.",
     ));
 
@@ -422,7 +422,7 @@ pub(crate) fn struct_key_expected_identifier<I>(
 ) -> ObjectDiagnostic {
     let mut diagnostic = Diagnostic::new(
         ObjectDiagnosticCategory::StructKeyExpectedIdentifier,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
@@ -433,10 +433,10 @@ pub(crate) fn struct_key_expected_identifier<I>(
         crate::parser::string::error::convert_parse_error(spans, key_span, parse_error);
 
     if let Some(expected) = expected {
-        diagnostic.help = Some(Help::new(expected));
+        diagnostic.add_help(Help::new(expected));
     }
 
-    diagnostic.note = Some(Note::new(STRUCT_KEY_IDENTIFIER_NOTE));
+    diagnostic.add_note(Note::new(STRUCT_KEY_IDENTIFIER_NOTE));
 
     diagnostic
 }
@@ -444,7 +444,7 @@ pub(crate) fn struct_key_expected_identifier<I>(
 pub(crate) fn dict_entry_expected_array(span: SpanId, found: SyntaxKind) -> ObjectDiagnostic {
     let mut diagnostic = Diagnostic::new(
         ObjectDiagnosticCategory::DictEntryExpectedArray,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
@@ -455,9 +455,9 @@ pub(crate) fn dict_entry_expected_array(span: SpanId, found: SyntaxKind) -> Obje
         "Found {found}, but dictionary entries must be arrays with exactly two elements [key, \
          value]"
     );
-    diagnostic.help = Some(Help::new(help_message));
+    diagnostic.add_help(Help::new(help_message));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "In the array-of-pairs format for dictionaries, each entry must be a two-element array.",
     ));
 
@@ -470,7 +470,7 @@ const DICT_ENTRY_FORMAT_NOTE: &str =
 pub(crate) fn dict_entry_too_few_items(span: SpanId, found: usize) -> ObjectDiagnostic {
     let mut diagnostic = Diagnostic::new(
         ObjectDiagnosticCategory::DictEntryTooFewItems,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     let label_text = if found == 0 {
@@ -482,9 +482,9 @@ pub(crate) fn dict_entry_too_few_items(span: SpanId, found: usize) -> ObjectDiag
     diagnostic.labels.push(Label::new(span, label_text));
 
     let help_message = format!("Expected 2 items (key and value), but found only {found}");
-    diagnostic.help = Some(Help::new(help_message));
+    diagnostic.add_help(Help::new(help_message));
 
-    diagnostic.note = Some(Note::new(DICT_ENTRY_FORMAT_NOTE));
+    diagnostic.add_note(Note::new(DICT_ENTRY_FORMAT_NOTE));
 
     diagnostic
 }
@@ -493,7 +493,7 @@ pub(crate) fn dict_entry_too_few_items(span: SpanId, found: usize) -> ObjectDiag
 pub(crate) fn dict_entry_too_many_items(excess_element_spans: &[SpanId]) -> ObjectDiagnostic {
     let mut diagnostic = Diagnostic::new(
         ObjectDiagnosticCategory::DictEntryTooManyItems,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     for (idx, &span) in excess_element_spans.iter().enumerate() {
@@ -512,9 +512,9 @@ pub(crate) fn dict_entry_too_many_items(excess_element_spans: &[SpanId]) -> Obje
         "Dictionary entries must contain exactly 2 items (key and value), but found {}",
         2 + excess_element_spans.len()
     );
-    diagnostic.help = Some(Help::new(help_message));
+    diagnostic.add_help(Help::new(help_message));
 
-    diagnostic.note = Some(Note::new(DICT_ENTRY_FORMAT_NOTE));
+    diagnostic.add_note(Note::new(DICT_ENTRY_FORMAT_NOTE));
 
     diagnostic
 }
@@ -522,7 +522,7 @@ pub(crate) fn dict_entry_too_many_items(excess_element_spans: &[SpanId]) -> Obje
 pub(crate) fn tuple_expected_array(span: SpanId, found: SyntaxKind) -> ObjectDiagnostic {
     let mut diagnostic = Diagnostic::new(
         ObjectDiagnosticCategory::TupleExpectedArray,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     // More accurate label for the position
@@ -535,9 +535,9 @@ pub(crate) fn tuple_expected_array(span: SpanId, found: SyntaxKind) -> ObjectDia
         "The #tuple construct requires an array of elements, but found {found}. Use square \
          brackets to define the tuple elements: [element1, element2, ...]"
     );
-    diagnostic.help = Some(Help::new(help_message));
+    diagnostic.add_help(Help::new(help_message));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Tuples in J-Expr represent fixed-size ordered collections where each position can have a \
          different type.",
     ));
@@ -547,7 +547,7 @@ pub(crate) fn tuple_expected_array(span: SpanId, found: SyntaxKind) -> ObjectDia
 
 pub(crate) fn list_expected_array(span: SpanId, found: SyntaxKind) -> ObjectDiagnostic {
     let mut diagnostic =
-        Diagnostic::new(ObjectDiagnosticCategory::ListExpectedArray, Severity::ERROR);
+        Diagnostic::new(ObjectDiagnosticCategory::ListExpectedArray, Severity::Error);
 
     // More accurate label for the position
     diagnostic
@@ -559,9 +559,9 @@ pub(crate) fn list_expected_array(span: SpanId, found: SyntaxKind) -> ObjectDiag
         "The #list construct requires an array of elements, but found {found}. Use square \
          brackets to define the list elements: [element1, element2, ...]"
     );
-    diagnostic.help = Some(Help::new(help_message));
+    diagnostic.add_help(Help::new(help_message));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Lists in J-Expr represent variable-length collections where all elements must have the \
          same type.",
     ));
@@ -572,7 +572,7 @@ pub(crate) fn list_expected_array(span: SpanId, found: SyntaxKind) -> ObjectDiag
 pub(crate) fn struct_expected_object(span: SpanId, found: SyntaxKind) -> ObjectDiagnostic {
     let mut diagnostic = Diagnostic::new(
         ObjectDiagnosticCategory::StructExpectedObject,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     // More accurate label for the position
@@ -585,9 +585,9 @@ pub(crate) fn struct_expected_object(span: SpanId, found: SyntaxKind) -> ObjectD
         "The #struct construct requires an object with field definitions, but found {found}. Use \
          curly braces to define the struct fields: {{\"field1\": value1, \"field2\": value2}}"
     );
-    diagnostic.help = Some(Help::new(help_message));
+    diagnostic.add_help(Help::new(help_message));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Structs in J-Expr represent collections of named fields, where each field can have a \
          different type.",
     ));
@@ -598,7 +598,7 @@ pub(crate) fn struct_expected_object(span: SpanId, found: SyntaxKind) -> ObjectD
 pub(crate) fn dict_expected_format(span: SpanId, found: SyntaxKind) -> ObjectDiagnostic {
     let mut diagnostic = Diagnostic::new(
         ObjectDiagnosticCategory::DictExpectedFormat,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     // More accurate label for the position
@@ -612,9 +612,9 @@ pub(crate) fn dict_expected_format(span: SpanId, found: SyntaxKind) -> ObjectDia
         "Found {found}, but the #dict construct requires either an object {{key: value, ...}} or \
          an array of pairs [[key, value], ...]"
     );
-    diagnostic.help = Some(Help::new(help_message));
+    diagnostic.add_help(Help::new(help_message));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         r#"Valid dictionary formats:
     1. Object syntax: {"key1": value1, "key2": value2, ...}
     2. Array of pairs: [[key1, value1], [key2, value2], ...]"#,
@@ -626,19 +626,19 @@ pub(crate) fn dict_expected_format(span: SpanId, found: SyntaxKind) -> ObjectDia
 pub(crate) fn type_expected_string(span: SpanId, found: SyntaxKind) -> ObjectDiagnostic {
     let mut diagnostic = Diagnostic::new(
         ObjectDiagnosticCategory::TypeExpectedString,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
         .labels
         .push(Label::new(span, "Invalid type specification"));
 
-    diagnostic.help = Some(Help::new(format!(
+    diagnostic.add_help(Help::new(format!(
         "Found {found}, which is not a valid type specification. Types must be represented as a \
          string.",
     )));
 
-    diagnostic.note = Some(Note::new(
+    diagnostic.add_note(Note::new(
         "Types in J-Expr must be specified through an embedded language represented in a string \
          that mimics that of Rust and TypeScript. See the language documentation for more details.",
     ));
@@ -649,7 +649,7 @@ pub(crate) fn type_expected_string(span: SpanId, found: SyntaxKind) -> ObjectDia
 pub(crate) fn literal_expected_primitive(span: SpanId, found: SyntaxKind) -> ObjectDiagnostic {
     let mut diagnostic = Diagnostic::new(
         ObjectDiagnosticCategory::LiteralExpectedPrimitive,
-        Severity::ERROR,
+        Severity::Error,
     );
 
     diagnostic
@@ -660,7 +660,7 @@ pub(crate) fn literal_expected_primitive(span: SpanId, found: SyntaxKind) -> Obj
         "Found {found}, which is not a valid primitive literal. Primitive literals are either \
          strings, numbers, or booleans."
     );
-    diagnostic.help = Some(Help::new(help_message));
+    diagnostic.add_help(Help::new(help_message));
 
     diagnostic
 }

--- a/libs/@local/hashql/syntax-jexpr/src/parser/string/error.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/string/error.rs
@@ -119,15 +119,15 @@ pub(crate) fn invalid_expr<I>(
     error: ParseError<I, ContextError>,
 ) -> StringDiagnostic {
     let mut diagnostic =
-        Diagnostic::new(StringDiagnosticCategory::InvalidExpression, Severity::ERROR);
+        Diagnostic::new(StringDiagnosticCategory::InvalidExpression, Severity::Error);
 
     let (label, expected) = convert_parse_error(spans, parent, error);
 
     diagnostic.labels.push(label);
 
     if let Some(expected) = expected {
-        diagnostic.help = Some(Help::new(expected));
-        diagnostic.note = Some(Note::new(SYNTAX_ERROR_NOTE));
+        diagnostic.add_help(Help::new(expected));
+        diagnostic.add_note(Note::new(SYNTAX_ERROR_NOTE));
     }
 
     diagnostic


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Renames the `COMPILER_BUG` into an `ICE` (still handled as a `Bug`) additionally touches up on the diagnostics. Specifically it converts the struct into an enum with all the variants (which makes it significantly smaller) overhauls the color serialization to consistently output hex codes, and adds the ability to use multiple notes and helps. This is helpful (pun intended) for scenarios where we want to attach some additional information. For example ICE's now have consistent messaging regarding reporting the issue. 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
