### PR TITLE
H-4901: Enable `wildcard-enum-match-arm` clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -358,7 +358,6 @@ multiple_inherent_impl  = "allow"
 panic                   = "allow"
 partial_pub_fields      = "allow"
 unwrap_in_result        = "allow"
-wildcard_enum_match_arm = "allow"
 
 # Consider enabling:
 default_numeric_fallback      = "allow"

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/mod.rs
@@ -501,13 +501,13 @@ impl Property {
                 PropertyPathElement::Property(key) => {
                     value = match value {
                         Self::Object(object) => object.properties().get(&key)?,
-                        _ => return None,
+                        Self::Array(_) | Self::Value(_) => return None,
                     };
                 }
                 PropertyPathElement::Index(index) => {
                     value = match value {
                         Self::Array(array) => array.get(index)?,
-                        _ => return None,
+                        Self::Object(_) | Self::Value(_) => return None,
                     };
                 }
             }

--- a/libs/@blockprotocol/type-system/rust/src/ontology/id/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/id/mod.rs
@@ -435,7 +435,10 @@ impl FromStr for VersionedUrl {
                                     )
                                 }
                             }
-                            _ => ParseVersionedUrlError::InvalidVersion(
+                            IntErrorKind::PosOverflow
+                            | IntErrorKind::NegOverflow
+                            | IntErrorKind::Zero
+                            | _ => ParseVersionedUrlError::InvalidVersion(
                                 version.to_owned(),
                                 error.to_string(),
                             ),

--- a/libs/@local/codegen/src/definitions/fields.rs
+++ b/libs/@local/codegen/src/definitions/fields.rs
@@ -22,11 +22,16 @@ impl Field {
             .ty()
             .map(|ty| Type::from_specta(ty, type_collection))?;
 
-        // If the field is optional, we don't want to use `null` but only the optional
-        // type.
         let field_type = match r#type {
             Type::Nullable(r#type) if field.optional() && !field.flatten() => *r#type,
-            field_type => field_type,
+            field_type @ (Type::Reference(_)
+            | Type::Primitive(_)
+            | Type::Enum(_)
+            | Type::Struct(_)
+            | Type::Tuple(_)
+            | Type::List(_)
+            | Type::Map(_)
+            | Type::Nullable(_)) => field_type,
         };
         Some(Self {
             r#type: field_type,

--- a/libs/@local/codegen/src/definitions/type.rs
+++ b/libs/@local/codegen/src/definitions/type.rs
@@ -61,7 +61,9 @@ impl Type {
             specta::DataType::Map(map_type) => {
                 Self::Map(Map::from_specta(map_type, type_collection))
             }
-            data_type => todo!("Unsupported data type {data_type:?}"),
+            data_type @ (specta::DataType::Literal(_) | specta::DataType::Generic(_)) => {
+                todo!("Unsupported data type {data_type:?}")
+            }
         }
     }
 }

--- a/libs/@local/codegen/src/typescript.rs
+++ b/libs/@local/codegen/src/typescript.rs
@@ -127,7 +127,13 @@ impl<'a, 'c> TypeScriptGenerator<'a, 'c> {
                     })
                     .r#type,
             ),
-            r#type => self.should_export_as_interface(r#type),
+            r#type @ (Type::Primitive(_)
+            | Type::Enum(_)
+            | Type::Struct(_)
+            | Type::Tuple(_)
+            | Type::List(_)
+            | Type::Map(_)
+            | Type::Nullable(_)) => self.should_export_as_interface(r#type),
         }
     }
 
@@ -146,7 +152,13 @@ impl<'a, 'c> TypeScriptGenerator<'a, 'c> {
                     false
                 }
             }
-            _ => false,
+            Type::Reference(_)
+            | Type::Primitive(_)
+            | Type::Enum(_)
+            | Type::Tuple(_)
+            | Type::List(_)
+            | Type::Map(_)
+            | Type::Nullable(_) => false,
         }
     }
 
@@ -282,11 +294,19 @@ impl<'a, 'c> TypeScriptGenerator<'a, 'c> {
                     }
                     (members, extends)
                 }
-                _ => unimplemented!(
+                Fields::Named { .. } | Fields::Unnamed { .. } | Fields::Unit => unimplemented!(
                     "Tried to generate an interface from tuple-struct or unit struct"
                 ),
             },
-            ty => unimplemented!("Tried to generate an interface from unsupported type: {ty:?}",),
+            ty @ (Type::Reference(_)
+            | Type::Primitive(_)
+            | Type::Enum(_)
+            | Type::Tuple(_)
+            | Type::List(_)
+            | Type::Map(_)
+            | Type::Nullable(_)) => {
+                unimplemented!("Tried to generate an interface from unsupported type: {ty:?}",)
+            }
         };
 
         self.ast.declaration_ts_interface(

--- a/libs/@local/graph/authorization/src/backend/spicedb/api.rs
+++ b/libs/@local/graph/authorization/src/backend/spicedb/api.rs
@@ -273,7 +273,9 @@ impl ZanzibarBackend for SpiceDbOpenApi {
                             //       current: 10ms, 40ms, 90ms
                             sleep(core::time::Duration::from_millis(10) * attempt * attempt).await;
                         }
-                        _ => break Err(report),
+                        InvocationError::Request
+                        | InvocationError::Response
+                        | InvocationError::Api(_) => break Err(report),
                     },
                 }
             }

--- a/libs/@local/graph/authorization/src/policies/cedar/expression_tree.rs
+++ b/libs/@local/graph/authorization/src/policies/cedar/expression_tree.rs
@@ -104,7 +104,20 @@ impl PolicyExpressionTree {
                 arg2,
             } => Self::from_contains(arg1, arg2)
                 .change_context(ParseExpressionError::ContainsExpression),
-            _ => Err(Report::new(ParseExpressionError::Unexpected)),
+            ast::ExprKind::Lit(_)
+            | ast::ExprKind::Var(_)
+            | ast::ExprKind::Slot(_)
+            | ast::ExprKind::Unknown(_)
+            | ast::ExprKind::If { .. }
+            | ast::ExprKind::UnaryApp { .. }
+            | ast::ExprKind::BinaryApp { .. }
+            | ast::ExprKind::ExtensionFunctionApp { .. }
+            | ast::ExprKind::GetAttr { .. }
+            | ast::ExprKind::HasAttr { .. }
+            | ast::ExprKind::Like { .. }
+            | ast::ExprKind::Is { .. }
+            | ast::ExprKind::Set(_)
+            | ast::ExprKind::Record(_) => Err(Report::new(ParseExpressionError::Unexpected)),
         }
         .attach_printable_lazy(|| expr.clone())
     }
@@ -123,12 +136,26 @@ impl PolicyExpressionTree {
 
         let mut all = match lhs {
             Self::All(expressions) => expressions,
-            expression => vec![expression],
+            expression @ (Self::Not(_)
+            | Self::Any(_)
+            | Self::Is(_)
+            | Self::In(_)
+            | Self::BaseUrl(_)
+            | Self::OntologyTypeVersion(_)
+            | Self::IsOfType(_)
+            | Self::CreatedByPrincipal) => vec![expression],
         };
 
         match rhs {
             Self::All(expressions) => all.extend(expressions),
-            expression => all.push(expression),
+            expression @ (Self::Not(_)
+            | Self::Any(_)
+            | Self::Is(_)
+            | Self::In(_)
+            | Self::BaseUrl(_)
+            | Self::OntologyTypeVersion(_)
+            | Self::IsOfType(_)
+            | Self::CreatedByPrincipal) => all.push(expression),
         }
 
         if all.len() == 1 {
@@ -148,12 +175,26 @@ impl PolicyExpressionTree {
 
         let mut any = match lhs {
             Self::Any(expressions) => expressions,
-            expression => vec![expression],
+            expression @ (Self::Not(_)
+            | Self::All(_)
+            | Self::Is(_)
+            | Self::In(_)
+            | Self::BaseUrl(_)
+            | Self::OntologyTypeVersion(_)
+            | Self::IsOfType(_)
+            | Self::CreatedByPrincipal) => vec![expression],
         };
 
         match rhs {
             Self::Any(expressions) => any.extend(expressions),
-            expression => any.push(expression),
+            expression @ (Self::Not(_)
+            | Self::All(_)
+            | Self::Is(_)
+            | Self::In(_)
+            | Self::BaseUrl(_)
+            | Self::OntologyTypeVersion(_)
+            | Self::IsOfType(_)
+            | Self::CreatedByPrincipal) => any.push(expression),
         }
 
         if any.len() == 1 {
@@ -173,8 +214,24 @@ impl PolicyExpressionTree {
                 _ => Err(Report::new(ParseGetAttrExpressionError::NoPrincipalId)
                     .attach_printable(Arc::clone(expr))),
             },
-            _ => Err(Report::new(ParseGetAttrExpressionError::NoPrincipalId)
-                .attach_printable(Arc::clone(expr))),
+            ast::ExprKind::Lit(_)
+            | ast::ExprKind::Var(_)
+            | ast::ExprKind::Slot(_)
+            | ast::ExprKind::Unknown(_)
+            | ast::ExprKind::If { .. }
+            | ast::ExprKind::And { .. }
+            | ast::ExprKind::Or { .. }
+            | ast::ExprKind::UnaryApp { .. }
+            | ast::ExprKind::BinaryApp { .. }
+            | ast::ExprKind::ExtensionFunctionApp { .. }
+            | ast::ExprKind::HasAttr { .. }
+            | ast::ExprKind::Like { .. }
+            | ast::ExprKind::Is { .. }
+            | ast::ExprKind::Set(_)
+            | ast::ExprKind::Record(_) => {
+                Err(Report::new(ParseGetAttrExpressionError::NoPrincipalId)
+                    .attach_printable(Arc::clone(expr)))
+            }
         }
     }
 
@@ -184,8 +241,25 @@ impl PolicyExpressionTree {
         match expr.expr_kind() {
             ast::ExprKind::Var(ast::Var::Resource) => Ok(()),
             ast::ExprKind::Unknown(unknown) if unknown.name == "resource" => Ok(()),
-            _ => Err(Report::new(ParseGetAttrExpressionError::NoResourceVariable)
-                .attach_printable(Arc::clone(expr))),
+            ast::ExprKind::Lit(_)
+            | ast::ExprKind::Var(_)
+            | ast::ExprKind::Slot(_)
+            | ast::ExprKind::Unknown(_)
+            | ast::ExprKind::If { .. }
+            | ast::ExprKind::And { .. }
+            | ast::ExprKind::Or { .. }
+            | ast::ExprKind::UnaryApp { .. }
+            | ast::ExprKind::BinaryApp { .. }
+            | ast::ExprKind::ExtensionFunctionApp { .. }
+            | ast::ExprKind::GetAttr { .. }
+            | ast::ExprKind::HasAttr { .. }
+            | ast::ExprKind::Like { .. }
+            | ast::ExprKind::Is { .. }
+            | ast::ExprKind::Set(_)
+            | ast::ExprKind::Record(_) => {
+                Err(Report::new(ParseGetAttrExpressionError::NoResourceVariable)
+                    .attach_printable(Arc::clone(expr)))
+            }
         }
     }
 
@@ -201,7 +275,22 @@ impl PolicyExpressionTree {
             ast::ExprKind::Lit(ast::Literal::EntityUID(euid)) => WebId::from_euid(euid)
                 .change_context(ParseBinaryExpressionError::Right)
                 .map(Self::In),
-            _ => Err(Report::new(ParseExpressionError::Unexpected)
+            ast::ExprKind::Lit(_)
+            | ast::ExprKind::Var(_)
+            | ast::ExprKind::Slot(_)
+            | ast::ExprKind::Unknown(_)
+            | ast::ExprKind::If { .. }
+            | ast::ExprKind::And { .. }
+            | ast::ExprKind::Or { .. }
+            | ast::ExprKind::UnaryApp { .. }
+            | ast::ExprKind::BinaryApp { .. }
+            | ast::ExprKind::ExtensionFunctionApp { .. }
+            | ast::ExprKind::GetAttr { .. }
+            | ast::ExprKind::HasAttr { .. }
+            | ast::ExprKind::Like { .. }
+            | ast::ExprKind::Is { .. }
+            | ast::ExprKind::Set(_)
+            | ast::ExprKind::Record(_) => Err(Report::new(ParseExpressionError::Unexpected)
                 .change_context(ParseBinaryExpressionError::Right)),
         }
         .attach_printable(Arc::clone(rhs))
@@ -239,7 +328,21 @@ impl PolicyExpressionTree {
             ast::ExprKind::Unknown(unknown) if unknown.name == "resource" => {
                 AttributeType::Resource
             }
-            _ => {
+            ast::ExprKind::Lit(_)
+            | ast::ExprKind::Var(_)
+            | ast::ExprKind::Slot(_)
+            | ast::ExprKind::Unknown(_)
+            | ast::ExprKind::If { .. }
+            | ast::ExprKind::And { .. }
+            | ast::ExprKind::Or { .. }
+            | ast::ExprKind::UnaryApp { .. }
+            | ast::ExprKind::BinaryApp { .. }
+            | ast::ExprKind::ExtensionFunctionApp { .. }
+            | ast::ExprKind::HasAttr { .. }
+            | ast::ExprKind::Like { .. }
+            | ast::ExprKind::Is { .. }
+            | ast::ExprKind::Set(_)
+            | ast::ExprKind::Record(_) => {
                 return Err(
                     Report::new(ParseBinaryExpressionError::Left).attach_printable(Arc::clone(lhs))
                 );
@@ -304,7 +407,21 @@ impl PolicyExpressionTree {
                     .attach_printable_lazy(|| Arc::clone(lhs))?;
                 attr_type
             }
-            _ => {
+            ast::ExprKind::Lit(_)
+            | ast::ExprKind::Var(_)
+            | ast::ExprKind::Slot(_)
+            | ast::ExprKind::Unknown(_)
+            | ast::ExprKind::If { .. }
+            | ast::ExprKind::And { .. }
+            | ast::ExprKind::Or { .. }
+            | ast::ExprKind::UnaryApp { .. }
+            | ast::ExprKind::BinaryApp { .. }
+            | ast::ExprKind::ExtensionFunctionApp { .. }
+            | ast::ExprKind::HasAttr { .. }
+            | ast::ExprKind::Like { .. }
+            | ast::ExprKind::Is { .. }
+            | ast::ExprKind::Set(_)
+            | ast::ExprKind::Record(_) => {
                 return Err(
                     Report::new(ParseBinaryExpressionError::Left).attach_printable(Arc::clone(lhs))
                 );

--- a/libs/@local/graph/authorization/src/policies/components.rs
+++ b/libs/@local/graph/authorization/src/policies/components.rs
@@ -648,7 +648,9 @@ mod tests {
             ResourceConstraint::Entity(EntityResourceConstraint::Exact { id }) => {
                 assert_eq!(*id, entity_uuid);
             }
-            _ => panic!("should create exact entity constraint"),
+            ResourceConstraint::Web { .. }
+            | ResourceConstraint::Entity(_)
+            | ResourceConstraint::EntityType(_) => panic!("should create exact entity constraint"),
         }
     }
 }

--- a/libs/@local/graph/authorization/src/policies/resource/entity.rs
+++ b/libs/@local/graph/authorization/src/policies/resource/entity.rs
@@ -70,7 +70,12 @@ impl TryFrom<PolicyExpressionTree> for EntityResourceFilter {
             }),
             PolicyExpressionTree::IsOfType(entity_type) => Ok(Self::IsOfType { entity_type }),
             PolicyExpressionTree::CreatedByPrincipal => Ok(Self::CreatedByPrincipal),
-            condition => Err(Report::new(InvalidEntityResourceFilter(condition))),
+            condition @ (PolicyExpressionTree::Is(_)
+            | PolicyExpressionTree::In(_)
+            | PolicyExpressionTree::BaseUrl(_)
+            | PolicyExpressionTree::OntologyTypeVersion(_)) => {
+                Err(Report::new(InvalidEntityResourceFilter(condition)))
+            }
         }
     }
 }

--- a/libs/@local/graph/authorization/src/policies/resource/entity_type.rs
+++ b/libs/@local/graph/authorization/src/policies/resource/entity_type.rs
@@ -143,7 +143,12 @@ impl TryFrom<PolicyExpressionTree> for EntityTypeResourceFilter {
             }),
             PolicyExpressionTree::BaseUrl(base_url) => Ok(Self::IsBaseUrl { base_url }),
             PolicyExpressionTree::OntologyTypeVersion(version) => Ok(Self::IsVersion { version }),
-            condition => Err(Report::new(InvalidEntityTypeResourceFilter(condition))),
+            condition @ (PolicyExpressionTree::Is(_)
+            | PolicyExpressionTree::In(_)
+            | PolicyExpressionTree::IsOfType(_)
+            | PolicyExpressionTree::CreatedByPrincipal) => {
+                Err(Report::new(InvalidEntityTypeResourceFilter(condition)))
+            }
         }
     }
 }

--- a/libs/@local/graph/postgres-store/src/permissions/mod.rs
+++ b/libs/@local/graph/postgres-store/src/permissions/mod.rs
@@ -356,7 +356,13 @@ where
             .map(|row| match row.get(0) {
                 PrincipalType::Web => ActorGroupId::Web(WebId::new(id)),
                 PrincipalType::Team => ActorGroupId::Team(TeamId::new(id)),
-                principal_type => unreachable!("Unexpected actor group type: {principal_type:?}"),
+                principal_type @ (PrincipalType::User
+                | PrincipalType::Machine
+                | PrincipalType::Ai
+                | PrincipalType::WebRole
+                | PrincipalType::TeamRole) => {
+                    unreachable!("Unexpected actor group type: {principal_type:?}")
+                }
             })
             .change_context(PrincipalError::StoreError)
     }
@@ -495,7 +501,11 @@ where
             .map_ok(|row| match row.get(0) {
                 PrincipalType::Web => ActorGroupId::Web(row.get(1)),
                 PrincipalType::Team => ActorGroupId::Team(row.get(1)),
-                principal_type => {
+                principal_type @ (PrincipalType::User
+                | PrincipalType::Machine
+                | PrincipalType::Ai
+                | PrincipalType::WebRole
+                | PrincipalType::TeamRole) => {
                     unreachable!("Unexpected principal type {principal_type}")
                 }
             })
@@ -763,7 +773,13 @@ where
                             name: row.get(3),
                         }),
                     ),
-                    principal_type => unreachable!("Unexpected role type: {principal_type:?}"),
+                    principal_type @ (PrincipalType::User
+                    | PrincipalType::Machine
+                    | PrincipalType::Ai
+                    | PrincipalType::Web
+                    | PrincipalType::Team) => {
+                        unreachable!("Unexpected role type: {principal_type:?}")
+                    }
                 }
             })
             .try_collect()
@@ -805,7 +821,12 @@ where
                 PrincipalType::User => ActorId::User(row.get(1)),
                 PrincipalType::Machine => ActorId::Machine(row.get(1)),
                 PrincipalType::Ai => ActorId::Ai(row.get(1)),
-                principal_type => unreachable!("Unexpected principal type: {principal_type:?}"),
+                principal_type @ (PrincipalType::Web
+                | PrincipalType::Team
+                | PrincipalType::WebRole
+                | PrincipalType::TeamRole) => {
+                    unreachable!("Unexpected principal type: {principal_type:?}")
+                }
             })
             .try_collect()
             .await

--- a/libs/@local/graph/postgres-store/src/snapshot/mod.rs
+++ b/libs/@local/graph/postgres-store/src/snapshot/mod.rs
@@ -396,7 +396,13 @@ impl PostgresStorePool {
                         .map(|(id, principal_type)| match principal_type {
                             PrincipalType::WebRole => RoleId::Web(WebRoleId::new(id)),
                             PrincipalType::TeamRole => RoleId::Team(TeamRoleId::new(id)),
-                            _ => unreachable!("Unexpected role type: {principal_type:?}"),
+                            PrincipalType::User
+                            | PrincipalType::Machine
+                            | PrincipalType::Ai
+                            | PrincipalType::Web
+                            | PrincipalType::Team => {
+                                unreachable!("Unexpected role type: {principal_type:?}")
+                            }
                         })
                         .collect(),
                 }))
@@ -444,7 +450,13 @@ impl PostgresStorePool {
                         .map(|(id, principal_type)| match principal_type {
                             PrincipalType::WebRole => RoleId::Web(WebRoleId::new(id)),
                             PrincipalType::TeamRole => RoleId::Team(TeamRoleId::new(id)),
-                            _ => unreachable!("Unexpected role type: {principal_type:?}"),
+                            PrincipalType::User
+                            | PrincipalType::Machine
+                            | PrincipalType::Ai
+                            | PrincipalType::Web
+                            | PrincipalType::Team => {
+                                unreachable!("Unexpected role type: {principal_type:?}")
+                            }
                         })
                         .collect(),
                 }))
@@ -492,7 +504,13 @@ impl PostgresStorePool {
                         .map(|(id, principal_type)| match principal_type {
                             PrincipalType::WebRole => RoleId::Web(WebRoleId::new(id)),
                             PrincipalType::TeamRole => RoleId::Team(TeamRoleId::new(id)),
-                            _ => unreachable!("Unexpected role type: {principal_type:?}"),
+                            PrincipalType::User
+                            | PrincipalType::Machine
+                            | PrincipalType::Ai
+                            | PrincipalType::Web
+                            | PrincipalType::Team => {
+                                unreachable!("Unexpected role type: {principal_type:?}")
+                            }
                         })
                         .collect(),
                 }))
@@ -568,7 +586,11 @@ impl PostgresStorePool {
                     parent_id: match row.get(1) {
                         PrincipalType::Web => ActorGroupId::Web(row.get(2)),
                         PrincipalType::Team => ActorGroupId::Team(row.get(2)),
-                        principal_type => {
+                        principal_type @ (PrincipalType::User
+                        | PrincipalType::Machine
+                        | PrincipalType::Ai
+                        | PrincipalType::WebRole
+                        | PrincipalType::TeamRole) => {
                             unreachable!("Unexpected principal type {principal_type}")
                         }
                     },
@@ -613,7 +635,13 @@ impl PostgresStorePool {
                         team_id: row.get(2),
                         name: row.get(3),
                     }),
-                    principal_type => unreachable!("Unexpected principal type {principal_type}"),
+                    principal_type @ (PrincipalType::User
+                    | PrincipalType::Machine
+                    | PrincipalType::Ai
+                    | PrincipalType::Web
+                    | PrincipalType::Team) => {
+                        unreachable!("Unexpected principal type {principal_type}")
+                    }
                 })
             })
             .map_err(|error| Report::new(error).change_context(SnapshotDumpError::Read)))

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -860,7 +860,12 @@ where
             PrincipalType::User => ActorId::User(UserId::new(actor_entity_uuid)),
             PrincipalType::Machine => ActorId::Machine(MachineId::new(actor_entity_uuid)),
             PrincipalType::Ai => ActorId::Ai(AiId::new(actor_entity_uuid)),
-            principal_type => unreachable!("Unexpected actor type: {principal_type:?}"),
+            principal_type @ (PrincipalType::Web
+            | PrincipalType::Team
+            | PrincipalType::WebRole
+            | PrincipalType::TeamRole) => {
+                unreachable!("Unexpected actor type: {principal_type:?}")
+            }
         }))
     }
 
@@ -940,13 +945,21 @@ where
                     parent_id: match row.get(3) {
                         PrincipalType::Web => ActorGroupId::Web(row.get(4)),
                         PrincipalType::Team => ActorGroupId::Team(row.get(4)),
-                        actor_group_type => {
+                        actor_group_type @ (PrincipalType::User
+                        | PrincipalType::Machine
+                        | PrincipalType::Ai
+                        | PrincipalType::WebRole
+                        | PrincipalType::TeamRole) => {
                             unreachable!("Unexpected actor group type: {actor_group_type:?}")
                         }
                     },
                     roles: HashSet::new(),
                 }),
-                actor_group_type => {
+                actor_group_type @ (PrincipalType::User
+                | PrincipalType::Machine
+                | PrincipalType::Ai
+                | PrincipalType::WebRole
+                | PrincipalType::TeamRole) => {
                     unreachable!("Unexpected actor group type: {actor_group_type:?}")
                 }
             })
@@ -989,7 +1002,10 @@ impl PolicyParts {
                 PrincipalType::User => Ok(ActorType::User),
                 PrincipalType::Machine => Ok(ActorType::Machine),
                 PrincipalType::Ai => Ok(ActorType::Ai),
-                _ => Err(GetPoliciesError::InvalidPrincipalConstraint),
+                PrincipalType::Web
+                | PrincipalType::Team
+                | PrincipalType::WebRole
+                | PrincipalType::TeamRole => Err(GetPoliciesError::InvalidPrincipalConstraint),
             })
             .transpose()?;
 
@@ -1920,7 +1936,10 @@ where
                         PrincipalType::User => ActorType::User,
                         PrincipalType::Machine => ActorType::Machine,
                         PrincipalType::Ai => ActorType::Ai,
-                        principal_type => unreachable!(
+                        principal_type @ (PrincipalType::Web
+                        | PrincipalType::Team
+                        | PrincipalType::WebRole
+                        | PrincipalType::TeamRole) => unreachable!(
                             "Unexpected actor type `{principal_type:?}` in entity context"
                         ),
                     },
@@ -2856,7 +2875,13 @@ impl<C: AsClient, A: AuthorizationApi> AccountStore for PostgresStore<C, A> {
                         .map(|(id, principal_type)| match principal_type {
                             PrincipalType::WebRole => RoleId::Web(WebRoleId::new(id)),
                             PrincipalType::TeamRole => RoleId::Team(TeamRoleId::new(id)),
-                            _ => unreachable!("Unexpected role type: {principal_type:?}"),
+                            PrincipalType::User
+                            | PrincipalType::Machine
+                            | PrincipalType::Ai
+                            | PrincipalType::Web
+                            | PrincipalType::Team => {
+                                unreachable!("Unexpected role type: {principal_type:?}")
+                            }
                         })
                         .collect(),
                 }
@@ -2897,7 +2922,13 @@ impl<C: AsClient, A: AuthorizationApi> AccountStore for PostgresStore<C, A> {
                         .map(|(id, principal_type)| match principal_type {
                             PrincipalType::WebRole => RoleId::Web(WebRoleId::new(id)),
                             PrincipalType::TeamRole => RoleId::Team(TeamRoleId::new(id)),
-                            _ => unreachable!("Unexpected role type: {principal_type:?}"),
+                            PrincipalType::User
+                            | PrincipalType::Machine
+                            | PrincipalType::Ai
+                            | PrincipalType::Web
+                            | PrincipalType::Team => {
+                                unreachable!("Unexpected role type: {principal_type:?}")
+                            }
                         })
                         .collect(),
                 }
@@ -2938,7 +2969,13 @@ impl<C: AsClient, A: AuthorizationApi> AccountStore for PostgresStore<C, A> {
                         .map(|(id, principal_type)| match principal_type {
                             PrincipalType::WebRole => RoleId::Web(WebRoleId::new(id)),
                             PrincipalType::TeamRole => RoleId::Team(TeamRoleId::new(id)),
-                            _ => unreachable!("Unexpected role type: {principal_type:?}"),
+                            PrincipalType::User
+                            | PrincipalType::Machine
+                            | PrincipalType::Ai
+                            | PrincipalType::Web
+                            | PrincipalType::Team => {
+                                unreachable!("Unexpected role type: {principal_type:?}")
+                            }
                         })
                         .collect(),
                 }
@@ -2979,7 +3016,13 @@ impl<C: AsClient, A: AuthorizationApi> AccountStore for PostgresStore<C, A> {
                         .map(|(id, principal_type)| match principal_type {
                             PrincipalType::WebRole => RoleId::Web(WebRoleId::new(id)),
                             PrincipalType::TeamRole => RoleId::Team(TeamRoleId::new(id)),
-                            _ => unreachable!("Unexpected role type: {principal_type:?}"),
+                            PrincipalType::User
+                            | PrincipalType::Machine
+                            | PrincipalType::Ai
+                            | PrincipalType::Web
+                            | PrincipalType::Team => {
+                                unreachable!("Unexpected role type: {principal_type:?}")
+                            }
                         })
                         .collect(),
                 }
@@ -3020,7 +3063,13 @@ impl<C: AsClient, A: AuthorizationApi> AccountStore for PostgresStore<C, A> {
                         .map(|(id, principal_type)| match principal_type {
                             PrincipalType::WebRole => RoleId::Web(WebRoleId::new(id)),
                             PrincipalType::TeamRole => RoleId::Team(TeamRoleId::new(id)),
-                            _ => unreachable!("Unexpected role type: {principal_type:?}"),
+                            PrincipalType::User
+                            | PrincipalType::Machine
+                            | PrincipalType::Ai
+                            | PrincipalType::Web
+                            | PrincipalType::Team => {
+                                unreachable!("Unexpected role type: {principal_type:?}")
+                            }
                         })
                         .collect(),
                 }
@@ -3258,7 +3307,11 @@ impl<C: AsClient, A: AuthorizationApi> AccountStore for PostgresStore<C, A> {
                     parent_id: match row.get(0) {
                         PrincipalType::Web => ActorGroupId::Web(row.get(1)),
                         PrincipalType::Team => ActorGroupId::Team(row.get(1)),
-                        principal_type => {
+                        principal_type @ (PrincipalType::User
+                        | PrincipalType::Machine
+                        | PrincipalType::Ai
+                        | PrincipalType::WebRole
+                        | PrincipalType::TeamRole) => {
                             unreachable!("Unexpected principal type {principal_type}")
                         }
                     },
@@ -3299,7 +3352,11 @@ impl<C: AsClient, A: AuthorizationApi> AccountStore for PostgresStore<C, A> {
                     parent_id: match row.get(1) {
                         PrincipalType::Web => ActorGroupId::Web(row.get(2)),
                         PrincipalType::Team => ActorGroupId::Team(row.get(2)),
-                        principal_type => {
+                        principal_type @ (PrincipalType::User
+                        | PrincipalType::Machine
+                        | PrincipalType::Ai
+                        | PrincipalType::WebRole
+                        | PrincipalType::TeamRole) => {
                             unreachable!("Unexpected principal type {principal_type}")
                         }
                     },

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile.rs
@@ -544,7 +544,31 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                             Table::EntityEmbeddings => {
                                 Column::EntityEmbeddings(EntityEmbeddings::Distance)
                             }
-                            _ => bail!(SelectCompilerError::UnsupportedEmbeddingPath),
+                            Table::OntologyIds
+                            | Table::OntologyTemporalMetadata
+                            | Table::OntologyOwnedMetadata
+                            | Table::OntologyExternalMetadata
+                            | Table::OntologyAdditionalMetadata
+                            | Table::DataTypes
+                            | Table::DataTypeConversions
+                            | Table::DataTypeConversionAggregation
+                            | Table::PropertyTypes
+                            | Table::EntityTypes
+                            | Table::FirstTitleForEntity
+                            | Table::LastTitleForEntity
+                            | Table::FirstLabelForEntity
+                            | Table::LastLabelForEntity
+                            | Table::EntityIds
+                            | Table::EntityDrafts
+                            | Table::EntityTemporalMetadata
+                            | Table::EntityEditions
+                            | Table::EntityIsOfType
+                            | Table::EntityIsOfTypeIds
+                            | Table::EntityHasLeftEntity
+                            | Table::EntityHasRightEntity
+                            | Table::Reference(_) => {
+                                bail!(SelectCompilerError::UnsupportedEmbeddingPath)
+                            }
                         },
                         table_alias: Some(path_alias),
                     };
@@ -575,7 +599,29 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                                 Column::EntityEmbeddings(EntityEmbeddings::WebId),
                                 Column::EntityEmbeddings(EntityEmbeddings::EntityUuid),
                             ],
-                            _ => unreachable!(),
+                            Table::OntologyIds
+                            | Table::OntologyTemporalMetadata
+                            | Table::OntologyOwnedMetadata
+                            | Table::OntologyExternalMetadata
+                            | Table::OntologyAdditionalMetadata
+                            | Table::DataTypes
+                            | Table::DataTypeConversions
+                            | Table::DataTypeConversionAggregation
+                            | Table::PropertyTypes
+                            | Table::EntityTypes
+                            | Table::FirstTitleForEntity
+                            | Table::LastTitleForEntity
+                            | Table::FirstLabelForEntity
+                            | Table::LastLabelForEntity
+                            | Table::EntityIds
+                            | Table::EntityDrafts
+                            | Table::EntityTemporalMetadata
+                            | Table::EntityEditions
+                            | Table::EntityIsOfType
+                            | Table::EntityIsOfTypeIds
+                            | Table::EntityHasLeftEntity
+                            | Table::EntityHasRightEntity
+                            | Table::Reference(_) => unreachable!(),
                         };
 
                         last_join.statement = Some(SelectStatement {
@@ -822,7 +868,18 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                 },
                 _ => None,
             },
-            _ => None,
+            Filter::All(_)
+            | Filter::Any(_)
+            | Filter::Not(_)
+            | Filter::Greater(..)
+            | Filter::GreaterOrEqual(..)
+            | Filter::Less(..)
+            | Filter::LessOrEqual(..)
+            | Filter::CosineDistance(..)
+            | Filter::In(..)
+            | Filter::StartsWith(..)
+            | Filter::EndsWith(..)
+            | Filter::ContainsSegment(..) => None,
         }
     }
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
@@ -94,7 +94,10 @@ impl ReferenceTable {
                 EntityIsOfType::InheritanceDepth,
                 inheritance_depth,
             )),
-            _ => None,
+            Self::PropertyTypeConstrainsValuesOn
+            | Self::PropertyTypeConstrainsPropertiesOn
+            | Self::EntityHasLeftEntity
+            | Self::EntityHasRightEntity => None,
         }
     }
 
@@ -1646,7 +1649,32 @@ impl Column {
             | Self::EntityTypeConstrainsLinksOn(_, inheritance_depth)
             | Self::EntityTypeConstrainsLinkDestinationsOn(_, inheritance_depth)
             | Self::EntityIsOfType(_, inheritance_depth) => inheritance_depth,
-            _ => None,
+            Self::OntologyIds(_)
+            | Self::OntologyTemporalMetadata(_)
+            | Self::OntologyOwnedMetadata(_)
+            | Self::OntologyExternalMetadata(_)
+            | Self::OntologyAdditionalMetadata(_)
+            | Self::DataTypes(_)
+            | Self::DataTypeEmbeddings(_)
+            | Self::DataTypeConversions(_)
+            | Self::DataTypeConversionAggregation(_)
+            | Self::PropertyTypes(_)
+            | Self::PropertyTypeEmbeddings(_)
+            | Self::EntityTypes(_)
+            | Self::EntityTypeEmbeddings(_)
+            | Self::EntityIds(_)
+            | Self::EntityTemporalMetadata(_)
+            | Self::EntityEditions(_)
+            | Self::FirstLabelForEntity(_)
+            | Self::LastLabelForEntity(_)
+            | Self::FirstTitleForEntity(_)
+            | Self::LastTitleForEntity(_)
+            | Self::EntityEmbeddings(_)
+            | Self::PropertyTypeConstrainsValuesOn(_)
+            | Self::PropertyTypeConstrainsPropertiesOn(_)
+            | Self::EntityIsOfTypeIds(_)
+            | Self::EntityHasLeftEntity(_)
+            | Self::EntityHasRightEntity(_) => None,
         }
     }
 

--- a/libs/@local/graph/store/src/filter/mod.rs
+++ b/libs/@local/graph/store/src/filter/mod.rs
@@ -775,6 +775,10 @@ impl<R: QueryRecord> FilterExpression<'_, R> {
 
 #[cfg(test)]
 mod tests {
+    #![expect(
+        clippy::wildcard_enum_match_arm,
+        reason = "It's fine to error on unused arms in tests"
+    )]
 
     use hash_graph_types::ontology::DataTypeLookup;
     use serde_json::json;
@@ -1507,7 +1511,9 @@ mod tests {
                     );
                     assert!(has_web_in, "should contain web ID IN clause optimization");
                 }
-                other => panic!("should create Any filter with both IN clauses, got: {other:?}"),
+                other => {
+                    panic!("should create Any filter with both IN clauses, got: {other:?}")
+                }
             }
         }
 

--- a/libs/@local/graph/temporal-versioning/src/interval.rs
+++ b/libs/@local/graph/temporal-versioning/src/interval.rs
@@ -475,7 +475,7 @@ where
                 BoundType::End,
                 PartialOrd::partial_cmp,
             ),
-            ordering => Some(ordering),
+            ordering @ (Ordering::Less | Ordering::Greater) => Some(ordering),
         }
     }
 }

--- a/libs/@local/harpc/net/src/transport/task.rs
+++ b/libs/@local/harpc/net/src/transport/task.rs
@@ -327,7 +327,22 @@ impl TransportTask {
             SwarmEvent::Behaviour(TransportBehaviourEvent::Ping(event)) => {
                 self.metrics.record(event);
             }
-            event => self.metrics.record(event),
+            event @ (SwarmEvent::Behaviour(_)
+            | SwarmEvent::ConnectionEstablished { .. }
+            | SwarmEvent::ConnectionClosed { .. }
+            | SwarmEvent::IncomingConnection { .. }
+            | SwarmEvent::IncomingConnectionError { .. }
+            | SwarmEvent::OutgoingConnectionError { .. }
+            | SwarmEvent::NewListenAddr { .. }
+            | SwarmEvent::ExpiredListenAddr { .. }
+            | SwarmEvent::ListenerClosed { .. }
+            | SwarmEvent::ListenerError { .. }
+            | SwarmEvent::Dialing { .. }
+            | SwarmEvent::NewExternalAddrCandidate { .. }
+            | SwarmEvent::ExternalAddrConfirmed { .. }
+            | SwarmEvent::ExternalAddrExpired { .. }
+            | SwarmEvent::NewExternalAddrOfPeer { .. }
+            | _) => self.metrics.record(event),
         }
 
         match event {
@@ -347,7 +362,19 @@ impl TransportTask {
             } => {
                 self.handle_outgoing_connection_error(connection_id, peer_id, error);
             }
-            _ => {}
+            SwarmEvent::Behaviour(_)
+            | SwarmEvent::ConnectionEstablished { .. }
+            | SwarmEvent::ConnectionClosed { .. }
+            | SwarmEvent::IncomingConnection { .. }
+            | SwarmEvent::IncomingConnectionError { .. }
+            | SwarmEvent::ExpiredListenAddr { .. }
+            | SwarmEvent::ListenerClosed { .. }
+            | SwarmEvent::ListenerError { .. }
+            | SwarmEvent::Dialing { .. }
+            | SwarmEvent::NewExternalAddrCandidate { .. }
+            | SwarmEvent::ExternalAddrConfirmed { .. }
+            | SwarmEvent::ExternalAddrExpired { .. }
+            | _ => {}
         }
     }
 

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
@@ -354,7 +354,23 @@ impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
                     self.handled_diagnostics = fatal;
                 }
             }
-            _ => {}
+            ExprKind::Call(_)
+            | ExprKind::Struct(_)
+            | ExprKind::Dict(_)
+            | ExprKind::Tuple(_)
+            | ExprKind::List(_)
+            | ExprKind::Literal(_)
+            | ExprKind::Let(_)
+            | ExprKind::Type(_)
+            | ExprKind::NewType(_)
+            | ExprKind::Input(_)
+            | ExprKind::Closure(_)
+            | ExprKind::If(_)
+            | ExprKind::Field(_)
+            | ExprKind::Index(_)
+            | ExprKind::Is(_)
+            | ExprKind::Underscore
+            | ExprKind::Dummy => {}
         }
     }
 

--- a/libs/@local/hashql/ast/src/lowering/special_form_expander/error.rs
+++ b/libs/@local/hashql/ast/src/lowering/special_form_expander/error.rs
@@ -492,7 +492,20 @@ pub(crate) fn invalid_type_expression(
         InvalidTypeExpressionKind::If => {
             Cow::Borrowed("Replace this conditional with a concrete type")
         }
-        _ => Cow::Owned(format!("Replace this {kind} with a proper type expression")),
+        InvalidTypeExpressionKind::Dict
+        | InvalidTypeExpressionKind::List
+        | InvalidTypeExpressionKind::Let
+        | InvalidTypeExpressionKind::Type
+        | InvalidTypeExpressionKind::NewType
+        | InvalidTypeExpressionKind::Use
+        | InvalidTypeExpressionKind::Input
+        | InvalidTypeExpressionKind::Closure
+        | InvalidTypeExpressionKind::Field
+        | InvalidTypeExpressionKind::Index
+        | InvalidTypeExpressionKind::Is
+        | InvalidTypeExpressionKind::Dummy => {
+            Cow::Owned(format!("Replace this {kind} with a proper type expression"))
+        }
     };
 
     diagnostic.labels.push(Label::new(span, message));
@@ -509,7 +522,19 @@ pub(crate) fn invalid_type_expression(
         InvalidTypeExpressionKind::If => {
             "HashQL does not support conditional types. Use a concrete type like Int or String."
         }
-        _ => "Replace this expression with a valid type reference, struct type, or tuple type",
+        InvalidTypeExpressionKind::Literal
+        | InvalidTypeExpressionKind::Let
+        | InvalidTypeExpressionKind::Type
+        | InvalidTypeExpressionKind::NewType
+        | InvalidTypeExpressionKind::Use
+        | InvalidTypeExpressionKind::Input
+        | InvalidTypeExpressionKind::Closure
+        | InvalidTypeExpressionKind::Field
+        | InvalidTypeExpressionKind::Index
+        | InvalidTypeExpressionKind::Is
+        | InvalidTypeExpressionKind::Dummy => {
+            "Replace this expression with a valid type reference, struct type, or tuple type"
+        }
     };
 
     diagnostic.add_help(Help::new(help_text));

--- a/libs/@local/hashql/ast/src/lowering/special_form_expander/mod.rs
+++ b/libs/@local/hashql/ast/src/lowering/special_form_expander/mod.rs
@@ -295,7 +295,11 @@ impl<'heap> SpecialFormExpander<'heap> {
                     ExprKind::Index(_) => InvalidTypeExpressionKind::Index,
                     ExprKind::Is(_) => InvalidTypeExpressionKind::Is,
                     ExprKind::Dummy => InvalidTypeExpressionKind::Dummy,
-                    _ => unreachable!(),
+                    ExprKind::Call(_)
+                    | ExprKind::Struct(_)
+                    | ExprKind::Tuple(_)
+                    | ExprKind::Path(_)
+                    | ExprKind::Underscore => unreachable!(),
                 };
 
                 self.diagnostics
@@ -720,7 +724,23 @@ impl<'heap> SpecialFormExpander<'heap> {
 
                     continue;
                 }
-                _ => {
+                ExprKind::Call(_)
+                | ExprKind::Struct(_)
+                | ExprKind::Dict(_)
+                | ExprKind::Tuple(_)
+                | ExprKind::List(_)
+                | ExprKind::Literal(_)
+                | ExprKind::Let(_)
+                | ExprKind::Type(_)
+                | ExprKind::NewType(_)
+                | ExprKind::Use(_)
+                | ExprKind::Input(_)
+                | ExprKind::Closure(_)
+                | ExprKind::If(_)
+                | ExprKind::Field(_)
+                | ExprKind::Index(_)
+                | ExprKind::Is(_)
+                | ExprKind::Dummy => {
                     self.diagnostics.push(invalid_use_import(entry.value.span));
                     continue;
                 }
@@ -827,7 +847,22 @@ impl<'heap> SpecialFormExpander<'heap> {
             }
             ExprKind::Struct(r#struct) => self.lower_use_imports_struct(r#struct),
             ExprKind::Tuple(tuple) => self.lower_use_imports_tuple(tuple),
-            _ => {
+            ExprKind::Call(_)
+            | ExprKind::Dict(_)
+            | ExprKind::List(_)
+            | ExprKind::Literal(_)
+            | ExprKind::Let(_)
+            | ExprKind::Type(_)
+            | ExprKind::NewType(_)
+            | ExprKind::Use(_)
+            | ExprKind::Input(_)
+            | ExprKind::Closure(_)
+            | ExprKind::If(_)
+            | ExprKind::Field(_)
+            | ExprKind::Index(_)
+            | ExprKind::Is(_)
+            | ExprKind::Underscore
+            | ExprKind::Dummy => {
                 self.diagnostics
                     .push(invalid_use_import(argument.value.span));
                 None
@@ -984,7 +1019,23 @@ impl<'heap> SpecialFormExpander<'heap> {
         match argument.value.kind {
             ExprKind::Tuple(tuple) => self.lower_fn_generics_tuple(tuple),
             ExprKind::Struct(r#struct) => self.lower_fn_generics_struct(r#struct),
-            _ => {
+            ExprKind::Call(_)
+            | ExprKind::Dict(_)
+            | ExprKind::List(_)
+            | ExprKind::Literal(_)
+            | ExprKind::Path(_)
+            | ExprKind::Let(_)
+            | ExprKind::Type(_)
+            | ExprKind::NewType(_)
+            | ExprKind::Use(_)
+            | ExprKind::Input(_)
+            | ExprKind::Closure(_)
+            | ExprKind::If(_)
+            | ExprKind::Field(_)
+            | ExprKind::Index(_)
+            | ExprKind::Is(_)
+            | ExprKind::Underscore
+            | ExprKind::Dummy => {
                 self.diagnostics
                     .push(invalid_fn_generics_expression(argument.value.span));
                 None

--- a/libs/@local/hashql/ast/src/lowering/type_extractor/definition.rs
+++ b/libs/@local/hashql/ast/src/lowering/type_extractor/definition.rs
@@ -279,7 +279,23 @@ impl<'heap> Visitor<'heap> for TypeDefinitionExtractor<'_, 'heap> {
 
                 body
             }
-            _ => unreachable!(),
+            ExprKind::Call(_)
+            | ExprKind::Struct(_)
+            | ExprKind::Dict(_)
+            | ExprKind::Tuple(_)
+            | ExprKind::List(_)
+            | ExprKind::Literal(_)
+            | ExprKind::Path(_)
+            | ExprKind::Let(_)
+            | ExprKind::Use(_)
+            | ExprKind::Input(_)
+            | ExprKind::Closure(_)
+            | ExprKind::If(_)
+            | ExprKind::Field(_)
+            | ExprKind::Index(_)
+            | ExprKind::Is(_)
+            | ExprKind::Underscore
+            | ExprKind::Dummy => unreachable!(),
         };
 
         *expr = body;

--- a/libs/@local/hashql/core/src/module/resolver.rs
+++ b/libs/@local/hashql/core/src/module/resolver.rs
@@ -126,7 +126,10 @@ impl<'heap> Resolver<'_, 'heap> {
             .copied()
             .find_map(|item| match item.kind {
                 ItemKind::Module(module) if item.name == name => Some(module),
-                _ => None,
+                ItemKind::Module(_)
+                | ItemKind::Type(_)
+                | ItemKind::Constructor(_)
+                | ItemKind::Intrinsic(_) => None,
             });
 
         let Some(module) = candidate else {
@@ -323,7 +326,10 @@ impl<'heap> Resolver<'_, 'heap> {
             .rev()
             .find_map(|import| match import.item.kind {
                 ItemKind::Module(module) if import.name == name => Some(module),
-                _ => None,
+                ItemKind::Module(_)
+                | ItemKind::Type(_)
+                | ItemKind::Constructor(_)
+                | ItemKind::Intrinsic(_) => None,
             });
 
         let Some(module) = module else {
@@ -362,7 +368,10 @@ impl<'heap> Resolver<'_, 'heap> {
                 .rev()
                 .find_map(|import| match import.item.kind {
                     ItemKind::Module(module) if import.name == name => Some(module),
-                    _ => None,
+                    ItemKind::Module(_)
+                    | ItemKind::Type(_)
+                    | ItemKind::Constructor(_)
+                    | ItemKind::Intrinsic(_) => None,
                 });
 
             let Some(module) = module else {

--- a/libs/@local/hashql/core/src/module/std_lib/mod.rs
+++ b/libs/@local/hashql/core/src/module/std_lib/mod.rs
@@ -123,7 +123,7 @@ impl<'heap> ModuleDef<'heap> {
     fn expect_type(&self, name: Symbol<'heap>) -> TypeDef<'heap> {
         match self.expect(name).def {
             ItemDef::Type(type_def) => type_def,
-            _ => panic!("expected type definition"),
+            ItemDef::Newtype(_) | ItemDef::Intrinsic(_) => panic!("expected type definition"),
         }
     }
 
@@ -131,7 +131,7 @@ impl<'heap> ModuleDef<'heap> {
     fn expect_newtype(&self, name: Symbol<'heap>) -> TypeDef<'heap> {
         match self.expect(name).def {
             ItemDef::Newtype(newtype_def) => newtype_def,
-            _ => panic!("expected newtype definition"),
+            ItemDef::Type(_) | ItemDef::Intrinsic(_) => panic!("expected newtype definition"),
         }
     }
 }

--- a/libs/@local/hashql/core/src/type/inference/solver/mod.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/mod.rs
@@ -455,7 +455,10 @@ impl<'env, 'heap> InferenceSolver<'env, 'heap> {
                     Some((EdgeKind::SubtypeOf, lhs, rhs)),
                     Some((EdgeKind::SubtypeOf, rhs, lhs)),
                 ],
-                _ => continue,
+                Constraint::UpperBound { .. }
+                | Constraint::LowerBound { .. }
+                | Constraint::Equals { .. }
+                | Constraint::Selection(..) => continue,
             };
 
             for (kind, source, target) in edges.into_iter().flatten() {
@@ -1476,7 +1479,12 @@ impl<'env, 'heap> InferenceSolver<'env, 'heap> {
                     // These might still exist, because we haven't made any progress, but(!) they
                     // should be the only ones that survive
                 }
-                _ => unreachable!(
+                Constraint::Unify { .. }
+                | Constraint::UpperBound { .. }
+                | Constraint::LowerBound { .. }
+                | Constraint::Equals { .. }
+                | Constraint::Ordering { .. }
+                | Constraint::Dependency { .. } => unreachable!(
                     "only selection constraints can be remaining on a fix-point system"
                 ),
             }

--- a/libs/@local/hashql/core/src/type/kind/mod.rs
+++ b/libs/@local/hashql/core/src/type/kind/mod.rs
@@ -77,7 +77,19 @@ impl<'heap> TypeKind<'heap> {
     pub const fn opaque(&self) -> Option<&OpaqueType<'heap>> {
         match self {
             Self::Opaque(r#type) => Some(r#type),
-            _ => None,
+            Self::Primitive(_)
+            | Self::Intrinsic(_)
+            | Self::Struct(_)
+            | Self::Tuple(_)
+            | Self::Union(_)
+            | Self::Intersection(_)
+            | Self::Closure(_)
+            | Self::Apply(_)
+            | Self::Generic(_)
+            | Self::Param(_)
+            | Self::Infer(_)
+            | Self::Never
+            | Self::Unknown => None,
         }
     }
 
@@ -85,7 +97,19 @@ impl<'heap> TypeKind<'heap> {
     pub const fn primitive(&self) -> Option<&PrimitiveType> {
         match self {
             Self::Primitive(r#type) => Some(r#type),
-            _ => None,
+            Self::Opaque(_)
+            | Self::Intrinsic(_)
+            | Self::Struct(_)
+            | Self::Tuple(_)
+            | Self::Union(_)
+            | Self::Intersection(_)
+            | Self::Closure(_)
+            | Self::Apply(_)
+            | Self::Generic(_)
+            | Self::Param(_)
+            | Self::Infer(_)
+            | Self::Never
+            | Self::Unknown => None,
         }
     }
 
@@ -93,7 +117,19 @@ impl<'heap> TypeKind<'heap> {
     pub const fn intrinsic(&self) -> Option<&IntrinsicType> {
         match self {
             Self::Intrinsic(r#type) => Some(r#type),
-            _ => None,
+            Self::Opaque(_)
+            | Self::Primitive(_)
+            | Self::Struct(_)
+            | Self::Tuple(_)
+            | Self::Union(_)
+            | Self::Intersection(_)
+            | Self::Closure(_)
+            | Self::Apply(_)
+            | Self::Generic(_)
+            | Self::Param(_)
+            | Self::Infer(_)
+            | Self::Never
+            | Self::Unknown => None,
         }
     }
 
@@ -101,7 +137,19 @@ impl<'heap> TypeKind<'heap> {
     pub const fn r#struct(&self) -> Option<&StructType<'heap>> {
         match self {
             Self::Struct(r#type) => Some(r#type),
-            _ => None,
+            Self::Opaque(_)
+            | Self::Primitive(_)
+            | Self::Intrinsic(_)
+            | Self::Tuple(_)
+            | Self::Union(_)
+            | Self::Intersection(_)
+            | Self::Closure(_)
+            | Self::Apply(_)
+            | Self::Generic(_)
+            | Self::Param(_)
+            | Self::Infer(_)
+            | Self::Never
+            | Self::Unknown => None,
         }
     }
 
@@ -109,7 +157,19 @@ impl<'heap> TypeKind<'heap> {
     pub const fn tuple(&self) -> Option<&TupleType<'heap>> {
         match self {
             Self::Tuple(r#type) => Some(r#type),
-            _ => None,
+            Self::Opaque(_)
+            | Self::Primitive(_)
+            | Self::Intrinsic(_)
+            | Self::Struct(_)
+            | Self::Union(_)
+            | Self::Intersection(_)
+            | Self::Closure(_)
+            | Self::Apply(_)
+            | Self::Generic(_)
+            | Self::Param(_)
+            | Self::Infer(_)
+            | Self::Never
+            | Self::Unknown => None,
         }
     }
 
@@ -117,7 +177,19 @@ impl<'heap> TypeKind<'heap> {
     pub const fn closure(&self) -> Option<&ClosureType<'heap>> {
         match self {
             Self::Closure(r#type) => Some(r#type),
-            _ => None,
+            Self::Opaque(_)
+            | Self::Primitive(_)
+            | Self::Intrinsic(_)
+            | Self::Struct(_)
+            | Self::Tuple(_)
+            | Self::Union(_)
+            | Self::Intersection(_)
+            | Self::Apply(_)
+            | Self::Generic(_)
+            | Self::Param(_)
+            | Self::Infer(_)
+            | Self::Never
+            | Self::Unknown => None,
         }
     }
 
@@ -125,7 +197,19 @@ impl<'heap> TypeKind<'heap> {
     pub const fn union(&self) -> Option<&UnionType<'heap>> {
         match self {
             Self::Union(r#type) => Some(r#type),
-            _ => None,
+            Self::Opaque(_)
+            | Self::Primitive(_)
+            | Self::Intrinsic(_)
+            | Self::Struct(_)
+            | Self::Tuple(_)
+            | Self::Intersection(_)
+            | Self::Closure(_)
+            | Self::Apply(_)
+            | Self::Generic(_)
+            | Self::Param(_)
+            | Self::Infer(_)
+            | Self::Never
+            | Self::Unknown => None,
         }
     }
 
@@ -133,7 +217,19 @@ impl<'heap> TypeKind<'heap> {
     pub const fn intersection(&self) -> Option<&IntersectionType<'heap>> {
         match self {
             Self::Intersection(r#type) => Some(r#type),
-            _ => None,
+            Self::Opaque(_)
+            | Self::Primitive(_)
+            | Self::Intrinsic(_)
+            | Self::Struct(_)
+            | Self::Tuple(_)
+            | Self::Union(_)
+            | Self::Closure(_)
+            | Self::Apply(_)
+            | Self::Generic(_)
+            | Self::Param(_)
+            | Self::Infer(_)
+            | Self::Never
+            | Self::Unknown => None,
         }
     }
 
@@ -141,7 +237,19 @@ impl<'heap> TypeKind<'heap> {
     pub const fn apply(&self) -> Option<&Apply<'heap>> {
         match self {
             Self::Apply(r#type) => Some(r#type),
-            _ => None,
+            Self::Opaque(_)
+            | Self::Primitive(_)
+            | Self::Intrinsic(_)
+            | Self::Struct(_)
+            | Self::Tuple(_)
+            | Self::Union(_)
+            | Self::Intersection(_)
+            | Self::Closure(_)
+            | Self::Generic(_)
+            | Self::Param(_)
+            | Self::Infer(_)
+            | Self::Never
+            | Self::Unknown => None,
         }
     }
 
@@ -149,7 +257,19 @@ impl<'heap> TypeKind<'heap> {
     pub const fn generic(&self) -> Option<&Generic<'heap>> {
         match self {
             Self::Generic(r#type) => Some(r#type),
-            _ => None,
+            Self::Opaque(_)
+            | Self::Primitive(_)
+            | Self::Intrinsic(_)
+            | Self::Struct(_)
+            | Self::Tuple(_)
+            | Self::Union(_)
+            | Self::Intersection(_)
+            | Self::Closure(_)
+            | Self::Apply(_)
+            | Self::Param(_)
+            | Self::Infer(_)
+            | Self::Never
+            | Self::Unknown => None,
         }
     }
 
@@ -157,7 +277,19 @@ impl<'heap> TypeKind<'heap> {
     pub const fn param(&self) -> Option<&Param> {
         match self {
             Self::Param(r#type) => Some(r#type),
-            _ => None,
+            Self::Opaque(_)
+            | Self::Primitive(_)
+            | Self::Intrinsic(_)
+            | Self::Struct(_)
+            | Self::Tuple(_)
+            | Self::Union(_)
+            | Self::Intersection(_)
+            | Self::Closure(_)
+            | Self::Apply(_)
+            | Self::Generic(_)
+            | Self::Infer(_)
+            | Self::Never
+            | Self::Unknown => None,
         }
     }
 
@@ -165,7 +297,18 @@ impl<'heap> TypeKind<'heap> {
         match self {
             Self::Infer(Infer { hole }) => Some(VariableKind::Hole(hole)),
             Self::Param(Param { argument }) => Some(VariableKind::Generic(argument)),
-            _ => None,
+            Self::Opaque(_)
+            | Self::Primitive(_)
+            | Self::Intrinsic(_)
+            | Self::Struct(_)
+            | Self::Tuple(_)
+            | Self::Union(_)
+            | Self::Intersection(_)
+            | Self::Closure(_)
+            | Self::Apply(_)
+            | Self::Generic(_)
+            | Self::Never
+            | Self::Unknown => None,
         }
     }
 }

--- a/libs/@local/hashql/diagnostics/src/severity.rs
+++ b/libs/@local/hashql/diagnostics/src/severity.rs
@@ -266,7 +266,7 @@ impl Severity {
                     ] as &[_]
                 }
             }
-            _ => &[],
+            Self::Fatal | Self::Error | Self::Warning | Self::Note | Self::Debug => &[],
         }
     }
 
@@ -285,7 +285,7 @@ impl Severity {
                     )] as &[_]
                 }
             }
-            _ => &[],
+            Self::Fatal | Self::Error | Self::Warning | Self::Note | Self::Debug => &[],
         }
     }
 

--- a/libs/@local/hashql/hir/src/node/closure.rs
+++ b/libs/@local/hashql/hir/src/node/closure.rs
@@ -24,7 +24,19 @@ pub(crate) fn extract_signature<'heap>(
                 type_id = base;
             }
             TypeKind::Closure(closure) => return closure,
-            _ => unreachable!("ClosureSignature::returns() called on a non-closure type"),
+            TypeKind::Opaque(_)
+            | TypeKind::Primitive(_)
+            | TypeKind::Intrinsic(_)
+            | TypeKind::Struct(_)
+            | TypeKind::Tuple(_)
+            | TypeKind::Union(_)
+            | TypeKind::Intersection(_)
+            | TypeKind::Param(_)
+            | TypeKind::Infer(_)
+            | TypeKind::Never
+            | TypeKind::Unknown => {
+                unreachable!("ClosureSignature::returns() called on a non-closure type")
+            }
         }
     }
 }
@@ -74,7 +86,19 @@ impl<'heap> ClosureSignature<'heap> {
                 }
                 TypeKind::Generic(generic) => return Some(generic),
                 TypeKind::Closure(_) => return None,
-                _ => unreachable!("ClosureSignature::returns() called on a non-closure type"),
+                TypeKind::Opaque(_)
+                | TypeKind::Primitive(_)
+                | TypeKind::Intrinsic(_)
+                | TypeKind::Struct(_)
+                | TypeKind::Tuple(_)
+                | TypeKind::Union(_)
+                | TypeKind::Intersection(_)
+                | TypeKind::Param(_)
+                | TypeKind::Infer(_)
+                | TypeKind::Never
+                | TypeKind::Unknown => {
+                    unreachable!("ClosureSignature::returns() called on a non-closure type")
+                }
             }
         }
     }

--- a/libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/lexer/mod.rs
@@ -407,10 +407,13 @@ mod test {
 
         match diagnostic.category {
             LexerDiagnosticCategory::InvalidNumber => {}
-            _ => panic!(
-                "Expected InvalidNumber error, got {:?}",
-                diagnostic.category
-            ),
+            category @ (LexerDiagnosticCategory::InvalidString
+            | LexerDiagnosticCategory::InvalidCharacter
+            | LexerDiagnosticCategory::InvalidUtf8
+            | LexerDiagnosticCategory::UnexpectedEof
+            | LexerDiagnosticCategory::UnexpectedToken) => {
+                panic!("Expected InvalidNumber error, got {category:?}")
+            }
         }
     }
 

--- a/libs/@local/hashql/syntax-jexpr/src/parser/array/error.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/array/error.rs
@@ -61,7 +61,12 @@ impl ArrayDiagnosticCategory {
     pub(crate) fn hoist(&self) -> &dyn DiagnosticCategory {
         match self {
             Self::Lexer(category) => category.subcategory().unwrap_or(category),
-            _ => self,
+            Self::LeadingComma
+            | Self::TrailingComma
+            | Self::ConsecutiveComma
+            | Self::Empty
+            | Self::LabeledArgumentMissingPrefix
+            | Self::LabeledArgumentInvalidIdentifier => self,
         }
     }
 }
@@ -70,14 +75,24 @@ impl DiagnosticCategory for ArrayDiagnosticCategory {
     fn id(&self) -> Cow<'_, str> {
         match self {
             Self::Lexer(category) => category.id(),
-            _ => Cow::Borrowed("array"),
+            Self::LeadingComma
+            | Self::TrailingComma
+            | Self::ConsecutiveComma
+            | Self::Empty
+            | Self::LabeledArgumentMissingPrefix
+            | Self::LabeledArgumentInvalidIdentifier => Cow::Borrowed("array"),
         }
     }
 
     fn name(&self) -> Cow<'_, str> {
         match self {
             Self::Lexer(category) => category.name(),
-            _ => Cow::Borrowed("Array"),
+            Self::LeadingComma
+            | Self::TrailingComma
+            | Self::ConsecutiveComma
+            | Self::Empty
+            | Self::LabeledArgumentMissingPrefix
+            | Self::LabeledArgumentInvalidIdentifier => Cow::Borrowed("Array"),
         }
     }
 

--- a/libs/@local/hashql/syntax-jexpr/src/parser/error.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/error.rs
@@ -43,7 +43,11 @@ impl DiagnosticCategory for ParserDiagnosticCategory {
             Self::Lexer(category)
             | Self::Object(ObjectDiagnosticCategory::Lexer(category))
             | Self::Array(ArrayDiagnosticCategory::Lexer(category)) => category.id(),
-            _ => Cow::Borrowed("parser"),
+            Self::String(_)
+            | Self::Array(_)
+            | Self::Object(_)
+            | Self::ExpectedLanguageItem
+            | Self::ExpectedEof => Cow::Borrowed("parser"),
         }
     }
 
@@ -52,7 +56,11 @@ impl DiagnosticCategory for ParserDiagnosticCategory {
             Self::Lexer(category)
             | Self::Object(ObjectDiagnosticCategory::Lexer(category))
             | Self::Array(ArrayDiagnosticCategory::Lexer(category)) => category.name(),
-            _ => Cow::Borrowed("Parser"),
+            Self::String(_)
+            | Self::Array(_)
+            | Self::Object(_)
+            | Self::ExpectedLanguageItem
+            | Self::ExpectedEof => Cow::Borrowed("Parser"),
         }
     }
 

--- a/libs/@local/hashql/syntax-jexpr/src/parser/expr.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/expr.rs
@@ -31,7 +31,14 @@ pub(crate) fn parse_expr<'heap>(
         }
         SyntaxKind::LBracket => parse_array(state, token),
         SyntaxKind::LBrace => parse_object(state, token),
-        _ => {
+        SyntaxKind::Number
+        | SyntaxKind::True
+        | SyntaxKind::False
+        | SyntaxKind::Null
+        | SyntaxKind::Comma
+        | SyntaxKind::Colon
+        | SyntaxKind::RBrace
+        | SyntaxKind::RBracket => {
             unreachable!()
         }
     }

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/dict.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/dict.rs
@@ -209,7 +209,15 @@ fn parse_dict<'heap>(
     let is_object = match token.kind.syntax() {
         SyntaxKind::LBrace => true,
         SyntaxKind::LBracket => false,
-        kind => {
+        kind @ (SyntaxKind::String
+        | SyntaxKind::Number
+        | SyntaxKind::True
+        | SyntaxKind::False
+        | SyntaxKind::Null
+        | SyntaxKind::Comma
+        | SyntaxKind::Colon
+        | SyntaxKind::RBrace
+        | SyntaxKind::RBracket) => {
             let span = state.insert_range(token.span);
 
             return Err(dict_expected_format(span, kind)).change_category(From::from)?;

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/error.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/error.rs
@@ -135,7 +135,24 @@ impl ObjectDiagnosticCategory {
     pub(crate) fn hoist(&self) -> &dyn DiagnosticCategory {
         match self {
             Self::Lexer(category) => category.subcategory().unwrap_or(category),
-            _ => self,
+            Self::LeadingComma
+            | Self::TrailingComma
+            | Self::ConsecutiveComma
+            | Self::ConsecutiveColon
+            | Self::UnknownKey
+            | Self::Empty
+            | Self::OrphanedType
+            | Self::DuplicateKey
+            | Self::StructExpectedObject
+            | Self::StructKeyExpectedIdentifier
+            | Self::DictExpectedFormat
+            | Self::DictEntryTooFewItems
+            | Self::DictEntryTooManyItems
+            | Self::DictEntryExpectedArray
+            | Self::TupleExpectedArray
+            | Self::ListExpectedArray
+            | Self::TypeExpectedString
+            | Self::LiteralExpectedPrimitive => self,
         }
     }
 }
@@ -144,14 +161,48 @@ impl DiagnosticCategory for ObjectDiagnosticCategory {
     fn id(&self) -> Cow<'_, str> {
         match self {
             Self::Lexer(category) => category.id(),
-            _ => Cow::Borrowed("object"),
+            Self::LeadingComma
+            | Self::TrailingComma
+            | Self::ConsecutiveComma
+            | Self::ConsecutiveColon
+            | Self::UnknownKey
+            | Self::Empty
+            | Self::OrphanedType
+            | Self::DuplicateKey
+            | Self::StructExpectedObject
+            | Self::StructKeyExpectedIdentifier
+            | Self::DictExpectedFormat
+            | Self::DictEntryTooFewItems
+            | Self::DictEntryTooManyItems
+            | Self::DictEntryExpectedArray
+            | Self::TupleExpectedArray
+            | Self::ListExpectedArray
+            | Self::TypeExpectedString
+            | Self::LiteralExpectedPrimitive => Cow::Borrowed("object"),
         }
     }
 
     fn name(&self) -> Cow<'_, str> {
         match self {
             Self::Lexer(category) => category.name(),
-            _ => Cow::Borrowed("Object"),
+            Self::LeadingComma
+            | Self::TrailingComma
+            | Self::ConsecutiveComma
+            | Self::ConsecutiveColon
+            | Self::UnknownKey
+            | Self::Empty
+            | Self::OrphanedType
+            | Self::DuplicateKey
+            | Self::StructExpectedObject
+            | Self::StructKeyExpectedIdentifier
+            | Self::DictExpectedFormat
+            | Self::DictEntryTooFewItems
+            | Self::DictEntryTooManyItems
+            | Self::DictEntryExpectedArray
+            | Self::TupleExpectedArray
+            | Self::ListExpectedArray
+            | Self::TypeExpectedString
+            | Self::LiteralExpectedPrimitive => Cow::Borrowed("Object"),
         }
     }
 

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/literal.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/literal.rs
@@ -102,7 +102,12 @@ fn parse_literal<'heap>(
         TokenKind::String(value) => LiteralKind::String(StringLiteral {
             value: state.intern_symbol(value),
         }),
-        kind => {
+        kind @ (TokenKind::LBrace
+        | TokenKind::RBrace
+        | TokenKind::LBracket
+        | TokenKind::RBracket
+        | TokenKind::Colon
+        | TokenKind::Comma) => {
             return Err(literal_expected_primitive(span, kind.syntax()).map_category(From::from));
         }
     };

--- a/libs/@local/hashql/syntax-jexpr/src/parser/string/error.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/string/error.rs
@@ -65,7 +65,7 @@ pub(crate) fn convert_parse_error<I>(
     // adapted from the `Display` for `ContextError`.
     let expression = error.context().find_map(|context| match context {
         StrContext::Label(label) => Some(*label),
-        _ => None,
+        StrContext::Expected(_) | _ => None,
     });
 
     let message = expression.map_or_else(
@@ -79,7 +79,7 @@ pub(crate) fn convert_parse_error<I>(
         .context()
         .filter_map(|context| match context {
             StrContext::Expected(expected) => Some(expected),
-            _ => None,
+            StrContext::Label(_) | _ => None,
         })
         .collect();
 

--- a/libs/@local/telemetry/src/logging/mod.rs
+++ b/libs/@local/telemetry/src/logging/mod.rs
@@ -404,10 +404,12 @@ where
             None,
             Right::<S, W>::Some(layer(format, level, writer, JsonFields::new(), ansi)),
         ),
-        _ => <Left<S, W> as Layer<S>>::and_then(
-            Some(layer(format, level, writer, DefaultFields::new(), ansi)),
-            Right::<S, W>::None,
-        ),
+        LogFormat::Full | LogFormat::Pretty | LogFormat::Compact => {
+            <Left<S, W> as Layer<S>>::and_then(
+                Some(layer(format, level, writer, DefaultFields::new(), ansi)),
+                Right::<S, W>::None,
+            )
+        }
     }
 }
 

--- a/libs/deer/desert/src/skip.rs
+++ b/libs/deer/desert/src/skip.rs
@@ -23,7 +23,18 @@ fn scan_object(deserializer: &Deserializer, stop: &Token) -> usize {
             Token::ArrayEnd => arrays = arrays.saturating_sub(1),
             Token::Object { .. } => objects += 1,
             Token::ObjectEnd => objects = objects.saturating_sub(1),
-            _ => {}
+            Token::Bool(_)
+            | Token::Number(_)
+            | Token::U128(_)
+            | Token::I128(_)
+            | Token::Char(_)
+            | Token::Str(_)
+            | Token::BorrowedStr(_)
+            | Token::String(_)
+            | Token::Bytes(_)
+            | Token::BorrowedBytes(_)
+            | Token::BytesBuf(_)
+            | Token::Null => {}
         }
 
         n += 1;
@@ -36,7 +47,20 @@ pub(crate) fn skip_tokens(deserializer: &mut Deserializer, start: &Token) {
     let n = match start {
         Token::Array { .. } => scan_object(&*deserializer, &Token::ArrayEnd),
         Token::Object { .. } => scan_object(&*deserializer, &Token::ObjectEnd),
-        _ => 0,
+        Token::Bool(_)
+        | Token::Number(_)
+        | Token::U128(_)
+        | Token::I128(_)
+        | Token::Char(_)
+        | Token::Str(_)
+        | Token::BorrowedStr(_)
+        | Token::String(_)
+        | Token::Bytes(_)
+        | Token::BorrowedBytes(_)
+        | Token::BytesBuf(_)
+        | Token::ArrayEnd
+        | Token::ObjectEnd
+        | Token::Null => 0,
     };
 
     if n > 0 {

--- a/libs/deer/json/src/deserializer.rs
+++ b/libs/deer/json/src/deserializer.rs
@@ -112,7 +112,10 @@ impl<'a, 'de> Deserializer<'a, 'de> {
         match token {
             ValueToken::Object => skip_tokens(&mut self.tokenizer, &Token::Object),
             ValueToken::Array => skip_tokens(&mut self.tokenizer, &Token::Array),
-            _ => {}
+            ValueToken::Null
+            | ValueToken::Bool(_)
+            | ValueToken::String(_)
+            | ValueToken::Number(_) => {}
         }
     }
 
@@ -222,7 +225,11 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
 
         match token {
             ValueToken::Null => visitor.visit_null().change_context(DeserializerError),
-            token => Err(self.error_invalid_type(&token, <()>::reflection())),
+            token @ (ValueToken::Bool(_)
+            | ValueToken::String(_)
+            | ValueToken::Number(_)
+            | ValueToken::Object
+            | ValueToken::Array) => Err(self.error_invalid_type(&token, <()>::reflection())),
         }
     }
 
@@ -234,7 +241,11 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
 
         match token {
             ValueToken::Bool(value) => visitor.visit_bool(value).change_context(DeserializerError),
-            token => Err(self.error_invalid_type(&token, bool::reflection())),
+            token @ (ValueToken::Null
+            | ValueToken::String(_)
+            | ValueToken::Number(_)
+            | ValueToken::Object
+            | ValueToken::Array) => Err(self.error_invalid_type(&token, bool::reflection())),
         }
     }
 
@@ -248,7 +259,11 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
             ValueToken::Number(value) => visitor
                 .visit_number(try_convert_number(&value).change_context(DeserializerError)?)
                 .change_context(DeserializerError),
-            token => Err(self.error_invalid_type(&token, Number::reflection())),
+            token @ (ValueToken::Null
+            | ValueToken::Bool(_)
+            | ValueToken::String(_)
+            | ValueToken::Object
+            | ValueToken::Array) => Err(self.error_invalid_type(&token, Number::reflection())),
         }
     }
 
@@ -278,7 +293,11 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
                 AnyStr::Borrowed(value) => visitor.visit_borrowed_str(value),
             }
             .change_context(DeserializerError),
-            token => Err(self.error_invalid_type(&token, str::document())),
+            token @ (ValueToken::Null
+            | ValueToken::Bool(_)
+            | ValueToken::Number(_)
+            | ValueToken::Object
+            | ValueToken::Array) => Err(self.error_invalid_type(&token, str::document())),
         }
     }
 
@@ -306,7 +325,13 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
             ValueToken::Array => visitor
                 .visit_array(ArrayAccess::new(self)?)
                 .change_context(DeserializerError),
-            token => Err(self.error_invalid_type(&token, ValueToken::Array.schema())),
+            token @ (ValueToken::Null
+            | ValueToken::Bool(_)
+            | ValueToken::String(_)
+            | ValueToken::Number(_)
+            | ValueToken::Object) => {
+                Err(self.error_invalid_type(&token, ValueToken::Array.schema()))
+            }
         }
     }
 
@@ -320,7 +345,13 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
             ValueToken::Object => visitor
                 .visit_object(ObjectAccess::new(self)?)
                 .change_context(DeserializerError),
-            token => Err(self.error_invalid_type(&token, ValueToken::Object.schema())),
+            token @ (ValueToken::Null
+            | ValueToken::Bool(_)
+            | ValueToken::String(_)
+            | ValueToken::Number(_)
+            | ValueToken::Array) => {
+                Err(self.error_invalid_type(&token, ValueToken::Object.schema()))
+            }
         }
     }
 
@@ -443,7 +474,13 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
                 .visit_object(ObjectAccess::new(self)?)
                 .change_context(DeserializerError),
 
-            token => Err(self.error_invalid_type(&token, ValueToken::Object.schema())),
+            token @ (ValueToken::Null
+            | ValueToken::Bool(_)
+            | ValueToken::String(_)
+            | ValueToken::Number(_)
+            | ValueToken::Array) => {
+                Err(self.error_invalid_type(&token, ValueToken::Object.schema()))
+            }
         }
     }
 
@@ -460,7 +497,11 @@ impl<'de> deer::Deserializer<'de> for &mut Deserializer<'_, 'de> {
             }
             .change_context(DeserializerError),
 
-            token => Err(self.error_invalid_type(&token, str::document())),
+            token @ (ValueToken::Null
+            | ValueToken::Bool(_)
+            | ValueToken::Number(_)
+            | ValueToken::Object
+            | ValueToken::Array) => Err(self.error_invalid_type(&token, str::document())),
         }
     }
 }

--- a/libs/deer/json/src/error.rs
+++ b/libs/deer/json/src/error.rs
@@ -267,7 +267,20 @@ pub(crate) fn convert_tokenizer_error(error: &justjson::Error) -> Report<deer::e
         ErrorKind::UnclosedString => SyntaxError::UnclosedString.into_error(),
         ErrorKind::ExpectedString => SyntaxError::ExpectedString.into_error(),
         ErrorKind::ExpectedNumber => SyntaxError::ExpectedNumber.into_error(),
-        kind => NativeError(kind.clone()).into_error(),
+        kind @ (ErrorKind::ExpectedObjectKey
+        | ErrorKind::ExpectedValue
+        | ErrorKind::ExpectedCommaOrEndOfObject
+        | ErrorKind::ExpectedCommaOrEndOfArray
+        | ErrorKind::IllegalTrailingComma
+        | ErrorKind::TrailingNonWhitespace
+        | ErrorKind::ObjectKeysMustBeStrings
+        | ErrorKind::UnclosedObject
+        | ErrorKind::UnclosedArray
+        | ErrorKind::RecursionLimitReached
+        | ErrorKind::PayloadsShouldBeObjectOrArray
+        | ErrorKind::PaylodTooLarge
+        | ErrorKind::ErrorFromDelegate(_)
+        | _) => NativeError(kind.clone()).into_error(),
     };
 
     Report::new(error).attach(Position::new(offset))

--- a/libs/deer/json/src/skip.rs
+++ b/libs/deer/json/src/skip.rs
@@ -29,7 +29,12 @@ fn skip_nested(tokenizer: &mut Tokenizer<false>, stop: &Token) {
             Token::ArrayEnd => arrays = arrays.saturating_sub(1),
             Token::Object => objects += 1,
             Token::ObjectEnd => objects = objects.saturating_sub(1),
-            _ => {}
+            Token::Null
+            | Token::Bool(_)
+            | Token::String(_)
+            | Token::Number(_)
+            | Token::Colon
+            | Token::Comma => {}
         }
     }
 }
@@ -40,6 +45,13 @@ pub(crate) fn skip_tokens(tokenizer: &mut Tokenizer<false>, start: &Token) {
     match start {
         Token::Array => skip_nested(tokenizer, &Token::ArrayEnd),
         Token::Object => skip_nested(tokenizer, &Token::ObjectEnd),
-        _ => {}
+        Token::Null
+        | Token::Bool(_)
+        | Token::String(_)
+        | Token::Number(_)
+        | Token::ObjectEnd
+        | Token::ArrayEnd
+        | Token::Colon
+        | Token::Comma => {}
     }
 }

--- a/tests/graph/integration/postgres/sorting.rs
+++ b/tests/graph/integration/postgres/sorting.rs
@@ -113,7 +113,9 @@ async fn test_root_sorting<A: AuthorizationApi>(
                 GraphElementVertexId::KnowledgeGraph(entity_vertex_id) => {
                     subgraph.vertices.entities.remove(&entity_vertex_id)
                 }
-                _ => unreachable!(),
+                GraphElementVertexId::DataType(_)
+                | GraphElementVertexId::PropertyType(_)
+                | GraphElementVertexId::EntityType(_) => unreachable!(),
             })
             .collect::<Vec<_>>();
         assert_eq!(count, Some(expected_order.len()));


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

If enum variants are added, it's easy to miss them if a wildcard is used (such as `_`). To prevent this, clippy has a `wildcard-enum-match-arm` lint. 

There are circumstances, where this is not wanted, e.g. in tests where we can simply panic on unexpected variants, for this, we should use the `#[expect]` attribute instead. Also, it adds some boilerplate on things like parsing, but generally this is manageable. In these locations, it's simple to use the RA diagnostic to generate the remaining patterns, otherwise this would become annoying.

`#[non-exhaustive]` enums are covered through `Variant::X | Variant::Y | _`