### PR TITLE
H-4759: Expose ECS task role name from Terraform state

### DIFF
--- a/infra/terraform/hash/hash_application/outputs.tf
+++ b/infra/terraform/hash/hash_application/outputs.tf
@@ -1,3 +1,3 @@
-output "ecs_iam_task_role_arn" {
-  value = aws_iam_role.task_role.arn
+output "ecs_iam_task_role" {
+  value = aws_iam_role.task_role
 }

--- a/infra/terraform/hash/outputs.tf
+++ b/infra/terraform/hash/outputs.tf
@@ -23,5 +23,9 @@ output "temporal_hostname" {
 }
 
 output "hash_application_ecs_iam_task_role_arn" {
-  value = module.application.ecs_iam_task_role_arn
+  value = module.application.ecs_iam_task_role.arn
+}
+
+output "hash_application_ecs_iam_task_role_name" {
+  value = module.application.ecs_iam_task_role.name
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

I need the role name to use in Vault config hosted elsewhere, so adding it to the Terraform state, from which it can be accessed elsewhere.