### PR TITLE
H-4708: `error-stack`: Extract owned types from `Report`

### DIFF
--- a/libs/error-stack/src/frame/frame_impl.rs
+++ b/libs/error-stack/src/frame/frame_impl.rs
@@ -15,7 +15,7 @@ pub(super) trait FrameImpl: Send + Sync + 'static {
 
     fn as_any_mut(&mut self) -> &mut dyn Any;
 
-    fn into_any(self: Box<Self>) -> Box<dyn Any>;
+    fn into_any(self: Box<Self>) -> Box<dyn Any + Send + Sync>;
 
     /// Provide values which can then be requested.
     #[cfg(nightly)]
@@ -41,14 +41,8 @@ impl Error for Box<dyn FrameImpl> {
     }
 }
 
-pub(super) struct ContextFrame<C> {
+struct ContextFrame<C> {
     context: C,
-}
-
-impl<C> ContextFrame<C> {
-    pub(super) const fn new(context: C) -> Self {
-        Self { context }
-    }
 }
 
 impl<C: Context> FrameImpl for ContextFrame<C> {
@@ -64,7 +58,7 @@ impl<C: Context> FrameImpl for ContextFrame<C> {
         &mut self.context
     }
 
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+    fn into_any(self: Box<Self>) -> Box<dyn Any + Send + Sync> {
         Box::new(self.context)
     }
 
@@ -74,14 +68,8 @@ impl<C: Context> FrameImpl for ContextFrame<C> {
     }
 }
 
-pub(super) struct AttachmentFrame<A> {
+struct AttachmentFrame<A> {
     attachment: A,
-}
-
-impl<A> AttachmentFrame<A> {
-    pub(super) const fn new(attachment: A) -> Self {
-        Self { attachment }
-    }
 }
 
 impl<A: 'static + Send + Sync> FrameImpl for AttachmentFrame<A> {
@@ -97,7 +85,7 @@ impl<A: 'static + Send + Sync> FrameImpl for AttachmentFrame<A> {
         &mut self.attachment
     }
 
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+    fn into_any(self: Box<Self>) -> Box<dyn Any + Send + Sync> {
         Box::new(self.attachment)
     }
 
@@ -107,14 +95,8 @@ impl<A: 'static + Send + Sync> FrameImpl for AttachmentFrame<A> {
     }
 }
 
-pub(super) struct PrintableAttachmentFrame<A> {
+struct PrintableAttachmentFrame<A> {
     attachment: A,
-}
-
-impl<A> PrintableAttachmentFrame<A> {
-    pub(super) const fn new(attachment: A) -> Self {
-        Self { attachment }
-    }
 }
 
 impl<A: 'static + fmt::Debug + fmt::Display + Send + Sync> FrameImpl
@@ -132,7 +114,7 @@ impl<A: 'static + fmt::Debug + fmt::Display + Send + Sync> FrameImpl
         &mut self.attachment
     }
 
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+    fn into_any(self: Box<Self>) -> Box<dyn Any + Send + Sync> {
         Box::new(self.attachment)
     }
 
@@ -182,7 +164,7 @@ impl FrameImpl for AnyhowContext {
         &mut self.0
     }
 
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+    fn into_any(self: Box<Self>) -> Box<dyn Any + Send + Sync> {
         Box::new(self.0)
     }
 
@@ -233,7 +215,7 @@ impl FrameImpl for EyreContext {
         &mut self.0
     }
 
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+    fn into_any(self: Box<Self>) -> Box<dyn Any + Send + Sync> {
         Box::new(self.0)
     }
 

--- a/libs/error-stack/tests/test_attach.rs
+++ b/libs/error-stack/tests/test_attach.rs
@@ -59,6 +59,7 @@ fn attach_group() {
     root.push(shallow);
 
     assert_eq!(root.current_contexts().count(), 3);
+    assert_eq!(root.into_current_contexts().count(), 3);
 }
 
 #[test]

--- a/libs/error-stack/tests/test_change_context.rs
+++ b/libs/error-stack/tests/test_change_context.rs
@@ -59,6 +59,7 @@ fn buried_duplicate_context_does_not_affect_current_contexts() {
     root.push(shallow);
 
     assert_eq!(root.current_contexts().count(), 3);
+    assert_eq!(root.into_current_contexts().count(), 3);
 }
 
 #[test]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
Derived from #7274

Some error types are not `Clone`, or are expensive to clone, but **need** to be owned to handle them. Not being able to extract/take owned types from a `Report` has been one of the trickiest aspects of a migration to ES I've experienced.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

The current implementation just replaces the types internally with an internal type that will have the same printable format.  Methods return an untyped `Report<dyn Error>` because this means `C: Unsized` and methods such as `current_context` or further calls to `pop_current_context` cannot be used, `downcast` etc must be used instead as type safety on `C` has been lost. 

`downcast_take<T>()` must also remove `C` from `Report<C>` and return an untyped (`Report<dyn Error>`), because `T` may equal `C` and act like `pop_current_context()`.

I'm not tied to the implementation, but the api hole is: 
_**There needs to be a way to pull owned types out of an existing report, for both the top level `C` and arbitrary nested contexts + attachments, without consuming the report, or affecting the printable representation.**_

This implementation seemed to solve that goal with the most concise change.

```rust

// These types CANNOT be called on Report<dyn Error>
impl<C> Report<C> {
    pub fn pop_current_context(self) -> (C, Report<dyn Error>)
        where
            C: Send + Sync + 'static

    pub fn into_current_context(self) -> C
        where
            C: Send + Sync + 'static
}

// These types CAN be called on Report<dyn Error>
impl<C: ?Sized> Report<C> {
    pub fn downcast<T: Send + Sync + 'static>(self) -> Result<T, Self>

    pub fn downcast_take<T: Send + Sync + 'static>(self) -> Result<(T, Report<dyn Error>), Self>
}
```
