### PR TITLE
H-4827: Allow direct conversion from policies to filters

### DIFF
--- a/libs/@local/graph/authorization/src/policies/components.rs
+++ b/libs/@local/graph/authorization/src/policies/components.rs
@@ -27,7 +27,7 @@ impl PolicyComponents {
         PolicyComponentsBuilder::new(store)
     }
 
-    /// Creates a [`PolicySet`] for Cedar evaluation.
+    /// Builds a [`PolicySet`] for Cedar evaluation.
     ///
     /// This is only needed when actually evaluating policies with Cedar.
     /// For filter optimization, use the raw `policies` field directly.
@@ -35,7 +35,7 @@ impl PolicyComponents {
     /// # Errors
     ///
     /// Returns error if policy set creation fails.
-    pub fn create_policy_set(
+    pub fn build_policy_set(
         &self,
     ) -> Result<PolicySet, Report<super::set::PolicySetInsertionError>> {
         PolicySet::default()

--- a/libs/@local/graph/authorization/src/policies/components.rs
+++ b/libs/@local/graph/authorization/src/policies/components.rs
@@ -7,7 +7,7 @@ use type_system::{
 };
 
 use super::{
-    Context, ContextBuilder, PolicySet,
+    Context, ContextBuilder, Policy, PolicySet,
     action::ActionName,
     principal::actor::AuthenticatedActor,
     store::{PolicyStore, PrincipalStore, ResolvePoliciesParams, error::ContextCreationError},
@@ -16,7 +16,8 @@ use super::{
 #[derive(Debug)]
 pub struct PolicyComponents {
     pub actor_id: Option<ActorId>,
-    pub policy_set: PolicySet,
+    pub policies: Vec<Policy>,
+    pub tracked_actions: HashSet<ActionName>,
     pub context: Context,
 }
 
@@ -24,6 +25,22 @@ impl PolicyComponents {
     #[must_use]
     pub fn builder<S>(store: &S) -> PolicyComponentsBuilder<'_, S> {
         PolicyComponentsBuilder::new(store)
+    }
+
+    /// Creates a [`PolicySet`] for Cedar evaluation.
+    ///
+    /// This is only needed when actually evaluating policies with Cedar.
+    /// For filter optimization, use the raw `policies` field directly.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if policy set creation fails.
+    pub fn create_policy_set(
+        &self,
+    ) -> Result<PolicySet, Report<super::set::PolicySetInsertionError>> {
+        PolicySet::default()
+            .with_tracked_actions(self.tracked_actions.clone())
+            .with_policies(&self.policies)
     }
 }
 
@@ -211,10 +228,8 @@ where
 
             Ok(PolicyComponents {
                 actor_id,
-                policy_set: PolicySet::default()
-                    .with_tracked_actions(self.actions)
-                    .with_policies(&policies)
-                    .change_context(ContextCreationError::CreatePolicySet)?,
+                policies,
+                tracked_actions: self.actions,
                 context: self
                     .context
                     .build()

--- a/libs/@local/graph/authorization/src/policies/store/error.rs
+++ b/libs/@local/graph/authorization/src/policies/store/error.rs
@@ -98,6 +98,8 @@ impl Error for ActorCreationError {}
 pub enum WebCreationError {
     #[display("Could not build policy components")]
     BuildPolicyComponents,
+    #[display("Could not create policy set")]
+    PolicySetCreation,
     #[display("Web with ID `{web_id}` already exists")]
     AlreadyExists { web_id: WebId },
     #[display("Permission to create web was denied")]

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -992,7 +992,7 @@ where
         let mut forbidden_instantiations = Vec::new();
         for entity_type_id in &entity_type_id_set {
             match policy_components
-                .create_policy_set()
+                .build_policy_set()
                 .change_context(InsertionError)?
                 .evaluate(
                     &Request {
@@ -1745,7 +1745,7 @@ where
             let mut forbidden_instantiations = Vec::new();
             for entity_type_id in &affected_type_ids {
                 match policy_components
-                    .create_policy_set()
+                    .build_policy_set()
                     .change_context(UpdateError)?
                     .evaluate(
                         &Request {

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -992,7 +992,8 @@ where
         let mut forbidden_instantiations = Vec::new();
         for entity_type_id in &entity_type_id_set {
             match policy_components
-                .policy_set
+                .create_policy_set()
+                .change_context(InsertionError)?
                 .evaluate(
                     &Request {
                         actor: policy_components.actor_id,
@@ -1744,7 +1745,8 @@ where
             let mut forbidden_instantiations = Vec::new();
             for entity_type_id in &affected_type_ids {
                 match policy_components
-                    .policy_set
+                    .create_policy_set()
+                    .change_context(UpdateError)?
                     .evaluate(
                         &Request {
                             actor: policy_components.actor_id,

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -268,7 +268,8 @@ where
         let web_id = WebId::new(parameter.id.unwrap_or_else(Uuid::new_v4));
 
         match policy_components
-            .policy_set
+            .create_policy_set()
+            .change_context(WebCreationError::PolicySetCreation)?
             .evaluate(
                 &Request {
                     actor: policy_components.actor_id,

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -268,7 +268,7 @@ where
         let web_id = WebId::new(parameter.id.unwrap_or_else(Uuid::new_v4));
 
         match policy_components
-            .create_policy_set()
+            .build_policy_set()
             .change_context(WebCreationError::PolicySetCreation)?
             .evaluate(
                 &Request {

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
@@ -1780,7 +1780,7 @@ where
                 // to see if the user can instantiate it.
                 for entity_type_id in iter::once(base).chain(parents) {
                     let allowed = policy_components
-                        .create_policy_set()
+                        .build_policy_set()
                         .change_context(QueryError)?
                         .evaluate(
                             &Request {

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
@@ -1780,7 +1780,8 @@ where
                 // to see if the user can instantiate it.
                 for entity_type_id in iter::once(base).chain(parents) {
                     let allowed = policy_components
-                        .policy_set
+                        .create_policy_set()
+                        .change_context(QueryError)?
                         .evaluate(
                             &Request {
                                 actor: policy_components.actor_id,

--- a/libs/@local/graph/store/src/filter/mod.rs
+++ b/libs/@local/graph/store/src/filter/mod.rs
@@ -781,7 +781,7 @@ mod tests {
     use type_system::{
         knowledge::entity::id::{DraftId, EntityUuid},
         ontology::data_type::{ClosedDataType, ConversionExpression},
-        principal::{actor::ActorId, actor_group::WebId},
+        principal::actor_group::WebId,
     };
     use uuid::Uuid;
 
@@ -974,7 +974,7 @@ mod tests {
             }
         }
 
-        /// Helper to extract (Effect, Option<ResourceConstraint>) tuples for Filter::for_policies
+        /// Helper to extract (Effect, Option<ResourceConstraint>) tuples for `Filter::for_policies`
         fn policy_to_tuple(policy: &Policy) -> (Effect, Option<&ResourceConstraint>) {
             (policy.effect, policy.resource.as_ref())
         }

--- a/libs/@local/graph/store/src/filter/mod.rs
+++ b/libs/@local/graph/store/src/filter/mod.rs
@@ -974,7 +974,8 @@ mod tests {
             }
         }
 
-        /// Helper to extract (Effect, Option<ResourceConstraint>) tuples for `Filter::for_policies`
+        /// Helper to extract (Effect, Option<ResourceConstraint>) tuples for
+        /// [`Filter::for_policies`]
         fn policy_to_tuple(policy: &Policy) -> (Effect, Option<&ResourceConstraint>) {
             (policy.effect, policy.resource.as_ref())
         }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR refactors the policy evaluation system to enable direct conversion from Cedar policies to database filters, setting the foundation for future policy filter optimizations. The main goal is to solve lifetime issues that were blocking OR-to-IN clause optimizations in policy-based database queries.

## 🔍 What does this change?

- **Refactor PolicyComponents structure**: Separate raw policy storage from PolicySet creation
  - `PolicyComponents` now stores `Vec<Policy>` directly instead of pre-built `PolicySet`
  - Add lazy `create_policy_set()` method that builds PolicySet only when needed for Cedar evaluation
  - Update all `PolicySet` usage sites to use the new lazy creation pattern

- **Add direct policy-to-filter conversion**: New `Filter::for_policies()` method
  - Converts policy constraints directly to database filter expressions
  - Handles permit/forbid logic correctly with proper boolean algebra
  - Supports complex policy combinations (multiple permits, forbids, blank policies)

- **Comprehensive test coverage**: Add extensive test suite for policy conversion scenarios
  - Test single permits and forbids
  - Test multiple permits (the target case for future OR-to-IN optimization)
  - Test mixed permit/forbid combinations
  - Test blank permit/forbid edge cases

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

None. This is a refactoring that maintains existing behavior while enabling future optimizations.

## 🐾 Next steps

- Implement optimization analyzer to detect `OR`-to-`IN` optimization opportunities
- Add optimization data storage to `PolicyComponents`
- Implement optimized filter generation using `IN` clauses for multiple entity permits

## 🛡 What tests cover this?

- All existing policy evaluation tests continue to pass
- New comprehensive test suite in `libs/@local/graph/store/src/filter/mod.rs` covering:
  - Single policy conversions (permit/forbid)
  - Multiple policy scenarios
  - Complex permit/forbid combinations
  - Edge cases with blank policies

## ❓ How to test this?

1. Checkout the branch
2. Run `cargo test --package hash-graph-store --lib filter::tests::policy_conversion`
3. Confirm all policy conversion tests pass
4. Run existing integration tests to ensure no regressions

## 📹 Demo

This is an internal refactoring - no user-facing changes to demonstrate.