### PR TITLE
H-4699: Support policy resource filter on the creator

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response.ts
@@ -15,7 +15,6 @@ import { generateUuid } from "@local/hash-isomorphic-utils/generate-uuid";
 import { systemLinkEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { stringifyError } from "@local/hash-isomorphic-utils/stringify-error";
 import type { IncurredIn } from "@local/hash-isomorphic-utils/system-types/usagerecord";
-import type { PrincipalConstraint } from "@rust/hash-graph-authorization/types";
 // import { StatusCode } from "@local/status";
 import { backOff } from "exponential-backoff";
 
@@ -206,19 +205,6 @@ export const getLlmResponse = async <T extends LlmParams>(
         } satisfies OriginProvenance,
       };
 
-      const viewPrincipals: PrincipalConstraint[] = [
-        {
-          type: "actor",
-          actorType: "user",
-          id: userAccountId,
-        },
-        {
-          type: "actor",
-          actorType: "ai",
-          id: aiAssistantAccountId,
-        },
-      ];
-
       const errors = await Promise.all(
         incurredInEntities.map(async ({ entityId }) => {
           try {
@@ -263,12 +249,6 @@ export const getLlmResponse = async <T extends LlmParams>(
                     },
                   },
                 ],
-                policies: viewPrincipals.map((principal) => ({
-                  name: `usage-record-view-entity-${incurredInEntityUuid}`,
-                  effect: "permit",
-                  actions: ["viewEntity"],
-                  principal,
-                })),
               },
             );
 

--- a/apps/hash-api/src/graph/knowledge/system-types/user-secret.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user-secret.ts
@@ -21,7 +21,6 @@ import {
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import type { UsesUserSecret } from "@local/hash-isomorphic-utils/system-types/google/shared";
 import type { UserSecret } from "@local/hash-isomorphic-utils/system-types/shared";
-import type { PrincipalConstraint } from "@rust/hash-graph-authorization/types";
 import type { Auth } from "googleapis";
 
 import { createEntity } from "../primitive/entity";
@@ -181,19 +180,6 @@ export const createUserSecret = async <
     );
   }
 
-  const viewPrincipals: PrincipalConstraint[] = [
-    {
-      type: "actor",
-      actorType: "user",
-      id: userAccountId,
-    },
-    {
-      type: "actor",
-      actorType: "machine",
-      id: managingBotAccountId,
-    },
-  ];
-
   const userSecretEntityUuid = generateUuid() as EntityUuid;
   const usesUserSecretEntityUuid = generateUuid() as EntityUuid;
 
@@ -206,16 +192,18 @@ export const createUserSecret = async <
       entityUuid: userSecretEntityUuid,
       properties: secretMetadata,
       relationships: botEditorUserViewerOnly,
-      policies: viewPrincipals.map((principal) => ({
-        name: `user-secret-view-entity-${userSecretEntityUuid}`,
-        principal,
-        effect: "permit",
-        actions: ["viewEntity"],
-        resource: {
-          type: "entity",
-          id: userSecretEntityUuid,
+      policies: [
+        {
+          name: `user-secret-view-entity-${userSecretEntityUuid}`,
+          principal: {
+            type: "actor",
+            actorType: "machine",
+            id: managingBotAccountId,
+          },
+          effect: "permit",
+          actions: ["viewEntity"],
         },
-      })),
+      ],
     },
   );
 
@@ -233,16 +221,18 @@ export const createUserSecret = async <
       },
       entityTypeIds: [systemLinkEntityTypes.usesUserSecret.linkEntityTypeId],
       relationships: botEditorUserViewerOnly,
-      policies: viewPrincipals.map((principal) => ({
-        name: `user-secret-view-entity-${usesUserSecretEntityUuid}`,
-        principal,
-        effect: "permit",
-        actions: ["viewEntity"],
-        resource: {
-          type: "entity",
-          id: usesUserSecretEntityUuid,
+      policies: [
+        {
+          name: `user-secret-view-entity-${userSecretEntityUuid}`,
+          principal: {
+            type: "actor",
+            actorType: "machine",
+            id: managingBotAccountId,
+          },
+          effect: "permit",
+          actions: ["viewEntity"],
         },
-      })),
+      ],
     },
   );
 

--- a/libs/@local/graph/authorization/schemas/policies.cedarschema
+++ b/libs/@local/graph/authorization/schemas/policies.cedarschema
@@ -10,6 +10,7 @@ namespace HASH {
 
   entity Entity in [Web] {
     entity_types: Set<EntityType>,
+    created_by: ActorId,
   };
 
   entity EntityType in [Web] {
@@ -18,9 +19,14 @@ namespace HASH {
   };
 
   entity User, Machine, Ai in [HASH::Web::Role, HASH::Team::Role] {
+    id: ActorId,
   };
 
   entity Public {
+    // This is required to add policies depending on `principal.id`
+    // in Cedar policies. Effectively, we set this to a dummy value
+    // `{"type": "public", "id": "00000000-0000-0000-0000-000000000000"}`.
+    id: ActorId,
   };
 
   action all;
@@ -48,6 +54,11 @@ namespace HASH {
   action instantiate in [all] appliesTo {
     principal: [User, Machine, Ai],
     resource: [EntityType],
+  };
+
+  type ActorId = {
+    type: String,
+    id: String,
   };
 }
 

--- a/libs/@local/graph/authorization/src/policies/cedar/actor.rs
+++ b/libs/@local/graph/authorization/src/policies/cedar/actor.rs
@@ -1,0 +1,102 @@
+use alloc::collections::BTreeMap;
+use core::{error::Error, fmt};
+
+use cedar_policy_core::ast;
+use error_stack::{Report, ResultExt as _};
+use smol_str::SmolStr;
+use type_system::principal::actor::{ActorEntityUuid, ActorId, AiId, MachineId, UserId};
+use uuid::Uuid;
+
+use super::CedarExpressionVisitor;
+
+#[derive(Debug, derive_more::Display)]
+pub(crate) enum ParseActorIdExpressionError {
+    #[display("Unexpected fields: `{}`", _0.join(", "))]
+    UnexpectedField(Vec<String>),
+    #[display("Missing field: `{_0}`")]
+    MissingField(String),
+    #[display("Invalid type: `{_0}`")]
+    InvalidTypeExpression(String),
+    #[display("Invalid type: `{_0}`")]
+    InvalidType(String),
+    #[display("Invalid UUID expression: `{_0}`")]
+    InvalidUuidExpression(String),
+    #[display("Invalid UUID: `{_0}`")]
+    InvalidUuid(String),
+}
+
+impl Error for ParseActorIdExpressionError {}
+
+pub(crate) struct ActorIdVisitor;
+
+impl CedarExpressionVisitor for ActorIdVisitor {
+    type Error = Report<ParseActorIdExpressionError>;
+    type Value = Option<ActorId>;
+
+    fn expecting(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_str("an actor id")
+    }
+
+    fn visit_record(
+        &self,
+        record: &BTreeMap<SmolStr, ast::Expr>,
+    ) -> Option<Result<Self::Value, Self::Error>> {
+        let Some(type_expr) = record.get("type") else {
+            return Some(Err(Report::new(ParseActorIdExpressionError::MissingField(
+                "type".to_owned(),
+            ))));
+        };
+        let Some(uuid_expr) = record.get("id") else {
+            return Some(Err(Report::new(ParseActorIdExpressionError::MissingField(
+                "id".to_owned(),
+            ))));
+        };
+        if record.len() != 2 {
+            return Some(Err(Report::new(
+                ParseActorIdExpressionError::UnexpectedField(
+                    record
+                        .keys()
+                        .filter(|&key| (key != "type" && key != "id"))
+                        .map(SmolStr::to_string)
+                        .collect(),
+                ),
+            )));
+        }
+
+        let ast::ExprKind::Lit(ast::Literal::String(type_string)) = type_expr.expr_kind() else {
+            return Some(Err(Report::new(
+                ParseActorIdExpressionError::InvalidTypeExpression(type_expr.to_string()),
+            )));
+        };
+
+        let ast::ExprKind::Lit(ast::Literal::String(uuid_string)) = uuid_expr.expr_kind() else {
+            return Some(Err(Report::new(
+                ParseActorIdExpressionError::InvalidUuidExpression(uuid_expr.to_string()),
+            )));
+        };
+
+        let actor_entity_uuid = match Uuid::parse_str(uuid_string)
+            .change_context_lazy(|| {
+                ParseActorIdExpressionError::InvalidUuid(uuid_string.to_string())
+            })
+            .attach_printable("Invalid UUID")
+        {
+            Ok(uuid) => ActorEntityUuid::new(uuid),
+            Err(error) => {
+                return Some(Err(error));
+            }
+        };
+
+        Some(Ok(match type_string.as_str() {
+            "user" => Some(ActorId::User(UserId::new(actor_entity_uuid))),
+            "machine" => Some(ActorId::Machine(MachineId::new(actor_entity_uuid))),
+            "ai" => Some(ActorId::Ai(AiId::new(actor_entity_uuid))),
+            "public" => None,
+            _ => {
+                return Some(Err(Report::new(ParseActorIdExpressionError::InvalidType(
+                    type_string.to_string(),
+                ))));
+            }
+        }))
+    }
+}

--- a/libs/@local/graph/authorization/src/policies/cedar/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/cedar/mod.rs
@@ -1,3 +1,4 @@
+mod actor;
 mod entity;
 mod expression_tree;
 mod ontology;
@@ -12,6 +13,7 @@ use error_stack::{IntoReport, Report, ResultExt as _};
 
 pub use self::expression_tree::PolicyExpressionTree;
 pub(crate) use self::{
+    actor::ActorIdVisitor,
     entity::EntityUuidVisitor,
     ontology::{BaseUrlVisitor, EntityTypeIdVisitor, OntologyTypeVersionVisitor},
     visitor::{
@@ -22,8 +24,21 @@ pub(crate) use self::{
 };
 use crate::policies::error::FromCedarRefernceError;
 
+pub(crate) trait ToCedarRestrictedExpr {
+    fn to_cedar_restricted_expr(&self) -> ast::RestrictedExpr;
+}
+
 pub(crate) trait ToCedarExpr {
-    fn to_cedar(&self) -> ast::Expr;
+    fn to_cedar_expr(&self) -> ast::Expr;
+}
+
+impl<T> ToCedarExpr for T
+where
+    T: ToCedarRestrictedExpr,
+{
+    fn to_cedar_expr(&self) -> ast::Expr {
+        self.to_cedar_restricted_expr().into()
+    }
 }
 
 pub(crate) trait FromCedarExpr: Sized {

--- a/libs/@local/graph/authorization/src/policies/components.rs
+++ b/libs/@local/graph/authorization/src/policies/components.rs
@@ -134,6 +134,8 @@ where
                     .build_principal_context(actor_id, &mut self.context)
                     .await
                     .change_context(ContextCreationError::BuildPrincipalContext { actor_id })?;
+            } else {
+                self.context.add_public_actor();
             }
 
             let entity_resources;

--- a/libs/@local/graph/authorization/src/policies/context.rs
+++ b/libs/@local/graph/authorization/src/policies/context.rs
@@ -11,6 +11,7 @@ use type_system::principal::{Actor, ActorGroup, Role};
 use super::{
     PolicyValidator,
     cedar::ToCedarEntity as _,
+    principal::actor::PublicActor,
     resource::{EntityResource, EntityTypeResource},
 };
 
@@ -50,6 +51,14 @@ impl ContextBuilder {
     /// making it available for matching against principal constraints in policies.
     pub fn add_actor(&mut self, actor: &Actor) {
         self.entities.push(actor.to_cedar_entity());
+    }
+
+    /// Adds the public actor to the context for policy evaluation.
+    ///
+    /// This allows the actor to be identified as a principal during authorization,
+    /// making it available for matching against principal constraints in policies.
+    pub fn add_public_actor(&mut self) {
+        self.entities.push(PublicActor.to_cedar_entity());
     }
 
     /// Adds an actor group to the context for policy evaluation.

--- a/libs/@local/graph/authorization/src/policies/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/mod.rs
@@ -459,6 +459,7 @@ mod tests {
                     VersionedUrl::from_str("https://hash.ai/@hash/types/entity-type/user/v/6")?,
                     VersionedUrl::from_str("https://hash.ai/@hash/types/entity-type/actor/v/2")?,
                 ]),
+                created_by: user.id.into(),
             };
             let resource_id = PartialResourceId::Entity(Some(user_entity.id.entity_uuid));
             let mut context = ContextBuilder::default();

--- a/libs/@local/graph/authorization/src/policies/principal/actor/ai.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/actor/ai.rs
@@ -4,13 +4,29 @@ use std::{collections::HashSet, sync::LazyLock};
 
 use cedar_policy_core::{ast, extensions::Extensions};
 use error_stack::Report;
+use smol_str::SmolStr;
 use type_system::principal::{
     actor::{Ai, AiId},
     role::RoleId,
 };
 use uuid::Uuid;
 
-use crate::policies::cedar::{FromCedarEntityId, ToCedarEntity, ToCedarEntityId};
+use crate::policies::cedar::{
+    FromCedarEntityId, ToCedarEntity, ToCedarEntityId, ToCedarRestrictedExpr,
+};
+
+impl ToCedarRestrictedExpr for AiId {
+    fn to_cedar_restricted_expr(&self) -> ast::RestrictedExpr {
+        ast::RestrictedExpr::record([
+            (
+                SmolStr::new_static("id"),
+                ast::RestrictedExpr::val(self.to_string()),
+            ),
+            (SmolStr::new_static("type"), ast::RestrictedExpr::val("ai")),
+        ])
+        .expect("No duplicate keys in ai record")
+    }
+}
 
 impl FromCedarEntityId for AiId {
     type Error = Report<uuid::Error>;
@@ -40,7 +56,10 @@ impl ToCedarEntity for Ai {
     fn to_cedar_entity(&self) -> ast::Entity {
         ast::Entity::new(
             self.id.to_euid(),
-            iter::empty(),
+            [(
+                SmolStr::new_static("id"),
+                self.id.to_cedar_restricted_expr(),
+            )],
             HashSet::new(),
             self.roles.iter().map(RoleId::to_euid).collect(),
             iter::empty(),

--- a/libs/@local/graph/authorization/src/policies/principal/actor/user.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/actor/user.rs
@@ -4,13 +4,32 @@ use std::{collections::HashSet, sync::LazyLock};
 
 use cedar_policy_core::{ast, extensions::Extensions};
 use error_stack::Report;
+use smol_str::SmolStr;
 use type_system::principal::{
     actor::{User, UserId},
     role::RoleId,
 };
 use uuid::Uuid;
 
-use crate::policies::cedar::{FromCedarEntityId, ToCedarEntity, ToCedarEntityId};
+use crate::policies::cedar::{
+    FromCedarEntityId, ToCedarEntity, ToCedarEntityId, ToCedarRestrictedExpr,
+};
+
+impl ToCedarRestrictedExpr for UserId {
+    fn to_cedar_restricted_expr(&self) -> ast::RestrictedExpr {
+        ast::RestrictedExpr::record([
+            (
+                SmolStr::new_static("id"),
+                ast::RestrictedExpr::val(self.to_string()),
+            ),
+            (
+                SmolStr::new_static("type"),
+                ast::RestrictedExpr::val("user"),
+            ),
+        ])
+        .expect("No duplicate keys in user record")
+    }
+}
 
 impl FromCedarEntityId for UserId {
     type Error = Report<uuid::Error>;
@@ -40,7 +59,10 @@ impl ToCedarEntity for User {
     fn to_cedar_entity(&self) -> ast::Entity {
         ast::Entity::new(
             self.id.to_euid(),
-            iter::empty(),
+            [(
+                SmolStr::new_static("id"),
+                self.id.to_cedar_restricted_expr(),
+            )],
             HashSet::new(),
             self.roles.iter().map(RoleId::to_euid).collect(),
             iter::empty(),

--- a/libs/@local/graph/authorization/src/policies/resource/entity_type.rs
+++ b/libs/@local/graph/authorization/src/policies/resource/entity_type.rs
@@ -149,19 +149,19 @@ impl TryFrom<PolicyExpressionTree> for EntityTypeResourceFilter {
 }
 
 impl ToCedarExpr for EntityTypeResourceFilter {
-    fn to_cedar(&self) -> ast::Expr {
+    fn to_cedar_expr(&self) -> ast::Expr {
         match self {
             Self::All { filters } => filters
                 .iter()
-                .map(Self::to_cedar)
+                .map(Self::to_cedar_expr)
                 .reduce(ast::Expr::and)
                 .unwrap_or_else(|| ast::Expr::val(true)),
             Self::Any { filters } => filters
                 .iter()
-                .map(Self::to_cedar)
+                .map(Self::to_cedar_expr)
                 .reduce(ast::Expr::or)
                 .unwrap_or_else(|| ast::Expr::val(false)),
-            Self::Not { filter } => ast::Expr::not(filter.to_cedar()),
+            Self::Not { filter } => ast::Expr::not(filter.to_cedar_expr()),
             Self::IsBaseUrl { base_url } => ast::Expr::is_eq(
                 ast::Expr::get_attr(
                     ast::Expr::var(ast::Var::Resource),
@@ -247,7 +247,7 @@ impl EntityTypeResourceConstraint {
         match self {
             Self::Any { filter } => (
                 ast::ResourceConstraint::is_entity_type(Arc::clone(EntityTypeId::entity_type())),
-                filter.to_cedar(),
+                filter.to_cedar_expr(),
             ),
             Self::Exact { id } => (
                 ast::ResourceConstraint::is_eq(Arc::new(id.to_euid())),
@@ -258,7 +258,7 @@ impl EntityTypeResourceConstraint {
                     Arc::clone(EntityTypeId::entity_type()),
                     Arc::new(web_id.to_euid()),
                 ),
-                filter.to_cedar(),
+                filter.to_cedar_expr(),
             ),
         }
     }

--- a/libs/@local/graph/authorization/tests/policies/main.rs
+++ b/libs/@local/graph/authorization/tests/policies/main.rs
@@ -109,6 +109,7 @@ impl TestUser {
                 draft_id: None,
             },
             entity_type: Cow::Borrowed(ENTITY_TYPES.as_slice()),
+            created_by: id.into(),
         };
 
         policy_store
@@ -154,6 +155,7 @@ impl TestMachine {
                 draft_id: None,
             },
             entity_type: Cow::Borrowed(ENTITY_TYPES.as_slice()),
+            created_by: id.into(),
         };
 
         context.add_entity(&entity);
@@ -223,6 +225,7 @@ impl TestSystem {
                 VersionedUrl::from_str("https://hash.ai/@h/types/entity-type/hash-instance/v/1")
                     .expect("should be a valid URL"),
             ]),
+            created_by: machine.id.into(),
         };
         context.add_entity(&hash_instance_entity);
         for policy in permit_hash_instance_admins(hash_instance_admins, hash_instance_entity.id) {
@@ -382,6 +385,7 @@ fn user_web_permissions() -> Result<(), Box<dyn Error>> {
             draft_id: None,
         },
         entity_type: Cow::Owned(vec![web_type.id.as_url().clone()]),
+        created_by: user.id.into(),
     };
     context.add_entity(&web_entity);
 
@@ -554,6 +558,7 @@ fn org_web_permissions() -> Result<(), Box<dyn Error>> {
             draft_id: None,
         },
         entity_type: Cow::Owned(vec![web_type.id.as_url().clone()]),
+        created_by: user.id.into(),
     };
     context.add_entity(&web_entity);
 

--- a/libs/@local/graph/authorization/types/index.snap.d.ts
+++ b/libs/@local/graph/authorization/types/index.snap.d.ts
@@ -54,6 +54,8 @@ export type EntityResourceFilter = {
 } | {
 	type: "isOfType"
 	entityType: VersionedUrl
+} | {
+	type: "createdByPrincipal"
 };
 export type EntityTypeId = string;
 export type EntityTypeResourceConstraint = {

--- a/libs/@local/hash-backend-utils/src/service-usage.ts
+++ b/libs/@local/hash-backend-utils/src/service-usage.ts
@@ -36,7 +36,6 @@ import type {
   RecordsUsageOf,
   UsageRecord,
 } from "@local/hash-isomorphic-utils/system-types/usagerecord";
-import type { PrincipalConstraint } from "@rust/hash-graph-authorization/types";
 import { backOff } from "exponential-backoff";
 
 import { getInstanceAdminsTeam } from "./hash-instance.js";
@@ -303,19 +302,6 @@ export const createUsageRecord = async (
     });
   }
 
-  const viewPrincipals: PrincipalConstraint[] = [
-    {
-      type: "actor",
-      actorType: "user",
-      id: userAccountId,
-    },
-    {
-      type: "actor",
-      actorType: "ai",
-      id: aiAssistantAccountId,
-    },
-  ];
-
   const usageRecordEntityUuid = generateUuid() as EntityUuid;
   const recordsUsageOfEntityUuid = generateUuid() as EntityUuid;
 
@@ -342,12 +328,18 @@ export const createUsageRecord = async (
       provenance,
       entityTypeIds: [systemEntityTypes.usageRecord.entityTypeId],
       relationships: entityRelationships,
-      policies: viewPrincipals.map((principal) => ({
-        name: `usage-record-view-entity-${usageRecordEntityUuid}`,
-        principal,
-        effect: "permit",
-        actions: ["viewEntity"],
-      })),
+      policies: [
+        {
+          name: `usage-record-view-entity-${recordsUsageOfEntityUuid}`,
+          principal: {
+            type: "actor",
+            actorType: "ai",
+            id: aiAssistantAccountId,
+          },
+          effect: "permit",
+          actions: ["viewEntity"],
+        },
+      ],
     },
     {
       webId: assignUsageToWebId,
@@ -361,12 +353,18 @@ export const createUsageRecord = async (
       },
       entityTypeIds: [systemLinkEntityTypes.recordsUsageOf.linkEntityTypeId],
       relationships: entityRelationships,
-      policies: viewPrincipals.map((principal) => ({
-        name: `usage-record-view-entity-${recordsUsageOfEntityUuid}`,
-        principal,
-        effect: "permit",
-        actions: ["viewEntity"],
-      })),
+      policies: [
+        {
+          name: `usage-record-view-entity-${recordsUsageOfEntityUuid}`,
+          principal: {
+            type: "actor",
+            actorType: "ai",
+            id: aiAssistantAccountId,
+          },
+          effect: "permit",
+          actions: ["viewEntity"],
+        },
+      ],
     },
   ]);
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For some entity types we require that only the entity creator can see the entity, for example for the `usage-record`s, not every member of the web should see them but only the admins and the creators.

## 🔍 What does this change?

- Implement a resource filter `createdByPrincipal`
- Remove per-entity policy for `incurred-in` entities
- Remove per-entity policy for entity creator for `usage-record`, `user-secret`, and `records-usage-of` entities

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph