### PR TITLE
H-4891: Introduce `CreateEntity` permission and fix policy optimization logic

### DIFF
--- a/libs/@local/graph/authorization/schemas/policies.cedarschema
+++ b/libs/@local/graph/authorization/schemas/policies.cedarschema
@@ -41,6 +41,11 @@ namespace HASH {
     resource: [Entity, EntityType],
   };
 
+  action createEntity in [create] appliesTo {
+    principal: [User, Machine, Ai],
+    resource: [Web],
+  };
+
   action viewEntity in [view] appliesTo {
     principal: [User, Machine, Ai, Public],
     resource: [Entity],

--- a/libs/@local/graph/authorization/src/policies/action/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/action/mod.rs
@@ -34,6 +34,7 @@ pub enum ActionName {
 
     #[cfg_attr(feature = "codegen", specta(skip))]
     Create,
+    CreateEntity,
     CreateWeb,
 
     #[cfg_attr(feature = "codegen", specta(skip))]
@@ -60,6 +61,7 @@ impl ActionName {
             Self::Create | Self::CreateWeb | Self::View | Self::Update | Self::Instantiate => {
                 Some(Self::All)
             }
+            Self::CreateEntity => Some(Self::Create),
             Self::ViewEntity | Self::ViewEntityType => Some(Self::View),
         }
     }
@@ -352,6 +354,10 @@ mod tests {
 
         // Second level actions have their direct parent and All as ancestors
         assert_eq!(
+            ActionName::CreateEntity.parents().collect::<Vec<_>>(),
+            vec![ActionName::Create, ActionName::All]
+        );
+        assert_eq!(
             ActionName::ViewEntity.parents().collect::<Vec<_>>(),
             vec![ActionName::View, ActionName::All]
         );
@@ -363,6 +369,9 @@ mod tests {
 
     #[test]
     fn is_parent_of() {
+        // Create is parent of CreateEntity
+        assert!(ActionName::Create.is_parent_of(ActionName::CreateEntity));
+
         // View is parent of ViewEntity and ViewEntityType
         assert!(ActionName::View.is_parent_of(ActionName::ViewEntity));
         assert!(ActionName::View.is_parent_of(ActionName::ViewEntityType));
@@ -372,10 +381,14 @@ mod tests {
         assert!(!ActionName::View.is_parent_of(ActionName::Create));
         assert!(!ActionName::All.is_parent_of(ActionName::All));
         assert!(!ActionName::ViewEntity.is_parent_of(ActionName::View));
+        assert!(!ActionName::CreateEntity.is_parent_of(ActionName::Create));
     }
 
     #[test]
     fn is_child_of() {
+        // CreateEntity is child of Create
+        assert!(ActionName::CreateEntity.is_child_of(ActionName::Create));
+
         // ViewEntity and ViewEntityType are children of View
         assert!(ActionName::ViewEntity.is_child_of(ActionName::View));
         assert!(ActionName::ViewEntityType.is_child_of(ActionName::View));
@@ -385,5 +398,6 @@ mod tests {
         assert!(!ActionName::Create.is_child_of(ActionName::View));
         assert!(!ActionName::All.is_child_of(ActionName::All));
         assert!(!ActionName::View.is_child_of(ActionName::ViewEntity));
+        assert!(!ActionName::Create.is_child_of(ActionName::CreateEntity));
     }
 }

--- a/libs/@local/graph/authorization/src/policies/components.rs
+++ b/libs/@local/graph/authorization/src/policies/components.rs
@@ -1,5 +1,5 @@
 use alloc::borrow::Cow;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use error_stack::{Report, ResultExt as _};
 use type_system::{
@@ -28,21 +28,12 @@ pub struct OptimizationData {
     pub permitted_web_ids: Vec<WebId>,
 }
 
-impl OptimizationData {
-    /// Returns true if any optimization opportunities were found.
-    #[must_use]
-    pub const fn has_optimizations(&self) -> bool {
-        !self.permitted_entity_uuids.is_empty() || !self.permitted_web_ids.is_empty()
-    }
-}
-
 #[derive(Debug)]
 pub struct PolicyComponents {
     actor_id: Option<ActorId>,
     policies: Vec<Policy>,
-    tracked_actions: HashSet<ActionName>,
+    tracked_actions: HashMap<ActionName, Option<OptimizationData>>,
     context: Context,
-    optimization_data: OptimizationData,
 }
 
 impl PolicyComponents {
@@ -63,21 +54,6 @@ impl PolicyComponents {
         &self.context
     }
 
-    /// Returns a reference to the policies for direct access.
-    ///
-    /// This is primarily used for filter optimization where the raw policies
-    /// need to be analyzed without building a full [`PolicySet`].
-    #[must_use]
-    pub fn policies(&self) -> &[Policy] {
-        &self.policies
-    }
-
-    /// Returns a reference to the tracked actions.
-    #[must_use]
-    pub const fn tracked_actions(&self) -> &HashSet<ActionName> {
-        &self.tracked_actions
-    }
-
     /// Extracts policy data suitable for database filter creation.
     ///
     /// This method returns an iterator of `(Effect, Option<&ResourceConstraint>)` tuples
@@ -89,7 +65,7 @@ impl PolicyComponents {
         action: ActionName,
     ) -> impl Iterator<Item = (Effect, Option<&ResourceConstraint>)> {
         debug_assert!(
-            self.tracked_actions.contains(&action),
+            self.tracked_actions.contains_key(&action),
             "action `{}` not tracked",
             action.to_string()
         );
@@ -108,8 +84,27 @@ impl PolicyComponents {
     /// `entity_uuid = a OR entity_uuid = b OR entity_uuid = c`
     /// to: `entity_uuid = ANY([a, b, c])`
     #[must_use]
-    pub const fn optimization_data(&self) -> &OptimizationData {
-        &self.optimization_data
+    pub fn optimization_data(&self, action: ActionName) -> &OptimizationData {
+        const EMPTY_OPTIMIZATION_DATA: &OptimizationData = &OptimizationData {
+            permitted_entity_uuids: Vec::new(),
+            permitted_web_ids: Vec::new(),
+        };
+
+        self.tracked_actions
+            .get(&action)
+            .unwrap_or_else(|| {
+                unreachable!("Action `{action}` is not tracked in this `PolicyComponents`")
+            })
+            .as_ref()
+            .unwrap_or_else(|| {
+                if cfg!(debug_assertions) {
+                    unreachable!("Action `{action}` is not optimized in this `PolicyComponents`")
+                }
+
+                tracing::warn!("No optimization data for action `{action}`");
+
+                EMPTY_OPTIMIZATION_DATA
+            })
     }
 
     /// Analyzes policies and extracts optimization opportunities.
@@ -127,13 +122,19 @@ impl PolicyComponents {
     /// - Multiple exact entity permits that can be converted to IN clauses
     /// - Multiple web resource permits that can be converted to IN clauses
     #[tracing::instrument(level = "info", skip(self))]
-    fn analyze_optimization_opportunities(&mut self) {
+    fn analyze_optimization_opportunities(&mut self, action: ActionName) {
         let mut entity_uuids_set = HashSet::new();
         let mut web_ids_set = HashSet::new();
 
         let mut i = 0;
         while i < self.policies.len() {
-            let should_extract = match (&self.policies[i].effect, &self.policies[i].resource) {
+            let policy = &mut self.policies[i];
+            if !policy.actions.contains(&action) {
+                i += 1;
+                continue;
+            }
+
+            let should_extract = match (policy.effect, &policy.resource) {
                 (
                     Effect::Permit,
                     Some(ResourceConstraint::Entity(EntityResourceConstraint::Exact { id })),
@@ -149,16 +150,29 @@ impl PolicyComponents {
             };
 
             if should_extract {
-                self.policies.swap_remove(i);
-                // Don't increment i since we just moved the last element to position i
+                // The policy matches the action and is optimizable, so we extract it from the
+                // policies vec.
+                policy.actions.retain(|&x| x != action);
+                if policy.actions.is_empty() {
+                    // If no actions remain, remove the policy
+                    self.policies.swap_remove(i);
+                } else {
+                    // Otherwise, keep the policy but remove the action
+                    i += 1;
+                }
             } else {
                 i += 1;
             }
         }
 
         // Convert HashSets to Vecs for efficient filter usage
-        self.optimization_data.permitted_entity_uuids = entity_uuids_set.into_iter().collect();
-        self.optimization_data.permitted_web_ids = web_ids_set.into_iter().collect();
+        self.tracked_actions
+            .entry(action)
+            .or_default()
+            .replace(OptimizationData {
+                permitted_entity_uuids: entity_uuids_set.into_iter().collect(),
+                permitted_web_ids: web_ids_set.into_iter().collect(),
+            });
     }
 
     /// Builds a [`PolicySet`] for Cedar evaluation.
@@ -171,21 +185,46 @@ impl PolicyComponents {
     /// # Errors
     ///
     /// Returns error if policy set creation fails or if optimization has occurred.
-    #[tracing::instrument(level = "info", skip(self))]
+    #[tracing::instrument(level = "info", skip(self, actions))]
     pub fn build_policy_set(
         &self,
+        actions: impl IntoIterator<Item = ActionName>,
     ) -> Result<PolicySet, Report<super::set::PolicySetInsertionError>> {
-        if self.optimization_data.has_optimizations() {
-            return Err(
-                Report::new(super::set::PolicySetInsertionError).attach_printable(
-                    "Cannot create PolicySet when optimization has occurred. Extracted policies \
-                     are missing proper action tracking. Use filter creation methods instead.",
-                ),
-            );
+        let tracked_actions = actions.into_iter().collect::<HashSet<_>>();
+        for action in &tracked_actions {
+            if let Some(optimization_data) = self.tracked_actions.get(action) {
+                if optimization_data.is_some() {
+                    return Err(
+                        Report::new(super::set::PolicySetInsertionError).attach_printable(format!(
+                            "Action `{action}` has been optimized and cannot be used to create a \
+                             `PolicySet`"
+                        )),
+                    );
+                }
+            } else {
+                return Err(
+                    Report::new(super::set::PolicySetInsertionError).attach_printable(format!(
+                        "Action `{action}` is not tracked in this `PolicyComponents`"
+                    )),
+                );
+            }
         }
 
+        // Note: We don't need to filter policies by actions here because the PolicySet
+        // only evaluates actions that are in `tracked_actions`. Including all policies
+        // is safe since untracked actions won't be evaluated anyway.
+        //
+        // Optional performance optimization: Filter policies to reduce PolicySet size:
+        // ```
+        // .with_policies(
+        //     &self.policies
+        //         .iter()
+        //         .filter(|p| p.actions.iter().any(|a| tracked_actions.contains(a)))
+        //         .collect::<Vec<_>>()
+        // )
+        // ```
         PolicySet::default()
-            .with_tracked_actions(self.tracked_actions.clone())
+            .with_tracked_actions(tracked_actions)
             .with_policies(&self.policies)
     }
 }
@@ -196,8 +235,8 @@ pub struct PolicyComponentsBuilder<'a, S> {
     context: ContextBuilder,
     entity_type_ids: HashSet<Cow<'a, VersionedUrl>>,
     entity_edition_ids: HashSet<EntityEditionId>,
-    actions: HashSet<ActionName>,
-    enable_optimization: bool,
+    /// Actions to track, with optimization flag.
+    actions: HashMap<ActionName, bool>,
 }
 
 impl<'a, S> PolicyComponentsBuilder<'a, S> {
@@ -209,8 +248,7 @@ impl<'a, S> PolicyComponentsBuilder<'a, S> {
             context: ContextBuilder::default(),
             entity_type_ids: HashSet::new(),
             entity_edition_ids: HashSet::new(),
-            actions: HashSet::new(),
-            enable_optimization: true, // Default to optimization enabled (opt-out)
+            actions: HashMap::new(),
         }
     }
 
@@ -274,39 +312,28 @@ impl<'a, S> PolicyComponentsBuilder<'a, S> {
         self
     }
 
-    pub fn add_action(&mut self, action: ActionName) {
-        self.actions.insert(action);
+    pub fn add_action(&mut self, action: ActionName, optimize: bool) {
+        self.actions.insert(action, optimize);
     }
 
-    pub fn add_actions(&mut self, actions: impl IntoIterator<Item = ActionName>) {
-        self.actions.extend(actions);
+    pub fn add_actions(&mut self, actions: impl IntoIterator<Item = ActionName>, optimize: bool) {
+        self.actions
+            .extend(actions.into_iter().map(|action| (action, optimize)));
     }
 
     #[must_use]
-    pub fn with_action(mut self, action: ActionName) -> Self {
-        self.add_action(action);
+    pub fn with_action(mut self, action: ActionName, optimize: bool) -> Self {
+        self.add_action(action, optimize);
         self
     }
 
     #[must_use]
-    pub fn with_actions(mut self, actions: impl IntoIterator<Item = ActionName>) -> Self {
-        self.add_actions(actions);
-        self
-    }
-
-    pub const fn set_optimization_enabled(&mut self, enabled: bool) {
-        self.enable_optimization = enabled;
-    }
-
-    #[must_use]
-    pub const fn with_optimization_enabled(mut self, enabled: bool) -> Self {
-        self.set_optimization_enabled(enabled);
-        self
-    }
-
-    #[must_use]
-    pub const fn without_optimization(mut self) -> Self {
-        self.set_optimization_enabled(false);
+    pub fn with_actions(
+        mut self,
+        actions: impl IntoIterator<Item = ActionName>,
+        optimize: bool,
+    ) -> Self {
+        self.add_actions(actions, optimize);
         self
     }
 }
@@ -375,7 +402,7 @@ where
                 }
             }
 
-            let actions = self.actions.iter().copied().collect::<Vec<_>>();
+            let actions = self.actions.keys().copied().collect::<Vec<_>>();
             let policies = if actions.is_empty() {
                 Vec::new()
             } else {
@@ -394,17 +421,18 @@ where
             let mut policy_components = PolicyComponents {
                 actor_id,
                 policies,
-                tracked_actions: self.actions,
+                tracked_actions: actions.iter().map(|action| (*action, None)).collect(),
                 context: self
                     .context
                     .build()
                     .change_context(ContextCreationError::CreatePolicyContext)?,
-                optimization_data: OptimizationData::default(),
             };
 
             // Analyze for optimization opportunities if enabled
-            if self.enable_optimization {
-                policy_components.analyze_optimization_opportunities();
+            for (action, optimize) in &self.actions {
+                if *optimize {
+                    policy_components.analyze_optimization_opportunities(*action);
+                }
             }
 
             Ok(policy_components)
@@ -414,12 +442,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::collections::HashMap;
 
     use type_system::{knowledge::entity::id::EntityUuid, principal::actor::ActorId};
     use uuid::Uuid;
 
-    use super::{OptimizationData, PolicyComponents};
+    use super::PolicyComponents;
     use crate::policies::{
         Context, Effect, Policy, PolicyId,
         action::ActionName,
@@ -440,32 +468,6 @@ mod tests {
         }
     }
 
-    /// Tests that default [`OptimizationData`] has no optimizations.
-    #[test]
-    fn optimization_data_empty_by_default() {
-        let optimization_data = OptimizationData::default();
-        assert!(
-            !optimization_data.has_optimizations(),
-            "should have no optimizations when empty"
-        );
-    }
-
-    /// Tests that [`OptimizationData`] detects optimizations when entity UUIDs are present.
-    #[test]
-    fn optimization_data_detects_entity_optimizations() {
-        let mut optimization_data = OptimizationData::default();
-        optimization_data
-            .permitted_entity_uuids
-            .push(EntityUuid::new(Uuid::new_v4()));
-        optimization_data
-            .permitted_entity_uuids
-            .push(EntityUuid::new(Uuid::new_v4()));
-        assert!(
-            optimization_data.has_optimizations(),
-            "should detect optimizations when entity UUIDs present"
-        );
-    }
-
     /// Tests that [`PolicySet`] creation is prevented after optimization.
     ///
     /// Verifies that optimization analysis makes [`PolicySet`] unavailable to prevent
@@ -483,19 +485,18 @@ mod tests {
         let mut policy_components = PolicyComponents {
             actor_id: None,
             policies,
-            tracked_actions: HashSet::new(),
+            tracked_actions: HashMap::new(),
             context: Context::default(),
-            optimization_data: OptimizationData::default(),
         };
 
-        let result_before = policy_components.build_policy_set();
+        let result_before = policy_components.build_policy_set([ActionName::View]);
         assert!(
             result_before.is_ok(),
             "should allow PolicySet creation before optimization"
         );
 
-        policy_components.analyze_optimization_opportunities();
-        let result_after = policy_components.build_policy_set();
+        policy_components.analyze_optimization_opportunities(ActionName::View);
+        let result_after = policy_components.build_policy_set([ActionName::View]);
         assert!(
             result_after.is_err(),
             "should prevent PolicySet creation after optimization"
@@ -532,19 +533,17 @@ mod tests {
         let policy_components_without_optimization = PolicyComponents {
             actor_id: None,
             policies: policies_without_optimization,
-            tracked_actions: HashSet::new(),
+            tracked_actions: HashMap::new(),
             context: Context::default(),
-            optimization_data: OptimizationData::default(),
         };
 
         assert!(
-            !policy_components_without_optimization
-                .optimization_data
-                .has_optimizations(),
+            policy_components_without_optimization.tracked_actions[&ActionName::View].is_none(),
             "should have no optimizations initially"
         );
 
-        let policy_set_result = policy_components_without_optimization.build_policy_set();
+        let policy_set_result =
+            policy_components_without_optimization.build_policy_set([ActionName::View]);
         assert!(
             policy_set_result.is_ok(),
             "should allow PolicySet creation when optimization disabled"
@@ -558,20 +557,18 @@ mod tests {
         let mut policy_components_with_optimization = PolicyComponents {
             actor_id: None,
             policies: policies_with_optimization,
-            tracked_actions: HashSet::new(),
+            tracked_actions: HashMap::new(),
             context: Context::default(),
-            optimization_data: OptimizationData::default(),
         };
 
-        policy_components_with_optimization.analyze_optimization_opportunities();
+        policy_components_with_optimization.analyze_optimization_opportunities(ActionName::View);
         assert!(
-            policy_components_with_optimization
-                .optimization_data
-                .has_optimizations(),
+            policy_components_with_optimization.tracked_actions[&ActionName::View].is_some(),
             "should detect optimizations"
         );
 
-        let policy_set_result = policy_components_with_optimization.build_policy_set();
+        let policy_set_result =
+            policy_components_with_optimization.build_policy_set([ActionName::View]);
         assert!(
             policy_set_result.is_err(),
             "should prevent PolicySet creation when optimization enabled"
@@ -592,9 +589,8 @@ mod tests {
                 Uuid::new_v4(),
             ))),
             policies: vec![policy],
-            tracked_actions: HashSet::from([ActionName::View]),
+            tracked_actions: HashMap::from([(ActionName::View, None)]),
             context: Context::default(),
-            optimization_data: OptimizationData::default(),
         };
 
         let filter_policies: Vec<_> = policy_components

--- a/libs/@local/graph/authorization/src/policies/components.rs
+++ b/libs/@local/graph/authorization/src/policies/components.rs
@@ -485,7 +485,7 @@ mod tests {
         let mut policy_components = PolicyComponents {
             actor_id: None,
             policies,
-            tracked_actions: HashMap::new(),
+            tracked_actions: HashMap::from([(ActionName::View, None)]),
             context: Context::default(),
         };
 
@@ -511,8 +511,10 @@ mod tests {
             "should show basic error message"
         );
         assert!(
-            debug_message.contains("Cannot create PolicySet when optimization has occurred"),
-            "should include detailed error information"
+            debug_message.contains(
+                "Action `view` has been optimized and cannot be used to create a `PolicySet`"
+            ),
+            "should include detailed error information",
         );
     }
 
@@ -533,7 +535,7 @@ mod tests {
         let policy_components_without_optimization = PolicyComponents {
             actor_id: None,
             policies: policies_without_optimization,
-            tracked_actions: HashMap::new(),
+            tracked_actions: HashMap::from([(ActionName::View, None)]),
             context: Context::default(),
         };
 

--- a/libs/@local/graph/authorization/src/policies/components.rs
+++ b/libs/@local/graph/authorization/src/policies/components.rs
@@ -312,21 +312,57 @@ impl<'a, S> PolicyComponentsBuilder<'a, S> {
         self
     }
 
+    /// Adds an action to be tracked during policy resolution.
+    ///
+    /// The `action` will be included in policy queries and evaluation. The `optimize`
+    /// parameter controls whether this action undergoes optimization analysis, which
+    /// can improve database query performance by extracting optimizable policies.
+    ///
+    /// When `optimize` is `true`, the resulting [`PolicyComponents`] cannot be used
+    /// to create a [`PolicySet`] for this action, as optimizable policies are
+    /// extracted during analysis.
     pub fn add_action(&mut self, action: ActionName, optimize: bool) {
         self.actions.insert(action, optimize);
     }
 
+    /// Adds multiple actions to be tracked during policy resolution.
+    ///
+    /// All provided `actions` will be included in policy queries and evaluation.
+    /// The `optimize` parameter applies to all actions and controls whether they
+    /// undergo optimization analysis for improved database query performance.
+    ///
+    /// When `optimize` is `true`, the resulting [`PolicyComponents`] cannot be used
+    /// to create a [`PolicySet`] for any of these actions, as optimizable policies
+    /// are extracted during analysis.
     pub fn add_actions(&mut self, actions: impl IntoIterator<Item = ActionName>, optimize: bool) {
         self.actions
             .extend(actions.into_iter().map(|action| (action, optimize)));
     }
 
+    /// Adds an action to be tracked and returns the builder.
+    ///
+    /// The `action` will be included in policy queries and evaluation. The `optimize`
+    /// parameter controls whether this action undergoes optimization analysis, which
+    /// can improve database query performance by extracting optimizable policies.
+    ///
+    /// When `optimize` is `true`, the resulting [`PolicyComponents`] cannot be used
+    /// to create a [`PolicySet`] for this action, as optimizable policies are
+    /// extracted during analysis.
     #[must_use]
     pub fn with_action(mut self, action: ActionName, optimize: bool) -> Self {
         self.add_action(action, optimize);
         self
     }
 
+    /// Adds multiple actions to be tracked and returns the builder.
+    ///
+    /// All provided `actions` will be included in policy queries and evaluation.
+    /// The `optimize` parameter applies to all actions and controls whether they
+    /// undergo optimization analysis for improved database query performance.
+    ///
+    /// When `optimize` is `true`, the resulting [`PolicyComponents`] cannot be used
+    /// to create a [`PolicySet`] for any of these actions, as optimizable policies
+    /// are extracted during analysis.
     #[must_use]
     pub fn with_actions(
         mut self,

--- a/libs/@local/graph/authorization/types/index.snap.d.ts
+++ b/libs/@local/graph/authorization/types/index.snap.d.ts
@@ -13,7 +13,7 @@ export interface Policy {
 }
 import type { Brand } from "@local/advanced-types/brand";
 export type PolicyId = Brand<string, "PolicyId">;
-export type ActionName = "createWeb" | "viewEntity" | "instantiate";
+export type ActionName = "createEntity" | "createWeb" | "viewEntity" | "instantiate";
 export type PrincipalConstraint = {
 	type: "actor"
 } & ActorId | {

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -15,7 +15,7 @@ use hash_graph_authorization::{
         resource::{EntityResourceConstraint, ResourceConstraint},
         store::{PolicyCreationParams, PolicyStore as _},
     },
-    schema::{EntityOwnerSubject, EntityPermission, EntityRelationAndSubject, WebPermission},
+    schema::{EntityOwnerSubject, EntityPermission, EntityRelationAndSubject},
     zanzibar::Consistency,
 };
 use hash_graph_store::{
@@ -406,7 +406,7 @@ where
         let policy_filter = Filter::for_policies(
             policy_components.extract_filter_policies(ActionName::ViewEntity),
             policy_components.actor_id(),
-            policy_components.optimization_data(),
+            policy_components.optimization_data(ActionName::ViewEntity),
         );
 
         let mut compiler = SelectCompiler::new(Some(temporal_axes), params.include_drafts);
@@ -741,8 +741,9 @@ where
                     .flat_map(|params| &params.entity_type_ids)
                     .collect::<HashSet<_>>(),
             )
-            .with_action(ActionName::Instantiate)
-            .with_action(ActionName::ViewEntity) // for validation
+            .with_action(ActionName::Instantiate, false)
+            .with_action(ActionName::CreateEntity,  false) // for entity creation authorization
+            .with_action(ActionName::ViewEntity, true) // for validation
             .await
             .change_context(InsertionError)?;
 
@@ -954,11 +955,13 @@ where
             );
         }
 
+        let policy_set = policy_components
+            .build_policy_set([ActionName::Instantiate, ActionName::CreateEntity])
+            .change_context(InsertionError)?;
+
         let mut forbidden_instantiations = Vec::new();
         for entity_type_id in &entity_type_id_set {
-            match policy_components
-                .build_policy_set()
-                .change_context(InsertionError)?
+            match policy_set
                 .evaluate(
                     &Request {
                         actor: policy_components.actor_id(),
@@ -992,40 +995,41 @@ where
                 ));
         }
 
-        if !checked_web_ids.is_empty() {
-            let (create_entity_permissions, _zookie) = transaction
-                .authorization_api
-                .check_webs_permission(
-                    actor_id,
-                    WebPermission::CreateEntity,
-                    checked_web_ids,
-                    Consistency::FullyConsistent,
-                )
-                .await
-                .change_context(InsertionError)?;
-            let forbidden_webs = create_entity_permissions
-                .iter()
-                .filter_map(
-                    |(web_id, permission)| {
-                        if *permission { None } else { Some(web_id) }
+        // Cedar authorization check for entity creation (per web)
+        let mut forbidden_web_creations = Vec::new();
+        for web_id in &checked_web_ids {
+            match policy_set
+                .evaluate(
+                    &Request {
+                        actor: policy_components.actor_id(),
+                        action: ActionName::CreateEntity,
+                        resource: &ResourceId::Web(*web_id),
+                        context: RequestContext::default(),
                     },
+                    policy_components.context(),
                 )
-                .collect::<Vec<_>>();
-            if !forbidden_webs.is_empty() {
-                return Err(Report::new(InsertionError)
-                    .attach(StatusCode::PermissionDenied)
-                    .attach_printable(
-                        "The actor does not have permission to create entities for one or more \
-                         web ids",
-                    )
-                    .attach_printable(
-                        forbidden_webs
-                            .into_iter()
-                            .map(ToString::to_string)
-                            .collect::<Vec<_>>()
-                            .join(", "),
-                    ));
+                .change_context(InsertionError)?
+            {
+                Authorized::Always => {}
+                Authorized::Never => {
+                    forbidden_web_creations.push(web_id);
+                }
             }
+        }
+
+        if !forbidden_web_creations.is_empty() {
+            return Err(Report::new(InsertionError)
+                .attach(StatusCode::PermissionDenied)
+                .attach_printable(
+                    "The actor does not have permission to create entities in one or more webs",
+                )
+                .attach_printable(
+                    forbidden_web_creations
+                        .into_iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                ));
         }
 
         let insertions = [
@@ -1163,7 +1167,7 @@ where
     ) -> Result<HashMap<usize, EntityValidationReport>, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
-            .with_action(ActionName::ViewEntity) // for validation
+            .with_action(ActionName::ViewEntity, true) // for validation
             .await
             .change_context(QueryError)?;
 
@@ -1250,7 +1254,7 @@ where
     ) -> Result<GetEntitiesResponse<'static>, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
-            .with_action(ActionName::ViewEntity)
+            .with_action(ActionName::ViewEntity, true)
             .await
             .change_context(QueryError)?;
 
@@ -1304,7 +1308,7 @@ where
     ) -> Result<GetEntitySubgraphResponse<'static>, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
-            .with_action(ActionName::ViewEntity)
+            .with_action(ActionName::ViewEntity, true)
             .into_future()
             .await
             .change_context(QueryError)?;
@@ -1484,7 +1488,7 @@ where
     ) -> Result<usize, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
-            .with_action(ActionName::ViewEntity)
+            .with_action(ActionName::ViewEntity, true)
             .await
             .change_context(QueryError)?;
 
@@ -1499,7 +1503,7 @@ where
         let policy_filter = Filter::for_policies(
             policy_components.extract_filter_policies(ActionName::ViewEntity),
             policy_components.actor_id(),
-            policy_components.optimization_data(),
+            policy_components.optimization_data(ActionName::ViewEntity),
         );
 
         let temporal_axes = params.temporal_axes.resolve();
@@ -1536,7 +1540,7 @@ where
     ) -> Result<Entity, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
-            .with_action(ActionName::ViewEntity)
+            .with_action(ActionName::ViewEntity, true)
             .await
             .change_context(QueryError)?;
 
@@ -1545,7 +1549,7 @@ where
         let filter = Filter::for_policies(
             policy_components.extract_filter_policies(ActionName::ViewEntity),
             policy_components.actor_id(),
-            policy_components.optimization_data(),
+            policy_components.optimization_data(ActionName::ViewEntity),
         );
         filters.push(filter);
 
@@ -1639,8 +1643,8 @@ where
             .with_actor(actor_id)
             .with_entity_edition_id(previous_entity.metadata.record_id.edition_id)
             .with_entity_type_ids(&params.entity_type_ids)
-            .with_action(ActionName::Instantiate)
-            .with_action(ActionName::ViewEntity) // for validation
+            .with_action(ActionName::Instantiate, false)
+            .with_action(ActionName::ViewEntity, true) // for validation
             .await
             .change_context(UpdateError)?;
 
@@ -1701,12 +1705,14 @@ where
             )
         };
 
+        let policy_set = policy_components
+            .build_policy_set([ActionName::Instantiate])
+            .change_context(UpdateError)?;
+
         if !affected_type_ids.is_empty() {
             let mut forbidden_instantiations = Vec::new();
             for entity_type_id in &affected_type_ids {
-                match policy_components
-                    .build_policy_set()
-                    .change_context(UpdateError)?
+                match policy_set
                     .evaluate(
                         &Request {
                             actor: policy_components.actor_id(),

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/read.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/read.rs
@@ -339,7 +339,7 @@ where
                 let permission_filter = Filter::for_policies(
                     policy_components.extract_filter_policies(ActionName::ViewEntity),
                     policy_components.actor_id(),
-                    policy_components.optimization_data(),
+                    policy_components.optimization_data(ActionName::ViewEntity),
                 );
                 compiler
                     .add_filter(&permission_filter)

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -262,14 +262,14 @@ where
     ) -> Result<CreateWebResponse, Report<WebCreationError>> {
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor)
-            .with_action(ActionName::CreateWeb)
+            .with_action(ActionName::CreateWeb, false)
             .await
             .change_context(WebCreationError::BuildPolicyComponents)?;
 
         let web_id = WebId::new(parameter.id.unwrap_or_else(Uuid::new_v4));
 
         match policy_components
-            .build_policy_set()
+            .build_policy_set([ActionName::CreateWeb])
             .change_context(WebCreationError::PolicySetCreation)?
             .evaluate(
                 &Request {

--- a/libs/@local/graph/postgres-store/src/store/postgres/seed_policies.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/seed_policies.rs
@@ -275,9 +275,26 @@ fn web_view_entity_policies(role: &WebRole) -> impl Iterator<Item = PolicyCreati
     })
 }
 
+fn web_create_entity_policies(role: &WebRole) -> impl Iterator<Item = PolicyCreationParams> {
+    iter::once(PolicyCreationParams {
+        name: Some("default-web-create-entity".to_owned()),
+        effect: Effect::Permit,
+        principal: Some(PrincipalConstraint::Role {
+            role: RoleId::Web(role.id),
+            actor_type: None,
+        }),
+        actions: vec![ActionName::CreateEntity],
+        resource: Some(ResourceConstraint::Web {
+            web_id: role.web_id,
+        }),
+    })
+}
+
 // TODO: Returning an iterator causes a borrow checker error
 pub(crate) fn web_policies(role: &WebRole) -> Vec<PolicyCreationParams> {
-    web_view_entity_policies(role).collect()
+    web_view_entity_policies(role)
+        .chain(web_create_entity_policies(role))
+        .collect()
 }
 
 fn instance_admins_view_entity_policy(

--- a/libs/@local/graph/postgres-store/src/store/validation.rs
+++ b/libs/@local/graph/postgres-store/src/store/validation.rs
@@ -615,7 +615,7 @@ where
             let filter = Filter::for_policies(
                 policy_components.extract_filter_policies(ActionName::ViewEntity),
                 policy_components.actor_id(),
-                policy_components.optimization_data(),
+                policy_components.optimization_data(ActionName::ViewEntity),
             );
             filters.push(filter);
         }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR implements Cedar-based authorization for entity creation by introducing the `CreateEntity` action. Previously, entity creation authorization was handled through Zanzibar permissions, but as part of the migration to Cedar-based authorization, we now have a dedicated Cedar action that provides more granular and consistent authorization control for entity creation operations.

## 🔍 What does this change?

- **Adds `CreateEntity` Cedar action**: New action in the Cedar schema that inherits from `Create` and applies to Web resources
- **Implements per-action optimization**: Refactors `PolicyComponents` to support per-action optimization instead of global optimization, allowing selective optimization of different actions
- **Updates entity creation authorization**: Replaces Zanzibar-based entity creation checks with Cedar-based authorization using the new `CreateEntity` action
- **Adds default policies**: Creates default policies in `seed_policies.rs` that grant `CreateEntity` permission to web members and administrators
- **Removes legacy Zanzibar code**: Eliminates the unused `WebPermission::CreateEntity` checks and related imports
- **Improves PolicyComponents flexibility**: Builder now accepts `optimize: bool` parameter per action, enabling fine-grained control over which actions get optimized
- **Fixes action filtering bug**: Ensures `analyze_optimization_opportunities` properly filters policies by the target action
- **Updates documentation**: Clarifies the relationship between policy filtering and PolicySet evaluation

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- None

## 🐾 Next steps

- Continue migration of other Zanzibar permissions to Cedar actions
- Monitor performance impact of the new authorization flow
- Consider implementing the optional policy filtering optimization in `build_policy_set` if needed for performance

## 🛡 What tests cover this?

- Existing Cedar action hierarchy tests cover the new `CreateEntity` action
- Updated unit tests for `PolicyComponents` per-action optimization
- Integration tests for entity creation flow continue to work with Cedar authorization
- Policy validation tests ensure Cedar schema correctness

## ❓ How to test this?

1. Checkout the branch
2. Run the entity creation tests: `cargo test --package hash-graph-postgres-store entity`
3. Verify that entity creation still works for authorized users
4. Confirm that unauthorized users are properly blocked from creating entities
5. Test the authorization in different web contexts

## 📹 Demo

Entity creation authorization now uses Cedar policies instead of Zanzibar permissions, providing more consistent and maintainable authorization decisions across the platform.
