### PR TITLE
H-847, H-4433: Use `viewEntity` policy over `viewer` relationships in the Graph

### DIFF
--- a/libs/@local/graph/postgres-store/src/store/postgres/crud.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/crud.rs
@@ -17,8 +17,8 @@ use crate::store::{
 };
 
 pub struct QueryIndices<R: QueryRecordDecode, S: QueryRecordDecode> {
-    record_indices: R::Indices,
-    cursor_indices: S::Indices,
+    pub record_indices: R::Indices,
+    pub cursor_indices: S::Indices,
 }
 
 pub trait QueryRecordDecode {

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -20,8 +20,8 @@ use hash_graph_authorization::{
 };
 use hash_graph_store::{
     entity::{
-        CountEntitiesParams, CreateEntityParams, EmptyEntityTypes, EntityQueryPath,
-        EntityQuerySorting, EntityStore, EntityTypeRetrieval, EntityTypesError,
+        CountEntitiesParams, CreateEntityParams, EmptyEntityTypes, EntityQueryCursor,
+        EntityQueryPath, EntityQuerySorting, EntityStore, EntityTypeRetrieval, EntityTypesError,
         EntityValidationReport, EntityValidationType, GetEntitiesParams, GetEntitiesResponse,
         GetEntitySubgraphParams, GetEntitySubgraphResponse, PatchEntityParams, QueryConversion,
         UpdateEntityEmbeddingsParams, ValidateEntityComponents, ValidateEntityParams,
@@ -29,7 +29,7 @@ use hash_graph_store::{
     entity_type::{EntityTypeQueryPath, EntityTypeStore as _, IncludeEntityTypeOption},
     error::{InsertionError, QueryError, UpdateError},
     filter::{Filter, FilterExpression, Parameter, ParameterList},
-    query::{QueryResult as _, Read, ReadPaginated, Sorting as _},
+    query::{QueryResult as _, Read},
     subgraph::{
         Subgraph, SubgraphRecord as _,
         edges::{EdgeDirection, GraphResolveDepths, KnowledgeGraphEdgeKind, SharedEdgeKind},
@@ -88,9 +88,11 @@ use crate::store::{
     error::{DeletionError, EntityDoesNotExist, RaceConditionOnUpdate},
     postgres::{
         ResponseCountMap, TraversalContext,
+        crud::{QueryIndices, TypedRow},
         knowledge::entity::read::EntityEdgeTraversalData,
         query::{
-            InsertStatementBuilder, ReferenceTable, SelectCompiler, Table,
+            Distinctness, InsertStatementBuilder, PostgresRecord as _, PostgresSorting as _,
+            ReferenceTable, SelectCompiler, Table,
             rows::{
                 EntityDraftRow, EntityEditionRow, EntityHasLeftEntityRow, EntityHasRightEntityRow,
                 EntityIdRow, EntityIsOfTypeRow, EntityTemporalMetadataRow,
@@ -393,284 +395,235 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(level = "info", skip(self, params, policy_components))]
+    #[tracing::instrument(level = "info", skip(self, params))]
     #[expect(clippy::too_many_lines)]
     async fn get_entities_impl(
         &self,
-        mut params: GetEntitiesImplParams<'_>,
+        params: GetEntitiesImplParams<'_>,
         temporal_axes: &QueryTemporalAxes,
         policy_components: &PolicyComponents,
     ) -> Result<GetEntitiesResponse<'static>, Report<QueryError>> {
-        let actor_id = policy_components
-            .actor_id()
-            .map_or_else(ActorEntityUuid::public_actor, ActorEntityUuid::from);
-        let mut root_entities = Vec::new();
-        let filters: [Filter<'_, Entity>; 1] = [params.filter];
+        let policy_filter = Filter::for_policies(
+            policy_components.extract_filter_policies(ActionName::ViewEntity),
+            policy_components.actor_id(),
+            policy_components.optimization_data(),
+        );
 
-        let (
-            permissions,
-            count,
-            web_ids,
-            created_by_ids,
-            edition_created_by_ids,
-            type_ids,
-            type_titles,
-        ) = if params.include_count
-            || params.include_web_ids
-            || params.include_created_by_ids
-            || params.include_edition_created_by_ids
-            || params.include_type_ids
-        {
-            let mut compiler = SelectCompiler::new(Some(temporal_axes), params.include_drafts);
-            let web_id_idx = compiler.add_selection_path(&EntityQueryPath::WebId);
-            let entity_uuid_idx = compiler.add_selection_path(&EntityQueryPath::Uuid);
-            let draft_id_idx = compiler.add_selection_path(&EntityQueryPath::DraftId);
-            let provenance_idx = params
-                .include_created_by_ids
-                .then(|| compiler.add_selection_path(&EntityQueryPath::Provenance(None)));
-            let edition_provenance_idx = params
-                .include_edition_created_by_ids
-                .then(|| compiler.add_selection_path(&EntityQueryPath::EditionProvenance(None)));
-            let type_ids_idx = (params.include_type_ids || params.include_type_titles).then(|| {
-                (
-                    compiler.add_selection_path(&EntityQueryPath::TypeBaseUrls),
-                    compiler.add_selection_path(&EntityQueryPath::TypeVersions),
-                )
-            });
+        let mut compiler = SelectCompiler::new(Some(temporal_axes), params.include_drafts);
+        compiler
+            .add_filter(&policy_filter)
+            .change_context(QueryError)?;
+        compiler
+            .add_filter(&params.filter)
+            .change_context(QueryError)?;
 
-            for filter in &filters {
-                compiler.add_filter(filter).change_context(QueryError)?;
-            }
-
-            let (statement, parameters) = compiler.compile();
-
-            let entities = self
-                .as_client()
-                .query_raw(&statement, parameters.iter().copied())
-                .instrument(tracing::trace_span!("query"))
-                .await
-                .change_context(QueryError)?
-                .map_ok(move |row| {
-                    (
-                        EntityId {
-                            web_id: row.get(web_id_idx),
-                            entity_uuid: row.get(entity_uuid_idx),
-                            draft_id: row.get(draft_id_idx),
-                        },
-                        row,
-                    )
-                })
-                .try_collect::<HashMap<_, _>>()
-                .await
-                .change_context(QueryError)?;
-
-            let (permissions, _zookie) = self
-                .authorization_api
-                .check_entities_permission(
-                    actor_id,
-                    EntityPermission::View,
-                    entities.keys().copied(),
-                    Consistency::FullyConsistent,
-                )
-                .await
-                .change_context(QueryError)?;
-
-            let permitted_ids = permissions
-                .into_iter()
-                .filter_map(|(entity_id, has_permission)| has_permission.then_some(entity_id))
-                .collect::<HashSet<_>>();
-
-            let mut web_ids = params.include_web_ids.then(ResponseCountMap::default);
-            let mut created_by_ids = params
-                .include_created_by_ids
-                .then(ResponseCountMap::default);
-            let mut edition_created_by_ids = params
-                .include_edition_created_by_ids
-                .then(ResponseCountMap::default);
-            let mut type_ids = (params.include_type_ids || params.include_type_titles)
-                .then(ResponseCountMap::default);
-
-            let count = entities
-                .into_iter()
-                .filter(|(entity_id, _)| permitted_ids.contains(&entity_id.entity_uuid))
-                .inspect(|(entity_id, row)| {
-                    if let Some(web_ids) = &mut web_ids {
-                        web_ids.extend_one(entity_id.web_id);
-                    }
-
-                    if let Some((created_by_ids, provenance_idx)) =
-                        created_by_ids.as_mut().zip(provenance_idx)
-                    {
-                        let provenance: InferredEntityProvenance = row.get(provenance_idx);
-                        created_by_ids.extend_one(provenance.created_by_id);
-                    }
-
-                    if let Some((edition_created_by_ids, provenance_idx)) =
-                        edition_created_by_ids.as_mut().zip(edition_provenance_idx)
-                    {
-                        let provenance: EntityEditionProvenance = row.get(provenance_idx);
-                        edition_created_by_ids.extend_one(provenance.created_by_id);
-                    }
-
-                    if let Some((type_ids, (base_urls_idx, versions_idx))) =
-                        type_ids.as_mut().zip(type_ids_idx)
-                    {
-                        let base_urls: Vec<BaseUrl> = row.get(base_urls_idx);
-                        let versions: Vec<OntologyTypeVersion> = row.get(versions_idx);
-                        type_ids.extend(
-                            base_urls
-                                .into_iter()
-                                .zip(versions)
-                                .map(|(base_url, version)| VersionedUrl { base_url, version }),
-                        );
-                    }
-                })
-                .count();
-            let type_ids = type_ids.map(HashMap::from);
-
-            let type_titles = if params.include_type_titles {
-                let type_uuids = type_ids
-                    .as_ref()
-                    .expect("type ids should be present")
-                    .keys()
-                    .map(EntityTypeUuid::from_url)
-                    .collect::<Vec<_>>();
-
-                let mut type_compiler = SelectCompiler::<EntityTypeWithMetadata>::new(
-                    Some(temporal_axes),
-                    params.include_drafts,
-                );
-                let base_url_idx = type_compiler.add_selection_path(&EntityTypeQueryPath::BaseUrl);
-                let version_idx = type_compiler.add_selection_path(&EntityTypeQueryPath::Version);
-                let title_idx = type_compiler.add_selection_path(&EntityTypeQueryPath::Title);
-
-                let filter = Filter::In(
-                    FilterExpression::Path {
-                        path: EntityTypeQueryPath::OntologyId,
-                    },
-                    ParameterList::EntityTypeIds(&type_uuids),
-                );
-                type_compiler
-                    .add_filter(&filter)
-                    .change_context(QueryError)?;
-
-                let (statement, parameters) = type_compiler.compile();
-
-                Some(
-                    self.as_client()
-                        .query_raw(&statement, parameters.iter().copied())
-                        .instrument(tracing::trace_span!("query"))
-                        .await
-                        .change_context(QueryError)?
-                        .map_ok(|row| {
-                            (
-                                VersionedUrl {
-                                    base_url: row.get(base_url_idx),
-                                    version: row.get(version_idx),
-                                },
-                                row.get::<_, String>(title_idx),
-                            )
-                        })
-                        .try_collect::<HashMap<_, _>>()
-                        .await
-                        .change_context(QueryError)?,
-                )
-            } else {
-                None
-            };
-
-            (
-                Some(permitted_ids),
-                params.include_count.then_some(count),
-                web_ids.map(HashMap::from),
-                created_by_ids.map(HashMap::from),
-                edition_created_by_ids.map(HashMap::from),
-                type_ids.filter(|_| params.include_type_ids),
-                type_titles,
-            )
-        } else {
-            (None, None, None, None, None, None, None)
-        };
-
-        let last = loop {
-            // We query one more than requested to determine if there are more entities to return.
-            let (rows, artifacts) =
-                ReadPaginated::<Entity, EntityQuerySorting>::read_paginated_vec(
-                    self,
-                    &filters,
-                    Some(temporal_axes),
-                    &params.sorting,
-                    params.limit,
-                    params.include_drafts,
-                )
-                .await?;
-            let entities = rows
-                .into_iter()
-                .map(|row| (row.decode_record(&artifacts), row))
-                .collect::<Vec<_>>();
-            if let Some(cursor) = entities
-                .last()
-                .map(|(_, row)| row.decode_cursor(&artifacts))
+        let (count, web_ids, created_by_ids, edition_created_by_ids, type_ids, type_titles) =
+            if params.include_count
+                || params.include_web_ids
+                || params.include_created_by_ids
+                || params.include_edition_created_by_ids
+                || params.include_type_ids
             {
-                params.sorting.set_cursor(cursor);
-            }
+                let web_id_idx = compiler.add_selection_path(&EntityQueryPath::WebId);
+                let entity_uuid_idx = compiler.add_selection_path(&EntityQueryPath::Uuid);
+                let draft_id_idx = compiler.add_selection_path(&EntityQueryPath::DraftId);
+                let provenance_idx = params
+                    .include_created_by_ids
+                    .then(|| compiler.add_selection_path(&EntityQueryPath::Provenance(None)));
+                let edition_provenance_idx = params.include_edition_created_by_ids.then(|| {
+                    compiler.add_selection_path(&EntityQueryPath::EditionProvenance(None))
+                });
+                let type_ids_idx =
+                    (params.include_type_ids || params.include_type_titles).then(|| {
+                        (
+                            compiler.add_selection_path(&EntityQueryPath::TypeBaseUrls),
+                            compiler.add_selection_path(&EntityQueryPath::TypeVersions),
+                        )
+                    });
 
-            let num_returned_entities = entities.len();
+                let (statement, parameters) = compiler.compile();
 
-            let permitted_ids = if let Some(permitted_ids) = &permissions {
-                Cow::<HashSet<EntityUuid>>::Borrowed(permitted_ids)
-            } else {
-                // TODO: The subgraph structure differs from the API interface. At the API the
-                //       vertices are stored in a nested `HashMap` and here it's flattened. We need
-                //       to adjust the subgraph anyway so instead of refactoring this now this will
-                //       just copy the ids.
-                //   see https://linear.app/hash/issue/H-297/revisit-subgraph-layout-to-allow-temporal-ontology-types
-                let filtered_ids = entities
-                    .iter()
-                    .map(|(entity, _)| entity.metadata.record_id.entity_id)
-                    .collect::<HashSet<_>>();
-
-                let (permissions, _zookie) = self
-                    .authorization_api
-                    .check_entities_permission(
-                        actor_id,
-                        EntityPermission::View,
-                        filtered_ids,
-                        Consistency::FullyConsistent,
-                    )
+                let entities = self
+                    .as_client()
+                    .query_raw(&statement, parameters.iter().copied())
+                    .instrument(tracing::trace_span!("query_entity_metadata"))
+                    .await
+                    .change_context(QueryError)?
+                    .map_ok(move |row| {
+                        (
+                            EntityId {
+                                web_id: row.get(web_id_idx),
+                                entity_uuid: row.get(entity_uuid_idx),
+                                draft_id: row.get(draft_id_idx),
+                            },
+                            row,
+                        )
+                    })
+                    .try_collect::<HashMap<_, _>>()
+                    .instrument(tracing::trace_span!("collect_entity_metadata"))
                     .await
                     .change_context(QueryError)?;
 
-                Cow::Owned(
-                    permissions
-                        .into_iter()
-                        .filter_map(|(entity_id, has_permission)| {
-                            has_permission.then_some(entity_id)
-                        })
-                        .collect::<HashSet<_>>(),
+                let mut web_ids = params.include_web_ids.then(ResponseCountMap::default);
+                let mut created_by_ids = params
+                    .include_created_by_ids
+                    .then(ResponseCountMap::default);
+                let mut edition_created_by_ids = params
+                    .include_edition_created_by_ids
+                    .then(ResponseCountMap::default);
+                let mut type_ids = (params.include_type_ids || params.include_type_titles)
+                    .then(ResponseCountMap::default);
+
+                let count = entities
+                    .into_iter()
+                    .inspect(|(entity_id, row)| {
+                        if let Some(web_ids) = &mut web_ids {
+                            web_ids.extend_one(entity_id.web_id);
+                        }
+
+                        if let Some((created_by_ids, provenance_idx)) =
+                            created_by_ids.as_mut().zip(provenance_idx)
+                        {
+                            let provenance: InferredEntityProvenance = row.get(provenance_idx);
+                            created_by_ids.extend_one(provenance.created_by_id);
+                        }
+
+                        if let Some((edition_created_by_ids, provenance_idx)) =
+                            edition_created_by_ids.as_mut().zip(edition_provenance_idx)
+                        {
+                            let provenance: EntityEditionProvenance = row.get(provenance_idx);
+                            edition_created_by_ids.extend_one(provenance.created_by_id);
+                        }
+
+                        if let Some((type_ids, (base_urls_idx, versions_idx))) =
+                            type_ids.as_mut().zip(type_ids_idx)
+                        {
+                            let base_urls: Vec<BaseUrl> = row.get(base_urls_idx);
+                            let versions: Vec<OntologyTypeVersion> = row.get(versions_idx);
+                            type_ids.extend(
+                                base_urls
+                                    .into_iter()
+                                    .zip(versions)
+                                    .map(|(base_url, version)| VersionedUrl { base_url, version }),
+                            );
+                        }
+                    })
+                    .count();
+                let type_ids = type_ids.map(HashMap::from);
+
+                let type_titles = if params.include_type_titles {
+                    let type_uuids = type_ids
+                        .as_ref()
+                        .expect("type ids should be present")
+                        .keys()
+                        .map(EntityTypeUuid::from_url)
+                        .collect::<Vec<_>>();
+
+                    let mut type_compiler = SelectCompiler::<EntityTypeWithMetadata>::new(
+                        Some(temporal_axes),
+                        params.include_drafts,
+                    );
+                    let base_url_idx =
+                        type_compiler.add_selection_path(&EntityTypeQueryPath::BaseUrl);
+                    let version_idx =
+                        type_compiler.add_selection_path(&EntityTypeQueryPath::Version);
+                    let title_idx = type_compiler.add_selection_path(&EntityTypeQueryPath::Title);
+
+                    let filter = Filter::In(
+                        FilterExpression::Path {
+                            path: EntityTypeQueryPath::OntologyId,
+                        },
+                        ParameterList::EntityTypeIds(&type_uuids),
+                    );
+                    type_compiler
+                        .add_filter(&filter)
+                        .change_context(QueryError)?;
+
+                    let (statement, parameters) = type_compiler.compile();
+
+                    Some(
+                        self.as_client()
+                            .query_raw(&statement, parameters.iter().copied())
+                            .instrument(tracing::trace_span!("query_entity_types"))
+                            .await
+                            .change_context(QueryError)?
+                            .map_ok(|row| {
+                                (
+                                    VersionedUrl {
+                                        base_url: row.get(base_url_idx),
+                                        version: row.get(version_idx),
+                                    },
+                                    row.get::<_, String>(title_idx),
+                                )
+                            })
+                            .try_collect::<HashMap<_, _>>()
+                            .instrument(tracing::trace_span!("collect_entity_types"))
+                            .await
+                            .change_context(QueryError)?,
+                    )
+                } else {
+                    None
+                };
+
+                (
+                    params.include_count.then_some(count),
+                    web_ids.map(HashMap::from),
+                    created_by_ids.map(HashMap::from),
+                    edition_created_by_ids.map(HashMap::from),
+                    type_ids.filter(|_| params.include_type_ids),
+                    type_titles,
                 )
+            } else {
+                (None, None, None, None, None, None)
             };
 
-            root_entities.extend(entities.into_iter().filter(|(entity, _)| {
-                permitted_ids.contains(&entity.metadata.record_id.entity_id.entity_uuid)
-            }));
+        if let Some(limit) = params.limit {
+            compiler.set_limit(limit);
+        }
 
-            if let Some(limit) = params.limit {
-                if num_returned_entities < limit {
-                    // When the returned entities are less than the requested amount we know
-                    // that there are no more entities to return.
-                    break None;
-                }
-                if root_entities.len() == limit {
-                    // The requested limit is reached, so we can stop here.
-                    break root_entities
-                        .last()
-                        .map(|(_, row)| row.decode_cursor(&artifacts));
-                }
-            } else {
-                // Without a limit all entities are returned.
-                break None;
-            }
+        let cursor_parameters = params.sorting.encode().change_context(QueryError)?;
+        let cursor_indices = params
+            .sorting
+            .compile(&mut compiler, cursor_parameters.as_ref(), temporal_axes)
+            .change_context(QueryError)?;
+
+        let record_parameters = Entity::parameters();
+        let record_indices = Entity::compile(&mut compiler, &record_parameters);
+
+        let (statement, parameters) = compiler.compile();
+
+        let rows = self
+            .as_client()
+            .query(&statement, parameters)
+            .instrument(tracing::info_span!(
+                "query_entities",
+                statement_length = statement.len(),
+                param_count = parameters.len()
+            ))
+            .await
+            .change_context(QueryError)?;
+        let artifacts = QueryIndices::<Entity, EntityQuerySorting> {
+            record_indices,
+            cursor_indices,
+        };
+
+        let (entities, cursor) = {
+            let _span =
+                tracing::trace_span!("process_query_results", row_count = rows.len()).entered();
+            let mut cursor = None;
+            let num_rows = rows.len();
+            let entities = rows
+                .into_iter()
+                .enumerate()
+                .map(|(idx, row)| {
+                    let row = TypedRow::<Entity, EntityQueryCursor>::from(row);
+                    if idx == num_rows - 1 && params.limit == Some(num_rows) {
+                        cursor = Some(row.decode_cursor(&artifacts));
+                    }
+                    row.decode_record(&artifacts)
+                })
+                .collect::<Vec<_>>();
+            (entities, cursor)
         };
 
         Ok(GetEntitiesResponse {
@@ -681,10 +634,12 @@ where
             closed_multi_entity_types: if params.include_entity_types.is_some() {
                 Some(
                     self.get_closed_multi_entity_types(
-                        actor_id,
-                        root_entities
+                        policy_components
+                            .actor_id()
+                            .map_or_else(ActorEntityUuid::public_actor, ActorEntityUuid::from),
+                        entities
                             .iter()
-                            .map(|(entity, _)| entity.metadata.entity_type_ids.clone()),
+                            .map(|entity| entity.metadata.entity_type_ids.clone()),
                         QueryTemporalAxesUnresolved::DecisionTime {
                             pinned: PinnedTemporalAxisUnresolved::new(None),
                             variable: VariableTemporalAxisUnresolved::new(None, None),
@@ -702,9 +657,9 @@ where
                     IncludeEntityTypeOption::Resolved
                     | IncludeEntityTypeOption::ResolvedWithDataTypeChildren,
                 ) => {
-                    let entity_type_uuids = root_entities
+                    let entity_type_uuids = entities
                         .iter()
-                        .flat_map(|(entity, _)| {
+                        .flat_map(|entity| {
                             entity
                                 .metadata
                                 .entity_type_ids
@@ -716,7 +671,9 @@ where
                         .collect::<Vec<_>>();
                     Some(
                         self.get_entity_type_resolve_definitions(
-                            actor_id,
+                            policy_components
+                                .actor_id()
+                                .map_or_else(ActorEntityUuid::public_actor, ActorEntityUuid::from),
                             &entity_type_uuids,
                             params.include_entity_types
                                 == Some(IncludeEntityTypeOption::ResolvedWithDataTypeChildren),
@@ -726,11 +683,8 @@ where
                 }
                 None | Some(IncludeEntityTypeOption::Closed) => None,
             },
-            entities: root_entities
-                .into_iter()
-                .map(|(entity, _)| entity)
-                .collect(),
-            cursor: last,
+            entities,
+            cursor,
             count,
             web_ids,
             created_by_ids,
@@ -788,6 +742,7 @@ where
                     .collect::<HashSet<_>>(),
             )
             .with_action(ActionName::Instantiate)
+            .with_action(ActionName::ViewEntity) // for validation
             .await
             .change_context(InsertionError)?;
 
@@ -1208,6 +1163,7 @@ where
     ) -> Result<HashMap<usize, EntityValidationReport>, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
+            .with_action(ActionName::ViewEntity) // for validation
             .await
             .change_context(QueryError)?;
 
@@ -1294,6 +1250,7 @@ where
     ) -> Result<GetEntitiesResponse<'static>, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
+            .with_action(ActionName::ViewEntity)
             .await
             .change_context(QueryError)?;
 
@@ -1347,6 +1304,8 @@ where
     ) -> Result<GetEntitySubgraphResponse<'static>, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
+            .with_action(ActionName::ViewEntity)
+            .into_future()
             .await
             .change_context(QueryError)?;
 
@@ -1376,6 +1335,7 @@ where
             type_titles,
         } = self
             .get_entities_impl(
+                // actor_id,
                 GetEntitiesImplParams {
                     filter: params.filter,
                     sorting: params.sorting,
@@ -1524,6 +1484,7 @@ where
     ) -> Result<usize, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
+            .with_action(ActionName::ViewEntity)
             .await
             .change_context(QueryError)?;
 
@@ -1535,39 +1496,35 @@ where
             .await
             .change_context(QueryError)?;
 
+        let policy_filter = Filter::for_policies(
+            policy_components.extract_filter_policies(ActionName::ViewEntity),
+            policy_components.actor_id(),
+            policy_components.optimization_data(),
+        );
+
         let temporal_axes = params.temporal_axes.resolve();
+        let mut compiler = SelectCompiler::new(Some(&temporal_axes), params.include_drafts);
+        compiler
+            .add_filter(&policy_filter)
+            .change_context(QueryError)?;
+        compiler
+            .add_filter(&params.filter)
+            .change_context(QueryError)?;
 
-        let entity_ids = Read::<Entity>::read(
-            self,
-            &[params.filter],
-            Some(&temporal_axes),
-            params.include_drafts,
-        )
-        .await?
-        .map_ok(|entity| entity.metadata.record_id.entity_id)
-        .try_collect::<Vec<_>>()
-        .await?;
+        compiler.add_distinct_selection_with_ordering(
+            &EntityQueryPath::EditionId,
+            Distinctness::Distinct,
+            None,
+        );
 
-        let permitted_ids = self
-            .authorization_api
-            .check_entities_permission(
-                actor_id,
-                EntityPermission::View,
-                entity_ids.iter().copied(),
-                Consistency::FullyConsistent,
-            )
-            .instrument(tracing::trace_span!("post_filter_entities"))
+        let (statement, parameters) = compiler.compile();
+        Ok(self
+            .as_client()
+            .query_raw(&statement, parameters.iter().copied())
             .await
             .change_context(QueryError)?
-            .0
-            .into_iter()
-            .filter_map(|(entity_id, has_permission)| has_permission.then_some(entity_id))
-            .collect::<HashSet<_>>();
-
-        Ok(entity_ids
-            .into_iter()
-            .filter(|id| permitted_ids.contains(&id.entity_uuid))
-            .count())
+            .count()
+            .await)
     }
 
     async fn get_entity_by_id(
@@ -1579,26 +1536,18 @@ where
     ) -> Result<Entity, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
+            .with_action(ActionName::ViewEntity)
             .await
             .change_context(QueryError)?;
 
-        let provider = StoreProvider::new(self, &policy_components);
+        let mut filters = vec![Filter::for_entity_by_entity_id(entity_id)];
 
-        provider
-            .store
-            .authorization_api
-            .check_entity_permission(
-                policy_components
-                    .actor_id()
-                    .map_or_else(ActorEntityUuid::public_actor, ActorEntityUuid::from),
-                EntityPermission::View,
-                entity_id,
-                Consistency::FullyConsistent,
-            )
-            .await
-            .change_context(QueryError)?
-            .assert_permission()
-            .change_context(QueryError)?;
+        let filter = Filter::for_policies(
+            policy_components.extract_filter_policies(ActionName::ViewEntity),
+            policy_components.actor_id(),
+            policy_components.optimization_data(),
+        );
+        filters.push(filter);
 
         let temporal_axes = QueryTemporalAxesUnresolved::TransactionTime {
             pinned: PinnedTemporalAxisUnresolved::new(decision_time),
@@ -1611,7 +1560,7 @@ where
 
         Read::<Entity>::read_one(
             self,
-            &[Filter::for_entity_by_entity_id(entity_id)],
+            &filters,
             Some(&temporal_axes),
             entity_id.draft_id.is_some(),
         )
@@ -1691,6 +1640,7 @@ where
             .with_entity_edition_id(previous_entity.metadata.record_id.edition_id)
             .with_entity_type_ids(&params.entity_type_ids)
             .with_action(ActionName::Instantiate)
+            .with_action(ActionName::ViewEntity) // for validation
             .await
             .change_context(UpdateError)?;
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/read.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/read.rs
@@ -1,32 +1,41 @@
 use alloc::borrow::Cow;
 use core::mem::swap;
+use std::collections::HashSet;
 
 use error_stack::{Report, ResultExt as _};
-use hash_graph_authorization::{AuthorizationApi, schema::EntityPermission, zanzibar::Consistency};
+use futures::TryStreamExt as _;
+use hash_graph_authorization::policies::action::ActionName;
 use hash_graph_store::{
+    entity::EntityQueryPath,
     error::QueryError,
+    filter::Filter,
     subgraph::{
         edges::{EdgeDirection, GraphResolveDepths},
         identifier::{EntityTypeVertexId, EntityVertexId},
-        temporal_axes::{PinnedAxis, VariableAxis},
+        temporal_axes::{
+            PinnedAxis, PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved, VariableAxis,
+            VariableTemporalAxisUnresolved,
+        },
     },
 };
 use hash_graph_temporal_versioning::{
-    LeftClosedTemporalInterval, RightBoundedTemporalInterval, TimeAxis, Timestamp,
+    LeftClosedTemporalInterval, RightBoundedTemporalInterval, TemporalTagged as _, TimeAxis,
+    Timestamp,
 };
+use postgres_types::ToSql;
 use tokio_postgres::GenericClient as _;
 use tracing::Instrument as _;
 use type_system::{
     knowledge::entity::id::{EntityEditionId, EntityId, EntityUuid},
     ontology::id::{BaseUrl, OntologyTypeUuid},
-    principal::{actor::ActorEntityUuid, actor_group::WebId},
+    principal::actor_group::WebId,
 };
 
 use crate::store::{
     StoreProvider,
     postgres::{
         AsClient, PostgresStore,
-        query::{ForeignKeyReference, ReferenceTable, Table, Transpile as _},
+        query::{ForeignKeyReference, ReferenceTable, SelectCompiler, Table, Transpile as _},
     },
 };
 
@@ -89,7 +98,7 @@ pub struct KnowledgeEdgeTraversal {
 impl<C, A> PostgresStore<C, A>
 where
     C: AsClient,
-    A: AuthorizationApi + Send + Sync,
+    A: Send + Sync,
 {
     #[tracing::instrument(level = "trace", skip(self))]
     pub(crate) async fn read_shared_edges<'t>(
@@ -219,10 +228,10 @@ where
             swap(&mut source_2, &mut target_2);
         }
 
-        let (entity_ids, knowledge_edges) = self
+        let (entity_edition_ids, edges) = self
             .client
             .as_client()
-            .query(
+            .query_raw(
                 &format!(
                     "
                         SELECT
@@ -255,8 +264,8 @@ where
                          AND target.entity_uuid = {target_2}
                     "
                 ),
-                &[
-                    &traversal_data.web_ids,
+                [
+                    &traversal_data.web_ids as &(dyn ToSql + Sync),
                     &traversal_data.entity_uuids,
                     &traversal_data.entity_revision_ids,
                     &traversal_data.intervals,
@@ -266,16 +275,11 @@ where
             .instrument(tracing::trace_span!("query_edges"))
             .await
             .change_context(QueryError)?
-            .into_iter()
-            .map(|row| {
+            .map_ok(|row| {
                 let index = usize::try_from(row.get::<_, i64>(0) - 1).expect("invalid index");
-                let right_endpoint_base_id = EntityId {
-                    web_id: row.get(1),
-                    entity_uuid: row.get(2),
-                    draft_id: None,
-                };
+                let right_endpoint_edition_id = row.get(4);
                 (
-                    right_endpoint_base_id,
+                    right_endpoint_edition_id,
                     KnowledgeEdgeTraversal {
                         left_endpoint: EntityVertexId {
                             base_id: EntityId {
@@ -286,52 +290,88 @@ where
                             revision_id: traversal_data.entity_revision_ids[index],
                         },
                         right_endpoint: EntityVertexId {
-                            base_id: right_endpoint_base_id,
+                            base_id: EntityId {
+                                web_id: row.get(1),
+                                entity_uuid: row.get(2),
+                                draft_id: None,
+                            },
                             revision_id: row.get(3),
                         },
-                        right_endpoint_edition_id: row.get(4),
+                        right_endpoint_edition_id,
                         edge_interval: row.get(5),
                         resolve_depths: traversal_data.resolve_depths[index],
                         traversal_interval: row.get(6),
                     },
                 )
             })
-            .collect::<(Vec<_>, Vec<_>)>();
+            .try_collect::<(Vec<_>, Vec<_>)>()
+            .instrument(tracing::trace_span!("collect_edges"))
+            .await
+            .change_context(QueryError)?;
 
-        let permissions = if let Some(policy_components) = provider.policy_components {
-            Some(
-                provider
-                    .store
-                    .authorization_api
-                    .check_entities_permission(
-                        policy_components
-                            .actor_id()
-                            .map_or_else(ActorEntityUuid::public_actor, ActorEntityUuid::from),
-                        EntityPermission::View,
-                        // TODO: Filter for entities, which were not already added to the
-                        //       subgraph to avoid unnecessary lookups.
-                        entity_ids.iter().copied(),
-                        Consistency::FullyConsistent,
-                    )
-                    .await
-                    .change_context(QueryError)?
-                    .0,
-            )
-        } else {
-            None
-        };
+        let permitted_entity_edition_ids =
+            if let Some(policy_components) = provider.policy_components {
+                let temporal_bounds = match traversal_data.variable_axis {
+                    TimeAxis::DecisionTime => QueryTemporalAxesUnresolved::DecisionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(Some(
+                            traversal_data.pinned_timestamp.cast(),
+                        )),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
+                    TimeAxis::TransactionTime => QueryTemporalAxesUnresolved::TransactionTime {
+                        pinned: PinnedTemporalAxisUnresolved::new(Some(
+                            traversal_data.pinned_timestamp.cast(),
+                        )),
+                        variable: VariableTemporalAxisUnresolved::new(None, None),
+                    },
+                }
+                .resolve();
+                let mut compiler = SelectCompiler::new(Some(&temporal_bounds), true);
 
-        Ok(knowledge_edges.into_iter().filter(move |edge| {
-            let Some(permissions) = &permissions else {
-                return true;
+                let entity_editions_filter = Filter::for_entity_edition_ids(&entity_edition_ids);
+                compiler
+                    .add_filter(&entity_editions_filter)
+                    .change_context(QueryError)?;
+
+                // TODO: Ideally, we'd incorporate the filter in the above query, but that's
+                //       not easily possible as the query above uses features that the query
+                //       compiler does not support yet.
+                let permission_filter = Filter::for_policies(
+                    policy_components.extract_filter_policies(ActionName::ViewEntity),
+                    policy_components.actor_id(),
+                    policy_components.optimization_data(),
+                );
+                compiler
+                    .add_filter(&permission_filter)
+                    .change_context(QueryError)?;
+
+                let edition_id_idx = compiler.add_selection_path(&EntityQueryPath::EditionId);
+
+                let (statement, parameters) = compiler.compile();
+
+                Some(
+                    provider
+                        .store
+                        .as_client()
+                        .query_raw(&statement, parameters.iter().copied())
+                        .instrument(tracing::trace_span!("query_permitted_entity_edition_ids"))
+                        .await
+                        .change_context(QueryError)?
+                        .map_ok(|row| row.get::<_, EntityEditionId>(edition_id_idx))
+                        .try_collect::<HashSet<_>>()
+                        .instrument(tracing::trace_span!("collect_permitted_entity_edition_ids"))
+                        .await
+                        .change_context(QueryError)?,
+                )
+            } else {
+                None
             };
 
-            // We can unwrap here because we checked permissions for all
-            // entities in question.
-            permissions
-                .get(&edge.right_endpoint.base_id.entity_uuid)
-                .copied()
-                .unwrap_or(true)
+        Ok(edges.into_iter().filter(move |edge| {
+            let Some(permitted_entity_edition_ids) = &permitted_entity_edition_ids else {
+                return true;
+            };
+            permitted_entity_edition_ids.contains(&edge.right_endpoint_edition_id)
         }))
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

I prepared everything in order to use the new `viewEntity` policy action and stop relying on SpiceDB for entity queries. This changes the implementation in the Graph.

## 🚫 Blocked by

- #7350 
- #7496 

## 🔍 What does this change?

All usages of `EntityPermission::View` has been replaced with the appropriated call to the new policy engine.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

- https://github.com/hashintel/hash/pull/7351

## 🛡 What tests cover this?

Pretty much every test around entities implicitly tests this

## ❓ How to test this?

Start the application and make sure everything is still working as expected