### PR TITLE
H-4532: HashQL: Unify string similarity infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3819,6 +3819,7 @@ dependencies = [
  "lexical",
  "orx-concurrent-vec",
  "pretty",
+ "rapidfuzz",
  "roaring",
  "scc",
  "serde",
@@ -3828,6 +3829,7 @@ dependencies = [
  "test-case",
  "text-size",
  "tracing",
+ "unicase",
 ]
 
 [[package]]
@@ -7305,6 +7307,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapidfuzz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "270e04e5ea61d40841942bb15e451c29ee1618637bcf97fc7ede5dd4a9b1601b"
+
+[[package]]
 name = "rav1e"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9672,6 +9680,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3830,6 +3830,7 @@ dependencies = [
  "text-size",
  "tracing",
  "unicase",
+ "unicode-segmentation",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3764,7 +3764,6 @@ dependencies = [
  "hashql-core",
  "hashql-diagnostics",
  "simple-mermaid",
- "strsim",
  "tracing",
 ]
 
@@ -3825,7 +3824,6 @@ dependencies = [
  "serde",
  "simple-mermaid",
  "smallvec 2.0.0-alpha.11",
- "strsim",
  "test-case",
  "text-size",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,6 @@ seq-macro                = { version = "=0.3.6", default-features = false }
 serde                    = { version = "=1.0.219", default-features = false }
 serde_json               = { version = "=1.0.140" }
 serde_plain              = { version = "=1.0.2", default-features = false }
-serde_with               = { version = "=3.12.0", default-features = false }
 sha2                     = { version = "=0.10.9", default-features = false }
 similar-asserts          = { version = "=1.7.0", default-features = false }
 simple-mermaid           = { version = "=0.2.0", default-features = false }

--- a/libs/@local/hashql/ast/Cargo.toml
+++ b/libs/@local/hashql/ast/Cargo.toml
@@ -21,7 +21,6 @@ enum-iterator.workspace = true
 foldhash                = { workspace = true }
 hashbrown               = { workspace = true }
 simple-mermaid          = { workspace = true }
-strsim                  = "0.11.1"
 tracing.workspace       = true
 
 [dev-dependencies]

--- a/libs/@local/hashql/ast/Cargo.toml
+++ b/libs/@local/hashql/ast/Cargo.toml
@@ -21,7 +21,7 @@ enum-iterator.workspace = true
 foldhash                = { workspace = true }
 hashbrown               = { workspace = true }
 simple-mermaid          = { workspace = true }
-tracing.workspace       = true
+tracing                 = { workspace = true }
 
 [dev-dependencies]
 hashql-compiletest = { workspace = true }

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/error.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/error.rs
@@ -11,6 +11,7 @@ use hashql_core::{
         error::{ResolutionError, ResolutionSuggestion},
         import::Import,
     },
+    similarity::did_you_mean,
     span::SpanId,
     symbol::{Ident, Symbol},
 };
@@ -23,7 +24,6 @@ use hashql_diagnostics::{
     note::Note,
     severity::Severity,
 };
-use strsim::jaro_winkler;
 
 use crate::node::path::Path;
 
@@ -184,57 +184,47 @@ pub(crate) fn generic_arguments_in_module(
     diagnostic
 }
 
-/// Format suggestions for display in diagnostics
-fn format_suggestions<T>(
-    suggestions: &mut [ResolutionSuggestion<T>],
-    mut render: impl for<'a> FnMut(&'a T) -> Cow<'a, str>,
+fn format_suggestions<'heap, T>(
+    name: Symbol<'heap>,
+    suggestions: &[ResolutionSuggestion<'heap, T>],
 ) -> Option<String> {
     if suggestions.is_empty() {
         return None;
     }
 
-    // Sort by score (descending)
-    suggestions.sort_by(
-        |ResolutionSuggestion { score: lhs, .. }, ResolutionSuggestion { score: rhs, .. }| {
-            rhs.total_cmp(lhs)
-        },
+    let max_suggestions = match suggestions.len() {
+        0 => return None,
+        1..=3 => suggestions.len(),
+        4..=8 => 4,
+        _ => 5,
+    };
+
+    let good_suggestions = did_you_mean(
+        name,
+        suggestions
+            .iter()
+            .map(|ResolutionSuggestion { name, .. }| *name),
+        Some(max_suggestions),
+        None,
     );
 
-    // Good suggestions have a score above 0.7
-    let good_suggestions_len =
-        suggestions.partition_point(|&ResolutionSuggestion { score, .. }| score > 0.7);
-
-    if good_suggestions_len == 0 {
-        // Fall back to taking the top 3 suggestions regardless of score, these are never empty, due
-        // to the check above
-        let suggestion: String = suggestions
-            .iter()
-            .take(3)
-            .map(|suggestion| render(&suggestion.item))
-            .intersperse(Cow::Borrowed("`, `"))
-            .collect();
-
-        let remaining = suggestions.len().saturating_sub(3);
-        let suffix = match remaining {
-            0 => String::new(),
-            1 => format!(" and `{}`", render(&suggestions[3].item)),
-            _ => format!(" and {remaining} others"),
-        };
-
-        return Some(format!(
-            "\n\nPossible alternatives are `{suggestion}`{suffix}."
-        ));
+    if good_suggestions.is_empty() {
+        return None;
     }
 
-    // Format the good suggestions with markdown-style backticks
-    let suggestion: String = suggestions
-        .iter()
-        .take_while(|&&ResolutionSuggestion { score, .. }| score > 0.7)
-        .map(|suggestion| render(&suggestion.item))
-        .intersperse(Cow::Borrowed("`, `"))
-        .collect();
+    let mut result = String::from("\n\nDid you mean:");
+    for suggestion in &good_suggestions {
+        write!(result, "\n  - {}", suggestion).unwrap_or_else(|_err| unreachable!());
+    }
 
-    Some(format!("\n\nDid you mean: `{suggestion}`?"))
+    let remaining_count = suggestions.len().saturating_sub(good_suggestions.len());
+    match remaining_count {
+        0 => {}
+        1 => result.push_str("\n(1 more available)"),
+        n => write!(result, "\n({n} more available)").unwrap_or_else(|_err| unreachable!()),
+    }
+
+    Some(result)
 }
 
 struct FormatPath<'a, 'heap>(bool, &'a [(SpanId, Symbol<'heap>)], Option<usize>);
@@ -261,7 +251,6 @@ impl Display for FormatPath<'_, '_> {
     }
 }
 
-#[expect(clippy::too_many_lines)]
 pub(crate) fn unresolved_variable<'heap>(
     registry: &ModuleRegistry<'heap>,
     universe: Universe,
@@ -284,37 +273,29 @@ pub(crate) fn unresolved_variable<'heap>(
     );
 
     // Remove any suggestions that are already in the locals set
-    suggestions.retain(|suggestion| !locals.contains(&suggestion.item.name));
+    suggestions.retain(|suggestion| !locals.contains(&suggestion.name));
     let import_suggestions: FastHashSet<_> = suggestions
         .iter()
-        .map(|suggestion| suggestion.item.name)
+        .map(|suggestion| suggestion.name)
         .collect();
 
     // Find similar local variables
-    let mut local_suggestions: Vec<_> = locals
-        .into_iter()
-        .filter_map(|&local| {
-            let score = jaro_winkler(ident.value.as_str(), local.as_str());
-            // Only include suggestions with a reasonably high similarity
-            (score > 0.7).then_some((local, score))
-        })
-        .collect();
-
-    // Sort by similarity score (highest first)
-    local_suggestions.sort_unstable_by(|&(_, lhs), &(_, rhs)| rhs.total_cmp(&lhs));
 
     let mut help = format!("The name '{}' doesn't exist in this scope.", ident.value);
 
     // Local variable suggestions section
-    if !local_suggestions.is_empty() {
+    let local_suggestions = did_you_mean(ident.value, locals, Some(3), None);
+    let has_local_suggestions = !local_suggestions.is_empty();
+    if has_local_suggestions {
         help.push_str("\n\nDid you mean one of these local variables?\n");
 
-        for (local, _) in local_suggestions.iter().take(3) {
+        let remaining = locals.len().saturating_sub(local_suggestions.len());
+
+        for local in local_suggestions {
             let _: fmt::Result = writeln!(help, "  - `{local}`");
         }
 
-        if local_suggestions.len() > 3 {
-            let remaining = local_suggestions.len() - 3;
+        if remaining > 0 {
             let _: fmt::Result = writeln!(help, "  - and {remaining} more similar variables");
         }
     }
@@ -322,35 +303,35 @@ pub(crate) fn unresolved_variable<'heap>(
     // Imported item suggestions section
     if !suggestions.is_empty() {
         // Add a connector if we've already shown local suggestions
-        if local_suggestions.is_empty() {
-            help.push_str("\n\nPerhaps you meant ");
-        } else {
+        if has_local_suggestions {
             help.push_str("\nOr perhaps you meant ");
+        } else {
+            help.push_str("\n\nPerhaps you meant ");
         }
 
         help.push_str("one of these imported items?\n");
 
         // Sort and filter imported item suggestions by score
-        suggestions.sort_by(|lhs, rhs| rhs.score.total_cmp(&lhs.score));
-        let good_suggestions: Vec<_> = suggestions
-            .iter()
-            .filter(|suggestion| suggestion.score > 0.7)
-            .take(3)
-            .collect();
+        let good_suggestions = did_you_mean(
+            ident.value,
+            suggestions.iter().map(|suggestion| suggestion.name),
+            Some(3),
+            None,
+        );
+        let remaining = suggestions.len().saturating_sub(good_suggestions.len());
 
         if good_suggestions.is_empty() {
             // Fall back to showing any suggestions if none have high similarity
-            for suggestion in suggestions.iter().take(3) {
-                let _: fmt::Result = writeln!(help, "  - `{}`", suggestion.item.name);
+            for suggestion in good_suggestions {
+                let _: fmt::Result = writeln!(help, "  - `{}`", suggestion);
             }
 
-            if suggestions.len() > 3 {
-                let remaining = suggestions.len() - 3;
+            if remaining > 3 {
                 let _: fmt::Result = writeln!(help, "  - and {remaining} more imported items");
             }
         } else {
             for suggestion in &good_suggestions {
-                let _: fmt::Result = writeln!(help, "  - `{}`", suggestion.item.name);
+                let _: fmt::Result = writeln!(help, "  - `{}`", suggestion);
             }
         }
     }
@@ -416,10 +397,9 @@ pub(crate) fn unresolved_variable<'heap>(
 #[expect(clippy::too_many_lines)]
 pub(crate) fn from_resolution_error<'heap>(
     use_span: Option<SpanId>,
-    registry: &ModuleRegistry<'heap>,
     path: &Path<'heap>,
     name: Option<(SpanId, Symbol<'heap>)>,
-    mut error: ResolutionError<'heap>,
+    error: ResolutionError<'heap>,
 ) -> ImportResolverDiagnostic {
     let mut diagnostic = Diagnostic::new(
         ImportResolverDiagnosticCategory::UnresolvedImport,
@@ -433,8 +413,8 @@ pub(crate) fn from_resolution_error<'heap>(
         .chain(name)
         .collect();
 
-    match &mut error {
-        &mut ResolutionError::InvalidQueryLength { expected } => {
+    match error {
+        ResolutionError::InvalidQueryLength { expected } => {
             diagnostic.labels.push(
                 // Primary label highlighting the problematic path
                 Label::new(path.span, "Expected more path segments")
@@ -462,7 +442,7 @@ pub(crate) fn from_resolution_error<'heap>(
             ));
         }
 
-        &mut ResolutionError::ModuleRequired { depth, found } => {
+        ResolutionError::ModuleRequired { depth, found } => {
             let (path_segment_span, _) = segments[depth];
 
             diagnostic.labels.extend([
@@ -499,8 +479,11 @@ pub(crate) fn from_resolution_error<'heap>(
             ));
         }
 
-        ResolutionError::PackageNotFound { depth, suggestions } => {
-            let depth = *depth;
+        ResolutionError::PackageNotFound {
+            depth,
+            name,
+            suggestions,
+        } => {
             let (package_span, package_name) = segments[depth];
 
             diagnostic.labels.push(
@@ -523,9 +506,7 @@ pub(crate) fn from_resolution_error<'heap>(
                             installed."
                 .to_owned();
 
-            if let Some(suggestion) = format_suggestions(suggestions, |&module| {
-                Cow::Owned(registry.modules.index(module).name.as_str().to_owned())
-            }) {
+            if let Some(suggestion) = format_suggestions(name, &suggestions) {
                 help.push_str(&suggestion);
             }
 
@@ -537,8 +518,11 @@ pub(crate) fn from_resolution_error<'heap>(
             ));
         }
 
-        ResolutionError::ImportNotFound { depth, suggestions } => {
-            let depth = *depth;
+        ResolutionError::ImportNotFound {
+            depth,
+            name,
+            suggestions,
+        } => {
             let (import_span, import_name) = segments[depth];
 
             diagnostic.labels.push(
@@ -564,9 +548,7 @@ pub(crate) fn from_resolution_error<'heap>(
                  is spelled correctly."
             );
 
-            if let Some(suggestion) =
-                format_suggestions(suggestions, |import| Cow::Borrowed(import.name.as_str()))
-            {
+            if let Some(suggestion) = format_suggestions(name, &suggestions) {
                 help.push_str(&suggestion);
             }
 
@@ -578,8 +560,11 @@ pub(crate) fn from_resolution_error<'heap>(
             ));
         }
 
-        ResolutionError::ModuleNotFound { depth, suggestions } => {
-            let depth = *depth;
+        ResolutionError::ModuleNotFound {
+            depth,
+            name,
+            suggestions,
+        } => {
             let (module_span, module_name) = segments[depth];
 
             diagnostic.labels.extend([
@@ -598,9 +583,7 @@ pub(crate) fn from_resolution_error<'heap>(
                 FormatPath(path.rooted, &segments, Some(depth))
             );
 
-            if let Some(suggestion) =
-                format_suggestions(suggestions, |item| Cow::Borrowed(item.name.as_str()))
-            {
+            if let Some(suggestion) = format_suggestions(name, &suggestions) {
                 help.push_str(&suggestion);
             }
 
@@ -612,8 +595,11 @@ pub(crate) fn from_resolution_error<'heap>(
             ));
         }
 
-        ResolutionError::ItemNotFound { depth, suggestions } => {
-            let depth = *depth;
+        ResolutionError::ItemNotFound {
+            depth,
+            name,
+            suggestions,
+        } => {
             let (item_span, item_name) = segments[depth];
 
             let label_text = if depth == 0 {
@@ -651,9 +637,7 @@ pub(crate) fn from_resolution_error<'heap>(
                             this context."
                 .to_owned();
 
-            if let Some(suggestion) =
-                format_suggestions(suggestions, |item| Cow::Borrowed(item.name.as_str()))
-            {
+            if let Some(suggestion) = format_suggestions(name, &suggestions) {
                 help.push_str(&suggestion);
             }
 
@@ -699,7 +683,7 @@ pub(crate) fn from_resolution_error<'heap>(
             ));
         }
 
-        &mut ResolutionError::ModuleEmpty { depth } => {
+        ResolutionError::ModuleEmpty { depth } => {
             let (module_span, _) = segments[depth];
 
             diagnostic.labels.extend([

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/error.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/error.rs
@@ -10,6 +10,7 @@ use hashql_core::{
         ModuleRegistry, Universe,
         error::{ResolutionError, ResolutionSuggestion},
         import::Import,
+        item::Item,
     },
     similarity::did_you_mean,
     span::SpanId,

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
@@ -188,7 +188,6 @@ impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
                     if let Err(error) = result {
                         self.diagnostics.push(from_resolution_error(
                             Some(*span),
-                            self.namespace.registry,
                             path,
                             Some((name.span, name.value)),
                             error,
@@ -212,13 +211,8 @@ impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
                 );
 
                 if let Err(error) = result {
-                    self.diagnostics.push(from_resolution_error(
-                        Some(*span),
-                        self.namespace.registry,
-                        path,
-                        None,
-                        error,
-                    ));
+                    self.diagnostics
+                        .push(from_resolution_error(Some(*span), path, None, error));
 
                     // We cannot continue here, so we replace the body with `Dummy`, this way we
                     // can still report the error and continue in the control flow
@@ -280,6 +274,7 @@ impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
             Ok(item) => item,
             Err(ResolutionError::ImportNotFound {
                 depth: _,
+                name: _,
                 suggestions,
             }) if modules.is_empty() => {
                 self.diagnostics.push(unresolved_variable(
@@ -297,13 +292,8 @@ impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
                 return;
             }
             Err(error) => {
-                self.diagnostics.push(from_resolution_error(
-                    None,
-                    self.namespace.registry,
-                    path,
-                    None,
-                    error,
-                ));
+                self.diagnostics
+                    .push(from_resolution_error(None, path, None, error));
 
                 walk_path(self, path);
                 return;

--- a/libs/@local/hashql/ast/src/lowering/type_extractor/translate.rs
+++ b/libs/@local/hashql/ast/src/lowering/type_extractor/translate.rs
@@ -201,7 +201,7 @@ pub(crate) trait LocalVariableResolver<'heap> {
     type GenericArgument: Into<GenericArgumentReference<'heap>> + Copy;
 
     fn find_by_ident(&self, ident: Ident<'heap>) -> Option<(TypeId, &[Self::GenericArgument])>;
-    fn names(&self) -> impl IntoIterator<Item = Symbol<'heap>>;
+    fn names(&self) -> impl IntoIterator<Item = Symbol<'heap>> + Clone;
 }
 
 impl<'heap> LocalVariableResolver<'heap> for FastHashMap<Symbol<'heap>, LocalVariable<'_, 'heap>> {
@@ -213,7 +213,7 @@ impl<'heap> LocalVariableResolver<'heap> for FastHashMap<Symbol<'heap>, LocalVar
         Some((variable.id.value(), &variable.arguments.value))
     }
 
-    fn names(&self) -> impl IntoIterator<Item = Symbol<'heap>> {
+    fn names(&self) -> impl IntoIterator<Item = Symbol<'heap>> + Clone {
         self.keys().copied()
     }
 }
@@ -227,7 +227,7 @@ impl<'heap> LocalVariableResolver<'heap> for TypeLocals<'heap> {
         Some((def.value.id, &def.value.arguments))
     }
 
-    fn names(&self) -> impl IntoIterator<Item = Symbol<'heap>> {
+    fn names(&self) -> impl IntoIterator<Item = Symbol<'heap>> + Clone {
         self.names()
     }
 }
@@ -456,6 +456,7 @@ where
             _ => {
                 self.diagnostics.push(unknown_intrinsic_type(
                     span,
+                    self.env.heap,
                     name,
                     &["::kernel::type::List", "::kernel::type::Dict"],
                 ));

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-nested.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-nested.stderr
@@ -7,11 +7,17 @@
    │ 
    │ Help: The name 'Bar' doesn't exist in this scope.
    │       
-   │       Perhaps you meant one of these imported items?
-   │         - `BaseUrl`
-   │         - `Err`
-   │         - `String`
-   │         - and 16 more imported items
+   │       Did you mean one of these local variables:
+   │         - Foo
+   │         - T
+   │       
+   │       Or perhaps you meant one of these imported items:
+   │         - Number
+   │         - Never
+   │         - Boolean
+   │         - Err
+   │         - BaseUrl
+   │         (14 more available)
    │ 
    │ Note: Variables must be defined before they can be used. This could be a typo, a variable used outside its scope, or a missing declaration. If it's a function or type from another module, you might need to import it first.
 ───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-nested.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-nested.stderr
@@ -6,18 +6,6 @@
    │            ╰─── Cannot find variable 'Bar'
    │ 
    │ Help: The name 'Bar' doesn't exist in this scope.
-   │       
-   │       Did you mean one of these local variables:
-   │         - Foo
-   │         - T
-   │       
-   │       Or perhaps you meant one of these imported items:
-   │         - Number
-   │         - Never
-   │         - Boolean
-   │         - Err
-   │         - BaseUrl
-   │         (14 more available)
    │ 
    │ Note: Variables must be defined before they can be used. This could be a typo, a variable used outside its scope, or a missing declaration. If it's a function or type from another module, you might need to import it first.
 ───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-type.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-type.stderr
@@ -11,11 +11,11 @@
    │         - Foo
    │       
    │       Or perhaps you meant one of these imported items:
-   │         - Err
    │         - Result
-   │         - Url
-   │         - Number
+   │         - Some
    │         - String
+   │         - Unknown
+   │         - Url
    │         (14 more available)
    │ 
    │ Note: Variables must be defined before they can be used. This could be a typo, a variable used outside its scope, or a missing declaration. If it's a function or type from another module, you might need to import it first.

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-type.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-type.stderr
@@ -7,11 +7,16 @@
    │ 
    │ Help: The name 'T' doesn't exist in this scope.
    │       
-   │       Perhaps you meant one of these imported items?
-   │         - `Boolean`
-   │         - `Number`
-   │         - `Integer`
-   │         - and 16 more imported items
+   │       Did you mean one of these local variables:
+   │         - Foo
+   │       
+   │       Or perhaps you meant one of these imported items:
+   │         - Err
+   │         - Result
+   │         - Url
+   │         - Number
+   │         - String
+   │         (14 more available)
    │ 
    │ Note: Variables must be defined before they can be used. This could be a typo, a variable used outside its scope, or a missing declaration. If it's a function or type from another module, you might need to import it first.
 ───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-value.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/unresolved-value.stderr
@@ -7,20 +7,12 @@
    │ 
    │ Help: The name 'bit_shl' doesn't exist in this scope.
    │       
-   │       Perhaps you meant one of these imported items?
-   │         - `List`
-   │         - `Dict`
-   │         - `cbrt`
-   │         - and 48 more imported items
+   │       Items with a similar name exist in other modules:
+   │         - ::math::bit_shl
    │       
-   │       Additionally, items with a similar name exist in other modules:
-   │         - `::math::bit_shl`
-   │       
-   │       To use an item like `::math::bit_shl`, you can either:
-   │       1. Add an import at the beginning of your file:
-   │            use ::math::bit_shl in
-   │       2. Use its fully qualified path directly in your code:
-   │            ::math::bit_shl
+   │       To use an item, you can either:
+   │         1. Import it: use ::math::bit_shl in
+   │         2. Use fully qualified path: ::math::bit_shl
    │ 
    │ Note: Variables must be defined before they can be used. This could be a typo, a variable used outside its scope, or a missing declaration. If it's a function or type from another module, you might need to import it first.
 ───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/use-not-found.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/use-not-found.stderr
@@ -9,7 +9,9 @@
    │ 
    │ Help: The module 'kernel::foo' doesn't exist in this scope. Check the spelling and ensure the module is available.
    │       
-   │       Possible alternatives are `special_form`, `type`.
+   │       Did you mean:
+   │         - type
+   │         - special_form
    │ 
    │ Note: Modules must be properly defined and exported from their parent module to be accessible.
 ───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/use-not-found.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/continue/use-not-found.stderr
@@ -8,10 +8,6 @@
    │         ╰─────── In this path
    │ 
    │ Help: The module 'kernel::foo' doesn't exist in this scope. Check the spelling and ensure the module is available.
-   │       
-   │       Did you mean:
-   │         - type
-   │         - special_form
    │ 
    │ Note: Modules must be properly defined and exported from their parent module to be accessible.
 ───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/glob-not-found.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/glob-not-found.stderr
@@ -8,10 +8,6 @@
    │               ╰─────── In this path
    │ 
    │ Help: The module 'kernel::foo' doesn't exist in this scope. Check the spelling and ensure the module is available.
-   │       
-   │       Did you mean:
-   │         - type
-   │         - special_form
    │ 
    │ Note: Modules must be properly defined and exported from their parent module to be accessible.
 ───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/glob-not-found.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/glob-not-found.stderr
@@ -9,7 +9,9 @@
    │ 
    │ Help: The module 'kernel::foo' doesn't exist in this scope. Check the spelling and ensure the module is available.
    │       
-   │       Possible alternatives are `special_form`, `type`.
+   │       Did you mean:
+   │         - type
+   │         - special_form
    │ 
    │ Note: Modules must be properly defined and exported from their parent module to be accessible.
 ───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/item-not-found.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/item-not-found.stderr
@@ -8,8 +8,6 @@
    │            ╰────────────────────────── This module
    │ 
    │ Help: Check the spelling and ensure the item is exported and available in this context.
-   │       
-   │       Possible alternatives are `sqrt`, `lt`, `bit_not` and 46 others.
    │ 
    │ Note: Items must be defined and accessible from the importing location. Make sure the item exists and is public.
 ───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/module-not-found.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/module-not-found.stderr
@@ -8,10 +8,6 @@
    │               ╰─────── In this path
    │ 
    │ Help: The module 'kernel::foo' doesn't exist in this scope. Check the spelling and ensure the module is available.
-   │       
-   │       Did you mean:
-   │         - type
-   │         - special_form
    │ 
    │ Note: Modules must be properly defined and exported from their parent module to be accessible.
 ───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/module-not-found.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/module-not-found.stderr
@@ -9,7 +9,9 @@
    │ 
    │ Help: The module 'kernel::foo' doesn't exist in this scope. Check the spelling and ensure the module is available.
    │       
-   │       Possible alternatives are `special_form`, `type`.
+   │       Did you mean:
+   │         - type
+   │         - special_form
    │ 
    │ Note: Modules must be properly defined and exported from their parent module to be accessible.
 ───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/rollback.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/rollback.stderr
@@ -7,20 +7,12 @@
    │ 
    │ Help: The name 'bit_shl' doesn't exist in this scope.
    │       
-   │       Perhaps you meant one of these imported items?
-   │         - `List`
-   │         - `Dict`
-   │         - `cbrt`
-   │         - and 48 more imported items
+   │       Items with a similar name exist in other modules:
+   │         - ::math::bit_shl
    │       
-   │       Additionally, items with a similar name exist in other modules:
-   │         - `::math::bit_shl`
-   │       
-   │       To use an item like `::math::bit_shl`, you can either:
-   │       1. Add an import at the beginning of your file:
-   │            use ::math::bit_shl in
-   │       2. Use its fully qualified path directly in your code:
-   │            ::math::bit_shl
+   │       To use an item, you can either:
+   │         1. Import it: use ::math::bit_shl in
+   │         2. Use fully qualified path: ::math::bit_shl
    │ 
    │ Note: Variables must be defined before they can be used. This could be a typo, a variable used outside its scope, or a missing declaration. If it's a function or type from another module, you might need to import it first.
 ───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/unresolver-variable.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/unresolver-variable.stderr
@@ -7,11 +7,13 @@
     │ 
     │ Help: The name 'föo' doesn't exist in this scope.
     │       
-    │       Did you mean one of these local variables?
-    │         - `foo`
+    │       Did you mean one of these local variables:
+    │         - foo
     │       
-    │       Or perhaps you meant one of these imported items?
-    │         - `fooo`
+    │       Or perhaps you meant one of these imported items:
+    │         - fn
+    │         - fooo
+    │         (50 more available)
     │ 
     │ Note: Variables must be defined before they can be used. This could be a typo, a variable used outside its scope, or a missing declaration. If it's a function or type from another module, you might need to import it first.
 ────╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/unresolver-variable.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/unresolver-variable.stderr
@@ -9,11 +9,6 @@
     │       
     │       Did you mean one of these local variables:
     │         - foo
-    │       
-    │       Or perhaps you meant one of these imported items:
-    │         - fn
-    │         - fooo
-    │         (50 more available)
     │ 
     │ Note: Variables must be defined before they can be used. This could be a typo, a variable used outside its scope, or a missing declaration. If it's a function or type from another module, you might need to import it first.
 ────╯

--- a/libs/@local/hashql/core/Cargo.toml
+++ b/libs/@local/hashql/core/Cargo.toml
@@ -33,7 +33,6 @@ rapidfuzz            = "0.5.0"
 roaring              = { workspace = true, features = ["std", "simd"] }
 serde                = { workspace = true, optional = true, features = ["alloc", "derive"] }
 simple-mermaid       = { workspace = true }
-strsim               = "0.11.1"
 tracing              = { workspace = true }
 unicase              = { version = "2.8.1", features = ["nightly"] }
 unicode-segmentation = "1.12.0"

--- a/libs/@local/hashql/core/Cargo.toml
+++ b/libs/@local/hashql/core/Cargo.toml
@@ -29,11 +29,13 @@ bumpalo        = { workspace = true }
 derive_more    = { workspace = true, features = ["debug"] }
 ena            = { workspace = true }
 lexical        = { workspace = true, features = ["parse-integers", "parse-floats", "format"] }
+rapidfuzz      = "0.5.0"
 roaring        = { workspace = true, features = ["std", "simd"] }
 serde          = { workspace = true, optional = true, features = ["alloc", "derive"] }
 simple-mermaid = { workspace = true }
 strsim         = "0.11.1"
 tracing        = { workspace = true }
+unicase        = { version = "2.8.1", features = ["nightly"] }
 
 
 [features]

--- a/libs/@local/hashql/core/Cargo.toml
+++ b/libs/@local/hashql/core/Cargo.toml
@@ -24,19 +24,19 @@ text-size          = { workspace = true, public = true }
 # Private workspace dependencies
 
 # Private third-party dependencies
-bitvec         = { workspace = true, features = ["alloc"] }
-bumpalo        = { workspace = true }
-derive_more    = { workspace = true, features = ["debug"] }
-ena            = { workspace = true }
-lexical        = { workspace = true, features = ["parse-integers", "parse-floats", "format"] }
-rapidfuzz      = "0.5.0"
-roaring        = { workspace = true, features = ["std", "simd"] }
-serde          = { workspace = true, optional = true, features = ["alloc", "derive"] }
-simple-mermaid = { workspace = true }
-strsim         = "0.11.1"
-tracing        = { workspace = true }
-unicase        = { version = "2.8.1", features = ["nightly"] }
-
+bitvec               = { workspace = true, features = ["alloc"] }
+bumpalo              = { workspace = true }
+derive_more          = { workspace = true, features = ["debug"] }
+ena                  = { workspace = true }
+lexical              = { workspace = true, features = ["parse-integers", "parse-floats", "format"] }
+rapidfuzz            = "0.5.0"
+roaring              = { workspace = true, features = ["std", "simd"] }
+serde                = { workspace = true, optional = true, features = ["alloc", "derive"] }
+simple-mermaid       = { workspace = true }
+strsim               = "0.11.1"
+tracing              = { workspace = true }
+unicase              = { version = "2.8.1", features = ["nightly"] }
+unicode-segmentation = "1.12.0"
 
 [features]
 serde = ["dep:serde", "text-size/serde"]

--- a/libs/@local/hashql/core/src/lib.rs
+++ b/libs/@local/hashql/core/src/lib.rs
@@ -6,6 +6,7 @@
     // Library Features
     allocator_api,
     assert_matches,
+    binary_heap_into_iter_sorted,
     cold_path,
     default_field_values,
     iter_map_windows,
@@ -28,6 +29,7 @@ pub mod literal;
 pub mod math;
 pub mod module;
 pub mod pretty;
+pub mod similarity;
 pub mod span;
 pub mod symbol;
 pub mod r#type;

--- a/libs/@local/hashql/core/src/module/error.rs
+++ b/libs/@local/hashql/core/src/module/error.rs
@@ -1,12 +1,13 @@
 use super::{ModuleId, Universe, import::Import, item::Item};
+use crate::symbol::Symbol;
 
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub struct ResolutionSuggestion<T> {
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct ResolutionSuggestion<'heap, T> {
     pub item: T,
-    pub score: f64,
+    pub name: Symbol<'heap>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ResolutionError<'heap> {
     InvalidQueryLength {
         expected: usize,
@@ -18,21 +19,25 @@ pub enum ResolutionError<'heap> {
 
     PackageNotFound {
         depth: usize,
-        suggestions: Vec<ResolutionSuggestion<ModuleId>>,
+        name: Symbol<'heap>,
+        suggestions: Vec<ResolutionSuggestion<'heap, ModuleId>>,
     },
     ImportNotFound {
         depth: usize,
-        suggestions: Vec<ResolutionSuggestion<Import<'heap>>>,
+        name: Symbol<'heap>,
+        suggestions: Vec<ResolutionSuggestion<'heap, Import<'heap>>>,
     },
 
     ModuleNotFound {
         depth: usize,
-        suggestions: Vec<ResolutionSuggestion<Item<'heap>>>,
+        name: Symbol<'heap>,
+        suggestions: Vec<ResolutionSuggestion<'heap, Item<'heap>>>,
     },
 
     ItemNotFound {
         depth: usize,
-        suggestions: Vec<ResolutionSuggestion<Item<'heap>>>,
+        name: Symbol<'heap>,
+        suggestions: Vec<ResolutionSuggestion<'heap, Item<'heap>>>,
     },
 
     Ambiguous(Item<'heap>),

--- a/libs/@local/hashql/core/src/module/locals.rs
+++ b/libs/@local/hashql/core/src/module/locals.rs
@@ -129,7 +129,7 @@ impl<'heap, T> Locals<'heap, T> {
     }
 
     #[must_use]
-    pub fn names(&self) -> impl IntoIterator<Item = Symbol<'heap>> + use<'_, 'heap, T> {
+    pub fn names(&self) -> impl IntoIterator<Item = Symbol<'heap>> + Clone + use<'_, 'heap, T> {
         self.lookup.keys().copied()
     }
 

--- a/libs/@local/hashql/core/src/module/mod.rs
+++ b/libs/@local/hashql/core/src/module/mod.rs
@@ -15,8 +15,6 @@ pub mod universe;
 use core::slice;
 use std::sync::RwLock;
 
-
-
 pub use self::universe::Universe;
 use self::{
     error::{ResolutionError, ResolutionSuggestion},

--- a/libs/@local/hashql/core/src/module/mod.rs
+++ b/libs/@local/hashql/core/src/module/mod.rs
@@ -15,7 +15,7 @@ pub mod universe;
 use core::slice;
 use std::sync::RwLock;
 
-use strsim::jaro_winkler;
+
 
 pub use self::universe::Universe;
 use self::{
@@ -151,15 +151,14 @@ impl<'heap> ModuleRegistry<'heap> {
     }
 
     /// Finds suggestions for the given name in the root namespace.
-    fn suggestions(&self, name: Symbol<'heap>) -> Vec<ResolutionSuggestion<ModuleId>> {
+    fn suggestions(&self) -> Vec<ResolutionSuggestion<'heap, ModuleId>> {
         let root = self.root.read().expect("lock should not be poisoned");
 
         let mut results = Vec::with_capacity(root.len());
         for (&key, &module) in &*root {
-            let score = jaro_winkler(key.as_str(), name.as_str());
             results.push(ResolutionSuggestion {
                 item: module,
-                score,
+                name: key,
             });
         }
         drop(root);
@@ -306,9 +305,8 @@ pub struct Module<'heap> {
 impl<'heap> Module<'heap> {
     fn suggestions(
         &self,
-        name: Symbol<'heap>,
         mut select: impl FnMut(&Item<'heap>) -> bool,
-    ) -> Vec<ResolutionSuggestion<Item<'heap>>> {
+    ) -> Vec<ResolutionSuggestion<'heap, Item<'heap>>> {
         let mut similarities = Vec::with_capacity(self.items.len());
 
         for &item in self.items {
@@ -316,8 +314,10 @@ impl<'heap> Module<'heap> {
                 continue;
             }
 
-            let score = jaro_winkler(item.name.as_str(), name.as_str());
-            similarities.push(ResolutionSuggestion { item, score });
+            similarities.push(ResolutionSuggestion {
+                item,
+                name: item.name,
+            });
         }
 
         similarities

--- a/libs/@local/hashql/core/src/module/namespace.rs
+++ b/libs/@local/hashql/core/src/module/namespace.rs
@@ -842,6 +842,7 @@ mod tests {
             error,
             ResolutionError::ModuleNotFound {
                 depth: 1,
+                name: _,
                 suggestions
             } if suggestions.is_empty()
         );

--- a/libs/@local/hashql/core/src/similarity.rs
+++ b/libs/@local/hashql/core/src/similarity.rs
@@ -7,10 +7,6 @@ use unicode_segmentation::UnicodeSegmentation as _;
 
 use crate::{collection::FastHashSet, symbol::Symbol};
 
-const EDIT_WEIGHT: f64 = 0.45;
-const PREFIX_WEIGHT: f64 = 0.30;
-const POSTFIX_WEIGHT: f64 = 0.25;
-
 struct Similarity<'heap> {
     score: f64,
     symbol: Symbol<'heap>,
@@ -32,21 +28,47 @@ impl PartialOrd for Similarity<'_> {
 
 impl Ord for Similarity<'_> {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        self.score.total_cmp(&other.score)
+        // Taking the symbol into account here means that the order is deterministic irrespective of
+        // insertion order.
+        self.score
+            .total_cmp(&other.score)
+            .then_with(|| self.symbol.cmp(&other.symbol))
     }
 }
 
-#[expect(clippy::float_arithmetic, clippy::cast_precision_loss)]
+const EDIT_WEIGHT: f64 = 0.45;
+const PREFIX_WEIGHT: f64 = 0.30;
+const POSTFIX_WEIGHT: f64 = 0.25;
+
+const CUTOFF_THRESHOLD: f64 = 3_f64;
+const TRANSITION_POINT: f64 = 3_f64;
+
+/// Calculate the cutoff score for a given string length.
+///
+/// See <https://www.desmos.com/calculator/gogpbccxdw> for the formula used to calculate the cutoff score.
+#[expect(
+    clippy::float_arithmetic,
+    clippy::cast_precision_loss,
+    clippy::min_ident_chars,
+    reason = "mathematical formula"
+)]
+const fn calculate_cutoff(length: usize) -> f64 {
+    let x = f64::max(length as f64, 1_f64);
+    let p = 1_f64 - 1_f64 / CUTOFF_THRESHOLD;
+    let t = TRANSITION_POINT;
+
+    (p / (1_f64 - 1_f64 / t)) * (1_f64 - (f64::max(x, t) / (t * x)))
+}
+
+#[expect(clippy::float_arithmetic)]
 fn edit_distance<'heap>(
     lookup: Symbol<'heap>,
     candidates: impl IntoIterator<Item: AsRef<Symbol<'heap>>>,
     top_n: Option<usize>,
     cutoff: Option<f64>,
 ) -> impl IntoIterator<Item = Symbol<'heap>> {
-    // Having the cutoff be at least 3 makes typos more forgiving for smaller strings
-    let len = lookup.as_str().len().max(1) as f64;
     let cutoff = cutoff
-        .unwrap_or_else(|| 1.0 - (f64::max(3_f64, len / 3_f64) / len))
+        .unwrap_or_else(|| calculate_cutoff(lookup.as_str().len()))
         .clamp(0_f64, 1_f64);
 
     let candidates = candidates.into_iter();
@@ -94,34 +116,43 @@ fn edit_distance<'heap>(
         .map(|Reverse(Similarity { score: _, symbol })| symbol)
 }
 
+// The more correct way would be to implement UTS#55 instead (https://www.unicode.org/reports/tr55/#Identifier-Chunks)
+// but there is no crate that does this and this gets us there pretty close (although
+// `CamelBoundary` and `HATBoundary`) are not respected.
+// There's also no implementation that actually supports this properly. Either the implementation
+// has it's implementation private (heck) or has poor execution (case-convert).
+fn split_words(input: &str) -> impl Iterator<Item = UniCase<&str>> {
+    input
+        .unicode_words()
+        .flat_map(|value| value.split('_'))
+        .filter(|word| !word.is_empty())
+        .map(UniCase::new)
+}
+
 #[expect(clippy::float_arithmetic, clippy::cast_precision_loss)]
 fn sorted_word_match<'heap>(
     lookup: Symbol<'heap>,
     candidates: impl IntoIterator<Item: AsRef<Symbol<'heap>>> + Clone,
     top_n: Option<usize>,
 ) -> impl IntoIterator<Item = Symbol<'heap>> {
-    // unlike other similarity functions, we need to collect the candidates first and sort them, so
-    // that the order stays deterministic across runs.
-    let mut candidates: Vec<_> = candidates
-        .into_iter()
-        .map(|value| *value.as_ref())
-        .collect();
-    candidates.sort_unstable();
+    let candidates = candidates.into_iter();
 
-    let words: FastHashSet<_> = lookup.as_str().unicode_words().collect();
+    let words: FastHashSet<_> = split_words(lookup.unwrap()).collect();
     let words_len = words.len() as f64;
 
-    let mut heap =
-        BinaryHeap::with_capacity(top_n.map_or_else(|| candidates.len(), |top_n| top_n + 1));
+    let mut heap = BinaryHeap::with_capacity(
+        top_n.map_or_else(|| candidates.size_hint().0, |top_n| top_n + 1),
+    );
 
     let mut candidate = FastHashSet::<_, Global>::default();
     for symbol in candidates {
-        candidate.extend(symbol.unwrap().unicode_words());
-        let mut candidate: FastHashSet<_> = symbol.as_str().unicode_words().collect();
+        let &symbol = symbol.as_ref();
+        candidate.extend(split_words(symbol.unwrap()));
 
         let common = words.intersection(&candidate).count();
 
         if common == 0 {
+            candidate.clear();
             continue;
         }
 
@@ -143,6 +174,67 @@ fn sorted_word_match<'heap>(
         .map(|Reverse(Similarity { score: _, symbol })| symbol)
 }
 
+/// Finds the most similar symbols to a lookup string from a set of candidates.
+///
+/// This function implements a three-tier matching strategy with fallback priority:
+/// 1. **Case-insensitive exact matches** - Returns all exact matches ignoring case
+/// 2. **Edit distance matching** - Uses weighted combination of Damerau-Levenshtein distance,
+///    prefix similarity, and postfix similarity with configurable cutoff thresholds
+/// 3. **Word-based matching** - Falls back to Unicode word intersection scoring
+///
+/// The edit distance matching uses an adaptive cutoff based on string length that becomes
+/// more permissive for shorter strings (where typos are more impactful) and more restrictive
+/// for longer identifiers. See [`calculate_cutoff`] for the mathematical formula.
+///
+/// # Arguments
+///
+/// * `lookup` - The symbol to find suggestions for
+/// * `candidates` - An iterable collection of potential matches. Must be cloneable as it may be
+///   iterated multiple times for different matching strategies
+/// * `top_n` - Optional limit on the number of results returned. If `None`, returns all matches
+///   above the similarity threshold
+/// * `cutoff` - Optional custom similarity threshold (0.0 to 1.0). If `None`, uses an adaptive
+///   cutoff calculated based on the lookup string length
+///
+/// Returns a vector of the most similar symbols, sorted by similarity score (best matches first).
+/// The vector will be empty if no sufficiently similar candidates are found.
+///
+/// # Examples
+///
+/// ```
+/// use hashql_core::{heap::Heap, similarity::did_you_mean, symbol::Symbol};
+///
+/// let heap = Heap::new();
+///
+/// // Case-insensitive exact match (highest priority)
+/// let lookup = heap.intern_symbol("Hello");
+/// let candidates = [heap.intern_symbol("hello"), heap.intern_symbol("world")];
+/// let matches = did_you_mean(lookup, &candidates, None, None);
+/// assert_eq!(matches[0].as_str(), "hello");
+///
+/// // Edit distance matching for typos
+/// let lookup = heap.intern_symbol("tset");
+/// let candidates = [
+///     heap.intern_symbol("test"),
+///     heap.intern_symbol("rest"),
+///     heap.intern_symbol("best"),
+/// ];
+/// let matches = did_you_mean(lookup, &candidates, Some(2), None);
+/// assert_eq!(matches.len(), 1);
+/// assert_eq!(matches[0].as_str(), "test"); // Best match for "tset"
+///
+/// // Word-based matching for compound identifiers
+/// let lookup = heap.intern_symbol("user name");
+/// let candidates = [
+///     heap.intern_symbol("username_field"),
+///     heap.intern_symbol("user_data"),
+///     heap.intern_symbol("profile_info"),
+/// ];
+/// let matches = did_you_mean(lookup, &candidates, None, None);
+/// // Will match "user_data" due to word overlap
+/// assert_eq!(matches.len(), 1);
+/// assert_eq!(matches[0].as_str(), "user_data");
+/// ```
 pub fn did_you_mean<'heap>(
     lookup: Symbol<'heap>,
     candidates: impl IntoIterator<Item: AsRef<Symbol<'heap>>> + Clone,
@@ -179,4 +271,208 @@ pub fn did_you_mean<'heap>(
     sorted_word_match(lookup, candidates, top_n)
         .into_iter()
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{heap::Heap, symbol::Symbol};
+
+    /// Helper function to create symbols from string literals for testing
+    fn collect_symbols(
+        heap: &Heap,
+        strings: impl IntoIterator<Item: AsRef<str>>,
+    ) -> Vec<Symbol<'_>> {
+        strings
+            .into_iter()
+            .map(|value| heap.intern_symbol(value.as_ref()))
+            .collect()
+    }
+
+    /// Helper function to extract string representations from symbol results
+    fn collect_strings<'heap>(
+        symbols: impl IntoIterator<Item: AsRef<Symbol<'heap>>>,
+    ) -> Vec<&'heap str> {
+        symbols
+            .into_iter()
+            .map(|symbol| symbol.as_ref().unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn case_insensitive_exact_match_priority() {
+        let heap = Heap::new();
+
+        let lookup = heap.intern_symbol("Hello");
+        let candidates = collect_symbols(&heap, &["hello", "HELLO", "helo", "world"]);
+
+        let matches = did_you_mean(lookup, &candidates, None, None);
+
+        assert_eq!(collect_strings(&matches), ["HELLO", "hello"]);
+    }
+
+    #[test]
+    fn edit_distance_matching() {
+        let heap = Heap::new();
+
+        let lookup = heap.intern_symbol("test");
+        let candidates = collect_symbols(
+            &heap,
+            &[
+                "tset",  // 2 swaps
+                "rest",  // 1 substitution
+                "tests", // 1 insertion
+                "est",   // 1 deletion
+                "best",  // 1 substitution
+                "xyz",   // No similarity
+            ],
+        );
+
+        let matches = did_you_mean(lookup, &candidates, None, None);
+        let matches = collect_strings(&matches);
+
+        assert!(!matches.is_empty(), "should find similar words");
+        assert!(
+            !matches.contains(&"xyz"),
+            "should reject dissimilar words like 'xyz'"
+        );
+        assert!(
+            matches.contains(&"tset"),
+            "should find transposed characters"
+        );
+    }
+
+    #[test]
+    fn top_n_limiting() {
+        let heap = Heap::new();
+
+        let lookup = heap.intern_symbol("test");
+        let candidates = collect_symbols(&heap, &["tset", "rest", "tests", "est", "best"]);
+
+        let matches = did_you_mean(lookup, &candidates, Some(2), None);
+
+        assert!(matches.len() <= 2, "should return at most 2 results");
+        assert!(!matches.is_empty(), "should find at least some matches");
+    }
+
+    #[test]
+    fn custom_cutoff() {
+        let heap = Heap::new();
+        let lookup = heap.intern_symbol("test");
+        let candidates = collect_symbols(&heap, &["tset", "xyz"]);
+
+        let strict_matches = did_you_mean(lookup, &candidates, None, Some(0.9));
+        assert!(
+            strict_matches.is_empty() || strict_matches.len() <= 1,
+            "should reject weak matches with strict cutoff"
+        );
+
+        let permissive_matches = did_you_mean(lookup, &candidates, None, Some(0.1));
+        assert!(
+            !permissive_matches.is_empty(),
+            "should accept more matches with permissive cutoff"
+        );
+    }
+
+    #[test]
+    fn word_based_matching_fallback() {
+        let heap = Heap::new();
+        let lookup = heap.intern_symbol("user name");
+        let candidates = collect_symbols(
+            &heap,
+            &[
+                "username_field", /* Contains both "user" and "name" concepts, but not
+                                   * separately, therefore discarded */
+                "user_data",      // Contains "user"
+                "profile_info",   // No word overlap
+                "name_validator", // Contains "name"
+            ],
+        );
+
+        let matches = did_you_mean(lookup, &candidates, None, Some(1.0));
+        let matches = collect_strings(&matches);
+
+        assert!(!matches.is_empty());
+
+        assert!(matches.contains(&"user_data"));
+        assert!(matches.contains(&"name_validator"));
+    }
+
+    #[test]
+    fn empty_candidates() {
+        let heap = Heap::new();
+        let lookup = heap.intern_symbol("test");
+
+        let matches = did_you_mean(lookup, core::iter::empty::<Symbol<'_>>(), None, None);
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn no_matches_found() {
+        let heap = Heap::new();
+        let lookup = heap.intern_symbol("test");
+        let candidates = collect_symbols(&heap, &["xyz", "abc", "123"]);
+
+        let matches = did_you_mean(lookup, &candidates, None, None);
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn single_character_strings() {
+        let heap = Heap::new();
+        let lookup = heap.intern_symbol("i");
+        let candidates = collect_symbols(&heap, &["I", "a", "o", "if", "in"]);
+
+        let matches = did_you_mean(lookup, &candidates, None, None);
+        let matches = collect_strings(&matches);
+
+        assert_eq!(matches, ["I"]);
+    }
+
+    #[test]
+    fn mixed_length_candidates() {
+        let heap = Heap::new();
+
+        let lookup = heap.intern_symbol("fn");
+        let candidates = collect_symbols(
+            &heap,
+            &["function", "func", "f", "fn_call", "main_fn", "FN"],
+        );
+
+        let matches = did_you_mean(lookup, &candidates, None, None);
+        let matches = collect_strings(&matches);
+
+        assert_eq!(
+            matches,
+            ["FN"],
+            "should prioritize case-insensitive exact match first"
+        );
+    }
+
+    #[test]
+    fn deterministic_results() {
+        let heap = Heap::new();
+        let lookup = heap.intern_symbol("test");
+        let mut candidates = collect_symbols(&heap, &["tset", "rest", "best", "west"]);
+
+        let first_run_matches = did_you_mean(lookup, &candidates, None, None);
+
+        // shuffle the candidates around (just rotate a bit)
+        candidates.rotate_left(3);
+
+        let second_run_matches = did_you_mean(lookup, &candidates, None, None);
+
+        assert_eq!(
+            first_run_matches.len(),
+            second_run_matches.len(),
+            "should produce consistent result count"
+        );
+        for (first_match, second_match) in first_run_matches.iter().zip(second_run_matches.iter()) {
+            assert_eq!(
+                first_match.as_str(),
+                second_match.as_str(),
+                "should produce identical results across multiple runs"
+            );
+        }
+    }
 }

--- a/libs/@local/hashql/core/src/similarity.rs
+++ b/libs/@local/hashql/core/src/similarity.rs
@@ -1,0 +1,140 @@
+use alloc::collections::BinaryHeap;
+use core::{cmp, cmp::Reverse};
+
+use rapidfuzz::distance::{damerau_levenshtein, postfix, prefix};
+use unicase::UniCase;
+
+use crate::symbol::Symbol;
+
+const EDIT_WEIGHT: f64 = 0.45;
+const PREFIX_WEIGHT: f64 = 0.30;
+const POSTFIX_WEIGHT: f64 = 0.25;
+
+struct Similarity<'heap> {
+    score: f64,
+    symbol: Symbol<'heap>,
+}
+
+impl PartialEq for Similarity<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.score == other.score
+    }
+}
+
+impl Eq for Similarity<'_> {}
+
+impl PartialOrd for Similarity<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Similarity<'_> {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.score.total_cmp(&other.score)
+    }
+}
+
+#[expect(clippy::float_arithmetic, clippy::cast_precision_loss)]
+fn edit_distance<'heap>(
+    lookup: Symbol<'heap>,
+    candidates: impl IntoIterator<Item: AsRef<Symbol<'heap>>>,
+    top_n: Option<usize>,
+    cutoff: Option<f64>,
+) -> impl IntoIterator<Item = Symbol<'heap>> {
+    // Having the cutoff be at least 3 makes typos more forgiving for smaller strings
+    let len = lookup.as_str().len().max(1) as f64;
+    let cutoff = cutoff
+        .unwrap_or_else(|| 1.0 - (f64::max(3_f64, len / 3_f64) / len))
+        .clamp(0_f64, 1_f64);
+
+    let candidates = candidates.into_iter();
+
+    // This is a min-heap
+    let mut heap = BinaryHeap::with_capacity(
+        // We add `+ 1` because we always have one extra element in the heap when we push but there
+        // isn't enough space
+        top_n.map_or_else(|| candidates.size_hint().0, |top_n| top_n + 1),
+    );
+
+    let prefix = prefix::BatchComparator::new(lookup.as_str().chars());
+    let postfix = postfix::BatchComparator::new(lookup.as_str().chars());
+
+    let edit = damerau_levenshtein::BatchComparator::new(lookup.as_str().chars());
+    let edit_args = damerau_levenshtein::Args::default().score_cutoff(cutoff);
+
+    for symbol in candidates {
+        let symbol = *symbol.as_ref();
+        let candidate = symbol.as_str();
+
+        let Some(edit_weight) = edit.normalized_similarity_with_args(candidate.chars(), &edit_args)
+        else {
+            continue;
+        };
+
+        let prefix_weight = prefix.normalized_similarity(candidate.chars());
+        let postfix_weight = postfix.normalized_similarity(candidate.chars());
+
+        let score = edit_weight.mul_add(
+            EDIT_WEIGHT,
+            prefix_weight.mul_add(PREFIX_WEIGHT, postfix_weight * POSTFIX_WEIGHT),
+        );
+
+        heap.push(Reverse(Similarity { score, symbol }));
+
+        if let Some(top_n) = top_n
+            && heap.len() > top_n
+        {
+            heap.pop();
+        }
+    }
+
+    heap.into_iter_sorted()
+        .map(|Reverse(Similarity { score: _, symbol })| symbol)
+}
+
+pub fn did_you_mean<'heap>(
+    lookup: Symbol<'heap>,
+    candidates: impl IntoIterator<Item: AsRef<Symbol<'heap>>> + Clone,
+    top_n: Option<usize>,
+    cutoff: Option<f64>,
+) -> Vec<Symbol<'heap>> {
+    let lookup_unicase = UniCase::new(lookup.as_str());
+
+    // Priority of matches:
+    // 1. Exact case-insensitive match
+    // 2. Edit Distance Match
+    // 3. Sorted Word Match
+    let mut case_insensitive: Vec<_> = candidates
+        .clone()
+        .into_iter()
+        .filter(|candidate| UniCase::new(candidate.as_ref().as_str()) == lookup_unicase)
+        .map(|candidate| *candidate.as_ref())
+        .collect();
+
+    if !case_insensitive.is_empty() {
+        // first sort the results
+        case_insensitive.sort_unstable();
+        return case_insensitive;
+    }
+
+    let edit_distance: Vec<_> = edit_distance(lookup, candidates.clone(), top_n, cutoff)
+        .into_iter()
+        .collect();
+
+    if !edit_distance.is_empty() {
+        return edit_distance;
+    }
+
+    let mut symbols: Vec<_> = candidates
+        .into_iter()
+        .map(|symbol| *symbol.as_ref())
+        .collect();
+    symbols.sort_unstable();
+
+    if let Some(top_n) = top_n {
+        symbols.truncate(top_n);
+    }
+
+    symbols
+}

--- a/libs/@local/hashql/core/src/similarity.rs
+++ b/libs/@local/hashql/core/src/similarity.rs
@@ -184,7 +184,7 @@ fn sorted_word_match<'heap>(
 ///
 /// The edit distance matching uses an adaptive cutoff based on string length that becomes
 /// more permissive for shorter strings (where typos are more impactful) and more restrictive
-/// for longer identifiers. See [`calculate_cutoff`] for the mathematical formula.
+/// for longer identifiers. See `calculate_cutoff` for the mathematical formula.
 ///
 /// # Arguments
 ///

--- a/libs/@local/hashql/core/src/symbol/mod.rs
+++ b/libs/@local/hashql/core/src/symbol/mod.rs
@@ -73,6 +73,13 @@ impl<'heap> Symbol<'heap> {
     }
 }
 
+impl AsRef<Self> for Symbol<'_> {
+    #[inline]
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 impl PartialEq for Symbol<'_> {
     fn eq(&self, other: &Self) -> bool {
         // Pointer equality implies string equality (due to the unique contents assumption)


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently we're using `jaro_winkler` in conjunction with a threshold directly, instead `hashql_core` should have a function dedicated to this, so that we don't have `> 0.7` floating around everywhere and we're free to change the internal implementation.

This adds a new function modeled similar to [what rustc does](https://github.com/rust-lang/rust/blob/master/compiler/rustc_span/src/edit_distance.rs). We basically have a 3 step process, rewarding prefix and postfix similarities.

Overall this results in fewer but _more meaningful_ suggestions.


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
