### PR TITLE
H-4644: HashQL: Implement `Subscript` for Unions

### DIFF
--- a/libs/@local/hashql/core/src/type/kind/union.rs
+++ b/libs/@local/hashql/core/src/type/kind/union.rs
@@ -2708,6 +2708,16 @@ mod test {
         );
         assert_eq!(lattice.diagnostics.len(), 2);
         assert_eq!(subscript, Subscript::Error);
+
+        let diagnostics = lattice.take_diagnostics().into_vec();
+        assert_eq!(
+            diagnostics[0].category,
+            TypeCheckDiagnosticCategory::UnsupportedSubscript
+        );
+        assert_eq!(
+            diagnostics[1].category,
+            TypeCheckDiagnosticCategory::UnsupportedSubscript
+        );
     }
 
     #[test]
@@ -2730,6 +2740,12 @@ mod test {
         );
         assert_eq!(lattice.diagnostics.len(), 1);
         assert_eq!(subscript, Subscript::Pending);
+
+        let diagnostics = lattice.take_diagnostics().into_vec();
+        assert_eq!(
+            diagnostics[0].category,
+            TypeCheckDiagnosticCategory::UnsupportedSubscript
+        );
     }
 
     #[test]
@@ -2752,7 +2768,7 @@ mod test {
         );
         assert_eq!(lattice.diagnostics.len(), 0);
         let Subscript::Resolved(id) = subscript else {
-            panic!("expected resolved projection")
+            panic!("Expected Subscript::Resolved but got {subscript:?}");
         };
 
         assert_equiv!(env, [id], [union!(env, [integer, string])]);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This pull request implements the `subscript` method for `UnionType` in the `Lattice` trait.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

