### PR TITLE
H-4879: Improve documentation of `hash-graph-postgres-store`

### DIFF
--- a/libs/@local/graph/postgres-store/src/store/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/mod.rs
@@ -3,7 +3,7 @@ pub mod error;
 mod config;
 mod validation;
 
-pub(crate) mod postgres;
+pub mod postgres;
 
 pub use self::{
     config::{DatabaseConnectionInfo, DatabasePoolConfig, DatabaseType},

--- a/libs/@local/graph/postgres-store/src/store/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/mod.rs
@@ -3,7 +3,7 @@ pub mod error;
 mod config;
 mod validation;
 
-pub mod postgres;
+pub(crate) mod postgres;
 
 pub use self::{
     config::{DatabaseConnectionInfo, DatabasePoolConfig, DatabaseType},

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -3,7 +3,7 @@ mod knowledge;
 mod migration;
 mod ontology;
 mod pool;
-pub(crate) mod query;
+pub mod query;
 mod seed_policies;
 mod traversal_context;
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile.rs
@@ -375,6 +375,10 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
     }
 
     /// Adds a new path to the selection which can be used as cursor.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if cursors are disallowed due to other query constraints.
     #[instrument(level = "debug", skip_all)]
     pub fn add_cursor_selection(
         &mut self,
@@ -402,6 +406,10 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
     }
 
     /// Adds a new filter to the selection.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the filter compilation fails.
     #[instrument(level = "debug", skip_all)]
     pub fn add_filter(
         &mut self,
@@ -426,6 +434,10 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
     }
 
     /// Compiles a [`Filter`] to a `Condition`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the filter compilation fails.
     #[expect(clippy::too_many_lines)]
     #[instrument(level = "debug", skip_all)]
     pub fn compile_filter(

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile.rs
@@ -137,6 +137,7 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
     }
 
     /// Creates a new compiler, which will select everything using the asterisk (`*`).
+    #[must_use]
     pub fn with_asterisk(
         temporal_axes: Option<&'p QueryTemporalAxes>,
         include_drafts: bool,

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/expression/join_clause.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/expression/join_clause.rs
@@ -59,6 +59,7 @@ pub struct JoinExpression {
 }
 
 impl JoinExpression {
+    #[must_use]
     pub fn from_foreign_key(
         foreign_key_reference: ForeignKeyReference,
         on_alias: Alias,

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/expression/order_clause.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/expression/order_clause.rs
@@ -28,6 +28,7 @@ impl OrderByExpression {
         self.columns.insert(0, (expression, ordering, nulls));
     }
 
+    #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.columns.is_empty()
     }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/expression/where_clause.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/expression/where_clause.rs
@@ -32,10 +32,12 @@ impl WhereExpression {
         self.cursor.push((lhs, rhs, ordering, null_location));
     }
 
+    #[must_use]
     pub const fn len(&self) -> usize {
         self.conditions.len()
     }
 
+    #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.conditions.is_empty()
     }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/expression/with_clause.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/expression/with_clause.rs
@@ -21,10 +21,12 @@ impl WithExpression {
         });
     }
 
+    #[must_use]
     pub const fn len(&self) -> usize {
         self.common_table_expressions.len()
     }
 
+    #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.common_table_expressions.is_empty()
     }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/mod.rs
@@ -39,12 +39,12 @@ pub use self::{
     statement::{
         Distinctness, InsertStatementBuilder, SelectStatement, Statement, WindowStatement,
     },
-    table::{Alias, AliasedTable, Column, ForeignKeyReference, ReferenceTable, Table},
+    table::{
+        Alias, AliasedTable, Column, ForeignKeyReference, JsonField, ReferenceTable, Relation,
+        Table,
+    },
 };
-use crate::store::postgres::{
-    crud::QueryRecordDecode,
-    query::table::{JsonField, Relation},
-};
+use crate::store::postgres::crud::QueryRecordDecode;
 
 pub trait PostgresRecord: QueryRecord + QueryRecordDecode<Output = Self> {
     type CompilationParameters: Send + 'static;

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/mod.rs
@@ -101,7 +101,7 @@ pub trait PostgresSorting<'s, R: QueryRecord>:
 {
     type CompilationParameters: Send;
 
-    type Error: Error + Send + Sync + 'static + Send + Sync + 'static;
+    type Error: Error + Send + Sync + 'static;
 
     /// Encodes the sorting parameters for use in the query.
     ///

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/statement/insert.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/statement/insert.rs
@@ -85,6 +85,7 @@ pub struct InsertStatementBuilder<'p> {
 struct SliceWrapper<'a, T>(&'a [T]);
 
 impl<'p> InsertStatementBuilder<'p> {
+    #[must_use]
     pub fn new(table: Table) -> Self {
         Self {
             statement: InsertStatement {
@@ -97,10 +98,12 @@ impl<'p> InsertStatementBuilder<'p> {
         }
     }
 
+    #[must_use]
     pub fn compile(self) -> (String, Vec<&'p (dyn ToSql + Sync)>) {
         (self.statement.transpile_to_string(), self.parameters)
     }
 
+    #[must_use]
     pub fn with_expression(mut self, column: impl Into<Column>, expression: Expression) -> Self {
         self.add_expression(column, expression);
         self
@@ -120,6 +123,7 @@ impl<'p> InsertStatementBuilder<'p> {
         self
     }
 
+    #[must_use]
     pub fn with_value(mut self, column: impl Into<Column>, value: &'p (impl ToSql + Sync)) -> Self {
         self.add_value(column, value);
         self
@@ -134,6 +138,7 @@ impl<'p> InsertStatementBuilder<'p> {
         self.add_expression(column, Expression::Parameter(self.parameters.len()))
     }
 
+    #[must_use]
     pub fn with_row(mut self, row: &'p (impl PostgresRow + Sync)) -> Self {
         self.add_row(row);
         self
@@ -155,6 +160,7 @@ impl<'p> InsertStatementBuilder<'p> {
         self
     }
 
+    #[must_use]
     pub fn from_rows<R>(table: Table, rows: &'p Vec<R>) -> Self
     where
         R: ToSql + Sync,

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/statement/window.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/statement/window.rs
@@ -8,6 +8,7 @@ pub struct WindowStatement {
 }
 
 impl WindowStatement {
+    #[must_use]
     pub fn partition_by(expression: Expression) -> Self {
         Self {
             partition: vec![expression],

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
@@ -62,6 +62,7 @@ pub enum ReferenceTable {
 }
 
 impl ReferenceTable {
+    #[must_use]
     pub const fn inheritance_depth_column(self) -> Option<Column> {
         match self {
             Self::DataTypeInheritsFrom { inheritance_depth } => Some(Column::DataTypeInheritsFrom(
@@ -97,6 +98,7 @@ impl ReferenceTable {
         }
     }
 
+    #[must_use]
     pub const fn source_relation(self) -> ForeignKeyReference {
         match self {
             Self::DataTypeInheritsFrom { inheritance_depth } => ForeignKeyReference::Single {
@@ -189,6 +191,7 @@ impl ReferenceTable {
         }
     }
 
+    #[must_use]
     pub const fn target_relation(self) -> ForeignKeyReference {
         match self {
             Self::DataTypeInheritsFrom { inheritance_depth } => ForeignKeyReference::Single {
@@ -312,10 +315,12 @@ impl ReferenceTable {
 }
 
 impl Table {
+    #[must_use]
     pub const fn aliased(self, alias: Alias) -> AliasedTable {
         AliasedTable { table: self, alias }
     }
 
+    #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::OntologyIds => "ontology_ids",
@@ -1573,6 +1578,7 @@ impl From<EntityHasRightEntity> for Column {
 }
 
 impl Column {
+    #[must_use]
     pub const fn table(self) -> Table {
         match self {
             Self::OntologyIds(_) => Table::OntologyIds,
@@ -1630,6 +1636,7 @@ impl Column {
         }
     }
 
+    #[must_use]
     pub const fn inheritance_depth(self) -> Option<u32> {
         match self {
             Self::DataTypeInheritsFrom(_, inheritance_depth)
@@ -1642,6 +1649,7 @@ impl Column {
         }
     }
 
+    #[must_use]
     pub const fn to_expression(self, table_alias: Option<Alias>) -> Expression {
         Expression::ColumnReference {
             column: self,
@@ -1881,6 +1889,7 @@ pub enum ForeignKeyReference {
 }
 
 impl ForeignKeyReference {
+    #[must_use]
     pub const fn reverse(self) -> Self {
         match self {
             Self::Single {

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
@@ -369,6 +369,7 @@ pub enum JsonField<'p> {
 }
 
 impl<'p> JsonField<'p> {
+    #[must_use]
     pub const fn into_owned(
         self,
         current_parameter_index: usize,
@@ -1948,6 +1949,7 @@ impl Iterator for ForeignKeyJoin {
 
 impl Relation {
     #[expect(clippy::too_many_lines)]
+    #[must_use]
     pub fn joins(self) -> ForeignKeyJoin {
         match self {
             Self::OntologyIds => ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
@@ -2111,6 +2113,7 @@ impl Relation {
         }
     }
 
+    #[must_use]
     pub fn additional_conditions(self, aliased_table: AliasedTable) -> Vec<Condition> {
         match (self, aliased_table.table) {
             (Self::Reference { table, .. }, Table::Reference(reference_table))

--- a/libs/@local/graph/postgres-store/src/store/postgres/traversal_context.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/traversal_context.rs
@@ -214,6 +214,12 @@ pub struct TraversalContext {
 }
 
 impl TraversalContext {
+    /// Reads all vertices that have been marked for traversal and inserts them into the subgraph.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any of the database read operations fail or if there are issues
+    /// inserting vertices into the subgraph.
     #[tracing::instrument(level = "info", skip(self, store, subgraph))]
     pub async fn read_traversed_vertices<C: AsClient, A: Send + Sync>(
         self,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Improves the documentation of several types in `hash-graph-postgres-store`, by adding error documentation and `must_use` where required.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

