### PR TITLE
H-4769: Simplify entry point for permission checks

### DIFF
--- a/libs/@local/graph/api/src/rest/entity.rs
+++ b/libs/@local/graph/api/src/rest/entity.rs
@@ -437,11 +437,11 @@ where
         .await
         .map_err(report_to_response)?;
 
-    let response = Ok(Json(
-        store
-            .validate_entity(actor_id, Consistency::FullyConsistent, params)
-            .await,
-    ));
+    let response = store
+        .validate_entity(actor_id, Consistency::FullyConsistent, params)
+        .await
+        .map_err(report_to_response)
+        .map(Json);
     if let Some(query_logger) = &mut query_logger {
         query_logger.send().await.map_err(report_to_response)?;
     }
@@ -1236,7 +1236,7 @@ async fn modify_entity_authorization_relationships<A>(
 where
     A: AuthorizationApiPool + Send + Sync,
 {
-    let mut authorization_api = authorization_api_pool
+    let authorization_api = authorization_api_pool
         .acquire()
         .await
         .map_err(report_to_response)?;

--- a/libs/@local/graph/api/src/rest/permissions.rs
+++ b/libs/@local/graph/api/src/rest/permissions.rs
@@ -113,7 +113,7 @@ where
         )
         .await
         .map_err(report_to_response)?
-        .create_policy(authenticated_actor_id, policy)
+        .create_policy(authenticated_actor_id.into(), policy)
         .await
         .map_err(report_to_response)
         .map(Json)
@@ -159,7 +159,7 @@ where
         )
         .await
         .map_err(report_to_response)?
-        .get_policy_by_id(authenticated_actor_id, policy_id)
+        .get_policy_by_id(authenticated_actor_id.into(), policy_id)
         .await
         .map_err(report_to_response)
         .map(Json)
@@ -205,7 +205,7 @@ where
         )
         .await
         .map_err(report_to_response)?
-        .query_policies(authenticated_actor_id, &filter)
+        .query_policies(authenticated_actor_id.into(), &filter)
         .await
         .map_err(report_to_response)
         .map(Json)
@@ -251,7 +251,7 @@ where
         )
         .await
         .map_err(report_to_response)?
-        .resolve_policies_for_actor(authenticated_actor_id, Some(actor_id))
+        .resolve_policies_for_actor(authenticated_actor_id.into(), Some(actor_id))
         .await
         .map_err(report_to_response)
         .map(Json)
@@ -299,7 +299,7 @@ where
         )
         .await
         .map_err(report_to_response)?
-        .update_policy_by_id(authenticated_actor_id, policy_id, &operations)
+        .update_policy_by_id(authenticated_actor_id.into(), policy_id, &operations)
         .await
         .map_err(report_to_response)
         .map(Json)
@@ -345,7 +345,7 @@ where
         )
         .await
         .map_err(report_to_response)?
-        .archive_policy_by_id(authenticated_actor_id, policy_id)
+        .archive_policy_by_id(authenticated_actor_id.into(), policy_id)
         .await
         .map_err(report_to_response)
         .map(|()| StatusCode::NO_CONTENT)
@@ -391,7 +391,7 @@ where
         )
         .await
         .map_err(report_to_response)?
-        .delete_policy_by_id(authenticated_actor_id, policy_id)
+        .delete_policy_by_id(authenticated_actor_id.into(), policy_id)
         .await
         .map_err(report_to_response)
         .map(|()| StatusCode::NO_CONTENT)

--- a/libs/@local/graph/authorization/src/api.rs
+++ b/libs/@local/graph/authorization/src/api.rs
@@ -136,7 +136,7 @@ pub trait AuthorizationApi: Send + Sync {
     ) -> impl Future<Output = Result<Vec<ActorIdOrPublic>, Report<ReadError>>> + Send;
 
     fn modify_entity_relations(
-        &mut self,
+        &self,
         relationships: impl IntoIterator<
             Item = (
                 ModifyRelationshipOperation,
@@ -365,7 +365,7 @@ impl<A: AuthorizationApi> AuthorizationApi for &mut A {
     }
 
     async fn modify_entity_relations(
-        &mut self,
+        &self,
         relationships: impl IntoIterator<
             Item = (
                 ModifyRelationshipOperation,

--- a/libs/@local/graph/authorization/src/backend/mod.rs
+++ b/libs/@local/graph/authorization/src/backend/mod.rs
@@ -54,7 +54,7 @@ pub trait ZanzibarBackend {
     ) -> impl Future<Output = Result<ExportSchemaResponse, Report<ExportSchemaError>>> + Send;
 
     fn modify_relationships<R>(
-        &mut self,
+        &self,
         relationships: impl IntoIterator<Item = (ModifyRelationshipOperation, R), IntoIter: Send> + Send,
     ) -> impl Future<Output = Result<ModifyRelationshipResponse, Report<ModifyRelationshipError>>> + Send
     where
@@ -76,7 +76,7 @@ pub trait ZanzibarBackend {
     ///
     /// Returns an error if the relation could not be created.
     fn touch_relationships<R>(
-        &mut self,
+        &self,
         relationships: impl IntoIterator<Item = R, IntoIter: Send> + Send,
     ) -> impl Future<Output = Result<ModifyRelationshipResponse, Report<ModifyRelationshipError>>> + Send
     where
@@ -280,7 +280,7 @@ impl<Z: ZanzibarBackend + Send + Sync> ZanzibarBackend for &mut Z {
     }
 
     async fn modify_relationships<R>(
-        &mut self,
+        &self,
         relationships: impl IntoIterator<Item = (ModifyRelationshipOperation, R), IntoIter: Send> + Send,
     ) -> Result<ModifyRelationshipResponse, Report<ModifyRelationshipError>>
     where
@@ -292,7 +292,7 @@ impl<Z: ZanzibarBackend + Send + Sync> ZanzibarBackend for &mut Z {
             > + Send
             + Sync,
     {
-        ZanzibarBackend::modify_relationships(&mut **self, relationships).await
+        ZanzibarBackend::modify_relationships(&**self, relationships).await
     }
 
     async fn check_permission<O, R, S>(
@@ -428,7 +428,7 @@ impl ZanzibarBackend for NoAuthorization {
     }
 
     async fn modify_relationships<T>(
-        &mut self,
+        &self,
         _: impl IntoIterator<Item = (ModifyRelationshipOperation, T), IntoIter: Send> + Send,
     ) -> Result<ModifyRelationshipResponse, Report<ModifyRelationshipError>>
     where

--- a/libs/@local/graph/authorization/src/backend/spicedb/api.rs
+++ b/libs/@local/graph/authorization/src/backend/spicedb/api.rs
@@ -189,7 +189,7 @@ impl ZanzibarBackend for SpiceDbOpenApi {
     }
 
     async fn modify_relationships<T>(
-        &mut self,
+        &self,
         relationships: impl IntoIterator<Item = (ModifyRelationshipOperation, T), IntoIter: Send> + Send,
     ) -> Result<ModifyRelationshipResponse, Report<ModifyRelationshipError>>
     where

--- a/libs/@local/graph/authorization/src/lib.rs
+++ b/libs/@local/graph/authorization/src/lib.rs
@@ -148,7 +148,7 @@ impl AuthorizationApi for NoAuthorization {
     }
 
     async fn modify_entity_relations(
-        &mut self,
+        &self,
         _: impl IntoIterator<
             Item = (
                 ModifyRelationshipOperation,

--- a/libs/@local/graph/authorization/src/policies/components.rs
+++ b/libs/@local/graph/authorization/src/policies/components.rs
@@ -1,0 +1,189 @@
+use alloc::borrow::Cow;
+use std::collections::HashSet;
+
+use error_stack::{Report, ResultExt as _};
+use type_system::{
+    knowledge::entity::id::EntityEditionId, ontology::VersionedUrl, principal::actor::ActorId,
+};
+
+use super::{
+    Context, ContextBuilder, PolicySet,
+    principal::actor::AuthenticatedActor,
+    store::{PolicyStore, PrincipalStore, error::ContextCreationError},
+};
+
+#[derive(Debug)]
+pub struct PolicyComponents {
+    pub actor_id: Option<ActorId>,
+    pub policy_set: PolicySet,
+    pub context: Context,
+}
+
+impl PolicyComponents {
+    #[must_use]
+    pub fn builder<S>(store: &S) -> PolicyComponentsBuilder<'_, S> {
+        PolicyComponentsBuilder::new(store)
+    }
+}
+
+pub struct PolicyComponentsBuilder<'a, S> {
+    store: &'a S,
+    actor: AuthenticatedActor,
+    context: ContextBuilder,
+    entity_type_ids: HashSet<Cow<'a, VersionedUrl>>,
+    entity_edition_ids: HashSet<EntityEditionId>,
+}
+
+impl<'a, S> PolicyComponentsBuilder<'a, S> {
+    #[must_use]
+    pub fn new(store: &'a S) -> Self {
+        Self {
+            store,
+            actor: AuthenticatedActor::Public,
+            context: ContextBuilder::default(),
+            entity_type_ids: HashSet::new(),
+            entity_edition_ids: HashSet::new(),
+        }
+    }
+
+    pub fn set_actor(&mut self, actor: impl Into<AuthenticatedActor>) {
+        self.actor = actor.into();
+    }
+
+    #[must_use]
+    pub fn with_actor(mut self, actor: impl Into<AuthenticatedActor>) -> Self {
+        self.set_actor(actor);
+        self
+    }
+
+    pub fn add_entity_type_id(&mut self, entity_type: &'a VersionedUrl) {
+        self.entity_type_ids.insert(Cow::Borrowed(entity_type));
+    }
+
+    pub fn add_entity_type_ids(&mut self, entity_type: impl IntoIterator<Item = &'a VersionedUrl>) {
+        self.entity_type_ids
+            .extend(entity_type.into_iter().map(Cow::Borrowed));
+    }
+
+    #[must_use]
+    pub fn with_entity_type_id(mut self, entity_type: &'a VersionedUrl) -> Self {
+        self.add_entity_type_id(entity_type);
+        self
+    }
+
+    #[must_use]
+    pub fn with_entity_type_ids(
+        mut self,
+        entity_types: impl IntoIterator<Item = &'a VersionedUrl>,
+    ) -> Self {
+        self.add_entity_type_ids(entity_types);
+        self
+    }
+
+    pub fn add_entity_edition_id(&mut self, entity_edition_id: EntityEditionId) {
+        self.entity_edition_ids.insert(entity_edition_id);
+    }
+
+    pub fn add_entity_edition_ids(
+        &mut self,
+        entity_edition_ids: impl IntoIterator<Item = EntityEditionId>,
+    ) {
+        self.entity_edition_ids.extend(entity_edition_ids);
+    }
+
+    #[must_use]
+    pub fn with_entity_edition_id(mut self, entity_edition_id: EntityEditionId) -> Self {
+        self.add_entity_edition_id(entity_edition_id);
+        self
+    }
+
+    #[must_use]
+    pub fn with_entity_edition_ids(
+        mut self,
+        entity_edition_ids: impl IntoIterator<Item = EntityEditionId>,
+    ) -> Self {
+        self.add_entity_edition_ids(entity_edition_ids);
+        self
+    }
+}
+
+impl<S> IntoFuture for PolicyComponentsBuilder<'_, S>
+where
+    S: PrincipalStore + PolicyStore + Sync,
+{
+    type Output = Result<PolicyComponents, Report<ContextCreationError>>;
+
+    type IntoFuture = impl Future<Output = Self::Output> + Send;
+
+    fn into_future(mut self) -> Self::IntoFuture {
+        async move {
+            let actor_id = match self.actor {
+                AuthenticatedActor::Public => None,
+                AuthenticatedActor::Id(actor_id) => Some(actor_id),
+                AuthenticatedActor::Uuid(actor_uuid) => self
+                    .store
+                    .determine_actor(actor_uuid)
+                    .await
+                    .change_context(ContextCreationError::DetermineActor {
+                        actor_id: actor_uuid,
+                    })?,
+            };
+
+            if let Some(actor_id) = actor_id {
+                self.store
+                    .build_principal_context(actor_id, &mut self.context)
+                    .await
+                    .change_context(ContextCreationError::BuildPrincipalContext { actor_id })?;
+            }
+
+            let entity_resources;
+            let mut entity_type_ids = self.entity_type_ids;
+            if !self.entity_edition_ids.is_empty() {
+                entity_resources = self
+                    .store
+                    .build_entity_context(
+                        &self.entity_edition_ids.iter().copied().collect::<Vec<_>>(),
+                    )
+                    .await
+                    .change_context(ContextCreationError::BuildEntityContext {
+                        entity_edition_ids: self.entity_edition_ids,
+                    })?;
+                for entity_resource in &entity_resources {
+                    self.context.add_entity(entity_resource);
+                    entity_type_ids.extend(entity_resource.entity_type.iter().map(Cow::Borrowed));
+                }
+            }
+
+            if !entity_type_ids.is_empty() {
+                let entity_type_ids = entity_type_ids.iter().map(Cow::as_ref).collect::<Vec<_>>();
+                let entity_type_resources = self
+                    .store
+                    .build_entity_type_context(&entity_type_ids)
+                    .await
+                    .change_context_lazy(|| ContextCreationError::BuildEntityTypeContext {
+                        entity_type_ids: entity_type_ids.into_iter().cloned().collect(),
+                    })?;
+                for entity_type_resource in &entity_type_resources {
+                    self.context.add_entity_type(entity_type_resource);
+                }
+            }
+
+            let policies = self
+                .store
+                .resolve_policies_for_actor(self.actor, actor_id)
+                .await
+                .change_context(ContextCreationError::ResolveActorPolicies { actor_id })?;
+
+            Ok(PolicyComponents {
+                actor_id,
+                policy_set: PolicySet::default()
+                    .with_policies(&policies)
+                    .change_context(ContextCreationError::CreatePolicySet)?,
+                context: self
+                    .context
+                    .build()
+                    .change_context(ContextCreationError::CreatePolicyContext)?,
+            })
+        }
+    }
+}

--- a/libs/@local/graph/authorization/src/policies/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/mod.rs
@@ -6,6 +6,7 @@ pub mod resource;
 pub mod store;
 
 pub(crate) mod cedar;
+mod components;
 mod context;
 mod set;
 mod validation;
@@ -31,6 +32,7 @@ use self::{
 };
 pub use self::{
     cedar::PolicyExpressionTree,
+    components::{PolicyComponents, PolicyComponentsBuilder},
     context::{Context, ContextBuilder, ContextError},
     set::{
         Authorized, PolicyConstraintError, PolicyEvaluationError, PolicySet,
@@ -381,7 +383,7 @@ mod tests {
         use std::collections::HashSet;
 
         use type_system::{
-            knowledge::entity::id::EntityUuid,
+            knowledge::entity::{EntityId, id::EntityUuid},
             ontology::VersionedUrl,
             principal::{
                 actor::{ActorId, User, UserId},
@@ -448,14 +450,17 @@ mod tests {
                 roles: HashSet::new(),
             };
             let user_entity = EntityResource {
-                web_id: WebId::from(user_id),
-                id: entity_uuid,
+                id: EntityId {
+                    web_id: WebId::from(user_id),
+                    entity_uuid,
+                    draft_id: None,
+                },
                 entity_type: Cow::Owned(vec![
                     VersionedUrl::from_str("https://hash.ai/@hash/types/entity-type/user/v/6")?,
                     VersionedUrl::from_str("https://hash.ai/@hash/types/entity-type/actor/v/2")?,
                 ]),
             };
-            let resource_id = PartialResourceId::Entity(Some(user_entity.id));
+            let resource_id = PartialResourceId::Entity(Some(user_entity.id.entity_uuid));
             let mut context = ContextBuilder::default();
             context.add_entity(&user_entity);
             let context = context.build()?;

--- a/libs/@local/graph/authorization/src/policies/principal/actor/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/actor/mod.rs
@@ -7,12 +7,59 @@ use std::sync::LazyLock;
 
 use cedar_policy_core::ast;
 use error_stack::{Report, ResultExt as _};
-use type_system::principal::actor::{Actor, ActorId, AiId, MachineId, UserId};
+use type_system::principal::actor::{Actor, ActorEntityUuid, ActorId, AiId, MachineId, UserId};
 
 use crate::policies::{
     cedar::{FromCedarEntityId as _, FromCedarEntityUId, ToCedarEntity, ToCedarEntityId},
     error::FromCedarRefernceError,
 };
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum AuthenticatedActor {
+    Public,
+    Id(ActorId),
+    Uuid(ActorEntityUuid),
+}
+
+impl From<AuthenticatedActor> for ActorEntityUuid {
+    fn from(authenticated_actor: AuthenticatedActor) -> Self {
+        match authenticated_actor {
+            AuthenticatedActor::Public => Self::public_actor(),
+            AuthenticatedActor::Id(actor_id) => Self::new(actor_id),
+            AuthenticatedActor::Uuid(actor_uuid) => actor_uuid,
+        }
+    }
+}
+
+impl From<ActorId> for AuthenticatedActor {
+    fn from(actor_id: ActorId) -> Self {
+        Self::Id(actor_id)
+    }
+}
+
+impl From<MachineId> for AuthenticatedActor {
+    fn from(machine_id: MachineId) -> Self {
+        Self::Id(machine_id.into())
+    }
+}
+
+impl From<UserId> for AuthenticatedActor {
+    fn from(user_id: UserId) -> Self {
+        Self::Id(user_id.into())
+    }
+}
+
+impl From<AiId> for AuthenticatedActor {
+    fn from(ai_id: AiId) -> Self {
+        Self::Id(ai_id.into())
+    }
+}
+
+impl From<ActorEntityUuid> for AuthenticatedActor {
+    fn from(actor_uuid: ActorEntityUuid) -> Self {
+        Self::Uuid(actor_uuid)
+    }
+}
 
 pub struct PublicActor;
 

--- a/libs/@local/graph/authorization/src/policies/resource/entity.rs
+++ b/libs/@local/graph/authorization/src/policies/resource/entity.rs
@@ -6,7 +6,9 @@ use cedar_policy_core::{ast, extensions::Extensions};
 use error_stack::{Report, ResultExt as _};
 use smol_str::SmolStr;
 use type_system::{
-    knowledge::entity::id::EntityUuid, ontology::VersionedUrl, principal::actor_group::WebId,
+    knowledge::entity::{EntityId, id::EntityUuid},
+    ontology::VersionedUrl,
+    principal::actor_group::WebId,
 };
 use uuid::Uuid;
 
@@ -19,8 +21,7 @@ use crate::policies::cedar::{
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EntityResource<'a> {
-    pub web_id: WebId,
-    pub id: EntityUuid,
+    pub id: EntityId,
     pub entity_type: Cow<'a, [VersionedUrl]>,
 }
 
@@ -124,7 +125,7 @@ impl FromCedarExpr for EntityResourceFilter {
 impl EntityResource<'_> {
     pub(crate) fn to_cedar_entity(&self) -> ast::Entity {
         ast::Entity::new(
-            self.id.to_euid(),
+            self.id.entity_uuid.to_euid(),
             [(
                 SmolStr::new_static("entity_types"),
                 ast::RestrictedExpr::set(
@@ -134,7 +135,7 @@ impl EntityResource<'_> {
                 ),
             )],
             HashSet::new(),
-            iter::once(self.web_id.to_euid()).collect(),
+            iter::once(self.id.web_id.to_euid()).collect(),
             iter::empty(),
             Extensions::none(),
         )

--- a/libs/@local/graph/authorization/src/policies/store/error.rs
+++ b/libs/@local/graph/authorization/src/policies/store/error.rs
@@ -1,10 +1,15 @@
 use core::error::Error;
+use std::collections::HashSet;
 
-use type_system::principal::{
-    PrincipalId,
-    actor::ActorId,
-    actor_group::{ActorGroupId, TeamId, WebId},
-    role::RoleName,
+use type_system::{
+    knowledge::entity::id::EntityEditionId,
+    ontology::VersionedUrl,
+    principal::{
+        PrincipalId,
+        actor::{ActorEntityUuid, ActorId},
+        actor_group::{ActorGroupId, TeamId, WebId},
+        role::RoleName,
+    },
 };
 
 use crate::policies::{PolicyId, action::ActionName};
@@ -52,6 +57,28 @@ pub enum EnsureSystemPoliciesError {
 }
 
 impl Error for EnsureSystemPoliciesError {}
+
+#[derive(Debug, derive_more::Display)]
+#[display("Could not build entity type context: {_variant}")]
+pub enum BuildEntityTypeContextError {
+    #[display("Entity type with ID `{entity_type_id}` does not exist")]
+    EntityTypeNotFound { entity_type_id: VersionedUrl },
+    #[display("Store operation failed")]
+    StoreError,
+}
+
+impl Error for BuildEntityTypeContextError {}
+
+#[derive(Debug, derive_more::Display)]
+#[display("Could not build entity type context: {_variant}")]
+pub enum BuildEntityContextError {
+    #[display("Entity with editionID `{}` does not exist", entity_edition_id.as_uuid())]
+    EntityNotFound { entity_edition_id: EntityEditionId },
+    #[display("Store operation failed")]
+    StoreError,
+}
+
+impl Error for BuildEntityContextError {}
 
 #[derive(Debug, derive_more::Display)]
 #[display("Could not create actor: {_variant}")]
@@ -173,11 +200,53 @@ impl Error for RoleAssignmentError {}
 pub enum ContextCreationError {
     #[display("Actor with ID `{actor_id}` does not exist")]
     ActorNotFound { actor_id: ActorId },
+    #[display("Actor with ID `{actor_id}` is not a valid actor")]
+    DetermineActor { actor_id: ActorEntityUuid },
+    #[display("Could not build principal context for actor with ID `{actor_id}`")]
+    BuildPrincipalContext { actor_id: ActorId },
+    #[display("Could not build entity type context for entity types with IDs `{}`",
+        entity_type_ids.iter().map(VersionedUrl::to_string).collect::<Vec<_>>().join(", "))]
+    BuildEntityTypeContext {
+        entity_type_ids: HashSet<VersionedUrl>,
+    },
+    #[display("Could not build entity context for entity with edition IDs `{}`",
+        entity_edition_ids.iter().map(|id| id.as_uuid().to_string()).collect::<Vec<_>>().join(", "))]
+    BuildEntityContext {
+        entity_edition_ids: HashSet<EntityEditionId>,
+    },
+    #[display("Could not resolve policies for actor with ID `{}`", actor_id.map_or_else(ActorEntityUuid::public_actor, ActorEntityUuid::from))]
+    ResolveActorPolicies { actor_id: Option<ActorId> },
+    #[display("Could not create policy set")]
+    CreatePolicySet,
+    #[display("Could not create policy context")]
+    CreatePolicyContext,
     #[display("Store operation failed")]
     StoreError,
 }
 
 impl Error for ContextCreationError {}
+
+#[derive(Debug, derive_more::Display)]
+#[display("Could not determine actor: {_variant}")]
+pub enum DetermineActorError {
+    #[display("Actor with ID `{actor_entity_uuid}` does not exist")]
+    ActorNotFound { actor_entity_uuid: ActorEntityUuid },
+    #[display("Store operation failed")]
+    StoreError,
+}
+
+impl Error for DetermineActorError {}
+
+#[derive(Debug, derive_more::Display)]
+#[display("Could not build principal context for actor with ID `{actor_id}`")]
+pub enum BuildPrincipalContextError {
+    #[display("Actor with ID `{actor_id}` does not exist")]
+    ActorNotFound { actor_id: ActorId },
+    #[display("Store operation failed")]
+    StoreError,
+}
+
+impl Error for BuildPrincipalContextError {}
 
 #[derive(Debug, derive_more::Display)]
 #[display("Could not store policy: {_variant}")]

--- a/libs/@local/graph/authorization/src/zanzibar/api.rs
+++ b/libs/@local/graph/authorization/src/zanzibar/api.rs
@@ -203,7 +203,7 @@ where
 
     #[tracing::instrument(level = "info", skip(self, relationships))]
     async fn modify_entity_relations(
-        &mut self,
+        &self,
         relationships: impl IntoIterator<
             Item = (
                 ModifyRelationshipOperation,
@@ -634,7 +634,7 @@ where
     }
 
     async fn modify_relationships<R>(
-        &mut self,
+        &self,
         relationships: impl IntoIterator<Item = (ModifyRelationshipOperation, R), IntoIter: Send> + Send,
     ) -> Result<ModifyRelationshipResponse, Report<ModifyRelationshipError>>
     where

--- a/libs/@local/graph/authorization/tests/policies/definitions/mod.rs
+++ b/libs/@local/graph/authorization/tests/policies/definitions/mod.rs
@@ -5,7 +5,7 @@ use error_stack::ResultExt as _;
 use hash_graph_authorization::policies::{Policy, PolicySet, PolicyValidator};
 use pretty_assertions::assert_eq;
 use type_system::{
-    knowledge::entity::id::EntityUuid,
+    knowledge::entity::EntityId,
     principal::{
         actor::MachineId,
         actor_group::{TeamId, WebId},
@@ -61,13 +61,16 @@ pub(crate) fn permit_admin_web(web_id: WebId, admin_role: WebRoleId) -> Vec<Poli
 
 pub(crate) fn permit_hash_instance_admins(
     team_id: TeamId,
-    hash_instance_entity_id: EntityUuid,
+    hash_instance_entity_id: EntityId,
 ) -> Vec<Policy> {
     #[expect(clippy::literal_string_with_formatting_args)]
     read_policies(
         &include_str!("permit-hash-instance-admins.cedar")
             .replace("{team_id}", &team_id.to_string())
-            .replace("{entity_id}", &hash_instance_entity_id.to_string()),
+            .replace(
+                "{entity_id}",
+                &hash_instance_entity_id.entity_uuid.to_string(),
+            ),
     )
 }
 

--- a/libs/@local/graph/authorization/tests/policies/main.rs
+++ b/libs/@local/graph/authorization/tests/policies/main.rs
@@ -19,7 +19,7 @@ use hash_graph_authorization::policies::{
     store::{MemoryPolicyStore, OldPolicyStore},
 };
 use type_system::{
-    knowledge::entity::id::EntityUuid,
+    knowledge::entity::{EntityId, id::EntityUuid},
     ontology::VersionedUrl,
     principal::{
         actor::{ActorId, MachineId, UserId},
@@ -103,8 +103,11 @@ impl TestUser {
         let web = TestWeb::generate(policy_store, context, shortname)?;
         let id = policy_store.create_user(web.id)?;
         let entity = EntityResource {
-            id: id.into(),
-            web_id: web.id,
+            id: EntityId {
+                web_id: web.id,
+                entity_uuid: id.into(),
+                draft_id: None,
+            },
             entity_type: Cow::Borrowed(ENTITY_TYPES.as_slice()),
         };
 
@@ -145,8 +148,11 @@ impl TestMachine {
 
         let id = policy_store.create_machine(name.into())?;
         let entity = EntityResource {
-            id: id.into(),
-            web_id,
+            id: EntityId {
+                web_id,
+                entity_uuid: id.into(),
+                draft_id: None,
+            },
             entity_type: Cow::Borrowed(ENTITY_TYPES.as_slice()),
         };
 
@@ -208,8 +214,11 @@ impl TestSystem {
             )
             .expect("should be able to assign role");
         let hash_instance_entity = EntityResource {
-            web_id: web.id,
-            id: EntityUuid::new(Uuid::new_v4()),
+            id: EntityId {
+                web_id: web.id,
+                entity_uuid: EntityUuid::new(Uuid::new_v4()),
+                draft_id: None,
+            },
             entity_type: Cow::Owned(vec![
                 VersionedUrl::from_str("https://hash.ai/@h/types/entity-type/hash-instance/v/1")
                     .expect("should be a valid URL"),
@@ -367,8 +376,11 @@ fn user_web_permissions() -> Result<(), Box<dyn Error>> {
     context.add_entity_type(&web_type);
 
     let web_entity = EntityResource {
-        web_id: user.web.id,
-        id: EntityUuid::new(Uuid::new_v4()),
+        id: EntityId {
+            web_id: user.web.id,
+            entity_uuid: EntityUuid::new(Uuid::new_v4()),
+            draft_id: None,
+        },
         entity_type: Cow::Owned(vec![web_type.id.as_url().clone()]),
     };
     context.add_entity(&web_entity);
@@ -435,7 +447,7 @@ fn user_web_permissions() -> Result<(), Box<dyn Error>> {
             &Request {
                 actor: Some(ActorId::User(user.id)),
                 action: ActionName::View,
-                resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
+                resource: Some(&PartialResourceId::Entity(Some(web_entity.id.entity_uuid))),
                 context: RequestContext::default(),
             },
             &context,
@@ -447,7 +459,7 @@ fn user_web_permissions() -> Result<(), Box<dyn Error>> {
             &Request {
                 actor: Some(ActorId::Machine(user.web.machine.id)),
                 action: ActionName::View,
-                resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
+                resource: Some(&PartialResourceId::Entity(Some(web_entity.id.entity_uuid))),
                 context: RequestContext::default(),
             },
             &context,
@@ -459,7 +471,7 @@ fn user_web_permissions() -> Result<(), Box<dyn Error>> {
             &Request {
                 actor: Some(ActorId::Machine(system.machine.id)),
                 action: ActionName::View,
-                resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
+                resource: Some(&PartialResourceId::Entity(Some(web_entity.id.entity_uuid))),
                 context: RequestContext::default(),
             },
             &context,
@@ -472,7 +484,7 @@ fn user_web_permissions() -> Result<(), Box<dyn Error>> {
             &Request {
                 actor: Some(ActorId::User(user.id)),
                 action: ActionName::Update,
-                resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
+                resource: Some(&PartialResourceId::Entity(Some(web_entity.id.entity_uuid))),
                 context: RequestContext::default(),
             },
             &context,
@@ -484,7 +496,7 @@ fn user_web_permissions() -> Result<(), Box<dyn Error>> {
             &Request {
                 actor: Some(ActorId::Machine(user.web.machine.id)),
                 action: ActionName::Update,
-                resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
+                resource: Some(&PartialResourceId::Entity(Some(web_entity.id.entity_uuid))),
                 context: RequestContext::default(),
             },
             &context,
@@ -496,7 +508,7 @@ fn user_web_permissions() -> Result<(), Box<dyn Error>> {
             &Request {
                 actor: Some(ActorId::Machine(system.machine.id)),
                 action: ActionName::Update,
-                resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
+                resource: Some(&PartialResourceId::Entity(Some(web_entity.id.entity_uuid))),
                 context: RequestContext::default(),
             },
             &context,
@@ -536,8 +548,11 @@ fn org_web_permissions() -> Result<(), Box<dyn Error>> {
     context.add_entity_type(&web_type);
 
     let web_entity = EntityResource {
-        web_id: org_web.id,
-        id: EntityUuid::new(Uuid::new_v4()),
+        id: EntityId {
+            web_id: org_web.id,
+            entity_uuid: EntityUuid::new(Uuid::new_v4()),
+            draft_id: None,
+        },
         entity_type: Cow::Owned(vec![web_type.id.as_url().clone()]),
     };
     context.add_entity(&web_entity);
@@ -581,7 +596,7 @@ fn org_web_permissions() -> Result<(), Box<dyn Error>> {
             &Request {
                 actor: Some(ActorId::User(user.id)),
                 action: ActionName::View,
-                resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
+                resource: Some(&PartialResourceId::Entity(Some(web_entity.id.entity_uuid))),
                 context: RequestContext::default(),
             },
             &context,
@@ -593,7 +608,7 @@ fn org_web_permissions() -> Result<(), Box<dyn Error>> {
             &Request {
                 actor: Some(ActorId::Machine(org_web.machine.id)),
                 action: ActionName::View,
-                resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
+                resource: Some(&PartialResourceId::Entity(Some(web_entity.id.entity_uuid))),
                 context: RequestContext::default(),
             },
             &context,
@@ -605,7 +620,7 @@ fn org_web_permissions() -> Result<(), Box<dyn Error>> {
             &Request {
                 actor: Some(ActorId::Machine(user.web.machine.id)),
                 action: ActionName::View,
-                resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
+                resource: Some(&PartialResourceId::Entity(Some(web_entity.id.entity_uuid))),
                 context: RequestContext::default(),
             },
             &context,
@@ -617,7 +632,7 @@ fn org_web_permissions() -> Result<(), Box<dyn Error>> {
             &Request {
                 actor: Some(ActorId::Machine(system.web.machine.id)),
                 action: ActionName::View,
-                resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
+                resource: Some(&PartialResourceId::Entity(Some(web_entity.id.entity_uuid))),
                 context: RequestContext::default(),
             },
             &context,
@@ -630,7 +645,7 @@ fn org_web_permissions() -> Result<(), Box<dyn Error>> {
             &Request {
                 actor: Some(ActorId::User(user.id)),
                 action: ActionName::Update,
-                resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
+                resource: Some(&PartialResourceId::Entity(Some(web_entity.id.entity_uuid))),
                 context: RequestContext::default(),
             },
             &context,
@@ -642,7 +657,7 @@ fn org_web_permissions() -> Result<(), Box<dyn Error>> {
             &Request {
                 actor: Some(ActorId::Machine(org_web.machine.id)),
                 action: ActionName::Update,
-                resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
+                resource: Some(&PartialResourceId::Entity(Some(web_entity.id.entity_uuid))),
                 context: RequestContext::default(),
             },
             &context,
@@ -654,7 +669,7 @@ fn org_web_permissions() -> Result<(), Box<dyn Error>> {
             &Request {
                 actor: Some(ActorId::Machine(user.web.machine.id)),
                 action: ActionName::Update,
-                resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
+                resource: Some(&PartialResourceId::Entity(Some(web_entity.id.entity_uuid))),
                 context: RequestContext::default(),
             },
             &context,
@@ -666,7 +681,7 @@ fn org_web_permissions() -> Result<(), Box<dyn Error>> {
             &Request {
                 actor: Some(ActorId::Machine(system.web.machine.id)),
                 action: ActionName::Update,
-                resource: Some(&PartialResourceId::Entity(Some(web_entity.id))),
+                resource: Some(&PartialResourceId::Entity(Some(web_entity.id.entity_uuid))),
                 context: RequestContext::default(),
             },
             &context,
@@ -700,7 +715,7 @@ fn instance_admin_without_access_permissions() -> Result<(), Box<dyn Error>> {
                 actor: Some(ActorId::User(user.id)),
                 action: ActionName::View,
                 resource: Some(&PartialResourceId::Entity(Some(
-                    system.hash_instance_entity.id
+                    system.hash_instance_entity.id.entity_uuid
                 ))),
                 context: RequestContext::default(),
             },
@@ -714,7 +729,7 @@ fn instance_admin_without_access_permissions() -> Result<(), Box<dyn Error>> {
                 actor: Some(ActorId::User(user.id)),
                 action: ActionName::Update,
                 resource: Some(&PartialResourceId::Entity(Some(
-                    system.hash_instance_entity.id
+                    system.hash_instance_entity.id.entity_uuid
                 ))),
                 context: RequestContext::default(),
             },
@@ -753,7 +768,7 @@ fn instance_admin_with_access_permissions() -> Result<(), Box<dyn Error>> {
                 actor: Some(ActorId::User(user.id)),
                 action: ActionName::View,
                 resource: Some(&PartialResourceId::Entity(Some(
-                    system.hash_instance_entity.id
+                    system.hash_instance_entity.id.entity_uuid
                 ))),
                 context: RequestContext::default(),
             },
@@ -767,7 +782,7 @@ fn instance_admin_with_access_permissions() -> Result<(), Box<dyn Error>> {
                 actor: Some(ActorId::User(user.id)),
                 action: ActionName::Update,
                 resource: Some(&PartialResourceId::Entity(Some(
-                    system.hash_instance_entity.id
+                    system.hash_instance_entity.id.entity_uuid
                 ))),
                 context: RequestContext::default(),
             },

--- a/libs/@local/graph/postgres-store/src/snapshot/entity/batch.rs
+++ b/libs/@local/graph/postgres-store/src/snapshot/entity/batch.rs
@@ -297,8 +297,8 @@ where
 
         let validator_provider = StoreProvider {
             store: postgres_client,
-            cache: StoreCache::default(),
-            authorization: None,
+            cache: Box::new(StoreCache::default()),
+            policy_components: None,
         };
 
         let mut edition_ids_updates = Vec::new();

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/read.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/read.rs
@@ -2,6 +2,7 @@ use alloc::borrow::Cow;
 use core::mem::swap;
 
 use error_stack::{Report, ResultExt as _};
+use hash_graph_authorization::{AuthorizationApi, schema::EntityPermission, zanzibar::Consistency};
 use hash_graph_store::{
     error::QueryError,
     subgraph::{
@@ -18,12 +19,15 @@ use tracing::Instrument as _;
 use type_system::{
     knowledge::entity::id::{EntityEditionId, EntityId, EntityUuid},
     ontology::id::{BaseUrl, OntologyTypeUuid},
-    principal::actor_group::WebId,
+    principal::{actor::ActorEntityUuid, actor_group::WebId},
 };
 
-use crate::store::postgres::{
-    AsClient, PostgresStore,
-    query::{ForeignKeyReference, ReferenceTable, Table, Transpile as _},
+use crate::store::{
+    StoreProvider,
+    postgres::{
+        AsClient, PostgresStore,
+        query::{ForeignKeyReference, ReferenceTable, Table, Transpile as _},
+    },
 };
 
 #[derive(Debug)]
@@ -85,7 +89,7 @@ pub struct KnowledgeEdgeTraversal {
 impl<C, A> PostgresStore<C, A>
 where
     C: AsClient,
-    A: Send + Sync,
+    A: AuthorizationApi + Send + Sync,
 {
     #[tracing::instrument(level = "trace", skip(self))]
     pub(crate) async fn read_shared_edges<'t>(
@@ -176,15 +180,15 @@ where
             }))
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "trace", skip(self, provider))]
     #[expect(clippy::too_many_lines)]
     pub(crate) async fn read_knowledge_edges<'t>(
         &self,
         traversal_data: &'t EntityEdgeTraversalData,
         reference_table: ReferenceTable,
         edge_direction: EdgeDirection,
-    ) -> Result<impl Iterator<Item = (EntityId, KnowledgeEdgeTraversal)> + 't, Report<QueryError>>
-    {
+        provider: &StoreProvider<'_, Self>,
+    ) -> Result<impl Iterator<Item = KnowledgeEdgeTraversal> + 't, Report<QueryError>> {
         let (pinned_axis, variable_axis) = match traversal_data.variable_axis {
             TimeAxis::DecisionTime => ("transaction_time", "decision_time"),
             TimeAxis::TransactionTime => ("decision_time", "transaction_time"),
@@ -215,7 +219,7 @@ where
             swap(&mut source_2, &mut target_2);
         }
 
-        Ok(self
+        let (entity_ids, knowledge_edges) = self
             .client
             .as_client()
             .query(
@@ -291,6 +295,43 @@ where
                         traversal_interval: row.get(6),
                     },
                 )
-            }))
+            })
+            .collect::<(Vec<_>, Vec<_>)>();
+
+        let permissions = if let Some(policy_components) = provider.policy_components {
+            Some(
+                provider
+                    .store
+                    .authorization_api
+                    .check_entities_permission(
+                        policy_components
+                            .actor_id
+                            .map_or_else(ActorEntityUuid::public_actor, ActorEntityUuid::from),
+                        EntityPermission::View,
+                        // TODO: Filter for entities, which were not already added to the
+                        //       subgraph to avoid unnecessary lookups.
+                        entity_ids.iter().copied(),
+                        Consistency::FullyConsistent,
+                    )
+                    .await
+                    .change_context(QueryError)?
+                    .0,
+            )
+        } else {
+            None
+        };
+
+        Ok(knowledge_edges.into_iter().filter(move |edge| {
+            let Some(permissions) = &permissions else {
+                return true;
+            };
+
+            // We can unwrap here because we checked permissions for all
+            // entities in question.
+            permissions
+                .get(&edge.right_endpoint.base_id.entity_uuid)
+                .copied()
+                .unwrap_or(true)
+        }))
     }
 }

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
@@ -7,8 +7,9 @@ use futures::StreamExt as _;
 use hash_graph_authorization::{
     AuthorizationApi,
     backend::ModifyRelationshipOperation,
+    policies::PolicyComponents,
     schema::{DataTypeOwnerSubject, DataTypePermission, DataTypeRelationAndSubject, WebPermission},
-    zanzibar::{Consistency, Zookie},
+    zanzibar::Consistency,
 };
 use hash_graph_store::{
     data_type::{
@@ -65,7 +66,7 @@ use crate::store::{
             Table, rows::DataTypeConversionsRow,
         },
     },
-    validation::{StoreCache, StoreProvider},
+    validation::StoreProvider,
 };
 
 impl<C, A> PostgresStore<C, A>
@@ -73,12 +74,10 @@ where
     C: AsClient,
     A: AuthorizationApi,
 {
-    #[tracing::instrument(level = "trace", skip(data_types, authorization_api, zookie))]
+    #[tracing::instrument(level = "trace", skip(data_types, provider))]
     pub(crate) async fn filter_data_types_by_permission<I, T>(
         data_types: impl IntoIterator<Item = (I, T)> + Send,
-        actor_id: ActorEntityUuid,
-        authorization_api: &A,
-        zookie: &Zookie<'static>,
+        provider: &StoreProvider<'_, Self>,
     ) -> Result<impl Iterator<Item = T>, Report<QueryError>>
     where
         I: Into<DataTypeUuid> + Send,
@@ -89,21 +88,35 @@ where
             .map(|(id, edge)| (id.into(), edge))
             .unzip();
 
-        let permissions = authorization_api
-            .check_data_types_permission(
-                actor_id,
-                DataTypePermission::View,
-                ids.iter().copied(),
-                Consistency::AtExactSnapshot(zookie),
+        let permissions = if let Some(policy_components) = provider.policy_components {
+            Some(
+                provider
+                    .store
+                    .authorization_api
+                    .check_data_types_permission(
+                        policy_components
+                            .actor_id
+                            .map_or_else(ActorEntityUuid::public_actor, ActorEntityUuid::from),
+                        DataTypePermission::View,
+                        ids.iter().copied(),
+                        Consistency::FullyConsistent,
+                    )
+                    .await
+                    .change_context(QueryError)?
+                    .0,
             )
-            .await
-            .change_context(QueryError)?
-            .0;
+        } else {
+            None
+        };
 
         Ok(ids
             .into_iter()
             .zip(data_types)
             .filter_map(move |(id, data_type)| {
+                let Some(permissions) = &permissions else {
+                    return Some(data_type);
+                };
+
                 permissions
                     .get(&id)
                     .copied()
@@ -164,7 +177,7 @@ where
         actor_id: ActorEntityUuid,
         params: GetDataTypesParams<'_>,
         temporal_axes: &QueryTemporalAxes,
-    ) -> Result<(GetDataTypesResponse, Zookie<'static>), Report<QueryError>> {
+    ) -> Result<GetDataTypesResponse, Report<QueryError>> {
         #[expect(clippy::if_then_some_else_none, reason = "Function is async")]
         let count = if params.include_count {
             Some(
@@ -213,7 +226,7 @@ where
             .map(|(data_type_id, _)| *data_type_id)
             .collect::<Vec<_>>();
 
-        let (permissions, zookie) = self
+        let (permissions, _zookie) = self
             .authorization_api
             .check_data_types_permission(
                 actor_id,
@@ -235,26 +248,23 @@ where
             })
             .collect::<Vec<_>>();
 
-        Ok((
-            GetDataTypesResponse {
-                cursor: if params.limit.is_some() {
-                    data_types
-                        .last()
-                        .map(|data_type| data_type.schema.id.clone())
-                } else {
-                    None
-                },
-                data_types,
-                count,
+        Ok(GetDataTypesResponse {
+            cursor: if params.limit.is_some() {
+                data_types
+                    .last()
+                    .map(|data_type| data_type.schema.id.clone())
+            } else {
+                None
             },
-            zookie,
-        ))
+            data_types,
+            count,
+        })
     }
 
     /// Internal method to read a [`DataTypeWithMetadata`] into a [`TraversalContext`].
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
-    #[tracing::instrument(level = "info", skip(self))]
+    #[tracing::instrument(level = "info", skip(self, provider, subgraph))]
     pub(crate) async fn traverse_data_types(
         &self,
         mut data_type_queue: Vec<(
@@ -263,8 +273,7 @@ where
             RightBoundedTemporalInterval<VariableAxis>,
         )>,
         traversal_context: &mut TraversalContext,
-        actor_id: ActorEntityUuid,
-        zookie: &Zookie<'static>,
+        provider: &StoreProvider<'_, Self>,
         subgraph: &mut Subgraph,
     ) -> Result<(), Report<QueryError>> {
         while !data_type_queue.is_empty() {
@@ -305,9 +314,7 @@ where
                                 table,
                             )
                             .await?,
-                            actor_id,
-                            &self.authorization_api,
-                            zookie,
+                            provider,
                         )
                         .await?
                         .flat_map(|edge| {
@@ -654,20 +661,20 @@ where
         actor_id: ActorEntityUuid,
         mut params: GetDataTypesParams<'_>,
     ) -> Result<GetDataTypesResponse, Report<QueryError>> {
+        let policy_components = PolicyComponents::builder(self)
+            .with_actor(actor_id)
+            .await
+            .change_context(QueryError)?;
+
         params
             .filter
-            .convert_parameters(&StoreProvider {
-                store: self,
-                cache: StoreCache::default(),
-                authorization: Some((actor_id, Consistency::FullyConsistent)),
-            })
+            .convert_parameters(&StoreProvider::new(self, &policy_components))
             .await
             .change_context(QueryError)?;
 
         let temporal_axes = params.temporal_axes.clone().resolve();
         self.get_data_types_impl(actor_id, params, &temporal_axes)
             .await
-            .map(|(response, _)| response)
     }
 
     // TODO: take actor ID into consideration, but currently we don't have any non-public data types
@@ -677,13 +684,14 @@ where
         actor_id: ActorEntityUuid,
         mut params: CountDataTypesParams<'_>,
     ) -> Result<usize, Report<QueryError>> {
+        let policy_components = PolicyComponents::builder(self)
+            .with_actor(actor_id)
+            .await
+            .change_context(QueryError)?;
+
         params
             .filter
-            .convert_parameters(&StoreProvider {
-                store: self,
-                cache: StoreCache::default(),
-                authorization: Some((actor_id, Consistency::FullyConsistent)),
-            })
+            .convert_parameters(&StoreProvider::new(self, &policy_components))
             .await
             .change_context(QueryError)?;
 
@@ -704,27 +712,27 @@ where
         actor_id: ActorEntityUuid,
         mut params: GetDataTypeSubgraphParams<'_>,
     ) -> Result<GetDataTypeSubgraphResponse, Report<QueryError>> {
+        let policy_components = PolicyComponents::builder(self)
+            .with_actor(actor_id)
+            .await
+            .change_context(QueryError)?;
+
+        let provider = StoreProvider::new(self, &policy_components);
+
         params
             .filter
-            .convert_parameters(&StoreProvider {
-                store: self,
-                cache: StoreCache::default(),
-                authorization: Some((actor_id, Consistency::FullyConsistent)),
-            })
+            .convert_parameters(&provider)
             .await
             .change_context(QueryError)?;
 
         let temporal_axes = params.temporal_axes.clone().resolve();
         let time_axis = temporal_axes.variable_time_axis();
 
-        let (
-            GetDataTypesResponse {
-                data_types,
-                cursor,
-                count,
-            },
-            zookie,
-        ) = self
+        let GetDataTypesResponse {
+            data_types,
+            cursor,
+            count,
+        } = self
             .get_data_types_impl(
                 actor_id,
                 GetDataTypesParams {
@@ -776,8 +784,7 @@ where
                 })
                 .collect(),
             &mut traversal_context,
-            actor_id,
-            &zookie,
+            &provider,
             &mut subgraph,
         )
         .await?;

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
@@ -8,13 +8,13 @@ use hash_graph_authorization::{
     AuthorizationApi,
     backend::ModifyRelationshipOperation,
     policies::{
-        Authorized, ContextBuilder, PartialResourceId, PolicySet, Request, RequestContext,
-        action::ActionName, resource::EntityTypeId, store::PolicyStore as _,
+        Authorized, PartialResourceId, PolicyComponents, Request, RequestContext,
+        action::ActionName,
     },
     schema::{
         EntityTypeOwnerSubject, EntityTypePermission, EntityTypeRelationAndSubject, WebPermission,
     },
-    zanzibar::{Consistency, Zookie},
+    zanzibar::Consistency,
 };
 use hash_graph_store::{
     entity::ClosedMultiEntityTypeMap,
@@ -42,7 +42,6 @@ use hash_graph_store::{
 };
 use hash_graph_temporal_versioning::{RightBoundedTemporalInterval, Timestamp, TransactionTime};
 use hash_graph_types::{Embedding, ontology::OntologyTypeProvider};
-use hash_status::StatusCode;
 use postgres_types::{Json, ToSql};
 use serde::Deserialize as _;
 use serde_json::Value as JsonValue;
@@ -77,7 +76,7 @@ use crate::store::{
         ontology::{PostgresOntologyOwnership, read::OntologyTypeTraversalData},
         query::{Distinctness, PostgresRecord, ReferenceTable, SelectCompiler, Table},
     },
-    validation::{StoreCache, StoreProvider},
+    validation::StoreProvider,
 };
 
 impl<C, A> PostgresStore<C, A>
@@ -85,38 +84,49 @@ where
     C: AsClient,
     A: AuthorizationApi,
 {
-    #[tracing::instrument(level = "trace", skip(entity_types, authorization_api, zookie))]
+    #[tracing::instrument(level = "trace", skip(entity_types, provider))]
     pub(crate) async fn filter_entity_types_by_permission<I, T>(
         entity_types: impl IntoIterator<Item = (I, T)> + Send,
-        actor_id: ActorEntityUuid,
-        authorization_api: &A,
-        zookie: &Zookie<'static>,
+        provider: &StoreProvider<'_, Self>,
     ) -> Result<impl Iterator<Item = T>, Report<QueryError>>
     where
         I: Into<EntityTypeUuid> + Send,
         T: Send,
-        A: AuthorizationApi,
     {
         let (ids, entity_types): (Vec<_>, Vec<_>) = entity_types
             .into_iter()
             .map(|(id, edge)| (id.into(), edge))
             .unzip();
 
-        let permissions = authorization_api
-            .check_entity_types_permission(
-                actor_id,
-                EntityTypePermission::View,
-                ids.iter().copied(),
-                Consistency::AtExactSnapshot(zookie),
+        let permissions = if let Some(policy_components) = provider.policy_components {
+            Some(
+                provider
+                    .store
+                    .authorization_api
+                    .check_entity_types_permission(
+                        policy_components
+                            .actor_id
+                            .map_or_else(ActorEntityUuid::public_actor, ActorEntityUuid::from),
+                        EntityTypePermission::View,
+                        ids.iter().copied(),
+                        Consistency::FullyConsistent,
+                    )
+                    .await
+                    .change_context(QueryError)?
+                    .0,
             )
-            .await
-            .change_context(QueryError)?
-            .0;
+        } else {
+            None
+        };
 
         Ok(ids
             .into_iter()
             .zip(entity_types)
             .filter_map(move |(id, entity_type)| {
+                let Some(permissions) = &permissions else {
+                    return Some(entity_type);
+                };
+
                 permissions
                     .get(&id)
                     .copied()
@@ -384,7 +394,7 @@ where
         actor_id: ActorEntityUuid,
         params: GetEntityTypesParams<'_>,
         temporal_axes: &QueryTemporalAxes,
-    ) -> Result<(GetEntityTypesResponse, Zookie<'static>), Report<QueryError>> {
+    ) -> Result<GetEntityTypesResponse, Report<QueryError>> {
         let (count, web_ids, edition_created_by_ids) = if params.include_count
             || params.include_web_ids
             || params.include_edition_created_by_ids
@@ -496,7 +506,7 @@ where
             .map(|(entity_type_id, _)| *entity_type_id)
             .collect::<Vec<_>>();
 
-        let (permissions, zookie) = self
+        let (permissions, _zookie) = self
             .authorization_api
             .check_entity_types_permission(
                 actor_id,
@@ -518,26 +528,22 @@ where
             })
             .collect::<Vec<_>>();
 
-        Ok((
-            GetEntityTypesResponse {
-                cursor: if params.limit.is_some() {
-                    entity_types
-                        .last()
-                        .map(|entity_type| entity_type.schema.id.clone())
-                } else {
-                    None
-                },
-                entity_types,
-                closed_entity_types: params.include_entity_types.is_some().then(Vec::new),
-                definitions: (params.include_entity_types
-                    == Some(IncludeEntityTypeOption::Resolved))
-                .then(EntityTypeResolveDefinitions::default),
-                count,
-                web_ids,
-                edition_created_by_ids,
+        Ok(GetEntityTypesResponse {
+            cursor: if params.limit.is_some() {
+                entity_types
+                    .last()
+                    .map(|entity_type| entity_type.schema.id.clone())
+            } else {
+                None
             },
-            zookie,
-        ))
+            entity_types,
+            closed_entity_types: params.include_entity_types.is_some().then(Vec::new),
+            definitions: (params.include_entity_types == Some(IncludeEntityTypeOption::Resolved))
+                .then(EntityTypeResolveDefinitions::default),
+            count,
+            web_ids,
+            edition_created_by_ids,
+        })
     }
 
     pub(crate) async fn get_closed_entity_types(
@@ -574,7 +580,7 @@ where
     /// Internal method to read a [`EntityTypeWithMetadata`] into four [`TraversalContext`]s.
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
-    #[tracing::instrument(level = "info", skip(self, traversal_context, subgraph, zookie))]
+    #[tracing::instrument(level = "info", skip(self, traversal_context, provider, subgraph))]
     #[expect(clippy::too_many_lines)]
     pub(crate) async fn traverse_entity_types(
         &self,
@@ -584,8 +590,7 @@ where
             RightBoundedTemporalInterval<VariableAxis>,
         )>,
         traversal_context: &mut TraversalContext,
-        actor_id: ActorEntityUuid,
-        zookie: &Zookie<'static>,
+        provider: &StoreProvider<'_, Self>,
         subgraph: &mut Subgraph,
     ) -> Result<(), Report<QueryError>> {
         let mut property_type_queue = Vec::new();
@@ -631,9 +636,7 @@ where
                             },
                         )
                         .await?,
-                        actor_id,
-                        &self.authorization_api,
-                        zookie,
+                        provider,
                     )
                     .await?
                     .flat_map(|edge| {
@@ -684,9 +687,7 @@ where
                                 table,
                             )
                             .await?,
-                            actor_id,
-                            &self.authorization_api,
-                            zookie,
+                            provider,
                         )
                         .await?
                         .flat_map(|edge| {
@@ -708,14 +709,8 @@ where
             }
         }
 
-        self.traverse_property_types(
-            property_type_queue,
-            traversal_context,
-            actor_id,
-            zookie,
-            subgraph,
-        )
-        .await?;
+        self.traverse_property_types(property_type_queue, traversal_context, provider, subgraph)
+            .await?;
 
         Ok(())
     }
@@ -1022,13 +1017,14 @@ where
         actor_id: ActorEntityUuid,
         mut params: CountEntityTypesParams<'_>,
     ) -> Result<usize, Report<QueryError>> {
+        let policy_components = PolicyComponents::builder(self)
+            .with_actor(actor_id)
+            .await
+            .change_context(QueryError)?;
+
         params
             .filter
-            .convert_parameters(&StoreProvider {
-                store: self,
-                cache: StoreCache::default(),
-                authorization: Some((actor_id, Consistency::FullyConsistent)),
-            })
+            .convert_parameters(&StoreProvider::new(self, &policy_components))
             .await
             .change_context(QueryError)?;
 
@@ -1048,20 +1044,21 @@ where
         actor_id: ActorEntityUuid,
         mut params: GetEntityTypesParams<'_>,
     ) -> Result<GetEntityTypesResponse, Report<QueryError>> {
+        let policy_components = PolicyComponents::builder(self)
+            .with_actor(actor_id)
+            .await
+            .change_context(QueryError)?;
+
         let include_entity_types = params.include_entity_types;
         params
             .filter
-            .convert_parameters(&StoreProvider {
-                store: self,
-                cache: StoreCache::default(),
-                authorization: Some((actor_id, Consistency::FullyConsistent)),
-            })
+            .convert_parameters(&StoreProvider::new(self, &policy_components))
             .await
             .change_context(QueryError)?;
 
         let temporal_axes = params.temporal_axes.clone();
         let resolved_temporal_axes = temporal_axes.clone().resolve();
-        let (mut response, _) = self
+        let mut response = self
             .get_entity_types_impl(actor_id, params, &resolved_temporal_axes)
             .await?;
 
@@ -1228,31 +1225,31 @@ where
         actor_id: ActorEntityUuid,
         mut params: GetEntityTypeSubgraphParams<'_>,
     ) -> Result<GetEntityTypeSubgraphResponse, Report<QueryError>> {
+        let policy_components = PolicyComponents::builder(self)
+            .with_actor(actor_id)
+            .await
+            .change_context(QueryError)?;
+
+        let provider = StoreProvider::new(self, &policy_components);
+
         params
             .filter
-            .convert_parameters(&StoreProvider {
-                store: self,
-                cache: StoreCache::default(),
-                authorization: Some((actor_id, Consistency::FullyConsistent)),
-            })
+            .convert_parameters(&provider)
             .await
             .change_context(QueryError)?;
 
         let temporal_axes = params.temporal_axes.clone().resolve();
         let time_axis = temporal_axes.variable_time_axis();
 
-        let (
-            GetEntityTypesResponse {
-                entity_types,
-                closed_entity_types: _,
-                definitions: _,
-                cursor,
-                count,
-                web_ids,
-                edition_created_by_ids,
-            },
-            zookie,
-        ) = self
+        let GetEntityTypesResponse {
+            entity_types,
+            closed_entity_types: _,
+            definitions: _,
+            cursor,
+            count,
+            web_ids,
+            edition_created_by_ids,
+        } = self
             .get_entity_types_impl(
                 actor_id,
                 GetEntityTypesParams {
@@ -1307,8 +1304,7 @@ where
                 })
                 .collect(),
             &mut traversal_context,
-            actor_id,
-            &zookie,
+            &provider,
             &mut subgraph,
         )
         .await?;
@@ -1747,30 +1743,13 @@ where
         authenticated_user: ActorEntityUuid,
         entity_type_ids: &[VersionedUrl],
     ) -> Result<Vec<bool>, Report<QueryError>> {
-        let actor = self
-            .determine_actor(authenticated_user)
-            .await
-            .change_context(QueryError)?
-            .ok_or(QueryError)
-            .attach(StatusCode::Unauthenticated)?;
-        let policies = self
-            .resolve_policies_for_actor(actor.into(), Some(actor))
-            .await
-            .change_context(QueryError)?;
-        let policy_set = PolicySet::default()
-            .with_policies(&policies)
-            .change_context(QueryError)?;
-
-        let mut policy_context_builder = ContextBuilder::default();
-        self.build_principal_context(actor, &mut policy_context_builder)
+        let policy_components = PolicyComponents::builder(self)
+            .with_actor(authenticated_user)
+            .with_entity_type_ids(entity_type_ids.iter())
             .await
             .change_context(QueryError)?;
 
-        let validator_provider = StoreProvider {
-            store: self,
-            cache: StoreCache::default(),
-            authorization: Some((authenticated_user, Consistency::FullyConsistent)),
-        };
+        let validator_provider = StoreProvider::new(self, &policy_components);
 
         let mut entity_type_id_set = HashMap::new();
         for entity_type_id in entity_type_ids {
@@ -1790,35 +1769,24 @@ where
             );
         }
 
-        let types_and_parents = entity_type_id_set
-            .iter()
-            .flat_map(|(base, parents)| iter::once(base.clone()).chain(parents.clone()))
-            .collect::<HashSet<_>>()
-            .into_iter()
-            .collect::<Vec<_>>();
-
-        self.build_entity_type_context(&types_and_parents, &mut policy_context_builder)
-            .await
-            .change_context(QueryError)?;
-        let policy_context = policy_context_builder.build().change_context(QueryError)?;
-
         entity_type_id_set
             .into_iter()
             .map(|(base, parents)| {
                 // We need to check the base entity type and all its parents
                 // to see if the user can instantiate it.
                 for entity_type_id in iter::once(base).chain(parents) {
-                    let allowed = policy_set
+                    let allowed = policy_components
+                        .policy_set
                         .evaluate(
                             &Request {
-                                actor: Some(actor),
+                                actor: policy_components.actor_id,
                                 action: ActionName::Instantiate,
-                                resource: Some(&PartialResourceId::EntityType(Some(Cow::Owned(
-                                    EntityTypeId::new(entity_type_id),
-                                )))),
+                                resource: Some(&PartialResourceId::EntityType(Some(
+                                    Cow::Borrowed((&entity_type_id).into()),
+                                ))),
                                 context: RequestContext::default(),
                             },
-                            &policy_context,
+                            &policy_components.context,
                         )
                         .change_context(QueryError)
                         .map(|authorized| match authorized {

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/property_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/property_type.rs
@@ -6,11 +6,12 @@ use futures::StreamExt as _;
 use hash_graph_authorization::{
     AuthorizationApi,
     backend::ModifyRelationshipOperation,
+    policies::PolicyComponents,
     schema::{
         PropertyTypeOwnerSubject, PropertyTypePermission, PropertyTypeRelationAndSubject,
         WebPermission,
     },
-    zanzibar::{Consistency, Zookie},
+    zanzibar::Consistency,
 };
 use hash_graph_store::{
     error::{InsertionError, QueryError, UpdateError},
@@ -56,7 +57,7 @@ use crate::store::{
         ontology::{PostgresOntologyOwnership, read::OntologyTypeTraversalData},
         query::{Distinctness, PostgresRecord, ReferenceTable, SelectCompiler, Table},
     },
-    validation::{StoreCache, StoreProvider},
+    validation::StoreProvider,
 };
 
 impl<C, A> PostgresStore<C, A>
@@ -64,12 +65,10 @@ where
     C: AsClient,
     A: AuthorizationApi,
 {
-    #[tracing::instrument(level = "debug", skip(property_types, authorization_api, zookie))]
+    #[tracing::instrument(level = "debug", skip(property_types, provider))]
     pub(crate) async fn filter_property_types_by_permission<I, T>(
         property_types: impl IntoIterator<Item = (I, T)> + Send,
-        actor_id: ActorEntityUuid,
-        authorization_api: &A,
-        zookie: &Zookie<'static>,
+        provider: &StoreProvider<'_, Self>,
     ) -> Result<impl Iterator<Item = T>, Report<QueryError>>
     where
         I: Into<PropertyTypeUuid> + Send,
@@ -80,21 +79,35 @@ where
             .map(|(id, edge)| (id.into(), edge))
             .unzip();
 
-        let permissions = authorization_api
-            .check_property_types_permission(
-                actor_id,
-                PropertyTypePermission::View,
-                ids.iter().copied(),
-                Consistency::AtExactSnapshot(zookie),
+        let permissions = if let Some(policy_components) = provider.policy_components {
+            Some(
+                provider
+                    .store
+                    .authorization_api
+                    .check_property_types_permission(
+                        policy_components
+                            .actor_id
+                            .map_or_else(ActorEntityUuid::public_actor, ActorEntityUuid::from),
+                        PropertyTypePermission::View,
+                        ids.iter().copied(),
+                        Consistency::FullyConsistent,
+                    )
+                    .await
+                    .change_context(QueryError)?
+                    .0,
             )
-            .await
-            .change_context(QueryError)?
-            .0;
+        } else {
+            None
+        };
 
         Ok(ids
             .into_iter()
             .zip(property_types)
             .filter_map(move |(id, property_type)| {
+                let Some(permissions) = &permissions else {
+                    return Some(property_type);
+                };
+
                 permissions
                     .get(&id)
                     .copied()
@@ -108,7 +121,7 @@ where
         actor_id: ActorEntityUuid,
         params: GetPropertyTypesParams<'_>,
         temporal_axes: &QueryTemporalAxes,
-    ) -> Result<(GetPropertyTypesResponse, Zookie<'static>), Report<QueryError>> {
+    ) -> Result<GetPropertyTypesResponse, Report<QueryError>> {
         #[expect(clippy::if_then_some_else_none, reason = "Function is async")]
         let count = if params.include_count {
             Some(
@@ -159,7 +172,7 @@ where
             .map(|(property_type_id, _)| *property_type_id)
             .collect::<Vec<_>>();
 
-        let (permissions, zookie) = self
+        let (permissions, _zookie) = self
             .authorization_api
             .check_property_types_permission(
                 actor_id,
@@ -181,26 +194,23 @@ where
             })
             .collect::<Vec<_>>();
 
-        Ok((
-            GetPropertyTypesResponse {
-                cursor: if params.limit.is_some() {
-                    property_types
-                        .last()
-                        .map(|property_type| property_type.schema.id.clone())
-                } else {
-                    None
-                },
-                property_types,
-                count,
+        Ok(GetPropertyTypesResponse {
+            cursor: if params.limit.is_some() {
+                property_types
+                    .last()
+                    .map(|property_type| property_type.schema.id.clone())
+            } else {
+                None
             },
-            zookie,
-        ))
+            property_types,
+            count,
+        })
     }
 
     /// Internal method to read a [`PropertyTypeWithMetadata`] into two [`TraversalContext`]s.
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
-    #[tracing::instrument(level = "info", skip(self, traversal_context, subgraph, zookie))]
+    #[tracing::instrument(level = "info", skip(self, traversal_context, provider, subgraph))]
     pub(crate) async fn traverse_property_types(
         &self,
         mut property_type_queue: Vec<(
@@ -209,8 +219,7 @@ where
             RightBoundedTemporalInterval<VariableAxis>,
         )>,
         traversal_context: &mut TraversalContext,
-        actor_id: ActorEntityUuid,
-        zookie: &Zookie<'static>,
+        provider: &StoreProvider<'_, Self>,
         subgraph: &mut Subgraph,
     ) -> Result<(), Report<QueryError>> {
         let mut data_type_queue = Vec::new();
@@ -249,9 +258,7 @@ where
                             ReferenceTable::PropertyTypeConstrainsValuesOn,
                         )
                         .await?,
-                        actor_id,
-                        &self.authorization_api,
-                        zookie,
+                        provider,
                     )
                     .await?
                     .flat_map(|edge| {
@@ -281,9 +288,7 @@ where
                             ReferenceTable::PropertyTypeConstrainsPropertiesOn,
                         )
                         .await?,
-                        actor_id,
-                        &self.authorization_api,
-                        zookie,
+                        provider,
                     )
                     .await?
                     .flat_map(|edge| {
@@ -304,14 +309,8 @@ where
             }
         }
 
-        self.traverse_data_types(
-            data_type_queue,
-            traversal_context,
-            actor_id,
-            zookie,
-            subgraph,
-        )
-        .await?;
+        self.traverse_data_types(data_type_queue, traversal_context, provider, subgraph)
+            .await?;
 
         Ok(())
     }
@@ -538,13 +537,14 @@ where
         actor_id: ActorEntityUuid,
         mut params: CountPropertyTypesParams<'_>,
     ) -> Result<usize, Report<QueryError>> {
+        let policy_components = PolicyComponents::builder(self)
+            .with_actor(actor_id)
+            .await
+            .change_context(QueryError)?;
+
         params
             .filter
-            .convert_parameters(&StoreProvider {
-                store: self,
-                cache: StoreCache::default(),
-                authorization: Some((actor_id, Consistency::FullyConsistent)),
-            })
+            .convert_parameters(&StoreProvider::new(self, &policy_components))
             .await
             .change_context(QueryError)?;
 
@@ -564,20 +564,20 @@ where
         actor_id: ActorEntityUuid,
         mut params: GetPropertyTypesParams<'_>,
     ) -> Result<GetPropertyTypesResponse, Report<QueryError>> {
+        let policy_components = PolicyComponents::builder(self)
+            .with_actor(actor_id)
+            .await
+            .change_context(QueryError)?;
+
         params
             .filter
-            .convert_parameters(&StoreProvider {
-                store: self,
-                cache: StoreCache::default(),
-                authorization: Some((actor_id, Consistency::FullyConsistent)),
-            })
+            .convert_parameters(&StoreProvider::new(self, &policy_components))
             .await
             .change_context(QueryError)?;
 
         let temporal_axes = params.temporal_axes.clone().resolve();
         self.get_property_types_impl(actor_id, params, &temporal_axes)
             .await
-            .map(|(response, _)| response)
     }
 
     #[tracing::instrument(level = "info", skip(self))]
@@ -586,27 +586,27 @@ where
         actor_id: ActorEntityUuid,
         mut params: GetPropertyTypeSubgraphParams<'_>,
     ) -> Result<GetPropertyTypeSubgraphResponse, Report<QueryError>> {
+        let policy_components = PolicyComponents::builder(self)
+            .with_actor(actor_id)
+            .await
+            .change_context(QueryError)?;
+
+        let provider = StoreProvider::new(self, &policy_components);
+
         params
             .filter
-            .convert_parameters(&StoreProvider {
-                store: self,
-                cache: StoreCache::default(),
-                authorization: Some((actor_id, Consistency::FullyConsistent)),
-            })
+            .convert_parameters(&provider)
             .await
             .change_context(QueryError)?;
 
         let temporal_axes = params.temporal_axes.clone().resolve();
         let time_axis = temporal_axes.variable_time_axis();
 
-        let (
-            GetPropertyTypesResponse {
-                property_types,
-                cursor,
-                count,
-            },
-            zookie,
-        ) = self
+        let GetPropertyTypesResponse {
+            property_types,
+            cursor,
+            count,
+        } = self
             .get_property_types_impl(
                 actor_id,
                 GetPropertyTypesParams {
@@ -658,8 +658,7 @@ where
                 })
                 .collect(),
             &mut traversal_context,
-            actor_id,
-            &zookie,
+            &provider,
             &mut subgraph,
         )
         .await?;

--- a/libs/@local/graph/store/src/entity/store.rs
+++ b/libs/@local/graph/store/src/entity/store.rs
@@ -419,7 +419,8 @@ pub trait EntityStore {
         actor_id: ActorEntityUuid,
         consistency: Consistency<'_>,
         params: ValidateEntityParams<'_>,
-    ) -> impl Future<Output = HashMap<usize, EntityValidationReport>> + Send {
+    ) -> impl Future<Output = Result<HashMap<usize, EntityValidationReport>, Report<QueryError>>> + Send
+    {
         self.validate_entities(actor_id, consistency, vec![params])
     }
 
@@ -433,7 +434,7 @@ pub trait EntityStore {
         actor_id: ActorEntityUuid,
         consistency: Consistency<'_>,
         params: Vec<ValidateEntityParams<'_>>,
-    ) -> impl Future<Output = HashMap<usize, EntityValidationReport>> + Send;
+    ) -> impl Future<Output = Result<HashMap<usize, EntityValidationReport>, Report<QueryError>>> + Send;
 
     /// Get a list of entities specified by the [`GetEntitiesParams`].
     ///

--- a/libs/@local/graph/type-fetcher/src/store.rs
+++ b/libs/@local/graph/type-fetcher/src/store.rs
@@ -6,14 +6,17 @@ use error_stack::{Report, ResultExt as _};
 use hash_graph_authorization::{
     AuthorizationApi,
     policies::{
-        Policy, PolicyId,
+        ContextBuilder, Policy, PolicyId,
+        principal::actor::AuthenticatedActor,
+        resource::{EntityResource, EntityTypeResource},
         store::{
             CreateWebParameter, CreateWebResponse, PolicyCreationParams, PolicyFilter, PolicyStore,
             PolicyUpdateOperation, PrincipalStore, RoleAssignmentStatus, RoleUnassignmentStatus,
             error::{
-                CreatePolicyError, EnsureSystemPoliciesError, GetPoliciesError,
-                GetSystemAccountError, RemovePolicyError, RoleAssignmentError, TeamRoleError,
-                UpdatePolicyError, WebCreationError, WebRoleError,
+                BuildEntityContextError, BuildEntityTypeContextError, BuildPrincipalContextError,
+                CreatePolicyError, DetermineActorError, EnsureSystemPoliciesError,
+                GetPoliciesError, GetSystemAccountError, RemovePolicyError, RoleAssignmentError,
+                TeamRoleError, UpdatePolicyError, WebCreationError, WebRoleError,
             },
         },
     },
@@ -76,7 +79,10 @@ use tracing::Instrument as _;
 use type_system::{
     knowledge::{
         Entity,
-        entity::{EntityId, id::EntityUuid},
+        entity::{
+            EntityId,
+            id::{EntityEditionId, EntityUuid},
+        },
     },
     ontology::{
         OntologyTemporalMetadata, OntologyTypeMetadata, OntologyTypeReference, OntologyTypeSchema,
@@ -185,8 +191,8 @@ pub struct FetchingStore<S, A> {
 
 impl<S, A> PrincipalStore for FetchingStore<S, A>
 where
-    S: PrincipalStore + Send,
-    A: Send,
+    S: PrincipalStore + Send + Sync,
+    A: Send + Sync,
 {
     async fn get_or_create_system_machine(
         &mut self,
@@ -258,6 +264,23 @@ where
             .unassign_role(actor_id, actor_to_unassign, actor_group_id, name)
             .await
     }
+
+    async fn determine_actor(
+        &self,
+        actor_entity_uuid: ActorEntityUuid,
+    ) -> Result<Option<ActorId>, Report<DetermineActorError>> {
+        self.store.determine_actor(actor_entity_uuid).await
+    }
+
+    async fn build_principal_context(
+        &self,
+        actor_id: ActorId,
+        context_builder: &mut ContextBuilder,
+    ) -> Result<(), Report<BuildPrincipalContextError>> {
+        self.store
+            .build_principal_context(actor_id, context_builder)
+            .await
+    }
 }
 
 impl<S, A> PolicyStore for FetchingStore<S, A>
@@ -267,7 +290,7 @@ where
 {
     async fn create_policy(
         &mut self,
-        authenticated_actor: ActorEntityUuid,
+        authenticated_actor: AuthenticatedActor,
         policy: PolicyCreationParams,
     ) -> Result<PolicyId, Report<CreatePolicyError>> {
         self.store.create_policy(authenticated_actor, policy).await
@@ -275,7 +298,7 @@ where
 
     async fn get_policy_by_id(
         &self,
-        authenticated_actor: ActorEntityUuid,
+        authenticated_actor: AuthenticatedActor,
         id: PolicyId,
     ) -> Result<Option<Policy>, Report<GetPoliciesError>> {
         self.store.get_policy_by_id(authenticated_actor, id).await
@@ -283,7 +306,7 @@ where
 
     async fn query_policies(
         &self,
-        authenticated_actor: ActorEntityUuid,
+        authenticated_actor: AuthenticatedActor,
         filter: &PolicyFilter,
     ) -> Result<Vec<Policy>, Report<GetPoliciesError>> {
         self.store.query_policies(authenticated_actor, filter).await
@@ -291,7 +314,7 @@ where
 
     async fn resolve_policies_for_actor(
         &self,
-        authenticated_actor: ActorEntityUuid,
+        authenticated_actor: AuthenticatedActor,
         actor_id: Option<ActorId>,
     ) -> Result<Vec<Policy>, Report<GetPoliciesError>> {
         self.store
@@ -301,7 +324,7 @@ where
 
     async fn update_policy_by_id(
         &mut self,
-        authenticated_actor: ActorEntityUuid,
+        authenticated_actor: AuthenticatedActor,
         policy_id: PolicyId,
         operations: &[PolicyUpdateOperation],
     ) -> Result<Policy, Report<UpdatePolicyError>> {
@@ -312,7 +335,7 @@ where
 
     async fn archive_policy_by_id(
         &mut self,
-        authenticated_actor: ActorEntityUuid,
+        authenticated_actor: AuthenticatedActor,
         policy_id: PolicyId,
     ) -> Result<(), Report<RemovePolicyError>> {
         self.store
@@ -322,7 +345,7 @@ where
 
     async fn delete_policy_by_id(
         &mut self,
-        authenticated_actor: ActorEntityUuid,
+        authenticated_actor: AuthenticatedActor,
         policy_id: PolicyId,
     ) -> Result<(), Report<RemovePolicyError>> {
         self.store
@@ -332,6 +355,20 @@ where
 
     async fn seed_system_policies(&mut self) -> Result<(), Report<EnsureSystemPoliciesError>> {
         self.store.seed_system_policies().await
+    }
+
+    async fn build_entity_type_context(
+        &self,
+        entity_type_ids: &[&VersionedUrl],
+    ) -> Result<Vec<EntityTypeResource<'_>>, Report<[BuildEntityTypeContextError]>> {
+        self.store.build_entity_type_context(entity_type_ids).await
+    }
+
+    async fn build_entity_context(
+        &self,
+        entity_edition_ids: &[EntityEditionId],
+    ) -> Result<Vec<EntityResource<'static>>, Report<[BuildEntityContextError]>> {
+        self.store.build_entity_context(entity_edition_ids).await
     }
 }
 
@@ -1576,7 +1613,7 @@ where
         actor_id: ActorEntityUuid,
         consistency: Consistency<'_>,
         params: Vec<ValidateEntityParams<'_>>,
-    ) -> HashMap<usize, EntityValidationReport> {
+    ) -> Result<HashMap<usize, EntityValidationReport>, Report<QueryError>> {
         self.store
             .validate_entities(actor_id, consistency, params)
             .await

--- a/tests/graph/benches/read_scaling/knowledge/complete/entity.rs
+++ b/tests/graph/benches/read_scaling/knowledge/complete/entity.rs
@@ -5,7 +5,7 @@ use criterion::{BatchSize::SmallInput, Bencher, BenchmarkId, Criterion, Sampling
 use criterion_macro::criterion;
 use hash_graph_authorization::{
     AuthorizationApi, NoAuthorization,
-    policies::store::{CreateWebParameter, LocalPrincipalStore as _, PolicyStore as _},
+    policies::store::{CreateWebParameter, PolicyStore as _, PrincipalStore as _},
 };
 use hash_graph_store::{
     entity::{CreateEntityParams, EntityQuerySorting, EntityStore as _, GetEntitySubgraphParams},

--- a/tests/graph/benches/read_scaling/knowledge/linkless/entity.rs
+++ b/tests/graph/benches/read_scaling/knowledge/linkless/entity.rs
@@ -5,7 +5,7 @@ use criterion::{BatchSize::SmallInput, Bencher, BenchmarkId, Criterion};
 use criterion_macro::criterion;
 use hash_graph_authorization::{
     AuthorizationApi, NoAuthorization,
-    policies::store::{CreateWebParameter, LocalPrincipalStore as _, PolicyStore as _},
+    policies::store::{CreateWebParameter, PolicyStore as _, PrincipalStore as _},
 };
 use hash_graph_store::{
     entity::{CreateEntityParams, EntityQuerySorting, EntityStore as _, GetEntitiesParams},

--- a/tests/graph/benches/representative_read/lib.rs
+++ b/tests/graph/benches/representative_read/lib.rs
@@ -68,7 +68,7 @@ fn bench_representative_read_entity(crit: &mut Criterion) {
     let mut group = crit.benchmark_group(group_id);
     let (runtime, mut store_wrapper) = setup(DB_NAME, false, false, account_id, NoAuthorization);
 
-    let samples = runtime.block_on(setup_and_extract_samples(&mut store_wrapper));
+    let samples = runtime.block_on(setup_and_extract_samples(&mut store_wrapper, account_id));
     let store = &store_wrapper.store;
 
     for (account_id, type_ids_and_entity_uuids) in samples.entities {
@@ -403,7 +403,7 @@ fn bench_representative_read_entity_type(crit: &mut Criterion) {
     let mut group = crit.benchmark_group(group_id);
     let (runtime, mut store_wrapper) = setup(DB_NAME, false, false, account_id, NoAuthorization);
 
-    let samples = runtime.block_on(setup_and_extract_samples(&mut store_wrapper));
+    let samples = runtime.block_on(setup_and_extract_samples(&mut store_wrapper, account_id));
     let store = &store_wrapper.store;
 
     for (account_id, entity_type_ids) in samples.entity_types {

--- a/tests/graph/benches/representative_read/seed.rs
+++ b/tests/graph/benches/representative_read/seed.rs
@@ -1,9 +1,9 @@
-use core::{iter::repeat_n, str::FromStr as _};
+use core::iter::repeat_n;
 use std::collections::{HashMap, HashSet, hash_map::Entry};
 
 use hash_graph_authorization::{
     AuthorizationApi,
-    policies::store::{CreateWebParameter, LocalPrincipalStore as _, PolicyStore as _},
+    policies::store::{CreateWebParameter, PolicyStore as _, PrincipalStore as _},
 };
 use hash_graph_postgres_store::store::AsClient as _;
 use hash_graph_store::entity::{CreateEntityParams, EntityStore as _};
@@ -20,7 +20,6 @@ use type_system::{
     },
     provenance::{OriginProvenance, OriginType},
 };
-use uuid::Uuid;
 
 use crate::util::{StoreWrapper, seed};
 
@@ -360,16 +359,8 @@ async fn get_samples<A: AuthorizationApi>(
 
 pub async fn setup_and_extract_samples<A: AuthorizationApi>(
     store_wrapper: &mut StoreWrapper<A>,
+    account_id: ActorEntityUuid,
 ) -> Samples {
-    // TODO: We'll want to test distribution across accounts
-    //   see https://linear.app/hash/issue/H-3012
-    //
-    // We use a hard-coded UUID to keep it consistent across tests so that we can use it as a
-    // parameter argument to criterion and get comparison analysis
-    let account_id = ActorEntityUuid::new(
-        Uuid::from_str("d4e16033-c281-4cde-aa35-9085bf2e7579").expect("invalid UUID"),
-    );
-
     // We use the existence of the account ID as a marker for if the DB has been seeded already
     let already_seeded: bool = store_wrapper
         .store

--- a/tests/graph/integration/postgres/lib.rs
+++ b/tests/graph/integration/postgres/lib.rs
@@ -29,7 +29,7 @@ use std::collections::HashMap;
 use error_stack::{Report, ResultExt as _};
 use hash_graph_authorization::{
     AuthorizationApi, NoAuthorization,
-    policies::store::{LocalPrincipalStore as _, PolicyStore as _},
+    policies::store::{PolicyStore as _, PrincipalStore as _},
     schema::{
         DataTypeRelationAndSubject, DataTypeViewerSubject, EntityRelationAndSubject,
         EntityTypeRelationAndSubject, EntityTypeSetting, EntityTypeSettingSubject,
@@ -783,7 +783,7 @@ where
         actor_id: ActorEntityUuid,
         consistency: Consistency<'_>,
         params: Vec<ValidateEntityParams<'_>>,
-    ) -> HashMap<usize, EntityValidationReport> {
+    ) -> Result<HashMap<usize, EntityValidationReport>, Report<QueryError>> {
         self.store
             .validate_entities(actor_id, consistency, params)
             .await


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, some quite big boilerplate is required to kick-of a permission check. This PR aims to improve that and simplifies the building of the policy context, the policy set, and determination of the actor UUID.

## 🔍 What does this change?

- Move relevant policy code to `@rust/hash-graph-authorization`
- Introduce a `PolicyComponents` struct. The name is not great but currently reflects what's in it. It can be changed later.
- Allow to dynamically build a `PolicyComponets` struct using a builder pattern which then can be `.await`ed for building
- Don't re-utilize `StoreProvider`, instead, it takes a reference to the policy components

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph