### PR TITLE
H-4635: Remove `Unification` from `InferenceEnvironment`

### DIFF
--- a/libs/@local/hashql/core/src/type/inference/mod.rs
+++ b/libs/@local/hashql/core/src/type/inference/mod.rs
@@ -152,6 +152,9 @@ impl<'heap> SelectionConstraint<'heap> {
 /// meaning the left type can be used wherever the right type is expected.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Constraint<'heap> {
+    /// Unifies two variables (`lhs ≡ rhs`)
+    Unify { lhs: Variable, rhs: Variable },
+
     /// Constraints a variable with an upper bound (`variable <: bound`)
     UpperBound { variable: Variable, bound: TypeId },
 
@@ -181,6 +184,7 @@ pub enum Constraint<'heap> {
 impl Constraint<'_> {
     pub(crate) fn variables(self) -> impl IntoIterator<Item = Variable> {
         let array = match self {
+            Self::Unify { lhs, rhs } => [Some(lhs), Some(rhs), None],
             Self::LowerBound { variable, bound: _ }
             | Self::UpperBound { variable, bound: _ }
             | Self::Equals {

--- a/libs/@local/hashql/core/src/type/kind/opaque.rs
+++ b/libs/@local/hashql/core/src/type/kind/opaque.rs
@@ -834,8 +834,20 @@ mod test {
 
         // Due to invariance, we should get an equality constraint between the generic parameters
         let constraints = inference_env.take_constraints();
-        assert!(constraints.is_empty());
-        assert!(inference_env.is_unioned(VariableKind::Generic(arg1), VariableKind::Generic(arg2)));
+        assert_eq!(constraints.len(), 1);
+        assert_eq!(
+            constraints[0],
+            Constraint::Unify {
+                lhs: Variable {
+                    span: SpanId::SYNTHETIC,
+                    kind: VariableKind::Generic(arg1)
+                },
+                rhs: Variable {
+                    span: SpanId::SYNTHETIC,
+                    kind: VariableKind::Generic(arg2)
+                }
+            }
+        );
     }
 
     #[test]
@@ -861,9 +873,19 @@ mod test {
 
         // Due to invariance, we should get an equality constraint between the inference variables
         let constraints = inference_env.take_constraints();
-        assert!(constraints.is_empty());
-        assert!(
-            inference_env.is_unioned(VariableKind::Hole(hole_var1), VariableKind::Hole(hole_var2))
+        assert_eq!(constraints.len(), 1);
+        assert_eq!(
+            constraints[0],
+            Constraint::Unify {
+                lhs: Variable {
+                    span: SpanId::SYNTHETIC,
+                    kind: VariableKind::Hole(hole_var1)
+                },
+                rhs: Variable {
+                    span: SpanId::SYNTHETIC,
+                    kind: VariableKind::Hole(hole_var2)
+                }
+            }
         );
     }
 
@@ -890,9 +912,19 @@ mod test {
         // Due to invariance, we should get an equality constraint between the inference variable
         // and the generic variable
         let constraints = inference_env.take_constraints();
-        assert!(constraints.is_empty());
-        assert!(
-            inference_env.is_unioned(VariableKind::Hole(hole_var1), VariableKind::Generic(arg))
+        assert_eq!(constraints.len(), 1);
+        assert_eq!(
+            constraints[0],
+            Constraint::Unify {
+                lhs: Variable {
+                    span: SpanId::SYNTHETIC,
+                    kind: VariableKind::Hole(hole_var1)
+                },
+                rhs: Variable {
+                    span: SpanId::SYNTHETIC,
+                    kind: VariableKind::Generic(arg)
+                }
+            }
         );
     }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Replace this in favour with a new constraint (`Constraint::Unify`) this is required, as [H-4545](https://linear.app/hash/issue/H-4545/hashql-implement-subscript-type-inferencechecking) may discharge additional constraints.


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph