### PR TITLE
H-4864: Add skip embedding creation option to server and update related logic

### DIFF
--- a/.config/mise/config.ci.toml
+++ b/.config/mise/config.ci.toml
@@ -1,3 +1,6 @@
 [tools]
 "cargo:clippy-sarif" = "0.6.5"
 "cargo:sarif-fmt"    = "0.6.5"
+
+[env]
+HASH_GRAPH_SKIP_EMBEDDING_CREATION = "true"

--- a/apps/hash-graph/src/subcommand/server.rs
+++ b/apps/hash-graph/src/subcommand/server.rs
@@ -177,6 +177,10 @@ pub struct ServerArgs {
     #[clap(long)]
     pub skip_link_validation: bool,
 
+    /// Skips the creation of embeddings when creating/updating entities or types.
+    #[clap(long, env = "HASH_GRAPH_SKIP_EMBEDDING_CREATION")]
+    pub skip_embedding_creation: bool,
+
     /// Outputs the queries made to the graph to the specified file.
     #[clap(long)]
     pub log_queries: Option<PathBuf>,
@@ -252,6 +256,7 @@ pub async fn server(args: ServerArgs) -> Result<(), Report<GraphError>> {
         NoTls,
         PostgresStoreSettings {
             validate_links: !args.skip_link_validation,
+            skip_embedding_creation: args.skip_embedding_creation,
         },
     )
     .await

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -1170,7 +1170,9 @@ where
 
             Err(error.change_context(InsertionError))
         } else {
-            if let Some(temporal_client) = &self.temporal_client {
+            if !self.settings.skip_embedding_creation
+                && let Some(temporal_client) = &self.temporal_client
+            {
                 temporal_client
                     .start_update_entity_embeddings_workflow(actor_id, &entities)
                     .await
@@ -2017,7 +2019,9 @@ where
 
         transaction.commit().await.change_context(UpdateError)?;
 
-        if let Some(temporal_client) = &self.temporal_client {
+        if !self.settings.skip_embedding_creation
+            && let Some(temporal_client) = &self.temporal_client
+        {
             temporal_client
                 .start_update_entity_embeddings_workflow(actor_id, &entities)
                 .await

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -95,12 +95,14 @@ use crate::store::error::{
 #[derive(Debug, Clone)]
 pub struct PostgresStoreSettings {
     pub validate_links: bool,
+    pub skip_embedding_creation: bool,
 }
 
 impl Default for PostgresStoreSettings {
     fn default() -> Self {
         Self {
             validate_links: true,
+            skip_embedding_creation: false,
         }
     }
 }

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
@@ -635,7 +635,9 @@ where
 
             Err(error.change_context(InsertionError))
         } else {
-            if let Some(temporal_client) = &self.temporal_client {
+            if !self.settings.skip_embedding_creation
+                && let Some(temporal_client) = &self.temporal_client
+            {
                 temporal_client
                     .start_update_data_type_embeddings_workflow(
                         actor_id,
@@ -1048,7 +1050,9 @@ where
 
             Err(error.change_context(UpdateError))
         } else {
-            if let Some(temporal_client) = &self.temporal_client {
+            if !self.settings.skip_embedding_creation
+                && let Some(temporal_client) = &self.temporal_client
+            {
                 temporal_client
                     .start_update_data_type_embeddings_workflow(
                         actor_id,

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
@@ -988,7 +988,9 @@ where
 
             Err(error.change_context(InsertionError))
         } else {
-            if let Some(temporal_client) = &self.temporal_client {
+            if !self.settings.skip_embedding_creation
+                && let Some(temporal_client) = &self.temporal_client
+            {
                 temporal_client
                     .start_update_entity_type_embeddings_workflow(
                         actor_id,
@@ -1544,7 +1546,9 @@ where
 
             Err(error.change_context(UpdateError))
         } else {
-            if let Some(temporal_client) = &self.temporal_client {
+            if !self.settings.skip_embedding_creation
+                && let Some(temporal_client) = &self.temporal_client
+            {
                 temporal_client
                     .start_update_entity_type_embeddings_workflow(
                         actor_id,

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/property_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/property_type.rs
@@ -516,7 +516,9 @@ where
 
             Err(error.change_context(InsertionError))
         } else {
-            if let Some(temporal_client) = &self.temporal_client {
+            if !self.settings.skip_embedding_creation
+                && let Some(temporal_client) = &self.temporal_client
+            {
                 temporal_client
                     .start_update_property_type_embeddings_workflow(
                         actor_id,
@@ -827,7 +829,9 @@ where
 
             Err(error.change_context(UpdateError))
         } else {
-            if let Some(temporal_client) = &self.temporal_client {
+            if !self.settings.skip_embedding_creation
+                && let Some(temporal_client) = &self.temporal_client
+            {
                 temporal_client
                     .start_update_property_type_embeddings_workflow(
                         actor_id,

--- a/libs/@local/graph/type-fetcher/src/fetcher_server.rs
+++ b/libs/@local/graph/type-fetcher/src/fetcher_server.rs
@@ -41,18 +41,9 @@ impl FetchServer {
                     .map_err(io::Error::from)
                     .attach_printable_lazy(|| file.path().display().to_string())?;
                 let id = match &ontology_type {
-                    FetchedOntologyType::DataType(data_type) => {
-                        tracing::info!(%data_type.id, "Loaded predefined data type");
-                        data_type.id.clone()
-                    }
-                    FetchedOntologyType::PropertyType(property_type) => {
-                        tracing::info!(%property_type.id, "Loaded predefined property type");
-                        property_type.id.clone()
-                    }
-                    FetchedOntologyType::EntityType(entity_type) => {
-                        tracing::info!(%entity_type.id, "Loaded predefined entity type");
-                        entity_type.id.clone()
-                    }
+                    FetchedOntologyType::DataType(data_type) => data_type.id.clone(),
+                    FetchedOntologyType::PropertyType(property_type) => property_type.id.clone(),
+                    FetchedOntologyType::EntityType(entity_type) => entity_type.id.clone(),
                 };
                 self.predefined_types.insert(id, ontology_type);
             }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We don't have a valid AI token in CI and the number of error logs is overwhelming/makes it very hard to read _actual_ CI errors.

## 🔍 What does this change?

- Introduced `skip_embedding_creation` flag in `ServerArgs` to control embedding creation during entity updates.
- Updated `PostgresStoreSettings` to include `skip_embedding_creation` with a default value of false.
- Modified embedding workflow calls in entity, entity type, data type, and property type modules to respect the new flag.
- Added environment variable `HASH_GRAPH_SKIP_EMBEDDING_CREATION` to configure the skip option via environment settings.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph