### PR TITLE
H-4642: Don't deploy node images before Rust image has been finished

### DIFF
--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -363,46 +363,6 @@ jobs:
           BUILD_ARGS: |
             TEMPORAL_VERSION=${{ env.HASH_TEMPORAL_VERSION }}
 
-  deploy-app:
-    name: Deploy HASH app images
-    runs-on: ubuntu-latest
-    needs:
-      - build-ts-worker
-      - build-api
-      - build-kratos
-      - build-hydra
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@7709c609789c5e27b757a85817483caadbb5939a # v3.3.0
-        with:
-          exportToken: true
-          url: ${{ env.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
-
-      - uses: ./.github/actions/docker-ecr-login
-        with:
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
-
-      - name: Redeploy HASH backend service
-        run: |
-          aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_APP_SERVICE_NAME }} --force-new-deployment 1> /dev/null
-
   deploy-graph:
     name: Deploy HASH graph images
     runs-on: ubuntu-latest
@@ -440,11 +400,55 @@ jobs:
         run: |
           aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_GRAPH_SERVICE_NAME }} --force-new-deployment 1> /dev/null
 
+  deploy-app:
+    name: Deploy HASH app images
+    runs-on: ubuntu-latest
+    needs:
+      - build-api
+      - build-kratos
+      - build-hydra
+      # Technically not needed but it's good if the graph has been finished already
+      - deploy-graph
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Authenticate Vault
+        id: secrets
+        uses: hashicorp/vault-action@7709c609789c5e27b757a85817483caadbb5939a # v3.3.0
+        with:
+          exportToken: true
+          url: ${{ env.VAULT_ADDR }}
+          method: jwt
+          role: prod
+          # Even though it could look like separate calls to fetch the secrets
+          # the responses here are cached, so we're only issuing a single set of credentials
+          secrets: |
+            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+
+      - uses: ./.github/actions/docker-ecr-login
+        with:
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+
+      - name: Redeploy HASH backend service
+        run: |
+          aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_APP_SERVICE_NAME }} --force-new-deployment 1> /dev/null
+
   deploy-workers:
     name: Deploy HASH worker images
     runs-on: ubuntu-latest
     needs:
+      - build-ts-worker
       - build-integration-worker
+      # Technically not needed but it's good if the graph has been finished already
+      - deploy-graph
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We have a few images (node API, workers) which will immediatly deploy as soon as they are all finished. We can block this at least on the graph image, so they will at least not deploy before the graph. There is no guarantee, that it will start deploying before the graph has finished, but it’s better than almost always start deploying before the graph starts.

<img width="975" alt="image" src="https://github.com/user-attachments/assets/4cfcad03-838b-405c-bf6c-d8acde30647e" />
