### PR TITLE
H-4885: Allow for incremental building of `JsonPath`

### DIFF
--- a/libs/@local/graph/store/src/filter/path.rs
+++ b/libs/@local/graph/store/src/filter/path.rs
@@ -47,6 +47,12 @@ pub struct JsonPath<'p> {
 }
 
 impl<'p> JsonPath<'p> {
+    /// Creates a new empty JSON path.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { path: Vec::new() }
+    }
+
     /// Creates a new JSON path from a sequence of path tokens.
     #[must_use]
     pub const fn from_path_tokens(path: Vec<PathToken<'p>>) -> Self {
@@ -86,6 +92,12 @@ impl<'p> JsonPath<'p> {
                 })
                 .collect(),
         }
+    }
+}
+
+impl Default for JsonPath<'_> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/libs/@local/graph/store/src/filter/path.rs
+++ b/libs/@local/graph/store/src/filter/path.rs
@@ -27,6 +27,10 @@ impl<'p> JsonPath<'p> {
         Self { path }
     }
 
+    pub fn push(&mut self, token: PathToken<'p>) {
+        self.path.push(token);
+    }
+
     fn write(&self, writer: &mut impl Write) -> Result<(), fmt::Error> {
         writer.write_char('$')?;
         for token in &self.path {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently a `JsonPath` is constructed in an all or nothing fashion from a vector of path tokens. This changes it so that the `JsonPath` can be built up incrementally by pushing tokens.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
