### PR TITLE
H-4863: Remove flaky sleep from Playwright test

### DIFF
--- a/tests/hash-playwright/tests/entity-editing.spec.ts
+++ b/tests/hash-playwright/tests/entity-editing.spec.ts
@@ -137,8 +137,9 @@ test("user can update values on property table", async ({ page }) => {
 
   await clickOnValueCell(page, propertyTableCanvas, 0);
 
+  await expect(page.getByPlaceholder("Start typing...")).toBeVisible();
+
   const profileUrl = "https://github.com/Example";
-  await sleep(200);
 
   await page.keyboard.type(profileUrl);
   await page.keyboard.press("Enter");


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Replaces a `sleep` with waiting for the desired element to appear in the entity editing Playwright test.

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

- [ ] Checking CI passes

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- The test it edits.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. See if Playwright tests pass in CI.

