### PR TITLE
`error-stack`: AnyReport: easier error propagation for arbitrary errors when no specialised user error needed, bridging the gap with anyhow/eyre error handling patterns

### DIFF
--- a/libs/error-stack/src/lib.rs
+++ b/libs/error-stack/src/lib.rs
@@ -525,7 +525,7 @@ pub use self::result::Result;
 #[cfg(feature = "unstable")]
 pub use self::sink::ReportSink;
 pub use self::{
-    any::{AnyError, AnyReport},
+    any::AnyReport,
     compat::IntoReportCompat,
     frame::{AttachmentKind, Frame, FrameKind},
     report::{IntoReport, Report},

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -469,6 +469,13 @@ impl<C> Report<C> {
     {
         crate::error::ReportError::from_ref(self)
     }
+
+    pub(crate) fn into_dyn(self) -> Report<dyn Context + Send + Sync + 'static> {
+        Report {
+            frames: self.frames,
+            _context: PhantomData,
+        }
+    }
 }
 
 impl<C: ?Sized> Report<C> {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

`error-stack` is a great library, but is somewhat painful to use in comparison to something like `anyhow`, when no specific error is needed in a given context, one has to add `.change_context(AnyErr)?` everywhere from both other `Report<E>` types, and base errors implementing `core::error::Error`.

This PR adds a `struct AnyReport(Report<AnyErr>);` type, which: 
- `impl<E: Into<Report<E>>> From<E> for AnyReport`
- `impl<C: ?Sized> From<Report<C>> for AnyReport`
- `impl IntoReport for AnyReport`
- implements `Deref` and `DerefMut` to `Report<AnyErr>`, allowing access to underlying methods
- reimplements remaining `fn (self, ..)` `Report` methods to provide parity with any other `Report<E>` type
- Exposes the `AnyErr` type and the `AnyReport` from the root of the `error-stack` library.

Imagine this type exactly like a `Report<AnyErr>`, except it can be `?` propagated from `E: Error` / `Report`, without needing `.change_context(AnyErr)`, making the base case of not needing targeted error handling much more ergonomic with `error-stack`.

This `AnyReport` type cannot be implemented in user-land, due to `upstream crates may add a new impl of trait` limitations, nor can these `From<>` impls be added directly to `Report<AnyErr>` due to trait conflicts.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] require changes to docs which are **not** made in this PR
  - Happy to add docs once the overall PR's intention is confirmed as wanted 

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] I am unsure / need advice

## 🛡 What tests cover this?

Added some new basic tests confirming `?` propagation.
