### PR TITLE
H-4803: Use Amazon Linux 2023 for Bastion host

### DIFF
--- a/infra/terraform/modules/bastion/main.tf
+++ b/infra/terraform/modules/bastion/main.tf
@@ -22,7 +22,7 @@ data "aws_ami" "amazon_linux" {
 
     # list with the following command to update:
     # `aws ec2 describe-images --owners amazon --filters "Name=name,Values=al2023-ami-ecs-hvm-*-x86_64" | jq '.Images | sort_by(.CreationDate) | reverse'`
-    # We don't wilcard here to not accidentialy update to a non-functioning image.
+    # We don't wildcard here to not accidentally update to a non-functioning image.
     #
     # IMPORTANT: if the image is changed, it breaks the dependency chain of the bastion host. This means, that the module needs to be re-applied
     # alone: `terraform apply --var-file prod-usea1.tfvars -target=module.bastion -target=module.tunnel`


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently use amzn2 images which has now a short deprecation window. We should use al2023 instead to have a larger deprecation window (2 years instead of 3 months)

## 🔍 What does this change?

- Change the image to Amazon Linux 2023
- Add instructions to update the modules without breaking the dependency chain