### PR TITLE
H-4745: Fix URL generation for entity tabs when draftId present

### DIFF
--- a/apps/hash-frontend/src/pages/shared/entity/shared/entity-editor-tabs.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity/shared/entity-editor-tabs.tsx
@@ -72,12 +72,16 @@ const getTabUrl = (tab: string, entityPath: string) => {
     .pathname;
 
   if (tab === defaultTab) {
-    return `${entityPathWithoutParams}?${searchParams.toString()}`;
+    return `${entityPathWithoutParams}${
+      searchParams.size ? `?${searchParams.toString()}` : ""
+    }`;
   }
 
   searchParams.set("tab", tab);
 
-  return `${entityPathWithoutParams}?${searchParams.toString()}`;
+  return `${entityPathWithoutParams}${
+    searchParams.size ? `?${searchParams.toString()}` : ""
+  }`;
 };
 
 export const EntityEditorTabs = ({

--- a/apps/hash-frontend/src/pages/shared/entity/shared/entity-editor-tabs.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity/shared/entity-editor-tabs.tsx
@@ -58,25 +58,26 @@ export const useEntityEditorTab = () => {
   return context;
 };
 
-const getTabUrl = (tab: string, entityPath: string, isInSlide: boolean) => {
+const getTabUrl = (tab: string, entityPath: string) => {
   let searchParams = new URLSearchParams();
 
-  if (!isInSlide) {
-    /**
-     * Preserve the search params (except tab) if we're on the entity's page
-     */
-    const url = new URL(window.location.href);
-    searchParams = new URLSearchParams(url.search);
-    searchParams.delete("tab");
-  }
+  /**
+   * Preserve search params except any existing tab param
+   */
+  const url = new URL(entityPath, window.location.href);
+  searchParams = new URLSearchParams(url.search);
+  searchParams.delete("tab");
+
+  const entityPathWithoutParams = new URL(entityPath, window.location.href)
+    .pathname;
 
   if (tab === defaultTab) {
-    return `${entityPath}?${searchParams.toString()}`;
+    return `${entityPathWithoutParams}?${searchParams.toString()}`;
   }
 
   searchParams.set("tab", tab);
 
-  return `${entityPath}?${searchParams.toString()}`;
+  return `${entityPathWithoutParams}?${searchParams.toString()}`;
 };
 
 export const EntityEditorTabs = ({
@@ -93,7 +94,7 @@ export const EntityEditorTabs = ({
       <Tabs value={tab}>
         <TabLink
           value="overview"
-          href={getTabUrl("overview", entityPath, isInSlide)}
+          href={getTabUrl("overview", entityPath)}
           onClick={
             isInSlide
               ? (event) => {
@@ -107,7 +108,7 @@ export const EntityEditorTabs = ({
         />
         <TabLink
           value="history"
-          href={getTabUrl("history", entityPath, isInSlide)}
+          href={getTabUrl("history", entityPath)}
           onClick={
             isInSlide
               ? (event) => {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When viewing a page for a draft entity, the URLs generated for the tabs (e.g. Overview, History) incorrectly duplicated the `draftId` param from the URL, causing a malformed request to the API (and the URL to be wrong).

This PR fixes that.


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. View a draft entity, check that switching to the History tab doesn't end up with multiple `draftId` in URL
