### PR TITLE
H-4755: Remove Vault token environment variable from Terraform config

### DIFF
--- a/apps/hash-ai-worker-ts/README.md
+++ b/apps/hash-ai-worker-ts/README.md
@@ -18,7 +18,7 @@ The service uses the following environment variables:
 - `INTERNAL_API_KEY`: The API key used to authenticate with the internal API, required for workflows making use of the `getWebSearchResultsActivity` activity
 - `HASH_VAULT_HOST`: The host address (including protocol) that the Vault server is running on, e.g. `http://127.0.0.1`
 - `HASH_VAULT_PORT`: The port that the Vault server is running on, e.g. `8200`
-- `HASH_VAULT_ROOT_TOKEN`: The token to authenticate with the Vault server.
+- `HASH_VAULT_ROOT_TOKEN`: The token to authenticate with the Vault server.  If not present, login via AWS IAM is attempted instead.
 - `GOOGLE_CLOUD_HASH_PROJECT_ID`: The projectId for a Google Cloud Platform project, used in document analysis (Vertex AI and Cloud Storage). Note that this is the Project ID, _not_ the Project Number.
 - `GOOGLE_CLOUD_STORAGE_BUCKET`: The name of the Google Cloud Storage bucket to use for document analysis.
 - `GOOGLE_APPLICATION_CREDENTIALS`: The path to a configuration file for GCP authentication. Automatically set locally by the `gcloud` CLI, and set manually during the build process.

--- a/apps/hash-api/README.md
+++ b/apps/hash-api/README.md
@@ -34,7 +34,7 @@ The HASH Backend API service is configured using the following environment varia
 - Vault
   - `HASH_VAULT_HOST`: The host address (including protocol) that the Vault server is running on, e.g. `http://127.0.0.1`
   - `HASH_VAULT_PORT`: The port that the Vault server is running on, e.g. `8200`
-  - `HASH_VAULT_ROOT_TOKEN`: The token to authenticate with the Vault server.
+  - `HASH_VAULT_ROOT_TOKEN`: The token to authenticate with the Vault server. If not present, login via AWS IAM is attempted instead.
 - Google integration
   - `GOOGLE_OAUTH_CLIENT_ID`: the client ID for the Google OAuth application.
   - `GOOGLE_OAUTH_CLIENT_SECRET`: the client secret for the Google OAuth application.

--- a/apps/hash-integration-worker/README.md
+++ b/apps/hash-integration-worker/README.md
@@ -14,4 +14,4 @@ The service uses the following environment variables:
 - `HASH_TEMPORAL_SERVER_PORT`: The port that the Temporal server is running on (defaults to `7233`).
 - `HASH_VAULT_HOST`: The host address (including protocol) that the Vault server is running on, e.g. `http://127.0.0.1`
 - `HASH_VAULT_PORT`: The port that the Vault server is running on, e.g. `8200`
-- `HASH_VAULT_ROOT_TOKEN`: The token to authenticate with the Vault server.
+- `HASH_VAULT_ROOT_TOKEN`: The token to authenticate with the Vault server. If not present, login via AWS IAM is attempted instead.

--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -372,10 +372,6 @@ module "application" {
       value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_vault_port"])
     },
     {
-      name  = "HASH_VAULT_ROOT_TOKEN", secret = true,
-      value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_vault_root_token"])
-    },
-    {
       name  = "INTERNAL_API_HOST", secret = true,
       value = sensitive(data.vault_kv_secret_v2.secrets.data["internal_api_host"])
     },
@@ -445,10 +441,6 @@ module "application" {
       value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_vault_port"])
     },
     {
-      name  = "HASH_VAULT_ROOT_TOKEN", secret = true,
-      value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_vault_root_token"])
-    },
-    {
       name  = "HASH_TEMPORAL_WORKER_AI_SENTRY_DSN", secret = true,
       value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_temporal_worker_ai_sentry_dsn"])
     },
@@ -489,10 +481,6 @@ module "application" {
     {
       name  = "HASH_VAULT_PORT", secret = true,
       value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_vault_port"])
-    },
-    {
-      name  = "HASH_VAULT_ROOT_TOKEN", secret = true,
-      value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_vault_root_token"])
     },
     {
       name  = "HASH_TEMPORAL_WORKER_INTEGRATION_SENTRY_DSN", secret = true,

--- a/libs/@local/hash-backend-utils/src/vault.ts
+++ b/libs/@local/hash-backend-utils/src/vault.ts
@@ -339,6 +339,10 @@ export const createVaultClient = async ({
     }
   }
 
+  logger.info(
+    "Creating Vault client with HASH_VAULT_ROOT_TOKEN from environment",
+  );
+
   return new VaultClient({
     endpoint: `${process.env.HASH_VAULT_HOST}:${process.env.HASH_VAULT_PORT}`,
     token: process.env.HASH_VAULT_ROOT_TOKEN,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Now that we have access to Vault handled via IAM, the root token environment variable can be removed from Terraform config, which will prompt an attempted login via IAM instead. The variable was never given a proper value in production.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
