### PR TITLE
H-4882, H-4883, H-4897: HashQL: Save the name of the opaque type in the HIR

### DIFF
--- a/libs/@local/hashql/hir/src/lower/ctor.rs
+++ b/libs/@local/hashql/hir/src/lower/ctor.rs
@@ -9,6 +9,7 @@ use hashql_core::{
         locals::{TypeDef, TypeLocals},
     },
     span::{SpanId, Spanned},
+    symbol::Symbol,
     r#type::{
         TypeBuilder, TypeId,
         environment::{Environment, instantiate::InstantiateEnvironment},
@@ -100,7 +101,7 @@ impl<'heap> ConvertTypeConstructor<'_, 'heap> {
         span: SpanId,
         opaque_id: TypeId,
         generics: GenericArguments<'heap>,
-    ) -> TypeId {
+    ) -> (Symbol<'heap>, TypeId) {
         let opaque = self
             .environment
             .r#type(opaque_id)
@@ -132,7 +133,7 @@ impl<'heap> ConvertTypeConstructor<'_, 'heap> {
             closure = builder.generic(generics, closure);
         }
 
-        closure
+        (opaque.name, closure)
     }
 
     fn apply_generics(
@@ -140,6 +141,7 @@ impl<'heap> ConvertTypeConstructor<'_, 'heap> {
         node: &Node<'heap>,
         variable: &Variable<'heap>,
         closure_def: TypeDef<'heap>,
+        name: Symbol<'heap>,
         generic_arguments: Interned<'heap, [Spanned<TypeId>]>,
     ) -> Option<Node<'heap>> {
         let make = |constructor| PartialNode {
@@ -157,6 +159,7 @@ impl<'heap> ConvertTypeConstructor<'_, 'heap> {
             // We're done here, as we don't need to apply anything
             return Some(self.interner.intern_node(make(TypeConstructor {
                 span: variable.span,
+                name,
                 closure: closure_def.id,
                 arguments: closure_def.arguments,
             })));
@@ -196,6 +199,7 @@ impl<'heap> ConvertTypeConstructor<'_, 'heap> {
         // unused and unique, we don't need to α-rename again.
         Some(self.interner.intern_node(make(TypeConstructor {
             span: variable.span,
+            name,
             closure: closure_id,
             arguments: self.environment.intern_generic_argument_references(&[]),
         })))
@@ -229,14 +233,14 @@ impl<'heap> ConvertTypeConstructor<'_, 'heap> {
             opaque_id = generic.base;
         }
 
-        let closure = self.build_closure(variable.span, opaque_id, generic_parameters);
+        let (name, closure) = self.build_closure(variable.span, opaque_id, generic_parameters);
         let mut closure_def = TypeDef {
             id: closure,
             arguments: generic_references,
         };
         closure_def.instantiate(&mut self.instantiate);
 
-        self.apply_generics(node, variable, closure_def, generic_arguments)
+        self.apply_generics(node, variable, closure_def, name, generic_arguments)
     }
 }
 

--- a/libs/@local/hashql/hir/src/lower/mod.rs
+++ b/libs/@local/hashql/hir/src/lower/mod.rs
@@ -1,6 +1,83 @@
+use hashql_ast::lowering::ExtractedTypes;
+use hashql_core::{module::ModuleRegistry, r#type::environment::Environment};
+
+use self::{
+    alias::AliasReplacement,
+    checking::TypeChecking,
+    ctor::ConvertTypeConstructor,
+    error::{LoweringDiagnostic, LoweringDiagnosticCategory},
+    inference::TypeInference,
+    specialization::Specialization,
+};
+use crate::{fold::Fold as _, intern::Interner, node::Node, visit::Visitor as _};
+
 pub mod alias;
 pub mod checking;
 pub mod ctor;
 pub mod error;
 pub mod inference;
 pub mod specialization;
+
+/// Lowers the given node by performing different phases.
+///
+/// This will set the "substitution" field of the environment given.
+///
+/// # Errors
+///
+/// Returns a vector of `LoweringDiagnostic` if any errors occurred during lowering.
+///
+/// The vector is guaranteed to be non-empty.
+pub fn lower<'heap>(
+    node: Node<'heap>,
+    types: &ExtractedTypes<'heap>,
+    env: &mut Environment<'heap>,
+    registry: &ModuleRegistry<'heap>,
+    interner: &Interner<'heap>,
+) -> Result<Node<'heap>, Vec<LoweringDiagnostic>> {
+    let mut replacement = AliasReplacement::new(interner);
+    let Ok(node) = replacement.fold_node(node);
+
+    let mut converter = ConvertTypeConstructor::new(interner, &types.locals, registry, env);
+    let node = converter.fold_node(node)?;
+
+    let mut inference = TypeInference::new(env, registry);
+    inference.visit_node(&node);
+
+    let (solver, inference_residual, inference_diagnostics) = inference.finish();
+    let (substitution, solver_diagnostics) = solver.solve();
+
+    // Diagnostic checkpoint, if an error happened during the inference phase, then we cannot
+    // continue
+    let diagnostics: Vec<_> = inference_diagnostics
+        .into_iter()
+        .chain(solver_diagnostics)
+        .map(|diagnostic| diagnostic.map_category(LoweringDiagnosticCategory::TypeChecking))
+        .collect();
+    if !diagnostics.is_empty() {
+        return Err(diagnostics);
+    }
+
+    env.substitution = substitution;
+
+    let mut checking = TypeChecking::new(env, registry, inference_residual);
+    checking.visit_node(&node);
+
+    let (mut residual, checking_diagnostics) = checking.finish();
+
+    // Diagnostic checkpoint, if an error happened during the type checking phase, then we cannot
+    // continue
+    if !checking_diagnostics.is_empty() {
+        return Err(checking_diagnostics);
+    }
+
+    let mut specialization =
+        Specialization::new(env, interner, &mut residual.types, residual.intrinsics);
+    let node = specialization.fold_node(node).map_err(|diagnostics| {
+        diagnostics
+            .into_iter()
+            .map(|diagnostic| diagnostic.map_category(LoweringDiagnosticCategory::Specialization))
+            .collect::<Vec<_>>()
+    })?;
+
+    Ok(node)
+}

--- a/libs/@local/hashql/hir/src/lower/specialization/mod.rs
+++ b/libs/@local/hashql/hir/src/lower/specialization/mod.rs
@@ -206,6 +206,8 @@ impl<'env, 'heap> Specialization<'env, 'heap> {
                     return Ok(None);
                 };
 
+                let read = fold::walk_graph_read(self, read)?;
+
                 return Ok(Some(self.interner.intern_node(PartialNode {
                     span: call.span,
                     kind: NodeKind::Graph(Graph {

--- a/libs/@local/hashql/hir/src/node/operation/type.rs
+++ b/libs/@local/hashql/hir/src/node/operation/type.rs
@@ -1,6 +1,7 @@
 use hashql_core::{
     intern::Interned,
     span::SpanId,
+    symbol::Symbol,
     r#type::{TypeId, kind::generic::GenericArgumentReference},
 };
 
@@ -47,6 +48,8 @@ pub struct TypeAssertion<'heap> {
 pub struct TypeConstructor<'heap> {
     pub span: SpanId,
 
+    /// The name of the opaque type being constructed.
+    pub name: Symbol<'heap>,
     // The closure that performs the conversion
     pub closure: TypeId,
     // Any unapplied arguments to the constructor

--- a/libs/@local/hashql/hir/src/visit.rs
+++ b/libs/@local/hashql/hir/src/visit.rs
@@ -54,7 +54,7 @@
 //! [`Fold`]: crate::fold::Fold
 use hashql_core::{
     span::SpanId,
-    symbol::Ident,
+    symbol::{Ident, Symbol},
     r#type::{TypeId, kind::generic::GenericArgumentReference},
 };
 
@@ -135,6 +135,11 @@ pub trait Visitor<'heap> {
 
     #[expect(unused_variables, reason = "trait definition")]
     fn visit_span(&mut self, span: SpanId) {
+        // do nothing, no fields to walk
+    }
+
+    #[expect(unused_variables, reason = "trait definition")]
+    fn visit_symbol(&mut self, symbol: &'heap Symbol<'heap>) {
         // do nothing, no fields to walk
     }
 
@@ -250,12 +255,13 @@ pub trait Visitor<'heap> {
 pub fn walk_ident<'heap, T: Visitor<'heap> + ?Sized>(
     visitor: &mut T,
     Ident {
-        value: _,
+        value,
         span,
         kind: _,
     }: &'heap Ident<'heap>,
 ) {
     visitor.visit_span(*span);
+    visitor.visit_symbol(value);
 }
 
 pub fn walk_qualified_path<'heap, T: Visitor<'heap> + ?Sized>(
@@ -427,11 +433,13 @@ pub fn walk_type_constructor<'heap, T: Visitor<'heap> + ?Sized>(
     visitor: &mut T,
     TypeConstructor {
         span,
+        name,
         closure,
         arguments,
     }: &'heap TypeConstructor<'heap>,
 ) {
     visitor.visit_span(*span);
+    visitor.visit_symbol(name);
     visitor.visit_type_id(*closure);
 
     for reference in arguments {

--- a/libs/@local/hashql/hir/tests/ui/lower/specialization/collect-filter-graph.stdout
+++ b/libs/@local/hashql/hir/tests/ui/lower/specialization/collect-filter-graph.stdout
@@ -21,7 +21,7 @@
     EntityUuid[Uuid[String]], web_id:
     WebId[ActorGroupEntityUuid[Uuid[String]]])])]]
   | None[Null]), properties: ?)]»): _1«Boolean» ->
-    ::core::cmp::eq(vertex:0.id.entity_id.entity_uuid, #ctor(fn(Uuid[String]) ->
+    (vertex:0.id.entity_id.entity_uuid == #ctor(fn(Uuid[String]) ->
     EntityUuid[Uuid[String]], arguments: [])(#ctor(fn(String) -> Uuid[String],
     arguments: [])("e2851dbb-7376-4959-9bca-f72cafc4448f"))))
 |> ::core::graph::tail::collect


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

### HashQL: Save the name of the opaque type in the HIR

Currently the type constructor in the HIR is unaware of the opaque type it's constructing. To be able to construct a correct `Value` type, the name of the opaque type needs to be known.

### HashQL: Continue to lower the body of closures when specialising graph read operations

The initial implementation erroneously skipped this step.

### HashQL: Provide a general `lower` function in the HIR

This function is used to properly orchestrate and call the different lower operations outside of tests, where we're mostly interested in the output of all stages one after the other.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
