### PR TITLE
H-1757: Add types tab/table to user/org profile pages

### DIFF
--- a/apps/hash-api/src/graphql/resolvers/ontology/entity-type.ts
+++ b/apps/hash-api/src/graphql/resolvers/ontology/entity-type.ts
@@ -96,7 +96,7 @@ export const queryEntityTypesResolver: ResolverFn<
           ? filter
             ? { all: [filter, latestOnlyFilter] }
             : latestOnlyFilter
-          : { all: [] },
+          : (filter ?? { all: [] }),
         graphResolveDepths: {
           ...zeroedGraphResolveDepths,
           constrainsValuesOn,

--- a/apps/hash-api/src/graphql/resolvers/ontology/property-type.ts
+++ b/apps/hash-api/src/graphql/resolvers/ontology/property-type.ts
@@ -70,6 +70,7 @@ export const queryPropertyTypesResolver: ResolverFn<
   {
     constrainsValuesOn,
     constrainsPropertiesOn,
+    filter,
     latestOnly = true,
     includeArchived = false,
   },
@@ -77,6 +78,10 @@ export const queryPropertyTypesResolver: ResolverFn<
   __,
 ) => {
   const { graphApi } = dataSources;
+
+  const latestOnlyFilter = {
+    equal: [{ path: ["version"] }, { parameter: "latest" }],
+  };
 
   /**
    * @todo: get all latest property types in specified account.
@@ -88,10 +93,10 @@ export const queryPropertyTypesResolver: ResolverFn<
     authentication.actorId,
     {
       filter: latestOnly
-        ? {
-            equal: [{ path: ["version"] }, { parameter: "latest" }],
-          }
-        : { all: [] },
+        ? filter
+          ? { all: [filter, latestOnlyFilter] }
+          : latestOnlyFilter
+        : (filter ?? { all: [] }),
       graphResolveDepths: {
         ...zeroedGraphResolveDepths,
         constrainsValuesOn,

--- a/apps/hash-frontend/next.config.js
+++ b/apps/hash-frontend/next.config.js
@@ -77,6 +77,10 @@ export default withSentryConfig(
             destination: `/entities?entityTypeIdOrBaseUrl=${pageEntityTypeBaseUrl}`,
           },
           {
+            source: "/@:shortname/types",
+            destination: "/@/:shortname?tab=Types",
+          },
+          {
             source: "/@:shortname/:path*",
             destination: "/@/:shortname/:path*",
           },

--- a/apps/hash-frontend/src/graphql/queries/ontology/property-type.queries.ts
+++ b/apps/hash-frontend/src/graphql/queries/ontology/property-type.queries.ts
@@ -24,12 +24,14 @@ export const queryPropertyTypesQuery = gql`
   query queryPropertyTypes(
     $constrainsValuesOn: OutgoingEdgeResolveDepthInput!
     $constrainsPropertiesOn: OutgoingEdgeResolveDepthInput!
+    $filter: Filter
     $latestOnly: Boolean = true
     $includeArchived: Boolean = false
   ) {
     queryPropertyTypes(
       constrainsValuesOn: $constrainsValuesOn
       constrainsPropertiesOn: $constrainsPropertiesOn
+      filter: $filter
       latestOnly: $latestOnly
       includeArchived: $includeArchived
     ) {

--- a/apps/hash-frontend/src/pages/@/[shortname].page/pinned-entity-type-tab-contents.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname].page/pinned-entity-type-tab-contents.tsx
@@ -129,10 +129,7 @@ const sortOrderHumanReadable: Record<SortOrder, string> = {
 };
 
 export const PinnedEntityTypeTabContents: FunctionComponent<{
-  currentTab: Extract<
-    ProfilePageTab,
-    { kind: "pinned-entity-type" | "profile-pages" }
-  >;
+  currentTab: Extract<ProfilePageTab, { kind: "pinned-entity-type" }>;
   profile: User | Org;
   isEditable: boolean;
 }> = ({ currentTab, profile, isEditable }) => {

--- a/apps/hash-frontend/src/pages/@/[shortname].page/profile-page-content.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname].page/profile-page-content.tsx
@@ -1,3 +1,8 @@
+import type {
+  DataTypeWithMetadata,
+  EntityTypeWithMetadata,
+  PropertyTypeWithMetadata,
+} from "@blockprotocol/type-system";
 import { Box, Container } from "@mui/material";
 import type { FunctionComponent } from "react";
 
@@ -5,6 +10,7 @@ import type { Org, User } from "../../../lib/user-and-org";
 import { PinnedEntityTypeTabContents } from "./pinned-entity-type-tab-contents";
 import { ProfilePageInfo } from "./profile-page-info";
 import { ProfileTab } from "./profile-tab";
+import { TypesTab } from "./types-tab";
 import type { ProfilePageTab } from "./util";
 import { leftColumnWidth } from "./util";
 
@@ -14,12 +20,20 @@ export const ProfilePageContent: FunctionComponent<{
   setDisplayEditUserProfileInfoModal: (display: boolean) => void;
   refetchProfile: () => Promise<void>;
   currentTab: ProfilePageTab;
+  webTypes: (
+    | PropertyTypeWithMetadata
+    | EntityTypeWithMetadata
+    | DataTypeWithMetadata
+  )[];
+  webTypesLoading: boolean;
 }> = ({
   profile,
   isEditable,
   setDisplayEditUserProfileInfoModal,
   currentTab,
   refetchProfile,
+  webTypes,
+  webTypesLoading,
 }) => {
   return (
     <Container sx={{ paddingTop: 4 }}>
@@ -42,12 +56,14 @@ export const ProfilePageContent: FunctionComponent<{
                 isEditable={isEditable}
                 refetchProfile={refetchProfile}
               />
-            ) : (
+            ) : currentTab.kind === "pinned-entity-type" ? (
               <PinnedEntityTypeTabContents
                 profile={profile}
                 isEditable={isEditable}
                 currentTab={currentTab}
               />
+            ) : (
+              <TypesTab loading={webTypesLoading} types={webTypes} />
             )
           ) : null}
         </Box>

--- a/apps/hash-frontend/src/pages/@/[shortname].page/profile-page-header.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname].page/profile-page-header.tsx
@@ -21,6 +21,7 @@ export const ProfilePageHeader: FunctionComponent<{
   tabs: ProfilePageTab[];
   currentTab: ProfilePageTab;
   refetchProfile: () => Promise<void>;
+  typesCount: number;
 }> = ({
   profile,
   isEditable,
@@ -28,6 +29,7 @@ export const ProfilePageHeader: FunctionComponent<{
   tabs,
   currentTab,
   refetchProfile,
+  typesCount,
 }) => {
   const [
     displayEditPinnedEntityTypesModal,
@@ -140,6 +142,7 @@ export const ProfilePageHeader: FunctionComponent<{
                 profile={profile}
                 tabs={tabs}
                 currentTab={currentTab}
+                typesCount={typesCount}
               />
               {isEditable ? (
                 <>

--- a/apps/hash-frontend/src/pages/@/[shortname].page/profile-page-info.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname].page/profile-page-info.tsx
@@ -172,7 +172,7 @@ const UserProfileWebsSection: FunctionComponent<{ webs: Org[] }> = ({
 };
 
 const PinnedEntityTypeTabInfo: FunctionComponent<
-  Extract<ProfilePageTab, { kind: "pinned-entity-type" | "profile-pages" }>
+  Extract<ProfilePageTab, { kind: "pinned-entity-type" }>
 > = ({ entities }) => {
   const latestEntityUpdatedAt = useMemo(() => {
     const latestEntity = entities?.reduce<HashEntity | undefined>(
@@ -282,10 +282,10 @@ export const ProfilePageInfo: FunctionComponent<{
             </IconButton>
           </Fade>
         </Box>
-        {currentTab.kind === "profile" ? (
-          <ProfileTabInfoSection profile={profile} />
-        ) : (
+        {currentTab.kind === "pinned-entity-type" ? (
           <PinnedEntityTypeTabInfo {...currentTab} />
+        ) : (
+          <ProfileTabInfoSection profile={profile} />
         )}
       </Box>
       {profile?.kind === "user" && webs && webs.length > 0 ? (

--- a/apps/hash-frontend/src/pages/@/[shortname].page/profile-page-tabs.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname].page/profile-page-tabs.tsx
@@ -10,15 +10,19 @@ export const ProfilePageTabs: FunctionComponent<{
   profile?: User | Org;
   tabs: ProfilePageTab[];
   currentTab: ProfilePageTab;
-}> = ({ tabs, currentTab, profile }) => {
+  typesCount: number;
+}> = ({ tabs, currentTab, profile, typesCount }) => {
   const currentTabLabel =
-    currentTab.kind === "profile" ? currentTab.title : currentTab.pluralTitle;
+    currentTab.kind === "pinned-entity-type"
+      ? currentTab.pluralTitle
+      : currentTab.title;
 
   return (
     <Box sx={{ overflowX: "auto", overflowY: "hidden" }}>
       <Tabs value={currentTabLabel}>
         {tabs.map((tab) => {
-          const label = tab.kind === "profile" ? tab.title : tab.pluralTitle;
+          const label =
+            tab.kind === "pinned-entity-type" ? tab.pluralTitle : tab.title;
 
           return (
             <TabLink
@@ -31,12 +35,18 @@ export const ProfilePageTabs: FunctionComponent<{
               label={label ?? <Skeleton width={60} />}
               value={label ?? ""}
               href={`/@${profile?.shortname}${
-                tab.kind === "profile" ? "" : `?tab=${label}`
+                tab.kind === "profile"
+                  ? ""
+                  : tab.kind === "types"
+                    ? "/types"
+                    : `?tab=${label}`
               }`}
               count={
                 tab.kind === "pinned-entity-type"
                   ? tab.entities?.length
-                  : undefined
+                  : tab.kind === "types"
+                    ? typesCount
+                    : undefined
               }
             />
           );

--- a/apps/hash-frontend/src/pages/@/[shortname].page/types-tab.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname].page/types-tab.tsx
@@ -1,0 +1,21 @@
+import type {
+  DataTypeWithMetadata,
+  EntityTypeWithMetadata,
+  PropertyTypeWithMetadata,
+} from "@blockprotocol/type-system";
+
+import { TypesTable } from "../../shared/types-table";
+
+export const TypesTab = ({
+  loading,
+  types,
+}: {
+  loading: boolean;
+  types: (
+    | PropertyTypeWithMetadata
+    | EntityTypeWithMetadata
+    | DataTypeWithMetadata
+  )[];
+}) => {
+  return <TypesTable loading={loading} onlyOneWeb types={types} kind="all" />;
+};

--- a/apps/hash-frontend/src/pages/@/[shortname].page/util.ts
+++ b/apps/hash-frontend/src/pages/@/[shortname].page/util.ts
@@ -12,6 +12,10 @@ export type ProfilePageTab =
       title: string;
     }
   | {
+      kind: "types";
+      title: string;
+    }
+  | {
       kind: "pinned-entity-type";
       entityTypeBaseUrl: BaseUrl;
       entityType?: EntityTypeWithMetadata;

--- a/apps/hash-frontend/src/pages/@/[shortname]/[page-slug].page.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname]/[page-slug].page.tsx
@@ -53,6 +53,7 @@ import {
   getBlockCollectionContentsStructuralQueryVariables,
 } from "../../shared/block-collection-contents";
 import { BlockCollectionContextProvider } from "../../shared/block-collection-context";
+import { NotFound } from "../../shared/not-found";
 import {
   TOP_CONTEXT_BAR_HEIGHT,
   TopContextBar,
@@ -290,11 +291,7 @@ const Page: NextPageWithLayout<PageProps> = () => {
   }
 
   if (error) {
-    return (
-      <PageSectionContainer {...pageSectionContainerProps}>
-        <h1>Error: {error.message}</h1>
-      </PageSectionContainer>
-    );
+    return <NotFound />;
   }
 
   if (

--- a/apps/hash-frontend/src/pages/types/[[...type-kind]].page.tsx
+++ b/apps/hash-frontend/src/pages/types/[[...type-kind]].page.tsx
@@ -16,11 +16,11 @@ import { getLayoutWithSidebar } from "../../shared/layout";
 import { usePropertyTypes } from "../../shared/property-types-context";
 import { CreateButton } from "../shared/create-button";
 import { TopContextBar } from "../shared/top-context-bar";
+import { TypesTable } from "../shared/types-table";
 import {
   tabTitles,
   TypesPageTabs,
 } from "./[[...type-kind]].page/types-page-tabs";
-import { TypesTable } from "./[[...type-kind]].page/types-table";
 
 type ParsedQueryKindParam =
   | "entity-type"

--- a/apps/hash-frontend/src/shared/table-header.tsx
+++ b/apps/hash-frontend/src/shared/table-header.tsx
@@ -38,7 +38,7 @@ import { useCallback, useState } from "react";
 import type { GridRow } from "../components/grid/grid";
 import type { MinimalUser } from "../lib/user-and-org";
 import type { EntitiesTableRow } from "../pages/shared/entities-visualizer/entities-table/types";
-import type { TypesTableRow } from "../pages/types/[[...type-kind]].page/types-table";
+import type { TypesTableRow } from "../pages/shared/types-table";
 import { EarthAmericasRegularIcon } from "./icons/earth-americas-regular";
 import { FilterListIcon } from "./icons/filter-list-icon";
 import { HouseRegularIcon } from "./icons/house-regular-icon";
@@ -117,6 +117,7 @@ type TableHeaderProps<R extends GridRow> = {
   loading: boolean;
   numberOfExternalItems?: number;
   numberOfUserWebItems?: number;
+  onlyOneWeb?: boolean;
   onBulkActionCompleted?: () => void;
   selectedItems?: (
     | HashEntity
@@ -146,6 +147,7 @@ export const TableHeader = <R extends GridRow>({
   loading,
   numberOfExternalItems,
   numberOfUserWebItems,
+  onlyOneWeb,
   onBulkActionCompleted,
   selectedItems,
   setFilterState,
@@ -242,7 +244,11 @@ export const TableHeader = <R extends GridRow>({
         ) : hideFilters ? null : (
           <>
             <NoMaxWidthTooltip
-              title="Visible to you inside your personal web and organizations you belong to"
+              title={
+                onlyOneWeb
+                  ? "Visible to you in this web"
+                  : "Visible to you inside your personal web and organizations you belong to"
+              }
               placement="top"
             >
               <Chip
@@ -253,7 +259,9 @@ export const TableHeader = <R extends GridRow>({
                     }}
                   />
                 }
-                label={`${numberOfUserWebItems ?? "–"} in your webs`}
+                label={`${numberOfUserWebItems ?? "–"} in ${
+                  onlyOneWeb ? "this web" : "your webs"
+                }`}
                 sx={{
                   ...commonChipSx,
                   [`.${chipClasses.label}`]: {
@@ -263,55 +271,57 @@ export const TableHeader = <R extends GridRow>({
                 }}
               />
             </NoMaxWidthTooltip>
-            <NoMaxWidthTooltip
-              title={`${
-                filterState.includeGlobal ? "Hide" : "Show"
-              } public ${itemLabelPlural} from outside of your webs`}
-              placement="top"
-            >
-              <Chip
-                onMouseEnter={() => setPublicFilterHovered(true)}
-                onMouseLeave={() => setPublicFilterHovered(false)}
-                onClick={() => {
-                  setDisplayFilters(true);
-                  setFilterState((prev) => ({
-                    ...prev,
-                    includeGlobal: !prev.includeGlobal,
-                  }));
-                }}
-                icon={
-                  filterState.includeGlobal ? (
-                    publicFilterHovered ? (
-                      <EyeSlashRegularIcon
+            {onlyOneWeb ? null : (
+              <NoMaxWidthTooltip
+                title={`${
+                  filterState.includeGlobal ? "Hide" : "Show"
+                } public ${itemLabelPlural} from outside of your webs`}
+                placement="top"
+              >
+                <Chip
+                  onMouseEnter={() => setPublicFilterHovered(true)}
+                  onMouseLeave={() => setPublicFilterHovered(false)}
+                  onClick={() => {
+                    setDisplayFilters(true);
+                    setFilterState((prev) => ({
+                      ...prev,
+                      includeGlobal: !prev.includeGlobal,
+                    }));
+                  }}
+                  icon={
+                    filterState.includeGlobal ? (
+                      publicFilterHovered ? (
+                        <EyeSlashRegularIcon
+                          sx={{ fill: ({ palette }) => palette.primary.main }}
+                        />
+                      ) : (
+                        <CheckIcon
+                          sx={{ fill: ({ palette }) => palette.primary.main }}
+                        />
+                      )
+                    ) : publicFilterHovered ? (
+                      <EyeRegularIcon
                         sx={{ fill: ({ palette }) => palette.primary.main }}
                       />
                     ) : (
-                      <CheckIcon
-                        sx={{ fill: ({ palette }) => palette.primary.main }}
-                      />
+                      <EarthAmericasRegularIcon />
                     )
-                  ) : publicFilterHovered ? (
-                    <EyeRegularIcon
-                      sx={{ fill: ({ palette }) => palette.primary.main }}
-                    />
-                  ) : (
-                    <EarthAmericasRegularIcon />
-                  )
-                }
-                label={`${numberOfExternalItems ?? "–"} others`}
-                sx={({ palette }) => ({
-                  ...commonChipSx,
-                  [`.${chipClasses.label}`]: {
-                    color: palette.gray[70],
-                    fontSize: 13,
-                  },
-                  "&:hover": {
-                    background: palette.common.white,
-                    border: palette.common.white,
-                  },
-                })}
-              />
-            </NoMaxWidthTooltip>
+                  }
+                  label={`${numberOfExternalItems ?? "–"} others`}
+                  sx={({ palette }) => ({
+                    ...commonChipSx,
+                    [`.${chipClasses.label}`]: {
+                      color: palette.gray[70],
+                      fontSize: 13,
+                    },
+                    "&:hover": {
+                      background: palette.common.white,
+                      border: palette.common.white,
+                    },
+                  })}
+                />
+              </NoMaxWidthTooltip>
+            )}
           </>
         )}
         {loading && <LoadingSpinner size={16} color={theme.palette.blue[70]} />}
@@ -365,16 +375,18 @@ export const TableHeader = <R extends GridRow>({
                     }
                   />
                 ) : null}
-                <CheckboxFilter
-                  label="Include external"
-                  checked={filterState.includeGlobal}
-                  onChange={(checked) =>
-                    setFilterState((prev) => ({
-                      ...prev,
-                      includeGlobal: checked,
-                    }))
-                  }
-                />
+                {onlyOneWeb ? null : (
+                  <CheckboxFilter
+                    label="Include external"
+                    checked={filterState.includeGlobal}
+                    onChange={(checked) =>
+                      setFilterState((prev) => ({
+                        ...prev,
+                        includeGlobal: checked,
+                      }))
+                    }
+                  />
+                )}
               </Box>
             </Box>
           </Box>

--- a/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/ontology/property-type.typedef.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/ontology/property-type.typedef.ts
@@ -12,6 +12,7 @@ export const propertyTypeTypedef = gql`
     queryPropertyTypes(
       constrainsValuesOn: OutgoingEdgeResolveDepthInput!
       constrainsPropertiesOn: OutgoingEdgeResolveDepthInput!
+      filter: Filter
       latestOnly: Boolean = true
       includeArchived: Boolean = false
     ): GqlSubgraph!


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds a 'Types' tab to user / org profile pages, available at `/@[shortname]/types`.

It will show a table of types belonging to that web.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Visit a profile page

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

https://github.com/user-attachments/assets/358e2673-152e-4922-b6cb-956109dafcbb

