### PR TITLE
H-4810: Fix Linear integrations query

### DIFF
--- a/apps/hash-frontend/src/pages/settings/integrations/linear/use-linear-integrations.ts
+++ b/apps/hash-frontend/src/pages/settings/integrations/linear/use-linear-integrations.ts
@@ -68,7 +68,7 @@ export const useLinearIntegrations = (): {
             },
             {
               equal: [
-                { path: ["metadata", "entityTypeId"] },
+                { path: ["type", "versionedUrl"] },
                 { parameter: systemEntityTypes.linearIntegration.entityTypeId },
               ],
             },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The query path is different for `getEntitySubgraph` versus the old BP filter queries, this PR fixes a place when fetching Linear integrations where the old version wasn't translated to the new.