### PR TITLE
H-4849: Tighten debug flag check in tunnel script

### DIFF
--- a/infra/terraform/modules/tunnel/ssh_tunnel.sh
+++ b/infra/terraform/modules/tunnel/ssh_tunnel.sh
@@ -6,7 +6,7 @@ TUNNEL_DEBUG=0
 
 input="$(< /dev/stdin)"
 
-if [ -n "$TUNNEL_DEBUG" ] ; then
+if [ "${TUNNEL_DEBUG:-0}" -ne 0 ]; then
   exec 2>/tmp/tunnel_logs
   set -x
   env >&2

--- a/infra/terraform/modules/tunnel/ssh_tunnel.sh
+++ b/infra/terraform/modules/tunnel/ssh_tunnel.sh
@@ -6,6 +6,8 @@ TUNNEL_DEBUG=0
 
 input="$(< /dev/stdin)"
 
+# Check if debugging is enabled. The fallback `${TUNNEL_DEBUG:-0}` ensures a default value of 0
+# if `TUNNEL_DEBUG` is unset. A non-zero value enables debugging.
 if [ "${TUNNEL_DEBUG:-0}" -ne 0 ]; then
   exec 2>/tmp/tunnel_logs
   set -x


### PR DESCRIPTION
## Summary

Codex flags: in the tunnel helper script debugging is currently enabled whenever `TUNNEL_DEBUG` has a value, irrespective of what this is.

The fix:
- Now explicitly compares the variable against zero by modifying the `ssh_tunnel.sh` script, so there is a default value of `0` for `TUNNEL_DEBUG`.
- Logging now activates only when `TUNNEL_DEBUG` is _non-zero_ (i.e. it has been changed to anything else).

------
https://chatgpt.com/codex/tasks/task_e_68442e327d1c8321b4430dce3cbcc9dd