### PR TITLE
H-4696: Expose ECS task role ARN from Terraform state

### DIFF
--- a/infra/terraform/hash/hash_application/outputs.tf
+++ b/infra/terraform/hash/hash_application/outputs.tf
@@ -1,0 +1,3 @@
+output "ecs_iam_task_role_arn" {
+  value = module.aws_iam_role.task_role.arn
+}

--- a/infra/terraform/hash/hash_application/outputs.tf
+++ b/infra/terraform/hash/hash_application/outputs.tf
@@ -1,3 +1,3 @@
 output "ecs_iam_task_role_arn" {
-  value = module.aws_iam_role.task_role.arn
+  value = aws_iam_role.task_role.arn
 }

--- a/infra/terraform/hash/outputs.tf
+++ b/infra/terraform/hash/outputs.tf
@@ -22,6 +22,6 @@ output "temporal_hostname" {
   value = module.temporal.temporal_private_hostname
 }
 
-output "hash_application_ecs_iam_task_role" {
-  value = module.hash_application.ecs_iam_task_role_arn
+output "hash_application_ecs_iam_task_role_arn" {
+  value = module.application.ecs_iam_task_role_arn
 }

--- a/infra/terraform/hash/outputs.tf
+++ b/infra/terraform/hash/outputs.tf
@@ -21,3 +21,7 @@ output "rds_hostname" {
 output "temporal_hostname" {
   value = module.temporal.temporal_private_hostname
 }
+
+output "hash_application_ecs_iam_task_role" {
+  value = module.hash_application.ecs_iam_task_role_arn
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We want to be able to refer to the task role running HASH ECS task roles elsewhere, which involves exposing it as an `output` from the Terraform config.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


