### PR TITLE
H-4786: Update bastion host ami image

### DIFF
--- a/infra/terraform/modules/bastion/main.tf
+++ b/infra/terraform/modules/bastion/main.tf
@@ -24,7 +24,7 @@ data "aws_ami" "amazon_linux" {
     # `aws ec2 describe-images --owners amazon --filters "Name=name,Values=amzn2-ami-hvm-*-x86_64-gp2" | jq '.Images | sort_by(.CreationDate) | reverse'`
     # We don't wilcard here to not accidentialy update to a non-functioning image.
     values = [
-      "amzn2-ami-hvm-2.0.20230612.0-x86_64-gp2",
+      "amzn2-ami-hvm-2.0.20250610.0-x86_64-gp2",
     ]
   }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Terraform `plan` and `apply` have started failing with this message:

```
Error: Your query returned no results. Please change your search criteria and try again.

  with module.bastion.data.aws_ami.amazon_linux,
  on ../modules/bastion/main.tf line 16, in data "aws_ami" "amazon_linux":
  16: data "aws_ami" "amazon_linux" {
```

The block the error references contains this filter:
```
  filter {
    name = "name"

    # list with the following command to update:
    # `aws ec2 describe-images --owners amazon --filters "Name=name,Values=amzn2-ami-hvm-*-x86_64-gp2" | jq '.Images | sort_by(.CreationDate) | reverse'`
    # We don't wilcard here to not accidentialy update to a non-functioning image.
    values = [
      "amzn2-ami-hvm-2.0.20230612.0-x86_64-gp2",
    ]
  }
```

so my theory is that this 2023 AMI image has been removed, or similar. This PR updates to a newer one that appears in the list returned by the command in that code block.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. See that `terraform plan` works in CI, whereas all other recent invocations are failing

