### PR TITLE
H-4804: Increase the volume size of the Bastion volume to the recommended 30 gigabytes

### DIFF
--- a/infra/terraform/modules/bastion/variables.tf
+++ b/infra/terraform/modules/bastion/variables.tf
@@ -57,7 +57,7 @@ variable "device_name" {
 variable "volume_size" {
   type        = number
   description = "The size of the volume in gigabytes."
-  default     = 10
+  default     = 30
 }
 
 variable "volume_type" {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Applying the bastion changes in https://github.com/hashintel/hash/pull/7438 failed that the volume size should be 30 gigabytes.

```
╷
│ Error: creating EC2 Instance: InvalidBlockDeviceMapping: Volume of size 10GB is smaller than snapshot ‘snap-05a309acce09f509e’, expect size>= 30GB
│       status code: 400, request id: 0aa45abc-1d47-45c7-a013-27cecb98cc2a
│
│   with module.bastion.aws_instance.bastion,
│   on ../modules/bastion/bastion.tf line 101, in resource “aws_instance” “bastion”:
│  101: resource “aws_instance” “bastion” {
│
╵
```

## 🔍 What does this change?

Set the volume size to 30 GB