### PR TITLE
H-4782, H-4784, H-4780: HashQL: Solve unconstrained variables through fix-point iteration

### DIFF
--- a/libs/@local/hashql/core/src/lib.rs
+++ b/libs/@local/hashql/core/src/lib.rs
@@ -16,11 +16,11 @@
     // Language Features
     arbitrary_self_types,
     associated_type_defaults,
+    impl_trait_in_assoc_type,
     macro_metavar_expr,
     macro_metavar_expr_concat,
     never_type,
     type_alias_impl_trait,
-    impl_trait_in_assoc_type
 )]
 
 extern crate alloc;

--- a/libs/@local/hashql/core/src/lib.rs
+++ b/libs/@local/hashql/core/src/lib.rs
@@ -20,6 +20,7 @@
     macro_metavar_expr_concat,
     never_type,
     type_alias_impl_trait,
+    impl_trait_in_assoc_type
 )]
 
 extern crate alloc;

--- a/libs/@local/hashql/core/src/type/environment/infer.rs
+++ b/libs/@local/hashql/core/src/type/environment/infer.rs
@@ -19,7 +19,7 @@ pub struct InferenceEnvironment<'env, 'heap> {
     pub environment: &'env Environment<'heap>,
     boundary: RecursionBoundary<'heap>,
 
-    constraints: Vec<Constraint<'heap>>,
+    pub constraints: Vec<Constraint<'heap>>,
 
     variance: Variance,
 }

--- a/libs/@local/hashql/core/src/type/environment/infer.rs
+++ b/libs/@local/hashql/core/src/type/environment/infer.rs
@@ -7,9 +7,8 @@ use crate::{
     r#type::{
         TypeId,
         inference::{
-            Constraint, DeferralDepth, Inference as _, InferenceSolver, PartialStructuralEdge,
-            ResolutionStrategy, SelectionConstraint, Subject, Variable,
-            VariableDependencyCollector, VariableKind,
+            Constraint, DeferralDepth, Inference as _, InferenceSolver, ResolutionStrategy,
+            SelectionConstraint, Subject, Variable, VariableDependencyCollector, VariableKind,
         },
         recursion::RecursionBoundary,
     },

--- a/libs/@local/hashql/core/src/type/environment/infer.rs
+++ b/libs/@local/hashql/core/src/type/environment/infer.rs
@@ -20,7 +20,7 @@ pub struct InferenceEnvironment<'env, 'heap> {
     boundary: RecursionBoundary<'heap>,
     variables: VariableDependencyCollector<'env, 'heap>,
 
-    constraints: Vec<Constraint<'heap>>,
+    pub constraints: Vec<Constraint<'heap>>,
 
     variance: Variance,
 }

--- a/libs/@local/hashql/core/src/type/environment/infer.rs
+++ b/libs/@local/hashql/core/src/type/environment/infer.rs
@@ -73,7 +73,7 @@ impl<'env, 'heap> InferenceEnvironment<'env, 'heap> {
                     lhs: lower,
                     rhs: upper,
                 },
-                Constraint::StructuralEdge {
+                Constraint::Dependency {
                     source: _,
                     target: _,
                 } => {
@@ -93,11 +93,11 @@ impl<'env, 'heap> InferenceEnvironment<'env, 'heap> {
 
     pub fn add_structural_edge(&mut self, variable: PartialStructuralEdge, other: Variable) {
         let constraint = match variable {
-            PartialStructuralEdge::Source(source) => Constraint::StructuralEdge {
+            PartialStructuralEdge::Source(source) => Constraint::Dependency {
                 source,
                 target: other,
             },
-            PartialStructuralEdge::Target(target) => Constraint::StructuralEdge {
+            PartialStructuralEdge::Target(target) => Constraint::Dependency {
                 source: other,
                 target,
             },

--- a/libs/@local/hashql/core/src/type/environment/lattice.rs
+++ b/libs/@local/hashql/core/src/type/environment/lattice.rs
@@ -65,6 +65,7 @@ impl<'env, 'heap> LatticeEnvironment<'env, 'heap> {
         self.simplify.contains_substitution(kind)
     }
 
+    #[inline]
     pub(crate) fn simplify(&mut self, id: TypeId) -> TypeId {
         self.simplify.simplify(id)
     }

--- a/libs/@local/hashql/core/src/type/inference/mod.rs
+++ b/libs/@local/hashql/core/src/type/inference/mod.rs
@@ -272,7 +272,7 @@ pub enum Constraint<'heap> {
     ///
     /// A structural edge is an edge, which explains that `source` flows into `target`, for example
     /// given: `_1 <: (name: _2)`, `_1` flows into `_2`.
-    StructuralEdge { source: Variable, target: Variable },
+    Dependency { source: Variable, target: Variable },
 
     /// Constraints for component selection operations (`subject.field` or `subject[index]`)
     ///
@@ -297,7 +297,7 @@ impl Constraint<'_> {
                 r#type: _,
             } => [Some(variable), None, None],
             Self::Ordering { lower, upper } => [Some(lower), Some(upper), None],
-            Self::StructuralEdge { source, target } => [Some(source), Some(target), None],
+            Self::Dependency { source, target } => [Some(source), Some(target), None],
             Self::Selection(
                 SelectionConstraint::Projection {
                     subject,

--- a/libs/@local/hashql/core/src/type/inference/mod.rs
+++ b/libs/@local/hashql/core/src/type/inference/mod.rs
@@ -341,11 +341,17 @@ impl Substitution {
     }
 
     pub(crate) fn insert(&mut self, key: VariableKind, value: TypeId) {
-        self.substitutions.insert(key, value);
+        let root = self.variables[key];
+
+        self.substitutions.insert(root, value);
     }
 
     pub(crate) fn contains(&self, kind: VariableKind) -> bool {
-        self.substitutions.contains_key(&kind)
+        let Some(root) = self.variables.get(kind) else {
+            return false;
+        };
+
+        self.substitutions.contains_key(&root)
     }
 
     #[must_use]

--- a/libs/@local/hashql/core/src/type/inference/mod.rs
+++ b/libs/@local/hashql/core/src/type/inference/mod.rs
@@ -1,43 +1,18 @@
 pub(crate) mod solver;
 mod variable;
+mod visit;
 
-pub(crate) use self::variable::VariableLookup;
 pub use self::{
     solver::InferenceSolver,
     variable::{Variable, VariableKind},
 };
+pub(crate) use self::{variable::VariableLookup, visit::VariableDependencyCollector};
 use super::{
     Type, TypeId,
     environment::{Environment, InferenceEnvironment, instantiate::InstantiateEnvironment},
     kind::{generic::GenericArgumentId, infer::HoleId},
 };
 use crate::{collection::FastHashMap, symbol::Ident};
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum PartialStructuralEdge {
-    Source(Variable),
-    Target(Variable),
-}
-
-impl PartialStructuralEdge {
-    #[must_use]
-    pub const fn invert(self) -> Self {
-        match self {
-            Self::Source(variable) => Self::Target(variable),
-            Self::Target(variable) => Self::Source(variable),
-        }
-    }
-
-    #[must_use]
-    pub const fn is_source(&self) -> bool {
-        matches!(self, Self::Source(_))
-    }
-
-    #[must_use]
-    pub const fn is_target(&self) -> bool {
-        matches!(self, Self::Target(_))
-    }
-}
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Subject {
@@ -387,26 +362,6 @@ pub trait Inference<'heap> {
     fn collect_constraints(
         self: Type<'heap, Self>,
         supertype: Type<'heap, Self>,
-        env: &mut InferenceEnvironment<'_, 'heap>,
-    );
-
-    /// Collects structural edges between this type and inference variables.
-    ///
-    /// This method tracks the propagation of type information through structural
-    /// relationships in types. It establishes directed flow connections between
-    /// types and their constituent parts, allowing the inference engine to
-    /// understand how type information should flow through complex nested structures.
-    ///
-    /// For example, when processing a record type with fields, this method would
-    /// track the relationship between the record variable and its field variables,
-    /// creating appropriate edges to represent these structural dependencies.
-    ///
-    /// The `variable` parameter specifies whether this type is the source or target
-    /// of the structural relationship, determining the direction of type flow during
-    /// inference.
-    fn collect_structural_edges(
-        self: Type<'heap, Self>,
-        variable: PartialStructuralEdge,
         env: &mut InferenceEnvironment<'_, 'heap>,
     );
 

--- a/libs/@local/hashql/core/src/type/inference/solver/graph.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/graph.rs
@@ -1,4 +1,4 @@
-use core::{mem, mem::size_of, ops::RangeInclusive};
+use core::{mem, ops::RangeInclusive};
 
 use ena::unify::UnifyKey as _;
 use roaring::RoaringBitmap;

--- a/libs/@local/hashql/core/src/type/inference/solver/graph.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/graph.rs
@@ -168,8 +168,8 @@ impl Graph {
         // do not have to worry about overflow for the max sentinel value. In case of 32 bit
         // systems, if the length is exactly `u32::MAX`, we need to error out.
         assert!(
-            size_of::<usize>() != size_of::<u32>() || length < u32::MAX as usize,
-            "Too many variables, cannot use `usize::MAX` as sentinel value"
+            length < 0x3FFF_FFFF,
+            "Too many variables, expected a maximum of 1.073.741.823 variables"
         );
 
         let offset = self.lookup.len();

--- a/libs/@local/hashql/core/src/type/inference/solver/graph.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/graph.rs
@@ -274,6 +274,23 @@ impl Graph {
     pub(crate) fn outgoing_edges_by_index(&self, node: usize) -> impl Iterator<Item = usize> {
         self.nodes[node].edges.iter().map(|edge| edge as usize)
     }
+
+    pub(crate) fn outgoing_edges(&self, node: VariableId) -> impl Iterator<Item = VariableId> {
+        self.outgoing_edges_by_index(self.lookup_id(node))
+            .map(|index| self.nodes[index].id)
+    }
+
+    pub(crate) fn incoming_edges(&self, node: VariableId) -> impl Iterator<Item = VariableId> {
+        let id = self.lookup_id(node);
+
+        self.nodes
+            .iter()
+            .filter(move |node| {
+                #[expect(clippy::cast_possible_truncation)]
+                node.edges.contains(id as u32)
+            })
+            .map(|node| node.id)
+    }
 }
 
 #[cfg(test)]

--- a/libs/@local/hashql/core/src/type/inference/solver/mod.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/mod.rs
@@ -1086,7 +1086,7 @@ impl<'env, 'heap> InferenceSolver<'env, 'heap> {
         // again *or* do it in a specific order. The substitutions have already been applied for the
         // lower and upper bounds respectively.
         let scc = Tarjan::new_in(graph, EdgeKind::Any, bump).compute(); // The scc are in reverse topological order
-        let topo = scc.into_iter().flatten().rev();
+        let topo = scc.into_iter().flatten();
 
         for index in topo {
             let id = graph.node(index as usize);

--- a/libs/@local/hashql/core/src/type/inference/solver/mod.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/mod.rs
@@ -938,6 +938,9 @@ impl<'env, 'heap> InferenceSolver<'env, 'heap> {
         // Step 1.4: First collect all constraints by variable
         self.collect_constraints(variables, selections);
 
+        // TODO: create a graph that makes use of the structural constraints to create an
+        // elimination order.
+
         // Step 1.5: Perform the forward pass to resolve lower bounds
         self.apply_constraints_forwards(graph, bump, variables);
 

--- a/libs/@local/hashql/core/src/type/inference/solver/tarjan.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/tarjan.rs
@@ -4,7 +4,7 @@ use core::alloc::Allocator;
 use bitvec::{bitbox, boxed::BitBox};
 use roaring::RoaringBitmap;
 
-use super::graph::Graph;
+use super::graph::{EdgeKind, Graph};
 
 /// Implementation of Tarjan's algorithm for finding strongly connected components (SCCs) in a
 /// directed graph.
@@ -26,6 +26,8 @@ use super::graph::Graph;
 pub(crate) struct Tarjan<'graph, A: Allocator = Global> {
     /// The directed graph
     graph: &'graph Graph,
+    /// The kind of edge to consider when computing SCCs
+    kind: EdgeKind,
 
     /// Next discovery index to assign to newly visited nodes.
     /// Each node gets a unique index in the order it's first visited.
@@ -64,8 +66,8 @@ impl<'graph> Tarjan<'graph> {
     /// Initializes all the necessary data structures to track the state of the algorithm.
     /// The capacities of vectors are pre-allocated based on the graph size to minimize
     /// re-allocations during execution.
-    pub(crate) fn new(graph: &'graph Graph) -> Self {
-        Self::new_in(graph, alloc::alloc::Global)
+    pub(crate) fn new(graph: &'graph Graph, kind: EdgeKind) -> Self {
+        Self::new_in(graph, kind, alloc::alloc::Global)
     }
 }
 
@@ -81,7 +83,7 @@ where
     /// The capacities of vectors are pre-allocated based on the graph size to minimize
     /// re-allocations during execution.
     #[expect(clippy::integer_division, clippy::integer_division_remainder_used)]
-    pub(crate) fn new_in(graph: &'graph Graph, allocator: A) -> Self
+    pub(crate) fn new_in(graph: &'graph Graph, kind: EdgeKind, allocator: A) -> Self
     where
         A: Clone,
     {
@@ -89,6 +91,7 @@ where
 
         Self {
             graph,
+            kind,
             next_discovery_index: 0,
             node_stack: Vec::with_capacity_in(
                 node_count / Self::EXPECTED_SCC_RATIO,
@@ -166,7 +169,7 @@ where
         self.visited.set(node, true);
 
         // 2) Explore all outbound neighbors and update lowlink values
-        for neighbour in self.graph.outgoing_edges_by_index(node) {
+        for neighbour in self.graph.outgoing_edges_by_index(self.kind, node) {
             if !self.visited[neighbour] {
                 // Tree edge: Neighbor hasn't been visited yet, so recursively process it
 
@@ -212,7 +215,10 @@ where
 mod test {
     use roaring::RoaringBitmap;
 
-    use crate::r#type::inference::solver::{graph::Graph, tarjan::Tarjan};
+    use crate::r#type::inference::solver::{
+        graph::{EdgeKind, Graph},
+        tarjan::Tarjan,
+    };
 
     /// Helper function to create a directed graph from an adjacency list
     fn create_graph(
@@ -275,35 +281,35 @@ mod test {
     #[test]
     fn empty_graph() {
         let graph = create_graph([] as [&[u32]; 0]);
-        let sccs = Tarjan::new(&graph).compute();
+        let sccs = Tarjan::new(&graph, EdgeKind::Any).compute();
         assert_eq!(sccs.len(), 0);
     }
 
     #[test]
     fn single_node() {
         let graph = create_graph([[]]);
-        let sccs = Tarjan::new(&graph).compute();
+        let sccs = Tarjan::new(&graph, EdgeKind::Any).compute();
         assert_sccs_equal(&sccs, [[0]]);
     }
 
     #[test]
     fn single_node_self_loop() {
         let graph = create_graph([[0]]);
-        let sccs = Tarjan::new(&graph).compute();
+        let sccs = Tarjan::new(&graph, EdgeKind::Any).compute();
         assert_sccs_equal(&sccs, [[0]]);
     }
 
     #[test]
     fn two_node_cycle() {
         let graph = create_graph([[1], [0]]);
-        let sccs = Tarjan::new(&graph).compute();
+        let sccs = Tarjan::new(&graph, EdgeKind::Any).compute();
         assert_sccs_equal(&sccs, [[0, 1]]);
     }
 
     #[test]
     fn directed_line() {
         let graph = create_graph([&[1], &[2], &[] as &[_]]);
-        let sccs = Tarjan::new(&graph).compute();
+        let sccs = Tarjan::new(&graph, EdgeKind::Any).compute();
         assert_sccs_equal(&sccs, [[0], [1], [2]]);
     }
 
@@ -351,7 +357,7 @@ mod test {
             }
         }
 
-        let sccs = Tarjan::new(&graph).compute();
+        let sccs = Tarjan::new(&graph, EdgeKind::Any).compute();
         assert_sccs_equal(&sccs, expected);
     }
 
@@ -363,7 +369,7 @@ mod test {
             [], // 2
         ]);
 
-        let sccs = Tarjan::new(&graph).compute();
+        let sccs = Tarjan::new(&graph, EdgeKind::Any).compute();
         assert_sccs_equal(&sccs, [[0], [1], [2]]);
     }
 
@@ -380,7 +386,7 @@ mod test {
             [3], // 5 -> 3
         ]);
 
-        let sccs = Tarjan::new(&graph).compute();
+        let sccs = Tarjan::new(&graph, EdgeKind::Any).compute();
         assert_sccs_equal(&sccs, [&[0_u32, 1, 2] as &[_], &[3, 4, 5]]);
     }
 
@@ -403,7 +409,7 @@ mod test {
             &[4],             // 6 -> 4
         ]);
 
-        let sccs = Tarjan::new(&graph).compute();
+        let sccs = Tarjan::new(&graph, EdgeKind::Any).compute();
         assert_sccs_equal(&sccs, [&[0_u32, 1, 2] as &[_], &[4, 5, 6], &[3]]);
     }
 
@@ -417,7 +423,7 @@ mod test {
         }
 
         let graph = create_graph(&adjacency_list);
-        let sccs = Tarjan::new(&graph).compute();
+        let sccs = Tarjan::new(&graph, EdgeKind::Any).compute();
 
         // The entire graph should be one SCC
         let expected = [(0..1000).collect::<Vec<_>>()];
@@ -439,7 +445,7 @@ mod test {
             &[],                 // 4
         ]);
 
-        let sccs = Tarjan::new(&graph).compute();
+        let sccs = Tarjan::new(&graph, EdgeKind::Any).compute();
 
         // In a DAG, each node should be its own SCC
         assert_sccs_equal(&sccs, [[0], [1], [2], [3], [4]]);
@@ -462,7 +468,7 @@ mod test {
         }
 
         let graph = create_graph(&adjacency_list);
-        let sccs = Tarjan::new(&graph).compute();
+        let sccs = Tarjan::new(&graph, EdgeKind::Any).compute();
 
         // The entire graph should be one SCC
         let expected = [(0..node_count).collect::<Vec<_>>()];
@@ -487,7 +493,7 @@ mod test {
         }
 
         let graph = create_graph(&adjacency_list);
-        let sccs = Tarjan::new(&graph).compute();
+        let sccs = Tarjan::new(&graph, EdgeKind::Any).compute();
 
         // The graph should have node_count/2 SCCs, each with 2 nodes
         assert_eq!(sccs.len(), node_count as usize / 2);
@@ -520,7 +526,7 @@ mod test {
             &[5],                // 6 -> 5
         ]);
 
-        let sccs = Tarjan::new(&graph).compute();
+        let sccs = Tarjan::new(&graph, EdgeKind::Any).compute();
         assert_sccs_equal(&sccs, [&[0_u32] as &[_], &[1], &[2], &[3], &[4], &[5, 6]]);
     }
 
@@ -539,7 +545,7 @@ mod test {
             &[1],             // 4 -> 1
         ]);
 
-        let sccs = Tarjan::new(&graph).compute();
+        let sccs = Tarjan::new(&graph, EdgeKind::Any).compute();
         assert_sccs_equal(&sccs, [&[0_u32] as &[_], &[1, 2, 4], &[3]]);
     }
 
@@ -560,7 +566,7 @@ mod test {
             &[],              // 7
         ]);
 
-        let sccs = Tarjan::new(&graph).compute();
+        let sccs = Tarjan::new(&graph, EdgeKind::Any).compute();
         assert_sccs_equal(&sccs, [&[0_u32, 1, 2] as &[_], &[3], &[4], &[5, 6], &[7]]);
     }
 }

--- a/libs/@local/hashql/core/src/type/inference/solver/tarjan.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/tarjan.rs
@@ -569,4 +569,24 @@ mod test {
         let sccs = Tarjan::new(&graph, EdgeKind::Any).compute();
         assert_sccs_equal(&sccs, [&[0_u32, 1, 2] as &[_], &[3], &[4], &[5, 6], &[7]]);
     }
+
+    #[test]
+    fn scc_order() {
+        // 0 → 1 → 2 → 0     (SCC1)
+        // 2 → 3             (SCC1 → SCC2)
+        // 3 → 4 → 5 → 3     (SCC2)
+        // 5 → 6             (SCC2 → SCC3)
+        let graph = create_graph([
+            &[1_u32] as &[_], // 0 -> 1
+            &[2],             // 1 -> 2
+            &[0, 3],          // 2 -> 0, 3
+            &[4],             // 3 -> 4
+            &[5],             // 4 -> 5
+            &[3, 6],          // 5 -> 3, 5 -> 6
+            &[],
+        ]);
+
+        let sccs = Tarjan::new(&graph, EdgeKind::Any).compute();
+        assert_sccs_equal(&sccs, [&[6_u32] as &[_], &[3, 4, 5], &[0, 1, 2]]);
+    }
 }

--- a/libs/@local/hashql/core/src/type/inference/solver/tests.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/tests.rs
@@ -2273,19 +2273,12 @@ fn nested_inference_constraints() {
     let hole1 = builder.fresh_hole();
 
     let hole2 = builder.fresh_hole();
-    let variable2 = Variable::synthetic(VariableKind::Hole(hole2));
 
     let string = builder.string();
 
     let mut inference = InferenceEnvironment::new(&env);
-    inference.add_constraint(Constraint::LowerBound {
-        variable: variable2,
-        bound: builder.list(builder.infer(hole1)),
-    });
-    inference.add_constraint(Constraint::UpperBound {
-        variable: variable2,
-        bound: builder.list(string),
-    });
+    inference.collect_constraints(builder.list(builder.infer(hole1)), builder.infer(hole2));
+    inference.collect_constraints(builder.infer(hole2), builder.list(string));
 
     let solver = inference.into_solver();
     let (substitution, diagnostics) = solver.solve();

--- a/libs/@local/hashql/core/src/type/inference/solver/tests.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/tests.rs
@@ -385,6 +385,7 @@ fn solve_constraints_with_equality() {
     applied_constraints.insert(var.kind, (var, vc));
 
     let mut solver = InferenceSolver::new(InferenceEnvironment::new(&env).with_constraints([]));
+    solver.unification.upsert_variable(VariableKind::Hole(hole));
 
     let mut substitutions = FastHashMap::default();
     solver.solve_constraints(
@@ -420,6 +421,7 @@ fn solve_constraints_with_incompatible_bounds() {
     applied_constraints.insert(var.kind, (var, vc));
 
     let mut solver = InferenceSolver::new(InferenceEnvironment::new(&env).with_constraints([]));
+    solver.unification.upsert_variable(VariableKind::Hole(hole));
 
     // These bounds are incompatible, so a diagnostic should be created
     let mut substitutions = FastHashMap::default();
@@ -461,6 +463,7 @@ fn solve_constraints_with_incompatible_equality() {
     applied_constraints.insert(var.kind, (var, vc));
 
     let mut solver = InferenceSolver::new(InferenceEnvironment::new(&env).with_constraints([]));
+    solver.unification.upsert_variable(VariableKind::Hole(hole));
 
     let mut substitutions = FastHashMap::default();
     solver.solve_constraints(
@@ -501,6 +504,7 @@ fn solve_constraints_with_incompatible_upper_equal_constraint() {
     applied_constraints.insert(var.kind, (var, vc));
 
     let mut solver = InferenceSolver::new(InferenceEnvironment::new(&env).with_constraints([]));
+    solver.unification.upsert_variable(VariableKind::Hole(hole));
 
     // This should exercise lines 916-929
     let mut substitutions = FastHashMap::default();
@@ -637,57 +641,6 @@ fn cyclic_ordering_constraints() {
         Constraint::Ordering {
             lower: variable3,
             upper: variable1,
-        },
-    ];
-
-    let mut solver =
-        InferenceSolver::new(InferenceEnvironment::new(&env).with_constraints(constraints));
-
-    // Directly call the anti-symmetry solver
-    let mut graph = Graph::new(&mut solver.unification);
-    let bump = Bump::new();
-    solver.upsert_variables(&mut graph);
-    solver.solve_anti_symmetry(&mut graph, &mut FastHashMap::default(), &bump);
-
-    // Verify all variables are unified
-    assert!(
-        solver
-            .unification
-            .is_unioned(variable1.kind, variable2.kind)
-    );
-    assert!(
-        solver
-            .unification
-            .is_unioned(variable2.kind, variable3.kind)
-    );
-}
-
-#[test]
-fn cyclic_structural_edges_constraints() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    let hole1 = HoleId::new(1);
-    let hole2 = HoleId::new(2);
-    let hole3 = HoleId::new(3);
-
-    let variable1 = Variable::synthetic(VariableKind::Hole(hole1));
-    let variable2 = Variable::synthetic(VariableKind::Hole(hole2));
-    let variable3 = Variable::synthetic(VariableKind::Hole(hole3));
-
-    // Create a cycle
-    let constraints = [
-        Constraint::StructuralEdge {
-            source: variable1,
-            target: variable2,
-        },
-        Constraint::StructuralEdge {
-            source: variable2,
-            target: variable3,
-        },
-        Constraint::StructuralEdge {
-            source: variable3,
-            target: variable1,
         },
     ];
 

--- a/libs/@local/hashql/core/src/type/inference/solver/tests.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/tests.rs
@@ -350,10 +350,15 @@ fn solve_constraints() {
     applied_constraints.insert(variable.kind, (variable, constraint));
 
     let mut solver = InferenceSolver::new(InferenceEnvironment::new(&env).with_constraints([]));
+    solver.unification.upsert_variable(variable.kind);
+
+    let graph = Graph::new(&mut solver.unification);
 
     // Directly call solve_constraints
     let mut substitutions = FastHashMap::default();
     solver.solve_constraints(
+        &graph,
+        &bump,
         &applied_constraints,
         &mut substitutions,
         &mut Vec::new_in(&bump),
@@ -388,8 +393,12 @@ fn solve_constraints_with_equality() {
     let mut solver = InferenceSolver::new(InferenceEnvironment::new(&env).with_constraints([]));
     solver.unification.upsert_variable(VariableKind::Hole(hole));
 
+    let graph = Graph::new(&mut solver.unification);
+
     let mut substitutions = FastHashMap::default();
     solver.solve_constraints(
+        &graph,
+        &bump,
         &applied_constraints,
         &mut substitutions,
         &mut Vec::new_in(&bump),
@@ -424,9 +433,13 @@ fn solve_constraints_with_incompatible_bounds() {
     let mut solver = InferenceSolver::new(InferenceEnvironment::new(&env).with_constraints([]));
     solver.unification.upsert_variable(VariableKind::Hole(hole));
 
+    let graph = Graph::new(&mut solver.unification);
+
     // These bounds are incompatible, so a diagnostic should be created
     let mut substitutions = FastHashMap::default();
     solver.solve_constraints(
+        &graph,
+        &bump,
         &applied_constraints,
         &mut substitutions,
         &mut Vec::new_in(&bump),
@@ -466,8 +479,12 @@ fn solve_constraints_with_incompatible_equality() {
     let mut solver = InferenceSolver::new(InferenceEnvironment::new(&env).with_constraints([]));
     solver.unification.upsert_variable(VariableKind::Hole(hole));
 
+    let graph = Graph::new(&mut solver.unification);
+
     let mut substitutions = FastHashMap::default();
     solver.solve_constraints(
+        &graph,
+        &bump,
         &applied_constraints,
         &mut substitutions,
         &mut Vec::new_in(&bump),
@@ -507,9 +524,13 @@ fn solve_constraints_with_incompatible_upper_equal_constraint() {
     let mut solver = InferenceSolver::new(InferenceEnvironment::new(&env).with_constraints([]));
     solver.unification.upsert_variable(VariableKind::Hole(hole));
 
+    let graph = Graph::new(&mut solver.unification);
+
     // This should exercise lines 916-929
     let mut substitutions = FastHashMap::default();
     solver.solve_constraints(
+        &graph,
+        &bump,
         &applied_constraints,
         &mut substitutions,
         &mut Vec::new_in(&bump),
@@ -710,7 +731,13 @@ fn bounds_at_lattice_extremes() {
 
     // These bounds should be compatible
     let mut substitutions = FastHashMap::default();
-    solver.solve_constraints(&variables, &mut substitutions, &mut Vec::new_in(&bump));
+    solver.solve_constraints(
+        &graph,
+        &bump,
+        &variables,
+        &mut substitutions,
+        &mut Vec::new_in(&bump),
+    );
     assert!(solver.diagnostics.is_empty());
 
     // The variable should be inferred to the lower bound (Never)

--- a/libs/@local/hashql/core/src/type/inference/solver/tests.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/tests.rs
@@ -329,6 +329,7 @@ fn apply_constraints_with_unification() {
 #[test]
 fn solve_constraints() {
     let heap = Heap::new();
+    let bump = Bump::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
     let hole = HoleId::new(0);
@@ -351,7 +352,11 @@ fn solve_constraints() {
 
     // Directly call solve_constraints
     let mut substitutions = FastHashMap::default();
-    solver.solve_constraints(&applied_constraints, &mut substitutions);
+    solver.solve_constraints(
+        &applied_constraints,
+        &mut substitutions,
+        &mut Vec::new_in(&bump),
+    );
 
     // Verify the substitution
     assert_eq!(substitutions.len(), 1);
@@ -361,6 +366,7 @@ fn solve_constraints() {
 #[test]
 fn solve_constraints_with_equality() {
     let heap = Heap::new();
+    let bump = Bump::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
     let hole = HoleId::new(0);
@@ -381,7 +387,11 @@ fn solve_constraints_with_equality() {
     let mut solver = InferenceSolver::new(InferenceEnvironment::new(&env).with_constraints([]));
 
     let mut substitutions = FastHashMap::default();
-    solver.solve_constraints(&applied_constraints, &mut substitutions);
+    solver.solve_constraints(
+        &applied_constraints,
+        &mut substitutions,
+        &mut Vec::new_in(&bump),
+    );
 
     assert_eq!(substitutions.len(), 1);
     assert_eq!(substitutions[&var.kind], string);
@@ -390,6 +400,7 @@ fn solve_constraints_with_equality() {
 #[test]
 fn solve_constraints_with_incompatible_bounds() {
     let heap = Heap::new();
+    let bump = Bump::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
     let hole = HoleId::new(0);
@@ -412,7 +423,11 @@ fn solve_constraints_with_incompatible_bounds() {
 
     // These bounds are incompatible, so a diagnostic should be created
     let mut substitutions = FastHashMap::default();
-    solver.solve_constraints(&applied_constraints, &mut substitutions);
+    solver.solve_constraints(
+        &applied_constraints,
+        &mut substitutions,
+        &mut Vec::new_in(&bump),
+    );
 
     let diagnostics = solver.diagnostics.into_vec();
     assert_eq!(diagnostics.len(), 1);
@@ -426,6 +441,7 @@ fn solve_constraints_with_incompatible_bounds() {
 #[test]
 fn solve_constraints_with_incompatible_equality() {
     let heap = Heap::new();
+    let bump = Bump::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
     let hole = HoleId::new(0);
@@ -447,7 +463,11 @@ fn solve_constraints_with_incompatible_equality() {
     let mut solver = InferenceSolver::new(InferenceEnvironment::new(&env).with_constraints([]));
 
     let mut substitutions = FastHashMap::default();
-    solver.solve_constraints(&applied_constraints, &mut substitutions);
+    solver.solve_constraints(
+        &applied_constraints,
+        &mut substitutions,
+        &mut Vec::new_in(&bump),
+    );
 
     let diagnostics = solver.diagnostics.into_vec();
     assert_eq!(diagnostics.len(), 1);
@@ -460,6 +480,7 @@ fn solve_constraints_with_incompatible_equality() {
 #[test]
 fn solve_constraints_with_incompatible_upper_equal_constraint() {
     let heap = Heap::new();
+    let bump = Bump::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
     let hole = HoleId::new(0);
@@ -483,7 +504,11 @@ fn solve_constraints_with_incompatible_upper_equal_constraint() {
 
     // This should exercise lines 916-929
     let mut substitutions = FastHashMap::default();
-    solver.solve_constraints(&applied_constraints, &mut substitutions);
+    solver.solve_constraints(
+        &applied_constraints,
+        &mut substitutions,
+        &mut Vec::new_in(&bump),
+    );
 
     // Should have a diagnostic for incompatible upper equal constraint
     let diagnostics = solver.diagnostics.into_vec();
@@ -731,7 +756,7 @@ fn bounds_at_lattice_extremes() {
 
     // These bounds should be compatible
     let mut substitutions = FastHashMap::default();
-    solver.solve_constraints(&variables, &mut substitutions);
+    solver.solve_constraints(&variables, &mut substitutions, &mut Vec::new_in(&bump));
     assert!(solver.diagnostics.is_empty());
 
     // The variable should be inferred to the lower bound (Never)

--- a/libs/@local/hashql/core/src/type/inference/solver/tests.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/tests.rs
@@ -729,7 +729,7 @@ fn collect_constraints_with_structural_edge() {
     let var2 = Variable::synthetic(VariableKind::Hole(hole2));
 
     // Create a structural edge constraint
-    let constraints = [Constraint::StructuralEdge {
+    let constraints = [Constraint::Dependency {
         source: var1,
         target: var2,
     }];
@@ -2232,6 +2232,9 @@ fn deferred_upper_constraint() {
     );
 }
 
+// The problem that we currently have is that when we have a nested inference constraint we do
+// **not** "freeze" a variable in place when we've already determined it's type. We require doing
+// so, so that we can propagate the type.
 #[test]
 fn nested_inference_constraints() {
     // List<?1> <: ?2

--- a/libs/@local/hashql/core/src/type/inference/visit.rs
+++ b/libs/@local/hashql/core/src/type/inference/visit.rs
@@ -1,0 +1,108 @@
+use super::{Variable, VariableKind};
+use crate::{
+    span::SpanId,
+    r#type::{
+        Type,
+        environment::Environment,
+        kind::{GenericArgument, Infer, Param, generic::GenericSubstitution},
+        recursion::RecursionBoundary,
+        visit::{self, Visitor},
+    },
+};
+
+pub(crate) struct VariableVisitorFilter(!);
+
+impl visit::filter::Filter for VariableVisitorFilter {
+    const DEEP: bool = true;
+    const GENERIC_PARAMETERS: bool = true;
+    const MEMBERS: bool = true;
+    const SUBSTITUTIONS: bool = false;
+}
+
+#[derive(Debug)]
+pub(crate) struct VariableDependencyCollector<'env, 'heap> {
+    env: &'env Environment<'heap>,
+    current_span: SpanId,
+    recursion: RecursionBoundary<'heap>,
+    variables: Vec<Variable>,
+}
+
+impl<'env, 'heap> VariableDependencyCollector<'env, 'heap> {
+    pub(crate) fn new(env: &'env Environment<'heap>) -> Self {
+        Self {
+            env,
+            current_span: SpanId::SYNTHETIC,
+            recursion: RecursionBoundary::new(),
+            variables: Vec::new(),
+        }
+    }
+
+    pub(crate) fn collect(
+        &mut self,
+        r#type: Type<'heap>,
+    ) -> impl IntoIterator<Item = Variable> + '_ {
+        self.visit_type(r#type);
+
+        self.variables.drain(..)
+    }
+}
+
+impl<'heap> Visitor<'heap> for VariableDependencyCollector<'_, 'heap> {
+    type Filter = VariableVisitorFilter;
+
+    fn env(&self) -> &Environment<'heap> {
+        self.env
+    }
+
+    fn visit_type(&mut self, r#type: Type<'heap>) {
+        if self.recursion.enter(r#type, r#type).is_break() {
+            // recursive type definition
+            return;
+        }
+
+        let previous = self.current_span;
+        self.current_span = r#type.span;
+
+        visit::walk_type(self, r#type);
+
+        self.current_span = previous;
+
+        self.recursion.exit(r#type, r#type);
+    }
+
+    fn visit_generic_argument(&mut self, argument: GenericArgument<'heap>) {
+        // We only depend on the introduced variable, but **not** the constraint itself, therefore
+        // we don't walk the argument.
+        self.variables.push(Variable {
+            span: self.current_span,
+            kind: VariableKind::Generic(argument.id),
+        });
+    }
+
+    fn visit_generic_substitution(&mut self, substitution: GenericSubstitution) {
+        // We only depend on the introduced variable, but **not** the constraint itself, therefore
+        // we don't walk the substitution.
+        self.variables.push(Variable {
+            span: self.current_span,
+            kind: VariableKind::Generic(substitution.argument),
+        });
+    }
+
+    fn visit_param(&mut self, param: Type<'heap, Param>) {
+        visit::walk_param(self, param);
+
+        self.variables.push(Variable {
+            span: param.span,
+            kind: VariableKind::Generic(param.kind.argument),
+        });
+    }
+
+    fn visit_infer(&mut self, infer: Type<'heap, Infer>) {
+        visit::walk_infer(self, infer);
+
+        self.variables.push(Variable {
+            span: infer.span,
+            kind: VariableKind::Hole(infer.kind.hole),
+        });
+    }
+}

--- a/libs/@local/hashql/core/src/type/kind/closure.rs
+++ b/libs/@local/hashql/core/src/type/kind/closure.rs
@@ -18,7 +18,7 @@ use crate::{
             UnsupportedProjectionCategory, UnsupportedSubscriptCategory,
             function_parameter_count_mismatch, unsupported_projection, unsupported_subscript,
         },
-        inference::{Inference, PartialStructuralEdge},
+        inference::Inference,
         lattice::{Lattice, Projection, Subscript},
     },
 };
@@ -304,18 +304,6 @@ impl<'heap> Inference<'heap> for ClosureType<'heap> {
 
         // Collect constraints for the return type
         env.in_covariant(|env| env.collect_constraints(self.kind.returns, supertype.kind.returns));
-    }
-
-    fn collect_structural_edges(
-        self: Type<'heap, Self>,
-        variable: PartialStructuralEdge,
-        env: &mut InferenceEnvironment<'_, 'heap>,
-    ) {
-        for &param in self.kind.params {
-            env.in_contravariant(|env| env.collect_structural_edges(param, variable));
-        }
-
-        env.in_covariant(|env| env.collect_structural_edges(self.kind.returns, variable));
     }
 
     fn instantiate(self: Type<'heap, Self>, env: &mut InstantiateEnvironment<'_, 'heap>) -> TypeId {

--- a/libs/@local/hashql/core/src/type/kind/generic/apply.rs
+++ b/libs/@local/hashql/core/src/type/kind/generic/apply.rs
@@ -16,7 +16,7 @@ use crate::{
             SimplifyEnvironment,
             instantiate::{InstantiateEnvironment, SubstitutionState},
         },
-        inference::{Inference, PartialStructuralEdge},
+        inference::Inference,
         kind::TypeKind,
         lattice::{Lattice, Projection, Subscript},
     },
@@ -372,16 +372,6 @@ impl<'heap> Inference<'heap> for Apply<'heap> {
             .collect_substitution_constraints(supertype.span, env);
 
         env.collect_constraints(self.kind.base, supertype.kind.base);
-    }
-
-    fn collect_structural_edges(
-        self: Type<'heap, Self>,
-        variable: PartialStructuralEdge,
-        env: &mut InferenceEnvironment<'_, 'heap>,
-    ) {
-        // As the value is invariant, there are no structural edges between the value of the
-        // substitution and argument
-        env.collect_structural_edges(self.kind.base, variable);
     }
 
     fn instantiate(self: Type<'heap, Self>, env: &mut InstantiateEnvironment<'_, 'heap>) -> TypeId {

--- a/libs/@local/hashql/core/src/type/kind/generic/mod.rs
+++ b/libs/@local/hashql/core/src/type/kind/generic/mod.rs
@@ -24,7 +24,7 @@ use crate::{
             SimplifyEnvironment,
             instantiate::{ArgumentsState, InstantiateEnvironment},
         },
-        inference::{Inference, PartialStructuralEdge},
+        inference::Inference,
         lattice::{Lattice, Projection, Subscript},
     },
 };
@@ -478,22 +478,6 @@ impl<'heap> Generic<'heap> {
             env.in_covariant(|env| env.collect_constraints(param, constraint));
         }
     }
-
-    pub fn collect_argument_structural_edges(
-        self,
-        variable: PartialStructuralEdge,
-        env: &mut InferenceEnvironment<'_, 'heap>,
-    ) {
-        // as arguments are covariant, we collect structural edges for each argument (if they have a
-        // constraint)
-        for &argument in &*self.arguments {
-            let Some(constraint) = argument.constraint else {
-                continue;
-            };
-
-            env.in_covariant(|env| env.collect_structural_edges(constraint, variable));
-        }
-    }
 }
 
 impl<'heap> Inference<'heap> for Generic<'heap> {
@@ -510,16 +494,6 @@ impl<'heap> Inference<'heap> for Generic<'heap> {
             .collect_argument_constraints(supertype.span, env, false);
 
         env.collect_constraints(self.kind.base, supertype.kind.base);
-    }
-
-    fn collect_structural_edges(
-        self: Type<'heap, Self>,
-        variable: PartialStructuralEdge,
-        env: &mut InferenceEnvironment<'_, 'heap>,
-    ) {
-        self.kind.collect_argument_structural_edges(variable, env);
-
-        env.collect_structural_edges(self.kind.base, variable);
     }
 
     fn instantiate(self: Type<'heap, Self>, env: &mut InstantiateEnvironment<'_, 'heap>) -> TypeId {

--- a/libs/@local/hashql/core/src/type/kind/intersection.rs
+++ b/libs/@local/hashql/core/src/type/kind/intersection.rs
@@ -682,16 +682,6 @@ impl<'heap> Inference<'heap> for IntersectionType<'heap> {
         );
     }
 
-    fn collect_structural_edges(
-        self: Type<'heap, Self>,
-        variable: crate::r#type::inference::PartialStructuralEdge,
-        env: &mut InferenceEnvironment<'_, 'heap>,
-    ) {
-        for &variant in self.kind.variants {
-            env.in_covariant(|env| env.collect_structural_edges(variant, variable));
-        }
-    }
-
     fn instantiate(self: Type<'heap, Self>, env: &mut InstantiateEnvironment<'_, 'heap>) -> TypeId {
         let (_guard, id) = env.provision(self.id);
 

--- a/libs/@local/hashql/core/src/type/kind/intrinsic.rs
+++ b/libs/@local/hashql/core/src/type/kind/intrinsic.rs
@@ -17,7 +17,7 @@ use crate::{
             UnsupportedProjectionCategory, dict_subscript_mismatch, list_subscript_mismatch,
             type_mismatch, unsupported_projection,
         },
-        inference::{Inference, PartialStructuralEdge},
+        inference::Inference,
         lattice::{Lattice, Projection, Subscript},
     },
 };
@@ -206,14 +206,6 @@ impl<'heap> Inference<'heap> for ListType {
         env.in_covariant(|env| {
             env.collect_constraints(self.kind.element, supertype.kind.element);
         });
-    }
-
-    fn collect_structural_edges(
-        self: Type<'heap, Self>,
-        variable: PartialStructuralEdge,
-        env: &mut InferenceEnvironment<'_, 'heap>,
-    ) {
-        env.in_covariant(|env| env.collect_structural_edges(self.kind.element, variable));
     }
 
     fn instantiate(self: Type<'heap, Self>, env: &mut InstantiateEnvironment<'_, 'heap>) -> TypeId {
@@ -538,15 +530,6 @@ impl<'heap> Inference<'heap> for DictType {
         env.in_covariant(|env| env.collect_constraints(self.kind.value, supertype.kind.value));
     }
 
-    fn collect_structural_edges(
-        self: Type<'heap, Self>,
-        variable: PartialStructuralEdge,
-        env: &mut InferenceEnvironment<'_, 'heap>,
-    ) {
-        env.in_invariant(|env| env.collect_structural_edges(self.kind.key, variable));
-        env.in_covariant(|env| env.collect_structural_edges(self.kind.value, variable));
-    }
-
     fn instantiate(self: Type<'heap, Self>, env: &mut InstantiateEnvironment<'_, 'heap>) -> TypeId {
         let (_guard, id) = env.provision(self.id);
 
@@ -804,21 +787,6 @@ impl<'heap> Inference<'heap> for IntrinsicType {
             _ => {
                 // During constraint collection we ignore any errors, as these will be caught during
                 // `is_subtype_of` checking later
-            }
-        }
-    }
-
-    fn collect_structural_edges(
-        self: Type<'heap, Self>,
-        variable: PartialStructuralEdge,
-        env: &mut InferenceEnvironment<'_, 'heap>,
-    ) {
-        match self.kind {
-            Self::List(list_type) => {
-                self.with(list_type).collect_structural_edges(variable, env);
-            }
-            Self::Dict(dict_type) => {
-                self.with(dict_type).collect_structural_edges(variable, env);
             }
         }
     }

--- a/libs/@local/hashql/core/src/type/kind/mod.rs
+++ b/libs/@local/hashql/core/src/type/kind/mod.rs
@@ -40,7 +40,7 @@ use super::{
         UnsupportedProjectionCategory, UnsupportedSubscriptCategory, no_type_inference,
         type_mismatch, type_parameter_not_found, unsupported_projection, unsupported_subscript,
     },
-    inference::{Constraint, Inference, PartialStructuralEdge, Variable, VariableKind},
+    inference::{Constraint, Inference, Variable, VariableKind},
     lattice::{Lattice, Projection, Subscript},
 };
 use crate::{
@@ -2078,7 +2078,7 @@ impl<'heap> Inference<'heap> for TypeKind<'heap> {
                     bound: supertype.id,
                 });
 
-                env.collect_structural_edges(supertype.id, PartialStructuralEdge::Source(variable));
+                env.collect_dependencies(supertype.id, variable);
             }
 
             // _ <: Infer
@@ -2093,7 +2093,7 @@ impl<'heap> Inference<'heap> for TypeKind<'heap> {
                     bound: self.id,
                 });
 
-                env.collect_structural_edges(self.id, PartialStructuralEdge::Target(variable));
+                env.collect_dependencies(self.id, variable);
             }
 
             // Param <: _
@@ -2108,7 +2108,7 @@ impl<'heap> Inference<'heap> for TypeKind<'heap> {
                     bound: supertype.id,
                 });
 
-                env.collect_structural_edges(supertype.id, PartialStructuralEdge::Source(variable));
+                env.collect_dependencies(supertype.id, variable);
             }
 
             // _ <: Param
@@ -2123,7 +2123,7 @@ impl<'heap> Inference<'heap> for TypeKind<'heap> {
                     bound: self.id,
                 });
 
-                env.collect_structural_edges(self.id, PartialStructuralEdge::Target(variable));
+                env.collect_dependencies(self.id, variable);
             }
 
             // `Never <: _` | `_ <: Never`
@@ -2131,60 +2131,6 @@ impl<'heap> Inference<'heap> for TypeKind<'heap> {
 
             // `_ <: Unknown` | `Unknown <: _`
             (_, Self::Unknown) | (Self::Unknown, _) => {}
-        }
-    }
-
-    fn collect_structural_edges(
-        self: Type<'heap, Self>,
-        variable: PartialStructuralEdge,
-        env: &mut InferenceEnvironment<'_, 'heap>,
-    ) {
-        #[expect(clippy::match_same_arms)]
-        match self.kind {
-            Self::Opaque(opaque_type) => self
-                .with(opaque_type)
-                .collect_structural_edges(variable, env),
-            Self::Primitive(primitive_type) => self
-                .with(primitive_type)
-                .collect_structural_edges(variable, env),
-            Self::Intrinsic(intrinsic_type) => self
-                .with(intrinsic_type)
-                .collect_structural_edges(variable, env),
-            Self::Struct(struct_type) => self
-                .with(struct_type)
-                .collect_structural_edges(variable, env),
-            Self::Tuple(tuple_type) => self
-                .with(tuple_type)
-                .collect_structural_edges(variable, env),
-            Self::Union(union_type) => self
-                .with(union_type)
-                .collect_structural_edges(variable, env),
-            Self::Intersection(intersection_type) => self
-                .with(intersection_type)
-                .collect_structural_edges(variable, env),
-            Self::Closure(closure_type) => self
-                .with(closure_type)
-                .collect_structural_edges(variable, env),
-            Self::Apply(apply_type) => self
-                .with(apply_type)
-                .collect_structural_edges(variable, env),
-            Self::Generic(generic) => self.with(generic).collect_structural_edges(variable, env),
-            &Self::Param(Param { argument }) => env.add_structural_edge(
-                variable,
-                Variable {
-                    span: self.span,
-                    kind: VariableKind::Generic(argument),
-                },
-            ),
-            &Self::Infer(Infer { hole }) => env.add_structural_edge(
-                variable,
-                Variable {
-                    span: self.span,
-                    kind: VariableKind::Hole(hole),
-                },
-            ),
-            Self::Never => {}
-            Self::Unknown => {}
         }
     }
 

--- a/libs/@local/hashql/core/src/type/kind/mod.rs
+++ b/libs/@local/hashql/core/src/type/kind/mod.rs
@@ -9,7 +9,7 @@ pub mod r#struct;
 #[cfg(test)]
 pub(crate) mod test;
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;
 pub mod tuple;
 pub mod union;
 

--- a/libs/@local/hashql/core/src/type/kind/mod.rs
+++ b/libs/@local/hashql/core/src/type/kind/mod.rs
@@ -1903,7 +1903,9 @@ impl<'heap> Inference<'heap> for TypeKind<'heap> {
                 | Self::Tuple(_)
                 | Self::Closure(_)
                 | Self::Union(_)
-                | Self::Intersection(_),
+                | Self::Intersection(_)
+                | Self::Infer(_)
+                | Self::Param(_),
             ) => {
                 lhs.collect_substitution_constraints(self.span, env);
                 env.collect_constraints(lhs.base, supertype.id);
@@ -1916,7 +1918,9 @@ impl<'heap> Inference<'heap> for TypeKind<'heap> {
                 | Self::Tuple(_)
                 | Self::Closure(_)
                 | Self::Union(_)
-                | Self::Intersection(_),
+                | Self::Intersection(_)
+                | Self::Infer(_)
+                | Self::Param(_),
                 Self::Apply(rhs),
             ) => {
                 rhs.collect_substitution_constraints(supertype.span, env);
@@ -1937,7 +1941,9 @@ impl<'heap> Inference<'heap> for TypeKind<'heap> {
                 | Self::Closure(_)
                 | Self::Union(_)
                 | Self::Intersection(_)
-                | Self::Apply(_),
+                | Self::Apply(_)
+                | Self::Infer(_)
+                | Self::Param(_),
             ) => {
                 lhs.collect_argument_constraints(self.span, env, false);
                 env.collect_constraints(lhs.base, supertype.id);
@@ -1951,7 +1957,9 @@ impl<'heap> Inference<'heap> for TypeKind<'heap> {
                 | Self::Closure(_)
                 | Self::Union(_)
                 | Self::Intersection(_)
-                | Self::Apply(_),
+                | Self::Apply(_)
+                | Self::Infer(_)
+                | Self::Param(_),
                 Self::Generic(rhs),
             ) => {
                 rhs.collect_argument_constraints(supertype.span, env, false);
@@ -1970,7 +1978,9 @@ impl<'heap> Inference<'heap> for TypeKind<'heap> {
                 | Self::Struct(_)
                 | Self::Tuple(_)
                 | Self::Closure(_)
-                | Self::Intersection(_),
+                | Self::Intersection(_)
+                | Self::Infer(_)
+                | Self::Param(_),
             ) => {
                 let self_variants = self.with(lhs).unnest(env);
                 let super_variants = [supertype.id];
@@ -1990,7 +2000,9 @@ impl<'heap> Inference<'heap> for TypeKind<'heap> {
                 | Self::Struct(_)
                 | Self::Tuple(_)
                 | Self::Closure(_)
-                | Self::Intersection(_),
+                | Self::Intersection(_)
+                | Self::Infer(_)
+                | Self::Param(_),
                 Self::Union(rhs),
             ) => {
                 let self_variants = [self.id];
@@ -2016,7 +2028,9 @@ impl<'heap> Inference<'heap> for TypeKind<'heap> {
                 | Self::Intrinsic(_)
                 | Self::Struct(_)
                 | Self::Tuple(_)
-                | Self::Closure(_),
+                | Self::Closure(_)
+                | Self::Infer(_)
+                | Self::Param(_),
             ) => {
                 let self_variants = self.with(lhs).unnest(env);
                 let super_variants = [supertype.id];
@@ -2035,7 +2049,9 @@ impl<'heap> Inference<'heap> for TypeKind<'heap> {
                 | Self::Intrinsic(_)
                 | Self::Struct(_)
                 | Self::Tuple(_)
-                | Self::Closure(_),
+                | Self::Closure(_)
+                | Self::Infer(_)
+                | Self::Param(_),
                 Self::Intersection(rhs),
             ) => {
                 let self_variants = [self.id];

--- a/libs/@local/hashql/core/src/type/kind/opaque.rs
+++ b/libs/@local/hashql/core/src/type/kind/opaque.rs
@@ -14,7 +14,7 @@ use crate::{
             SimplifyEnvironment, instantiate::InstantiateEnvironment,
         },
         error::opaque_type_name_mismatch,
-        inference::{Inference, PartialStructuralEdge},
+        inference::Inference,
         lattice::{Lattice, Projection, Subscript},
     },
 };
@@ -307,15 +307,6 @@ impl<'heap> Inference<'heap> for OpaqueType<'heap> {
 
         // Opaque types are invariant in regards to their arguments
         env.in_invariant(|env| env.collect_constraints(self.kind.repr, supertype.kind.repr));
-    }
-
-    fn collect_structural_edges(
-        self: Type<'heap, Self>,
-        variable: PartialStructuralEdge,
-        env: &mut InferenceEnvironment<'_, 'heap>,
-    ) {
-        // Opaque types are invariant in regards to their arguments
-        env.in_invariant(|env| env.collect_structural_edges(self.kind.repr, variable));
     }
 
     fn instantiate(self: Type<'heap, Self>, env: &mut InstantiateEnvironment<'_, 'heap>) -> TypeId {

--- a/libs/@local/hashql/core/src/type/kind/primitive.rs
+++ b/libs/@local/hashql/core/src/type/kind/primitive.rs
@@ -16,7 +16,7 @@ use crate::{
             UnsupportedProjectionCategory, UnsupportedSubscriptCategory, type_mismatch,
             unsupported_projection, unsupported_subscript,
         },
-        inference::{Inference, PartialStructuralEdge},
+        inference::Inference,
         lattice::{Lattice, Projection, Subscript},
     },
 };
@@ -223,13 +223,6 @@ impl<'heap> Inference<'heap> for PrimitiveType {
     fn collect_constraints(
         self: Type<'heap, Self>,
         _: Type<'heap, Self>,
-        _: &mut InferenceEnvironment<'_, 'heap>,
-    ) {
-    }
-
-    fn collect_structural_edges(
-        self: Type<'heap, Self>,
-        _: PartialStructuralEdge,
         _: &mut InferenceEnvironment<'_, 'heap>,
     ) {
     }

--- a/libs/@local/hashql/core/src/type/kind/struct.rs
+++ b/libs/@local/hashql/core/src/type/kind/struct.rs
@@ -20,7 +20,7 @@ use crate::{
             UnsupportedSubscriptCategory, missing_struct_field, struct_field_mismatch,
             struct_field_not_found, unsupported_subscript,
         },
-        inference::{Inference, PartialStructuralEdge},
+        inference::Inference,
         lattice::{Lattice, Projection, Subscript},
     },
 };
@@ -524,16 +524,6 @@ impl<'heap> Inference<'heap> for StructType<'heap> {
             };
 
             env.in_covariant(|env| env.collect_constraints(self_field.value, super_field.value));
-        }
-    }
-
-    fn collect_structural_edges(
-        self: Type<'heap, Self>,
-        variable: PartialStructuralEdge,
-        env: &mut InferenceEnvironment<'_, 'heap>,
-    ) {
-        for field in &*self.kind.fields {
-            env.in_covariant(|env| env.collect_structural_edges(field.value, variable));
         }
     }
 

--- a/libs/@local/hashql/core/src/type/kind/tests/closure.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/closure.rs
@@ -15,7 +15,7 @@ use crate::{
             SimplifyEnvironment, instantiate::InstantiateEnvironment,
         },
         error::TypeCheckDiagnosticCategory,
-        inference::{Constraint, Inference as _, PartialStructuralEdge, Variable, VariableKind},
+        inference::{Constraint, Inference as _, Variable, VariableKind},
         kind::{
             ClosureType, Generic, Param, TypeKind,
             generic::{GenericArgument, GenericArgumentId},
@@ -775,7 +775,7 @@ fn collect_constraints_with_generic_args() {
 }
 
 #[test]
-fn collect_structural_edges_param() {
+fn collect_dependencies_param() {
     let heap = Heap::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
@@ -790,11 +790,10 @@ fn collect_structural_edges_param() {
     let mut inference_env = InferenceEnvironment::new(&env);
 
     // Create a variable to use as the source in a structural edge
-    let source_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Source(source_var);
+    let variable = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
 
     // Collect structural edges
-    param_fn.collect_structural_edges(partial_edge, &mut inference_env);
+    inference_env.collect_dependencies(param_fn.id, variable);
 
     // Since parameters are contravariant, the flow direction is from param to the source
     // We expect _0 -> _1 (where _0 is the param infer var and _1 is the source var)
@@ -802,49 +801,14 @@ fn collect_structural_edges_param() {
     assert_eq!(
         constraints,
         [Constraint::Dependency {
-            source: Variable::synthetic(VariableKind::Hole(hole)),
-            target: source_var,
-        }]
-    );
-}
-
-#[test]
-fn collect_structural_edges_param_target() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create an inference variable
-    let hole = HoleId::new(0);
-    let infer_var = instantiate_infer(&env, hole);
-    let string = primitive!(env, PrimitiveType::String);
-
-    // Create a closure with an inference variable in parameter position: fn(_0) -> String
-    closure!(env, param_fn, [infer_var], string);
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Create a variable to use as the target in a structural edge
-    let target_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Target(target_var);
-
-    // Collect structural edges
-    param_fn.collect_structural_edges(partial_edge, &mut inference_env);
-
-    // Since parameters are contravariant and we're using Target, the flow is from target to
-    // param We expect _1 -> _0 (where _1 is the target var and _0 is the param infer
-    // var)
-    let constraints = inference_env.take_constraints();
-    assert_eq!(
-        constraints,
-        [Constraint::Dependency {
-            source: target_var,
+            source: variable,
             target: Variable::synthetic(VariableKind::Hole(hole)),
         }]
     );
 }
 
 #[test]
-fn collect_structural_edges_return() {
+fn collect_dependencies_return() {
     let heap = Heap::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
@@ -859,11 +823,10 @@ fn collect_structural_edges_return() {
     let mut inference_env = InferenceEnvironment::new(&env);
 
     // Create a variable to use as the target in a structural edge
-    let target_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Target(target_var);
+    let variable = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
 
     // Collect structural edges
-    return_fn.collect_structural_edges(partial_edge, &mut inference_env);
+    inference_env.collect_dependencies(return_fn.id, variable);
 
     // Since return types are covariant, the flow is from return to target
     // We expect _0 -> _1 (where _0 is the infer var in return position and _1 is target)
@@ -871,48 +834,14 @@ fn collect_structural_edges_return() {
     assert_eq!(
         constraints,
         [Constraint::Dependency {
-            source: Variable::synthetic(VariableKind::Hole(hole)),
-            target: target_var,
-        }]
-    );
-}
-
-#[test]
-fn collect_structural_edges_return_source() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create an inference variable
-    let hole = HoleId::new(0);
-    let infer_var = instantiate_infer(&env, hole);
-    let number = primitive!(env, PrimitiveType::Number);
-
-    // Create a closure with an inference variable in return position: fn(Number) -> _0
-    closure!(env, return_fn, [number], infer_var);
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Create a variable to use as the source in a structural edge
-    let source_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Source(source_var);
-
-    // Collect structural edges
-    return_fn.collect_structural_edges(partial_edge, &mut inference_env);
-
-    // Since return types are covariant, the flow is from source to return
-    // We expect _1 -> _0 (where _1 is the source var and _0 is return)
-    let constraints = inference_env.take_constraints();
-    assert_eq!(
-        constraints,
-        [Constraint::Dependency {
-            source: source_var,
+            source: variable,
             target: Variable::synthetic(VariableKind::Hole(hole)),
         }]
     );
 }
 
 #[test]
-fn collect_structural_edges_both_param_and_return() {
+fn collect_dependencies_both_param_and_return() {
     let heap = Heap::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
@@ -928,11 +857,10 @@ fn collect_structural_edges_both_param_and_return() {
     let mut inference_env = InferenceEnvironment::new(&env);
 
     // Create a variable to use as the source in a structural edge
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(2)));
-    let partial_edge = PartialStructuralEdge::Source(edge_var);
+    let variable = Variable::synthetic(VariableKind::Hole(HoleId::new(2)));
 
     // Collect structural edges
-    both_fn.collect_structural_edges(partial_edge, &mut inference_env);
+    inference_env.collect_dependencies(both_fn.id, variable);
 
     // We expect two edges:
     // 1. _0 -> _2 (contravariant parameter position: param flows to source)
@@ -942,11 +870,11 @@ fn collect_structural_edges_both_param_and_return() {
         constraints,
         [
             Constraint::Dependency {
-                source: Variable::synthetic(VariableKind::Hole(hole_param)),
-                target: edge_var,
+                source: variable,
+                target: Variable::synthetic(VariableKind::Hole(hole_param)),
             },
             Constraint::Dependency {
-                source: edge_var,
+                source: variable,
                 target: Variable::synthetic(VariableKind::Hole(hole_return)),
             }
         ]
@@ -954,7 +882,7 @@ fn collect_structural_edges_both_param_and_return() {
 }
 
 #[test]
-fn collect_structural_edges_multiple_params() {
+fn collect_dependencies_multiple_params() {
     let heap = Heap::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
@@ -971,11 +899,10 @@ fn collect_structural_edges_multiple_params() {
     let mut inference_env = InferenceEnvironment::new(&env);
 
     // Create a variable for the edge
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(3)));
-    let partial_edge = PartialStructuralEdge::Target(edge_var);
+    let variable = Variable::synthetic(VariableKind::Hole(HoleId::new(3)));
 
     // Collect structural edges
-    multi_param_fn.collect_structural_edges(partial_edge, &mut inference_env);
+    inference_env.collect_dependencies(multi_param_fn.id, variable);
 
     // Since parameters are contravariant and we provided a Target edge,
     // we expect the flow from the target to each parameter:
@@ -987,11 +914,11 @@ fn collect_structural_edges_multiple_params() {
         constraints,
         [
             Constraint::Dependency {
-                source: edge_var,
+                source: variable,
                 target: Variable::synthetic(VariableKind::Hole(hole1)),
             },
             Constraint::Dependency {
-                source: edge_var,
+                source: variable,
                 target: Variable::synthetic(VariableKind::Hole(hole2)),
             }
         ]
@@ -999,7 +926,7 @@ fn collect_structural_edges_multiple_params() {
 }
 
 #[test]
-fn collect_structural_edges_nested_closure() {
+fn collect_dependencies_nested_closure() {
     let heap = Heap::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
@@ -1019,11 +946,10 @@ fn collect_structural_edges_nested_closure() {
     let mut inference_env = InferenceEnvironment::new(&env);
 
     // Edge variable
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(2)));
-    let partial_edge = PartialStructuralEdge::Source(edge_var);
+    let variable = Variable::synthetic(VariableKind::Hole(HoleId::new(2)));
 
     // Collect structural edges for the outer function
-    outer_fn.collect_structural_edges(partial_edge, &mut inference_env);
+    inference_env.collect_dependencies(outer_fn.id, variable);
 
     // We expect:
     // 1. _1 -> _2 (contravariant parameter of outer closure flows to source)
@@ -1033,11 +959,11 @@ fn collect_structural_edges_nested_closure() {
         constraints,
         [
             Constraint::Dependency {
-                source: Variable::synthetic(VariableKind::Hole(hole_outer)),
-                target: edge_var,
+                source: variable,
+                target: Variable::synthetic(VariableKind::Hole(hole_outer)),
             },
             Constraint::Dependency {
-                source: edge_var,
+                source: variable,
                 target: Variable::synthetic(VariableKind::Hole(hole_inner)),
             }
         ]
@@ -1045,7 +971,7 @@ fn collect_structural_edges_nested_closure() {
 }
 
 #[test]
-fn collect_structural_edges_invariant_context() {
+fn collect_dependencies_invariant_context() {
     let heap = Heap::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
@@ -1061,17 +987,22 @@ fn collect_structural_edges_invariant_context() {
     let mut inference_env = InferenceEnvironment::new(&env);
 
     // Edge variable
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Source(edge_var);
+    let variable = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
 
     // Collect structural edges in an invariant context
     inference_env.in_invariant(|env| {
-        fn_with_infer.collect_structural_edges(partial_edge, env);
+        env.collect_dependencies(fn_with_infer.id, variable);
     });
 
     // In invariant context, no structural edges should be collected
     let constraints = inference_env.take_constraints();
-    assert!(constraints.is_empty());
+    assert_eq!(
+        constraints,
+        [Constraint::Dependency {
+            source: variable,
+            target: Variable::synthetic(VariableKind::Hole(hole)),
+        },]
+    );
 }
 
 #[test]

--- a/libs/@local/hashql/core/src/type/kind/tests/closure.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/closure.rs
@@ -801,7 +801,7 @@ fn collect_structural_edges_param() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: Variable::synthetic(VariableKind::Hole(hole)),
             target: source_var,
         }]
@@ -836,7 +836,7 @@ fn collect_structural_edges_param_target() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: target_var,
             target: Variable::synthetic(VariableKind::Hole(hole)),
         }]
@@ -870,7 +870,7 @@ fn collect_structural_edges_return() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: Variable::synthetic(VariableKind::Hole(hole)),
             target: target_var,
         }]
@@ -904,7 +904,7 @@ fn collect_structural_edges_return_source() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: source_var,
             target: Variable::synthetic(VariableKind::Hole(hole)),
         }]
@@ -941,11 +941,11 @@ fn collect_structural_edges_both_param_and_return() {
     assert_eq!(
         constraints,
         [
-            Constraint::StructuralEdge {
+            Constraint::Dependency {
                 source: Variable::synthetic(VariableKind::Hole(hole_param)),
                 target: edge_var,
             },
-            Constraint::StructuralEdge {
+            Constraint::Dependency {
                 source: edge_var,
                 target: Variable::synthetic(VariableKind::Hole(hole_return)),
             }
@@ -986,11 +986,11 @@ fn collect_structural_edges_multiple_params() {
     assert_eq!(
         constraints,
         [
-            Constraint::StructuralEdge {
+            Constraint::Dependency {
                 source: edge_var,
                 target: Variable::synthetic(VariableKind::Hole(hole1)),
             },
-            Constraint::StructuralEdge {
+            Constraint::Dependency {
                 source: edge_var,
                 target: Variable::synthetic(VariableKind::Hole(hole2)),
             }
@@ -1032,11 +1032,11 @@ fn collect_structural_edges_nested_closure() {
     assert_eq!(
         constraints,
         [
-            Constraint::StructuralEdge {
+            Constraint::Dependency {
                 source: Variable::synthetic(VariableKind::Hole(hole_outer)),
                 target: edge_var,
             },
-            Constraint::StructuralEdge {
+            Constraint::Dependency {
                 source: edge_var,
                 target: Variable::synthetic(VariableKind::Hole(hole_inner)),
             }

--- a/libs/@local/hashql/core/src/type/kind/tests/generic.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/generic.rs
@@ -8,7 +8,7 @@ use crate::{
             AnalysisEnvironment, Environment, InferenceEnvironment, LatticeEnvironment,
             SimplifyEnvironment, instantiate::InstantiateEnvironment,
         },
-        inference::{Constraint, PartialStructuralEdge, Variable, VariableKind},
+        inference::{Constraint, Variable, VariableKind},
         kind::{
             Generic, GenericArgument, GenericArguments, IntersectionType, PrimitiveType,
             StructType, TypeKind, UnionType,
@@ -671,7 +671,7 @@ fn collect_constraints() {
 }
 
 #[test]
-fn collect_structural_constraints() {
+fn collect_dependencies() {
     // Nothing should happen as they are invariant
     let heap = Heap::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
@@ -688,9 +688,9 @@ fn collect_structural_constraints() {
         }]
     );
 
-    infer.collect_structural_edges(
+    infer.collect_dependencies(
         subtype,
-        PartialStructuralEdge::Source(Variable::synthetic(VariableKind::Hole(HoleId::new(0)))),
+        Variable::synthetic(VariableKind::Hole(HoleId::new(0))),
     );
 
     let constraints = infer.take_constraints();

--- a/libs/@local/hashql/core/src/type/kind/tests/generic.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/generic.rs
@@ -696,7 +696,7 @@ fn collect_structural_constraints() {
     let constraints = infer.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: Variable::synthetic(VariableKind::Hole(HoleId::new(0))),
             target: Variable::synthetic(VariableKind::Hole(HoleId::new(1)))
         }]

--- a/libs/@local/hashql/core/src/type/kind/tests/generic.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/generic.rs
@@ -672,7 +672,6 @@ fn collect_constraints() {
 
 #[test]
 fn collect_dependencies() {
-    // Nothing should happen as they are invariant
     let heap = Heap::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
@@ -698,7 +697,7 @@ fn collect_dependencies() {
         constraints,
         [Constraint::Dependency {
             source: Variable::synthetic(VariableKind::Hole(HoleId::new(0))),
-            target: Variable::synthetic(VariableKind::Hole(HoleId::new(1)))
+            target: Variable::synthetic(VariableKind::Generic(GenericArgumentId::new(0)))
         }]
     );
 }

--- a/libs/@local/hashql/core/src/type/kind/tests/generic_apply.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/generic_apply.rs
@@ -8,7 +8,7 @@ use crate::{
             AnalysisEnvironment, Environment, InferenceEnvironment, LatticeEnvironment,
             SimplifyEnvironment, instantiate::InstantiateEnvironment,
         },
-        inference::{Constraint, PartialStructuralEdge, Variable, VariableKind},
+        inference::{Constraint, Variable, VariableKind},
         kind::{
             Apply, Generic, GenericArgument, IntersectionType, PrimitiveType, StructType, TypeKind,
             UnionType,
@@ -621,9 +621,9 @@ fn collect_structural_constraints() {
         }]
     );
 
-    infer.collect_structural_edges(
+    infer.collect_dependencies(
         subtype,
-        PartialStructuralEdge::Source(Variable::synthetic(VariableKind::Hole(HoleId::new(0)))),
+        Variable::synthetic(VariableKind::Hole(HoleId::new(0))),
     );
 
     let constraints = infer.take_constraints();

--- a/libs/@local/hashql/core/src/type/kind/tests/generic_apply.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/generic_apply.rs
@@ -605,8 +605,7 @@ fn collect_constraints() {
 }
 
 #[test]
-fn collect_structural_constraints() {
-    // Nothing should happen as they are invariant
+fn collect_dependencies() {
     let heap = Heap::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
@@ -627,7 +626,13 @@ fn collect_structural_constraints() {
     );
 
     let constraints = infer.take_constraints();
-    assert_eq!(constraints, []);
+    assert_eq!(
+        constraints,
+        [Constraint::Dependency {
+            source: Variable::synthetic(VariableKind::Hole(HoleId::new(0))),
+            target: Variable::synthetic(VariableKind::Generic(GenericArgumentId::new(0)))
+        }]
+    );
 }
 
 #[test]

--- a/libs/@local/hashql/core/src/type/kind/tests/intersection.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/intersection.rs
@@ -1234,7 +1234,7 @@ fn collect_structural_edges_basic() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: source_var,
             target: Variable::synthetic(VariableKind::Hole(hole)),
         }]
@@ -1271,7 +1271,7 @@ fn collect_structural_edges_target() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: Variable::synthetic(VariableKind::Hole(hole)),
             target: target_var,
         }]
@@ -1309,11 +1309,11 @@ fn collect_structural_edges_multiple_infer_vars() {
     assert_eq!(
         constraints,
         [
-            Constraint::StructuralEdge {
+            Constraint::Dependency {
                 source: edge_var,
                 target: Variable::synthetic(VariableKind::Hole(hole1)),
             },
-            Constraint::StructuralEdge {
+            Constraint::Dependency {
                 source: edge_var,
                 target: Variable::synthetic(VariableKind::Hole(hole2)),
             }
@@ -1355,11 +1355,11 @@ fn collect_structural_edges_nested_intersection() {
     assert_eq!(
         constraints,
         [
-            Constraint::StructuralEdge {
+            Constraint::Dependency {
                 source: edge_var,
                 target: Variable::synthetic(VariableKind::Hole(hole_outer)),
             },
-            Constraint::StructuralEdge {
+            Constraint::Dependency {
                 source: edge_var,
                 target: Variable::synthetic(VariableKind::Hole(hole_inner)),
             }
@@ -1399,7 +1399,7 @@ fn collect_structural_edges_contravariant_context() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: Variable::synthetic(VariableKind::Hole(hole)),
             target: edge_var,
         }]
@@ -1494,11 +1494,11 @@ fn collect_structural_edges_mixed_types() {
     assert_eq!(
         constraints,
         [
-            Constraint::StructuralEdge {
+            Constraint::Dependency {
                 source: edge_var,
                 target: Variable::synthetic(VariableKind::Hole(hole1)),
             },
-            Constraint::StructuralEdge {
+            Constraint::Dependency {
                 source: edge_var,
                 target: Variable::synthetic(VariableKind::Hole(hole2)),
             }

--- a/libs/@local/hashql/core/src/type/kind/tests/intersection.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/intersection.rs
@@ -12,7 +12,7 @@ use crate::{
             SimplifyEnvironment, instantiate::InstantiateEnvironment,
         },
         error::TypeCheckDiagnosticCategory,
-        inference::{Constraint, Inference as _, PartialStructuralEdge, Variable, VariableKind},
+        inference::{Constraint, Inference as _, Variable, VariableKind},
         kind::{
             Generic, IntersectionType, OpaqueType, Param, StructType, TypeKind,
             generic::{GenericArgument, GenericArgumentId},
@@ -1205,7 +1205,7 @@ fn collect_constraints_concrete_types_only() {
 }
 
 #[test]
-fn collect_structural_edges_basic() {
+fn collect_dependencies() {
     let heap = Heap::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
@@ -1223,11 +1223,10 @@ fn collect_structural_edges_basic() {
     let mut inference_env = InferenceEnvironment::new(&env);
 
     // Create a variable to use as the source in a structural edge
-    let source_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Source(source_var);
+    let variable = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
 
     // Collect structural edges
-    basic_intersection.collect_structural_edges(partial_edge, &mut inference_env);
+    inference_env.collect_dependencies(basic_intersection.id, variable);
 
     // Since intersections are covariant in all their variants, the flow is preserved
     // We expect source (_1) flowing to the infer_var (_0) within the intersection
@@ -1235,51 +1234,14 @@ fn collect_structural_edges_basic() {
     assert_eq!(
         constraints,
         [Constraint::Dependency {
-            source: source_var,
+            source: variable,
             target: Variable::synthetic(VariableKind::Hole(hole)),
         }]
     );
 }
 
 #[test]
-fn collect_structural_edges_target() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create an inference variable
-    let hole = HoleId::new(0);
-    let infer_var = instantiate_infer(&env, hole);
-
-    // Create an intersection with an inference variable: infer_var & String
-    intersection!(
-        env,
-        intersection_type,
-        [infer_var, primitive!(env, PrimitiveType::String)]
-    );
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Create a variable to use as the target in a structural edge
-    let target_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Target(target_var);
-
-    // Collect structural edges
-    intersection_type.collect_structural_edges(partial_edge, &mut inference_env);
-
-    // Since intersections are covariant in all their variants, the flow is from the infer var
-    // to target We expect the infer_var (_0) flowing to the target (_1)
-    let constraints = inference_env.take_constraints();
-    assert_eq!(
-        constraints,
-        [Constraint::Dependency {
-            source: Variable::synthetic(VariableKind::Hole(hole)),
-            target: target_var,
-        }]
-    );
-}
-
-#[test]
-fn collect_structural_edges_multiple_infer_vars() {
+fn collect_dependencies_multiple_infer_vars() {
     let heap = Heap::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
@@ -1295,11 +1257,10 @@ fn collect_structural_edges_multiple_infer_vars() {
     let mut inference_env = InferenceEnvironment::new(&env);
 
     // Create a variable for the edge
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(3)));
-    let partial_edge = PartialStructuralEdge::Source(edge_var);
+    let variable = Variable::synthetic(VariableKind::Hole(HoleId::new(3)));
 
     // Collect structural edges
-    multi_infer_intersection.collect_structural_edges(partial_edge, &mut inference_env);
+    inference_env.collect_dependencies(multi_infer_intersection.id, variable);
 
     // Since intersections are covariant, the source should flow to both variables
     // We expect:
@@ -1310,11 +1271,11 @@ fn collect_structural_edges_multiple_infer_vars() {
         constraints,
         [
             Constraint::Dependency {
-                source: edge_var,
+                source: variable,
                 target: Variable::synthetic(VariableKind::Hole(hole1)),
             },
             Constraint::Dependency {
-                source: edge_var,
+                source: variable,
                 target: Variable::synthetic(VariableKind::Hole(hole2)),
             }
         ]
@@ -1322,7 +1283,7 @@ fn collect_structural_edges_multiple_infer_vars() {
 }
 
 #[test]
-fn collect_structural_edges_nested_intersection() {
+fn collect_dependencies_nested_intersection() {
     let heap = Heap::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
@@ -1342,11 +1303,10 @@ fn collect_structural_edges_nested_intersection() {
     let mut inference_env = InferenceEnvironment::new(&env);
 
     // Edge variable
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(2)));
-    let partial_edge = PartialStructuralEdge::Source(edge_var);
+    let variable = Variable::synthetic(VariableKind::Hole(HoleId::new(2)));
 
     // Collect structural edges for the outer intersection
-    outer_intersection.collect_structural_edges(partial_edge, &mut inference_env);
+    inference_env.collect_dependencies(outer_intersection.id, variable);
 
     // We expect:
     // 1. _2 -> _1 (source flows to outer infer var)
@@ -1356,11 +1316,11 @@ fn collect_structural_edges_nested_intersection() {
         constraints,
         [
             Constraint::Dependency {
-                source: edge_var,
+                source: variable,
                 target: Variable::synthetic(VariableKind::Hole(hole_outer)),
             },
             Constraint::Dependency {
-                source: edge_var,
+                source: variable,
                 target: Variable::synthetic(VariableKind::Hole(hole_inner)),
             }
         ]
@@ -1368,78 +1328,7 @@ fn collect_structural_edges_nested_intersection() {
 }
 
 #[test]
-fn collect_structural_edges_contravariant_context() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create an inference variable
-    let hole = HoleId::new(0);
-    let infer_var = instantiate_infer(&env, hole);
-
-    // Create an intersection with an inference variable
-    intersection!(
-        env,
-        intersection_type,
-        [infer_var, primitive!(env, PrimitiveType::Number)]
-    );
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Edge variable
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Source(edge_var);
-
-    // Collect structural edges in a contravariant context
-    inference_env.in_contravariant(|env| {
-        intersection_type.collect_structural_edges(partial_edge, env);
-    });
-
-    // In a contravariant context, the edge direction is inverted
-    // We expect infer_var (_0) flows to source (_1)
-    let constraints = inference_env.take_constraints();
-    assert_eq!(
-        constraints,
-        [Constraint::Dependency {
-            source: Variable::synthetic(VariableKind::Hole(hole)),
-            target: edge_var,
-        }]
-    );
-}
-
-#[test]
-fn collect_structural_edges_invariant_context() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create an inference variable
-    let hole = HoleId::new(0);
-    let infer_var = instantiate_infer(&env, hole);
-
-    // Create an intersection with an inference variable
-    intersection!(
-        env,
-        intersection_type,
-        [infer_var, primitive!(env, PrimitiveType::Number)]
-    );
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Edge variable
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Source(edge_var);
-
-    // Collect structural edges in an invariant context
-    inference_env.in_invariant(|env| {
-        intersection_type.collect_structural_edges(partial_edge, env);
-    });
-
-    // In invariant context, no structural edges should be collected
-    let constraints = inference_env.take_constraints();
-    assert!(constraints.is_empty());
-}
-
-#[test]
-fn collect_structural_edges_empty_intersection() {
+fn collect_dependencies_empty_intersection() {
     let heap = Heap::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
@@ -1449,11 +1338,10 @@ fn collect_structural_edges_empty_intersection() {
     let mut inference_env = InferenceEnvironment::new(&env);
 
     // Edge variable
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(0)));
-    let partial_edge = PartialStructuralEdge::Source(edge_var);
+    let variable = Variable::synthetic(VariableKind::Hole(HoleId::new(0)));
 
     // Collect structural edges for an empty intersection
-    empty_intersection.collect_structural_edges(partial_edge, &mut inference_env);
+    inference_env.collect_dependencies(empty_intersection.id, variable);
 
     // Empty intersection has no variants, so no edges should be collected
     let constraints = inference_env.take_constraints();
@@ -1461,7 +1349,7 @@ fn collect_structural_edges_empty_intersection() {
 }
 
 #[test]
-fn collect_structural_edges_mixed_types() {
+fn collect_dependencies_mixed_types() {
     let heap = Heap::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
@@ -1480,11 +1368,10 @@ fn collect_structural_edges_mixed_types() {
     let mut inference_env = InferenceEnvironment::new(&env);
 
     // Edge variable
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(3)));
-    let partial_edge = PartialStructuralEdge::Source(edge_var);
+    let variable = Variable::synthetic(VariableKind::Hole(HoleId::new(3)));
 
     // Collect structural edges
-    mixed_intersection.collect_structural_edges(partial_edge, &mut inference_env);
+    inference_env.collect_dependencies(mixed_intersection.id, variable);
 
     // Edges should be collected for all inference variables
     // We expect:
@@ -1495,11 +1382,11 @@ fn collect_structural_edges_mixed_types() {
         constraints,
         [
             Constraint::Dependency {
-                source: edge_var,
+                source: variable,
                 target: Variable::synthetic(VariableKind::Hole(hole1)),
             },
             Constraint::Dependency {
-                source: edge_var,
+                source: variable,
                 target: Variable::synthetic(VariableKind::Hole(hole2)),
             }
         ]

--- a/libs/@local/hashql/core/src/type/kind/tests/intrinsic.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/intrinsic.rs
@@ -996,7 +996,7 @@ fn collect_structural_edges_list_basic() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: source_var,
             target: Variable::synthetic(VariableKind::Hole(hole)),
         }]
@@ -1029,7 +1029,7 @@ fn collect_structural_edges_list_target() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: Variable::synthetic(VariableKind::Hole(hole)),
             target: target_var,
         }]
@@ -1064,7 +1064,7 @@ fn collect_structural_edges_nested_list() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: source_var,
             target: Variable::synthetic(VariableKind::Hole(hole)),
         }]
@@ -1099,7 +1099,7 @@ fn collect_structural_edges_list_contravariant_context() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: Variable::synthetic(VariableKind::Hole(hole)),
             target: source_var,
         }]
@@ -1162,7 +1162,7 @@ fn collect_structural_edges_dict_value() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: source_var,
             target: Variable::synthetic(VariableKind::Hole(value_hole)),
         }]
@@ -1197,7 +1197,7 @@ fn collect_structural_edges_dict_both_vars() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: source_var,
             target: Variable::synthetic(VariableKind::Hole(value_hole)),
         }]
@@ -1233,7 +1233,7 @@ fn collect_structural_edges_dict_contravariant_context() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: Variable::synthetic(VariableKind::Hole(value_hole)),
             target: source_var,
         }]
@@ -1268,7 +1268,7 @@ fn collect_structural_edges_dict_nested() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: source_var,
             target: Variable::synthetic(VariableKind::Hole(hole)),
         }]
@@ -1306,7 +1306,7 @@ fn collect_structural_edges_dict_list_nested_complex() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: source_var,
             target: Variable::synthetic(VariableKind::Hole(value_hole)),
         }]
@@ -1347,7 +1347,7 @@ fn collect_structural_edges_intrinsic_type_delegation() {
     let list_constraints = inference_env.take_constraints();
     assert_eq!(
         list_constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: source_var,
             target: Variable::synthetic(VariableKind::Hole(list_hole)),
         }]
@@ -1361,7 +1361,7 @@ fn collect_structural_edges_intrinsic_type_delegation() {
     let dict_constraints = inference_env.take_constraints();
     assert_eq!(
         dict_constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: source_var,
             target: Variable::synthetic(VariableKind::Hole(dict_hole)),
         }]

--- a/libs/@local/hashql/core/src/type/kind/tests/intrinsic.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/intrinsic.rs
@@ -1029,10 +1029,16 @@ fn collect_dependencies_dict() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::Dependency {
-            source: variable,
-            target: Variable::synthetic(VariableKind::Hole(value_hole)),
-        }]
+        [
+            Constraint::Dependency {
+                source: variable,
+                target: Variable::synthetic(VariableKind::Hole(key_hole))
+            },
+            Constraint::Dependency {
+                source: variable,
+                target: Variable::synthetic(VariableKind::Hole(value_hole)),
+            }
+        ]
     );
 }
 

--- a/libs/@local/hashql/core/src/type/kind/tests/intrinsic.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/intrinsic.rs
@@ -12,7 +12,7 @@ use crate::{
             SimplifyEnvironment, instantiate::InstantiateEnvironment,
         },
         error::TypeCheckDiagnosticCategory,
-        inference::{Constraint, Inference as _, PartialStructuralEdge, Variable, VariableKind},
+        inference::{Constraint, Inference as _, Variable, VariableKind},
         kind::{
             Generic, IntrinsicType, OpaqueType, Param, TypeKind,
             generic::GenericArgument,
@@ -971,7 +971,7 @@ fn collect_constraints_concrete_intrinsics() {
 
 // Tests for ListType.collect_structural_edges
 #[test]
-fn collect_structural_edges_list_basic() {
+fn collect_dependencies_list() {
     let heap = Heap::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
@@ -985,11 +985,10 @@ fn collect_structural_edges_list_basic() {
     let mut inference_env = InferenceEnvironment::new(&env);
 
     // Create a variable to use as the source in a structural edge
-    let source_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Source(source_var);
+    let variable = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
 
     // Collect structural edges
-    list_type.collect_structural_edges(partial_edge, &mut inference_env);
+    inference_env.collect_dependencies(list_type.id, variable);
 
     // Since list elements are covariant, the source should flow to the element infer var
     // We expect: _1 -> _0
@@ -997,180 +996,14 @@ fn collect_structural_edges_list_basic() {
     assert_eq!(
         constraints,
         [Constraint::Dependency {
-            source: source_var,
+            source: variable,
             target: Variable::synthetic(VariableKind::Hole(hole)),
         }]
     );
 }
 
 #[test]
-fn collect_structural_edges_list_target() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create an inference variable
-    let hole = HoleId::new(0);
-    let infer_var = instantiate_infer(&env, hole);
-
-    // Create a list with an inference variable: List<_0>
-    list!(env, list_type, infer_var);
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Create a variable to use as the target in a structural edge
-    let target_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Target(target_var);
-
-    // Collect structural edges
-    list_type.collect_structural_edges(partial_edge, &mut inference_env);
-
-    // Since list elements are covariant, the element infer var should flow to the target
-    // We expect: _0 -> _1
-    let constraints = inference_env.take_constraints();
-    assert_eq!(
-        constraints,
-        [Constraint::Dependency {
-            source: Variable::synthetic(VariableKind::Hole(hole)),
-            target: target_var,
-        }]
-    );
-}
-
-#[test]
-fn collect_structural_edges_nested_list() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create an inference variable
-    let hole = HoleId::new(0);
-    let infer_var = instantiate_infer(&env, hole);
-
-    // Create a nested list: List<List<_0>>
-    let inner_list = list!(env, infer_var);
-    list!(env, nested_list, inner_list);
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Create a variable to use as the source in a structural edge
-    let source_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Source(source_var);
-
-    // Collect structural edges
-    nested_list.collect_structural_edges(partial_edge, &mut inference_env);
-
-    // Since list elements are covariant at both levels, the source should flow through to the
-    // innermost element We expect: _1 -> _0 (flow from source through both covariant
-    // positions to infer var)
-    let constraints = inference_env.take_constraints();
-    assert_eq!(
-        constraints,
-        [Constraint::Dependency {
-            source: source_var,
-            target: Variable::synthetic(VariableKind::Hole(hole)),
-        }]
-    );
-}
-
-#[test]
-fn collect_structural_edges_list_contravariant_context() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create an inference variable
-    let hole = HoleId::new(0);
-    let infer_var = instantiate_infer(&env, hole);
-
-    // Create a list with an inference variable: List<_0>
-    list!(env, list_type, infer_var);
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Create a variable to use as the source in a structural edge
-    let source_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Source(source_var);
-
-    // Collect structural edges in a contravariant context
-    inference_env.in_contravariant(|env| {
-        list_type.collect_structural_edges(partial_edge, env);
-    });
-
-    // In a contravariant context, the flow direction is inverted
-    // We expect: _0 -> _1 (element flows to source)
-    let constraints = inference_env.take_constraints();
-    assert_eq!(
-        constraints,
-        [Constraint::Dependency {
-            source: Variable::synthetic(VariableKind::Hole(hole)),
-            target: source_var,
-        }]
-    );
-}
-
-// Tests for DictType.collect_structural_edges
-#[test]
-fn collect_structural_edges_dict_key() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create inference variables
-    let key_hole = HoleId::new(0);
-    let key_var = instantiate_infer(&env, key_hole);
-    let string = primitive!(env, PrimitiveType::String);
-
-    // Create a dict with an inference variable as key: Dict<_0, String>
-    dict!(env, dict_type, key_var, string);
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Create a variable to use as the source in a structural edge
-    let source_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Source(source_var);
-
-    // Collect structural edges
-    dict_type.collect_structural_edges(partial_edge, &mut inference_env);
-
-    // Dict keys are invariant, so no structural edges should be collected for the key
-    // The environment will discard edges for invariant positions
-    let constraints = inference_env.take_constraints();
-    assert!(constraints.is_empty());
-}
-
-#[test]
-fn collect_structural_edges_dict_value() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create inference variables
-    let value_hole = HoleId::new(0);
-    let value_var = instantiate_infer(&env, value_hole);
-    let string = primitive!(env, PrimitiveType::String);
-
-    // Create a dict with an inference variable as value: Dict<String, _0>
-    dict!(env, dict_type, string, value_var);
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Create a variable to use as the source in a structural edge
-    let source_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Source(source_var);
-
-    // Collect structural edges
-    dict_type.collect_structural_edges(partial_edge, &mut inference_env);
-
-    // Dict values are covariant, so the source should flow to the value infer var
-    // We expect: _1 -> _0
-    let constraints = inference_env.take_constraints();
-    assert_eq!(
-        constraints,
-        [Constraint::Dependency {
-            source: source_var,
-            target: Variable::synthetic(VariableKind::Hole(value_hole)),
-        }]
-    );
-}
-
-#[test]
-fn collect_structural_edges_dict_both_vars() {
+fn collect_dependencies_dict() {
     let heap = Heap::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
@@ -1186,11 +1019,10 @@ fn collect_structural_edges_dict_both_vars() {
     let mut inference_env = InferenceEnvironment::new(&env);
 
     // Create a variable to use as the source in a structural edge
-    let source_var = Variable::synthetic(VariableKind::Hole(HoleId::new(2)));
-    let partial_edge = PartialStructuralEdge::Source(source_var);
+    let variable = Variable::synthetic(VariableKind::Hole(HoleId::new(2)));
 
     // Collect structural edges
-    dict_type.collect_structural_edges(partial_edge, &mut inference_env);
+    inference_env.collect_dependencies(dict_type.id, variable);
 
     // Dict keys are invariant (no edge), values are covariant (source flows to value)
     // We expect only: _2 -> _1
@@ -1198,172 +1030,8 @@ fn collect_structural_edges_dict_both_vars() {
     assert_eq!(
         constraints,
         [Constraint::Dependency {
-            source: source_var,
+            source: variable,
             target: Variable::synthetic(VariableKind::Hole(value_hole)),
-        }]
-    );
-}
-
-#[test]
-fn collect_structural_edges_dict_contravariant_context() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create an inference variable for the value
-    let value_hole = HoleId::new(0);
-    let value_var = instantiate_infer(&env, value_hole);
-    let string = primitive!(env, PrimitiveType::String);
-
-    // Create a dict with an inference variable as value: Dict<String, _0>
-    dict!(env, dict_type, string, value_var);
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Create a variable to use as the source in a structural edge
-    let source_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Source(source_var);
-
-    // Collect structural edges in a contravariant context
-    inference_env.in_contravariant(|env| {
-        dict_type.collect_structural_edges(partial_edge, env);
-    });
-
-    // In a contravariant context, the flow direction is inverted for covariant positions
-    // We expect: _0 -> _1 (value flows to source)
-    let constraints = inference_env.take_constraints();
-    assert_eq!(
-        constraints,
-        [Constraint::Dependency {
-            source: Variable::synthetic(VariableKind::Hole(value_hole)),
-            target: source_var,
-        }]
-    );
-}
-
-#[test]
-fn collect_structural_edges_dict_nested() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create an inference variable
-    let hole = HoleId::new(0);
-    let infer_var = instantiate_infer(&env, hole);
-    let string = primitive!(env, PrimitiveType::String);
-
-    // Create a nested structure: Dict<String, List<_0>>
-    let inner_list = list!(env, infer_var);
-    dict!(env, nested_dict, string, inner_list);
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Create a variable to use as the source in a structural edge
-    let source_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Source(source_var);
-
-    // Collect structural edges
-    nested_dict.collect_structural_edges(partial_edge, &mut inference_env);
-
-    // Dict values and list elements are both covariant, so the source should flow through to
-    // the innermost element We expect: _1 -> _0
-    let constraints = inference_env.take_constraints();
-    assert_eq!(
-        constraints,
-        [Constraint::Dependency {
-            source: source_var,
-            target: Variable::synthetic(VariableKind::Hole(hole)),
-        }]
-    );
-}
-
-#[test]
-fn collect_structural_edges_dict_list_nested_complex() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create inference variables
-    let key_hole = HoleId::new(0);
-    let key_var = instantiate_infer(&env, key_hole);
-    let value_hole = HoleId::new(1);
-    let value_var = instantiate_infer(&env, value_hole);
-
-    // Create a complex nested structure: Dict<List<_0>, List<_1>>
-    let key_list = list!(env, key_var);
-    let value_list = list!(env, value_var);
-    dict!(env, complex_dict, key_list, value_list);
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Create a variable to use as the source in a structural edge
-    let source_var = Variable::synthetic(VariableKind::Hole(HoleId::new(2)));
-    let partial_edge = PartialStructuralEdge::Source(source_var);
-
-    // Collect structural edges
-    complex_dict.collect_structural_edges(partial_edge, &mut inference_env);
-
-    // Dict keys are invariant, so no edge for key_var
-    // Dict values and list elements are covariant, so source flows to value_var
-    // We expect only: _2 -> _1
-    let constraints = inference_env.take_constraints();
-    assert_eq!(
-        constraints,
-        [Constraint::Dependency {
-            source: source_var,
-            target: Variable::synthetic(VariableKind::Hole(value_hole)),
-        }]
-    );
-}
-
-#[test]
-fn collect_structural_edges_intrinsic_type_delegation() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create inference variables
-    let list_hole = HoleId::new(0);
-    let list_var = instantiate_infer(&env, list_hole);
-    let dict_hole = HoleId::new(1);
-    let dict_var = instantiate_infer(&env, dict_hole);
-    let string = primitive!(env, PrimitiveType::String);
-
-    // Create intrinsic types
-    let list = list!(env, list_var);
-    let dict = dict!(env, string, dict_var);
-
-    // Get the TypeIds for the intrinsic types
-    let list_id = list;
-    let dict_id = dict;
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Create a variable to use as the source in a structural edge
-    let source_var = Variable::synthetic(VariableKind::Hole(HoleId::new(2)));
-    let partial_edge = PartialStructuralEdge::Source(source_var);
-
-    // Collect structural edges for both intrinsic types
-    env.r#type(list_id)
-        .collect_structural_edges(partial_edge, &mut inference_env);
-
-    // The IntrinsicType should delegate to ListType
-    let list_constraints = inference_env.take_constraints();
-    assert_eq!(
-        list_constraints,
-        [Constraint::Dependency {
-            source: source_var,
-            target: Variable::synthetic(VariableKind::Hole(list_hole)),
-        }]
-    );
-
-    // Now test dict
-    env.r#type(dict_id)
-        .collect_structural_edges(partial_edge, &mut inference_env);
-
-    // The IntrinsicType should delegate to DictType
-    let dict_constraints = inference_env.take_constraints();
-    assert_eq!(
-        dict_constraints,
-        [Constraint::Dependency {
-            source: source_var,
-            target: Variable::synthetic(VariableKind::Hole(dict_hole)),
         }]
     );
 }

--- a/libs/@local/hashql/core/src/type/kind/tests/mod.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/mod.rs
@@ -22,7 +22,12 @@ mod tuple;
 mod union;
 
 #[track_caller]
-fn assert_join(lattice: &mut LatticeEnvironment, lhs: TypeId, rhs: TypeId, expected: &[TypeId]) {
+pub(crate) fn assert_join(
+    lattice: &mut LatticeEnvironment,
+    lhs: TypeId,
+    rhs: TypeId,
+    expected: &[TypeId],
+) {
     let lhs = lattice.r#type(lhs);
     let rhs = lattice.r#type(rhs);
 
@@ -31,7 +36,12 @@ fn assert_join(lattice: &mut LatticeEnvironment, lhs: TypeId, rhs: TypeId, expec
 }
 
 #[track_caller]
-fn assert_meet(env: &mut LatticeEnvironment, lhs: TypeId, rhs: TypeId, expected: &[TypeId]) {
+pub(crate) fn assert_meet(
+    env: &mut LatticeEnvironment,
+    lhs: TypeId,
+    rhs: TypeId,
+    expected: &[TypeId],
+) {
     let lhs = env.r#type(lhs);
     let rhs = env.r#type(rhs);
 
@@ -40,7 +50,7 @@ fn assert_meet(env: &mut LatticeEnvironment, lhs: TypeId, rhs: TypeId, expected:
 }
 
 #[track_caller]
-fn assert_lattice(env: &Environment, lhs: &[TypeId], rhs: &[TypeId]) {
+pub(crate) fn assert_lattice(env: &Environment, lhs: &[TypeId], rhs: &[TypeId]) {
     assert_eq!(
         lhs.len(),
         rhs.len(),
@@ -53,7 +63,7 @@ fn assert_lattice(env: &Environment, lhs: &[TypeId], rhs: &[TypeId]) {
 }
 
 #[track_caller]
-fn assert_equivalent(env: &Environment, lhs: TypeId, rhs: TypeId) {
+pub(crate) fn assert_equivalent(env: &Environment, lhs: TypeId, rhs: TypeId) {
     let mut analysis = AnalysisEnvironment::new(env);
 
     let lhs_repr = analysis

--- a/libs/@local/hashql/core/src/type/kind/tests/opaque.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/opaque.rs
@@ -11,7 +11,7 @@ use crate::{
             AnalysisEnvironment, Environment, InferenceEnvironment, LatticeEnvironment,
             SimplifyEnvironment, instantiate::InstantiateEnvironment,
         },
-        inference::{Constraint, Inference as _, PartialStructuralEdge, Variable, VariableKind},
+        inference::{Constraint, Inference as _, Variable, VariableKind},
         kind::{
             Generic, OpaqueType, Param, TypeKind,
             generic::{GenericArgument, GenericArgumentId},
@@ -581,7 +581,7 @@ fn collect_constraints_infer_and_generic_var() {
 }
 
 #[test]
-fn collect_structural_edges_opaque_invariant_behavior() {
+fn collect_dependencies() {
     let heap = Heap::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
@@ -595,31 +595,16 @@ fn collect_structural_edges_opaque_invariant_behavior() {
     let mut inference_env = InferenceEnvironment::new(&env);
 
     // Create variables for testing both source and target edges
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let source_edge = PartialStructuralEdge::Source(edge_var);
-    let target_edge = PartialStructuralEdge::Target(edge_var);
+    let variable = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
 
-    // Test in default (covariant) context with source edge
-    opaque_type.collect_structural_edges(source_edge, &mut inference_env);
-    assert!(
-        inference_env.take_constraints().is_empty(),
-        "Opaque type should block structural edges due to invariance (source edge)"
-    );
+    inference_env.collect_dependencies(opaque_type.id, variable);
 
-    // Test with target edge
-    opaque_type.collect_structural_edges(target_edge, &mut inference_env);
-    assert!(
-        inference_env.take_constraints().is_empty(),
-        "Opaque type should block structural edges due to invariance (target edge)"
-    );
-
-    // Test in contravariant context
-    inference_env.in_contravariant(|env| {
-        opaque_type.collect_structural_edges(source_edge, env);
-    });
-    assert!(
-        inference_env.take_constraints().is_empty(),
-        "Opaque type should block structural edges even in contravariant context"
+    assert_eq!(
+        inference_env.take_constraints(),
+        [Constraint::Dependency {
+            source: variable,
+            target: Variable::synthetic(VariableKind::Hole(hole))
+        }]
     );
 }
 

--- a/libs/@local/hashql/core/src/type/kind/tests/struct.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/struct.rs
@@ -1133,12 +1133,12 @@ fn collect_dependencies() {
         constraints,
         [
             Constraint::Dependency {
-                source: Variable::synthetic(VariableKind::Hole(hole1)),
-                target: variable,
+                source: variable,
+                target: Variable::synthetic(VariableKind::Hole(hole1)),
             },
             Constraint::Dependency {
-                source: Variable::synthetic(VariableKind::Hole(hole2)),
-                target: variable,
+                source: variable,
+                target: Variable::synthetic(VariableKind::Hole(hole2)),
             }
         ]
     );

--- a/libs/@local/hashql/core/src/type/kind/tests/struct.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/struct.rs
@@ -1123,7 +1123,7 @@ fn collect_structural_edges_struct_basic() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: edge_var,
             target: Variable::synthetic(VariableKind::Hole(hole)),
         }]
@@ -1166,11 +1166,11 @@ fn collect_structural_edges_struct_multiple_fields() {
     assert_eq!(
         constraints,
         [
-            Constraint::StructuralEdge {
+            Constraint::Dependency {
                 source: Variable::synthetic(VariableKind::Hole(hole1)),
                 target: edge_var,
             },
-            Constraint::StructuralEdge {
+            Constraint::Dependency {
                 source: Variable::synthetic(VariableKind::Hole(hole2)),
                 target: edge_var,
             }
@@ -1210,7 +1210,7 @@ fn collect_structural_edges_nested_struct() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: edge_var,
             target: Variable::synthetic(VariableKind::Hole(hole)),
         }]
@@ -1245,7 +1245,7 @@ fn collect_structural_edges_contravariant_context() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: Variable::synthetic(VariableKind::Hole(hole)),
             target: edge_var,
         }]
@@ -1311,7 +1311,7 @@ fn collect_structural_edges_mixed_concrete_and_infer() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: edge_var,
             target: Variable::synthetic(VariableKind::Hole(hole)),
         }]

--- a/libs/@local/hashql/core/src/type/kind/tests/struct.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/struct.rs
@@ -12,7 +12,7 @@ use crate::{
             SimplifyEnvironment, instantiate::InstantiateEnvironment,
         },
         error::TypeCheckDiagnosticCategory,
-        inference::{Constraint, Inference as _, PartialStructuralEdge, Variable, VariableKind},
+        inference::{Constraint, Inference as _, Variable, VariableKind},
         kind::{
             Generic, GenericArgument, StructType, TypeKind,
             generic::GenericArgumentId,
@@ -1098,40 +1098,7 @@ fn collect_constraints_concrete() {
 }
 
 #[test]
-fn collect_structural_edges_struct_basic() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create an inference variable
-    let hole = HoleId::new(0);
-    let infer_var = instantiate_infer(&env, hole);
-
-    // Create a struct with a field containing an inference variable: { value: _0 }
-    r#struct!(env, struct_type, [struct_field!(env, "value", infer_var)]);
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Create a variable to use as the source in a structural edge
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Source(edge_var);
-
-    // Collect structural edges
-    struct_type.collect_structural_edges(partial_edge, &mut inference_env);
-
-    // Struct fields are covariant, so the source should flow to the field inference variable
-    // We expect: _1 -> _0
-    let constraints = inference_env.take_constraints();
-    assert_eq!(
-        constraints,
-        [Constraint::Dependency {
-            source: edge_var,
-            target: Variable::synthetic(VariableKind::Hole(hole)),
-        }]
-    );
-}
-
-#[test]
-fn collect_structural_edges_struct_multiple_fields() {
+fn collect_dependencies() {
     let heap = Heap::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
@@ -1154,11 +1121,10 @@ fn collect_structural_edges_struct_multiple_fields() {
     let mut inference_env = InferenceEnvironment::new(&env);
 
     // Create a variable to use as the target in a structural edge
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(2)));
-    let partial_edge = PartialStructuralEdge::Target(edge_var);
+    let variable = Variable::synthetic(VariableKind::Hole(HoleId::new(2)));
 
     // Collect structural edges
-    struct_type.collect_structural_edges(partial_edge, &mut inference_env);
+    inference_env.collect_dependencies(struct_type.id, variable);
 
     // Struct fields are covariant, so the field inference variables should flow to the target
     // We expect: _0 -> _2 and _1 -> _2
@@ -1168,153 +1134,13 @@ fn collect_structural_edges_struct_multiple_fields() {
         [
             Constraint::Dependency {
                 source: Variable::synthetic(VariableKind::Hole(hole1)),
-                target: edge_var,
+                target: variable,
             },
             Constraint::Dependency {
                 source: Variable::synthetic(VariableKind::Hole(hole2)),
-                target: edge_var,
+                target: variable,
             }
         ]
-    );
-}
-
-#[test]
-fn collect_structural_edges_nested_struct() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create an inference variable
-    let hole = HoleId::new(0);
-    let infer_var = instantiate_infer(&env, hole);
-
-    // Create a nested struct: { outer: { inner: _0 } }
-    let inner_struct = r#struct!(env, [struct_field!(env, "inner", infer_var)]);
-
-    r#struct!(
-        env,
-        outer_struct,
-        [struct_field!(env, "outer", inner_struct)]
-    );
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Create a variable to use as the source in a structural edge
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Source(edge_var);
-
-    // Collect structural edges
-    outer_struct.collect_structural_edges(partial_edge, &mut inference_env);
-
-    // All struct fields are covariant, so the source should flow through to the innermost field
-    // We expect: _1 -> _0
-    let constraints = inference_env.take_constraints();
-    assert_eq!(
-        constraints,
-        [Constraint::Dependency {
-            source: edge_var,
-            target: Variable::synthetic(VariableKind::Hole(hole)),
-        }]
-    );
-}
-
-#[test]
-fn collect_structural_edges_contravariant_context() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create an inference variable
-    let hole = HoleId::new(0);
-    let infer_var = instantiate_infer(&env, hole);
-
-    // Create a struct with a field containing an inference variable
-    r#struct!(env, struct_type, [struct_field!(env, "value", infer_var)]);
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Create a variable to use as the source in a structural edge
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Source(edge_var);
-
-    // Collect structural edges in a contravariant context
-    inference_env.in_contravariant(|env| {
-        struct_type.collect_structural_edges(partial_edge, env);
-    });
-
-    // In a contravariant context, the flow direction is inverted
-    // We expect: _0 -> _1
-    let constraints = inference_env.take_constraints();
-    assert_eq!(
-        constraints,
-        [Constraint::Dependency {
-            source: Variable::synthetic(VariableKind::Hole(hole)),
-            target: edge_var,
-        }]
-    );
-}
-
-#[test]
-fn collect_structural_edges_empty_struct() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create an empty struct: {}
-    r#struct!(env, empty_struct, []);
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Create a variable to use as the source in a structural edge
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(0)));
-    let partial_edge = PartialStructuralEdge::Source(edge_var);
-
-    // Collect structural edges
-    empty_struct.collect_structural_edges(partial_edge, &mut inference_env);
-
-    // Empty struct has no inference variables, so no edges should be collected
-    let constraints = inference_env.take_constraints();
-    assert!(
-        constraints.is_empty(),
-        "Empty struct should not produce any structural edges"
-    );
-}
-
-#[test]
-fn collect_structural_edges_mixed_concrete_and_infer() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create an inference variable
-    let hole = HoleId::new(0);
-    let infer_var = instantiate_infer(&env, hole);
-    let string = primitive!(env, PrimitiveType::String);
-
-    // Create a struct with mixed concrete and inference variable fields
-    r#struct!(
-        env,
-        mixed_struct,
-        [
-            struct_field!(env, "concrete", string),
-            struct_field!(env, "inferred", infer_var)
-        ]
-    );
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Create a variable to use as the source in a structural edge
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Source(edge_var);
-
-    // Collect structural edges
-    mixed_struct.collect_structural_edges(partial_edge, &mut inference_env);
-
-    // Only the inference variable field should produce a structural edge
-    // We expect: _1 -> _0
-    let constraints = inference_env.take_constraints();
-    assert_eq!(
-        constraints,
-        [Constraint::Dependency {
-            source: edge_var,
-            target: Variable::synthetic(VariableKind::Hole(hole)),
-        }]
     );
 }
 

--- a/libs/@local/hashql/core/src/type/kind/tests/tuple.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/tuple.rs
@@ -979,7 +979,7 @@ fn collect_structural_edges_tuple_basic() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: edge_var,
             target: Variable::synthetic(VariableKind::Hole(hole)),
         }]
@@ -1040,11 +1040,11 @@ fn collect_structural_edges_tuple_multiple_elements() {
     assert_eq!(
         constraints,
         [
-            Constraint::StructuralEdge {
+            Constraint::Dependency {
                 source: Variable::synthetic(VariableKind::Hole(hole1)),
                 target: edge_var,
             },
-            Constraint::StructuralEdge {
+            Constraint::Dependency {
                 source: Variable::synthetic(VariableKind::Hole(hole2)),
                 target: edge_var,
             }
@@ -1086,7 +1086,7 @@ fn collect_structural_edges_tuple_with_generic_args() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: edge_var,
             target: Variable::synthetic(VariableKind::Hole(hole)),
         }]
@@ -1121,7 +1121,7 @@ fn collect_structural_edges_tuple_contravariant_context() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: Variable::synthetic(VariableKind::Hole(hole)),
             target: edge_var,
         }]

--- a/libs/@local/hashql/core/src/type/kind/tests/tuple.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/tuple.rs
@@ -982,12 +982,12 @@ fn collect_dependencies() {
         constraints,
         [
             Constraint::Dependency {
-                source: Variable::synthetic(VariableKind::Hole(hole1)),
-                target: variable,
+                source: variable,
+                target: Variable::synthetic(VariableKind::Hole(hole1)),
             },
             Constraint::Dependency {
-                source: Variable::synthetic(VariableKind::Hole(hole2)),
-                target: variable,
+                source: variable,
+                target: Variable::synthetic(VariableKind::Hole(hole2)),
             }
         ]
     );

--- a/libs/@local/hashql/core/src/type/kind/tests/tuple.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/tuple.rs
@@ -12,7 +12,7 @@ use crate::{
             SimplifyEnvironment, instantiate::InstantiateEnvironment,
         },
         error::TypeCheckDiagnosticCategory,
-        inference::{Constraint, Inference as _, PartialStructuralEdge, Variable, VariableKind},
+        inference::{Constraint, Inference as _, Variable, VariableKind},
         kind::{
             Generic, GenericArgument, TupleType, TypeKind,
             generic::GenericArgumentId,
@@ -954,65 +954,7 @@ fn collect_constraints_concrete() {
 }
 
 #[test]
-fn collect_structural_edges_tuple_basic() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create an inference variable
-    let hole = HoleId::new(0);
-    let infer_var = instantiate_infer(&env, hole);
-
-    // Create a tuple with an inference variable: (_0,)
-    tuple!(env, tuple_type, [infer_var]);
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Create a variable to use as the source in a structural edge
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Source(edge_var);
-
-    // Collect structural edges
-    tuple_type.collect_structural_edges(partial_edge, &mut inference_env);
-
-    // Tuple fields are covariant, so the source should flow to the field inference variable
-    // We expect: _1 -> _0
-    let constraints = inference_env.take_constraints();
-    assert_eq!(
-        constraints,
-        [Constraint::Dependency {
-            source: edge_var,
-            target: Variable::synthetic(VariableKind::Hole(hole)),
-        }]
-    );
-}
-
-#[test]
-fn collect_structural_edges_tuple_empty() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create an empty tuple: ()
-    tuple!(env, empty_tuple, []);
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Create a variable to use as the source in a structural edge
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(0)));
-    let partial_edge = PartialStructuralEdge::Source(edge_var);
-
-    // Collect structural edges
-    empty_tuple.collect_structural_edges(partial_edge, &mut inference_env);
-
-    // Empty tuple has no inference variables, so no edges should be collected
-    let constraints = inference_env.take_constraints();
-    assert!(
-        constraints.is_empty(),
-        "Empty tuple should not produce any structural edges"
-    );
-}
-
-#[test]
-fn collect_structural_edges_tuple_multiple_elements() {
+fn collect_dependencies() {
     let heap = Heap::new();
     let env = Environment::new(SpanId::SYNTHETIC, &heap);
 
@@ -1028,11 +970,10 @@ fn collect_structural_edges_tuple_multiple_elements() {
     let mut inference_env = InferenceEnvironment::new(&env);
 
     // Create a variable to use as the target in a structural edge
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(2)));
-    let partial_edge = PartialStructuralEdge::Target(edge_var);
+    let variable = Variable::synthetic(VariableKind::Hole(HoleId::new(2)));
 
     // Collect structural edges
-    tuple_type.collect_structural_edges(partial_edge, &mut inference_env);
+    inference_env.collect_dependencies(tuple_type.id, variable);
 
     // Tuple elements are covariant, so both inference variables should flow to the target
     // We expect: _0 -> _2 and _1 -> _2
@@ -1042,89 +983,13 @@ fn collect_structural_edges_tuple_multiple_elements() {
         [
             Constraint::Dependency {
                 source: Variable::synthetic(VariableKind::Hole(hole1)),
-                target: edge_var,
+                target: variable,
             },
             Constraint::Dependency {
                 source: Variable::synthetic(VariableKind::Hole(hole2)),
-                target: edge_var,
+                target: variable,
             }
         ]
-    );
-}
-
-#[test]
-fn collect_structural_edges_tuple_with_generic_args() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create a generic argument
-    let arg_id = GenericArgumentId::new(0);
-    let generic_arg = GenericArgument {
-        id: arg_id,
-        name: heap.intern_symbol("T"),
-        constraint: None,
-    };
-
-    // Create an inference variable
-    let hole = HoleId::new(0);
-    let infer_var = instantiate_infer(&env, hole);
-
-    // Create a tuple with generic arguments: T<_0>
-    let tuple_type = generic!(env, tuple!(env, [infer_var]), [generic_arg]);
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Create a variable to use as the source in a structural edge
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Source(edge_var);
-
-    // Collect structural edges
-    inference_env.collect_structural_edges(tuple_type, partial_edge);
-
-    // The generic arguments shouldn't affect the edge propagation behavior
-    // We expect: _1 -> _0
-    let constraints = inference_env.take_constraints();
-    assert_eq!(
-        constraints,
-        [Constraint::Dependency {
-            source: edge_var,
-            target: Variable::synthetic(VariableKind::Hole(hole)),
-        }]
-    );
-}
-
-#[test]
-fn collect_structural_edges_tuple_contravariant_context() {
-    let heap = Heap::new();
-    let env = Environment::new(SpanId::SYNTHETIC, &heap);
-
-    // Create an inference variable
-    let hole = HoleId::new(0);
-    let infer_var = instantiate_infer(&env, hole);
-
-    // Create a tuple with an inference variable: (_0,)
-    tuple!(env, tuple_type, [infer_var]);
-
-    let mut inference_env = InferenceEnvironment::new(&env);
-
-    // Create a variable to use as the source in a structural edge
-    let edge_var = Variable::synthetic(VariableKind::Hole(HoleId::new(1)));
-    let partial_edge = PartialStructuralEdge::Source(edge_var);
-
-    // Collect structural edges in a contravariant context
-    inference_env.in_contravariant(|env| {
-        tuple_type.collect_structural_edges(partial_edge, env);
-    });
-
-    // In a contravariant context, the flow direction is inverted
-    // We expect: _0 -> _1
-    let constraints = inference_env.take_constraints();
-    assert_eq!(
-        constraints,
-        [Constraint::Dependency {
-            source: Variable::synthetic(VariableKind::Hole(hole)),
-            target: edge_var,
-        }]
     );
 }
 

--- a/libs/@local/hashql/core/src/type/kind/tests/union.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/union.rs
@@ -1500,11 +1500,11 @@ fn collect_structural_edges_union_target() {
     assert_eq!(
         constraints,
         [
-            Constraint::StructuralEdge {
+            Constraint::Dependency {
                 source: Variable::synthetic(VariableKind::Hole(hole1)),
                 target: edge_var,
             },
-            Constraint::StructuralEdge {
+            Constraint::Dependency {
                 source: Variable::synthetic(VariableKind::Hole(hole2)),
                 target: edge_var,
             }
@@ -1573,7 +1573,7 @@ fn collect_structural_edges_union_mixed_variants() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: Variable::synthetic(VariableKind::Hole(hole)),
             target: edge_var,
         }]
@@ -1612,11 +1612,11 @@ fn collect_structural_edges_union_contravariant_context() {
     assert_eq!(
         constraints,
         [
-            Constraint::StructuralEdge {
+            Constraint::Dependency {
                 source: edge_var,
                 target: Variable::synthetic(VariableKind::Hole(hole1)),
             },
-            Constraint::StructuralEdge {
+            Constraint::Dependency {
                 source: edge_var,
                 target: Variable::synthetic(VariableKind::Hole(hole2)),
             }
@@ -1656,7 +1656,7 @@ fn collect_structural_edges_nested_union() {
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::StructuralEdge {
+        [Constraint::Dependency {
             source: Variable::synthetic(VariableKind::Hole(hole)),
             target: edge_var,
         }]

--- a/libs/@local/hashql/core/src/type/kind/tests/union.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/union.rs
@@ -1453,13 +1453,20 @@ fn collect_constraints_with_intersection() {
 
     // Should generate a constraint from the inference var to the intersection
     let constraints = inference_env.take_constraints();
-    assert_eq!(constraints.len(), 1);
+    assert_eq!(constraints.len(), 2);
     assert_matches!(
         &constraints[0],
         Constraint::UpperBound {
             variable: Variable { span: SpanId::SYNTHETIC, kind: VariableKind::Hole(h) },
             bound
-        } if *h == hole && *bound == intersection_type
+        } if *h == hole && *bound == string
+    );
+    assert_matches!(
+        &constraints[1],
+        Constraint::UpperBound {
+            variable: Variable { span: SpanId::SYNTHETIC, kind: VariableKind::Hole(h) },
+            bound
+        } if *h == hole && *bound == number
     );
 }
 

--- a/libs/@local/hashql/core/src/type/kind/tuple.rs
+++ b/libs/@local/hashql/core/src/type/kind/tuple.rs
@@ -19,7 +19,7 @@ use crate::{
             UnsupportedSubscriptCategory, invalid_tuple_index, tuple_index_out_of_bounds,
             tuple_length_mismatch, unsupported_subscript,
         },
-        inference::{Inference, PartialStructuralEdge},
+        inference::Inference,
         lattice::{Lattice, Projection, Subscript},
     },
 };
@@ -334,16 +334,6 @@ impl<'heap> Inference<'heap> for TupleType<'heap> {
         for (&field, &supertype_field) in self.kind.fields.iter().zip(supertype.kind.fields.iter())
         {
             env.in_covariant(|env| env.collect_constraints(field, supertype_field));
-        }
-    }
-
-    fn collect_structural_edges(
-        self: Type<'heap, Self>,
-        variable: PartialStructuralEdge,
-        env: &mut InferenceEnvironment<'_, 'heap>,
-    ) {
-        for &field in self.kind.fields {
-            env.in_covariant(|env| env.collect_structural_edges(field, variable));
         }
     }
 

--- a/libs/@local/hashql/core/src/type/kind/union.rs
+++ b/libs/@local/hashql/core/src/type/kind/union.rs
@@ -18,7 +18,7 @@ use crate::{
             SimplifyEnvironment, instantiate::InstantiateEnvironment,
         },
         error::{cannot_be_subtype_of_never, type_mismatch, union_variant_mismatch},
-        inference::{Constraint, Inference, PartialStructuralEdge, Variable},
+        inference::{Constraint, Inference, Variable},
         lattice::{Lattice, Projection, Subscript},
     },
 };
@@ -663,26 +663,6 @@ impl<'heap> Inference<'heap> for UnionType<'heap> {
             &super_variants,
             env,
         );
-    }
-
-    fn collect_structural_edges(
-        self: Type<'heap, Self>,
-        variable: PartialStructuralEdge,
-        env: &mut InferenceEnvironment<'_, 'heap>,
-    ) {
-        // We cannot collect any constraints union types **if** they are on the right side (e.g. the
-        // edge is a source), as `union-right` resolves into an or, and therefore any constraint
-        // wouldn't be additive.
-        // This is not the case with union-left, as union-left resolves into an and, and therefore
-        // any constraint would be additive.
-        if variable.is_source() {
-            // union-right
-            return;
-        }
-
-        for &variant in self.kind.variants {
-            env.in_covariant(|env| env.collect_structural_edges(variant, variable));
-        }
     }
 
     fn instantiate(self: Type<'heap, Self>, env: &mut InstantiateEnvironment<'_, 'heap>) -> TypeId {

--- a/libs/@local/hashql/core/src/type/visit.rs
+++ b/libs/@local/hashql/core/src/type/visit.rs
@@ -1,4 +1,4 @@
-use self::filter::{Deep, Filter};
+use self::filter::{Deep, Filter as _};
 use super::{
     Type, TypeId,
     environment::Environment,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

During inference one might discover nested inference variables (such as `List<T> <: List<Number>`) if that is the case we shouldn't error out immediately but instead record the newly created constraint.

This is what enables the removal of [H-4780](https://linear.app/hash/issue/H-4780/hashql-remove-structural-edges-during-type-inference), as we gradually discover new edges when required.

---

Structural edges are required for https://linear.app/hash/issue/H-4790/hashql-implement-polarized-µ-blocks-during-type-inference to work properly and for to create a proper order during solving of constraints. They cannot be unified like normal edges (as to why look at H-4790).

This changes it so that structural edges (dependencies) are considered during

---

There are cases in which we cannot propagate a bound during inference, for example given:

```
?1 <: ?2
Number <: ?2
```

During constraint generation when trying to determine the upper bound of `?1` we currently look at the upper bound of `?2`, but because there's no upper bound to speak of `?1` keeps being unconstrained.

This changes it so that after we've solved any constraints (setting `?2 = Number`) we go through any of the unconstraint variables and insert the previously unconstrained variables to their value.

> These have been folded into a single PR, as it was very hard to 


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
