### PR TITLE
H-4865: Increase timeout for healthchecks for Workers

### DIFF
--- a/apps/hash-ai-worker-ts/package.json
+++ b/apps/hash-ai-worker-ts/package.json
@@ -35,9 +35,9 @@
     "sanitize-html": "NODE_ENV=development yarn exe ./scripts/sanitize-html.ts",
     "sentry:sourcemaps": "sentry-cli sourcemaps inject --org hashintel --project hash-temporal-worker-ai ./dist && sentry-cli sourcemaps upload --org hashintel --project hash-temporal-worker-ai ./dist",
     "start": "NODE_ENV=production NODE_OPTIONS=--max-old-space-size=2048 node ./dist/main.js",
-    "start:healthcheck": "wait-on --timeout 300000 http-get://localhost:4100/health",
+    "start:healthcheck": "wait-on --timeout 600000 http-get://localhost:4100/health",
     "start:test": "NODE_ENV=test NODE_OPTIONS=--max-old-space-size=2048 node ./dist/main.js",
-    "start:test:healthcheck": "wait-on --timeout 300000 http-get://localhost:4100/health",
+    "start:test:healthcheck": "wait-on --timeout 600000 http-get://localhost:4100/health",
     "temporal:clean": "temporal workflow terminate --query \"TaskQueue='ai'\" --reason=\"Batch terminate from CLI\"",
     "test:unit": "vitest --run  --exclude \"**/*.ai.test.ts\""
   },

--- a/apps/hash-api/package.json
+++ b/apps/hash-api/package.json
@@ -15,10 +15,10 @@
     "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "start": "NODE_ENV=production NODE_OPTIONS=--max-old-space-size=2048 tsx --import ./src/instrument.mjs ./src/index.ts",
-    "start:healthcheck": "wait-on --timeout 500000 http://localhost:5001",
+    "start:healthcheck": "wait-on --timeout 600000 http://localhost:5001",
     "start:migrate": "NODE_ENV=production tsx ./src/ensure-system-graph-is-initialized.ts",
     "start:test": "NODE_ENV=test NODE_OPTIONS=--max-old-space-size=2048 tsx ./src/index.ts",
-    "start:test:healthcheck": "wait-on --timeout 500000 http://localhost:5001",
+    "start:test:healthcheck": "wait-on --timeout 600000 http://localhost:5001",
     "start:test:migrate": "NODE_ENV=test tsx ./src/ensure-system-graph-is-initialized.ts",
     "test:unit": "vitest --run"
   },

--- a/apps/hash-integration-worker/package.json
+++ b/apps/hash-integration-worker/package.json
@@ -15,9 +15,9 @@
     "lint:tsc": "tsc --noEmit",
     "sentry:sourcemaps": "sentry-cli sourcemaps inject --org hashintel --project hash-temporal-worker-integration ./dist && sentry-cli sourcemaps upload --org hashintel --project hash-temporal-worker-integration ./dist",
     "start": "NODE_ENV=production NODE_OPTIONS=--max-old-space-size=2048 tsx ./src/main.ts",
-    "start:healthcheck": "wait-on --timeout 300000 http-get://localhost:4300/health",
+    "start:healthcheck": "wait-on --timeout 600000 http-get://localhost:4300/health",
     "start:test": "NODE_ENV=test NODE_OPTIONS=--max-old-space-size=2048 tsx ./dist/main.js",
-    "start:test:healthcheck": "wait-on --timeout 300000 http-get://localhost:4300/health"
+    "start:test:healthcheck": "wait-on --timeout 600000 http-get://localhost:4300/health"
   },
   "dependencies": {
     "@blockprotocol/graph": "0.4.0-canary.0",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

CI integration tests were failing because workers weren't becoming alive within the timeout period. Workers need to wait for `hash-api` to become alive first before they can pass their own healthchecks.


## 🔍 What does this change?

- `hash-integration-worker` (`apps/hash-integration-worker/package.json:18,20`): Increased healthcheck timeout from 300000ms (5 min) to 600000ms (10 min)
- `hash-ai-worker-ts` (`apps/hash-ai-worker-ts/package.json:38,40`): Increased healthcheck timeout from 300000ms (5 min) to 600000ms (10 min)
- Align `hash-api` timeout to also use 10 min.