### PR TITLE
H-4726: Fix inconsistencies between `viewer` relationship and `viewEntity` policy action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -252,7 +252,7 @@ jobs:
             echo ''
             echo ''
             echo 'ℹ️ ℹ️ ℹ️'
-            echo 'Try running `yarn fix:biome` locally to apply autofixes.'
+            echo 'Try running `yarn fix:format` locally to apply autofixes.'
             echo 'ℹ️ ℹ️ ℹ️'
             exit 1
           fi

--- a/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -648,7 +648,7 @@ export const removeEntityViewerResolver: ResolverFn<
   MutationRemoveEntityViewerArgs
 > = async (_, { entityId, viewer }, graphQLContext) => {
   if (viewer.kind !== AuthorizationSubjectKind.Public) {
-    throw new UserInputError("Only public viewers can be added to an entity");
+    throw new UserInputError("Only public viewers can be removed from an entity");
   }
 
   const { authentication } = graphQLContext;

--- a/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -648,7 +648,9 @@ export const removeEntityViewerResolver: ResolverFn<
   MutationRemoveEntityViewerArgs
 > = async (_, { entityId, viewer }, graphQLContext) => {
   if (viewer.kind !== AuthorizationSubjectKind.Public) {
-    throw new UserInputError("Only public viewers can be removed from an entity");
+    throw new UserInputError(
+      "Only public viewers can be removed from an entity",
+    );
   }
 
   const { authentication } = graphQLContext;

--- a/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -5,7 +5,11 @@ import type {
   EntityId,
   WebId,
 } from "@blockprotocol/type-system";
-import { mustHaveAtLeastOne, splitEntityId } from "@blockprotocol/type-system";
+import {
+  extractEntityUuidFromEntityId,
+  mustHaveAtLeastOne,
+  splitEntityId,
+} from "@blockprotocol/type-system";
 import { convertBpFilterToGraphFilter } from "@local/hash-backend-utils/convert-bp-filter-to-graph-filter";
 import { publicUserAccountId } from "@local/hash-backend-utils/public-user-account-id";
 import type {
@@ -13,6 +17,11 @@ import type {
   QueryTemporalAxesUnresolved,
 } from "@local/hash-graph-client";
 import { HashEntity } from "@local/hash-graph-sdk/entity";
+import {
+  createPolicy,
+  deletePolicyById,
+  queryPolicies,
+} from "@local/hash-graph-sdk/policy";
 import type { EntityValidationReport } from "@local/hash-graph-sdk/validation";
 import {
   createDefaultAuthorizationRelationships,
@@ -596,6 +605,10 @@ export const addEntityViewerResolver: ResolverFn<
   LoggedInGraphQLContext,
   MutationAddEntityViewerArgs
 > = async (_, { entityId, viewer }, graphQLContext) => {
+  if (viewer.kind !== AuthorizationSubjectKind.Public) {
+    throw new UserInputError("Only public viewers can be added to an entity");
+  }
+
   const { authentication } = graphQLContext;
   const context = graphQLContextToImpureGraphContext(graphQLContext);
 
@@ -613,6 +626,18 @@ export const addEntityViewerResolver: ResolverFn<
     },
   ]);
 
+  const entityUuid = extractEntityUuidFromEntityId(entityId);
+  await createPolicy(context.graphApi, authentication, {
+    name: `public-view-entity-${entityUuid}`,
+    effect: "permit",
+    actions: ["viewEntity"],
+    principal: null,
+    resource: {
+      type: "entity",
+      id: entityUuid,
+    },
+  });
+
   return true;
 };
 
@@ -622,6 +647,10 @@ export const removeEntityViewerResolver: ResolverFn<
   LoggedInGraphQLContext,
   MutationRemoveEntityViewerArgs
 > = async (_, { entityId, viewer }, graphQLContext) => {
+  if (viewer.kind !== AuthorizationSubjectKind.Public) {
+    throw new UserInputError("Only public viewers can be added to an entity");
+  }
+
   const { authentication } = graphQLContext;
   const context = graphQLContextToImpureGraphContext(graphQLContext);
 
@@ -638,6 +667,20 @@ export const removeEntityViewerResolver: ResolverFn<
       },
     },
   ]);
+
+  const entityUuid = extractEntityUuidFromEntityId(entityId);
+  const [policy] = await queryPolicies(context.graphApi, authentication, {
+    name: `public-view-entity-${entityUuid}`,
+    principal: {
+      filter: "unconstrained",
+    },
+  });
+
+  if (!policy) {
+    return true; // No policy to delete, nothing to do
+  }
+
+  await deletePolicyById(context.graphApi, authentication, policy.id);
 
   return true;
 };

--- a/apps/hash-integration-worker/src/linear-activities.ts
+++ b/apps/hash-integration-worker/src/linear-activities.ts
@@ -155,10 +155,12 @@ const createHashEntity = async (params: {
 
   // TODO: allow creating policies alongside entity creation
   //   see https://linear.app/hash/issue/H-4622/allow-creating-policies-alongside-entity-creation
-  for (const linkEntity of linkEntities) {
-    const linkEntityUuid = extractEntityUuidFromEntityId(linkEntity.entityId);
+  for (const createdEntity of [entity, ...linkEntities]) {
+    const createdEntityUuid = extractEntityUuidFromEntityId(
+      createdEntity.entityId,
+    );
     await createPolicy(graphApiClient, params.authentication, {
-      name: `linear-synced-administer-entity-${linkEntityUuid}`,
+      name: `linear-synced-administer-entity-${createdEntityUuid}`,
       effect: "permit",
       principal: {
         type: "actor",
@@ -168,7 +170,7 @@ const createHashEntity = async (params: {
       actions: ["viewEntity"],
       resource: {
         type: "entity",
-        id: linkEntityUuid,
+        id: createdEntityUuid,
       },
     });
   }

--- a/libs/@local/graph/postgres-store/src/store/postgres/seed_policies.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/seed_policies.rs
@@ -236,10 +236,22 @@ fn web_view_entity_policies(role: &WebRole) -> impl Iterator<Item = PolicyCreati
         1,
     ));
     if role.name != RoleName::Administrator {
-        filters.extend(create_version_filters(
-            base_url!("https://hash.ai/@h/types/entity-type/usage-record/"),
-            2,
-        ));
+        filters.extend(
+            create_version_filters(
+                base_url!("https://hash.ai/@h/types/entity-type/usage-record/"),
+                2,
+            )
+            .chain(
+                create_version_filters(
+                    base_url!("https://hash.ai/@h/types/entity-type/incurred-in/"),
+                    2,
+                )
+                .chain(create_version_filters(
+                    base_url!("https://hash.ai/@h/types/entity-type/records-usage-of/"),
+                    1,
+                )),
+            ),
+        );
     }
 
     iter::once(PolicyCreationParams {

--- a/libs/@local/graph/postgres-store/src/store/postgres/seed_policies.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/seed_policies.rs
@@ -91,6 +91,26 @@ fn system_actor_view_entity_policies(
                     base_url!("https://hash.ai/@h/types/entity-type/prospective-user/"),
                     1,
                 ))
+                .chain(create_version_filters(
+                    base_url!("https://hash.ai/@h/types/entity-type/triggered-by-user/"),
+                    1,
+                ))
+                .chain(create_version_filters(
+                    base_url!("https://hash.ai/@h/types/entity-type/occurred-in-block/"),
+                    1,
+                ))
+                .chain(create_version_filters(
+                    base_url!("https://hash.ai/@h/types/entity-type/occurred-in-entity/"),
+                    2,
+                ))
+                .chain(create_version_filters(
+                    base_url!("https://hash.ai/@h/types/entity-type/occurred-in-comment/"),
+                    1,
+                ))
+                .chain(create_version_filters(
+                    base_url!("https://hash.ai/@h/types/entity-type/occurred-in-text/"),
+                    1,
+                ))
                 .collect(),
             },
         })),

--- a/libs/@local/graph/postgres-store/src/store/postgres/seed_policies.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/seed_policies.rs
@@ -91,30 +91,6 @@ fn system_actor_view_entity_policies(
                     base_url!("https://hash.ai/@h/types/entity-type/prospective-user/"),
                     1,
                 ))
-                .chain(create_version_filters(
-                    base_url!("https://hash.ai/@h/types/entity-type/notification/"),
-                    1,
-                ))
-                .chain(create_version_filters(
-                    base_url!("https://hash.ai/@h/types/entity-type/triggered-by-user/"),
-                    1,
-                ))
-                .chain(create_version_filters(
-                    base_url!("https://hash.ai/@h/types/entity-type/occurred-in-block/"),
-                    1,
-                ))
-                .chain(create_version_filters(
-                    base_url!("https://hash.ai/@h/types/entity-type/occurred-in-entity/"),
-                    2,
-                ))
-                .chain(create_version_filters(
-                    base_url!("https://hash.ai/@h/types/entity-type/occurred-in-comment/"),
-                    1,
-                ))
-                .chain(create_version_filters(
-                    base_url!("https://hash.ai/@h/types/entity-type/occurred-in-text/"),
-                    1,
-                ))
                 .collect(),
             },
         })),

--- a/libs/@local/graph/postgres-store/src/store/postgres/seed_policies.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/seed_policies.rs
@@ -92,6 +92,10 @@ fn system_actor_view_entity_policies(
                     1,
                 ))
                 .chain(create_version_filters(
+                    base_url!("https://hash.ai/@h/types/entity-type/notification/"),
+                    1,
+                ))
+                .chain(create_version_filters(
                     base_url!("https://hash.ai/@h/types/entity-type/triggered-by-user/"),
                     1,
                 ))


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A few inconsistencies are remaining between the old SpiceDB based policy engine and the new engine:
- `incurred-in` entities should have the same policies as `usage-record` and `records-usage-of`
    - Web-admins should have access to these as well
- When manually creating relationships, policies are not updated (i.e. `viewer` permissions`
- synchronized linear link-entities get a permission, but the source entity does not
- view permissions for the system actor on
	- triggered-by-user
	- occurred-in-block
	- occurred-in-entity
	- occurred-in-comment
	- occurred-in-text

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph