### PR TITLE
AnyReport alternative, Report<dyn Context> that can be defaulted to with error_stack::Result<T>

### DIFF
--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -471,6 +471,27 @@ impl<C> Report<C> {
     }
 }
 
+impl<E: Into<Report<E>>> From<E> for Report<dyn Context + Send + Sync + 'static> {
+    #[track_caller]
+    fn from(value: E) -> Self {
+        value.into().into()
+    }
+}
+
+impl<C> From<Report<C>> for Report<dyn Context + Send + Sync + 'static> {
+    #[track_caller]
+    fn from(value: Report<C>) -> Self {
+        Report {
+            frames: value.frames,
+            _context: PhantomData,
+        }
+        .attach_printable(format!(
+            "into Report<dyn Context> at {}",
+            Location::caller()
+        ))
+    }
+}
+
 impl<C: ?Sized> Report<C> {
     /// Retrieves the current frames of the `Report`, regardless of its current type state.
     ///

--- a/libs/error-stack/src/result.rs
+++ b/libs/error-stack/src/result.rs
@@ -45,7 +45,7 @@ use crate::{Context, IntoReport, Report};
     note = "Use `core::result::Result<T, Report<C>>` instead",
     since = "0.6.0"
 )]
-pub type Result<T, C> = core::result::Result<T, Report<C>>;
+pub type Result<T, C = dyn Context + Send + Sync + 'static> = core::result::Result<T, Report<C>>;
 
 /// Extension trait for [`Result`][core::result::Result] to provide context information on
 /// [`Report`]s.

--- a/libs/error-stack/tests/test_conversion.rs
+++ b/libs/error-stack/tests/test_conversion.rs
@@ -87,8 +87,8 @@ fn error() {
 }
 
 #[test]
-fn into_report() {
-    let report = io_error().map_err(Report::from).expect_err("not an error");
+fn mapped_report() {
+    let report = io_error().map_err(Report::new).expect_err("not an error");
     assert!(report.contains::<io::Error>());
     assert_eq!(report.current_context().kind(), io::ErrorKind::Other);
 }

--- a/libs/error-stack/tests/test_provision.rs
+++ b/libs/error-stack/tests/test_provision.rs
@@ -45,6 +45,6 @@ fn request_context() {
 
 #[test]
 fn context_provision() {
-    let report = Report::from(ContextA(10));
+    let report = Report::new(ContextA(10));
     assert_eq!(report.request_ref::<u32>().count(), 1);
 }


### PR DESCRIPTION
Alternative to #7256 that adds `?` support to `Report<dyn Context + Send + Sync + 'static>` instead of an `AnyReport` wrapper.

This is even more powerful because the `error_stack::Result` type alias can be updated to: 
```rust
pub type Result<T, C = dyn Context + Send + Sync + 'static> = core::result::Result<T, Report<C>>;
```

Which makes switching between specific contexts and a catch all completely painless. `Result<T, E>` can simply remove the `E` to make it catch-all.

This is at the cost of a breaking change, the new `From` impl breaks `Report::from` type inference, meaning some `Report::from` need changing to `Report::new`. #7256 is a breaking change.