### PR TITLE
H-4783: HashQL: Improve compiletest panics

### DIFF
--- a/libs/@local/hashql/compiletest/src/lib.rs
+++ b/libs/@local/hashql/compiletest/src/lib.rs
@@ -7,6 +7,7 @@
     file_buffered,
     formatting_options,
     lock_value_accessors,
+    panic_payload_as_str,
     pattern,
     // Language Features
     decl_macro,
@@ -14,9 +15,12 @@
 )]
 extern crate alloc;
 
+use core::sync::atomic::{AtomicBool, Ordering};
 use std::{
+    backtrace::Backtrace,
     env,
     io::{Write as _, stdout},
+    panic::{self, PanicHookInfo},
     path::PathBuf,
     process::exit,
 };
@@ -39,6 +43,21 @@ mod find;
 mod reporter;
 mod styles;
 mod suite;
+
+static PANICKED: AtomicBool = AtomicBool::new(false);
+
+fn panic_hook(panic_info: &PanicHookInfo) {
+    let message = panic_info
+        .payload_as_str()
+        .map_or_else(|| "Box<dyn Any>".to_owned(), ToOwned::to_owned);
+
+    let location = panic_info.location().map(ToString::to_string);
+
+    let backtrace = Backtrace::force_capture();
+
+    tracing::error!(message, location, %backtrace, "encountered panic");
+    PANICKED.store(true, Ordering::SeqCst);
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
 struct Spec {
@@ -110,6 +129,7 @@ impl Options {
                 let ignored = trials.ignored();
 
                 setup_progress_header!(reporter, Summary { total, ignored }, statistics);
+                panic::set_hook(Box::new(panic_hook));
 
                 let reports = trials.run(&TrialContext { bless });
                 let failures = reports.len();
@@ -122,7 +142,8 @@ impl Options {
 
                 Reporter::report_errors(reports).expect("should be able to report errors");
 
-                if failures > 0 {
+                let panicked = PANICKED.load(Ordering::SeqCst);
+                if failures > 0 || panicked {
                     exit(1);
                 }
             }

--- a/libs/@local/hashql/compiletest/src/reporter.rs
+++ b/libs/@local/hashql/compiletest/src/reporter.rs
@@ -193,7 +193,8 @@ impl Reporter {
 
             write!(stderr, "{delimiter} ---")?;
             write!(stderr, "\n\n")?;
-            write!(stderr, "{report}")?;
+            #[expect(clippy::use_debug)]
+            write!(stderr, "{report:?}")?;
             write!(stderr, "\n\n")?;
             write!(stderr, "{delimiter} ---")?;
 

--- a/libs/@local/hashql/compiletest/src/suite/mod.rs
+++ b/libs/@local/hashql/compiletest/src/suite/mod.rs
@@ -18,6 +18,8 @@ mod hir_lower_specialization;
 mod hir_reify;
 mod parse_syntax_dump;
 
+use core::panic::RefUnwindSafe;
+
 use hashql_ast::node::expr::Expr;
 use hashql_core::{heap::Heap, span::SpanId};
 use hashql_diagnostics::{Diagnostic, category::DiagnosticCategory, span::AbsoluteDiagnosticSpan};
@@ -44,7 +46,7 @@ pub(crate) type SuiteDiagnostic = Diagnostic<Box<dyn DiagnosticCategory>, SpanId
 pub(crate) type ResolvedSuiteDiagnostic =
     Diagnostic<Box<dyn DiagnosticCategory>, AbsoluteDiagnosticSpan>;
 
-pub(crate) trait Suite: Send + Sync + 'static {
+pub(crate) trait Suite: RefUnwindSafe + Send + Sync + 'static {
     fn name(&self) -> &'static str;
 
     fn run<'heap>(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Panics in compiletest are currently quite opaque, as they do not have any backtraces and sometimes the output of tracing just removes them from the output.

Using `catch_unwind` and a custom hook we're able to make the error clearer.

> Sadly no output, because well... you need to have an error for that to happen.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

