### PR TITLE
H-4632, H-4637: Better admin user management table, profile page default

### DIFF
--- a/apps/hash-api/src/graphql/resolvers/knowledge/hash-instance/hash-instance.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/hash-instance/hash-instance.ts
@@ -1,6 +1,8 @@
-import { getHashInstance } from "@local/hash-backend-utils/hash-instance";
+import {
+  getHashInstance,
+  isUserHashInstanceAdmin,
+} from "@local/hash-backend-utils/hash-instance";
 
-import { checkEntityPermission } from "../../../../graph/knowledge/primitive/entity";
 import type { HashInstanceSettings, ResolverFn } from "../../../api-types.gen";
 import type { GraphQLContext } from "../../../context";
 import { graphQLContextToImpureGraphContext } from "../../util";
@@ -16,16 +18,11 @@ export const hashInstanceSettingsResolver: ResolverFn<
 
   const { entity } = await getHashInstance(context, authentication);
 
-  const isUserAdmin = graphQLContext.user
-    ? await checkEntityPermission(
-        graphQLContextToImpureGraphContext(graphQLContext),
-        graphQLContext.authentication,
-        {
-          entityId: entity.metadata.recordId.entityId,
-          permission: "update",
-        },
-      )
-    : false;
+  const isUserAdmin = await isUserHashInstanceAdmin(
+    graphQLContextToImpureGraphContext(graphQLContext),
+    graphQLContext.authentication,
+    { userAccountId: authentication.actorId },
+  );
 
   return {
     entity: entity.toJSON(),

--- a/apps/hash-frontend/src/components/hooks/use-users.ts
+++ b/apps/hash-frontend/src/components/hooks/use-users.ts
@@ -20,9 +20,10 @@ import { useMemoCompare } from "../../shared/use-memo-compare";
 
 export const useUsers = (): {
   loading: boolean;
+  refetch: () => void;
   users?: MinimalUser[];
 } => {
-  const { data, loading } = useQuery<
+  const { data, loading, refetch } = useQuery<
     QueryEntitiesQuery,
     QueryEntitiesQueryVariables
   >(queryEntitiesQuery, {
@@ -117,6 +118,7 @@ export const useUsers = (): {
 
   return {
     loading,
+    refetch,
     users,
   };
 };

--- a/apps/hash-frontend/src/pages/@/[shortname].page.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname].page.tsx
@@ -222,10 +222,14 @@ const ProfilePage: NextPageWithLayout = () => {
 
   const baseTabs = useMemo<ProfilePageTab[]>(
     () => [
-      {
-        kind: "profile",
-        title: "Profile",
-      },
+      ...(enabledFeatureFlags.pages
+        ? [
+            {
+              kind: "profile",
+              title: "Profile",
+            } as const,
+          ]
+        : []),
       ...pinnedEntityTypeBaseUrls.map<ProfilePageTab>((entityTypeBaseUrl) => ({
         kind: "pinned-entity-type",
         entityTypeBaseUrl,
@@ -235,7 +239,7 @@ const ProfilePage: NextPageWithLayout = () => {
         title: "Types",
       },
     ],
-    [pinnedEntityTypeBaseUrls],
+    [enabledFeatureFlags.pages, pinnedEntityTypeBaseUrls],
   );
 
   const includeEntityTypeIds = useMemo(

--- a/apps/hash-frontend/src/pages/admin/admin-page-layout.tsx
+++ b/apps/hash-frontend/src/pages/admin/admin-page-layout.tsx
@@ -16,7 +16,7 @@ import { SettingsSidebar } from "../shared/settings-layout/settings-sidebar";
 import { TopContextBar } from "../shared/top-context-bar";
 
 const containerSx = {
-  maxWidth: { lg: 1040 },
+  maxWidth: { lg: 1240, xl: 1400 },
   margin: "0 auto",
   px: { xs: 4 },
 };
@@ -83,7 +83,11 @@ const AdminLayout = ({ children }: PropsWithChildren) => {
       </Box>
       <Container sx={{ ...containerSx, py: 6 }}>
         <Box sx={{ display: "flex", justifyContent: "space-between" }}>
-          <SettingsSidebar heading="Instance" menuItems={menuItems} />
+          <SettingsSidebar
+            heading="Instance"
+            menuItems={menuItems}
+            width={120}
+          />
           <Box sx={{ flex: 1 }}>{children}</Box>
         </Box>
       </Container>

--- a/apps/hash-frontend/src/pages/shared/settings-layout/settings-sidebar.tsx
+++ b/apps/hash-frontend/src/pages/shared/settings-layout/settings-sidebar.tsx
@@ -36,7 +36,7 @@ const ItemLink = styled(Link)<{
   font-size: ${Math.max(16 - level, 13)}px;
   font-weight: ${level === 2 && active ? 600 : 500};
   text-decoration: none;
-  
+
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -197,9 +197,11 @@ const SidebarItem = ({
 export const SettingsSidebar = ({
   menuItems,
   heading,
+  width = 200,
 }: {
   menuItems: SidebarItemData[];
   heading: ReactNode;
+  width?: number;
 }) => {
   const router = useRouter();
 
@@ -274,7 +276,7 @@ export const SettingsSidebar = ({
   }, [handlePathChange, router.events]);
 
   return (
-    <Box mr={4} width={200}>
+    <Box mr={4} width={width}>
       <Typography
         variant="microText"
         sx={({ palette }) => ({

--- a/apps/hash-frontend/src/pages/shared/use-enabled-feature-flags.tsx
+++ b/apps/hash-frontend/src/pages/shared/use-enabled-feature-flags.tsx
@@ -5,7 +5,7 @@ import { useMemo } from "react";
 import { useAuthenticatedUser } from "./auth-info-context";
 
 export const useEnabledFeatureFlags = () => {
-  const { authenticatedUser, isInstanceAdmin } = useAuthenticatedUser();
+  const { authenticatedUser } = useAuthenticatedUser();
 
   return useMemo(() => {
     /**
@@ -16,9 +16,7 @@ export const useEnabledFeatureFlags = () => {
      * @todo: revise this when we have an `/admin` page to manage
      * feature flags.
      */
-    const enabledFeatureFlags = isInstanceAdmin
-      ? Array.from(featureFlags)
-      : authenticatedUser.enabledFeatureFlags;
+    const { enabledFeatureFlags } = authenticatedUser;
 
     return featureFlags.reduce<Record<FeatureFlag, boolean>>(
       (prev, featureFlag) => ({
@@ -27,5 +25,5 @@ export const useEnabledFeatureFlags = () => {
       }),
       {} as Record<FeatureFlag, boolean>,
     );
-  }, [authenticatedUser, isInstanceAdmin]);
+  }, [authenticatedUser]);
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR:
1. Improves the user table admins can see by making columns sortable
2. Adds a dropdown to toggle feature flags enabled for each user

On a user's profile page, it also hides the 'Profile' section if the pages feature flag is disabled, defaulting to their types table instead (empty state to be changed here in a follow-up).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. If you are an instance admin, visit the instance settings page.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

https://github.com/user-attachments/assets/d4524c43-3a9a-4af3-8c8a-ca9376423df7

