### PR TITLE
H-4884: Allow resolving the query temporal axes relative to a specific now

### DIFF
--- a/libs/@local/graph/store/src/subgraph/temporal_axes.rs
+++ b/libs/@local/graph/store/src/subgraph/temporal_axes.rs
@@ -256,20 +256,20 @@ impl Default for QueryTemporalAxesUnresolved {
 }
 
 impl QueryTemporalAxesUnresolved {
-    /// Resolves temporal axes relative to the specified timestamp.
+    /// Resolves temporal axes using the provided timestamp.
     ///
-    /// Converts unresolved temporal axes into concrete temporal axes by resolving
-    /// relative timestamps and intervals against the provided reference time.
+    /// Converts unresolved temporal axes into concrete temporal axes by resolving unset values
+    /// with the provided timestamp.
     #[must_use]
-    pub fn resolve_relative_to(self, now: Timestamp<()>) -> QueryTemporalAxes {
+    pub fn resolve_with(self, timestamp: Timestamp<()>) -> QueryTemporalAxes {
         match self {
             Self::DecisionTime { pinned, variable } => QueryTemporalAxes::DecisionTime {
-                pinned: pinned.resolve(now),
-                variable: variable.resolve(now),
+                pinned: pinned.resolve(timestamp),
+                variable: variable.resolve(timestamp),
             },
             Self::TransactionTime { pinned, variable } => QueryTemporalAxes::TransactionTime {
-                pinned: pinned.resolve(now),
-                variable: variable.resolve(now),
+                pinned: pinned.resolve(timestamp),
+                variable: variable.resolve(timestamp),
             },
         }
     }
@@ -281,7 +281,7 @@ impl QueryTemporalAxesUnresolved {
     #[must_use]
     pub fn resolve(self) -> QueryTemporalAxes {
         let now = Timestamp::now();
-        self.resolve_relative_to(now)
+        self.resolve_with(now)
     }
 }
 

--- a/libs/@local/graph/store/src/subgraph/temporal_axes.rs
+++ b/libs/@local/graph/store/src/subgraph/temporal_axes.rs
@@ -256,6 +256,10 @@ impl Default for QueryTemporalAxesUnresolved {
 }
 
 impl QueryTemporalAxesUnresolved {
+    /// Resolves temporal axes relative to the specified timestamp.
+    ///
+    /// Converts unresolved temporal axes into concrete temporal axes by resolving
+    /// relative timestamps and intervals against the provided reference time.
     #[must_use]
     pub fn resolve_relative_to(self, now: Timestamp<()>) -> QueryTemporalAxes {
         match self {
@@ -270,6 +274,10 @@ impl QueryTemporalAxesUnresolved {
         }
     }
 
+    /// Resolves temporal axes using the current timestamp.
+    ///
+    /// Convenience method that resolves temporal axes against the current time.
+    /// Equivalent to calling `resolve_relative_to(Timestamp::now())`.
     #[must_use]
     pub fn resolve(self) -> QueryTemporalAxes {
         let now = Timestamp::now();

--- a/libs/@local/graph/store/src/subgraph/temporal_axes.rs
+++ b/libs/@local/graph/store/src/subgraph/temporal_axes.rs
@@ -257,8 +257,7 @@ impl Default for QueryTemporalAxesUnresolved {
 
 impl QueryTemporalAxesUnresolved {
     #[must_use]
-    pub fn resolve(self) -> QueryTemporalAxes {
-        let now = Timestamp::now();
+    pub fn resolve_relative_to(self, now: Timestamp<()>) -> QueryTemporalAxes {
         match self {
             Self::DecisionTime { pinned, variable } => QueryTemporalAxes::DecisionTime {
                 pinned: pinned.resolve(now),
@@ -269,6 +268,12 @@ impl QueryTemporalAxesUnresolved {
                 variable: variable.resolve(now),
             },
         }
+    }
+
+    #[must_use]
+    pub fn resolve(self) -> QueryTemporalAxes {
+        let now = Timestamp::now();
+        self.resolve_relative_to(now)
     }
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently the `QueryTemporalAxesUnresolved` can only be resolved to the current time (`now`) as it means that we're unable to reliably use it during tests that make use of snapshots, as the time is **(usually)** monotonically increasing.

This changes it to introduce a new method that takes a `Timestamp` as `now`, and uses that instead.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
