### PR TITLE
H-4823: Read policies for actors filtered by actions

### DIFF
--- a/libs/@local/graph/api/openapi/openapi.json
+++ b/libs/@local/graph/api/openapi/openapi.json
@@ -3259,50 +3259,6 @@
         }
       }
     },
-    "/policies/resolve/actor": {
-      "post": {
-        "tags": [
-          "Graph",
-          "Permission"
-        ],
-        "operationId": "resolve_policies_for_actor",
-        "parameters": [
-          {
-            "name": "X-Authenticated-User-Actor-Id",
-            "in": "header",
-            "description": "The ID of the actor which is used to authorize the request",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/ActorEntityUuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {}
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "List of policies found for the actor",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {}
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Store error occurred"
-          }
-        }
-      }
-    },
     "/policies/seed": {
       "get": {
         "tags": [

--- a/libs/@local/graph/api/src/rest/permissions.rs
+++ b/libs/@local/graph/api/src/rest/permissions.rs
@@ -18,7 +18,6 @@ use hash_graph_authorization::{
 use hash_graph_store::pool::StorePool;
 use hash_temporal_client::TemporalClient;
 use http::StatusCode;
-use type_system::principal::actor::ActorId;
 use utoipa::OpenApi;
 
 use crate::rest::{AuthenticatedUserHeader, json::Json, status::report_to_response};
@@ -29,7 +28,6 @@ use crate::rest::{AuthenticatedUserHeader, json::Json, status::report_to_respons
         create_policy,
         get_policy_by_id,
         query_policies,
-        resolve_policies_for_actor,
         update_policy_by_id,
         archive_policy_by_id,
         delete_policy_by_id,
@@ -67,7 +65,6 @@ impl PermissionResource {
                         .route("/delete", delete(delete_policy_by_id::<S, A>)),
                 )
                 .route("/query", post(query_policies::<S, A>))
-                .route("/resolve/actor", post(resolve_policies_for_actor::<S, A>))
                 .route("/seed", get(seed_system_policies::<S, A>)),
         )
     }
@@ -206,52 +203,6 @@ where
         .await
         .map_err(report_to_response)?
         .query_policies(authenticated_actor_id.into(), &filter)
-        .await
-        .map_err(report_to_response)
-        .map(Json)
-}
-
-#[utoipa::path(
-    post,
-    path = "/policies/resolve/actor",
-    request_body = Value,
-    tag = "Permission",
-    params(
-        ("X-Authenticated-User-Actor-Id" = ActorEntityUuid, Header, description = "The ID of the actor which is used to authorize the request"),
-    ),
-    responses(
-        (status = 200, content_type = "application/json", description = "List of policies found for the actor", body = Vec<Value>),
-
-        (status = 500, description = "Store error occurred"),
-    )
-)]
-#[tracing::instrument(
-    level = "info",
-    skip(store_pool, authorization_api_pool, temporal_client)
-)]
-async fn resolve_policies_for_actor<S, A>(
-    AuthenticatedUserHeader(authenticated_actor_id): AuthenticatedUserHeader,
-    store_pool: Extension<Arc<S>>,
-    authorization_api_pool: Extension<Arc<A>>,
-    temporal_client: Extension<Option<Arc<TemporalClient>>>,
-    Json(actor_id): Json<ActorId>,
-) -> Result<Json<Vec<Policy>>, Response>
-where
-    S: StorePool + Send + Sync,
-    A: AuthorizationApiPool + Send + Sync,
-    for<'p, 'a> S::Store<'p, A::Api<'a>>: PolicyStore,
-{
-    store_pool
-        .acquire(
-            authorization_api_pool
-                .acquire()
-                .await
-                .map_err(report_to_response)?,
-            temporal_client.0,
-        )
-        .await
-        .map_err(report_to_response)?
-        .resolve_policies_for_actor(authenticated_actor_id.into(), Some(actor_id))
         .await
         .map_err(report_to_response)
         .map(Json)

--- a/libs/@local/graph/authorization/src/policies/set/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/set/mod.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use std::collections::HashSet;
 
 use cedar_policy_core::{
     ast,
@@ -8,6 +9,7 @@ use error_stack::{Report, ResultExt as _, TryReportIteratorExt as _};
 
 use super::{
     Context, Policy, Request,
+    action::ActionName,
     cedar::{CedarExpressionParser as _, SimpleParser},
     evaluation::{PermissionCondition, PermissionConditionVisitor},
 };
@@ -23,6 +25,7 @@ pub struct PolicyEvaluationError;
 #[derive(Default)]
 pub struct PolicySet {
     policies: ast::PolicySet,
+    tracked_actions: HashSet<ActionName>,
 }
 
 impl fmt::Debug for PolicySet {
@@ -48,6 +51,15 @@ pub enum Authorized {
 }
 
 impl PolicySet {
+    /// Sets the tracked actions for the policy set.
+    ///
+    /// The policy set will fail to evaluate requests with actions that are not in this set.
+    #[must_use]
+    pub fn with_tracked_actions(mut self, actions: HashSet<ActionName>) -> Self {
+        self.tracked_actions = actions;
+        self
+    }
+
     /// Adds a list of policies to the policy set.
     ///
     /// # Errors
@@ -121,6 +133,13 @@ impl PolicySet {
         request: &Request,
         context: &Context,
     ) -> Result<Authorized, Report<PolicyEvaluationError>> {
+        if !self.tracked_actions.contains(&request.action) {
+            return Err(Report::new(PolicyEvaluationError).attach_printable(format!(
+                "Action `{}` is not tracked and cannot be evaluated",
+                request.action
+            )));
+        }
+
         let authorizer = Authorizer::new();
 
         let response =

--- a/libs/@local/graph/authorization/src/policies/store/error.rs
+++ b/libs/@local/graph/authorization/src/policies/store/error.rs
@@ -96,6 +96,8 @@ impl Error for ActorCreationError {}
 #[derive(Debug, derive_more::Display)]
 #[display("Could not create web: {_variant}")]
 pub enum WebCreationError {
+    #[display("Could not build policy components")]
+    BuildPolicyComponents,
     #[display("Web with ID `{web_id}` already exists")]
     AlreadyExists { web_id: WebId },
     #[display("Permission to create web was denied")]

--- a/libs/@local/graph/authorization/src/policies/store/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/store/mod.rs
@@ -242,6 +242,7 @@ pub trait PolicyStore {
         &self,
         authenticated_actor: AuthenticatedActor,
         actor_id: Option<ActorId>,
+        actions: &[ActionName],
     ) -> Result<Vec<Policy>, Report<GetPoliciesError>>;
 
     /// Updates the policy specified by its ID.

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -777,6 +777,7 @@ where
                     .flat_map(|params| &params.entity_type_ids)
                     .collect::<HashSet<_>>(),
             )
+            .with_action(ActionName::Instantiate)
             .await
             .change_context(InsertionError)?;
 
@@ -1682,6 +1683,7 @@ where
             .with_actor(actor_id)
             .with_entity_edition_id(previous_entity.metadata.record_id.edition_id)
             .with_entity_type_ids(&params.entity_type_ids)
+            .with_action(ActionName::Instantiate)
             .await
             .change_context(UpdateError)?;
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -17,7 +17,7 @@ use hash_graph_authorization::{
     AuthorizationApi,
     backend::ModifyRelationshipOperation,
     policies::{
-        Authorized, ContextBuilder, Effect, PartialResourceId, Policy, PolicyId, PolicySet,
+        Authorized, ContextBuilder, Effect, PartialResourceId, Policy, PolicyComponents, PolicyId,
         Request, RequestContext,
         action::ActionName,
         principal::{PrincipalConstraint, actor::AuthenticatedActor},
@@ -257,32 +257,24 @@ where
         actor: ActorId,
         parameter: CreateWebParameter,
     ) -> Result<CreateWebResponse, Report<WebCreationError>> {
-        let mut context_builder = ContextBuilder::default();
-        self.build_principal_context(actor, &mut context_builder)
+        let policy_components = PolicyComponents::builder(self)
+            .with_actor(actor)
+            .with_action(ActionName::CreateWeb)
             .await
-            .change_context(WebCreationError::StoreError)?;
-        let context = context_builder
-            .build()
-            .change_context(WebCreationError::StoreError)?;
-        let policies = self
-            .resolve_policies_for_actor(actor.into(), Some(actor))
-            .await
-            .change_context(WebCreationError::StoreError)?;
+            .change_context(WebCreationError::BuildPolicyComponents)?;
 
         let web_id = WebId::new(parameter.id.unwrap_or_else(Uuid::new_v4));
 
-        let policy_set = PolicySet::default()
-            .with_policies(&policies)
-            .change_context(WebCreationError::StoreError)?;
-        match policy_set
+        match policy_components
+            .policy_set
             .evaluate(
                 &Request {
-                    actor: Some(actor),
+                    actor: policy_components.actor_id,
                     action: ActionName::CreateWeb,
                     resource: Some(&PartialResourceId::Web(Some(web_id))),
                     context: RequestContext::default(),
                 },
-                &context,
+                &policy_components.context,
             )
             .change_context(WebCreationError::StoreError)?
         {
@@ -1282,6 +1274,7 @@ where
         &self,
         authenticated_actor: AuthenticatedActor,
         actor_id: Option<ActorId>,
+        actions: &[ActionName],
     ) -> Result<Vec<Policy>, Report<GetPoliciesError>> {
         let Some(actor_id) = actor_id else {
             // If no actor is provided, only policies without principal constraints are returned.
@@ -1382,6 +1375,7 @@ where
                 LEFT JOIN policy_action
                        ON policy_action.policy_id = policy_edition.id
                       AND policy_action.transaction_time @> now()
+                      AND policy_action.action_name = ANY($3)
                 GROUP BY
                     policy_edition.id,
                     policy_edition.name,
@@ -1394,6 +1388,7 @@ where
                 [
                     &actor_id as &(dyn ToSql + Sync),
                     &PrincipalType::from(actor_id.actor_type()),
+                    &actions,
                 ],
             )
             .await

--- a/libs/@local/graph/postgres-store/tests/principals/policies.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/policies.rs
@@ -401,25 +401,41 @@ async fn global_policies() -> Result<(), Box<dyn Error>> {
 
     // Every actor should get global policies
     let user1_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user1)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::User(env.user1)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| policy.id)
         .collect::<HashSet<_>>();
     let user2_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user2)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::User(env.user2)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| policy.id)
         .collect::<HashSet<_>>();
     let machine_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::Machine(env.machine_id)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::Machine(env.machine_id)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| policy.id)
         .collect::<HashSet<_>>();
     let ai_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::Ai(env.ai_id)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::Ai(env.ai_id)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| policy.id)
@@ -428,6 +444,7 @@ async fn global_policies() -> Result<(), Box<dyn Error>> {
         .resolve_policies_for_actor(
             actor_id.into(),
             Some(ActorId::User(UserId::new(Uuid::new_v4()))),
+            &[ActionName::All],
         )
         .await?
         .into_iter()
@@ -468,19 +485,31 @@ async fn actor_type_policies() -> Result<(), Box<dyn Error>> {
 
     // Test user type policies
     let user1_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user1)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::User(env.user1)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| policy.id)
         .collect::<HashSet<_>>();
     let user2_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user2)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::User(env.user2)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| policy.id)
         .collect::<HashSet<_>>();
     let machine_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::Machine(env.machine_id)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::Machine(env.machine_id)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| policy.id)
@@ -489,6 +518,7 @@ async fn actor_type_policies() -> Result<(), Box<dyn Error>> {
         .resolve_policies_for_actor(
             actor_id.into(),
             Some(ActorId::Machine(MachineId::new(Uuid::new_v4()))),
+            &[ActionName::All],
         )
         .await?
         .into_iter()
@@ -543,13 +573,21 @@ async fn specific_actor_policies() -> Result<(), Box<dyn Error>> {
 
     // user1 has a specific policy assigned
     let user1_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user1)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::User(env.user1)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| policy.id)
         .collect::<HashSet<_>>();
     let user2_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user2)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::User(env.user2)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| policy.id)
@@ -558,6 +596,7 @@ async fn specific_actor_policies() -> Result<(), Box<dyn Error>> {
         .resolve_policies_for_actor(
             actor_id.into(),
             Some(ActorId::User(UserId::new(Uuid::new_v4()))),
+            &[ActionName::All],
         )
         .await?
         .into_iter()
@@ -590,13 +629,21 @@ async fn role_based_policies() -> Result<(), Box<dyn Error>> {
 
     // Test role-based policies
     let user1_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user1)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::User(env.user1)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| policy.id)
         .collect::<HashSet<_>>();
     let user2_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user2)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::User(env.user2)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| policy.id)
@@ -624,7 +671,11 @@ async fn role_based_policies() -> Result<(), Box<dyn Error>> {
         .await?;
 
     let machine_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::Machine(special_machine_id)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::Machine(special_machine_id)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| policy.id)
@@ -654,13 +705,21 @@ async fn team_hierarchy_policies() -> Result<(), Box<dyn Error>> {
     // Test team hierarchies
     // User2 has team1_role, AI has nested_team_role which is under team1
     let user2_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user2)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::User(env.user2)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| policy.id)
         .collect::<HashSet<_>>();
     let ai_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::Ai(env.ai_id)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::Ai(env.ai_id)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| policy.id)
@@ -682,6 +741,7 @@ async fn team_hierarchy_policies() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test]
+#[expect(clippy::too_many_lines)]
 async fn policy_count_and_content() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
     let (mut client, actor_id) = db.seed().await?;
@@ -691,31 +751,51 @@ async fn policy_count_and_content() -> Result<(), Box<dyn Error>> {
     let nonexistent_id = UserId::new(Uuid::new_v4());
 
     let user1_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user1)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::User(env.user1)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| (policy.id, policy))
         .collect::<HashMap<_, _>>();
     let user2_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user2)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::User(env.user2)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| (policy.id, policy))
         .collect::<HashMap<_, _>>();
     let machine_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::Machine(env.machine_id)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::Machine(env.machine_id)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| (policy.id, policy))
         .collect::<HashMap<_, _>>();
     let ai_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::Ai(env.ai_id)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::Ai(env.ai_id)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| (policy.id, policy))
         .collect::<HashMap<_, _>>();
     let nonexistent_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(nonexistent_id)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::User(nonexistent_id)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| (policy.id, policy))
@@ -786,7 +866,11 @@ async fn role_assignment_changes() -> Result<(), Box<dyn Error>> {
 
     // Initial policy count
     let user2_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user2)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::User(env.user2)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| policy.id)
@@ -805,7 +889,11 @@ async fn role_assignment_changes() -> Result<(), Box<dyn Error>> {
 
     // Should have fewer policies now
     let updated_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user2)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::User(env.user2)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| policy.id)
@@ -826,7 +914,11 @@ async fn role_assignment_changes() -> Result<(), Box<dyn Error>> {
 
     // Should have different policies now after adding a new role
     let final_policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(env.user2)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::User(env.user2)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| policy.id)
@@ -869,7 +961,11 @@ async fn resource_constraints_are_preserved() -> Result<(), Box<dyn Error>> {
         .await?;
 
     let policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(user_id)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::User(user_id)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| (policy.id, policy))
@@ -897,6 +993,7 @@ async fn resource_constraints_are_preserved() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test]
+#[expect(clippy::too_many_lines)]
 async fn deep_team_hierarchy() -> Result<(), Box<dyn Error>> {
     let mut db = DatabaseTestWrapper::new().await;
     let (mut client, actor_id) = db.seed().await?;
@@ -993,7 +1090,11 @@ async fn deep_team_hierarchy() -> Result<(), Box<dyn Error>> {
 
     // User should get all policies through the hierarchy
     let policies = client
-        .resolve_policies_for_actor(actor_id.into(), Some(ActorId::User(user_id)))
+        .resolve_policies_for_actor(
+            actor_id.into(),
+            Some(ActorId::User(user_id)),
+            &[ActionName::All],
+        )
         .await?
         .into_iter()
         .map(|policy| policy.id)

--- a/libs/@local/graph/sdk/typescript/src/policy.ts
+++ b/libs/@local/graph/sdk/typescript/src/policy.ts
@@ -1,4 +1,3 @@
-import type { ActorId } from "@blockprotocol/type-system";
 import type { GraphApi } from "@local/hash-graph-client";
 import type {
   Policy,
@@ -58,28 +57,6 @@ export const queryPolicies = (
 ): Promise<Policy[]> =>
   graphAPI
     .queryPolicies(authentication.actorId, filter)
-    .then(({ data: policies }) => policies as Policy[]);
-
-/**
- * Searches for policies that apply to the given actor.
- *
- * This method queries the underlying policy store to find policies that are relevant to the
- * specified actor. The policies returned may include those that apply to the actor directly,
- * as well as policies that apply to any roles the actor has.
- *
- * This provides a complete set of policies that apply to an actor, including all policies that
- *   - apply to the actor itself,
- *   - apply to the actor's roles,
- *   - apply to the actor's groups, and
- *   - apply to the actor's parent groups (for teams).
- */
-export const resolvePoliciesForActor = (
-  graphAPI: GraphApi,
-  authentication: AuthenticationContext,
-  actorId: ActorId,
-): Promise<Policy[]> =>
-  graphAPI
-    .resolvePoliciesForActor(authentication.actorId, actorId)
     .then(({ data: policies }) => policies as Policy[]);
 
 /**

--- a/libs/@local/graph/type-fetcher/src/store.rs
+++ b/libs/@local/graph/type-fetcher/src/store.rs
@@ -7,6 +7,7 @@ use hash_graph_authorization::{
     AuthorizationApi,
     policies::{
         ContextBuilder, Policy, PolicyId,
+        action::ActionName,
         principal::actor::AuthenticatedActor,
         resource::{EntityResource, EntityTypeResource},
         store::{
@@ -316,9 +317,10 @@ where
         &self,
         authenticated_actor: AuthenticatedActor,
         actor_id: Option<ActorId>,
+        actions: &[ActionName],
     ) -> Result<Vec<Policy>, Report<GetPoliciesError>> {
         self.store
-            .resolve_policies_for_actor(authenticated_actor, actor_id)
+            .resolve_policies_for_actor(authenticated_actor, actor_id, actions)
             .await
     }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We typically only need a few policies based on the actions we're going to do.

## 🔍 What does this change?

- Add functions to allow adding actions to the policy components
- The actions are persisted in the policy set, so if a request with a different action is being issued, it will fail if the action was not previously used. This helps in tracking issues, e.g. when it was forgotten to request the `instantiate` policy and the request evaluates to "cannot instantiate" it is hard to track down why a user may cannot instantiate an entity type. With tracked actions there is a clear error message that the `instantiate` action was not tracked at all

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing
### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph