### PR TITLE
H-4832: Increase timeout on Node API healthcheck

### DIFF
--- a/apps/hash-api/package.json
+++ b/apps/hash-api/package.json
@@ -15,10 +15,10 @@
     "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "start": "NODE_ENV=production NODE_OPTIONS=--max-old-space-size=2048 tsx --import ./src/instrument.mjs ./src/index.ts",
-    "start:healthcheck": "wait-on --timeout 300000 http://localhost:5001",
+    "start:healthcheck": "wait-on --timeout 500000 http://localhost:5001",
     "start:migrate": "NODE_ENV=production tsx ./src/ensure-system-graph-is-initialized.ts",
     "start:test": "NODE_ENV=test NODE_OPTIONS=--max-old-space-size=2048 tsx ./src/index.ts",
-    "start:test:healthcheck": "wait-on --timeout 300000 http://localhost:5001",
+    "start:test:healthcheck": "wait-on --timeout 500000 http://localhost:5001",
     "start:test:migrate": "NODE_ENV=test tsx ./src/ensure-system-graph-is-initialized.ts",
     "test:unit": "vitest --run"
   },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We encounter quite a few issues recently on timing out healthchecks. It could be possible that the wait timeout is too low.
