### PR TITLE
Support enum variant skipping in codegen

### DIFF
--- a/libs/@local/codegen/src/definitions/enum.rs
+++ b/libs/@local/codegen/src/definitions/enum.rs
@@ -52,6 +52,7 @@ impl Enum {
             variants: enum_type
                 .variants()
                 .iter()
+                .filter(|&(_, variant)| !variant.skip())
                 .map(|(name, variant)| EnumVariant {
                     name: name.clone(),
                     fields: Fields::from_specta(variant.fields(), type_collection),

--- a/libs/@local/codegen/tests/standalone-types/enums.rs
+++ b/libs/@local/codegen/tests/standalone-types/enums.rs
@@ -90,3 +90,56 @@ pub(crate) enum EnumUntagged {
         simple: StructSimple,
     },
 }
+
+// Untagged - no discriminator field, purely based on shape
+#[derive(specta::Type)]
+#[serde(untagged)]
+pub(crate) enum EnumWithSkippedVariants {
+    NotSkipped,
+    #[specta(skip)]
+    SkippedSpectaUnit,
+    #[serde(skip)]
+    SkippedSerdeUnit,
+    #[specta(skip)]
+    SkippedSpectaSingleUnnamed(i32),
+    #[serde(skip)]
+    SkippedSerdeSingleUnnamed(i32),
+    #[specta(skip)]
+    SkippedSpectaDoubleUnnamed(bool, String),
+    #[serde(skip)]
+    SkippedSerdeDoubleUnnamed(bool, String),
+    #[specta(skip)]
+    SkippedSpectaEmptyNamed {},
+    #[serde(skip)]
+    SkippedSerdeEmptyNamed {},
+    #[specta(skip)]
+    SkippedSpectaSingleNamed {
+        value: i32,
+    },
+    #[serde(skip)]
+    SkippedSerdeSingleNamed {
+        value: i32,
+    },
+    #[specta(skip)]
+    SkippedSpectaMultiNamed {
+        value_1: i32,
+        value_2: String,
+    },
+    #[serde(skip)]
+    SkippedSerdeMultiNamed {
+        value_1: i32,
+        value_2: String,
+    },
+    #[specta(skip)]
+    SkippedSpectaFlattenedStruct {
+        name: String,
+        #[serde(flatten)]
+        simple: StructSimple,
+    },
+    #[serde(skip)]
+    SkippedSerdeFlattenedStruct {
+        name: String,
+        #[serde(flatten)]
+        simple: StructSimple,
+    },
+}

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__EnumWithSkippedVariants::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__EnumWithSkippedVariants::Typescript.snap
@@ -1,0 +1,5 @@
+---
+source: libs/@local/codegen/tests/standalone-types/main.rs
+expression: generated
+---
+export type EnumWithSkippedVariants = null;

--- a/libs/@local/graph/authorization/src/policies/action/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/action/mod.rs
@@ -29,15 +29,20 @@ use crate::policies::cedar::FromCedarEntityId;
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
 #[serde(rename_all = "camelCase")]
 pub enum ActionName {
+    #[cfg_attr(feature = "codegen", specta(skip))]
     All,
 
+    #[cfg_attr(feature = "codegen", specta(skip))]
     Create,
     CreateWeb,
 
+    #[cfg_attr(feature = "codegen", specta(skip))]
     View,
     ViewEntity,
+    #[cfg_attr(feature = "codegen", specta(skip))]
     ViewEntityType,
 
+    #[cfg_attr(feature = "codegen", specta(skip))]
     Update,
 
     Instantiate,

--- a/libs/@local/graph/authorization/types/index.snap.d.ts
+++ b/libs/@local/graph/authorization/types/index.snap.d.ts
@@ -13,7 +13,7 @@ export interface Policy {
 }
 import type { Brand } from "@local/advanced-types/brand";
 export type PolicyId = Brand<string, "PolicyId">;
-export type ActionName = "all" | "create" | "createWeb" | "view" | "viewEntity" | "viewEntityType" | "update" | "instantiate";
+export type ActionName = "createWeb" | "viewEntity" | "instantiate";
 export type PrincipalConstraint = {
 	type: "actor"
 } & ActorId | {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently have more actions present in the graph than being used. To only expose the used actions, we need variant skipping in codegen.